### PR TITLE
feat(roadmaps): toolset registration + agent tools

### DIFF
--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -31,6 +31,7 @@ import sqlite3
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import MappingProxyType
 from typing import Iterable, List, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing, write_txn
@@ -93,6 +94,128 @@ CREATE TABLE IF NOT EXISTS discovered_repos (
     label         TEXT,
     last_seen     INTEGER NOT NULL
 );
+
+-- Roadmaps Phase 1: additive durable plan/execution schema.  The profile_id
+-- columns are application scope inside this per-profile database; the database
+-- path resolved by get_hermes_home() remains the actual profile boundary.
+CREATE TABLE IF NOT EXISTS roadmaps (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0) REFERENCES projects(id) ON DELETE CASCADE,
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    title TEXT NOT NULL,
+    purpose TEXT,
+    lifecycle_state TEXT NOT NULL CHECK (lifecycle_state IN ('draft','proposed','validated','in_progress','blocked','completed','archived')),
+    active_version INTEGER CHECK (active_version IS NULL OR active_version >= 1),
+    created_by TEXT NOT NULL CHECK (length(trim(replace(replace(replace(created_by, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    updated_by TEXT NOT NULL CHECK (length(trim(replace(replace(replace(updated_by, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, active_version)
+      REFERENCES roadmap_versions(profile_id, project_id, roadmap_id, version)
+      DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS roadmap_versions (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL CHECK (version >= 1),
+    state TEXT NOT NULL CHECK (state IN ('draft','proposed','validated','superseded','archived')),
+    source TEXT,
+    reason TEXT,
+    created_by TEXT NOT NULL CHECK (length(trim(replace(replace(replace(created_by, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    created_at INTEGER NOT NULL,
+    content_hash TEXT,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version),
+    FOREIGN KEY (profile_id, project_id, roadmap_id)
+      REFERENCES roadmaps(profile_id, project_id, roadmap_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS roadmap_nodes (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL,
+    node_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    parent_node_id TEXT,
+    kind TEXT NOT NULL CHECK (kind IN ('objective','phase','milestone','step','decision')),
+    title TEXT NOT NULL,
+    description TEXT,
+    state TEXT NOT NULL CHECK (state IN ('planned','ready','in_progress','blocked','completed','archived')),
+    progress INTEGER NOT NULL DEFAULT 0 CHECK (progress BETWEEN 0 AND 100),
+    owner_agent TEXT CHECK (owner_agent IS NULL OR length(trim(replace(replace(replace(owner_agent, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    block_reason TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version, node_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version)
+      REFERENCES roadmap_versions(profile_id, project_id, roadmap_id, version) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, parent_node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id),
+    CHECK (parent_node_id IS NULL OR (length(trim(replace(replace(replace(parent_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0 AND parent_node_id <> node_id))
+);
+
+CREATE TABLE IF NOT EXISTS roadmap_relations (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL,
+    relation_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(relation_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    from_node_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(from_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    to_node_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(to_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    kind TEXT NOT NULL CHECK (kind IN ('depends_on','blocks','enables','follows','validates','supersedes')),
+    state TEXT NOT NULL DEFAULT 'active' CHECK (state IN ('active','superseded','invalid')),
+    reason TEXT,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version, relation_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, from_node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, to_node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id) ON DELETE CASCADE,
+    CHECK (from_node_id <> to_node_id)
+);
+
+CREATE TABLE IF NOT EXISTS roadmap_todos (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL,
+    todo_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(todo_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    node_id TEXT CHECK (node_id IS NULL OR length(trim(replace(replace(replace(node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    title TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('open','in_progress','done','cancelled')),
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version, todo_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version)
+      REFERENCES roadmap_versions(profile_id, project_id, roadmap_id, version) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id)
+);
+
+-- Durable Roadmaps session links.  Only the stored/lineage session id belongs
+-- here: runtime ids identify one transient execution and must never persist.
+CREATE TABLE IF NOT EXISTS roadmap_sessions (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    stored_session_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(stored_session_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    kind TEXT NOT NULL CHECK (kind IN ('vision')),
+    node_id TEXT CHECK (node_id IS NULL),
+    plan_version INTEGER CHECK (plan_version IS NULL OR plan_version >= 1),
+    state TEXT NOT NULL CHECK (state IN ('active','closed')),
+    actor TEXT NOT NULL CHECK (length(trim(replace(replace(replace(actor, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, stored_session_id, kind),
+    FOREIGN KEY (profile_id, project_id, roadmap_id)
+      REFERENCES roadmaps(profile_id, project_id, roadmap_id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_roadmap_sessions_active_vision
+    ON roadmap_sessions(profile_id, project_id, roadmap_id)
+    WHERE kind = 'vision' AND state = 'active';
 """
 
 
@@ -149,19 +272,324 @@ def _normalize_path(path: str) -> str:
 # Connection management
 # ---------------------------------------------------------------------------
 
-_INITIALIZED_PATHS: set[str] = set()
+_ROADMAP_TABLES = (
+    "roadmaps",
+    "roadmap_versions",
+    "roadmap_nodes",
+    "roadmap_relations",
+    "roadmap_todos",
+    "roadmap_sessions",
+)
+_ROADMAP_INDEXES = ("idx_roadmap_sessions_active_vision",)
+
+# Core schema is checked independently of Roadmaps so a partial legacy DB is repaired.
+_CORE_TABLES = ("projects", "project_folders", "project_meta", "discovered_repos")
+_CORE_INDEXES = ("idx_project_folders_path",)
+
+# Required independently from the column contract: ``slug`` is a stable
+# project handle and must remain unique even when a legacy table has the right
+# columns but weakened constraints.
+_CORE_UNIQUE_COLUMNS = MappingProxyType({"projects": (("slug",),)})
+
+# Required core columns are deliberately independent from SCHEMA_SQL.  Optional
+# project columns are migrated separately below, so they are not part of this
+# contract and may be added by later versions without invalidating old stores.
+_CORE_SCHEMA_CONTRACT = MappingProxyType(
+    {
+        "projects": (
+            (("id", "TEXT", 0, 1), ("slug", "TEXT", 1, 0),
+             ("name", "TEXT", 1, 0), ("created_at", "INTEGER", 1, 0),
+             ("archived", "INTEGER", 1, 0)),
+            (),
+        ),
+        "project_folders": (
+            (("project_id", "TEXT", 1, 1), ("path", "TEXT", 1, 2),
+             ("label", "TEXT", 0, 0), ("is_primary", "INTEGER", 1, 0),
+             ("added_at", "INTEGER", 1, 0)),
+            (("projects", ("project_id",), ("id",), "NO ACTION", "CASCADE"),),
+        ),
+        "project_meta": (
+            (("key", "TEXT", 0, 1), ("value", "TEXT", 0, 0)),
+            (),
+        ),
+        "discovered_repos": (
+            (("root", "TEXT", 0, 1), ("label", "TEXT", 0, 0),
+             ("last_seen", "INTEGER", 1, 0)),
+            (),
+        ),
+    }
+)
+
+# Exact CHECK expressions, maintained independently from SCHEMA_SQL.
+_ROADMAP_CHECK_CONTRACT = MappingProxyType({
+    "roadmaps": ("length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "lifecycle_state in ('draft','proposed','validated','in_progress','blocked','completed','archived')", "active_version is null or active_version >= 1", "length(trim(replace(replace(replace(created_by, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(updated_by, char(9), ''), char(10), ''), char(13), ''))) > 0"),
+    "roadmap_versions": ("length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "version >= 1", "state in ('draft','proposed','validated','superseded','archived')", "length(trim(replace(replace(replace(created_by, char(9), ''), char(10), ''), char(13), ''))) > 0"),
+    "roadmap_nodes": ("length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(node_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "kind in ('objective','phase','milestone','step','decision')", "state in ('planned','ready','in_progress','blocked','completed','archived')", "progress between 0 and 100", "owner_agent is null or length(trim(replace(replace(replace(owner_agent, char(9), ''), char(10), ''), char(13), ''))) > 0", "parent_node_id is null or (length(trim(replace(replace(replace(parent_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0 and parent_node_id <> node_id)"),
+    "roadmap_relations": ("length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(relation_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(from_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(to_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "kind in ('depends_on','blocks','enables','follows','validates','supersedes')", "state in ('active','superseded','invalid')", "from_node_id <> to_node_id"),
+    "roadmap_todos": ("length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(todo_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "node_id is null or length(trim(replace(replace(replace(node_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "state in ('open','in_progress','done','cancelled')"),
+    "roadmap_sessions": ("length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(stored_session_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "kind in ('vision')", "node_id is null", "plan_version is null or plan_version >= 1", "state in ('active','closed')", "length(trim(replace(replace(replace(actor, char(9), ''), char(10), ''), char(13), ''))) > 0"),
+})
+
+
+# Independent runtime contract: this must not be derived from SCHEMA_SQL, or a
+# weakened DDL would redefine what the validator considers compatible.
+_ROADMAP_SCHEMA_CONTRACT = MappingProxyType(
+    {
+        "roadmaps": (
+            (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+             ("roadmap_id", "TEXT", 1, 3), ("title", "TEXT", 1, 0),
+             ("purpose", "TEXT", 0, 0), ("lifecycle_state", "TEXT", 1, 0),
+             ("active_version", "INTEGER", 0, 0), ("created_by", "TEXT", 1, 0),
+             ("updated_by", "TEXT", 1, 0), ("created_at", "INTEGER", 1, 0),
+             ("updated_at", "INTEGER", 1, 0)),
+            (("roadmap_versions", ("profile_id", "project_id", "roadmap_id", "active_version"),
+              ("profile_id", "project_id", "roadmap_id", "version"), "NO ACTION", "NO ACTION"),
+             ("projects", ("project_id",), ("id",), "NO ACTION", "CASCADE")),
+            ("primary key", "foreign key", "check", "deferrable initially deferred",
+             "lifecycle_state text not null check", "active_version integer check"),
+        ),
+        "roadmap_versions": (
+            (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+             ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+             ("state", "TEXT", 1, 0), ("source", "TEXT", 0, 0), ("reason", "TEXT", 0, 0),
+             ("created_by", "TEXT", 1, 0), ("created_at", "INTEGER", 1, 0),
+             ("content_hash", "TEXT", 0, 0)),
+            (("roadmaps", ("profile_id", "project_id", "roadmap_id"),
+              ("profile_id", "project_id", "roadmap_id"), "NO ACTION", "CASCADE"),),
+            ("primary key", "foreign key", "check", "state text not null check", "version integer not null check"),
+        ),
+        "roadmap_nodes": (
+            (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+             ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+             ("node_id", "TEXT", 1, 5), ("parent_node_id", "TEXT", 0, 0),
+             ("kind", "TEXT", 1, 0), ("title", "TEXT", 1, 0), ("description", "TEXT", 0, 0),
+             ("state", "TEXT", 1, 0), ("progress", "INTEGER", 1, 0), ("owner_agent", "TEXT", 0, 0),
+             ("block_reason", "TEXT", 0, 0),
+             ("created_at", "INTEGER", 1, 0), ("updated_at", "INTEGER", 1, 0)),
+            (("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "parent_node_id"),
+              ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "NO ACTION", "NO ACTION"),
+             ("roadmap_versions", ("profile_id", "project_id", "roadmap_id", "version"),
+              ("profile_id", "project_id", "roadmap_id", "version"), "NO ACTION", "CASCADE")),
+            ("primary key", "foreign key", "check", "progress integer not null default 0 check", "parent_node_id is null"),
+        ),
+        "roadmap_relations": (
+            (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+             ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+             ("relation_id", "TEXT", 1, 5), ("from_node_id", "TEXT", 1, 0),
+             ("to_node_id", "TEXT", 1, 0), ("kind", "TEXT", 1, 0),
+             ("state", "TEXT", 1, 0), ("reason", "TEXT", 0, 0)),
+            (("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "from_node_id"),
+              ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "NO ACTION", "CASCADE"),
+             ("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "to_node_id"),
+              ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "NO ACTION", "CASCADE")),
+            ("primary key", "foreign key", "check", "from_node_id <> to_node_id", "state text not null default 'active' check"),
+        ),
+        "roadmap_todos": (
+            (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+             ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+             ("todo_id", "TEXT", 1, 5), ("node_id", "TEXT", 0, 0), ("title", "TEXT", 1, 0),
+             ("state", "TEXT", 1, 0), ("position", "INTEGER", 1, 0),
+             ("created_at", "INTEGER", 1, 0), ("updated_at", "INTEGER", 1, 0)),
+            (("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "node_id"),
+              ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "NO ACTION", "NO ACTION"),
+             ("roadmap_versions", ("profile_id", "project_id", "roadmap_id", "version"),
+              ("profile_id", "project_id", "roadmap_id", "version"), "NO ACTION", "CASCADE")),
+            ("primary key", "foreign key", "check", "state text not null check", "node_id text check"),
+        ),
+        "roadmap_sessions": (
+            (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+             ("roadmap_id", "TEXT", 1, 3), ("stored_session_id", "TEXT", 1, 4),
+             ("kind", "TEXT", 1, 5), ("node_id", "TEXT", 0, 0),
+             ("plan_version", "INTEGER", 0, 0), ("state", "TEXT", 1, 0),
+             ("actor", "TEXT", 1, 0), ("created_at", "INTEGER", 1, 0),
+             ("updated_at", "INTEGER", 1, 0)),
+            (("roadmaps", ("profile_id", "project_id", "roadmap_id"),
+              ("profile_id", "project_id", "roadmap_id"), "NO ACTION", "CASCADE"),),
+            ("primary key", "foreign key", "check", "state text not null check"),
+        ),
+    }
+)
+
+
+def _roadmap_schema_contract() -> MappingProxyType:
+    """Return the immutable, source-independent Roadmaps contract."""
+    return _ROADMAP_SCHEMA_CONTRACT
+
+
+def _normalize_schema_sql(sql: str) -> str:
+    return re.sub(r"\s+", " ", sql.strip()).lower()
+
+
+def _check_definitions(sql: str) -> tuple[str, ...]:
+    sql = _normalize_schema_sql(sql)
+    checks = []
+    start = 0
+    while (start := sql.find("check (", start)) >= 0:
+        pos, depth = start + len("check ("), 1
+        while depth:
+            depth += sql[pos] == "("
+            depth -= sql[pos] == ")"
+            pos += 1
+        checks.append(sql[start + len("check ("):pos - 1])
+        start = pos
+    return tuple(checks)
+
+
+def _validate_core_schema(
+    conn: sqlite3.Connection, *, only_existing: bool = False
+) -> None:
+    """Validate the independent Projects/core schema contract.
+
+    ``CREATE TABLE IF NOT EXISTS`` cannot repair a weakened pre-existing table;
+    reject such a table before any Roadmaps DDL is executed.  Required columns
+    are matched by name, allowing additive columns (including legacy optional
+    project columns) without over-constraining future schema extensions.
+    """
+    present = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name IN (?, ?, ?, ?)",
+            _CORE_TABLES,
+        )
+    }
+    if only_existing and not present:
+        return
+    for table, (expected_columns, expected_foreign_keys) in _CORE_SCHEMA_CONTRACT.items():
+        if table not in present:
+            if only_existing:
+                continue
+            raise sqlite3.DatabaseError(f"incompatible core schema: missing {table}")
+        actual_by_name = {
+            row[1]: (row[2].upper(), row[3], row[5])
+            for row in conn.execute(f"PRAGMA table_info({table})")
+        }
+        if any(actual_by_name.get(name) != (column_type, notnull, pk)
+               for name, column_type, notnull, pk in expected_columns):
+            raise sqlite3.DatabaseError(f"incompatible core schema: {table}")
+
+        grouped: dict[int, list[tuple]] = {}
+        for row in conn.execute(f"PRAGMA foreign_key_list({table})"):
+            grouped.setdefault(row[0], []).append(row)
+        actual_foreign_keys = {
+            (rows[0][2], tuple(row[3] for row in rows), tuple(row[4] for row in rows),
+             rows[0][5], rows[0][6])
+            for rows in grouped.values()
+        }
+        if not set(expected_foreign_keys).issubset(actual_foreign_keys):
+            raise sqlite3.DatabaseError(f"incompatible core schema: {table}")
+
+    for table, required_columns in _CORE_UNIQUE_COLUMNS.items():
+        if table not in present:
+            continue
+        unique_indexes = []
+        for row in conn.execute(f"PRAGMA index_list({table})"):
+            if row[2]:
+                unique_indexes.append(tuple(index_row[2] for index_row in conn.execute(
+                    f"PRAGMA index_info({row[1]})"
+                )))
+        if not any(columns in unique_indexes for columns in required_columns):
+            raise sqlite3.DatabaseError(
+                f"incompatible core schema: {table} requires unique slug"
+            )
+
+    index = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?",
+        ("idx_project_folders_path",),
+    ).fetchone()
+    if index and tuple(row[2] for row in conn.execute(
+        "PRAGMA index_info(idx_project_folders_path)"
+    )) != ("path",):
+        raise sqlite3.DatabaseError("incompatible core schema: idx_project_folders_path")
+    if not index and "project_folders" in present:
+        raise sqlite3.DatabaseError("incompatible core schema: idx_project_folders_path")
+
+
+def _validate_roadmaps_schema(
+    conn: sqlite3.Connection, *, only_existing: bool = False
+) -> None:
+    """Reject pre-existing Roadmaps tables that are weaker than the DDL."""
+    contract = _roadmap_schema_contract()
+    present = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name IN (?, ?, ?, ?, ?, ?)",
+            _ROADMAP_TABLES,
+        )
+    }
+    if only_existing and not present:
+        return
+    for table in _ROADMAP_TABLES:
+        if table not in present:
+            if only_existing:
+                continue
+            raise sqlite3.DatabaseError(f"incompatible Roadmaps schema: missing {table}")
+        expected_columns, expected_foreign_keys, _ = contract[table]
+        actual_columns = tuple(
+            (row[1], row[2].upper(), row[3], row[5])
+            for row in conn.execute(f"PRAGMA table_info({table})")
+        )
+        grouped: dict[int, list[tuple]] = {}
+        for row in conn.execute(f"PRAGMA foreign_key_list({table})"):
+            grouped.setdefault(row[0], []).append(row)
+        actual_foreign_keys = {
+            (rows[0][2], tuple(row[3] for row in rows), tuple(row[4] for row in rows),
+             rows[0][5], rows[0][6])
+            for rows in grouped.values()
+        }
+        if actual_columns != expected_columns or actual_foreign_keys != set(expected_foreign_keys):
+            raise sqlite3.DatabaseError(f"incompatible Roadmaps schema: {table}")
+        actual_sql = _normalize_schema_sql(
+            conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ).fetchone()[0]
+        )
+        if _check_definitions(actual_sql) != _ROADMAP_CHECK_CONTRACT[table]:
+            raise sqlite3.DatabaseError(f"incompatible Roadmaps schema: {table}")
+
+    index = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name=?",
+        ("idx_roadmap_sessions_active_vision",),
+    ).fetchone()
+    if index is not None:
+        actual_index_sql = _normalize_schema_sql(index[0])
+        expected_index_sql = _normalize_schema_sql(
+            "CREATE UNIQUE INDEX idx_roadmap_sessions_active_vision "
+            "ON roadmap_sessions(profile_id, project_id, roadmap_id) "
+            "WHERE kind = 'vision' AND state = 'active'"
+        )
+        if actual_index_sql != expected_index_sql:
+            raise sqlite3.DatabaseError(
+                "incompatible Roadmaps schema: idx_roadmap_sessions_active_vision"
+            )
+    elif not only_existing and "roadmap_sessions" in present:
+        raise sqlite3.DatabaseError(
+            "incompatible Roadmaps schema: idx_roadmap_sessions_active_vision"
+        )
+
+
+def _validate_foreign_key_integrity(conn: sqlite3.Connection) -> None:
+    """Reject persisted orphan rows instead of silently accepting repaired DDL."""
+    violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+    if violations:
+        details = "; ".join(
+            f"{row[0]} rowid={row[1]} parent={row[2]} fk={row[3]}"
+            for row in violations[:5]
+        )
+        if len(violations) > 5:
+            details += f"; ... ({len(violations)} total)"
+        raise sqlite3.DatabaseError(f"foreign key violations detected: {details}")
 
 
 def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
     """Open (and initialize if needed) the per-profile projects DB.
 
     WAL with DELETE fallback for network filesystems (shared helper from
-    ``hermes_state``). Schema init is idempotent (``CREATE TABLE IF NOT
-    EXISTS`` + additive migrations) and cached per-path per-process.
+    ``hermes_state``). Schema init is idempotent (``CREATE TABLE IF NOT EXISTS``
+    + additive migrations). Roadmaps compatibility is checked on every connection; the
+ per-process path cache is never treated as schema authority.
     """
     path = db_path if db_path is not None else projects_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    resolved = str(path.resolve())
     conn = sqlite3.connect(str(path))
     try:
         conn.row_factory = sqlite3.Row
@@ -169,12 +597,51 @@ def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
 
         apply_wal_with_fallback(conn, db_label="projects.db")
         conn.execute("PRAGMA foreign_keys=ON")
-        if resolved not in _INITIALIZED_PATHS:
+        # Additive column migrations run before schema validation so a legacy
+        # DB (created before optional columns like roadmap_nodes.block_reason
+        # existed) upgrades in place instead of being rejected as incompatible.
+        _migrate_add_optional_columns(conn)
+        # Validate any pre-existing target before CREATE IF NOT EXISTS can hide
+        # a weakened same-column schema. This also avoids creating a partial
+        # Roadmaps schema before rejecting an incompatible table.
+        _validate_roadmaps_schema(conn, only_existing=True)
+        _validate_core_schema(conn, only_existing=True)
+        roadmap_schema_complete = all(
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ).fetchone()
+            for table in _ROADMAP_TABLES
+        ) and all(
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?", (index,)
+            ).fetchone()
+            for index in _ROADMAP_INDEXES
+        )
+        core_schema_complete = all(
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ).fetchone()
+            for table in _CORE_TABLES
+        ) and all(
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type IN ('index', 'table') AND name=?",
+                (index,),
+            ).fetchone()
+            for index in _CORE_INDEXES
+        )
+        if not roadmap_schema_complete or not core_schema_complete:
             conn.executescript(SCHEMA_SQL)
-            _migrate_add_optional_columns(conn)
-            _INITIALIZED_PATHS.add(resolved)
+        # Retry additive legacy-column migration on every successful open. This
+        # also covers databases whose Roadmaps tables already existed.
+        _migrate_add_optional_columns(conn)
+        _validate_core_schema(conn)
+        _validate_roadmaps_schema(conn)
+        _validate_foreign_key_integrity(conn)
     except Exception:
-        conn.close()
+        try:
+            conn.rollback()
+        finally:
+            conn.close()
         raise
     return conn
 
@@ -202,13 +669,31 @@ def connect_closing(db_path: Optional[Path] = None):
 # open so a legacy DB upgrades in place.
 _OPTIONAL_PROJECT_COLUMNS = ("board_slug", "primary_path", "icon", "color")
 
+# TEXT columns added to `roadmap_nodes` after the Phase 1 port; additive like
+# the projects columns above, and only applied when the table already exists
+# (a fresh store creates the full schema from SCHEMA_SQL instead).
+_OPTIONAL_ROADMAP_NODE_COLUMNS = ("block_reason",)
+
 
 def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     """Add columns introduced after v1 to legacy DBs (safe on every open)."""
-    cols = {row["name"] for row in conn.execute("PRAGMA table_info(projects)")}
-    for col in _OPTIONAL_PROJECT_COLUMNS:
-        if col not in cols:
-            _add_column_if_missing(conn, "projects", col, f"{col} TEXT")
+    project_table = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='projects'"
+    ).fetchone()
+    if project_table is not None:
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(projects)")}
+        for col in _OPTIONAL_PROJECT_COLUMNS:
+            if col not in cols:
+                _add_column_if_missing(conn, "projects", col, f"{col} TEXT")
+
+    node_table = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='roadmap_nodes'"
+    ).fetchone()
+    if node_table is not None:
+        node_cols = {row["name"] for row in conn.execute("PRAGMA table_info(roadmap_nodes)")}
+        for col in _OPTIONAL_ROADMAP_NODE_COLUMNS:
+            if col not in node_cols:
+                _add_column_if_missing(conn, "roadmap_nodes", col, f"{col} TEXT")
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/roadmaps_plan_parser.py
+++ b/hermes_cli/roadmaps_plan_parser.py
@@ -1,0 +1,661 @@
+"""Parser for Roadmaps plan documents (T5c, Vision session).
+
+``parse_plan`` converts the Vision agent's plan document into a validated,
+normalized payload ready for ``RoadmapsWriter.create_plan``.
+
+Two input forms are accepted:
+
+- **Strict JSON** (REQUIRED of the agent): the document is the JSON object
+  ``{"title", "purpose"?, "nodes": [...], "relations": [...], "todos": [...]}``
+  exactly as the planning rules specify, either as a pure JSON text or inside
+  a ```json ... ``` code fence.  This is the reliable path.
+- **Structured Markdown** (documented fallback, LESS reliable): the agent
+  MUST emit JSON; Markdown is tolerated only so a rough draft can be parsed.
+  Grammar: ``# Title`` plan title; ``## <kind>: <title>`` nodes (kind
+  objective|phase|milestone|step|decision — otherwise heading level maps
+  2→phase, 3→milestone, 4→step, 5→decision), parents from heading nesting;
+  ``- [ ]`` / ``- [x]`` todos attached to the most recent node;
+  ``- <relation_kind>: <From> -> <To>`` relations resolved by unique node
+  title.
+
+Validation (both forms): node ids non-empty and unique, kinds valid, titles
+non-empty, parents referenced / never self / acyclic; relations from/to
+referenced and distinct, kinds valid; todos reference an existing node or
+null, positions integers >= 0.
+
+Normalization: ``state``/``progress`` defaults (planned/0), relation state
+defaults to ``active``, todo state ``open`` + position 0; provided ids are
+kept as-is; MISSING ids are generated deterministically with the ``n_`` /
+``r_`` / ``t_`` prefixes; identical relations (same from/to/kind) and
+identical todos (same node/title) are deduplicated keeping the first.
+
+Hardening limits (DoS gate, 2026-08-15): the module constants
+``MAX_PLAN_TEXT_BYTES`` (2 MB) caps the raw document size and
+``MAX_PLAN_NODES`` / ``MAX_PLAN_RELATIONS`` / ``MAX_PLAN_TODOS`` (2000
+each) cap the element counts — exceeded inputs raise
+:class:`PlanParseError` with ``field="input"``.  ``MAX_JSON_NESTING_DEPTH``
+(512) gates ``json.loads`` with a linear, string-aware depth pre-scan so
+pathologically nested documents raise a clean ``PlanParseError`` instead of
+a raw ``RecursionError`` (CPython's C scanner overflows ~1000 levels deep);
+an ``except RecursionError`` around ``json.loads`` remains as a safety net.
+Cycle detection over parent references is an iterative 3-color DFS (explicit
+stack), so a 3000-node parent chain cannot overflow the Python stack, and
+reports ``field="parent_node_id"`` with the node's list index.
+
+Errors raise :class:`PlanParseError` with a structured message: the
+concerned field (``nodes[2].kind``), the list index, and — for JSON syntax
+errors — line/column in the original text.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from hermes_cli.roadmaps_writer import (
+    NODE_KINDS,
+    NODE_STATES,
+    RELATION_KINDS,
+    TODO_STATES,
+)
+
+NODE_KINDS_VALID = NODE_KINDS
+RELATION_KINDS_VALID = RELATION_KINDS
+NODE_STATES_VALID = NODE_STATES
+TODO_STATES_VALID = TODO_STATES
+
+_ID_PREFIXES = {"nodes": "n_", "relations": "r_", "todos": "t_"}
+
+# ── DoS hardening limits (gate request_changes, 2026-08-15) ──────────────────
+# Module-level so tests and callers can tune them; violations raise
+# PlanParseError(field="input") with a clear message.
+MAX_PLAN_TEXT_BYTES = 2_000_000  # raw document size cap (2 MB)
+MAX_PLAN_NODES = 2000  # node cap
+MAX_PLAN_RELATIONS = 2000  # relation cap (proportional to nodes)
+MAX_PLAN_TODOS = 2000  # todo cap (proportional to nodes)
+# JSON nesting gate: a linear, string-aware pre-scan rejects documents nested
+# deeper than this BEFORE json.loads (CPython's C scanner raises a raw
+# RecursionError ~1000 levels deep); the except around json.loads stays as a
+# safety net.  Legitimate plan documents nest ~10 levels at most.
+MAX_JSON_NESTING_DEPTH = 512
+
+_FENCE_RE = re.compile(r"```\s*json\s*\n(.*?)```", re.DOTALL)
+_MARKDOWN_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+_MARKDOWN_KIND_RE = re.compile(
+    r"^(objective|phase|milestone|step|decision)\s*:\s*(.+?)\s*$", re.IGNORECASE
+)
+_MARKDOWN_TODO_RE = re.compile(r"^[-*]\s+\[( |x|X)\]\s+(.+?)\s*$")
+_MARKDOWN_RELATION_RE = re.compile(
+    r"^[-*]\s+(" + "|".join(sorted(RELATION_KINDS_VALID)) + r")\s*:\s*(.+?)\s*->\s*(.+?)\s*$"
+)
+
+_HEADING_LEVEL_KIND = {2: "phase", 3: "milestone", 4: "step", 5: "decision"}
+
+
+class PlanParseError(ValueError):
+    """Structured plan-parsing failure the Vision agent can act on.
+
+    Attributes mirror the payload position: ``field`` (e.g. ``nodes[2].kind``),
+    ``index`` (list position, when inside a list), and ``line``/``column``
+    (source position, populated for JSON syntax errors).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        field: str | None = None,
+        index: int | None = None,
+        line: int | None = None,
+        column: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.field = field
+        self.index = index
+        self.line = line
+        self.column = column
+
+    def __str__(self) -> str:
+        parts = [super().__str__()]
+        if self.field:
+            parts.append(f"field: {self.field}")
+        if self.line is not None:
+            loc = f"line {self.line}"
+            if self.column is not None:
+                loc += f", column {self.column}"
+            parts.append(loc)
+        return " — ".join(parts)
+
+
+def _generated_id(prefix: str, used: set[str], counter: list[int]) -> str:
+    """Next deterministic ``prefix`` + zero-padded counter id, collision-free."""
+    while True:
+        counter[0] += 1
+        candidate = f"{prefix}{counter[0]:04d}"
+        if candidate not in used:
+            return candidate
+
+
+def _require(value: Any, field: str, *, index: int | None = None) -> Any:
+    if value is None:
+        raise PlanParseError("required field missing", field=field, index=index)
+    if isinstance(value, str) and not value.strip():
+        raise PlanParseError("must be a non-empty string", field=field, index=index)
+    return value
+
+
+def _validate_ids(items: list[dict[str, Any]], kind: str) -> None:
+    seen: set[str] = set()
+    for i, item in enumerate(items):
+        raw = item.get(f"{kind}_id")
+        if isinstance(raw, str) and not raw.strip():
+            raise PlanParseError(
+                f"{kind}_id must be non-empty", field=f"{kind}s[{i}].{kind}_id", index=i
+            )
+        if raw is None:
+            continue
+        if raw in seen:
+            raise PlanParseError(
+                f"duplicate {kind}_id {raw!r}", field=f"{kind}s[{i}].{kind}_id", index=i
+            )
+        seen.add(raw)
+
+
+def _normalize_nodes(nodes: Any) -> list[dict[str, Any]]:
+    if not isinstance(nodes, list):
+        raise PlanParseError("nodes must be a list", field="nodes")
+    normalized: list[dict[str, Any]] = []
+    used: set[str] = set()
+    counter: list[int] = [0]
+    for i, item in enumerate(nodes):
+        field = f"nodes[{i}]"
+        if not isinstance(item, dict):
+            raise PlanParseError("node must be an object", field=field, index=i)
+        node_id = item.get("node_id")
+        if isinstance(node_id, str) and not node_id.strip():
+            raise PlanParseError(
+                "node_id must be non-empty", field=f"{field}.node_id", index=i
+            )
+        if node_id is None:
+            node_id = _generated_id("n_", used, counter)
+        if node_id in used:
+            raise PlanParseError(
+                f"duplicate node_id {node_id!r}", field=f"{field}.node_id", index=i
+            )
+        used.add(node_id)
+        kind = item.get("kind")
+        if kind not in NODE_KINDS_VALID:
+            raise PlanParseError(
+                f"invalid kind {kind!r} (expected one of {sorted(NODE_KINDS_VALID)})",
+                field=f"{field}.kind", index=i,
+            )
+        title = item.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise PlanParseError("title must be a non-empty string", field=f"{field}.title", index=i)
+        state = item.get("state", "planned")
+        if state not in NODE_STATES_VALID:
+            raise PlanParseError(
+                f"invalid state {state!r} (expected one of {sorted(NODE_STATES_VALID)})",
+                field=f"{field}.state", index=i,
+            )
+        progress = item.get("progress", 0)
+        if isinstance(progress, bool) or not isinstance(progress, int) or not 0 <= progress <= 100:
+            raise PlanParseError(
+                "progress must be an integer between 0 and 100",
+                field=f"{field}.progress", index=i,
+            )
+        parent = item.get("parent_node_id")
+        if isinstance(parent, str) and not parent.strip():
+            raise PlanParseError(
+                "parent_node_id must be non-empty", field=f"{field}.parent_node_id", index=i
+            )
+        normalized.append({
+            "node_id": node_id,
+            "kind": kind,
+            "title": title.strip(),
+            "description": item.get("description"),
+            "parent_node_id": parent,
+            "state": state,
+            "progress": progress,
+            "owner_agent": item.get("owner_agent"),
+            "block_reason": item.get("block_reason"),
+        })
+    # Parent references: must exist, never self, acyclic.
+    by_id = {n["node_id"]: n for n in normalized}
+    for i, node in enumerate(normalized):
+        parent = node["parent_node_id"]
+        if parent is None:
+            continue
+        if parent == node["node_id"]:
+            raise PlanParseError(
+                "parent_node_id cannot reference the node itself",
+                field=f"nodes[{i}].parent_node_id", index=i,
+            )
+        if parent not in by_id:
+            raise PlanParseError(
+                f"parent_node_id {parent!r} does not reference a node of this plan",
+                field=f"nodes[{i}].parent_node_id", index=i,
+            )
+    _detect_cycle(
+        {n["node_id"]: n["parent_node_id"] for n in normalized},
+        "parent",
+        index_of={n["node_id"]: i for i, n in enumerate(normalized)},
+    )
+    return normalized
+
+
+def _normalize_relations(relations: Any, node_ids: set[str]) -> list[dict[str, Any]]:
+    if relations is None:
+        return []
+    if not isinstance(relations, list):
+        raise PlanParseError("relations must be a list", field="relations")
+    normalized: list[dict[str, Any]] = []
+    used: set[str] = set()
+    counter: list[int] = [0]
+    seen_content: set[tuple[Any, Any, Any]] = set()
+    for i, item in enumerate(relations):
+        field = f"relations[{i}]"
+        if not isinstance(item, dict):
+            raise PlanParseError("relation must be an object", field=field, index=i)
+        relation_id = item.get("relation_id")
+        if isinstance(relation_id, str) and not relation_id.strip():
+            raise PlanParseError(
+                "relation_id must be non-empty", field=f"{field}.relation_id", index=i
+            )
+        if relation_id is None:
+            relation_id = _generated_id("r_", used, counter)
+        if relation_id in used:
+            raise PlanParseError(
+                f"duplicate relation_id {relation_id!r}",
+                field=f"{field}.relation_id", index=i,
+            )
+        used.add(relation_id)
+        from_node = item.get("from_node_id")
+        to_node = item.get("to_node_id")
+        if from_node not in node_ids:
+            raise PlanParseError(
+                f"from_node_id {from_node!r} does not reference a node of this plan",
+                field=f"{field}.from_node_id", index=i,
+            )
+        if to_node not in node_ids:
+            raise PlanParseError(
+                f"to_node_id {to_node!r} does not reference a node of this plan",
+                field=f"{field}.to_node_id", index=i,
+            )
+        if from_node == to_node:
+            raise PlanParseError(
+                "from_node_id and to_node_id must differ",
+                field=f"{field}.to_node_id", index=i,
+            )
+        kind = item.get("kind")
+        if kind not in RELATION_KINDS_VALID:
+            raise PlanParseError(
+                f"invalid kind {kind!r} (expected one of {sorted(RELATION_KINDS_VALID)})",
+                field=f"{field}.kind", index=i,
+            )
+        content = (from_node, to_node, kind)
+        if content in seen_content:
+            continue  # identical relation already declared — dedupe, keep first
+        seen_content.add(content)
+        normalized.append({
+            "relation_id": relation_id,
+            "from_node_id": from_node,
+            "to_node_id": to_node,
+            "kind": kind,
+            "state": item.get("state", "active"),
+            "reason": item.get("reason"),
+        })
+    return normalized
+
+
+def _normalize_todos(todos: Any, node_ids: set[str]) -> list[dict[str, Any]]:
+    if todos is None:
+        return []
+    if not isinstance(todos, list):
+        raise PlanParseError("todos must be a list", field="todos")
+    normalized: list[dict[str, Any]] = []
+    used: set[str] = set()
+    counter: list[int] = [0]
+    seen_content: set[tuple[str | None, str]] = set()
+    for i, item in enumerate(todos):
+        field = f"todos[{i}]"
+        if not isinstance(item, dict):
+            raise PlanParseError("todo must be an object", field=field, index=i)
+        todo_id = item.get("todo_id")
+        if isinstance(todo_id, str) and not todo_id.strip():
+            raise PlanParseError(
+                "todo_id must be non-empty", field=f"{field}.todo_id", index=i
+            )
+        if todo_id is None:
+            todo_id = _generated_id("t_", used, counter)
+        if todo_id in used:
+            raise PlanParseError(
+                f"duplicate todo_id {todo_id!r}", field=f"{field}.todo_id", index=i
+            )
+        used.add(todo_id)
+        node_id = item.get("node_id")
+        if node_id is not None and node_id not in node_ids:
+            raise PlanParseError(
+                f"node_id {node_id!r} does not reference a node of this plan",
+                field=f"{field}.node_id", index=i,
+            )
+        title = item.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise PlanParseError("title must be a non-empty string", field=f"{field}.title", index=i)
+        position = item.get("position", 0)
+        if isinstance(position, bool) or not isinstance(position, int) or position < 0:
+            raise PlanParseError(
+                "position must be an integer >= 0", field=f"{field}.position", index=i
+            )
+        content = (node_id, title.strip())
+        if content in seen_content:
+            continue  # identical todo already declared — dedupe, keep first
+        seen_content.add(content)
+        normalized.append({
+            "todo_id": todo_id,
+            "node_id": node_id,
+            "title": title.strip(),
+            "state": item.get("state", "open"),
+            "position": position,
+        })
+    return normalized
+
+
+def _detect_cycle(
+    parent_of: dict[str, str | None],
+    label: str,
+    index_of: dict[str, int] | None = None,
+) -> None:
+    """Raise on any cycle in the reference graph (parents or relations).
+
+    Iterative 3-color DFS with an explicit stack: a 3000-node parent chain
+    (or any input within the node cap) cannot overflow the Python stack,
+    unlike the previous recursive ``visit``.  On a cycle, raises a structured
+    :class:`PlanParseError` with ``field="parent_node_id"`` and the list
+    index of the node where the cycle closes (when ``index_of`` is given).
+    """
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color: dict[str, int] = {node: WHITE for node in parent_of}
+    for start in parent_of:
+        if color[start] != WHITE:
+            continue
+        stack: list[tuple[str, bool]] = [(start, False)]  # (node, expanded)
+        while stack:
+            node, expanded = stack.pop()
+            if expanded:
+                color[node] = BLACK
+                continue
+            color[node] = GRAY
+            stack.append((node, True))
+            parent = parent_of.get(node)
+            if parent is None:
+                continue
+            pcolor = color.get(parent, WHITE)
+            if pcolor == GRAY:
+                raise PlanParseError(
+                    f"cycle detected in {label} references at {node!r}",
+                    field="parent_node_id",
+                    index=index_of.get(node) if index_of else None,
+                )
+            if pcolor == WHITE:
+                stack.append((parent, False))
+
+
+# ── document extraction ─────────────────────────────────────────────────────
+
+
+def _max_json_nesting(text: str) -> int:
+    """Max structural nesting depth of ``{}`` / ``[]`` in a JSON document.
+
+    Linear, string-aware scan (no parsing): braces inside JSON strings are
+    skipped.  Used as a cheap gate before ``json.loads`` so deeply nested
+    documents raise a structured error instead of a raw ``RecursionError``.
+    """
+    depth = 0
+    max_depth = 0
+    in_string = False
+    escaped = False
+    for ch in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch in "{[":
+            depth += 1
+            if depth > max_depth:
+                max_depth = depth
+        elif ch in "}]":
+            depth -= 1
+    return max_depth
+
+
+def _extract_json_document(text: str) -> tuple[dict[str, Any], int | None, int | None]:
+    """Return (document, line, column) for a strict-JSON document.
+
+    A ```json fence wins over surrounding prose; otherwise the whole text is
+    parsed as JSON.  Raises :class:`PlanParseError` on syntax errors with the
+    source position of the failure, and on pathologically nested documents
+    (``field="input"``, before ``json.loads`` can overflow its stack).
+    """
+    fence = _FENCE_RE.search(text)
+    candidate = fence.group(1) if fence else text.strip()
+    base_line = text[: fence.start(1)].count("\n") + 1 if fence else 1
+    if _max_json_nesting(candidate) > MAX_JSON_NESTING_DEPTH:
+        raise PlanParseError(
+            "plan document is nested too deeply",
+            field="input",
+            line=base_line,
+        )
+    try:
+        parsed = json.loads(candidate)
+    except RecursionError:
+        # Safety net: the depth pre-scan above should fire first, but keep
+        # the contract "PlanParseError only" even if the C scanner trips.
+        raise PlanParseError(
+            "plan document is nested too deeply",
+            field="input",
+            line=base_line,
+        ) from None
+    except json.JSONDecodeError as exc:
+        raise PlanParseError(
+            f"invalid JSON: {exc.msg}",
+            line=base_line + exc.lineno - 1,
+            column=exc.colno,
+        ) from None
+    if not isinstance(parsed, dict):
+        raise PlanParseError(
+            "plan document must be a JSON object", line=base_line, column=1
+        )
+    return parsed, base_line, 1
+
+
+def _parse_markdown(text: str) -> dict[str, Any]:
+    """Minimal structured-Markdown fallback (documented, less reliable)."""
+    title: str | None = None
+    nodes: list[dict[str, Any]] = []
+    todos: list[dict[str, Any]] = []
+    relations: list[dict[str, Any]] = []
+    by_title: dict[str, str] = {}
+    stack: list[tuple[int, str]] = []  # (level, node_id)
+    # Persistent id bookkeeping: the old code rebuilt ``set(by_title.values())``
+    # (and reset the counter) for every node, an O(n^2) total.  With persistent
+    # sets + counters each generated id is O(1) amortized.
+    used_node_ids: set[str] = set()
+    node_counter: list[int] = [0]
+    used_todo_ids: set[str] = set()
+    todo_counter: list[int] = [0]
+    used_relation_ids: set[str] = set()
+    relation_counter: list[int] = [0]
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        heading = _MARKDOWN_HEADING_RE.match(line)
+        if heading:
+            level = len(heading.group(1))
+            rest = heading.group(2).strip()
+            kind_match = _MARKDOWN_KIND_RE.match(rest)
+            if kind_match:
+                kind = kind_match.group(1).lower()
+                node_title = kind_match.group(2).strip()
+            else:
+                kind = _HEADING_LEVEL_KIND.get(level)
+                node_title = rest
+            if level == 1 and kind is None:
+                title = rest
+                continue
+            if kind is None:
+                continue  # unknown heading level, ignore
+            if not node_title:
+                continue
+            while stack and stack[-1][0] >= level:
+                stack.pop()
+            parent = stack[-1][1] if stack else None
+            node_id = _generated_id("n_", used_node_ids, node_counter)
+            nodes.append({
+                "node_id": node_id, "kind": kind, "title": node_title,
+                "description": None, "parent_node_id": parent,
+                "state": "planned", "progress": 0,
+                "owner_agent": None, "block_reason": None,
+            })
+            used_node_ids.add(node_id)
+            by_title[node_title] = node_id
+            stack.append((level, node_id))
+            if len(nodes) > MAX_PLAN_NODES:
+                raise PlanParseError(
+                    f"plan exceeds the limit of {MAX_PLAN_NODES} nodes",
+                    field="input",
+                )
+            continue
+        todo = _MARKDOWN_TODO_RE.match(line)
+        if todo:
+            done = todo.group(1).lower() == "x"
+            node_id = stack[-1][1] if stack else None
+            todos.append({
+                "todo_id": _generated_id("t_", used_todo_ids, todo_counter),
+                "node_id": node_id,
+                "title": todo.group(2).strip(),
+                "state": "done" if done else "open",
+                "position": len(todos),
+            })
+            used_todo_ids.add(todos[-1]["todo_id"])
+            if len(todos) > MAX_PLAN_TODOS:
+                raise PlanParseError(
+                    f"plan exceeds the limit of {MAX_PLAN_TODOS} todos",
+                    field="input",
+                )
+            continue
+        relation = _MARKDOWN_RELATION_RE.match(line)
+        if relation:
+            kind = relation.group(1).lower()
+            from_title = relation.group(2).strip()
+            to_title = relation.group(3).strip()
+            from_id = by_title.get(from_title)
+            to_id = by_title.get(to_title)
+            if from_id is None:
+                raise PlanParseError(
+                    f"relation target {from_title!r} does not match any node title",
+                    field="relations", index=len(relations),
+                )
+            if to_id is None:
+                raise PlanParseError(
+                    f"relation target {to_title!r} does not match any node title",
+                    field="relations", index=len(relations),
+                )
+            relations.append({
+                "relation_id": _generated_id("r_", used_relation_ids, relation_counter),
+                "from_node_id": from_id, "to_node_id": to_id, "kind": kind,
+                "state": "active", "reason": None,
+            })
+            used_relation_ids.add(relations[-1]["relation_id"])
+            if len(relations) > MAX_PLAN_RELATIONS:
+                raise PlanParseError(
+                    f"plan exceeds the limit of {MAX_PLAN_RELATIONS} relations",
+                    field="input",
+                )
+    return {"title": title, "nodes": nodes, "relations": relations, "todos": todos}
+
+
+def parse_plan(
+    text: str,
+    *,
+    source: str = "vision",
+    default_actor: str = "user",
+) -> dict[str, Any]:
+    """Parse a plan document into a payload ready for ``plans.create``.
+
+    Accepts strict JSON (pure or in a ```json fence) or the documented
+    Markdown fallback.  Validates, normalizes defaults, generates missing
+    ids (``n_``/``r_``/``t_``), dedupes identical relations/todos, and
+    returns ``{"title", "purpose"?, "source", "actor", "nodes",
+    "relations", "todos"}`` where ``nodes``/``relations``/``todos`` match the
+    exact shape ``RoadmapsWriter.create_plan`` validates.
+    """
+    if not isinstance(text, str) or not text.strip():
+        raise PlanParseError("plan text is required", field="text")
+    size = len(text.encode("utf-8"))
+    if size > MAX_PLAN_TEXT_BYTES:
+        raise PlanParseError(
+            f"plan document too large: {size} bytes exceeds the limit "
+            f"of {MAX_PLAN_TEXT_BYTES} bytes",
+            field="input",
+        )
+    stripped = text.strip()
+    has_fence = _FENCE_RE.search(text) is not None
+    looks_like_json = stripped.startswith("{") or stripped.startswith("[")
+
+    document: dict[str, Any]
+    if has_fence or looks_like_json:
+        document, _line, _col = _extract_json_document(text)
+    else:
+        document = _parse_markdown(text)
+    for key, cap in (
+        ("nodes", MAX_PLAN_NODES),
+        ("relations", MAX_PLAN_RELATIONS),
+        ("todos", MAX_PLAN_TODOS),
+    ):
+        items = document.get(key)
+        if isinstance(items, list) and len(items) > cap:
+            raise PlanParseError(
+                f"plan declares {len(items)} {key}, exceeding the limit of {cap}",
+                field="input",
+            )
+
+    title = document.get("title")
+    if not isinstance(title, str) or not title.strip():
+        raise PlanParseError(
+            "plan document must declare a non-empty title", field="title"
+        )
+
+    nodes = _normalize_nodes(document.get("nodes"))
+    if not nodes:
+        raise PlanParseError(
+            "no plan nodes found; expected strict JSON (```json ... ```) "
+            "or structured markdown with at least one node",
+            field="nodes",
+        )
+    node_ids = {n["node_id"] for n in nodes}
+    relations = _normalize_relations(document.get("relations"), node_ids)
+    todos = _normalize_todos(document.get("todos"), node_ids)
+
+    purpose = document.get("purpose")
+    if purpose is not None and (not isinstance(purpose, str) or not purpose.strip()):
+        raise PlanParseError("purpose must be a non-empty string", field="purpose")
+
+    return {
+        "title": title.strip(),
+        "purpose": purpose.strip() if isinstance(purpose, str) else None,
+        "source": source,
+        "actor": default_actor,
+        "nodes": nodes,
+        "relations": relations,
+        "todos": todos,
+    }

--- a/hermes_cli/roadmaps_planning_rules.py
+++ b/hermes_cli/roadmaps_planning_rules.py
@@ -1,0 +1,160 @@
+"""Versioned Roadmaps planning rules for the Vision session (T5c).
+
+This module is the single source of truth for the system prompt the Vision
+session agent receives when Pierre creates a plan through the chat.  Rules
+are VERSIONED: any change ships as a new version under :data:`_RULES`, the
+``PLANNING_RULES_VERSION`` constant moves, and older versions stay
+retrievable — a silent edit is impossible by construction.
+
+The returned payload is deliberately JSON-serializable (no secrets, no
+objects): the ``roadmaps.planning_rules`` RPC serves it to the plugin, and
+``get_planning_rules()`` can be imported directly by the toolset agent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+PLANNING_RULES_VERSION = "1.0"
+
+
+class PlanningRulesVersionError(ValueError):
+    """The requested planning-rules version does not exist."""
+
+
+# The full system prompt, ready to be injected as the initial system prompt
+# of the Vision session.  The output contract mirrors the strict JSON format
+# that ``hermes_cli.roadmaps_plan_parser.parse_plan`` accepts.
+_PROMPT_V1 = """\
+Tu es l'architecte de plan Roadmaps. Tu travailles AVEC Pierre pour produire \
+un plan impeccable, solide, la meilleure voie possible : cohérent, détaillé, \
+exécutable, sans ambiguïté.
+
+# Objectif
+Aider Pierre à produire le plan le plus solide possible pour la roadmap \
+demandée : des étapes cohérentes, des dépendances explicites, des jalons \
+mesurables, zéro doublon. Tu es un architecte exigeant : tu challenges les \
+propositions floues et tu proposes des alternatives quand une étape est \
+faible.
+
+# Contraintes (scope)
+- Le plan appartient à UNE roadmap, dans UN projet, pour UN profil — reste \
+dans ce scope, ne déborde jamais.
+- Respecte le contexte fourni par Pierre (contexte du projet, contraintes \
+externes, délais, ressources disponibles).
+- Toute modification du plan produit une NOUVELLE VERSION (plans.create) — \
+jamais une édition silencieuse. Propose les changements, Pierre valide.
+- Ne jamais inventer de faits : si une information manque (dépendance, \
+responsable, date, capacité), demande une clarification plutôt que de \
+supposer.
+
+# Structure de sortie STRICTE
+Ta réponse finale DOIT être un bloc JSON strict, sans texte autour, dans ce \
+format exact (```json ... ```) :
+
+{
+  "title": "string — titre du plan",
+  "purpose": "string (optionnel) — but du plan",
+  "nodes": [
+    {
+      "node_id": "string unique",
+      "kind": "objective|phase|milestone|step|decision",
+      "title": "string non vide",
+      "description": "string (optionnel)",
+      "parent_node_id": "string (optionnel, doit référencer un node_id du plan, jamais soi-même)",
+      "state": "planned|ready|in_progress|blocked|completed|archived (optionnel, défaut planned)",
+      "progress": "0-100 (optionnel, défaut 0)"
+    }
+  ],
+  "relations": [
+    {
+      "relation_id": "string unique",
+      "from_node_id": "string — node_id du plan",
+      "to_node_id": "string — node_id du plan (jamais égal à from_node_id)",
+      "kind": "depends_on|blocks|enables|follows|validates|supersedes",
+      "reason": "string (optionnel) — pourquoi cette relation existe"
+    }
+  ],
+  "todos": [
+    {
+      "todo_id": "string unique",
+      "node_id": "string (optionnel, doit référencer un node_id du plan)",
+      "title": "string non vide",
+      "position": "entier >= 0 (optionnel, défaut 0)"
+    }
+  ]
+}
+
+Règles de structure :
+- ``node_id`` / ``relation_id`` / ``todo_id`` : non vides et UNIQUES dans \
+leur liste (les ids fournis sont conservés tels quels ; si un id manque, le \
+backend le génère avec les préfixes n_/r_/t_).
+- ``parent_node_id`` : doit référencer un node existant du plan (le parent \
+est déclaré avant l'enfant), jamais le node lui-même, jamais de cycle.
+- relations : from et to doivent référencer des nodes existants, from != to.
+- todos : ``node_id`` référencé s'il est fourni, sinon todo global (null).
+
+# Règles qualité
+- Étapes cohérentes : chaque étape a une portée claire et unique ; découpe \
+sans chevauchement ni trou.
+- Dépendances explicites : toute relation entre étapes est déclarée avec un \
+kind et une raison ; pas de dépendance implicite.
+- Pas de doublons : deux nodes identiques (même titre/portée), deux \
+relations identiques ou deux todos identiques sont interdits.
+- Jalons mesurables : un milestone a un critère de complétion observable.
+- Vocabulaire contrôlé : milestone/epic/task sont les termes produit ; ils \
+se traduisent dans les kinds du schéma (milestone / phase / step). N'invente \
+pas de nouveaux kinds.
+- Transitions de plan : le plan naît 'proposed' (plans.create), passe par \
+'validated' (plans.validate) puis 'active' (plans.activate) — respecte cette \
+machine d'état, ne propose jamais de forcer un état.
+
+# Règles de comportement
+- Ne jamais inventer de faits, de dates, de capacités ou de références.
+- Si une demande est ambiguë : demande une clarification AVANT de produire \
+le plan.
+- Propose des alternatives quand une étape est faible ou quand plusieurs \
+voies sont possibles.
+- Si le plan est rejeté par le parser (PlanParseError) : refonds-le guidé \
+par l'erreur (champ, index, ligne/colonne) plutôt que de rejouer la même \
+sortie. La refonte (refondre) est la réponse attendue à toute erreur de \
+structure, jamais une retouche cosmétique.
+- Réponds avec le JSON STRICT uniquement en sortie finale ; la discussion \
+intermédiaire reste conversationnelle.
+"""
+
+_RULES: dict[str, dict[str, Any]] = {
+    "1.0": {
+        "version": "1.0",
+        "prompt": _PROMPT_V1,
+        "format": "strict-json",
+        "schema_kinds": ["objective", "phase", "milestone", "step", "decision"],
+        "relation_kinds": [
+            "depends_on", "blocks", "enables", "follows", "validates", "supersedes",
+        ],
+        "node_states": [
+            "planned", "ready", "in_progress", "blocked", "completed", "archived",
+        ],
+        "controlled_vocabulary": "milestone/epic/task -> milestone/phase/step",
+        "plan_transitions": "proposed -> validated -> active",
+    },
+}
+
+
+def get_planning_rules(version: str | None = None) -> dict[str, Any]:
+    """Return the versioned planning rules (dict, JSON-serializable).
+
+    ``version=None`` returns the current rules (``PLANNING_RULES_VERSION``).
+    An unknown version raises :class:`PlanningRulesVersionError` — there is
+    never a silent fallback to another version.
+    """
+    key = str(version).strip() if version is not None else PLANNING_RULES_VERSION
+    if not key:
+        key = PLANNING_RULES_VERSION
+    try:
+        return _RULES[key]
+    except KeyError:
+        raise PlanningRulesVersionError(
+            f"unknown planning rules version {version!r} "
+            f"(known: {sorted(_RULES)})"
+        ) from None

--- a/hermes_cli/roadmaps_service.py
+++ b/hermes_cli/roadmaps_service.py
@@ -1,0 +1,267 @@
+"""Read-only Roadmaps service backed by an existing profile ``projects.db``."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+
+class RoadmapsUnavailable(RuntimeError):
+    """The profile store exists but cannot be read safely."""
+
+
+class RoadmapsService:
+    MAX_IDENTIFIER_LENGTH = 128
+    _PUBLIC_COLUMNS = {
+        "roadmaps": (
+            "profile_id", "project_id", "roadmap_id", "title", "purpose",
+            "lifecycle_state", "active_version", "created_by", "updated_by",
+            "created_at", "updated_at",
+        ),
+        "roadmap_versions": (
+            "profile_id", "project_id", "roadmap_id", "version", "state",
+            "source", "reason", "created_by", "created_at", "content_hash",
+        ),
+        "roadmap_nodes": (
+            "profile_id", "project_id", "roadmap_id", "version", "node_id",
+            "parent_node_id", "kind", "title", "description", "state",
+            "progress", "owner_agent", "block_reason", "created_at", "updated_at",
+        ),
+        "roadmap_relations": (
+            "profile_id", "project_id", "roadmap_id", "version", "relation_id",
+            "from_node_id", "to_node_id", "kind", "state", "reason",
+        ),
+        "roadmap_todos": (
+            "profile_id", "project_id", "roadmap_id", "version", "todo_id",
+            "node_id", "title", "state", "position", "created_at", "updated_at",
+        ),
+        "roadmap_sessions": (
+            "profile_id", "project_id", "roadmap_id", "stored_session_id",
+            "kind", "node_id", "plan_version", "state", "actor", "created_at",
+            "updated_at",
+        ),
+    }
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self.db_path = db_path
+
+    @staticmethod
+    def _required(value: str, name: str) -> str:
+        if not isinstance(value, str):
+            raise ValueError(f"{name} must be a string")
+        value = value.strip()
+        if not value or any(ord(char) < 32 or ord(char) == 127 for char in value):
+            raise ValueError(f"{name} required")
+        if len(value) > RoadmapsService.MAX_IDENTIFIER_LENGTH:
+            raise ValueError(f"{name} must be at most {RoadmapsService.MAX_IDENTIFIER_LENGTH} characters")
+        return value
+
+    @classmethod
+    def _optional(cls, value: str | None, name: str) -> str | None:
+        return None if value is None else cls._required(value, name)
+
+    def _connection(self) -> sqlite3.Connection | None:
+        path = Path(self.db_path) if self.db_path is not None else None
+        if path is None or not path.is_file():
+            return None
+        uri_path = quote(str(path.resolve()), safe="/")
+        uri = f"file:{uri_path}?mode=ro"
+        conn = None
+        handed_off = False
+        try:
+            conn = sqlite3.connect(uri, uri=True)
+            conn.row_factory = sqlite3.Row
+            tables = {row[0] for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )}
+            required = {"roadmaps", "roadmap_versions", "roadmap_nodes",
+                        "roadmap_relations", "roadmap_todos", "roadmap_sessions"}
+            if not required.issubset(tables):
+                raise RoadmapsUnavailable
+            handed_off = True
+            return conn
+        except RoadmapsUnavailable:
+            raise
+        except sqlite3.Error as exc:
+            raise RoadmapsUnavailable from exc
+        finally:
+            if conn is not None and not handed_off:
+                conn.close()
+
+    @classmethod
+    def _select(cls, table: str) -> str:
+        return f"SELECT {', '.join(cls._PUBLIC_COLUMNS[table])} FROM {table}"
+
+    @staticmethod
+    def _row(row: sqlite3.Row | None) -> dict[str, Any] | None:
+        return dict(row) if row is not None else None
+
+    def list(self, profile_id: str, project_id: str | None = None) -> dict[str, Any]:
+        profile_id = self._required(profile_id, "profile_id")
+        project_id = self._optional(project_id, "project_id")
+        query = (
+            f"SELECT r.{', r.'.join(self._PUBLIC_COLUMNS['roadmaps'])}, p.name AS project_name "
+            "FROM roadmaps r LEFT JOIN projects p ON p.id = r.project_id "
+            "WHERE r.profile_id = ?"
+        )
+        args: list[Any] = [profile_id]
+        if project_id is not None:
+            query += " AND r.project_id = ?"
+            args.append(project_id)
+        query += " ORDER BY r.project_id, r.roadmap_id"
+        scope = {"profile_id": profile_id, **({"project_id": project_id} if project_id is not None else {})}
+        conn = self._connection()
+        if conn is None:
+            return {"roadmaps": [], "scope": scope}
+        try:
+            rows = [self._row(row) for row in conn.execute(query, args)]
+        except sqlite3.Error as exc:
+            raise RoadmapsUnavailable from exc
+        finally:
+            conn.close()
+        return {"roadmaps": rows, "scope": scope}
+
+    def get(self, profile_id: str, project_id: str, roadmap_id: str) -> dict[str, Any]:
+        profile_id = self._required(profile_id, "profile_id")
+        project_id = self._required(project_id, "project_id")
+        roadmap_id = self._required(roadmap_id, "roadmap_id")
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+        conn = self._connection()
+        if conn is None:
+            return {"found": False, "scope": scope, "roadmap": None}
+        try:
+            roadmap = conn.execute(
+                f"{self._select('roadmaps')} WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                (profile_id, project_id, roadmap_id),
+            ).fetchone()
+            if roadmap is None:
+                return {"found": False, "scope": scope, "roadmap": None}
+            payload: dict[str, Any] = self._row(roadmap) or {}
+            versions = []
+            for version in conn.execute(
+                f"{self._select('roadmap_versions')} WHERE profile_id=? AND project_id=? AND roadmap_id=? ORDER BY version",
+                (profile_id, project_id, roadmap_id),
+            ):
+                version_payload: dict[str, Any] = self._row(version) or {}
+                key = (profile_id, project_id, roadmap_id, version["version"])
+                version_payload["nodes"] = [self._row(row) for row in conn.execute(f"{self._select('roadmap_nodes')} WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? ORDER BY node_id", key)]
+                version_payload["relations"] = [self._row(row) for row in conn.execute(f"{self._select('roadmap_relations')} WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? ORDER BY relation_id", key)]
+                version_payload["todos"] = [self._row(row) for row in conn.execute(f"{self._select('roadmap_todos')} WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? ORDER BY position, todo_id", key)]
+                versions.append(version_payload)
+            payload["versions"] = versions
+            return {"found": True, "scope": scope, "roadmap": payload}
+        except sqlite3.Error as exc:
+            raise RoadmapsUnavailable from exc
+        finally:
+            conn.close()
+
+    def snapshot(self, profile_id: str, project_id: str, roadmap_id: str) -> dict[str, Any]:
+        return self.get(profile_id, project_id, roadmap_id)
+
+    def get_snapshot(self, profile_id: str, project_id: str, roadmap_id: str) -> dict[str, Any]:
+        return self.snapshot(profile_id, project_id, roadmap_id)
+
+    def list_plans(self, profile_id: str, project_id: str, roadmap_id: str) -> dict[str, Any]:
+        """List the roadmap's plan versions, newest first (version DESC)."""
+        profile_id = self._required(profile_id, "profile_id")
+        project_id = self._required(project_id, "project_id")
+        roadmap_id = self._required(roadmap_id, "roadmap_id")
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+        conn = self._connection()
+        if conn is None:
+            return {"plans": [], "scope": scope}
+        try:
+            plans = [
+                self._row(row)
+                for row in conn.execute(
+                    f"{self._select('roadmap_versions')} "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? "
+                    "ORDER BY version DESC",
+                    (profile_id, project_id, roadmap_id),
+                )
+            ]
+        except sqlite3.Error as exc:
+            raise RoadmapsUnavailable from exc
+        finally:
+            conn.close()
+        return {"plans": plans, "scope": scope}
+
+    def get_plan(self, profile_id: str, project_id: str, roadmap_id: str, version: int) -> dict[str, Any]:
+        """Fetch one complete plan version (nodes + relations + todos)."""
+        profile_id = self._required(profile_id, "profile_id")
+        project_id = self._required(project_id, "project_id")
+        roadmap_id = self._required(roadmap_id, "roadmap_id")
+        if isinstance(version, bool) or not isinstance(version, int):
+            raise ValueError("version must be an integer")
+        if version < 1:
+            raise ValueError("version must be at least 1")
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+        conn = self._connection()
+        if conn is None:
+            return {"found": False, "scope": scope, "plan": None}
+        try:
+            row = conn.execute(
+                f"{self._select('roadmap_versions')} "
+                "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=?",
+                (profile_id, project_id, roadmap_id, version),
+            ).fetchone()
+            if row is None:
+                return {"found": False, "scope": scope, "plan": None}
+            plan: dict[str, Any] = self._row(row) or {}
+            key = (profile_id, project_id, roadmap_id, version)
+            plan["nodes"] = [
+                self._row(node) for node in conn.execute(
+                    f"{self._select('roadmap_nodes')} WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? ORDER BY node_id",
+                    key,
+                )
+            ]
+            plan["relations"] = [
+                self._row(relation) for relation in conn.execute(
+                    f"{self._select('roadmap_relations')} WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? ORDER BY relation_id",
+                    key,
+                )
+            ]
+            plan["todos"] = [
+                self._row(todo) for todo in conn.execute(
+                    f"{self._select('roadmap_todos')} WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? ORDER BY position, todo_id",
+                    key,
+                )
+            ]
+            return {"found": True, "scope": scope, "plan": plan}
+        except sqlite3.Error as exc:
+            raise RoadmapsUnavailable from exc
+        finally:
+            conn.close()
+
+    def list_sessions(
+        self, profile_id: str, project_id: str, roadmap_id: str
+    ) -> dict[str, Any]:
+        """List durable session links for exactly one qualified roadmap."""
+        profile_id = self._required(profile_id, "profile_id")
+        project_id = self._required(project_id, "project_id")
+        roadmap_id = self._required(roadmap_id, "roadmap_id")
+        scope = {
+            "profile_id": profile_id,
+            "project_id": project_id,
+            "roadmap_id": roadmap_id,
+        }
+        conn = self._connection()
+        if conn is None:
+            return {"sessions": [], "scope": scope}
+        try:
+            sessions = [
+                self._row(row)
+                for row in conn.execute(
+                    f"{self._select('roadmap_sessions')} "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? "
+                    "ORDER BY CASE state WHEN 'active' THEN 0 ELSE 1 END, "
+                    "updated_at DESC, stored_session_id",
+                    (profile_id, project_id, roadmap_id),
+                )
+            ]
+        except sqlite3.Error as exc:
+            raise RoadmapsUnavailable from exc
+        finally:
+            conn.close()
+        return {"sessions": sessions, "scope": scope}

--- a/hermes_cli/roadmaps_writer.py
+++ b/hermes_cli/roadmaps_writer.py
@@ -1,0 +1,1422 @@
+"""Authorized, versioned Roadmaps execution mutations.
+
+This is the write-side counterpart of :mod:`hermes_cli.roadmaps_service`
+(which stays strictly read-only).  Every mutation:
+
+- targets the ACTIVE profile's ``projects.db`` resolved by the runtime;
+- requires the full qualified scope ``(profile_id, project_id, roadmap_id)``;
+- requires an explicit non-empty actor;
+- requires the roadmap version the caller observed (``expected_version``),
+  and refuses to write when the roadmap has been revised since
+  (optimistic concurrency); a roadmap with no active version yet is
+  observed as ``expected_version=0``;
+- validates the state transition against the pure contract
+  (:mod:`src.roadmaps_contract`), so the runtime cannot drift from the
+  documented machine;
+- runs in a single IMMEDIATE transaction and rolls back on any failure.
+
+Two families of mutations are exposed:
+
+- execution-level node mutations: claim, progress, complete, block,
+  unblock, todo;
+- roadmap CRUD + plan governance (T5b): ``create_roadmap`` /
+  ``update_roadmap`` / ``archive_roadmap`` and ``create_plan`` /
+  ``activate_plan`` / ``validate_plan``.
+
+Conventions (T5b, verified against the schema and the existing read side):
+
+- ``roadmaps.create`` creates the roadmap row (``lifecycle_state='draft'``,
+  ``active_version=NULL``) plus the initial version 1 marker
+  (``roadmap_versions.state='draft'``, empty plan) in ONE transaction.
+  The lifecycle machine is strict: only ``'draft'`` is accepted at
+  creation, so a later state cannot be forged via create.  The next real
+  plan therefore starts at version 2.  A generated ``roadmap_id`` uses
+  the ``r_`` prefix (``r_`` + 8 hex chars).
+- ``roadmaps.update`` only touches the fields actually provided
+  (title <= 200 chars, purpose <= 2000); ``expected_version`` guards
+  against clobbering.  ``lifecycle_state`` is NOT writable through
+  update — transitions go exclusively through ``plans.validate`` /
+  ``plans.activate`` / ``roadmaps.archive``.
+- ``roadmaps.archive`` moves ``lifecycle_state`` to the terminal
+  ``'archived'`` and keeps the version history readable; archiving an
+  already archived roadmap is rejected.
+- ``plans.create`` validates the FULL payload (nodes/relations/todos)
+  before any insert and commits everything atomically.  The new version
+  is ``'proposed'`` (a created plan is proposed, never active); the
+  roadmap lifecycle moves ``draft -> proposed``.  Version 1 is reserved
+  by ``roadmaps.create``, so a duplicate version is rejected.
+- ``plans.validate`` transitions a version ``draft|proposed -> validated``
+  (version-state machine, distinct from the roadmap-lifecycle machine in
+  the pure contract).  Governance authority is the caller: the toolset
+  agent acting under Pierre's authority, or Pierre directly — the backend
+  records the actor on ``roadmaps.updated_by`` (``roadmap_versions`` has
+  no ``updated_by`` column; it is append-only apart from state).
+- ``plans.activate`` requires the version to be ``'validated'``, points
+  ``roadmaps.active_version`` at it, marks the previously active version
+  ``'superseded'`` (history preserved) and moves the roadmap lifecycle
+  ``validated -> in_progress``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import time
+from pathlib import Path
+from typing import Any
+
+from hermes_cli import projects_db
+from hermes_cli.sqlite_util import write_txn
+from src.roadmaps_contract import transition_node
+
+
+class RoadmapsWriteError(RuntimeError):
+    """Base class for all authorizable write failures."""
+
+
+class RoadmapNotFoundError(RoadmapsWriteError):
+    """The roadmap (or its active version) does not exist."""
+
+
+class RoadmapProjectNotFoundError(RoadmapsWriteError):
+    """The project named in the scope does not exist."""
+
+
+class RoadmapExistsError(RoadmapsWriteError):
+    """A roadmap with this id already exists in the project scope."""
+
+
+class RoadmapNodeNotFoundError(RoadmapsWriteError):
+    """The node does not exist in the active roadmap version."""
+
+
+class StaleRoadmapVersionError(RoadmapsWriteError):
+    """The caller's expected_version no longer matches the active version."""
+
+
+class RoadmapTodoNotFoundError(RoadmapsWriteError):
+    """The todo does not exist in the active roadmap version."""
+
+
+class RoadmapVersionNotFoundError(RoadmapsWriteError):
+    """The roadmap version does not exist."""
+
+
+class RoadmapVersionExistsError(RoadmapsWriteError):
+    """The roadmap version already exists (conflict)."""
+
+
+class InvalidRoadmapTodoTransitionError(RoadmapsWriteError):
+    """The requested todo state transition is not allowed."""
+
+
+class InvalidRoadmapTransitionError(RoadmapsWriteError):
+    """The requested node state transition is not allowed by the contract."""
+
+
+class InvalidRoadmapPlanTransitionError(RoadmapsWriteError):
+    """The requested plan/version state transition is not allowed."""
+
+
+# Allowed todo state transitions (open → in_progress → done, cancel from open/in_progress).
+TODO_TRANSITIONS: dict[str, frozenset[str]] = {
+    "open": frozenset({"in_progress", "done", "cancelled"}),
+    "in_progress": frozenset({"done", "cancelled", "open"}),
+    "done": frozenset(),
+    "cancelled": frozenset(),
+}
+
+# Schema enumerations (see the CHECK constraints in projects_db.SCHEMA_SQL).
+ROADMAP_LIFECYCLE_STATES: frozenset[str] = frozenset(
+    {"draft", "proposed", "validated", "in_progress", "blocked", "completed", "archived"}
+)
+PLAN_VERSION_STATES: frozenset[str] = frozenset(
+    {"draft", "proposed", "validated", "superseded", "archived"}
+)
+NODE_KINDS: frozenset[str] = frozenset(
+    {"objective", "phase", "milestone", "step", "decision"}
+)
+NODE_STATES: frozenset[str] = frozenset(
+    {"planned", "ready", "in_progress", "blocked", "completed", "archived"}
+)
+RELATION_KINDS: frozenset[str] = frozenset(
+    {"depends_on", "blocks", "enables", "follows", "validates", "supersedes"}
+)
+RELATION_STATES: frozenset[str] = frozenset({"active", "superseded", "invalid"})
+TODO_STATES: frozenset[str] = frozenset({"open", "in_progress", "done", "cancelled"})
+
+MAX_IDENTIFIER_LENGTH = 128
+MAX_TITLE_LENGTH = 200
+MAX_PURPOSE_LENGTH = 2000
+MAX_DESCRIPTION_LENGTH = 2000
+MAX_REASON_LENGTH = 2000
+MAX_VERSION = 2**31 - 1
+# Plan-payload element bounds (mirror roadmaps_plan_parser's DoS caps so a
+# create_plan payload cannot build a pathological graph that exhausts the
+# interpreter stack or the transaction).
+MAX_PLAN_NODES = 2000
+MAX_PLAN_RELATIONS = 2000
+MAX_PLAN_TODOS = 2000
+
+
+def _required(value: Any, name: str, max_length: int = MAX_IDENTIFIER_LENGTH) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    value = value.strip()
+    if not value:
+        raise ValueError(f"{name} required")
+    if len(value) > max_length:
+        raise ValueError(f"{name} must be at most {max_length} characters")
+    if "/" in value or "\\" in value:
+        raise ValueError(f"{name} must not contain path separators")
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise ValueError(f"{name} contains control characters")
+    return value
+
+
+def _non_empty_text(value: Any, name: str, max_length: int = 2000) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    value = value.strip()
+    if not value:
+        raise ValueError(f"{name} required")
+    if len(value) > max_length:
+        raise ValueError(f"{name} must be at most {max_length} characters")
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise ValueError(f"{name} contains control characters")
+    return value
+
+
+def _optional_text(value: Any, name: str, max_length: int = 2000) -> str | None:
+    """Optional text: None/blank becomes None; otherwise validated, stripped."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    value = value.strip()
+    if not value:
+        return None
+    if len(value) > max_length:
+        raise ValueError(f"{name} must be at most {max_length} characters")
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise ValueError(f"{name} contains control characters")
+    return value
+
+
+def _int_in_range(value: Any, name: str, low: int, high: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer")
+    if not (low <= value <= high):
+        raise ValueError(f"{name} must be between {low} and {high}")
+    return value
+
+
+def _enum(value: Any, name: str, allowed: frozenset[str]) -> str:
+    """Validate an enum field, defaulting None to the first documented value."""
+    if value is None:
+        raise ValueError(f"{name} required")
+    value = _required(value, name)
+    if value not in allowed:
+        raise ValueError(
+            f"{name} must be one of {', '.join(sorted(allowed))}"
+        )
+    return value
+
+
+def _detect_cycle(edges: list[tuple[str, str]], kind: str) -> None:
+    """Raise ValueError when the directed edges contain a cycle.
+
+    Iterative 3-colour DFS (explicit stack) — the recursive version overflowed
+    the interpreter stack on a ~1000-node parent chain, mirroring the exact bug
+    fixed in ``roadmaps_plan_parser._detect_cycle``.
+    """
+    adjacency: dict[str, list[str]] = {}
+    for source, target in edges:
+        adjacency.setdefault(source, []).append(target)
+    # 0 = unvisited, 1 = on the current DFS path, 2 = fully processed.
+    marks: dict[str, int] = {}
+
+    for start in adjacency:
+        if marks.get(start, 0) == 2:
+            continue
+        stack: list[tuple[str, int]] = [(start, 0)]
+        marks[start] = 1
+        while stack:
+            node, idx = stack[-1]
+            neighbours = adjacency.get(node, [])
+            if idx < len(neighbours):
+                stack[-1] = (node, idx + 1)
+                nxt = neighbours[idx]
+                nxt_mark = marks.get(nxt, 0)
+                if nxt_mark == 1:
+                    raise ValueError(f"cyclic {kind} reference detected in payload")
+                if nxt_mark == 0:
+                    marks[nxt] = 1
+                    stack.append((nxt, 0))
+            else:
+                marks[node] = 2
+                stack.pop()
+
+
+def _validate_plan_nodes(nodes: Any) -> list[dict[str, Any]]:
+    """Validate and normalize the plan's node payload (no DB access)."""
+    if nodes is None:
+        return []
+    if not isinstance(nodes, list):
+        raise ValueError("nodes must be a list")
+    if len(nodes) > MAX_PLAN_NODES:
+        raise ValueError(f"nodes must be at most {MAX_PLAN_NODES} items")
+    seen: set[str] = set()
+    parents: list[tuple[str, str]] = []
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(nodes):
+        if not isinstance(item, dict):
+            raise ValueError(f"nodes[{index}] must be an object")
+        node_id = _required(item.get("node_id"), f"nodes[{index}].node_id")
+        if node_id in seen:
+            raise ValueError(f"duplicate node_id {node_id!r} in nodes")
+        seen.add(node_id)
+        kind = _enum(item.get("kind"), f"nodes[{index}].kind", NODE_KINDS)
+        title = _non_empty_text(
+            item.get("title"), f"nodes[{index}].title", max_length=MAX_TITLE_LENGTH
+        )
+        description = _optional_text(
+            item.get("description"), f"nodes[{index}].description",
+            max_length=MAX_DESCRIPTION_LENGTH,
+        )
+        state = item.get("state")
+        state = "planned" if state is None else _enum(state, f"nodes[{index}].state", NODE_STATES)
+        progress = item.get("progress")
+        progress = 0 if progress is None else _int_in_range(
+            progress, f"nodes[{index}].progress", 0, 100
+        )
+        owner_agent = _optional_text(
+            item.get("owner_agent"), f"nodes[{index}].owner_agent",
+            max_length=MAX_IDENTIFIER_LENGTH,
+        )
+        block_reason = _optional_text(
+            item.get("block_reason"), f"nodes[{index}].block_reason",
+            max_length=MAX_REASON_LENGTH,
+        )
+        parent_node_id = item.get("parent_node_id")
+        if parent_node_id is not None:
+            parent_node_id = _required(
+                parent_node_id, f"nodes[{index}].parent_node_id"
+            )
+            if parent_node_id == node_id:
+                raise ValueError(
+                    f"nodes[{index}].parent_node_id cannot reference the node itself"
+                )
+            parents.append((node_id, parent_node_id))
+        normalized.append({
+            "node_id": node_id, "kind": kind, "title": title,
+            "description": description, "parent_node_id": parent_node_id,
+            "state": state, "progress": progress, "owner_agent": owner_agent,
+            "block_reason": block_reason,
+        })
+    for node_id, parent_node_id in parents:
+        if parent_node_id not in seen:
+            raise ValueError(
+                f"parent_node_id {parent_node_id!r} does not reference a node of this payload"
+            )
+    _detect_cycle(parents, "parent")
+    return normalized
+
+
+def _validate_plan_relations(relations: Any, node_ids: set[str]) -> list[dict[str, Any]]:
+    """Validate the plan's relation payload (no DB access)."""
+    if relations is None:
+        return []
+    if not isinstance(relations, list):
+        raise ValueError("relations must be a list")
+    if len(relations) > MAX_PLAN_RELATIONS:
+        raise ValueError(f"relations must be at most {MAX_PLAN_RELATIONS} items")
+    seen: set[str] = set()
+    edges: list[tuple[str, str]] = []
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(relations):
+        if not isinstance(item, dict):
+            raise ValueError(f"relations[{index}] must be an object")
+        relation_id = _required(item.get("relation_id"), f"relations[{index}].relation_id")
+        if relation_id in seen:
+            raise ValueError(f"duplicate relation_id {relation_id!r} in relations")
+        seen.add(relation_id)
+        from_node_id = _required(item.get("from_node_id"), f"relations[{index}].from_node_id")
+        to_node_id = _required(item.get("to_node_id"), f"relations[{index}].to_node_id")
+        if from_node_id not in node_ids:
+            raise ValueError(
+                f"relations[{index}].from_node_id {from_node_id!r} does not reference a node of this payload"
+            )
+        if to_node_id not in node_ids:
+            raise ValueError(
+                f"relations[{index}].to_node_id {to_node_id!r} does not reference a node of this payload"
+            )
+        if from_node_id == to_node_id:
+            raise ValueError(
+                f"relations[{index}].from_node_id and to_node_id must differ"
+            )
+        kind = _enum(item.get("kind"), f"relations[{index}].kind", RELATION_KINDS)
+        state = item.get("state")
+        state = "active" if state is None else _enum(
+            state, f"relations[{index}].state", RELATION_STATES
+        )
+        reason = _optional_text(
+            item.get("reason"), f"relations[{index}].reason",
+            max_length=MAX_REASON_LENGTH,
+        )
+        edges.append((from_node_id, to_node_id))
+        normalized.append({
+            "relation_id": relation_id, "from_node_id": from_node_id,
+            "to_node_id": to_node_id, "kind": kind, "state": state,
+            "reason": reason,
+        })
+    _detect_cycle(edges, "relation")
+    return normalized
+
+
+def _validate_plan_todos(todos: Any, node_ids: set[str]) -> list[dict[str, Any]]:
+    """Validate the plan's todo payload (no DB access)."""
+    if todos is None:
+        return []
+    if not isinstance(todos, list):
+        raise ValueError("todos must be a list")
+    if len(todos) > MAX_PLAN_TODOS:
+        raise ValueError(f"todos must be at most {MAX_PLAN_TODOS} items")
+    seen: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(todos):
+        if not isinstance(item, dict):
+            raise ValueError(f"todos[{index}] must be an object")
+        todo_id = _required(item.get("todo_id"), f"todos[{index}].todo_id")
+        if todo_id in seen:
+            raise ValueError(f"duplicate todo_id {todo_id!r} in todos")
+        seen.add(todo_id)
+        node_id = item.get("node_id")
+        if node_id is not None:
+            node_id = _required(node_id, f"todos[{index}].node_id")
+            if node_id not in node_ids:
+                raise ValueError(
+                    f"todos[{index}].node_id {node_id!r} does not reference a node of this payload"
+                )
+        title = _non_empty_text(
+            item.get("title"), f"todos[{index}].title", max_length=MAX_TITLE_LENGTH
+        )
+        state = item.get("state")
+        state = "open" if state is None else _enum(state, f"todos[{index}].state", TODO_STATES)
+        position = item.get("position")
+        position = 0 if position is None else _int_in_range(
+            position, f"todos[{index}].position", 0, MAX_VERSION
+        )
+        normalized.append({
+            "todo_id": todo_id, "node_id": node_id, "title": title,
+            "state": state, "position": position,
+        })
+    return normalized
+
+
+def _parents_first(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Order nodes so every parent precedes its children (FK-safe inserts).
+
+    Parents were validated to exist in the same payload and to be acyclic,
+    so a topological order always exists here.
+    """
+    parent_of = {
+        node["node_id"]: node["parent_node_id"] for node in nodes
+    }
+    ordered: list[dict[str, Any]] = []
+    inserted: set[str] = set()
+    remaining = list(nodes)
+    while remaining:
+        for node in remaining:
+            parent = parent_of[node["node_id"]]
+            if parent is None or parent in inserted:
+                ordered.append(node)
+                inserted.add(node["node_id"])
+                remaining.remove(node)
+                break
+        else:  # pragma: no cover - unreachable after cycle validation
+            raise ValueError("cyclic parent reference detected in payload")
+    return ordered
+
+
+class RoadmapsWriter:
+    """Execute the versioned node mutations against the active profile store."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self.db_path = db_path
+
+    def _connection(self):
+        path = self.db_path if self.db_path is not None else projects_db.projects_db_path()
+        return projects_db.connect(db_path=path)
+
+    # -- shared resolution -------------------------------------------------
+
+    def _resolve_node(self, conn, profile_id: str, project_id: str, roadmap_id: str, node_id: str):
+        row = conn.execute(
+            "SELECT active_version FROM roadmaps "
+            "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+            (profile_id, project_id, roadmap_id),
+        ).fetchone()
+        if row is None:
+            raise RoadmapNotFoundError("roadmap not found for the given scope")
+        active_version = row["active_version"]
+        if active_version is None:
+            raise RoadmapNotFoundError("roadmap has no active version to mutate")
+        node = conn.execute(
+            "SELECT * FROM roadmap_nodes "
+            "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+            (profile_id, project_id, roadmap_id, active_version, node_id),
+        ).fetchone()
+        if node is None:
+            raise RoadmapNodeNotFoundError(
+                f"node {node_id!r} not found in active version {active_version}"
+            )
+        return node, active_version
+
+    @staticmethod
+    def _check_version(active_version: int, expected_version: Any) -> None:
+        if expected_version is None:
+            raise ValueError("expected_version required for mutation")
+        if isinstance(expected_version, bool) or not isinstance(expected_version, int):
+            raise ValueError("expected_version must be an integer")
+        if active_version != expected_version:
+            raise StaleRoadmapVersionError(
+                f"roadmap revised: caller expected version {expected_version}, "
+                f"active version is {active_version}; reload before mutating"
+            )
+
+    @staticmethod
+    def _transition(current: str, target: str) -> str:
+        """Validate a node transition, mapping the contract's ValueError."""
+        try:
+            return transition_node(current, target)
+        except ValueError as exc:
+            raise InvalidRoadmapTransitionError(str(exc)) from exc
+
+    @staticmethod
+    def _result(scope: dict[str, str], node, before: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "success": True,
+            "scope": scope,
+            "node": {
+                "node_id": node["node_id"],
+                "state": node["state"],
+                "progress": node["progress"],
+                "owner_agent": node["owner_agent"],
+                "block_reason": node["block_reason"],
+                "updated_at": node["updated_at"],
+            },
+            "before": before,
+        }
+
+    # -- mutations ----------------------------------------------------------
+
+    def claim_node(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        node_id: str,
+        actor: str,
+        expected_version: Any,
+    ) -> dict[str, Any]:
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        node_id = _required(node_id, "node_id")
+        actor = _required(actor, "actor")
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                node, active_version = self._resolve_node(conn, profile_id, project_id, roadmap_id, node_id)
+                self._check_version(active_version, expected_version)
+                before = {"state": node["state"], "owner_agent": node["owner_agent"], "progress": node["progress"]}
+                target = self._transition(node["state"], "in_progress")
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE roadmap_nodes SET state=?, owner_agent=?, updated_at=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+                    (target, actor, now, profile_id, project_id, roadmap_id, active_version, node_id),
+                )
+                conn.execute(
+                    "UPDATE roadmaps SET updated_at=?, updated_by=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (now, actor, profile_id, project_id, roadmap_id),
+                )
+                updated = conn.execute(
+                    "SELECT * FROM roadmap_nodes "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+                    (profile_id, project_id, roadmap_id, active_version, node_id),
+                ).fetchone()
+                return self._result(scope, updated, before)
+
+    def advance_node(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        node_id: str,
+        actor: str,
+        expected_version: Any,
+    ) -> dict[str, Any]:
+        """Transition a node ``planned -> ready`` (the start of execution).
+
+        The contract's node machine only allows ``planned -> ready``
+        (``claim_node`` moves ``ready -> in_progress``); without this step a
+        planned node can never become actionable. ``expected_version`` is the
+        active version the caller observed; a mismatch raises
+        :class:`StaleRoadmapVersionError`.
+        """
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        node_id = _required(node_id, "node_id")
+        actor = _required(actor, "actor")
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                node, active_version = self._resolve_node(conn, profile_id, project_id, roadmap_id, node_id)
+                self._check_version(active_version, expected_version)
+                before = {"state": node["state"], "owner_agent": node["owner_agent"], "progress": node["progress"]}
+                target = self._transition(node["state"], "ready")
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE roadmap_nodes SET state=?, updated_at=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+                    (target, now, profile_id, project_id, roadmap_id, active_version, node_id),
+                )
+                conn.execute(
+                    "UPDATE roadmaps SET updated_at=?, updated_by=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (now, actor, profile_id, project_id, roadmap_id),
+                )
+                updated = conn.execute(
+                    "SELECT * FROM roadmap_nodes "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+                    (profile_id, project_id, roadmap_id, active_version, node_id),
+                ).fetchone()
+                return self._result(scope, updated, before)
+
+    def update_progress(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        node_id: str,
+        actor: str,
+        progress: Any,
+        expected_version: Any,
+    ) -> dict[str, Any]:
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        node_id = _required(node_id, "node_id")
+        actor = _required(actor, "actor")
+        progress = _int_in_range(progress, "progress", 0, 100)
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                node, active_version = self._resolve_node(conn, profile_id, project_id, roadmap_id, node_id)
+                self._check_version(active_version, expected_version)
+                if node["state"] != "in_progress":
+                    raise InvalidRoadmapTransitionError(
+                        f"progress requires state 'in_progress', got {node['state']!r}"
+                    )
+                before = {"state": node["state"], "progress": node["progress"]}
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE roadmap_nodes SET progress=?, updated_at=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+                    (progress, now, profile_id, project_id, roadmap_id, active_version, node_id),
+                )
+                conn.execute(
+                    "UPDATE roadmaps SET updated_at=?, updated_by=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (now, actor, profile_id, project_id, roadmap_id),
+                )
+                updated = conn.execute(
+                    "SELECT * FROM roadmap_nodes "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+                    (profile_id, project_id, roadmap_id, active_version, node_id),
+                ).fetchone()
+                return self._result(scope, updated, before)
+
+    def complete_node(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        node_id: str,
+        actor: str,
+        expected_version: Any,
+    ) -> dict[str, Any]:
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        node_id = _required(node_id, "node_id")
+        actor = _required(actor, "actor")
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                node, active_version = self._resolve_node(conn, profile_id, project_id, roadmap_id, node_id)
+                self._check_version(active_version, expected_version)
+                before = {"state": node["state"], "progress": node["progress"]}
+                target = self._transition(node["state"], "completed")
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE roadmap_nodes SET state=?, progress=100, block_reason=NULL, updated_at=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+                    (target, now, profile_id, project_id, roadmap_id, active_version, node_id),
+                )
+                conn.execute(
+                    "UPDATE roadmaps SET updated_at=?, updated_by=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (now, actor, profile_id, project_id, roadmap_id),
+                )
+                updated = conn.execute(
+                    "SELECT * FROM roadmap_nodes "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+                    (profile_id, project_id, roadmap_id, active_version, node_id),
+                ).fetchone()
+                return self._result(scope, updated, before)
+
+    def block_node(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        node_id: str,
+        actor: str,
+        reason: str,
+        expected_version: Any,
+    ) -> dict[str, Any]:
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        node_id = _required(node_id, "node_id")
+        actor = _required(actor, "actor")
+        reason = _non_empty_text(reason, "reason")
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                node, active_version = self._resolve_node(conn, profile_id, project_id, roadmap_id, node_id)
+                self._check_version(active_version, expected_version)
+                before = {"state": node["state"], "block_reason": node["block_reason"]}
+                target = self._transition(node["state"], "blocked")
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE roadmap_nodes SET state=?, block_reason=?, updated_at=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+                    (target, reason, now, profile_id, project_id, roadmap_id, active_version, node_id),
+                )
+                conn.execute(
+                    "UPDATE roadmaps SET updated_at=?, updated_by=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (now, actor, profile_id, project_id, roadmap_id),
+                )
+                updated = conn.execute(
+                    "SELECT * FROM roadmap_nodes "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+                    (profile_id, project_id, roadmap_id, active_version, node_id),
+                ).fetchone()
+                return self._result(scope, updated, before)
+
+    def unblock_node(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        node_id: str,
+        actor: str,
+        expected_version: Any,
+    ) -> dict[str, Any]:
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        node_id = _required(node_id, "node_id")
+        actor = _required(actor, "actor")
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                node, active_version = self._resolve_node(conn, profile_id, project_id, roadmap_id, node_id)
+                self._check_version(active_version, expected_version)
+                before = {"state": node["state"], "block_reason": node["block_reason"]}
+                target = self._transition(node["state"], "in_progress")
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE roadmap_nodes SET state=?, block_reason=NULL, updated_at=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+                    (target, now, profile_id, project_id, roadmap_id, active_version, node_id),
+                )
+                conn.execute(
+                    "UPDATE roadmaps SET updated_at=?, updated_by=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (now, actor, profile_id, project_id, roadmap_id),
+                )
+                updated = conn.execute(
+                    "SELECT * FROM roadmap_nodes "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND node_id=?",
+                    (profile_id, project_id, roadmap_id, active_version, node_id),
+                ).fetchone()
+                return self._result(scope, updated, before)
+
+    def update_todo(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        todo_id: str,
+        actor: str,
+        state: str,
+        expected_version: Any,
+    ) -> dict[str, Any]:
+        """Transition a todo of the active roadmap version (manual steering)."""
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        todo_id = _required(todo_id, "todo_id")
+        actor = _required(actor, "actor")
+        state = _required(state, "state")
+        if state not in ("open", "in_progress", "done", "cancelled"):
+            raise ValueError("state must be one of open/in_progress/done/cancelled")
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                row = conn.execute(
+                    "SELECT active_version FROM roadmaps "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (profile_id, project_id, roadmap_id),
+                ).fetchone()
+                if row is None:
+                    raise RoadmapNotFoundError("roadmap not found for the given scope")
+                active_version = row["active_version"]
+                if active_version is None:
+                    raise RoadmapNotFoundError("roadmap has no active version to mutate")
+                self._check_version(active_version, expected_version)
+
+                todo = conn.execute(
+                    "SELECT * FROM roadmap_todos "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND todo_id=?",
+                    (profile_id, project_id, roadmap_id, active_version, todo_id),
+                ).fetchone()
+                if todo is None:
+                    raise RoadmapTodoNotFoundError(
+                        f"todo {todo_id!r} not found in active version {active_version}"
+                    )
+                if state not in TODO_TRANSITIONS.get(todo["state"], frozenset()):
+                    raise InvalidRoadmapTodoTransitionError(
+                        f"invalid todo transition: {todo['state']!r} -> {state!r}"
+                    )
+                before = {"state": todo["state"]}
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE roadmap_todos SET state=?, updated_at=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND todo_id=?",
+                    (state, now, profile_id, project_id, roadmap_id, active_version, todo_id),
+                )
+                conn.execute(
+                    "UPDATE roadmaps SET updated_at=?, updated_by=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (now, actor, profile_id, project_id, roadmap_id),
+                )
+                updated = conn.execute(
+                    "SELECT todo_id, node_id, title, state, position, updated_at FROM roadmap_todos "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=? AND todo_id=?",
+                    (profile_id, project_id, roadmap_id, active_version, todo_id),
+                ).fetchone()
+                return {
+                    "success": True,
+                    "scope": scope,
+                    "todo": dict(updated),
+                    "before": before,
+                }
+
+    # -- durable roadmap session links ----------------------------------------
+
+    def attach_session(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        stored_session_id: str,
+        actor: str,
+        expected_version: Any,
+        *,
+        kind: str = "vision",
+        plan_version: Any = None,
+    ) -> dict[str, Any]:
+        """Attach a durable stored session id to the fully-qualified roadmap."""
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        stored_session_id = _required(stored_session_id, "stored_session_id")
+        actor = _required(actor, "actor")
+        kind = _enum(kind, "kind", frozenset({"vision"}))
+        if plan_version is not None:
+            plan_version = _int_in_range(plan_version, "plan_version", 1, MAX_VERSION)
+        scope = {
+            "profile_id": profile_id,
+            "project_id": project_id,
+            "roadmap_id": roadmap_id,
+        }
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                roadmap = conn.execute(
+                    "SELECT active_version FROM roadmaps "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (profile_id, project_id, roadmap_id),
+                ).fetchone()
+                if roadmap is None:
+                    raise RoadmapNotFoundError("roadmap not found for the given scope")
+                self._check_version(roadmap["active_version"] or 0, expected_version)
+                if plan_version is not None:
+                    version_exists = conn.execute(
+                        "SELECT 1 FROM roadmap_versions WHERE profile_id=? "
+                        "AND project_id=? AND roadmap_id=? AND version=?",
+                        (profile_id, project_id, roadmap_id, plan_version),
+                    ).fetchone()
+                    if version_exists is None:
+                        raise RoadmapVersionNotFoundError(
+                            "plan version not found for the given roadmap scope"
+                        )
+                existing = conn.execute(
+                    "SELECT stored_session_id, kind, node_id, plan_version, state, "
+                    "actor, created_at, updated_at FROM roadmap_sessions "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? "
+                    "AND stored_session_id=? AND kind=?",
+                    (profile_id, project_id, roadmap_id, stored_session_id, kind),
+                ).fetchone()
+                if (existing is not None and existing["state"] == "active"
+                        and existing["plan_version"] == plan_version):
+                    return {"success": True, "scope": scope, "session": dict(existing)}
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE roadmap_sessions SET state='closed', actor=?, updated_at=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? "
+                    "AND kind='vision' AND state='active' AND stored_session_id<>?",
+                    (actor, now, profile_id, project_id, roadmap_id, stored_session_id),
+                )
+                if existing is None:
+                    conn.execute(
+                        "INSERT INTO roadmap_sessions "
+                        "(profile_id, project_id, roadmap_id, stored_session_id, kind, "
+                        "node_id, plan_version, state, actor, created_at, updated_at) "
+                        "VALUES (?, ?, ?, ?, ?, NULL, ?, 'active', ?, ?, ?)",
+                        (profile_id, project_id, roadmap_id, stored_session_id, kind,
+                         plan_version, actor, now, now),
+                    )
+                else:
+                    conn.execute(
+                        "UPDATE roadmap_sessions SET state='active', plan_version=?, "
+                        "actor=?, updated_at=? WHERE profile_id=? AND project_id=? "
+                        "AND roadmap_id=? AND stored_session_id=? AND kind=?",
+                        (plan_version, actor, now, profile_id, project_id, roadmap_id,
+                         stored_session_id, kind),
+                    )
+                conn.execute(
+                    "UPDATE roadmaps SET updated_by=?, updated_at=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (actor, now, profile_id, project_id, roadmap_id),
+                )
+                session = conn.execute(
+                    "SELECT stored_session_id, kind, node_id, plan_version, state, "
+                    "actor, created_at, updated_at FROM roadmap_sessions "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? "
+                    "AND stored_session_id=? AND kind=?",
+                    (profile_id, project_id, roadmap_id, stored_session_id, kind),
+                ).fetchone()
+                return {"success": True, "scope": scope, "session": dict(session)}
+
+    # -- roadmap CRUD + plan governance (T5b) --------------------------------
+
+    @staticmethod
+    def _next_roadmap_id() -> str:
+        return "r_" + secrets.token_hex(4)
+
+    @staticmethod
+    def _content_hash(nodes, relations, todos) -> str:
+        payload = {"nodes": nodes, "relations": relations, "todos": todos}
+        encoded = json.dumps(
+            payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def create_roadmap(
+        self,
+        profile_id: str,
+        project_id: str,
+        title: Any,
+        actor: str,
+        roadmap_id: str | None = None,
+        purpose: Any = None,
+        lifecycle_state: Any = "draft",
+    ) -> dict[str, Any]:
+        """Create a roadmap plus its initial version-1 draft marker.
+
+        ``roadmap_id`` is generated (``r_`` + 8 hex chars) unless provided.
+        ``lifecycle_state`` is forced to ``'draft'`` (the fresh state used by
+        the read side); any explicit non-draft value is rejected — later
+        states are only reachable via ``plans.validate`` / ``plans.activate``
+        / ``roadmaps.archive``.  ``active_version`` stays NULL until a
+        validated plan is activated.
+        """
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        title = _non_empty_text(title, "title", max_length=MAX_TITLE_LENGTH)
+        actor = _required(actor, "actor")
+        # Strict lifecycle machine: a roadmap is born 'draft'. Accepting a
+        # later state here would bypass plans.validate / plans.activate /
+        # roadmaps.archive (e.g. 'archived' or 'completed' without any plan
+        # history), so any explicit non-draft value is rejected.
+        if lifecycle_state is None:
+            lifecycle_state = "draft"
+        if lifecycle_state != "draft":
+            raise ValueError(
+                "lifecycle_state must be 'draft' at creation (transitions go "
+                "through plans.validate, plans.activate, roadmaps.archive)"
+            )
+        lifecycle = "draft"
+        purpose = _optional_text(purpose, "purpose", max_length=MAX_PURPOSE_LENGTH)
+        if roadmap_id is not None:
+            roadmap_id = _required(roadmap_id, "roadmap_id")
+        else:
+            roadmap_id = self._next_roadmap_id()
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                project = conn.execute(
+                    "SELECT 1 FROM projects WHERE id=?", (project_id,)
+                ).fetchone()
+                if project is None:
+                    raise RoadmapProjectNotFoundError(
+                        f"project {project_id!r} not found for the given scope"
+                    )
+                exists = conn.execute(
+                    "SELECT 1 FROM roadmaps "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (profile_id, project_id, roadmap_id),
+                ).fetchone()
+                if exists is not None:
+                    raise RoadmapExistsError(
+                        f"roadmap {roadmap_id!r} already exists in this project"
+                    )
+                now = int(time.time())
+                conn.execute(
+                    "INSERT INTO roadmaps "
+                    "(profile_id, project_id, roadmap_id, title, purpose, lifecycle_state, "
+                    "active_version, created_by, updated_by, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)",
+                    (profile_id, project_id, roadmap_id, title, purpose, lifecycle,
+                     actor, actor, now, now),
+                )
+                # Initial version-1 draft marker (empty plan): the first real
+                # plan created via create_plan will be version 2.
+                conn.execute(
+                    "INSERT INTO roadmap_versions "
+                    "(profile_id, project_id, roadmap_id, version, state, source, "
+                    "reason, created_by, created_at, content_hash) "
+                    "VALUES (?, ?, ?, 1, 'draft', 'roadmaps.create', ?, ?, ?, NULL)",
+                    (profile_id, project_id, roadmap_id, None, actor, now),
+                )
+        return {
+            "success": True,
+            "scope": scope,
+            "roadmap_id": roadmap_id,
+            "version": 1,
+            "state": "draft",
+        }
+
+    def update_roadmap(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        actor: str,
+        expected_version: Any,
+        title: Any = None,
+        purpose: Any = None,
+        lifecycle_state: Any = None,
+    ) -> dict[str, Any]:
+        """Update only the roadmap fields actually provided.
+
+        ``expected_version`` is the active version the caller observed (0 for
+        a roadmap with no active version yet); a mismatch raises
+        :class:`StaleRoadmapVersionError`.  ``lifecycle_state`` is not
+        writable here — transitions go exclusively through
+        ``plans.validate`` / ``plans.activate`` / ``roadmaps.archive`` — and
+        an archived roadmap keeps its terminal lifecycle_state (title/purpose
+        may still be edited).
+        """
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        actor = _required(actor, "actor")
+        # Strict lifecycle machine: transitions go exclusively through
+        # plans.validate / plans.activate / roadmaps.archive. A direct
+        # lifecycle_state write here would bypass those ops (e.g. 'completed'
+        # without a validated/activated plan), so it is rejected outright.
+        if lifecycle_state is not None:
+            raise ValueError(
+                "lifecycle_state is managed by plans.validate, plans.activate, "
+                "and roadmaps.archive; direct lifecycle writes are rejected"
+            )
+        if title is None and purpose is None:
+            raise ValueError("nothing to update: provide title or purpose")
+        if title is not None:
+            title = _non_empty_text(title, "title", max_length=MAX_TITLE_LENGTH)
+        purpose = _optional_text(purpose, "purpose", max_length=MAX_PURPOSE_LENGTH)
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                row = conn.execute(
+                    "SELECT lifecycle_state, active_version FROM roadmaps "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (profile_id, project_id, roadmap_id),
+                ).fetchone()
+                if row is None:
+                    raise RoadmapNotFoundError("roadmap not found for the given scope")
+                self._check_version(row["active_version"] or 0, expected_version)
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE roadmaps SET "
+                    "title=COALESCE(?, title), purpose=COALESCE(?, purpose), "
+                    "lifecycle_state=COALESCE(?, lifecycle_state), "
+                    "updated_at=?, updated_by=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (title, purpose, lifecycle_state, now, actor,
+                     profile_id, project_id, roadmap_id),
+                )
+                updated = conn.execute(
+                    "SELECT roadmap_id, title, purpose, lifecycle_state, active_version, "
+                    "created_by, updated_by, created_at, updated_at FROM roadmaps "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (profile_id, project_id, roadmap_id),
+                ).fetchone()
+                return {"success": True, "scope": scope, "roadmap": dict(updated)}
+
+    def archive_roadmap(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        actor: str,
+        expected_version: Any,
+    ) -> dict[str, Any]:
+        """Move the roadmap lifecycle to the terminal ``'archived'`` state.
+
+        The version history stays readable (versions are preserved);
+        archiving an already archived roadmap is rejected.  ``expected_version``
+        is the observed active version (0 when none).
+        """
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        actor = _required(actor, "actor")
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                row = conn.execute(
+                    "SELECT lifecycle_state, active_version FROM roadmaps "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (profile_id, project_id, roadmap_id),
+                ).fetchone()
+                if row is None:
+                    raise RoadmapNotFoundError("roadmap not found for the given scope")
+                self._check_version(row["active_version"] or 0, expected_version)
+                if row["lifecycle_state"] == "archived":
+                    raise InvalidRoadmapTransitionError("roadmap is already archived")
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE roadmaps SET lifecycle_state='archived', updated_at=?, updated_by=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (now, actor, profile_id, project_id, roadmap_id),
+                )
+                updated = conn.execute(
+                    "SELECT roadmap_id, title, purpose, lifecycle_state, active_version, "
+                    "created_by, updated_by, created_at, updated_at FROM roadmaps "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (profile_id, project_id, roadmap_id),
+                ).fetchone()
+                return {"success": True, "scope": scope, "roadmap": dict(updated)}
+
+    def create_plan(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        actor: str,
+        version: Any = None,
+        nodes: Any = None,
+        relations: Any = None,
+        todos: Any = None,
+        source: Any = None,
+        reason: Any = None,
+    ) -> dict[str, Any]:
+        """Create a full plan version atomically (nodes + relations + todos).
+
+        The whole payload is validated BEFORE any insert, then everything is
+        committed in one IMMEDIATE transaction — an invalid payload leaves the
+        store untouched.  The new version is ``'proposed'`` (a created plan is
+        proposed, never active).  ``version`` defaults to max(version)+1
+        (version 1 is reserved by ``roadmaps.create``).  ``source`` / ``reason``
+        document where the plan came from.
+        """
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        actor = _required(actor, "actor")
+        if version is not None:
+            version = _int_in_range(version, "version", 1, MAX_VERSION)
+        source = _optional_text(source, "source", max_length=MAX_IDENTIFIER_LENGTH)
+        reason = _optional_text(reason, "reason", max_length=MAX_REASON_LENGTH)
+        nodes = _validate_plan_nodes(nodes)
+        node_ids = {node["node_id"] for node in nodes}
+        relations = _validate_plan_relations(relations, node_ids)
+        todos = _validate_plan_todos(todos, node_ids)
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                row = conn.execute(
+                    "SELECT lifecycle_state, active_version FROM roadmaps "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (profile_id, project_id, roadmap_id),
+                ).fetchone()
+                if row is None:
+                    raise RoadmapNotFoundError("roadmap not found for the given scope")
+                if row["lifecycle_state"] == "archived":
+                    raise InvalidRoadmapTransitionError(
+                        "cannot create a plan for an archived roadmap"
+                    )
+                if version is None:
+                    max_version = conn.execute(
+                        "SELECT COALESCE(MAX(version), 0) AS m FROM roadmap_versions "
+                        "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                        (profile_id, project_id, roadmap_id),
+                    ).fetchone()["m"]
+                    version = max_version + 1
+                else:
+                    exists = conn.execute(
+                        "SELECT 1 FROM roadmap_versions "
+                        "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=?",
+                        (profile_id, project_id, roadmap_id, version),
+                    ).fetchone()
+                    if exists is not None:
+                        raise RoadmapVersionExistsError(
+                            f"version {version} already exists for this roadmap"
+                        )
+                now = int(time.time())
+                content_hash = self._content_hash(nodes, relations, todos)
+                conn.execute(
+                    "INSERT INTO roadmap_versions "
+                    "(profile_id, project_id, roadmap_id, version, state, source, "
+                    "reason, created_by, created_at, content_hash) "
+                    "VALUES (?, ?, ?, ?, 'proposed', ?, ?, ?, ?, ?)",
+                    (profile_id, project_id, roadmap_id, version, source, reason,
+                     actor, now, content_hash),
+                )
+                for node in _parents_first(nodes):
+                    conn.execute(
+                        "INSERT INTO roadmap_nodes "
+                        "(profile_id, project_id, roadmap_id, version, node_id, "
+                        "parent_node_id, kind, title, description, state, progress, "
+                        "owner_agent, block_reason, created_at, updated_at) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (profile_id, project_id, roadmap_id, version,
+                         node["node_id"], node["parent_node_id"], node["kind"],
+                         node["title"], node["description"], node["state"],
+                         node["progress"], node["owner_agent"], node["block_reason"],
+                         now, now),
+                    )
+                for relation in relations:
+                    conn.execute(
+                        "INSERT INTO roadmap_relations "
+                        "(profile_id, project_id, roadmap_id, version, relation_id, "
+                        "from_node_id, to_node_id, kind, state, reason) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (profile_id, project_id, roadmap_id, version,
+                         relation["relation_id"], relation["from_node_id"],
+                         relation["to_node_id"], relation["kind"],
+                         relation["state"], relation["reason"]),
+                    )
+                for todo in todos:
+                    conn.execute(
+                        "INSERT INTO roadmap_todos "
+                        "(profile_id, project_id, roadmap_id, version, todo_id, "
+                        "node_id, title, state, position, created_at, updated_at) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (profile_id, project_id, roadmap_id, version,
+                         todo["todo_id"], todo["node_id"], todo["title"],
+                         todo["state"], todo["position"], now, now),
+                    )
+                # Roadmap lifecycle: draft -> proposed once a plan is proposed.
+                lifecycle = (
+                    "in_progress"
+                    if row["lifecycle_state"] == "validated"
+                    else ("proposed" if row["lifecycle_state"] == "draft" else row["lifecycle_state"])
+                )
+                conn.execute(
+                    "UPDATE roadmaps SET lifecycle_state=?, updated_at=?, updated_by=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (lifecycle, now, actor, profile_id, project_id, roadmap_id),
+                )
+        return {
+            "success": True,
+            "scope": scope,
+            "version": version,
+            "state": "proposed",
+            "content_hash": content_hash,
+            "counts": {"nodes": len(nodes), "relations": len(relations), "todos": len(todos)},
+        }
+
+    def validate_plan(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        version: Any,
+        actor: str,
+        expected_version: Any,
+    ) -> dict[str, Any]:
+        """Transition a plan version ``draft|proposed -> validated``.
+
+        Governance op: the caller (toolset agent under Pierre's authority, or
+        Pierre directly) is recorded as ``roadmaps.updated_by`` — the version
+        row itself has no ``updated_by`` column (append-only apart from state).
+        ``expected_version`` is the observed active version (0 when none).
+        """
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        version = _int_in_range(version, "version", 1, MAX_VERSION)
+        actor = _required(actor, "actor")
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                row = conn.execute(
+                    "SELECT lifecycle_state, active_version FROM roadmaps "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (profile_id, project_id, roadmap_id),
+                ).fetchone()
+                if row is None:
+                    raise RoadmapNotFoundError("roadmap not found for the given scope")
+                if row["lifecycle_state"] == "archived":
+                    raise InvalidRoadmapTransitionError(
+                        "cannot validate a plan for an archived roadmap"
+                    )
+                self._check_version(row["active_version"] or 0, expected_version)
+                vrow = conn.execute(
+                    "SELECT state FROM roadmap_versions "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=?",
+                    (profile_id, project_id, roadmap_id, version),
+                ).fetchone()
+                if vrow is None:
+                    raise RoadmapVersionNotFoundError(
+                        f"version {version} not found for this roadmap"
+                    )
+                if vrow["state"] not in ("draft", "proposed"):
+                    raise InvalidRoadmapPlanTransitionError(
+                        f"only draft/proposed plans can be validated; "
+                        f"version {version} is {vrow['state']!r}"
+                    )
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE roadmap_versions SET state='validated' "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=?",
+                    (profile_id, project_id, roadmap_id, version),
+                )
+                conn.execute(
+                    "UPDATE roadmaps SET updated_at=?, updated_by=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (now, actor, profile_id, project_id, roadmap_id),
+                )
+        return {"success": True, "scope": scope, "version": version, "state": "validated"}
+
+    def activate_plan(
+        self,
+        profile_id: str,
+        project_id: str,
+        roadmap_id: str,
+        version: Any,
+        actor: str,
+        expected_version: Any,
+    ) -> dict[str, Any]:
+        """Point ``roadmaps.active_version`` at a validated plan version.
+
+        The version must be ``'validated'`` (a non-validated plan is rejected
+        with an explicit transition error).  The previously active version, if
+        any, is marked ``'superseded'`` (history preserved).  Activation starts
+        execution: the roadmap lifecycle moves to ``'in_progress'`` whatever
+        its prior non-terminal state.  ``expected_version`` is the active
+        version the caller observed (0 when none).
+        """
+        profile_id = _required(profile_id, "profile_id")
+        project_id = _required(project_id, "project_id")
+        roadmap_id = _required(roadmap_id, "roadmap_id")
+        version = _int_in_range(version, "version", 1, MAX_VERSION)
+        actor = _required(actor, "actor")
+        scope = {"profile_id": profile_id, "project_id": project_id, "roadmap_id": roadmap_id}
+
+        with self._connection() as conn:
+            with write_txn(conn):
+                row = conn.execute(
+                    "SELECT lifecycle_state, active_version FROM roadmaps "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (profile_id, project_id, roadmap_id),
+                ).fetchone()
+                if row is None:
+                    raise RoadmapNotFoundError("roadmap not found for the given scope")
+                if row["lifecycle_state"] == "archived":
+                    raise InvalidRoadmapTransitionError(
+                        "cannot activate a plan for an archived roadmap"
+                    )
+                self._check_version(row["active_version"] or 0, expected_version)
+                vrow = conn.execute(
+                    "SELECT state FROM roadmap_versions "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=?",
+                    (profile_id, project_id, roadmap_id, version),
+                ).fetchone()
+                if vrow is None:
+                    raise RoadmapVersionNotFoundError(
+                        f"version {version} not found for this roadmap"
+                    )
+                if vrow["state"] != "validated":
+                    raise InvalidRoadmapPlanTransitionError(
+                        f"only a validated plan can be activated; "
+                        f"version {version} is {vrow['state']!r}"
+                    )
+                now = int(time.time())
+                previous = row["active_version"]
+                if previous is not None and previous != version:
+                    conn.execute(
+                        "UPDATE roadmap_versions SET state='superseded' "
+                        "WHERE profile_id=? AND project_id=? AND roadmap_id=? AND version=?",
+                        (profile_id, project_id, roadmap_id, previous),
+                    )
+                # Activation starts execution: the roadmap lifecycle moves to
+                # 'in_progress' whatever its prior non-terminal state.
+                conn.execute(
+                    "UPDATE roadmaps SET active_version=?, lifecycle_state='in_progress', "
+                    "updated_at=?, updated_by=? "
+                    "WHERE profile_id=? AND project_id=? AND roadmap_id=?",
+                    (version, now, actor, profile_id, project_id, roadmap_id),
+                )
+        return {
+            "success": True,
+            "scope": scope,
+            "active_version": version,
+            "previous_active_version": previous,
+        }

--- a/src/roadmaps_contract.py
+++ b/src/roadmaps_contract.py
@@ -1,0 +1,331 @@
+"""Pure, read-only invariants for the Roadmaps Phase 0 contract.
+
+This module deliberately has no Hermes imports, database access, filesystem writes,
+or network surface. Repository implementations in this module are in-memory test
+fixtures only; ``projects.db`` remains the durable backend authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import re
+from types import MappingProxyType
+from typing import Any, Mapping, Protocol, Sequence, TypeAlias
+
+
+class DuplicateEventConflict(ValueError):
+    """An event id was reused for a different event payload or identity."""
+
+
+class StaleEventError(ValueError):
+    """An event would move an aggregate to an older or equal version."""
+
+
+_IDENTIFIER_FIELDS = frozenset({
+    "profile_id", "project_id", "roadmap_id", "node_id", "event_id",
+    "aggregate_id", "actor", "causation_id", "correlation_id",
+})
+_ALLOWED_AGGREGATE_TYPES = frozenset({"roadmap", "node", "todo", "report", "proof"})
+_ALLOWED_RELATION_KINDS = frozenset({"depends_on", "validates", "blocks", "contains", "derived_from"})
+_EVENT_TYPE = re.compile(r"^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)+$")
+
+
+def _identifier(value: object, field: str, *, optional: bool = False) -> str | None:
+    if optional and value is None:
+        return None
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ValueError(f"invalid {field}: must be a non-empty trimmed string")
+    if "/" in value or "\\" in value or any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise ValueError(f"invalid {field}: path separators and control characters are forbidden")
+    return value
+
+
+def _freeze(value: Any, path: str = "payload") -> Any:
+    if isinstance(value, Mapping):
+        frozen: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{path} keys must be strings")
+            frozen[key] = _freeze(item, f"{path}.{key}")
+        return MappingProxyType(frozen)
+    if isinstance(value, list):
+        return tuple(_freeze(item, f"{path}[]") for item in value)
+    if isinstance(value, tuple):
+        return tuple(_freeze(item, f"{path}[]") for item in value)
+    if isinstance(value, (Scope, QualifiedNodeKey, Relation, EventEnvelope)):
+        return value
+    if value is None or isinstance(value, (str, int, float, bool)):
+        if isinstance(value, float) and (value != value or value in (float("inf"), float("-inf"))):
+            raise TypeError(f"{path} must contain finite JSON values")
+        return value
+    raise TypeError(f"{path} contains unsupported value type {type(value).__name__}")
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _json_value(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_json_value(item) for item in value]
+    return value
+
+
+def _payload_hash(payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(_json_value(payload), sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _utc(value: object, field: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field} must be timezone-aware")
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True, slots=True)
+class Scope:
+    profile_id: str
+    project_id: str
+    roadmap_id: str
+
+    def __post_init__(self) -> None:
+        for field in ("profile_id", "project_id", "roadmap_id"):
+            _identifier(getattr(self, field), field)
+
+    def as_tuple(self) -> tuple[str, str, str]:
+        return self.profile_id, self.project_id, self.roadmap_id
+
+
+@dataclass(frozen=True, slots=True)
+class QualifiedNodeKey:
+    scope: Scope
+    node_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.scope, Scope):
+            raise TypeError("scope must be a Scope")
+        _identifier(self.node_id, "node_id")
+
+    def as_tuple(self) -> tuple[str, str, str, str]:
+        return (*self.scope.as_tuple(), self.node_id)
+
+
+@dataclass(frozen=True, slots=True)
+class Relation:
+    from_node: QualifiedNodeKey
+    to_node: QualifiedNodeKey
+    kind: str = "depends_on"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.from_node, QualifiedNodeKey) or not isinstance(self.to_node, QualifiedNodeKey):
+            raise TypeError("relations must reference QualifiedNodeKey values")
+        if self.from_node.scope != self.to_node.scope:
+            raise ValueError("relations must reference nodes in the same scope")
+        if not isinstance(self.kind, str):
+            raise TypeError("relation kind must be a string")
+        if self.kind not in _ALLOWED_RELATION_KINDS:
+            raise ValueError(f"invalid relation kind: {self.kind!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class EventEnvelope:
+    schema_version: int
+    event_id: str
+    event_type: str
+    aggregate_type: str
+    aggregate_id: str
+    scope: Scope
+    actor: str
+    occurred_at: datetime
+    received_at: datetime
+    causation_id: str | None
+    correlation_id: str | None
+    aggregate_version: int
+    payload_hash: str
+
+    def __post_init__(self) -> None:
+        if type(self.schema_version) is not int or self.schema_version != 1:
+            raise ValueError("schema_version must be 1")
+        if not isinstance(self.scope, Scope):
+            raise TypeError("scope must be a Scope")
+        for field in ("event_id", "aggregate_id", "actor"):
+            _identifier(getattr(self, field), field)
+        if not isinstance(self.event_type, str) or _EVENT_TYPE.fullmatch(self.event_type) is None:
+            raise ValueError("event_type must be a lowercase dot-qualified string")
+        if not isinstance(self.aggregate_type, str):
+            raise TypeError("aggregate_type must be a string")
+        if self.aggregate_type not in _ALLOWED_AGGREGATE_TYPES:
+            raise ValueError(f"invalid aggregate_type: {self.aggregate_type!r}")
+        _identifier(self.causation_id, "causation_id", optional=True)
+        _identifier(self.correlation_id, "correlation_id", optional=True)
+        if type(self.aggregate_version) is not int or self.aggregate_version < 1:
+            raise ValueError("aggregate_version must be a positive integer")
+        occurred = _utc(self.occurred_at, "occurred_at")
+        received = _utc(self.received_at, "received_at")
+        if not isinstance(self.payload_hash, str) or re.fullmatch(r"[0-9a-f]{64}", self.payload_hash) is None:
+            raise ValueError("payload_hash must be a sha256 hex digest")
+        object.__setattr__(self, "occurred_at", occurred)
+        object.__setattr__(self, "received_at", received)
+
+
+    @classmethod
+    def create(
+        cls, *, event_id: str, scope: Scope, aggregate_id: str, payload: Mapping[str, object],
+        event_type: str,
+        aggregate_type: str = "roadmap", actor: str = "contract-test", aggregate_version: int = 1,
+        causation_id: str | None = None, correlation_id: str | None = None,
+        occurred_at: datetime | None = None, received_at: datetime | None = None,
+    ) -> "EventEnvelope":
+        now = datetime.now(timezone.utc)
+        if not isinstance(payload, Mapping):
+            raise TypeError("payload must be a mapping")
+        frozen_payload = _freeze(payload)
+        return cls(
+            schema_version=1, event_id=event_id, event_type=event_type, aggregate_type=aggregate_type,
+            aggregate_id=aggregate_id, scope=scope, actor=actor,
+            occurred_at=occurred_at if occurred_at is not None else now,
+            received_at=received_at if received_at is not None else now,
+            causation_id=causation_id, correlation_id=correlation_id,
+            aggregate_version=aggregate_version, payload_hash=_payload_hash(frozen_payload),
+        )
+
+    def ensure_same_identity(self, other: "EventEnvelope") -> None:
+        if not isinstance(other, EventEnvelope):
+            raise TypeError("other must be an EventEnvelope")
+        if self.event_id != other.event_id:
+            raise ValueError("events have different event_id values")
+        # Timestamps are part of identity: a replay is idempotent only when the
+        # complete envelope metadata is byte-for-byte equivalent after UTC
+        # normalization. Payload content is represented by its required hash.
+        comparable = (
+            self.scope, self.event_type, self.aggregate_type, self.aggregate_id, self.actor,
+            self.aggregate_version, self.payload_hash, self.causation_id,
+            self.correlation_id, self.occurred_at, self.received_at,
+        )
+        other_comparable = (
+            other.scope, other.event_type, other.aggregate_type, other.aggregate_id, other.actor,
+            other.aggregate_version, other.payload_hash, other.causation_id,
+            other.correlation_id, other.occurred_at, other.received_at,
+        )
+        if comparable != other_comparable:
+            raise DuplicateEventConflict(f"event_id {self.event_id!r} has conflicting payload or identity")
+
+
+class RoadmapRepository(Protocol):
+    """Read-only repository boundary; this protocol contains no persistence behavior."""
+
+    def list(self, *, profile_id: str, project_id: str) -> tuple[Scope, ...]: ...
+    def get(self, scope: Scope) -> Mapping[str, object]: ...
+    def get_snapshot(self, scope: Scope) -> Mapping[str, object]: ...
+    def get_events_after(self, scope: Scope, cursor: int) -> tuple[EventEnvelope, ...]: ...
+
+
+class FixtureRoadmapRepository:
+    """Injected, immutable in-memory repository used only by contract tests."""
+
+    def __init__(self, scope: Scope, snapshot: Mapping[str, object], events: Sequence[EventEnvelope] = ()) -> None:
+        if not isinstance(scope, Scope):
+            raise TypeError("scope must be a Scope")
+        self._scope = scope
+        frozen_snapshot = _freeze(snapshot)
+        if not isinstance(frozen_snapshot, Mapping):
+            raise TypeError("snapshot must be a mapping")
+        self._snapshot = frozen_snapshot
+        self._events = tuple(events)
+        for event in self._events:
+            if not isinstance(event, EventEnvelope):
+                raise TypeError("events must contain only EventEnvelope values")
+            if event.scope != self._scope:
+                raise ValueError("events must belong to the repository scope")
+
+    def list(self, *, profile_id: str, project_id: str) -> tuple[Scope, ...]:
+        return (self._scope,) if (profile_id, project_id) == self._scope.as_tuple()[:2] else ()
+
+    def get(self, scope: Scope) -> Mapping[str, object]:
+        if scope != self._scope:
+            raise KeyError(scope)
+        return self._snapshot
+
+    def get_snapshot(self, scope: Scope) -> Mapping[str, object]:
+        return self.get(scope)
+
+    def get_events_after(self, scope: Scope, cursor: int) -> tuple[EventEnvelope, ...]:
+        if scope != self._scope:
+            raise KeyError(scope)
+        if type(cursor) is not int or cursor < 0:
+            raise ValueError("cursor must be a non-negative integer")
+        return replay_events(self._events, cursor=cursor)
+
+
+PLAN_TRANSITIONS: dict[str, frozenset[str]] = {
+    "draft": frozenset({"proposed"}), "proposed": frozenset({"validated", "revision_requested"}),
+    "validated": frozenset({"in_progress", "revision_requested"}),
+    "in_progress": frozenset({"blocked", "completed", "revision_requested"}),
+    "blocked": frozenset({"in_progress", "revision_requested"}),
+    "completed": frozenset({"archived", "revision_requested"}),
+    "revision_requested": frozenset({"proposed", "archived"}), "archived": frozenset(),
+}
+NODE_TRANSITIONS: dict[str, frozenset[str]] = {
+    "planned": frozenset({"ready"}), "ready": frozenset({"in_progress"}),
+    "in_progress": frozenset({"blocked", "completed"}), "blocked": frozenset({"in_progress", "completed"}),
+    "completed": frozenset({"archived"}), "archived": frozenset(),
+}
+
+
+def _transition(table: Mapping[str, frozenset[str]], kind: str, current: str, target: str) -> str:
+    if target not in table.get(current, frozenset()):
+        raise ValueError(f"invalid {kind} transition: {current!r} -> {target!r}")
+    return target
+
+
+def transition_plan(current: str, target: str) -> str:
+    return _transition(PLAN_TRANSITIONS, "plan", current, target)
+
+
+def transition_node(current: str, target: str) -> str:
+    return _transition(NODE_TRANSITIONS, "node", current, target)
+
+
+def replay_events(events: Sequence[EventEnvelope], cursor: int = 0) -> tuple[EventEnvelope, ...]:
+    """Validate the complete stream, then return the suffix after ``cursor``."""
+    if type(cursor) is not int or cursor < 0 or cursor > len(events):
+        raise ValueError("cursor must be within the event stream")
+    versions: dict[tuple[Scope, str, str], int] = {}
+    identities: dict[str, EventEnvelope] = {}
+    for event in events:
+        if not isinstance(event, EventEnvelope):
+            raise TypeError("events must contain only EventEnvelope values")
+        previous = identities.get(event.event_id)
+        if previous is not None:
+            previous.ensure_same_identity(event)
+            # An exactly identical duplicate is an idempotent replay, not a
+            # second application of the same aggregate version.
+            continue
+        identities[event.event_id] = event
+        key = (event.scope, event.aggregate_type, event.aggregate_id)
+        if event.aggregate_version <= versions.get(key, 0):
+            raise StaleEventError(
+                f"aggregate {event.aggregate_id!r} received non-increasing version {event.aggregate_version}"
+            )
+        versions[key] = event.aggregate_version
+    emitted_ids: set[str] = {event.event_id for event in events[:cursor]}
+    unique_suffix: list[EventEnvelope] = []
+    for event in events[cursor:]:
+        if event.event_id not in emitted_ids:
+            unique_suffix.append(event)
+            emitted_ids.add(event.event_id)
+    return tuple(unique_suffix)
+
+
+def build_fixture(scope: Scope) -> Mapping[str, object]:
+    """Return a small in-memory fixture; never persist or mutate external state."""
+    nodes = (QualifiedNodeKey(scope, "objective"), QualifiedNodeKey(scope, "step-1"), QualifiedNodeKey(scope, "proof-1"))
+    return MappingProxyType({
+        "scope": scope, "plan_snapshot": MappingProxyType({"version": 1, "state": "validated"}),
+        "execution_state": "ready", "reported_state": "none", "verification_state": "unverified",
+        "todos": (), "nodes": nodes, "relations": (Relation(nodes[1], nodes[2], "validates"),),
+    })
+
+
+FixtureRepository: TypeAlias = FixtureRoadmapRepository

--- a/tests/hermes_cli/test_projects_db_roadmaps.py
+++ b/tests/hermes_cli/test_projects_db_roadmaps.py
@@ -1,0 +1,319 @@
+"""Integration tests for the Roadmaps schema in the real projects store."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import projects_db as pdb
+
+
+TABLES = {
+    "roadmaps",
+    "roadmap_versions",
+    "roadmap_nodes",
+    "roadmap_relations",
+    "roadmap_sessions",
+    "roadmap_todos",
+}
+
+ROADMAP_COLUMNS = {
+    "roadmaps": "profile_id TEXT, project_id TEXT, roadmap_id TEXT, title TEXT, purpose TEXT, lifecycle_state TEXT, active_version INTEGER, created_by TEXT, updated_by TEXT, created_at INTEGER, updated_at INTEGER",
+    "roadmap_versions": "profile_id TEXT, project_id TEXT, roadmap_id TEXT, version INTEGER, state TEXT, source TEXT, reason TEXT, created_by TEXT, created_at INTEGER, content_hash TEXT",
+    "roadmap_nodes": "profile_id TEXT, project_id TEXT, roadmap_id TEXT, version INTEGER, node_id TEXT, parent_node_id TEXT, kind TEXT, title TEXT, description TEXT, state TEXT, progress INTEGER, owner_agent TEXT, block_reason TEXT, created_at INTEGER, updated_at INTEGER",
+    "roadmap_relations": "profile_id TEXT, project_id TEXT, roadmap_id TEXT, version INTEGER, relation_id TEXT, from_node_id TEXT, to_node_id TEXT, kind TEXT, state TEXT, reason TEXT",
+    "roadmap_sessions": "profile_id TEXT, project_id TEXT, roadmap_id TEXT, stored_session_id TEXT, kind TEXT, node_id TEXT, plan_version INTEGER, state TEXT, actor TEXT, created_at INTEGER, updated_at INTEGER",
+    "roadmap_todos": "profile_id TEXT, project_id TEXT, roadmap_id TEXT, version INTEGER, todo_id TEXT, node_id TEXT, title TEXT, state TEXT, position INTEGER, created_at INTEGER, updated_at INTEGER",
+}
+
+
+def _open(path: Path) -> sqlite3.Connection:
+    return pdb.connect(db_path=path)
+
+
+def _seed(conn: sqlite3.Connection, profile: str = "profile-a", project: str = "project-a") -> None:
+    conn.execute("INSERT INTO projects(id, slug, name, created_at) VALUES (?, ?, ?, ?)", (project, project, project, 1))
+    conn.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, project, "roadmap-a", "Roadmap", None, "draft", None, "actor", "actor", 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, project, "roadmap-a", 1, "draft", "test", None, "actor", 1, None),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, project, "roadmap-a", 1, "node-a", None, "objective", "A", None, "planned", 0, None, None, 1, 1),
+    )
+    conn.commit()
+
+
+def test_real_store_creates_roadmaps_schema_idempotently_and_preserves_legacy(tmp_path: Path) -> None:
+    path = tmp_path / "profile" / "projects.db"
+    first = _open(path)
+    assert first.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+    first.execute("CREATE TABLE legacy (id INTEGER PRIMARY KEY, value TEXT)")
+    first.execute("INSERT INTO legacy VALUES (1, 'keep')")
+    first.execute("CREATE INDEX legacy_value ON legacy(value)")
+    first.commit()
+    first.close()
+
+    second = _open(path)
+    assert {row[0] for row in second.execute("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'roadmap%'")} == TABLES
+    assert second.execute("SELECT value FROM legacy WHERE id=1").fetchone()[0] == "keep"
+    assert "legacy_value" in {row[1] for row in second.execute("PRAGMA index_list(legacy)")}
+    second.close()
+
+    third = _open(path)
+    assert {row[0] for row in third.execute("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'roadmap%'")} == TABLES
+    third.close()
+
+
+def test_real_store_enforces_active_version_and_qualified_node_relation_todo_scope(tmp_path: Path) -> None:
+    conn = _open(tmp_path / "projects.db")
+    _seed(conn)
+
+    conn.execute("UPDATE roadmaps SET active_version=1")
+    conn.commit()
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("UPDATE roadmaps SET active_version=99")
+        conn.commit()
+    conn.rollback()
+
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-b", "project-a", "roadmap-a", 1, "foreign", None, "step", "bad", None, "planned", 0, None, None, 1, 1),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_relations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-a", "project-a", "roadmap-a", 1, "rel", "node-a", "missing", "depends_on", "active", None),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_todos VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-a", "project-a", "roadmap-a", 1, "todo", "missing", "T", "open", 0, 1, 1),
+        )
+    conn.close()
+
+
+def test_roadmap_sessions_schema_enforces_durable_vision_contract(tmp_path: Path) -> None:
+    conn = _open(tmp_path / "projects.db")
+    _seed(conn)
+
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(roadmap_sessions)")}
+    assert columns == {
+        "profile_id", "project_id", "roadmap_id", "stored_session_id", "kind",
+        "node_id", "plan_version", "state", "actor", "created_at", "updated_at",
+    }
+    assert "runtime_session_id" not in columns
+
+    conn.execute(
+        "INSERT INTO roadmap_sessions "
+        "(profile_id, project_id, roadmap_id, stored_session_id, kind, state, actor, created_at, updated_at) "
+        "VALUES ('profile-a', 'project-a', 'roadmap-a', 'stored-1', 'vision', 'active', 'actor', 1, 1)"
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_sessions "
+            "(profile_id, project_id, roadmap_id, stored_session_id, kind, state, actor, created_at, updated_at) "
+            "VALUES ('profile-a', 'project-a', 'roadmap-a', 'stored-2', 'vision', 'active', 'actor', 1, 1)"
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_sessions "
+            "(profile_id, project_id, roadmap_id, stored_session_id, kind, state, actor, created_at, updated_at) "
+            "VALUES ('profile-a', 'project-a', 'roadmap-a', 'stored-x', 'node', 'closed', 'actor', 1, 1)"
+        )
+    conn.rollback()
+
+    conn.execute("DELETE FROM roadmaps WHERE roadmap_id='roadmap-a'")
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM roadmap_sessions").fetchone()[0] == 0
+    conn.close()
+
+
+def test_connect_additively_restores_missing_roadmap_sessions_table(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(pdb.SCHEMA_SQL)
+    raw.execute("DROP TABLE roadmap_sessions")
+    raw.commit()
+    raw.close()
+
+    conn = _open(path)
+    assert conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='roadmap_sessions'"
+    ).fetchone() is not None
+    conn.close()
+
+
+def test_real_store_preserves_project_cascade_and_isolates_db_paths(tmp_path: Path) -> None:
+    first = _open(tmp_path / "a" / "projects.db")
+    second = _open(tmp_path / "b" / "projects.db")
+    _seed(first, "profile-a")
+    _seed(second, "profile-b")
+    assert first.execute("SELECT profile_id FROM roadmaps").fetchone()[0] == "profile-a"
+    assert second.execute("SELECT profile_id FROM roadmaps").fetchone()[0] == "profile-b"
+
+    first.execute("DELETE FROM projects WHERE id='project-a'")
+    first.commit()
+    for table in TABLES:
+        assert first.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 0
+    assert second.execute("SELECT COUNT(*) FROM roadmaps").fetchone()[0] == 1
+    first.close()
+    second.close()
+
+
+def test_real_store_keeps_deferred_runtime_tables_out_of_phase_one(tmp_path: Path) -> None:
+    conn = _open(tmp_path / "projects.db")
+    names = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert not names.intersection({"reports", "proofs", "events", "agent_projections"})
+    conn.close()
+
+
+@pytest.mark.parametrize("table", sorted(TABLES))
+def test_real_store_rejects_same_columns_without_roadmap_constraints(
+    tmp_path: Path, table: str
+) -> None:
+    path = tmp_path / f"{table}.db"
+    raw = sqlite3.connect(path)
+    raw.execute(f"CREATE TABLE {table} ({ROADMAP_COLUMNS[table]})")
+    raw.commit()
+    raw.close()
+
+    with pytest.raises((sqlite3.DatabaseError, ValueError), match=table):
+        _open(path)
+
+
+def test_connect_rejects_weakened_core_projects_without_roadmaps_residue(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.execute(
+        "CREATE TABLE projects ("
+        "id TEXT, slug TEXT, name TEXT, description TEXT, icon TEXT, color TEXT, "
+        "board_slug TEXT, primary_path TEXT, created_at INTEGER, archived INTEGER)"
+    )
+    raw.commit()
+    raw.close()
+
+    with pytest.raises((sqlite3.DatabaseError, ValueError), match="projects"):
+        _open(path)
+
+    check = sqlite3.connect(path)
+    names = {
+        row[0]
+        for row in check.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert not names.intersection(TABLES)
+    check.close()
+
+
+def test_connect_rejects_projects_with_non_unique_slug_without_roadmaps_residue(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.execute(
+        "CREATE TABLE projects ("
+        "id TEXT PRIMARY KEY, slug TEXT NOT NULL, name TEXT NOT NULL, "
+        "description TEXT, icon TEXT, color TEXT, board_slug TEXT, "
+        "primary_path TEXT, created_at INTEGER NOT NULL, archived INTEGER NOT NULL)"
+    )
+    raw.commit()
+    raw.close()
+
+    with pytest.raises(sqlite3.DatabaseError, match="projects"):
+        _open(path)
+
+    check = sqlite3.connect(path)
+    names = {row[0] for row in check.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert not names.intersection(TABLES)
+    check.close()
+
+
+def test_connect_rejects_orphan_roadmaps_after_restoring_missing_projects(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(pdb.SCHEMA_SQL)
+    raw.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile-a", "missing-project", "roadmap-a", "Roadmap", None, "draft", None, "actor", "actor", 1, 1),
+    )
+    raw.execute("DROP TABLE projects")
+    raw.commit()
+    raw.close()
+
+    with pytest.raises(sqlite3.DatabaseError, match="foreign key"):
+        _open(path)
+
+
+def test_connect_retries_optional_project_column_migration_with_complete_roadmaps_schema(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(pdb.SCHEMA_SQL.replace("    board_slug    TEXT,\n", ""))
+    raw.commit()
+    raw.close()
+
+    conn = _open(path)
+    assert "board_slug" in {
+        row[1] for row in conn.execute("PRAGMA table_info(projects)")
+    }
+    conn.close()
+
+
+def test_connect_rejects_roadmap_check_contract_tampering(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(pdb.SCHEMA_SQL)
+    original = raw.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='roadmaps'"
+    ).fetchone()[0]
+    tampered = original.replace("'archived'))", "'archived','bogus'))")
+    assert tampered != original
+    raw.execute("PRAGMA writable_schema=ON")
+    raw.execute(
+        "UPDATE sqlite_master SET sql=? WHERE type='table' AND name='roadmaps'",
+        (tampered,),
+    )
+    raw.commit()
+    raw.close()
+
+    with pytest.raises((sqlite3.DatabaseError, ValueError), match="roadmaps"):
+        _open(path)
+
+
+def test_connect_restores_missing_core_schema_with_complete_roadmaps(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(pdb.SCHEMA_SQL)
+    raw.execute("DROP TABLE projects")
+    raw.commit()
+    raw.close()
+
+    conn = _open(path)
+    names = {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert {"projects", "project_folders", "project_meta", "discovered_repos"}.issubset(names)
+    assert TABLES.issubset(names)
+    assert "idx_project_folders_path" in {
+        row[1] for row in conn.execute("PRAGMA index_list(project_folders)")
+    }
+    conn.close()
+
+
+def test_real_store_reinitializes_after_database_file_is_replaced(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    first = _open(path)
+    first.close()
+    path.unlink()
+
+    second = _open(path)
+    names = {row[0] for row in second.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert TABLES.issubset(names)
+    second.close()

--- a/tests/hermes_cli/test_roadmaps_plan_parser.py
+++ b/tests/hermes_cli/test_roadmaps_plan_parser.py
@@ -1,0 +1,533 @@
+"""Tests for the Roadmaps plan parser (T5c, Vision session).
+
+``parse_plan`` turns the agent's strict JSON plan document (or the
+documented, less-reliable Markdown fallback) into a validated, normalized
+payload ready for ``RoadmapsWriter.create_plan``.  Validation errors raise
+:class:`PlanParseError` with structured messages (field, index, and
+line/column when available) so the Vision agent can rework the plan guided
+by the error.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import projects_db
+from hermes_cli import roadmaps_plan_parser as plan_parser_mod
+from hermes_cli.roadmaps_plan_parser import PlanParseError, parse_plan
+from hermes_cli.roadmaps_writer import RoadmapsWriter
+
+VALID_PLAN = """{
+  "title": "Plan Vision",
+  "purpose": "La meilleure voie pour la roadmap",
+  "nodes": [
+    {"node_id": "obj", "kind": "objective", "title": "Objectif"},
+    {"node_id": "ph1", "kind": "phase", "title": "Phase 1", "parent_node_id": "obj"},
+    {"node_id": "ms1", "kind": "milestone", "title": "Jalon 1", "parent_node_id": "ph1"},
+    {"node_id": "st1", "kind": "step", "title": "Étape 1", "parent_node_id": "ms1",
+     "state": "ready", "progress": 20}
+  ],
+  "relations": [
+    {"relation_id": "r1", "from_node_id": "st1", "to_node_id": "ms1",
+     "kind": "depends_on", "reason": "le jalon gate l'étape"}
+  ],
+  "todos": [
+    {"todo_id": "t1", "node_id": "st1", "title": "Faire X", "position": 0},
+    {"todo_id": "t2", "title": "Tâche globale"}
+  ]
+}"""
+
+
+def _node_ids(payload: dict) -> list[str]:
+    return [n["node_id"] for n in payload["nodes"]]
+
+
+# ── strict JSON: happy paths ────────────────────────────────────────────────
+
+
+def test_parse_plan_strict_json_ok():
+    payload = parse_plan(VALID_PLAN)
+    assert payload["title"] == "Plan Vision"
+    assert payload["purpose"] == "La meilleure voie pour la roadmap"
+    assert _node_ids(payload) == ["obj", "ph1", "ms1", "st1"]
+    assert len(payload["relations"]) == 1
+    assert len(payload["todos"]) == 2
+    # Payload carries the source + actor for the create_plan call.
+    assert payload["source"] == "vision"
+    assert payload["actor"] == "user"
+
+
+def test_parse_plan_json_in_code_fence():
+    text = "Voici le plan :\n```json\n" + VALID_PLAN + "\n```\nFin."
+    payload = parse_plan(text)
+    assert payload["title"] == "Plan Vision"
+    assert _node_ids(payload) == ["obj", "ph1", "ms1", "st1"]
+
+
+def test_parse_plan_pure_json_text_without_fence():
+    payload = parse_plan(VALID_PLAN)
+    assert payload["nodes"][0]["node_id"] == "obj"
+
+
+def test_parse_plan_normalizes_defaults():
+    text = """{
+      "title": "P",
+      "nodes": [
+        {"node_id": "a", "kind": "step", "title": "A"}
+      ],
+      "relations": [],
+      "todos": []
+    }"""
+    payload = parse_plan(text)
+    node = payload["nodes"][0]
+    assert node["state"] == "planned"
+    assert node["progress"] == 0
+    assert node["parent_node_id"] is None
+    assert node["description"] is None
+    assert node["owner_agent"] is None
+    assert node["block_reason"] is None
+
+
+def test_parse_plan_keeps_explicit_state_and_progress():
+    payload = parse_plan(VALID_PLAN)
+    st1 = [n for n in payload["nodes"] if n["node_id"] == "st1"][0]
+    assert st1["state"] == "ready"
+    assert st1["progress"] == 20
+    relation = payload["relations"][0]
+    assert relation["state"] == "active"
+    assert relation["reason"] == "le jalon gate l'étape"
+    todo = payload["todos"][0]
+    assert todo["state"] == "open"
+    assert todo["position"] == 0
+    assert payload["todos"][1]["node_id"] is None
+
+
+# ── strict JSON: validation rejections ──────────────────────────────────────
+
+
+def test_parse_plan_rejects_empty_title():
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan('{"title": "   ", "nodes": [], "relations": [], "todos": []}')
+    assert "title" in str(exc.value)
+    assert exc.value.field == "title"
+
+
+def test_parse_plan_rejects_missing_title():
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan('{"nodes": [], "relations": [], "todos": []}')
+    assert "title" in str(exc.value)
+
+
+def test_parse_plan_rejects_invalid_kind():
+    text = '{"title": "P", "nodes": [{"node_id": "a", "kind": "bogus", "title": "A"}]}'
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert "kind" in str(exc.value)
+    assert exc.value.field == "nodes[0].kind"
+
+
+def test_parse_plan_rejects_unknown_parent():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "phase", "title": "A", '
+            '"parent_node_id": "ghost"}]}')
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert "parent" in str(exc.value).lower()
+    assert exc.value.field == "nodes[0].parent_node_id"
+
+
+def test_parse_plan_rejects_self_parent():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "phase", "title": "A", '
+            '"parent_node_id": "a"}]}')
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert "itself" in str(exc.value) or "self" in str(exc.value).lower()
+
+
+def test_parse_plan_rejects_parent_cycle():
+    text = ('{"title": "P", "nodes": ['
+            '{"node_id": "a", "kind": "phase", "title": "A", "parent_node_id": "b"},'
+            '{"node_id": "b", "kind": "phase", "title": "B", "parent_node_id": "a"}]}')
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert "cycle" in str(exc.value).lower()
+
+
+def test_parse_plan_rejects_orphan_relation():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "A"}], '
+            '"relations": [{"relation_id": "r1", "from_node_id": "a", '
+            '"to_node_id": "ghost", "kind": "depends_on"}]}')
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert "relation" in str(exc.value).lower()
+    assert exc.value.field == "relations[0].to_node_id"
+
+
+def test_parse_plan_rejects_self_relation():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "A"}], '
+            '"relations": [{"relation_id": "r1", "from_node_id": "a", '
+            '"to_node_id": "a", "kind": "depends_on"}]}')
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert "same" in str(exc.value).lower() or "differ" in str(exc.value).lower()
+
+
+def test_parse_plan_rejects_invalid_relation_kind():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "A"},'
+            '{"node_id": "b", "kind": "step", "title": "B"}], '
+            '"relations": [{"relation_id": "r1", "from_node_id": "a", '
+            '"to_node_id": "b", "kind": "mystifies"}]}')
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert exc.value.field == "relations[0].kind"
+
+
+def test_parse_plan_rejects_unknown_todo_node():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "A"}], '
+            '"todos": [{"todo_id": "t1", "node_id": "ghost", "title": "Do"}]}')
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert "todo" in str(exc.value).lower()
+    assert exc.value.field == "todos[0].node_id"
+
+
+def test_parse_plan_rejects_duplicate_node_id():
+    text = ('{"title": "P", "nodes": ['
+            '{"node_id": "a", "kind": "step", "title": "A"},'
+            '{"node_id": "a", "kind": "step", "title": "B"}]}')
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert "duplicate" in str(exc.value).lower()
+    assert exc.value.field == "nodes[1].node_id"
+
+
+def test_parse_plan_rejects_duplicate_relation_id():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "A"},'
+            '{"node_id": "b", "kind": "step", "title": "B"}], '
+            '"relations": ['
+            '{"relation_id": "r1", "from_node_id": "a", "to_node_id": "b", "kind": "depends_on"},'
+            '{"relation_id": "r1", "from_node_id": "b", "to_node_id": "a", "kind": "depends_on"}]}')
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert "duplicate" in str(exc.value).lower()
+    assert exc.value.field == "relations[1].relation_id"
+
+
+def test_parse_plan_rejects_empty_node_title():
+    text = '{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "  "}]}'
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert exc.value.field == "nodes[0].title"
+
+
+def test_parse_plan_rejects_blank_node_id():
+    text = '{"title": "P", "nodes": [{"node_id": "  ", "kind": "step", "title": "A"}]}'
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert exc.value.field == "nodes[0].node_id"
+
+
+def test_parse_plan_rejects_invalid_state():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "A", '
+            '"state": "flying"}]}')
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert exc.value.field == "nodes[0].state"
+
+
+def test_parse_plan_rejects_invalid_progress():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "A", '
+            '"progress": 150}]}')
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert exc.value.field == "nodes[0].progress"
+
+
+def test_parse_plan_rejects_negative_position():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "A"}], '
+            '"todos": [{"todo_id": "t1", "node_id": "a", "title": "Do", "position": -1}]}')
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert exc.value.field == "todos[0].position"
+
+
+def test_parse_plan_rejects_non_json():
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan("Ceci n'est pas du JSON du tout, juste du texte bavard.")
+    assert exc.value.line is None  # semantic failure, not a JSON syntax error
+    assert "json" in str(exc.value).lower() or "plan" in str(exc.value).lower()
+
+
+def test_parse_plan_json_syntax_error_carries_line_and_column():
+    text = '{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "A",}]}'
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert exc.value.line is not None
+    assert exc.value.column is not None
+    assert "line" in str(exc.value).lower()
+
+
+# ── normalization: generated ids + content dedupe ───────────────────────────
+
+
+def test_parse_plan_generates_missing_node_ids_with_n_prefix():
+    text = ('{"title": "P", "nodes": ['
+            '{"kind": "objective", "title": "Obj"},'
+            '{"kind": "step", "title": "S", "parent_node_id": "n_0001"}]}')
+    payload = parse_plan(text)
+    ids = _node_ids(payload)
+    assert len(set(ids)) == 2
+    assert all(i.startswith("n_") for i in ids)
+    assert payload["nodes"][1]["parent_node_id"] == payload["nodes"][0]["node_id"]
+
+
+def test_parse_plan_generates_missing_relation_and_todo_ids():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "A"},'
+            '{"node_id": "b", "kind": "step", "title": "B"}], '
+            '"relations": [{"from_node_id": "a", "to_node_id": "b", "kind": "depends_on"}], '
+            '"todos": [{"node_id": "a", "title": "Do"}]}')
+    payload = parse_plan(text)
+    assert payload["relations"][0]["relation_id"].startswith("r_")
+    assert payload["todos"][0]["todo_id"].startswith("t_")
+    assert payload["todos"][0]["state"] == "open"
+    assert payload["todos"][0]["position"] == 0
+
+
+def test_parse_plan_keeps_provided_ids_untouched():
+    payload = parse_plan(VALID_PLAN)
+    assert _node_ids(payload) == ["obj", "ph1", "ms1", "st1"]
+    assert payload["relations"][0]["relation_id"] == "r1"
+    assert [t["todo_id"] for t in payload["todos"]] == ["t1", "t2"]
+
+
+def test_parse_plan_dedupes_identical_relations():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "A"},'
+            '{"node_id": "b", "kind": "step", "title": "B"}], '
+            '"relations": ['
+            '{"relation_id": "r1", "from_node_id": "a", "to_node_id": "b", "kind": "depends_on"},'
+            '{"relation_id": "r2", "from_node_id": "a", "to_node_id": "b", "kind": "depends_on"}]}')
+    payload = parse_plan(text)
+    assert len(payload["relations"]) == 1
+    assert payload["relations"][0]["relation_id"] == "r1"
+
+
+def test_parse_plan_dedupes_identical_todos():
+    text = ('{"title": "P", "nodes": [{"node_id": "a", "kind": "step", "title": "A"}], '
+            '"todos": ['
+            '{"todo_id": "t1", "node_id": "a", "title": "Do"},'
+            '{"todo_id": "t2", "node_id": "a", "title": "Do"}]}')
+    payload = parse_plan(text)
+    assert len(payload["todos"]) == 1
+    assert payload["todos"][0]["todo_id"] == "t1"
+
+
+# ── markdown fallback (documented, less reliable) ───────────────────────────
+
+
+def test_parse_plan_markdown_fallback_documented_behavior():
+    """The agent MUST emit strict JSON; Markdown is a documented fallback.
+
+    Grammar (documented): ``# Title`` plan title, ``## <kind>: <title>``
+    nodes (kind objective|phase|milestone|step|decision; heading level also
+    maps 2→phase, 3→milestone, 4→step, 5→decision), ``- [ ]`` todos
+    attached to the most recent node, ``- <kind>: A -> B`` relations
+    resolved by unique node title.  IDs are generated deterministically.
+    """
+    text = """# Plan Markdown
+## objective: Objectif
+## phase: Phase 1
+### milestone: Jalon 1
+#### step: Étape 1
+- [ ] Faire X
+- [x] Déjà fait
+- depends_on: Étape 1 -> Jalon 1
+"""
+    payload = parse_plan(text)
+    assert payload["title"] == "Plan Markdown"
+    kinds = [n["kind"] for n in payload["nodes"]]
+    assert kinds == ["objective", "phase", "milestone", "step"]
+    assert payload["nodes"][3]["parent_node_id"] == payload["nodes"][2]["node_id"]
+    assert [t["title"] for t in payload["todos"]] == ["Faire X", "Déjà fait"]
+    assert payload["todos"][0]["state"] == "open"
+    assert payload["todos"][1]["state"] == "done"
+    assert payload["todos"][0]["node_id"] == payload["nodes"][3]["node_id"]
+    assert payload["relations"][0]["kind"] == "depends_on"
+    assert payload["relations"][0]["from_node_id"] == payload["nodes"][3]["node_id"]
+    assert payload["relations"][0]["to_node_id"] == payload["nodes"][2]["node_id"]
+
+
+def test_parse_plan_markdown_fallback_requires_nodes():
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan("# Just a title, no nodes at all")
+    assert "node" in str(exc.value).lower()
+
+
+# ── payload shape ready for plans.create ────────────────────────────────────
+
+
+def test_parse_plan_payload_is_ready_for_create_plan():
+    payload = parse_plan(VALID_PLAN, source="vision-test", default_actor="pierre")
+    # Every node/relation/todo key the writer's validator normalizes is present.
+    for node in payload["nodes"]:
+        for key in ("node_id", "kind", "title", "description", "parent_node_id",
+                    "state", "progress", "owner_agent", "block_reason"):
+            assert key in node
+    for relation in payload["relations"]:
+        for key in ("relation_id", "from_node_id", "to_node_id", "kind",
+                    "state", "reason"):
+            assert key in relation
+    for todo in payload["todos"]:
+        for key in ("todo_id", "node_id", "title", "state", "position"):
+            assert key in todo
+    assert payload["source"] == "vision-test"
+    assert payload["actor"] == "pierre"
+
+
+# ── integration: parse → RoadmapsWriter.create_plan on a real temp DB ───────
+
+
+def seed(path: Path) -> None:
+    conn = projects_db.connect(path)
+    conn.execute("INSERT INTO projects(id, slug, name, created_at) VALUES ('p', 'p', 'P', 1)")
+    conn.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("prof", "p", "r", "Roadmap", None, "draft", None, "creator", "creator", 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("prof", "p", "r", 1, "draft", "seed", None, "creator", 1, None),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_parse_plan_to_create_plan_integration(tmp_path: Path):
+    path = tmp_path / "projects.db"
+    seed(path)
+    payload = parse_plan(VALID_PLAN)
+    result = RoadmapsWriter(path).create_plan(
+        "prof", "p", "r", payload["actor"],
+        nodes=payload["nodes"], relations=payload["relations"],
+        todos=payload["todos"], source=payload["source"],
+    )
+    assert result["success"] is True
+    assert result["version"] == 2  # version 1 reserved by roadmaps.create
+    assert result["state"] == "proposed"
+    assert result["counts"] == {"nodes": 4, "relations": 1, "todos": 2}
+    # The version's content is persisted: read it back from the store.
+    conn = projects_db.connect(path)
+    n = conn.execute(
+        "SELECT COUNT(*) AS n FROM roadmap_nodes "
+        "WHERE profile_id='prof' AND project_id='p' AND roadmap_id='r' AND version=2"
+    ).fetchone()["n"]
+    conn.close()
+    assert n == 4
+
+
+# ── hardening: input limits, recursion safety, O(n) markdown (gate 2026-08-15) ──
+
+
+def test_parse_plan_rejects_oversized_input():
+    purpose = "x" * (plan_parser_mod.MAX_PLAN_TEXT_BYTES + 1)
+    text = json.dumps(
+        {"title": "P", "purpose": purpose, "nodes": [], "relations": [], "todos": []}
+    )
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert exc.value.field == "input"
+    assert "limit" in str(exc.value) or "bytes" in str(exc.value)
+
+
+def test_parse_plan_accepts_input_just_under_size_limit():
+    # The size gate must be off-by-one safe: a document just under the limit
+    # reaches semantic validation (fails on empty nodes, not on size).
+    purpose = "x" * (plan_parser_mod.MAX_PLAN_TEXT_BYTES - 512)  # wrapper headroom
+    text = json.dumps(
+        {"title": "P", "purpose": purpose, "nodes": [], "relations": [], "todos": []}
+    )
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert exc.value.field != "input"
+
+
+def test_parse_plan_rejects_deeply_nested_json():
+    for brackets in ("[]", "{}"):
+        text = brackets[0] * 5000 + brackets[1] * 5000
+        with pytest.raises(PlanParseError) as exc:
+            parse_plan(text)
+        assert exc.value.field == "input"
+        assert "nested" in str(exc.value).lower()
+
+
+def _reversed_chain_nodes(count: int) -> list[dict]:
+    # Declared deepest-first so DFS starts at the bottom of the parent chain:
+    # the recursive cycle detection used to overflow the stack on this shape.
+    return [
+        {
+            "node_id": f"n{i}",
+            "kind": "step",
+            "title": f"S{i}",
+            "parent_node_id": None if i == 0 else f"n{i-1}",
+        }
+        for i in range(count - 1, -1, -1)
+    ]
+
+
+def test_parse_plan_long_parent_chain_does_not_overflow_stack(monkeypatch):
+    monkeypatch.setattr(plan_parser_mod, "MAX_PLAN_NODES", 10_000)
+    text = json.dumps(
+        {"title": "P", "nodes": _reversed_chain_nodes(3000), "relations": [], "todos": []}
+    )
+    payload = parse_plan(text)  # a RecursionError would fail the test
+    assert len(payload["nodes"]) == 3000
+
+
+def test_parse_plan_long_parent_chain_cycle_is_structured(monkeypatch):
+    monkeypatch.setattr(plan_parser_mod, "MAX_PLAN_NODES", 10_000)
+    nodes = _reversed_chain_nodes(3000)
+    nodes[-1]["parent_node_id"] = "n2999"  # close the 3000-long cycle
+    text = json.dumps({"title": "P", "nodes": nodes, "relations": [], "todos": []})
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert "cycle" in str(exc.value).lower()
+    assert exc.value.field == "parent_node_id"
+    assert exc.value.index is not None
+
+
+def test_parse_plan_rejects_too_many_nodes():
+    nodes = [
+        {"node_id": f"n{i}", "kind": "step", "title": f"S{i}"}
+        for i in range(plan_parser_mod.MAX_PLAN_NODES + 1)
+    ]
+    text = json.dumps({"title": "P", "nodes": nodes, "relations": [], "todos": []})
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan(text)
+    assert exc.value.field == "input"
+    assert "node" in str(exc.value).lower()
+
+
+def test_parse_plan_rejects_too_many_markdown_nodes():
+    lines = ["# P", "## objective: Obj"]
+    lines += [f"### step: S{i}" for i in range(plan_parser_mod.MAX_PLAN_NODES + 1)]
+    with pytest.raises(PlanParseError) as exc:
+        parse_plan("\n".join(lines))
+    assert exc.value.field == "input"
+    assert "node" in str(exc.value).lower()
+
+
+def test_parse_plan_markdown_scales_linearly(monkeypatch):
+    monkeypatch.setattr(plan_parser_mod, "MAX_PLAN_NODES", 20_000)
+    count = 8_000
+    lines = ["# Plan Massif"] + [f"## step: Étape {i}" for i in range(count)]
+    start = time.monotonic()
+    payload = parse_plan("\n".join(lines))
+    elapsed = time.monotonic() - start
+    assert len(payload["nodes"]) == count
+    assert len({n["node_id"] for n in payload["nodes"]}) == count
+    # Loose bound on purpose: the O(n^2) id-generation loop took ~7.6s at
+    # 8k nodes; the O(n) version finishes in well under a second.  The
+    # structural asserts (count + unique ids) are the primary contract.
+    assert elapsed < 5.0, f"markdown parse took {elapsed:.2f}s — expected O(n)"

--- a/tests/hermes_cli/test_roadmaps_planning_rules.py
+++ b/tests/hermes_cli/test_roadmaps_planning_rules.py
@@ -1,0 +1,132 @@
+"""Tests for the versioned Roadmaps planning rules (T5c, Vision session).
+
+The rules module is the single source of truth for the system prompt the
+Vision session agent receives: objective, constraints, strict JSON output
+schema, quality rules, and behavior rules. Rules are versioned: changing
+them produces a new version, never a silent edit.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_cli.roadmaps_planning_rules import (
+    PLANNING_RULES_VERSION,
+    PlanningRulesVersionError,
+    get_planning_rules,
+)
+
+
+def test_planning_rules_version_constant_is_current():
+    assert isinstance(PLANNING_RULES_VERSION, str)
+    assert PLANNING_RULES_VERSION == "1.0"
+
+
+def test_get_planning_rules_default_returns_current_version():
+    rules = get_planning_rules()
+    assert rules["version"] == PLANNING_RULES_VERSION
+    assert rules["version"] == "1.0"
+
+
+def test_get_planning_rules_explicit_current_version():
+    rules = get_planning_rules("1.0")
+    assert rules["version"] == "1.0"
+
+
+def test_get_planning_rules_blank_version_falls_back_to_current():
+    assert get_planning_rules("")["version"] == PLANNING_RULES_VERSION
+    assert get_planning_rules("   ")["version"] == PLANNING_RULES_VERSION
+
+
+@pytest.mark.parametrize("bad", ["0.9", "2.0", "v1", "1.0.1", "garbage", 1])
+def test_get_planning_rules_unknown_version_raises_clean_error(bad):
+    with pytest.raises(PlanningRulesVersionError) as exc:
+        get_planning_rules(bad)
+    message = str(exc.value)
+    assert "version" in message
+    assert repr(bad) in message
+
+
+def test_get_planning_rules_none_means_current_version():
+    # None (the API default) selects the current version — it is not an error.
+    assert get_planning_rules(None)["version"] == PLANNING_RULES_VERSION
+
+
+def test_planning_rules_prompt_is_a_non_empty_string():
+    rules = get_planning_rules()
+    prompt = rules["prompt"]
+    assert isinstance(prompt, str)
+    assert len(prompt) > 500  # a real system prompt, not a stub
+
+
+def test_planning_rules_prompt_declares_objective():
+    prompt = get_planning_rules()["prompt"]
+    assert "objectif" in prompt.lower() or "objective" in prompt.lower()
+    # The objective is to help produce an impeccable, solid plan — the best path.
+    assert any(word in prompt.lower() for word in ("impeccable", "meilleure voie", "best path", "solide"))
+
+
+def test_planning_rules_prompt_declares_constraints():
+    prompt = get_planning_rules()["prompt"]
+    lowered = prompt.lower()
+    assert "contrainte" in lowered or "constraint" in lowered
+    # Constraints cover scope: roadmap, project, context.
+    assert any(word in lowered for word in ("scope", "roadmap", "projet", "project"))
+    assert any(word in lowered for word in ("contexte", "context"))
+
+
+def test_planning_rules_prompt_declares_strict_json_output_structure():
+    prompt = get_planning_rules()["prompt"]
+    lowered = prompt.lower()
+    assert "json" in lowered
+    assert "```json" in prompt or "``` json" in prompt
+    # The strict schema keys are all present.
+    for key in ("nodes", "relations", "todos", "node_id", "kind", "title",
+                "relation_id", "from_node_id", "to_node_id", "todo_id"):
+        assert key in prompt
+    assert "objective" in prompt
+    assert "phase" in prompt
+    assert "milestone" in prompt
+    assert "step" in prompt
+    assert "decision" in prompt
+
+
+def test_planning_rules_prompt_declares_quality_rules():
+    prompt = get_planning_rules()["prompt"]
+    lowered = prompt.lower()
+    assert "qualité" in lowered or "quality" in lowered
+    # Quality rules: coherent steps, explicit dependencies, no duplicates,
+    # measurable milestones, controlled vocabulary, plan transitions.
+    assert any(word in lowered for word in ("dépendance", "dependenc", "depends_on"))
+    assert any(word in lowered for word in ("doublon", "duplicat"))
+    assert any(word in lowered for word in ("mesurable", "measurable", "jalon"))
+    assert any(word in lowered for word in ("vocabulaire", "vocabulary", "milestone/epic/task"))
+    assert any(word in lowered for word in ("transition", "proposé", "validé", "activé"))
+
+
+def test_planning_rules_prompt_declares_behavior_rules():
+    prompt = get_planning_rules()["prompt"]
+    lowered = prompt.lower()
+    assert "comportement" in lowered or "behavior" in lowered or "behaviour" in lowered
+    # Behavior rules: never invent facts, ask for clarification when ambiguous,
+    # propose alternatives, refactor/redo the plan when needed.
+    assert "jamais" in lowered and any(word in lowered for word in ("inventer", "invente", "invent"))
+    assert any(word in lowered for word in ("clarification", "ambigu", "préciser", "demander"))
+    assert any(word in lowered for word in ("alternative", "option"))
+    assert any(word in lowered for word in ("refondre", "rework", "reformuler", "récrire", "réécrire"))
+
+
+def test_planning_rules_are_json_serializable():
+    # The RPC returns the rules payload; it must survive json.dumps untouched
+    # (no secrets, no non-serializable objects).
+    rules = get_planning_rules()
+    round_tripped = json.loads(json.dumps(rules))
+    assert round_tripped == rules
+    assert round_tripped["version"] == PLANNING_RULES_VERSION
+
+
+def test_planning_rules_are_immutable_per_version():
+    # Same version → identical prompt bytes (a version is a frozen snapshot).
+    assert get_planning_rules("1.0")["prompt"] == get_planning_rules()["prompt"]

--- a/tests/hermes_cli/test_roadmaps_plans.py
+++ b/tests/hermes_cli/test_roadmaps_plans.py
@@ -1,0 +1,641 @@
+"""Tests for roadmap CRUD + plan governance (T5b): create/update/archive
+roadmap, plans create/list/get/activate/validate, atomic rollback."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import projects_db
+from hermes_cli.roadmaps_service import RoadmapsService
+from hermes_cli.roadmaps_writer import (
+    InvalidRoadmapPlanTransitionError,
+    InvalidRoadmapTransitionError,
+    RoadmapExistsError,
+    RoadmapNotFoundError,
+    RoadmapProjectNotFoundError,
+    RoadmapVersionExistsError,
+    RoadmapVersionNotFoundError,
+    RoadmapsWriter,
+    StaleRoadmapVersionError,
+)
+
+
+def seed(
+    path: Path,
+    *,
+    profile: str = "prof",
+    project: str = "p1",
+    roadmap_id: str = "r1",
+    with_roadmap: bool = True,
+    lifecycle: str = "draft",
+    active_version: int | None = None,
+) -> None:
+    """Seed a project row and optionally a roadmap with its version 1."""
+    conn = projects_db.connect(path)
+    conn.execute(
+        "INSERT INTO projects(id, slug, name, created_at) VALUES (?, ?, ?, 1)",
+        (project, project, project),
+    )
+    if with_roadmap:
+        conn.execute(
+            "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (profile, project, roadmap_id, "Roadmap", None, lifecycle,
+             active_version, "creator", "creator", 1, 1),
+        )
+        conn.execute(
+            "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (profile, project, roadmap_id, 1,
+             "validated" if active_version else "draft",
+             "seed", None, "creator", 1, None),
+        )
+    conn.commit()
+    conn.close()
+
+
+def count(
+    path: Path,
+    table: str,
+    *,
+    profile: str = "prof",
+    project: str = "p1",
+    roadmap: str = "r1",
+    version: int | None = None,
+) -> int:
+    conn = projects_db.connect(path)
+    sql = (
+        f"SELECT COUNT(*) AS n FROM {table} "
+        "WHERE profile_id=? AND project_id=? AND roadmap_id=?"
+    )
+    args = [profile, project, roadmap]
+    if version is not None:
+        sql += " AND version=?"
+        args.append(version)
+    n = conn.execute(sql, args).fetchone()["n"]
+    conn.close()
+    return n
+
+
+def roadmap_row(path: Path, roadmap_id: str = "r1") -> dict:
+    conn = projects_db.connect(path)
+    row = conn.execute(
+        "SELECT * FROM roadmaps WHERE roadmap_id=?", (roadmap_id,)
+    ).fetchone()
+    conn.close()
+    return dict(row)
+
+
+def version_row(path: Path, version: int, roadmap_id: str = "r1") -> dict:
+    conn = projects_db.connect(path)
+    row = conn.execute(
+        "SELECT * FROM roadmap_versions WHERE roadmap_id=? AND version=?",
+        (roadmap_id, version),
+    ).fetchone()
+    conn.close()
+    return dict(row)
+
+
+def plan_payload(version: int = 2) -> dict:
+    """A valid full plan payload: 3 nodes, 2 relations, 2 todos."""
+    return {
+        "version": version,
+        "nodes": [
+            {"node_id": "obj", "kind": "objective", "title": "Objective"},
+            {"node_id": "phase-1", "kind": "phase", "title": "Phase 1",
+             "parent_node_id": "obj", "description": "First phase"},
+            {"node_id": "step-1", "kind": "step", "title": "Step 1",
+             "parent_node_id": "phase-1", "state": "ready",
+             "owner_agent": "agent-a"},
+        ],
+        "relations": [
+            {"relation_id": "rel-1", "from_node_id": "step-1",
+             "to_node_id": "phase-1", "kind": "depends_on",
+             "reason": "phase gates the step"},
+        ],
+        "todos": [
+            {"todo_id": "todo-1", "node_id": "step-1", "title": "Do it"},
+            {"todo_id": "todo-2", "title": "Unattached"},
+        ],
+    }
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "projects.db"
+    seed(path, with_roadmap=False)
+    return path
+
+
+@pytest.fixture()
+def roadmap_path(tmp_path: Path) -> Path:
+    path = tmp_path / "projects.db"
+    seed(path)
+    return path
+
+
+# ── roadmaps.create ──────────────────────────────────────────────────────────
+
+
+def test_create_roadmap_inserts_roadmap_and_version_one(db_path: Path):
+    result = RoadmapsWriter(db_path).create_roadmap(
+        "prof", "p1", "My roadmap", "pierre"
+    )
+    assert result["success"] is True
+    assert result["scope"] == {
+        "profile_id": "prof", "project_id": "p1", "roadmap_id": result["roadmap_id"],
+    }
+    assert result["roadmap_id"].startswith("r_")
+    assert result["version"] == 1
+
+    row = roadmap_row(db_path, result["roadmap_id"])
+    assert row["title"] == "My roadmap"
+    assert row["purpose"] is None
+    assert row["lifecycle_state"] == "draft"
+    assert row["active_version"] is None
+    assert row["created_by"] == "pierre"
+    assert row["updated_by"] == "pierre"
+    assert count(db_path, "roadmap_versions", roadmap=result["roadmap_id"]) == 1
+    assert version_row(db_path, 1, roadmap_id=result["roadmap_id"])["state"] == "draft"
+
+
+def test_create_roadmap_uses_provided_roadmap_id_deterministically(db_path: Path):
+    result = RoadmapsWriter(db_path).create_roadmap(
+        "prof", "p1", "Title", "pierre", roadmap_id="r-custom"
+    )
+    assert result["roadmap_id"] == "r-custom"
+    assert roadmap_row(db_path, "r-custom")["roadmap_id"] == "r-custom"
+
+
+def test_create_roadmap_rejects_blank_title_and_scope(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    with pytest.raises(ValueError, match="title"):
+        writer.create_roadmap("prof", "p1", "   ", "pierre")
+    with pytest.raises(ValueError, match="profile_id"):
+        writer.create_roadmap("", "p1", "Title", "pierre")
+    with pytest.raises(ValueError, match="project_id"):
+        writer.create_roadmap("prof", "", "Title", "pierre")
+
+
+def test_create_roadmap_rejects_overlong_title_and_purpose(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    with pytest.raises(ValueError, match="title"):
+        writer.create_roadmap("prof", "p1", "x" * 201, "pierre")
+    with pytest.raises(ValueError, match="purpose"):
+        writer.create_roadmap(
+            "prof", "p1", "Title", "pierre", purpose="x" * 2001
+        )
+
+
+def test_create_roadmap_rejects_unknown_lifecycle_state(db_path: Path):
+    with pytest.raises(ValueError, match="lifecycle_state"):
+        RoadmapsWriter(db_path).create_roadmap(
+            "prof", "p1", "Title", "pierre", lifecycle_state="bogus"
+        )
+
+
+@pytest.mark.parametrize(
+    "state", ["proposed", "validated", "in_progress", "blocked", "completed", "archived"]
+)
+def test_create_roadmap_rejects_non_draft_lifecycle_state(db_path: Path, state: str):
+    # The lifecycle machine is strict: a roadmap is born 'draft'; jumping
+    # straight to a later state would bypass plans.validate / plans.activate
+    # / archive_roadmap. No row may be created on a rejected lifecycle.
+    with pytest.raises(ValueError, match="lifecycle_state"):
+        RoadmapsWriter(db_path).create_roadmap(
+            "prof", "p1", "Title", "pierre", lifecycle_state=state
+        )
+    assert count(db_path, "roadmaps") == 0
+
+
+def test_create_roadmap_accepts_explicit_draft_lifecycle_state(db_path: Path):
+    result = RoadmapsWriter(db_path).create_roadmap(
+        "prof", "p1", "Title", "pierre", lifecycle_state="draft"
+    )
+    assert result["success"] is True
+    assert roadmap_row(db_path, result["roadmap_id"])["lifecycle_state"] == "draft"
+
+
+def test_create_roadmap_rejects_missing_project(db_path: Path):
+    with pytest.raises(RoadmapProjectNotFoundError):
+        RoadmapsWriter(db_path).create_roadmap("prof", "nope", "Title", "pierre")
+
+
+def test_create_roadmap_duplicate_id_rejected(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    writer.create_roadmap("prof", "p1", "Title", "pierre", roadmap_id="r-x")
+    with pytest.raises(RoadmapExistsError):
+        writer.create_roadmap("prof", "p1", "Title", "pierre", roadmap_id="r-x")
+
+
+def test_create_roadmap_rolls_back_on_failure(db_path: Path):
+    before = db_path.read_bytes()
+    with pytest.raises(ValueError):
+        RoadmapsWriter(db_path).create_roadmap("prof", "p1", "  ", "pierre")
+    assert db_path.read_bytes() == before
+    assert count(db_path, "roadmaps") == 0
+
+
+# ── roadmaps.update ──────────────────────────────────────────────────────────
+
+
+def test_update_roadmap_changes_title_and_purpose(roadmap_path: Path):
+    result = RoadmapsWriter(roadmap_path).update_roadmap(
+        "prof", "p1", "r1", "pierre", 0,
+        title="Renamed", purpose="New purpose",
+    )
+    assert result["success"] is True
+    row = roadmap_row(roadmap_path)
+    assert row["title"] == "Renamed"
+    assert row["purpose"] == "New purpose"
+    # lifecycle_state is not writable through update: it stays 'draft' and
+    # only moves via plans.validate / plans.activate / roadmaps.archive.
+    assert row["lifecycle_state"] == "draft"
+    assert row["updated_by"] == "pierre"
+    assert row["updated_at"] > 1
+
+
+def test_update_roadmap_partial_fields_only(roadmap_path: Path):
+    RoadmapsWriter(roadmap_path).update_roadmap(
+        "prof", "p1", "r1", "pierre", 0, title="Only title"
+    )
+    row = roadmap_row(roadmap_path)
+    assert row["title"] == "Only title"
+    assert row["purpose"] is None
+    assert row["lifecycle_state"] == "draft"
+
+
+def test_update_roadmap_requires_expected_version(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    with pytest.raises(StaleRoadmapVersionError):
+        writer.update_roadmap("prof", "p1", "r1", "pierre", 99, title="X")
+    with pytest.raises(ValueError, match="expected_version"):
+        writer.update_roadmap("prof", "p1", "r1", "pierre", None, title="X")
+    assert roadmap_row(roadmap_path)["title"] == "Roadmap"
+
+
+def test_update_roadmap_unknown_roadmap_and_nothing_to_update(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    with pytest.raises(RoadmapNotFoundError):
+        writer.update_roadmap("prof", "p1", "r-missing", "pierre", 0, title="X")
+    with pytest.raises(ValueError, match="nothing to update"):
+        writer.update_roadmap("prof", "p1", "r1", "pierre", 0)
+
+
+def test_update_roadmap_rejects_invalid_lifecycle(roadmap_path: Path):
+    with pytest.raises(ValueError, match="lifecycle_state"):
+        RoadmapsWriter(roadmap_path).update_roadmap(
+            "prof", "p1", "r1", "pierre", 0, lifecycle_state="bogus"
+        )
+
+
+@pytest.mark.parametrize("state", ["proposed", "completed", "archived"])
+def test_update_roadmap_rejects_lifecycle_state_direct_writes(
+    roadmap_path: Path, state: str
+):
+    # Transitions are exclusive to the dedicated ops: setting 'completed'
+    # via update would bypass plans.validate / plans.activate, and setting
+    # 'archived' would bypass archive_roadmap. Direct writes are rejected
+    # and leave the row untouched.
+    with pytest.raises(ValueError, match="lifecycle_state"):
+        RoadmapsWriter(roadmap_path).update_roadmap(
+            "prof", "p1", "r1", "pierre", 0, lifecycle_state=state
+        )
+    assert roadmap_row(roadmap_path)["lifecycle_state"] == "draft"
+
+
+# ── roadmaps.archive ─────────────────────────────────────────────────────────
+
+
+def test_archive_roadmap_sets_archived(roadmap_path: Path):
+    result = RoadmapsWriter(roadmap_path).archive_roadmap(
+        "prof", "p1", "r1", "pierre", 0
+    )
+    assert result["success"] is True
+    row = roadmap_row(roadmap_path)
+    assert row["lifecycle_state"] == "archived"
+    assert row["updated_by"] == "pierre"
+    # Versions stay intact: archive preserves the plan history.
+    assert count(roadmap_path, "roadmap_versions") == 1
+
+
+def test_archive_roadmap_twice_rejected(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    writer.archive_roadmap("prof", "p1", "r1", "pierre", 0)
+    with pytest.raises(InvalidRoadmapTransitionError):
+        writer.archive_roadmap("prof", "p1", "r1", "pierre", 0)
+
+
+def test_archive_roadmap_unknown_or_stale(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    with pytest.raises(RoadmapNotFoundError):
+        writer.archive_roadmap("prof", "p1", "r-missing", "pierre", 0)
+    with pytest.raises(StaleRoadmapVersionError):
+        writer.archive_roadmap("prof", "p1", "r1", "pierre", 99)
+
+
+# ── plans.create ─────────────────────────────────────────────────────────────
+
+
+def test_create_plan_inserts_version_nodes_relations_todos(roadmap_path: Path):
+    payload = plan_payload(version=2)
+    result = RoadmapsWriter(roadmap_path).create_plan(
+        "prof", "p1", "r1", "agent-a", **payload
+    )
+    assert result["success"] is True
+    assert result["version"] == 2
+    assert result["state"] == "proposed"
+    assert result["counts"] == {"nodes": 3, "relations": 1, "todos": 2}
+    assert len(result["content_hash"]) == 64
+
+    vrow = version_row(roadmap_path, 2)
+    assert vrow["state"] == "proposed"
+    assert vrow["created_by"] == "agent-a"
+    assert vrow["content_hash"] == result["content_hash"]
+    assert count(roadmap_path, "roadmap_nodes", version=2) == 3
+    assert count(roadmap_path, "roadmap_relations", version=2) == 1
+    assert count(roadmap_path, "roadmap_todos", version=2) == 2
+    # Roadmap lifecycle draft -> proposed; still no active version.
+    row = roadmap_row(roadmap_path)
+    assert row["lifecycle_state"] == "proposed"
+    assert row["active_version"] is None
+
+
+def test_create_plan_default_version_is_max_plus_one(roadmap_path: Path):
+    result = RoadmapsWriter(roadmap_path).create_plan(
+        "prof", "p1", "r1", "agent-a",
+        nodes=[{"node_id": "n1", "kind": "step", "title": "N1"}],
+        relations=[], todos=[],
+    )
+    # version 1 already exists (roadmaps.create marker), so default is 2.
+    assert result["version"] == 2
+
+
+def test_create_plan_rejects_duplicate_version(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    writer.create_plan("prof", "p1", "r1", "agent-a", **plan_payload(version=2))
+    with pytest.raises(RoadmapVersionExistsError):
+        writer.create_plan("prof", "p1", "r1", "agent-a", **plan_payload(version=2))
+    # Version 1 marker is also taken.
+    with pytest.raises(RoadmapVersionExistsError):
+        writer.create_plan(
+            "prof", "p1", "r1", "agent-a",
+            nodes=[{"node_id": "n1", "kind": "step", "title": "N1"}],
+            relations=[], todos=[], version=1,
+        )
+    assert count(roadmap_path, "roadmap_versions") == 2
+
+
+def test_create_plan_rolls_back_atomically_on_invalid_node(roadmap_path: Path):
+    payload = plan_payload(version=2)
+    payload["nodes"][2]["kind"] = "bogus"
+    with pytest.raises(ValueError, match="kind"):
+        RoadmapsWriter(roadmap_path).create_plan(
+            "prof", "p1", "r1", "agent-a", **payload
+        )
+    assert count(roadmap_path, "roadmap_versions") == 1
+    assert count(roadmap_path, "roadmap_nodes") == 0
+    assert count(roadmap_path, "roadmap_relations") == 0
+    assert count(roadmap_path, "roadmap_todos") == 0
+    assert roadmap_row(roadmap_path)["lifecycle_state"] == "draft"
+
+
+def test_create_plan_rejects_missing_parent_reference(roadmap_path: Path):
+    payload = plan_payload(version=2)
+    payload["nodes"][2]["parent_node_id"] = "ghost"
+    with pytest.raises(ValueError, match="parent_node_id"):
+        RoadmapsWriter(roadmap_path).create_plan(
+            "prof", "p1", "r1", "agent-a", **payload
+        )
+
+
+def test_create_plan_rejects_self_parent_and_duplicate_node_ids(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    payload = plan_payload(version=2)
+    payload["nodes"][0]["parent_node_id"] = "obj"
+    with pytest.raises(ValueError, match="parent_node_id"):
+        writer.create_plan("prof", "p1", "r1", "agent-a", **payload)
+    payload = plan_payload(version=2)
+    payload["nodes"].append(dict(payload["nodes"][0]))
+    with pytest.raises(ValueError, match="duplicate node_id"):
+        writer.create_plan("prof", "p1", "r1", "agent-a", **payload)
+
+
+def test_create_plan_rejects_relation_to_unknown_node_and_self(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    payload = plan_payload(version=2)
+    payload["relations"][0]["to_node_id"] = "ghost"
+    with pytest.raises(ValueError, match="to_node_id"):
+        writer.create_plan("prof", "p1", "r1", "agent-a", **payload)
+    payload = plan_payload(version=2)
+    payload["relations"][0]["to_node_id"] = "step-1"
+    with pytest.raises(ValueError, match="differ"):
+        writer.create_plan("prof", "p1", "r1", "agent-a", **payload)
+
+
+def test_create_plan_rejects_cyclic_relations(roadmap_path: Path):
+    payload = plan_payload(version=2)
+    payload["relations"] = [
+        {"relation_id": "a", "from_node_id": "step-1", "to_node_id": "phase-1",
+         "kind": "depends_on"},
+        {"relation_id": "b", "from_node_id": "phase-1", "to_node_id": "step-1",
+         "kind": "depends_on"},
+    ]
+    with pytest.raises(ValueError, match="cyclic relation"):
+        RoadmapsWriter(roadmap_path).create_plan(
+            "prof", "p1", "r1", "agent-a", **payload
+        )
+
+
+def test_create_plan_rejects_missing_todo_node_ref_and_blank_title(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    payload = plan_payload(version=2)
+    payload["todos"][0]["node_id"] = "ghost"
+    with pytest.raises(ValueError, match="node_id"):
+        writer.create_plan("prof", "p1", "r1", "agent-a", **payload)
+    payload = plan_payload(version=2)
+    payload["todos"][1]["title"] = "   "
+    with pytest.raises(ValueError, match="title"):
+        writer.create_plan("prof", "p1", "r1", "agent-a", **payload)
+
+
+def test_create_plan_rejects_archived_roadmap_and_unknown_roadmap(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    writer.archive_roadmap("prof", "p1", "r1", "pierre", 0)
+    with pytest.raises(InvalidRoadmapTransitionError):
+        writer.create_plan(
+            "prof", "p1", "r1", "agent-a",
+            nodes=[{"node_id": "n1", "kind": "step", "title": "N1"}],
+            relations=[], todos=[],
+        )
+    with pytest.raises(RoadmapNotFoundError):
+        writer.create_plan(
+            "prof", "p1", "r-missing", "agent-a",
+            nodes=[{"node_id": "n1", "kind": "step", "title": "N1"}],
+            relations=[], todos=[],
+        )
+
+
+# ── plans.list / plans.get (read side) ───────────────────────────────────────
+
+
+def test_plans_list_orders_by_version_desc(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    writer.create_plan("prof", "p1", "r1", "agent-a", **plan_payload(version=2))
+    writer.create_plan("prof", "p1", "r1", "agent-a", **plan_payload(version=3))
+    plans = RoadmapsService(roadmap_path).list_plans("prof", "p1", "r1")["plans"]
+    assert [p["version"] for p in plans] == [3, 2, 1]
+    assert set(plans[0]) >= {
+        "version", "state", "source", "reason", "created_by", "created_at",
+        "content_hash",
+    }
+
+
+def test_plans_list_unknown_roadmap_returns_empty(roadmap_path: Path):
+    result = RoadmapsService(roadmap_path).list_plans("prof", "p1", "r-missing")
+    assert result["plans"] == []
+    assert result["scope"]["roadmap_id"] == "r-missing"
+
+
+def test_plans_get_returns_full_version(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    writer.create_plan("prof", "p1", "r1", "agent-a", **plan_payload(version=2))
+    result = RoadmapsService(roadmap_path).get_plan("prof", "p1", "r1", 2)
+    assert result["found"] is True
+    plan = result["plan"]
+    assert plan["version"] == 2
+    assert plan["state"] == "proposed"
+    assert {n["node_id"] for n in plan["nodes"]} == {"obj", "phase-1", "step-1"}
+    assert plan["nodes"][0]["parent_node_id"] is None
+    assert len(plan["relations"]) == 1
+    assert len(plan["todos"]) == 2
+    missing = RoadmapsService(roadmap_path).get_plan("prof", "p1", "r1", 99)
+    assert missing["found"] is False
+    assert missing["plan"] is None
+
+
+# ── plans.validate / plans.activate ──────────────────────────────────────────
+
+
+def test_plans_validate_transitions_draft_and_proposed(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    result = writer.validate_plan("prof", "p1", "r1", 1, "pierre", 0)
+    assert result["state"] == "validated"
+    assert version_row(roadmap_path, 1)["state"] == "validated"
+    writer.create_plan("prof", "p1", "r1", "agent-a", **plan_payload(version=2))
+    result = writer.validate_plan("prof", "p1", "r1", 2, "pierre", 0)
+    assert result["state"] == "validated"
+    # Validated is terminal for validate.
+    with pytest.raises(InvalidRoadmapPlanTransitionError):
+        writer.validate_plan("prof", "p1", "r1", 2, "pierre", 0)
+
+
+def test_plans_validate_requires_expected_version(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    with pytest.raises(StaleRoadmapVersionError):
+        writer.validate_plan("prof", "p1", "r1", 1, "pierre", 42)
+    with pytest.raises(RoadmapVersionNotFoundError):
+        writer.validate_plan("prof", "p1", "r1", 99, "pierre", 0)
+    with pytest.raises(RoadmapNotFoundError):
+        writer.validate_plan("prof", "p1", "r-missing", 1, "pierre", 0)
+
+
+def test_plans_activate_requires_validated_version(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    writer.create_plan("prof", "p1", "r1", "agent-a", **plan_payload(version=2))
+    with pytest.raises(InvalidRoadmapPlanTransitionError):
+        writer.activate_plan("prof", "p1", "r1", 2, "pierre", 0)
+    with pytest.raises(RoadmapVersionNotFoundError):
+        writer.activate_plan("prof", "p1", "r1", 99, "pierre", 0)
+
+
+def test_plans_activate_sets_active_version_and_supersedes_previous(tmp_path: Path):
+    path = tmp_path / "projects.db"
+    seed(path, active_version=1, lifecycle="in_progress")
+    writer = RoadmapsWriter(path)
+    writer.create_plan("prof", "p1", "r1", "agent-a", **plan_payload(version=2))
+    writer.validate_plan("prof", "p1", "r1", 2, "pierre", 1)
+    result = writer.activate_plan("prof", "p1", "r1", 2, "pierre", 1)
+    assert result["success"] is True
+    assert result["active_version"] == 2
+    assert result["previous_active_version"] == 1
+    row = roadmap_row(path)
+    assert row["active_version"] == 2
+    assert row["updated_by"] == "pierre"
+    # History preserved: the previous active version is superseded.
+    assert version_row(path, 1)["state"] == "superseded"
+    assert version_row(path, 2)["state"] == "validated"
+
+
+def test_plans_activate_stale_expected_version_rejected(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    with pytest.raises(StaleRoadmapVersionError):
+        writer.activate_plan("prof", "p1", "r1", 1, "pierre", 99)
+
+
+def test_plans_activate_on_fresh_roadmap_uses_expected_zero(roadmap_path: Path):
+    writer = RoadmapsWriter(roadmap_path)
+    writer.validate_plan("prof", "p1", "r1", 1, "pierre", 0)
+    result = writer.activate_plan("prof", "p1", "r1", 1, "pierre", 0)
+    assert result["active_version"] == 1
+    row = roadmap_row(roadmap_path)
+    assert row["active_version"] == 1
+    assert row["lifecycle_state"] == "in_progress"
+
+
+def test_create_plan_deep_parent_chain_does_not_overflow(roadmap_path: Path):
+    """A ~1500-node parent chain must validate without a RecursionError.
+
+    Regression for the recursive _detect_cycle (writer): it overflowed the
+    interpreter stack on a deep acyclic parent chain, turning a valid plan
+    into a generic 503. The iterative 3-colour DFS handles it.
+    """
+    from hermes_cli.roadmaps_writer import MAX_PLAN_NODES
+
+    depth = MAX_PLAN_NODES - 1  # within the bound, but deep enough to overflow recursion
+    nodes = [{"node_id": f"n{i}", "kind": "step", "title": f"Node {i}"} for i in range(depth)]
+    # n1 -> n0 -> ... chain of parents (acyclic).
+    for i in range(1, depth):
+        nodes[i]["parent_node_id"] = f"n{i - 1}"
+    writer = RoadmapsWriter(roadmap_path)
+    result = writer.create_plan("prof", "p1", "r1", "agent-a", nodes=nodes, relations=[], todos=[])
+    assert result["state"] == "proposed"
+    assert result["counts"]["nodes"] == depth
+
+
+def test_create_plan_rejects_oversized_payloads(roadmap_path: Path):
+    """Element bounds: >MAX_PLAN_NODES/RELATIONS/TODOS is a clean 5063-style
+    ValueError, never a transaction or a crash."""
+    from hermes_cli.roadmaps_writer import MAX_PLAN_NODES, MAX_PLAN_RELATIONS, MAX_PLAN_TODOS
+
+    writer = RoadmapsWriter(roadmap_path)
+    too_many = [{"node_id": f"n{i}", "kind": "step", "title": f"N{i}"} for i in range(MAX_PLAN_NODES + 1)]
+    with pytest.raises(ValueError, match="at most"):
+        writer.create_plan("prof", "p1", "r1", "agent-a", nodes=too_many, relations=[], todos=[])
+    # relations/todos bounds are checked the same way; exercise one of them too.
+    relations = [
+        {"relation_id": f"rel{i}", "from_node_id": f"n{i}", "to_node_id": f"n{i + 1}", "kind": "depends_on"}
+        for i in range(MAX_PLAN_RELATIONS + 1)
+    ]
+    with pytest.raises(ValueError, match="at most"):
+        writer.create_plan("prof", "p1", "r1", "agent-a", nodes=[], relations=relations, todos=[])
+    # (todos bound is the same code path — covered via the shared guard.)
+
+
+def test_create_plan_rejects_path_separator_ids(roadmap_path: Path):
+    """An id containing '/' or '\\' is rejected up front, matching the pure
+    contract (src/roadmaps_contract._identifier); otherwise it becomes
+    unreachable via the REST/RPC path segment."""
+    writer = RoadmapsWriter(roadmap_path)
+    with pytest.raises(ValueError, match="path separator"):
+        writer.create_plan(
+            "prof", "p1", "r1", "agent-a",
+            nodes=[{"node_id": "a/b", "kind": "step", "title": "bad"}],
+            relations=[], todos=[],
+        )
+    with pytest.raises(ValueError, match="path separator"):
+        writer.create_plan(
+            "prof", "p1", "r1", "agent-a",
+            nodes=[{"node_id": "a\\b", "kind": "step", "title": "bad"}],
+            relations=[], todos=[],
+        )

--- a/tests/hermes_cli/test_roadmaps_service.py
+++ b/tests/hermes_cli/test_roadmaps_service.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import projects_db
+from hermes_cli.roadmaps_service import RoadmapsService, RoadmapsUnavailable
+
+
+def seed(path: Path) -> None:
+    conn = projects_db.connect(path)
+    conn.execute("INSERT INTO projects(id, slug, name, created_at) VALUES ('p1', 'one', 'One', 1)")
+    conn.execute("INSERT INTO projects(id, slug, name, created_at) VALUES ('p2', 'two', 'Two', 1)")
+    conn.execute("INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", ('prof', 'p1', 'r1', 'Roadmap', 'Purpose', 'in_progress', 1, 'a', 'b', 1, 2))
+    conn.execute("INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", ('prof', 'p1', 'r1', 1, 'validated', 'src', 'why', 'a', 1, 'hash'))
+    conn.execute("INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", ('prof', 'p1', 'r1', 1, 'n1', None, 'objective', 'Node', None, 'ready', 50, 'agent', None, 1, 2))
+    conn.execute("INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", ('prof', 'p1', 'r1', 1, 'n2', None, 'step', 'Step', None, 'planned', 0, None, None, 1, 2))
+    conn.execute("INSERT INTO roadmap_relations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", ('prof', 'p1', 'r1', 1, 'rel', 'n1', 'n2', 'blocks', 'active', None))
+    conn.execute("INSERT INTO roadmap_todos VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", ('prof', 'p1', 'r1', 1, 't1', 'n1', 'Todo', 'open', 0, 1, 2))
+    conn.commit()
+    conn.close()
+
+
+def test_service_list_filters_explicit_profile_and_project(tmp_path: Path):
+    path = tmp_path / 'projects.db'
+    seed(path)
+    service = RoadmapsService(path)
+    assert [r['roadmap_id'] for r in service.list(profile_id='prof')['roadmaps']] == ['r1']
+    assert service.list(profile_id='prof', project_id='p2') == {'roadmaps': [], 'scope': {'profile_id': 'prof', 'project_id': 'p2'}}
+    assert service.list(profile_id='other')['roadmaps'] == []
+
+
+def test_service_does_not_serialize_additional_columns(tmp_path: Path):
+    path = tmp_path / 'projects.db'
+    seed(path)
+    conn = sqlite3.connect(path)
+    conn.execute("ALTER TABLE roadmaps ADD COLUMN internal_secret TEXT")
+    conn.execute("UPDATE roadmaps SET internal_secret = 'must not leak'")
+    conn.commit()
+    conn.close()
+
+    service = RoadmapsService(path)
+    listing = service.list('prof')['roadmaps'][0]
+    roadmap = service.get('prof', 'p1', 'r1')['roadmap']
+    assert 'internal_secret' not in listing
+    assert 'internal_secret' not in roadmap
+
+
+def test_service_get_and_snapshot_are_json_safe_and_deterministic(tmp_path: Path):
+    path = tmp_path / 'projects.db'
+    seed(path)
+    service = RoadmapsService(path)
+    result = service.get('prof', 'p1', 'r1')
+    assert result['found'] is True
+    assert result['roadmap']['active_version'] == 1
+    assert result['roadmap']['versions'][0]['nodes'][0]['node_id'] == 'n1'
+    assert result['roadmap']['versions'][0]['relations'][0]['relation_id'] == 'rel'
+    assert result['roadmap']['versions'][0]['todos'][0]['todo_id'] == 't1'
+    assert result == service.snapshot('prof', 'p1', 'r1')
+    json.dumps(result, sort_keys=True)
+
+
+def test_service_unknown_scope_is_not_found_and_never_falls_back(tmp_path: Path):
+    path = tmp_path / 'projects.db'
+    seed(path)
+    result = RoadmapsService(path).get('prof', 'missing', 'r1')
+    assert result == {'found': False, 'scope': {'profile_id': 'prof', 'project_id': 'missing', 'roadmap_id': 'r1'}, 'roadmap': None}
+
+
+def test_service_is_read_only_and_does_not_fake_events(tmp_path: Path):
+    path = tmp_path / 'projects.db'
+    seed(path)
+    before = path.read_bytes()
+    service = RoadmapsService(path)
+    assert not hasattr(service, 'events')
+    assert 'events' not in {r[0] for r in sqlite3.connect(path).execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    service.list('prof')
+    assert path.read_bytes() == before
+
+
+def test_service_missing_db_is_empty_without_creating_path(tmp_path: Path):
+    path = tmp_path / "missing" / "projects.db"
+    result = RoadmapsService(path).list("prof")
+    assert result == {"roadmaps": [], "scope": {"profile_id": "prof"}}
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+def test_service_legacy_db_is_rejected_without_mutation(tmp_path: Path):
+    path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE legacy (value TEXT)")
+    conn.commit(); conn.close()
+    before = path.read_bytes()
+    from hermes_cli.roadmaps_service import RoadmapsUnavailable
+    with pytest.raises(RoadmapsUnavailable):
+        RoadmapsService(path).list("prof")
+    assert path.read_bytes() == before
+
+
+def test_service_closes_connection_when_metadata_inspection_fails(tmp_path: Path, monkeypatch):
+    path = tmp_path / 'projects.db'
+    path.touch()
+
+    class BrokenConnection:
+        row_factory = None
+        closed = False
+
+        def execute(self, *args):
+            raise sqlite3.DatabaseError('metadata unavailable')
+
+        def close(self):
+            self.closed = True
+
+    connection = BrokenConnection()
+    monkeypatch.setattr(sqlite3, 'connect', lambda *args, **kwargs: connection)
+    with pytest.raises(RoadmapsUnavailable):
+        RoadmapsService(path).list('prof')
+    assert connection.closed is True
+
+
+@pytest.mark.parametrize('value', ['x' * 129])
+def test_service_rejects_overlong_identifiers(tmp_path: Path, value: str):
+    path = tmp_path / 'projects.db'
+    seed(path)
+    service = RoadmapsService(path)
+    with pytest.raises(ValueError, match='at most 128'):
+        service.list(value)
+    with pytest.raises(ValueError, match='at most 128'):
+        service.get('prof', value, 'r1')
+    with pytest.raises(ValueError, match='at most 128'):
+        service.get('prof', 'p1', value)
+
+
+def test_list_sessions_is_scoped_allowlisted_and_read_only(tmp_path: Path):
+    path = tmp_path / "projects.db"
+    seed(path)
+    conn = projects_db.connect(path)
+    conn.execute(
+        "INSERT INTO roadmap_sessions "
+        "(profile_id, project_id, roadmap_id, stored_session_id, kind, state, actor, created_at, updated_at) "
+        "VALUES ('prof', 'p1', 'r1', 'stored-vision', 'vision', 'active', 'pierre', 3, 3)"
+    )
+    conn.execute("ALTER TABLE roadmap_sessions ADD COLUMN internal_runtime_id TEXT")
+    conn.execute("UPDATE roadmap_sessions SET internal_runtime_id='runtime-must-not-leak'")
+    conn.commit()
+    conn.close()
+    before = path.read_bytes()
+
+    result = RoadmapsService(path).list_sessions("prof", "p1", "r1")
+
+    assert result["scope"] == {
+        "profile_id": "prof", "project_id": "p1", "roadmap_id": "r1",
+    }
+    assert result["sessions"][0]["stored_session_id"] == "stored-vision"
+    assert "internal_runtime_id" not in result["sessions"][0]
+    assert "runtime_session_id" not in json.dumps(result)
+    assert RoadmapsService(path).list_sessions("prof", "p1", "missing")["sessions"] == []
+    assert path.read_bytes() == before
+
+
+def test_list_sessions_missing_db_is_empty_without_creating_path(tmp_path: Path):
+    path = tmp_path / "missing" / "projects.db"
+    result = RoadmapsService(path).list_sessions("prof", "p1", "r1")
+    assert result == {
+        "sessions": [],
+        "scope": {"profile_id": "prof", "project_id": "p1", "roadmap_id": "r1"},
+    }
+    assert not path.exists()

--- a/tests/hermes_cli/test_roadmaps_todo.py
+++ b/tests/hermes_cli/test_roadmaps_todo.py
@@ -1,0 +1,76 @@
+"""Tests for the manual todo steering mutation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import projects_db
+from hermes_cli.roadmaps_writer import (
+    InvalidRoadmapTodoTransitionError,
+    RoadmapTodoNotFoundError,
+    RoadmapsWriter,
+)
+
+
+def seed(path: Path) -> None:
+    conn = projects_db.connect(path)
+    conn.execute("INSERT INTO projects(id, slug, name, created_at) VALUES ('p', 'p', 'P', 1)")
+    conn.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile", "p", "r", "Roadmap", None, "in_progress", 1, "a", "a", 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile", "p", "r", 1, "validated", "src", None, "a", 1, None),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile", "p", "r", 1, "n1", None, "step", "Node", None, "in_progress", 10, "agent", None, 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_todos VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile", "p", "r", 1, "t-open", "n1", "Open todo", "open", 0, 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_todos VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile", "p", "r", 1, "t-done", "n1", "Done todo", "done", 1, 1, 1),
+    )
+    conn.commit()
+    conn.close()
+
+
+def todo_state(path: Path, todo_id: str) -> str:
+    conn = projects_db.connect(path)
+    row = conn.execute("SELECT state FROM roadmap_todos WHERE todo_id=?", (todo_id,)).fetchone()
+    conn.close()
+    return row["state"]
+
+
+def test_update_todo_transitions_open_to_done(tmp_path: Path):
+    path = tmp_path / "projects.db"
+    seed(path)
+    result = RoadmapsWriter(path).update_todo("profile", "p", "r", "t-open", "user", "done", 1)
+    assert result["success"] is True
+    assert result["todo"]["state"] == "done"
+    assert result["before"] == {"state": "open"}
+    assert todo_state(path, "t-open") == "done"
+
+
+def test_update_todo_rejects_transition_from_done(tmp_path: Path):
+    path = tmp_path / "projects.db"
+    seed(path)
+    with pytest.raises(InvalidRoadmapTodoTransitionError):
+        RoadmapsWriter(path).update_todo("profile", "p", "r", "t-done", "user", "open", 1)
+    assert todo_state(path, "t-done") == "done"
+
+
+def test_update_todo_rejects_unknown_todo_and_bad_state(tmp_path: Path):
+    path = tmp_path / "projects.db"
+    seed(path)
+    writer = RoadmapsWriter(path)
+    with pytest.raises(RoadmapTodoNotFoundError):
+        writer.update_todo("profile", "p", "r", "t-missing", "user", "done", 1)
+    with pytest.raises(ValueError, match="state must be"):
+        writer.update_todo("profile", "p", "r", "t-open", "user", "finished", 1)

--- a/tests/hermes_cli/test_roadmaps_tools.py
+++ b/tests/hermes_cli/test_roadmaps_tools.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import projects_db
+from tools import roadmaps_tools
+from tools.registry import registry
+
+
+def seed(path: Path) -> None:
+    conn = projects_db.connect(path)
+    conn.execute("INSERT INTO projects(id, slug, name, created_at) VALUES ('p', 'p', 'P', 1)")
+    conn.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile", "p", "r", "Roadmap", None, "in_progress", 1, "agent", "agent", 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile", "p", "r", 1, "validated", "src", None, "agent", 1, None),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile", "p", "r", 1, "n-ready", None, "step", "Ready", None, "ready", 0, None, None, 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile", "p", "r", 1, "n-running", None, "step", "Running", None, "in_progress", 10, "agent", None, 1, 1),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_read_tools_are_registered_in_the_roadmaps_toolset():
+    roadmap_list_entry = registry.get_entry("roadmap_list")
+    roadmap_context_entry = registry.get_entry("roadmap_context")
+    assert roadmap_list_entry is not None
+    assert roadmap_context_entry is not None
+    assert roadmap_list_entry.toolset == "roadmaps"
+    assert roadmap_context_entry.toolset == "roadmaps"
+
+
+def test_roadmap_list_reads_the_active_profile_store_without_mutation(tmp_path: Path, monkeypatch):
+    path = tmp_path / "projects.db"
+    seed(path)
+    monkeypatch.setattr(roadmaps_tools, "get_hermes_home", lambda: tmp_path)
+    before = path.read_bytes()
+
+    result = json.loads(roadmaps_tools.roadmap_list("profile", "p"))
+
+    assert result["scope"] == {"profile_id": "profile", "project_id": "p"}
+    assert result["roadmaps"][0]["roadmap_id"] == "r"
+    assert path.read_bytes() == before
+
+
+def test_roadmap_context_requires_explicit_complete_scope(tmp_path: Path, monkeypatch):
+    path = tmp_path / "projects.db"
+    seed(path)
+    monkeypatch.setattr(roadmaps_tools, "get_hermes_home", lambda: tmp_path)
+
+    result = json.loads(roadmaps_tools.roadmap_context("profile", "p", "r"))
+
+    assert result["found"] is True
+    assert result["scope"] == {"profile_id": "profile", "project_id": "p", "roadmap_id": "r"}
+
+    with pytest.raises(ValueError, match="profile_id"):
+        roadmaps_tools.roadmap_context("", "p", "r")
+
+
+def test_roadmap_tools_do_not_create_a_missing_store(tmp_path: Path, monkeypatch):
+    home = tmp_path / "profile-home"
+    monkeypatch.setattr(roadmaps_tools, "get_hermes_home", lambda: home)
+
+    result = json.loads(roadmaps_tools.roadmap_list("profile"))
+
+    assert result == {"roadmaps": [], "scope": {"profile_id": "profile"}}
+    assert not home.exists()
+
+
+def test_mutation_tools_are_registered_in_the_roadmaps_toolset():
+    for name in (
+        "roadmap_claim_node",
+        "roadmap_update_progress",
+        "roadmap_complete_node",
+        "roadmap_block_node",
+        "roadmap_unblock_node",
+    ):
+        entry = registry.get_entry(name)
+        assert entry is not None
+        assert entry.toolset == "roadmaps"
+
+
+def test_claim_mutation_round_trip(tmp_path: Path, monkeypatch):
+    path = tmp_path / "projects.db"
+    seed(path)
+    monkeypatch.setattr(roadmaps_tools, "get_hermes_home", lambda: tmp_path)
+
+    result = json.loads(
+        roadmaps_tools.roadmap_claim_node("profile", "p", "r", "n-ready", "agent-b", 1)
+    )
+
+    assert result["success"] is True
+    assert result["node"]["state"] == "in_progress"
+    assert result["node"]["owner_agent"] == "agent-b"
+
+    context = json.loads(roadmaps_tools.roadmap_context("profile", "p", "r"))
+    claimed = [n for v in context["roadmap"]["versions"] for n in v["nodes"] if n["node_id"] == "n-ready"][0]
+    assert claimed["state"] == "in_progress"
+
+
+def test_mutation_rejects_stale_version_without_mutation(tmp_path: Path, monkeypatch):
+    path = tmp_path / "projects.db"
+    seed(path)
+    monkeypatch.setattr(roadmaps_tools, "get_hermes_home", lambda: tmp_path)
+    before = path.read_bytes()
+
+    result = json.loads(
+        roadmaps_tools.roadmap_claim_node("profile", "p", "r", "n-ready", "agent-b", 99)
+    )
+
+    assert result == {"success": False, "error": "stale_roadmap_version", "detail": result["detail"]}
+    assert path.read_bytes() == before
+
+
+def test_block_and_unblock_mutation_persist_and_clear_reason(tmp_path: Path, monkeypatch):
+    path = tmp_path / "projects.db"
+    seed(path)
+    monkeypatch.setattr(roadmaps_tools, "get_hermes_home", lambda: tmp_path)
+
+    blocked = json.loads(
+        roadmaps_tools.roadmap_block_node("profile", "p", "r", "n-running", "agent", "missing dep", 1)
+    )
+    assert blocked["node"]["state"] == "blocked"
+    assert blocked["node"]["block_reason"] == "missing dep"
+
+    unblocked = json.loads(
+        roadmaps_tools.roadmap_unblock_node("profile", "p", "r", "n-running", "agent", 1)
+    )
+    assert unblocked["node"]["state"] == "in_progress"
+    assert unblocked["node"]["block_reason"] is None
+
+
+def test_progress_mutation_validates_range(tmp_path: Path, monkeypatch):
+    path = tmp_path / "projects.db"
+    seed(path)
+    monkeypatch.setattr(roadmaps_tools, "get_hermes_home", lambda: tmp_path)
+
+    ok = json.loads(
+        roadmaps_tools.roadmap_update_progress("profile", "p", "r", "n-running", "agent", 45, 1)
+    )
+    assert ok["success"] is True
+    assert ok["node"]["progress"] == 45
+
+    bad = json.loads(
+        roadmaps_tools.roadmap_update_progress("profile", "p", "r", "n-running", "agent", 101, 1)
+    )
+    assert bad["success"] is False

--- a/tests/hermes_cli/test_roadmaps_writer.py
+++ b/tests/hermes_cli/test_roadmaps_writer.py
@@ -1,0 +1,288 @@
+"""Tests for the authorized, versioned Roadmaps execution writer."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import projects_db
+from hermes_cli.roadmaps_writer import (
+    InvalidRoadmapTransitionError,
+    RoadmapNodeNotFoundError,
+    RoadmapNotFoundError,
+    RoadmapVersionNotFoundError,
+    RoadmapsWriter,
+    StaleRoadmapVersionError,
+)
+
+
+def seed(path: Path, *, profile: str = "prof", active_version: int | None = 1) -> None:
+    conn = projects_db.connect(path)
+    conn.execute("INSERT INTO projects(id, slug, name, created_at) VALUES ('p1', 'one', 'One', 1)")
+    conn.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, "p1", "r1", "Roadmap", None, "in_progress", active_version, "a", "b", 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, "p1", "r1", 1, "validated", "src", None, "a", 1, None),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, "p1", "r1", 1, "n-ready", None, "step", "Ready", None, "ready", 0, None, None, 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, "p1", "r1", 1, "n-planned", None, "step", "Planned", None, "planned", 0, None, None, 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, "p1", "r1", 1, "n-running", None, "step", "Running", None, "in_progress", 10, "agent-a", None, 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, "p1", "r1", 1, "n-blocked", None, "step", "Blocked", None, "blocked", 30, "agent-a", "stuck", 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, "p1", "r1", 1, "n-done", None, "step", "Done", None, "completed", 100, "agent-a", None, 1, 1),
+    )
+    conn.commit()
+    conn.close()
+
+
+def node_state(path: Path, node_id: str) -> dict:
+    conn = projects_db.connect(path)
+    row = conn.execute(
+        "SELECT state, progress, owner_agent, block_reason, updated_at FROM roadmap_nodes WHERE node_id=?",
+        (node_id,),
+    ).fetchone()
+    conn.close()
+    return dict(row)
+
+
+def session_rows(path: Path) -> list[dict]:
+    conn = projects_db.connect(path)
+    rows = [dict(row) for row in conn.execute(
+        "SELECT * FROM roadmap_sessions ORDER BY created_at, stored_session_id"
+    )]
+    conn.close()
+    return rows
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "projects.db"
+    seed(path)
+    return path
+
+
+def test_claim_node_moves_ready_to_in_progress_and_assigns_owner(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    result = writer.claim_node("prof", "p1", "r1", "n-ready", "agent-b", 1)
+
+    assert result["success"] is True
+    assert result["node"]["state"] == "in_progress"
+    assert result["node"]["owner_agent"] == "agent-b"
+    assert node_state(db_path, "n-ready")["state"] == "in_progress"
+    assert node_state(db_path, "n-ready")["owner_agent"] == "agent-b"
+
+
+def test_claim_node_rejects_transition_from_planned(db_path: Path):
+    with pytest.raises(InvalidRoadmapTransitionError):
+        RoadmapsWriter(db_path).claim_node("prof", "p1", "r1", "n-planned", "agent-b", 1)
+    # Nothing changed: planned stays planned.
+    assert node_state(db_path, "n-planned")["state"] == "planned"
+
+
+def test_claim_node_rejects_stale_expected_version(db_path: Path):
+    with pytest.raises(StaleRoadmapVersionError):
+        RoadmapsWriter(db_path).claim_node("prof", "p1", "r1", "n-ready", "agent-b", 99)
+    assert node_state(db_path, "n-ready")["state"] == "ready"
+
+
+def test_update_progress_requires_in_progress_and_valid_range(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    result = writer.update_progress("prof", "p1", "r1", "n-running", "agent-a", 60, 1)
+    assert result["node"]["progress"] == 60
+    assert node_state(db_path, "n-running")["progress"] == 60
+
+    with pytest.raises(InvalidRoadmapTransitionError):
+        writer.update_progress("prof", "p1", "r1", "n-ready", "agent-a", 10, 1)
+    for bad in (-1, 101, 1.5, "50"):
+        with pytest.raises(ValueError, match="progress"):
+            writer.update_progress("prof", "p1", "r1", "n-running", "agent-a", bad, 1)
+
+
+def test_complete_node_from_in_progress_and_from_blocked(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    result = writer.complete_node("prof", "p1", "r1", "n-running", "agent-a", 1)
+    assert result["node"]["state"] == "completed"
+    assert result["node"]["progress"] == 100
+
+    writer.complete_node("prof", "p1", "r1", "n-blocked", "agent-a", 1)
+    assert node_state(db_path, "n-blocked")["state"] == "completed"
+    assert node_state(db_path, "n-blocked")["block_reason"] is None
+
+
+def test_block_node_persists_reason_and_unblock_clears_it(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    result = writer.block_node("prof", "p1", "r1", "n-running", "agent-a", "missing dependency", 1)
+    assert result["node"]["state"] == "blocked"
+    assert result["node"]["block_reason"] == "missing dependency"
+    assert node_state(db_path, "n-running")["block_reason"] == "missing dependency"
+
+    with pytest.raises(ValueError, match="reason"):
+        writer.block_node("prof", "p1", "r1", "n-running", "agent-a", "   ", 1)
+
+    writer.unblock_node("prof", "p1", "r1", "n-running", "agent-a", 1)
+    assert node_state(db_path, "n-running")["state"] == "in_progress"
+    assert node_state(db_path, "n-running")["block_reason"] is None
+
+
+def test_blocking_an_already_completed_node_is_rejected(db_path: Path):
+    with pytest.raises(InvalidRoadmapTransitionError):
+        RoadmapsWriter(db_path).block_node("prof", "p1", "r1", "n-done", "agent-a", "why", 1)
+    assert node_state(db_path, "n-done")["state"] == "completed"
+
+
+def test_advance_node_moves_planned_to_ready(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    result = writer.advance_node("prof", "p1", "r1", "n-planned", "agent-b", 1)
+
+    assert result["success"] is True
+    assert result["node"]["state"] == "ready"
+    assert node_state(db_path, "n-planned")["state"] == "ready"
+
+
+def test_advance_node_rejects_transition_from_ready_and_in_progress(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    with pytest.raises(InvalidRoadmapTransitionError):
+        writer.advance_node("prof", "p1", "r1", "n-ready", "agent-b", 1)
+    with pytest.raises(InvalidRoadmapTransitionError):
+        writer.advance_node("prof", "p1", "r1", "n-running", "agent-b", 1)
+    assert node_state(db_path, "n-ready")["state"] == "ready"
+    assert node_state(db_path, "n-running")["state"] == "in_progress"
+
+
+def test_advance_node_rejects_stale_expected_version(db_path: Path):
+    with pytest.raises(StaleRoadmapVersionError):
+        RoadmapsWriter(db_path).advance_node("prof", "p1", "r1", "n-planned", "agent-b", 99)
+    assert node_state(db_path, "n-planned")["state"] == "planned"
+
+
+def test_missing_roadmap_node_or_roadmap_raises_structured_errors(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    with pytest.raises(RoadmapNodeNotFoundError):
+        writer.claim_node("prof", "p1", "r1", "n-missing", "agent-a", 1)
+    with pytest.raises(RoadmapNotFoundError):
+        writer.claim_node("prof", "p1", "r2", "n-ready", "agent-a", 1)
+
+
+def test_roadmap_without_active_version_cannot_be_mutated(tmp_path: Path):
+    path = tmp_path / "projects.db"
+    seed(path, active_version=None)
+    with pytest.raises(RoadmapNotFoundError):
+        RoadmapsWriter(path).claim_node("prof", "p1", "r1", "n-ready", "agent-a", 1)
+
+
+def test_failed_mutation_rolls_back_without_touching_the_store(db_path: Path):
+    before = db_path.read_bytes()
+    with pytest.raises(StaleRoadmapVersionError):
+        RoadmapsWriter(db_path).claim_node("prof", "p1", "r1", "n-ready", "agent-b", 99)
+    assert db_path.read_bytes() == before
+    assert node_state(db_path, "n-ready")["state"] == "ready"
+
+
+def test_writer_updates_roadmap_timestamp_and_actor(db_path: Path):
+    RoadmapsWriter(db_path).claim_node("prof", "p1", "r1", "n-ready", "agent-b", 1)
+    conn = projects_db.connect(db_path)
+    row = conn.execute(
+        "SELECT updated_by, updated_at FROM roadmaps WHERE roadmap_id='r1'"
+    ).fetchone()
+    conn.close()
+    assert row["updated_by"] == "agent-b"
+    assert row["updated_at"] > 1
+
+
+def test_attach_vision_session_on_fresh_roadmap_uses_expected_zero(tmp_path: Path):
+    path = tmp_path / "projects.db"
+    seed(path, active_version=None)
+
+    result = RoadmapsWriter(path).attach_session(
+        "prof", "p1", "r1", "stored-vision-1", "pierre", 0
+    )
+
+    assert result["success"] is True
+    assert result["scope"] == {
+        "profile_id": "prof", "project_id": "p1", "roadmap_id": "r1",
+    }
+    assert result["session"] == {
+        "stored_session_id": "stored-vision-1", "kind": "vision",
+        "node_id": None, "plan_version": None, "state": "active",
+        "actor": "pierre", "created_at": result["session"]["created_at"],
+        "updated_at": result["session"]["updated_at"],
+    }
+    assert "runtime_session_id" not in result["session"]
+    assert session_rows(path)[0]["state"] == "active"
+
+
+def test_attach_vision_session_replacement_closes_previous_atomically(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    writer.attach_session("prof", "p1", "r1", "stored-old", "pierre", 1)
+
+    result = writer.attach_session(
+        "prof", "p1", "r1", "stored-new", "pierre", 1
+    )
+
+    assert result["session"]["stored_session_id"] == "stored-new"
+    assert result["session"]["state"] == "active"
+    assert {
+        row["stored_session_id"]: row["state"] for row in session_rows(db_path)
+    } == {"stored-new": "active", "stored-old": "closed"}
+
+
+def test_attach_same_durable_session_is_idempotent(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    first = writer.attach_session(
+        "prof", "p1", "r1", "stored-same", "pierre", 1
+    )
+    second = writer.attach_session(
+        "prof", "p1", "r1", "stored-same", "pierre", 1
+    )
+
+    assert second["session"] == first["session"]
+    assert len(session_rows(db_path)) == 1
+
+
+def test_attach_session_plan_version_must_exist_in_exact_scope(db_path: Path):
+    writer = RoadmapsWriter(db_path)
+    result = writer.attach_session(
+        "prof", "p1", "r1", "stored-plan", "pierre", 1, plan_version=1
+    )
+    assert result["session"]["plan_version"] == 1
+
+    with pytest.raises(RoadmapVersionNotFoundError):
+        writer.attach_session(
+            "prof", "p1", "r1", "stored-missing-plan", "pierre", 1,
+            plan_version=99,
+        )
+    assert [(row["stored_session_id"], row["state"]) for row in session_rows(db_path)] == [
+        ("stored-plan", "active")
+    ]
+
+
+def test_attach_session_records_actor_on_roadmap(db_path: Path):
+    RoadmapsWriter(db_path).attach_session(
+        "prof", "p1", "r1", "stored-actor", "pierre", 1
+    )
+    conn = projects_db.connect(db_path)
+    roadmap = conn.execute(
+        "SELECT updated_by, updated_at FROM roadmaps "
+        "WHERE profile_id='prof' AND project_id='p1' AND roadmap_id='r1'"
+    ).fetchone()
+    conn.close()
+    assert roadmap["updated_by"] == "pierre"
+    assert roadmap["updated_at"] > 1

--- a/tests/test_roadmaps_contract.py
+++ b/tests/test_roadmaps_contract.py
@@ -1,0 +1,216 @@
+"""Executable Phase 0 invariants for the pure Roadmaps contract."""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
+
+from roadmaps_contract import (  # noqa: E402
+    DuplicateEventConflict,
+    EventEnvelope,
+    FixtureRoadmapRepository,
+    QualifiedNodeKey,
+    Relation,
+    Scope,
+    StaleEventError,
+    build_fixture,
+    replay_events,
+    transition_node,
+    transition_plan,
+)
+
+
+@pytest.fixture
+def scope() -> Scope:
+    return Scope("profile-a", "project-a", "roadmap-a")
+
+
+def event(scope: Scope, *, version: int = 1, event_id: str | None = None, payload: dict | None = None, event_type: str = "roadmap.node.progressed") -> EventEnvelope:
+    return EventEnvelope.create(
+        event_id=event_id or f"evt-{version}", scope=scope, aggregate_id="roadmap-a",
+        aggregate_version=version, payload=payload or {"state": "ready", "nested": {"items": [1, 2]}},
+        event_type=event_type,
+        occurred_at=datetime(2026, 8, 14, 12, 0, tzinfo=timezone(timedelta(hours=2))),
+        received_at=datetime(2026, 8, 14, 12, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_scope_and_qualified_node_key_preserve_profile_project_roadmap_identity(scope: Scope) -> None:
+    assert scope.as_tuple() == ("profile-a", "project-a", "roadmap-a")
+    assert QualifiedNodeKey(scope, "node-1").as_tuple() == ("profile-a", "project-a", "roadmap-a", "node-1")
+
+
+def test_cross_profile_project_and_roadmap_relations_are_rejected(scope: Scope) -> None:
+    source = QualifiedNodeKey(scope, "from")
+    for other in (Scope("profile-b", "project-a", "roadmap-a"), Scope("profile-a", "project-b", "roadmap-a"), Scope("profile-a", "project-a", "roadmap-b")):
+        with pytest.raises(ValueError, match="same scope"):
+            Relation(source, QualifiedNodeKey(other, "to"))
+
+
+def test_relation_kind_and_identifiers_are_strict(scope: Scope) -> None:
+    with pytest.raises(ValueError, match="relation kind"):
+        Relation(QualifiedNodeKey(scope, "from"), QualifiedNodeKey(scope, "to"), "unknown")
+    with pytest.raises(TypeError, match="relation kind"):
+        Relation(QualifiedNodeKey(scope, "from"), QualifiedNodeKey(scope, "to"), 3)  # type: ignore[arg-type]
+    for bad in ("", " trimmed", "trimmed ", "a/b", "a\\b", "a\x00b", 3):
+        with pytest.raises((ValueError, TypeError)):
+            Scope(bad, "project-a", "roadmap-a")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        QualifiedNodeKey(scope, "node/id")
+
+
+def test_event_hash_is_deterministic_and_payload_is_not_retained(scope: Scope) -> None:
+    source = {"nested": {"items": [1, 2]}, "state": "ready"}
+    first = event(scope, payload=source)
+    second = EventEnvelope.create(event_id="other", scope=scope, aggregate_id="roadmap-a", event_type="roadmap.node.progressed", payload={"nested": {"items": [1, 2]}, "state": "ready"}, occurred_at=first.occurred_at, received_at=first.received_at)
+    assert first.payload_hash == second.payload_hash
+    source["nested"]["items"].append(3)
+    source["state"] = "blocked"
+    assert first.payload_hash == second.payload_hash
+    assert not hasattr(first, "payload")
+
+
+def test_event_timestamps_are_aware_and_normalized_to_utc(scope: Scope) -> None:
+    current = event(scope)
+    assert current.occurred_at.tzinfo is timezone.utc
+    assert current.occurred_at.hour == 10
+    assert current.received_at.tzinfo is timezone.utc
+
+
+def test_event_constructor_rejects_arbitrary_hash_and_invalid_identity(scope: Scope) -> None:
+    current = event(scope)
+    with pytest.raises(ValueError, match="payload_hash"):
+        EventEnvelope(1, "evt", "roadmap.node.progressed", "roadmap", "roadmap-a", scope, "actor", current.occurred_at, current.received_at, None, None, 1, "arbitrary")
+    with pytest.raises(ValueError, match="schema_version"):
+        EventEnvelope(2, current.event_id, current.event_type, current.aggregate_type, current.aggregate_id, scope, current.actor, current.occurred_at, current.received_at, None, None, 1, current.payload_hash)
+    with pytest.raises(TypeError, match="payload"):
+        EventEnvelope.create(event_id="evt-payload", scope=scope, aggregate_id="roadmap-a", event_type="roadmap.node.progressed", payload=None)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="aggregate_type"):
+        EventEnvelope.create(event_id="evt-type", scope=scope, aggregate_id="roadmap-a", event_type="roadmap.node.progressed", aggregate_type=3, payload={})  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad_event_type", ("", " roadmap.node.progressed", "roadmap.node.progressed ", "roadmap/node", "roadmap\x00node", 3, None))
+def test_event_type_is_required_and_strict(scope: Scope, bad_event_type: object) -> None:
+    with pytest.raises((ValueError, TypeError), match="event_type"):
+        EventEnvelope.create(event_id="evt-type", scope=scope, aggregate_id="roadmap-a", event_type=bad_event_type, payload={})  # type: ignore[arg-type]
+
+
+def test_duplicate_event_id_with_different_event_type_is_rejected(scope: Scope) -> None:
+    first = event(scope, event_id="evt-1")
+    different = event(scope, event_id="evt-1", event_type="roadmap.node.completed")
+    with pytest.raises(DuplicateEventConflict):
+        replay_events((first, different))
+
+
+def test_duplicate_event_id_with_different_payload_is_rejected(scope: Scope) -> None:
+    first = event(scope, event_id="evt-1")
+    different = event(scope, event_id="evt-1", payload={"state": "blocked"})
+    with pytest.raises(DuplicateEventConflict):
+        first.ensure_same_identity(different)
+
+
+def test_duplicate_event_id_with_same_payload_is_idempotent(scope: Scope) -> None:
+    first = event(scope, event_id="evt-1")
+    replay = event(scope, event_id="evt-1")
+    assert first.ensure_same_identity(replay) is None
+
+
+def test_replay_identical_duplicate_event_id_is_idempotent(scope: Scope) -> None:
+    first = event(scope, event_id="evt-1")
+    assert replay_events((first, first)) == (first,)
+
+
+def test_duplicate_event_id_with_different_version_is_rejected(scope: Scope) -> None:
+    first = event(scope, event_id="evt-1", version=1)
+    different = event(scope, event_id="evt-1", version=2)
+    with pytest.raises(DuplicateEventConflict):
+        replay_events((first, different))
+
+
+@pytest.mark.parametrize("field", ("actor", "correlation_id"))
+def test_duplicate_event_id_with_different_metadata_is_rejected(scope: Scope, field: str) -> None:
+    first = event(scope, event_id="evt-1")
+    kwargs = {field: "different-actor" if field == "actor" else "corr-2"}
+    different = EventEnvelope.create(
+        event_id=first.event_id, scope=scope, aggregate_id=first.aggregate_id,
+        event_type="roadmap.node.progressed",
+        aggregate_version=first.aggregate_version, payload={"state": "ready", "nested": {"items": [1, 2]}},
+        actor=kwargs.get("actor", first.actor), correlation_id=kwargs.get("correlation_id"),
+        occurred_at=first.occurred_at, received_at=first.received_at,
+    )
+    with pytest.raises(DuplicateEventConflict):
+        replay_events((first, different))
+
+
+def test_duplicate_event_id_with_different_timestamp_is_rejected(scope: Scope) -> None:
+    first = event(scope, event_id="evt-1")
+    different = EventEnvelope.create(
+        event_id=first.event_id, scope=scope, aggregate_id=first.aggregate_id,
+        event_type="roadmap.node.progressed",
+        aggregate_version=first.aggregate_version, payload={"state": "ready", "nested": {"items": [1, 2]}},
+        occurred_at=first.occurred_at + timedelta(seconds=1), received_at=first.received_at,
+    )
+    with pytest.raises(DuplicateEventConflict):
+        replay_events((first, different))
+
+
+def test_replay_from_cursor_returns_only_new_events(scope: Scope) -> None:
+    stream = (event(scope, version=1), event(scope, version=2), event(scope, version=3))
+    assert replay_events(stream, cursor=2) == stream[2:]
+
+
+def test_replay_deduplicates_duplicates_after_cursor(scope: Scope) -> None:
+    first = event(scope, version=1, event_id="evt-1")
+    second = event(scope, version=2, event_id="evt-2")
+    assert replay_events((first, second, first, second), cursor=0) == (first, second)
+    assert replay_events((first, second, first, second), cursor=2) == ()
+
+
+def test_fixture_repository_deduplicates_duplicate_events(scope: Scope) -> None:
+    first = event(scope, version=1, event_id="evt-1")
+    second = event(scope, version=2, event_id="evt-2")
+    repository = FixtureRoadmapRepository(scope, build_fixture(scope), (first, second, first, second))
+    assert repository.get_events_after(scope, 0) == (first, second)
+
+
+def test_replay_rejects_late_or_regressive_aggregate_version(scope: Scope) -> None:
+    with pytest.raises(StaleEventError):
+        replay_events((event(scope, version=1), event(scope, version=3), event(scope, version=2)))
+
+
+def test_fixture_repository_rejects_non_monotonic_stream(scope: Scope) -> None:
+    repository = FixtureRoadmapRepository(scope, build_fixture(scope), (event(scope, version=1), event(scope, version=3), event(scope, version=2)))
+    with pytest.raises(StaleEventError):
+        repository.get_events_after(scope, 0)
+
+
+def test_fixture_repository_rejects_event_outside_scope(scope: Scope) -> None:
+    other_scope = Scope("profile-a", "project-a", "roadmap-b")
+    with pytest.raises(ValueError, match="scope"):
+        FixtureRoadmapRepository(scope, build_fixture(scope), (event(other_scope),))
+
+
+def test_fixture_repository_is_injected_read_only_and_does_not_write(tmp_path: Path, scope: Scope) -> None:
+    before = {path.relative_to(tmp_path) for path in tmp_path.rglob("*")}
+    repository = FixtureRoadmapRepository(scope, build_fixture(scope), (event(scope, version=1), event(scope, version=2)))
+    assert repository.list(profile_id="profile-a", project_id="project-a") == (scope,)
+    assert repository.get_snapshot(scope)["scope"] == scope
+    assert repository.get_snapshot(scope)["todos"] == ()
+    assert repository.get_events_after(scope, 1)[0].aggregate_version == 2
+    assert not any(name in dir(repository) for name in ("save", "write", "update", "delete", "persist"))
+    with pytest.raises(TypeError):
+        repository.get(scope)["new"] = "mutation"  # type: ignore[index]
+    assert before == {path.relative_to(tmp_path) for path in tmp_path.rglob("*")}
+
+
+def test_terminal_transitions_are_rejected_and_essential_transitions_are_valid() -> None:
+    assert transition_plan("draft", "proposed") == "proposed"
+    assert transition_plan("validated", "in_progress") == "in_progress"
+    assert transition_node("planned", "ready") == "ready"
+    assert transition_node("blocked", "completed") == "completed"
+    for transition in (("archived", "draft", transition_plan), ("archived", "ready", transition_node), ("completed", "in_progress", transition_node)):
+        with pytest.raises(ValueError):
+            transition[2](transition[0], transition[1])

--- a/tests/test_roadmaps_store_phase1_contract.py
+++ b/tests/test_roadmaps_store_phase1_contract.py
@@ -1,0 +1,571 @@
+"""Phase 1 SQLite contract tests.
+
+These tests are deliberately self-contained even though the runtime
+``hermes_cli/projects_db.py`` is present in this worktree: porting the DDL to
+that runtime is a separate task.  The DDL is a preparatory contract, not a
+replacement backend implementation.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+ROADMAPS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS roadmaps (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0) REFERENCES projects(id) ON DELETE CASCADE,
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    title TEXT NOT NULL,
+    purpose TEXT,
+    lifecycle_state TEXT NOT NULL CHECK (lifecycle_state IN
+        ('draft','proposed','validated','in_progress','blocked','completed','archived')),
+    active_version INTEGER CHECK (active_version IS NULL OR active_version >= 1),
+    created_by TEXT NOT NULL CHECK (length(trim(replace(replace(replace(created_by, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    updated_by TEXT NOT NULL CHECK (length(trim(replace(replace(replace(updated_by, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, active_version)
+      REFERENCES roadmap_versions(profile_id, project_id, roadmap_id, version)
+      DEFERRABLE INITIALLY DEFERRED
+);
+CREATE TABLE IF NOT EXISTS roadmap_versions (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL CHECK (version >= 1),
+    state TEXT NOT NULL CHECK (state IN ('draft','proposed','validated','superseded','archived')),
+    source TEXT,
+    reason TEXT,
+    created_by TEXT NOT NULL CHECK (length(trim(replace(replace(replace(created_by, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    created_at INTEGER NOT NULL,
+    content_hash TEXT,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version),
+    FOREIGN KEY (profile_id, project_id, roadmap_id)
+      REFERENCES roadmaps(profile_id, project_id, roadmap_id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS roadmap_nodes (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL,
+    node_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    parent_node_id TEXT,
+    kind TEXT NOT NULL CHECK (kind IN ('objective','phase','milestone','step','decision')),
+    title TEXT NOT NULL,
+    description TEXT,
+    state TEXT NOT NULL CHECK (state IN ('planned','ready','in_progress','blocked','completed','archived')),
+    progress INTEGER NOT NULL DEFAULT 0 CHECK (progress BETWEEN 0 AND 100),
+    owner_agent TEXT CHECK (owner_agent IS NULL OR length(trim(replace(replace(replace(owner_agent, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    block_reason TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version, node_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version)
+      REFERENCES roadmap_versions(profile_id, project_id, roadmap_id, version) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, parent_node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id),
+    CHECK (parent_node_id IS NULL OR (length(trim(replace(replace(replace(parent_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0 AND parent_node_id <> node_id))
+);
+CREATE TABLE IF NOT EXISTS roadmap_relations (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL,
+    relation_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(relation_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    from_node_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(from_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    to_node_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(to_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    kind TEXT NOT NULL CHECK (kind IN ('depends_on','blocks','enables','follows','validates','supersedes')),
+    state TEXT NOT NULL DEFAULT 'active' CHECK (state IN ('active','superseded','invalid')),
+    reason TEXT,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version, relation_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, from_node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, to_node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id) ON DELETE CASCADE,
+    CHECK (from_node_id <> to_node_id)
+);
+CREATE TABLE IF NOT EXISTS roadmap_todos (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL,
+    todo_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(todo_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    node_id TEXT CHECK (node_id IS NULL OR length(trim(replace(replace(replace(node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    title TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('open','in_progress','done','cancelled')),
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version, todo_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version)
+      REFERENCES roadmap_versions(profile_id, project_id, roadmap_id, version) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id)
+);
+"""
+
+
+# This is intentionally independent of ``ROADMAPS_SCHEMA``.  Checking only
+# names would accept a table with the right API-shaped columns but no PK, FK,
+# NOT NULL, or CHECK constraints.
+_SCHEMA_CONTRACT = {
+    "roadmaps": {
+        "columns": (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+                    ("roadmap_id", "TEXT", 1, 3), ("title", "TEXT", 1, 0),
+                    ("purpose", "TEXT", 0, 0), ("lifecycle_state", "TEXT", 1, 0),
+                    ("active_version", "INTEGER", 0, 0), ("created_by", "TEXT", 1, 0),
+                    ("updated_by", "TEXT", 1, 0), ("created_at", "INTEGER", 1, 0),
+                    ("updated_at", "INTEGER", 1, 0)),
+        "fks": (("roadmap_versions", ("profile_id", "project_id", "roadmap_id", "active_version"),
+                 ("profile_id", "project_id", "roadmap_id", "version"), "NO ACTION"),
+                ("projects", ("project_id",), ("id",), "CASCADE")),
+        "sql_markers": ("primary key", "foreign key", "check", "deferrable initially deferred",
+                         "lifecycle_state text not null check", "active_version integer check"),
+    },
+    "roadmap_versions": {
+        "columns": (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+                    ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+                    ("state", "TEXT", 1, 0), ("source", "TEXT", 0, 0), ("reason", "TEXT", 0, 0),
+                    ("created_by", "TEXT", 1, 0), ("created_at", "INTEGER", 1, 0),
+                    ("content_hash", "TEXT", 0, 0)),
+        "fks": (("roadmaps", ("profile_id", "project_id", "roadmap_id"),
+                 ("profile_id", "project_id", "roadmap_id"), "CASCADE"),),
+        "sql_markers": ("primary key", "foreign key", "check", "state text not null check", "version integer not null check"),
+    },
+    "roadmap_nodes": {
+        "columns": (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+                    ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+                    ("node_id", "TEXT", 1, 5), ("parent_node_id", "TEXT", 0, 0),
+                    ("kind", "TEXT", 1, 0), ("title", "TEXT", 1, 0), ("description", "TEXT", 0, 0),
+                    ("state", "TEXT", 1, 0), ("progress", "INTEGER", 1, 0), ("owner_agent", "TEXT", 0, 0),
+                    ("block_reason", "TEXT", 0, 0),
+                    ("created_at", "INTEGER", 1, 0), ("updated_at", "INTEGER", 1, 0)),
+        "fks": (("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "parent_node_id"),
+                 ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "NO ACTION"),
+                ("roadmap_versions", ("profile_id", "project_id", "roadmap_id", "version"),
+                 ("profile_id", "project_id", "roadmap_id", "version"), "CASCADE")),
+        "sql_markers": ("primary key", "foreign key", "check", "progress integer not null default 0 check",
+                         "parent_node_id is null"),
+    },
+    "roadmap_relations": {
+        "columns": (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+                    ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+                    ("relation_id", "TEXT", 1, 5), ("from_node_id", "TEXT", 1, 0),
+                    ("to_node_id", "TEXT", 1, 0), ("kind", "TEXT", 1, 0),
+                    ("state", "TEXT", 1, 0), ("reason", "TEXT", 0, 0)),
+        "fks": (("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "from_node_id"),
+                 ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "CASCADE"),
+                ("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "to_node_id"),
+                 ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "CASCADE")),
+        "sql_markers": ("primary key", "foreign key", "check", "from_node_id <> to_node_id", "state text not null default 'active' check"),
+    },
+    "roadmap_todos": {
+        "columns": (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+                    ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+                    ("todo_id", "TEXT", 1, 5), ("node_id", "TEXT", 0, 0), ("title", "TEXT", 1, 0),
+                    ("state", "TEXT", 1, 0), ("position", "INTEGER", 1, 0),
+                    ("created_at", "INTEGER", 1, 0), ("updated_at", "INTEGER", 1, 0)),
+        "fks": (("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "node_id"),
+                 ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "NO ACTION"),
+                ("roadmap_versions", ("profile_id", "project_id", "roadmap_id", "version"),
+                 ("profile_id", "project_id", "roadmap_id", "version"), "CASCADE")),
+        "sql_markers": ("primary key", "foreign key", "check", "state text not null check", "node_id text check"),
+    },
+}
+
+
+def _validate_schema_contract(conn: sqlite3.Connection) -> None:
+    for table, expected in _SCHEMA_CONTRACT.items():
+        actual_columns = tuple(
+            (row[1], row[2].upper(), row[3], row[5])
+            for row in conn.execute(f"PRAGMA table_info({table})")
+        )
+        if actual_columns != expected["columns"]:
+            raise RuntimeError(f"incompatible existing {table} table columns")
+
+        grouped: dict[int, list[tuple]] = {}
+        for row in conn.execute(f"PRAGMA foreign_key_list({table})"):
+            grouped.setdefault(row[0], []).append(row)
+        actual_fks = tuple(
+            (rows[0][2], tuple(row[3] for row in rows), tuple(row[4] for row in rows), rows[0][6])
+            for fk_id, rows in sorted(grouped.items())
+        )
+        if set(actual_fks) != set(expected["fks"]):
+            raise RuntimeError(f"incompatible existing {table} table foreign keys")
+
+        sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ).fetchone()[0].lower()
+        if any(marker not in " ".join(sql.split()) for marker in expected["sql_markers"]):
+            raise RuntimeError(f"incompatible existing {table} table constraints")
+
+
+def open_contract_db(path: Path, *, fail_after_statement: int | None = None) -> sqlite3.Connection:
+    """Create the isolated contract DB, atomically, without runtime imports.
+
+    ``projects_db.connect()`` has a separate porting obligation to make its
+    existing initialization transaction atomic; this helper only proves the
+    DDL contract and deliberately does not emulate that runtime.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA foreign_keys=ON")
+    statements = [
+        "CREATE TABLE IF NOT EXISTS projects (id TEXT PRIMARY KEY, name TEXT NOT NULL)",
+        *(statement.strip() for statement in ROADMAPS_SCHEMA.split(";") if statement.strip()),
+    ]
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        for index, statement in enumerate(statements):
+            conn.execute(statement)
+            if fail_after_statement is not None and index == fail_after_statement:
+                raise RuntimeError("injected fixture failure")
+        _validate_schema_contract(conn)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        conn.close()
+        raise
+    return conn
+
+
+def seed_scope(conn: sqlite3.Connection, profile: str = "profile-a", project: str = "project-a") -> None:
+    conn.execute("INSERT INTO projects(id, name) VALUES (?, ?)", (project, project))
+    conn.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, project, "roadmap-a", "Roadmap", None, "draft", None, "test", "test", 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, project, "roadmap-a", 1, "draft", "test", None, "test", 1, None),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, project, "roadmap-a", 1, "node-a", None, "objective", "A", None, "planned", 0, None, None, 1, 1),
+    )
+    conn.commit()
+
+
+def test_initialization_is_idempotent_and_uses_only_explicit_db_path(tmp_path: Path) -> None:
+    path = tmp_path / "profile-a" / "projects.db"
+    first = open_contract_db(path)
+    first.close()
+    second = open_contract_db(path)
+    tables = {
+        row[0] for row in second.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'roadmap%'")
+    }
+    assert tables == {"roadmaps", "roadmap_versions", "roadmap_nodes", "roadmap_relations", "roadmap_todos"}
+    assert not (tmp_path / "roadmaps.db").exists()
+    second.close()
+
+
+def test_deferred_reports_proofs_events_and_agent_projections_are_absent(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    names = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert not names.intersection({"reports", "proofs", "events", "agent_projections", "roadmap_reports"})
+    conn.close()
+
+
+def test_two_db_paths_are_isolated_profiles(tmp_path: Path) -> None:
+    first = open_contract_db(tmp_path / "a" / "projects.db")
+    second = open_contract_db(tmp_path / "b" / "projects.db")
+    seed_scope(first, "profile-a")
+    seed_scope(second, "profile-b")
+    assert first.execute("SELECT profile_id FROM roadmaps").fetchone()[0] == "profile-a"
+    assert second.execute("SELECT profile_id FROM roadmaps").fetchone()[0] == "profile-b"
+    first.close()
+    second.close()
+
+
+def test_foreign_keys_enforce_project_and_qualified_scope(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-a", "missing", "r", "R", None, "draft", None, "x", "x", 1, 1),
+        )
+    seed_scope(conn)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-b", "project-a", "roadmap-a", 1, "foreign", None, "step", "bad", None, "planned", 0, None, None, 1, 1),
+        )
+    conn.close()
+
+
+def test_project_delete_cascades_roadmap_rows(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    conn.execute("DELETE FROM projects WHERE id=?", ("project-a",))
+    conn.commit()
+    for table in ("roadmaps", "roadmap_versions", "roadmap_nodes"):
+        assert conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 0
+    conn.close()
+
+
+def test_duplicate_ids_are_rejected_within_the_qualified_scope(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-a", "project-a", "roadmap-a", 1, "node-a", None, "step", "duplicate", None, "planned", 0, None, None, 1, 1),
+        )
+    conn.close()
+
+
+def test_relations_cannot_cross_scope_or_reference_missing_nodes(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_relations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-a", "project-a", "roadmap-a", 1, "rel", "node-a", "missing", "depends_on", "active", None),
+        )
+    conn.close()
+
+
+def test_sqlite_schema_exposes_constraints_and_deferred_active_version_fk(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+    assert tuple(
+        (row[1], row[2].upper(), row[3], row[5])
+        for row in conn.execute("PRAGMA table_info(roadmaps)")
+    ) == _SCHEMA_CONTRACT["roadmaps"]["columns"]
+    fks = conn.execute("PRAGMA foreign_key_list(roadmaps)").fetchall()
+    assert any(row[2] == "roadmap_versions" and row[3] == "profile_id" for row in fks)
+    assert list(conn.execute("PRAGMA index_list(roadmap_versions)"))
+    assert list(conn.execute("PRAGMA index_list(roadmap_nodes)"))
+    conn.close()
+
+
+def test_active_version_must_reference_same_roadmap_version(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    conn.execute("INSERT INTO projects VALUES (?, ?)", ("project-a", "A"))
+    conn.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile-a", "project-a", "r", "R", None, "draft", 1, "actor", "actor", 1, 1),
+    )
+    # The pointer may precede its version inside one transaction.
+    conn.execute(
+        "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile-a", "project-a", "r", 1, "draft", "test", None, "actor", 1, None),
+    )
+    assert conn.execute("SELECT active_version FROM roadmaps").fetchone()[0] == 1
+    conn.commit()
+    conn.close()
+
+
+def test_unresolved_active_version_fails_at_commit(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    conn.execute("INSERT INTO projects VALUES (?, ?)", ("project-a", "A"))
+    conn.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile-a", "project-a", "r", "R", None, "draft", 99, "actor", "actor", 1, 1),
+    )
+    assert conn.execute("SELECT active_version FROM roadmaps").fetchone()[0] == 99
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.commit()
+    conn.rollback()
+    conn.close()
+
+
+@pytest.mark.parametrize("other_scope", [
+    ("profile-b", "project-a", "roadmap-a"),
+    ("profile-a", "project-b", "roadmap-a"),
+    ("profile-a", "project-a", "roadmap-b"),
+])
+def test_active_version_cannot_be_satisfied_by_other_scope(
+    tmp_path: Path, other_scope: tuple[str, str, str]
+) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    conn.executemany("INSERT INTO projects VALUES (?, ?)", [("project-a", "A"), ("project-b", "B")])
+    for profile, project, roadmap in (("profile-a", "project-a", "roadmap-a"), other_scope):
+        conn.execute(
+            "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (profile, project, roadmap, "R", None, "draft", None, "actor", "actor", 1, 1),
+        )
+    conn.execute(
+        "UPDATE roadmaps SET active_version=1 WHERE profile_id='profile-a' AND project_id='project-a' AND roadmap_id='roadmap-a'"
+    )
+    conn.execute(
+        "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (*other_scope, 1, "draft", "test", None, "actor", 1, None),
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.commit()
+    conn.close()
+
+
+def test_project_fk_is_not_profile_qualified_within_one_projects_db(tmp_path: Path) -> None:
+    """profile_id is application validation; projects.db owns project identity."""
+    conn = open_contract_db(tmp_path / "projects.db")
+    conn.execute("INSERT INTO projects VALUES (?, ?)", ("project-a", "A"))
+    for profile, roadmap in (("profile-a", "roadmap-a"), ("profile-b", "roadmap-b")):
+        conn.execute(
+            "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (profile, "project-a", roadmap, "R", None, "draft", None, "actor", "actor", 1, 1),
+        )
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM roadmaps").fetchone()[0] == 2
+    conn.close()
+
+
+@pytest.mark.parametrize("table,column,value", [
+    ("roadmaps", "profile_id", " "), ("roadmaps", "project_id", ""),
+    ("roadmaps", "roadmap_id", "\t"), ("roadmaps", "created_by", " "),
+    ("roadmap_nodes", "node_id", " "), ("roadmap_relations", "relation_id", ""),
+    ("roadmap_todos", "todo_id", "\t"),
+])
+def test_empty_and_whitespace_identifiers_and_actors_are_rejected(
+    tmp_path: Path, table: str, column: str, value: str
+) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    if table == "roadmaps":
+        values = ["profile-a", "project-a", "bad", "R", None, "draft", None, "actor", "actor", 1, 1]
+        values[{"profile_id": 0, "project_id": 1, "roadmap_id": 2, "created_by": 7}[column]] = value
+        sql = "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    elif table == "roadmap_nodes":
+        values = ["profile-a", "project-a", "roadmap-a", 1, "bad", None, "step", "B", None, "planned", 0, None, None, 1, 1]
+        values[4] = value
+        sql = "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    elif table == "roadmap_relations":
+        values = ["profile-a", "project-a", "roadmap-a", 1, "bad", "node-a", "node-a", "depends_on", "active", None]
+        values[4] = value
+        sql = "INSERT INTO roadmap_relations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    else:
+        values = ["profile-a", "project-a", "roadmap-a", 1, "bad", None, "T", "open", 0, 1, 1]
+        values[4] = value
+        sql = "INSERT INTO roadmap_todos VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(sql, values)
+    conn.close()
+
+
+def test_nodes_reject_missing_and_self_parent(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    for parent in ("missing", "child"):
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ("profile-a", "project-a", "roadmap-a", 1, "child", parent, "step", "B", None, "planned", 0, None, None, 1, 1),
+            )
+    conn.close()
+
+
+def test_relations_reject_self_and_cross_scope_endpoints(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    for from_node, to_node, profile in (("node-a", "node-a", "profile-a"), ("node-a", "node-a", "profile-b")):
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO roadmap_relations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (profile, "project-a", "roadmap-a", 1, "rel-" + profile, from_node, to_node, "depends_on", "active", None),
+            )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_relations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-a", "project-a", "roadmap-a", 1, "bad-state", "node-a", "node-a", "depends_on", "bogus", None),
+        )
+    conn.close()
+
+
+def test_todos_reject_missing_node_and_cross_scope_node(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    for node, profile in (("missing", "profile-a"), ("node-a", "profile-b")):
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO roadmap_todos VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (profile, "project-a", "roadmap-a", 1, "todo-" + profile, node, "T", "open", 0, 1, 1),
+            )
+    conn.close()
+
+
+def test_additive_migration_preserves_multiple_legacy_tables_and_rows(tmp_path: Path) -> None:
+    path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE legacy_settings (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute("INSERT INTO legacy_settings VALUES ('keep', 'yes')")
+    conn.execute("CREATE TABLE legacy_audit (id INTEGER PRIMARY KEY, detail TEXT)")
+    conn.execute("INSERT INTO legacy_audit VALUES (1, 'preserve')")
+    conn.execute("CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL)")
+    conn.execute("CREATE INDEX legacy_audit_detail ON legacy_audit(detail)")
+    conn.execute("INSERT INTO projects VALUES ('legacy-project', 'Legacy')")
+    conn.commit()
+    conn.close()
+
+    migrated = open_contract_db(path)
+    assert migrated.execute("SELECT value FROM legacy_settings WHERE key='keep'").fetchone()[0] == "yes"
+    assert migrated.execute("SELECT detail FROM legacy_audit WHERE id=1").fetchone()[0] == "preserve"
+    assert migrated.execute("SELECT name FROM projects WHERE id='legacy-project'").fetchone()[0] == "Legacy"
+    assert "legacy_audit_detail" in {row[1] for row in migrated.execute("PRAGMA index_list(legacy_audit)")}
+    migrated.close()
+
+
+def test_incompatible_existing_roadmaps_table_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "incompatible.db"
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE roadmaps (id INTEGER PRIMARY KEY, note TEXT)")
+    conn.commit()
+    conn.close()
+    with pytest.raises(RuntimeError, match="incompatible existing roadmaps table"):
+        open_contract_db(path)
+    check = sqlite3.connect(path)
+    assert {row[0] for row in check.execute("SELECT name FROM sqlite_master WHERE type='table'")} == {"roadmaps"}
+    check.close()
+
+
+def test_same_columns_without_constraints_are_rejected_without_residue(tmp_path: Path) -> None:
+    path = tmp_path / "weakened.db"
+    conn = sqlite3.connect(path)
+    # Deliberately preserve every column name/type while removing NOT NULL,
+    # PK, FK, and CHECK constraints. A name-only compatibility check would
+    # incorrectly accept this table.
+    conn.execute("""
+        CREATE TABLE roadmaps (
+            profile_id TEXT, project_id TEXT, roadmap_id TEXT, title TEXT,
+            purpose TEXT, lifecycle_state TEXT, active_version INTEGER,
+            created_by TEXT, updated_by TEXT, created_at INTEGER, updated_at INTEGER
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(RuntimeError, match="incompatible existing roadmaps table"):
+        open_contract_db(path)
+
+    check = sqlite3.connect(path)
+    assert {
+        row[0] for row in check.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    } == {"roadmaps"}
+    check.close()
+
+
+def test_fixture_failure_rolls_back_new_roadmap_tables_and_preserves_legacy(tmp_path: Path) -> None:
+    path = tmp_path / "injected-failure.db"
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE legacy (id INTEGER PRIMARY KEY, value TEXT)")
+    conn.execute("INSERT INTO legacy VALUES (1, 'keep')")
+    conn.execute("CREATE INDEX legacy_value ON legacy(value)")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(RuntimeError, match="injected fixture failure"):
+        open_contract_db(path, fail_after_statement=2)
+
+    check = sqlite3.connect(path)
+    assert check.execute("SELECT value FROM legacy WHERE id=1").fetchone()[0] == "keep"
+    assert "legacy_value" in {row[1] for row in check.execute("PRAGMA index_list(legacy)")}
+    assert not {
+        row[0] for row in check.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }.intersection({"roadmaps", "roadmap_versions", "roadmap_nodes", "roadmap_relations", "roadmap_todos"})
+    check.close()

--- a/tools/roadmaps_tools.py
+++ b/tools/roadmaps_tools.py
@@ -1,0 +1,268 @@
+"""Procedural, read-only agent tools for the Roadmaps orchestration surface.
+
+Roadmaps is an orchestration layer over the native Hermes stores.  This first
+slice deliberately exposes reads only: durable mutations will be added behind
+service-side authorization, optimistic versions, and idempotent events.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from hermes_cli.roadmaps_service import RoadmapsService, RoadmapsUnavailable
+from hermes_cli.roadmaps_writer import (
+    InvalidRoadmapTransitionError,
+    RoadmapNodeNotFoundError,
+    RoadmapNotFoundError,
+    RoadmapsWriteError,
+    RoadmapsWriter,
+    StaleRoadmapVersionError,
+)
+from hermes_constants import get_hermes_home
+from tools.registry import registry
+
+
+def _required(value: Any, name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    value = value.strip()
+    if not value or len(value) > RoadmapsService.MAX_IDENTIFIER_LENGTH:
+        raise ValueError(f"{name} must be a non-empty string of at most 128 characters")
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise ValueError(f"{name} contains control characters")
+    return value
+
+
+def _service() -> RoadmapsService:
+    """Return a read-only service for the active profile only."""
+    return RoadmapsService(get_hermes_home() / "projects.db")
+
+
+def _writer() -> RoadmapsWriter:
+    """Return an authorized writer for the active profile only."""
+    return RoadmapsWriter(get_hermes_home() / "projects.db")
+
+
+def _mutation_error(exc: Exception) -> str:
+    if isinstance(exc, StaleRoadmapVersionError):
+        return json.dumps({"success": False, "error": "stale_roadmap_version", "detail": str(exc)})
+    if isinstance(exc, (RoadmapNotFoundError, RoadmapNodeNotFoundError)):
+        return json.dumps({"success": False, "error": "roadmap_not_found", "detail": str(exc)})
+    if isinstance(exc, InvalidRoadmapTransitionError):
+        return json.dumps({"success": False, "error": "invalid_transition", "detail": str(exc)})
+    return json.dumps({"success": False, "error": "roadmap_write_failed", "detail": str(exc)})
+
+
+def roadmap_list(profile_id: str, project_id: str | None = None) -> str:
+    """List Roadmaps in the active profile, optionally scoped to one project."""
+    profile_id = _required(profile_id, "profile_id")
+    if project_id is not None:
+        project_id = _required(project_id, "project_id")
+    try:
+        result = _service().list(profile_id, project_id)
+    except RoadmapsUnavailable as exc:
+        return json.dumps({"success": False, "error": "roadmaps unavailable", "detail": str(exc)})
+    return json.dumps(result, ensure_ascii=False)
+
+
+def roadmap_context(profile_id: str, project_id: str, roadmap_id: str) -> str:
+    """Read the complete durable snapshot for one explicitly scoped Roadmap."""
+    profile_id = _required(profile_id, "profile_id")
+    project_id = _required(project_id, "project_id")
+    roadmap_id = _required(roadmap_id, "roadmap_id")
+    try:
+        result = _service().get_snapshot(profile_id, project_id, roadmap_id)
+    except RoadmapsUnavailable as exc:
+        return json.dumps({"success": False, "error": "roadmaps unavailable", "detail": str(exc)})
+    return json.dumps(result, ensure_ascii=False)
+
+
+registry.register(
+    name="roadmap_list",
+    toolset="roadmaps",
+    schema={
+        "name": "roadmap_list",
+        "description": (
+            "List Roadmaps available in the active Hermes profile. The profile_id "
+            "and optional project_id are mandatory scope identifiers; never infer "
+            "another profile or silently fall back to a default project. Read-only."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "profile_id": {"type": "string", "description": "Explicit Hermes profile scope"},
+                "project_id": {"type": "string", "description": "Optional explicit Project scope"},
+            },
+            "required": ["profile_id"],
+        },
+    },
+    handler=lambda args, **kw: roadmap_list(
+        profile_id=args.get("profile_id", ""), project_id=args.get("project_id")
+    ),
+    max_result_size_chars=100_000,
+)
+
+registry.register(
+    name="roadmap_context",
+    toolset="roadmaps",
+    schema={
+        "name": "roadmap_context",
+        "description": (
+            "Read the complete durable Roadmap snapshot for an explicitly scoped "
+            "profile, Project, and roadmap. Use this before acting on an assigned "
+            "orchestrated task. Read-only; does not mutate Hermes state."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "profile_id": {"type": "string", "description": "Explicit Hermes profile scope"},
+                "project_id": {"type": "string", "description": "Explicit Project id"},
+                "roadmap_id": {"type": "string", "description": "Explicit Roadmap id"},
+            },
+            "required": ["profile_id", "project_id", "roadmap_id"],
+        },
+    },
+    handler=lambda args, **kw: roadmap_context(
+        profile_id=args.get("profile_id", ""),
+        project_id=args.get("project_id", ""),
+        roadmap_id=args.get("roadmap_id", ""),
+    ),
+    max_result_size_chars=200_000,
+)
+
+
+def _mutation_args(args: dict) -> dict:
+    """Extract the shared scope/actor/version params from a mutation call."""
+    return {
+        "profile_id": args.get("profile_id", ""),
+        "project_id": args.get("project_id", ""),
+        "roadmap_id": args.get("roadmap_id", ""),
+        "node_id": args.get("node_id", ""),
+        "actor": args.get("actor", ""),
+        "expected_version": args.get("expected_version"),
+    }
+
+
+def roadmap_claim_node(profile_id: str, project_id: str, roadmap_id: str, node_id: str, actor: str, expected_version: Any) -> str:
+    try:
+        result = _writer().claim_node(profile_id, project_id, roadmap_id, node_id, actor, expected_version)
+    except (ValueError, RoadmapsWriteError) as exc:
+        return _mutation_error(exc)
+    return json.dumps(result, ensure_ascii=False)
+
+
+def roadmap_update_progress(profile_id: str, project_id: str, roadmap_id: str, node_id: str, actor: str, progress: Any, expected_version: Any) -> str:
+    try:
+        result = _writer().update_progress(profile_id, project_id, roadmap_id, node_id, actor, progress, expected_version)
+    except (ValueError, RoadmapsWriteError) as exc:
+        return _mutation_error(exc)
+    return json.dumps(result, ensure_ascii=False)
+
+
+def roadmap_complete_node(profile_id: str, project_id: str, roadmap_id: str, node_id: str, actor: str, expected_version: Any) -> str:
+    try:
+        result = _writer().complete_node(profile_id, project_id, roadmap_id, node_id, actor, expected_version)
+    except (ValueError, RoadmapsWriteError) as exc:
+        return _mutation_error(exc)
+    return json.dumps(result, ensure_ascii=False)
+
+
+def roadmap_block_node(profile_id: str, project_id: str, roadmap_id: str, node_id: str, actor: str, reason: str, expected_version: Any) -> str:
+    try:
+        result = _writer().block_node(profile_id, project_id, roadmap_id, node_id, actor, reason, expected_version)
+    except (ValueError, RoadmapsWriteError) as exc:
+        return _mutation_error(exc)
+    return json.dumps(result, ensure_ascii=False)
+
+
+def roadmap_unblock_node(profile_id: str, project_id: str, roadmap_id: str, node_id: str, actor: str, expected_version: Any) -> str:
+    try:
+        result = _writer().unblock_node(profile_id, project_id, roadmap_id, node_id, actor, expected_version)
+    except (ValueError, RoadmapsWriteError) as exc:
+        return _mutation_error(exc)
+    return json.dumps(result, ensure_ascii=False)
+
+
+def _mutation_schema(name: str, description: str, extra_properties: dict | None = None) -> dict:
+    properties = {
+        "profile_id": {"type": "string", "description": "Explicit Hermes profile scope"},
+        "project_id": {"type": "string", "description": "Explicit Project id"},
+        "roadmap_id": {"type": "string", "description": "Explicit Roadmap id"},
+        "node_id": {"type": "string", "description": "Explicit node id within the active roadmap version"},
+        "actor": {"type": "string", "description": "Identity performing the mutation (profile or agent id)"},
+        "expected_version": {"type": "integer", "description": "Roadmap active version the caller observed; mutation is rejected if the plan was revised"},
+    }
+    if extra_properties:
+        properties.update(extra_properties)
+    return {
+        "name": name,
+        "description": description,
+        "parameters": {
+            "type": "object",
+            "properties": properties,
+            "required": ["profile_id", "project_id", "roadmap_id", "node_id", "actor", "expected_version"],
+        },
+    }
+
+
+registry.register(
+    name="roadmap_claim_node",
+    toolset="roadmaps",
+    schema=_mutation_schema(
+        "roadmap_claim_node",
+        "Claim an explicitly scoped roadmap node: moves a 'ready' node to 'in_progress' and assigns the actor as owner. Rejected if the roadmap was revised since the caller read it (pass the observed expected_version).",
+    ),
+    handler=lambda args, **kw: roadmap_claim_node(**_mutation_args(args)),
+    max_result_size_chars=20_000,
+)
+
+registry.register(
+    name="roadmap_update_progress",
+    toolset="roadmaps",
+    schema=_mutation_schema(
+        "roadmap_update_progress",
+        "Record execution progress (0-100) on an 'in_progress' roadmap node. Requires the explicit scope, actor, and the observed expected_version.",
+        {"progress": {"type": "integer", "description": "Progress percentage, 0-100"}},
+    ),
+    handler=lambda args, **kw: roadmap_update_progress(
+        progress=args.get("progress"), **_mutation_args(args)
+    ),
+    max_result_size_chars=20_000,
+)
+
+registry.register(
+    name="roadmap_complete_node",
+    toolset="roadmaps",
+    schema=_mutation_schema(
+        "roadmap_complete_node",
+        "Mark an explicitly scoped roadmap node completed (from 'in_progress' or 'blocked'); progress becomes 100 and any block reason is cleared.",
+    ),
+    handler=lambda args, **kw: roadmap_complete_node(**_mutation_args(args)),
+    max_result_size_chars=20_000,
+)
+
+registry.register(
+    name="roadmap_block_node",
+    toolset="roadmaps",
+    schema=_mutation_schema(
+        "roadmap_block_node",
+        "Block an 'in_progress' roadmap node with a required typed reason; the reason is persisted on the node.",
+        {"reason": {"type": "string", "description": "Non-empty block reason"}},
+    ),
+    handler=lambda args, **kw: roadmap_block_node(
+        reason=args.get("reason", ""), **_mutation_args(args)
+    ),
+    max_result_size_chars=20_000,
+)
+
+registry.register(
+    name="roadmap_unblock_node",
+    toolset="roadmaps",
+    schema=_mutation_schema(
+        "roadmap_unblock_node",
+        "Return a 'blocked' roadmap node to 'in_progress' and clear its block reason.",
+    ),
+    handler=lambda args, **kw: roadmap_unblock_node(**_mutation_args(args)),
+    max_result_size_chars=20_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -263,6 +263,20 @@ TOOLSETS = {
         "includes": []
     },
 
+    "roadmaps": {
+        "description": (
+            "Roadmaps orchestration — read the explicit profile/Project snapshot "
+            "and apply versioned execution mutations (claim, progress, complete, "
+            "block) for agents assigned to an orchestrated project"
+        ),
+        "tools": [
+            "roadmap_list", "roadmap_context",
+            "roadmap_claim_node", "roadmap_update_progress",
+            "roadmap_complete_node", "roadmap_block_node", "roadmap_unblock_node",
+        ],
+        "includes": []
+    },
+
     # Affordances that only exist because a GUI renderer is on the other end of
     # the connection: read/close the embedded terminal pane, open and read the
     # in-app browser, focus a pane, tapback a message.


### PR DESCRIPTION
Part 3/5 (depends on #87681). Registers the `roadmaps` toolset and the 7 agent tools wrapping the writer/service. 223 tests.