### PR TITLE
fix(desktop): gate transcript budget cap on hot-hidden pane so Show earlier works

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -309,3 +309,25 @@ describe('liveTailStart', () => {
     }
   })
 })
+
+// Regression for the "Show earlier" no-op (#55191-adjacent): the render-phase
+// budget cap must only shrink a HOT-HIDDEN pane's budget, never a VISIBLE pane.
+// A visible pane legitimately grows its DOM budget ABOVE the shared paneBudget
+// on every "Show earlier" click, and an ungated cap reverted that growth on the
+// next render — so the click did nothing. The cap's contract lives in
+// list.tsx, but the boundary it must respect is expressed by transcriptPaneBudget:
+// a visible pane gets the full screen budget, a hot-hidden pane gets the small
+// retention budget. If that guarantee ever inverts, the click-to-page path
+// silently dies for visible panes.
+describe('render-phase budget cap respects pane visibility', () => {
+  it('grants a visible pane the full screen budget (room to grow on Show earlier)', () => {
+    // Single visible pane → full RENDER_BUDGET (600). "Show earlier" raises the
+    // DOM budget above this; the cap must not snap it back for a visible pane.
+    expect(transcriptPaneBudget(1, false)).toBeGreaterThan(HIDDEN_TRANSCRIPT_RENDER_BUDGET)
+    expect(transcriptPaneBudget(1, false)).toBe(600)
+  })
+
+  it('grants a hot-hidden pane only the small retention budget', () => {
+    expect(transcriptPaneBudget(1, true)).toBe(HIDDEN_TRANSCRIPT_RENDER_BUDGET)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -433,9 +433,14 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     setBudgetSessionKey(sessionKey)
     setHadGroups(hasGroups)
     setRenderBudget(FIRST_PAINT_BUDGET)
-  } else if (renderBudget > paneBudget) {
+  } else if (paneLifecycle === 'hot-hidden' && renderBudget > paneBudget) {
     // Apply the hidden budget during render so React never first commits the
-    // stale full transcript after this pane moves to the background.
+    // stale full transcript after this pane moves to the background. Guarded on
+    // the pane being hot-hidden: a VISIBLE pane legitimately grows its budget
+    // above paneBudget — each "Show earlier" click adds a full pane page — and
+    // an ungated cap reverts that growth on the very next render, making the
+    // click a no-op (regression from 62eefff697, "bound long-running app
+    // resource use").
     setRenderBudget(paneBudget)
   } else if (hadGroups !== hasGroups) {
     setHadGroups(hasGroups)


### PR DESCRIPTION
What does this PR do?
The "Show earlier messages" button in the desktop transcript renders but does nothing when clicked. This PR fixes the root cause: the render-phase budget cap added in 62eefff697 ("bound long-running app resource use") shrank the transcript render budget whenever renderBudget > paneBudget with no check on pane visibility.

"Show earlier" works by raising the DOM render budget ABOVE paneBudget on each click (setRenderBudget(budget => budget + paneBudget) — one full pane page per click). The ungated cap reverted that growth on the very next render, so the click had no visible effect — for both the DOM-page path and the store-window (expandWindow) path.

The fix gates the cap on the pane actually being hot-hidden (paneLifecycle === 'hot-hidden'), which is its original intent: only a backgrounded, retained transcript should be snapped down to the small retention budget. A visible pane keeps whatever budget the user has paged to.

Related Issue
Fixes the transcript-history regression introduced by 62eefff697.

Related (same area, different root cause):

#80141 — Desktop: sticky pinned user message covers the "view earlier messages" button in long sessions
#87182 — Timeline rail click does nothing for messages not yet materialized in the DOM (behind "Show earlier")
Type of Change
 🐛 Bug fix (non-breaking change that fixes an issue)
 ✅ Tests (adding or improving test coverage)
Changes Made
apps/desktop/src/components/assistant-ui/thread/list.tsx — gate the render-phase budget cap on paneLifecycle === 'hot-hidden' so a visible pane's "Show earlier" growth survives.
apps/desktop/src/components/assistant-ui/thread/list.test.ts — regression test pinning the budget contract (visible pane gets full screen budget; hot-hidden pane only the retention budget).
How to Test
Open a long session (enough transcript that "Show earlier messages" appears at the top).
Click "Show earlier messages".
Before: nothing happens (button renders, no history revealed).
After: older turns are prepended / the store window expands, and the view stays anchored.
Unit: npx vitest run src/components/assistant-ui/thread/list.test.ts
Checklist
 I've read the Contributing Guide
 Commit follows Conventional Commits (fix(desktop):)
 Searched existing PRs (no open PR addresses this exact root cause)
 PR contains only changes related to this fix
 Tests added for the change (required for bug fixes)
 Tested on: Windows 11 (the platform that surfaced the regression)
 Cross-platform impact considered: the cap guard is visibility-based, not OS-based — N/A