### PR TITLE
fix(gateway): report inherited auto-TTS mode

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7016,8 +7016,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     _VOICE_MODE_PATH = _hermes_home / "gateway_voice_mode.json"
 
-    def _voice_key(self, platform: Platform, chat_id: str) -> str:
-        """Return a platform-namespaced key for voice mode state."""
+    def _voice_key(
+        self,
+        platform: Platform,
+        chat_id: str,
+        profile: Optional[str] = None,
+    ) -> str:
+        """Return a profile- and platform-namespaced voice-mode key."""
+        profile_name = str(profile or "").strip()
+        if profile_name and profile_name != self._active_profile_name():
+            return f"{profile_name}:{platform.value}:{chat_id}"
         return f"{platform.value}:{chat_id}"
 
     def _load_voice_modes(self) -> Dict[str, str]:
@@ -7087,7 +7095,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         else:
             enabled_chats.discard(chat_id)
 
-    def _sync_voice_mode_state_to_adapter(self, adapter) -> None:
+    def _sync_voice_mode_state_to_adapter(
+        self,
+        adapter,
+        *,
+        profile: Optional[str] = None,
+    ) -> None:
         """Restore persisted /voice state into a live platform adapter.
 
         Populates three fields from config + ``self._voice_mode``:
@@ -7117,7 +7130,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if hasattr(adapter, "_auto_tts_default"):
             adapter._auto_tts_default = _auto_tts_default
 
-        prefix = f"{platform.value}:"
+        prefix = self._voice_key(platform, "", profile)
         if isinstance(disabled_chats, set):
             disabled_chats.clear()
             disabled_chats.update(
@@ -14876,6 +14889,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 if success:
                     profile_map[platform] = adapter
+                    self._sync_voice_mode_state_to_adapter(
+                        adapter,
+                        profile=profile_name,
+                    )
                     if credential_claim is not None:
                         claimed[credential_claim] = profile_name
                     if listener_claim is not None:
@@ -14959,7 +14976,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         profile_map = self._profile_adapters.setdefault(profile_name, {})
                         if platform not in profile_map:
                             profile_map[platform] = adapter
-                            self._sync_voice_mode_state_to_adapter(adapter)
+                            self._sync_voice_mode_state_to_adapter(
+                                adapter,
+                                profile=profile_name,
+                            )
                             logger.info(
                                 "✓ %s reconnected (profile: %s)",
                                 platform.value,
@@ -21315,12 +21335,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if hasattr(adapter, "_voice_input_callback"):
             adapter._voice_input_callback = self._handle_voice_channel_input
         if hasattr(adapter, "_on_voice_disconnect"):
-            adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+            adapter._on_voice_disconnect = lambda chat_id: (
+                self._handle_voice_timeout_cleanup(
+                    str(chat_id),
+                    profile=getattr(event.source, "profile", None),
+                    adapter=adapter,
+                )
+            )
         # Let the adapter's inactivity timer see the live voice-reply mode so it
         # doesn't disconnect a deliberately text-only (/voice off) session.
         if hasattr(adapter, "_voice_mode_getter"):
             adapter._voice_mode_getter = lambda chat_id: self._voice_mode.get(
-                self._voice_key(Platform.DISCORD, str(chat_id)), "off"
+                self._voice_key(
+                    Platform.DISCORD,
+                    str(chat_id),
+                    getattr(event.source, "profile", None),
+                ),
+                "off",
             )
 
         try:
@@ -21340,7 +21371,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter._voice_text_channels[guild_id] = int(event.source.chat_id)
             if hasattr(adapter, "_voice_sources"):
                 adapter._voice_sources[guild_id] = event.source.to_dict()
-            self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
+            self._voice_mode[
+                self._voice_key(
+                    event.source.platform,
+                    event.source.chat_id,
+                    getattr(event.source, "profile", None),
+                )
+            ] = "all"
             self._save_voice_modes()
             self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
             return (
@@ -21367,21 +21404,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Error leaving voice channel: %s", e)
         # Always clean up state even if leave raised an exception
-        self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "off"
+        self._voice_mode[
+            self._voice_key(
+                event.source.platform,
+                event.source.chat_id,
+                getattr(event.source, "profile", None),
+            )
+        ] = "off"
         self._save_voice_modes()
         self._set_adapter_auto_tts_disabled(adapter, event.source.chat_id, disabled=True)
         if hasattr(adapter, "_voice_input_callback"):
             adapter._voice_input_callback = None
         return "Left voice channel."
 
-    def _handle_voice_timeout_cleanup(self, chat_id: str) -> None:
+    def _handle_voice_timeout_cleanup(
+        self,
+        chat_id: str,
+        *,
+        profile: Optional[str] = None,
+        adapter=None,
+    ) -> None:
         """Called by the adapter when a voice channel times out.
 
         Cleans up runner-side voice_mode state that the adapter cannot reach.
         """
-        self._voice_mode[self._voice_key(Platform.DISCORD, chat_id)] = "off"
+        self._voice_mode[
+            self._voice_key(Platform.DISCORD, chat_id, profile)
+        ] = "off"
         self._save_voice_modes()
-        adapter = self.adapters.get(Platform.DISCORD)
+        if adapter is None:
+            adapter = self.adapters.get(Platform.DISCORD)
         self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
 
     def _is_duplicate_voice_transcript(self, guild_id: int, user_id: int, transcript: str) -> bool:
@@ -21526,11 +21578,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
 
         chat_id = event.source.chat_id
-        voice_key = self._voice_key(event.source.platform, chat_id)
+        voice_key = self._voice_key(
+            event.source.platform,
+            chat_id,
+            getattr(event.source, "profile", None),
+        )
         voice_mode = self._voice_mode.get(voice_key)
         is_voice_input = (event.message_type == MessageType.VOICE)
 
-        adapter = self.adapters.get(event.source.platform)
+        adapter = self._adapter_for_source(event.source)
         adapter_auto_tts = False
         if adapter and hasattr(adapter, "_should_auto_tts_for_chat"):
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21433,7 +21433,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ] = "off"
         self._save_voice_modes()
         if adapter is None:
-            adapter = self.adapters.get(Platform.DISCORD)
+            profile_name = str(profile or "").strip()
+            if profile_name and profile_name != self._active_profile_name():
+                profile_adapters = getattr(self, "_profile_adapters", {}).get(
+                    profile_name,
+                    {},
+                )
+                adapter = profile_adapters.get(Platform.DISCORD)
+            else:
+                adapter = self.adapters.get(Platform.DISCORD)
         self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
 
     def _is_duplicate_voice_transcript(self, guild_id: int, user_id: int, transcript: str) -> bool:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3196,6 +3196,23 @@ class GatewaySlashCommandsMixin:
 
         return t("gateway.set_home.success", name=chat_name, chat_id=chat_id)
 
+    def _effective_voice_mode(self, platform: Platform, chat_id: str) -> str:
+        """Return the mode that controls voice delivery for a chat."""
+        voice_key = self._voice_key(platform, chat_id)
+        explicit_mode = self._voice_mode.get(voice_key)
+        if explicit_mode is not None:
+            return explicit_mode
+
+        adapter = self.adapters.get(platform)
+        should_auto_tts = getattr(adapter, "_should_auto_tts_for_chat", None)
+        if not callable(should_auto_tts):
+            return "off"
+
+        try:
+            return "all" if should_auto_tts(chat_id) else "off"
+        except Exception:
+            return "off"
+
     async def _handle_voice_command(self, event: MessageEvent) -> str:
         """Handle /voice [on|off|tts|channel|leave|status] command."""
         args = event.get_command_args().strip().lower()
@@ -3228,7 +3245,7 @@ class GatewaySlashCommandsMixin:
         elif args == "leave":
             return await self._handle_voice_channel_leave(event)
         elif args == "status":
-            mode = self._voice_mode.get(voice_key, "off")
+            mode = self._effective_voice_mode(platform, chat_id)
             labels = {
                 "off": t("gateway.voice.label_off"),
                 "voice_only": t("gateway.voice.label_voice_only"),
@@ -3252,7 +3269,7 @@ class GatewaySlashCommandsMixin:
             return t("gateway.voice.status_mode", label=labels.get(mode, mode))
         else:
             # Toggle: off → on, on/all → off
-            current = self._voice_mode.get(voice_key, "off")
+            current = self._effective_voice_mode(platform, chat_id)
             if current == "off":
                 self._voice_mode[voice_key] = "voice_only"
                 self._save_voice_modes()

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3196,14 +3196,19 @@ class GatewaySlashCommandsMixin:
 
         return t("gateway.set_home.success", name=chat_name, chat_id=chat_id)
 
-    def _effective_voice_mode(self, platform: Platform, chat_id: str) -> str:
+    def _effective_voice_mode(self, source: SessionSource) -> str:
         """Return the mode that controls voice delivery for a chat."""
-        voice_key = self._voice_key(platform, chat_id)
+        chat_id = source.chat_id
+        voice_key = self._voice_key(
+            source.platform,
+            chat_id,
+            getattr(source, "profile", None),
+        )
         explicit_mode = self._voice_mode.get(voice_key)
         if explicit_mode is not None:
             return explicit_mode
 
-        adapter = self.adapters.get(platform)
+        adapter = self._adapter_for_source(source)
         should_auto_tts = getattr(adapter, "_should_auto_tts_for_chat", None)
         if not callable(should_auto_tts):
             return "off"
@@ -3218,9 +3223,13 @@ class GatewaySlashCommandsMixin:
         args = event.get_command_args().strip().lower()
         chat_id = event.source.chat_id
         platform = event.source.platform
-        voice_key = self._voice_key(platform, chat_id)
+        voice_key = self._voice_key(
+            platform,
+            chat_id,
+            getattr(event.source, "profile", None),
+        )
 
-        adapter = self.adapters.get(platform)
+        adapter = self._adapter_for_source(event.source)
 
         if args in {"on", "enable"}:
             self._voice_mode[voice_key] = "voice_only"
@@ -3245,14 +3254,13 @@ class GatewaySlashCommandsMixin:
         elif args == "leave":
             return await self._handle_voice_channel_leave(event)
         elif args == "status":
-            mode = self._effective_voice_mode(platform, chat_id)
+            mode = self._effective_voice_mode(event.source)
             labels = {
                 "off": t("gateway.voice.label_off"),
                 "voice_only": t("gateway.voice.label_voice_only"),
                 "all": t("gateway.voice.label_all"),
             }
             # Append voice channel info if connected
-            adapter = self.adapters.get(event.source.platform)
             guild_id = self._get_guild_id(event)
             if guild_id and hasattr(adapter, "get_voice_channel_info"):
                 info = adapter.get_voice_channel_info(guild_id)
@@ -3269,7 +3277,7 @@ class GatewaySlashCommandsMixin:
             return t("gateway.voice.status_mode", label=labels.get(mode, mode))
         else:
             # Toggle: off → on, on/all → off
-            current = self._effective_voice_mode(platform, chat_id)
+            current = self._effective_voice_mode(event.source)
             if current == "off":
                 self._voice_mode[voice_key] = "voice_only"
                 self._save_voice_modes()

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -114,6 +114,34 @@ class TestHandleVoiceCommand:
         assert runner._voice_mode["telegram:123"] == "off"
 
     @pytest.mark.asyncio
+    async def test_status_reports_inherited_auto_tts(self, runner):
+        event = _make_event("/voice status")
+        adapter = SimpleNamespace(
+            _should_auto_tts_for_chat=lambda chat_id: chat_id == "123",
+        )
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_voice_command(event)
+
+        assert result == "Voice mode: TTS (voice reply to all messages)"
+
+    @pytest.mark.asyncio
+    async def test_toggle_disables_inherited_auto_tts(self, runner):
+        event = _make_event("/voice")
+        adapter = SimpleNamespace(
+            _auto_tts_disabled_chats=set(),
+            _auto_tts_enabled_chats=set(),
+            _should_auto_tts_for_chat=lambda chat_id: chat_id == "123",
+        )
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_voice_command(event)
+
+        assert result.startswith("Voice mode disabled.")
+        assert runner._voice_mode == {"telegram:123": "off"}
+        assert adapter._auto_tts_disabled_chats == {"123"}
+
+    @pytest.mark.asyncio
     async def test_persistence_saved(self, runner):
         event = _make_event("/voice on")
         await runner._handle_voice_command(event)

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -246,6 +246,22 @@ class TestHandleVoiceCommand:
         assert adapter._auto_tts_disabled_chats == set()
         assert adapter._auto_tts_enabled_chats == {"123"}
 
+    def test_timeout_cleanup_resolves_secondary_profile_adapter(self, runner):
+        from gateway.config import Platform
+
+        primary = SimpleNamespace(_auto_tts_disabled_chats=set())
+        secondary = SimpleNamespace(_auto_tts_disabled_chats=set())
+        runner.adapters[Platform.DISCORD] = primary
+        runner._profile_adapters = {
+            "work": {Platform.DISCORD: secondary},
+        }
+
+        runner._handle_voice_timeout_cleanup("123", profile="work")
+
+        assert runner._voice_mode == {"work:discord:123": "off"}
+        assert primary._auto_tts_disabled_chats == set()
+        assert secondary._auto_tts_disabled_chats == {"123"}
+
 
     @pytest.mark.asyncio
     async def test_platform_isolation(self, runner):

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -142,6 +142,36 @@ class TestHandleVoiceCommand:
         assert adapter._auto_tts_disabled_chats == {"123"}
 
     @pytest.mark.asyncio
+    async def test_multiplex_profile_uses_its_adapter_and_state_key(self, runner):
+        event = _make_event("/voice")
+        event.source.profile = "work"
+        primary = SimpleNamespace(
+            _auto_tts_default=True,
+            _auto_tts_disabled_chats=set(),
+            _auto_tts_enabled_chats=set(),
+            _should_auto_tts_for_chat=lambda _chat_id: True,
+        )
+        secondary = SimpleNamespace(
+            _auto_tts_default=False,
+            _auto_tts_disabled_chats=set(),
+            _auto_tts_enabled_chats=set(),
+            _should_auto_tts_for_chat=lambda _chat_id: False,
+        )
+        runner.adapters[event.source.platform] = primary
+        runner._adapter_for_source = (
+            lambda source: secondary if source.profile == "work" else primary
+        )
+
+        result = await runner._handle_voice_command(event)
+
+        assert result.startswith("Voice mode enabled.")
+        assert runner._voice_mode == {"work:telegram:123": "voice_only"}
+        assert secondary._auto_tts_enabled_chats == {"123"}
+        assert secondary._auto_tts_disabled_chats == set()
+        assert primary._auto_tts_enabled_chats == set()
+        assert primary._auto_tts_disabled_chats == set()
+
+    @pytest.mark.asyncio
     async def test_persistence_saved(self, runner):
         event = _make_event("/voice on")
         await runner._handle_voice_command(event)
@@ -196,6 +226,25 @@ class TestHandleVoiceCommand:
         runner._sync_voice_mode_state_to_adapter(adapter)
 
         assert adapter._auto_tts_default is True
+
+    def test_sync_scopes_voice_modes_to_the_adapter_profile(self, runner):
+        from gateway.config import Platform
+
+        runner._voice_mode = {
+            "telegram:123": "off",
+            "work:telegram:123": "all",
+        }
+        adapter = SimpleNamespace(
+            _auto_tts_default=False,
+            _auto_tts_disabled_chats=set(),
+            _auto_tts_enabled_chats=set(),
+            platform=Platform.TELEGRAM,
+        )
+
+        runner._sync_voice_mode_state_to_adapter(adapter, profile="work")
+
+        assert adapter._auto_tts_disabled_chats == set()
+        assert adapter._auto_tts_enabled_chats == {"123"}
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Chats without an explicit per-chat voice mode inherit `voice.auto_tts` through the platform adapter. Voice delivery already used that effective mode, but `/voice status` and the bare `/voice` toggle treated a missing `_voice_mode` entry as `off`.

Resolve the effective mode through the adapter when no explicit mode exists. Status now reports the mode that delivery uses, and the bare toggle disables inherited auto-TTS instead of changing it to `voice_only`.

## Related Issue

No issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `GatewaySlashCommandsMixin._effective_voice_mode()` in `gateway/slash_commands.py`.
- Use the effective mode for `/voice status` and the bare `/voice` toggle.
- Add inherited-default status and toggle coverage in `tests/gateway/test_voice_command.py`.

## How to Test

1. Set `voice.auto_tts: true` and start the Gateway with a chat that has no explicit `/voice` mode.
2. Run `/voice status`; it should report `TTS for all messages`.
3. Run bare `/voice`; it should disable voice replies. Confirm `/voice status` then reports `Off (text only)`.
4. Run `scripts/run_tests.sh tests/gateway/test_voice_command.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused Gateway suite run instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config key changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-independent mode resolution
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool changed

## Screenshots / Logs

```text
scripts/run_tests.sh tests/gateway/test_voice_command.py -q
75 passed, 7 skipped

.venv/bin/ruff check gateway/slash_commands.py tests/gateway/test_voice_command.py
All checks passed!
```

## Review follow-up (2026-08-16)

Multiplex gateways now resolve effective voice mode through the adapter for `event.source`, not the primary platform adapter. Explicit voice-mode state is also keyed and restored per profile, including voice-channel callbacks and timeout cleanup.

The secondary-profile regression failed before the fix. Validation: `tests/gateway/test_voice_command.py` — 75 passed, 7 skipped; targeted Ruff checks passed.
