### PR TITLE
fix(models): resolve GLM-5.3 context to 1M instead of generic 202K fallback

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -501,13 +501,19 @@ DEFAULT_CONTEXT_LENGTHS = {
     # https://platform.minimax.io/docs/api-reference/text-chat-openai
     "minimax-m3": 1000000,
     "minimax": 204800,
-    # GLM — GLM-5.2 ships with a 1M context window (verified empirically:
-    # needle-in-a-haystack retrieval at 789K prompt tokens succeeded with
-    # zero errors on api.z.ai/api/coding/paas/v4).  Older GLM models
-    # (5, 5.1, 5-turbo) are ~202K.  Longest-key-first substring matching
-    # ensures "glm-5.2" resolves to 1M while older variants still hit the
-    # generic 202K fallback.
+    # GLM — GLM-5.2 and GLM-5.3 ship with a 1M context window.
+    # GLM-5.2 verified empirically: needle-in-a-haystack retrieval at 789K
+    # prompt tokens succeeded with zero errors on api.z.ai/api/coding/paas/v4.
+    # GLM-5.3 verified empirically (2026-08-16): a 1,020,024-token prompt was
+    # accepted and answered via open.bigmodel.cn/api/anthropic with the bare
+    # model id (no [1m] suffix — that suffix is a Claude Code client-side
+    # marker, not part of the API model id; requests with the suffix are
+    # rejected with error 1214 "model not found").
+    # Older GLM models (5, 5.1, 5-turbo) are ~202K.  Longest-key-first
+    # substring matching ensures "glm-5.2"/"glm-5.3" resolve to 1M while
+    # older variants still hit the generic 202K fallback.
     "glm-5.2": 1_048_576,
+    "glm-5.3": 1_048_576,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -837,6 +837,39 @@ class TestGetModelContextLength:
         )
         assert result == 202752  # "glm" entry in DEFAULT_CONTEXT_LENGTHS
 
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_glm_5_3_resolves_to_1m_not_generic_fallback(self, mock_endpoint_fetch, mock_fetch):
+        """GLM-5.3 must resolve to the 1M entry, not the generic ~202K "glm"
+        fallback.
+
+        Before the "glm-5.3" key was added to DEFAULT_CONTEXT_LENGTHS,
+        longest-key-first substring matching fell through to "glm" (202752),
+        under-reporting the real context window by ~5x and firing context
+        compression five times earlier than necessary on Zhipu endpoints
+        (verified empirically: a 1,020,024-token prompt is accepted by
+        open.bigmodel.cn/api/anthropic with the bare "glm-5.3" model id).
+        """
+        mock_fetch.return_value = {}
+        mock_endpoint_fetch.return_value = {}
+
+        result = get_model_context_length(
+            "glm-5.3",
+            base_url="https://open.bigmodel.cn/api/anthropic",
+            api_key="test-key",
+        )
+        assert result == 1_048_576
+
+        # Config override still wins over the catalog entry (resolution
+        # step 0), so users on restricted endpoints keep full control.
+        result_override = get_model_context_length(
+            "glm-5.3",
+            base_url="https://open.bigmodel.cn/api/anthropic",
+            api_key="test-key",
+            config_context_length=123_456,
+        )
+        assert result_override == 123_456
+
 
 
 


### PR DESCRIPTION
## Summary

- Adds the `glm-5.3` key to `DEFAULT_CONTEXT_LENGTHS` in `agent/model_metadata.py`, resolving it to 1,048,576 tokens instead of falling through to the generic `"glm"` entry (202,752).
- Adds a regression test (`test_glm_5_3_resolves_to_1m_not_generic_fallback`) covering both the catalog hit and the config-override precedence.

## Problem

GLM-5.3 was absent from the hardcoded catalog, so longest-key-first substring matching fell through to `"glm": 202752`. On Zhipu endpoints this under-reported the real context window by ~5x, which:

- showed a wrong denominator in the status bar (`51.5K/202.8K` at only 5% actual usage), and
- fired automatic context compression at ~101K instead of ~524K (`compression.threshold: 0.50`), discarding conversation detail five times earlier than necessary.

## Verification

Verified empirically against the live API (2026-08-16), Zhipu GLM Coding Plan, `https://open.bigmodel.cn/api/anthropic`:

- 289,024-token prompt: accepted, answered normally
- **1,020,024-token prompt: accepted, answered normally** — the full 1M window is usable

Note on the `[1m]` suffix from the Zhipu "switch model" docs: it is a **Claude Code client-side marker**, not part of the API model id. Sending `glm-5.3[1m]` directly to either `open.bigmodel.cn/api/anthropic` or `open.bigmodel.cn/api/coding/paas/v4` is rejected with error `1214` (model not found). The bare `glm-5.3` id already serves the 1M window, so no suffix handling is needed here.

## Testing

- `./venv/bin/python -m pytest tests/agent/test_model_metadata.py -o 'addopts=' -q` → **83 passed** (82 existing + 1 new), both in the live checkout and in a fresh `git clone --shared` copy.
