### PR TITLE
docs: define voice.auto_tts across surfaces

### DIFF
--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -168,7 +168,7 @@ voice:
   record_key: "ctrl+b"
   submit_mode: "direct"  # TUI: direct | draft
   max_recording_seconds: 120
-  auto_tts: false
+  auto_tts: false         # Keep automatic speech off by default
   beep_enabled: true
   silence_threshold: 200
   silence_duration: 3.0
@@ -185,6 +185,16 @@ tts:
 ```
 
 This is a good conservative default for most people.
+
+Leave `auto_tts` set to `false` if you want speech to remain opt-in. When it is
+`true`, the classic CLI enables TTS when you run `/voice on`, Desktop reads
+each completed assistant reply aloud outside a full voice conversation, and
+the gateway speaks every reply in chats without an explicit `/voice` setting.
+The TUI does not read this key; use `/voice tts` to control speech for the
+current runtime. See the [automatic TTS reference][automatic-tts] for the
+complete per-surface behaviour.
+
+[automatic-tts]: /user-guide/features/voice-mode#voiceauto_tts
 
 In the TUI, `voice.submit_mode` controls what happens after transcription:
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2011,20 +2011,30 @@ stt:
 The final prompt is sent to the configured STT provider alongside the audio file. Keep secrets and session-derived context out of `stt.prompt` and out of anything a `pre_transcription` hook returns, especially when the provider is a hosted API rather than local `faster-whisper`.
 :::
 
-## Voice Mode (CLI)
+## Voice and automatic TTS
 
 ```yaml
 voice:
   record_key: "ctrl+b"         # Push-to-talk key inside the CLI
   max_recording_seconds: 120    # Hard stop for long recordings
-  auto_tts: false               # Enable spoken replies automatically when /voice on
+  auto_tts: false               # Shared automatic speech preference
   beep_enabled: true            # Play record start/stop beeps in CLI voice mode
   beep_volume: 0.3              # Beep amplitude (0.0-1.0); raise it on quiet systems / headphones
   silence_threshold: 200        # RMS threshold for speech detection
   silence_duration: 3.0         # Seconds of silence before auto-stop
 ```
 
-Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. See [Voice Mode](/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.
+`voice.auto_tts` does not enable microphone mode. It controls automatic speech,
+but each surface applies it at a different point. The classic CLI reads it when
+`/voice on` starts voice mode. Desktop uses it for **Read Responses Aloud**.
+The gateway uses it as the default for chats without an explicit `/voice`
+setting. The TUI currently uses its runtime `/voice tts` setting instead.
+
+Use `/voice on` in the classic CLI to enable microphone mode, and use
+`record_key` to start or stop recording. See [Voice Mode][voice-mode] for the
+complete per-surface behaviour.
+
+[voice-mode]: /user-guide/features/voice-mode
 
 ## Streaming
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2017,7 +2017,7 @@ The final prompt is sent to the configured STT provider alongside the audio file
 voice:
   record_key: "ctrl+b"         # Push-to-talk key inside the CLI
   max_recording_seconds: 120    # Hard stop for long recordings
-  auto_tts: false               # Shared automatic speech preference
+  auto_tts: false               # Automatic speech; does not enable microphone mode
   beep_enabled: true            # Play record start/stop beeps in CLI voice mode
   beep_volume: 0.3              # Beep amplitude (0.0-1.0); raise it on quiet systems / headphones
   silence_threshold: 200        # RMS threshold for speech detection

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -111,7 +111,7 @@ If `faster-whisper` is installed, voice mode works with **zero API keys** for ST
 
 ## CLI Voice Mode
 
-Voice mode is available in both the **classic CLI** (`hermes chat`) and the **TUI** (`hermes --tui`). Behavior is identical across both — same slash commands, same VAD silence detection, same streaming TTS, same hallucination filter. The TUI additionally forwards crash-forensic logs to `~/.hermes/logs/` so push-to-talk failures on exotic audio backends can be reported with a full stack trace rather than disappearing silently.
+Voice mode is available in both the **classic CLI** (`hermes chat`) and the **TUI** (`hermes --tui`). Both use the same slash commands, VAD silence detection, streaming TTS, and hallucination filter. Their automatic TTS initialisation differs: the classic CLI reads `voice.auto_tts` when `/voice on` starts voice mode, while the TUI uses its runtime `/voice tts` setting. The TUI additionally forwards crash-forensic logs to `~/.hermes/logs/` so push-to-talk failures on exotic audio backends can be reported with a full stack trace rather than disappearing silently.
 
 ### Quick Start
 
@@ -247,11 +247,13 @@ These work in both Telegram and Discord (DMs and text channels):
 
 | Mode | Command | Behavior |
 |------|---------|----------|
-| `off` | `/voice off` | Text only (default) |
+| `off` | `/voice off` | Text only |
 | `voice_only` | `/voice on` | Speaks reply only when you send a voice message |
 | `all` | `/voice tts` | Speaks reply to every message |
 
-Voice mode setting is persisted across gateway restarts.
+Voice mode setting is persisted across gateway restarts. Before a chat has an
+explicit setting, `voice.auto_tts: true` gives it the effective `all` mode;
+otherwise its effective mode is `off`.
 
 ### Platform Delivery
 
@@ -407,11 +409,11 @@ DISCORD_ALLOWED_USERS=284102345871466496
 ### config.yaml
 
 ```yaml
-# Voice recording (CLI)
+# Voice recording and automatic speech
 voice:
   record_key: "ctrl+b"            # Key to start/stop recording
   max_recording_seconds: 120       # Maximum recording length
-  auto_tts: false                  # Auto-enable TTS when voice mode starts
+  auto_tts: false                  # Shared automatic speech preference
   beep_enabled: true               # Play record start/stop beeps
   silence_threshold: 200           # RMS level (0-32767) below which counts as silence
   silence_duration: 3.0            # Seconds of silence before auto-stop
@@ -455,6 +457,18 @@ tts:
     model: neuphonic/neutts-air-q4-gguf
     device: cpu
 ```
+
+### `voice.auto_tts`
+
+This key is a shared automatic speech preference, not a switch for microphone
+mode. Each surface applies the preference according to its interaction model:
+
+| Surface | Behaviour when `voice.auto_tts` is `true` |
+|---------|--------------------------------------------|
+| Classic CLI | `/voice on` starts voice mode with TTS enabled. The key does not enable voice mode itself. |
+| TUI | No initial effect. Use `/voice tts` to change TTS for the current runtime. |
+| Desktop | **Read Responses Aloud** reads each completed assistant response outside a full voice conversation. A full voice conversation speaks through its own conversation loop. |
+| Gateway | Chats without an explicit voice mode receive spoken replies to every message. `/voice on`, `/voice tts`, and `/voice off` override the default for that chat. |
 
 ### Environment Variables
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -413,7 +413,7 @@ DISCORD_ALLOWED_USERS=284102345871466496
 voice:
   record_key: "ctrl+b"            # Key to start/stop recording
   max_recording_seconds: 120       # Maximum recording length
-  auto_tts: false                  # Shared automatic speech preference
+  auto_tts: false                  # Automatic speech; does not enable microphone mode
   beep_enabled: true               # Play record start/stop beeps
   silence_threshold: 200           # RMS level (0-32767) below which counts as silence
   silence_duration: 3.0            # Seconds of silence before auto-stop


### PR DESCRIPTION
## What does this PR do?

The configuration reference described `voice.auto_tts` only as a classic CLI voice-mode default. Desktop and the Gateway also consume the key, while the TUI currently uses its runtime toggle, so users could not determine which replies the setting affects.

Define `voice.auto_tts` as a shared automatic speech preference, separate it from microphone mode, and document its current behaviour for the classic CLI, TUI, Desktop, and Gateway.

## Related Issue

No issue. Related PR: #87687 is an independent Gateway status and toggle fix.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `website/docs/user-guide/configuration.md` to describe the shared preference and link to the per-surface contract.
- Update `website/docs/user-guide/features/voice-mode.md` with the CLI, TUI, Desktop, and Gateway behaviours.
- Update `website/docs/guides/use-voice-mode-with-hermes.md` to explain that the recommended default controls automatic speech, not microphone mode.

## How to Test

1. Run `npm ci` in `website/`.
2. Run `npm run build:fast`.
3. Open the Voice Mode configuration reference and follow the `voice.auto_tts` links from the configuration and setup pages.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (documentation-only change)
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A (documentation-only change)
- [x] I've tested on my platform: macOS 26.6.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config key changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A; documentation only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool changed

## Screenshots / Logs

```text
npm run build:fast
[SUCCESS] Generated static files in build.
```

Docusaurus also reports the existing `/docs/llms.txt` and `/docs/llms-full.txt` broken-link warnings. `npm run lint:diagrams` could not run because the locked website install does not provide the `ascii-guard` executable.

## Review follow-up (2026-08-16)

The context-blind review found no code or documentation defect in this PR. A production Docusaurus build completed using the checkout's shared installed dependencies.

Merge this after #51806 because both PRs edit `website/docs/user-guide/features/voice-mode.md`; rebase after #51806 lands to keep the documentation diff focused.
