### PR TITLE
fix(auxiliary): honor explicitly-requested :free models under free_only gate and report skip reasons accurately (#85315)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2800,7 +2800,13 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
             "auxiliary.free_only.",
             or_model,
         )
-        _mark_provider_unhealthy("openrouter", ttl=60)
+        # A config-gate skip is a local policy decision, not a provider
+        # failure: do NOT mark OpenRouter unhealthy here. The unhealthy cache
+        # hides the provider from fallback-chain iteration for its TTL, which
+        # would suppress a subsequent *legitimate* explicitly-requested :free
+        # model from another caller within the window (the second half of
+        # #85315). The gate never touched the provider, so there is nothing
+        # to cool down.
         return None, None
     if not _is_free_model(or_model):
         _warn_paid_lane_once(or_model)
@@ -2819,15 +2825,33 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
 
     or_key = explicit_api_key or _scoped_key_env("OPENROUTER_API_KEY")
     if not or_key:
-        _mark_provider_unhealthy("openrouter", ttl=60)
+        _mark_provider_unhealthy(
+            "openrouter", ttl=60, reason="no OpenRouter credentials"
+        )
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return _create_openai_client(api_key=or_key, base_url=OPENROUTER_BASE_URL,
                    default_headers=build_or_headers()), or_model
 
 
-def _describe_openrouter_unavailable() -> str:
-    """Return a more precise OpenRouter auth failure reason for logs."""
+def _describe_openrouter_unavailable(model: Optional[str] = None) -> str:
+    """Return the policy or credential reason OpenRouter was unavailable.
+
+    ``model`` is the slug the caller actually requested (``None`` when the
+    caller let config/default decide). The ``auxiliary.free_only`` gate is
+    checked first: it rejects OpenRouter before any credential is read, so
+    reporting a credential problem there would send the user hunting for a
+    key that is present and funded (#85315).
+    """
+    free_only, cfg_model = _aux_openrouter_settings()
+    or_model = model or cfg_model
+    if free_only and not _is_free_model(or_model):
+        return (
+            f"auxiliary.free_only rejected non-free model {or_model!r}; "
+            "the request was skipped before provider availability checks. "
+            "Set auxiliary.openrouter_model to a :free model or disable "
+            "auxiliary.free_only"
+        )
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
         if entry is None:
@@ -3999,10 +4023,19 @@ def _normalize_chain_label(provider: str) -> str:
     return _AUX_UNHEALTHY_LABEL_ALIASES.get(p, p)
 
 
-def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None:
-    """Mark ``provider`` as recently-402'd, hidden from chain iteration
+def _mark_provider_unhealthy(
+    provider: str,
+    ttl: Optional[float] = None,
+    reason: str = "payment / credit error",
+) -> None:
+    """Mark ``provider`` as recently-failed, hidden from chain iteration
     until the TTL expires. Called from the payment-fallback branches in
     ``call_llm`` and ``acall_llm`` after a confirmed payment error.
+
+    ``reason`` is surfaced verbatim in the WARNING. It defaults to the
+    historical payment wording for the payment-fallback callers; other
+    callers (config gates, missing credentials) pass their own so a skip
+    is not misreported as a payment error (#85315).
     """
     label = _normalize_chain_label(provider)
     if not label:
@@ -4010,10 +4043,11 @@ def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None
     expires_at = time.time() + (ttl if ttl is not None else _AUX_UNHEALTHY_TTL_SECONDS)
     _aux_unhealthy_until[label] = expires_at
     logger.warning(
-        "Auxiliary: marking %s unhealthy for %ds (payment / credit error). "
+        "Auxiliary: marking %s unhealthy for %ds (%s). "
         "Subsequent auxiliary calls will skip it until %s.",
         label,
         int(ttl if ttl is not None else _AUX_UNHEALTHY_TTL_SECONDS),
+        reason,
         time.strftime("%H:%M:%S", time.localtime(expires_at)),
     )
 
@@ -6274,11 +6308,17 @@ def resolve_provider_client(
 
     # ── OpenRouter ───────────────────────────────────────────
     if provider == "openrouter":
-        client, default = _try_openrouter(explicit_api_key=explicit_api_key)
+        # Forward the caller's model so the ``auxiliary.free_only`` gate judges
+        # the slug that will actually be sent, not the config default ─ a caller
+        # explicitly requesting a :free model was otherwise rejected on the
+        # unrelated paid default from auxiliary.openrouter_model (#85315).
+        client, default = _try_openrouter(
+            explicit_api_key=explicit_api_key, model=model
+        )
         if client is None:
             logger.warning(
                 "resolve_provider_client: openrouter requested but %s",
-                _describe_openrouter_unavailable(),
+                _describe_openrouter_unavailable(model),
             )
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1042,6 +1042,51 @@ class TestOpenRouterPaidLaneGuard:
         assert model is None
         mock_openai.assert_not_called()
 
+    def test_resolver_forwards_explicit_free_model_to_gate(self, monkeypatch):
+        """The concrete OpenRouter route gates the caller's model, not its default."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client = MagicMock(name="openrouter_client")
+            mock_openai.return_value = mock_client
+            client, model = resolve_provider_client(
+                "openrouter", model="nvidia/nemotron-3-ultra-550b-a55b:free"
+            )
+
+        assert client is mock_client
+        assert model == "nvidia/nemotron-3-ultra-550b-a55b:free"
+
+    def test_free_only_gate_does_not_mark_openrouter_unhealthy(self, monkeypatch):
+        """A config-gate skip is not a provider failure: health cache untouched."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client._mark_provider_unhealthy") as mark_unhealthy:
+            client, model = resolve_provider_client(
+                "openrouter", model="google/gemini-3.6-flash"
+            )
+
+        assert client is None
+        assert model is None
+        mark_unhealthy.assert_not_called()
+
+    def test_free_only_gate_reports_policy_not_credentials(self, monkeypatch, caplog):
+        """A policy skip must not claim a payment/credential failure."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+            resolve_provider_client("openrouter", model="google/gemini-3.6-flash")
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("free_only" in message and "google/gemini-3.6-flash" in message
+                   for message in messages)
+        assert not any("credentials" in message for message in messages)
+
     def test_paid_lane_warns_once(self, monkeypatch, caplog):
         """Engaging the default paid model logs a WARNING (once per model)."""
         import logging
@@ -1074,6 +1119,242 @@ class TestOpenRouterPaidLaneGuard:
         assert not _is_free_model("google/gemini-3.6-flash")
         assert not _is_free_model("")
         assert not _is_free_model(None)
+
+
+class TestFreeOnlyGateHonoursCallerModel:
+    """Regression: the free_only gate must judge the model actually requested.
+
+    ``resolve_provider_client()`` used to drop its ``model`` argument on the
+    floor, so the gate evaluated ``auxiliary.openrouter_model`` (whose default
+    is the PAID ``google/gemini-3.6-flash``) even when the caller explicitly
+    asked for a ``:free`` SKU. Every such call was rejected, OpenRouter was
+    marked unhealthy as a bogus "payment / credit error", and the log blamed
+    missing credentials on a key that is present and funded.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_unhealthy(self):
+        from agent.auxiliary_client import _aux_unhealthy_until
+        _aux_unhealthy_until.clear()
+        yield
+        _aux_unhealthy_until.clear()
+
+    def test_explicit_free_model_passes_gate_despite_paid_config_default(
+        self, monkeypatch
+    ):
+        """Caller asks for a :free model → resolved, not skipped."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        free_sku = "nvidia/nemotron-3-ultra-550b-a55b:free"
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock(name="openrouter_client")
+            client, model = resolve_provider_client("openrouter", free_sku)
+
+        assert client is not None
+        assert model == free_sku
+
+    def test_paid_caller_model_still_blocked_by_gate(self, monkeypatch):
+        """The cost guard itself is intact: a PAID caller model is skipped."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = resolve_provider_client(
+                "openrouter", "google/gemini-3.6-flash"
+            )
+
+        assert client is None
+        assert model is None
+        mock_openai.assert_not_called()
+
+    def test_gate_rejection_is_not_reported_as_payment_error(
+        self, monkeypatch, caplog
+    ):
+        """A config-gate skip must not claim a payment/credit failure."""
+        import logging
+        from agent.auxiliary_client import _try_openrouter
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI"):
+            with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+                _try_openrouter(model="google/gemini-3.6-flash")
+
+        messages = " ".join(r.getMessage() for r in caplog.records)
+        assert "payment / credit error" not in messages
+        assert "free_only" in messages
+
+    def test_unavailable_description_blames_the_gate_not_credentials(
+        self, monkeypatch
+    ):
+        """Diagnostic names the free_only gate while the key is present."""
+        from agent.auxiliary_client import _describe_openrouter_unavailable
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}):
+            reason = _describe_openrouter_unavailable("google/gemini-3.6-flash")
+
+        assert "free_only" in reason
+        assert "credentials" not in reason
+
+
+class TestFreeOnlyGateE2EConfig:
+    """End-to-end: a real config.yaml on disk drives the free_only gate.
+
+    No config mocks here. We point HERMES_HOME at a temp dir with a real
+    ``config.yaml`` and let ``_aux_openrouter_settings()`` read it through
+    ``load_config_readonly()``, then resolve an OpenRouter client through
+    ``resolve_provider_client()``. Verifies the caller's ``:free`` model
+    actually reaches the gate (the regression) and that the gate is genuinely
+    armed from the file (a paid model is still rejected).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_home(self, tmp_path, monkeypatch):
+        from agent.auxiliary_client import _aux_unhealthy_until
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        monkeypatch.setattr(
+            "hermes_cli.config.get_hermes_home", lambda: tmp_path
+        )
+        _aux_unhealthy_until.clear()
+        yield
+        _aux_unhealthy_until.clear()
+
+    @staticmethod
+    def _write_config(hermes_home, **auxiliary):
+        body = "auxiliary:\n" + "".join(
+            f"  {key}: {str(value).lower()}\n"
+            for key, value in auxiliary.items()
+        )
+        (hermes_home / "config.yaml").write_text(body)
+
+    def test_explicit_free_model_resolves_through_real_config(self, tmp_path):
+        """Caller-set :free model is honored when free_only is really loaded."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        self._write_config(tmp_path, free_only=True)
+        free_sku = "nvidia/nemotron-3-ultra-550b-a55b:free"
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock(name="openrouter_client")
+            client, model = resolve_provider_client("openrouter", free_sku)
+
+        assert client is not None
+        assert model == free_sku
+
+    def test_real_config_free_only_still_blocks_paid_caller_model(self, tmp_path):
+        """free_only loaded from disk genuinely rejects a paid caller model."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        self._write_config(tmp_path, free_only=True)
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = resolve_provider_client(
+                "openrouter", "google/gemini-3.6-flash"
+            )
+
+        assert client is None
+        assert model is None
+        mock_openai.assert_not_called()
+
+
+class TestFreeOnlyGateCombinedBoundaries:
+    """Boundaries across the combined fix (#85315): gate-off behavior, unhealthy
+    cache hygiene (the second-order suppression), reason surfacing, and
+    preserved credential diagnostics."""
+
+    def test_explicit_free_model_passes_when_gate_disabled(self, monkeypatch):
+        """free_only=false: the explicit :free slug is used, gate never blocks."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": False}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client = MagicMock(name="openrouter_client")
+            mock_openai.return_value = mock_client
+            client, model = resolve_provider_client(
+                "openrouter", model="nvidia/nemotron-3-ultra-550b-a55b:free"
+            )
+
+        assert client is mock_client
+        assert model == "nvidia/nemotron-3-ultra-550b-a55b:free"
+
+    def test_gate_rejection_leaves_openrouter_healthy_for_later_free_requests(
+        self, monkeypatch
+    ):
+        """After a paid-model gate skip, OpenRouter must not be suppressed from
+        the fallback chain: a later explicit :free request resolves within the
+        same window (the second-order half of #85315)."""
+        from agent.auxiliary_client import _is_provider_unhealthy, _aux_unhealthy_until
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI"):
+            client, model = resolve_provider_client(
+                "openrouter", model="google/gemini-3.6-flash"
+            )
+
+        assert client is None
+        assert model is None
+        # The gate skip must not have poisoned the unhealthy cache.
+        assert _is_provider_unhealthy("openrouter") is False
+        assert "openrouter" not in _aux_unhealthy_until
+
+        # Same window: the explicit :free request still resolves.
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client = MagicMock(name="openrouter_client")
+            mock_openai.return_value = mock_client
+            client, model = resolve_provider_client(
+                "openrouter", model="nvidia/nemotron-3-ultra-550b-a55b:free"
+            )
+
+        assert client is mock_client
+        assert model == "nvidia/nemotron-3-ultra-550b-a55b:free"
+
+    def test_mark_provider_unhealthy_surfaces_reason_verbatim(self, caplog):
+        """The unhealthy warning names the actual reason, not always a payment
+        error; the payment default is preserved for payment-fallback callers."""
+        import logging
+        from agent.auxiliary_client import _mark_provider_unhealthy, _aux_unhealthy_until
+
+        _aux_unhealthy_until.clear()
+        with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+            _mark_provider_unhealthy("openrouter", ttl=60, reason="no OpenRouter credentials")
+            _mark_provider_unhealthy("nous")
+
+        messages = " ".join(r.getMessage() for r in caplog.records)
+        assert "no OpenRouter credentials" in messages
+        assert "payment / credit error" in messages
+        _aux_unhealthy_until.clear()
+
+    def test_unavailable_still_reports_credentials_when_gate_off(self, monkeypatch):
+        """Gate off + no key: the credential diagnostics are preserved."""
+        from agent.auxiliary_client import _describe_openrouter_unavailable
+
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly", return_value={"auxiliary": {}}):
+            reason = _describe_openrouter_unavailable("google/gemini-3.6-flash")
+
+        assert "OPENROUTER_API_KEY" in reason or "credentials" in reason
+        assert "free_only" not in reason
 
 
 class TestGetTextAuxiliaryClient:


### PR DESCRIPTION
## What does this PR do?

Comprehensive fix for #85315: the `auxiliary.free_only` gate now honors **explicitly-requested** OpenRouter `:free` models, and a config-gate skip is no longer misreported as a payment/credential error — nor does it poison provider health and suppress the very `:free` traffic the option exists to guarantee.

**Combined from #85336 and #85338** — this PR is the synthesis of the two independent fixes for the same issue. It takes the forwarding + policy-diagnostic core from both, #85336's unhealthy-cache hygiene, and #85338's systemic `reason` plumbing + E2E config coverage, and closes the gaps neither covered alone.

### Symptom

A caller explicitly requesting an OpenRouter `:free` model (e.g. `auxiliary.title_generation.model`) can receive no client when `auxiliary.free_only: true` and the configured fallback model is paid. The warning then blames missing/expired credentials, even though the request was rejected by local policy before any provider availability check — on a key that is present and funded.

### Impact

- Explicit `:free` auxiliary tasks are silently skipped despite satisfying the free-only policy.
- A rejected paid model marks OpenRouter unhealthy for 60s (`_mark_provider_unhealthy("openrouter", ttl=60)`), hiding it from fallback-chain iteration — which **re-suppresses subsequent legitimate explicit `:free` requests** from other callers within the window (the second-order half of the bug).
- The diagnostic hunts for a credential problem that does not exist.

### Bug Cause

`resolve_provider_client(provider="openrouter", model="...:free")` called `_try_openrouter(explicit_api_key=...)` **without forwarding `model`**, so the gate computed `or_model = model or cfg_model` and judged the paid config default (`auxiliary.openrouter_model`, default `google/gemini-3.6-flash`) instead of the caller's `:free` slug. On rejection, `_mark_provider_unhealthy("openrouter", ttl=60)` logged a bogus "payment / credit error" and poisoned the unhealthy cache, while `_describe_openrouter_unavailable()` (no `model` param) could only name credential problems.

**Why it is wrong:** the free_only gate must evaluate the effective model for *this request*. A local policy skip is not evidence that the provider or its credentials are unhealthy.

### Fix (absorbing both PRs, closing the class)

| Concern | #85336 | #85338 | Combined (this PR) |
|---|---|---|---|
| Forward caller `model` into `_try_openrouter` so the gate judges the slug that will actually be sent | ✅ | ✅ | ✅ (both) |
| `_describe_openrouter_unavailable(model)` names the gate, not credentials | ✅ | ✅ (with actionable guidance) | ✅ merged wording: names the gate + rejected slug + "skipped before provider availability checks" + actionable fix |
| Gate-rejection must **not** mark OpenRouter unhealthy | ✅ removes the call | ❌ keeps it (only adds a reason) | ✅ removes it — a policy skip must not suppress later legitimate `:free` requests from the fallback chain (the second-order bug #85338 leaves open) |
| `_mark_provider_unhealthy` gains a `reason` param surfaced verbatim in the WARNING (systemic misreport fix; payment fallback callers keep the historical default) | ❌ | ✅ | ✅ |
| Missing-credential branch logs an accurate reason (`"no OpenRouter credentials"`) | ❌ | ✅ | ✅ |
| Tests: explicit `:free` + free_only → resolved | ✅ 1 | ✅ 1 | ✅ both |
| Tests: paid model still blocked by gate | ❌ | ✅ | ✅ |
| Tests: skip not reported as payment error / policy diagnostics | ✅ 1 | ✅ 2 | ✅ both (3) |
| Tests: unhealthy-cache hygiene on gate skip | ✅ 1 | ❌ | ✅ |
| Tests: E2E with a real `config.yaml` on disk (no config mocks) | ❌ | ✅ 2 | ✅ |
| Tests (new in combined): gate-off boundary, cache-hygiene → later `:free` still resolves in same window, reason surfacing (custom + default), credential diagnostics preserved when gate is off | — | — | ✅ 4 |

**Net: 13 regression tests** (3 from #85336, 6 from #85338, 4 new boundaries), all passing.

### Changes Made

- `agent/auxiliary_client.py`
  - `resolve_provider_client` OpenRouter branch forwards `model` into `_try_openrouter` and `_describe_openrouter_unavailable`.
  - `_try_openrouter`: free_only gate skip no longer calls `_mark_provider_unhealthy` (policy decision ≠ provider failure; avoids suppressing later explicit `:free` requests from the chain); missing-credential branch passes `reason="no OpenRouter credentials"`.
  - `_describe_openrouter_unavailable(model=None)`: checks the free_only gate first and returns a policy reason (rejected slug + skipped-before-availability-checks + actionable guidance); credential diagnostics preserved when the gate is off.
  - `_mark_provider_unhealthy(provider, ttl=None, reason="payment / credit error")`: `reason` is logged verbatim; default preserved for payment-fallback callers.
- `tests/agent/test_auxiliary_client.py` — `TestOpenRouterPaidLaneGuard` (3 new), `TestFreeOnlyGateHonoursCallerModel` (4), `TestFreeOnlyGateE2EConfig` (2, real config on disk), `TestFreeOnlyGateCombinedBoundaries` (4).

### How to Test

1. Enable `auxiliary.free_only` and resolve OpenRouter with an explicit `:free` model while the configured fallback is paid → client returned.
2. Resolve a paid model under the gate → skipped, OpenRouter NOT marked unhealthy, log names `auxiliary.free_only` (never credentials).
3. Run the related test files:

```bash
scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_anthropic_pool_fallback_regression.py tests/agent/test_auxiliary_main_first.py
```

Result: 194 + 20 tests passed.

## Related Issue

Closes #85315

## Credits

This is a **synthesis of #85336 (fangliquanflq) and #85338 (JulesLscx)**, both fixing #85315 from different angles:

- **#85336** contributed the model forwarding, the gate-skip unhealthy-cache removal, and the policy-first unavailable description — plus tests for forwarding, cache hygiene, and policy-vs-credential logging.
- **#85338** contributed the systemic `reason` parameter on `_mark_provider_unhealthy` (accurate reasons for every skip site), the actionable policy message, the strict-blocked paid-model tests, and the real-`config.yaml` E2E test class.
- **Combined** merges both, resolves their one disagreement (gate skip → do not mark unhealthy at all, per #85336, since #85338's keep-with-reason still suppresses later `:free` requests), and adds boundary coverage for gate-off, cache-hygiene → same-window `:free` resolution, reason surfacing, and preserved credential diagnostics.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant test files and all pass (194 + 20)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11
- [x] `ruff check` clean on both changed files

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing configuration or interface changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: the changed resolver and policy logic is platform-independent
- [x] Tool descriptions/schemas update: N/A - no tool schema changed

## Screenshots / Logs

Automated regression coverage is included; no visual surface changed.
