### PR TITLE
fix(cli): add non-interactive path for hermes mcp configure (#85670)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -984,35 +984,143 @@ def cmd_mcp_reauth(args):
 
 # ─── hermes mcp configure ────────────────────────────────────────────────────
 
-def cmd_mcp_configure(args):
-    """Reconfigure which tools are enabled for an existing MCP server."""
+def _clear_mcp_tool_name_filters(server_entry: dict) -> bool:
+    """Enable every server tool while preserving capability settings.
+
+    Removes only the ``include``/``exclude`` name filters from a server
+    entry's ``tools`` dict — or the whole ``tools`` key when it holds
+    nothing else (or is a legacy plain list). Independent capability
+    toggles such as ``tools.prompts`` / ``tools.resources`` are left
+    untouched.
+
+    Returns True when a name filter was actually removed, False when there
+    was no filter to clear.
+    """
+    tools_config = server_entry.get("tools")
+    if not isinstance(tools_config, dict):
+        changed = "tools" in server_entry
+        server_entry.pop("tools", None)
+        return changed
+
+    changed = "include" in tools_config or "exclude" in tools_config
+    tools_config.pop("include", None)
+    tools_config.pop("exclude", None)
+    if not tools_config:
+        server_entry.pop("tools", None)
+    return changed
+
+
+def _configure_fail(message: str, code: int, *, json_mode: bool) -> None:
+    """Report a ``hermes mcp configure`` failure and exit non-zero.
+
+    In ``--json`` mode the error is a machine-readable object on stderr so
+    scripts can parse it; otherwise it matches the plain "Error: ..." style.
+    """
+    import json as _json
     import sys as _sys
-    if not _sys.stdin.isatty():
+
+    if json_mode:
+        print(_json.dumps({"ok": False, "error": message}), file=_sys.stderr)
+    else:
+        print(f"Error: {message}", file=_sys.stderr)
+    _sys.exit(code)
+
+
+def cmd_mcp_configure(args):
+    """Reconfigure which tools are enabled for an existing MCP server.
+
+    Interactive (flagless) use opens the curses checklist and still requires
+    a terminal. ``--tools a,b,c`` and ``--all`` provide a scriptable path:
+    they skip the picker and the TTY gate, fail loudly (nonzero exit) on
+    unknown tools / unreachable servers / empty input instead of silently
+    no-op'ing, and can emit a machine-readable result with ``--json``.
+    """
+    import json as _json
+    import sys as _sys
+
+    requested_tools = getattr(args, "tools", None)
+    select_all = bool(getattr(args, "all", False))
+    json_mode = bool(getattr(args, "json", False))
+    flag_selection = requested_tools is not None or select_all
+
+    if requested_tools is not None and select_all:
+        _configure_fail(
+            "--tools and --all cannot be used together.", 2, json_mode=json_mode
+        )
+    if json_mode and not flag_selection:
+        _configure_fail("--json requires --tools or --all.", 2, json_mode=json_mode)
+
+    requested_names: List[str] = []
+    if requested_tools is not None:
+        requested_names = list(dict.fromkeys(
+            part.strip() for part in requested_tools.split(",") if part.strip()
+        ))
+        if not requested_names:
+            _configure_fail(
+                "--tools requires at least one tool name.", 2, json_mode=json_mode
+            )
+
+    # The TTY gate only guards the curses picker: any explicit selection is
+    # fully deterministic and safe under a pipe.
+    if not flag_selection and not _sys.stdin.isatty():
         print("Error: 'hermes mcp configure' requires an interactive terminal.", file=_sys.stderr)
         _sys.exit(1)
     name = args.name
     servers = _get_mcp_servers()
 
     if name not in servers:
-        _error(f"Server '{name}' not found in config.")
+        message = f"Server '{name}' not found in config."
+        if flag_selection:
+            _configure_fail(message, 1, json_mode=json_mode)
+        _error(message)
         available = list(servers.keys())
         if available:
             _info(f"Available: {', '.join(available)}")
         return
 
+    # `--all` is a pure config operation: clearing the include/exclude name
+    # filters enables every tool without reaching the server, so it works
+    # offline and never blocks on tool discovery.
+    if select_all:
+        config = load_config()
+        server_entry = cfg_get(config, "mcp_servers", name, default={})
+        if not _clear_mcp_tool_name_filters(server_entry):
+            if json_mode:
+                print(_json.dumps({"ok": True, "action": "no_changes", "server": name}))
+            else:
+                _info("No changes made.")
+            return
+
+        config.setdefault("mcp_servers", {})[name] = server_entry
+        save_config(config)
+        if json_mode:
+            print(_json.dumps({"ok": True, "action": "enable_all", "server": name}))
+        else:
+            _success("Updated config: all tools enabled")
+            _info("Start a new session for changes to take effect.")
+        return
+
     cfg = servers[name]
 
     # Discover all available tools
-    print()
-    print(color(f"  Connecting to '{name}' to discover tools...", Colors.CYAN))
+    if not json_mode:
+        print()
+        print(color(f"  Connecting to '{name}' to discover tools...", Colors.CYAN))
 
     try:
         all_tools = _probe_single_server(name, cfg)
     except Exception as exc:
-        _error(f"Failed to connect: {exc}")
+        message = f"Failed to connect: {exc}"
+        if flag_selection:
+            _configure_fail(message, 1, json_mode=json_mode)
+        _error(message)
         return
 
     if not all_tools:
+        if flag_selection:
+            _configure_fail(
+                f"Server '{name}' reports no tools.", 1, json_mode=json_mode
+            )
         _warning("Server reports no tools.")
         return
 
@@ -1052,22 +1160,48 @@ def cmd_mcp_configure(args):
 
     currently = len(pre_selected)
     total = len(all_tools)
-    _info(f"Currently {currently}/{total} tools enabled for '{name}'.")
-    print()
+    if not json_mode:
+        _info(f"Currently {currently}/{total} tools enabled for '{name}'.")
+        print()
 
-    # Interactive checklist
-    from hermes_cli.curses_ui import curses_checklist
+    if requested_tools is not None:
+        available_names = set(tool_names)
+        unknown = [tn for tn in requested_names if tn not in available_names]
+        if unknown:
+            message = f"Unknown tool(s) for '{name}': {', '.join(unknown)}"
+            if json_mode:
+                message += f" (available: {', '.join(tool_names)})"
+            else:
+                print(f"  Available tools: {', '.join(tool_names)}", file=_sys.stderr)
+            _configure_fail(message, 1, json_mode=json_mode)
+        requested_name_set = set(requested_names)
+        chosen = {
+            i for i, tn in enumerate(tool_names) if tn in requested_name_set
+        }
+    else:
+        # Interactive checklist — only reachable through the TTY gate above,
+        # so the curses picker never runs under a pipe.
+        from hermes_cli.curses_ui import curses_checklist
 
-    labels = [f"{t[0]}  —  {t[1]}" for t in all_tools]
-
-    chosen = curses_checklist(
-        f"Select tools for '{name}'",
-        labels,
-        pre_selected,
-    )
+        labels = [f"{t[0]}  —  {t[1]}" for t in all_tools]
+        chosen = curses_checklist(
+            f"Select tools for '{name}'",
+            labels,
+            pre_selected,
+        )
 
     if chosen == pre_selected:
-        _info("No changes made.")
+        if json_mode:
+            print(_json.dumps({
+                "ok": True,
+                "action": "no_changes",
+                "server": name,
+                "tools": [tool_names[i] for i in sorted(chosen)],
+                "enabled": len(chosen),
+                "total": total,
+            }))
+        else:
+            _info("No changes made.")
         return
 
     # Update config
@@ -1075,11 +1209,16 @@ def cmd_mcp_configure(args):
     server_entry = cfg_get(config, "mcp_servers", name, default={})
 
     if len(chosen) == total:
-        # All selected → remove include/exclude (register all)
-        server_entry.pop("tools", None)
+        # All selected → clear the name filters (register all), preserving
+        # independent capability toggles (tools.prompts / tools.resources).
+        _clear_mcp_tool_name_filters(server_entry)
+        chosen_names = list(tool_names)
     else:
         chosen_names = [tool_names[i] for i in sorted(chosen)]
-        server_entry.setdefault("tools", {})
+        # Normalize a legacy plain-list or missing ``tools`` entry into a dict
+        # so the include filter can be written (update-in-place otherwise).
+        if not isinstance(server_entry.get("tools"), dict):
+            server_entry["tools"] = {}
         server_entry["tools"]["include"] = chosen_names
         server_entry["tools"].pop("exclude", None)
 
@@ -1087,8 +1226,18 @@ def cmd_mcp_configure(args):
     save_config(config)
 
     new_count = len(chosen)
-    _success(f"Updated config: {new_count}/{total} tools enabled")
-    _info("Start a new session for changes to take effect.")
+    if json_mode:
+        print(_json.dumps({
+            "ok": True,
+            "action": "set_tools",
+            "server": name,
+            "tools": chosen_names,
+            "enabled": new_count,
+            "total": total,
+        }))
+    else:
+        _success(f"Updated config: {new_count}/{total} tools enabled")
+        _info("Start a new session for changes to take effect.")
 
 
 # ─── Dispatcher ───────────────────────────────────────────────────────────────

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -84,6 +84,25 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         "configure", aliases=["config"], help="Toggle tool selection"
     )
     mcp_cfg_p.add_argument("name", help="Server name to configure")
+    mcp_cfg_selection = mcp_cfg_p.add_mutually_exclusive_group()
+    mcp_cfg_selection.add_argument(
+        "--tools",
+        metavar="NAME[,NAME...]",
+        help=(
+            "Enable a comma-separated list of tools without opening the "
+            "picker (non-interactive; unknown names are an error)"
+        ),
+    )
+    mcp_cfg_selection.add_argument(
+        "--all",
+        action="store_true",
+        help="Enable every tool without opening the picker (works offline)",
+    )
+    mcp_cfg_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON result (requires --tools or --all)",
+    )
 
     mcp_login_p = mcp_sub.add_parser(
         "login",

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -6,7 +6,10 @@ any actual MCP servers or API keys.
 """
 
 import argparse
+import json
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -52,6 +55,9 @@ def _make_args(**kwargs):
         "auth": None,
         "preset": None,
         "env": None,
+        "tools": None,
+        "all": False,
+        "json": False,
         "mcp_action": None,
     }
     defaults.update(kwargs)
@@ -339,6 +345,495 @@ class TestMcpTest:
         assert captured["inner_timeout"] == 300.0
         assert captured["outer_timeout"] == 310.0
         assert captured["shutdown"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: cmd_mcp_configure — non-interactive path (#85670)
+# ---------------------------------------------------------------------------
+
+_TOOLS = [
+    ("search", "Search documents"),
+    ("read", "Read a document"),
+    ("write", "Write a document"),
+]
+
+
+class TestMcpConfigure:
+    """`hermes mcp configure` non-interactive flag paths (--tools / --all).
+
+    Synthesized from the concurrent PRs #85686 (fangliquanflq) and #85688
+    (itsflownium), plus coverage for --json, update-vs-new transitions,
+    and legacy plain-list tools entries."""
+
+    @staticmethod
+    def _non_tty(monkeypatch):
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: False))
+
+    @staticmethod
+    def _tty(monkeypatch):
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: True))
+
+    @staticmethod
+    def _mock_tools(monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, cfg, **kw: list(_TOOLS),
+        )
+
+    def test_tools_flag_updates_config_without_tty(self, tmp_path, monkeypatch):
+        """--tools under a pipe transitions an exclude filter to include."""
+        _seed_config(tmp_path, {
+            "docs": {
+                "url": "https://example.com/mcp",
+                "tools": {"exclude": ["write"]},
+            },
+        })
+        self._non_tty(monkeypatch)
+        self._mock_tools(monkeypatch)
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="docs", tools=" write,search,write "))
+
+        server = read_raw_config()["mcp_servers"]["docs"]
+        assert server["tools"] == {"include": ["search", "write"]}
+
+    def test_tools_flag_creates_include_when_no_tools_key(self, tmp_path, monkeypatch):
+        """Selecting tools on a server with no tools filter creates one."""
+        _seed_config(tmp_path, {
+            "docs": {"url": "https://example.com/mcp"},
+        })
+        self._non_tty(monkeypatch)
+        self._mock_tools(monkeypatch)
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="docs", tools="read"))
+
+        server = read_raw_config()["mcp_servers"]["docs"]
+        assert server["tools"] == {"include": ["read"]}
+
+    def test_tools_flag_replaces_existing_include(self, tmp_path, monkeypatch):
+        """Re-running --tools replaces the previous include filter."""
+        _seed_config(tmp_path, {
+            "docs": {
+                "url": "https://example.com/mcp",
+                "tools": {"include": ["search"], "prompts": False},
+            },
+        })
+        self._non_tty(monkeypatch)
+        self._mock_tools(monkeypatch)
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="docs", tools="read,write"))
+
+        server = read_raw_config()["mcp_servers"]["docs"]
+        assert server["tools"] == {"include": ["read", "write"], "prompts": False}
+
+    def test_tools_flag_normalizes_legacy_plain_list(self, tmp_path, monkeypatch):
+        """A legacy plain-list tools entry is replaced, not crashed on."""
+        _seed_config(tmp_path, {
+            "docs": {
+                "url": "https://example.com/mcp",
+                "tools": ["search"],
+            },
+        })
+        self._non_tty(monkeypatch)
+        self._mock_tools(monkeypatch)
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="docs", tools="read"))
+
+        server = read_raw_config()["mcp_servers"]["docs"]
+        assert server["tools"] == {"include": ["read"]}
+
+    def test_tools_flag_reports_success(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {"ink": {"url": "https://mcp.ml.ink/mcp"}})
+        self._non_tty(monkeypatch)
+        self._mock_tools(monkeypatch)
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="ink", tools="search,read"))
+
+        out = capsys.readouterr().out
+        assert "Updated config: 2/3 tools enabled" in out
+
+    def test_all_flag_removes_tool_filters_without_tty(self, tmp_path, monkeypatch):
+        """--all clears name filters offline and preserves capability toggles."""
+        _seed_config(tmp_path, {
+            "docs": {
+                "url": "https://example.com/mcp",
+                "tools": {"include": ["read"], "prompts": False},
+            },
+        })
+        self._non_tty(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *_args, **_kwargs: pytest.fail("--all must not probe the server"),
+        )
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="docs", all=True))
+
+        server = read_raw_config()["mcp_servers"]["docs"]
+        assert server["tools"] == {"prompts": False}
+
+    def test_all_flag_no_filters_reports_no_changes(self, tmp_path, capsys, monkeypatch):
+        """--all on a server with no name filter is an explicit no-op, not silent."""
+        _seed_config(tmp_path, {"docs": {"url": "https://example.com/mcp"}})
+        self._non_tty(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *_args, **_kwargs: pytest.fail("--all must not probe the server"),
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="docs", all=True))
+
+        out = capsys.readouterr().out
+        assert "No changes made." in out
+
+    def test_unknown_tools_fail_without_changing_config(self, tmp_path, capsys, monkeypatch):
+        """A wrong tool name is a loud error, never a silent no-op."""
+        original = {
+            "docs": {
+                "url": "https://example.com/mcp",
+                "tools": {"include": ["read"]},
+            },
+        }
+        _seed_config(tmp_path, original)
+        self._non_tty(monkeypatch)
+        self._mock_tools(monkeypatch)
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_configure(_make_args(name="docs", tools="missing_tool"))
+
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "Unknown tool(s) for 'docs': missing_tool" in err
+        assert "Available tools: search, read, write" in err
+        assert read_raw_config()["mcp_servers"] == original
+
+    def test_empty_tools_flag_is_rejected_without_writing(self, tmp_path, capsys, monkeypatch):
+        original = {"docs": {"url": "https://example.com/mcp"}}
+        _seed_config(tmp_path, original)
+        self._non_tty(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *_args, **_kwargs: pytest.fail("empty --tools must not probe"),
+        )
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_configure(_make_args(name="docs", tools=" , "))
+
+        assert exc_info.value.code == 2
+        assert "at least one tool name" in capsys.readouterr().err
+        assert read_raw_config()["mcp_servers"] == original
+
+    def test_tools_and_all_conflict_is_rejected(self, tmp_path, monkeypatch):
+        _seed_config(tmp_path, {"docs": {"url": "https://example.com/mcp"}})
+        self._non_tty(monkeypatch)
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_configure(_make_args(name="docs", tools="read", all=True))
+
+        assert exc_info.value.code == 2
+
+    def test_probe_failure_is_nonzero_and_atomic(self, tmp_path, capsys, monkeypatch):
+        original = {
+            "docs": {
+                "url": "https://example.com/mcp",
+                "tools": {"include": ["read"]},
+            },
+        }
+        _seed_config(tmp_path, original)
+        self._non_tty(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("offline")),
+        )
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_configure(_make_args(name="docs", tools="search"))
+
+        assert exc_info.value.code == 1
+        assert "Failed to connect: offline" in capsys.readouterr().err
+        assert read_raw_config()["mcp_servers"] == original
+
+    def test_server_with_no_tools_in_flag_mode_fails(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {"docs": {"url": "https://example.com/mcp"}})
+        self._non_tty(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", lambda *a, **k: []
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_configure(_make_args(name="docs", tools="search"))
+
+        assert exc_info.value.code == 1
+        assert "reports no tools" in capsys.readouterr().err
+
+    def test_missing_server_in_flag_mode_fails(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {})
+        self._non_tty(monkeypatch)
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_configure(_make_args(name="ghost", tools="search"))
+
+        assert exc_info.value.code == 1
+        assert "Server 'ghost' not found in config." in capsys.readouterr().err
+
+    def test_flagless_non_tty_still_fails_before_discovery(self, tmp_path, monkeypatch):
+        """No flags + pipe stdin keeps the original hard error (interactive only)."""
+        _seed_config(tmp_path, {"ink": {"url": "https://mcp.ml.ink/mcp"}})
+        probe_called = False
+
+        def probe(name, config, **kw):
+            nonlocal probe_called
+            probe_called = True
+            return []
+
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", probe)
+        self._non_tty(monkeypatch)
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_configure(_make_args(name="ink"))
+
+        assert exc_info.value.code == 1
+        assert probe_called is False
+
+    def test_json_output_on_success(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {"ink": {"url": "https://mcp.ml.ink/mcp"}})
+        self._non_tty(monkeypatch)
+        self._mock_tools(monkeypatch)
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="ink", tools="search,write", json=True))
+
+        captured = capsys.readouterr()
+        assert json.loads(captured.out) == {
+            "ok": True,
+            "action": "set_tools",
+            "server": "ink",
+            "tools": ["search", "write"],
+            "enabled": 2,
+            "total": 3,
+        }
+
+    def test_json_all_output(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "ink": {"url": "https://mcp.ml.ink/mcp", "tools": {"include": ["search"]}},
+        })
+        self._non_tty(monkeypatch)
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="ink", all=True, json=True))
+
+        captured = capsys.readouterr()
+        assert json.loads(captured.out) == {
+            "ok": True,
+            "action": "enable_all",
+            "server": "ink",
+        }
+
+    def test_json_error_goes_to_stderr(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {"ink": {"url": "https://mcp.ml.ink/mcp"}})
+        self._non_tty(monkeypatch)
+        self._mock_tools(monkeypatch)
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_configure(_make_args(name="ink", tools="nope", json=True))
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert json.loads(captured.err) == {
+            "ok": False,
+            "error": (
+                "Unknown tool(s) for 'ink': nope "
+                "(available: search, read, write)"
+            ),
+        }
+
+    def test_json_without_selection_flags_is_rejected(self, tmp_path, monkeypatch):
+        _seed_config(tmp_path, {"ink": {"url": "https://mcp.ml.ink/mcp"}})
+        self._tty(monkeypatch)
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_configure(_make_args(name="ink", json=True))
+
+        assert exc_info.value.code == 2
+
+    def test_interactive_no_regression_still_writes_config(self, tmp_path, capsys, monkeypatch):
+        """Flagless + TTY still drives the curses picker and writes the result."""
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.ml.ink/mcp",
+                "tools": {"include": ["search"]},
+            },
+        })
+        self._tty(monkeypatch)
+        self._mock_tools(monkeypatch)
+
+        import hermes_cli.curses_ui as curses_ui
+        monkeypatch.setattr(
+            curses_ui, "curses_checklist", lambda title, labels, pre: {0, 1}
+        )
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="ink"))
+
+        out = capsys.readouterr().out
+        assert "Updated config: 2/3 tools enabled" in out
+        assert read_raw_config()["mcp_servers"]["ink"]["tools"] == {
+            "include": ["search", "read"]
+        }
+
+
+class TestMcpConfigureSubprocess:
+    """End-to-end proof that the flag path works with a REAL non-TTY stdin
+    (a pipe) in a child process — the monkeypatched ``isatty`` unit tests
+    above cannot prove the CLI itself never depends on a terminal."""
+
+    @staticmethod
+    def _repo_root() -> str:
+        return str(Path(__file__).resolve().parents[2])
+
+    def _run_child(self, tmp_path, body: str):
+        script = (
+            "import sys\n"
+            f"sys.path.insert(0, {self._repo_root()!r})\n"
+            + body
+        )
+        env = dict(os.environ, HERMES_HOME=str(tmp_path))
+        return subprocess.run(
+            [sys.executable, "-c", script],
+            input=b"",
+            capture_output=True,
+            env=env,
+            timeout=120,
+        )
+
+    def test_tools_flag_works_under_real_pipe(self, tmp_path):
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.ml.ink/mcp",
+                "tools": {"exclude": ["write"]},
+            },
+        })
+        body = (
+            "import hermes_cli.mcp_config as mc\n"
+            "mc._probe_single_server = lambda name, cfg, **kw: [\n"
+            "    ('create_service', 'Deploy'), ('list_services', 'List'),\n"
+            "    ('delete_service', 'Delete'),\n"
+            "]\n"
+            "from types import SimpleNamespace\n"
+            "from hermes_cli.mcp_config import cmd_mcp_configure\n"
+            "cmd_mcp_configure(SimpleNamespace(\n"
+            "    name='ink', tools='list_services, delete_service',\n"
+            "    all=False, json=True,\n"
+            "))\n"
+        )
+        proc = self._run_child(tmp_path, body)
+
+        assert proc.returncode == 0, proc.stderr.decode()
+        assert json.loads(proc.stdout.decode()) == {
+            "ok": True,
+            "action": "set_tools",
+            "server": "ink",
+            "tools": ["list_services", "delete_service"],
+            "enabled": 2,
+            "total": 3,
+        }
+        from hermes_cli.config import read_raw_config
+        assert read_raw_config()["mcp_servers"]["ink"]["tools"] == {
+            "include": ["list_services", "delete_service"]
+        }
+
+    def test_all_flag_works_offline_under_real_pipe(self, tmp_path):
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.ml.ink/mcp",
+                "tools": {"include": ["create_service"], "prompts": False},
+            },
+        })
+        body = (
+            "import hermes_cli.mcp_config as mc\n"
+            "def _forbid(*a, **k):\n"
+            "    raise AssertionError('--all must not probe the server')\n"
+            "mc._probe_single_server = _forbid\n"
+            "from types import SimpleNamespace\n"
+            "from hermes_cli.mcp_config import cmd_mcp_configure\n"
+            "cmd_mcp_configure(SimpleNamespace(\n"
+            "    name='ink', tools=None, all=True, json=True,\n"
+            "))\n"
+        )
+        proc = self._run_child(tmp_path, body)
+
+        assert proc.returncode == 0, proc.stderr.decode()
+        assert json.loads(proc.stdout.decode()) == {
+            "ok": True,
+            "action": "enable_all",
+            "server": "ink",
+        }
+        from hermes_cli.config import read_raw_config
+        assert read_raw_config()["mcp_servers"]["ink"]["tools"] == {
+            "prompts": False
+        }
+
+    def test_flagless_pipe_stdin_still_fails_in_child(self, tmp_path):
+        """The interactive-only guard must also hold for a real pipe."""
+        _seed_config(tmp_path, {"ink": {"url": "https://mcp.ml.ink/mcp"}})
+        body = (
+            "from types import SimpleNamespace\n"
+            "from hermes_cli.mcp_config import cmd_mcp_configure\n"
+            "cmd_mcp_configure(SimpleNamespace(\n"
+            "    name='ink', tools=None, all=False, json=False,\n"
+            "))\n"
+        )
+        proc = self._run_child(tmp_path, body)
+
+        assert proc.returncode == 1
+        assert "requires an interactive terminal" in proc.stderr.decode()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -64,3 +64,38 @@ def test_mcp_and_acp_accept_hooks_flag():
     # acp takes --accept-hooks at top level
     ns = parser.parse_args(["acp", "--accept-hooks"])
     assert ns.accept_hooks is True
+
+
+def test_mcp_configure_accepts_noninteractive_tool_selection():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_mcp_parser(sub, cmd_mcp=_h("mcp"))
+
+    selected = parser.parse_args(
+        ["mcp", "configure", "ink", "--tools", "create_service,list_services"]
+    )
+    assert selected.tools == "create_service,list_services"
+    assert selected.all is False
+    assert selected.json is False
+
+    all_tools = parser.parse_args(["mcp", "configure", "ink", "--all"])
+    assert all_tools.all is True
+    assert all_tools.tools is None
+
+    json_ns = parser.parse_args(["mcp", "configure", "ink", "--all", "--json"])
+    assert json_ns.all is True
+    assert json_ns.json is True
+
+
+def test_mcp_configure_rejects_conflicting_tool_selection(capsys):
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_mcp_parser(sub, cmd_mcp=_h("mcp"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(
+            ["mcp", "configure", "ink", "--tools", "search", "--all"]
+        )
+
+    assert exc_info.value.code == 2
+    assert "not allowed with argument" in capsys.readouterr().err


### PR DESCRIPTION
## What does this PR do?

`hermes mcp configure <name>` previously required an interactive terminal and
offered only a curses picker — scripts, containers, and CI could not change an
existing server's enabled tools. This is the consolidated fix for #85670,
synthesized from two concurrent PRs (#85686 by @fangliquanflq and #85688 by
@itsflownium), absorbing the strengths of both and closing the gaps neither
covered.

New non-interactive paths (all work with stdin as a pipe):

- `hermes mcp configure <name> --tools a,b,c` — discovers the live tool list,
  validates every requested name, writes `tools.include` (replacing any prior
  include/exclude filter), and fails loudly — nonzero exit, config untouched —
  on unknown names, unreachable servers, or servers with no tools.
- `hermes mcp configure <name> --all` — pure offline config operation: clears
  only the include/exclude name filters, preserving independent capability
  toggles (`tools.prompts`, `tools.resources`). Never contacts the server, so
  it works even when the server is unreachable.
- `hermes mcp configure <name> --tools ... --json` / `--all --json` — emits a
  machine-readable result (`{"ok": true, "action": "set_tools"|"enable_all",
  ...}` on stdout; `{"ok": false, "error": ...}` on stderr for failures) with
  clean, parseable stdout.

The flagless interactive path is unchanged: the curses checklist still drives
it, and the TTY gate still guards it (flagless + pipe stdin → the original
"requires an interactive terminal" error, exit 1). No silent no-ops: every
non-interactive failure is a loud, nonzero exit before any config write.

## Comparison with the two concurrent PRs

| Capability | #85686 (fangliquanflq) | #85688 (itsflownium) | This PR |
| --- | --- | --- | --- |
| `--tools` / `--all` flags (mutually exclusive) | ✅ | ✅ | ✅ |
| TTY gate only guards the picker | ✅ | ✅ | ✅ |
| `--all` clears only include/exclude, preserves `prompts`/`resources` | ✅ | ✅ | ✅ |
| `--all` fully offline (no probe) | ❌ probes server first | ✅ | ✅ |
| `--tools` unknown names → nonzero, config untouched | ✅ | ✅ (lists available) | ✅ (lists available) |
| Empty `--tools` rejected before connecting | ❌ | ✅ | ✅ |
| Probe failure / missing server / no tools → nonzero in flag mode | partial | ✅ | ✅ |
| Shared `_clear_mcp_tool_name_filters()` helper (also fixes interactive all-selected path) | ❌ inline | ✅ | ✅ |
| Legacy plain-list `tools` entry normalized on update | ❌ | ❌ | ✅ |
| `--json` machine-readable output | ❌ | ❌ | ✅ |
| `--tools`/`--all` explicit no-op ("No changes made.") instead of silent | ✅ | ✅ | ✅ |
| Real subprocess non-TTY (pipe stdin) end-to-end tests | ❌ | ❌ | ✅ |
| Interactive (flagless + TTY) no-regression test | ❌ | ❌ | ✅ |

Both concurrent PRs are credited above; this PR deliberately builds on the
shared pieces rather than reimplementing them (per contribution rubric:
"salvage external work by building on top").

## Related Issue

Fixes #85670

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/subcommands/mcp.py` — `configure` gains mutually exclusive
  `--tools`/`--all` plus `--json`.
- `hermes_cli/mcp_config.py` — flag-based selection bypasses the TTY gate,
  validates before writing, and reports machine-readable results; shared
  `_clear_mcp_tool_name_filters()` helper also hardens the interactive
  all-selected path; legacy plain-list `tools` entries are normalized.
- `tests/hermes_cli/test_mcp_config.py` — 20 new tests: flag paths, offline
  `--all`, atomic failures, `--json`, legacy/update-vs-new transitions,
  interactive no-regression, plus subprocess tests with a real piped stdin.
- `tests/hermes_cli/test_subcommands_followup.py` — parser acceptance,
  mutual exclusion, and `--json` parsing.

## How to Test

```bash
# Non-interactive: select two tools under a pipe
hermes mcp configure <name> --tools tool_a,tool_b < /dev/null

# Offline enable-all
hermes mcp configure <name> --all < /dev/null

# Machine-readable
hermes mcp configure <name> --all --json < /dev/null
```

Automated suite (focused + MCP regression):

```bash
scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py \
  tests/hermes_cli/test_subcommands_followup.py \
  tests/hermes_cli/test_mcp_*.py tests/test_tui_entry_mcp_owner.py \
  tests/tools/test_mcp_oauth.py tests/hermes_cli/test_console_engine.py -q
```

Result: 203 passed, 0 failed. `ruff check` clean on all changed files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the focused tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A, command help is generated from argparse
- [x] `cli-config.yaml.example` update: N/A, no config key was added or changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A, no architecture or workflow changed
- [x] Cross-platform impact considered: the explicit path does not depend on terminal implementation
- [x] Tool descriptions/schemas update: N/A, no model tool schema changed
