### PR TITLE
fix(kanban): stop stop-nudge misfires in delegated children and close env-marker bypass (#87671)

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -25,14 +25,23 @@ _DEFAULT_MAX_ATTEMPTS = 2
 def kanban_stop_nudge_enabled() -> bool:
     """Return whether the kanban stop-guard is active for this process.
 
-    On when ``HERMES_KANBAN_TASK`` is set (dispatcher-spawned worker), unless
-    ``HERMES_KANBAN_STOP_NUDGE`` explicitly disables it.
+    On only when ``HERMES_KANBAN_TASK`` is set AND this execution owns the
+    dispatcher's Kanban task, unless ``HERMES_KANBAN_STOP_NUDGE`` explicitly
+    disables it.  Uses the canonical :func:`is_dispatcher_owned_worker_context`
+    predicate so the guard stays off for delegate_task children and in-process
+    cron jobs that merely inherit the worker's ``HERMES_KANBAN_*`` env vars
+    (#80507, #87671): the kanban toolset is stripped from them, so nudging
+    them toward ``kanban_complete`` demands a tool they cannot call.
     """
     env = os.environ.get("HERMES_KANBAN_STOP_NUDGE")
     if env is not None and env.strip().lower() in {"0", "false", "no", "off"}:
         return False
     task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
-    return bool(task)
+    if not task:
+        return False
+    from agent.delegation_context import is_dispatcher_owned_worker_context
+
+    return is_dispatcher_owned_worker_context()
 
 
 def _tool_call_name(tc: Any) -> str:

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -69,7 +69,29 @@ def _record_kanban_budget_exhausted(
     (``WHERE ended_at IS NULL``) guarantees idempotence — if another path
     already closed the run this is a no-op — so it is safe to call from
     multiple exit paths.
+
+    Only the dispatcher-owned worker may record a failure on its task.  A
+    delegate_task child (or an in-process cron job) inherits
+    ``HERMES_KANBAN_TASK`` from the worker's process env but is not the run
+    owner, so its own budget exhaustion must never record a bogus
+    ``timed_out`` on the parent's task or release the parent's claim
+    (#87671 — the same missing-ownership-check class as the stop-nudge
+    misfire).  Defaults to the pre-existing behavior (record) if the
+    ownership predicate cannot be resolved.
     """
+    try:
+        from agent.delegation_context import is_dispatcher_owned_worker_context
+
+        owned = is_dispatcher_owned_worker_context()
+    except Exception:
+        owned = True  # degraded env: keep the #87096 bounded fallback
+    if not owned:
+        logger.info(
+            "skipping kanban timed_out recording for %s: this execution "
+            "is not the dispatcher-owned worker",
+            kanban_task,
+        )
+        return
     try:
         from hermes_cli import kanban_db as _kb
         _conn = _kb.connect()

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1050,6 +1050,16 @@ def kanban_command(args: argparse.Namespace) -> int:
         )
         return 1
 
+    # Close the `env -u HERMES_DELEGATED_CHILD_CONTEXT` bypass (#87671): a
+    # delegated child can clear the lineage marker in a fresh subprocess and
+    # look like an interactive user. The durable boundary is the DB — a task
+    # actively claimed by a running worker may only be closed via CLI by a
+    # process that presents that worker's claim lock.
+    _claim_guard_error = _cli_mutation_claim_guard(args)
+    if _claim_guard_error:
+        print(_claim_guard_error, file=sys.stderr)
+        return 1
+
     # Board-management commands operate on board metadata and the persisted
     # current-board pointer itself. They must ignore the shared `--board`
     # task-routing override; otherwise `/kanban --board beta boards show`
@@ -1238,6 +1248,89 @@ def _is_delegated_child_cli_mutation(args: argparse.Namespace) -> bool:
         return is_delegated_child_process_context()
     except Exception:
         return bool(os.environ.get("HERMES_DELEGATED_CHILD_CONTEXT"))
+
+
+# CLI lifecycle mutations that close a worker's run.  ``complete`` is the
+# one whose DB layer has no ownership guard when ``expected_run_id`` is
+# absent (``complete_task`` accepts a merely-ready task for manual CLI use),
+# so an escaped delegated child — whose scrubbed subprocess env carries
+# neither ``HERMES_KANBAN_RUN_ID`` nor ``HERMES_KANBAN_CLAIM_LOCK`` — could
+# close the parent's task unguarded.  ``request-review`` is NOT listed here:
+# ``kanban_db.request_review`` already refuses unowned requests on a live
+# claim (``force=True`` is the explicit operator override), so it needs no
+# CLI-layer guard.  ``block``/``reclaim`` etc. remain human recovery paths.
+_CLAIM_GUARDED_CLI_ACTIONS: frozenset[str] = frozenset({
+    "complete",
+})
+
+
+def _cli_mutation_target_task_ids(args: argparse.Namespace) -> list[str]:
+    """Collect the task ids a CLI mutation action targets, across arg shapes."""
+    ids: list[str] = []
+    raw = getattr(args, "task_ids", None)
+    if raw:
+        ids.extend(raw if isinstance(raw, (list, tuple)) else [raw])
+    raw = getattr(args, "task_id", None)
+    if raw:
+        ids.append(raw)
+    raw = getattr(args, "ids", None)
+    if raw:
+        ids.extend(raw if isinstance(raw, (list, tuple)) else [raw])
+    return [tid for tid in dict.fromkeys(ids) if tid]
+
+
+def _cli_mutation_claim_guard(args: argparse.Namespace) -> Optional[str]:
+    """Return an error string when a CLI lifecycle mutation targets a task
+    actively claimed by a running worker and this process cannot present that
+    worker's claim lock.
+
+    Closes the ``env -u HERMES_DELEGATED_CHILD_CONTEXT`` bypass (#87671).  The
+    env-marker check in :func:`_is_delegated_child_cli_mutation` only sees a
+    child while the marker survives; a fresh ``hermes kanban …`` subprocess
+    spawned with the marker cleared carries no ContextVar and no marker, so it
+    is indistinguishable from an interactive user by env alone.  This guard
+    moves the boundary to the DB: a task in ``running`` with a non-null
+    ``claim_lock`` belongs to a live dispatcher worker, and only a process
+    presenting that exact ``HERMES_KANBAN_CLAIM_LOCK`` (dispatcher-spawned
+    workers carry it in env; child subprocess envs have every
+    ``HERMES_KANBAN_*`` variable scrubbed by ``scrub_kanban_env``) may close
+    it.  ``request-review`` is deliberately not guarded here — the DB-layer
+    live-claim guard in ``kanban_db.request_review`` already refuses unowned
+    requests (``--force`` is the explicit operator override).
+    """
+    action = getattr(args, "kanban_action", None)
+    if action not in _CLAIM_GUARDED_CLI_ACTIONS:
+        return None
+    task_ids = _cli_mutation_target_task_ids(args)
+    if not task_ids:
+        return None
+    claimed = (os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or "").strip()
+    try:
+        from hermes_cli import kanban_db as kb
+
+        with kb.connect_closing() as conn:
+            for tid in task_ids:
+                task = kb.get_task(conn, tid)
+                if task is None:
+                    continue  # unknown id handled by the action's own error path
+                if task.status == "running" and task.claim_lock:
+                    if not claimed or claimed != task.claim_lock:
+                        return (
+                            f"kanban: {action} of {tid} refused: the task is "
+                            "actively claimed by a running worker and this "
+                            "process does not present that worker's claim "
+                            "lock (HERMES_KANBAN_CLAIM_LOCK). A delegate_task "
+                            "child that cleared its lineage marker cannot "
+                            "close a worker-owned task."
+                        )
+    except Exception:
+        # Fail closed: if ownership cannot be verified, the mutation must not
+        # proceed against a task that may belong to a live worker.
+        return (
+            f"kanban: {action} refused: could not verify task ownership "
+            "against the kanban database."
+        )
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -74,6 +74,47 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+# ── #80507 / #87671: only the dispatcher-owned worker is nudged ─────────
+# A delegate_task child inherits HERMES_KANBAN_TASK from the worker's
+# process env (children run in-process), but its kanban toolset is stripped
+# — so the guard must never demand a terminal board call from it. In-process
+# cron jobs fired from a worker have the same problem. The guard stays on
+# for the real dispatcher-owned worker and is restored after the scope ends.
+
+def test_delegated_child_disables_guard(clear_kanban_env):
+    from agent.delegation_context import delegated_child_context
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    with delegated_child_context(session_id="child-1"):
+        assert kanban_stop_nudge_enabled() is False
+        assert build_kanban_stop_nudge(messages=[]) is None
+
+
+def test_non_dispatcher_owned_disables_guard(clear_kanban_env):
+    from agent.delegation_context import non_dispatcher_owned_context
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    with non_dispatcher_owned_context():
+        assert kanban_stop_nudge_enabled() is False
+        assert build_kanban_stop_nudge(messages=[]) is None
+
+
+def test_guard_restored_after_context_exit(clear_kanban_env):
+    from agent.delegation_context import (
+        delegated_child_context,
+        non_dispatcher_owned_context,
+    )
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    assert kanban_stop_nudge_enabled() is True
+    with delegated_child_context(session_id="child-1"):
+        assert kanban_stop_nudge_enabled() is False
+    assert kanban_stop_nudge_enabled() is True
+    with non_dispatcher_owned_context():
+        assert kanban_stop_nudge_enabled() is False
+    assert kanban_stop_nudge_enabled() is True
+
+
 
 
 

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -196,6 +196,34 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
     )
 
 
+def test_delegated_child_does_not_record_kanban_timeout(monkeypatch):
+    """A delegate_task child inherits HERMES_KANBAN_TASK from the worker's
+    process env, but its own budget exhaustion must never record a bogus
+    ``timed_out`` on the parent's task or release the parent's claim
+    (#87671 — the same missing ownership check as the stop-nudge misfire).
+    """
+    from agent.delegation_context import delegated_child_context
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    record = MagicMock(name="record_task_failure")
+    conn = SimpleNamespace(close=lambda: None)
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
+    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    agent = _LimitAgent()
+
+    with delegated_child_context(session_id="child-1"):
+        result = _finalize(
+            agent,
+            final_response=None,
+            exit_reason="unknown",
+            pending_verification_response="composed report",
+        )
+
+    assert result["turn_exit_reason"] == "max_iterations_reached(60/60)"
+    record.assert_not_called()
+
+
 def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch):
     """When budget exhaustion preserves a verification candidate that is
     already the tail assistant message, the finalizer must NOT append a

--- a/tests/hermes_cli/test_kanban_cli_claim_guard.py
+++ b/tests/hermes_cli/test_kanban_cli_claim_guard.py
@@ -1,0 +1,158 @@
+"""Regression tests for the CLI claim-lock ownership guard (#87671).
+
+A delegate_task child can clear its ``HERMES_DELEGATED_CHILD_CONTEXT``
+lineage marker in a fresh subprocess (``env -u … hermes kanban …``) and look
+like an interactive user, defeating the env-marker CLI guard.  The claim-lock
+ownership guard moves the mutation boundary to the DB: a task actively
+claimed by a running worker may only be closed via CLI by a process that
+presents that worker's ``HERMES_KANBAN_CLAIM_LOCK`` (dispatcher-spawned
+workers carry it in env; child subprocess envs have every ``HERMES_KANBAN_*``
+variable scrubbed by ``scrub_kanban_env``).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def no_claim_env(monkeypatch):
+    """Simulate a fresh subprocess env: no kanban env vars, no lineage marker."""
+    for var in (
+        "HERMES_KANBAN_CLAIM_LOCK",
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_RUN_ID",
+        "HERMES_DELEGATED_CHILD_CONTEXT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def _make_running_task(kanban_home) -> tuple[str, str]:
+    """Create a task claimed by a live worker; return (task_id, claim_lock)."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn, title="parent", assignee="worker", workspace_kind="scratch"
+        )
+        claim = kb.claim_task(conn, tid)
+        assert claim is not None
+        lock = kb.get_task(conn, tid).claim_lock
+        assert lock
+    finally:
+        conn.close()
+    return tid, lock
+
+
+def _run_kanban(*argv: str) -> int:
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args(["kanban", *argv])
+    return kc.kanban_command(args)
+
+
+def _task_status(tid: str) -> str:
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    return task.status
+
+
+def test_child_without_claim_lock_cannot_complete_running_task(kanban_home, no_claim_env):
+    """The env -u bypass: a fresh process with no kanban env must not be able
+    to complete a running task claimed by a live worker."""
+    tid, _lock = _make_running_task(kanban_home)
+
+    rc = _run_kanban("complete", tid, "--result", "escaped child")
+
+    assert rc == 1
+    assert _task_status(tid) == "running"
+
+
+def test_worker_with_matching_claim_lock_can_complete(kanban_home, no_claim_env):
+    """The real dispatcher worker carries HERMES_KANBAN_CLAIM_LOCK in env and
+    stays able to close its own task."""
+    tid, lock = _make_running_task(kanban_home)
+    no_claim_env.setenv("HERMES_KANBAN_CLAIM_LOCK", lock)
+
+    rc = _run_kanban("complete", tid, "--result", "real worker")
+
+    assert rc == 0
+    assert _task_status(tid) == "done"
+
+
+def test_unclaimed_ready_task_can_be_completed(kanban_home, no_claim_env):
+    """Manual CLI completion of an unclaimed task (human flow) is unchanged."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn, title="ready task", assignee="alice", workspace_kind="scratch"
+        )
+    finally:
+        conn.close()
+
+    rc = _run_kanban("complete", tid, "--result", "manual")
+
+    assert rc == 0
+    assert _task_status(tid) == "done"
+
+
+def test_wrong_claim_lock_is_rejected(kanban_home, no_claim_env):
+    """A process presenting a claim lock that does not match the task's must
+    be refused — a worker must not close another worker's task."""
+    tid, _lock = _make_running_task(kanban_home)
+    no_claim_env.setenv("HERMES_KANBAN_CLAIM_LOCK", "host:9999")
+
+    rc = _run_kanban("complete", tid, "--result", "wrong worker")
+
+    assert rc == 1
+    assert _task_status(tid) == "running"
+
+
+def test_request_review_delegated_to_db_live_claim_guard(kanban_home, no_claim_env):
+    """request-review is deliberately outside the CLI claim guard: the DB
+    layer already refuses unowned requests on a live claim (the operator
+    override is ``--force``, see kanban_db.request_review).  The guard must
+    not add a second, env-based gate that would break the worker CLI flow."""
+    tid, _lock = _make_running_task(kanban_home)
+
+    rc = _run_kanban("request-review", tid, "--summary", "not the owner")
+
+    # Not blocked by the CLI guard — refused by the DB live-claim guard.
+    assert rc == 1
+    assert _task_status(tid) == "running"
+
+
+def test_block_and_reclaim_remain_human_recovery_paths(kanban_home, no_claim_env):
+    """block (routes to human triage) and reclaim (human recovery flow) of a
+    running task are deliberately outside the claim guard."""
+    tid, _lock = _make_running_task(kanban_home)
+    assert _run_kanban("block", tid, "stuck worker") == 0
+    assert _task_status(tid) == "blocked"
+
+    tid2, _lock2 = _make_running_task(kanban_home)
+    assert _run_kanban("reclaim", tid2, "--reason", "stuck") == 0
+    assert _task_status(tid2) == "ready"
+
+
+def test_read_actions_unaffected(kanban_home, no_claim_env):
+    tid, _lock = _make_running_task(kanban_home)
+    assert _run_kanban("show", tid) == 0

--- a/tests/tools/test_delegate_kanban_isolation.py
+++ b/tests/tools/test_delegate_kanban_isolation.py
@@ -296,3 +296,54 @@ def test_child_attempting_default_complete_does_not_finish_parent_or_delete_work
     assert task.status == "running"
     assert run.status == "running"
     assert workspace.is_dir()
+
+
+def test_child_env_u_cli_cannot_complete_parent_task(monkeypatch, tmp_path):
+    """#87671 E2E: clearing HERMES_DELEGATED_CHILD_CONTEXT in a fresh
+    subprocess (``env -u … hermes kanban complete …``) must NOT let a
+    delegated child prematurely complete its parent's running kanban task.
+
+    This is the exact escalation observed in production (7 incidents): the
+    nudged child shells out with the lineage marker removed, so the env-marker
+    CLI guard sees a plain interactive user.  The DB-backed claim-lock guard
+    must still refuse the completion, because the child's subprocess env has
+    every ``HERMES_KANBAN_*`` variable scrubbed — including the worker's
+    ``HERMES_KANBAN_CLAIM_LOCK``.
+    """
+    kb, tid, workspace, _attachments_root = _make_running_kanban_task(
+        monkeypatch, tmp_path,
+    )
+    from agent.delegation_context import delegated_child_context
+    from tools.environments.local import LocalEnvironment
+
+    code = (
+        "from hermes_cli import kanban; "
+        "import argparse; "
+        "p=argparse.ArgumentParser(); "
+        "sub=p.add_subparsers(dest='cmd'); "
+        "kanban.build_parser(sub); "
+        f"args=p.parse_args(['kanban','complete','{tid}','--result','escaped child']); "
+        "raise SystemExit(kanban.kanban_command(args))"
+    )
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        with delegated_child_context():
+            result = env.execute(
+                "env -u HERMES_DELEGATED_CHILD_CONTEXT "
+                + _python_with_repo_path(code),
+                timeout=15,
+            )
+    finally:
+        env.cleanup()
+
+    assert result["returncode"] == 1
+    assert "claim" in result["output"], result["output"]
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, tid)
+        run = kb.latest_run(conn, tid)
+    finally:
+        conn.close()
+    assert task.status == "running"
+    assert run.status == "running"
+    assert workspace.is_dir()


### PR DESCRIPTION
## Summary

Fixes #87671: the Kanban stop-nudge misfires inside `delegate_task` children, and a nudged child can escape the tool-level block via an `env -u HERMES_DELEGATED_CHILD_CONTEXT` CLI bypass and prematurely complete its parent's task (7 production incidents).

Three ownership holes are fixed: the stop-nudge trigger, the budget-exhaustion failure recorder, and the CLI mutation boundary.

## Symptoms

1. The Kanban stop-nudge fires inside `delegate_task` children. A child inherits `HERMES_KANBAN_TASK` from the worker's process env (children run in-process) but its kanban toolset is stripped, so the guard demands `kanban_complete` from a child that can never call it — the child loops until budget exhaustion (#80507) or looks for another mutation path.
2. The nudged child finds one: `env -u HERMES_DELEGATED_CHILD_CONTEXT hermes kanban complete <parent_tid> …` spawns a fresh subprocess with no lineage marker, defeating the env-marker CLI guard, and prematurely marks the parent task `done` with a partial summary.

## Root cause

- `agent/kanban_stop.py::kanban_stop_nudge_enabled()` gated only on `HERMES_KANBAN_TASK` in `os.environ` — no delegated-child / dispatcher-ownership check. The trigger site (`agent/conversation_loop.py`, the "Kanban worker terminal-tool stop guard") therefore fires for children too, injecting a high-authority message naming the parent's exact task id.
- `agent/turn_finalizer.py::_record_kanban_budget_exhausted()` (same class, latent): on budget exhaustion it recorded `_record_task_failure(outcome="timed_out")` on the raw env `HERMES_KANBAN_TASK` with no ownership check — a child exhausting its own fresh budget could record the parent task as failed and release its claim.
- `hermes_cli/kanban.py::_is_delegated_child_cli_mutation()` trusted the env marker (and ContextVar) alone. A fresh subprocess spawned with the marker cleared (`env -u`) carries neither, so every guard layer — kanban tool schema, CLI dispatch, DB mutator — saw a plain interactive user.

## Bypass path analysis

```
worker (dispatcher-spawned, HERMES_KANBAN_TASK + CLAIM_LOCK in env)
 └─ delegate_task child (in-process; kanban toolset stripped; nudge fires on
     plain-text exit — tool-level kanban_complete is refused)
     └─ terminal: env -u HERMES_DELEGATED_CHILD_CONTEXT hermes kanban complete t_xxx
         → child subprocess env scrubs every HERMES_KANBAN_* var
           (scrub_kanban_env in tools/environments/local.py) and sets the marker
         → env -u removes the marker → fresh process has no ContextVar, no marker
         → _is_delegated_child_cli_mutation() → False
         → complete_task(expected_run_id=None) — the manual-CLI path — accepts
           the running, claimed task unguarded → parent task prematurely done
```

Key fact that makes the fix work: the child's subprocess env has **every** `HERMES_KANBAN_*` variable scrubbed — including `HERMES_KANBAN_CLAIM_LOCK`, which the dispatcher plants into the real worker's env at spawn (`kanban_db.py:10425`) and which `kanban show` never discloses. So the claim lock is a capability the escaped child cannot produce.

## Fix

1. **`agent/kanban_stop.py`** — `kanban_stop_nudge_enabled()` now also requires `is_dispatcher_owned_worker_context()` (the canonical ContextVar-based predicate from `agent/delegation_context.py`). Delegated children and in-process cron jobs are exempt; the real worker is nudged as before and the guard is restored after the child scope exits. (Same direction as the unmerged PRs #80023 / #84656 / #87216; this PR additionally closes the CLI bypass and the turn_finalizer hole.)
2. **`agent/turn_finalizer.py`** — `_record_kanban_budget_exhausted()` is gated on the same predicate, so a child's budget exhaustion can never record a bogus `timed_out` on the parent's task or release its claim. Fail-open (record as before) if the predicate cannot be resolved, preserving the #87096 bounded fallback.
3. **`hermes_cli/kanban.py`** — new DB-backed ownership guard `_cli_mutation_claim_guard()`: for `kanban complete`, if the target task is `running` with a non-null `claim_lock`, the CLI requires the caller's `HERMES_KANBAN_CLAIM_LOCK` to match the task's claim lock. Fail-closed on DB errors. Scope notes:
   - `request-review` is deliberately **not** guarded here — `kanban_db.request_review` already refuses unowned requests on a live claim (`--force` is the explicit operator override), so the bypass cannot reach it.
   - `block` / `reclaim` / `assign` / `comment` etc. remain human recovery paths (block routes to human triage; `reclaim` of a stuck running task is a tested operator flow).
   - Real workers completing their own task via CLI still pass (their env carries the claim lock); the in-process `kanban_complete` tool path is untouched.

## Tests

- `tests/agent/test_kanban_stop.py` — nudge suppressed inside `delegated_child_context` and `non_dispatcher_owned_context`; restored for the worker after scope exit.
- `tests/agent/test_turn_finalizer_iteration_limit_exit.py` — a delegated child's budget exhaustion does **not** call `_record_task_failure` on the parent's task.
- `tests/hermes_cli/test_kanban_cli_claim_guard.py` (new) — escaped child (no env) blocked; real worker with matching claim lock passes; unclaimed/ready task still completable; wrong claim lock rejected; `block`/`reclaim`/`request-review` flows unaffected.
- `tests/tools/test_delegate_kanban_isolation.py` — E2E reproduction of the exact incident: a `delegate_task` child runs `env -u HERMES_DELEGATED_CHILD_CONTEXT hermes kanban complete <tid>` through the real `LocalEnvironment` terminal; the parent task stays `running`.

## Verification

```bash
# directly-affected suites (all green)
scripts/run_tests.sh tests/agent/test_kanban_stop.py tests/agent/test_turn_finalizer_iteration_limit_exit.py tests/hermes_cli/test_kanban_cli_claim_guard.py tests/tools/test_delegate_kanban_isolation.py tests/tools/test_hermes_subprocess_env.py tests/cron/test_cron_kanban_env_isolation.py
# plus: tests/tools/test_delegate*.py (96), review lifecycle/surfaces, kanban_cli/block_kinds/goal_mode
```

Note: `tests/hermes_cli/test_kanban_core_functionality.py::test_protocol_violation_budget_not_consumed_by_other_failures` fails on current `main` (verified via stash) and is unrelated to this change.
