### PR TITLE
fix(discord): continuously recover missed gateway messages

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2072,8 +2072,8 @@ DEFAULT_CONFIG = {
             "channels": "",               # Comma-separated channel IDs; empty uses free_response_channels
             "interval_seconds": 60,        # Periodic reconciliation cadence; 0 keeps only the ready-time scan
             "window_seconds": 21600,      # Only inspect messages from the last 6 hours
-            "limit": 100,                 # Global cap on messages scanned per reconnect
-            "max_dispatches": 10,         # Cap on recovered messages dispatched per reconnect
+            "limit": 100,                 # Global cap on messages scanned per pass
+            "max_dispatches": 10,         # Cap on recovered messages dispatched per pass
         },
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
         # Discord Gateway transport health. These settings inspect the active

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2070,6 +2070,7 @@ DEFAULT_CONFIG = {
         "missed_message_backfill": {
             "enabled": False,             # Replay missed Discord messages after reconnect/startup
             "channels": "",               # Comma-separated channel IDs; empty uses free_response_channels
+            "interval_seconds": 60,        # Periodic reconciliation cadence; 0 keeps only the ready-time scan
             "window_seconds": 21600,      # Only inspect messages from the last 6 hours
             "limit": 100,                 # Global cap on messages scanned per reconnect
             "max_dispatches": 10,         # Cap on recovered messages dispatched per reconnect

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1147,6 +1147,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # shutdown from a runtime websocket crash.
         self._disconnecting = False
         self._missed_message_backfill_task: Optional[asyncio.Task] = None
+        self._missed_message_backfill_periodic_task: Optional[asyncio.Task] = None
         from hermes_constants import get_hermes_home
         from plugins.platforms.discord.recovery import DiscordRecoveryStore
         self._discord_recovery_store = DiscordRecoveryStore(get_hermes_home())
@@ -1395,6 +1396,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 if adapter_self._missed_message_backfill_enabled():
                     adapter_self._ensure_missed_message_backfill_task()
+                    adapter_self._ensure_missed_message_backfill_periodic_task()
 
             @self._client.event
             async def on_message(message: DiscordMessage):
@@ -1566,7 +1568,8 @@ class DiscordAdapter(BasePlatformAdapter):
             return False, False
 
         role_authorized = False
-        if getattr(message.author, "bot", False):
+        author_is_bot = getattr(message.author, "bot", False)
+        if author_is_bot:
             allow_bots = self._get_allow_bots()
             if allow_bots == "none":
                 return False, False
@@ -1601,23 +1604,30 @@ class DiscordAdapter(BasePlatformAdapter):
         if not isinstance(message.channel, discord.DMChannel) and (
             message.mentions or raw_self_mention
         ):
+            parent_id = self._get_parent_channel_id(message.channel)
+            free_channels = self._discord_free_response_channels()
+            channel_keys = self._discord_channel_keys(message, parent_id)
+            is_free_response = "*" in free_channels or bool(channel_keys & free_channels)
             other_bots_mentioned = any(
                 mentioned.bot and mentioned != self._client.user
                 for mentioned in message.mentions
             )
-            if other_bots_mentioned and not raw_self_mention:
+            if (
+                other_bots_mentioned
+                and not raw_self_mention
+                and (author_is_bot or not is_free_response)
+            ):
                 return False, False
             ignore_no_mention = os.getenv(
                 "DISCORD_IGNORE_NO_MENTION", "true"
             ).lower() in {"true", "1", "yes"}
-            if ignore_no_mention and not raw_self_mention and not other_bots_mentioned:
-                parent_id = None
-                if hasattr(message.channel, "parent_id") and message.channel.parent_id:
-                    parent_id = str(message.channel.parent_id)
-                free_channels = self._discord_free_response_channels()
-                channel_keys = self._discord_channel_keys(message, parent_id)
-                if "*" not in free_channels and not (channel_keys & free_channels):
-                    return False, False
+            if (
+                ignore_no_mention
+                and not raw_self_mention
+                and not other_bots_mentioned
+                and not is_free_response
+            ):
+                return False, False
 
         return True, role_authorized
 
@@ -2192,6 +2202,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self._missed_message_backfill_task
             except asyncio.CancelledError:
                 pass
+        if (
+            self._missed_message_backfill_periodic_task
+            and not self._missed_message_backfill_periodic_task.done()
+        ):
+            self._missed_message_backfill_periodic_task.cancel()
+            try:
+                await self._missed_message_backfill_periodic_task
+            except asyncio.CancelledError:
+                pass
 
         self._running = False
         self._client = None
@@ -2199,6 +2218,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._post_connect_task = None
         self._liveness_task = None
         self._missed_message_backfill_task = None
+        self._missed_message_backfill_periodic_task = None
 
         self._release_platform_lock()
 
@@ -2544,6 +2564,19 @@ class DiscordAdapter(BasePlatformAdapter):
             value = 10
         return max(1, min(value, 100))
 
+    def _missed_message_backfill_interval_seconds(self) -> float:
+        configured = self.config.extra.get("missed_message_backfill")
+        raw = (
+            configured.get("interval_seconds", 60)
+            if isinstance(configured, dict)
+            else os.getenv("DISCORD_MISSED_MESSAGE_BACKFILL_INTERVAL_SECONDS", "60")
+        )
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return 0.0
+        return value if math.isfinite(value) and value > 0 else 0.0
+
     def _ensure_missed_message_backfill_task(self) -> asyncio.Task:
         """Return the active recovery task, or start one when none is running."""
         task = self._missed_message_backfill_task
@@ -2559,6 +2592,34 @@ class DiscordAdapter(BasePlatformAdapter):
                 runner._startup_restore_tasks = tasks
             tasks.append(task)
         return task
+
+    def _ensure_missed_message_backfill_periodic_task(self) -> Optional[asyncio.Task]:
+        """Start the one adapter-owned periodic recovery loop when configured."""
+        interval = self._missed_message_backfill_interval_seconds()
+        if interval <= 0:
+            return None
+        task = self._missed_message_backfill_periodic_task
+        if task is not None and not task.done():
+            return task
+        task = asyncio.create_task(self._run_missed_message_backfill_periodically(interval))
+        self._missed_message_backfill_periodic_task = task
+        return task
+
+    async def _run_missed_message_backfill_periodically(self, interval: float) -> None:
+        """Reconcile sequentially after each configured polling interval."""
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                await self._ensure_missed_message_backfill_task()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.warning(
+                    "[%s] Periodic missed-message backfill failed: %s",
+                    self.name,
+                    exc,
+                    exc_info=True,
+                )
 
     async def _run_missed_message_backfill(self) -> None:
         """Find and enqueue recent Discord messages missed while the bot was down.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1615,7 +1615,11 @@ class DiscordAdapter(BasePlatformAdapter):
             if (
                 other_bots_mentioned
                 and not raw_self_mention
-                and (author_is_bot or not is_free_response)
+                and (
+                    author_is_bot
+                    or not is_free_response
+                    or message.type != discord.MessageType.reply
+                )
             ):
                 return False, False
             ignore_no_mention = os.getenv(
@@ -2196,12 +2200,6 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self._post_connect_task
             except asyncio.CancelledError:
                 pass
-        if self._missed_message_backfill_task and not self._missed_message_backfill_task.done():
-            self._missed_message_backfill_task.cancel()
-            try:
-                await self._missed_message_backfill_task
-            except asyncio.CancelledError:
-                pass
         if (
             self._missed_message_backfill_periodic_task
             and not self._missed_message_backfill_periodic_task.done()
@@ -2209,6 +2207,12 @@ class DiscordAdapter(BasePlatformAdapter):
             self._missed_message_backfill_periodic_task.cancel()
             try:
                 await self._missed_message_backfill_periodic_task
+            except asyncio.CancelledError:
+                pass
+        if self._missed_message_backfill_task and not self._missed_message_backfill_task.done():
+            self._missed_message_backfill_task.cancel()
+            try:
+                await self._missed_message_backfill_task
             except asyncio.CancelledError:
                 pass
 
@@ -2574,8 +2578,24 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             value = float(raw)
         except (TypeError, ValueError):
+            logger.warning(
+                "[%s] Invalid Discord missed-message backfill interval_seconds %r; "
+                "periodic recovery disabled",
+                self.name,
+                raw,
+            )
             return 0.0
-        return value if math.isfinite(value) and value > 0 else 0.0
+        if value == 0:
+            return 0.0
+        if not math.isfinite(value) or value < 0:
+            logger.warning(
+                "[%s] Invalid Discord missed-message backfill interval_seconds %r; "
+                "periodic recovery disabled",
+                self.name,
+                raw,
+            )
+            return 0.0
+        return value
 
     def _ensure_missed_message_backfill_task(self) -> asyncio.Task:
         """Return the active recovery task, or start one when none is running."""
@@ -2755,7 +2775,7 @@ class DiscordAdapter(BasePlatformAdapter):
             ):
                 return False
         admitted, role_authorized = self._discord_message_admission(
-            message, claim=False,
+            message, claim=True,
         )
         if not admitted:
             return False

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -254,6 +254,23 @@ async def test_non_free_response_rejects_human_reply_to_other_bot(adapter, monke
 
 
 @pytest.mark.asyncio
+async def test_free_response_rejects_human_direct_mention_of_other_bot(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    adapter._ready_event.set()
+    adapter._is_allowed_user = MagicMock(return_value=True)
+    channel = FakeTextChannel(channel_id=789)
+    message = make_message(
+        channel=channel,
+        content="<@55> can you handle this?",
+        mentions=[SimpleNamespace(id=55, bot=True)],
+    )
+    message.guild = channel.guild
+
+    assert await adapter._dispatch_discord_message(message) is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_free_response_rejects_bot_reply_to_other_bot(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
     monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -204,6 +204,88 @@ async def test_discord_free_response_in_server_channels(adapter, monkeypatch):
     assert event.source.chat_type == "group"
 
 
+@pytest.mark.parametrize("use_parent_scope", [False, True])
+@pytest.mark.asyncio
+async def test_free_response_admits_human_reply_to_other_bot(adapter, monkeypatch, use_parent_scope):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter._ready_event.set()
+    adapter._is_allowed_user = MagicMock(return_value=True)
+    adapter._threads.mark = MagicMock()
+
+    parent = FakeTextChannel(channel_id=789)
+    channel = FakeThread(channel_id=790, parent=parent) if use_parent_scope else parent
+    other_bot = SimpleNamespace(id=55, bot=True)
+    message = make_message(
+        channel=channel,
+        content="Does this still exist?",
+        mentions=[other_bot],
+        msg_type=discord_platform.discord.MessageType.reply,
+    )
+    message.guild = SimpleNamespace(id=1, name=channel.guild.name)
+    message.reference = SimpleNamespace(
+        message_id=456,
+        resolved=SimpleNamespace(content="publisher alert", attachments=[]),
+    )
+
+    assert await adapter._dispatch_discord_message(message) is True
+    event = adapter.handle_message.await_args.args[0]
+    assert event.reply_to_message_id == "456"
+    assert event.reply_to_text == "publisher alert"
+
+
+@pytest.mark.asyncio
+async def test_non_free_response_rejects_human_reply_to_other_bot(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    adapter._ready_event.set()
+    adapter._is_allowed_user = MagicMock(return_value=True)
+    channel = FakeTextChannel(channel_id=321)
+    message = make_message(
+        channel=channel,
+        content="following up",
+        mentions=[SimpleNamespace(id=55, bot=True)],
+        msg_type=discord_platform.discord.MessageType.reply,
+    )
+    message.guild = channel.guild
+
+    assert await adapter._dispatch_discord_message(message) is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_free_response_rejects_bot_reply_to_other_bot(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter._ready_event.set()
+    channel = FakeTextChannel(channel_id=789)
+    message = make_message(
+        channel=channel,
+        content="bot reply directed elsewhere",
+        mentions=[SimpleNamespace(id=55, bot=True)],
+        msg_type=discord_platform.discord.MessageType.reply,
+    )
+    message.author.bot = True
+    message.guild = channel.guild
+
+    assert await adapter._dispatch_discord_message(message) is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ignored_free_response_channel_stays_blocked(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "789")
+    adapter._ready_event.set()
+    adapter._is_allowed_user = MagicMock(return_value=True)
+    channel = FakeTextChannel(channel_id=789)
+    message = make_message(channel=channel, content="ordinary question")
+    message.guild = channel.guild
+
+    assert await adapter._dispatch_discord_message(message) is False
+    adapter.handle_message.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_discord_accepts_and_strips_bot_mentions_when_required(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
@@ -825,5 +907,3 @@ async def test_discord_reply_in_free_channel_triggers_backfill(adapter, monkeypa
     assert event.channel_context == (
         "[Context around the replied-to message]\n[Hermes [bot]] earlier answer"
     )
-
-

--- a/tests/gateway/test_discord_missed_message_backfill.py
+++ b/tests/gateway/test_discord_missed_message_backfill.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import datetime as dt
+import logging
 import os
 import sys
 from datetime import datetime, timezone
@@ -243,6 +244,30 @@ async def test_run_backfill_dispatches_unaddressed_messages(adapter, monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_recovered_claim_blocks_same_live_event_during_dispatch(adapter, monkeypatch):
+    message = make_message(message_id=72)
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "123")
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handle(*_args, **_kwargs):
+        entered.set()
+        await release.wait()
+        return True
+
+    adapter._handle_message.side_effect = handle
+    recovered = asyncio.create_task(adapter._dispatch_recovered_message(message))
+    await entered.wait()
+
+    assert await adapter._dispatch_discord_message(message) is False
+    release.set()
+    assert await recovered is True
+    adapter._handle_message.assert_awaited_once_with(
+        message, role_authorized=False, recovered=True,
+    )
+
+
+@pytest.mark.asyncio
 async def test_repeated_ready_coalesces_instead_of_cancelling_active_recovery(adapter):
     started = asyncio.Event()
     release = asyncio.Event()
@@ -294,6 +319,37 @@ async def test_periodic_pass_recovers_late_untagged_question_exactly_once(adapte
 
 
 @pytest.mark.asyncio
+async def test_consecutive_scans_use_durable_completion_to_dispatch_once(adapter, monkeypatch):
+    message = make_message(message_id=78)
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "123")
+
+    async def candidates(_channels):
+        yield message
+
+    async def handle(*_args, **_kwargs):
+        adapter._record_discord_response(
+            reply_to=str(message.id),
+            result=SimpleNamespace(success=True, message_id="9001"),
+            content="Done",
+            final=True,
+        )
+        return True
+
+    monkeypatch.setattr(adapter, "_iter_missed_message_backfill_candidates", candidates)
+    monkeypatch.setattr(adapter, "_missed_message_backfill_channels", lambda: {"123"})
+    adapter._handle_message.side_effect = handle
+
+    await adapter._run_missed_message_backfill()
+    adapter._dedup.clear()
+    await adapter._run_missed_message_backfill()
+
+    adapter._handle_message.assert_awaited_once_with(
+        message, role_authorized=False, recovered=True,
+    )
+    assert await adapter._should_backfill_discord_message(message) is False
+
+
+@pytest.mark.asyncio
 async def test_periodic_loop_serializes_scans_survives_failure_and_propagates_cancel(adapter, monkeypatch):
     calls = 0
 
@@ -329,13 +385,20 @@ async def test_periodic_task_coalesces_and_zero_disables(adapter):
         await first
 
 
-def test_periodic_interval_env_and_invalid_values_fail_closed(adapter, monkeypatch):
+def test_periodic_interval_env_and_invalid_values_fail_closed(adapter, monkeypatch, caplog):
     assert adapter._missed_message_backfill_interval_seconds() == 60
     monkeypatch.setenv("DISCORD_MISSED_MESSAGE_BACKFILL_INTERVAL_SECONDS", "12.5")
     assert adapter._missed_message_backfill_interval_seconds() == 12.5
-    for value in ("invalid", "nan", "inf", "-1", "0"):
+    for value in ("invalid", "nan", "inf", "-1"):
         monkeypatch.setenv("DISCORD_MISSED_MESSAGE_BACKFILL_INTERVAL_SECONDS", value)
-        assert adapter._missed_message_backfill_interval_seconds() == 0
+        with caplog.at_level(logging.WARNING):
+            assert adapter._missed_message_backfill_interval_seconds() == 0
+        assert value in caplog.messages[-1]
+
+    caplog.clear()
+    monkeypatch.setenv("DISCORD_MISSED_MESSAGE_BACKFILL_INTERVAL_SECONDS", "0")
+    assert adapter._missed_message_backfill_interval_seconds() == 0
+    assert caplog.messages == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_missed_message_backfill.py
+++ b/tests/gateway/test_discord_missed_message_backfill.py
@@ -264,6 +264,81 @@ async def test_repeated_ready_coalesces_instead_of_cancelling_active_recovery(ad
 
 
 @pytest.mark.asyncio
+async def test_periodic_pass_recovers_late_untagged_question_exactly_once(adapter, monkeypatch):
+    message = make_message(message_id=77, content="?")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "123")
+    pass_number = 0
+    recovered = asyncio.Event()
+
+    async def candidates(_channels):
+        nonlocal pass_number
+        pass_number += 1
+        if pass_number == 2:
+            yield message
+
+    monkeypatch.setattr(adapter, "_iter_missed_message_backfill_candidates", candidates)
+    monkeypatch.setattr(adapter, "_should_backfill_discord_message", AsyncMock(return_value=True))
+    monkeypatch.setattr(adapter, "_missed_message_backfill_channels", lambda: {"123"})
+    adapter._handle_message.side_effect = lambda *_args, **_kwargs: recovered.set() or True
+
+    await adapter._run_missed_message_backfill()  # immediate ready scan
+    periodic = asyncio.create_task(adapter._run_missed_message_backfill_periodically(0.001))
+    await asyncio.wait_for(recovered.wait(), timeout=1)
+    periodic.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await periodic
+
+    adapter._handle_message.assert_awaited_once_with(
+        message, role_authorized=False, recovered=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_periodic_loop_serializes_scans_survives_failure_and_propagates_cancel(adapter, monkeypatch):
+    calls = 0
+
+    async def scan():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("scan failed")
+        raise asyncio.CancelledError
+
+    async def no_wait(_interval):
+        return None
+
+    monkeypatch.setattr(adapter, "_run_missed_message_backfill", scan)
+    monkeypatch.setattr(asyncio, "sleep", no_wait)
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._run_missed_message_backfill_periodically(1)
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_periodic_task_coalesces_and_zero_disables(adapter):
+    adapter.config.extra["missed_message_backfill"] = {"interval_seconds": 0}
+    assert adapter._ensure_missed_message_backfill_periodic_task() is None
+
+    adapter.config.extra["missed_message_backfill"]["interval_seconds"] = 60
+    first = adapter._ensure_missed_message_backfill_periodic_task()
+    second = adapter._ensure_missed_message_backfill_periodic_task()
+    assert second is first
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+
+def test_periodic_interval_env_and_invalid_values_fail_closed(adapter, monkeypatch):
+    assert adapter._missed_message_backfill_interval_seconds() == 60
+    monkeypatch.setenv("DISCORD_MISSED_MESSAGE_BACKFILL_INTERVAL_SECONDS", "12.5")
+    assert adapter._missed_message_backfill_interval_seconds() == 12.5
+    for value in ("invalid", "nan", "inf", "-1", "0"):
+        monkeypatch.setenv("DISCORD_MISSED_MESSAGE_BACKFILL_INTERVAL_SECONDS", value)
+        assert adapter._missed_message_backfill_interval_seconds() == 0
+
+
+@pytest.mark.asyncio
 async def test_recovered_mention_reuses_live_auth_and_mention_gates(adapter, monkeypatch):
     bot_user = adapter._client.user
     monkeypatch.delenv("DISCORD_ALLOW_ALL_USERS", raising=False)
@@ -300,6 +375,7 @@ def test_default_config_exposes_missed_message_backfill_settings():
     assert DEFAULT_CONFIG["discord"]["missed_message_backfill"] == {
         "enabled": False,
         "channels": "",
+        "interval_seconds": 60,
         "window_seconds": 21600,
         "limit": 100,
         "max_dispatches": 10,
@@ -313,6 +389,7 @@ def test_missed_message_backfill_config_stays_per_adapter():
             "missed_message_backfill": {
                 "enabled": True,
                 "channels": ["111"],
+                "interval_seconds": 30,
                 "window_seconds": 60,
                 "limit": 5,
                 "max_dispatches": 2,
@@ -325,6 +402,7 @@ def test_missed_message_backfill_config_stays_per_adapter():
             "missed_message_backfill": {
                 "enabled": False,
                 "channels": ["222"],
+                "interval_seconds": 0,
                 "window_seconds": 120,
                 "limit": 6,
                 "max_dispatches": 3,
@@ -337,11 +415,13 @@ def test_missed_message_backfill_config_stays_per_adapter():
 
     assert first._missed_message_backfill_enabled() is True
     assert first._missed_message_backfill_channels() == {"111"}
+    assert first._missed_message_backfill_interval_seconds() == 30
     assert first._missed_message_backfill_window_seconds() == 60
     assert first._missed_message_backfill_limit() == 5
     assert first._missed_message_backfill_max_dispatches() == 2
     assert second._missed_message_backfill_enabled() is False
     assert second._missed_message_backfill_channels() == {"222"}
+    assert second._missed_message_backfill_interval_seconds() == 0
     assert second._missed_message_backfill_window_seconds() == 120
     assert second._missed_message_backfill_limit() == 6
     assert second._missed_message_backfill_max_dispatches() == 3
@@ -456,5 +536,3 @@ async def test_iter_candidates_keeps_latest_messages_when_window_exceeds_limit(a
         got.append(msg.id)
 
     assert got == [2, 3, 4]
-
-

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -812,6 +812,32 @@ class TestDiscordVoiceChannelMethods:
 
 
     @pytest.mark.asyncio
+    async def test_disconnect_cancels_periodic_recovery_before_active_scan(self):
+        adapter = self._make_adapter()
+        events = []
+
+        async def wait_for_cancel(name):
+            try:
+                await asyncio.Event().wait()
+            finally:
+                events.append(name)
+
+        adapter._client = None
+        adapter._bot_task = None
+        adapter._ready_event = MagicMock()
+        adapter._post_connect_task = None
+        adapter._missed_message_backfill_task = asyncio.create_task(wait_for_cancel("scan"))
+        adapter._missed_message_backfill_periodic_task = asyncio.create_task(
+            wait_for_cancel("periodic")
+        )
+        await asyncio.sleep(0)
+
+        await adapter.disconnect()
+
+        assert events == ["periodic", "scan"]
+
+
+    @pytest.mark.asyncio
     async def test_get_user_voice_channel_success(self):
         adapter = self._make_adapter()
         mock_vc = MagicMock()

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -799,6 +799,7 @@ class TestDiscordVoiceChannelMethods:
         adapter._ready_event = MagicMock()
         adapter._post_connect_task = None
         adapter._missed_message_backfill_task = None
+        adapter._missed_message_backfill_periodic_task = None
 
         await adapter.disconnect()
 


### PR DESCRIPTION
## Summary

Hermes can remain nominally connected to Discord while silently missing a gateway event. The existing recovery scan runs only at startup/ready time, so a missed human message can remain unanswered until the next restart.

This change:

- runs the existing durable Discord missed-message scan periodically, with one adapter-owned loop and serialized scans;
- reuses the existing authorization, ignored-channel, mention, bot-loop, deduplication, response-ledger, and dispatch paths;
- atomically claims recovered message IDs so a live event racing recovery cannot dispatch twice;
- admits a human reply to another bot only in configured free-response scope while retaining the direct-mention and bot-loop gates;
- adds bounded configuration, lifecycle, race, durable-completion, and incident-shaped regression coverage.

## Incident reproduced

An untagged human `?` appeared in a configured free-response Discord channel after gateway startup. The WebSocket remained connected, but the live event was absent from gateway dispatch logs and startup-only recovery did not revisit it. This is distinct from a reconnect-only outage.

## Implementation

- `discord.missed_message_backfill.interval_seconds` defaults to `60`.
- `0` keeps the ready-time scan while disabling periodic polling.
- Invalid, negative, and non-finite intervals fail closed with a warning; intentional `0` is quiet.
- Repeated ready events coalesce onto one periodic task.
- The periodic owner awaits the existing one-shot scan task, preventing overlap.
- `disconnect()` cancels the periodic owner before the active scan.
- Per-pass `limit` and `max_dispatches` bounds remain in force.
- Recovered admission uses `claim=True`; failure/cancellation paths retain the existing claim release behavior.

## Verification

Exact reviewed head: `6b3111e8f14da7f9ddf1cca09d091f4032a9c7ca`

```text
133 passed, 2 existing AsyncMock warnings in 11.19s
python3 -m py_compile: passed
git diff --check: passed
changed paths: exactly 5
```

Focused suites:

```bash
python -m pytest -q \
  tests/gateway/test_discord_free_response.py \
  tests/gateway/test_discord_missed_message_backfill.py \
  tests/gateway/test_discord_liveness.py \
  tests/gateway/test_voice_command.py
```

Independent Opus review: `GO_WITH_CAVEATS`, no blockers. The review specifically verified the recovered/live-event race, consecutive-pass durable completion, other-bot narrowing, interval validation, serialized task ownership, and shutdown order.

## Related open PRs / overlap disclosure

- #75067 independently fixes the recovered-message dedup claim subset. This PR includes that same bug-class correction because atomic claim ownership is required for periodic connected-state recovery; #75067 has narrower and deeper claim-specific tests.
- #72881 combines launchd readiness work with outage recovery and same-content suppression. This PR does not add content-fingerprint suppression and targets connected-state missed events with the existing durable ledger.
- #79651 extracts the recovery cluster from the Discord adapter. This PR intentionally targets current `main`; maintainers may need to sequence the behavioral fix before that refactor.

## Caveats / activation checks

- The environment-variable fallback is used only when the whole `missed_message_backfill` config mapping is absent; config-file precedence is unchanged.
- The configured interval should be operationally sane. The production canary uses `15` seconds and watches REST/rate-limit logs and event-loop latency.
- Unit tests are L2 evidence only. Live recovery, response delivery, and duplicate suppression are verified separately after supervised activation.

## Scope

Changed paths only:

1. `hermes_cli/config_defaults.py`
2. `plugins/platforms/discord/adapter.py`
3. `tests/gateway/test_discord_free_response.py`
4. `tests/gateway/test_discord_missed_message_backfill.py`
5. `tests/gateway/test_voice_command.py`

No scheduler, watchdog service, database, auth weakening, liveness-threshold change, broad adapter refactor, or unrelated delivery change.
