### PR TITLE
fix(desktop): preserve public launcher in Linux entry

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -60,16 +60,24 @@ def icon_path(project_root: Path) -> Path:
 def resolve_exec_command() -> str:
     """Build the absolute ``Exec=`` command line for ``hermes desktop``.
 
-    Prefer the real ``hermes`` executable (argv[0] or PATH). When Hermes
-    runs as a module with no launcher installed, use the current
-    interpreter, also absolute.
+    Prefer the public ``hermes`` launcher on PATH. The installer's launcher
+    execs the checkout's Python entry point, so by the time this code runs,
+    ``sys.argv[0]`` points at ``~/.hermes/hermes-agent/hermes`` rather than
+    the stable ``~/.local/bin/hermes`` command the user invoked. When no
+    public launcher is available, fall back to the current executable or the
+    current interpreter, also absolute.
     """
     from hermes_cli.relaunch import resolve_hermes_bin
 
-    bin_path = resolve_hermes_bin()
+    path_launcher = shutil.which("hermes")
+    bin_path = path_launcher or resolve_hermes_bin()
     if bin_path:
-        resolved = Path(bin_path).resolve()
-        if _needs_interpreter(resolved):
+        # Preserve the public launcher path even when it is a symlink. The
+        # launcher is the stable interface; its target may change on update.
+        absolute_bin = (
+            Path(bin_path).absolute() if path_launcher else Path(bin_path).resolve()
+        )
+        if _needs_interpreter(absolute_bin):
             # The resolved launcher is a Python script whose shebang points at
             # a NON-venv interpreter (e.g. the repo's `hermes` script with
             # `#!/usr/bin/env python3` when argv[0] came from the shell
@@ -78,9 +86,9 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            argv = [str(Path(sys.executable).resolve()), str(absolute_bin), "desktop"]
         else:
-            argv = [str(resolved), "desktop"]
+            argv = [str(absolute_bin), "desktop"]
     else:
         argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -40,6 +40,7 @@ def test_install_writes_entry_with_absolute_exec_and_icon(tmp_path, xdg_home, mo
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
     hermes_bin.write_text("", encoding="utf-8")
+    monkeypatch.setattr(lde.shutil, "which", lambda _name: None)
     monkeypatch.setattr(
         "hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin)
     )
@@ -66,8 +67,46 @@ def test_install_writes_entry_with_absolute_exec_and_icon(tmp_path, xdg_home, mo
     assert values["Terminal"] == "false"
 
 
+def test_exec_prefers_public_path_launcher_over_internal_entrypoint(
+    tmp_path, monkeypatch
+):
+    public_launcher = tmp_path / ".local" / "bin" / "hermes"
+    public_launcher.parent.mkdir(parents=True)
+    public_launcher.write_text("", encoding="utf-8")
+    internal_entrypoint = tmp_path / ".hermes" / "hermes-agent" / "hermes"
+
+    monkeypatch.setattr(
+        lde.shutil,
+        "which",
+        lambda name: str(public_launcher) if name == "hermes" else None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.relaunch.resolve_hermes_bin", lambda: str(internal_entrypoint)
+    )
+
+    assert lde.resolve_exec_command() == f"{public_launcher} desktop"
+
+
+def test_exec_preserves_public_path_launcher_symlink(tmp_path, monkeypatch):
+    launcher_target = tmp_path / "install" / "hermes-wrapper"
+    launcher_target.parent.mkdir(parents=True)
+    launcher_target.write_text("#!/bin/sh\n", encoding="utf-8")
+    public_launcher = tmp_path / ".local" / "bin" / "hermes"
+    public_launcher.parent.mkdir(parents=True)
+    public_launcher.symlink_to(launcher_target)
+
+    monkeypatch.setattr(
+        lde.shutil,
+        "which",
+        lambda name: str(public_launcher) if name == "hermes" else None,
+    )
+
+    assert lde.resolve_exec_command() == f"{public_launcher} desktop"
+
+
 def test_installed_entry_is_executable(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
+    monkeypatch.setattr(lde.shutil, "which", lambda _name: None)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
 
@@ -78,6 +117,7 @@ def test_installed_entry_is_executable(tmp_path, xdg_home, monkeypatch):
 
 def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
+    monkeypatch.setattr(lde.shutil, "which", lambda _name: None)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: None)
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
 
@@ -101,6 +141,7 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     hermes_bin.parent.mkdir()
     hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
+    monkeypatch.setattr(lde.shutil, "which", lambda _name: None)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
 
@@ -119,6 +160,7 @@ def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypat
     hermes_bin.parent.mkdir()
     hermes_bin.write_text('#!/bin/bash\nexec /opt/hermes/venv/bin/python "$@"\n', encoding="utf-8")
     hermes_bin.chmod(0o755)
+    monkeypatch.setattr(lde.shutil, "which", lambda _name: None)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
 
@@ -138,6 +180,7 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     interpreter = str(Path(sys.executable).resolve())
     hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
+    monkeypatch.setattr(lde.shutil, "which", lambda _name: None)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
 
@@ -151,6 +194,7 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
 
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
+    monkeypatch.setattr(lde.shutil, "which", lambda _name: None)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")
     calls: list[Path] = []
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda d: calls.append(d) or [])
@@ -166,6 +210,7 @@ def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monke
 def test_install_without_source_icon_uses_themed_name(tmp_path, xdg_home, monkeypatch):
     root = tmp_path / "hermes-agent"
     root.mkdir()
+    monkeypatch.setattr(lde.shutil, "which", lambda _name: None)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
 
@@ -257,6 +302,7 @@ def test_exec_arg_quoting_handles_spaces(tmp_path, xdg_home, monkeypatch):
     spaced = tmp_path / "my apps" / "hermes"
     spaced.parent.mkdir()
     spaced.write_text("", encoding="utf-8")
+    monkeypatch.setattr(lde.shutil, "which", lambda _name: None)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(spaced))
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Linux XDG desktop entry generated by `hermes desktop` so its `Exec=` line points to the stable public Hermes launcher instead of the checkout-internal Python entry point.

On per-user installs, `~/.local/bin/hermes` is a wrapper that execs `~/.hermes/hermes-agent/hermes`. By the time the CLI registers the desktop entry, `sys.argv[0]` therefore contains the internal entry point. `resolve_hermes_bin()` prioritizes that value, causing every desktop launch to rewrite the entry as:

```ini
Exec=/home/user/.hermes/hermes-agent/hermes desktop
```

Launching the internal script directly bypasses the installed wrapper and its managed Python environment. In a per-user installation, the broken `Exec=` command reproduces as:

```console
$ /home/user/.hermes/hermes-agent/hermes desktop
Traceback (most recent call last):
  File "/home/user/.hermes/hermes-agent/hermes", line 10, in <module>
    from hermes_cli.main import main
  File "/home/user/.hermes/hermes-agent/hermes_cli/main.py", line 697, in <module>
    from hermes_cli.env_loader import load_hermes_dotenv
  File "/home/user/.hermes/hermes-agent/hermes_cli/env_loader.py", line 12, in <module>
    from dotenv import load_dotenv
ModuleNotFoundError: No module named 'dotenv'
```

The public launcher avoids this failure by selecting the managed venv interpreter. The working entry is:

```ini
Exec=/home/user/.local/bin/hermes desktop
```

This change makes desktop-entry resolution prefer `hermes` from `PATH`, preserves that public path even if it is a symlink, and retains the existing argv/interpreter fallbacks for installations without a public launcher.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Prefer the public `hermes` launcher from `PATH` when rendering the Linux `Exec=` command.
- Preserve the launcher path rather than resolving through a symlink to an update-managed target.
- Add a regression test for the real wrapper-to-internal-entry-point chain.
- Make existing fallback tests independent of the developer machine PATH.

## How to Test

1. Install Hermes per-user so `hermes` resolves to `~/.local/bin/hermes`.
2. Run `hermes desktop` on Linux.
3. Confirm `~/.local/share/applications/hermes.desktop` contains `Exec=/home/<user>/.local/bin/hermes desktop`.

Automated validation:

```text
scripts/run_tests.sh tests/hermes_cli/test_linux_desktop_entry.py tests/hermes_cli/test_gui_command.py -q
39 tests passed, 0 failed, 7 skipped

ruff check hermes_cli/linux_desktop_entry.py tests/hermes_cli/test_linux_desktop_entry.py
All checks passed!
```

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs and found no duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I ran the focused canonical test suites and all host-applicable tests pass.
- [x] I added a regression test for the bug.
- [x] I tested on Omarchy Linux.

### Documentation & Housekeeping

- [x] Documentation changes are N/A; the supported install path is unchanged.
- [x] Config example changes are N/A; no config keys changed.
- [x] Contributor/agent guide changes are N/A; architecture and workflows are unchanged.
- [x] Cross-platform impact considered; desktop-entry installation remains Linux/BSD-only and existing macOS/Windows native tests are unchanged.
- [x] Tool schema changes are N/A.
