### PR TITLE
feat(skills): add MiniMax Code CLI delegation

### DIFF
--- a/optional-skills/autonomous-ai-agents/mcode-cli/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/mcode-cli/SKILL.md
@@ -46,6 +46,8 @@ second opinion.
    `mcode login --region cn`. For BYOK, configure a provider with
    `mcode provider` instead.
 4. Confirm the headless contract with `mcode exec --help`.
+5. Use the platform's Python launcher for the wrapper: normally `python3` on
+   Linux/macOS, or `py -3` / `python` on Windows.
 
 If npm blocks native install scripts, follow npm's prompt or reinstall with
 the narrow allow-list for `@minimax-ai/code` and `better-sqlite3`; do not
@@ -76,9 +78,10 @@ terminal(
 )
 ```
 
-The wrapper sends the prompt to `mcode exec --input - --input-format json`,
-requests `--output-format json`, validates the final `ExecResultV1`, writes one
-JSON object to stdout, and preserves MCode's nonzero exit code and stderr.
+The wrapper sends the prompt as UTF-8 JSON to
+`mcode exec --input - --input-format json`, requests `--output-format json`,
+validates the final `ExecResultV1`, writes one JSON object to stdout, and
+preserves MCode's nonzero exit code and stderr.
 
 ## Quick Reference
 
@@ -97,6 +100,9 @@ JSON object to stdout, and preserves MCode's nonzero exit code and stderr.
 
 `--session` and `--continue` are mutually exclusive. The wrapper defaults to
 `smart`; headless runs exit as blocked when an action still requires a human.
+The final statuses and public exit codes are `succeeded` (0), `failed`
+(3, 4, or 70 according to error category), `blocked` (5), `timeout` (6),
+`limit_exceeded` (7), and `cancelled` (130).
 
 ## Procedure
 
@@ -104,9 +110,11 @@ JSON object to stdout, and preserves MCode's nonzero exit code and stderr.
    delegating. Create any required branch or worktree first.
 2. Give MCode a concrete task, constraints, expected files, and focused
    verification commands. Do not hand it an ambiguous product decision.
-3. Choose a bounded inner `--timeout` and a slightly longer Hermes terminal
-   timeout. Use background execution with `notify_on_complete=true` for long
-   tasks, then inspect it with the `process` tool.
+3. Choose a bounded inner `--timeout` and set the Hermes terminal timeout at
+   least 30-60 seconds longer. The wrapper forwards MCode's run timeout; the
+   terminal timeout is the independent outer deadline. Use background execution
+   with `notify_on_complete=true` for long tasks, then inspect it with the
+   `process` tool.
 4. Read the JSON result. Treat `status: "succeeded"` as the worker's report,
    not proof that the change is correct.
 5. Inspect the actual diff and run the repository's required tests yourself.

--- a/optional-skills/autonomous-ai-agents/mcode-cli/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/mcode-cli/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: mcode-cli
+description: Delegate coding tasks to the MiniMax Code CLI.
+version: 0.1.0
+author: DanielWalnut (hetaoBackend), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+prerequisites:
+  commands: [mcode]
+metadata:
+  hermes:
+    tags: [Coding-Agent, MiniMax-Code, CLI, Delegation, Code-Review]
+    related_skills: [antigravity-cli, claude-code, codex, grok, hermes-agent, openhands]
+    requires_toolsets: [terminal]
+---
+
+# MiniMax Code CLI Skill
+
+Delegate bounded coding tasks to the `mcode` headless runner from Hermes. Use
+the bundled wrapper for deterministic JSON output and safe prompt transport;
+keep Hermes responsible for scope, review, and final verification.
+
+## When to Use
+
+- The user explicitly asks to use MiniMax Code or MCode.
+- A feature, fix, refactor, or review benefits from an independent coding agent.
+- A task should run in a separate workspace or continue an existing MCode session.
+- You need a structured `ExecResultV1` result instead of an interactive TUI.
+
+Use Hermes-native `delegate_task` for ordinary subagents. Use this skill when
+MCode itself is the requested execution backend or a useful independent
+second opinion.
+
+## Prerequisites
+
+1. Verify Node.js satisfies the package's current `engines` declaration.
+2. Install the public package and verify the active command:
+
+   ```text
+   npm install --global @minimax-ai/code@latest --registry https://registry.npmjs.org/
+   command -v mcode
+   mcode --version
+   ```
+
+3. Authenticate once with `mcode login --region global` or
+   `mcode login --region cn`. For BYOK, configure a provider with
+   `mcode provider` instead.
+4. Confirm the headless contract with `mcode exec --help`.
+
+If npm blocks native install scripts, follow npm's prompt or reinstall with
+the narrow allow-list for `@minimax-ai/code` and `better-sqlite3`; do not
+enable arbitrary package scripts globally.
+
+## How to Run
+
+`SKILL_DIR` is the directory containing this `SKILL.md`. Run the wrapper
+through the Hermes `terminal` tool:
+
+```text
+terminal(
+  command="python3 SKILL_DIR/scripts/run_mcode.py --cwd /path/to/repo --timeout 10m 'Fix the failing focused test and verify it.'",
+  workdir="/path/to/repo",
+  timeout=660
+)
+```
+
+For prompts containing shell syntax, secrets, or long specifications, write a
+UTF-8 task file with `write_file` and pass `--prompt-file`; do not interpolate
+untrusted text into a shell command:
+
+```text
+terminal(
+  command="python3 SKILL_DIR/scripts/run_mcode.py --cwd /path/to/repo --prompt-file /path/to/task.md --timeout 20m",
+  workdir="/path/to/repo",
+  timeout=1260
+)
+```
+
+The wrapper sends the prompt to `mcode exec --input - --input-format json`,
+requests `--output-format json`, validates the final `ExecResultV1`, writes one
+JSON object to stdout, and preserves MCode's nonzero exit code and stderr.
+
+## Quick Reference
+
+| Wrapper option | Purpose |
+| --- | --- |
+| `--cwd PATH` | Workspace MCode may inspect and modify. |
+| `--prompt-file PATH` | Read the task without shell interpolation. |
+| `--model PROVIDER/MODEL` | Override the model for this run only. |
+| `--session ID` | Continue a specific active MCode session. |
+| `--continue` | Continue the latest active session in `--cwd`. |
+| `--permission smart` | Default; auto-handle low-risk actions. |
+| `--permission full` | Allow all actions only with explicit authority. |
+| `--timeout 10m` | Bound the inner MCode run. |
+| `--max-steps N` | Bound assistant steps. |
+| `--mcode PATH` | Use an explicit MCode executable. |
+
+`--session` and `--continue` are mutually exclusive. The wrapper defaults to
+`smart`; headless runs exit as blocked when an action still requires a human.
+
+## Procedure
+
+1. Inspect repository instructions, status, and the requested scope before
+   delegating. Create any required branch or worktree first.
+2. Give MCode a concrete task, constraints, expected files, and focused
+   verification commands. Do not hand it an ambiguous product decision.
+3. Choose a bounded inner `--timeout` and a slightly longer Hermes terminal
+   timeout. Use background execution with `notify_on_complete=true` for long
+   tasks, then inspect it with the `process` tool.
+4. Read the JSON result. Treat `status: "succeeded"` as the worker's report,
+   not proof that the change is correct.
+5. Inspect the actual diff and run the repository's required tests yourself.
+   Fix or revert out-of-scope changes before presenting the result.
+6. Report the MCode session ID when continuity may be useful; use `--session`
+   or `--continue` for a follow-up in the same workspace.
+
+## Pitfalls
+
+- Do not run the interactive `mcode` TUI without a PTY. Prefer this headless
+  wrapper for delegation.
+- Do not parse `stream-json` when only the final outcome is needed. The wrapper
+  deliberately uses the single-document JSON contract.
+- Do not treat exit code 5 / `status: "blocked"` as a model failure. A pending
+  permission or questionnaire needs a different permission policy or a human.
+- Do not use `--permission full` unless the user's authority covers the
+  resulting writes and commands.
+- Do not expose tokens, local auth files, full environment dumps, or sensitive
+  prompts in logs or summaries.
+- Do not let two agents edit the same checkout concurrently. Use isolated git
+  worktrees for parallel tasks.
+- Do not trust `command -v mcode` alone after upgrades. Check `mcode --version`
+  and run a small headless smoke task.
+
+## Verification
+
+Run a read-only smoke task in a temporary or disposable workspace:
+
+```text
+python3 SKILL_DIR/scripts/run_mcode.py \
+  --cwd /path/to/disposable/repo \
+  --permission off \
+  --timeout 2m \
+  'Reply with exactly MCODE_HERMES_OK. Do not modify files.'
+```
+
+Verification passes only when the process exits 0 and the emitted object has
+`type: "exec.result"`, `schemaVersion: 1`, `status: "succeeded"`, and an answer
+containing `MCODE_HERMES_OK`. For real coding tasks, also inspect `git diff`
+and run the repository's focused tests after MCode exits.

--- a/optional-skills/autonomous-ai-agents/mcode-cli/scripts/run_mcode.py
+++ b/optional-skills/autonomous-ai-agents/mcode-cli/scripts/run_mcode.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Run one MiniMax Code task through its stable headless JSON contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from shutil import which as find_executable
+from typing import Callable, Sequence
+
+
+Writer = Callable[[str], object]
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+Which = Callable[[str], str | None]
+
+
+def build_command(
+    *,
+    mcode: str,
+    cwd: Path,
+    permission: str,
+    model: str | None = None,
+    session: str | None = None,
+    continue_session: bool = False,
+    timeout: str | None = None,
+    max_steps: int | None = None,
+) -> list[str]:
+    """Build an argv-only invocation; task text is intentionally excluded."""
+    command = [
+        mcode,
+        "exec",
+        "--input",
+        "-",
+        "--input-format",
+        "json",
+        "--output-format",
+        "json",
+        "--cwd",
+        str(cwd),
+        "--permission",
+        permission,
+    ]
+    if model:
+        command.extend(["--model", model])
+    if session:
+        command.extend(["--session", session])
+    if continue_session:
+        command.append("--continue")
+    if timeout:
+        command.extend(["--timeout", timeout])
+    if max_steps is not None:
+        command.extend(["--max-steps", str(max_steps)])
+    return command
+
+
+def _is_exec_result(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    return (
+        value.get("schemaVersion") == 1
+        and value.get("type") == "exec.result"
+        and isinstance(value.get("sessionId"), str)
+        and isinstance(value.get("turnId"), str)
+        and value.get("status") in {"succeeded", "failed", "blocked", "cancelled"}
+    )
+
+
+def run_mcode(
+    *,
+    prompt: str,
+    cwd: Path,
+    mcode: str = "mcode",
+    permission: str = "smart",
+    model: str | None = None,
+    session: str | None = None,
+    continue_session: bool = False,
+    timeout: str | None = None,
+    max_steps: int | None = None,
+    runner: Runner = subprocess.run,
+    which: Which = find_executable,
+    stdout: Writer = sys.stdout.write,
+    stderr: Writer = sys.stderr.write,
+) -> int:
+    """Execute MCode and preserve its machine result and exit semantics."""
+    resolved_mcode = which(mcode)
+    if not resolved_mcode:
+        stderr("mcode was not found on PATH. Install @minimax-ai/code first.\n")
+        return 127
+    command = build_command(
+        mcode=resolved_mcode,
+        cwd=cwd,
+        permission=permission,
+        model=model,
+        session=session,
+        continue_session=continue_session,
+        timeout=timeout,
+        max_steps=max_steps,
+    )
+    try:
+        completed = runner(
+            command,
+            input=json.dumps({"prompt": prompt}, ensure_ascii=False),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        stderr("mcode was not found on PATH. Install @minimax-ai/code first.\n")
+        return 127
+    except KeyboardInterrupt:
+        stderr("mcode run interrupted.\n")
+        return 130
+
+    if completed.stderr:
+        stderr(completed.stderr)
+
+    try:
+        result = json.loads(completed.stdout)
+    except (json.JSONDecodeError, TypeError):
+        result = None
+
+    if not _is_exec_result(result):
+        if completed.returncode == 0 or not completed.stderr:
+            stderr("mcode returned invalid ExecResultV1 JSON.\n")
+        return completed.returncode or 1
+
+    stdout(f"{json.dumps(result, ensure_ascii=False)}\n")
+    if completed.returncode:
+        return completed.returncode
+    return 0 if result["status"] == "succeeded" else 1
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run MiniMax Code headlessly and emit one ExecResultV1 JSON object."
+    )
+    prompt_source = parser.add_mutually_exclusive_group(required=True)
+    prompt_source.add_argument("prompt", nargs="?", help="Task prompt")
+    prompt_source.add_argument(
+        "--prompt-file", type=Path, help="UTF-8 file containing the task"
+    )
+    parser.add_argument(
+        "--cwd", type=Path, default=Path.cwd(), help="Workspace directory"
+    )
+    parser.add_argument("--mcode", default="mcode", help="MCode executable path")
+    parser.add_argument("--model", help="Temporary provider/model override")
+    session = parser.add_mutually_exclusive_group()
+    session.add_argument("--session", help="Existing active MCode session ID")
+    session.add_argument("--continue", dest="continue_session", action="store_true")
+    parser.add_argument(
+        "--permission",
+        choices=("ask", "smart", "full", "off"),
+        default="smart",
+        help="MCode permission policy (default: smart)",
+    )
+    parser.add_argument("--timeout", help="MCode run timeout, such as 30s or 10m")
+    parser.add_argument("--max-steps", type=int, help="Maximum assistant steps")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        cwd = args.cwd.expanduser().resolve(strict=True)
+        if not cwd.is_dir():
+            raise ValueError(f"--cwd is not a directory: {cwd}")
+        prompt = (
+            args.prompt_file.expanduser().read_text(encoding="utf-8")
+            if args.prompt_file
+            else args.prompt
+        )
+        if not prompt or not prompt.strip():
+            raise ValueError("task prompt cannot be empty")
+        if args.max_steps is not None and args.max_steps < 1:
+            raise ValueError("--max-steps must be positive")
+    except (OSError, ValueError) as exc:
+        sys.stderr.write(f"mcode wrapper error: {exc}\n")
+        return 2
+
+    return run_mcode(
+        prompt=prompt,
+        cwd=cwd,
+        mcode=args.mcode,
+        permission=args.permission,
+        model=args.model,
+        session=args.session,
+        continue_session=args.continue_session,
+        timeout=args.timeout,
+        max_steps=args.max_steps,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/optional-skills/autonomous-ai-agents/mcode-cli/scripts/run_mcode.py
+++ b/optional-skills/autonomous-ai-agents/mcode-cli/scripts/run_mcode.py
@@ -15,6 +15,14 @@ from typing import Callable, Sequence
 Writer = Callable[[str], object]
 Runner = Callable[..., subprocess.CompletedProcess[str]]
 Which = Callable[[str], str | None]
+EXEC_RESULT_STATUSES = {
+    "succeeded",
+    "failed",
+    "blocked",
+    "timeout",
+    "cancelled",
+    "limit_exceeded",
+}
 
 
 def build_command(
@@ -56,6 +64,10 @@ def build_command(
     return command
 
 
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-standard JSON constant: {value}")
+
+
 def _is_exec_result(value: object) -> bool:
     if not isinstance(value, dict):
         return False
@@ -64,7 +76,9 @@ def _is_exec_result(value: object) -> bool:
         and value.get("type") == "exec.result"
         and isinstance(value.get("sessionId"), str)
         and isinstance(value.get("turnId"), str)
-        and value.get("status") in {"succeeded", "failed", "blocked", "cancelled"}
+        and isinstance(value.get("durationMs"), (int, float))
+        and not isinstance(value.get("durationMs"), bool)
+        and value.get("status") in EXEC_RESULT_STATUSES
     )
 
 
@@ -104,6 +118,8 @@ def run_mcode(
             command,
             input=json.dumps({"prompt": prompt}, ensure_ascii=False),
             text=True,
+            encoding="utf-8",
+            errors="strict",
             capture_output=True,
             check=False,
         )
@@ -118,8 +134,8 @@ def run_mcode(
         stderr(completed.stderr)
 
     try:
-        result = json.loads(completed.stdout)
-    except (json.JSONDecodeError, TypeError):
+        result = json.loads(completed.stdout, parse_constant=_reject_json_constant)
+    except (json.JSONDecodeError, TypeError, ValueError):
         result = None
 
     if not _is_exec_result(result):
@@ -127,7 +143,7 @@ def run_mcode(
             stderr("mcode returned invalid ExecResultV1 JSON.\n")
         return completed.returncode or 1
 
-    stdout(f"{json.dumps(result, ensure_ascii=False)}\n")
+    stdout(f"{json.dumps(result, ensure_ascii=False, allow_nan=False)}\n")
     if completed.returncode:
         return completed.returncode
     return 0 if result["status"] == "succeeded" else 1

--- a/tests/skills/test_mcode_cli_skill.py
+++ b/tests/skills/test_mcode_cli_skill.py
@@ -1,0 +1,216 @@
+"""Behavioral tests for the MiniMax Code CLI skill wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "autonomous-ai-agents"
+    / "mcode-cli"
+    / "scripts"
+    / "run_mcode.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("mcode_skill_wrapper", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _success_result(answer: str = "done") -> dict:
+    return {
+        "schemaVersion": 1,
+        "type": "exec.result",
+        "sessionId": "session-1",
+        "turnId": "turn-1",
+        "status": "succeeded",
+        "answer": answer,
+        "durationMs": 12,
+    }
+
+
+def test_build_command_keeps_prompt_out_of_argv(tmp_path):
+    wrapper = _load_module()
+
+    command = wrapper.build_command(
+        mcode="mcode",
+        cwd=tmp_path,
+        permission="smart",
+        model="minimax/MiniMax-M2.5",
+        session="session-1",
+        continue_session=False,
+        timeout="2m",
+        max_steps=8,
+    )
+
+    assert command == [
+        "mcode",
+        "exec",
+        "--input",
+        "-",
+        "--input-format",
+        "json",
+        "--output-format",
+        "json",
+        "--cwd",
+        str(tmp_path),
+        "--permission",
+        "smart",
+        "--model",
+        "minimax/MiniMax-M2.5",
+        "--session",
+        "session-1",
+        "--timeout",
+        "2m",
+        "--max-steps",
+        "8",
+    ]
+
+
+def test_run_passes_prompt_over_stdin_and_emits_valid_result(tmp_path):
+    wrapper = _load_module()
+    captured = {}
+
+    def fake_runner(command, **kwargs):
+        captured["command"] = command
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(
+            command, 0, json.dumps(_success_result("fixed")), ""
+        )
+
+    stdout: list[str] = []
+    stderr: list[str] = []
+    exit_code = wrapper.run_mcode(
+        prompt="Fix the failing test; $(touch should-not-run)",
+        cwd=tmp_path,
+        runner=fake_runner,
+        which=lambda _command: "/tools/mcode.cmd",
+        stdout=stdout.append,
+        stderr=stderr.append,
+    )
+
+    assert exit_code == 0
+    assert captured["command"][0] == "/tools/mcode.cmd"
+    assert captured["command"][-2:] == ["--permission", "smart"]
+    assert json.loads(captured["input"]) == {
+        "prompt": "Fix the failing test; $(touch should-not-run)"
+    }
+    assert captured["text"] is True
+    assert captured["capture_output"] is True
+    assert json.loads(stdout[0]) == _success_result("fixed")
+    assert stderr == []
+
+
+def test_run_preserves_mcode_failure_and_diagnostics(tmp_path):
+    wrapper = _load_module()
+    failed = {
+        **_success_result(),
+        "status": "failed",
+        "answer": None,
+        "error": {"category": "runtime", "message": "provider unavailable"},
+    }
+
+    def fake_runner(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command, 4, json.dumps(failed), "provider unavailable\n"
+        )
+
+    stdout: list[str] = []
+    stderr: list[str] = []
+    exit_code = wrapper.run_mcode(
+        prompt="Fix it",
+        cwd=tmp_path,
+        runner=fake_runner,
+        which=lambda _command: "/tools/mcode",
+        stdout=stdout.append,
+        stderr=stderr.append,
+    )
+
+    assert exit_code == 4
+    assert json.loads(stdout[0]) == failed
+    assert stderr == ["provider unavailable\n"]
+
+
+def test_run_rejects_non_contract_stdout(tmp_path):
+    wrapper = _load_module()
+
+    def fake_runner(command, **_kwargs):
+        return subprocess.CompletedProcess(command, 0, "not-json\n", "")
+
+    stdout: list[str] = []
+    stderr: list[str] = []
+    exit_code = wrapper.run_mcode(
+        prompt="Fix it",
+        cwd=tmp_path,
+        runner=fake_runner,
+        which=lambda _command: "/tools/mcode",
+        stdout=stdout.append,
+        stderr=stderr.append,
+    )
+
+    assert exit_code == 1
+    assert stdout == []
+    assert stderr == ["mcode returned invalid ExecResultV1 JSON.\n"]
+
+
+def test_run_reports_missing_mcode_binary(tmp_path):
+    wrapper = _load_module()
+    runner_called = False
+
+    def fake_runner(_command, **_kwargs):
+        nonlocal runner_called
+        runner_called = True
+        raise AssertionError("runner must not start when mcode cannot be resolved")
+
+    stderr: list[str] = []
+    exit_code = wrapper.run_mcode(
+        prompt="Fix it",
+        cwd=tmp_path,
+        runner=fake_runner,
+        which=lambda _command: None,
+        stdout=lambda _value: None,
+        stderr=stderr.append,
+    )
+
+    assert exit_code == 127
+    assert runner_called is False
+    assert stderr == ["mcode was not found on PATH. Install @minimax-ai/code first.\n"]
+
+
+def test_main_reads_prompt_file_and_resolves_workspace(tmp_path, monkeypatch):
+    wrapper = _load_module()
+    prompt_file = tmp_path / "task.md"
+    prompt_file.write_text("Fix the focused test.\n", encoding="utf-8")
+    captured = {}
+
+    def fake_run_mcode(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(wrapper, "run_mcode", fake_run_mcode)
+
+    exit_code = wrapper.main([
+        "--cwd",
+        str(tmp_path),
+        "--prompt-file",
+        str(prompt_file),
+        "--permission",
+        "off",
+        "--max-steps",
+        "3",
+    ])
+
+    assert exit_code == 0
+    assert captured["prompt"] == "Fix the focused test.\n"
+    assert captured["cwd"] == tmp_path.resolve()
+    assert captured["permission"] == "off"
+    assert captured["max_steps"] == 3

--- a/tests/skills/test_mcode_cli_skill.py
+++ b/tests/skills/test_mcode_cli_skill.py
@@ -7,6 +7,8 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 SCRIPT = (
     Path(__file__).resolve().parents[2]
@@ -90,7 +92,7 @@ def test_run_passes_prompt_over_stdin_and_emits_valid_result(tmp_path):
     stdout: list[str] = []
     stderr: list[str] = []
     exit_code = wrapper.run_mcode(
-        prompt="Fix the failing test; $(touch should-not-run)",
+        prompt="修复失败的测试；不要执行 $(touch should-not-run)",
         cwd=tmp_path,
         runner=fake_runner,
         which=lambda _command: "/tools/mcode.cmd",
@@ -102,12 +104,89 @@ def test_run_passes_prompt_over_stdin_and_emits_valid_result(tmp_path):
     assert captured["command"][0] == "/tools/mcode.cmd"
     assert captured["command"][-2:] == ["--permission", "smart"]
     assert json.loads(captured["input"]) == {
-        "prompt": "Fix the failing test; $(touch should-not-run)"
+        "prompt": "修复失败的测试；不要执行 $(touch should-not-run)"
     }
     assert captured["text"] is True
+    assert captured["encoding"] == "utf-8"
+    assert captured["errors"] == "strict"
     assert captured["capture_output"] is True
     assert json.loads(stdout[0]) == _success_result("fixed")
     assert stderr == []
+
+
+@pytest.mark.parametrize(
+    ("status", "returncode"),
+    (("timeout", 6), ("limit_exceeded", 7), ("cancelled", 130)),
+)
+def test_run_accepts_all_exec_result_terminal_statuses(tmp_path, status, returncode):
+    wrapper = _load_module()
+    result = {**_success_result(), "status": status, "answer": None}
+
+    def fake_runner(command, **_kwargs):
+        return subprocess.CompletedProcess(command, returncode, json.dumps(result), "")
+
+    stdout: list[str] = []
+    stderr: list[str] = []
+    exit_code = wrapper.run_mcode(
+        prompt="Keep working",
+        cwd=tmp_path,
+        runner=fake_runner,
+        which=lambda _command: "/tools/mcode",
+        stdout=stdout.append,
+        stderr=stderr.append,
+    )
+
+    assert exit_code == returncode
+    assert json.loads(stdout[0]) == result
+    assert stderr == []
+
+
+def test_run_rejects_exec_result_without_duration(tmp_path):
+    wrapper = _load_module()
+    result = _success_result()
+    result.pop("durationMs")
+
+    def fake_runner(command, **_kwargs):
+        return subprocess.CompletedProcess(command, 0, json.dumps(result), "")
+
+    stdout: list[str] = []
+    stderr: list[str] = []
+    exit_code = wrapper.run_mcode(
+        prompt="Keep working",
+        cwd=tmp_path,
+        runner=fake_runner,
+        which=lambda _command: "/tools/mcode",
+        stdout=stdout.append,
+        stderr=stderr.append,
+    )
+
+    assert exit_code == 1
+    assert stdout == []
+    assert stderr == ["mcode returned invalid ExecResultV1 JSON.\n"]
+
+
+@pytest.mark.parametrize("constant", ("NaN", "Infinity", "-Infinity"))
+def test_run_rejects_non_standard_json_constants(tmp_path, constant):
+    wrapper = _load_module()
+    raw_result = json.dumps(_success_result()).replace("12", constant, 1)
+
+    def fake_runner(command, **_kwargs):
+        return subprocess.CompletedProcess(command, 0, raw_result, "")
+
+    stdout: list[str] = []
+    stderr: list[str] = []
+    exit_code = wrapper.run_mcode(
+        prompt="Keep working",
+        cwd=tmp_path,
+        runner=fake_runner,
+        which=lambda _command: "/tools/mcode",
+        stdout=stdout.append,
+        stderr=stderr.append,
+    )
+
+    assert exit_code == 1
+    assert stdout == []
+    assert stderr == ["mcode returned invalid ExecResultV1 JSON.\n"]
 
 
 def test_run_preserves_mcode_failure_and_diagnostics(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Adds an optional `mcode-cli` skill that lets Hermes delegate bounded coding tasks to the MiniMax Code CLI through its stable headless `mcode exec` JSON contract.

The integration lives under `optional-skills/` rather than core because MCode is a third-party coding agent and Hermes already has generic ACP work in progress. The bundled stdlib-only wrapper keeps prompts out of argv, validates `ExecResultV1`, preserves MCode diagnostics and exit codes, and resolves executables cross-platform (including Windows `.cmd` shims).

## Related Issue

N/A — I searched existing issues and PRs and did not find an MCode CLI skill integration.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- Add `optional-skills/autonomous-ai-agents/mcode-cli/SKILL.md` with triggers, setup, safe delegation procedure, session continuation, permissions, pitfalls, and verification guidance.
- Add `scripts/run_mcode.py`, a dependency-free wrapper around `mcode exec --output-format json`.
- Add behavioral tests for argv construction, stdin prompt transport, contract validation, failure propagation, missing executables, Windows command resolution, and prompt files.

## How to Test

1. Run `HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/skills/test_mcode_cli_skill.py tests/skills/test_authoring_standards.py -q`.
2. Run `ruff format --check optional-skills/autonomous-ai-agents/mcode-cli/scripts/run_mcode.py tests/skills/test_mcode_cli_skill.py` and `ruff check` on the same files.
3. With MCode authenticated, run `python3 optional-skills/autonomous-ai-agents/mcode-cli/scripts/run_mcode.py --cwd /path/to/disposable/repo --permission off --timeout 2m 'Reply with exactly MCODE_HERMES_OK. Do not modify files.'` and verify a successful `ExecResultV1` response.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused repository tests passed: 1,196 tests
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, MCode 0.1.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the skill documentation is the user-facing integration guide
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — N/A; this is intentionally optional
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available — requires the optional `@minimax-ai/code` package; the wrapper itself is stdlib-only
- [ ] I've tested the skill end-to-end with `hermes --toolsets skills -q` — not run; direct authenticated MCode wrapper smoke passed with the expected sentinel

## Screenshots / Logs

Focused repository validation:

```text
tests/skills/test_mcode_cli_skill.py       6 passed
tests/skills/test_authoring_standards.py   1190 passed
ruff format --check                       passed
ruff check                                passed
check-windows-footguns.py                  passed
```

Authenticated MCode 0.1.2 smoke: exit 0, `type: exec.result`, `schemaVersion: 1`, `status: succeeded`, answer `MCODE_HERMES_OK`.
