### PR TITLE
fix(auth): resolve provider auto-detection keys through the profile scope (salvage #86918)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1288,6 +1288,30 @@ automatically scope to the active profile.
    This is intentional — it lets `hermes -p coder profile list` see all profiles regardless
    of which one is active.
 
+7. **Multiplex profile-scoped env reads MUST fail closed — never borrow from `os.environ`**
+   (`agent/secret_scope.py` contract; #72348, #86905). Under `gateway.multiplex_profiles`,
+   `os.environ` holds the **default profile's** values; a secondary profile's `.env` lives
+   only in its secret scope (installed per-turn by `_profile_runtime_scope`). Any
+   profile-level env config — credentials (`app_secret`, tokens) AND authorization
+   (`FEISHU_ALLOWED_USERS`, `{PLATFORM}_ALLOW_ALL_USERS`, `GATEWAY_ALLOW_ALL_USERS`,
+   `group_policy`, `allow_bots`, ...) — must be read scope-aware:
+   - Adapters: `_get_scoped_secret()` (canonical fail-closed copy in
+     `plugins/platforms/feishu/adapter.py`, #86905).
+   - Gateway authz: `_auth_env()` / `_platform_gate_env()` (`gateway/authz_mixin.py`).
+   Rules:
+   - Scope installed + multiplex active → a scoped miss returns the **default**.
+     NEVER fall through to `os.environ` — that leaks another profile's value and
+     silently breaks routing/admission (a leaked default allowlist skips the
+     allow-all check and rejects every secondary-profile sender, #86905).
+   - Unscoped default-profile path (`UnscopedSecretError`) and single-profile
+     deployments keep the `os.environ` read — there it IS the profile's own value.
+   - Authorization config is the sharpest edge: allowlist/allow-all leaks cause
+     silent rejections (or worse, fail-open) that only show up as missing replies.
+   - The `_get_scoped_secret` wrapper is copy-pasted across ~15 platform adapters —
+     when touching any of them, make sure the fail-closed semantics are present;
+     do not reintroduce the `except _UnscopedSecretError: val = os.getenv(...)`
+     fallback-after-miss shape.
+
 ## Known Pitfalls
 
 ### DO NOT hardcode `~/.hermes` paths

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2184,10 +2184,21 @@ def resolve_provider(
     # live only in its secret scope, not os.environ — a bare getenv here
     # would find nothing and auto-resolution would report "No LLM provider
     # configured" for every secondary profile (same class as #86905).
+    # Catch ONLY ImportError: any other failure inside auxiliary_client must
+    # propagate — silently falling back to os.getenv would reintroduce the
+    # very fail-open this PR removes, with zero trace.
     try:
         from agent.auxiliary_client import _scoped_key_env
-    except Exception:  # pragma: no cover — defensive
-        _scoped_key_env = lambda name: os.getenv(name) or ""
+    except ImportError:
+        logger.warning(
+            "agent.auxiliary_client unavailable (%s); provider auto-detection "
+            "will read keys from the process environment only — under "
+            "multiplex, secondary profiles may report 'No LLM provider'.",
+            "import failed",
+        )
+
+        def _scoped_key_env(name: str) -> str:
+            return os.getenv(name) or ""
 
     if has_usable_secret(_scoped_key_env("OPENAI_API_KEY")) or has_usable_secret(
         _scoped_key_env("OPENROUTER_API_KEY")

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2180,7 +2180,18 @@ def resolve_provider(
     except Exception as e:
         logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
 
-    if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
+    # Scope-aware key reads: under multiplex a secondary profile's API keys
+    # live only in its secret scope, not os.environ — a bare getenv here
+    # would find nothing and auto-resolution would report "No LLM provider
+    # configured" for every secondary profile (same class as #86905).
+    try:
+        from agent.auxiliary_client import _scoped_key_env
+    except Exception:  # pragma: no cover — defensive
+        _scoped_key_env = lambda name: os.getenv(name) or ""
+
+    if has_usable_secret(_scoped_key_env("OPENAI_API_KEY")) or has_usable_secret(
+        _scoped_key_env("OPENROUTER_API_KEY")
+    ):
         return "openrouter"
 
     # Auto-detect an OpenRouter credential added via `hermes auth add openrouter`
@@ -2223,7 +2234,7 @@ def resolve_provider(
         if pid in {"copilot", "lmstudio"}:
             continue
         for env_var in pconfig.api_key_env_vars:
-            if has_usable_secret(os.getenv(env_var, "")):
+            if has_usable_secret(_scoped_key_env(env_var)):
                 # An exported API key now wins over a logged-in OAuth provider
                 # (the #29285 fix). Surface that so a user who deliberately uses
                 # OAuth but has a stale key in ~/.hermes/.env isn't silently

--- a/tests/hermes_cli/test_auth_provider_scope.py
+++ b/tests/hermes_cli/test_auth_provider_scope.py
@@ -1,0 +1,82 @@
+"""resolve_provider auto-detection must read provider keys through the
+profile secret scope under multiplex (#86917).
+
+A secondary profile whose config uses ``model.provider: auto`` and whose
+API key lives only in its profile ``.env`` (installed per-turn as the
+secret scope) failed with "No LLM provider configured": the auto path
+read keys with bare ``os.getenv``, which under multiplex holds the
+DEFAULT profile's values.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import agent.secret_scope as ss
+from hermes_constants import (
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+
+
+def _install_profile(tmp_path: Path, provider: str, env_text: str) -> Path:
+    """Create a profile home with a model section and a .env."""
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        f"model:\n  provider: {provider}\n", encoding="utf-8"
+    )
+    (home / ".env").write_text(env_text, encoding="utf-8")
+    return home
+
+
+def test_auto_resolution_sees_profile_scoped_key(tmp_path):
+    """The scoped provider key must be visible to auto-detection.
+
+    Before the fix: the DEEPSEEK_API_KEY lived only in the scope, bare
+    os.getenv found nothing, and auto-resolution reported no provider.
+    """
+    from hermes_cli.auth import resolve_provider
+
+    home = _install_profile(tmp_path, "auto", "DEEPSEEK_API_KEY=sk-scoped\n")
+
+    ss.set_multiplex_active(True)
+    home_token = set_hermes_home_override(str(home))
+    try:
+        scope_token = ss.set_secret_scope(ss.build_profile_secret_scope(home))
+        try:
+            assert resolve_provider("auto") == "deepseek"
+        finally:
+            ss.reset_secret_scope(scope_token)
+    finally:
+        reset_hermes_home_override(home_token)
+        ss.set_multiplex_active(False)
+
+
+def test_auto_resolution_falls_back_to_os_environ_when_unscoped(monkeypatch):
+    """Single-profile / CLI path unchanged: exported env keys still win."""
+    from hermes_cli.auth import resolve_provider
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-env")
+    assert resolve_provider("auto") == "openrouter"
+
+
+def test_auto_resolution_honors_explicit_config_provider(tmp_path):
+    """An explicit config provider still wins over env-key detection."""
+    from hermes_cli.auth import resolve_provider
+
+    home = _install_profile(tmp_path, "opencode-go", "OPENCODE_GO_API_KEY=sk\n")
+
+    ss.set_multiplex_active(True)
+    home_token = set_hermes_home_override(str(home))
+    try:
+        scope_token = ss.set_secret_scope(ss.build_profile_secret_scope(home))
+        try:
+            assert resolve_provider("auto") == "opencode-go"
+        finally:
+            ss.reset_secret_scope(scope_token)
+    finally:
+        reset_hermes_home_override(home_token)
+        ss.set_multiplex_active(False)

--- a/tests/test_gitlock.py
+++ b/tests/test_gitlock.py
@@ -55,14 +55,31 @@ def _touch(path: Path, age_seconds: float) -> None:
     os.utime(path, (old, old))
 
 
-def test_clear_removes_stale_shallow_lock(repo: Path) -> None:
+@pytest.fixture
+def no_git_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the process guard: pretend no git process is running.
+
+    The removal tests exercise the sweep itself, not the guard.  Without
+    this pin they are flaky on CI: the parallel per-file test runner is
+    almost always running a real ``git`` subprocess somewhere, the
+    ``pgrep -x git`` probe hits, and the sweep (correctly) refuses to
+    remove anything — failing the assertion for reasons unrelated to the
+    code under test.  The guard's own behavior is pinned separately in
+    :func:`test_clear_skips_sweep_while_git_running`.
+    """
+    import hermes_cli.gitlock as gitlock
+
+    monkeypatch.setattr(gitlock, "_git_proc_running", lambda: False)
+
+
+def test_clear_removes_stale_shallow_lock(repo: Path, no_git_running: None) -> None:
     _touch(repo / ".git" / "shallow.lock", STALE_LOCK_MIN_AGE_SECONDS + 60)
     removed = clear_stale_git_locks(repo)
     assert str(repo / ".git" / "shallow.lock") in removed
     assert not (repo / ".git" / "shallow.lock").exists()
 
 
-def test_clear_removes_all_stale_lock_kinds(repo: Path) -> None:
+def test_clear_removes_all_stale_lock_kinds(repo: Path, no_git_running: None) -> None:
     for name in LOCK_NAMES:
         _touch(repo / ".git" / name, STALE_LOCK_MIN_AGE_SECONDS + 60)
     removed = clear_stale_git_locks(repo)
@@ -71,7 +88,18 @@ def test_clear_removes_all_stale_lock_kinds(repo: Path) -> None:
         assert not (repo / ".git" / name).exists()
 
 
-def test_clear_keeps_young_lock(repo: Path) -> None:
+def test_clear_skips_sweep_while_git_running(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A running git process must block the sweep even for stale locks."""
+    import hermes_cli.gitlock as gitlock
+
+    monkeypatch.setattr(gitlock, "_git_proc_running", lambda: True)
+    _touch(repo / ".git" / "shallow.lock", STALE_LOCK_MIN_AGE_SECONDS + 60)
+    removed = clear_stale_git_locks(repo)
+    assert removed == []
+    assert (repo / ".git" / "shallow.lock").exists()
+
+
+def test_clear_keeps_young_lock(repo: Path, no_git_running: None) -> None:
     _touch(repo / ".git" / "shallow.lock", 1)  # 1 second old — presumably live
     removed = clear_stale_git_locks(repo)
     assert removed == []


### PR DESCRIPTION
## Summary
Multiplex secondary profiles no longer get "No LLM provider configured": `resolve_provider("auto")` reads provider keys through the profile secret scope (scoped read wins; scoped miss does NOT borrow from os.environ), matching the established fail-closed contract.

Salvage of #86918 by @pittosporum-seu (all 4 commits, authorship preserved). The PR's red slice was an unrelated latent gitlock-test flake (sweep tests sensitive to any live `git` process on the runner) — deflaked with a pinned fixture + a new guard-behavior test.

## Changes
- theirs: `hermes_cli/auth.py` scoped reads, `tests/hermes_cli/test_auth_provider_scope.py`, AGENTS.md fail-closed rule docs
- ours: `tests/test_gitlock.py` deflake (`no_git_running` fixture + guard-pinning test)

## Validation
| | Result |
|---|---|
| test_gitlock.py | 10 passed (also with live git proc) |
| all test_auth*.py | 152 passed, 2 skipped |

Fixes #86917. Credit: @pittosporum-seu (#86918).

## Infographic

![infographic](https://files.catbox.moe/umir1m.png)
