### PR TITLE
feat(image-gen): add Grok Imagine Image 2.0 to the xAI image catalog

### DIFF
--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -1,6 +1,7 @@
 """xAI image generation backend.
 
-Exposes xAI's ``grok-imagine-image`` model as an
+Exposes xAI's Grok Imagine image models (``grok-imagine-image``,
+``grok-imagine-image-quality``, ``grok-imagine-image-2.0``) as an
 :class:`ImageGenProvider` implementation.
 
 Features:
@@ -54,15 +55,29 @@ _MODELS: Dict[str, Dict[str, Any]] = {
         "display": "Grok Imagine Image",
         "speed": "~5-10s",
         "strengths": "Fast, high-quality",
+        "supports_edit": False,
     },
     "grok-imagine-image-quality": {
         "display": "Grok Imagine Image (Quality)",
         "speed": "~10-20s",
         "strengths": "Higher fidelity / detail; slower than the standard model.",
+        "supports_edit": True,
+    },
+    "grok-imagine-image-2.0": {
+        "display": "Grok Imagine Image 2.0",
+        "speed": "~10-20s",
+        "strengths": (
+            "Strongest instruction following, typography and layout; "
+            "generation and editing with up to 3 source images."
+        ),
+        "supports_edit": True,
     },
 }
 
 DEFAULT_MODEL = "grok-imagine-image"
+
+# Editing model used when the resolved model cannot edit (``grok-imagine-image``).
+DEFAULT_EDIT_MODEL = "grok-imagine-image-quality"
 
 # xAI aspect ratios (more options than FAL/OpenAI)
 _XAI_ASPECT_RATIOS = {
@@ -224,9 +239,10 @@ class XAIImageGenProvider(ImageGenProvider):
 
         Routing: when ``image_url`` is provided, POST to ``/v1/images/edits``
         with the source image; otherwise POST to ``/v1/images/generations``.
-        Per xAI docs, editing uses the ``grok-imagine-image-quality`` model and
-        a JSON body (the OpenAI SDK's multipart ``images.edit()`` is NOT
-        supported by xAI).
+        Editing uses the resolved model when it supports editing
+        (``grok-imagine-image-quality``, ``grok-imagine-image-2.0``) and
+        otherwise falls back to :data:`DEFAULT_EDIT_MODEL`, with a JSON body
+        (the OpenAI SDK's multipart ``images.edit()`` is NOT supported by xAI).
         """
         creds = resolve_xai_http_credentials()
         api_key = str(creds.get("api_key") or "").strip()
@@ -240,6 +256,9 @@ class XAIImageGenProvider(ImageGenProvider):
             )
 
         model_id, meta = _resolve_model()
+        # Resolved up-front so error envelopes report the model the request
+        # would actually have used.
+        edit_model = model_id if meta.get("supports_edit") else DEFAULT_EDIT_MODEL
         aspect = resolve_aspect_ratio(aspect_ratio)
         xai_ar = _XAI_ASPECT_RATIOS.get(aspect, "1:1")
         resolution = _resolve_resolution()
@@ -256,7 +275,7 @@ class XAIImageGenProvider(ImageGenProvider):
                 error="xAI image editing supports at most 3 source images",
                 error_type="too_many_references",
                 provider=provider_name,
-                model="grok-imagine-image-quality",
+                model=edit_model,
                 prompt=prompt,
                 aspect_ratio=aspect,
             )
@@ -273,7 +292,7 @@ class XAIImageGenProvider(ImageGenProvider):
                         ),
                         error_type="invalid_image_url",
                         provider=provider_name,
-                        model="grok-imagine-image-quality",
+                        model=edit_model,
                         prompt=prompt,
                         aspect_ratio=aspect,
                     )
@@ -296,10 +315,11 @@ class XAIImageGenProvider(ImageGenProvider):
         storage_cfg = read_xai_imagine_storage_config("image_gen")
 
         if is_edit:
-            # Editing requires the quality model per xAI docs. The source
-            # image may be a public URL or a base64 data URI; local file paths
-            # are converted to a data URI here.
-            edit_model = "grok-imagine-image-quality"
+            # ``edit_model`` was resolved above: a user-selected edit-capable
+            # model (Quality, 2.0) is preserved, and ``grok-imagine-image``
+            # (generation-only) falls back to the documented editing model.
+            # The source image may be a public URL or a base64 data URI; local
+            # file paths are converted to a data URI here.
             try:
                 image_fields = [_xai_image_field(source) for source in source_images]
             except Exception as exc:

--- a/plugins/image_gen/xai/plugin.yaml
+++ b/plugins/image_gen/xai/plugin.yaml
@@ -1,6 +1,6 @@
 name: xai
 version: 1.0.0
-description: "xAI image generation backend (grok-imagine-image). Text-to-image."
+description: "xAI image generation backend (Grok Imagine, incl. Image 2.0). Text-to-image and image editing."
 author: Julien Talbot
 kind: backend
 requires_env:

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -63,6 +63,32 @@ class TestXAIImageGenProvider:
         assert len(models) >= 1
         assert models[0]["id"] == "grok-imagine-image"
 
+    def test_list_models_includes_imagine_image_2(self):
+        """Imagine Image 2.0 is GA in the Imagine API and must be selectable.
+
+        Source: https://docs.x.ai/developers/model-capabilities/imagine
+        """
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        ids = {m["id"] for m in XAIImageGenProvider().list_models()}
+        assert "grok-imagine-image-2.0" in ids
+
+    def test_every_model_declares_edit_support(self):
+        """``supports_edit`` drives edit routing, so it must never be absent.
+
+        A missing key would silently read as False and downgrade the request
+        to the fallback edit model.
+        """
+        from plugins.image_gen.xai import _MODELS
+
+        for model_id, meta in _MODELS.items():
+            assert isinstance(meta.get("supports_edit"), bool), model_id
+
+    def test_default_edit_model_is_edit_capable(self):
+        from plugins.image_gen.xai import DEFAULT_EDIT_MODEL, _MODELS
+
+        assert _MODELS[DEFAULT_EDIT_MODEL]["supports_edit"] is True
+
     def test_default_model(self):
         from plugins.image_gen.xai import XAIImageGenProvider
 
@@ -104,6 +130,21 @@ class TestConfig:
 
         model_id, _ = _resolve_model()
         assert model_id == "grok-imagine-image"
+
+    def test_resolve_imagine_image_2(self, monkeypatch):
+        monkeypatch.setenv("XAI_IMAGE_MODEL", "grok-imagine-image-2.0")
+        from plugins.image_gen.xai import _resolve_model
+
+        model_id, meta = _resolve_model()
+        assert model_id == "grok-imagine-image-2.0"
+        assert meta["supports_edit"] is True
+
+    def test_unknown_model_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("XAI_IMAGE_MODEL", "grok-imagine-image-9.9")
+        from plugins.image_gen.xai import DEFAULT_MODEL, _resolve_model
+
+        model_id, _ = _resolve_model()
+        assert model_id == DEFAULT_MODEL
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +213,88 @@ class TestGenerate:
             "Cache failure must not turn into a tool error — gateway gets a chance to retry"
         )
         assert result["image"] == "https://imgen.x.ai/xai-tmp-imgen-already-404.jpeg"
+
+    def test_generation_uses_selected_imagine_image_2(self, monkeypatch):
+        monkeypatch.setenv("XAI_IMAGE_MODEL", "grok-imagine-image-2.0")
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdC1pbWFnZS1kYXRh"}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/test.png"):
+            result = XAIImageGenProvider().generate(prompt="A concert poster")
+
+        assert result["success"] is True
+        assert post.call_args.kwargs["json"]["model"] == "grok-imagine-image-2.0"
+        assert post.call_args.args[0].endswith("/images/generations")
+        assert result["model"] == "grok-imagine-image-2.0"
+
+    def test_edit_preserves_selected_edit_capable_model(self, monkeypatch):
+        """Editing with Image 2.0 selected must NOT downgrade to the fallback.
+
+        Regression guard: the edit model used to be hardcoded, so selecting
+        2.0 and passing a source image silently produced a Quality-model edit.
+        """
+        monkeypatch.setenv("XAI_IMAGE_MODEL", "grok-imagine-image-2.0")
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdC1pbWFnZS1kYXRh"}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/test.png"):
+            result = XAIImageGenProvider().generate(
+                prompt="Render as a pencil sketch",
+                image_url="https://example.com/source.png",
+            )
+
+        assert result["success"] is True
+        assert post.call_args.kwargs["json"]["model"] == "grok-imagine-image-2.0"
+        assert post.call_args.args[0].endswith("/images/edits")
+
+    def test_edit_falls_back_when_selected_model_cannot_edit(self, monkeypatch):
+        """``grok-imagine-image`` is generation-only, so edits must fall back."""
+        monkeypatch.setenv("XAI_IMAGE_MODEL", "grok-imagine-image")
+        from plugins.image_gen.xai import DEFAULT_EDIT_MODEL, XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdC1pbWFnZS1kYXRh"}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/test.png"):
+            result = XAIImageGenProvider().generate(
+                prompt="Render as a pencil sketch",
+                image_url="https://example.com/source.png",
+            )
+
+        assert result["success"] is True
+        assert post.call_args.kwargs["json"]["model"] == DEFAULT_EDIT_MODEL
+        assert post.call_args.args[0].endswith("/images/edits")
+
+    def test_too_many_sources_error_reports_selected_edit_model(self, monkeypatch):
+        monkeypatch.setenv("XAI_IMAGE_MODEL", "grok-imagine-image-2.0")
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        result = XAIImageGenProvider().generate(
+            prompt="combine these",
+            image_url="https://example.com/a.png",
+            reference_image_urls=[
+                "https://example.com/b.png",
+                "https://example.com/c.png",
+                "https://example.com/d.png",
+            ],
+        )
+
+        assert result["success"] is False
+        assert result["error_type"] == "too_many_references"
+        assert result["model"] == "grok-imagine-image-2.0"
 
     def test_api_error(self):
         import requests as req_lib

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -160,8 +160,9 @@ The `x_search` toolset auto-enables whenever xAI credentials (a SuperGrok / X Pr
 | Chat | `grok-4.20-0309-reasoning` | Reasoning variant |
 | Chat | `grok-4.20-0309-non-reasoning` | Non-reasoning variant |
 | Chat | `grok-4.20-multi-agent-0309` | Multi-agent variant |
-| Image | `grok-imagine-image` | Default; ~5–10 s |
-| Image | `grok-imagine-image-quality` | Higher fidelity; ~10–20 s |
+| Image | `grok-imagine-image` | Default; ~5–10 s; generation only |
+| Image | `grok-imagine-image-quality` | Higher fidelity; ~10–20 s; supports editing |
+| Image | `grok-imagine-image-2.0` | Imagine Image 2.0; strongest instruction following, typography and layout; supports editing |
 | Video | `grok-imagine-video` | Text-to-video |
 | Video | `grok-imagine-video-1.5-preview` | Image-to-video; dated alias `grok-imagine-video-1.5-2026-05-30` |
 | TTS | (default voice) | xAI `/v1/tts` endpoint |

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -117,7 +117,7 @@ Two inputs drive the edit:
 |---|---|---|---|
 | **FAL.ai** (edit-capable models below) | ✓ | up to 9 | routes to the model's `/edit` endpoint |
 | **OpenAI** (`gpt-image-2`) | ✓ | up to 16 | `images.edit()` |
-| **xAI** (Grok Imagine) | ✓ | 1 | `/v1/images/edits` (`grok-imagine-image-quality`) |
+| **xAI** (Grok Imagine) | ✓ | 1 | `/v1/images/edits` (`grok-imagine-image-2.0` or `grok-imagine-image-quality`; the generation-only `grok-imagine-image` falls back to `grok-imagine-image-quality`) |
 | **Krea** (`Krea 2`) | ✓ | up to 10 | reference-guided generation (`image_style_references`) |
 | **OpenAI (Codex auth)** | ✓ | up to 16 | Codex Responses `image_generation` tool with `input_image` content parts |
 


### PR DESCRIPTION
## What does this PR do?

Adds `grok-imagine-image-2.0` to the xAI image plugin's model catalog, and makes image editing respect the selected model instead of a hardcoded one.

Imagine Image 2.0 is generally available in the Imagine API for both generation and editing ([docs](https://docs.x.ai/developers/model-capabilities/imagine), [announcement](https://x.ai/news/grok-imagine-image-2)), but the plugin catalog only listed `grok-imagine-image` and `grok-imagine-image-quality`.

### Why this is a bug, not just a missing model

`_resolve_model()` validates the configured id against `_MODELS` and falls through to `DEFAULT_MODEL` when it doesn't match. So setting:

```yaml
image_gen:
  provider: xai
  xai:
    model: grok-imagine-image-2.0
```

does **not** raise — it silently generates with `grok-imagine-image`. The user believes they selected 2.0 and gets old-model output with no signal anywhere. Same for the `XAI_IMAGE_MODEL` env override.

Editing had a related problem: `edit_model` was hardcoded to `grok-imagine-image-quality`, so even once 2.0 became selectable, any request carrying a source image would quietly downgrade.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [x] 📝 Documentation update

## Changes Made

- Add `grok-imagine-image-2.0` to `_MODELS`.
- Add an explicit `supports_edit` flag per model. `grok-imagine-image` is generation-only; Quality and 2.0 support editing.
- Route edits to the resolved model when it is edit-capable, falling back to the new `DEFAULT_EDIT_MODEL` otherwise. Existing behavior for `grok-imagine-image` users is unchanged.
- Resolve the edit model up-front so the two pre-flight error envelopes (`too_many_references`, `invalid_image_url`) report the model the request would actually have used, instead of always naming the Quality model.
- Update plugin metadata and the two user-facing docs tables.

`DEFAULT_MODEL` is unchanged, so this is not a silent upgrade for anyone — 2.0 is opt-in.

## How to Test

```bash
scripts/run_tests.sh tests/plugins/image_gen/test_xai_provider.py -q   # 32 passed
scripts/run_tests.sh tests/plugins/image_gen/ -q                       # 142 passed
```

Ten new tests. The two regression guards were verified to be genuine: reverting the `edit_model` line to the old hardcoded string makes `test_edit_preserves_selected_edit_capable_model` and `test_too_many_sources_error_reports_selected_edit_model` fail with `assert 'grok-imagine-image-quality' == 'grok-imagine-image-2.0'`, then pass again once restored.

Tests assert routing behavior (which model id and which endpoint the request actually used) rather than freezing catalog contents, per the change-detector guidance in AGENTS.md. `test_every_model_declares_edit_support` is an invariant guard: a future model added without `supports_edit` would otherwise read as False and silently downgrade edits.

Pre-existing unrelated failures in `tests/plugins/memory/test_hindsight_provider.py` were confirmed present on a clean `origin/main` checkout before these changes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing open PRs for duplicates (#87465 adds Imagine 2.0 to the **FAL** catalog — different backend, no overlap)
- [x] My PR contains only related changes
- [x] All image-provider tests pass (142)
- [x] I've added tests for the changes
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] Updated docstrings and plugin metadata
- [x] `cli-config.yaml.example`: N/A (no new config keys; uses the existing `image_gen.xai.model`)
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A (no architecture change)
- [x] Considered cross-platform impact; provider logic remains platform-neutral
