### PR TITLE
feat(vision): vision_ocr tool and OCR grounding for the auxiliary vision path

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -1004,3 +1004,155 @@ class TestVisionCpuBurstCap:
             f"analyses were serialized to the cap (peak={calls_peak}); only the "
             "encode burst should be bounded, not the whole call"
         )
+
+
+class TestVisionOcrTool:
+    @pytest.mark.asyncio
+    async def test_ocr_routes_to_auxiliary_ocr_task_with_configured_model(self):
+        from tools.vision_tools import _handle_vision_ocr
+
+        jpeg_b64 = base64.b64encode(b"\xff\xd8\xff\xe0fakejpeg").decode()
+        data_url = f"data:image/jpeg;base64,{jpeg_b64}"
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "text [1,2,3,4]hello"
+        mock_response.choices = [mock_choice]
+
+        fake_cfg = {"auxiliary": {"ocr": {"model": "unlimited-test", "timeout": 300}}}
+        with (
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/jpeg;base64,abc",
+            ),
+            patch("hermes_cli.config.load_config", return_value=fake_cfg),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ) as mock_llm,
+        ):
+            result = await _handle_vision_ocr({"image_url": data_url, "question": "total"})
+
+        assert "hello" in result
+        kwargs = mock_llm.call_args.kwargs
+        assert kwargs["task"] == "ocr"
+        assert kwargs["model"] == "unlimited-test"
+        assert kwargs["max_tokens"] == 4000
+        assert kwargs["timeout"] == 300.0
+        prompt_text = kwargs["messages"][0]["content"][0]["text"]
+        assert "verbatim" in prompt_text.lower()
+        assert "total" in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_ocr_without_configured_model_fails_closed_with_guidance(self, monkeypatch):
+        from tools.vision_tools import _handle_vision_ocr
+
+        monkeypatch.delenv("AUXILIARY_OCR_MODEL", raising=False)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            result = await _handle_vision_ocr({"image_url": "data:image/png;base64,aaaa"})
+        assert "not configured" in result
+        assert "vision_analyze" in result
+
+
+class TestVisionOcrContext:
+    @pytest.mark.asyncio
+    async def test_vision_analyze_prepends_ocr_transcript(self):
+        from tools.vision_tools import _handle_vision_analyze
+
+        jpeg_b64 = base64.b64encode(b"\xff\xd8\xff\xe0fakejpeg").decode()
+        data_url = f"data:image/jpeg;base64,{jpeg_b64}"
+
+        def _resp(text):
+            r = MagicMock()
+            ch = MagicMock()
+            ch.message.content = text
+            r.choices = [ch]
+            return r
+
+        fake_cfg = {
+            "auxiliary": {
+                "ocr": {"model": "unlimited-test"},
+                "vision": {"model": "scene-test"},
+            }
+        }
+        calls = []
+
+        async def fake_llm(**kwargs):
+            calls.append(kwargs)
+            if kwargs["task"] == "ocr":
+                return _resp("text [1,2,3,4]TOTAL: 42.00 GEL")
+            return _resp("A receipt on a table")
+
+        with (
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/jpeg;base64,abc",
+            ),
+            patch("hermes_cli.config.load_config", return_value=fake_cfg),
+            patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=False),
+            patch("tools.vision_tools.async_call_llm", side_effect=fake_llm),
+        ):
+            result = await _handle_vision_analyze(
+                {"image_url": data_url, "question": "what is this"}
+            )
+
+        assert "receipt" in result
+        assert [c["task"] for c in calls] == ["ocr", "vision"]
+        vision_prompt = calls[1]["messages"][0]["content"][0]["text"]
+        assert "TOTAL: 42.00 GEL" in vision_prompt
+        assert "Verbatim OCR transcript" in vision_prompt
+        assert calls[1]["model"] == "scene-test"
+
+    @pytest.mark.asyncio
+    async def test_vision_analyze_fails_open_when_ocr_errors(self):
+        from tools.vision_tools import _handle_vision_analyze
+
+        jpeg_b64 = base64.b64encode(b"\xff\xd8\xff\xe0fakejpeg").decode()
+        data_url = f"data:image/jpeg;base64,{jpeg_b64}"
+
+        fake_cfg = {
+            "auxiliary": {
+                "ocr": {"model": "unlimited-test"},
+                "vision": {"model": "scene-test"},
+            }
+        }
+        calls = []
+
+        async def fake_llm(**kwargs):
+            calls.append(kwargs)
+            if kwargs["task"] == "ocr":
+                raise RuntimeError("ocr backend down")
+            r = MagicMock()
+            ch = MagicMock()
+            ch.message.content = "A cat"
+            r.choices = [ch]
+            return r
+
+        with (
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/jpeg;base64,abc",
+            ),
+            patch("hermes_cli.config.load_config", return_value=fake_cfg),
+            patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=False),
+            patch("tools.vision_tools.async_call_llm", side_effect=fake_llm),
+        ):
+            result = await _handle_vision_analyze({"image_url": data_url, "question": "who"})
+
+        assert "cat" in result
+        vision_prompt = calls[-1]["messages"][0]["content"][0]["text"]
+        assert "Verbatim OCR transcript" not in vision_prompt
+
+    @pytest.mark.asyncio
+    async def test_vision_analyze_ocr_context_opt_out(self):
+        from tools.vision_tools import _maybe_ocr_context
+
+        fake_cfg = {
+            "auxiliary": {
+                "ocr": {"model": "unlimited-test"},
+                "vision": {"ocr_context": False},
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            assert await _maybe_ocr_context("data:image/png;base64,aaaa") == ""

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1302,6 +1302,8 @@ async def vision_analyze_tool(
     model: str = None,
     task_id: Optional[str] = None,
     region: Optional[list] = None,
+    task: str = "vision",
+    max_tokens: Optional[int] = None,
 ) -> str:
     """
     Analyze an image from a URL or local file path using vision AI.
@@ -1488,7 +1490,7 @@ async def vision_analyze_tool(
         try:
             from hermes_cli.config import cfg_get, load_config
             _cfg = load_config()
-            _vision_cfg = cfg_get(_cfg, "auxiliary", "vision", default={})
+            _vision_cfg = cfg_get(_cfg, "auxiliary", task, default={})
             _vt = _vision_cfg.get("timeout")
             if _vt is not None:
                 vision_timeout = float(_vt)
@@ -1498,11 +1500,13 @@ async def vision_analyze_tool(
         except Exception:
             pass
         call_kwargs = {
-            "task": "vision",
+            "task": task,
             "messages": messages,
             "temperature": vision_temperature,
             "timeout": vision_timeout,
         }
+        if max_tokens is not None:
+            call_kwargs["max_tokens"] = max_tokens
         if model:
             call_kwargs["model"] = model
         _load_auxiliary_client()
@@ -1791,6 +1795,9 @@ async def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> str:
         pass
     if not model:
         model = os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
+    ocr_context = await _maybe_ocr_context(image_url, region=region, task_id=task_id)
+    if ocr_context:
+        full_prompt += "\n\n" + ocr_context
     return await vision_analyze_tool(image_url, full_prompt, model, task_id=task_id, region=region)
 
 
@@ -1802,6 +1809,153 @@ registry.register(
     check_fn=check_vision_requirements,
     is_async=True,
     emoji="👁️",
+)
+
+
+VISION_OCR_SCHEMA = {
+    "name": "vision_ocr",
+    "description": (
+        "Extract text from an image VERBATIM using the dedicated local OCR "
+        "model (fast, exact, includes layout bounding boxes). PREFER this "
+        "over vision_analyze whenever the image is primarily text: "
+        "screenshots, documents, receipts, invoices, error dialogs, chat "
+        "captures, signs, tables, forms. Use vision_analyze only for scenes, "
+        "objects, people, or when you need interpretation rather than the "
+        "exact text. Accepts a URL, local file path, or data URL."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "image_url": {
+                "type": "string",
+                "description": "Image URL (http/https), local file path, or data: URL to OCR."
+            },
+            "question": {
+                "type": "string",
+                "description": (
+                    "Optional focus, e.g. 'only the table' or 'the total "
+                    "amount'. Leave empty for a full verbatim transcription."
+                )
+            },
+            "region": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "minItems": 4,
+                "maxItems": 4,
+                "description": (
+                    "Optional [x1, y1, x2, y2] crop region in pixel "
+                    "coordinates of the ORIGINAL image, applied before any "
+                    "downscaling."
+                )
+            }
+        },
+        "required": ["image_url"]
+    }
+}
+
+
+async def _maybe_ocr_context(
+    image_url: str,
+    *,
+    region: Optional[list] = None,
+    task_id: Optional[str] = None,
+) -> str:
+    """Cheap verbatim OCR transcript to ground the auxiliary vision model.
+
+    Small scene models read embedded text poorly; the dedicated OCR model is
+    a ~5s CPU call. When ``auxiliary.ocr.model`` is configured (and
+    ``auxiliary.vision.ocr_context`` is not set to false), run OCR first and
+    return a prompt section with the transcript. Fail-open: any error or an
+    empty transcript returns "" and vision proceeds as before. The native
+    fast path does not use this yet (multimodal envelope shape).
+    """
+    ocr_model = None
+    try:
+        from hermes_cli.config import cfg_get, load_config
+        _cfg = load_config()
+        if cfg_get(_cfg, "auxiliary", "vision", "ocr_context") is False:
+            return ""
+        _omodel = cfg_get(_cfg, "auxiliary", "ocr", "model")
+        if _omodel:
+            ocr_model = str(_omodel).strip() or None
+    except Exception:
+        return ""
+    if not ocr_model:
+        return ""
+    try:
+        raw = await vision_analyze_tool(
+            image_url,
+            "OCR this image. Output the text verbatim.",
+            ocr_model,
+            task_id=task_id,
+            region=region,
+            task="ocr",
+            max_tokens=4000,
+        )
+        parsed = json.loads(raw)
+        transcript = (parsed.get("analysis") or "").strip() if parsed.get("success") else ""
+        if not transcript:
+            return ""
+        return (
+            "Verbatim OCR transcript of this image (layout blocks with "
+            "[x1, y1, x2, y2] pixel boxes) — trust it for any text content, "
+            "you only need to describe the visual/scene aspects:\n"
+            + transcript
+        )
+    except Exception:
+        logger.info("vision_analyze: OCR context unavailable, proceeding without", exc_info=True)
+        return ""
+
+
+async def _handle_vision_ocr(args: Dict[str, Any], **kw: Any) -> str:
+    image_url = args.get("image_url", "")
+    question = (args.get("question") or "").strip()
+    region = args.get("region")
+    task_id = kw.get("task_id")
+
+    # No native fast path here on purpose: even a vision-capable main model
+    # reads pixels lossily, while the dedicated OCR model returns verbatim
+    # text with layout boxes. This tool is only as good as its pinned model.
+    prompt = "OCR this image. Output the text verbatim."
+    if question:
+        prompt += f" Focus: {question}"
+
+    model = None
+    try:
+        from hermes_cli.config import cfg_get, load_config
+        _cfg = load_config()
+        _omodel = cfg_get(_cfg, "auxiliary", "ocr", "model")
+        if _omodel:
+            model = str(_omodel).strip() or None
+    except Exception:
+        pass
+    if not model:
+        model = os.getenv("AUXILIARY_OCR_MODEL", "").strip() or None
+    if not model:
+        return tool_error(
+            "vision_ocr is not configured: set auxiliary.ocr.model (and "
+            "provider) in config.yaml, or use vision_analyze instead.",
+            success=False,
+        )
+    return await vision_analyze_tool(
+        image_url,
+        prompt,
+        model,
+        task_id=task_id,
+        region=region,
+        task="ocr",
+        max_tokens=4000,
+    )
+
+
+registry.register(
+    name="vision_ocr",
+    toolset="vision",
+    schema=VISION_OCR_SCHEMA,
+    handler=_handle_vision_ocr,
+    check_fn=check_vision_requirements,
+    is_async=True,
+    emoji="🔤",
 )
 
 


### PR DESCRIPTION
## Motivation

Dedicated OCR models (PaddleOCR-VL, baidu/Unlimited-OCR, …) are ~1-3B, run in seconds on a CPU, and return verbatim text with layout bounding boxes. Two places in hermes-agent benefit:

1. When the active main model has no image support (a text-only quant behind an OpenAI-compatible source returns `image input is not supported`), the auxiliary path is all there is — and small auxiliary scene models are notoriously bad at reading embedded text (screenshots, receipts, error dialogs).
2. Even with a working vision route, "what does this screenshot say" is answered faster and exactly by an OCR model than by any pixel-reading round trip.

## What

- `vision_analyze_tool` gains `task="vision"` and optional `max_tokens` parameters, so the existing download/normalize/encode pipeline can serve any `auxiliary.<task>` route; the timeout/temperature config lookup follows the task key. Default behavior is unchanged (`max_tokens` stays absent from the call unless explicitly passed — the existing `TestVisionConfig` contract still holds).
- New **`vision_ocr`** tool, configured via `auxiliary.ocr.provider` / `auxiliary.ocr.model`: verbatim extraction with an optional focus question and crop `region`. Its description steers the agent: text-heavy images → `vision_ocr`; scenes/objects/people → `vision_analyze`. It deliberately never takes the native fast path (a main model reading pixels is not verbatim), and fails closed with guidance when no OCR model is configured.
- **OCR grounding for the auxiliary vision path**: when `auxiliary.ocr.model` is configured, `vision_analyze` first runs the cheap OCR call and prepends the transcript to the scene model's prompt ("trust it for any text content, you only need to describe the visual/scene aspects"). Fail-open: any OCR error or empty transcript falls back to the previous behavior. Opt-out: `auxiliary.vision.ocr_context: false`. The native fast path is unchanged (its multimodal envelope could carry the transcript too — left as a follow-up, not promised).

## Config example

```yaml
auxiliary:
  ocr:
    provider: custom:my-openai-compatible
    model: unlimited-ocr
    timeout: 300
```

## Tests

`tests/tools/test_vision_tools.py`: five new tests — OCR routing (task/model/prompt/max_tokens/timeout from config), transcript injection with call order `ocr → vision`, fail-open when OCR errors, `ocr_context` opt-out, and the unconfigured fail-closed message. Full vision suites pass: `test_vision_tools.py` + `test_vision_native_fast_path.py` + `test_vision_region.py` (62 passed).

Running in production on the author's deployment (OCR = baidu/Unlimited-OCR GGUF on CPU behind an OpenAI-compatible source; verbatim screenshot transcription in ~5s).
