### PR TITLE
fix(tools): isolate cached tool schemas

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -24,6 +24,7 @@ import os
 import json
 import re
 import asyncio
+from copy import deepcopy
 from contextlib import contextmanager
 from contextvars import ContextVar
 import logging
@@ -382,14 +383,15 @@ def get_tool_definitions(
             # consistent state even on a cache hit.
             global _last_resolved_tool_names
             _last_resolved_tool_names = [t["function"]["name"] for t in cached]
-            # Return a shallow copy of the list but share the dict references —
-            # schemas are treated as read-only by all known callers.
-            return list(cached)
+            # Give every caller its own schema tree. The outer list copy alone
+            # does not protect cached nested function/parameter dictionaries
+            # from a caller that customizes a schema before sending it.
+            return deepcopy(cached)
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
                                        skip_tool_search_assembly=skip_tool_search_assembly)
     if quiet_mode and cache_key is not None:
-        # Cache the freshly-computed list, but hand callers a shallow copy so
+        # Cache the freshly-computed list, but hand callers a deep copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
         # schemas to self.tools) don't poison the cache. Without this, a
         # long-lived Gateway process accumulates duplicate tool names across
@@ -408,7 +410,7 @@ def get_tool_definitions(
                     _tool_defs_cache.pop(next(iter(_tool_defs_cache)))
                 _tool_defs_cache[cache_key] = result
                 cached = result
-        return list(cached)
+        return deepcopy(cached)
     if quiet_mode:
         return list(result)
     return result

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -92,6 +92,19 @@ class TestQuietModeCacheIsolation:
         assert second[0]["function"]["parameters"]["properties"]["message"]["type"] == "string"
         assert second[0]["content"][0]["text"] == "original content"
 
+        second[0]["function"]["description"] = "cache-hit caller mutation"
+        second[0]["function"]["parameters"]["properties"]["message"]["type"] = "number"
+        second[0]["content"][0]["text"] = "cache-hit content mutation"
+        second.append({"type": "function", "function": {"name": "cache-hit added"}})
+
+        third = model_tools.get_tool_definitions(quiet_mode=True)
+
+        assert compute_calls == 1
+        assert len(third) == 1
+        assert third[0]["function"]["description"] == "original description"
+        assert third[0]["function"]["parameters"]["properties"]["message"]["type"] == "string"
+        assert third[0]["content"][0]["text"] == "original content"
+
 
 
     def test_cache_bounded_by_eviction(self):

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -55,6 +55,43 @@ class TestQuietModeCacheIsolation:
         cached = next(iter(model_tools._tool_defs_cache.values()))
         assert second is not cached
 
+    def test_cache_hit_does_not_share_nested_schemas(self, monkeypatch):
+        """A caller must not be able to alter schemas seen by later callers."""
+        computed = [{
+            "type": "function",
+            "content": [{"type": "text", "text": "original content"}],
+            "function": {
+                "name": "example",
+                "description": "original description",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                },
+            },
+        }]
+        compute_calls = 0
+
+        def compute(*args, **kwargs):
+            nonlocal compute_calls
+            compute_calls += 1
+            return computed
+
+        monkeypatch.setattr(model_tools, "_compute_tool_definitions", compute)
+
+        first = model_tools.get_tool_definitions(quiet_mode=True)
+        first[0]["function"]["description"] = "caller mutation"
+        first[0]["function"]["parameters"]["properties"]["message"]["type"] = "integer"
+        first[0]["content"][0]["text"] = "caller content mutation"
+        first.append({"type": "function", "function": {"name": "added"}})
+
+        second = model_tools.get_tool_definitions(quiet_mode=True)
+
+        assert compute_calls == 1
+        assert len(second) == 1
+        assert second[0]["function"]["description"] == "original description"
+        assert second[0]["function"]["parameters"]["properties"]["message"]["type"] == "string"
+        assert second[0]["content"][0]["text"] == "original content"
+
 
 
     def test_cache_bounded_by_eviction(self):


### PR DESCRIPTION
## Summary
- Deep-copy quiet-mode cache results so callers cannot mutate nested tool schemas shared with later sessions.
- Add a deterministic regression test covering nested function, parameter, content, and outer-list mutations across a confirmed cache hit.

## Validation
- `scripts/run_tests.sh tests/test_get_tool_definitions_cache_isolation.py -q`
- `uv run ruff check model_tools.py tests/test_get_tool_definitions_cache_isolation.py`
- Independent staged-diff review: passed