### PR TITLE
fix(cli): resolve bracket-style list indices in config set/get/unset (#87689)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -734,29 +734,67 @@ def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
 
 
 def _split_key_path(key: str) -> list[str]:
-    """Split a dotted config-key path, honoring backslash-escaped dots (``a\\.b`` -> ``a.b``).
-    Backslashes before any other character are preserved verbatim.
+    """Split a dotted config-key path, honoring backslash-escaped dots (``a\\.b`` -> ``a.b``) and
+    bracket-style list indices. Backslashes before any other character are preserved verbatim.
 
     ``hermes config set`` uses ``.`` as the nesting separator, so a key that itself contains a literal dot
     (e.g. provider names like ``qwen3.5-397b-wafer``) was silently split into bogus nested segments
     (#84064).
+
+    A trailing ``[N]`` list index on a segment becomes its own numeric segment, so it navigates the real
+    list instead of writing an inert literal ``name[N]`` key (#87689)::
+
+        _split_key_path("hooks.pre_llm_call[1].command") -> ["hooks", "pre_llm_call", "1", "command"]
+
+    Because the normalization lives at this single seam every navigation (``_set_nested`` / ``_get_nested`` /
+    ``_unset_nested``) already routes through, ``[N]`` and dotted ``.N`` become exactly equivalent and the
+    ``\\.`` escape handling composes with it for free. Only ``[<digits>]`` is recognized; any other bracket
+    content is left verbatim.
     """
     parts: list[str] = []
     current: list[str] = []
     i = 0
+    # True immediately after a ``[N]`` index was emitted, so a bracket index at the very end of the key
+    # (``foo[0]``, ``a[0][1]``) does not tack on a trailing empty segment via the final flush below. A real
+    # trailing dot (``agent.``) still yields the empty segment the caller validates against.
+    after_bracket = False
     while i < len(key):
         ch = key[i]
         if ch == "\\" and key[i + 1:i + 2] == ".":
             current.append(".")
+            after_bracket = False
             i += 2
             continue
         if ch == ".":
             parts.append("".join(current))
             current = []
-        else:
-            current.append(ch)
+            after_bracket = False
+            i += 1
+            continue
+        if ch == "[":
+            j = i + 1
+            while j < len(key) and key[j].isdigit():
+                j += 1
+            if j > i + 1 and j < len(key) and key[j] == "]":
+                # ``name[N]`` -> segment ``name`` followed by segment ``N``. Consecutive indices
+                # (``a[0][1]``) chain without emitting an empty segment for the already-flushed ``current``.
+                if current:
+                    parts.append("".join(current))
+                    current = []
+                parts.append(key[i + 1:j])
+                i = j + 1
+                after_bracket = True
+                # ``[N]`` already acts as a separator, so a dot immediately after ``]``
+                # (``name[0].command``) must not emit an empty segment between the index and the key.
+                if i < len(key) and key[i] == ".":
+                    i += 1
+                    after_bracket = False
+                continue
+        current.append(ch)
+        after_bracket = False
         i += 1
-    parts.append("".join(current))
+    if current or not after_bracket:
+        parts.append("".join(current))
     return parts
 
 
@@ -3516,6 +3554,14 @@ def set_config_value(key: str, value: str, force: bool = False):
         _set_nested(user_config, key, value)
     except ValueError as e:
         _exit_invalid(f"✗ {e}")
+    except (TypeError, IndexError) as e:
+        # A list index past the end (``IndexError``) or a non-numeric segment into a list
+        # (``TypeError``) used to fall through to a silently-inert literal key like
+        # ``pre_llm_call[1]`` (#87689). Surface a clear error instead — this CLI navigates
+        # existing structure and does not grow lists.
+        _exit_invalid(
+            f"✗ Cannot set {key!r}: {e}. This CLI navigates existing structure and does not "
+            f"grow lists — check that the list index is within range and the path is correct.")
     # api_base -> base_url alias at set-time too (mirrors _normalize_root_model_keys).
     if key.strip().lower() in ("model.api_base", "api_base"):
         # Normalize the api_base → base_url alias at set-time too (issue #8919), so a fresh `hermes config

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -308,6 +308,94 @@ class TestListNavigation:
         assert allowlist[1] == {"name": "bob", "role": "admin"}
 
 
+class TestBracketIndexNavigation:
+    """hermes config set/get/unset must resolve bracket-style list indices
+    (``hooks.pre_llm_call[0].command``) against the real list instead of
+    silently creating an inert literal ``pre_llm_call[0]`` key (#87689).
+    """
+
+    def _write_config(self, tmp_path, body):
+        (tmp_path / "config.yaml").write_text(body)
+
+    def _hooks_body(self):
+        return (
+            "hooks:\n"
+            "  pre_llm_call:\n"
+            "  - command: existing.py\n"
+            "    timeout: 3\n"
+        )
+
+    def test_bracket_index_updates_existing_entry(self, _isolated_hermes_home):
+        """``[0]`` addresses the existing list entry, not a new dict key."""
+        self._write_config(_isolated_hermes_home, self._hooks_body())
+
+        set_config_value("hooks.pre_llm_call[0].command", "/path/new.py")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        # No literal junk key was created.
+        assert "pre_llm_call[0]" not in reloaded["hooks"]
+        entry = reloaded["hooks"]["pre_llm_call"]
+        assert isinstance(entry, list)
+        assert len(entry) == 1
+        assert entry[0]["command"] == "/path/new.py"
+        # Sibling field is preserved.
+        assert entry[0]["timeout"] == 3
+
+    def test_bracket_and_dot_index_are_equivalent(self, _isolated_hermes_home):
+        """``[0]`` and ``.0`` write to the same place."""
+        self._write_config(_isolated_hermes_home, self._hooks_body())
+        set_config_value("hooks.pre_llm_call[0].timeout", "9")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["hooks"]["pre_llm_call"][0]["timeout"] == 9
+        assert "pre_llm_call[0]" not in reloaded["hooks"]
+
+    def test_out_of_range_bracket_index_errors_without_junk(
+        self, _isolated_hermes_home, capsys
+    ):
+        """The issue's repro (``[1]`` on a 1-element list) must fail cleanly,
+        not report success while writing an inert literal key.
+        """
+        self._write_config(_isolated_hermes_home, self._hooks_body())
+
+        with pytest.raises(SystemExit) as exc_info:
+            set_config_value("hooks.pre_llm_call[1].command", "/path/new.py")
+        assert exc_info.value.code == 1
+
+        err = capsys.readouterr().err
+        assert "Cannot set" in err
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        # No literal junk key, and the original entry is untouched.
+        assert "pre_llm_call[1]" not in reloaded["hooks"]
+        assert reloaded["hooks"]["pre_llm_call"] == [
+            {"command": "existing.py", "timeout": 3}
+        ]
+
+    def test_get_resolves_bracket_index(self, _isolated_hermes_home, capsys):
+        from hermes_cli.config import get_config_value
+
+        self._write_config(_isolated_hermes_home, self._hooks_body())
+        get_config_value("hooks.pre_llm_call[0].command")
+        out = capsys.readouterr().out
+        assert "existing.py" in out
+
+    def test_unset_resolves_bracket_index(self, _isolated_hermes_home):
+        from hermes_cli.config import unset_config_value
+
+        self._write_config(_isolated_hermes_home, self._hooks_body())
+        unset_config_value("hooks.pre_llm_call[0].timeout")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        entry = reloaded["hooks"]["pre_llm_call"][0]
+        assert "timeout" not in entry
+        assert entry["command"] == "existing.py"
+
+
 # ---------------------------------------------------------------------------
 # Cron drift guard warning — regression tests for #59031
 # ---------------------------------------------------------------------------
@@ -810,6 +898,32 @@ class TestLiteralDotKeyEscaping:
         assert _split_key_path("model") == ["model"]
         # Backslash before a non-dot char is preserved verbatim.
         assert _split_key_path("win\\path.key") == ["win\\path", "key"]
+
+    def test_split_key_path_bracket_index(self):
+        """``[N]`` is normalized to its own numeric segment at the shared seam
+        (#87689), so ``_set_nested`` / ``_get_nested`` / ``_unset_nested`` all
+        inherit list navigation and ``[N]`` is exactly equivalent to ``.N``.
+        """
+        from hermes_cli.config import _split_key_path
+
+        assert _split_key_path("hooks.pre_llm_call[1].command") == [
+            "hooks", "pre_llm_call", "1", "command",
+        ]
+        # ``[N]`` and dotted ``.N`` produce the identical segment list.
+        assert (
+            _split_key_path("hooks.pre_llm_call[0].command")
+            == _split_key_path("hooks.pre_llm_call.0.command")
+        )
+        # A trailing index does not tack on an empty segment (would be rejected
+        # by the empty-segment guard); chained indices navigate nested lists.
+        assert _split_key_path("custom_providers[2]") == ["custom_providers", "2"]
+        assert _split_key_path("a[0][1]") == ["a", "0", "1"]
+        # Escape handling composes with bracket normalization at the same seam.
+        assert _split_key_path("providers.qwen3\\.5[0].api_key") == [
+            "providers", "qwen3.5", "0", "api_key",
+        ]
+        # Non-numeric bracket content is left verbatim (not an index).
+        assert _split_key_path("name[abc]") == ["name[abc]"]
 
     def test_set_preserves_literal_dot_in_provider_key(self, _isolated_hermes_home, capsys):
         self._write_config(_isolated_hermes_home, {


### PR DESCRIPTION
## Problem

`hermes config set` accepts bracket-style list indices like
`hooks.pre_llm_call[1].command`, prints `✓ Set`, and writes a **literal
top-level key** `"pre_llm_call[1]"` next to the real list. `_set_nested`
splits only on `.`, so a bracketed segment never matches the numeric-index
navigation added in #17876 and falls through to plain dict assignment.

The config parses, the junk key shows up in `hermes config get`, and it is
completely inert at runtime. For `hooks:` this is a security-relevant false
belief — an operator thinks a `pre_tool_call`/`pre_llm_call` guard is
registered when nothing will ever fire (`hermes hooks doctor` doesn't surface
the junk key either, since the loader never sees it as a hook entry).

Fixes #87689.

## Fix

- Add `_normalize_indexed_key()` that rewrites `name[N]` → `name.N` (applied
  repeatedly, so `a[0][1]` normalizes too), and call it at the top of
  `_set_nested`, `_get_nested`, and `_unset_nested`. Bracket indices now
  navigate the real list, **symmetrically** across set/get/unset — the two
  spellings `hooks.pre_llm_call[0].command` and `hooks.pre_llm_call.0.command`
  become equivalent.
- `hermes config set` wraps the navigation so an out-of-range (or otherwise
  unresolvable) index surfaces a **clear error** and exits 1, instead of
  silently writing an inert literal key. This CLI navigates existing structure
  and does not grow lists — appending a new entry stays a `hermes config edit`
  operation.

Non-indexed keys pass through unchanged, so existing behavior (including the
#17876 list-preservation guard) is untouched.

## Tests

New `TestBracketIndexNavigation` in `tests/hermes_cli/test_set_config_value.py`:
- `[0]` updates the existing entry and creates **no** literal `pre_llm_call[0]` key.
- `[0]` and `.0` are equivalent.
- The issue's exact repro (`[1]` on a 1-element list) fails with `✗ Cannot set …`,
  exits 1, and leaves the original list untouched — no junk key.
- `config get`/`config unset` also resolve bracket indices.

`tests/hermes_cli/test_set_config_value.py` (88) + `test_config.py` +
`test_config_validation.py` → 177 passing. `ruff --select PLW1514` clean;
windows-footgun `--all` clean.

_The arm64 fork-Docker CI job is expected to fail on fork PRs and is unrelated to this change._
