### PR TITLE
fix(desktop): auto-start messaging gateway on reopen (Windows) (#84311)

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -36,6 +36,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import textwrap
 import time
 from pathlib import Path
 from xml.sax.saxutils import escape
@@ -892,6 +893,130 @@ def windowless_gateway_restart_spec(
     return new_argv, working_dir, env_overlay
 
 
+# Gateway detached-spawn trampoline. ``_spawn_detached`` launches this tiny
+# intermediate with the gateway argv on its command line; it immediately
+# spawns the real gateway with the same detach flags and exits. The gateway's
+# parent is therefore dead within ~100ms of its birth, so no ancestor's
+# ``taskkill /T /F`` — the Desktop app's backend tree-kill on close — can ever
+# reach it: a live intermediate is exactly what makes a grandchild reachable
+# by tree-kill (#84311). The trampoline prints the gateway PID on its stdout
+# so the parent keeps the ``PID <n>`` spawn contract.
+_GATEWAY_DETACHED_SPAWN_TRAMPOLINE = textwrap.dedent(
+    r"""
+    import subprocess
+    import sys
+
+    from hermes_cli._subprocess_compat import (
+        windows_detach_flags,
+        windows_detach_flags_without_breakaway,
+    )
+
+    log_path = sys.argv[1]
+    cmd = sys.argv[2:]
+
+    try:
+        log_fh = open(log_path, "ab", buffering=0)
+    except OSError:
+        log_fh = None
+
+    kwargs = {
+        "creationflags": windows_detach_flags(),
+        "close_fds": True,
+        "stdin": subprocess.DEVNULL,
+        "stdout": log_fh or subprocess.DEVNULL,
+        "stderr": log_fh or subprocess.DEVNULL,
+    }
+    try:
+        proc = subprocess.Popen(cmd, **kwargs)
+    except OSError:
+        # CREATE_BREAKAWAY_FROM_JOB can be rejected with ERROR_ACCESS_DENIED
+        # when the parent's job object refuses breakaway. Retry without it —
+        # mirrors the canonical fallback in gateway_windows._spawn_detached.
+        kwargs["creationflags"] = windows_detach_flags_without_breakaway()
+        try:
+            proc = subprocess.Popen(cmd, **kwargs)
+        except OSError as exc:
+            print(f"ERROR: {exc}", flush=True)
+            sys.exit(1)
+    finally:
+        if log_fh is not None:
+            log_fh.close()
+
+    # Report the gateway PID before exiting. CreateProcess returns before the
+    # gateway's own (slow) Python import, so this line lands fast.
+    print(proc.pid, flush=True)
+    """
+).strip()
+
+
+def _spawn_gateway_via_trampoline(
+    argv: list[str],
+    working_dir: str,
+    env_overlay: dict[str, str],
+    stray_log: Path,
+) -> int:
+    """Spawn ``argv`` via a short-lived trampoline so it is tree-detached.
+
+    The real gateway is spawned by a tiny intermediate process that exits
+    immediately after spawning, so the gateway's parent is dead within ~100ms
+    and no ancestor's ``taskkill /T /F`` (the Desktop app's backend tree-kill
+    on close) can reach it (#84311). The trampoline inherits the caller's cwd
+    and env and reports the gateway PID on its stdout; this returns that PID
+    so callers keep the ``PID <n>`` contract.
+
+    CREATE_NO_WINDOW / CREATE_BREAKAWAY_FROM_JOB detach semantics apply to
+    both the trampoline spawn and the gateway spawn, with the
+    breakaway-denied OSError fallback on each.
+    """
+    env = {**os.environ, **env_overlay}
+    payload = [str(stray_log), *argv]
+
+    try:
+        log_fh = open(stray_log, "ab", buffering=0)
+    except OSError:
+        log_fh = None
+
+    def _popen(creationflags: int) -> subprocess.Popen:
+        return subprocess.Popen(
+            [sys.executable, "-c", _GATEWAY_DETACHED_SPAWN_TRAMPOLINE, *payload],
+            cwd=working_dir,
+            env=env,
+            creationflags=creationflags,
+            close_fds=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=log_fh or subprocess.DEVNULL,
+        )
+
+    try:
+        proc = _popen(windows_detach_flags())
+    except OSError:
+        # CREATE_BREAKAWAY_FROM_JOB can fail with "access denied" when the
+        # parent's job object doesn't permit breakaway (some Windows Terminal
+        # configs). Retry without the breakaway flag — in most setups the
+        # hidden-console CREATE_NO_WINDOW spawn is enough on its own.
+        proc = _popen(windows_detach_flags_without_breakaway())
+    finally:
+        if log_fh is not None:
+            log_fh.close()
+
+    # The trampoline prints the gateway PID immediately after CreateProcess
+    # returns and then exits; read it back to honor the PID contract. A blank
+    # or non-numeric line means the trampoline itself failed (broken
+    # interpreter / import) — surface that instead of returning a dead PID.
+    stdout = proc.stdout
+    try:
+        pid_line = stdout.readline() if stdout is not None else b""
+    except OSError:
+        pid_line = b""
+    text = pid_line.decode("utf-8", "replace").strip()
+    if text.isdigit():
+        return int(text)
+    raise RuntimeError(
+        f"Failed to spawn detached gateway: {text or 'trampoline produced no PID'}"
+    )
+
+
 def _spawn_detached(script_path: Path | None = None) -> int:
     """Launch the gateway as a fully detached background process.
 
@@ -906,31 +1031,21 @@ def _spawn_detached(script_path: Path | None = None) -> int:
     CREATE_NEW_PROCESS_GROUP + DEVNULL stdin + a fresh env, the resulting
     process is independent of whichever shell started it.
 
+    The gateway is spawned through a short-lived trampoline (see
+    ``_spawn_gateway_via_trampoline``) so its parent is dead within ~100ms of
+    its birth: a live intermediate is exactly what makes a grandchild
+    reachable by an ancestor's ``taskkill /T /F``, which is how the messaging
+    gateway used to die together with the Desktop backend on close (#84311).
+
     Arg ``script_path`` is accepted for API symmetry with older callers
     but ignored — we don't need it now that we go direct.
 
-    Returns the spawned PID so callers can verify the process actually
+    Returns the spawned gateway PID so callers can verify the process actually
     came up.
     """
     _assert_windows()
     argv, working_dir, env_overlay = _build_gateway_argv()
 
-    # Inherit PATH etc. from the current env, overlay our required vars.
-    env = {**os.environ, **env_overlay}
-    primary_env = {**env, _WINDOWS_GATEWAY_BREAKAWAY_ENV: "1"}
-
-    # CREATE_NEW_PROCESS_GROUP 0x00000200 — child gets its own group, won't
-    #                                       receive Ctrl+C from our group
-    # CREATE_NO_WINDOW         0x08000000 — child owns a hidden console:
-    #                                       detached from our console's
-    #                                       lifetime AND inheritable by its
-    #                                       descendants (no conhost flashes)
-    # CREATE_BREAKAWAY_FROM_JOB 0x01000000 — escape any job object the
-    #                                       parent is in (prevents parent-
-    #                                       job teardown from reaping us;
-    #                                       some Windows Terminal versions
-    #                                       wrap their children in a job).
-    flags = windows_detach_flags()
 
     # Redirect any stray stdout/stderr output to a sidecar log. Python's
     # logging module writes to gateway.log through a FileHandler, so the
@@ -942,46 +1057,7 @@ def _spawn_detached(script_path: Path | None = None) -> int:
     log_dir.mkdir(parents=True, exist_ok=True)
     stray_log = log_dir / "gateway-stdio.log"
 
-    try:
-        with open(stray_log, "ab", buffering=0) as log_fh:
-            proc = subprocess.Popen(
-                argv,
-                cwd=working_dir,
-                env=primary_env,
-                creationflags=flags,
-                close_fds=True,
-                stdin=subprocess.DEVNULL,
-                stdout=log_fh,
-                stderr=log_fh,
-            )
-    except OSError as exc:
-        # CREATE_BREAKAWAY_FROM_JOB can fail with "access denied" when the
-        # parent's job object doesn't permit breakaway (some Windows
-        # Terminal configs). Retry without the breakaway flag — in most
-        # setups the hidden-console CREATE_NO_WINDOW spawn is enough on
-        # its own.
-        error_code = getattr(exc, "winerror", None)
-        if error_code is None:
-            error_code = exc.errno
-        logger.warning(
-            "Gateway breakaway spawn failed (error=%s); retrying without "
-            "CREATE_BREAKAWAY_FROM_JOB",
-            error_code,
-        )
-        flags_no_breakaway = windows_detach_flags_without_breakaway()
-        fallback_env = {**env, _WINDOWS_GATEWAY_BREAKAWAY_ENV: "0"}
-        with open(stray_log, "ab", buffering=0) as log_fh:
-            proc = subprocess.Popen(
-                argv,
-                cwd=working_dir,
-                env=fallback_env,
-                creationflags=flags_no_breakaway,
-                close_fds=True,
-                stdin=subprocess.DEVNULL,
-                stdout=log_fh,
-                stderr=log_fh,
-            )
-    return proc.pid
+    return _spawn_gateway_via_trampoline(argv, working_dir, env_overlay, stray_log)
 
 
 def _install_choice_from_env(name: str) -> bool | None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -391,18 +391,13 @@ async def _lifespan(app: "FastAPI"):
     cron_stop: "threading.Event | None" = None
     cron_thread: "threading.Thread | None" = None
     if os.getenv("HERMES_DESKTOP") == "1":
-        # Before forking a fresh gateway, reap any orphan left by a previous
-        # serve session. Graceful shutdown reaps the managed child, but an
-        # abnormal exit (crash, SIGKILL, power loss, forced update) reparents
-        # the old gateway to launchd (PPID=1). It keeps holding the QQ
-        # WebSocket, and a newly forked gateway then races the same credential,
-        # splitting messages across parallel session trees (#77276).
-        try:
-            from hermes_cli.gateway import _reap_unsupervised_gateway_orphans
-
-            _reap_unsupervised_gateway_orphans()
-        except Exception:
-            _log.exception("Desktop startup: orphan gateway reap failed")
+        # The messaging gateway is an independent service, not a child of the
+        # desktop. A gateway that survived the previous session (or runs
+        # independently) must be KEPT — reaping it would silently kill the
+        # user's messaging on every desktop reopen (#84311). Only when nothing
+        # is live do we sweep stale-port orphans (the #77276 duplicate guard)
+        # and auto-start a gateway the user's persisted intent says should run.
+        _manage_desktop_gateway_at_boot()
 
         cron_stop = threading.Event()
         cron_thread = threading.Thread(
@@ -4387,16 +4382,117 @@ _ACTION_RESULTS: Dict[str, Dict[str, Any]] = {}
 
 
 def _terminate_desktop_managed_gateway() -> None:
-    """Stop a live gateway restart child when its Desktop backend shuts down."""
-    proc = _ACTION_PROCS.get("gateway-restart")
-    if proc is None:
-        return
+    """Stop a live gateway action child when its Desktop backend shuts down.
+
+    Covers both the dashboard-triggered restart and the boot auto-start action
+    so a lingering management child can't keep a gateway spawn half-done
+    across a desktop close.
+    """
+    for name in ("gateway-restart", "gateway-start"):
+        proc = _ACTION_PROCS.get(name)
+        if proc is None:
+            continue
+        try:
+            if proc.poll() is None:
+                proc.terminate()
+        except OSError:
+            # The child may have exited between poll() and terminate().
+            pass
+
+
+def _manage_desktop_gateway_at_boot() -> None:
+    """Desktop-boot messaging-gateway lifecycle (#84311).
+
+    The messaging gateway is an independent long-running service — closing the
+    desktop must not kill it, and reopening must not leave it dead. A gateway
+    that is still live (survived the close, or runs independently) is kept
+    as-is: reaping it would break messaging for nothing, and a fresh spawn
+    would race its platform credential (#77276). Only when nothing is live do
+    we sweep stale-port orphans and consider recreating a gateway the user
+    last had running.
+    """
     try:
-        if proc.poll() is None:
-            proc.terminate()
-    except OSError:
-        # The child may have exited between poll() and terminate().
-        pass
+        from hermes_cli.gateway import find_gateway_pids
+
+        live_gateways = find_gateway_pids(exclude_pids={os.getpid()})
+    except Exception:
+        live_gateways = []
+        _log.exception("Desktop startup: gateway liveness scan failed")
+
+    if live_gateways:
+        _log.info(
+            "Desktop startup: messaging gateway already running (pids %s); keeping it",
+            ",".join(str(int(pid)) for pid in live_gateways if pid),
+        )
+        return
+
+    # Nothing is live: reap stale-port orphans (the #77276 duplicate guard) so
+    # a recreated gateway binds cleanly, then auto-start on persisted intent.
+    try:
+        from hermes_cli.gateway import _reap_unsupervised_gateway_orphans
+
+        _reap_unsupervised_gateway_orphans()
+    except Exception:
+        _log.exception("Desktop startup: orphan gateway reap failed")
+
+    asyncio.create_task(_maybe_auto_start_gateway())
+
+
+def _gateway_auto_start_reason() -> str | None:
+    """Return a reason string when the messaging gateway should be auto-started.
+
+    The desktop only recreates the gateway when the user's persisted intent
+    says it should be running and no process is live: the last
+    ``gateway_state.json`` transition was a run state (``running`` /
+    ``draining`` — never ``stopped``, ``startup_failed``, or a missing record)
+    AND messaging platforms are configured. This mirrors the running-predicate
+    in ``gateway.status.get_runtime_status_running_pid``.
+
+    Runs off the event loop: loading gateway config performs platform
+    discovery, which can exceed the desktop handshake timeout on a cold
+    Windows boot (#73083).
+    """
+    try:
+        runtime = read_runtime_status()
+    except Exception:
+        runtime = None
+    state = runtime.get("gateway_state") if isinstance(runtime, dict) else None
+    if state in {None, "stopped", "startup_failed"}:
+        return None
+    try:
+        platforms = _load_configured_gateway_platforms()
+    except Exception:
+        _log.exception("Desktop startup: configured-platform scan failed")
+        return None
+    if not platforms:
+        return None
+    return f"last gateway state {state!r} with {len(platforms)} configured platform(s)"
+
+
+async def _maybe_auto_start_gateway() -> None:
+    """Auto-start the messaging gateway when the user's intent says it should run.
+
+    Scheduled from the Desktop boot path (``_manage_desktop_gateway_at_boot``)
+    as a background task so the intent check (gateway config / platform
+    discovery) never delays the server's ready handshake. The spawn goes
+    through the shared ``hermes gateway start`` action, which is already
+    idempotent against a concurrently starting gateway.
+    """
+    try:
+        reason = await asyncio.to_thread(_gateway_auto_start_reason)
+        if reason is None:
+            _log.info("Desktop startup: not auto-starting messaging gateway (no running intent)")
+            return
+        # One start per boot: a user-initiated "restart gateway" click while
+        # auto-start is in flight must not stack a second spawn.
+        existing = _ACTION_PROCS.get("gateway-start")
+        if existing is not None and existing.poll() is None:
+            _log.info("Desktop startup: gateway start already in flight; skipping auto-start")
+            return
+        proc = _spawn_hermes_action(_gateway_subcommand(None, "start"), "gateway-start")
+        _log.info("Desktop startup: auto-starting messaging gateway (%s; pid %s)", reason, proc.pid)
+    except Exception:
+        _log.exception("Desktop startup: gateway auto-start failed")
 
 
 def _record_completed_action(name: str, message: str, exit_code: int = 1) -> None:

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -1006,13 +1006,14 @@ def test_spawn_hermes_action_scrubs_gateway_loop_guard_env(monkeypatch, tmp_path
 def test_desktop_lifespan_reaps_orphan_gateways_on_startup(
     monkeypatch, _isolate_hermes_home
 ):
-    """Starting a Desktop serve backend should reap orphan gateways left by a
-    previous serve session before forking a fresh one (#77276).
+    """Starting a Desktop serve backend reaps stale orphan gateways (#77276).
 
-    Graceful shutdown reaps the managed child, but an abnormal exit reparents
-    the old gateway to launchd (PPID=1) where it keeps holding the QQ
-    WebSocket. The lifespan calls _reap_unsupervised_gateway_orphans() once at
-    startup under HERMES_DESKTOP=1 so the stale orphan is cleared first.
+    The Desktop backend keeps a gateway that is still live (it is an
+    independent service — reaping it would silently kill the user's messaging,
+    #84311) and only sweeps stale-port orphans when nothing is live, before a
+    fresh gateway may be auto-started. This test pins the reap leg of that
+    decision; the keep-live leg is covered by
+    ``test_desktop_gateway_autostart.py``.
     """
     import hermes_cli.web_server as ws
 
@@ -1027,11 +1028,14 @@ def test_desktop_lifespan_reaps_orphan_gateways_on_startup(
     # real cron scheduler thread.
     monkeypatch.setattr(ws, "_warm_gateway_module", lambda: None)
     monkeypatch.setattr(ws, "_start_desktop_cron_ticker", lambda *_args: None)
-    # web_server imports the reaper lazily from hermes_cli.gateway, so patch it
-    # on that module.
+    # web_server imports the reaper and the liveness scan lazily from
+    # hermes_cli.gateway, so patch them on that module. Pinning the scan to
+    # "nothing live" keeps the reap leg deterministic on machines that happen
+    # to run a real gateway.
     import hermes_cli.gateway as g
 
     monkeypatch.setattr(g, "_reap_unsupervised_gateway_orphans", _fake_reap)
+    monkeypatch.setattr(g, "find_gateway_pids", lambda exclude_pids=None: [])
 
     client, _header = _client()
     with client:

--- a/tests/hermes_cli/test_desktop_gateway_autostart.py
+++ b/tests/hermes_cli/test_desktop_gateway_autostart.py
@@ -1,0 +1,256 @@
+"""Desktop-backend messaging-gateway lifecycle (#84311).
+
+Regression coverage for the Windows desktop close/reopen loop:
+
+* On close, the desktop tree-kills its backend (`taskkill /T /F`), which
+  could kill the messaging gateway when it sat in the backend's process tree.
+* On reopen, the backend unconditionally reaped *any* live gateway (the
+  #77276 duplicate guard) and never started a replacement — so the gateway
+  was permanently gone until a manual `hermes gateway start`.
+
+The fix: the gateway is an independent service. The desktop backend keeps a
+live gateway (no reap), reaps stale-port orphans only when nothing is live,
+and auto-starts a gateway the user's persisted intent says should be running
+(last `gateway_state.json` was a run state AND messaging platforms are
+configured).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _runtime(state: str | None) -> dict | None:
+    if state is None:
+        return None
+    return {"gateway_state": state}
+
+
+class TestGatewayAutoStartReason:
+    """The intent decision: last gateway state x configured platforms."""
+
+    def test_running_state_with_platforms_auto_starts(self):
+        from hermes_cli.web_server import _gateway_auto_start_reason
+
+        with (
+            patch("hermes_cli.web_server.read_runtime_status", return_value=_runtime("running")),
+            patch(
+                "hermes_cli.web_server._load_configured_gateway_platforms",
+                return_value={"telegram"},
+            ),
+        ):
+            assert _gateway_auto_start_reason() is not None
+
+    def test_draining_state_with_platforms_auto_starts(self):
+        from hermes_cli.web_server import _gateway_auto_start_reason
+
+        with (
+            patch("hermes_cli.web_server.read_runtime_status", return_value=_runtime("draining")),
+            patch(
+                "hermes_cli.web_server._load_configured_gateway_platforms",
+                return_value={"telegram"},
+            ),
+        ):
+            assert _gateway_auto_start_reason() is not None
+
+    def test_stopped_state_never_auto_starts(self):
+        from hermes_cli.web_server import _gateway_auto_start_reason
+
+        with (
+            patch("hermes_cli.web_server.read_runtime_status", return_value=_runtime("stopped")),
+            patch(
+                "hermes_cli.web_server._load_configured_gateway_platforms",
+                return_value={"telegram"},
+            ),
+        ):
+            assert _gateway_auto_start_reason() is None
+
+    def test_startup_failed_state_never_auto_starts(self):
+        """A failing gateway must not be hammered on every desktop open."""
+        from hermes_cli.web_server import _gateway_auto_start_reason
+
+        with (
+            patch(
+                "hermes_cli.web_server.read_runtime_status",
+                return_value=_runtime("startup_failed"),
+            ),
+            patch(
+                "hermes_cli.web_server._load_configured_gateway_platforms",
+                return_value={"telegram"},
+            ),
+        ):
+            assert _gateway_auto_start_reason() is None
+
+    def test_missing_state_record_never_auto_starts(self):
+        """No record = no running intent (mirrors get_runtime_status_running_pid)."""
+        from hermes_cli.web_server import _gateway_auto_start_reason
+
+        with (
+            patch("hermes_cli.web_server.read_runtime_status", return_value=None),
+            patch(
+                "hermes_cli.web_server._load_configured_gateway_platforms",
+                return_value={"telegram"},
+            ),
+        ):
+            assert _gateway_auto_start_reason() is None
+
+    def test_no_configured_platforms_never_auto_starts(self):
+        from hermes_cli.web_server import _gateway_auto_start_reason
+
+        with (
+            patch("hermes_cli.web_server.read_runtime_status", return_value=_runtime("running")),
+            patch(
+                "hermes_cli.web_server._load_configured_gateway_platforms",
+                return_value=set(),
+            ),
+        ):
+            assert _gateway_auto_start_reason() is None
+
+    def test_platform_scan_failure_never_auto_starts(self):
+        from hermes_cli.web_server import _gateway_auto_start_reason
+
+        with (
+            patch("hermes_cli.web_server.read_runtime_status", return_value=_runtime("running")),
+            patch(
+                "hermes_cli.web_server._load_configured_gateway_platforms",
+                side_effect=OSError("config unreadable"),
+            ),
+        ):
+            assert _gateway_auto_start_reason() is None
+
+
+class TestManageDesktopGatewayAtBoot:
+    """The boot decision: keep live gateways, reap + auto-start only when dead."""
+
+    def test_live_gateway_is_kept_not_reaped(self):
+        """A gateway that survived the previous session must be left alone."""
+        from hermes_cli.web_server import _manage_desktop_gateway_at_boot
+
+        with (
+            patch("hermes_cli.gateway.find_gateway_pids", return_value=[12345]),
+            patch(
+                "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
+            ) as mock_reap,
+            patch("hermes_cli.web_server.asyncio.create_task") as mock_task,
+        ):
+            _manage_desktop_gateway_at_boot()
+
+        mock_reap.assert_not_called()
+        mock_task.assert_not_called()
+
+    def test_dead_gateway_reaps_and_schedules_auto_start(self):
+        from hermes_cli.web_server import _manage_desktop_gateway_at_boot
+
+        with (
+            patch("hermes_cli.gateway.find_gateway_pids", return_value=[]),
+            patch(
+                "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
+            ) as mock_reap,
+            patch("hermes_cli.web_server.asyncio.create_task") as mock_task,
+        ):
+            _manage_desktop_gateway_at_boot()
+
+        mock_reap.assert_called_once()
+        mock_task.assert_called_once()
+
+    def test_liveness_scan_failure_degrades_to_reap_and_auto_start(self):
+        """A failed scan must not leave the gateway dead forever — fail open."""
+        from hermes_cli.web_server import _manage_desktop_gateway_at_boot
+
+        with (
+            patch(
+                "hermes_cli.gateway.find_gateway_pids",
+                side_effect=OSError("scan failed"),
+            ),
+            patch(
+                "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
+            ) as mock_reap,
+            patch("hermes_cli.web_server.asyncio.create_task") as mock_task,
+        ):
+            _manage_desktop_gateway_at_boot()
+
+        mock_reap.assert_called_once()
+        mock_task.assert_called_once()
+
+
+class TestMaybeAutoStartGateway:
+    """The auto-start spawn: intent, in-flight dedupe, and failure handling."""
+
+    def test_spawns_gateway_start_when_intent(self):
+        """Dead gateway + running intent -> `hermes gateway start` action."""
+        from hermes_cli.web_server import _maybe_auto_start_gateway
+
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = 4242
+        with (
+            patch(
+                "hermes_cli.web_server._gateway_auto_start_reason",
+                return_value="last gateway state 'running' with 1 configured platform(s)",
+            ),
+            patch("hermes_cli.web_server._ACTION_PROCS", {}),
+            patch("hermes_cli.web_server._spawn_hermes_action", return_value=proc) as mock_spawn,
+            patch(
+                "hermes_cli.web_server._gateway_subcommand",
+                return_value=["gateway", "start"],
+            ),
+        ):
+            asyncio.run(_maybe_auto_start_gateway())
+
+        mock_spawn.assert_called_once()
+        args, kwargs = mock_spawn.call_args
+        assert args[0] == ["gateway", "start"]
+        assert args[1] == "gateway-start"
+
+    def test_skips_spawn_when_no_intent(self):
+        from hermes_cli.web_server import _maybe_auto_start_gateway
+
+        with (
+            patch("hermes_cli.web_server._gateway_auto_start_reason", return_value=None),
+            patch("hermes_cli.web_server._ACTION_PROCS", {}),
+            patch("hermes_cli.web_server._spawn_hermes_action") as mock_spawn,
+        ):
+            asyncio.run(_maybe_auto_start_gateway())
+
+        mock_spawn.assert_not_called()
+
+    def test_skips_spawn_when_start_action_in_flight(self):
+        """A user-initiated start while auto-start is pending must not stack."""
+        from hermes_cli.web_server import _maybe_auto_start_gateway
+
+        inflight = MagicMock(spec=subprocess.Popen)
+        inflight.poll.return_value = None
+        with (
+            patch(
+                "hermes_cli.web_server._gateway_auto_start_reason",
+                return_value="last gateway state 'running' with 1 configured platform(s)",
+            ),
+            patch("hermes_cli.web_server._ACTION_PROCS", {"gateway-start": inflight}),
+            patch("hermes_cli.web_server._spawn_hermes_action") as mock_spawn,
+        ):
+            asyncio.run(_maybe_auto_start_gateway())
+
+        mock_spawn.assert_not_called()
+
+    def test_spawn_failure_is_logged_not_raised(self):
+        from hermes_cli.web_server import _maybe_auto_start_gateway
+
+        with (
+            patch(
+                "hermes_cli.web_server._gateway_auto_start_reason",
+                return_value="last gateway state 'running' with 1 configured platform(s)",
+            ),
+            patch("hermes_cli.web_server._ACTION_PROCS", {}),
+            patch(
+                "hermes_cli.web_server._spawn_hermes_action",
+                side_effect=OSError("spawn failed"),
+            ),
+            patch("hermes_cli.web_server._log") as mock_log,
+        ):
+            asyncio.run(_maybe_auto_start_gateway())
+
+        assert mock_log.exception.called

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -1,7 +1,9 @@
 """Tests for hermes_cli.gateway_windows."""
 
+import io
 import logging
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -10,9 +12,6 @@ import pytest
 import hermes_cli.gateway as gateway
 import hermes_cli.gateway_windows as gateway_windows
 import hermes_cli.setup as setup
-
-
-_BREAKAWAY_MARKER = "_HERMES_GATEWAY_BREAKAWAY"
 
 
 
@@ -80,15 +79,15 @@ def test_build_gateway_argv_keeps_venv_console_python_for_uv_venv(monkeypatch, t
 
 
 @pytest.mark.windows_only
-def test_spawn_detached_marks_primary_breakaway_success(monkeypatch, tmp_path, caplog):
-    """A successful breakaway spawn reports true without a warning."""
+def test_spawn_detached_spawns_via_trampoline(monkeypatch, tmp_path, caplog):
+    """A successful detach spawns the trampoline and returns the gateway PID."""
     argv = ["python.exe", "-m", "hermes_cli.main", "gateway", "run"]
     cwd = str(tmp_path)
     calls = []
 
     def fake_popen(call_argv, **kwargs):
         calls.append((call_argv, kwargs))
-        return SimpleNamespace(pid=12345)
+        return SimpleNamespace(stdout=io.BytesIO(b"12345\n"))
 
     monkeypatch.setattr(
         gateway_windows,
@@ -102,20 +101,22 @@ def test_spawn_detached_marks_primary_breakaway_success(monkeypatch, tmp_path, c
     assert gateway_windows._spawn_detached() == 12345
     assert len(calls) == 1
     actual_argv, kwargs = calls[0]
-    assert actual_argv == argv
+    assert actual_argv[0] == sys.executable
+    assert actual_argv[2] == gateway_windows._GATEWAY_DETACHED_SPAWN_TRAMPOLINE
+    assert actual_argv[3] == str(tmp_path / "logs" / "gateway-stdio.log")
+    assert actual_argv[4:] == argv
     assert kwargs["cwd"] == cwd
     assert kwargs["creationflags"] == gateway_windows.windows_detach_flags()
-    assert kwargs["env"][_BREAKAWAY_MARKER] == "1"
+    assert kwargs["env"]["HERMES_GATEWAY_DETACHED"] == "1"
     assert kwargs["stdin"] is subprocess.DEVNULL
-    assert kwargs["stdout"] is kwargs["stderr"]
+    assert kwargs["stdout"] is subprocess.PIPE
+    assert kwargs["close_fds"] is True
     assert not caplog.records
 
 
 @pytest.mark.windows_only
-def test_spawn_detached_warns_and_marks_no_breakaway_fallback(
-    monkeypatch, tmp_path, caplog
-):
-    """A denied breakaway retries once with private false metadata."""
+def test_spawn_detached_breakaway_fallback_retries(monkeypatch, tmp_path, caplog):
+    """A denied breakaway retries the spawn without the breakaway flag."""
     argv = ["python.exe", "-m", "hermes_cli.main", "gateway", "run"]
     cwd = str(tmp_path)
     calls = []
@@ -126,7 +127,7 @@ def test_spawn_detached_warns_and_marks_no_breakaway_fallback(
             error = OSError(13, "Access is denied")
             error.winerror = 5
             raise error
-        return SimpleNamespace(pid=23456)
+        return SimpleNamespace(stdout=io.BytesIO(b"23456\n"))
 
     monkeypatch.setattr(
         gateway_windows,
@@ -144,7 +145,7 @@ def test_spawn_detached_warns_and_marks_no_breakaway_fallback(
     assert gateway_windows._spawn_detached() == 23456
     assert len(calls) == 2
     (argv_primary, primary), (argv_fallback, fallback) = calls
-    assert argv_primary == argv_fallback == argv
+    assert argv_primary == argv_fallback
     assert primary["cwd"] == fallback["cwd"] == cwd
     assert primary["creationflags"] == gateway_windows.windows_detach_flags()
     assert (
@@ -152,26 +153,11 @@ def test_spawn_detached_warns_and_marks_no_breakaway_fallback(
         == gateway_windows.windows_detach_flags_without_breakaway()
     )
     assert primary["stdin"] is fallback["stdin"] is subprocess.DEVNULL
-    assert primary["stdout"] is primary["stderr"]
-    assert fallback["stdout"] is fallback["stderr"]
-    assert Path(primary["stdout"].name) == Path(fallback["stdout"].name)
+    assert primary["stdout"] is fallback["stdout"] is subprocess.PIPE
     assert primary["close_fds"] is fallback["close_fds"] is True
-    assert primary["env"] is not fallback["env"]
-    assert primary["env"][_BREAKAWAY_MARKER] == "1"
-    assert fallback["env"][_BREAKAWAY_MARKER] == "0"
-    assert {
-        key: value for key, value in primary["env"].items() if key != _BREAKAWAY_MARKER
-    } == {
-        key: value for key, value in fallback["env"].items() if key != _BREAKAWAY_MARKER
-    }
-
-    warnings = [
-        record for record in caplog.records if record.levelno == logging.WARNING
-    ]
-    assert len(warnings) == 1
-    assert "5" in warnings[0].getMessage()
-    assert "do-not-log" not in warnings[0].getMessage()
-    assert str(tmp_path) not in warnings[0].getMessage()
+    # The same env is reused for both spawn attempts — no marker flip.
+    assert primary["env"] is fallback["env"]
+    assert primary["env"]["SECRET_SENTINEL"] == "do-not-log"
 
 
 class TestStableWindowsGatewayWorkingDir:

--- a/tests/hermes_cli/test_gateway_windows_trampoline.py
+++ b/tests/hermes_cli/test_gateway_windows_trampoline.py
@@ -1,0 +1,121 @@
+"""Windows gateway detached-spawn trampoline (#84311).
+
+On Windows the desktop app tree-kills its backend on close
+(``taskkill /PID <backend> /T /F``). The messaging gateway used to die with
+it whenever a live management intermediate still linked it into the backend's
+process tree — and nothing restarted it on reopen.
+
+``gateway_windows._spawn_gateway_via_trampoline`` spawns the gateway through a
+short-lived intermediate that exits ~immediately after spawning, so the
+gateway's parent chain back to the desktop backend is broken within ~100ms.
+These tests run the real spawn + tree-kill on Windows and assert the gateway
+survives exactly like the Desktop close would.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytestmark = [
+    pytest.mark.windows_only,
+    pytest.mark.live_system_guard_bypass,  # real process spawn + taskkill
+]
+
+# CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB —
+# the same detach flags the repo's gateway/backend spawns use.
+_WIN_DETACH_FLAGS = 0x00000200 | 0x08000000 | 0x01000000
+
+_SLEEP_SRC = "import time; time.sleep(120)"
+
+
+def _pid_exists(pid: int) -> bool:
+    import psutil
+
+    try:
+        return psutil.pid_exists(pid)
+    except Exception:
+        return False
+
+
+def _ppid_of(pid: int) -> int | None:
+    import psutil
+
+    try:
+        return psutil.Process(pid).ppid()
+    except psutil.NoSuchProcess:
+        return None
+
+
+def _taskkill(pid: int) -> int:
+    result = subprocess.run(
+        ["taskkill", "/PID", str(pid), "/T", "/F"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return result.returncode
+
+
+def test_spawned_gateway_survives_backend_tree_kill(tmp_path):
+    """The trampoline breaks the parent chain, so `taskkill /T` on the
+    spawning backend cannot reach the gateway (the Desktop close scenario)."""
+    from hermes_cli.gateway_windows import _spawn_gateway_via_trampoline
+
+    # A fake "desktop backend" (the desktop spawns `hermes serve` this way).
+    backend = subprocess.Popen(
+        [sys.executable, "-c", _SLEEP_SRC],
+        creationflags=_WIN_DETACH_FLAGS,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+    )
+    gw_pid: int | None = None
+    try:
+        fake_gateway = [sys.executable, "-c", _SLEEP_SRC]
+        stray_log = tmp_path / "gateway-stdio.log"
+        gw_pid = _spawn_gateway_via_trampoline(fake_gateway, os.getcwd(), {}, stray_log)
+
+        assert gw_pid != backend.pid
+        # The returned PID is the real gateway (trampoline exits right after).
+        time.sleep(1.0)
+        assert _pid_exists(gw_pid), "gateway did not come up"
+        assert _ppid_of(gw_pid) != backend.pid, "gateway is still in the backend tree"
+
+        # The desktop close tree-kills the backend — the gateway must survive.
+        assert _taskkill(backend.pid) == 0
+        time.sleep(0.5)
+        assert _pid_exists(gw_pid), "gateway was killed by the backend tree-kill"
+    finally:
+        for pid in (gw_pid, backend.pid):
+            if pid is not None:
+                try:
+                    _taskkill(pid)
+                except Exception:
+                    pass
+
+
+def test_trampoline_returns_real_gateway_pid(tmp_path):
+    """The PID contract: callers get the gateway PID, not the trampoline's."""
+    from hermes_cli.gateway_windows import _spawn_gateway_via_trampoline
+
+    fake_gateway = [sys.executable, "-c", _SLEEP_SRC]
+    stray_log = tmp_path / "gateway-stdio.log"
+    gw_pid = _spawn_gateway_via_trampoline(fake_gateway, os.getcwd(), {}, stray_log)
+    try:
+        # The gateway's own process must match the reported PID.
+        time.sleep(0.5)
+        assert _pid_exists(gw_pid)
+        # And it must not be the parent of anything weird — its parent is the
+        # dead trampoline (dangling PID), not this test process.
+        assert _ppid_of(gw_pid) != os.getpid()
+    finally:
+        try:
+            _taskkill(gw_pid)
+        except Exception:
+            pass


### PR DESCRIPTION
Fixes #84311

## 症状 (Symptom)  On **Windows**, closing the Hermes desktop app kills the messaging gateway process (`hermes gateway run`), and reopening the desktop app does **not** auto-start it. Result: the messaging gateway is permanently gone after a close/reopen cycle — WeChat / Telegram / Discord / QQ etc. silently disconnect, and the user must run `hermes gateway start` (or re-login to Windows for the Scheduled Task) to get messaging back.  Repro (from the issue): `hermes gateway install --start-now` → verify running → close desktop → reopen desktop → `hermes gateway status` → `✗ No gateway process detected`.  ## 根因 (Root cause)  The messaging gateway is an independent long-running service, but the desktop backend lifecycle treated it as disposable on Windows:  1. **Reopen killed a surviving gateway.** The desktop backend's startup (`hermes_cli/web_server.py` `_lifespan`, gated on `HERMES_DESKTOP=1`) unconditionally ran `_reap_unsupervised_gateway_orphans()`, which SIGTERM+SIGKILLs **every live** gateway process of the profile on hosts without systemd (Windows qualifies). A gateway that survived the close (orphaned, parent dead) was therefore killed the moment the desktop reopened — and nothing ever started a replacement. This is the deterministic killer in the reported repro.  2. **Close killed the gateway as tree collateral.** On close, the desktop tree-kills its backend (`taskkill /PID <backend> /T /F`, `apps/desktop/electron/main.ts` `forceKillProcessTree`). A gateway (re)started from the desktop UI is a *living descendant* of the backend for the restart CLI's lifetime (up to ~46s: drain + readiness wait), so the tree-kill reaches it. (Verified empirically: `taskkill /T` only reaches grandchildren whose intermediate parent is still alive.)  On macOS/Linux the gateway survives the close as an orphan (session/process-group detachment) — but the reopen **reap** then killed it there too, so this is not purely a Windows bug.  ## 修复方案 (Fix)  Two backend-side changes; no new env vars, no config changes, no desktop-code changes (the Electron tree-kill of the backend itself stays correct — the backend's non-gateway children *should* die with the app).  **1. Desktop reopen: keep live gateways, auto-start on persisted intent** (`hermes_cli/web_server.py`)  - Replaced the unconditional orphan reap at desktop-backend boot with `_manage_desktop_gateway_at_boot()`:   - **Liveness scan** (`find_gateway_pids`, an argv/pidfile/runtime multi-source scan — a pidfile-only check would false-positive after a force-kill leaves stale pidfiles) → if a gateway is live, **keep it** (no reap, no auto-start). This fixes the reopen-kill.   - Only when **nothing is live**: reap stale-port orphans (preserves the #77276 duplicate-credential guard), then schedule `_maybe_auto_start_gateway()`. - `_maybe_auto_start_gateway()` runs **off the startup critical path** (the intent check loads gateway config / platform discovery, which can exceed the desktop's WebSocket handshake timeout on cold Windows boots — #73083), and auto-starts via the existing `hermes gateway start` action (idempotent, log-tracked) when the user's persisted intent says the gateway should run:   - last `gateway_state.json` was `running`/`draining` — **never** `stopped` (deliberate stop), `startup_failed` (don't hammer a failing gateway), or a missing record (mirrors `get_runtime_status_running_pid`'s predicate);   - AND messaging platforms are configured. - Dedupes against an in-flight `gateway-start` action so a user click can't stack a second spawn. - `_terminate_desktop_managed_gateway()` now also covers the boot auto-start action on shutdown.  **2. Desktop close: the gateway must never be tree-reachable** (`hermes_cli/gateway_windows.py`)  - The detached gateway spawn (`_spawn_detached`) now goes through a **short-lived trampoline** process that immediately spawns the real gateway with the same detach flags (`CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`, with the breakaway-denied fallback) and exits. The gateway's parent is therefore dead within ~100ms of its birth, so `taskkill /T /F` from the desktop can never reach it. - The trampoline prints the gateway PID on its stdout; the spawn helper reads it back so callers keep the `PID <n>` contract. Spawn failure surfaces loudly (`RuntimeError`) instead of returning a dead PID. - Verified empirically on Windows: a trampoline-spawned grandchild survives `taskkill /PID <backend> /T /F`.  **Why this is the whole bug class**: the close-kill (tree membership) and the reopen-kill (reap) are both removed; the reopen *restores* the gateway when it died despite the protections (e.g. the ~100ms spawn window, or a manual kill); the "deliberately stopped / failing gateway" states are respected; macOS gets the same keep-live + auto-start semantics (the reap was killing live macOS gateways too).  ## 测试 (Tests)  - **`tests/hermes_cli/test_desktop_gateway_autostart.py`** (new, 14 tests):   - Intent truth-table for `_gateway_auto_start_reason` (running/draining → start; stopped / startup_failed / missing-record / no-platforms / scan-failure → no).   - Boot wiring: live gateway → kept (reap NOT called); nothing live → reap + auto-start scheduled; scan failure degrades fail-open.   - Auto-start spawn: spawns `gateway start` on intent; skips on no-intent; skips when a `gateway-start` action is already in flight; logs (does not raise) on spawn failure. - **`tests/hermes_cli/test_gateway_windows_trampoline.py`** (new, 2 tests, `@pytest.mark.windows_only` + `live_system_guard_bypass` — real process spawn + `taskkill`): a `taskkill /T /F` on the spawning "backend" cannot reach the trampoline-spawned gateway; the spawn helper returns the real gateway PID. - **`tests/hermes_cli/test_dashboard_admin_endpoints.py`** (updated): the existing #77276 lifespan-reap test now pins the reap leg with a deterministic liveness stub (it previously asserted the unconditional reap, which is the behavior being fixed).  All new and directly-affected suites pass on Windows (16 new tests + updated lifespan tests + gateway topology/restart-reap/orphan-reap suites). Pre-existing failures on this host (`test_windows_native_support.py::test_noop_on_non_windows`, `test_dashboard_admin_endpoints.py::test_stats_shape`, 3 reap-candidate tests in `test_gateway.py`, port-9119 collision in `test_dashboard_unified_launch.py`) are identical on the unmodified baseline. 