### PR TITLE
fix(gateway): enforce session-owned private routing

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1794,6 +1794,106 @@ def test_voice_record_start_handles_non_dict_voice_cfg(monkeypatch):
         assert captured["auto_restart"] is False
 
 
+def test_voice_record_callbacks_cannot_follow_reused_or_changed_owner(monkeypatch):
+    class CaptureTransport:
+        def __init__(self):
+            self.frames: list[dict] = []
+            self._closed = False
+
+        def write(self, frame):
+            self.frames.append(frame)
+            return True
+
+    captured: dict = {}
+    old_transport = CaptureTransport()
+    replacement_transport = CaptureTransport()
+    old_session = {"transport": old_transport}
+    server._sessions["voice-sid"] = old_session
+
+    def fake_start_continuous(**kwargs):
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.voice",
+        types.SimpleNamespace(
+            start_continuous=fake_start_continuous,
+            stop_continuous=lambda **_kwargs: None,
+            set_voice_busy_probe=lambda _probe: None,
+        ),
+    )
+    monkeypatch.setenv("HERMES_VOICE", "1")
+    monkeypatch.setattr(server, "current_transport", lambda: old_transport)
+    monkeypatch.setattr(server, "_wake_owner_snapshot", lambda: (None, None))
+    monkeypatch.setattr(server, "_resume_voice_wake", lambda: None)
+    monkeypatch.setattr(server, "_tts_stream_stop", lambda **_kwargs: None)
+
+    response = server._methods["voice.record"](
+        "voice-owned", {"action": "start", "session_id": "voice-sid"}
+    )
+    assert response["result"]["status"] == "recording"
+
+    server._sessions["voice-sid"] = {"transport": replacement_transport}
+    with server._voice_sid_lock:
+        server._voice_event_sid = "different-owner"
+
+    captured["on_transcript"]("opaque")
+    captured["on_silent_limit"]()
+    captured["on_status"]("idle")
+    captured["on_stop_phrase"]("opaque")
+
+    assert len(old_transport.frames) == 0
+    assert len(replacement_transport.frames) == 0
+
+
+def test_voice_record_callbacks_without_owner_never_use_fallback(monkeypatch):
+    class CaptureTransport:
+        def __init__(self):
+            self.frames: list[dict] = []
+            self._closed = False
+
+        def write(self, frame):
+            self.frames.append(frame)
+            return True
+
+    captured: dict = {}
+    fallback = CaptureTransport()
+
+    def fake_start_continuous(**kwargs):
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.voice",
+        types.SimpleNamespace(
+            start_continuous=fake_start_continuous,
+            stop_continuous=lambda **_kwargs: None,
+            set_voice_busy_probe=lambda _probe: None,
+        ),
+    )
+    monkeypatch.setenv("HERMES_VOICE", "1")
+    monkeypatch.setattr(server, "_voice_event_sid", "")
+    monkeypatch.setattr(server, "current_transport", lambda: fallback)
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+    monkeypatch.setattr(server, "_wake_owner_snapshot", lambda: (None, None))
+    monkeypatch.setattr(server, "_resume_voice_wake", lambda: None)
+    monkeypatch.setattr(server, "_tts_stream_stop", lambda **_kwargs: None)
+
+    response = server._methods["voice.record"](
+        "voice-unowned", {"action": "start"}
+    )
+    assert response["result"]["status"] == "recording"
+
+    captured["on_transcript"]("opaque")
+    captured["on_silent_limit"]()
+    captured["on_status"]("idle")
+    captured["on_stop_phrase"]("opaque")
+
+    assert fallback.frames == []
+
+
 def test_prompt_submit_typed_stop_phrase_ends_voice_chat(monkeypatch):
     """Typed bare stop phrase during an active voice chat is consumed at the
     prompt.submit choke point: voice mode flips off, a distinct
@@ -16724,7 +16824,10 @@ def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):
     seen = []
     monkeypatch.setattr(
         server, "_close_session_by_id",
-        lambda sid, *, end_reason: bool(seen.append((sid, end_reason))) or True,
+        lambda sid, *, end_reason, **_kwargs: bool(
+            seen.append((sid, end_reason))
+        )
+        or True,
     )
     # Detached session "b" would schedule a real grace-reap threading.Timer that
     # outlives the test; grace=0 short-circuits it so no thread lingers.

--- a/tests/tui_gateway/test_profile_session_lifecycle.py
+++ b/tests/tui_gateway/test_profile_session_lifecycle.py
@@ -1,0 +1,305 @@
+"""Profile lifecycle isolation regressions for session create/resume."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, cast
+
+from tui_gateway import server
+from tui_gateway.transport import Transport, bind_transport, reset_transport
+
+
+class _Transport:
+    def write(self, _obj: dict[str, Any]) -> bool:
+        return True
+
+    def close(self) -> None:
+        pass
+
+
+def _clear_added_sessions(known: set[str]) -> None:
+    with server._sessions_lock:
+        for sid in [sid for sid in server._sessions if sid not in known]:
+            server._sessions.pop(sid, None)
+
+
+def test_create_and_resume_fail_closed_after_profile_is_deleted(monkeypatch, tmp_path):
+    """RPC-time profile resolution fails closed after a profile is deleted."""
+    profile_home = tmp_path / "profiles" / "coder_2"
+    profile_home.mkdir(parents=True)
+    profile_home.rmdir()
+    launch_db_calls: list[str] = []
+    monkeypatch.setattr(
+        server,
+        "_profile_home",
+        lambda profile: profile_home
+        if profile == "coder_2" and profile_home.exists()
+        else None,
+    )
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "coder_1")
+    monkeypatch.setattr(
+        server, "_get_db", lambda: launch_db_calls.append("launch") or object()
+    )
+
+    known = set(server._sessions)
+    create = server._methods["session.create"]("create", {"profile": "coder_2"})
+    resume = server._methods["session.resume"](
+        "resume", {"profile": "coder_2", "session_id": "same-id"}
+    )
+
+    assert create["error"]["code"] == 5006
+    assert resume["error"]["code"] == 5000
+    assert set(server._sessions) == known
+    assert launch_db_calls == []
+
+
+def test_absent_explicit_profile_never_falls_back_to_launch_db(monkeypatch):
+    launch_db = object()
+    calls = []
+    monkeypatch.setattr(server, "_profile_home", lambda _profile: None)
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "coder_1")
+    monkeypatch.setattr(
+        server, "_get_db", lambda: calls.append("launch") or launch_db
+    )
+
+    assert server._db_for_profile("coder_2") == (None, False)
+    assert calls == []
+    assert server._db_for_profile("coder_1") == (launch_db, False)
+    assert server._db_for_profile() == (launch_db, False)
+    assert calls == ["launch", "launch"]
+
+
+def test_omitted_and_explicit_launch_profile_create_remain_valid(monkeypatch, tmp_path):
+    class LaunchDB:
+        def get_session(self, _target):
+            return None
+
+        def get_session_by_title(self, _target):
+            return None
+
+    launch_db_calls: list[str] = []
+    monkeypatch.setattr(server, "_profile_home", lambda _profile: None)
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "coder_1")
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: launch_db_calls.append("launch") or LaunchDB(),
+    )
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_completion_cwd", lambda _params=None: str(tmp_path))
+
+    known = set(server._sessions)
+    try:
+        omitted = server._methods["session.create"]("omitted", {})
+        explicit = server._methods["session.create"](
+            "explicit", {"profile": "coder_1"}
+        )
+        assert "result" in omitted
+        assert "result" in explicit
+        assert omitted["result"]["info"]["profile_name"] == "coder_1"
+        assert explicit["result"]["info"]["profile_name"] == "coder_1"
+        omitted_resume = server._methods["session.resume"](
+            "omitted-resume", {"session_id": "missing"}
+        )
+        explicit_resume = server._methods["session.resume"](
+            "explicit-resume", {"profile": "coder_1", "session_id": "missing"}
+        )
+        assert omitted_resume["error"]["code"] == 4007
+        assert explicit_resume["error"]["code"] == 4007
+        assert launch_db_calls == ["launch", "launch"]
+    finally:
+        _clear_added_sessions(known)
+
+
+def test_lazy_resume_race_uses_profile_scoped_child_liveness(monkeypatch, tmp_path):
+    """Profile B liveness cannot authorize profile A's missing durable row."""
+    profile_a = tmp_path / "profiles" / "coder_a"
+    profile_b = tmp_path / "profiles" / "coder_b"
+    profile_a.mkdir(parents=True)
+    profile_b.mkdir(parents=True)
+
+    class MissingRowDB:
+        def __init__(self, db_path=None):
+            self.db_path = db_path
+
+        def close(self):
+            pass
+
+        def get_session(self, _target):
+            return None
+
+        def get_session_by_title(self, _target):
+            return None
+
+        def reopen_session(self, _target):
+            pass
+
+        def get_messages_as_conversation(self, _target, **_kwargs):
+            return []
+
+    monkeypatch.setattr(
+        server,
+        "_profile_home",
+        lambda profile: {"coder_a": profile_a, "coder_b": profile_b}.get(profile),
+    )
+    monkeypatch.setattr("hermes_state.SessionDB", MissingRowDB)
+    monkeypatch.setattr(server, "_profile_configured_cwd", lambda _home: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    known = set(server._sessions)
+    key_b = server._child_runtime_key(profile_b, "same-child")
+    server._active_child_runs[key_b] = server.time.time()
+    try:
+        denied_a = server._methods["session.resume"](
+            "a",
+            {"profile": "coder_a", "session_id": "same-child", "lazy": True},
+        )
+        allowed_b = server._methods["session.resume"](
+            "b",
+            {"profile": "coder_b", "session_id": "same-child", "lazy": True},
+        )
+
+        assert denied_a["error"]["code"] == 4007
+        assert allowed_b["result"]["running"] is True
+        assert allowed_b["result"]["status"] == "streaming"
+    finally:
+        server._active_child_runs.pop(key_b, None)
+        _clear_added_sessions(known)
+
+
+def test_concurrent_same_key_claims_are_isolated_by_profile(monkeypatch, tmp_path):
+    """Different profiles may own the same durable id without transport theft."""
+    profile_a = tmp_path / "profiles" / "coder_1"
+    profile_b = tmp_path / "profiles" / "coder_2"
+    profile_a.mkdir(parents=True)
+    profile_b.mkdir(parents=True)
+    transport_a = _Transport()
+    transport_b = _Transport()
+    records = {
+        "runtime-a": {
+            "session_key": "same-id",
+            "profile_home": str(profile_a),
+            "transport": transport_a,
+        },
+        "runtime-b": {
+            "session_key": "same-id",
+            "profile_home": str(profile_b),
+            "transport": transport_b,
+        },
+    }
+    barrier = threading.Barrier(3)
+    outcomes: dict[str, object] = {}
+    known = dict(server._sessions)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+
+    def claim(sid: str) -> None:
+        barrier.wait()
+        outcomes[sid] = server._claim_or_reuse_live(
+            sid, "same-id", records[sid], None
+        )
+
+    threads = [
+        threading.Thread(target=claim, args=(sid,)) for sid in records
+    ]
+    try:
+        server._sessions.clear()
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join(timeout=2)
+            assert not thread.is_alive()
+
+        assert outcomes == {"runtime-a": None, "runtime-b": None}
+        assert server._find_live_session_by_key(
+            "same-id", profile_home=profile_a
+        ) == ("runtime-a", records["runtime-a"])
+        assert server._find_live_session_by_key(
+            "same-id", profile_home=profile_b
+        ) == ("runtime-b", records["runtime-b"])
+        assert server._sessions["runtime-a"]["transport"] is transport_a
+        assert server._sessions["runtime-b"]["transport"] is transport_b
+    finally:
+        for thread in threads:
+            thread.join(timeout=2)
+        server._sessions.clear()
+        server._sessions.update(known)
+
+
+def test_resume_reuses_only_matching_profile_transport(monkeypatch, tmp_path):
+    """Fast resume cannot attach profile B to profile A's live runtime."""
+    profile_a = tmp_path / "profiles" / "coder_1"
+    profile_b = tmp_path / "profiles" / "coder_2"
+    profile_a.mkdir(parents=True)
+    profile_b.mkdir(parents=True)
+    transport_a = _Transport()
+    transport_b = _Transport()
+
+    class ProfileDB:
+        def __init__(self, db_path=None):
+            self.db_path = db_path
+
+        def close(self):
+            pass
+
+        def get_session(self, target):
+            return {"id": target, "cwd": str(tmp_path), "message_count": 0}
+
+        def get_session_by_title(self, _target):
+            return None
+
+        def resolve_resume_session_id(self, target):
+            return target
+
+        def reopen_session(self, _target):
+            pass
+
+        def get_resume_conversations(self, _target):
+            return ([], [])
+
+        def get_ancestor_display_prefix(self, _target):
+            return []
+
+    monkeypatch.setattr(
+        server,
+        "_profile_home",
+        lambda profile: {"coder_1": profile_a, "coder_2": profile_b}.get(profile),
+    )
+    monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
+    monkeypatch.setattr(server, "_profile_configured_cwd", lambda _home: str(tmp_path))
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_stored_session_runtime_overrides", lambda _row: {})
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+
+    existing = {
+        "session_key": "same-id",
+        "profile_home": str(profile_a),
+        "transport": transport_a,
+        "history": [],
+        "created_at": 1.0,
+        "last_active": 1.0,
+        "running": False,
+        "agent": None,
+    }
+    known = dict(server._sessions)
+    token = bind_transport(cast(Transport, transport_b))
+    try:
+        server._sessions.clear()
+        server._sessions["runtime-a"] = existing
+        response = server._methods["session.resume"](
+            "resume",
+            {"profile": "coder_2", "session_id": "same-id"},
+        )
+        assert "result" in response, response
+        runtime_b = response["result"]["session_id"]
+        assert runtime_b != "runtime-a"
+        assert server._sessions["runtime-a"]["transport"] is transport_a
+        assert server._sessions[runtime_b]["profile_home"] == str(profile_b)
+        assert server._sessions[runtime_b]["transport"] is transport_b
+    finally:
+        reset_transport(token)
+        server._sessions.clear()
+        server._sessions.update(known)

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -96,7 +96,13 @@ def capture(server):
     """Redirect server's real stdout to a StringIO and return (server, buf)."""
     buf = io.StringIO()
     server._real_stdout = buf
-    return server, buf
+    # Private nonempty-SID frames require a live registered owner.  This is a
+    # real standalone-stdio session, not fallback after ownership disappears.
+    server._sessions["s1"] = {"transport": server._stdio_transport}
+    try:
+        yield server, buf
+    finally:
+        server._sessions.pop("s1", None)
 
 
 # ── JSON-RPC envelope ────────────────────────────────────────────────

--- a/tests/tui_gateway/test_session_db_ownership_teardown.py
+++ b/tests/tui_gateway/test_session_db_ownership_teardown.py
@@ -260,7 +260,7 @@ def build_env(monkeypatch, tmp_path):
         ("_emit", lambda *a, **k: None),
         ("_schedule_mcp_late_refresh", lambda *a, **k: None),
         ("_session_source", lambda _current: None),
-        ("_child_run_active", lambda _key: False),
+        ("_child_run_active", lambda _key, *, profile_home: False),
     ]:
         if hasattr(server, name):
             monkeypatch.setattr(server, name, value)

--- a/tests/tui_gateway/test_session_private_routing.py
+++ b/tests/tui_gateway/test_session_private_routing.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import threading
+import sys
+import types
+
+import pytest
+
+from tui_gateway import server
+
+
+class RecordingTransport:
+    def __init__(self) -> None:
+        self.count = 0
+        self._closed = False
+
+    def write(self, _obj: dict) -> bool:
+        self.count += 1
+        return True
+
+    def close(self) -> None:
+        pass
+
+
+class FalseTransport(RecordingTransport):
+    def write(self, _obj: dict) -> bool:
+        self.count += 1
+        return False
+
+
+class RaisingTransport(RecordingTransport):
+    def write(self, _obj: dict) -> bool:
+        self.count += 1
+        raise RuntimeError("closed")
+
+
+@pytest.fixture(autouse=True)
+def isolated_sessions():
+    known = dict(server._sessions)
+    known_compute_owners = dict(server._compute_host_event_owners)
+    server._sessions.clear()
+    server._compute_host_event_owners.clear()
+    try:
+        yield
+    finally:
+        server._sessions.clear()
+        server._sessions.update(known)
+        server._compute_host_event_owners.clear()
+        server._compute_host_event_owners.update(known_compute_owners)
+
+
+def frame(sid: str) -> dict:
+    return server._event_frame("message.delta", sid, {"text": "opaque"})
+
+
+def test_compression_approval_callback_cannot_follow_reused_sid(monkeypatch):
+    captured: dict[str, object] = {}
+    old_transport = RecordingTransport()
+    replacement_transport = RecordingTransport()
+    agent = types.SimpleNamespace(session_id="continued")
+    old_session = {
+        "agent": agent,
+        "session_key": "original",
+        "transport": old_transport,
+    }
+    server._sessions["same"] = old_session
+    monkeypatch.setattr(server, "_transfer_active_session_slot", lambda *a, **k: True)
+    approval = types.SimpleNamespace(
+        unregister_gateway_notify=lambda _key: None,
+        register_gateway_notify=lambda _key, cb: captured.__setitem__("callback", cb),
+        is_session_yolo_enabled=lambda _key: False,
+        enable_session_yolo=lambda _key: None,
+        disable_session_yolo=lambda _key: None,
+    )
+    monkeypatch.setitem(sys.modules, "tools.approval", approval)
+
+    server._sync_session_key_after_compress(
+        "same", old_session, clear_pending_title=False, restart_slash_worker=False
+    )
+    server._sessions["same"] = {"transport": replacement_transport}
+    callback = captured["callback"]
+    assert callable(callback)
+    callback({"opaque": True})
+
+    assert old_transport.count == 0
+    assert replacement_transport.count == 0
+
+
+def test_private_missing_sid_never_falls_back_to_current_or_stdio(monkeypatch):
+    current = RecordingTransport()
+    stdio = RecordingTransport()
+    monkeypatch.setattr(server, "current_transport", lambda: current)
+    monkeypatch.setattr(server, "_stdio_transport", stdio)
+
+    assert server.write_json(frame("absent")) is False
+    assert (current.count, stdio.count) == (0, 0)
+
+    monkeypatch.setattr(server, "current_transport", lambda: None)
+    assert server.write_json(frame("absent")) is False
+    assert (current.count, stdio.count) == (0, 0)
+
+
+def test_private_finalized_and_dead_sessions_emit_zero_frames(monkeypatch):
+    fallback = RecordingTransport()
+    finalized = RecordingTransport()
+    server._sessions["final"] = {"transport": finalized, "_finalized": True}
+    server._sessions["dead"] = {"transport": server._detached_ws_transport}
+    monkeypatch.setattr(server, "current_transport", lambda: fallback)
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+
+    assert server.write_json(frame("final")) is False
+    assert server.write_json(frame("dead")) is False
+    assert (finalized.count, fallback.count) == (0, 0)
+
+
+@pytest.mark.parametrize("transport_type", [FalseTransport, RaisingTransport])
+def test_private_write_failure_never_retries_fallback(monkeypatch, transport_type):
+    owned = transport_type()
+    fallback = RecordingTransport()
+    server._sessions["owned"] = {"transport": owned}
+    monkeypatch.setattr(server, "current_transport", lambda: fallback)
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+
+    assert server.write_json(frame("owned")) is False
+    assert (owned.count, fallback.count) == (1, 0)
+
+
+def test_private_closed_transport_is_rejected_without_write(monkeypatch):
+    closed = RecordingTransport()
+    closed._closed = True
+    fallback = RecordingTransport()
+    server._sessions["closed"] = {"transport": closed}
+    monkeypatch.setattr(server, "current_transport", lambda: fallback)
+
+    assert server.write_json(frame("closed")) is False
+    assert (closed.count, fallback.count) == (0, 0)
+
+
+def test_stale_generation_callback_cannot_route_to_sid_replacement():
+    old_transport = RecordingTransport()
+    new_transport = RecordingTransport()
+    old = {"transport": old_transport}
+    server._sessions["same"] = old
+
+    def stale_callback() -> bool:
+        return server._run_session_owned(
+            old, server._emit, "message.delta", "same", {"text": "opaque"}
+        )
+
+    replacement = {"transport": new_transport}
+    server._sessions["same"] = replacement
+
+    assert stale_callback() is False
+    assert (old_transport.count, new_transport.count) == (0, 0)
+
+
+def test_live_registered_stdio_session_still_emits(monkeypatch):
+    stdio = RecordingTransport()
+    monkeypatch.setattr(server, "_stdio_transport", stdio)
+    server._sessions["stdio"] = {"transport": stdio}
+
+    assert server.write_json(frame("stdio")) is True
+    assert stdio.count == 1
+
+
+@pytest.mark.parametrize(
+    ("callback_name", "args"),
+    [
+        ("thinking_callback", ("opaque",)),
+        ("reasoning_callback", ("opaque",)),
+        ("tool_start_callback", ("tool-id", "terminal", {})),
+        ("clarify_callback", ("opaque", [])),
+    ],
+)
+def test_ordinary_agent_callbacks_are_generation_fenced(
+    monkeypatch, callback_name, args
+):
+    old_transport = RecordingTransport()
+    new_transport = RecordingTransport()
+    old = {"transport": old_transport, "tool_started_at": {}}
+    server._sessions["same"] = old
+    monkeypatch.setattr(
+        server,
+        "_on_tool_start",
+        lambda sid, *_args: server._emit("tool.start", sid, {}),
+    )
+    monkeypatch.setattr(
+        server,
+        "_block",
+        lambda event, sid, *_args, **_kwargs: server._emit(event, sid, {}),
+    )
+    callbacks = server._agent_cbs("same")
+    server._sessions["same"] = {"transport": new_transport}
+
+    callbacks[callback_name](*args)
+
+    assert (old_transport.count, new_transport.count) == (0, 0)
+
+
+def test_review_callback_style_expected_record_is_generation_fenced():
+    old = {"transport": RecordingTransport()}
+    replacement_transport = RecordingTransport()
+    server._sessions["same"] = {"transport": replacement_transport}
+
+    assert (
+        server._emit(
+            "review.summary", "same", {"text": "opaque"}, expected_session=old
+        )
+        is False
+    )
+    assert replacement_transport.count == 0
+
+
+def test_compute_host_owners_are_independent_and_generation_fenced():
+    ta = RecordingTransport()
+    tb = RecordingTransport()
+    old_a = {"transport": ta}
+    owner_b = {"transport": tb}
+    server._sessions.update({"a": old_a, "b": owner_b})
+    server._compute_host_event_owners.update({"a": old_a, "b": owner_b})
+
+    assert server._write_compute_host_rpc(frame("a")) is True
+    assert server._write_compute_host_rpc(frame("b")) is True
+    assert (ta.count, tb.count) == (1, 1)
+
+    replacement = {"transport": RecordingTransport()}
+    server._sessions["a"] = replacement
+    assert server._write_compute_host_rpc(frame("a")) is False
+    assert replacement["transport"].count == 0
+
+
+def test_old_disconnect_teardown_cannot_detach_rebound_transport(monkeypatch):
+    old_transport = RecordingTransport()
+    rebound_transport = RecordingTransport()
+    entered = threading.Event()
+    release = threading.Event()
+
+    class BlockingRecord(dict):
+        blocked = False
+
+        def get(self, key, default=None):
+            if key == "close_on_disconnect" and not self.blocked:
+                self.blocked = True
+                entered.set()
+                assert release.wait(timeout=2)
+            return super().get(key, default)
+
+    record = BlockingRecord(
+        transport=old_transport,
+        close_on_disconnect=False,
+    )
+    server._sessions["race"] = record
+    monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda _sid: None)
+    result: list[tuple[int, int]] = []
+    worker = threading.Thread(
+        target=lambda: result.append(
+            server._close_sessions_for_transport(old_transport)
+        )
+    )
+    worker.start()
+    assert entered.wait(timeout=2)
+    with server._session_resume_lock:
+        record["transport"] = server._detached_ws_transport
+        assert server._rebind_live_session_transport(
+            "race", record, rebound_transport
+        )
+    release.set()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert result == [(0, 0)]
+    assert record["transport"] is rebound_transport
+
+
+def test_old_close_on_disconnect_teardown_cannot_close_rebound_transport(monkeypatch):
+    old_transport = RecordingTransport()
+    rebound_transport = RecordingTransport()
+    entered = threading.Event()
+    release = threading.Event()
+
+    class BlockingRecord(dict):
+        blocked = False
+
+        def get(self, key, default=None):
+            if key == "close_on_disconnect" and not self.blocked:
+                self.blocked = True
+                entered.set()
+                assert release.wait(timeout=2)
+            return super().get(key, default)
+
+    record = BlockingRecord(transport=old_transport, close_on_disconnect=True)
+    server._sessions["race"] = record
+    teardowns: list[dict] = []
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda session, **_kwargs: teardowns.append(session),
+    )
+    result: list[tuple[int, int]] = []
+    worker = threading.Thread(
+        target=lambda: result.append(
+            server._close_sessions_for_transport(old_transport)
+        )
+    )
+    worker.start()
+    assert entered.wait(timeout=2)
+    with server._session_resume_lock:
+        record["transport"] = server._detached_ws_transport
+        assert server._rebind_live_session_transport(
+            "race", record, rebound_transport
+        )
+    release.set()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert result == [(0, 0)]
+    assert server._sessions["race"] is record
+    assert record["transport"] is rebound_transport
+    assert teardowns == []

--- a/tests/tui_gateway/test_session_resume_db_ownership.py
+++ b/tests/tui_gateway/test_session_resume_db_ownership.py
@@ -34,6 +34,7 @@ import types
 import pytest
 
 from tui_gateway import server
+from tui_gateway.transport import bind_transport, reset_transport
 
 
 class _RecordingDB:
@@ -98,7 +99,7 @@ def profile_dbs(monkeypatch, tmp_path):
     # The handler builds nothing on the paths under test; keep it hermetic and
     # off the real agent/secret/HERMES_HOME machinery.
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
-    monkeypatch.setattr(server, "_find_live_session_by_key", lambda _key: None)
+    monkeypatch.setattr(server, "_find_live_session_by_key", lambda *a, **k: None)
     monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
     monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
     monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *a, **k: None)
@@ -159,17 +160,91 @@ def test_resume_closes_profile_db_on_live_session_fast_path(profile_dbs, monkeyp
         return db
 
     monkeypatch.setattr("hermes_state.SessionDB", _factory)
-    monkeypatch.setattr(server, "_find_live_session_by_key", lambda _key: ("live-sid", {}))
+    record = {"transport": server._stdio_transport}
+    server._sessions["live-sid"] = record
+    monkeypatch.setattr(
+        server, "_find_live_session_by_key", lambda *a, **k: ("live-sid", record)
+    )
     monkeypatch.setattr(
         server,
         "_live_session_payload",
         lambda sid, session, **_kwargs: {"session_id": sid},
     )
-    monkeypatch.setattr(server, "_child_run_active", lambda _key: False)
+    monkeypatch.setattr(
+        server, "_child_run_active", lambda _key, *, profile_home: False
+    )
 
     resp = _resume(session_id="s1", profile="work")
 
     assert resp["result"]["resumed"] == "s1"
+    assert profile_dbs[0].closed == 1
+
+
+@pytest.mark.parametrize(
+    ("prior_kind", "expect_success"),
+    [
+        ("healthy_other", False),
+        ("same", True),
+        ("detached", True),
+        ("closed", True),
+    ],
+)
+def test_resume_live_transport_rebind_policy_is_cas_stable(
+    profile_dbs, monkeypatch, prior_kind, expect_success
+):
+    class _Transport:
+        def __init__(self, *, closed=False):
+            self._closed = closed
+
+        def write(self, _obj):
+            return not self._closed
+
+        def close(self):
+            self._closed = True
+
+    def _factory(db_path=None, **kwargs):
+        db = _RecordingDB(db_path=db_path, **kwargs)
+        db.rows["s1"] = {"id": "s1", "cwd": ""}
+        profile_dbs.append(db)
+        return db
+
+    incoming = _Transport()
+    prior = {
+        "healthy_other": _Transport(),
+        "same": incoming,
+        "detached": server._detached_ws_transport,
+        "closed": _Transport(closed=True),
+    }[prior_kind]
+    record = {"transport": prior, "agent": object()}
+    server._sessions["live-cas"] = record
+    monkeypatch.setattr("hermes_state.SessionDB", _factory)
+    monkeypatch.setattr(
+        server, "_find_live_session_by_key", lambda *a, **k: ("live-cas", record)
+    )
+    monkeypatch.setattr(
+        server,
+        "_live_session_payload",
+        lambda sid, session, **_kwargs: {"session_id": sid},
+    )
+    monkeypatch.setattr(
+        server, "_child_run_active", lambda _key, *, profile_home: False
+    )
+
+    token = bind_transport(incoming)
+    try:
+        resp = _resume(session_id="s1", profile="work")
+    finally:
+        reset_transport(token)
+
+    if expect_success:
+        assert resp["result"]["resumed"] == "s1"
+        assert record["transport"] is incoming
+    else:
+        assert resp["error"] == {
+            "code": 4009,
+            "message": "session is already attached to another live transport",
+        }
+        assert record["transport"] is prior
     assert profile_dbs[0].closed == 1
 
 

--- a/tests/tui_gateway/test_subagent_child_mirror.py
+++ b/tests/tui_gateway/test_subagent_child_mirror.py
@@ -15,6 +15,18 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+class _RecordingTransport:
+    def __init__(self):
+        self.frames: list[dict] = []
+
+    def write(self, obj: dict) -> bool:
+        self.frames.append(obj)
+        return True
+
+    def close(self) -> None:
+        pass
+
+
 @pytest.fixture()
 def server():
     # Mocks are scoped to the initial import only (see
@@ -45,17 +57,25 @@ def server():
 @pytest.fixture()
 def emits(server, monkeypatch):
     captured: list = []
-    monkeypatch.setattr(
-        server,
-        "_emit",
-        lambda event, sid, payload=None: captured.append((event, sid, payload)),
-    )
+    original = server._emit_session_owned
+
+    def record(event, sid, payload=None, **kwargs):
+        written = original(event, sid, payload, **kwargs)
+        if written and event is not None:
+            captured.append((event, sid, payload))
+        return written
+
+    monkeypatch.setattr(server, "_emit_session_owned", record)
     monkeypatch.setattr(server, "_tool_progress_enabled", lambda sid: True)
     return captured
 
 
 def _relay(server, event_type, **payload):
     """Drive _on_tool_progress the way the delegate relay does."""
+    server._sessions.setdefault(
+        "parent-sid",
+        {"profile_home": None, "transport": _RecordingTransport()},
+    )
     server._on_tool_progress(
         "parent-sid",
         event_type,
@@ -69,6 +89,16 @@ def _relay(server, event_type, **payload):
     )
 
 
+def _watch(server, child_key="child-1", sid="live-1"):
+    transport = _RecordingTransport()
+    server._sessions[sid] = {
+        "session_key": child_key,
+        "agent": None,
+        "transport": transport,
+    }
+    return transport
+
+
 def test_no_live_child_session_no_mirror(server, emits):
     _relay(server, "subagent.tool", tool_name="terminal", child_session_id="child-1")
 
@@ -77,9 +107,334 @@ def test_no_live_child_session_no_mirror(server, emits):
     assert server._child_mirrors == {}
 
 
+def test_missing_parent_drops_subagent_event_before_fallback_transport(server, monkeypatch):
+    """An absent parent cannot leak child output through process fallback IO."""
+    fallback = _RecordingTransport()
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+    monkeypatch.setattr(server, "current_transport", lambda: fallback)
+    server._sessions.pop("missing-parent", None)
+
+    server._on_tool_progress(
+        "missing-parent",
+        "subagent.tool",
+        name="terminal",
+        preview="private child output",
+        child_session_id="child-1",
+    )
+    server._on_tool_progress(
+        "missing-parent",
+        "subagent.complete",
+        child_session_id="child-1",
+        status="completed",
+        summary="private completion",
+    )
+
+    assert len(fallback.frames) == 0
+    assert server._child_mirrors == {}
+    assert server._active_child_runs == {}
+
+
+def test_parent_without_explicit_transport_drops_entire_relay(server, monkeypatch):
+    fallback = _RecordingTransport()
+    child = _watch(server)
+    server._sessions["parent-sid"] = {"profile_home": None}
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+    monkeypatch.setattr(server, "current_transport", lambda: fallback)
+
+    _relay(server, "subagent.text", preview="sensitive", child_session_id="child-1")
+
+    assert len(child.frames) == 0
+    assert len(fallback.frames) == 0
+    assert server._child_mirrors == {}
+    assert server._active_child_runs == {}
+
+
+def test_detached_parent_text_cannot_authorize_child_mirror(server, monkeypatch):
+    """A parked disconnected parent is resumable state, not live authority."""
+    fallback = _RecordingTransport()
+    child = _watch(server)
+    server._sessions["parent-sid"] = {
+        "profile_home": None,
+        "transport": server._detached_ws_transport,
+    }
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+    monkeypatch.setattr(server, "current_transport", lambda: fallback)
+
+    _relay(server, "subagent.text", preview="sensitive", child_session_id="child-1")
+
+    assert len(child.frames) == 0
+    assert len(fallback.frames) == 0
+    assert server._child_mirrors == {}
+    assert server._active_child_runs == {}
+
+
+def test_closed_parent_text_cannot_authorize_child_mirror(server, monkeypatch):
+    """A closed WSTransport-equivalent cannot authorize during detach races."""
+    fallback = _RecordingTransport()
+    child = _watch(server)
+    closed_parent = _RecordingTransport()
+    setattr(closed_parent, "_closed", True)
+    server._sessions["parent-sid"] = {
+        "profile_home": None,
+        "transport": closed_parent,
+    }
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+    monkeypatch.setattr(server, "current_transport", lambda: fallback)
+
+    _relay(server, "subagent.text", preview="sensitive", child_session_id="child-1")
+
+    assert len(closed_parent.frames) == 0
+    assert len(child.frames) == 0
+    assert len(fallback.frames) == 0
+    assert server._child_mirrors == {}
+    assert server._active_child_runs == {}
+
+
+def test_parent_closing_during_write_cannot_authorize_child(server, monkeypatch):
+    """A successful-looking write that closes its transport fails revalidation."""
+    fallback = _RecordingTransport()
+    child = _watch(server)
+
+    class ClosingTransport(_RecordingTransport):
+        def write(self, obj):
+            written = super().write(obj)
+            setattr(self, "_closed", True)
+            return written
+
+    parent = ClosingTransport()
+    server._sessions["parent-sid"] = {
+        "profile_home": None,
+        "transport": parent,
+    }
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+    monkeypatch.setattr(server, "current_transport", lambda: fallback)
+
+    _relay(server, "subagent.tool", tool_name="terminal", child_session_id="child-1")
+
+    assert [frame["params"]["type"] for frame in parent.frames] == ["subagent.tool"]
+    assert len(child.frames) == 0
+    assert len(fallback.frames) == 0
+    assert server._child_mirrors == {}
+    assert server._active_child_runs == {}
+
+
+def test_child_without_explicit_transport_drops_only_synthetic_state(server, monkeypatch):
+    fallback = _RecordingTransport()
+    parent = _RecordingTransport()
+    server._sessions.update(
+        {
+            "parent-sid": {"profile_home": None, "transport": parent},
+            "live-1": {"session_key": "child-1", "agent": None},
+        }
+    )
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+    monkeypatch.setattr(server, "current_transport", lambda: fallback)
+
+    _relay(server, "subagent.tool", tool_name="terminal", child_session_id="child-1")
+
+    assert [frame["params"]["type"] for frame in parent.frames] == ["subagent.tool"]
+    assert len(fallback.frames) == 0
+    assert server._child_mirrors == {}
+    assert server._child_run_active("child-1", profile_home=None)
+
+
+def test_finalized_registered_parent_drops_entire_relay(server, monkeypatch):
+    fallback = _RecordingTransport()
+    parent = _RecordingTransport()
+    child = _watch(server)
+    server._sessions["final-parent"] = {
+        "_finalized": True,
+        "profile_home": None,
+        "transport": parent,
+    }
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+    monkeypatch.setattr(server, "current_transport", lambda: fallback)
+
+    server._on_tool_progress(
+        "final-parent",
+        "subagent.text",
+        preview="sensitive",
+        child_session_id="child-1",
+    )
+
+    assert len(parent.frames) == 0
+    assert len(child.frames) == 0
+    assert len(fallback.frames) == 0
+    assert server._child_mirrors == {}
+    assert server._active_child_runs == {}
+
+
+@pytest.mark.parametrize("finalize", [False, True], ids=["removed", "finalized"])
+@pytest.mark.parametrize("event_type", ["subagent.tool", "subagent.text"])
+def test_parent_lifecycle_race_cannot_fallback_or_authorize_child(
+    server, monkeypatch, finalize, event_type
+):
+    """Barrier parent teardown between initial lookup and scoped authorization."""
+    fallback = _RecordingTransport()
+    current = _RecordingTransport()
+    parent = _RecordingTransport()
+    child = _watch(server)
+    parent_session = {
+        "profile_home": None,
+        "transport": parent,
+    }
+    server._sessions["racing-parent"] = parent_session
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+    monkeypatch.setattr(server, "current_transport", lambda: current)
+    original = server._emit_session_owned
+    crossed = False
+
+    def teardown_before_scoped_emit(event, sid, payload=None, **kwargs):
+        nonlocal crossed
+        if sid == "racing-parent" and not crossed:
+            crossed = True
+            if finalize:
+                parent_session["_finalized"] = True
+            else:
+                server._sessions.pop(sid, None)
+        return original(event, sid, payload, **kwargs)
+
+    monkeypatch.setattr(server, "_emit_session_owned", teardown_before_scoped_emit)
+    server._on_tool_progress(
+        "racing-parent",
+        event_type,
+        name="terminal",
+        preview="sensitive",
+        child_session_id="child-1",
+    )
+
+    assert crossed
+    assert len(parent.frames) == 0
+    assert len(child.frames) == 0
+    assert len(current.frames) == 0
+    assert len(fallback.frames) == 0
+    assert server._child_mirrors == {}
+    assert server._active_child_runs == {}
+
+
+@pytest.mark.parametrize("finalize", [False, True], ids=["removed", "finalized"])
+def test_parent_teardown_during_direct_write_cannot_authorize_child(
+    server, monkeypatch, finalize
+):
+    """A write-triggered teardown is revalidated before mirror/liveness work."""
+    fallback = _RecordingTransport()
+    current = _RecordingTransport()
+    child = _watch(server)
+    parent_session: dict = {"profile_home": None}
+
+    class TeardownTransport(_RecordingTransport):
+        def write(self, obj):
+            if finalize:
+                parent_session["_finalized"] = True
+            else:
+                server._sessions.pop("racing-parent", None)
+            return super().write(obj)
+
+    parent = TeardownTransport()
+    parent_session["transport"] = parent
+    server._sessions["racing-parent"] = parent_session
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+    monkeypatch.setattr(server, "current_transport", lambda: current)
+
+    server._on_tool_progress(
+        "racing-parent",
+        "subagent.tool",
+        name="terminal",
+        preview="sensitive",
+        child_session_id="child-1",
+    )
+
+    assert [frame["params"]["type"] for frame in parent.frames] == ["subagent.tool"]
+    assert len(child.frames) == 0
+    assert len(current.frames) == 0
+    assert len(fallback.frames) == 0
+    assert server._child_mirrors == {}
+    assert server._active_child_runs == {}
+
+
+@pytest.mark.parametrize("finalize", [False, True], ids=["removed", "finalized"])
+def test_child_lifecycle_race_before_first_emit_drops_mirror_without_fallback(
+    server, monkeypatch, finalize
+):
+    """Barrier child teardown after lookup but before message.start."""
+    fallback = _RecordingTransport()
+    current = _RecordingTransport()
+    parent = _RecordingTransport()
+    child = _watch(server)
+    child_session = server._sessions["live-1"]
+    server._sessions["parent-sid"] = {
+        "profile_home": None,
+        "transport": parent,
+    }
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+    monkeypatch.setattr(server, "current_transport", lambda: current)
+    original_find = server._find_live_session_by_key
+
+    def teardown_after_lookup(child_key, **kwargs):
+        live = original_find(child_key, **kwargs)
+        assert live is not None
+        if finalize:
+            child_session["_finalized"] = True
+        else:
+            server._sessions.pop(live[0], None)
+        return live
+
+    monkeypatch.setattr(server, "_find_live_session_by_key", teardown_after_lookup)
+    _relay(server, "subagent.tool", tool_name="terminal", child_session_id="child-1")
+
+    assert [frame["params"]["type"] for frame in parent.frames] == ["subagent.tool"]
+    assert len(child.frames) == 0
+    assert len(current.frames) == 0
+    assert len(fallback.frames) == 0
+    assert server._child_mirrors == {}
+    assert server._child_run_active("child-1", profile_home=None)
+
+
+@pytest.mark.parametrize("finalize", [False, True], ids=["removed", "finalized"])
+def test_child_lifecycle_race_between_mirror_emits_drops_state_without_fallback(
+    server, monkeypatch, finalize
+):
+    """Barrier child teardown after message.start but before the next frame."""
+    fallback = _RecordingTransport()
+    current = _RecordingTransport()
+    parent = _RecordingTransport()
+    child = _watch(server)
+    child_session = server._sessions["live-1"]
+    server._sessions["parent-sid"] = {
+        "profile_home": None,
+        "transport": parent,
+    }
+    monkeypatch.setattr(server, "_stdio_transport", fallback)
+    monkeypatch.setattr(server, "current_transport", lambda: current)
+    original = server._emit_session_owned
+    child_calls = 0
+
+    def teardown_before_second_child_emit(event, sid, payload=None, **kwargs):
+        nonlocal child_calls
+        if sid == "live-1":
+            child_calls += 1
+            if child_calls == 2:
+                if finalize:
+                    child_session["_finalized"] = True
+                else:
+                    server._sessions.pop(sid, None)
+        return original(event, sid, payload, **kwargs)
+
+    monkeypatch.setattr(server, "_emit_session_owned", teardown_before_second_child_emit)
+    _relay(server, "subagent.tool", tool_name="terminal", child_session_id="child-1")
+
+    assert child_calls == 2
+    assert [frame["params"]["type"] for frame in parent.frames] == ["subagent.tool"]
+    assert [frame["params"]["type"] for frame in child.frames] == ["message.start"]
+    assert len(current.frames) == 0
+    assert len(fallback.frames) == 0
+    assert server._child_mirrors == {}
+    assert server._child_run_active("child-1", profile_home=None)
+
+
 def test_live_child_session_gets_native_stream(server, emits):
     # A window resumed the child session: live sid differs from the stored key.
-    server._sessions["live-1"] = {"session_key": "child-1", "agent": None}
+    _watch(server)
 
     _relay(server, "subagent.tool", tool_name="terminal", preview="ls", child_session_id="child-1")
     _relay(server, "subagent.thinking", preview="hmm", child_session_id="child-1")
@@ -124,9 +479,9 @@ def test_live_child_session_gets_native_stream(server, emits):
 
 
 def test_window_closed_midrun_drops_state_then_fresh_turn_on_reopen(server, emits):
-    server._sessions["live-1"] = {"session_key": "child-1", "agent": None}
+    _watch(server)
     _relay(server, "subagent.tool", tool_name="terminal", child_session_id="child-1")
-    assert "child-1" in server._child_mirrors
+    assert (None, "child-1") in server._child_mirrors
 
     # Window closes → live session gone → state dropped on the next event.
     server._sessions.clear()
@@ -135,7 +490,7 @@ def test_window_closed_midrun_drops_state_then_fresh_turn_on_reopen(server, emit
 
     # Reopen under a new live sid → a fresh synthetic turn starts.
     emits.clear()
-    server._sessions["live-2"] = {"session_key": "child-1", "agent": None}
+    _watch(server, sid="live-2")
     _relay(server, "subagent.tool", tool_name="web_search", child_session_id="child-1")
     assert [(e, s) for e, s, _ in emits if s == "live-2"] == [
         ("message.start", "live-2"),
@@ -146,25 +501,29 @@ def test_window_closed_midrun_drops_state_then_fresh_turn_on_reopen(server, emit
 def test_upgraded_child_session_not_mirrored(server, emits):
     """A watch window upgraded to a full session (agent built) owns a real
     native stream — mirroring on top would interleave two turns on one sid."""
-    server._sessions["live-1"] = {"session_key": "child-1", "agent": object()}
+    server._sessions["live-1"] = {
+        "session_key": "child-1",
+        "agent": object(),
+        "transport": _RecordingTransport(),
+    }
 
     _relay(server, "subagent.tool", tool_name="terminal", child_session_id="child-1")
 
     assert [(e, s) for e, s, _ in emits] == [("subagent.tool", "parent-sid")]
     assert server._child_mirrors == {}
     # Liveness registry still updates — it serves resume, not the mirror.
-    assert "child-1" in server._active_child_runs
+    assert (None, "child-1") in server._active_child_runs
 
 
 def test_stale_child_run_not_reported_active(server, emits):
     """A leaked registry entry (lost completion event) must age out instead of
     pinning running=true on every future lazy resume of that child."""
-    server._active_child_runs["child-1"] = 0.0  # epoch — ancient
+    server._active_child_runs[(None, "child-1")] = 0.0  # epoch — ancient
 
-    assert server._child_run_active("child-1") is False
+    assert server._child_run_active("child-1", profile_home=None) is False
 
     _relay(server, "subagent.tool", tool_name="terminal", child_session_id="child-1")
-    assert server._child_run_active("child-1") is True
+    assert server._child_run_active("child-1", profile_home=None) is True
 
 
 def test_prompt_submit_rejected_while_child_run_active(server, emits):
@@ -178,6 +537,7 @@ def test_prompt_submit_rejected_while_child_run_active(server, emits):
         "lazy": True,
         "running": False,
         "session_key": "child-1",
+        "transport": _RecordingTransport(),
     }
     _relay(server, "subagent.tool", tool_name="terminal", child_session_id="child-1")
 
@@ -187,7 +547,7 @@ def test_prompt_submit_rejected_while_child_run_active(server, emits):
     # Run completes → the same submit upgrades into a real conversation
     # (passes the guard; fails later only because this test stubs no agent).
     _relay(server, "subagent.complete", child_session_id="child-1", status="completed", summary="ok")
-    assert server._child_run_active("child-1") is False
+    assert server._child_run_active("child-1", profile_home=None) is False
 
 
 def test_active_child_runs_registry_tracks_liveness(server, emits):
@@ -195,17 +555,96 @@ def test_active_child_runs_registry_tracks_liveness(server, emits):
     open), and completion clears it — lazy watch resumes read this registry to
     report running=true while the child is silent inside a long tool call."""
     _relay(server, "subagent.start", preview="go", child_session_id="child-1")
-    assert "child-1" in server._active_child_runs
+    assert (None, "child-1") in server._active_child_runs
 
     _relay(server, "subagent.tool", tool_name="terminal", child_session_id="child-1")
-    assert "child-1" in server._active_child_runs
+    assert (None, "child-1") in server._active_child_runs
 
     _relay(server, "subagent.complete", child_session_id="child-1", status="completed", summary="ok")
-    assert "child-1" not in server._active_child_runs
+    assert (None, "child-1") not in server._active_child_runs
+
+
+def test_duplicate_child_ids_are_mirrored_and_tracked_per_profile(server, tmp_path):
+    """Profile B relay frames and completion cannot touch profile A state."""
+    profile_a = tmp_path / "profiles" / "a"
+    profile_b = tmp_path / "profiles" / "b"
+    profile_a.mkdir(parents=True)
+    profile_b.mkdir(parents=True)
+    watch_a = _RecordingTransport()
+    watch_b = _RecordingTransport()
+
+    server._sessions.update(
+        {
+            "parent-a": {
+                "profile_home": str(profile_a),
+                "transport": _RecordingTransport(),
+            },
+            "parent-b": {
+                "profile_home": str(profile_b),
+                "transport": _RecordingTransport(),
+            },
+            "watch-a": {
+                "session_key": "duplicate-child",
+                "profile_home": str(profile_a),
+                "agent": None,
+                "transport": watch_a,
+            },
+            "watch-b": {
+                "session_key": "duplicate-child",
+                "profile_home": str(profile_b),
+                "agent": None,
+                "transport": watch_b,
+            },
+        }
+    )
+
+    server._on_tool_progress(
+        "parent-b",
+        "subagent.text",
+        preview="B only",
+        child_session_id="duplicate-child",
+    )
+
+    assert len(watch_a.frames) == 0
+    assert [frame["params"]["type"] for frame in watch_b.frames] == [
+        "message.start",
+        "message.delta",
+    ]
+    assert watch_b.frames[-1]["params"]["payload"] == {"text": "B only"}
+    key_a = server._child_runtime_key(profile_a, "duplicate-child")
+    key_b = server._child_runtime_key(profile_b, "duplicate-child")
+    assert key_a != key_b
+    assert key_b in server._child_mirrors
+    assert key_a not in server._child_mirrors
+    assert server._child_run_active("duplicate-child", profile_home=profile_b)
+    assert not server._child_run_active("duplicate-child", profile_home=profile_a)
+
+    server._on_tool_progress(
+        "parent-a",
+        "subagent.tool",
+        name="terminal",
+        child_session_id="duplicate-child",
+    )
+    assert key_a in server._child_mirrors
+    assert key_b in server._child_mirrors
+    assert server._child_run_active("duplicate-child", profile_home=profile_a)
+    assert server._child_run_active("duplicate-child", profile_home=profile_b)
+
+    server._on_tool_progress(
+        "parent-b",
+        "subagent.complete",
+        child_session_id="duplicate-child",
+        status="completed",
+        summary="B done",
+    )
+    assert key_b not in server._child_mirrors
+    assert key_a in server._child_mirrors
+    assert not server._child_run_active("duplicate-child", profile_home=profile_b)
+    assert server._child_run_active("duplicate-child", profile_home=profile_a)
 
 
 def test_start_mirrors_as_immediate_header_line(server, emits):
-    server._sessions["live-1"] = {"session_key": "child-1", "agent": None}
+    _watch(server)
 
     # subagent.start emits a one-time header (the goal) so a freshly opened
     # window shows context immediately. subagent.progress (batched tool-name
@@ -225,7 +664,7 @@ def test_text_mirrors_as_message_delta(server, emits):
     """The child's streamed reply (subagent.text) becomes a native
     message.delta on the live child sid — the watch window streams it as the
     agent 'talking', the piece that was previously missing entirely."""
-    server._sessions["live-1"] = {"session_key": "child-1", "agent": None}
+    _watch(server)
 
     _relay(server, "subagent.text", preview="Here is ", child_session_id="child-1")
     _relay(server, "subagent.text", preview="the answer.", child_session_id="child-1")

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -370,7 +370,10 @@ def _(rid, params: dict) -> dict:
         # racing the in-flight child on the same stored session (interleaved
         # transcript, stale fork). After the run completes, submitting is fine:
         # the upgrade resumes the child's transcript as a normal conversation.
-        if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
+        if session.get("lazy") and _child_run_active(
+            str(session.get("session_key") or ""),
+            profile_home=session.get("profile_home"),
+        ):
             return _err(rid, 4009, "subagent still running — wait for it to finish")
         truncate_message_id = params.get("truncate_before_message_id")
         truncate_row_id = params.get("truncate_before_row_id")
@@ -795,7 +798,10 @@ def _(rid, params: dict) -> dict:
                 return
         _run_prompt_submit(rid, sid, session, text)
 
-    run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
+    run_thread = threading.Thread(
+        target=lambda: _run_session_owned(session, run_after_agent_ready),
+        daemon=True,
+    )
     # Keep a handle so session.interrupt can tell a live turn from a stuck
     # `running` flag (a turn that died without clearing it) and recover the latter.
     session["_run_thread"] = run_thread
@@ -1245,12 +1251,14 @@ def _(rid, params: dict) -> dict:
                         else str(result)
                     ),
                 },
+                expected_session=session,
             )
         except Exception as e:
             _emit(
                 "background.complete",
                 parent,
                 {"task_id": task_id, "text": f"error: {e}"},
+                expected_session=session,
             )
         finally:
             _clear_session_context(session_tokens)
@@ -1338,6 +1346,7 @@ def _(rid, params: dict) -> dict:
                 "preview.restart.progress",
                 parent,
                 {"task_id": task_id, "text": f"Starting hidden restart agent{history_note}"},
+                expected_session=session,
             )
             # Bug #50233: ephemeral preview-restart agent threads don't inherit
             # the session's HERMES_HOME override (the ContextVar set on the
@@ -1357,7 +1366,9 @@ def _(rid, params: dict) -> dict:
             try:
                 result = AIAgent(
                     **_ephemeral_preview_agent_kwargs(session["agent"], task_id),
-                    **_preview_restart_callbacks(parent, task_id),
+                    **_preview_restart_callbacks(
+                        parent, task_id, expected_session=session
+                    ),
                 ).run_conversation(
                     user_message=prompt,
                     task_id=task_id,
@@ -1371,12 +1382,18 @@ def _(rid, params: dict) -> dict:
                 if isinstance(result, dict)
                 else str(result)
             )
-            _emit("preview.restart.complete", parent, {"task_id": task_id, "text": text})
+            _emit(
+                "preview.restart.complete",
+                parent,
+                {"task_id": task_id, "text": text},
+                expected_session=session,
+            )
         except Exception as e:
             _emit(
                 "preview.restart.complete",
                 parent,
                 {"task_id": task_id, "text": f"error: {e}"},
+                expected_session=session,
             )
         finally:
             try:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -41,6 +41,8 @@ def _(rid, params: dict) -> dict:
     # and each turn re-bind HERMES_HOME. None/own profile → launch (unchanged).
     profile = (params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
+    if profile and profile_home is None and profile != _current_profile_name():
+        return _db_unavailable_error(rid, code=5006)
 
     # The desktop composer owns its model/effort/fast as plain UI state and ships
     # it on every session.create. Honor each as a PER-SESSION override (built into
@@ -317,6 +319,8 @@ def _(rid, params: dict) -> dict:
     # local profile's state.db. None/own profile → the launch profile (unchanged).
     profile = (params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
+    if profile and profile_home is None and profile != _current_profile_name():
+        return _db_unavailable_error(rid, code=5000)
     defer_history = is_truthy_value(params.get("defer_history", False))
     # Desktop hydrates persisted transcripts through the authenticated REST
     # route in parallel. Suppress the duplicate WebSocket transcript only when
@@ -344,7 +348,9 @@ def _(rid, params: dict) -> dict:
             found = db.get_session_by_title(target)
             if found:
                 target = found["id"]
-            elif is_truthy_value(params.get("lazy", False)) and _child_run_active(target):
+            elif is_truthy_value(params.get("lazy", False)) and _child_run_active(
+                target, profile_home=profile_home
+            ):
                 # Race: a watch window opened on a freshly-spawned subagent. The
                 # child relays `subagent.start` (which carries child_session_id and
                 # triggers the window) BEFORE its first run_conversation() flushes
@@ -416,14 +422,21 @@ def _(rid, params: dict) -> dict:
         )
 
         def _reuse_live_payload(sid: str, session: dict) -> dict:
-            payload = _live_session_payload(
-                sid,
-                session,
-                cols=cols,
-                touch=True,
-                transport=current_transport() or _stdio_transport,
-                omit_messages=omit_messages,
-            )
+            transport = current_transport() or _stdio_transport
+            with _session_resume_lock:
+                if not _rebind_live_session_transport(sid, session, transport):
+                    return _err(
+                        rid,
+                        4009,
+                        "session is already attached to another live transport",
+                    )
+                payload = _live_session_payload(
+                    sid,
+                    session,
+                    cols=cols,
+                    touch=True,
+                    omit_messages=omit_messages,
+                )
             payload["resumed"] = target
             if defer_history:
                 payload["messages"] = []
@@ -434,16 +447,19 @@ def _(rid, params: dict) -> dict:
             # A lazy watch session never owns a run loop, so its payload's running
             # flag is always False — overlay the child-run registry so a reconnecting
             # watch window keeps its busy indicator while the child is still mid-run.
-            if session.get("agent") is None and _child_run_active(target):
+            if session.get("agent") is None and _child_run_active(
+                target, profile_home=profile_home
+            ):
                 payload["running"] = True
                 payload["status"] = "streaming"
             return payload
 
         # Fast path: if the session is already live, reuse it under the lock.
         with _session_resume_lock:
-            live = _find_live_session_by_key(target)
+            live = _find_live_session_by_key(target, profile_home=profile_home)
             if live is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                reused = _reuse_live_payload(*live)
+                return reused if "error" in reused else _ok(rid, reused)
 
         # Lazy/watch resume: register the live session WITHOUT building an agent.
         # Used by the desktop's subagent windows — the child runs inside the
@@ -484,10 +500,11 @@ def _(rid, params: dict) -> dict:
                 lazy=True,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                reused = _reuse_live_payload(*live)
+                return reused if "error" in reused else _ok(rid, reused)
             # A delegated child mid-run emits no session events of its own — report
             # its liveness from the relay registry so the window shows a busy turn.
-            child_running = _child_run_active(target)
+            child_running = _child_run_active(target, profile_home=profile_home)
             # User-visible messages use the VERBATIM display projection (child-only,
             # no ancestors — matching the repaired read above), so model-invisible
             # rows persisted by #65919 (verification candidates collapsed by
@@ -648,7 +665,8 @@ def _(rid, params: dict) -> dict:
                 resume_runtime_overrides=overrides or None,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                reused = _reuse_live_payload(*live)
+                return reused if "error" in reused else _ok(rid, reused)
 
             _schedule_agent_build(sid)
             _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
@@ -749,7 +767,7 @@ def _(rid, params: dict) -> dict:
         # live session while we were building. Re-check under the lock; if it won,
         # discard our just-built agent and reuse theirs (no worker/poller wired yet).
         with _session_resume_lock:
-            live = _find_live_session_by_key(target)
+            live = _find_live_session_by_key(target, profile_home=profile_home)
             if live is not None:
                 try:
                     if hasattr(agent, "close"):
@@ -759,12 +777,20 @@ def _(rid, params: dict) -> dict:
                 if lease is not None:
                     lease.release()
                 other_sid, other_session = live
+                transport = current_transport() or _stdio_transport
+                if not _rebind_live_session_transport(
+                    other_sid, other_session, transport
+                ):
+                    return _err(
+                        rid,
+                        4009,
+                        "session is already attached to another live transport",
+                    )
                 payload = _live_session_payload(
                     other_sid,
                     other_session,
                     cols=cols,
                     touch=True,
-                    transport=current_transport() or _stdio_transport,
                     omit_messages=omit_messages,
                 )
                 payload["resumed"] = target
@@ -1034,16 +1060,20 @@ def _(rid, params: dict) -> dict:
         return err
     assert session is not None
 
-    return _ok(
-        rid,
-        _live_session_payload(
+    with _session_resume_lock:
+        if not _rebind_live_session_transport(
+            sid, session, current_transport() or _stdio_transport
+        ):
+            return _err(
+                rid, 4009, "session is already attached to another live transport"
+            )
+        payload = _live_session_payload(
             sid,
             session,
             touch=True,
-            transport=current_transport() or _stdio_transport,
             omit_messages=is_truthy_value(params.get("omit_messages", False)),
-        ),
-    )
+        )
+    return _ok(rid, payload)
 
 
 @method("session.delete")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -154,7 +154,8 @@ _prompt_lock = threading.Lock()
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _cfg_path = None
-_session_resume_lock = threading.Lock()
+_session_resume_lock = threading.RLock()
+_ANY_PROFILE_HOME = object()
 try:
     _slash_timeout = float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S") or "45")
 except (ValueError, TypeError):
@@ -340,6 +341,27 @@ atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))
 _current_runtime_session_record: contextvars.ContextVar[dict | None] = (
     contextvars.ContextVar("hermes_gateway_runtime_session_record", default=None)
 )
+
+
+def _run_session_owned(session: dict | None, fn: Callable, *args, **kwargs):
+    """Run a callback with exact session-generation routing authority."""
+    if session is None:
+        return fn(*args, **kwargs)
+    token = _current_runtime_session_record.set(session)
+    try:
+        return fn(*args, **kwargs)
+    finally:
+        _current_runtime_session_record.reset(token)
+
+
+def _runtime_session_for_sid(sid: str) -> dict | None:
+    """Resolve ``sid`` without letting scoped stale callbacks adopt a reuse."""
+    expected = _current_runtime_session_record.get()
+    with _sessions_lock:
+        current = _sessions.get(sid)
+        if expected is not None and current is not expected:
+            return None
+        return current
 
 # Reserve real stdout for JSON-RPC only; redirect Python's stdout to stderr
 # so stray print() from libraries/tools becomes harmless gateway.stderr instead
@@ -1185,14 +1207,26 @@ def _close_sessions_for_transport(
     detached = 0
     for sid, session in owned:
         if session.get("close_on_disconnect"):
-            _close_session_by_id(sid, end_reason=end_reason)
-            reaped += 1
+            # The snapshot can be stale by the time teardown runs. Claim only
+            # if both record generation and old transport still match.
+            if _close_session_by_id(
+                sid,
+                end_reason=end_reason,
+                predicate=lambda current, _session=session: (
+                    current is _session and current.get("transport") is transport
+                ),
+            ):
+                reaped += 1
         else:
             # Point detached sessions at the drop sentinel (NOT real stdio) so
             # _ws_session_is_orphaned recognizes them and the grace-reap can
             # actually fire; a standalone `hermes --tui` keeps real _stdio.
-            session["transport"] = _detached_ws_transport
-            detached += 1
+            with _sessions_lock:
+                current = _sessions.get(sid)
+                if current is not session or current.get("transport") is not transport:
+                    continue
+                current["transport"] = _detached_ws_transport
+                detached += 1
             try:
                 _schedule_ws_orphan_reap(sid)
             except Exception:
@@ -1424,7 +1458,11 @@ def _db_for_profile(profile: str | None = None):
 
     Returns (db, owns_handle). ``db`` is None when unavailable.
     """
-    profile_home = _profile_home(profile)
+    requested = (profile or "").strip()
+    profile_home = _profile_home(requested)
+    if requested and profile_home is None and requested != _current_profile_name():
+        logger.warning("TUI rejected unavailable profile session store: %s", requested)
+        return None, False
     if profile_home is None:
         return _get_db(), False
     try:
@@ -1634,14 +1672,39 @@ def _default_session_cwd() -> str:
     return _launch_configured_cwd() or os.getenv("TERMINAL_CWD") or os.getcwd()
 
 
-def write_json(obj: dict) -> bool:
+def _live_session_transport(
+    sid: str, *, expected_session: dict | None = None
+) -> tuple[dict, Transport] | None:
+    """Return the exact live owner and transport for a private session frame.
+
+    A nonempty sid is never authority by itself.  Missing, finalized, detached,
+    closed, or replaced generations fail closed; callers write the captured
+    transport once and never retry through request/stdin fallback.
+    """
+    if not sid:
+        return None
+    with _sessions_lock:
+        session = _sessions.get(sid)
+        if (
+            session is None
+            or session.get("_finalized")
+            or (expected_session is not None and session is not expected_session)
+        ):
+            return None
+        transport = session.get("transport")
+        if transport is None or _transport_is_dead(transport):
+            return None
+        return session, transport
+
+
+def write_json(obj: dict, *, expected_session: dict | None = None) -> bool:
     """Emit one JSON frame. Routes via the most-specific transport available.
 
     Precedence:
 
-    1. Event frames with a session id → the transport stored on that session,
-       so async events land with the client that owns the session even if
-       the emitting thread has no contextvar binding.
+    1. Event frames with a nonempty session id → only the explicit live
+       transport of that exact non-finalized session generation.  They never
+       fall through to a request transport or stdio.
     2. Otherwise the transport bound on the current context (set by
        :func:`dispatch` for the lifetime of a request).
     3. Otherwise the module-level stdio transport, matching the historical
@@ -1649,8 +1712,20 @@ def write_json(obj: dict) -> bool:
     """
     if obj.get("method") == "event":
         sid = ((obj.get("params") or {}).get("session_id")) or ""
-        if sid and (t := (_sessions.get(sid) or {}).get("transport")) is not None:
-            return t.write(obj)
+        if sid:
+            effective_expected = (
+                expected_session
+                if expected_session is not None
+                else _current_runtime_session_record.get()
+            )
+            owner = _live_session_transport(sid, expected_session=effective_expected)
+            if owner is None:
+                return False
+            try:
+                return bool(owner[1].write(obj))
+            except Exception:
+                logger.debug("private session event write failed sid=%s", sid, exc_info=True)
+                return False
 
     return (current_transport() or _stdio_transport).write(obj)
 
@@ -1662,8 +1737,80 @@ def _event_frame(event: str, sid: str, payload: dict | None = None) -> dict:
     return {"jsonrpc": "2.0", "method": "event", "params": params}
 
 
-def _emit(event: str, sid: str, payload: dict | None = None):
-    write_json(_event_frame(event, sid, payload))
+def _emit(
+    event: str,
+    sid: str,
+    payload: dict | None = None,
+    *,
+    expected_session: dict | None = None,
+):
+    """Emit an event, optionally fenced to an exact session generation.
+
+    Synchronous callers may omit ``expected_session``: private routing still
+    fails closed for absent/final/dead records and turn threads inherit the
+    exact generation from ``_current_runtime_session_record``.  Async producers
+    that outlive their initiating call must capture and pass the record.
+    """
+    return write_json(
+        _event_frame(event, sid, payload), expected_session=expected_session
+    )
+
+
+def _emit_for_session(
+    session: dict | None, event: str, sid: str, payload: dict | None = None
+) -> bool:
+    """Emit under exact generation context while preserving _emit's call ABI."""
+    return bool(_run_session_owned(session, _emit, event, sid, payload))
+
+
+def _emit_session_owned(
+    event: str | None,
+    sid: str,
+    payload: dict | None = None,
+    *,
+    expected_session: dict | None = None,
+) -> bool:
+    """Write only through ``sid``'s explicit live-session transport.
+
+    Unlike :func:`_emit`, this helper never falls back to the request-bound or
+    stdio transport.  Session removal/finalization, id reuse, and missing
+    transport all fail closed.  ``event=None`` performs the same scoped
+    authorization without writing; this is used for parent-suppressed
+    ``subagent.text`` events before child mirroring.
+    """
+    owner = _live_session_transport(sid, expected_session=expected_session)
+    if owner is None:
+        return False
+    session, transport = owner
+
+    if event is None:
+        return True
+    try:
+        written = bool(transport.write(_event_frame(event, sid, payload)))
+    except Exception:
+        # A failed session-owned write is terminal for this event.  In
+        # particular, never reroute private relay data through current/stdin.
+        logger.debug(
+            "session-owned event write failed type=%s sid=%s",
+            event,
+            sid,
+            exc_info=True,
+        )
+        return False
+    if not written:
+        return False
+
+    # A transport write may synchronously trigger disconnect/finalization.
+    # Treat that as failed authorization for any dependent child mirror work,
+    # while retaining the already-captured direct write (never reroute it).
+    with _sessions_lock:
+        current = _sessions.get(sid)
+        return bool(
+            current is session
+            and not session.get("_finalized")
+            and session.get("transport") is transport
+            and not _transport_is_dead(transport)
+        )
 
 
 # Live client transports, one per connected WS peer (maintained by tui_gateway.ws).
@@ -1714,6 +1861,24 @@ def _broadcast_global_event(event: str, payload: dict | None = None) -> None:
 
 _compute_host_supervisor = None
 _compute_host_supervisor_lock = threading.Lock()
+_compute_host_event_owner_lock = threading.Lock()
+# Independent sessions may overlap in the shared host. Fence each sid to its
+# exact in-memory generation instead of using one process-global owner.
+_compute_host_event_owners: dict[str, dict] = {}
+
+
+def _write_compute_host_rpc(obj: dict) -> bool:
+    """Fence host-reader events to the exact record owning the active turn."""
+    sid = ""
+    if obj.get("method") == "event":
+        sid = str(((obj.get("params") or {}).get("session_id")) or "")
+    with _compute_host_event_owner_lock:
+        owner = _compute_host_event_owners.get(sid)
+    if sid:
+        if owner is None:
+            return False
+        return write_json(obj, expected_session=owner)
+    return write_json(obj)
 
 
 def _inside_compute_host_child() -> bool:
@@ -1746,7 +1911,7 @@ def _get_compute_host_supervisor(cfg: dict | None = None):
             from tui_gateway.host_supervisor import HostSupervisor
 
             _compute_host_supervisor = HostSupervisor(
-                rpc_sink=write_json,
+                rpc_sink=_write_compute_host_rpc,
                 heartbeat_secs=int(isolation_cfg.get("compute_host_heartbeat_secs") or 15),
                 respawn_max=int(isolation_cfg.get("compute_host_respawn_max") or 3),
             )
@@ -1845,14 +2010,22 @@ def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -
         _clear_inflight_turn(session)
     if is_error:
         message = str(frame.get("message") or "compute host turn failed")
-        _emit("message.complete", sid, {"text": f"Error: {message}", "status": "error"})
+        _emit_for_session(
+            session,
+            "message.complete",
+            sid,
+            {"text": f"Error: {message}", "status": "error"},
+        )
     _apply_compute_host_metadata_mirror(session, frame)
     try:
         info = _session_info(session.get("agent"), session)
     except TypeError:
         info = _session_info(session.get("agent"))
     if not frame.get("session_info_emitted"):
-        _emit("session.info", sid, info)
+        _emit_for_session(session, "session.info", sid, info)
+    with _compute_host_event_owner_lock:
+        if _compute_host_event_owners.get(sid) is session:
+            _compute_host_event_owners.pop(sid, None)
     _drain_queued_prompt(rid, sid, session)
 
 
@@ -1884,8 +2057,13 @@ def _submit_prompt_to_compute_host(
         _on_compute_host_turn_done(rid, sid, session, done)
 
     try:
+        with _compute_host_event_owner_lock:
+            _compute_host_event_owners[sid] = session
         _get_compute_host_supervisor(cfg).submit_turn(frame, on_complete=_complete)
     except Exception as exc:
+        with _compute_host_event_owner_lock:
+            if _compute_host_event_owners.get(sid) is session:
+                _compute_host_event_owners.pop(sid, None)
         return _err(rid, 5019, f"compute-host dispatch failed: {exc}")
     with session["history_lock"]:
         session["_compute_host_active"] = True
@@ -2278,7 +2456,10 @@ def _start_agent_build(sid: str, session: dict) -> None:
     # to a full agent mid-stream and silently kill the mirror (the mirror bails
     # once agent is set). Once the child completes, the guard lifts and the next
     # prompt/RPC builds the agent normally so the user can talk to the session.
-    if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
+    if session.get("lazy") and _child_run_active(
+        str(session.get("session_key") or ""),
+        profile_home=session.get("profile_home"),
+    ):
         return
     lock = session.setdefault("agent_build_lock", threading.Lock())
     with lock:
@@ -2399,7 +2580,10 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 )
 
                 register_gateway_notify(
-                    key, lambda data: _emit_approval_request(sid, data)
+                    key,
+                    lambda data, _session=current: _run_session_owned(
+                        _session, _emit_approval_request, sid, data
+                    ),
                 )
                 notify_registered = True
                 load_permanent_allowlist()
@@ -2414,8 +2598,11 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # default cold resume) build through here, so without this their
             # review summaries would leak to stdout instead of the chat.
             try:
-                agent.background_review_callback = lambda message, _sid=sid: _emit(
-                    "review.summary", _sid, {"text": str(message)}
+                agent.background_review_callback = lambda message, _sid=sid, _session=current: _emit_for_session(
+                    _session,
+                    "review.summary",
+                    _sid,
+                    {"text": str(message)},
                 )
                 agent.memory_notifications = _load_memory_notifications()
             except Exception:
@@ -2439,7 +2626,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
             if cfg_warn:
                 info["config_warning"] = cfg_warn
                 logger.warning(cfg_warn)
-            _emit("session.info", sid, info)
+            _emit_for_session(current, "session.info", sid, info)
             # If MCP discovery is still in flight (a server slower than the
             # bounded wait_for_mcp_discovery join in _make_agent), the agent
             # was built without those tools. Catch up once they land — see
@@ -2447,7 +2634,12 @@ def _start_agent_build(sid: str, session: dict) -> None:
             _schedule_mcp_late_refresh(sid, agent)
         except Exception as e:
             current["agent_error"] = str(e)
-            _emit("error", sid, {"message": f"agent init failed: {e}"})
+            _emit_for_session(
+                current,
+                "error",
+                sid,
+                {"message": f"agent init failed: {e}"},
+            )
         finally:
             if home_token is not None:
                 reset_hermes_home_override(home_token)
@@ -5233,7 +5425,9 @@ def _sync_session_key_after_compress(
         try:
             register_gateway_notify(
                 new_session_id,
-                lambda data: _emit_approval_request(sid, data),
+                lambda data, _session=session: _run_session_owned(
+                    _session, _emit_approval_request, sid, data
+                ),
             )
         except Exception:
             pass
@@ -5737,7 +5931,7 @@ def _tool_summary(name: str, result: str, duration_s: float | None) -> str | Non
 
 
 def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
-    session = _sessions.get(sid)
+    session = _runtime_session_for_sid(sid)
     if session is not None:
         try:
             from agent.display import capture_local_edit_snapshot
@@ -5770,9 +5964,13 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
         _emit("tool.start", sid, payload)
 
 
+_process_event_owners: dict[str, tuple[str, dict]] = {}
+_process_event_owners_lock = threading.Lock()
+
+
 def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result: str):
     payload = {"tool_id": tool_call_id, "name": name, "args": args}
-    session = _sessions.get(sid)
+    session = _runtime_session_for_sid(sid)
     snapshot = None
     started_at = None
     if session is not None:
@@ -5785,6 +5983,19 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
         payload["result"] = json.loads(result)
     except Exception:
         payload["result"] = result
+    if (
+        session is not None
+        and name in {"terminal", "process"}
+        and isinstance(payload["result"], dict)
+    ):
+        process_id = str(
+            payload["result"].get("session_id")
+            or payload["result"].get("process_id")
+            or ""
+        )
+        if process_id:
+            with _process_event_owners_lock:
+                _process_event_owners[process_id] = (sid, session)
     summary = _tool_summary(name, result, duration_s)
     if summary:
         payload["summary"] = summary
@@ -5907,6 +6118,13 @@ def _on_tool_progress(
         _emit("moa.phase", sid, phase_payload)
         return
     if event_type.startswith("subagent."):
+        # Relay events are authorized by the exact originating live parent
+        # generation.  The scoped writer below revalidates that generation and
+        # writes directly to its captured transport, never through _emit's
+        # current/stdin fallback ladder.
+        parent_session = _runtime_session_for_sid(sid)
+        if parent_session is None or parent_session.get("_finalized"):
+            return
         payload = {
             "goal": str(_kwargs.get("goal") or ""),
             "task_count": int(_kwargs.get("task_count") or 1),
@@ -5966,9 +6184,21 @@ def _on_tool_progress(
         # skip the parent emit — sending hundreds of ignored token frames there
         # is wasted traffic and a trap for any future parent-side subagent
         # catch-all. The mirror keys off the child sid and is unaffected.
-        if event_type != "subagent.text":
-            _emit(event_type, sid, payload)
-        _mirror_subagent_to_child(event_type, payload)
+        if not _emit_session_owned(
+            None if event_type == "subagent.text" else event_type,
+            sid,
+            payload,
+            expected_session=parent_session,
+        ):
+            return
+        # A durable child id is only unique inside its profile. Scope the relay
+        # from the parent live session so cloned/imported profiles with the same
+        # child id cannot steal each other's watch transport or liveness state.
+        _mirror_subagent_to_child(
+            event_type,
+            payload,
+            profile_home=parent_session.get("profile_home"),
+        )
 
 
 # ── Child-session live mirror ────────────────────────────────────────
@@ -5979,68 +6209,99 @@ def _on_tool_progress(
 # open-in-new-window), that window would otherwise sit silent until the run
 # persists. Translate the relayed events into the native stream events the
 # window already renders — emitted on the CHILD sid, routed to its transport
-# by write_json — so the window shows a real midstream turn.
-_child_mirrors: dict[str, dict] = {}
+# directly through that session's explicit transport — so the window shows a
+# real midstream turn without any current/stdin fallback route.
+_child_mirrors: dict[tuple[str | None, str], dict] = {}
 _child_mirrors_lock = threading.Lock()
 # Stored child session ids with a delegation run currently in flight (refreshed
 # on every relayed subagent.* event, popped on subagent.complete). Lets a lazy
 # watch resume report running=true so the window shows a busy indicator even
 # while the child is silent inside a long tool call (no events for 25s+).
-_active_child_runs: dict[str, float] = {}
+_active_child_runs: dict[tuple[str | None, str], float] = {}
 # Staleness bound for the registry: entries refresh on every relayed event, so
 # anything this quiet means the completion event was lost (callback raised,
 # parent crashed) — don't let a leaked entry pin "running" forever.
 _CHILD_RUN_STALE_S = 3600.0
 
 
-def _child_run_active(child_key: str) -> bool:
-    ts = _active_child_runs.get(child_key)
+def _child_runtime_key(profile_home: object, child_key: str) -> tuple[str | None, str]:
+    """Canonical profile-scoped identity for child mirror runtime state."""
+    return (_profile_home_identity(profile_home), str(child_key or ""))
+
+
+def _child_run_active(child_key: str, *, profile_home: object) -> bool:
+    ts = _active_child_runs.get(_child_runtime_key(profile_home, child_key))
     return ts is not None and (time.time() - ts) < _CHILD_RUN_STALE_S
 
 
-def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
+def _mirror_subagent_to_child(
+    event_type: str, payload: dict, *, profile_home: object
+) -> None:
     child_key = str(payload.get("child_session_id") or "")
     if not child_key:
         return
+    runtime_key = _child_runtime_key(profile_home, child_key)
     # Liveness registry first — it must be accurate even when no window is
     # open, so a window opened mid-run can immediately know the child is busy.
     if event_type == "subagent.complete":
-        _active_child_runs.pop(child_key, None)
+        _active_child_runs.pop(runtime_key, None)
     else:
-        _active_child_runs[child_key] = time.time()
+        _active_child_runs[runtime_key] = time.time()
     # Mirror only into a live watch session (keyed by session_key; its live sid
     # differs from the stored id) that has NOT been upgraded to a full agent.
     # No window / closed → nothing to mirror; an upgraded session owns a real
     # native stream and mirroring on top would interleave two turns on one sid.
     # Either way drop state so a reopened window starts a fresh synthetic turn.
-    live = _find_live_session_by_key(child_key)
+    live = _find_live_session_by_key(child_key, profile_home=profile_home)
     if live is None or live[1].get("agent") is not None:
         with _child_mirrors_lock:
-            _child_mirrors.pop(child_key, None)
+            _child_mirrors.pop(runtime_key, None)
         return
     csid = live[0]
     with _child_mirrors_lock:
-        st = _child_mirrors.setdefault(child_key, {"seq": 0, "open_tool": None, "started": False})
+        st = _child_mirrors.setdefault(
+            runtime_key, {"seq": 0, "open_tool": None, "started": False}
+        )
+
+        def child_emit(event: str, body: dict | None = None) -> bool:
+            if _emit_session_owned(
+                event,
+                csid,
+                body,
+                expected_session=live[1],
+            ):
+                return True
+            # The watch disappeared, finalized, lost its explicit transport, or
+            # was replaced between lookup and any synthetic frame.  Preserve
+            # active-run liveness, but never retain stale synthetic turn state.
+            _child_mirrors.pop(runtime_key, None)
+            return False
+
         if not st["started"]:
             st["started"] = True
-            _emit("message.start", csid)
+            if not child_emit("message.start"):
+                return
         if event_type == "subagent.thinking":
             if text := str(payload.get("text") or ""):
-                _emit("reasoning.delta", csid, {"text": text})
+                if not child_emit("reasoning.delta", {"text": text}):
+                    return
         elif event_type == "subagent.text":
             # The child's streamed reply text — the actual "agent talking".
             # Relayed token-by-token from the child's run_conversation
             # stream_callback, so the watch window streams the reply live.
             if text := str(payload.get("text") or ""):
-                _emit("message.delta", csid, {"text": text})
+                if not child_emit("message.delta", {"text": text}):
+                    return
         elif event_type == "subagent.start":
             # One-time header line (the child's goal) so a freshly opened window
             # shows immediate context before the first reply token streams.
             if text := str(payload.get("text") or ""):
-                _emit("message.delta", csid, {"text": f"{text}\n"})
+                if not child_emit("message.delta", {"text": f"{text}\n"}):
+                    return
         elif event_type == "subagent.tool":
             if st["open_tool"]:
-                _emit("tool.complete", csid, st["open_tool"])
+                if not child_emit("tool.complete", st["open_tool"]):
+                    return
             st["seq"] += 1
             tool = {
                 "name": str(payload.get("tool_name") or "tool"),
@@ -6050,44 +6311,55 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
             if preview := str(payload.get("tool_preview") or payload.get("text") or ""):
                 tool["preview"] = preview
             st["open_tool"] = tool
-            _emit("tool.start", csid, tool)
+            if not child_emit("tool.start", tool):
+                return
         elif event_type == "subagent.complete":
             if st["open_tool"]:
-                _emit("tool.complete", csid, st["open_tool"])
+                if not child_emit("tool.complete", st["open_tool"]):
+                    return
             summary = str(payload.get("summary") or payload.get("text") or "")
-            _emit("message.complete", csid, {"text": summary})
-            _child_mirrors.pop(child_key, None)
+            if not child_emit("message.complete", {"text": summary}):
+                return
+            _child_mirrors.pop(runtime_key, None)
 
 
 def _agent_cbs(sid: str) -> dict:
+    # Deferred builds already have a registered record. Capture it so callbacks
+    # that fire after their turn/context ends cannot route into a reused sid.
+    with _sessions_lock:
+        expected_session = _sessions.get(sid)
+
+    def owned(fn: Callable, *args, **kwargs):
+        return _run_session_owned(expected_session, fn, *args, **kwargs)
+
     callbacks = {
-        "tool_start_callback": lambda tc_id, name, args: _on_tool_start(
+        "tool_start_callback": lambda tc_id, name, args: owned(_on_tool_start,
             sid, tc_id, name, args
         ),
-        "tool_complete_callback": lambda tc_id, name, args, result: _on_tool_complete(
+        "tool_complete_callback": lambda tc_id, name, args, result: owned(_on_tool_complete,
             sid, tc_id, name, args, result
         ),
-        "tool_progress_callback": lambda event_type, name=None, preview=None, args=None, **kwargs: _on_tool_progress(
+        "tool_progress_callback": lambda event_type, name=None, preview=None, args=None, **kwargs: owned(_on_tool_progress,
             sid, event_type, name, preview, args, **kwargs
         ),
         "tool_gen_callback": lambda name: _tool_progress_enabled(sid)
-        and _emit("tool.generating", sid, {"name": name}),
-        "thinking_callback": lambda text: _emit("thinking.delta", sid, {"text": text}),
+        and owned(_emit, "tool.generating", sid, {"name": name}),
+        "thinking_callback": lambda text: owned(_emit, "thinking.delta", sid, {"text": text}),
         # Affection reaction (ily / <3 / good bot) → hearts. Core-detected, so
         # the TUI heart and desktop floating hearts share one signal.
-        "reaction_callback": lambda kind: _emit("reaction", sid, {"kind": kind}),
-        "reasoning_callback": lambda text: _emit(
+        "reaction_callback": lambda kind: owned(_emit, "reaction", sid, {"kind": kind}),
+        "reasoning_callback": lambda text: owned(_emit,
             "reasoning.delta",
             sid,
             {"text": text, **({"verbose": True} if _session_verbose(sid) else {})},
         ),
-        "status_callback": lambda kind, text=None: _status_update(
+        "status_callback": lambda kind, text=None: owned(_status_update,
             sid, str(kind), None if text is None else str(text)
         ),
         # Credits/notice spine (L1): an AgentNotice fired by the agent becomes a
         # notification.show WS event; a recovery clear becomes notification.clear.
         # Snake_case payload to match the existing gateway-event convention.
-        "notice_callback": lambda n: _emit(
+        "notice_callback": lambda n: owned(_emit,
             "notification.show",
             sid,
             {
@@ -6099,10 +6371,10 @@ def _agent_cbs(sid: str) -> dict:
                 "id": n.id,
             },
         ),
-        "notice_clear_callback": lambda key: _emit(
+        "notice_clear_callback": lambda key: owned(_emit,
             "notification.clear", sid, {"key": key}
         ),
-        "clarify_callback": lambda q, c, multi_select=False: _block(
+        "clarify_callback": lambda q, c, multi_select=False: owned(_block,
             "clarify.request",
             sid,
             # multi_select is a pass-through hint: renderers with checkbox
@@ -6119,7 +6391,7 @@ def _agent_cbs(sid: str) -> dict:
         ),
         # read_terminal tool (desktop GUI): same blocking bridge as clarify — the
         # renderer answers terminal.read.respond with the serialized buffer.
-        "read_terminal_callback": lambda start=None, count=None: _block(
+        "read_terminal_callback": lambda start=None, count=None: owned(_block,
             "terminal.read.request",
             sid,
             {k: v for k, v in (("start", start), ("count", count)) if v is not None},
@@ -6129,7 +6401,7 @@ def _agent_cbs(sid: str) -> dict:
         # preview tab (a Browser webview's readable text, a file's identity)
         # and answers preview.read.respond. Longer timeout than the terminal
         # read — a URL tab extracts text from a live page.
-        "read_preview_callback": lambda start=None, count=None: _block(
+        "read_preview_callback": lambda start=None, count=None: owned(_block,
             "preview.read.request",
             sid,
             {k: v for k, v in (("start", start), ("count", count)) if v is not None},
@@ -6139,7 +6411,7 @@ def _agent_cbs(sid: str) -> dict:
         # process (which owns native window enumeration) which OS window sits
         # directly underneath the Hermes window, and answers
         # window.read.respond with the serialized metadata.
-        "read_window_below_callback": lambda: _block(
+        "read_window_below_callback": lambda: owned(_block,
             "window.read.request",
             sid,
             {},
@@ -6166,7 +6438,7 @@ def _agent_cbs(sid: str) -> dict:
     # this, and the finally block clears it so a stale closure can't fire.
     if _load_interim_assistant_messages():
         callbacks["interim_assistant_callback"] = (
-            lambda text, *, already_streamed=False: _emit(
+            lambda text, *, already_streamed=False: owned(_emit,
                 "message.interim",
                 sid,
                 {"text": str(text), "already_streamed": bool(already_streamed)},
@@ -6546,13 +6818,20 @@ def _preview_tool_result_preview(name: str, result: str) -> str:
     return str(data.get("error") or "").strip()[:1200]
 
 
-def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
+def _preview_restart_callbacks(
+    parent: str, task_id: str, *, expected_session: dict | None = None
+) -> dict:
     started_at: dict[str, float] = {}
 
     def progress(message: str, level: str = "info") -> None:
         text = str(message or "").strip()
         if text:
-            _emit("preview.restart.progress", parent, {"task_id": task_id, "level": level, "text": text})
+            _emit_for_session(
+                expected_session,
+                "preview.restart.progress",
+                parent,
+                {"task_id": task_id, "level": level, "text": text},
+            )
 
     def tool_start(tool_call_id: str, name: str, args: dict) -> None:
         started_at[tool_call_id] = time.time()
@@ -6688,8 +6967,8 @@ def _schedule_mcp_late_refresh(sid: str, agent) -> None:
             if not added:
                 return
             info = _session_info(agent, session)
-        # Emit outside the lock — write_json must not block under _sessions_lock.
-        _emit("session.info", sid, info)
+        # Emit outside the lock through the exact generation captured above.
+        _emit_for_session(session, "session.info", sid, info)
     threading.Thread(
         target=_wait_then_refresh,
         name=f"tui-mcp-late-refresh-{sid}",
@@ -7037,7 +7316,12 @@ def _init_session(
     try:
         from tools.approval import register_gateway_notify, load_permanent_allowlist
 
-        register_gateway_notify(key, lambda data: _emit_approval_request(sid, data))
+        register_gateway_notify(
+            key,
+            lambda data, _session=_sessions.get(sid): _run_session_owned(
+                _session, _emit_approval_request, sid, data
+            ),
+        )
         load_permanent_allowlist()
     except Exception:
         pass
@@ -7047,8 +7331,11 @@ def _init_session(
     # prompt_toolkit; the TUI has no equivalent print surface, so without
     # this callback the review would write the skill/memory change silently.
     try:
-        agent.background_review_callback = lambda message, _sid=sid: _emit(
-            "review.summary", _sid, {"text": str(message)}
+        agent.background_review_callback = lambda message, _sid=sid, _session=_sessions.get(sid): _emit_for_session(
+            _session,
+            "review.summary",
+            _sid,
+            {"text": str(message)},
         )
         # Honor display.memory_notifications (off | on | verbose) like the
         # messaging gateway and CLI do — otherwise the review always behaved as
@@ -7063,7 +7350,12 @@ def _init_session(
         if sid in _sessions:
             _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
     _notify_session_boundary("on_session_reset", key, _session_source(_sessions.get(sid, {})))
-    _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
+    _emit_for_session(
+        _sessions.get(sid),
+        "session.info",
+        sid,
+        _session_info(agent, _sessions.get(sid, {})),
+    )
     _schedule_mcp_late_refresh(sid, agent)
 
 
@@ -7796,7 +8088,10 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
             with session["history_lock"]:
                 session["running"] = False
 
-    threading.Thread(target=kickoff, daemon=True).start()
+    threading.Thread(
+        target=lambda: _run_session_owned(session, kickoff),
+        daemon=True,
+    ).start()
     logger.info(
         "auto-continue scheduled for session %s (attempt %d, interrupted %.0fs ago)",
         session_key,
@@ -8365,7 +8660,9 @@ def _claim_or_reuse_live(
     resume lock, or — if a concurrent resume already won — release ``lease`` and
     return the winner for the caller to reuse."""
     with _session_resume_lock:
-        live = _find_live_session_by_key(session_key)
+        live = _find_live_session_by_key(
+            session_key, profile_home=record.get("profile_home")
+        )
         if live is not None:
             if lease is not None:
                 lease.release()
@@ -8539,9 +8836,34 @@ def _session_lookup_key(session: dict, *, fallback: str = "") -> str:
     )
 
 
-def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
+def _profile_home_identity(profile_home: object) -> str | None:
+    """Canonical identity for a live session's profile scope."""
+    if profile_home is None:
+        return None
+    value = str(profile_home).strip()
+    if not value:
+        return None
+    try:
+        return str(Path(value).resolve())
+    except Exception:
+        return os.path.abspath(os.path.expanduser(value))
+
+
+def _find_live_session_by_key(
+    session_key: str, *, profile_home: object = _ANY_PROFILE_HOME
+) -> tuple[str, dict] | None:
+    requested_profile = (
+        _ANY_PROFILE_HOME
+        if profile_home is _ANY_PROFILE_HOME
+        else _profile_home_identity(profile_home)
+    )
     for sid, session in list(_sessions.items()):
         if session.get("_finalized"):
+            continue
+        if (
+            requested_profile is not _ANY_PROFILE_HOME
+            and _profile_home_identity(session.get("profile_home")) != requested_profile
+        ):
             continue
         if _session_lookup_key(session, fallback=sid) == session_key:
             return sid, session
@@ -8660,8 +8982,6 @@ def _live_session_payload(
     with session["history_lock"]:
         if cols is not None:
             session["cols"] = cols
-        if transport is not None:
-            session["transport"] = transport
         if touch:
             session["last_active"] = time.time()
         in_memory_history = list(session.get("display_history_prefix") or []) + list(
@@ -8710,6 +9030,26 @@ def _live_session_payload(
     if clarify := _pending_clarify_request_payload(sid):
         payload["pending_clarify"] = clarify
     return payload
+
+
+def _rebind_live_session_transport(
+    sid: str, session: dict, transport: Transport
+) -> bool:
+    """CAS a resume/activate transport without stealing a healthy live owner.
+
+    Callers serialize this with ``_session_resume_lock``. Same-owner resumes
+    are idempotent; only a dead/detached prior owner may be rebound.
+    """
+    with _sessions_lock:
+        if _sessions.get(sid) is not session or session.get("_finalized"):
+            return False
+        current = session.get("transport")
+        if current is transport:
+            return True
+        if current is not None and not _transport_is_dead(current):
+            return False
+        session["transport"] = transport
+        return True
 
 
 def _main_runtime_from_agent(agent) -> dict | None:
@@ -10128,28 +10468,31 @@ def _wire_agent_terminal_output() -> None:
     if has_output_sink and has_close_sink:
         return
 
-    def _owner_sid_for_process(session) -> str:
-        session_key = str(getattr(session, "session_key", "") or "")
-        if not session_key:
-            return ""
-        with _sessions_lock:
-            for sid, tui_session in _sessions.items():
-                if str(tui_session.get("session_key") or "") == session_key:
-                    return sid
-        return ""
+    def _owner_for_process(process_id: str) -> tuple[str, dict | None]:
+        with _process_event_owners_lock:
+            return _process_event_owners.get(process_id, ("", None))
 
     def _emit_agent_terminal_output(session, chunk):
-        _emit(
+        sid, owner = _owner_for_process(str(session.id))
+        _emit_for_session(
+            owner,
             "agent.terminal.output",
-            _owner_sid_for_process(session),
+            sid,
             {"process_id": session.id, "chunk": chunk},
         )
 
     def _emit_agent_terminal_close(session, process_id):
-        # session may be None (process already finished/pruned) — the tab can
-        # still linger and be closed; route to the owning window when we can.
-        sid = _owner_sid_for_process(session) if session is not None else ""
-        _emit("terminal.close", sid, {"process_id": process_id})
+        # session may be None (process already finished/pruned) — use the exact
+        # generation captured when the process-start tool completed.
+        sid, owner = _owner_for_process(str(process_id))
+        _emit_for_session(
+            owner,
+            "terminal.close",
+            sid,
+            {"process_id": process_id},
+        )
+        with _process_event_owners_lock:
+            _process_event_owners.pop(str(process_id), None)
 
     if not has_output_sink:
         process_registry.on_output = _emit_agent_terminal_output
@@ -10175,7 +10518,12 @@ def _wire_desktop_ui() -> None:
     except Exception:
         return
 
-    desktop_ui.set_emitter(lambda sid, event, payload: _emit(event, sid, payload))
+    def emit_owned(sid: str, event: str, payload: dict) -> None:
+        owner = _current_runtime_session_record.get()
+        if owner is not None:
+            _emit_for_session(owner, event, sid, payload)
+
+    desktop_ui.set_emitter(emit_owned)
     _desktop_ui_wired = True
 
 
@@ -10191,8 +10539,8 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     _wire_desktop_ui()
     stop = threading.Event()
     t = threading.Thread(
-        target=_notification_poller_loop,
-        args=(stop, sid, session),
+        target=_run_session_owned,
+        args=(session, _notification_poller_loop, stop, sid, session),
         daemon=True,
         # Stable, greppable name for debuggers and test teardowns.
         name=f"tui-notif-poller-{sid}",
@@ -14794,9 +15142,29 @@ def _(rid, params: dict) -> dict:
             if not _voice_mode_enabled():
                 return _err(rid, 4015, "voice mode is off — enable with /voice on")
 
+            requested_voice_sid = str(params.get("session_id") or "")
             with _voice_sid_lock:
                 global _voice_event_sid, _voice_wake_owner
-                _voice_event_sid = params.get("session_id") or _voice_event_sid
+                voice_sid = requested_voice_sid or _voice_event_sid
+                _voice_event_sid = voice_sid
+            with _sessions_lock:
+                voice_session = _sessions.get(voice_sid) if voice_sid else None
+
+            def _recording_voice_emit(event: str, payload: dict | None = None) -> None:
+                # A recording owns the exact session generation present when it
+                # started. Late audio callbacks must not follow mutable global
+                # voice state into a reused sid or a newer recording owner.
+                # Missing ownership also fails closed: an empty sid is the
+                # intentional global-broadcast route and is never valid for
+                # private recording output.
+                if not voice_sid or voice_session is None:
+                    return
+                _emit_session_owned(
+                    event,
+                    voice_sid,
+                    payload,
+                    expected_session=voice_session,
+                )
 
             from hermes_cli.voice import start_continuous
 
@@ -14847,11 +15215,11 @@ def _(rid, params: dict) -> dict:
                     _voice_wake_owner = transport
 
             def _on_transcript(t):
-                _voice_emit("voice.transcript", {"text": t})
+                _recording_voice_emit("voice.transcript", {"text": t})
                 _resume_voice_wake()
 
             def _on_silent():
-                _voice_emit("voice.transcript", {"no_speech_limit": True})
+                _recording_voice_emit("voice.transcript", {"no_speech_limit": True})
                 _resume_voice_wake()
 
             def _on_stop_phrase(t):
@@ -14868,11 +15236,13 @@ def _(rid, params: dict) -> dict:
                     _tts_stream_stop(user_barge=False)
                 except Exception:
                     pass
-                _voice_emit("voice.transcript", {"stop_phrase": True, "text": t})
+                _recording_voice_emit(
+                    "voice.transcript", {"stop_phrase": True, "text": t}
+                )
                 _resume_voice_wake()
 
             def _on_status(state):
-                _voice_emit("voice.status", {"state": state})
+                _recording_voice_emit("voice.status", {"state": state})
                 if state == "idle":
                     _resume_voice_wake()
 
@@ -14902,6 +15272,9 @@ def _(rid, params: dict) -> dict:
             return _ok(rid, {"status": "recording"})
 
         # action == "stop"
+        # Preserve the process-global UI owner for subsequent non-recording
+        # voice events. Active recording callbacks do not consult this mutable
+        # value: they are fenced to the immutable owner captured at start.
         with _voice_sid_lock:
             _voice_event_sid = params.get("session_id") or _voice_event_sid
 


### PR DESCRIPTION
## Problem
Current `main` can misroute session-private output when asynchronous producers outlive their original runtime-session generation. The vulnerable call paths are the generic gateway routing and lifecycle helpers in `tui_gateway/server.py`: `write_json`/`_emit` can fall through without proving the exact live owner, resume can rebind a healthy session transport, and disconnect/callback teardown can act on a reused session ID rather than the captured record.

This can send stale voice, compression, child-relay, terminal/process, preview, notification, or background output to a replacement transport after reconnect or session-ID reuse.

## Fix
- require nonempty session IDs to resolve to the exact live, non-finalized runtime record and healthy explicit transport
- capture runtime-session record identity in asynchronous producers and reject stale generations
- make resume/activate transport rebinding compare-and-set and refuse healthy transport theft
- make disconnect teardown compare-and-set the exact record and old transport
- key parent/child runtime state by profile home plus child session ID
- fail closed for explicit missing profiles instead of falling back to the launch database
- preserve normal sessionless global output behavior

## Scope
This PR is limited to generic TUI gateway session ownership and regressions: 10 files, with no local-client capability broker, ticket subsystem, Desktop integration, product-specific profile roster, Docker mailbox bridge, or new configuration/environment variable.

## Verification
- focused session-ownership regressions: **132 passed**
- complete TUI gateway suite: **1,105 passed**
- changed Python modules compiled successfully
- product-coupling diff scan passed
- `git diff --check` passed

## Invariant
For every nonempty session ID, private output fails closed unless the exact captured live session generation owns a healthy explicit transport. Only the intentional sessionless path may use global fallback.