### PR TITLE
fix(update): bound the cua-driver installer drain after a failed kill

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1130,6 +1130,15 @@ def install_cua_driver(
 # headroom for the actual download/swap.
 _CUA_INSTALLER_TIMEOUT = 660
 
+# Grace period for draining the installer's pipes after a timeout kill. The
+# kill is best-effort (see _reap_after_timeout), so this drain has to be
+# bounded: a descendant that survived the kill still holds the inherited
+# stdout handle, and an unbounded read waits on an EOF that never comes,
+# which turns the ceiling above into no ceiling at all (issue #87703). A
+# successful kill closes the pipe immediately, so this costs nothing in the
+# normal case; it only caps how long a failed one can stall the update.
+_CUA_INSTALLER_DRAIN_GRACE = 15
+
 # Upstream installer's stale-lock threshold (LOCK_STALE_AFTER_SECONDS in
 # _install-rust.sh). Used by the pre-clear below to avoid yanking a lock
 # that a live-but-slow install still holds.
@@ -1540,6 +1549,44 @@ def _run_cua_driver_installer(
         except (OSError, ProcessLookupError):
             proc.kill()
 
+    def _reap_after_timeout(proc):
+        """Kill the installer tree, then drain its pipes under a deadline.
+
+        ``_kill_installer_tree`` is best-effort by construction: every
+        ``psutil.Error`` it can raise is logged at debug level and stepped
+        over, on the reasoning that a partly-killed tree beats none. The case
+        that matters is an ``install.ps1`` which self-elevated through
+        ``Start-Process -Verb RunAs``: that descendant runs at High integrity,
+        a medium-integrity kill gets ``AccessDenied``, and the survivor is
+        still holding the ``stdout=PIPE`` write handle it inherited.
+
+        Draining with no deadline then blocks on an EOF that only arrives when
+        someone kills that process by hand, so the ``_CUA_INSTALLER_TIMEOUT``
+        ceiling stops bounding anything and ``hermes update`` hangs past its
+        own timeout warning (#87703). Bound the drain instead: a kill that
+        landed closes the pipe at once, and one that did not costs
+        ``_CUA_INSTALLER_DRAIN_GRACE`` rather than forever. The caller
+        re-raises the original ``TimeoutExpired`` either way, so the manual
+        re-run hint still prints and the update unwinds. Losing the tail of a
+        timed-out installer's log is the cheaper half of that trade.
+        """
+        _kill_installer_tree(proc)
+        try:
+            proc.communicate(timeout=_CUA_INSTALLER_DRAIN_GRACE)
+        except subprocess.TimeoutExpired:
+            # Deliberately not closing proc.stdout here. communicate()'s
+            # reader threads are still blocked on that handle and closing it
+            # underneath them races; they are daemon threads, so abandoning
+            # them does not keep the interpreter alive.
+            logger.debug(
+                "cua-driver installer pipes still open %ss after the kill — "
+                "abandoning the drain, a surviving descendant holds the "
+                "inherited handle",
+                _CUA_INSTALLER_DRAIN_GRACE,
+            )
+        except (OSError, ValueError) as e:
+            logger.debug("cua-driver installer drain failed: %s", e)
+
     try:
         # When not verbose (e.g. `hermes update`'s refresh), capture the
         # installer's chatty "Next steps" wall instead of dumping it to the
@@ -1555,8 +1602,7 @@ def _run_cua_driver_installer(
             try:
                 proc.communicate(timeout=_CUA_INSTALLER_TIMEOUT)
             except subprocess.TimeoutExpired:
-                _kill_installer_tree(proc)
-                proc.communicate()
+                _reap_after_timeout(proc)
                 raise
             result = subprocess.CompletedProcess(
                 install_cmd, proc.returncode, stdout=None, stderr=None
@@ -1572,8 +1618,7 @@ def _run_cua_driver_installer(
             try:
                 out, _ = proc.communicate(timeout=_CUA_INSTALLER_TIMEOUT)
             except subprocess.TimeoutExpired:
-                _kill_installer_tree(proc)
-                proc.communicate()
+                _reap_after_timeout(proc)
                 raise
             result = subprocess.CompletedProcess(
                 install_cmd, proc.returncode, stdout=out, stderr=None

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -764,6 +764,189 @@ class TestInstallerTimeoutKillsProcessGroup:
         assert fake_proc.communicate.call_count == 2
 
 
+class TestInstallerTimeoutDrainIsBounded:
+    """The drain that follows the timeout kill must carry its own deadline.
+
+    ``_kill_installer_tree`` is best-effort: every ``psutil.Error`` it can hit
+    is logged at debug level and stepped over, so the tree it leaves behind
+    can still contain a live process — on Windows, most concretely, an
+    ``install.ps1`` that self-elevated through ``Start-Process -Verb RunAs``
+    and cannot be killed from a medium-integrity parent. That survivor holds
+    the ``stdout=PIPE`` write handle it inherited, so reading to EOF is
+    reading for something that will not happen, and ``_CUA_INSTALLER_TIMEOUT``
+    stops being a ceiling (#87703).
+
+    Asserted through the ``timeout`` kwarg rather than by timing: a test that
+    proved the hang by hanging would be the same defect wearing a test's name.
+    """
+
+    def test_drain_grace_is_short_relative_to_the_run_ceiling(self):
+        from hermes_cli import tools_config
+
+        # This is a grace period for a pipe that a live process is holding
+        # open, not a second budget for the install itself — the install is
+        # already over by the time it is used.
+        assert 0 < tools_config._CUA_INSTALLER_DRAIN_GRACE
+        assert (
+            tools_config._CUA_INSTALLER_DRAIN_GRACE
+            < tools_config._CUA_INSTALLER_TIMEOUT / 10
+        )
+
+    @pytest.mark.linux_only
+    def test_post_kill_drain_passes_a_deadline(self):
+        """``linux_only``: reaches the timeout handler through the real POSIX
+        ``killpg`` branch, so the drain under test is the one this lane runs.
+        """
+        import subprocess
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 12345
+        fake_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="x", timeout=1),
+            ("", None),
+        ]
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stderr="")), \
+             patch("subprocess.Popen", return_value=fake_proc), \
+             patch.object(tools_config.os, "getpgid", return_value=99999, create=True), \
+             patch.object(tools_config.os, "killpg", create=True), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"):
+            ok = tools_config._run_cua_driver_installer(label="Refreshing", verbose=False)
+
+        assert ok is False
+        assert fake_proc.communicate.call_count == 2
+        drain_timeout = fake_proc.communicate.call_args_list[1].kwargs.get("timeout")
+        assert drain_timeout is not None, (
+            "the post-kill drain was issued without a deadline, so a survivor "
+            "of the kill can hold it open indefinitely"
+        )
+        assert drain_timeout == tools_config._CUA_INSTALLER_DRAIN_GRACE
+
+    @pytest.mark.linux_only
+    def test_verbose_path_drains_under_the_same_deadline(self):
+        """The streaming install has the same handler and had the same hole.
+
+        Its child inherits the console rather than a pipe, so the stall is
+        harder to hit there, but the two branches should not be allowed to
+        drift on a rule this small.
+        """
+        import subprocess
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 12345
+        fake_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="x", timeout=1),
+            ("", None),
+        ]
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stderr="")), \
+             patch("subprocess.Popen", return_value=fake_proc), \
+             patch.object(tools_config.os, "getpgid", return_value=99999, create=True), \
+             patch.object(tools_config.os, "killpg", create=True), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"), \
+             patch.object(tools_config, "_print_success"):
+            ok = tools_config._run_cua_driver_installer(label="Installing", verbose=True)
+
+        assert ok is False
+        assert fake_proc.communicate.call_count == 2
+        drain_timeout = fake_proc.communicate.call_args_list[1].kwargs.get("timeout")
+        assert drain_timeout is not None, (
+            "the streaming path's drain was issued without a deadline"
+        )
+        assert drain_timeout == tools_config._CUA_INSTALLER_DRAIN_GRACE
+
+    @pytest.mark.windows_only
+    def test_unkillable_elevated_descendant_does_not_stall_the_drain(self):
+        """The reported scenario, with the kill refused exactly where it is.
+
+        ``install.ps1`` self-elevates, so the descendant is High-IL and
+        ``child.kill()`` raises ``AccessDenied`` — which the tree-kill catches
+        and logs, by design. The survivor is then still holding the pipe, and
+        the drain is the only thing standing between that and an indefinite
+        hang.
+        """
+        import psutil
+        import subprocess
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        child = MagicMock()
+        child.kill.side_effect = psutil.AccessDenied(pid=999)
+        parent = MagicMock()
+        parent.children.return_value = [child]
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 12345
+        fake_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="powershell", timeout=1),
+            ("", None),
+        ]
+
+        with patch("subprocess.Popen", return_value=fake_proc), \
+             patch("psutil.Process", return_value=parent), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"):
+            ok = tools_config._run_cua_driver_installer(
+                label="Refreshing", verbose=False
+            )
+
+        assert ok is False
+        # The refused child kill must not abort the rest of the sweep.
+        parent.kill.assert_called_once_with()
+        drain_timeout = fake_proc.communicate.call_args_list[1].kwargs.get("timeout")
+        assert drain_timeout is not None, (
+            "a High-IL descendant survived the kill and the drain was issued "
+            "without a deadline, which is the reported hang"
+        )
+        assert drain_timeout == tools_config._CUA_INSTALLER_DRAIN_GRACE
+
+    @pytest.mark.windows_only
+    def test_drain_that_times_out_still_surfaces_the_run_timeout(self):
+        """A guardrail, not a regression test — it passes without the fix too.
+
+        What it pins is that the drain's own ``TimeoutExpired`` must not be
+        the one that escapes: the caller has to see the original run timeout
+        so the existing manual re-run hint prints and ``hermes update``
+        unwinds. That is the behaviour a future refactor of the drain is most
+        likely to break silently.
+        """
+        import subprocess
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        parent = MagicMock()
+        parent.children.return_value = []
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 12345
+        fake_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="powershell", timeout=660),
+            subprocess.TimeoutExpired(cmd="powershell", timeout=15),
+        ]
+
+        with patch("subprocess.Popen", return_value=fake_proc), \
+             patch("psutil.Process", return_value=parent), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_print_warning") as warn, \
+             patch.object(tools_config, "_print_info"):
+            ok = tools_config._run_cua_driver_installer(
+                label="Refreshing", verbose=False
+            )
+
+        assert ok is False
+        warned = " ".join(str(c.args[0]) for c in warn.call_args_list if c.args)
+        assert "timed out after" in warned
+
+
 @pytest.mark.linux_only
 class TestInstallerNoShell:
     """The POSIX installer path must not use shell=True or command


### PR DESCRIPTION
## What does this PR do?

On Windows, `hermes update` can hang past its own 660s cua-driver timeout until the user kills an orphaned PowerShell by hand. The ceiling is not the problem; the code that runs after it is.

`_run_cua_driver_installer` handles `TimeoutExpired` by killing the process tree and then draining the pipes with a bare `proc.communicate()`:

```python
except subprocess.TimeoutExpired:
    _kill_installer_tree(proc)
    proc.communicate()          # no timeout
    raise
```

`_kill_installer_tree` is best-effort by construction: every `psutil.Error` it can hit is logged at debug level and stepped over, on the reasoning that a partly killed tree beats none. That is the right call, but it means the drain has to survive a partial kill, and an unbounded drain does not.

The concrete case is the one reported in #87703. `install.ps1` self-elevates through `Start-Process -Verb RunAs`, so the descendant runs at High integrity and a medium-integrity `child.kill()` raises `psutil.AccessDenied`. The per-child handler logs it and moves on. That survivor is still holding the `stdout=PIPE` write handle it inherited, so the `communicate()` that follows waits for an EOF which arrives only when somebody kills that process manually. A bounded 660s wait becomes an unbounded one, after the warning has already printed. The comment above the Windows branch already anticipates the shape of this ("descendants inherit stdout and can keep both `communicate()` and `install.lock` wedged") and mitigates it by killing leaf-up, but leaf-up ordering does not help when a kill is refused outright.

The POSIX path is safer only by accident: `killpg` with `SIGKILL` cannot be blocked. The fix is not platform-specific because the hole is in the handler, not the killer.

**Why bounding rather than closing the handles or hardening the kill.** Closing `proc.stdout` here would race: `communicate()`'s reader threads are still blocked on that handle. They are daemon threads, so abandoning them does not hold the interpreter open. Hardening the kill (elevating to kill a High-IL process) is not something an update step should be doing, and would still leave the drain unbounded for every other reason a kill can fail. Bounding is the smallest change that makes the failure survivable, and it degrades in the right direction: the only thing lost is the tail of the log of a run that has already failed.

## Related Issue

Fixes #87703

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/tools_config.py` — added `_CUA_INSTALLER_DRAIN_GRACE = 15`, the deadline for draining a timed-out installer's pipes. Documented as a grace period for a pipe a live process is holding, not a second budget for the install.
- `hermes_cli/tools_config.py` — added `_reap_after_timeout(proc)`, which wraps `_kill_installer_tree` plus a bounded drain, and swallows only the drain's own `TimeoutExpired`. Both timeout handlers (streaming and captured) now call it, so the original run timeout is still what reaches the caller and the existing manual re-run hint still prints.
- `tests/hermes_cli/test_install_cua_driver.py` — new `TestInstallerTimeoutDrainIsBounded` with 5 tests.

The streaming branch had the same hole. Its child inherits the console rather than a pipe, so stalling there is much harder, but the two branches should not be allowed to drift on a rule this small.

## How to Test

1. **Regression tests fail without the fix.** Revert only `hermes_cli/tools_config.py` and run `pytest tests/hermes_cli/test_install_cua_driver.py::TestInstallerTimeoutDrainIsBounded -q`. Two fail, with the behaviour named rather than an attribute error:

   ```
   AssertionError: a High-IL descendant survived the kill and the drain was issued
   without a deadline, which is the reported hang
   assert None is not None
   ```

2. **Full file, with the fix** (Windows 11, Python 3.13): `31 passed, 17 skipped, 5 failed`. The same 5 fail identically on clean `upstream/main` at `56526bc0d` with no changes applied. They are Linux-lane tests that carry no platform marker and assert POSIX-only values on a Windows host (e.g. `test_posix_default_unchanged` asserts `8.0`, gets the Windows default `25.0`; the `runs_installer` cases need `powershell` resolution the fakes do not provide). Unrelated to this change, and worth a separate issue if maintainers want them marked.

3. **The reported scenario, end to end**: `test_unkillable_elevated_descendant_does_not_stall_the_drain` sets `child.kill.side_effect = psutil.AccessDenied(...)`, which is exactly what a medium-IL process gets when it tries to kill a UAC-elevated `install.ps1`, and asserts both that the refused kill does not abort the rest of the sweep and that the drain still carries a deadline.

4. **`ruff check`** clean on both files. **`scripts/check-windows-footguns.py --all`** clean, 973 files.

The deadline is asserted as a `timeout` kwarg rather than by wall-clock timing on purpose: a test that proved the hang by hanging would be the same defect wearing a test's name.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — see "How to Test" step 2 for the 5 pre-existing platform-lane failures, reproduced on clean `main`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro 26200, Python 3.13.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper carries the full rationale in its docstring; no user-facing docs describe this internal timeout
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the bug is reachable on Windows in practice, but the fix is in the shared handler and both platforms take it. POSIX gets there through `killpg`/`SIGKILL`, which normally closes the pipe at once, so the grace period costs it nothing. Two of the new tests are `linux_only` and two are `windows_only`, so each lane exercises its own branch rather than faking the other's process model.
- [x] N/A — no tool behaviour or schema change

## Notes for reviewers

**Overlap with #79871, deliberately avoided.** #79684 / open PR #79871 fix a different mechanism in this same function: `install.ps1`'s `Read-Host` prompt writes into the captured stdout while stdin stays inherited, so the installer blocks on input nobody can supply. That fix is a one-line `stdin=subprocess.DEVNULL` on the `Popen` call. This PR does not touch that line, and the two should merge cleanly. They are also genuinely independent: `DEVNULL` cannot unblock a `Start-Process -Verb RunAs` UAC dialog, which is a GUI elevation prompt rather than a stdin read, and this PR does nothing to stop the prompt from appearing. Both are needed.

**Style.** The new tests use backslash-continued `with` statements, matching every other test in the file. `ruff format` would rewrite them to parenthesized form, but it wants to rewrite 167 pre-existing hunks in this file the same way, so following it here would make four tests look unlike their forty neighbours without making the file any more compliant. Happy to flip them if you would rather.

**Not addressed, on purpose.** `_kill_installer_tree` still reports a refused kill only at debug level, so a user whose descendant survived sees the generic timeout warning and no hint about why. Surfacing that would be a real improvement, but it changes user-facing output and belongs in its own change rather than riding along here.
