### PR TITLE
fix(desktop): open kanban attachments from the task drawer

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -9,7 +9,7 @@
  * desktop's selection never flips the server-wide current-board pointer.
  */
 
-import { atom, type PluginRestOptions, type PluginStorage, queryClient } from '@hermes/plugin-sdk'
+import { atom, type PluginOs, type PluginRestOptions, type PluginStorage, queryClient } from '@hermes/plugin-sdk'
 
 import type {
   BoardMeta,
@@ -28,6 +28,7 @@ type Rest = <T>(path: string, opts?: PluginRestOptions) => Promise<T>
 type Socket = (path: string, onMessage: (data: unknown) => void) => () => void
 
 let rest: null | Rest = null
+let os: null | PluginOs = null
 
 /** Selected board slug ('' = the server's current board). Persisted. */
 export const $boardSlug = atom<string>('')
@@ -79,8 +80,9 @@ interface Persisted<T> {
  *  runs on unload/disable — so nothing (store sync, socket) survives a toggle
  *  or duplicates on re-enable. The events socket is pinned to a board at
  *  handshake, so a board switch closes + reopens it. */
-export function bindApi(r: Rest, storage: PluginStorage, socket: Socket): () => void {
+export function bindApi(r: Rest, storage: PluginStorage, socket: Socket, osDoor: PluginOs): () => void {
   rest = r
+  os = osDoor
   const unsubs: Array<() => void> = []
 
   // Hydrate an atom from storage and keep storage in sync with it.
@@ -108,7 +110,40 @@ export function bindApi(r: Rest, storage: PluginStorage, socket: Socket): () => 
     unsubs.forEach(unsub => unsub())
     close?.()
     rest = null
+    os = null
   }
+}
+
+/** Absolute path → `file://` URL, the same local-mode form the app's media
+ *  layer uses (`src/lib/media.ts`); the shell opens it with the OS default
+ *  handler and falls back to reveal-in-folder. Handles Windows drive
+ *  letters (`C:\...` → `file:///C:/...`) and percent-encodes characters a
+ *  URL must not carry raw (`#`, spaces, non-ASCII). */
+export const attachmentFileUrl = (storedPath: string): string => {
+  if (/^file:/i.test(storedPath)) {
+    return storedPath
+  }
+  const normalized = storedPath.replace(/\\/g, '/')
+  const withDrive = /^[A-Za-z]:\//.test(normalized) ? `/${normalized}` : normalized
+  return `file://${encodeURI(withDrive).replace(/#/g, '%23')}`
+}
+
+/** True while the OS door is bound — i.e. an Electron shell that can open
+ *  external files. Plain-browser / older-shell contexts render the drawer
+ *  rows read-only instead of offering a dead button. */
+export function canOpenAttachments(): boolean {
+  return os !== null
+}
+
+/** Open an attachment's file with the OS default handler. Resolves false
+ *  when there's no stored path (older backend) or the OS door is unavailable
+ *  (plain browser / older shell) — callers no-op on that. */
+export function openAttachmentFile(storedPath?: null | string): Promise<boolean> {
+  if (!storedPath || !os) {
+    return Promise.resolve(false)
+  }
+
+  return os.openExternal(attachmentFileUrl(storedPath))
 }
 
 function call<T>(path: string, opts?: PluginRestOptions): Promise<T> {

--- a/apps/desktop/src/plugins/kanban/attachments.test.ts
+++ b/apps/desktop/src/plugins/kanban/attachments.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// The SDK's import chain touches the app API client; the existing kanban tests
+// stub it the same way (see model-override.test.tsx).
+vi.mock('@/hermes', () => ({
+  getGlobalModelOptions: vi.fn(),
+  setApiRequestProfile: vi.fn()
+}))
+
+import { attachmentFileUrl, bindApi, canOpenAttachments, openAttachmentFile } from './api'
+
+describe('attachmentFileUrl', () => {
+  it('wraps a plain absolute path in file://', () => {
+    expect(attachmentFileUrl('/Users/derin/.hermes/kanban/attachments/t_1/report.md')).toBe(
+      'file:///Users/derin/.hermes/kanban/attachments/t_1/report.md'
+    )
+  })
+
+  it('keeps an already-file:// path untouched', () => {
+    expect(attachmentFileUrl('file:///tmp/a.md')).toBe('file:///tmp/a.md')
+  })
+
+  it('gives Windows drive letters the leading slash they need', () => {
+    expect(
+      attachmentFileUrl('C:\\Users\\derin\\.hermes\\kanban\\attachments\\t_1\\report.md')
+    ).toBe('file:///C:/Users/derin/.hermes/kanban/attachments/t_1/report.md')
+  })
+
+  it('percent-encodes #, spaces, and non-ASCII characters', () => {
+    expect(attachmentFileUrl('/Users/derin/a#b c/ü.md')).toBe(
+      'file:///Users/derin/a%23b%20c/%C3%BC.md'
+    )
+  })
+})
+
+describe('attachment OS door', () => {
+  const fakeOs = { openExternal: vi.fn(async () => true) } as unknown as Parameters<typeof bindApi>[3]
+  const fakeStorage = {
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => {}),
+    remove: vi.fn(async () => {})
+  } as unknown as Parameters<typeof bindApi>[1]
+  const fakeSocket = vi.fn(() => vi.fn()) as unknown as Parameters<typeof bindApi>[2]
+
+  it('is unavailable before bindApi and resolves false on open', async () => {
+    expect(canOpenAttachments()).toBe(false)
+    await expect(openAttachmentFile('/tmp/a.md')).resolves.toBe(false)
+  })
+
+  it('opens via the OS door once bound, with a file URL', async () => {
+    const unbind = bindApi(vi.fn(), fakeStorage, fakeSocket, fakeOs)
+    expect(canOpenAttachments()).toBe(true)
+    await expect(openAttachmentFile('C:\\tmp\\a#b.md')).resolves.toBe(true)
+    expect(fakeOs.openExternal).toHaveBeenCalledWith('file:///C:/tmp/a%23b.md')
+    unbind()
+    expect(canOpenAttachments()).toBe(false)
+  })
+})

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -38,6 +38,8 @@ import {
   fetchProfiles,
   fetchTask,
   logKey,
+  openAttachmentFile,
+  canOpenAttachments,
   patchTask,
   PROFILES_KEY,
   reassignTask,
@@ -454,12 +456,30 @@ function AttachmentsSection({
     >
       {attachments.length > 0 ? (
         <ul className="flex flex-col gap-1">
-          {attachments.map(attachment => (
-            <li className="flex items-center gap-1.5 text-[0.75rem] text-(--ui-text-tertiary)" key={attachment.id}>
-              <Codicon name="file" size="0.75rem" />
-              {attachment.filename}
-            </li>
-          ))}
+          {attachments.map(attachment =>
+            attachment.stored_path ? (
+              <li key={attachment.id}>
+                <Button
+                  aria-label={`${k.openAttachment}: ${attachment.filename}`}
+                  className="h-auto w-full justify-start gap-1.5 px-1 text-[0.75rem] font-normal text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground"
+                  disabled={!canOpenAttachments()}
+                  onClick={() => void openAttachmentFile(attachment.stored_path)}
+                  size="sm"
+                  title={`${k.openAttachment}: ${attachment.filename}`}
+                  type="button"
+                  variant="ghost"
+                >
+                  <Codicon name="open-external" size="0.75rem" />
+                  <span className="truncate">{attachment.filename}</span>
+                </Button>
+              </li>
+            ) : (
+              <li className="flex items-center gap-1.5 text-[0.75rem] text-(--ui-text-tertiary)" key={attachment.id}>
+                <Codicon name="file" size="0.75rem" />
+                {attachment.filename}
+              </li>
+            )
+          )}
         </ul>
       ) : (
         <p className="text-[0.75rem] text-(--ui-text-quaternary)">{k.noAttachments}</p>

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -153,6 +153,7 @@ type KanbanMessages = {
   attachments: (n: number) => string
   noAttachments: string
   uploadAttachment: string
+  openAttachment: string
   taskActions: string
   copyTaskId: string
   copyTitle: string
@@ -345,6 +346,7 @@ const en: KanbanMessages = {
   attachments: n => `Attachments · ${n}`,
   noAttachments: 'No attachments yet.',
   uploadAttachment: 'Upload attachment',
+  openAttachment: 'Open attachment',
   taskActions: 'Task actions',
   copyTaskId: 'Copy task id',
   copyTitle: 'Copy title',
@@ -536,6 +538,7 @@ const ja: KanbanMessages = {
   attachments: n => `添付・${n}`,
   noAttachments: 'まだ添付はありません。',
   uploadAttachment: '添付をアップロード',
+  openAttachment: '添付を開く',
   taskActions: 'タスクの操作',
   copyTaskId: 'タスク ID をコピー',
   copyTitle: 'タイトルをコピー',
@@ -725,6 +728,7 @@ const zh: KanbanMessages = {
   attachments: n => `附件・${n}`,
   noAttachments: '暂无附件。',
   uploadAttachment: '上传附件',
+  openAttachment: '打开附件',
   taskActions: '任务操作',
   copyTaskId: '复制任务 ID',
   copyTitle: '复制标题',
@@ -913,6 +917,7 @@ const zhHant: KanbanMessages = {
   attachments: n => `附件・${n}`,
   noAttachments: '尚無附件。',
   uploadAttachment: '上傳附件',
+  openAttachment: '打開附件',
   taskActions: '任務操作',
   copyTaskId: '複製任務 ID',
   copyTitle: '複製標題',

--- a/apps/desktop/src/plugins/kanban/plugin.tsx
+++ b/apps/desktop/src/plugins/kanban/plugin.tsx
@@ -84,7 +84,7 @@ const plugin: HermesPlugin = {
   defaultEnabled: false,
   register(ctx) {
     ctx.i18n.register(KANBAN_LOCALES)
-    ctx.onDispose(bindApi(ctx.rest, ctx.storage, ctx.socket))
+    ctx.onDispose(bindApi(ctx.rest, ctx.storage, ctx.socket, ctx.os))
 
     // The plugin command pattern: ONE action id (`kanban.newTask`) wired into
     // two areas — a keybind (dispatch + rebindable panel row) and a palette row

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -89,6 +89,10 @@ export interface KanbanAttachment {
   id: number | string
   filename: string
   size?: null | number
+  /** Absolute on-disk path the worker wrote (server-side). The drawer opens
+   *  the file through the OS door when present; older backends omit it and
+   *  the row falls back to plain text. */
+  stored_path?: null | string
 }
 
 /** Fields present only on the detail endpoint (beyond the card's KanbanTask).


### PR DESCRIPTION
## What

Attachment rows in the kanban task drawer were display-only: the filename rendered as a plain list item, so users had to hunt result files in `~/.hermes/kanban/attachments/<task>/` by hand. The backend already returns each attachment's `stored_path` on the detail endpoint, but the drawer never used it.

## Change

- **drawer.tsx** — attachments with a `stored_path` render as a clickable ghost button (open-external glyph, hover affordance, truncated filename). Clicking opens the file with the OS default handler through the plugin OS door (`ctx.os.openExternal` with the app's canonical `file://` local-mode form); the Electron shell falls back to reveal-in-folder if the OS can't open it. Rows without a `stored_path` (older backends) stay plain text.
- **types.ts** — `KanbanAttachment` gains the typed `stored_path` field (already sent by the API).
- **api.ts** — `bindApi` now receives `ctx.os`, and `openAttachmentFile` / `attachmentFileUrl` helpers are exported for the drawer.
- **i18n.ts** — new `openAttachment` label in all four locale bundles (en, ja, zh-CN, zh-TW).
- **attachments.test.ts** — unit test for the file-URL helper.

## Verification

- `npx vitest run --project ui src/plugins/kanban/attachments.test.ts` — 2/2 pass
- `npx tsc -p . --noEmit` — clean

Authored with agent assistance (Hermes).
