### PR TITLE
fix(telegram): make numbered Sources citations clickable

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -492,6 +492,76 @@ def _strip_mdv2(text: str) -> str:
     return cleaned
 
 
+def _citation_source_urls(content: str) -> tuple[Optional[int], dict[str, str]]:
+    """Return the Sources block line and its numbered URL mappings.
+
+    Research replies may use ``[16]`` inline citations and declare the
+    corresponding URLs later under ``Sources`` or ``Источники``.  Markdown
+    treats the marker as plain text, so it needs to be joined with its URL
+    before Telegram's MarkdownV2 conversion.  The block boundary is returned
+    so callers can leave the bibliography itself unchanged.
+    """
+    lines = content.splitlines()
+    source_start = None
+    for index, line in enumerate(lines):
+        normalized = line.strip().strip("*#_ ").rstrip(":").strip("*#_ ").strip().lower()
+        if normalized in {"sources", "источники"}:
+            source_start = index
+            break
+    if source_start is None:
+        return None, {}
+
+    mappings: dict[str, str] = {}
+    for line in lines[source_start + 1 :]:
+        match = re.match(r"^\s*\[(\d+)\]\s+(.+?)\s*$", line)
+        if not match:
+            continue
+        number, remainder = match.groups()
+
+        # Prefer an existing Markdown link, including simple parenthesized
+        # URL segments such as ``https://example.com/paper_(2026)``.
+        link_match = re.search(
+            r"\]\((https?://(?:[^()]|\([^()]*\))*)\)", remainder
+        )
+        if link_match:
+            mappings[number] = link_match.group(1)
+            continue
+
+        bare_match = re.search(r"https?://\S+", remainder)
+        if bare_match:
+            mappings[number] = bare_match.group(0).rstrip(".,;:!?\u3002\u3001")
+    return source_start, mappings
+
+
+def _link_citations_to_sources(content: str) -> str:
+    """Turn declared bare citation markers such as ``[16]`` into links."""
+    source_start, source_urls = _citation_source_urls(content)
+    if source_start is None or not source_urls:
+        return content
+
+    lines = content.splitlines(keepends=True)
+    before_sources = "".join(lines[:source_start])
+    sources_block = "".join(lines[source_start:])
+
+    def replace(match: re.Match[str]) -> str:
+        number = match.group(1)
+        url = source_urls.get(number)
+        # The nested brackets make the visible link text ``[16]`` rather than
+        # using the outer Markdown brackets as the only link syntax.
+        return f"[[{number}]]({url})" if url else match.group(0)
+
+    def replace_outside_code(text: str) -> str:
+        parts = re.split(r"(```[\\s\\S]*?```|`[^`]+`)", text)
+        for index in range(0, len(parts), 2):
+            parts[index] = re.sub(r"\[(\d+)\](?!\()", replace, parts[index])
+        return "".join(parts)
+
+    # Do not rewrite the numbered entries in the Sources block itself.  They
+    # may already have a linked title, and changing them would duplicate the
+    # same URL in the rendered bibliography.
+    return replace_outside_code(before_sources) + sources_block
+
+
 _CHUNK_INDICATOR_ON_FENCE_RE = re.compile(
     r'(?m)^``` (?P<indicator>(?:\\)?\(\d+/\d+(?:\\)?\))$'
 )
@@ -8349,16 +8419,23 @@ class TelegramAdapter(BasePlatformAdapter):
             text,
         )
 
-        # 3) Convert markdown links – escape the display text; inside the URL
-        #    only ')' and '\' need escaping per the MarkdownV2 spec.
+        # 3) Join numbered citations with URLs declared in the Sources block.
+        text = _link_citations_to_sources(text)
+
+        # 4) Convert markdown links – escape the display text; inside the URL
+        #    only ')' and '\\' need escaping per the MarkdownV2 spec.
         def _convert_link(m):
             display = _escape_mdv2(m.group(1))
             url = m.group(2).replace('\\', '\\\\').replace(')', '\\)')
             return _ph(f'[{display}]({url})')
 
-        text = re.sub(r'\[([^\]]+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)', _convert_link, text)
+        text = re.sub(
+            r'\[((?:\[[^\]]+\]|[^\]])+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)',
+            _convert_link,
+            text,
+        )
 
-        # 4) Convert markdown headers (## Title) → bold *Title*
+        # 5) Convert markdown headers (## Title) → bold *Title*
         def _convert_header(m):
             inner = m.group(1).strip()
             # Strip redundant bold markers that may appear inside a header
@@ -8369,14 +8446,14 @@ class TelegramAdapter(BasePlatformAdapter):
             r'^#{1,6}\s+(.+)$', _convert_header, text, flags=re.MULTILINE
         )
 
-        # 5) Convert bold: **text** → *text* (MarkdownV2 bold)
+        # 6) Convert bold: **text** → *text* (MarkdownV2 bold)
         text = re.sub(
             r'\*\*(.+?)\*\*',
             lambda m: _ph(f'*{_escape_mdv2(m.group(1))}*'),
             text,
         )
 
-        # 6) Convert italic: *text* (single asterisk) → _text_ (MarkdownV2 italic)
+        # 7) Convert italic: *text* (single asterisk) → _text_ (MarkdownV2 italic)
         #    [^*\n]+ prevents matching across newlines (which would corrupt
         #    bullet lists using * markers and multi-line content).
         text = re.sub(
@@ -8385,21 +8462,21 @@ class TelegramAdapter(BasePlatformAdapter):
             text,
         )
 
-        # 7) Convert strikethrough: ~~text~~ → ~text~ (MarkdownV2)
+        # 8) Convert strikethrough: ~~text~~ → ~text~ (MarkdownV2)
         text = re.sub(
             r'~~(.+?)~~',
             lambda m: _ph(f'~{_escape_mdv2(m.group(1))}~'),
             text,
         )
 
-        # 8) Convert spoiler: ||text|| → ||text|| (protect from | escaping)
+        # 9) Convert spoiler: ||text|| → ||text|| (protect from | escaping)
         text = re.sub(
             r'\|\|(.+?)\|\|',
             lambda m: _ph(f'||{_escape_mdv2(m.group(1))}||'),
             text,
         )
 
-        # 9) Convert blockquotes: > at line start → protect > from escaping
+        # 10) Convert blockquotes: > at line start → protect > from escaping
         #    Handle both regular blockquotes (> text) and expandable blockquotes
         #    (Telegram MarkdownV2: **> for expandable start, || to end the quote)
         def _convert_blockquote(m):
@@ -8418,15 +8495,15 @@ class TelegramAdapter(BasePlatformAdapter):
             flags=re.MULTILINE,
         )
 
-        # 10) Escape remaining special characters in plain text
+        # 11) Escape remaining special characters in plain text
         text = _escape_mdv2(text)
 
-        # 11) Restore placeholders in reverse insertion order so that
+        # 12) Restore placeholders in reverse insertion order so that
         #    nested references (a placeholder inside another) resolve correctly.
         for key in reversed(list(placeholders.keys())):
             text = text.replace(key, placeholders[key])
 
-        # 12) Safety net: escape unescaped ( ) { } that slipped through
+        # 13) Safety net: escape unescaped ( ) { } that slipped through
         #     placeholder processing.  Split the text into code/non-code
         #     segments so we never touch content inside ``` or ` spans.
         _code_split = re.split(r'(```[\s\S]*?```|`[^`]+`)', text)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -504,8 +504,15 @@ def _citation_source_urls(content: str) -> tuple[Optional[int], dict[str, str]]:
     lines = content.splitlines()
     source_start = None
     for index, line in enumerate(lines):
-        normalized = line.strip().strip("*#_ ").rstrip(":").strip("*#_ ").strip().lower()
-        if normalized in {"sources", "источники"}:
+        stripped = line.strip()
+        heading_match = re.fullmatch(
+            r"(?:#{1,6}\s+(sources|источники):?"
+            r"|(?:\*\*|__)(sources|источники):?(?:\*\*|__)"
+            r"|(sources|источники):)",
+            stripped,
+            re.IGNORECASE,
+        )
+        if heading_match:
             source_start = index
             break
     if source_start is None:
@@ -551,7 +558,7 @@ def _link_citations_to_sources(content: str) -> str:
         return f"[[{number}]]({url})" if url else match.group(0)
 
     def replace_outside_code(text: str) -> str:
-        parts = re.split(r"(```[\\s\\S]*?```|`[^`]+`)", text)
+        parts = re.split(r"(```[\s\S]*?```|`[^`]+`)", text)
         for index in range(0, len(parts), 2):
             parts[index] = re.sub(r"\[(\d+)\](?!\()", replace, parts[index])
         return "".join(parts)

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -38,6 +38,7 @@ _ensure_telegram_mock()
 from plugins.platforms.telegram.adapter import (  # noqa: E402
     TelegramAdapter,
     _escape_mdv2,
+    _link_citations_to_sources,
     _strip_mdv2,
     _wrap_markdown_tables,
 )
@@ -224,6 +225,36 @@ class TestFormatMessageLinks:
         result = adapter.format_message("[link](https://example.com/path_(1))")
         # The ) in URL should be escaped
         assert "\\)" in result
+
+    def test_numbered_citation_links_to_declared_source_url(self, adapter):
+        text = (
+            "Claim supported by [16].\n\n"
+            "**Sources:**\n"
+            "[16] [Source title](https://example.com/source)\n"
+        )
+        result = adapter.format_message(text)
+        assert r"[\[16\]](https://example.com/source)" in result
+
+    def test_numbered_citation_supports_bare_source_url(self):
+        text = "Claim [2].\n\n## Sources\n[2] https://example.com/article - Article"
+        assert _link_citations_to_sources(text).startswith(
+            "Claim [[2]](https://example.com/article)."
+        )
+
+    def test_adjacent_numbered_citations_are_each_linked(self):
+        text = "Claim [2][16].\n\n## Sources\n[2] https://example.com/a\n[16] https://example.com/b"
+        assert _link_citations_to_sources(text).startswith(
+            "Claim [[2]](https://example.com/a)[[16]](https://example.com/b)."
+        )
+
+    def test_unlisted_bracket_number_is_unchanged(self, adapter):
+        result = adapter.format_message("Array [16] without a Sources block")
+        assert "\\[16\\]" in result
+
+    def test_numbered_citation_includes_square_brackets_in_link_text(self, adapter):
+        text = "Claim [16].\n\n## Sources\n[16] https://example.com/source"
+        result = adapter.format_message(text)
+        assert r"[\[16\]](https://example.com/source)" in result
 
 
 # =========================================================================

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -256,6 +256,24 @@ class TestFormatMessageLinks:
         result = adapter.format_message(text)
         assert r"[\[16\]](https://example.com/source)" in result
 
+    def test_numbered_citation_inside_fenced_code_is_not_linked(self):
+        text = (
+            "```text\n[16]\n```\nClaim [16].\n\n"
+            "## Sources\n[16] https://example.com/source"
+        )
+        result = _link_citations_to_sources(text)
+        assert "```text\n[16]\n```" in result
+        assert "Claim [[16]](https://example.com/source)." in result
+
+    def test_plain_sources_word_does_not_start_bibliography(self):
+        text = "Sources\nClaim [16].\n[16] https://example.com/source"
+        assert _link_citations_to_sources(text) == text
+
+    def test_source_url_with_underscore_is_preserved(self, adapter):
+        text = "Claim [16].\n\nSources:\n[16] https://example.com/some_page"
+        result = adapter.format_message(text)
+        assert r"[\[16\]](https://example.com/some_page)" in result
+
 
 # =========================================================================
 # format_message - BUG: italic regex spans newlines


### PR DESCRIPTION
## Summary

- make the complete visible citation marker, including square brackets (for example `[16]`), clickable in Telegram replies
- resolve citation numbers only from an explicit `Sources` or `Источники` block
- preserve code blocks, ordinary bracketed text, and the bibliography's existing links
- support adjacent citations such as `[2][16]` and bare or Markdown-linked source URLs

Fixes #87729

## Problem

The Telegram adapter already converts standard Markdown links, but a research reply that uses `[16]` inline and declares the URL later in `Sources` leaves `[16]` as plain text. The user has to locate the matching URL manually.

The visible hyperlink text must be the complete marker `[16]`, not only the digits `16`. The formatter therefore emits Telegram MarkdownV2 shaped as `[\[16\]](URL)`, where the escaped inner brackets are part of the clickable label.

## Tests

- `python -m pytest tests/gateway/test_telegram_format.py -q -o addopts=`: 50 passed
- `python -m ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_format.py`
- `python -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_format.py`
- `git diff --check`

The repository's canonical `scripts/run_tests.sh` wrapper could not run in the isolated worktree because it has no `.venv`/`venv` with pytest. The targeted test was run with the installed Hermes Python environment.

## Scope

This is limited to outbound Telegram MarkdownV2 formatting. It does not change inbound Telegram link entities or replace MarkdownV2 with `MessageEntity`.
