### PR TITLE
feat(config): append values to list settings without rewriting YAML

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5464,12 +5464,20 @@ def append_config_value(key: str, value: str):
         )
         sys.exit(1)
 
+    default_value = _get_nested(DEFAULT_CONFIG, key)
+    if default_value is not _MISSING and not isinstance(default_value, list):
+        print(
+            f"✗ Cannot append to '{key}': this configuration path is not "
+            "configured as a list.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     config_path = get_config_path()
     require_readable_config_before_write(config_path)
     try:
         from utils import atomic_roundtrip_yaml_append
 
-        default_value = _get_nested(DEFAULT_CONFIG, key)
         initial_values = (
             copy.deepcopy(default_value) if isinstance(default_value, list) else None
         )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -10,6 +10,7 @@ This module provides:
 - hermes config edit     - Open config in editor
 - hermes config get      - Print a resolved configuration value
 - hermes config set      - Set a specific value
+- hermes config append   - Append a JSON value to a list
 - hermes config unset    - Remove a user configuration value
 - hermes config wizard   - Re-run setup wizard
 """
@@ -5426,6 +5427,48 @@ def set_config_value(key: str, value: str, force: bool = False):
         ))
 
 
+def append_config_value(key: str, value: str):
+    """Parse a JSON value and append it to a list-valued config path."""
+    if is_managed():
+        managed_error("append configuration values")
+        return
+
+    from hermes_cli import managed_scope
+
+    if managed_scope.is_key_managed(key):
+        managed_dir = managed_scope.get_managed_dir()
+        src = (managed_dir / "config.yaml") if managed_dir else "the managed scope"
+        print(
+            f"Cannot append to '{key}': it is managed by your administrator "
+            f"({src}) and cannot be changed. Contact your administrator to modify it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        parsed_value = json.loads(value)
+    except json.JSONDecodeError as exc:
+        print(
+            f"✗ Cannot append to '{key}': value must be valid JSON "
+            f"({exc.msg} at column {exc.colno}).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    config_path = get_config_path()
+    require_readable_config_before_write(config_path)
+    try:
+        from utils import atomic_roundtrip_yaml_append
+
+        atomic_roundtrip_yaml_append(config_path, key, parsed_value)
+    except (ValueError, TimeoutError) as exc:
+        print(f"✗ Cannot append to '{key}': {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    ensure_hermes_home()
+    print(f"✓ Appended value to {key} in {config_path}")
+
+
 def get_config_value(key: str, *, as_json: bool = False):
     """Print a resolved configuration value."""
     if _is_env_config_key(key):
@@ -5548,6 +5591,20 @@ def config_command(args):
             print("           and allow a scalar to replace a whole mapping section")
             sys.exit(1)
         set_config_value(key, value, force=force)
+
+    elif subcmd == "append":
+        key = getattr(args, "key", None)
+        value = getattr(args, "value", None)
+        if not key or value is None:
+            print("Usage: hermes config append <dotted-list-path> <json-value>")
+            print()
+            print("Example:")
+            print(
+                "  hermes config append hooks.pre_llm_call "
+                "'{\"command\":\"/path/check.py\",\"timeout\":9}'"
+            )
+            sys.exit(1)
+        append_config_value(key, value)
 
     elif subcmd == "unset":
         key = getattr(args, 'key', None)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5435,7 +5435,16 @@ def append_config_value(key: str, value: str):
 
     from hermes_cli import managed_scope
 
-    if managed_scope.is_key_managed(key):
+    managed_keys = managed_scope.managed_config_keys()
+    managed_key = next(
+        (
+            candidate
+            for candidate in managed_keys
+            if key == candidate or key.startswith(f"{candidate}.")
+        ),
+        None,
+    )
+    if managed_key is not None:
         managed_dir = managed_scope.get_managed_dir()
         src = (managed_dir / "config.yaml") if managed_dir else "the managed scope"
         print(
@@ -5460,7 +5469,16 @@ def append_config_value(key: str, value: str):
     try:
         from utils import atomic_roundtrip_yaml_append
 
-        atomic_roundtrip_yaml_append(config_path, key, parsed_value)
+        default_value = _get_nested(DEFAULT_CONFIG, key)
+        initial_values = (
+            copy.deepcopy(default_value) if isinstance(default_value, list) else None
+        )
+        atomic_roundtrip_yaml_append(
+            config_path,
+            key,
+            parsed_value,
+            initial_values=initial_values,
+        )
     except (ValueError, TimeoutError) as exc:
         print(f"✗ Cannot append to '{key}': {exc}", file=sys.stderr)
         sys.exit(1)

--- a/hermes_cli/subcommands/config.py
+++ b/hermes_cli/subcommands/config.py
@@ -47,6 +47,15 @@ def build_config_parser(subparsers, *, cmd_config: Callable) -> None:
         "running version doesn't recognize (the value is saved either way).",
     )
 
+    # config append
+    config_append = config_subparsers.add_parser(
+        "append", help="Append a JSON value to a list"
+    )
+    config_append.add_argument(
+        "key", nargs="?", help="Dotted list path (e.g., hooks.pre_llm_call)"
+    )
+    config_append.add_argument("value", nargs="?", help="JSON value to append")
+
     # config unset
     config_unset = config_subparsers.add_parser(
         "unset", help="Remove a configuration value"

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -399,6 +399,17 @@ class TestListAppend:
         assert exc.value.code == 1
         assert "Cannot parse" in capsys.readouterr().err
 
+    def test_append_reports_non_utf8_config(self, _isolated_hermes_home, capsys):
+        from hermes_cli.config import append_config_value
+
+        (_isolated_hermes_home / "config.yaml").write_bytes(b"hooks: \xff\n")
+
+        with pytest.raises(SystemExit) as exc:
+            append_config_value("hooks.pre_llm_call", '"check.py"')
+
+        assert exc.value.code == 1
+        assert "Cannot parse" in capsys.readouterr().err
+
     def test_append_rejects_managed_list(self, monkeypatch, capsys):
         from hermes_cli import managed_scope
         from hermes_cli.config import append_config_value

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -362,6 +362,18 @@ class TestListAppend:
 
         assert load_config()["toolsets"] == ["hermes-cli", "web"]
 
+    def test_append_rejects_known_non_list_default(
+        self, _isolated_hermes_home, capsys
+    ):
+        from hermes_cli.config import append_config_value
+
+        with pytest.raises(SystemExit) as exc:
+            append_config_value("model", '"gpt-4"')
+
+        assert exc.value.code == 1
+        assert "configured as a list" in capsys.readouterr().err
+        assert not (_isolated_hermes_home / "config.yaml").exists()
+
     def test_append_rejects_invalid_json(self, capsys):
         from hermes_cli.config import append_config_value
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -410,6 +410,25 @@ class TestListAppend:
         assert exc.value.code == 1
         assert "Cannot parse" in capsys.readouterr().err
 
+    @pytest.mark.parametrize("document", ["false\n", "0\n", "[]\n"])
+    def test_append_rejects_falsy_non_mapping_root(
+        self,
+        _isolated_hermes_home,
+        capsys,
+        document,
+    ):
+        from hermes_cli.config import append_config_value
+
+        config_path = _isolated_hermes_home / "config.yaml"
+        config_path.write_text(document, encoding="utf-8")
+
+        with pytest.raises(SystemExit) as exc:
+            append_config_value("hooks.pre_llm_call", '"check.py"')
+
+        assert exc.value.code == 1
+        assert "root is not a mapping" in capsys.readouterr().err
+        assert config_path.read_text(encoding="utf-8") == document
+
     def test_append_rejects_managed_list(self, monkeypatch, capsys):
         from hermes_cli import managed_scope
         from hermes_cli.config import append_config_value

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -335,6 +335,28 @@ class TestListAppend:
             "/opt/hermes/second.py",
         ]
 
+    def test_append_preserves_json_string_types(self, _isolated_hermes_home):
+        from hermes_cli.config import append_config_value
+
+        append_config_value(
+            "hooks.pre_llm_call",
+            '{"name":"on","values":["off","null","ordinary"]}',
+        )
+
+        import yaml
+
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["hooks"]["pre_llm_call"] == [
+            {"name": "on", "values": ["off", "null", "ordinary"]}
+        ]
+
+    def test_append_seeds_nonempty_default_list(self, _isolated_hermes_home):
+        from hermes_cli.config import append_config_value, load_config
+
+        append_config_value("toolsets", '"web"')
+
+        assert load_config()["toolsets"] == ["hermes-cli", "web"]
+
     def test_append_rejects_invalid_json(self, capsys):
         from hermes_cli.config import append_config_value
 
@@ -376,11 +398,15 @@ class TestListAppend:
         from hermes_cli import managed_scope
         from hermes_cli.config import append_config_value
 
-        monkeypatch.setattr(managed_scope, "is_key_managed", lambda key: True)
+        monkeypatch.setattr(
+            managed_scope,
+            "managed_config_keys",
+            lambda: {"custom_providers"},
+        )
         monkeypatch.setattr(managed_scope, "get_managed_dir", lambda: Path("managed"))
 
         with pytest.raises(SystemExit) as exc:
-            append_config_value("hooks.pre_llm_call", '"check.py"')
+            append_config_value("custom_providers.0.models", '"check.py"')
 
         assert exc.value.code == 1
         assert "managed by your administrator" in capsys.readouterr().err
@@ -429,7 +455,6 @@ class TestListAppend:
 
         saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         assert sorted(saved["hooks"]["pre_llm_call"]) == list(range(6))
-
 
 # ---------------------------------------------------------------------------
 # Cron drift guard warning — regression tests for #59031

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -3,6 +3,10 @@
 import argparse
 import json
 import os
+import subprocess
+import sys
+import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -284,6 +288,147 @@ class TestListNavigation:
         assert isinstance(allowlist, list)
         assert allowlist[0] == {"name": "alice", "role": "admin"}
         assert allowlist[1] == {"name": "bob", "role": "admin"}
+
+
+class TestListAppend:
+    def test_append_creates_list_with_json_value(self, _isolated_hermes_home):
+        from hermes_cli.config import append_config_value
+
+        append_config_value(
+            "hooks.pre_llm_call",
+            '{"command":"/opt/hermes/check.py","timeout":9}',
+        )
+
+        import yaml
+
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["hooks"]["pre_llm_call"] == [
+            {"command": "/opt/hermes/check.py", "timeout": 9}
+        ]
+
+    def test_append_preserves_existing_items_and_comments(self, _isolated_hermes_home):
+        from hermes_cli.config import append_config_value
+
+        config_path = _isolated_hermes_home / "config.yaml"
+        config_path.write_text(
+            "# operator note\n"
+            "hooks:\n"
+            "  pre_llm_call:\n"
+            "    - command: /opt/hermes/first.py  # keep inline\n",
+            encoding="utf-8",
+        )
+
+        append_config_value(
+            "hooks.pre_llm_call",
+            '{"command":"/opt/hermes/second.py"}',
+        )
+
+        text = config_path.read_text(encoding="utf-8")
+        assert "# operator note" in text
+        assert "# keep inline" in text
+
+        import yaml
+
+        saved = yaml.safe_load(text)
+        assert [item["command"] for item in saved["hooks"]["pre_llm_call"]] == [
+            "/opt/hermes/first.py",
+            "/opt/hermes/second.py",
+        ]
+
+    def test_append_rejects_invalid_json(self, capsys):
+        from hermes_cli.config import append_config_value
+
+        with pytest.raises(SystemExit) as exc:
+            append_config_value("hooks.pre_llm_call", "{not-json}")
+
+        assert exc.value.code == 1
+        assert "value must be valid JSON" in capsys.readouterr().err
+
+    def test_append_rejects_non_list_target(self, _isolated_hermes_home, capsys):
+        from hermes_cli.config import append_config_value
+
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "hooks:\n  pre_llm_call: disabled\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            append_config_value("hooks.pre_llm_call", '"check.py"')
+
+        assert exc.value.code == 1
+        assert "not a list" in capsys.readouterr().err
+
+    def test_append_reports_malformed_config(self, _isolated_hermes_home, capsys):
+        from hermes_cli.config import append_config_value
+
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "hooks: [unterminated\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            append_config_value("hooks.pre_llm_call", '"check.py"')
+
+        assert exc.value.code == 1
+        assert "Cannot parse" in capsys.readouterr().err
+
+    def test_append_rejects_managed_list(self, monkeypatch, capsys):
+        from hermes_cli import managed_scope
+        from hermes_cli.config import append_config_value
+
+        monkeypatch.setattr(managed_scope, "is_key_managed", lambda key: True)
+        monkeypatch.setattr(managed_scope, "get_managed_dir", lambda: Path("managed"))
+
+        with pytest.raises(SystemExit) as exc:
+            append_config_value("hooks.pre_llm_call", '"check.py"')
+
+        assert exc.value.code == 1
+        assert "managed by your administrator" in capsys.readouterr().err
+
+    def test_concurrent_appenders_do_not_lose_items(self, _isolated_hermes_home):
+        config_path = _isolated_hermes_home / "config.yaml"
+        ready_dir = _isolated_hermes_home / "ready"
+        ready_dir.mkdir()
+        go_file = _isolated_hermes_home / "go"
+        worker = (
+            "import pathlib,sys,time; "
+            "from utils import atomic_roundtrip_yaml_append; "
+            "cfg=pathlib.Path(sys.argv[1]); ready=pathlib.Path(sys.argv[2]); "
+            "go=pathlib.Path(sys.argv[3]); value=int(sys.argv[4]); "
+            "ready.write_text('ready'); "
+            "deadline=time.monotonic()+10; "
+            "\nwhile not go.exists():\n"
+            "    assert time.monotonic() < deadline\n"
+            "    time.sleep(0.01)\n"
+            "atomic_roundtrip_yaml_append(cfg, 'hooks.pre_llm_call', value)"
+        )
+        processes = [
+            subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    worker,
+                    str(config_path),
+                    str(ready_dir / str(index)),
+                    str(go_file),
+                    str(index),
+                ],
+                cwd=str(Path(__file__).resolve().parents[2]),
+            )
+            for index in range(6)
+        ]
+        deadline = time.monotonic() + 10
+        while len(list(ready_dir.iterdir())) < len(processes):
+            assert time.monotonic() < deadline
+            time.sleep(0.01)
+        go_file.touch()
+        for process in processes:
+            assert process.wait(timeout=15) == 0
+
+        import yaml
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert sorted(saved["hooks"]["pre_llm_call"]) == list(range(6))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -340,14 +340,19 @@ class TestListAppend:
 
         append_config_value(
             "hooks.pre_llm_call",
-            '{"name":"on","values":["off","null","ordinary"]}',
+            '{"name":"on","values":["off","null","ordinary"],'
+            '"metadata":{"on":"yes"}}',
         )
 
         import yaml
 
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
         assert saved["hooks"]["pre_llm_call"] == [
-            {"name": "on", "values": ["off", "null", "ordinary"]}
+            {
+                "name": "on",
+                "values": ["off", "null", "ordinary"],
+                "metadata": {"on": "yes"},
+            }
         ]
 
     def test_append_seeds_nonempty_default_list(self, _isolated_hermes_home):

--- a/tests/hermes_cli/test_subcommands_batch.py
+++ b/tests/hermes_cli/test_subcommands_batch.py
@@ -78,8 +78,8 @@ SINGLE_HANDLER_CASES = [
 
 
 
-def test_config_get_unset_subcommands_parse():
-    """`hermes config get/unset` parse key args (and --json for get)."""
+def test_config_get_unset_append_subcommands_parse():
+    """Config value subcommands parse their key/value options."""
     parser = argparse.ArgumentParser(prog="hermes")
     sub = parser.add_subparsers(dest="command")
     handler = _h("config")
@@ -95,6 +95,14 @@ def test_config_get_unset_subcommands_parse():
     assert ns.func is handler
     assert ns.config_command == "unset"
     assert ns.key == "terminal.backend"
+
+    ns = parser.parse_args(
+        ["config", "append", "hooks.pre_llm_call", '{"command":"check.py"}']
+    )
+    assert ns.func is handler
+    assert ns.config_command == "append"
+    assert ns.key == "hooks.pre_llm_call"
+    assert ns.value == '{"command":"check.py"}'
 
 
 

--- a/utils.py
+++ b/utils.py
@@ -711,7 +711,8 @@ def atomic_roundtrip_yaml_append(
             return DoubleQuotedScalarString(item)
         if isinstance(item, dict):
             return CommentedMap(
-                (key, _yaml11_safe_value(child)) for key, child in item.items()
+                (_yaml11_safe_value(key), _yaml11_safe_value(child))
+                for key, child in item.items()
             )
         if isinstance(item, list):
             return CommentedSeq(_yaml11_safe_value(child) for child in item)

--- a/utils.py
+++ b/utils.py
@@ -722,7 +722,8 @@ def atomic_roundtrip_yaml_append(
         if path.exists():
             try:
                 with path.open("r", encoding="utf-8") as f:
-                    config = yaml_rt.load(f) or CommentedMap()
+                    loaded = yaml_rt.load(f)
+                    config = CommentedMap() if loaded is None else loaded
             except (YAMLError, UnicodeError) as exc:
                 raise ValueError(f"Cannot parse {path}: {exc}") from exc
         else:

--- a/utils.py
+++ b/utils.py
@@ -723,7 +723,7 @@ def atomic_roundtrip_yaml_append(
             try:
                 with path.open("r", encoding="utf-8") as f:
                     config = yaml_rt.load(f) or CommentedMap()
-            except YAMLError as exc:
+            except (YAMLError, UnicodeError) as exc:
                 raise ValueError(f"Cannot parse {path}: {exc}") from exc
         else:
             config = CommentedMap()

--- a/utils.py
+++ b/utils.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 
 _YAML_MUTATION_LOCKS: dict[str, threading.RLock] = {}
 _YAML_MUTATION_LOCKS_GUARD = threading.Lock()
+_YAML11_AMBIGUOUS_WORDS = {
+    "y", "n", "yes", "no", "true", "false", "on", "off", "null", "~",
+}
 
 
 TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
@@ -626,8 +629,9 @@ def atomic_roundtrip_yaml_update(
 
 
 @contextlib.contextmanager
-def _yaml_mutation_lock(path: Path, timeout: float = 10.0):
+def _yaml_mutation_lock(path: Union[str, Path], timeout: float = 10.0):
     """Serialize a YAML read-modify-write section across threads and processes."""
+    path = Path(path)
     lock_key = str(path.resolve())
     with _YAML_MUTATION_LOCKS_GUARD:
         thread_lock = _YAML_MUTATION_LOCKS.setdefault(lock_key, threading.RLock())
@@ -684,11 +688,14 @@ def atomic_roundtrip_yaml_append(
     path: Union[str, Path],
     key_path: str,
     value: Any,
+    *,
+    initial_values: list[Any] | None = None,
 ) -> None:
     """Append to a dotted list path without losing YAML formatting or updates."""
     from ruamel.yaml import YAML
     from ruamel.yaml.comments import CommentedMap, CommentedSeq
     from ruamel.yaml.error import YAMLError
+    from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -698,6 +705,17 @@ def atomic_roundtrip_yaml_append(
     yaml_rt.allow_unicode = True
     yaml_rt.default_flow_style = False
     yaml_rt.indent(mapping=2, sequence=4, offset=2)
+
+    def _yaml11_safe_value(item: Any) -> Any:
+        if isinstance(item, str) and item.lower() in _YAML11_AMBIGUOUS_WORDS:
+            return DoubleQuotedScalarString(item)
+        if isinstance(item, dict):
+            return CommentedMap(
+                (key, _yaml11_safe_value(child)) for key, child in item.items()
+            )
+        if isinstance(item, list):
+            return CommentedSeq(_yaml11_safe_value(child) for child in item)
+        return item
 
     with _yaml_mutation_lock(path):
         if path.exists():
@@ -748,13 +766,15 @@ def atomic_roundtrip_yaml_append(
                 ) from exc
         else:
             if leaf not in current:
-                current[leaf] = CommentedSeq()
+                current[leaf] = CommentedSeq(
+                    _yaml11_safe_value(item) for item in (initial_values or [])
+                )
             target = current[leaf]
         if not isinstance(target, list):
             raise ValueError(
                 f"target contains {type(target).__name__}, not a list"
             )
-        target.append(value)
+        target.append(_yaml11_safe_value(value))
 
         original_mode = _preserve_file_mode(path)
         original_owner = _preserve_file_owner(path)
@@ -846,10 +866,6 @@ def atomic_roundtrip_yaml_save(
     # `approvals.mode: off` silently round-trips back as `False` under
     # yaml.safe_load. Force-quote any new string value that YAML 1.1 would
     # otherwise misparse as bool/null.
-    _YAML11_AMBIGUOUS_WORDS = {
-        "y", "n", "yes", "no", "true", "false", "on", "off", "null", "~",
-    }
-
     def _quote_if_yaml11_ambiguous(value):
         if isinstance(value, str) and value.lower() in _YAML11_AMBIGUOUS_WORDS:
             return DoubleQuotedScalarString(value)

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 """Shared utility functions for hermes-agent."""
 
+import contextlib
 import errno
 import json
 import logging
@@ -7,6 +8,7 @@ import os
 import shutil
 import stat
 import tempfile
+import threading
 import time
 from pathlib import Path
 from typing import Any, Union
@@ -15,6 +17,9 @@ from urllib.parse import urlparse
 import yaml
 
 logger = logging.getLogger(__name__)
+
+_YAML_MUTATION_LOCKS: dict[str, threading.RLock] = {}
+_YAML_MUTATION_LOCKS_GUARD = threading.Lock()
 
 
 TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
@@ -618,6 +623,161 @@ def atomic_roundtrip_yaml_update(
         except OSError:
             pass
         raise
+
+
+@contextlib.contextmanager
+def _yaml_mutation_lock(path: Path, timeout: float = 10.0):
+    """Serialize a YAML read-modify-write section across threads and processes."""
+    lock_key = str(path.resolve())
+    with _YAML_MUTATION_LOCKS_GUARD:
+        thread_lock = _YAML_MUTATION_LOCKS.setdefault(lock_key, threading.RLock())
+
+    with thread_lock:
+        lock_path = path.with_name(f".{path.name}.lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_file = lock_path.open("a+b")
+        acquired = False
+        try:
+            lock_file.seek(0, os.SEEK_END)
+            if lock_file.tell() == 0:
+                lock_file.write(b"0")
+                lock_file.flush()
+            deadline = time.monotonic() + timeout
+            while True:
+                try:
+                    lock_file.seek(0)
+                    if os.name == "nt":
+                        import msvcrt
+
+                        msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    acquired = True
+                    break
+                except (OSError, IOError):
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            f"Timed out waiting for configuration lock {lock_path}"
+                        )
+                    time.sleep(0.05)
+            yield
+        finally:
+            if acquired:
+                try:
+                    lock_file.seek(0)
+                    if os.name == "nt":
+                        import msvcrt
+
+                        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
+            lock_file.close()
+
+
+def atomic_roundtrip_yaml_append(
+    path: Union[str, Path],
+    key_path: str,
+    value: Any,
+) -> None:
+    """Append to a dotted list path without losing YAML formatting or updates."""
+    from ruamel.yaml import YAML
+    from ruamel.yaml.comments import CommentedMap, CommentedSeq
+    from ruamel.yaml.error import YAMLError
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    yaml_rt = YAML(typ="rt")
+    yaml_rt.preserve_quotes = True
+    yaml_rt.allow_unicode = True
+    yaml_rt.default_flow_style = False
+    yaml_rt.indent(mapping=2, sequence=4, offset=2)
+
+    with _yaml_mutation_lock(path):
+        if path.exists():
+            try:
+                with path.open("r", encoding="utf-8") as f:
+                    config = yaml_rt.load(f) or CommentedMap()
+            except YAMLError as exc:
+                raise ValueError(f"Cannot parse {path}: {exc}") from exc
+        else:
+            config = CommentedMap()
+        if not isinstance(config, CommentedMap):
+            raise ValueError("configuration root is not a mapping")
+
+        parts = key_path.split(".")
+        if not key_path or any(not part for part in parts):
+            raise ValueError("list path must contain non-empty dotted segments")
+
+        current: Any = config
+        for part in parts[:-1]:
+            if isinstance(current, list):
+                try:
+                    current = current[int(part)]
+                except (TypeError, ValueError, IndexError) as exc:
+                    raise ValueError(
+                        f"segment {part!r} is not an existing list index"
+                    ) from exc
+            elif isinstance(current, dict):
+                if part not in current:
+                    current[part] = CommentedMap()
+                elif not isinstance(current[part], (dict, list)):
+                    raise ValueError(
+                        f"segment {part!r} contains "
+                        f"{type(current[part]).__name__}, not a container"
+                    )
+                current = current[part]
+            else:
+                raise ValueError(
+                    f"encountered {type(current).__name__} before the list target"
+                )
+
+        leaf = parts[-1]
+        if isinstance(current, list):
+            try:
+                target = current[int(leaf)]
+            except (TypeError, ValueError, IndexError) as exc:
+                raise ValueError(
+                    f"segment {leaf!r} is not an existing list index"
+                ) from exc
+        else:
+            if leaf not in current:
+                current[leaf] = CommentedSeq()
+            target = current[leaf]
+        if not isinstance(target, list):
+            raise ValueError(
+                f"target contains {type(target).__name__}, not a list"
+            )
+        target.append(value)
+
+        original_mode = _preserve_file_mode(path)
+        original_owner = _preserve_file_owner(path)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(path.parent),
+            prefix=f".{path.stem}_",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                yaml_rt.dump(config, f)
+                f.flush()
+                os.fsync(f.fileno())
+            real_path = atomic_replace(tmp_path, path)
+            real_path_obj = Path(real_path)
+            _restore_file_owner(real_path_obj, original_owner)
+            _restore_file_mode(real_path_obj, original_mode)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
 
 def atomic_roundtrip_yaml_save(


### PR DESCRIPTION
## What does this PR do?

Adds `hermes config append <dotted-list-path> <json-value>` so users and automation can safely add typed values to list settings such as hooks without rewriting the entire `config.yaml`. The command preserves comments, ordering, quoting, file metadata, effective default list entries, and concurrent updates while returning actionable errors for invalid JSON, malformed YAML, non-list targets, and managed settings.

### Motivation

`hermes config set` can replace values and edit existing list indices, but it cannot append a new list item. Since direct file tools intentionally refuse `config.yaml`, hook setup and similar workflows otherwise require an unsafe whole-file rewrite that can discard comments or overwrite concurrent changes.

### Behavior

- Accepts any JSON value and appends it to a dotted list path.
- Creates missing mapping segments and list targets, seeding list defaults when the effective configuration already defines them.
- Preserves YAML comments, ordering, quotes, ambiguous string types, file mode, and ownership.
- Serializes read-modify-write operations across threads and processes.
- Rejects invalid JSON, malformed or non-mapping YAML, invalid list navigation, non-list targets, and administrator-managed paths with actionable messages.
- Does not add hook-specific approval or allowlist lifecycle behavior.

### Implementation

The config subcommand parser and dispatcher expose the new operation. A shared round-trip YAML append helper performs the locked mutation through a temporary file and atomic replacement, and focused tests cover parser behavior, data fidelity, default preservation, validation failures, managed settings, and concurrent appenders.

## Related Issue

Closes #87690

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/subcommands/config.py` - register the `config append` CLI syntax.
- `hermes_cli/config.py` - validate JSON and managed configuration before dispatching the append mutation.
- `utils.py` - add cross-platform locked, atomic, round-trip YAML list appends.
- `tests/hermes_cli/test_set_config_value.py` - cover append behavior, preservation, failures, defaults, and concurrency.
- `tests/hermes_cli/test_subcommands_batch.py` - cover parser routing for the new subcommand.

## How to Test

1. Set `HERMES_HOME` to a temporary directory.
2. Run `hermes config append hooks.pre_llm_call '{"command":"/opt/hermes/check.py","timeout":9}'` twice with distinct commands.
3. Run `hermes config get hooks.pre_llm_call --json` and verify both objects are present while existing YAML comments remain intact.
4. Run the focused automated suite (98 tests passed locally):

```bash
scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_subcommands_batch.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; the command includes CLI help and usage text
- [x] `cli-config.yaml.example` update is N/A; no configuration key changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow contract changed
- [x] I've considered cross-platform impact; locking has dedicated Windows and POSIX implementations
- [x] Tool description/schema updates are N/A; no model tool changed
