### PR TITLE
fix: pass single_query_deny_message to approval gate for ssh config writes

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1008,6 +1008,9 @@ def _check_approval_required_write(paths: list[str],
         display_target=f"<write to {display_targets}>",
         cron_deny_message=blocked.format(
             why="requires approval but this cron session denies it."),
+        single_query_deny_message=blocked.format(
+            why="requires approval but single-query mode (-q) runs without "
+                "a user present to approve it."),
         autoapprove_log_prefix="ssh_config_write",
         fail_closed_when_no_human=True,
         no_human_block_message=blocked.format(


### PR DESCRIPTION
## What

Writing to `~/.ssh/config` (or any SSH client config file) via the `patch` / file tools crashes with:

```
TypeError: _run_approval_gate() missing 1 required keyword-only argument: 'single_query_deny_message'
```

instead of running the human-approval gate, so the SSH config write protection is completely broken.

## Root cause

`_run_approval_gate()` in `tools/approval.py` requires `single_query_deny_message: str` (keyword-only, no default), but the `ssh_config_write` call site in `_check_approval_required_write()` (`tools/file_tools.py`) does not pass it. The other two call sites (`check_dangerous_command` and the plugin pre_tool_call approval path) both pass it.

## Repro

Call `_check_approval_required_write(["/Users/<user>/.ssh/config"], task_id)` — or simply attempt any `patch`/`write` targeting `~/.ssh/config` — and observe the `TypeError` instead of a proper approval prompt/deny message.

## Fix

Pass `single_query_deny_message`, reusing the same `blocked.format(why=...)` wording style as the existing `cron_deny_message` / `no_human_block_message` branches in this call site.

## Verification

- `python3 -m py_compile tools/file_tools.py` passes.
- After the fix, `_check_approval_required_write(["/Users/kwang/.ssh/config"], "test")` returns the expected fail-closed BLOCKED message (`⚠️ This action is potentially dangerous (Write to SSH client config file(s)...`) instead of raising `TypeError`.
