### PR TITLE
fix(terminal): restore venv PATH before the login-shell snapshot dump

### DIFF
--- a/tests/tools/test_login_shell_path_preservation.py
+++ b/tests/tools/test_login_shell_path_preservation.py
@@ -1,0 +1,84 @@
+"""Tests for login-shell PATH preservation in _run_bash.
+
+On Debian-based systems, /etc/profile unconditionally resets PATH for
+non-root shells, discarding venv entries set by the Dockerfile's ENV PATH.
+_run_bash must save and restore PATH around the login shell so the snapshot
+(export -p) captures the correct venv entries.
+
+See: https://github.com/NousResearch/hermes-agent/issues/56634
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments.local import _make_run_env, _path_env_key
+
+
+class TestLoginShellPathPreservation:
+    """Verify that _run_bash wraps login=True invocations with PATH
+    save/restore so Debian's /etc/profile reset doesn't discard venv
+    entries from the captured snapshot."""
+
+    def test_path_restore_prelude_appended_for_login(self, tmp_path, monkeypatch):
+        """When login=True, the cmd_string should include PATH save/restore."""
+        from tools.environments.local import LocalEnvironment
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        env = LocalEnvironment(cwd=str(tmp_path), env={})
+
+        # Capture the args passed to Popen
+        captured = {}
+
+        original_popen = __import__("subprocess").Popen
+
+        def mock_popen(args, **kwargs):
+            captured["args"] = args
+            captured["env"] = kwargs.get("env")
+            # Return a dummy process that exits immediately
+            raise SystemExit(0)
+
+        with patch("subprocess.Popen", side_effect=mock_popen):
+            try:
+                env._run_bash("echo hello", login=True)
+            except SystemExit:
+                pass
+
+        cmd = captured["args"][-1]  # bash -l -c <cmd>
+        assert "__hermes_prelogin_path" in cmd
+        assert "unset __hermes_prelogin_path" in cmd
+
+    def test_no_path_restore_for_non_login(self, tmp_path, monkeypatch):
+        """When login=False, no PATH save/restore should be injected."""
+        from tools.environments.local import LocalEnvironment
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        env = LocalEnvironment(cwd=str(tmp_path), env={})
+
+        captured = {}
+
+        def mock_popen(args, **kwargs):
+            captured["args"] = args
+            raise SystemExit(0)
+
+        with patch("subprocess.Popen", side_effect=mock_popen):
+            try:
+                env._run_bash("echo hello", login=False)
+            except SystemExit:
+                pass
+
+        cmd = captured["args"][2]
+        assert "__hermes_prelogin_path" not in cmd
+
+    def test_make_run_env_preserves_venv_path(self, tmp_path, monkeypatch):
+        """_make_run_env should keep venv entries on PATH."""
+        venv_bin = "/opt/hermes/.venv/bin"
+        original_path = f"{venv_bin}:/usr/local/bin:/usr/bin:/bin"
+        monkeypatch.setenv("PATH", original_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        run_env = _make_run_env({})
+        path_key = _path_env_key(run_env)
+        assert path_key is not None
+        assert venv_bin in run_env[path_key]

--- a/tests/tools/test_login_shell_path_preservation.py
+++ b/tests/tools/test_login_shell_path_preservation.py
@@ -2,13 +2,20 @@
 
 On Debian-based systems, /etc/profile unconditionally resets PATH for
 non-root shells, discarding venv entries set by the Dockerfile's ENV PATH.
-_run_bash must save and restore PATH around the login shell so the snapshot
-(export -p) captures the correct venv entries.
+_run_bash must restore PATH at the very start of the login shell body -- so
+the snapshot (export -p) captures the correct venv entries -- not merely
+somewhere in the constructed script. init_session's bootstrap runs its own
+``export -p`` dump as its second statement (see base.py's
+``_export_dump_excluding_session_vars``), so a restore appended *after* the
+whole cmd_string fixes the live shell's PATH too late: the dump has already
+captured and persisted the profile-reset value by then (the bug #56634's
+fix PR #56642 originally shipped with, per review).
 
 See: https://github.com/NousResearch/hermes-agent/issues/56634
 """
 
 import os
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -17,43 +24,54 @@ from tools.environments.local import _make_run_env, _path_env_key
 
 
 class TestLoginShellPathPreservation:
-    """Verify that _run_bash wraps login=True invocations with PATH
-    save/restore so Debian's /etc/profile reset doesn't discard venv
-    entries from the captured snapshot."""
+    """Verify that _run_bash restores PATH before anything else in a
+    login=True invocation runs, so Debian's /etc/profile reset doesn't reach
+    the captured snapshot."""
 
-    def test_path_restore_prelude_appended_for_login(self, tmp_path, monkeypatch):
-        """When login=True, the cmd_string should include PATH save/restore."""
+    def test_path_restore_precedes_rest_of_cmd_string(self, tmp_path, monkeypatch):
+        """The PATH restore must be the first statement, before both the
+        shell-init prelude and the caller's own cmd_string (which, for the
+        real init_session caller, contains the export -p snapshot dump)."""
         from tools.environments.local import LocalEnvironment
 
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("PATH", "/opt/hermes/venv/bin:/usr/bin:/bin")
         env = LocalEnvironment(cwd=str(tmp_path), env={})
 
-        # Capture the args passed to Popen
         captured = {}
-
-        original_popen = __import__("subprocess").Popen
 
         def mock_popen(args, **kwargs):
             captured["args"] = args
             captured["env"] = kwargs.get("env")
-            # Return a dummy process that exits immediately
             raise SystemExit(0)
+
+        # A stand-in for init_session's bootstrap: its own export -p marker
+        # appears partway through, exactly like the real snapshot dump does.
+        marker_cmd = "umask 077\nexport -p >> /tmp/fake-snapshot\necho done\n"
 
         with patch("subprocess.Popen", side_effect=mock_popen):
             try:
-                env._run_bash("echo hello", login=True)
+                env._run_bash(marker_cmd, login=True)
             except SystemExit:
                 pass
 
         cmd = captured["args"][-1]  # bash -l -c <cmd>
-        assert "__hermes_prelogin_path" in cmd
-        assert "unset __hermes_prelogin_path" in cmd
+        assert "/opt/hermes/venv/bin" in cmd
+        restore_pos = cmd.find("/opt/hermes/venv/bin")
+        dump_pos = cmd.find("export -p >> /tmp/fake-snapshot")
+        assert dump_pos != -1, "test's own marker command must survive unmodified"
+        assert restore_pos < dump_pos, (
+            "PATH restore must precede the export -p dump, or the dump "
+            "captures /etc/profile's reset value instead of the venv PATH"
+        )
 
     def test_no_path_restore_for_non_login(self, tmp_path, monkeypatch):
-        """When login=False, no PATH save/restore should be injected."""
+        """When login=False, no PATH restore should be injected (non-login
+        shells never source /etc/profile, so nothing needs restoring)."""
         from tools.environments.local import LocalEnvironment
 
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("PATH", "/opt/hermes/venv/bin:/usr/bin:/bin")
         env = LocalEnvironment(cwd=str(tmp_path), env={})
 
         captured = {}
@@ -69,7 +87,7 @@ class TestLoginShellPathPreservation:
                 pass
 
         cmd = captured["args"][2]
-        assert "__hermes_prelogin_path" not in cmd
+        assert cmd == "echo hello"
 
     def test_make_run_env_preserves_venv_path(self, tmp_path, monkeypatch):
         """_make_run_env should keep venv entries on PATH."""
@@ -82,3 +100,68 @@ class TestLoginShellPathPreservation:
         path_key = _path_env_key(run_env)
         assert path_key is not None
         assert venv_bin in run_env[path_key]
+
+
+@pytest.mark.linux_only
+class TestLoginShellPathPreservationE2E:
+    """Real bash regression for #56634: reproduces the actual failure mode
+    (not a mock) by running init_session's own bootstrap shape -- an
+    export -p dump partway through the script, same as base.py's
+    ``_export_dump_excluding_session_vars`` -- through a real ``bash -l``
+    subprocess, and inspecting the file that dump wrote.
+
+    Self-verifying: skips rather than false-passes on a host whose
+    /etc/profile doesn't reset PATH (the precondition this bug depends on),
+    instead of assuming every Linux CI runner is Debian-family.
+    """
+
+    @staticmethod
+    def _etc_profile_resets_path(marker_dir: str) -> bool:
+        """True if a plain (unpatched) login shell drops *marker_dir* from
+        PATH -- i.e. this host reproduces the /etc/profile precondition."""
+        import subprocess
+
+        probe_env = {**os.environ, "PATH": f"{marker_dir}:/usr/bin:/bin"}
+        result = subprocess.run(
+            ["bash", "-l", "-c", "echo $PATH"],
+            env=probe_env,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        return marker_dir not in result.stdout
+
+    def test_snapshot_dump_captures_venv_path_through_profile_reset(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.environments.local import LocalEnvironment
+
+        marker_dir = str(tmp_path / "fake-hermes-venv" / "bin")
+        os.makedirs(marker_dir, exist_ok=True)
+
+        if not self._etc_profile_resets_path(marker_dir):
+            pytest.skip(
+                "this host's /etc/profile doesn't reset PATH for login "
+                "shells -- #56634's precondition doesn't reproduce here"
+            )
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("PATH", f"{marker_dir}:/usr/bin:/bin")
+        env = LocalEnvironment(cwd=str(tmp_path), env={})
+
+        snapshot_file = tmp_path / "snapshot-dump"
+        # Same shape as init_session's real bootstrap: export -p as an
+        # early statement, well before the script ends.
+        bootstrap = f"umask 077\nexport -p > {snapshot_file}\necho ok\n"
+
+        proc = env._run_bash(bootstrap, login=True, timeout=15)
+        stdout, _ = proc.communicate(timeout=15)
+        assert proc.returncode == 0, stdout
+
+        dumped = snapshot_file.read_text()
+        path_lines = [line for line in dumped.splitlines() if line.startswith("declare -x PATH=")]
+        assert path_lines, "export -p dump did not capture a PATH entry at all"
+        assert marker_dir in path_lines[0], (
+            "the venv PATH entry did not survive into the export -p "
+            "snapshot -- the restore ran too late relative to the dump"
+        )

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -5,6 +5,7 @@ import ntpath
 import os
 import platform
 import re
+import shlex
 import shutil
 import signal
 import subprocess
@@ -1714,6 +1715,8 @@ class LocalEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         bash = _find_bash()
+        run_env = _make_run_env(self.env)
+
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
         # custom init files so tools registered outside bash_profile
@@ -1724,8 +1727,22 @@ class LocalEnvironment(BaseEnvironment):
             init_files = _resolve_shell_init_files()
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
+            # Debian's /etc/profile unconditionally resets PATH for
+            # non-root shells *before* sourcing /etc/profile.d/*.sh,
+            # discarding venv entries the Dockerfile's ENV PATH sets up.
+            # Save and restore the PATH around the login shell so that
+            # the snapshot (export -p) captures the correct venv entries.
+            # See issue #56634.
+            path_key = _path_env_key(run_env)
+            if path_key is not None:
+                saved = shlex.quote(run_env.get(path_key, ""))
+                cmd_string = (
+                    f"__hermes_prelogin_path={saved}\n"
+                    f"{cmd_string}"
+                    f"export {path_key}=$__hermes_prelogin_path\n"
+                    f"unset __hermes_prelogin_path\n"
+                )
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
-        run_env = _make_run_env(self.env)
 
         # Recover when the cwd has been deleted out from under us — usually by
         # a previous tool call that ran ``rm -rf`` on its own working dir

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1730,18 +1730,26 @@ class LocalEnvironment(BaseEnvironment):
             # Debian's /etc/profile unconditionally resets PATH for
             # non-root shells *before* sourcing /etc/profile.d/*.sh,
             # discarding venv entries the Dockerfile's ENV PATH sets up.
-            # Save and restore the PATH around the login shell so that
-            # the snapshot (export -p) captures the correct venv entries.
-            # See issue #56634.
+            # Restore it immediately, before anything else in this login
+            # shell runs — including the init-file sourcing just prepended
+            # above, and (for init_session's bootstrap specifically)
+            # cmd_string's own ``export -p`` snapshot dump (see base.py's
+            # ``_export_dump_excluding_session_vars``), which persists
+            # whatever PATH is current at that moment into the snapshot
+            # file every later terminal call sources. This restore must be
+            # the FIRST thing that runs, prepended in front of the
+            # init-file prelude too — not appended after cmd_string (the
+            # original placement here), which fixed the live shell's PATH
+            # too late: the dump had already captured and persisted the
+            # profile-reset value by then, so every subsequent command in
+            # the session still lost the venv. Init files still run after
+            # this and may freely extend PATH further (nvm/pyenv/asdf), so
+            # their own additions are unaffected and still land in the
+            # snapshot. See issue #56634.
             path_key = _path_env_key(run_env)
             if path_key is not None:
                 saved = shlex.quote(run_env.get(path_key, ""))
-                cmd_string = (
-                    f"__hermes_prelogin_path={saved}\n"
-                    f"{cmd_string}"
-                    f"export {path_key}=$__hermes_prelogin_path\n"
-                    f"unset __hermes_prelogin_path\n"
-                )
+                cmd_string = f"export {path_key}={saved}\n" + cmd_string
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
 
         # Recover when the cwd has been deleted out from under us — usually by


### PR DESCRIPTION
## What does this PR do?

Debian's `/etc/profile` unconditionally resets `PATH` for non-root login shells before sourcing `/etc/profile.d/*.sh`, discarding whatever venv-inclusive `PATH` a parent process set up. The terminal tool's `LocalEnvironment.init_session()` builds its per-session command-execution snapshot via a login shell (`bash -l`), so it silently loses the venv from `PATH` — any later terminal call that shells out to a bare `python3`/`pip` resolves to the system interpreter instead.

This fixes the restore's *ordering*. `init_session`'s bootstrap contains its own `export -p` snapshot-capture dump as an early statement (see `_export_dump_excluding_session_vars` in `base.py`), which persists whatever `PATH` is current at that moment into the snapshot file every later terminal call sources. The restore now runs at the very start of the login-shell body — before both the shell-init prelude and the caller's `cmd_string` — so it's in effect before the dump ever runs.

## Related Issue

Fixes #56634

## Relationship to other PRs

Completes #56642 (credit: @liuhao1024, who correctly diagnosed the root cause and shipped the save/restore mechanism). That PR's restore was appended *after* the entire `cmd_string`, which — as reviewer `teknium1` flagged (salvageability=medium) — fixes the live shell's `PATH` too late relative to the `export -p` dump embedded partway through `cmd_string`: the dump captures and persists the profile-reset value before the trailing restore ever executes, so every subsequent terminal call in the session still loses the venv. This PR moves the restore in front of everything else in the login-shell body instead of appending it at the end, and strengthens the regression test accordingly.

Out of scope / not touched: #64849 and #70923, which address the Docker sandbox backend (`docker.py`) rather than `LocalEnvironment` — a related but distinct code path for issue #56634's reproduction (`terminal.backend: local`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/environments/local.py`: `_run_bash` now prepends the `PATH` restore ahead of both the shell-init prelude and `cmd_string`, instead of appending it after the whole thing.
- `tests/tools/test_login_shell_path_preservation.py`:
  - Rewrote the login-shell test to assert the restore's *position* relative to a stand-in `export -p` dump marker (the original only checked that marker strings existed anywhere in the constructed command, which would not have caught the ordering bug).
  - Updated the non-login test to match the simplified restore mechanism.
  - Added a real end-to-end regression test (`TestLoginShellPathPreservationE2E`, `linux_only`) that runs an `init_session`-shaped bootstrap (with its own `export -p` dump) through a genuine `bash -l` subprocess and asserts the captured snapshot file's `PATH` retains the venv entry. Self-verifying: it probes whether the host's actual `/etc/profile` reproduces the reset precondition first and skips otherwise, rather than assuming every Linux CI runner is Debian-family.

## How to Test

1. `uv pip install -e ".[all,dev]"` in a venv per `CONTRIBUTING.md`.
2. `pytest tests/tools/test_login_shell_path_preservation.py -v`
3. On a Debian/Ubuntu host: compare `bash -c 'which python3'` vs `bash -l -c 'which python3'` before/after the fix — with a venv on `PATH`, both should now resolve to the venv interpreter.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate (see Relationship to other PRs above)
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass (663 passed / 30 skipped across `tests/tools/` filtered to local/terminal/environments/shell; one unrelated pre-existing test-order flake in `test_stt_cloud_trim.py` confirmed to fail identically on unmodified `main` when run in the same batch, and to pass standalone regardless of this change)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested on Linux only

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed