### PR TITLE
feat(kanban): add per-board profile policies

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -43,6 +43,11 @@ export const $lanesByProfile = atom<boolean>(false)
  *  auto: empty lanes collapse to a rail, occupied lanes expand. Persisted. */
 export const $collapsedLanes = atom<Record<string, boolean>>({})
 
+/** Global profile-description writes are not board-scoped. Keep their owner
+ * outside any panel so a board switch/remount cannot start a second write while
+ * the first request is still in flight. */
+export const $profileDescriptionWriteOwner = atom<null | symbol>(null)
+
 const BOARD_SLUG_KEY = 'boardSlug'
 const INTRO_KEY = 'introDismissed'
 const LANES_KEY = 'lanesByProfile'
@@ -58,7 +63,7 @@ function onEventsFrame(slug: string, data: unknown): void {
     return
   }
 
-  void queryClient.invalidateQueries({ queryKey: ['kanban', 'board'] })
+  void queryClient.invalidateQueries({ queryKey: ['kanban', 'board', slug] })
   // Any event can change a board's card count — keep the switcher badge honest.
   void queryClient.invalidateQueries({ queryKey: BOARDS_KEY })
 
@@ -107,6 +112,8 @@ export function bindApi(r: Rest, storage: PluginStorage, socket: Socket): () => 
   return () => {
     unsubs.forEach(unsub => unsub())
     close?.()
+    nudgeTimers.forEach(timer => clearTimeout(timer))
+    nudgeTimers.clear()
     rest = null
   }
 }
@@ -115,10 +122,9 @@ function call<T>(path: string, opts?: PluginRestOptions): Promise<T> {
   return rest ? rest<T>(path, opts) : Promise.reject(new Error('kanban api not ready'))
 }
 
-/** Append the selected board (and other params) to a path. */
-function withBoard(path: string, params: Record<string, string> = {}): string {
+/** Append one explicitly captured board (and other params) to a path. */
+function withBoard(slug: string, path: string, params: Record<string, string> = {}): string {
   const search = new URLSearchParams(params)
-  const slug = $boardSlug.get()
 
   if (slug) {
     search.set('board', slug)
@@ -138,85 +144,151 @@ export const BOARDS_KEY = ['kanban', 'boards'] as const
 export const PROFILES_KEY = ['kanban', 'profiles'] as const
 export const PROJECTS_KEY = ['kanban', 'projects'] as const
 export const ORCHESTRATION_KEY = ['kanban', 'orchestration'] as const
+export const ORCHESTRATION_MUTATION_KEY = ['kanban', 'orchestration-write'] as const
+export const ORCHESTRATION_MUTATION_SCOPE = { id: 'kanban:orchestration-write' } as const
+export const PROFILE_DESCRIPTION_MUTATION_KEY = ['kanban', 'profile-description-write'] as const
+export const PROFILE_DESCRIPTION_MUTATION_SCOPE = { id: 'kanban:profile-description-write' } as const
+export const profilesKey = (slug: string) => [...PROFILES_KEY, slug] as const
+export const orchestrationKey = (slug: string) => [...ORCHESTRATION_KEY, slug] as const
 
 // ── reads ─────────────────────────────────────────────────────────────────────
 
-export const fetchBoard = (archived: boolean) =>
-  call<KanbanBoard>(withBoard('/board', archived ? { include_archived: 'true' } : {}))
+export const fetchBoard = (slug: string, archived = false): Promise<KanbanBoard> =>
+  call<KanbanBoard>(withBoard(slug, '/board', archived ? { include_archived: 'true' } : {}))
 
-export const fetchTask = (id: string) => call<KanbanTaskDetail>(withBoard(`/tasks/${id}`))
+export const fetchTask = (slug: string, id: string) => call<KanbanTaskDetail>(withBoard(slug, `/tasks/${id}`))
 
 /** Worker stdout/stderr tail (last 16 KiB — plenty for the drawer). */
-export const fetchLog = (id: string) => call<WorkerLog>(withBoard(`/tasks/${id}/log`, { tail: '16384' }))
+export const fetchLog = (slug: string, id: string) =>
+  call<WorkerLog>(withBoard(slug, `/tasks/${id}/log`, { tail: '16384' }))
 
 export const fetchBoards = () => call<BoardsResponse>('/boards')
 
-export const fetchProfiles = () => call<{ profiles: KanbanProfile[] }>('/profiles')
+export const fetchProfiles = (slug: string) => call<{ profiles: KanbanProfile[] }>(withBoard(slug, '/profiles'))
+
+/** Shared query contract for every board-scoped assignment roster surface. */
+export const profileQueryOptions = (slug: string) => ({
+  queryFn: () => fetchProfiles(slug),
+  queryKey: profilesKey(slug),
+  staleTime: 60_000
+})
 
 /** First-class Hermes projects, for scoping a board's default workspace. */
 export const fetchProjects = () => call<{ projects: KanbanProject[] }>('/projects')
 
-export const fetchOrchestration = () => call<OrchestrationSettings>('/orchestration')
+export const fetchOrchestration = (slug: string) => call<OrchestrationSettings>(withBoard(slug, '/orchestration'))
 
 // ── writes ────────────────────────────────────────────────────────────────────
+
+/** Claim the one global profile-description write slot synchronously, before a
+ * React Query mutation can be queued. The matching owner token prevents an old
+ * completion from releasing a newer claim. */
+export function claimProfileDescriptionWrite(): null | symbol {
+  if ($profileDescriptionWriteOwner.get()) {
+    return null
+  }
+
+  const owner = Symbol('kanban-profile-description-write')
+  $profileDescriptionWriteOwner.set(owner)
+
+  return owner
+}
+
+export function runProfileDescriptionWrite<T>(owner: symbol, write: () => Promise<T>): Promise<T> {
+  if ($profileDescriptionWriteOwner.get() !== owner) {
+    return Promise.reject(new Error('profile description write is already in progress'))
+  }
+
+  let request: Promise<T>
+
+  try {
+    request = write()
+  } catch (error) {
+    if ($profileDescriptionWriteOwner.get() === owner) {
+      $profileDescriptionWriteOwner.set(null)
+    }
+
+    return Promise.reject(error)
+  }
+
+  return request.finally(() => {
+    if ($profileDescriptionWriteOwner.get() === owner) {
+      $profileDescriptionWriteOwner.set(null)
+    }
+  })
+}
 
 // Every board edit nudges the dispatcher (debounced, fire-and-forget) so the
 // change takes effect NOW instead of on the next 60s tick — create a ready
 // task and the worker spawns immediately, no manual "nudge" ritual. The tick
 // is lock-guarded and ~1ms when there's nothing to do, so over-nudging is
 // free; failures are non-events (the periodic tick still exists).
-let nudgeTimer: null | ReturnType<typeof setTimeout> = null
+const nudgeTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
-function autoNudge(): void {
-  if (nudgeTimer != null) {
-    clearTimeout(nudgeTimer)
+function autoNudge(slug: string): void {
+  const pending = nudgeTimers.get(slug)
+
+  if (pending != null) {
+    clearTimeout(pending)
   }
 
-  nudgeTimer = setTimeout(() => {
-    nudgeTimer = null
-    nudgeDispatcher().catch(() => undefined)
-  }, 400)
+  nudgeTimers.set(
+    slug,
+    setTimeout(() => {
+      nudgeTimers.delete(slug)
+      nudgeDispatcher(slug).catch(() => undefined)
+    }, 400)
+  )
 }
 
 /** Resolve the write, then kick the dispatcher. Rejections pass through. */
-function nudged<T>(write: Promise<T>): Promise<T> {
+function nudged<T>(slug: string, write: Promise<T>): Promise<T> {
   return write.then(value => {
-    autoNudge()
+    autoNudge(slug)
 
     return value
   })
 }
 
-export const patchTask = (id: string, patch: Record<string, unknown>) =>
-  nudged(call(withBoard(`/tasks/${id}`), { method: 'PATCH', body: patch }))
+export const patchTask = (slug: string, id: string, patch: Record<string, unknown>) =>
+  nudged(slug, call(withBoard(slug, `/tasks/${id}`), { method: 'PATCH', body: patch }))
 
-export const createTask = (body: Record<string, unknown>) =>
-  nudged(call<{ task: KanbanTask | null; warning?: string }>(withBoard('/tasks'), { method: 'POST', body }))
+export const createTask = (slug: string, body: Record<string, unknown>) =>
+  nudged(slug, call<{ task: KanbanTask | null; warning?: string }>(withBoard(slug, '/tasks'), { method: 'POST', body }))
 
 // Deleting can unblock dependants (a gone parent no longer gates), so it
 // nudges too.
-export const deleteTask = (id: string) => nudged(call(withBoard(`/tasks/${id}`), { method: 'DELETE' }))
+export const deleteTask = (slug: string, id: string) =>
+  nudged(slug, call(withBoard(slug, `/tasks/${id}`), { method: 'DELETE' }))
 
 /** One patch, many ids — independent per-id application; returns per-id
  *  outcomes so the UI can toast partial failures. */
-export const bulkTasks = (ids: string[], patch: Record<string, unknown>) =>
+export const bulkTasks = (slug: string, ids: string[], patch: Record<string, unknown>) =>
   nudged(
-    call<{ results: Array<{ id: string; ok: boolean; error?: string }> }>(withBoard('/tasks/bulk'), {
+    slug,
+    call<{ results: Array<{ id: string; ok: boolean; error?: string }> }>(withBoard(slug, '/tasks/bulk'), {
       method: 'POST',
       body: { ids, ...patch }
     })
   )
 
-export const addComment = (id: string, body: string) =>
-  call(withBoard(`/tasks/${id}/comments`), { method: 'POST', body: { author: 'desktop', body } })
+export const addComment = (slug: string, id: string, body: string) =>
+  call(withBoard(slug, `/tasks/${id}/comments`), { method: 'POST', body: { author: 'desktop', body } })
 
-export const reassignTask = (id: string, profile: string) =>
-  nudged(call(withBoard(`/tasks/${id}/reassign`), { method: 'POST', body: { profile, reclaim_first: true } }))
+export const assignTask = (slug: string, id: string, profile: null | string) =>
+  nudged(
+    slug,
+    call(withBoard(slug, `/tasks/${id}/reassign`), { method: 'POST', body: { profile, reclaim_first: true } })
+  )
 
-export const reclaimTask = (id: string) => nudged(call(withBoard(`/tasks/${id}/reclaim`), { method: 'POST', body: {} }))
+export const reclaimTask = (slug: string, id: string) =>
+  nudged(slug, call(withBoard(slug, `/tasks/${id}/reclaim`), { method: 'POST', body: {} }))
 
-export const uploadAttachment = (id: string, upload: { filename: string; contentType?: string; bytes: ArrayBuffer }) =>
-  call(withBoard(`/tasks/${id}/attachments`), { method: 'POST', upload })
+export const uploadAttachment = (
+  slug: string,
+  id: string,
+  upload: { filename: string; contentType?: string; bytes: ArrayBuffer }
+) => call(withBoard(slug, `/tasks/${id}/attachments`), { method: 'POST', upload })
 
 export const createBoard = (slug: string, name: string, projectId?: string) =>
   call<{ board: { slug: string } }>('/boards', {
@@ -226,8 +298,8 @@ export const createBoard = (slug: string, name: string, projectId?: string) =>
 
 /** Rough auxiliary-model estimate for a task (tokens + complexity). Makes a
  *  model call — gate behind an explicit user action + disclaimer. */
-export const estimateTask = (id: string) =>
-  call<TaskEstimate>(withBoard(`/tasks/${id}/estimate`), { method: 'POST', body: {} })
+export const estimateTask = (slug: string, id: string) =>
+  call<TaskEstimate>(withBoard(slug, `/tasks/${id}/estimate`), { method: 'POST', body: {} })
 
 /** Estimate from typed title/body before a task exists (create dialog). */
 export const estimateNew = (title: string, body: string) =>
@@ -238,10 +310,11 @@ export const estimateNew = (title: string, body: string) =>
 export const updateBoard = (slug: string, patch: Record<string, unknown>) =>
   call<{ board: BoardMeta }>(`/boards/${encodeURIComponent(slug)}`, { method: 'PATCH', body: patch })
 
-export const nudgeDispatcher = () => call<{ spawned?: unknown[] }>(withBoard('/dispatch'), { method: 'POST', body: {} })
+export const nudgeDispatcher = (slug: string) =>
+  call<{ spawned?: unknown[] }>(withBoard(slug, '/dispatch'), { method: 'POST', body: {} })
 
-export const saveOrchestration = (patch: Record<string, unknown>) =>
-  call<OrchestrationSettings>('/orchestration', { method: 'PUT', body: patch })
+export const saveOrchestration = (slug: string, patch: Record<string, unknown>) =>
+  call<OrchestrationSettings>(withBoard(slug, '/orchestration'), { method: 'PUT', body: patch })
 
 export const saveProfileDescription = (name: string, description: string) =>
   call(`/profiles/${encodeURIComponent(name)}`, { method: 'PATCH', body: { description } })

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -54,6 +54,7 @@ import {
   type CSSProperties,
   type DragEvent as ReactDragEvent,
   type ReactNode,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -73,9 +74,11 @@ import {
   estimateNew,
   fetchBoard,
   fetchBoards,
-  fetchProfiles,
+  fetchOrchestration,
+  orchestrationKey,
   patchTask,
-  PROFILES_KEY
+  profileQueryOptions,
+  taskKey
 } from './api'
 import { BoardSwitcher } from './board-switcher'
 import { TaskDrawer } from './drawer'
@@ -96,7 +99,6 @@ import {
   lockedReason,
   RunClock,
   shortId,
-  useDefaultAssignee,
   useKanban,
   useOrchestration
 } from './ui'
@@ -144,12 +146,20 @@ function Meta({ children, icon }: { children: ReactNode; icon: string }) {
   )
 }
 
-function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
+function CardFooter({
+  arc,
+  fallback,
+  orchestrator,
+  task
+}: {
+  arc: ArcState | null
+  fallback: string
+  orchestrator: string
+  task: KanbanTask
+}) {
   const k = useKanban()
   const created = ago(task.created_at)
   const links = task.link_counts ? task.link_counts.parents + task.link_counts.children : 0
-  const fallback = useDefaultAssignee()
-  const orchestrator = useOrchestration()?.resolved_orchestrator_profile ?? ''
   // Ready + no assignee: with a configured default assignee the dispatcher
   // auto-assigns on its next tick (#27145) — say THAT, not "won't run". Only
   // a board with no fallback has the genuine silent failure.
@@ -237,7 +247,19 @@ function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
   )
 }
 
-function Card({
+function nestedInteractiveTarget(currentTarget: HTMLElement, target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false
+  }
+
+  const interactive = target.closest(
+    'button, a, input, select, textarea, [role="button"], [role="menuitem"], [contenteditable="true"]'
+  )
+
+  return interactive !== null && interactive !== currentTarget
+}
+
+export function Card({
   columns,
   onDelete,
   onMove,
@@ -258,13 +280,16 @@ function Card({
   const [dragging, setDragging] = useState(false)
   const meta = columnMeta(task.status)
   const summary = task.latest_summary || task.body
-  const fallback = useDefaultAssignee()
+  const orchestration = useOrchestration()
+  const fallback = orchestration?.resolved_default_assignee?.trim() ?? ''
+  const orchestrator = orchestration?.resolved_orchestrator_profile ?? ''
   const arc = arcState(task, fallback)
 
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <div
+          aria-label={task.title || task.id}
           className={cn(
             'group relative flex cursor-grab flex-col gap-2 rounded-md border border-(--ui-stroke-tertiary) border-l-2 bg-(--ui-bg-elevated) p-2.5',
             // Hover matches the provider-picker rows: a quiet primary fill;
@@ -274,7 +299,17 @@ function Card({
             dragging && 'opacity-40'
           )}
           draggable
-          onClick={event => (event.metaKey || event.ctrlKey ? onToggleSelect(task.id) : onOpen(task.id))}
+          onClick={event => {
+            if (nestedInteractiveTarget(event.currentTarget, event.target)) {
+              return
+            }
+
+            if (event.metaKey || event.ctrlKey) {
+              onToggleSelect(task.id)
+            } else {
+              onOpen(task.id)
+            }
+          }}
           onDragEnd={() => setDragging(false)}
           onDragStart={event => {
             event.dataTransfer.setData('text/plain', task.id)
@@ -284,7 +319,25 @@ function Card({
             event.dataTransfer.setDragImage(event.currentTarget, event.nativeEvent.offsetX, event.nativeEvent.offsetY)
             setDragging(true)
           }}
+          onKeyDown={event => {
+            if (
+              nestedInteractiveTarget(event.currentTarget, event.target) ||
+              (event.key !== 'Enter' && event.key !== ' ')
+            ) {
+              return
+            }
+
+            event.preventDefault()
+
+            if (event.metaKey || event.ctrlKey) {
+              onToggleSelect(task.id)
+            } else {
+              onOpen(task.id)
+            }
+          }}
+          role="button"
           style={{ '--kanban-tone': meta.tone, borderLeftColor: meta.tone } as CSSProperties}
+          tabIndex={0}
         >
           {/* Machine-activity arc: animates ONLY while an agent is actually on
               the card (claimed + working; amber when the heartbeat is gone).
@@ -300,7 +353,7 @@ function Card({
           {summary && (
             <span className="line-clamp-2 text-[0.6875rem] leading-snug text-(--ui-text-tertiary)">{summary}</span>
           )}
-          <CardFooter arc={arc} task={task} />
+          <CardFooter arc={arc} fallback={fallback} orchestrator={orchestrator} task={task} />
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent>
@@ -467,7 +520,7 @@ function Column({
               <div className="flex flex-col gap-2" key={assignee}>
                 <div className="flex items-center gap-1.5 px-1 pt-1 text-[0.625rem] text-(--ui-text-quaternary)">
                   {assignee !== UNASSIGNED_LANE && <Avatar name={assignee} size="0.875rem" />}
-                  {assignee}
+                  {assignee === UNASSIGNED_LANE ? k.unassigned : assignee}
                   <span className="tabular-nums">{tasks.length}</span>
                 </div>
                 {tasks.map(task => (
@@ -525,6 +578,28 @@ const NO_PARENT = '__none__'
 const PARKED = '__parked__'
 const WORKSPACE_KINDS = ['scratch', 'worktree', 'dir'] as const
 
+interface NewTaskOperation {
+  board: string
+  generation: number
+  target: string
+}
+
+export function resolveNewTaskAssignee(
+  selection: string,
+  effectiveDefault: null | string | undefined,
+  effectiveProfiles: ReadonlySet<string>
+): string | undefined {
+  if (selection === PARKED) {
+    return undefined
+  }
+
+  if (selection && effectiveProfiles.has(selection)) {
+    return selection
+  }
+
+  return effectiveDefault && effectiveProfiles.has(effectiveDefault) ? effectiveDefault : undefined
+}
+
 function Field({ children, label }: { children: ReactNode; label: string }) {
   return (
     <label className="flex flex-col gap-1">
@@ -534,28 +609,86 @@ function Field({ children, label }: { children: ReactNode; label: string }) {
   )
 }
 
-function NewTaskDialog({
+export function NewTaskDialog({
   onClose,
   parents,
   target
 }: {
-  onClose: () => void
+  onClose: (board: string) => void
   parents: Array<{ id: string; title: string }>
   target: null | string
 }) {
   const k = useKanban()
   const qc = useQueryClient()
-  const { data: roster } = useQuery({ queryKey: PROFILES_KEY, queryFn: fetchProfiles, staleTime: 60_000 })
-  // Title-only creates must RUN: "auto" resolves to the orchestration default
-  // (ultimately the active profile), applied at create time. Never silently
-  // unassigned — parking a card is the explicit choice, not the default.
-  const resolvedDefault = useOrchestration()?.resolved_default_assignee || 'default'
+  const selectedSlug = useValue($boardSlug)
+  const dialogOpen = Boolean(target)
+  const lifecycle = useRef({ board: selectedSlug, generation: 0, open: dialogOpen, target })
+  const createOwner = useRef<null | number>(null)
+  const estimateOwner = useRef<null | number>(null)
+
+  if (
+    lifecycle.current.board !== selectedSlug ||
+    lifecycle.current.open !== dialogOpen ||
+    lifecycle.current.target !== target
+  ) {
+    lifecycle.current = {
+      board: selectedSlug,
+      generation: lifecycle.current.generation + 1,
+      open: dialogOpen,
+      target
+    }
+    createOwner.current = null
+    estimateOwner.current = null
+  }
+
+  const lifecycleGeneration = lifecycle.current.generation
+
+  const operation: NewTaskOperation | null = target
+    ? { board: selectedSlug, generation: lifecycleGeneration, target }
+    : null
+
+  const isCurrent = (candidate: NewTaskOperation) => {
+    const current = lifecycle.current
+
+    return (
+      current.open &&
+      current.board === candidate.board &&
+      current.generation === candidate.generation &&
+      current.target === candidate.target
+    )
+  }
+
+  const rosterQuery = useQuery(profileQueryOptions(selectedSlug))
+
+  const orchestrationQuery = useQuery({
+    queryFn: () => fetchOrchestration(selectedSlug),
+    queryKey: orchestrationKey(selectedSlug),
+    staleTime: 60_000
+  })
+
+  const roster = rosterQuery.data
+  const orchestration = orchestrationQuery.data
+  const policyError = rosterQuery.error ?? orchestrationQuery.error
+
+  const effectiveProfiles = new Set(
+    (roster?.profiles ?? [])
+      .filter(profile => profile.effective_allowed && orchestration?.effective_allowed_profiles.includes(profile.name))
+      .map(profile => profile.name)
+  )
+
+  // Title-only creates run under the effective orchestration default when one
+  // exists. A deny-all board has no default and therefore parks the task; never
+  // fabricate a profile that the board policy excludes.
+  const candidateDefault = orchestration?.resolved_default_assignee ?? ''
+  const resolvedDefault = effectiveProfiles.has(candidateDefault) ? candidateDefault : ''
+
+  const policyReady =
+    Boolean(roster && orchestration) && !policyError && !rosterQuery.isFetching && !orchestrationQuery.isFetching
 
   // Board-level workspace default: a task inherits the current board's
   // configured project dir (scratch when unset, worktree in a git repo, else
   // dir) unless the operator overrides it below. Set the board default in the
   // board switcher's "Board settings…".
-  const selectedSlug = useValue($boardSlug)
   const { data: boards } = useQuery({ queryKey: BOARDS_KEY, queryFn: fetchBoards, staleTime: 30_000 })
   const currentBoard = boards?.boards.find(b => b.slug === (selectedSlug || boards.current))
   const boardDefaultKind = currentBoard?.default_workspace_kind || 'scratch'
@@ -577,49 +710,119 @@ function NewTaskDialog({
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<null | string>(null)
   const [estimate, setEstimate] = useState<null | TaskEstimate>(null)
+  const [estimating, setEstimating] = useState(false)
+  const [workspaceTouched, setWorkspaceTouched] = useState(false)
+
+  // Reset per open/board only. Metadata can arrive after the dialog opens, but
+  // it must never erase title/body input the user already typed.
+  useEffect(() => {
+    const current = lifecycle.current
+
+    if (
+      !target ||
+      !current.open ||
+      current.board !== selectedSlug ||
+      current.generation !== lifecycleGeneration ||
+      current.target !== target
+    ) {
+      return
+    }
+
+    setTitle('')
+    setBodyText('')
+    setAssignee('')
+    setPriority('0')
+    setSkills('')
+    setWorkspaceTouched(false)
+    setWorkspaceKind('scratch')
+    setWorkspacePath('')
+    setParent('')
+    setModelOverride(EMPTY_OVERRIDE)
+    setGoalMode(false)
+    setError(null)
+    setBusy(false)
+    setEstimate(null)
+    setEstimating(false)
+  }, [lifecycleGeneration, selectedSlug, target])
+
+  // Adopt a late board workspace default only while that selector is pristine.
+  useEffect(() => {
+    const current = lifecycle.current
+
+    if (
+      target &&
+      !workspaceTouched &&
+      current.open &&
+      current.board === selectedSlug &&
+      current.generation === lifecycleGeneration &&
+      current.target === target
+    ) {
+      setWorkspaceKind(boardDefaultKind)
+    }
+  }, [boardDefaultKind, lifecycleGeneration, selectedSlug, target, workspaceTouched])
+
+  const closeDialog = (candidate: NewTaskOperation | null) => {
+    if (!candidate || !isCurrent(candidate)) {
+      return
+    }
+
+    const current = lifecycle.current
+    lifecycle.current = {
+      board: current.board,
+      generation: current.generation + 1,
+      open: false,
+      target: null
+    }
+    onClose(candidate.board)
+  }
 
   // Rough effort estimate from the typed title/body (before the task exists),
   // via the auto-routed auxiliary model. Makes a model call — explicit action.
-  const estMut = useMutation({
-    mutationFn: () => estimateNew(title.trim(), bodyText.trim()),
-    onError: err => host.notify({ kind: 'error', message: errText(err) }),
-    onSuccess: r => {
-      if (r.ok) {
-        setEstimate(r)
+  const runEstimate = async () => {
+    if (!operation || !title.trim() || estimateOwner.current === operation.generation) {
+      return
+    }
+
+    const candidate = operation
+    const estimateTitle = title.trim()
+    const estimateBody = bodyText.trim()
+    estimateOwner.current = candidate.generation
+    setEstimating(true)
+
+    try {
+      const result = await estimateNew(estimateTitle, estimateBody)
+
+      if (!isCurrent(candidate)) {
+        return
+      }
+
+      if (result.ok) {
+        setEstimate(result)
       } else {
-        host.notify({ kind: 'warning', message: r.reason || k.couldNotEstimate })
+        host.notify({ kind: 'warning', message: result.reason || k.couldNotEstimate })
+      }
+    } catch (err) {
+      if (isCurrent(candidate)) {
+        host.notify({ kind: 'error', message: errText(err) })
+      }
+    } finally {
+      if (isCurrent(candidate) && estimateOwner.current === candidate.generation) {
+        estimateOwner.current = null
+        setEstimating(false)
       }
     }
-  })
-
-  // Reset per open — the dialog is externally controlled (open = target set),
-  // so onOpenChange(true) never fires; key the reset off `target` (and the
-  // resolved board default, which may arrive after the first open).
-  useEffect(() => {
-    if (target) {
-      setTitle('')
-      setBodyText('')
-      setAssignee('')
-      setPriority('0')
-      setSkills('')
-      setWorkspaceKind(boardDefaultKind)
-      setWorkspacePath('')
-      setParent('')
-      setModelOverride(EMPTY_OVERRIDE)
-      setGoalMode(false)
-      setError(null)
-      setBusy(false)
-      setEstimate(null)
-    }
-  }, [target, boardDefaultKind])
+  }
 
   const submit = async () => {
     const trimmed = title.trim()
 
-    if (!trimmed || !target || busy) {
+    if (!trimmed || !operation || createOwner.current === operation.generation || !policyReady) {
       return
     }
 
+    const candidate = operation
+    const board = candidate.board
+    createOwner.current = candidate.generation
     setBusy(true)
     setError(null)
 
@@ -631,41 +834,54 @@ function NewTaskDialog({
 
       // create() derives status (triage flag → 'triage', else 'ready'); move to
       // the requested column when they differ, so a per-column add lands right.
-      const { task, warning } = await createTask({
-        assignee: assignee === PARKED ? undefined : assignee || resolvedDefault,
+      const { task, warning } = await createTask(board, {
+        assignee: resolveNewTaskAssignee(assignee, resolvedDefault, effectiveProfiles),
         body: bodyText.trim() || undefined,
         goal_mode: goalMode,
         parents: parent ? [parent] : undefined,
         priority: Number(priority) || 0,
         skills: skillList.length ? skillList : undefined,
         title: trimmed,
-        triage: isTriage,
+        triage: candidate.target === 'triage',
         workspace_kind: workspaceKind,
         ...overrideCreateFields(modelOverride),
         // Empty → backend inherits the board's default project dir.
         workspace_path: workspaceKind !== 'scratch' && workspacePath.trim() ? workspacePath.trim() : undefined
       })
 
-      if (task && task.status !== target) {
-        await patchTask(task.id, { status: target })
+      if (task && task.status !== candidate.target) {
+        await patchTask(board, task.id, { status: candidate.target })
       }
 
       // Dispatcher-presence warning ("this ready task will sit idle") — not an
       // error, but the user should know.
-      if (warning) {
+      if (warning && isCurrent(candidate)) {
         host.notify({ kind: 'warning', message: warning })
       }
 
-      await qc.invalidateQueries({ queryKey: ['kanban', 'board'] })
-      onClose()
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['kanban', 'board', board] }),
+        qc.invalidateQueries({ queryKey: BOARDS_KEY }),
+        ...(task ? [qc.invalidateQueries({ queryKey: taskKey(board, task.id) })] : [])
+      ])
+
+      if (isCurrent(candidate)) {
+        closeDialog(candidate)
+      }
     } catch (err) {
-      setError(errText(err))
-      setBusy(false)
+      if (isCurrent(candidate)) {
+        setError(errText(err))
+      }
+    } finally {
+      if (isCurrent(candidate) && createOwner.current === candidate.generation) {
+        createOwner.current = null
+        setBusy(false)
+      }
     }
   }
 
   return (
-    <Dialog onOpenChange={open => !open && onClose()} open={Boolean(target)}>
+    <Dialog onOpenChange={open => !open && closeDialog(operation)} open={dialogOpen}>
       {/* `overflow-visible`: DialogContent publishes ITSELF as the portal
           container for popovers opened inside it (dialog-portal-context), and
           its default `overflow-y-auto` then crops them at the dialog's edge —
@@ -703,7 +919,13 @@ function NewTaskDialog({
               <Input onChange={event => setPriority(event.target.value)} type="number" value={priority} />
             </Field>
             <Field label={k.workspace}>
-              <Select onValueChange={setWorkspaceKind} value={workspaceKind}>
+              <Select
+                onValueChange={value => {
+                  setWorkspaceTouched(true)
+                  setWorkspaceKind(value)
+                }}
+                value={workspaceKind}
+              >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
@@ -732,15 +954,36 @@ function NewTaskDialog({
             </Field>
           )}
 
+          {policyError && (
+            <ErrorState description={errText(policyError)} title={k.taskPolicyLoadError}>
+              <Button
+                disabled={rosterQuery.isFetching || orchestrationQuery.isFetching}
+                onClick={() => void Promise.all([rosterQuery.refetch(), orchestrationQuery.refetch()])}
+                size="sm"
+                variant="outline"
+              >
+                <Codicon name="refresh" size="0.8rem" />
+                {k.retry}
+              </Button>
+            </ErrorState>
+          )}
+
           <Field label={k.assignee}>
-            <Select onValueChange={v => setAssignee(v === NO_PARENT ? '' : v)} value={assignee || NO_PARENT}>
+            <Select
+              disabled={!policyReady}
+              onValueChange={v => setAssignee(v === NO_PARENT ? '' : v)}
+              value={
+                (assignee === PARKED || effectiveProfiles.has(assignee) ? assignee : '') ||
+                (resolvedDefault ? NO_PARENT : PARKED)
+              }
+            >
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value={NO_PARENT}>{k.defaultOption(resolvedDefault)}</SelectItem>
+                {resolvedDefault && <SelectItem value={NO_PARENT}>{k.defaultOption(resolvedDefault)}</SelectItem>}
                 {(roster?.profiles ?? [])
-                  .filter(profile => profile.name !== resolvedDefault)
+                  .filter(profile => profile.effective_allowed && profile.name !== resolvedDefault)
                   .map(profile => (
                     <SelectItem key={profile.name} value={profile.name}>
                       {profile.name}
@@ -798,37 +1041,33 @@ function NewTaskDialog({
                 <Tip label={k.reEstimate}>
                   <Button
                     aria-label={k.reEstimate}
-                    disabled={!title.trim() || estMut.isPending}
-                    onClick={() => estMut.mutate()}
+                    disabled={!title.trim() || estimating}
+                    onClick={() => void runEstimate()}
                     size="icon-xs"
                     variant="ghost"
                   >
-                    <Codicon name="refresh" size="0.7rem" spinning={estMut.isPending} />
+                    <Codicon name="refresh" size="0.7rem" spinning={estimating} />
                   </Button>
                 </Tip>
               </>
             ) : (
               <Tip label={k.estimateTip}>
                 <Button
-                  disabled={!title.trim() || estMut.isPending}
-                  onClick={() => estMut.mutate()}
+                  disabled={!title.trim() || estimating}
+                  onClick={() => void runEstimate()}
                   size="xs"
                   variant="ghost"
                 >
-                  <Codicon
-                    name={estMut.isPending ? 'loading' : 'dashboard'}
-                    size="0.75rem"
-                    spinning={estMut.isPending}
-                  />
-                  {estMut.isPending ? k.estimating : k.estimate}
+                  <Codicon name={estimating ? 'loading' : 'dashboard'} size="0.75rem" spinning={estimating} />
+                  {estimating ? k.estimating : k.estimate}
                 </Button>
               </Tip>
             )}
           </div>
-          <Button onClick={onClose} variant="text">
+          <Button onClick={() => closeDialog(operation)} variant="text">
             {k.cancel}
           </Button>
-          <Button disabled={!title.trim() || busy} onClick={() => void submit()}>
+          <Button disabled={!title.trim() || busy || !policyReady} onClick={() => void submit()}>
             {busy ? k.creating : k.createTask}
           </Button>
         </DialogFooter>
@@ -951,45 +1190,114 @@ function FilterMenu({
  * done, reassign after a profile change) via POST /tasks/bulk, which applies
  * per-id and reports partial failures — failed cards stay selected.
  */
-function SelectionBar({
+interface BulkOperation {
+  board: string
+  generation: number
+  ids: string[]
+  owner: symbol
+}
+
+export function SelectionBar({
   columns,
+  generation,
+  isCurrent,
   onClear,
   onDone,
   selected
 }: {
   columns: string[]
+  generation: number
+  isCurrent: (board: string, generation: number) => boolean
   onClear: () => void
-  onDone: (failed: string[]) => void
+  onDone: (board: string, generation: number, failed: string[]) => void
   selected: ReadonlySet<string>
 }) {
   const k = useKanban()
   const qc = useQueryClient()
-  const { data: roster } = useQuery({ queryKey: PROFILES_KEY, queryFn: fetchProfiles, staleTime: 60_000 })
+  const slug = useValue($boardSlug)
+  const { data: roster } = useQuery(profileQueryOptions(slug))
+  const pendingOwner = useRef<null | symbol>(null)
+  const [pending, setPending] = useState<null | { board: string; generation: number; owner: symbol }>(null)
 
-  const finish = (failed: Array<{ error?: string; id: string }>) => {
-    void qc.invalidateQueries({ queryKey: ['kanban', 'board'] })
+  const finish = (
+    operation: BulkOperation,
+    failed: Array<{ error?: string; id: string }>,
+    total: number,
+    countChanged: boolean
+  ) => {
+    const { board, generation: operationGeneration, ids } = operation
+    void qc.invalidateQueries({ queryKey: ['kanban', 'board', board] })
+
+    for (const id of ids) {
+      void qc.invalidateQueries({ queryKey: taskKey(board, id) })
+    }
+
+    if (countChanged) {
+      void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+    }
+
+    if (!isCurrent(board, operationGeneration)) {
+      return
+    }
 
     if (failed.length > 0) {
       host.notify({
         kind: 'warning',
-        message: k.bulkFailed(failed.length, selected.size, failed[0].error ?? k.refused)
+        message: k.bulkFailed(failed.length, total, failed[0].error ?? k.refused)
       })
     }
 
-    onDone(failed.map(f => f.id))
+    onDone(
+      board,
+      operationGeneration,
+      failed.map(f => f.id)
+    )
   }
 
   const bulk = useMutation({
-    mutationFn: (patch: Record<string, unknown>) => bulkTasks([...selected], patch),
-    onError: err => host.notify({ kind: 'error', message: errText(err) }),
-    onSuccess: data => finish(data.results.filter(r => !r.ok))
+    mutationFn: ({ board, ids, patch }: BulkOperation & { patch: Record<string, unknown> }) =>
+      bulkTasks(board, ids, patch),
+    onError: (err, vars) => {
+      if (isCurrent(vars.board, vars.generation)) {
+        host.notify({ kind: 'error', message: errText(err) })
+      }
+    },
+    onSettled: (_data, _error, vars) => {
+      if (pendingOwner.current === vars.owner) {
+        pendingOwner.current = null
+
+        if (isCurrent(vars.board, vars.generation)) {
+          setPending(null)
+        }
+      }
+    },
+    onSuccess: (data, vars) =>
+      finish(
+        vars,
+        data.results.filter(r => !r.ok),
+        vars.ids.length,
+        Object.hasOwn(vars.patch, 'status') || vars.patch.archive === true
+      )
   })
+
+  const start = (run: (operation: BulkOperation) => void) => {
+    if (pending?.board === slug && pending.generation === generation) {
+      return
+    }
+
+    const owner = Symbol('kanban-bulk-write')
+    const operation = { board: slug, generation, ids: [...selected], owner }
+    pendingOwner.current = owner
+    setPending({ board: slug, generation, owner })
+    run(operation)
+  }
+
+  const runBulk = (patch: Record<string, unknown>) => start(operation => bulk.mutate({ ...operation, patch }))
 
   // No bulk-delete on the backend — fan out per id, same partial-failure story.
   const bulkDelete = useMutation({
-    mutationFn: async () => {
-      const ids = [...selected]
-      const settled = await Promise.allSettled(ids.map(id => deleteTask(id)))
+    mutationFn: async ({ board, ids }: BulkOperation) => {
+      const settled = await Promise.allSettled(ids.map(id => deleteTask(board, id)))
 
       return ids.flatMap((id, i) => {
         const result = settled[i]
@@ -997,10 +1305,24 @@ function SelectionBar({
         return result.status === 'rejected' ? [{ error: errText(result.reason), id }] : []
       })
     },
-    onSuccess: finish
+    onError: (err, vars) => {
+      if (isCurrent(vars.board, vars.generation)) {
+        host.notify({ kind: 'error', message: errText(err) })
+      }
+    },
+    onSettled: (_data, _error, vars) => {
+      if (pendingOwner.current === vars.owner) {
+        pendingOwner.current = null
+
+        if (isCurrent(vars.board, vars.generation)) {
+          setPending(null)
+        }
+      }
+    },
+    onSuccess: (failed, vars) => finish(vars, failed, vars.ids.length, true)
   })
 
-  const busy = bulk.isPending || bulkDelete.isPending
+  const busy = pending?.board === slug && pending.generation === generation
   // One menu at a time — controlled, so a click on the second trigger can
   // never race Radix's dismiss layer into two open menus.
   const [menu, setMenu] = useState<'assign' | 'move' | null>(null)
@@ -1022,7 +1344,7 @@ function SelectionBar({
             {columns
               .filter(name => !isLockedTarget(name))
               .map(name => (
-                <DropdownMenuItem key={name} onSelect={() => bulk.mutate({ status: name })}>
+                <DropdownMenuItem key={name} onSelect={() => runBulk({ status: name })}>
                   <span className="size-2 rounded-full" style={{ backgroundColor: columnMeta(name).tone }} />
                   {columnLabel(k, name)}
                 </DropdownMenuItem>
@@ -1038,29 +1360,31 @@ function SelectionBar({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="center">
-            {(roster?.profiles ?? []).map(profile => (
-              <DropdownMenuItem
-                key={profile.name}
-                onSelect={() => bulk.mutate({ assignee: profile.name, reclaim_first: true })}
-              >
-                <Avatar name={profile.name} size="0.875rem" />
-                {profile.name}
-              </DropdownMenuItem>
-            ))}
+            {(roster?.profiles ?? [])
+              .filter(profile => profile.effective_allowed)
+              .map(profile => (
+                <DropdownMenuItem
+                  key={profile.name}
+                  onSelect={() => runBulk({ assignee: profile.name, reclaim_first: true })}
+                >
+                  <Avatar name={profile.name} size="0.875rem" />
+                  {profile.name}
+                </DropdownMenuItem>
+              ))}
             <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={() => bulk.mutate({ assignee: '', reclaim_first: true })}>
+            <DropdownMenuItem onSelect={() => runBulk({ assignee: '', reclaim_first: true })}>
               {k.unassignAction}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
 
-        <Button disabled={busy} onClick={() => bulk.mutate({ archive: true })} size="xs" variant="ghost">
+        <Button disabled={busy} onClick={() => runBulk({ archive: true })} size="xs" variant="ghost">
           {k.archive}
         </Button>
         <Button
           className="text-destructive"
           disabled={busy}
-          onClick={() => bulkDelete.mutate()}
+          onClick={() => start(operation => bulkDelete.mutate(operation))}
           size="xs"
           variant="ghost"
         >
@@ -1087,11 +1411,13 @@ export function KanbanBoardPage() {
 
   // Live updates ride the events socket (bindApi); this interval is only the
   // slow heartbeat for socketless paths (OAuth remotes, dropped connections).
-  const { data: board, error } = useQuery({
-    queryFn: () => fetchBoard(archived),
+  const boardQuery = useQuery({
+    queryFn: () => fetchBoard(slug, archived),
     queryKey: boardKey(slug, archived),
     refetchInterval: 60_000
   })
+
+  const { data: board, error } = boardQuery
 
   const [openId, setOpenId] = useState<null | string>(null)
   const [addStatus, setAddStatus] = useState<null | string>(null)
@@ -1100,6 +1426,43 @@ export function KanbanBoardPage() {
   const [tenant, setTenant] = useState('')
   const [assignee, setAssignee] = useState('')
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set())
+  const selectedRef = useRef(selected)
+  selectedRef.current = selected
+  const selectionGeneration = useRef(0)
+  const selectionBoard = useRef(slug)
+  const currentSlug = useRef(slug)
+  currentSlug.current = slug
+
+  const replaceSelection = useCallback((next: ReadonlySet<string>) => {
+    selectionGeneration.current += 1
+    selectedRef.current = next
+    setSelected(next)
+  }, [])
+
+  if (selectionBoard.current !== slug) {
+    selectionBoard.current = slug
+    selectionGeneration.current += 1
+  }
+
+  // Observe every board transition, not only the final render, so A→B→A can
+  // never make an old bulk completion look current by string equality alone.
+  useEffect(
+    () =>
+      $boardSlug.listen(next => {
+        if (selectionBoard.current !== next) {
+          selectionBoard.current = next
+          selectionGeneration.current += 1
+        }
+      }),
+    []
+  )
+
+  useEffect(() => {
+    setOpenId(null)
+    setAddStatus(null)
+    setSettingsOpen(false)
+    replaceSelection(new Set())
+  }, [replaceSelection, slug])
 
   // A new-task request raised from outside the page (⌘⌥N, the palette row).
   // The command navigates here and parks the lane; the page picks it up on
@@ -1117,15 +1480,13 @@ export function KanbanBoardPage() {
   }, [requestedLane])
 
   const toggleSelect = (id: string) => {
-    setSelected(prev => {
-      const next = new Set(prev)
+    const next = new Set(selectedRef.current)
 
-      if (!next.delete(id)) {
-        next.add(id)
-      }
+    if (!next.delete(id)) {
+      next.add(id)
+    }
 
-      return next
-    })
+    replaceSelection(next)
   }
 
   // Prune ids that left the board (completed elsewhere, deleted, filtered by
@@ -1137,12 +1498,13 @@ export function KanbanBoardPage() {
 
     const alive = new Set(board.columns.flatMap(col => col.tasks.map(task => task.id)))
 
-    setSelected(prev => {
-      const kept = [...prev].filter(id => alive.has(id))
+    const previous = selectedRef.current
+    const kept = [...previous].filter(id => alive.has(id))
 
-      return kept.length === prev.size ? prev : new Set(kept)
-    })
-  }, [board])
+    if (kept.length !== previous.size) {
+      replaceSelection(new Set(kept))
+    }
+  }, [board, replaceSelection])
 
   useEffect(() => {
     if (selected.size === 0) {
@@ -1151,14 +1513,14 @@ export function KanbanBoardPage() {
 
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        setSelected(new Set())
+        replaceSelection(new Set())
       }
     }
 
     window.addEventListener('keydown', onKey)
 
     return () => window.removeEventListener('keydown', onKey)
-  }, [selected.size])
+  }, [replaceSelection, selected.size])
 
   const columnNames = board?.columns.map(col => col.name) ?? []
 
@@ -1186,50 +1548,71 @@ export function KanbanBoardPage() {
   const total = filtered?.columns.reduce((sum, col) => sum + col.tasks.length, 0) ?? 0
 
   const moveMut = useMutation({
-    mutationFn: ({ id, status }: { id: string; status: string }) => patchTask(id, { status }),
-    onMutate: async ({ id, status }) => {
-      await qc.cancelQueries({ queryKey: boardKey(slug, archived) })
-      const previous = qc.getQueryData<KanbanBoard>(boardKey(slug, archived))
+    mutationFn: ({
+      board: targetBoard,
+      id,
+      status
+    }: {
+      archived: boolean
+      board: string
+      fromStatus: string
+      id: string
+      status: string
+    }) => patchTask(targetBoard, id, { status }),
+    onMutate: async ({ archived: targetArchived, board: targetBoard, id, status }) => {
+      const key = boardKey(targetBoard, targetArchived)
+      await qc.cancelQueries({ queryKey: key })
+      const previous = qc.getQueryData<KanbanBoard>(key)
 
       if (previous) {
-        qc.setQueryData(boardKey(slug, archived), moveCard(previous, id, status))
+        qc.setQueryData(key, moveCard(previous, id, status))
       }
 
-      return { previous }
+      return { key, previous }
     },
     onError: (err, _vars, context) => {
       if (context?.previous) {
-        qc.setQueryData(boardKey(slug, archived), context.previous)
+        qc.setQueryData(context.key, context.previous)
       }
 
       host.notify({ kind: 'error', message: errText(err) })
     },
     onSettled: (_data, _err, vars) => {
-      void qc.invalidateQueries({ queryKey: ['kanban', 'board'] })
-      void qc.invalidateQueries({ queryKey: ['kanban', 'task', slug, vars.id] })
+      void qc.invalidateQueries({ queryKey: ['kanban', 'board', vars.board] })
+      void qc.invalidateQueries({ queryKey: taskKey(vars.board, vars.id) })
+
+      if (vars.fromStatus === 'archived' || vars.status === 'archived') {
+        void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+      }
     }
   })
 
   const deleteMut = useMutation({
-    mutationFn: (id: string) => deleteTask(id),
-    onMutate: async id => {
-      await qc.cancelQueries({ queryKey: boardKey(slug, archived) })
-      const previous = qc.getQueryData<KanbanBoard>(boardKey(slug, archived))
+    mutationFn: ({ board: targetBoard, id }: { archived: boolean; board: string; id: string }) =>
+      deleteTask(targetBoard, id),
+    onMutate: async ({ archived: targetArchived, board: targetBoard, id }) => {
+      const key = boardKey(targetBoard, targetArchived)
+      await qc.cancelQueries({ queryKey: key })
+      const previous = qc.getQueryData<KanbanBoard>(key)
 
       if (previous) {
-        qc.setQueryData(boardKey(slug, archived), removeCard(previous, id))
+        qc.setQueryData(key, removeCard(previous, id))
       }
 
-      return { previous }
+      return { key, previous }
     },
     onError: (err, _id, context) => {
       if (context?.previous) {
-        qc.setQueryData(boardKey(slug, archived), context.previous)
+        qc.setQueryData(context.key, context.previous)
       }
 
       host.notify({ kind: 'error', message: errText(err) })
     },
-    onSettled: () => void qc.invalidateQueries({ queryKey: ['kanban', 'board'] })
+    onSettled: (_data, _err, vars) => {
+      void qc.invalidateQueries({ queryKey: ['kanban', 'board', vars.board] })
+      void qc.invalidateQueries({ queryKey: taskKey(vars.board, vars.id) })
+      void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+    }
   })
 
   const onMove = (id: string, status: string) => {
@@ -1245,7 +1628,7 @@ export function KanbanBoardPage() {
       return
     }
 
-    moveMut.mutate({ id, status })
+    moveMut.mutate({ archived, board: slug, fromStatus: task.status, id, status })
   }
 
   const errorMessage = error ? errText(error) : null
@@ -1369,7 +1752,12 @@ export function KanbanBoardPage() {
 
       {errorMessage && !board ? (
         <div className="grid flex-1 place-items-center">
-          <ErrorState title={errorMessage} />
+          <ErrorState description={errorMessage} title={k.boardLoadError}>
+            <Button onClick={() => void boardQuery.refetch()} size="sm" variant="outline">
+              <Codicon name="refresh" size="0.8rem" />
+              {k.retry}
+            </Button>
+          </ErrorState>
         </div>
       ) : !filtered ? (
         <div className="grid flex-1 place-items-center">
@@ -1402,7 +1790,7 @@ export function KanbanBoardPage() {
                 columns={columnNames}
                 key={col.name}
                 onAdd={setAddStatus}
-                onDelete={id => deleteMut.mutate(id)}
+                onDelete={id => deleteMut.mutate({ archived, board: slug, id })}
                 onDropTask={onMove}
                 onMove={onMove}
                 onOpen={setOpenId}
@@ -1418,13 +1806,31 @@ export function KanbanBoardPage() {
       {selected.size > 0 && (
         <SelectionBar
           columns={columnNames}
-          onClear={() => setSelected(new Set())}
-          onDone={failed => setSelected(new Set(failed))}
+          generation={selectionGeneration.current}
+          isCurrent={(board, generation) =>
+            $boardSlug.get() === board && currentSlug.current === board && selectionGeneration.current === generation
+          }
+          onClear={() => {
+            replaceSelection(new Set())
+          }}
+          onDone={(board, generation, failed) => {
+            if (
+              $boardSlug.get() === board &&
+              currentSlug.current === board &&
+              selectionGeneration.current === generation
+            ) {
+              replaceSelection(new Set(failed))
+            }
+          }}
           selected={selected}
         />
       )}
 
-      <NewTaskDialog onClose={() => setAddStatus(null)} parents={parentOptions} target={addStatus} />
+      <NewTaskDialog
+        onClose={board => board === currentSlug.current && setAddStatus(null)}
+        parents={parentOptions}
+        target={addStatus}
+      />
       <TaskDrawer columns={columnNames} id={openId} onClose={() => setOpenId(null)} onOpen={setOpenId} />
     </div>
   )

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -27,20 +27,28 @@ import {
   useQueryClient,
   useValue
 } from '@hermes/plugin-sdk'
-import { type ReactNode, useEffect, useRef, useState } from 'react'
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState
+} from 'react'
 
 import {
   $boardSlug,
   addComment,
+  assignTask,
+  BOARDS_KEY,
   deleteTask,
   estimateTask,
   fetchLog,
-  fetchProfiles,
   fetchTask,
   logKey,
   patchTask,
-  PROFILES_KEY,
-  reassignTask,
+  profileQueryOptions,
   reclaimTask,
   taskKey,
   uploadAttachment
@@ -234,20 +242,26 @@ function Diagnostics({ items, onReclaim }: { items: Diagnostic[]; onReclaim: () 
  *  assignee to reassign (reclaims a running worker first, resets the failure
  *  streak — the explicit human recovery action). */
 function AssigneeMenu({
+  busy,
   current,
-  onReassign
+  onAssign
 }: {
+  busy: boolean
   current: null | string | undefined
-  onReassign: (p: string) => void
+  onAssign: (profile: null | string) => void
 }) {
   const k = useKanban()
-  const { data: roster } = useQuery({ queryKey: PROFILES_KEY, queryFn: fetchProfiles, staleTime: 60_000 })
+  const slug = useValue($boardSlug)
+  const { data: roster } = useQuery(profileQueryOptions(slug))
+  const effectiveProfiles = (roster?.profiles ?? []).filter(profile => profile.effective_allowed)
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
+          aria-label={current ?? k.unassigned}
           className="-mx-1 inline-flex max-w-full items-center gap-1.5 rounded px-1 py-0.5 text-left transition-colors hover:bg-(--chrome-action-hover)"
+          disabled={busy}
           type="button"
         >
           {current ? (
@@ -262,13 +276,17 @@ function AssigneeMenu({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
-        {(roster?.profiles ?? []).map(profile => (
-          <DropdownMenuItem key={profile.name} onSelect={() => onReassign(profile.name)}>
+        {effectiveProfiles.map(profile => (
+          <DropdownMenuItem disabled={busy} key={profile.name} onSelect={() => onAssign(profile.name)}>
             <Avatar name={profile.name} size="0.875rem" />
             {profile.name}
             {profile.name === current && <Codicon className="ml-auto" name="check" size="0.8rem" />}
           </DropdownMenuItem>
         ))}
+        {effectiveProfiles.length > 0 && <DropdownMenuSeparator />}
+        <DropdownMenuItem disabled={busy || !current} onSelect={() => onAssign(null)}>
+          {current ? k.unassignAction : k.unassigned}
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )
@@ -473,14 +491,50 @@ function AttachmentsSection({
 // behind an explicit click + disclaimer since it makes a model call. The
 // control keeps a stable footprint (spinner swaps in place) so there's no
 // layout jump when it runs.
-function EstimateSection({ id }: { id: string }) {
+interface DrawerAction {
+  board: string
+  generation: number
+  taskId: string
+}
+
+interface AssignmentOperation extends DrawerAction {
+  owner: symbol
+  profile: null | string
+}
+
+const DRAWER_FOCUSABLE = 'a[href], button, input, select, textarea, [tabindex]'
+
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return [...container.querySelectorAll<HTMLElement>(DRAWER_FOCUSABLE)].filter(
+    element =>
+      element.tabIndex >= 0 &&
+      !element.matches(':disabled, input[type="hidden"]') &&
+      !element.closest('[hidden], [aria-hidden="true"]')
+  )
+}
+
+function EstimateSection({
+  action,
+  isCurrent
+}: {
+  action: DrawerAction
+  isCurrent: (action: DrawerAction) => boolean
+}) {
   const k = useKanban()
   const [result, setResult] = useState<null | TaskEstimate>(null)
 
   const est = useMutation({
-    mutationFn: () => estimateTask(id),
-    onError: err => host.notify({ kind: 'error', message: errText(err) }),
-    onSuccess: r => {
+    mutationFn: (candidate: DrawerAction) => estimateTask(candidate.board, candidate.taskId),
+    onError: (err, candidate) => {
+      if (isCurrent(candidate)) {
+        host.notify({ kind: 'error', message: errText(err) })
+      }
+    },
+    onSuccess: (r, candidate) => {
+      if (!isCurrent(candidate)) {
+        return
+      }
+
       if (r.ok) {
         setResult(r)
       } else {
@@ -489,8 +543,11 @@ function EstimateSection({ id }: { id: string }) {
     }
   })
 
-  // A new task resets the cached estimate (the drawer reuses one instance).
-  useEffect(() => setResult(null), [id])
+  // Every drawer lifecycle gets a clean estimate, including close/reopen with
+  // the same board/task identity.
+  useEffect(() => setResult(null), [action.generation])
+
+  const estimating = est.isPending && Boolean(est.variables && isCurrent(est.variables))
 
   return (
     <Section label={k.estimate}>
@@ -509,12 +566,12 @@ function EstimateSection({ id }: { id: string }) {
               <Button
                 aria-label={k.reEstimate}
                 className="ml-auto"
-                disabled={est.isPending}
-                onClick={() => est.mutate()}
+                disabled={estimating}
+                onClick={() => est.mutate(action)}
                 size="icon-xs"
                 variant="ghost"
               >
-                <Codicon name="refresh" size="0.75rem" spinning={est.isPending} />
+                <Codicon name="refresh" size="0.75rem" spinning={estimating} />
               </Button>
             </Tip>
           </div>
@@ -524,9 +581,9 @@ function EstimateSection({ id }: { id: string }) {
         </div>
       ) : (
         <div className="flex items-center gap-2">
-          <Button disabled={est.isPending} onClick={() => est.mutate()} size="xs" variant="outline">
-            <Codicon name={est.isPending ? 'loading' : 'dashboard'} size="0.75rem" spinning={est.isPending} />
-            {est.isPending ? k.estimating : k.estimateEffort}
+          <Button disabled={estimating} onClick={() => est.mutate(action)} size="xs" variant="outline">
+            <Codicon name={estimating ? 'loading' : 'dashboard'} size="0.75rem" spinning={estimating} />
+            {estimating ? k.estimating : k.estimateEffort}
           </Button>
           <Tip label={k.estimateTipLong}>
             <span className="text-[0.625rem] text-(--ui-text-quaternary)">{k.makesModelCall}</span>
@@ -551,14 +608,78 @@ export function TaskDrawer({
   const k = useKanban()
   const qc = useQueryClient()
   const slug = useValue($boardSlug)
+  const drawerOpen = Boolean(id)
+  const lifecycle = useRef({ board: slug, generation: 0, open: drawerOpen, taskId: id })
+  const assignmentOwner = useRef<null | symbol>(null)
+  const drawerRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const titleId = useId()
+
+  if (lifecycle.current.board !== slug || lifecycle.current.open !== drawerOpen || lifecycle.current.taskId !== id) {
+    lifecycle.current = {
+      board: slug,
+      generation: lifecycle.current.generation + 1,
+      open: drawerOpen,
+      taskId: id
+    }
+  }
+
+  const action: DrawerAction | null = id ? { board: slug, generation: lifecycle.current.generation, taskId: id } : null
+
+  const isCurrent = useCallback((candidate: DrawerAction) => {
+    const current = lifecycle.current
+
+    return (
+      current.open &&
+      current.board === candidate.board &&
+      current.generation === candidate.generation &&
+      current.taskId === candidate.taskId
+    )
+  }, [])
+
+  const closeDrawer = useCallback(
+    (candidate: DrawerAction) => {
+      if (!isCurrent(candidate)) {
+        return
+      }
+
+      const current = lifecycle.current
+      lifecycle.current = {
+        board: current.board,
+        generation: current.generation + 1,
+        open: false,
+        taskId: null
+      }
+      onClose()
+    },
+    [isCurrent, onClose]
+  )
+
+  const openDrawerTask = (taskId: string) => {
+    const current = lifecycle.current
+
+    if (!current.open) {
+      return
+    }
+
+    lifecycle.current = {
+      board: slug,
+      generation: current.generation + 1,
+      open: true,
+      taskId
+    }
+    onOpen(taskId)
+  }
 
   // Socket-invalidated (bindApi); the interval is only the socketless heartbeat.
-  const { data: detail, error } = useQuery({
+  const detailQuery = useQuery({
     enabled: !!id,
-    queryFn: () => fetchTask(id!),
+    queryFn: () => fetchTask(slug, id!),
     queryKey: taskKey(slug, id ?? ''),
     refetchInterval: 30_000
   })
+
+  const { data: detail, error } = detailQuery
 
   const task = detail?.task
   const running = task?.status === 'running'
@@ -566,97 +687,251 @@ export function TaskDrawer({
 
   const { data: log } = useQuery({
     enabled: !!id,
-    queryFn: () => fetchLog(id!),
+    queryFn: () => fetchLog(slug, id!),
     queryKey: logKey(slug, id ?? ''),
     refetchInterval: running ? 3_000 : 15_000
   })
 
-  // Esc closes the drawer even though it isn't modal (no backdrop to click off).
+  // Move focus into the modal drawer. Restore the prior target only when focus
+  // is still owned by this drawer (or fell back to body) so cleanup never steals
+  // a deliberate focus move elsewhere.
   useEffect(() => {
-    if (!id) {
+    if (!drawerOpen) {
       return
     }
 
-    const onKey = (event: KeyboardEvent) => event.key === 'Escape' && onClose()
-    window.addEventListener('keydown', onKey)
+    const previous = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const drawer = drawerRef.current
+    closeButtonRef.current?.focus()
 
-    return () => window.removeEventListener('keydown', onKey)
-  }, [id, onClose])
+    return () => {
+      const active = document.activeElement
 
-  const invalidate = () => {
-    void qc.invalidateQueries({ queryKey: taskKey(slug, id!) })
-    void qc.invalidateQueries({ queryKey: ['kanban', 'board', slug] })
+      if (
+        previous?.isConnected &&
+        (active === document.body || (active instanceof Node && Boolean(drawer?.contains(active))))
+      ) {
+        previous.focus()
+      }
+    }
+  }, [drawerOpen])
+
+  // Capture Escape before shell shortcuts so one key closes exactly one modal.
+  useEffect(() => {
+    if (!drawerOpen) {
+      return
+    }
+
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        const drawer = drawerRef.current
+        const active = document.activeElement
+
+        // Portaled menus/selects own their first Escape. Their focused content
+        // sits outside the drawer node even though it belongs to this dialog.
+        if (active instanceof Node && active !== document.body && !drawer?.contains(active)) {
+          return
+        }
+
+        event.preventDefault()
+        event.stopPropagation()
+
+        const current = lifecycle.current
+
+        if (current.open && current.taskId) {
+          closeDrawer({ board: current.board, generation: current.generation, taskId: current.taskId })
+        }
+      }
+    }
+
+    window.addEventListener('keydown', onKey, true)
+
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [closeDrawer, drawerOpen])
+
+  const trapFocus = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Tab') {
+      return
+    }
+
+    const drawer = drawerRef.current
+    const focusable = drawer ? getFocusable(drawer) : []
+
+    if (focusable.length === 0) {
+      event.preventDefault()
+
+      return
+    }
+
+    const first = focusable[0]
+    const last = focusable.at(-1)!
+    const active = document.activeElement
+
+    if (event.shiftKey ? active === first || !drawer?.contains(active) : active === last || !drawer?.contains(active)) {
+      event.preventDefault()
+      ;(event.shiftKey ? last : first).focus()
+    }
   }
+
+  const invalidate = (board = slug, taskId = id!, countChanged = false) => {
+    void qc.invalidateQueries({ queryKey: taskKey(board, taskId) })
+    void qc.invalidateQueries({ queryKey: ['kanban', 'board', board] })
+
+    if (countChanged) {
+      void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+    }
+  }
+
+  const assignment = useMutation({
+    mutationFn: ({ board, profile, taskId }: AssignmentOperation) => assignTask(board, taskId, profile),
+    onError: (err, vars, context) => {
+      if (context?.optimistic && context.previous && isCurrent(vars)) {
+        qc.setQueryData(context.key, context.previous)
+      }
+
+      if (isCurrent(vars)) {
+        host.notify({ kind: 'error', message: errText(err) })
+      }
+    },
+    onMutate: async (vars: AssignmentOperation) => {
+      const key = taskKey(vars.board, vars.taskId)
+      await qc.cancelQueries({ queryKey: key })
+      const previous = qc.getQueryData<KanbanTaskDetail>(key)
+      const optimistic = Boolean(previous && isCurrent(vars))
+
+      if (previous && optimistic) {
+        qc.setQueryData(key, { ...previous, task: { ...previous.task, assignee: vars.profile } })
+      }
+
+      return { key, optimistic, previous }
+    },
+    onSettled: (_data, _error, vars) => {
+      if (assignmentOwner.current === vars.owner) {
+        assignmentOwner.current = null
+      }
+
+      invalidate(vars.board, vars.taskId)
+    }
+  })
 
   // Optimistic status change against the task cache; rolls back + toasts on a
   // rejected transition (the backend enforces the workflow).
   const moveMut = useMutation({
-    mutationFn: (status: string) => patchTask(id!, { status }),
-    onMutate: async status => {
-      await qc.cancelQueries({ queryKey: taskKey(slug, id!) })
-      const previous = qc.getQueryData<KanbanTaskDetail>(taskKey(slug, id!))
+    mutationFn: ({ board, status, taskId }: DrawerAction & { fromStatus: string; status: string }) =>
+      patchTask(board, taskId, { status }),
+    onMutate: async ({ board, status, taskId }) => {
+      const key = taskKey(board, taskId)
+      await qc.cancelQueries({ queryKey: key })
+      const previous = qc.getQueryData<KanbanTaskDetail>(key)
 
       if (previous) {
-        qc.setQueryData(taskKey(slug, id!), { ...previous, task: { ...previous.task, status } })
+        qc.setQueryData(key, { ...previous, task: { ...previous.task, status } })
       }
 
-      return { previous }
+      return { key, previous }
     },
-    onError: (err, _status, context) => {
-      if (context?.previous) {
-        qc.setQueryData(taskKey(slug, id!), context.previous)
+    onError: (err, vars, context) => {
+      if (context?.previous && isCurrent(vars)) {
+        qc.setQueryData(context.key, context.previous)
       }
 
-      host.notify({ kind: 'error', message: errText(err) })
+      if (isCurrent(vars)) {
+        host.notify({ kind: 'error', message: errText(err) })
+      }
     },
-    onSettled: invalidate
+    onSettled: (_data, _error, vars) =>
+      invalidate(vars.board, vars.taskId, vars.fromStatus === 'archived' || vars.status === 'archived')
   })
 
-  const mutate = (fn: () => Promise<unknown>, onDone?: () => void) => () =>
-    fn().then(
-      () => {
-        invalidate()
-        onDone?.()
-      },
-      (err: unknown) => host.notify({ kind: 'error', message: errText(err) })
-    )
+  const mutate =
+    (
+      fn: (candidate: DrawerAction) => Promise<unknown>,
+      onDone?: (candidate: DrawerAction) => void,
+      countChanged = false
+    ) =>
+    () => {
+      const candidate = action
+
+      if (!candidate) {
+        return
+      }
+
+      void fn(candidate).then(
+        () => {
+          invalidate(candidate.board, candidate.taskId, countChanged)
+
+          if (isCurrent(candidate)) {
+            onDone?.(candidate)
+          }
+        },
+        (err: unknown) => {
+          if (isCurrent(candidate)) {
+            host.notify({ kind: 'error', message: errText(err) })
+          }
+        }
+      )
+    }
 
   const commentMut = useMutation({
-    mutationFn: (body: string) => addComment(id!, body),
-    onError: err => host.notify({ kind: 'error', message: errText(err) }),
-    onSuccess: invalidate
+    mutationFn: ({ board, body, taskId }: DrawerAction & { body: string }) => addComment(board, taskId, body),
+    onError: (err, vars) => {
+      if (isCurrent(vars)) {
+        host.notify({ kind: 'error', message: errText(err) })
+      }
+    },
+    onSuccess: (_data, vars) => invalidate(vars.board, vars.taskId)
   })
 
   // "Note & requeue" for a running task: post the note, then reclaim so the
   // dispatcher re-runs it with the note in the worker's context — the one-click
   // replacement for the block → comment → unblock dance.
   const requeueMut = useMutation({
-    mutationFn: async (body: string) => {
-      await addComment(id!, body)
-      await reclaimTask(id!)
+    mutationFn: async ({ board, body, taskId }: DrawerAction & { body: string }) => {
+      await addComment(board, taskId, body)
+      await reclaimTask(board, taskId)
     },
-    onError: err => host.notify({ kind: 'error', message: errText(err) }),
-    onSuccess: () => {
-      host.notify({ kind: 'info', message: k.notePosted })
-      invalidate()
+    onError: (err, vars) => {
+      if (isCurrent(vars)) {
+        host.notify({ kind: 'error', message: errText(err) })
+      }
+    },
+    onSuccess: (_data, vars) => {
+      invalidate(vars.board, vars.taskId)
+
+      if (isCurrent(vars)) {
+        host.notify({ kind: 'info', message: k.notePosted })
+      }
     }
   })
 
   const uploadMut = useMutation({
-    mutationFn: async (file: File) =>
-      uploadAttachment(id!, {
+    mutationFn: async ({ board, file, taskId }: DrawerAction & { file: File }) =>
+      uploadAttachment(board, taskId, {
         bytes: await file.arrayBuffer(),
         contentType: file.type || undefined,
         filename: file.name
       }),
-    onError: err => host.notify({ kind: 'error', message: errText(err) }),
-    onSuccess: invalidate
+    onError: (err, vars) => {
+      if (isCurrent(vars)) {
+        host.notify({ kind: 'error', message: errText(err) })
+      }
+    },
+    onSuccess: (_data, vars) => invalidate(vars.board, vars.taskId)
   })
 
   if (!id) {
     return null
   }
 
+  const currentAction = action!
+
+  const assignmentBusy = assignmentOwner.current !== null
+
+  const commentPending =
+    (commentMut.isPending && Boolean(commentMut.variables && isCurrent(commentMut.variables))) ||
+    (requeueMut.isPending && Boolean(requeueMut.variables && isCurrent(requeueMut.variables)))
+
+  const uploadPending = uploadMut.isPending && Boolean(uploadMut.variables && isCurrent(uploadMut.variables))
   const errorMessage = error ? errText(error) : null
 
   const move = (status: string) => {
@@ -670,11 +945,30 @@ export function TaskDrawer({
       return
     }
 
-    moveMut.mutate(status)
+    if (action) {
+      moveMut.mutate({ ...action, fromStatus: task.status, status })
+    }
+  }
+
+  const assign = (profile: null | string) => {
+    if (assignmentOwner.current || (task?.assignee ?? null) === profile) {
+      return
+    }
+
+    const owner = Symbol('kanban-drawer-assignment')
+    assignmentOwner.current = owner
+    assignment.mutate({ ...currentAction, owner, profile })
   }
 
   return (
-    <div className="absolute inset-y-0 right-0 z-20 flex w-[26rem] flex-col border-l border-(--ui-stroke-tertiary) bg-(--ui-bg-elevated) duration-150 ease-out animate-in fade-in slide-in-from-right-4">
+    <div
+      aria-labelledby={titleId}
+      aria-modal="true"
+      className="absolute inset-y-0 right-0 z-20 flex w-[26rem] flex-col border-l border-(--ui-stroke-tertiary) bg-(--ui-bg-elevated) duration-150 ease-out animate-in fade-in slide-in-from-right-4"
+      onKeyDown={trapFocus}
+      ref={drawerRef}
+      role="dialog"
+    >
       <header className="flex flex-col gap-2 px-4 pt-3.5 pb-3">
         <div className="flex items-center gap-2">
           {task ? (
@@ -719,11 +1013,20 @@ export function TaskDrawer({
                     {k.copyTitle}
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem onSelect={mutate(() => patchTask(task.id, { status: 'archived' }), onClose)}>
+                  <DropdownMenuItem
+                    onSelect={mutate(
+                      candidate => patchTask(candidate.board, candidate.taskId, { status: 'archived' }),
+                      closeDrawer,
+                      true
+                    )}
+                  >
                     <Codicon name="archive" size="0.85rem" />
                     {k.archiveTask}
                   </DropdownMenuItem>
-                  <DropdownMenuItem className="text-destructive" onSelect={mutate(() => deleteTask(task.id), onClose)}>
+                  <DropdownMenuItem
+                    className="text-destructive"
+                    onSelect={mutate(candidate => deleteTask(candidate.board, candidate.taskId), closeDrawer, true)}
+                  >
                     <Codicon name="trash" size="0.85rem" />
                     {k.deleteTask}
                   </DropdownMenuItem>
@@ -733,23 +1036,27 @@ export function TaskDrawer({
             <button
               aria-label={k.close}
               className="grid size-6 place-items-center rounded text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground"
-              onClick={onClose}
+              onClick={() => closeDrawer(currentAction)}
+              ref={closeButtonRef}
               type="button"
             >
               <Codicon name="close" size="0.9rem" />
             </button>
           </div>
         </div>
-        {task && (
-          <h2 className="text-sm leading-snug font-semibold text-foreground" data-selectable-text="true">
-            {task.title || task.id}
-          </h2>
-        )}
+        <h2 className="text-sm leading-snug font-semibold text-foreground" data-selectable-text="true" id={titleId}>
+          {task?.title || task?.id || shortId(id)}
+        </h2>
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4" data-selectable-text="true">
-        {errorMessage ? (
-          <ErrorState title={errorMessage} />
+        {errorMessage && !detail ? (
+          <ErrorState description={errorMessage} title={k.taskLoadError}>
+            <Button onClick={() => void detailQuery.refetch()} size="sm" variant="outline">
+              <Codicon name="refresh" size="0.8rem" />
+              {k.retry}
+            </Button>
+          </ErrorState>
         ) : !detail || !task ? (
           <div className="grid h-32 place-items-center">
             <Loader type="lemniscate-bloom" />
@@ -758,10 +1065,7 @@ export function TaskDrawer({
           <div className="flex flex-col gap-4 text-sm">
             <div className="grid grid-cols-[6rem_minmax(0,1fr)] gap-x-3 gap-y-1 text-[0.71rem]">
               <MetaRow label={k.assignee}>
-                <AssigneeMenu
-                  current={task.assignee}
-                  onReassign={profile => void mutate(() => reassignTask(task.id, profile))()}
-                />
+                <AssigneeMenu busy={assignmentBusy} current={task.assignee} onAssign={assign} />
               </MetaRow>
               {typeof task.priority === 'number' && <MetaRow label={k.metaPriority}>{task.priority}</MetaRow>}
               {task.tenant && <MetaRow label={k.metaTenant}>{task.tenant}</MetaRow>}
@@ -773,7 +1077,9 @@ export function TaskDrawer({
               )}
               <MetaRow label={k.model}>
                 <ModelOverrideField
-                  onChange={next => void mutate(() => patchTask(task.id, overridePatch(next)))()}
+                  onChange={next =>
+                    void mutate(candidate => patchTask(candidate.board, candidate.taskId, overridePatch(next)))()
+                  }
                   value={{
                     effort: task.reasoning_effort ?? '',
                     model: task.model_override ?? '',
@@ -794,13 +1100,19 @@ export function TaskDrawer({
 
             {task.diagnostics && task.diagnostics.length > 0 && (
               <Section label={k.diagnosticsN(task.diagnostics.length)}>
-                <Diagnostics items={task.diagnostics} onReclaim={() => void mutate(() => reclaimTask(task.id))()} />
+                <Diagnostics
+                  items={task.diagnostics}
+                  onReclaim={() => void mutate(candidate => reclaimTask(candidate.board, candidate.taskId))()}
+                />
               </Section>
             )}
 
-            <DescriptionSection body={task.body} onSave={body => void mutate(() => patchTask(task.id, { body }))()} />
+            <DescriptionSection
+              body={task.body}
+              onSave={body => void mutate(candidate => patchTask(candidate.board, candidate.taskId, { body }))()}
+            />
 
-            <EstimateSection id={task.id} />
+            <EstimateSection action={currentAction} isCurrent={isCurrent} />
 
             {task.result && (
               <Section label={k.result}>
@@ -826,7 +1138,7 @@ export function TaskDrawer({
                         <button
                           className="rounded bg-(--ui-bg-quaternary) px-1.5 py-0.5 font-mono text-[0.625rem] text-(--ui-text-secondary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground"
                           key={linked}
-                          onClick={() => onOpen(linked)}
+                          onClick={() => openDrawerTask(linked)}
                           type="button"
                         >
                           {shortId(linked)}
@@ -862,9 +1174,9 @@ export function TaskDrawer({
                 </ul>
               )}
               <CommentComposer
-                onRequeue={body => requeueMut.mutate(body)}
-                onSubmit={body => commentMut.mutate(body)}
-                pending={commentMut.isPending || requeueMut.isPending}
+                onRequeue={body => requeueMut.mutate({ ...currentAction, body })}
+                onSubmit={body => commentMut.mutate({ ...currentAction, body })}
+                pending={commentPending}
                 running={running}
               />
             </Section>
@@ -947,8 +1259,8 @@ export function TaskDrawer({
 
             <AttachmentsSection
               attachments={detail.attachments}
-              onUpload={file => uploadMut.mutate(file)}
-              pending={uploadMut.isPending}
+              onUpload={file => uploadMut.mutate({ ...currentAction, file })}
+              pending={uploadPending}
             />
           </div>
         )}

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -185,6 +185,20 @@ type KanbanMessages = {
   profileDescriptionsHint: string
   profileGoodAt: string
   auto: string
+  profilesAllowedBoard: string
+  inheritMachinePolicy: string
+  blockedByMachinePolicy: string
+  noWorkersCanRun: string
+  orchestrationLoadError: string
+  retry: string
+  boardLoadError: string
+  taskLoadError: string
+  taskPolicyLoadError: string
+  autoDescribeFailed: string
+  configuredBlocked: (name: string) => string
+  defaultResolved: (name: string) => string
+  effectiveFallback: (name: string) => string
+  none: string
 }
 
 const en: KanbanMessages = {
@@ -376,7 +390,21 @@ const en: KanbanMessages = {
   profileDescriptionsHint:
     'Descriptions guide the decomposer’s routing. Auto-generate with the auxiliary model, or write your own.',
   profileGoodAt: 'What is this profile good at?',
-  auto: 'Auto'
+  auto: 'Auto',
+  profilesAllowedBoard: 'Profiles allowed on this board',
+  inheritMachinePolicy: 'Inherit machine policy',
+  blockedByMachinePolicy: 'blocked by machine policy',
+  noWorkersCanRun: 'No workers can run on this board.',
+  orchestrationLoadError: 'Couldn’t load orchestration settings',
+  retry: 'Retry',
+  boardLoadError: 'Couldn’t load this board',
+  taskLoadError: 'Couldn’t load this task',
+  taskPolicyLoadError: 'Couldn’t load assignment policy',
+  autoDescribeFailed: 'Couldn’t generate a profile description',
+  configuredBlocked: name => `${name} (configured, blocked)`,
+  defaultResolved: name => `Default (effective: ${name})`,
+  effectiveFallback: name => `Effective fallback: ${name}`,
+  none: 'None'
 }
 
 const ja: KanbanMessages = {
@@ -567,7 +595,21 @@ const ja: KanbanMessages = {
   profileDescriptionsHint:
     '説明はデコンポーザーのルーティングを導きます。補助モデルで自動生成するか、自分で書いてください。',
   profileGoodAt: 'このプロフィールの得意分野は？',
-  auto: '自動'
+  auto: '自動',
+  profilesAllowedBoard: 'このボードで許可するプロフィール',
+  inheritMachinePolicy: 'マシンポリシーを継承',
+  blockedByMachinePolicy: 'マシンポリシーでブロック',
+  noWorkersCanRun: 'このボードではワーカーを実行できません。',
+  orchestrationLoadError: 'オーケストレーション設定を読み込めませんでした',
+  retry: '再試行',
+  boardLoadError: 'このボードを読み込めませんでした',
+  taskLoadError: 'このタスクを読み込めませんでした',
+  taskPolicyLoadError: '割り当てポリシーを読み込めませんでした',
+  autoDescribeFailed: 'プロフィールの説明を生成できませんでした',
+  configuredBlocked: name => `${name}（設定済み・ブロック）`,
+  defaultResolved: name => `既定（有効: ${name}）`,
+  effectiveFallback: name => `実際のフォールバック: ${name}`,
+  none: 'なし'
 }
 
 const zh: KanbanMessages = {
@@ -755,7 +797,21 @@ const zh: KanbanMessages = {
   profileDescriptions: '配置档说明',
   profileDescriptionsHint: '说明用于引导分解器的路由。可用辅助模型自动生成，或自行填写。',
   profileGoodAt: '这个配置档擅长什么？',
-  auto: '自动'
+  auto: '自动',
+  profilesAllowedBoard: '此面板允许的配置档',
+  inheritMachinePolicy: '继承机器策略',
+  blockedByMachinePolicy: '受机器策略阻止',
+  noWorkersCanRun: '此面板没有可运行的工作单元。',
+  orchestrationLoadError: '无法加载编排设置',
+  retry: '重试',
+  boardLoadError: '无法加载此面板',
+  taskLoadError: '无法加载此任务',
+  taskPolicyLoadError: '无法加载分配策略',
+  autoDescribeFailed: '无法生成配置档说明',
+  configuredBlocked: name => `${name}（已配置，已阻止）`,
+  defaultResolved: name => `默认（实际生效：${name}）`,
+  effectiveFallback: name => `实际回退：${name}`,
+  none: '无'
 }
 
 const zhHant: KanbanMessages = {
@@ -943,7 +999,21 @@ const zhHant: KanbanMessages = {
   profileDescriptions: '設定檔說明',
   profileDescriptionsHint: '說明用於引導分解器的路由。可用輔助模型自動產生，或自行填寫。',
   profileGoodAt: '這個設定檔擅長什麼？',
-  auto: '自動'
+  auto: '自動',
+  profilesAllowedBoard: '此面板允許的設定檔',
+  inheritMachinePolicy: '繼承機器政策',
+  blockedByMachinePolicy: '受機器政策阻擋',
+  noWorkersCanRun: '此面板沒有可執行的工作單元。',
+  orchestrationLoadError: '無法載入編排設定',
+  retry: '重試',
+  boardLoadError: '無法載入此面板',
+  taskLoadError: '無法載入此任務',
+  taskPolicyLoadError: '無法載入指派政策',
+  autoDescribeFailed: '無法產生設定檔說明',
+  configuredBlocked: name => `${name}（已設定，已阻擋）`,
+  defaultResolved: name => `預設（實際生效：${name}）`,
+  effectiveFallback: name => `實際回退：${name}`,
+  none: '無'
 }
 
 /** Registered via `ctx.i18n.register` at plugin load (disposer tracked). */

--- a/apps/desktop/src/plugins/kanban/orchestration.test.tsx
+++ b/apps/desktop/src/plugins/kanban/orchestration.test.tsx
@@ -1,0 +1,1779 @@
+import { host, type PluginRestOptions, type PluginStorage, useQuery, useValue } from '@hermes/plugin-sdk'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useEffect, useRef, useState } from 'react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import {
+  $boardSlug,
+  $profileDescriptionWriteOwner,
+  bindApi,
+  boardKey,
+  BOARDS_KEY,
+  createTask,
+  fetchBoard,
+  fetchLog,
+  fetchOrchestration,
+  fetchProfiles,
+  fetchTask,
+  logKey,
+  ORCHESTRATION_KEY,
+  orchestrationKey,
+  patchTask,
+  profileQueryOptions,
+  PROFILES_KEY,
+  profilesKey,
+  saveOrchestration,
+  taskKey
+} from './api'
+import { Card, KanbanBoardPage, NewTaskDialog, resolveNewTaskAssignee, SelectionBar } from './board'
+import { TaskDrawer } from './drawer'
+import { OrchestrationPanel } from './orchestration'
+import type { KanbanProfile, OrchestrationSettings } from './types'
+import { useDefaultAssignee, useOrchestration } from './ui'
+
+vi.mock('./i18n', () => ({
+  columnHelp: (_messages: unknown, name: string) => name,
+  columnLabel: (_messages: unknown, name: string) => name,
+  lockedReason: (_messages: unknown, name: string) => name,
+  useKanban: () => ({
+    assignee: 'Assignee',
+    addComment: 'Add a comment',
+    archive: 'Archive',
+    archiveTask: 'Archive task',
+    attachments: (count: number) => `Attachments · ${count}`,
+    auto: 'Auto',
+    autoDescribeFailed: 'Could not generate a profile description',
+    autoDecompose: 'Auto-decompose',
+    boardLoadError: 'Could not load this board',
+    boardDefaultSuffix: ' (board default)',
+    blockedByMachinePolicy: 'blocked by machine policy',
+    bulkFailed: (failed: number, total: number, error: string) => `${failed}/${total}: ${error}`,
+    cancel: 'Cancel',
+    cancelEdit: 'Cancel edit',
+    close: 'Close',
+    clearSelection: 'Clear selection',
+    col: {
+      archived: { help: '', label: 'Archived' },
+      blocked: { help: '', label: 'Blocked' },
+      done: { help: '', label: 'Done' },
+      ready: { help: '', label: 'Ready' },
+      review: { help: '', label: 'Review' },
+      running: { help: '', label: 'Running' },
+      scheduled: { help: '', label: 'Scheduled' },
+      todo: { help: '', label: 'Todo' },
+      triage: { help: '', label: 'Triage' }
+    },
+    comment: 'Comment',
+    comments: (count: number) => `Comments · ${count}`,
+    commentsHelp: 'Comments help',
+    complexity: { L: 'Large', M: 'Medium', S: 'Small' },
+    couldNotEstimate: 'Could not estimate',
+    createTask: 'Create task',
+    creating: 'Creating…',
+    copiedId: (id: string) => `Copied ${id}`,
+    copiedTitle: 'Copied title',
+    copyTaskId: 'Copy task id',
+    copyTitle: 'Copy title',
+    defaultOption: (name: string) => `Default (${name})`,
+    defaultResolved: (name: string) => `Default (effective: ${name})`,
+    defaultAssignee: 'Default assignee',
+    defaultParen: '(default)',
+    delete: 'Delete',
+    deleteTask: 'Delete task',
+    deselect: 'Deselect',
+    description: 'Description',
+    descPlaceholder: 'Description',
+    editDescription: 'Edit description',
+    estimate: 'Estimate',
+    estimateEffort: 'Estimate effort',
+    estimateTip: 'Estimate task',
+    estimateTipLong: 'Estimate task effort',
+    estimating: 'Estimating…',
+    goalMode: 'Goal mode',
+    inheritMachinePolicy: 'Inherit machine policy',
+    makesModelCall: 'makes a model call',
+    model: 'Model',
+    modelClear: 'Clear model',
+    modelHint: 'Optional model override',
+    modelInherit: 'Inherit profile model',
+    newTask: 'New task',
+    newTaskIn: (name: string) => `New task in ${name}`,
+    noAttachments: 'No attachments',
+    noDescription: 'No description',
+    noParent: 'No parent',
+    noTasks: 'No tasks on this board',
+    noWorkersCanRun: 'No workers can run on this board.',
+    nSelected: (count: number) => `${count} selected`,
+    none: 'None',
+    orchestrationLoadError: 'Could not load orchestration settings',
+    orchestratorProfile: 'Orchestrator profile',
+    open: 'Open',
+    parent: 'Parent',
+    parkedOption: 'Parked',
+    priority: 'Priority',
+    profileDescriptions: 'Profile descriptions',
+    profileDescriptionsHint: 'Used by the decomposer to route work.',
+    profileGoodAt: 'What this profile is good at',
+    profilesAllowedBoard: 'Profiles allowed on this board',
+    refused: 'refused',
+    configuredBlocked: (name: string) => `${name} (configured, blocked)`,
+    effectiveFallback: (name: string) => `Effective fallback: ${name}`,
+    reEstimate: 'Re-estimate',
+    retry: 'Retry',
+    roughEstimate: 'Rough estimate',
+    save: 'Save',
+    select: (modifier: string) => `Select (${modifier})`,
+    skills: 'Skills',
+    skillsPlaceholder: 'Comma-separated skills',
+    taskActions: 'Task actions',
+    taskLoadError: 'Could not load this task',
+    taskPolicyLoadError: 'Could not load assignment policy',
+    title: 'Kanban',
+    titlePlaceholder: 'Task title',
+    titlePlaceholderTriage: 'Triage title',
+    tokUnit: 'tokens',
+    unassigned: 'Unassigned',
+    unassignAction: 'Unassign',
+    uploadAttachment: 'Upload attachment',
+    workspace: 'Workspace',
+    workspaceInherit: 'Inherit board workspace',
+    workspaceInheritDir: (dir: string) => `Inherit ${dir}`,
+    workspaceInheritGeneric: 'Inherit the board workspace',
+    workspaceOverride: 'Workspace override',
+    assign: 'Assign',
+    moveToShort: 'Move to'
+  })
+}))
+
+type Rest = Parameters<typeof bindApi>[0]
+
+interface PolicyBoard {
+  allowed: null | string[]
+  effective: string[]
+}
+
+const MACHINE_ALLOWED = ['alpha', 'beta']
+
+function profile(name: string, board: PolicyBoard): KanbanProfile {
+  const machineAllowed = MACHINE_ALLOWED.includes(name)
+
+  return {
+    name,
+    is_default: false,
+    description: `${name} description`,
+    description_auto: false,
+    machine_allowed: machineAllowed,
+    board_selected: board.allowed === null || board.allowed.includes(name),
+    effective_allowed: board.effective.includes(name)
+  }
+}
+
+function orchestration(boardName: string, board: PolicyBoard): OrchestrationSettings {
+  const resolvedOrchestrator = board.effective.includes('alpha') ? 'alpha' : (board.effective[0] ?? null)
+  const resolvedDefault = board.effective.includes('beta') ? 'beta' : (board.effective[0] ?? null)
+
+  return {
+    board: boardName,
+    orchestrator_profile: 'alpha',
+    default_assignee: 'beta',
+    auto_decompose: true,
+    auto_promote_children: true,
+    resolved_orchestrator_profile: resolvedOrchestrator,
+    resolved_default_assignee: resolvedDefault,
+    active_profile: 'alpha',
+    board_allowed_profiles: board.allowed,
+    effective_allowed_profiles: [...board.effective]
+  }
+}
+
+function createPolicyRest(putGate?: Promise<void>, boardsGate?: Promise<void>, policyGate?: Promise<void>) {
+  const boards: Record<string, PolicyBoard> = {
+    'board-a': { allowed: ['alpha', 'blocked'], effective: ['alpha'] },
+    'board-b': { allowed: null, effective: ['alpha', 'beta'] },
+    'board/a': { allowed: ['alpha'], effective: ['alpha'] },
+    empty: { allowed: [], effective: [] }
+  }
+
+  const requests: Array<{ body: unknown; method: string; path: string }> = []
+
+  const rest = vi.fn(async (path: string, opts?: PluginRestOptions) => {
+    const url = new URL(path, 'http://kanban.test')
+    const boardName = url.searchParams.get('board') ?? 'board-a'
+    const board = boards[boardName]
+    const method = opts?.method ?? 'GET'
+
+    if (!board) {
+      throw new Error(`unknown board ${boardName}`)
+    }
+
+    requests.push({ body: opts?.body, method, path })
+
+    if (url.pathname === '/profiles' && method === 'GET') {
+      await policyGate
+
+      return { profiles: ['alpha', 'beta', 'blocked'].map(name => profile(name, board)) }
+    }
+
+    if (url.pathname === '/boards' && method === 'GET') {
+      await boardsGate
+
+      return {
+        boards: Object.keys(boards).map(slug => ({
+          default_workspace_kind: slug === 'board-b' ? 'worktree' : 'scratch',
+          slug
+        })),
+        current: 'board-a'
+      }
+    }
+
+    if (url.pathname === '/orchestration' && method === 'GET') {
+      await policyGate
+
+      return orchestration(boardName, board)
+    }
+
+    if (url.pathname === '/orchestration' && method === 'PUT') {
+      await putGate
+      const patch = (opts?.body ?? {}) as Record<string, unknown>
+
+      if (Object.hasOwn(patch, 'allowed_profiles')) {
+        const allowed = patch.allowed_profiles as null | string[]
+        board.allowed = allowed === null ? null : [...allowed]
+        board.effective =
+          allowed === null ? [...MACHINE_ALLOWED] : allowed.filter(name => MACHINE_ALLOWED.includes(name))
+      }
+
+      return orchestration(boardName, board)
+    }
+
+    if (/^\/profiles\/[^/]+$/.test(url.pathname) && method === 'PATCH') {
+      return {}
+    }
+
+    if (/^\/profiles\/[^/]+\/describe-auto$/.test(url.pathname) && method === 'POST') {
+      return { description: 'Generated profile description', ok: true }
+    }
+
+    if (url.pathname === '/tasks' && method === 'POST') {
+      const body = opts?.body as { title?: string }
+
+      return { task: { id: 't-created', status: 'triage', title: String(body.title) } }
+    }
+
+    throw new Error(`unexpected request ${method} ${path}`)
+  }) as unknown as Rest
+
+  return { boards, requests, rest }
+}
+
+function allowedProfiles(body: unknown): unknown {
+  return body && typeof body === 'object' ? (body as { allowed_profiles?: unknown }).allowed_profiles : undefined
+}
+
+const clients: QueryClient[] = []
+let disposeApi: null | (() => void) = null
+
+function bind(rest: Rest) {
+  const storage: PluginStorage = {
+    get: <T,>(_key: string, fallback: T) => fallback,
+    remove: vi.fn(),
+    set: vi.fn()
+  }
+
+  const socket = vi.fn(() => vi.fn())
+
+  disposeApi = bindApi(rest, storage, socket)
+}
+
+function renderPanel(rest: Rest, board = 'board-a') {
+  bind(rest)
+  $boardSlug.set(board)
+
+  const client = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } })
+  clients.push(client)
+
+  render(
+    <QueryClientProvider client={client}>
+      <OrchestrationPanel />
+    </QueryClientProvider>
+  )
+
+  return client
+}
+
+function FallbackProbe() {
+  const settings = useOrchestration()
+
+  return (
+    <p data-testid="fallback">
+      {settings ? `${settings.board}:${settings.resolved_default_assignee ?? 'none'}` : 'loading'}
+    </p>
+  )
+}
+
+function DefaultProbe() {
+  const assignee = useDefaultAssignee()
+
+  return <p data-testid="default-assignee">{assignee || 'none'}</p>
+}
+
+function BoardProbe() {
+  const slug = useValue($boardSlug)
+
+  const { data } = useQuery({
+    queryFn: () => fetchBoard(slug, false),
+    queryKey: boardKey(slug, false)
+  })
+
+  return <p data-testid="board">{data ? `${slug}:${data.now}` : 'loading'}</p>
+}
+
+function drawerDetail(board: string, taskId: string) {
+  return {
+    attachments: [],
+    comments: [],
+    events: [],
+    links: { children: [], parents: [] },
+    runs: [],
+    task: { assignee: 'alpha', id: taskId, status: 'done', title: `${board}:${taskId}` }
+  }
+}
+
+function cacheDrawerTask(client: QueryClient, board: string, taskId: string) {
+  client.setQueryData(taskKey(board, taskId), drawerDetail(board, taskId))
+  client.setQueryData(logKey(board, taskId), { content: '', exists: false, size_bytes: 0, truncated: false })
+  client.setQueryData(profilesKey(board), { profiles: [] })
+  client.setQueryData(orchestrationKey(board), orchestration(board, { allowed: null, effective: [] }))
+}
+
+function DrawerHarness({ id, onClose }: { id: string; onClose: () => void }) {
+  const [openId, setOpenId] = useState<null | string>(id)
+
+  useEffect(() => setOpenId(id), [id])
+
+  return (
+    <TaskDrawer
+      columns={['done']}
+      id={openId}
+      onClose={() => {
+        onClose()
+        setOpenId(null)
+      }}
+      onOpen={setOpenId}
+    />
+  )
+}
+
+function ReopenDrawerHarness() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)} type="button">
+        Open drawer
+      </button>
+      <TaskDrawer columns={['done']} id={open ? 'task-a' : null} onClose={() => setOpen(false)} onOpen={vi.fn()} />
+    </>
+  )
+}
+
+function ControlledNewTaskHarness({ onClose }: { onClose: (board: string) => void }) {
+  const [target, setTarget] = useState<null | string>('triage')
+
+  return (
+    <NewTaskDialog
+      onClose={board => {
+        onClose(board)
+        setTarget(null)
+      }}
+      parents={[]}
+      target={target}
+    />
+  )
+}
+
+function BulkSelectionHarness() {
+  const [selection, setSelection] = useState({ generation: 0, ids: new Set(['old-task']) })
+  const current = useRef(selection)
+  current.current = selection
+
+  const replace = (ids: string[]) =>
+    setSelection(previous => ({ generation: previous.generation + 1, ids: new Set(ids) }))
+
+  return (
+    <>
+      <button onClick={() => replace(['new-task'])} type="button">
+        Replace selection
+      </button>
+      <output data-testid="selection">{[...selection.ids].join(',')}</output>
+      <SelectionBar
+        columns={['done']}
+        generation={selection.generation}
+        isCurrent={(board, generation) => $boardSlug.get() === board && current.current.generation === generation}
+        onClear={() => replace([])}
+        onDone={(board, generation, failed) => {
+          if ($boardSlug.get() === board && current.current.generation === generation) {
+            replace(failed)
+          }
+        }}
+        selected={selection.ids}
+      />
+    </>
+  )
+}
+
+function createDeferredDrawerRest() {
+  const requests: Array<{ body: unknown; method: string; path: string }> = []
+  let releaseWrite!: () => void
+
+  const writeGate = new Promise<void>(resolve => {
+    releaseWrite = resolve
+  })
+
+  const rest = vi.fn(async (path: string, opts?: PluginRestOptions) => {
+    const url = new URL(path, 'http://kanban.test')
+    const board = url.searchParams.get('board') ?? ''
+    const method = opts?.method ?? 'GET'
+    const attachmentMatch = /^\/tasks\/([^/]+)\/attachments$/.exec(url.pathname)
+    const taskMatch = /^\/tasks\/([^/]+)$/.exec(url.pathname)
+    requests.push({ body: opts?.body, method, path })
+
+    if (taskMatch && method === 'GET') {
+      return drawerDetail(board, decodeURIComponent(taskMatch[1]))
+    }
+
+    if (taskMatch && (method === 'PATCH' || method === 'DELETE')) {
+      await writeGate
+
+      return {}
+    }
+
+    if (attachmentMatch && method === 'POST') {
+      await writeGate
+
+      return {}
+    }
+
+    if (url.pathname === '/dispatch' && method === 'POST') {
+      return {}
+    }
+
+    throw new Error(`unexpected request ${method} ${path}`)
+  }) as unknown as Rest
+
+  return { releaseWrite, requests, rest }
+}
+
+function createDeferredAssignmentRest() {
+  const assignees = new Map<string, null | string>([
+    ['empty:task-a', 'alpha'],
+    ['board-b:task-b', 'alpha']
+  ])
+
+  const requests: Array<{ body: unknown; method: string; path: string }> = []
+  let releaseAssignment!: () => void
+
+  const assignmentGate = new Promise<void>(resolve => {
+    releaseAssignment = resolve
+  })
+
+  const rest = vi.fn(async (path: string, opts?: PluginRestOptions) => {
+    const url = new URL(path, 'http://kanban.test')
+    const board = url.searchParams.get('board') ?? ''
+    const method = opts?.method ?? 'GET'
+    const logMatch = /^\/tasks\/([^/]+)\/log$/.exec(url.pathname)
+    const reassignMatch = /^\/tasks\/([^/]+)\/reassign$/.exec(url.pathname)
+    const taskMatch = /^\/tasks\/([^/]+)$/.exec(url.pathname)
+    requests.push({ body: opts?.body, method, path })
+
+    if (taskMatch && method === 'GET') {
+      const taskId = decodeURIComponent(taskMatch[1])
+      const detail = drawerDetail(board, taskId)
+      const key = `${board}:${taskId}`
+
+      return { ...detail, task: { ...detail.task, assignee: assignees.has(key) ? assignees.get(key) : 'alpha' } }
+    }
+
+    if (logMatch && method === 'GET') {
+      return { content: '', exists: false, size_bytes: 0, truncated: false }
+    }
+
+    if (reassignMatch && method === 'POST') {
+      await assignmentGate
+      const taskId = decodeURIComponent(reassignMatch[1])
+      const profile = (opts?.body as { profile: null | string }).profile
+      assignees.set(`${board}:${taskId}`, profile)
+
+      return { assignee: profile, ok: true, task_id: taskId }
+    }
+
+    if (url.pathname === '/dispatch' && method === 'POST') {
+      return {}
+    }
+
+    throw new Error(`unexpected request ${method} ${path}`)
+  }) as unknown as Rest
+
+  return { releaseAssignment, requests, rest }
+}
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+afterEach(() => {
+  cleanup()
+  disposeApi?.()
+  disposeApi = null
+  $boardSlug.set('')
+  $profileDescriptionWriteOwner.set(null)
+  clients.splice(0).forEach(client => client.clear())
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('board-scoped orchestration API', () => {
+  it('scopes profile and orchestration GETs and PUTs to the selected board', async () => {
+    const { requests, rest } = createPolicyRest()
+    bind(rest)
+    $boardSlug.set('board/a')
+
+    await fetchProfiles('board/a')
+    await fetchOrchestration('board/a')
+    await saveOrchestration('board/a', { allowed_profiles: null })
+
+    expect(requests.map(request => [request.method, request.path])).toEqual([
+      ['GET', '/profiles?board=board%2Fa'],
+      ['GET', '/orchestration?board=board%2Fa'],
+      ['PUT', '/orchestration?board=board%2Fa']
+    ])
+  })
+
+  it('keeps fallback reads in independent caches and refetches when the board changes', async () => {
+    const { requests, rest } = createPolicyRest()
+    bind(rest)
+    $boardSlug.set('board-a')
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    clients.push(client)
+    render(
+      <QueryClientProvider client={client}>
+        <FallbackProbe />
+      </QueryClientProvider>
+    )
+
+    expect(await screen.findByText('board-a:alpha')).toBeTruthy()
+
+    act(() => $boardSlug.set('board-b'))
+
+    expect(await screen.findByText('board-b:beta')).toBeTruthy()
+    expect(requests.filter(request => request.path === '/orchestration?board=board-a')).toHaveLength(1)
+    expect(requests.filter(request => request.path === '/orchestration?board=board-b')).toHaveLength(1)
+    expect(client.getQueryData<OrchestrationSettings>(orchestrationKey('board-a'))?.board).toBe('board-a')
+    expect(client.getQueryData<OrchestrationSettings>(orchestrationKey('board-b'))?.board).toBe('board-b')
+  })
+
+  it('keeps assignment rosters in independent board caches even when the selected board differs', async () => {
+    const { requests, rest } = createPolicyRest()
+    bind(rest)
+    $boardSlug.set('board-b')
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    clients.push(client)
+
+    const boardA = await client.fetchQuery(profileQueryOptions('board-a'))
+    const boardB = await client.fetchQuery(profileQueryOptions('board-b'))
+
+    expect(boardA.profiles.filter(profile => profile.effective_allowed).map(profile => profile.name)).toEqual(['alpha'])
+    expect(boardB.profiles.filter(profile => profile.effective_allowed).map(profile => profile.name)).toEqual([
+      'alpha',
+      'beta'
+    ])
+    expect(requests.filter(request => request.path === '/profiles?board=board-a')).toHaveLength(1)
+    expect(requests.filter(request => request.path === '/profiles?board=board-b')).toHaveLength(1)
+    expect(client.getQueryData(profilesKey('board-a'))).toBe(boardA)
+    expect(client.getQueryData(profilesKey('board-b'))).toBe(boardB)
+  })
+
+  it('refetches board data on A→B and pins delayed task writes and per-board nudges to their boards', async () => {
+    const requests: Array<{ body: unknown; method: string; path: string }> = []
+    let releaseCreate!: () => void
+
+    const createGate = new Promise<void>(resolve => {
+      releaseCreate = resolve
+    })
+
+    const rest = vi.fn(async (path: string, opts?: PluginRestOptions) => {
+      const url = new URL(path, 'http://kanban.test')
+      const board = url.searchParams.get('board') ?? ''
+      const method = opts?.method ?? 'GET'
+      requests.push({ body: opts?.body, method, path })
+
+      if (url.pathname === '/board') {
+        return { assignees: [], columns: [], latest_event_id: 0, now: board === 'board-a' ? 1 : 2, tenants: [] }
+      }
+
+      if (url.pathname === '/tasks/t-1' && method === 'GET') {
+        return { attachments: [], comments: [], events: [], links: { children: [], parents: [] }, runs: [], task: {} }
+      }
+
+      if (url.pathname === '/tasks/t-1/log') {
+        return { content: '', exists: false, size_bytes: 0, truncated: false }
+      }
+
+      if (url.pathname === '/tasks' && method === 'POST') {
+        await createGate
+
+        return { task: { id: 't-1', status: 'ready', title: 'Pinned task' } }
+      }
+
+      if ((url.pathname === '/tasks/t-1' && method === 'PATCH') || url.pathname === '/dispatch') {
+        return {}
+      }
+
+      throw new Error(`unexpected request ${method} ${path}`)
+    }) as unknown as Rest
+
+    bind(rest)
+    $boardSlug.set('board-a')
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    clients.push(client)
+    render(
+      <QueryClientProvider client={client}>
+        <BoardProbe />
+      </QueryClientProvider>
+    )
+
+    expect(await screen.findByText('board-a:1')).toBeTruthy()
+    await fetchTask('board-a', 't-1')
+    await fetchLog('board-a', 't-1')
+
+    const creating = createTask('board-a', { title: 'Pinned task' })
+    act(() => $boardSlug.set('board-b'))
+    expect(await screen.findByText('board-b:2')).toBeTruthy()
+
+    vi.useFakeTimers()
+    releaseCreate()
+    const { task } = await creating
+    await patchTask('board-a', task!.id, { status: 'triage' })
+    await patchTask('board-b', 't-1', { status: 'done' })
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(requests.filter(request => request.path === '/board?board=board-a')).toHaveLength(1)
+    expect(requests.filter(request => request.path === '/board?board=board-b')).toHaveLength(1)
+    expect(requests).toContainEqual({ body: { status: 'triage' }, method: 'PATCH', path: '/tasks/t-1?board=board-a' })
+    expect(requests).toContainEqual({ body: { status: 'done' }, method: 'PATCH', path: '/tasks/t-1?board=board-b' })
+    expect(requests.filter(request => request.path === '/dispatch?board=board-a')).toHaveLength(1)
+    expect(requests.filter(request => request.path === '/dispatch?board=board-b')).toHaveLength(1)
+  })
+})
+
+describe('task drawer action identity', () => {
+  it('keeps the B drawer open when a deferred A archive completes', async () => {
+    const { releaseWrite, requests, rest } = createDeferredDrawerRest()
+    bind(rest)
+    $boardSlug.set('board-a')
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false, staleTime: Infinity } }
+    })
+
+    const onClose = vi.fn()
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+    clients.push(client)
+    cacheDrawerTask(client, 'board-a', 'task-a')
+    cacheDrawerTask(client, 'board-b', 'task-b')
+
+    const view = render(
+      <QueryClientProvider client={client}>
+        <DrawerHarness id="task-a" onClose={onClose} />
+      </QueryClientProvider>
+    )
+
+    expect(await screen.findByText('board-a:task-a')).toBeTruthy()
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Task actions' }), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: 'mouse'
+    })
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Archive task' }))
+    await waitFor(() =>
+      expect(requests).toContainEqual({
+        body: { status: 'archived' },
+        method: 'PATCH',
+        path: '/tasks/task-a?board=board-a'
+      })
+    )
+
+    act(() => $boardSlug.set('board-b'))
+    view.rerender(
+      <QueryClientProvider client={client}>
+        <DrawerHarness id="task-b" onClose={onClose} />
+      </QueryClientProvider>
+    )
+    expect(await screen.findByText('board-b:task-b')).toBeTruthy()
+
+    releaseWrite()
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: taskKey('board-a', 'task-a') }))
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['kanban', 'board', 'board-a'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: BOARDS_KEY })
+
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.getByText('board-b:task-b')).toBeTruthy()
+  })
+
+  it('unassigns on a deny-all board with exact ownership and authoritative cache reconciliation', async () => {
+    const { releaseAssignment, requests, rest } = createDeferredAssignmentRest()
+    bind(rest)
+    $boardSlug.set('empty')
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false, staleTime: Infinity } }
+    })
+
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+    const denyAll = { allowed: [], effective: [] }
+    clients.push(client)
+    cacheDrawerTask(client, 'empty', 'task-a')
+    client.setQueryData(profilesKey('empty'), {
+      profiles: ['alpha', 'beta', 'blocked'].map(name => profile(name, denyAll))
+    })
+    cacheDrawerTask(client, 'board-b', 'task-b')
+
+    const renderDrawer = (taskId: string) => (
+      <QueryClientProvider client={client}>
+        <TaskDrawer columns={['done']} id={taskId} onClose={vi.fn()} onOpen={vi.fn()} />
+      </QueryClientProvider>
+    )
+
+    const view = render(renderDrawer('task-a'))
+    expect(await screen.findByRole('dialog', { name: 'empty:task-a' })).toBeTruthy()
+
+    const assignee = screen.getByRole('button', { name: 'alpha' })
+    fireEvent.keyDown(assignee, { key: 'Enter' })
+    const unassign = await screen.findByRole('menuitem', { name: 'Unassign' })
+    expect(screen.queryByRole('menuitem', { name: 'alpha' })).toBeNull()
+    unassign.focus()
+    fireEvent.keyDown(unassign, { key: 'Enter' })
+
+    await waitFor(() =>
+      expect(requests).toContainEqual({
+        body: { profile: null, reclaim_first: true },
+        method: 'POST',
+        path: '/tasks/task-a/reassign?board=empty'
+      })
+    )
+    await waitFor(() =>
+      expect(
+        client.getQueryData<{ task: { assignee?: null | string } }>(taskKey('empty', 'task-a'))?.task.assignee
+      ).toBeNull()
+    )
+    expect(screen.getByRole('button', { name: 'Unassigned' }).hasAttribute('disabled')).toBe(true)
+
+    act(() => $boardSlug.set('board-b'))
+    view.rerender(renderDrawer('task-b'))
+    expect(await screen.findByRole('dialog', { name: 'board-b:task-b' })).toBeTruthy()
+    const boardBAssignee = screen.getByRole('button', { name: 'alpha' })
+    expect(boardBAssignee.hasAttribute('disabled')).toBe(true)
+    fireEvent.click(boardBAssignee)
+    expect(requests.filter(request => request.path.includes('/reassign'))).toHaveLength(1)
+
+    releaseAssignment()
+    await waitFor(() => expect(boardBAssignee.hasAttribute('disabled')).toBe(false))
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: taskKey('empty', 'task-a') })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['kanban', 'board', 'empty'] })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: taskKey('board-b', 'task-b') })
+    expect(
+      client.getQueryData<{ task: { assignee?: null | string } }>(taskKey('board-b', 'task-b'))?.task.assignee
+    ).toBe('alpha')
+    expect(screen.getByRole('button', { name: 'alpha' })).toBeTruthy()
+
+    act(() => $boardSlug.set('empty'))
+    view.rerender(renderDrawer('task-a'))
+    expect(await screen.findByRole('dialog', { name: 'empty:task-a' })).toBeTruthy()
+    await waitFor(() =>
+      expect(requests.filter(request => request.path === '/tasks/task-a?board=empty')).toHaveLength(1)
+    )
+    expect(
+      client.getQueryData<{ task: { assignee?: null | string } }>(taskKey('empty', 'task-a'))?.task.assignee
+    ).toBeNull()
+
+    const unassigned = screen.getByRole('button', { name: 'Unassigned' })
+    expect(unassigned.hasAttribute('disabled')).toBe(false)
+    fireEvent.keyDown(unassigned, { key: 'Enter' })
+    expect((await screen.findByRole('menuitem', { name: 'Unassigned' })).getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('closes normally when a deferred delete completes for the current task identity', async () => {
+    const { releaseWrite, requests, rest } = createDeferredDrawerRest()
+    bind(rest)
+    $boardSlug.set('board-a')
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false, staleTime: Infinity } }
+    })
+
+    const onClose = vi.fn()
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+    clients.push(client)
+    cacheDrawerTask(client, 'board-a', 'task-a')
+
+    render(
+      <QueryClientProvider client={client}>
+        <DrawerHarness id="task-a" onClose={onClose} />
+      </QueryClientProvider>
+    )
+
+    expect(await screen.findByText('board-a:task-a')).toBeTruthy()
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Task actions' }), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: 'mouse'
+    })
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Delete task' }))
+    await waitFor(() =>
+      expect(requests).toContainEqual({ body: undefined, method: 'DELETE', path: '/tasks/task-a?board=board-a' })
+    )
+
+    releaseWrite()
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce())
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: taskKey('board-a', 'task-a') })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['kanban', 'board', 'board-a'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: BOARDS_KEY })
+    expect(screen.queryByText('board-a:task-a')).toBeNull()
+  })
+
+  it('rejects an old archive completion after closing and reopening the same drawer identity', async () => {
+    const { releaseWrite, requests, rest } = createDeferredDrawerRest()
+    bind(rest)
+    $boardSlug.set('board-a')
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false, staleTime: Infinity } }
+    })
+
+    clients.push(client)
+    cacheDrawerTask(client, 'board-a', 'task-a')
+    render(
+      <QueryClientProvider client={client}>
+        <ReopenDrawerHarness />
+      </QueryClientProvider>
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Open drawer' })
+    fireEvent.click(trigger)
+    expect(await screen.findByRole('dialog', { name: 'board-a:task-a' })).toBeTruthy()
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Task actions' }), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: 'mouse'
+    })
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Archive task' }))
+    await waitFor(() =>
+      expect(requests).toContainEqual({
+        body: { status: 'archived' },
+        method: 'PATCH',
+        path: '/tasks/task-a?board=board-a'
+      })
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(screen.queryByRole('dialog')).toBeNull()
+    fireEvent.click(trigger)
+    expect(await screen.findByRole('dialog', { name: 'board-a:task-a' })).toBeTruthy()
+
+    releaseWrite()
+    await waitFor(() =>
+      expect(requests.filter(request => request.path === '/tasks/task-a?board=board-a')).toHaveLength(1)
+    )
+    expect(screen.getByRole('dialog', { name: 'board-a:task-a' })).toBeTruthy()
+  })
+
+  it('owns modal focus, loops Tab in both directions, closes on Escape, and restores prior focus', async () => {
+    const { rest } = createDeferredDrawerRest()
+    bind(rest)
+    $boardSlug.set('board-a')
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false, staleTime: Infinity } }
+    })
+
+    clients.push(client)
+    cacheDrawerTask(client, 'board-a', 'task-a')
+    render(
+      <QueryClientProvider client={client}>
+        <ReopenDrawerHarness />
+      </QueryClientProvider>
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Open drawer' })
+    trigger.focus()
+    fireEvent.click(trigger)
+
+    const dialog = await screen.findByRole('dialog', { name: 'board-a:task-a' })
+    const close = screen.getByRole('button', { name: 'Close' })
+    expect(dialog.getAttribute('aria-modal')).toBe('true')
+    expect(window.document.activeElement).toBe(close)
+
+    const focusable = [
+      ...dialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+    ]
+
+    const first = focusable[0]
+    const last = focusable.at(-1)!
+
+    last.focus()
+    fireEvent.keyDown(last, { key: 'Tab' })
+    expect(window.document.activeElement).toBe(first)
+
+    first.focus()
+    fireEvent.keyDown(first, { key: 'Tab', shiftKey: true })
+    expect(window.document.activeElement).toBe(last)
+
+    fireEvent.keyDown(last, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(window.document.activeElement).toBe(trigger)
+  })
+
+  it('loops focus past a hidden file input while its visible upload control is disabled', async () => {
+    const { releaseWrite, requests, rest } = createDeferredDrawerRest()
+    bind(rest)
+    $boardSlug.set('board-a')
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false, staleTime: Infinity } }
+    })
+
+    clients.push(client)
+    cacheDrawerTask(client, 'board-a', 'task-a')
+    render(
+      <QueryClientProvider client={client}>
+        <ReopenDrawerHarness />
+      </QueryClientProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }))
+    const dialog = await screen.findByRole('dialog', { name: 'board-a:task-a' })
+    const first = screen.getByRole('button', { name: 'done' })
+    const actualLast = screen.getByPlaceholderText('Add a comment')
+    const uploadButton = screen.getByRole('button', { name: 'Upload attachment' })
+    const hiddenInput = dialog.querySelector<HTMLInputElement>('input[type="file"]')!
+    const hiddenFocus = vi.fn()
+    hiddenInput.addEventListener('focus', hiddenFocus)
+
+    fireEvent.change(hiddenInput, {
+      target: { files: [new File(['attachment'], 'attachment.txt', { type: 'text/plain' })] }
+    })
+    await waitFor(() =>
+      expect(requests).toContainEqual({
+        body: undefined,
+        method: 'POST',
+        path: '/tasks/task-a/attachments?board=board-a'
+      })
+    )
+    expect(uploadButton.hasAttribute('disabled')).toBe(true)
+
+    actualLast.focus()
+    fireEvent.keyDown(actualLast, { key: 'Tab' })
+    expect(window.document.activeElement).toBe(first)
+
+    first.focus()
+    fireEvent.keyDown(first, { key: 'Tab', shiftKey: true })
+    expect(window.document.activeElement).toBe(actualLast)
+    expect(window.document.activeElement).not.toBe(hiddenInput)
+    expect(hiddenFocus).not.toHaveBeenCalled()
+
+    releaseWrite()
+    await waitFor(() => expect(uploadButton.hasAttribute('disabled')).toBe(false))
+  })
+})
+
+describe('terminal query recovery', () => {
+  it('retries a terminal board load error against the same board', async () => {
+    const base = createPolicyRest()
+    const paths: string[] = []
+    let failing = true
+
+    const rest = vi.fn((path: string, opts?: PluginRestOptions) => {
+      const url = new URL(path, 'http://kanban.test')
+
+      if (url.pathname === '/board') {
+        paths.push(path)
+
+        if (failing) {
+          return Promise.reject(new Error('board offline'))
+        }
+
+        return Promise.resolve({
+          assignees: [],
+          columns: [{ name: 'triage', tasks: [] }],
+          latest_event_id: 0,
+          now: 1,
+          tenants: []
+        })
+      }
+
+      return base.rest(path, opts)
+    }) as unknown as Rest
+
+    bind(rest)
+    $boardSlug.set('board-a')
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    clients.push(client)
+    render(
+      <QueryClientProvider client={client}>
+        <KanbanBoardPage />
+      </QueryClientProvider>
+    )
+
+    expect(await screen.findByText('Could not load this board')).toBeTruthy()
+    failing = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('No tasks on this board')).toBeTruthy()
+    expect(paths).toEqual(['/board?board=board-a', '/board?board=board-a'])
+  })
+
+  it('retries a terminal drawer load error against the same task identity', async () => {
+    const base = createPolicyRest()
+    const paths: string[] = []
+    let failing = true
+
+    const rest = vi.fn((path: string, opts?: PluginRestOptions) => {
+      const url = new URL(path, 'http://kanban.test')
+      const method = opts?.method ?? 'GET'
+
+      if (url.pathname === '/tasks/task-a' && method === 'GET') {
+        paths.push(path)
+
+        return failing ? Promise.reject(new Error('task offline')) : Promise.resolve(drawerDetail('board-a', 'task-a'))
+      }
+
+      if (url.pathname === '/tasks/task-a/log' && method === 'GET') {
+        return Promise.resolve({ content: '', exists: false, size_bytes: 0, truncated: false })
+      }
+
+      return base.rest(path, opts)
+    }) as unknown as Rest
+
+    bind(rest)
+    $boardSlug.set('board-a')
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    clients.push(client)
+    render(
+      <QueryClientProvider client={client}>
+        <TaskDrawer columns={['done']} id="task-a" onClose={vi.fn()} onOpen={vi.fn()} />
+      </QueryClientProvider>
+    )
+
+    expect(await screen.findByText('Could not load this task')).toBeTruthy()
+    failing = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('board-a:task-a')).toBeTruthy()
+    expect(paths).toEqual(['/tasks/task-a?board=board-a', '/tasks/task-a?board=board-a'])
+  })
+})
+
+describe('task card keyboard access', () => {
+  it('opens with Enter/Space and retains modifier-selection behavior', () => {
+    $boardSlug.set('board-a')
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    client.setQueryData(orchestrationKey('board-a'), orchestration('board-a', { allowed: null, effective: ['alpha'] }))
+    clients.push(client)
+    const onOpen = vi.fn()
+    const onToggleSelect = vi.fn()
+
+    render(
+      <QueryClientProvider client={client}>
+        <Card
+          columns={['done']}
+          onDelete={vi.fn()}
+          onMove={vi.fn()}
+          onOpen={onOpen}
+          onToggleSelect={onToggleSelect}
+          selected={false}
+          task={{ id: 'keyboard-task', status: 'done', title: 'Keyboard task' }}
+        />
+      </QueryClientProvider>
+    )
+
+    const card = screen.getByRole('button', { name: 'Keyboard task' })
+    fireEvent.keyDown(card, { key: 'Enter' })
+    fireEvent.keyDown(card, { key: ' ' })
+    fireEvent.keyDown(card, { ctrlKey: true, key: 'Enter' })
+    fireEvent.click(card, { ctrlKey: true })
+
+    expect(onOpen).toHaveBeenCalledTimes(2)
+    expect(onOpen).toHaveBeenNthCalledWith(1, 'keyboard-task')
+    expect(onOpen).toHaveBeenNthCalledWith(2, 'keyboard-task')
+    expect(onToggleSelect).toHaveBeenCalledTimes(2)
+    expect(onToggleSelect).toHaveBeenCalledWith('keyboard-task')
+  })
+})
+
+describe('new-task effective default resolution', () => {
+  it('uses the resolved default rather than a blocked raw configured default, including null', async () => {
+    const { rest } = createPolicyRest()
+    bind(rest)
+    $boardSlug.set('board-a')
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    clients.push(client)
+    render(
+      <QueryClientProvider client={client}>
+        <DefaultProbe />
+      </QueryClientProvider>
+    )
+
+    // board-a stores raw beta, but policy resolves it to alpha.
+    expect(await screen.findByText('alpha')).toBeTruthy()
+
+    act(() => $boardSlug.set('empty'))
+    expect(await screen.findByText('none')).toBeTruthy()
+  })
+
+  it('never fabricates a default when the board has no effective worker', () => {
+    const alpha = new Set(['alpha'])
+
+    expect(resolveNewTaskAssignee('', null, alpha)).toBeUndefined()
+    expect(resolveNewTaskAssignee('', undefined, alpha)).toBeUndefined()
+    expect(resolveNewTaskAssignee('__parked__', 'alpha', alpha)).toBeUndefined()
+    expect(resolveNewTaskAssignee('', 'alpha', alpha)).toBe('alpha')
+    expect(resolveNewTaskAssignee('beta', 'alpha', alpha)).toBe('alpha')
+    expect(resolveNewTaskAssignee('beta', null, new Set())).toBeUndefined()
+  })
+
+  it('keeps typed form input when late board metadata initializes a pristine workspace default', async () => {
+    let releaseBoards!: () => void
+
+    const boardsGate = new Promise<void>(resolve => {
+      releaseBoards = resolve
+    })
+
+    const { rest } = createPolicyRest(undefined, boardsGate)
+    bind(rest)
+    $boardSlug.set('board-b')
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    clients.push(client)
+    render(
+      <QueryClientProvider client={client}>
+        <NewTaskDialog onClose={vi.fn()} parents={[]} target="triage" />
+      </QueryClientProvider>
+    )
+
+    const title = await screen.findByPlaceholderText('Triage title')
+    fireEvent.change(title, { target: { value: 'Do not erase me' } })
+    releaseBoards()
+
+    const workspace = await screen.findByRole('combobox', { name: 'Workspace' })
+    await waitFor(() => expect(workspace.textContent).toContain('worktree'))
+    expect((title as HTMLInputElement).value).toBe('Do not erase me')
+  })
+
+  it('keeps create disabled until both orchestration and the effective profile roster load', async () => {
+    let releasePolicy!: () => void
+
+    const policyGate = new Promise<void>(resolve => {
+      releasePolicy = resolve
+    })
+
+    const { rest } = createPolicyRest(undefined, undefined, policyGate)
+    bind(rest)
+    $boardSlug.set('board-b')
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    clients.push(client)
+    render(
+      <QueryClientProvider client={client}>
+        <NewTaskDialog onClose={vi.fn()} parents={[]} target="triage" />
+      </QueryClientProvider>
+    )
+
+    fireEvent.change(await screen.findByPlaceholderText('Triage title'), { target: { value: 'Wait for policy' } })
+    const create = screen.getByRole('button', { name: 'Create task' })
+    expect(create.hasAttribute('disabled')).toBe(true)
+
+    releasePolicy()
+    await waitFor(() => expect(create.hasAttribute('disabled')).toBe(false))
+  })
+
+  it('keeps create disabled after a policy load error and retries the exact board', async () => {
+    const base = createPolicyRest()
+    const attempts: string[] = []
+    let failing = true
+
+    const rest = vi.fn((path: string, opts?: PluginRestOptions) => {
+      const url = new URL(path, 'http://kanban.test')
+      const method = opts?.method ?? 'GET'
+
+      if (method === 'GET' && (url.pathname === '/profiles' || url.pathname === '/orchestration')) {
+        attempts.push(path)
+
+        if (failing) {
+          return Promise.reject(new Error('policy offline'))
+        }
+      }
+
+      return base.rest(path, opts)
+    }) as unknown as Rest
+
+    bind(rest)
+    $boardSlug.set('board-b')
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    clients.push(client)
+    render(
+      <QueryClientProvider client={client}>
+        <NewTaskDialog onClose={vi.fn()} parents={[]} target="triage" />
+      </QueryClientProvider>
+    )
+
+    fireEvent.change(await screen.findByPlaceholderText('Triage title'), { target: { value: 'Retry policy' } })
+    expect(await screen.findByText('Could not load assignment policy')).toBeTruthy()
+    const create = screen.getByRole('button', { name: 'Create task' })
+    expect(create.hasAttribute('disabled')).toBe(true)
+
+    failing = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(create.hasAttribute('disabled')).toBe(false))
+    expect(attempts).toEqual([
+      '/profiles?board=board-b',
+      '/orchestration?board=board-b',
+      '/profiles?board=board-b',
+      '/orchestration?board=board-b'
+    ])
+  })
+
+  it('sanitizes a stale explicit assignee against a deny/list transition in the actual create payload', async () => {
+    const { boards, requests, rest } = createPolicyRest()
+    bind(rest)
+    $boardSlug.set('board-b')
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } })
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+    clients.push(client)
+    render(
+      <QueryClientProvider client={client}>
+        <NewTaskDialog onClose={vi.fn()} parents={[]} target="triage" />
+      </QueryClientProvider>
+    )
+
+    fireEvent.change(await screen.findByPlaceholderText('Triage title'), { target: { value: 'Policy-safe task' } })
+    const assignee = await screen.findByRole('combobox', { name: 'Assignee' })
+    fireEvent.click(assignee)
+    fireEvent.click(await screen.findByRole('option', { name: 'alpha' }))
+    expect(assignee.textContent).toBe('alpha')
+
+    boards['board-b'].allowed = ['beta']
+    boards['board-b'].effective = ['beta']
+    await act(async () => {
+      await Promise.all([
+        client.invalidateQueries({ queryKey: orchestrationKey('board-b') }),
+        client.invalidateQueries({ queryKey: profilesKey('board-b') })
+      ])
+    })
+
+    await waitFor(() => expect(assignee.textContent).toBe('Default (beta)'))
+    const create = screen.getByRole('button', { name: 'Create task' })
+    await waitFor(() => expect(create.hasAttribute('disabled')).toBe(false))
+    fireEvent.click(create)
+
+    await waitFor(() =>
+      expect(
+        requests.some(
+          request =>
+            request.method === 'POST' &&
+            request.path === '/tasks?board=board-b' &&
+            (request.body as { assignee?: string }).assignee === 'beta'
+        )
+      ).toBe(true)
+    )
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: ['kanban', 'board', 'board-b'] }))
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: taskKey('board-b', 't-created') })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: BOARDS_KEY })
+  })
+
+  it('rejects an A estimate completion after A→B→A and keeps the newer A result', async () => {
+    let releaseEstimate!: () => void
+
+    const estimateGate = new Promise<void>(resolve => {
+      releaseEstimate = resolve
+    })
+
+    const base = createPolicyRest()
+    const estimateTitles: string[] = []
+
+    const rest = vi.fn(async (path: string, opts?: PluginRestOptions) => {
+      const url = new URL(path, 'http://kanban.test')
+
+      if (url.pathname === '/estimate' && opts?.method === 'POST') {
+        const title = String((opts.body as { title?: string }).title)
+        estimateTitles.push(title)
+
+        if (title === 'Old estimate') {
+          await estimateGate
+
+          return { complexity: 'S', est_tokens: 111, ok: true }
+        }
+
+        return { complexity: 'M', est_tokens: 222, ok: true }
+      }
+
+      return base.rest(path, opts)
+    }) as unknown as Rest
+
+    bind(rest)
+    $boardSlug.set('board-a')
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } })
+    clients.push(client)
+    render(
+      <QueryClientProvider client={client}>
+        <NewTaskDialog onClose={vi.fn()} parents={[]} target="triage" />
+      </QueryClientProvider>
+    )
+
+    const title = await screen.findByPlaceholderText('Triage title')
+    fireEvent.change(title, { target: { value: 'Old estimate' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Estimate' }))
+    await waitFor(() => expect(estimateTitles).toEqual(['Old estimate']))
+
+    act(() => $boardSlug.set('board-b'))
+    await waitFor(() => expect((title as HTMLInputElement).value).toBe(''))
+    act(() => $boardSlug.set('board-a'))
+    await waitFor(() => expect((title as HTMLInputElement).value).toBe(''))
+
+    fireEvent.change(title, { target: { value: 'Fresh estimate' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Estimate' }))
+    expect(await screen.findByText(/~222/)).toBeTruthy()
+
+    releaseEstimate()
+    await waitFor(() => expect(estimateTitles).toEqual(['Old estimate', 'Fresh estimate']))
+    expect(screen.getByText(/~222/)).toBeTruthy()
+    expect(screen.queryByText(/~111/)).toBeNull()
+  })
+
+  it('rejects an A create completion after A→B→A and never closes or reports into the newer lifecycle', async () => {
+    let releaseCreate!: () => void
+
+    const createGate = new Promise<void>(resolve => {
+      releaseCreate = resolve
+    })
+
+    const base = createPolicyRest()
+    const createTitles: string[] = []
+
+    const rest = vi.fn(async (path: string, opts?: PluginRestOptions) => {
+      const url = new URL(path, 'http://kanban.test')
+
+      if (url.pathname === '/tasks' && opts?.method === 'POST') {
+        const title = String((opts.body as { title?: string }).title)
+        createTitles.push(title)
+
+        if (title === 'Old create') {
+          await createGate
+
+          return { task: { id: 'old-task', status: 'triage', title }, warning: 'stale warning' }
+        }
+
+        return { task: { id: 'fresh-task', status: 'triage', title } }
+      }
+
+      return base.rest(path, opts)
+    }) as unknown as Rest
+
+    bind(rest)
+    $boardSlug.set('board-a')
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } })
+    const onClose = vi.fn()
+    const notify = vi.spyOn(host, 'notify')
+    clients.push(client)
+    render(
+      <QueryClientProvider client={client}>
+        <ControlledNewTaskHarness onClose={onClose} />
+      </QueryClientProvider>
+    )
+
+    const title = await screen.findByPlaceholderText('Triage title')
+    fireEvent.change(title, { target: { value: 'Old create' } })
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Create task' }).hasAttribute('disabled')).toBe(false)
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Create task' }))
+    await waitFor(() => expect(createTitles).toEqual(['Old create']))
+
+    act(() => $boardSlug.set('board-b'))
+    await waitFor(() => expect((title as HTMLInputElement).value).toBe(''))
+    act(() => $boardSlug.set('board-a'))
+    await waitFor(() => expect((title as HTMLInputElement).value).toBe(''))
+
+    fireEvent.change(title, { target: { value: 'Fresh create' } })
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Create task' }).hasAttribute('disabled')).toBe(false)
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Create task' }))
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce())
+    expect(onClose).toHaveBeenCalledWith('board-a')
+
+    releaseCreate()
+    await waitFor(() => expect(createTitles).toEqual(['Old create', 'Fresh create']))
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(notify).not.toHaveBeenCalledWith(expect.objectContaining({ message: 'stale warning' }))
+  })
+})
+
+describe('bulk selection lifecycle', () => {
+  it('keeps a replacement selection and suppresses stale partial-failure UI', async () => {
+    let releaseBulk!: () => void
+
+    const bulkGate = new Promise<void>(resolve => {
+      releaseBulk = resolve
+    })
+
+    const base = createPolicyRest()
+    const bulkRequests: string[] = []
+
+    const rest = vi.fn(async (path: string, opts?: PluginRestOptions) => {
+      const url = new URL(path, 'http://kanban.test')
+
+      if (url.pathname === '/tasks/bulk' && opts?.method === 'POST') {
+        bulkRequests.push(path)
+        await bulkGate
+
+        return { results: [{ error: 'old refusal', id: 'old-task', ok: false }] }
+      }
+
+      return base.rest(path, opts)
+    }) as unknown as Rest
+
+    bind(rest)
+    $boardSlug.set('board-a')
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false, staleTime: Infinity } }
+    })
+
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+    const notify = vi.spyOn(host, 'notify')
+    clients.push(client)
+    client.setQueryData(profilesKey('board-a'), { profiles: [] })
+    render(
+      <QueryClientProvider client={client}>
+        <BulkSelectionHarness />
+      </QueryClientProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Archive' }))
+    await waitFor(() => expect(bulkRequests).toEqual(['/tasks/bulk?board=board-a']))
+    fireEvent.click(screen.getByRole('button', { name: 'Replace selection' }))
+    expect(screen.getByTestId('selection').textContent).toBe('new-task')
+
+    releaseBulk()
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: taskKey('board-a', 'old-task') }))
+    expect(screen.getByTestId('selection').textContent).toBe('new-task')
+    expect(notify).not.toHaveBeenCalled()
+  })
+})
+
+describe('per-board profile policy controls', () => {
+  it('saves null for inheritance and starts an explicit policy from the effective roster', async () => {
+    const { requests, rest } = createPolicyRest()
+    renderPanel(rest, 'board-a')
+
+    const inherit = await screen.findByRole('checkbox', { name: 'Inherit machine policy' })
+    expect(inherit.getAttribute('aria-checked')).toBe('false')
+
+    fireEvent.click(inherit)
+
+    await waitFor(() =>
+      expect(requests.some(request => request.method === 'PUT' && allowedProfiles(request.body) === null)).toBe(true)
+    )
+
+    act(() => $boardSlug.set('board-b'))
+    const inherited = await screen.findByRole('checkbox', { name: 'Inherit machine policy' })
+    await waitFor(() => expect(inherited.getAttribute('aria-checked')).toBe('true'))
+
+    fireEvent.click(inherited)
+
+    await waitFor(() =>
+      expect(
+        requests.some(
+          request =>
+            request.method === 'PUT' &&
+            request.path === '/orchestration?board=board-b' &&
+            JSON.stringify(allowedProfiles(request.body)) === JSON.stringify(['alpha', 'beta'])
+        )
+      ).toBe(true)
+    )
+  })
+
+  it('warns clearly when the effective policy leaves no workers', async () => {
+    const { rest } = createPolicyRest()
+    renderPanel(rest, 'empty')
+
+    expect((await screen.findByRole('alert')).textContent).toBe('No workers can run on this board.')
+  })
+
+  it('keeps a historically selected machine-blocked profile visible, checked, and disabled', async () => {
+    const { rest } = createPolicyRest()
+    renderPanel(rest)
+
+    const blocked = await screen.findByRole('checkbox', { name: 'blocked — blocked by machine policy' })
+
+    expect(blocked.getAttribute('aria-checked')).toBe('true')
+    expect(blocked.hasAttribute('disabled')).toBe(true)
+    expect(screen.getByText('blocked by machine policy')).toBeTruthy()
+    expect(screen.getByDisplayValue('blocked description')).toBeTruthy()
+  })
+
+  it('saves only machine-permitted names and invalidates/refetches both board queries', async () => {
+    const { requests, rest } = createPolicyRest()
+    const client = renderPanel(rest)
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+
+    const beta = await screen.findByRole('checkbox', { name: 'beta' })
+    const initialGets = requests.filter(request => request.method === 'GET').length
+    fireEvent.click(beta)
+
+    await waitFor(() =>
+      expect(
+        requests.some(
+          request =>
+            request.method === 'PUT' &&
+            request.path === '/orchestration?board=board-a' &&
+            JSON.stringify(allowedProfiles(request.body)) === JSON.stringify(['alpha', 'beta'])
+        )
+      ).toBe(true)
+    )
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: orchestrationKey('board-a') }))
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: profilesKey('board-a') }))
+    await waitFor(() =>
+      expect(requests.filter(request => request.method === 'GET').length).toBeGreaterThan(initialGets)
+    )
+  })
+
+  it('invalidates all orchestration caches for global fields while keeping roster invalidation board-scoped', async () => {
+    const { requests, rest } = createPolicyRest()
+    const client = renderPanel(rest)
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+    const autoDecompose = await screen.findByRole('switch', { name: 'Auto-decompose' })
+
+    fireEvent.click(autoDecompose)
+
+    await waitFor(() =>
+      expect(
+        requests.some(
+          request =>
+            request.method === 'PUT' && JSON.stringify(request.body) === JSON.stringify({ auto_decompose: false })
+        )
+      ).toBe(true)
+    )
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: ORCHESTRATION_KEY }))
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: profilesKey('board-a') }))
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ['kanban', 'profiles'] })
+  })
+
+  it('serializes orchestration saves and disables every panel control while the write is pending', async () => {
+    let releasePut!: () => void
+
+    const putGate = new Promise<void>(resolve => {
+      releasePut = resolve
+    })
+
+    const { requests, rest } = createPolicyRest(putGate)
+    renderPanel(rest)
+    const autoDecompose = await screen.findByRole('switch', { name: 'Auto-decompose' })
+
+    fireEvent.click(autoDecompose)
+    fireEvent.click(autoDecompose)
+
+    await waitFor(() => expect(requests.filter(request => request.method === 'PUT')).toHaveLength(1))
+    expect(requests.find(request => request.method === 'PUT')?.body).toEqual({ auto_decompose: false })
+    expect(screen.getAllByRole('combobox').every(control => control.hasAttribute('disabled'))).toBe(true)
+    expect(screen.getAllByRole('checkbox').every(control => control.hasAttribute('disabled'))).toBe(true)
+    expect(screen.getAllByRole('textbox').every(control => control.hasAttribute('disabled'))).toBe(true)
+    expect(screen.getAllByRole('button').every(control => control.hasAttribute('disabled'))).toBe(true)
+
+    releasePut()
+    await waitFor(() => expect(autoDecompose.hasAttribute('disabled')).toBe(false))
+    expect(requests.filter(request => request.method === 'PUT')).toHaveLength(1)
+  })
+
+  it('keeps the orchestration PUT lock across panel unmount and remount', async () => {
+    let releasePut!: () => void
+
+    const putGate = new Promise<void>(resolve => {
+      releasePut = resolve
+    })
+
+    const { requests, rest } = createPolicyRest(putGate)
+    bind(rest)
+    $boardSlug.set('board-a')
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false, staleTime: Infinity } }
+    })
+
+    clients.push(client)
+
+    const renderCurrent = () =>
+      render(
+        <QueryClientProvider client={client}>
+          <OrchestrationPanel />
+        </QueryClientProvider>
+      )
+
+    const first = renderCurrent()
+    fireEvent.click(await screen.findByRole('switch', { name: 'Auto-decompose' }))
+    await waitFor(() => expect(requests.filter(request => request.method === 'PUT')).toHaveLength(1))
+
+    first.unmount()
+    renderCurrent()
+    const remounted = await screen.findByRole('switch', { name: 'Auto-decompose' })
+    expect(remounted.hasAttribute('disabled')).toBe(true)
+    fireEvent.click(remounted)
+    expect(requests.filter(request => request.method === 'PUT')).toHaveLength(1)
+
+    releasePut()
+    await waitFor(() => expect(remounted.hasAttribute('disabled')).toBe(false))
+    expect(requests.filter(request => request.method === 'PUT')).toHaveLength(1)
+  })
+
+  it('keeps profile Save and Auto globally locked across a board-switch remount', async () => {
+    let releaseWrite!: () => void
+
+    const writeGate = new Promise<void>(resolve => {
+      releaseWrite = resolve
+    })
+
+    const base = createPolicyRest()
+    const writes: Array<{ method: string; path: string }> = []
+
+    const rest = vi.fn((path: string, opts?: PluginRestOptions) => {
+      const url = new URL(path, 'http://kanban.test')
+      const method = opts?.method ?? 'GET'
+
+      if (/^\/profiles\/[^/]+(?:\/describe-auto)?$/.test(url.pathname) && method !== 'GET') {
+        writes.push({ method, path })
+
+        return writeGate.then(() => (method === 'POST' ? { description: 'Generated', ok: true } : {}))
+      }
+
+      return base.rest(path, opts)
+    }) as unknown as Rest
+
+    bind(rest)
+    $boardSlug.set('board-a')
+
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false, staleTime: Infinity } }
+    })
+
+    clients.push(client)
+
+    const renderCurrent = () =>
+      render(
+        <QueryClientProvider client={client}>
+          <OrchestrationPanel />
+        </QueryClientProvider>
+      )
+
+    const first = renderCurrent()
+    const description = await screen.findByDisplayValue('alpha description')
+    fireEvent.change(description, { target: { value: 'Updated alpha' } })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[0])
+    await waitFor(() => expect(writes).toHaveLength(1))
+
+    first.unmount()
+    act(() => $boardSlug.set('board-b'))
+    renderCurrent()
+    await screen.findByDisplayValue('alpha description')
+    const auto = screen.getAllByRole('button', { name: 'Auto' })[0]
+    expect(auto.hasAttribute('disabled')).toBe(true)
+    fireEvent.click(auto)
+    expect(writes).toHaveLength(1)
+
+    releaseWrite()
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Auto' })[0].hasAttribute('disabled')).toBe(false))
+    expect(writes).toEqual([{ method: 'PATCH', path: '/profiles/alpha' }])
+  })
+
+  it('invalidates every board profile cache after a global description save', async () => {
+    const { requests, rest } = createPolicyRest()
+    const client = renderPanel(rest)
+    client.setQueryData(profilesKey('board-b'), { profiles: [] })
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+
+    const description = await screen.findByDisplayValue('alpha description')
+    fireEvent.change(description, { target: { value: 'Updated alpha' } })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[0])
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: PROFILES_KEY }))
+    expect(client.getQueryState(profilesKey('board-b'))?.isInvalidated).toBe(true)
+    expect(requests).toContainEqual({
+      body: { description: 'Updated alpha' },
+      method: 'PATCH',
+      path: '/profiles/alpha'
+    })
+  })
+
+  it('renders a terminal load error with a working retry instead of an empty panel', async () => {
+    const base = createPolicyRest()
+    let failing = true
+
+    const rest = vi.fn((path: string, opts?: PluginRestOptions) => {
+      if (failing && (opts?.method ?? 'GET') === 'GET') {
+        return Promise.reject(new Error('offline'))
+      }
+
+      return base.rest(path, opts)
+    }) as unknown as Rest
+
+    renderPanel(rest)
+
+    expect(await screen.findByText('Could not load orchestration settings')).toBeTruthy()
+    failing = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByRole('checkbox', { name: 'Inherit machine policy' })).toBeTruthy()
+  })
+
+  it('shows blocked configured selector truth and preserves it while saving an unrelated field', async () => {
+    const { requests, rest } = createPolicyRest()
+    renderPanel(rest)
+
+    const [orchestrator, defaultAssignee] = await screen.findAllByRole('combobox')
+    expect(orchestrator.textContent).toBe('alpha')
+    expect(defaultAssignee.textContent).toBe('beta (configured, blocked)')
+    expect(screen.getByRole('status').textContent).toBe('Effective fallback: alpha')
+    fireEvent.click(defaultAssignee)
+    const blockedConfigured = await screen.findByRole('option', { name: 'beta (configured, blocked)' })
+    expect(blockedConfigured.getAttribute('aria-disabled')).toBe('true')
+    expect(screen.queryByRole('option', { name: 'beta' })).toBeNull()
+    fireEvent.keyDown(window.document, { key: 'Escape' })
+    fireEvent.click(orchestrator)
+
+    expect(await screen.findByRole('option', { name: 'alpha' })).toBeTruthy()
+    expect(screen.queryByRole('option', { name: 'beta' })).toBeNull()
+    expect(screen.queryByRole('option', { name: 'blocked' })).toBeNull()
+    fireEvent.keyDown(window.document, { key: 'Escape' })
+    expect(screen.getByDisplayValue('alpha description')).toBeTruthy()
+    expect(screen.getByDisplayValue('beta description')).toBeTruthy()
+    expect(screen.getByDisplayValue('blocked description')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Auto-decompose' }))
+    await waitFor(() =>
+      expect(requests).toContainEqual({
+        body: { auto_decompose: false },
+        method: 'PUT',
+        path: '/orchestration?board=board-a'
+      })
+    )
+    expect(defaultAssignee.textContent).toBe('beta (configured, blocked)')
+  })
+})

--- a/apps/desktop/src/plugins/kanban/orchestration.tsx
+++ b/apps/desktop/src/plugins/kanban/orchestration.tsx
@@ -6,9 +6,12 @@
 
 import {
   Button,
+  Checkbox,
   Codicon,
+  ErrorState,
   host,
   Input,
+  Loader,
   Select,
   SelectContent,
   SelectItem,
@@ -17,16 +20,28 @@ import {
   Switch,
   useMutation,
   useQuery,
-  useQueryClient
+  useQueryClient,
+  useValue
 } from '@hermes/plugin-sdk'
-import { useState } from 'react'
+import { useIsMutating } from '@tanstack/react-query'
+import { useRef, useState } from 'react'
 
 import {
+  $boardSlug,
+  $profileDescriptionWriteOwner,
   autoDescribeProfile,
+  claimProfileDescriptionWrite,
   fetchOrchestration,
-  fetchProfiles,
   ORCHESTRATION_KEY,
+  ORCHESTRATION_MUTATION_KEY,
+  ORCHESTRATION_MUTATION_SCOPE,
+  orchestrationKey,
+  PROFILE_DESCRIPTION_MUTATION_KEY,
+  PROFILE_DESCRIPTION_MUTATION_SCOPE,
+  profileQueryOptions,
   PROFILES_KEY,
+  profilesKey,
+  runProfileDescriptionWrite,
   saveOrchestration,
   saveProfileDescription
 } from './api'
@@ -34,29 +49,51 @@ import type { KanbanProfile } from './types'
 import { errText, FIELD_LABEL, useKanban } from './ui'
 
 const DEFAULT_SENTINEL = '__default__'
+const BLOCKED_SENTINEL = '__configured_blocked__'
 
 function ProfilePicker({
+  configured,
+  disabled,
   label,
   onSave,
   profiles,
-  value
+  resolved
 }: {
+  configured: string
+  disabled: boolean
   label: string
   onSave: (name: string) => void
   profiles: KanbanProfile[]
-  value: string
+  resolved: null | string
 }) {
   const k = useKanban()
+  const configuredAllowed = Boolean(configured) && profiles.some(profile => profile.name === configured)
+  const configuredBlocked = Boolean(configured) && !configuredAllowed
+  const normalizedValue = configuredBlocked ? BLOCKED_SENTINEL : configured || DEFAULT_SENTINEL
+  const effective = resolved?.trim() || k.none
 
   return (
     <label className="flex min-w-0 flex-col gap-1">
       <span className={FIELD_LABEL}>{label}</span>
-      <Select onValueChange={name => onSave(name === DEFAULT_SENTINEL ? '' : name)} value={value || DEFAULT_SENTINEL}>
+      <Select
+        disabled={disabled}
+        onValueChange={name => {
+          if (name !== BLOCKED_SENTINEL) {
+            onSave(name === DEFAULT_SENTINEL ? '' : name)
+          }
+        }}
+        value={normalizedValue}
+      >
         <SelectTrigger className="w-44">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value={DEFAULT_SENTINEL}>{k.defaultParen}</SelectItem>
+          {configuredBlocked && (
+            <SelectItem disabled value={BLOCKED_SENTINEL}>
+              {k.configuredBlocked(configured)}
+            </SelectItem>
+          )}
+          <SelectItem value={DEFAULT_SENTINEL}>{k.defaultResolved(effective)}</SelectItem>
           {profiles.map(profile => (
             <SelectItem key={profile.name} value={profile.name}>
               {profile.name}
@@ -64,34 +101,64 @@ function ProfilePicker({
           ))}
         </SelectContent>
       </Select>
+      {configuredBlocked && (
+        <span className="text-[0.625rem] text-(--ui-text-quaternary)" role="status">
+          {k.effectiveFallback(effective)}
+        </span>
+      )}
     </label>
   )
 }
 
-function ProfileDescriptionRow({ profile }: { profile: KanbanProfile }) {
+function ProfileDescriptionRow({ disabled, profile }: { disabled: boolean; profile: KanbanProfile }) {
   const k = useKanban()
   const qc = useQueryClient()
   const [draft, setDraft] = useState(profile.description)
-  const invalidate = () => void qc.invalidateQueries({ queryKey: PROFILES_KEY })
+  const profileWritePending = useValue($profileDescriptionWriteOwner) !== null
+  const rowDisabled = disabled || profileWritePending
+  const invalidate = () => qc.invalidateQueries({ queryKey: PROFILES_KEY })
 
   const save = useMutation({
-    mutationFn: () => saveProfileDescription(profile.name, draft.trim()),
+    mutationFn: ({ description, owner }: { description: string; owner: symbol }) =>
+      runProfileDescriptionWrite(owner, () => saveProfileDescription(profile.name, description)),
+    mutationKey: PROFILE_DESCRIPTION_MUTATION_KEY,
     onError: err => host.notify({ kind: 'error', message: errText(err) }),
-    onSuccess: invalidate
+    onSuccess: invalidate,
+    scope: PROFILE_DESCRIPTION_MUTATION_SCOPE
   })
 
   const auto = useMutation({
-    mutationFn: () => autoDescribeProfile(profile.name),
+    mutationFn: ({ owner }: { owner: symbol }) =>
+      runProfileDescriptionWrite(owner, () => autoDescribeProfile(profile.name)),
+    mutationKey: PROFILE_DESCRIPTION_MUTATION_KEY,
     onError: err => host.notify({ kind: 'error', message: errText(err) }),
     onSuccess: result => {
       if (result.ok) {
         setDraft(result.description ?? '')
-        invalidate()
+
+        return invalidate()
       } else {
-        host.notify({ kind: 'warning', message: result.reason || 'Auto-describe failed' })
+        host.notify({ kind: 'warning', message: result.reason || k.autoDescribeFailed })
       }
-    }
+    },
+    scope: PROFILE_DESCRIPTION_MUTATION_SCOPE
   })
+
+  const startSave = () => {
+    const owner = claimProfileDescriptionWrite()
+
+    if (owner) {
+      save.mutate({ description: draft.trim(), owner })
+    }
+  }
+
+  const startAuto = () => {
+    const owner = claimProfileDescriptionWrite()
+
+    if (owner) {
+      auto.mutate({ owner })
+    }
+  }
 
   return (
     <div className="flex items-center gap-2">
@@ -103,13 +170,14 @@ function ProfileDescriptionRow({ profile }: { profile: KanbanProfile }) {
       </span>
       <Input
         className="h-7 flex-1 text-[0.71rem]"
+        disabled={rowDisabled}
         onChange={event => setDraft(event.target.value)}
         placeholder={k.profileGoodAt}
         value={draft}
       />
       <Button
-        disabled={save.isPending || draft.trim() === profile.description}
-        onClick={() => save.mutate()}
+        disabled={rowDisabled || save.isPending || draft.trim() === profile.description}
+        onClick={startSave}
         size="xs"
         variant="outline"
       >
@@ -117,7 +185,13 @@ function ProfileDescriptionRow({ profile }: { profile: KanbanProfile }) {
       </Button>
       {/* Overlay the spinner so the button keeps its "Auto" width — the aux
           model can take a few seconds and a text swap would jump the row. */}
-      <Button className="relative" disabled={auto.isPending} onClick={() => auto.mutate()} size="xs" variant="ghost">
+      <Button
+        className="relative"
+        disabled={rowDisabled || auto.isPending}
+        onClick={startAuto}
+        size="xs"
+        variant="ghost"
+      >
         <span className={auto.isPending ? 'invisible' : ''}>{k.auto}</span>
         {auto.isPending && (
           <span className="absolute inset-0 grid place-items-center">
@@ -132,39 +206,140 @@ function ProfileDescriptionRow({ profile }: { profile: KanbanProfile }) {
 export function OrchestrationPanel() {
   const k = useKanban()
   const qc = useQueryClient()
-  const { data: settings } = useQuery({ queryKey: ORCHESTRATION_KEY, queryFn: fetchOrchestration })
-  const { data: roster } = useQuery({ queryKey: PROFILES_KEY, queryFn: fetchProfiles, staleTime: 60_000 })
+  const slug = useValue($boardSlug)
+  const profileWritePending = useValue($profileDescriptionWriteOwner) !== null
 
-  const save = useMutation({
-    mutationFn: (patch: Record<string, unknown>) => saveOrchestration(patch),
-    onError: err => host.notify({ kind: 'error', message: errText(err) }),
-    onSuccess: () => void qc.invalidateQueries({ queryKey: ORCHESTRATION_KEY })
+  const settingsQuery = useQuery({
+    queryKey: orchestrationKey(slug),
+    queryFn: () => fetchOrchestration(slug)
   })
 
+  const rosterQuery = useQuery(profileQueryOptions(slug))
+  const orchestrationWrites = useIsMutating({ exact: true, mutationKey: ORCHESTRATION_MUTATION_KEY })
+  const saveOwner = useRef<null | symbol>(null)
+  const savePending = orchestrationWrites > 0
+
+  const save = useMutation({
+    mutationFn: ({ board, patch }: { board: string; owner: symbol; patch: Record<string, unknown> }) =>
+      saveOrchestration(board, patch),
+    mutationKey: ORCHESTRATION_MUTATION_KEY,
+    onError: err => host.notify({ kind: 'error', message: errText(err) }),
+    onSettled: (_data, _error, { owner }) => {
+      if (saveOwner.current === owner) {
+        saveOwner.current = null
+      }
+    },
+    onSuccess: (result, { board, patch }) => {
+      qc.setQueryData(orchestrationKey(board), result)
+
+      const global = ['orchestrator_profile', 'default_assignee', 'auto_decompose', 'auto_promote_children'].some(
+        field => Object.hasOwn(patch, field)
+      )
+
+      return Promise.all([
+        qc.invalidateQueries({ queryKey: global ? ORCHESTRATION_KEY : orchestrationKey(board) }),
+        qc.invalidateQueries({ queryKey: profilesKey(board) })
+      ])
+    },
+    scope: ORCHESTRATION_MUTATION_SCOPE
+  })
+
+  const settings = settingsQuery.data
+  const roster = rosterQuery.data
+  const loadError = settingsQuery.error ?? rosterQuery.error
+
+  if (loadError && (!settings || !roster)) {
+    return (
+      <div className="grid min-h-40 place-items-center border-t border-(--ui-stroke-tertiary) px-4 py-3">
+        <ErrorState description={errText(loadError)} title={k.orchestrationLoadError}>
+          <Button
+            className="justify-self-center"
+            onClick={() => void Promise.all([settingsQuery.refetch(), rosterQuery.refetch()])}
+            size="sm"
+            variant="outline"
+          >
+            <Codicon name="refresh" size="0.8rem" />
+            {k.retry}
+          </Button>
+        </ErrorState>
+      </div>
+    )
+  }
+
   if (!settings || !roster) {
-    return null
+    return (
+      <div className="grid min-h-40 place-items-center border-t border-(--ui-stroke-tertiary) px-4 py-3">
+        <Loader type="lemniscate-bloom" />
+      </div>
+    )
+  }
+
+  const effectiveProfiles = roster.profiles.filter(profile => profile.effective_allowed)
+  const inherited = settings.board_allowed_profiles === null
+
+  const savePatch = (patch: Record<string, unknown>) => {
+    if (savePending || saveOwner.current) {
+      return
+    }
+
+    const owner = Symbol('kanban-orchestration-write')
+    saveOwner.current = owner
+    save.mutate({ board: slug, owner, patch })
+  }
+
+  const setInherited = (next: boolean) =>
+    savePatch({
+      allowed_profiles: next
+        ? null
+        : roster.profiles
+            .filter(profile => profile.machine_allowed && profile.effective_allowed)
+            .map(profile => profile.name)
+    })
+
+  const setProfileAllowed = (name: string, checked: boolean) => {
+    const selected = new Set(settings.board_allowed_profiles ?? [])
+
+    if (checked) {
+      selected.add(name)
+    } else {
+      selected.delete(name)
+    }
+
+    savePatch({
+      allowed_profiles: roster.profiles
+        .filter(profile => profile.machine_allowed && selected.has(profile.name))
+        .map(profile => profile.name)
+    })
   }
 
   return (
-    <div className="flex flex-col gap-4 border-t border-(--ui-stroke-tertiary) px-4 py-3">
+    <div
+      aria-busy={savePending || profileWritePending}
+      className="flex flex-col gap-4 border-t border-(--ui-stroke-tertiary) px-4 py-3"
+    >
       <div className="flex flex-wrap items-end gap-4">
         <ProfilePicker
+          configured={settings.orchestrator_profile}
+          disabled={savePending}
           label={k.orchestratorProfile}
-          onSave={name => save.mutate({ orchestrator_profile: name })}
-          profiles={roster.profiles}
-          value={settings.orchestrator_profile}
+          onSave={name => savePatch({ orchestrator_profile: name })}
+          profiles={effectiveProfiles}
+          resolved={settings.resolved_orchestrator_profile}
         />
         <ProfilePicker
+          configured={settings.default_assignee}
+          disabled={savePending}
           label={k.defaultAssignee}
-          onSave={name => save.mutate({ default_assignee: name })}
-          profiles={roster.profiles}
-          value={settings.default_assignee}
+          onSave={name => savePatch({ default_assignee: name })}
+          profiles={effectiveProfiles}
+          resolved={settings.resolved_default_assignee}
         />
         <label className="flex cursor-pointer items-center gap-2 pb-1.5 text-[0.75rem] text-(--ui-text-secondary)">
           <Switch
             aria-label={k.autoDecompose}
             checked={settings.auto_decompose}
-            onCheckedChange={checked => save.mutate({ auto_decompose: checked })}
+            disabled={savePending}
+            onCheckedChange={checked => savePatch({ auto_decompose: checked })}
             size="xs"
           />
           {k.autoDecompose}
@@ -172,10 +347,55 @@ export function OrchestrationPanel() {
       </div>
 
       <div className="flex flex-col gap-1.5">
+        <span className={FIELD_LABEL}>{k.profilesAllowedBoard}</span>
+        <label className="flex cursor-pointer items-center gap-2 text-[0.75rem] text-(--ui-text-secondary)">
+          <Checkbox
+            aria-label={k.inheritMachinePolicy}
+            checked={inherited}
+            disabled={savePending}
+            onCheckedChange={checked => setInherited(checked === true)}
+          />
+          {k.inheritMachinePolicy}
+        </label>
+        <div className="flex flex-wrap gap-x-4 gap-y-1">
+          {roster.profiles.map(profile => {
+            const blockedReasonId = `kanban-machine-policy-${profile.name.replace(/[^a-zA-Z0-9_-]/g, '-')}`
+
+            return (
+              <label className="flex items-center gap-1.5 text-[0.75rem] text-(--ui-text-secondary)" key={profile.name}>
+                <Checkbox
+                  aria-describedby={!profile.machine_allowed ? blockedReasonId : undefined}
+                  aria-label={profile.machine_allowed ? profile.name : `${profile.name} — ${k.blockedByMachinePolicy}`}
+                  checked={inherited ? profile.effective_allowed : profile.board_selected}
+                  disabled={inherited || !profile.machine_allowed || savePending}
+                  onCheckedChange={checked => setProfileAllowed(profile.name, checked === true)}
+                />
+                <span>{profile.name}</span>
+                {!profile.machine_allowed && (
+                  <span className="text-[0.6875rem] text-(--ui-text-quaternary)" id={blockedReasonId}>
+                    {k.blockedByMachinePolicy}
+                  </span>
+                )}
+              </label>
+            )
+          })}
+        </div>
+        {settings.effective_allowed_profiles.length === 0 && (
+          <p className="text-[0.6875rem] font-medium text-(--destructive)" role="alert">
+            {k.noWorkersCanRun}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
         <span className={FIELD_LABEL}>{k.profileDescriptions}</span>
         <p className="text-[0.6875rem] text-(--ui-text-quaternary)">{k.profileDescriptionsHint}</p>
         {roster.profiles.map(profile => (
-          <ProfileDescriptionRow key={`${profile.name}:${profile.description}`} profile={profile} />
+          <ProfileDescriptionRow
+            disabled={savePending}
+            key={`${profile.name}:${profile.description}`}
+            profile={profile}
+          />
         ))}
       </div>
     </div>

--- a/apps/desktop/src/plugins/kanban/plugin.tsx
+++ b/apps/desktop/src/plugins/kanban/plugin.tsx
@@ -44,7 +44,7 @@ function KanbanCount() {
 
   // Socket-invalidated like the page (same cache); slow socketless heartbeat.
   const { data: board } = useQuery({
-    queryFn: () => fetchBoard(false),
+    queryFn: () => fetchBoard(slug, false),
     queryKey: boardKey(slug, false),
     refetchInterval: 60_000
   })
@@ -114,7 +114,7 @@ const plugin: HermesPlugin = {
         id: 'nav',
         area: SIDEBAR_NAV_AREA,
         order: 50,
-        data: { codicon: 'project', label: 'Kanban', path: '/kanban' } satisfies SidebarNavContribution
+        data: { codicon: 'project', label: ctx.i18n.t('nav'), path: '/kanban' } satisfies SidebarNavContribution
       },
       {
         id: 'count',
@@ -127,7 +127,7 @@ const plugin: HermesPlugin = {
         area: PALETTE_AREA,
         data: {
           id: 'kanban.open',
-          label: 'Kanban: Open board',
+          label: ctx.i18n.t('openBoard'),
           keywords: ['kanban', 'board', 'tasks', 'agents'],
           run: () => host.navigate('/kanban')
         } satisfies PaletteContribution

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -173,11 +173,16 @@ export interface WorkerLog {
 
 /** GET /orchestration — dispatcher knobs from config.yaml + resolved values. */
 export interface OrchestrationSettings {
+  board: string
   orchestrator_profile: string
   default_assignee: string
   auto_decompose: boolean
-  resolved_orchestrator_profile: string
-  resolved_default_assignee: string
+  auto_promote_children: boolean
+  resolved_orchestrator_profile: null | string
+  resolved_default_assignee: null | string
+  active_profile: string
+  board_allowed_profiles: null | string[]
+  effective_allowed_profiles: string[]
 }
 
 /** GET /profiles — the roster the decomposer routes across. */
@@ -186,6 +191,9 @@ export interface KanbanProfile {
   is_default: boolean
   description: string
   description_auto: boolean
+  machine_allowed: boolean
+  board_selected: boolean
+  effective_allowed: boolean
 }
 
 /** Column presentation — codicon + tone only. Labels + help live in i18n

--- a/apps/desktop/src/plugins/kanban/ui.tsx
+++ b/apps/desktop/src/plugins/kanban/ui.tsx
@@ -13,11 +13,12 @@ import {
   profileColor,
   profileColorSoft,
   relativeTime,
-  useQuery
+  useQuery,
+  useValue
 } from '@hermes/plugin-sdk'
 import { type ReactNode, useEffect, useState } from 'react'
 
-import { fetchOrchestration, ORCHESTRATION_KEY } from './api'
+import { $boardSlug, fetchOrchestration, orchestrationKey } from './api'
 import { columnLabel, useKanban } from './i18n'
 import { columnMeta, type KanbanTask } from './types'
 
@@ -32,15 +33,17 @@ export { columnHelp, columnLabel, type KanbanText, lockedReason, useKanban } fro
  *  persisted, so a remount can't reopen a dialog the user already dismissed. */
 export const $newTaskLane = atom<null | string>(null)
 
-/** Orchestration knobs (cached app-wide; the settings panel invalidates). */
+/** Orchestration knobs cached independently for each selected board. */
 export function useOrchestration() {
-  return useQuery({ queryKey: ORCHESTRATION_KEY, queryFn: fetchOrchestration, staleTime: 60_000 }).data
+  const slug = useValue($boardSlug)
+
+  return useQuery({ queryKey: orchestrationKey(slug), queryFn: () => fetchOrchestration(slug), staleTime: 60_000 }).data
 }
 
 /** The dispatcher's configured fallback for unassigned ready cards
  *  (`kanban.default_assignee`) — '' when unset, i.e. unassigned never runs. */
 export function useDefaultAssignee(): string {
-  return useOrchestration()?.default_assignee.trim() ?? ''
+  return useOrchestration()?.resolved_default_assignee?.trim() ?? ''
 }
 
 // System-owned drop targets — you can drag a card OUT of these, never INTO

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -306,6 +306,11 @@ model:
 # Disable this only when every review is performed manually from the dashboard.
 kanban:
   review_dispatch: true
+  # Optional machine-wide assignment safety ceiling. Boards may narrow this
+  # list but cannot allow profiles outside it. Omit/null = unrestricted;
+  # an empty list denies all assignments.
+  # allowed_profiles:
+  #   - default
 
 # =============================================================================
 # Terminal Tool Configuration

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2467,6 +2467,13 @@ DEFAULT_CONFIG = {
     # each claimable ready task. One dispatcher per profile is sufficient;
     # running more than one on the same kanban.db will race for claims.
     "kanban": {
+        # Machine safety ceiling for profiles that may own Kanban tasks;
+        # individual boards may narrow it but cannot widen it. ``None``
+        # preserves the historical unrestricted behavior; ``[]`` disables
+        # profile assignment entirely. The ceiling is read from the
+        # default/shared Hermes root so named-profile CLIs and secondary
+        # gateways cannot bypass it with profile-local config.
+        "allowed_profiles": None,
         # Auto-subscribe the originating gateway/TUI session to task
         # completion + block events when ``kanban_create`` is called from
         # inside a session that has a persistent delivery channel. The

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -525,6 +525,7 @@ def _relative_age(ts: Optional[int], now: Optional[int] = None) -> str:
 # ---------------------------------------------------------------------------
 
 DEFAULT_BOARD = "default"
+_ALLOWED_PROFILES_UNSET = object()
 _CURRENT_BOARD_OVERRIDE: ContextVar[str | None] = ContextVar(
     "hermes_kanban_current_board_override",
     default=None,
@@ -812,8 +813,8 @@ def board_metadata_path(board: Optional[str] = None) -> Path:
     """Return the path to ``board.json`` for ``board``.
 
     Stores display metadata (display name, description, icon, color,
-    created_at). The on-disk slug is the canonical identity; this file
-    is purely for presentation in the CLI / dashboard.
+    created_at) and board policy such as ``allowed_profiles``. The on-disk
+    slug is the canonical identity.
     """
     slug = _normalize_board_slug(board) or DEFAULT_BOARD
     return board_dir(slug) / "board.json"
@@ -829,22 +830,16 @@ def _default_board_display_name(slug: str) -> str:
     return " ".join(part.capitalize() for part in slug.replace("_", "-").split("-") if part) or slug
 
 
-def read_board_metadata(board: Optional[str] = None) -> dict:
-    """Return ``board.json`` contents (or synthesized defaults).
-
-    Never raises — a missing / malformed ``board.json`` falls back to a
-    synthesised entry so the dashboard always has something to render.
-    Includes the canonical ``slug`` and ``db_path`` so the caller
-    doesn't need to reconstruct them.
-    """
-    slug = _normalize_board_slug(board) or DEFAULT_BOARD
-    meta: dict[str, Any] = {
+def _board_metadata_defaults(slug: str) -> dict[str, Any]:
+    """Return the synthesized metadata schema for one canonical board slug."""
+    return {
         "slug": slug,
         "name": _default_board_display_name(slug),
         "description": "",
         "icon": "",
         "color": "",
         "default_workdir": None,
+        "allowed_profiles": None,
         # Optional first-class Project this board is scoped to. When set, new
         # tasks inherit it (deterministic worktree + branch under the project's
         # primary repo) and ``default_workdir`` mirrors the project's primary
@@ -853,18 +848,80 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
         "created_at": None,
         "archived": False,
     }
+
+
+def _normalize_allowed_profiles_api(value: object) -> Optional[list[str]]:
+    """Validate and canonicalize an API-supplied board profile subset."""
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise ValueError("allowed_profiles must be a list of profile names or None")
+
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for entry in value:
+        if not isinstance(entry, str):
+            raise ValueError("allowed_profiles entries must be profile names")
+        try:
+            profile = normalize_profile_name(entry)
+            validate_profile_name(profile)
+        except ValueError as exc:
+            raise ValueError(f"invalid allowed_profiles entry {entry!r}: {exc}") from exc
+        if profile not in seen:
+            normalized.append(profile)
+            seen.add(profile)
+    return normalized
+
+
+def read_board_metadata(board: Optional[str] = None) -> dict:
+    """Return board display/policy metadata (or synthesized defaults).
+
+    Never raises — a missing / malformed ``board.json`` falls back to a
+    synthesised entry so the dashboard always has something to render.
+    Includes the canonical ``slug`` and ``db_path`` so the caller
+    doesn't need to reconstruct them.
+    """
+    slug = _normalize_board_slug(board) or DEFAULT_BOARD
+    meta = _board_metadata_defaults(slug)
     try:
         p = board_metadata_path(slug)
         if p.exists():
             raw = json.loads(p.read_text(encoding="utf-8"))
-            if isinstance(raw, dict):
+            if isinstance(raw, Mapping):
+                meta.update(raw)
                 # Never let the metadata file claim a different slug than
                 # its directory — trust the filesystem.
-                raw["slug"] = slug
-                meta.update(raw)
-    except (OSError, json.JSONDecodeError):
+                meta["slug"] = slug
+    except (OSError, UnicodeError, json.JSONDecodeError):
         pass
     meta["db_path"] = str(kanban_db_path(slug))
+    return meta
+
+
+def _load_board_metadata_for_update(slug: str) -> dict[str, Any]:
+    """Strictly load existing metadata before a destructive rewrite."""
+    path = board_metadata_path(slug)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return _board_metadata_defaults(slug)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"refusing to update board metadata {path}: "
+            "existing board.json cannot be read or parsed"
+        ) from exc
+    if not isinstance(raw, Mapping):
+        raise ValueError(
+            f"refusing to update board metadata {path}: "
+            "existing board.json is not a mapping"
+        )
+
+    meta = _board_metadata_defaults(slug)
+    meta.update(raw)
+    # Never let the metadata file claim a different slug than its directory.
+    meta["slug"] = slug
     return meta
 
 
@@ -878,19 +935,22 @@ def write_board_metadata(
     archived: Optional[bool] = None,
     default_workdir: Optional[str] = None,
     project_id: Optional[str] = None,
+    allowed_profiles: object = _ALLOWED_PROFILES_UNSET,
 ) -> dict:
-    """Create / update ``board.json`` for ``board``.
+    """Create / update board display and policy metadata in ``board.json``.
 
     Preserves any existing fields not mentioned in the call. Sets
     ``created_at`` on first write. Returns the resulting metadata dict.
 
     ``project_id``: ``None`` leaves it unchanged; empty string clears the
     project scope; a value sets it (not validated here — the caller resolves
-    it against ``projects_db``).
+    it against ``projects_db``). ``allowed_profiles`` uses three-way semantics:
+    omitting it preserves the current policy, ``None`` clears it to inherit the
+    machine ceiling, and a list stores an explicit (possibly empty) subset.
     """
     _assert_not_delegated_child_mutation()
     slug = _normalize_board_slug(board) or DEFAULT_BOARD
-    meta = read_board_metadata(slug)
+    meta = _load_board_metadata_for_update(slug)
     # Preserve existing DB-derived fields — they get re-computed each
     # read but shouldn't be written into board.json.
     meta.pop("db_path", None)
@@ -908,13 +968,20 @@ def write_board_metadata(
         meta["default_workdir"] = str(default_workdir) if default_workdir else None
     if project_id is not None:
         meta["project_id"] = str(project_id) if project_id else None
+    if allowed_profiles is not _ALLOWED_PROFILES_UNSET:
+        meta["allowed_profiles"] = _normalize_allowed_profiles_api(
+            allowed_profiles
+        )
     if not meta.get("created_at"):
         meta["created_at"] = int(time.time())
     path = board_metadata_path(slug)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
+    from utils import atomic_write_text
+
+    atomic_write_text(
+        path,
         json.dumps(meta, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
+        preserve_mode=True,
     )
     meta["db_path"] = str(kanban_db_path(slug))
     return meta
@@ -929,6 +996,7 @@ def create_board(
     color: Optional[str] = None,
     default_workdir: Optional[str] = None,
     project_id: Optional[str] = None,
+    allowed_profiles: object = _ALLOWED_PROFILES_UNSET,
 ) -> dict:
     """Create a new board directory + DB + metadata. Idempotent.
 
@@ -947,6 +1015,7 @@ def create_board(
         color=color,
         default_workdir=default_workdir,
         project_id=project_id,
+        allowed_profiles=allowed_profiles,
     )
     # Touch the DB so list_boards() sees it immediately.
     init_db(board=normed)
@@ -2324,6 +2393,21 @@ def _schema_is_present(conn: sqlite3.Connection) -> bool:
     return row is not None
 
 
+def _set_connection_board_hint(
+    conn: sqlite3.Connection,
+    board: Optional[str],
+) -> None:
+    """Attach best-effort board context for non-standard DB path overrides."""
+    if board is None:
+        return
+    try:
+        setattr(conn, "_hermes_kanban_board_hint", board)
+    except (AttributeError, TypeError):
+        # Some lightweight connection test doubles do not allow attributes.
+        # Policy lookup still has the canonical PRAGMA path fallback.
+        pass
+
+
 def connect(
     db_path: Optional[Path] = None,
     *,
@@ -2347,6 +2431,10 @@ def connect(
       ``HERMES_KANBAN_DB`` env → ``HERMES_KANBAN_BOARD`` env →
       ``<root>/kanban/current`` → ``default``.
     """
+    board_hint = _normalize_board_slug(board)
+    if board_hint is None and db_path is None:
+        board_hint = get_current_board()
+
     if db_path is not None:
         path = db_path
     else:
@@ -2366,6 +2454,7 @@ def connect(
     resolved = str(path.resolve())
     if resolved in _INITIALIZED_PATHS:
         conn = _sqlite_connect(path)
+        _set_connection_board_hint(conn, board_hint)
         try:
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:
@@ -2419,6 +2508,7 @@ def connect(
         _guard_existing_db_is_healthy(path)
         resolved = str(path.resolve())
         conn = _sqlite_connect(path)
+        _set_connection_board_hint(conn, board_hint)
         try:
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:
@@ -3146,13 +3236,308 @@ def _claimer_id() -> str:
 # Task creation / mutation
 # ---------------------------------------------------------------------------
 
-def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
-    """Lowercase-assignee normalization for Kanban rows (dashboard/CLI parity)."""
-    if assignee is None:
+def _configured_profile_policy(
+    raw: object,
+    *,
+    source: str,
+) -> Optional[frozenset[str]]:
+    """Parse one configured policy layer, failing closed when malformed."""
+    if raw is None:
         return None
+    if not isinstance(raw, list):
+        _log.warning(
+            "kanban profile policy from %s must be a list or null; "
+            "rejecting all profile assignments",
+            source,
+        )
+        return frozenset()
+
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+    allowed: set[str] = set()
+    for entry in raw:
+        if not isinstance(entry, str):
+            _log.warning(
+                "kanban profile policy from %s contains non-string entry %r; "
+                "rejecting all profile assignments",
+                source,
+                entry,
+            )
+            return frozenset()
+        try:
+            profile = normalize_profile_name(entry)
+            validate_profile_name(profile)
+        except ValueError as exc:
+            _log.warning(
+                "kanban profile policy from %s contains invalid profile %r (%s); "
+                "rejecting all profile assignments",
+                source,
+                entry,
+                exc,
+            )
+            return frozenset()
+        allowed.add(profile)
+    return frozenset(allowed)
+
+
+def _machine_kanban_allowed_profiles() -> Optional[frozenset[str]]:
+    """Read the machine safety ceiling from the shared/default Hermes root."""
+    import yaml
+
+    from hermes_constants import get_default_hermes_root
+
+    config_path = get_default_hermes_root() / "config.yaml"
+    if not config_path.is_file():
+        return None
+    try:
+        payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        _log.warning(
+            "kanban machine profile policy from %s could not be read (%s); "
+            "rejecting all profile assignments",
+            config_path,
+            exc,
+        )
+        return frozenset()
+
+    if payload is None:
+        return None
+    if not isinstance(payload, Mapping):
+        _log.warning(
+            "kanban machine profile policy source %s is not a mapping; "
+            "rejecting all profile assignments",
+            config_path,
+        )
+        return frozenset()
+    if "kanban" not in payload:
+        return None
+    kanban_cfg = payload.get("kanban")
+    if not isinstance(kanban_cfg, Mapping):
+        _log.warning(
+            "kanban machine profile policy source %s has a malformed kanban "
+            "container; rejecting all profile assignments",
+            config_path,
+        )
+        return frozenset()
+    if "allowed_profiles" not in kanban_cfg:
+        return None
+    return _configured_profile_policy(
+        kanban_cfg.get("allowed_profiles"),
+        source=f"machine config {config_path} (kanban.allowed_profiles)",
+    )
+
+
+def _connection_main_db_path(conn: sqlite3.Connection) -> Optional[Path]:
+    """Return SQLite's canonical path for the connection's ``main`` DB."""
+    try:
+        cursor = conn.execute("PRAGMA database_list")
+        fetchall = getattr(cursor, "fetchall", None)
+        if callable(fetchall):
+            rows = fetchall()
+        else:
+            row = cursor.fetchone()
+            rows = [row] if row is not None else []
+    except Exception:
+        return None
+    for row in rows:
+        try:
+            name, raw_path = row[1], row[2]
+        except (IndexError, KeyError, TypeError):
+            continue
+        if name != "main" or not raw_path:
+            continue
+        try:
+            return Path(str(raw_path)).expanduser().resolve()
+        except OSError:
+            return Path(str(raw_path)).expanduser()
+    return None
+
+
+def _board_slug_from_connection(conn: sqlite3.Connection) -> Optional[str]:
+    """Identify a board from its canonical DB path, then its frozen open hint."""
+    db_path = _connection_main_db_path(conn)
+    if db_path is not None:
+        try:
+            home = kanban_home().expanduser().resolve()
+        except OSError:
+            home = kanban_home().expanduser()
+        if db_path == home / "kanban.db":
+            return DEFAULT_BOARD
+        try:
+            relative = db_path.relative_to(home / "kanban" / "boards")
+        except ValueError:
+            relative = None
+        if relative is not None and len(relative.parts) == 2:
+            slug, filename = relative.parts
+            if filename == "kanban.db":
+                try:
+                    return _normalize_board_slug(slug)
+                except ValueError:
+                    return None
+
+    hint = getattr(conn, "_hermes_kanban_board_hint", None)
+    if hint:
+        try:
+            return _normalize_board_slug(str(hint))
+        except ValueError:
+            return None
+    return None
+
+
+def _mutation_board_slug(
+    conn: sqlite3.Connection,
+    board: Optional[str],
+) -> Optional[str]:
+    """Bind a mutating call's explicit board to stable connection provenance.
+
+    Canonical board DB paths are authoritative. Non-standard paths opened by
+    :func:`connect` retain their frozen board hint. Connections and safe test
+    doubles with neither form of provenance remain compatible with an explicit
+    board context, but an identifiable connection can never be retagged by a
+    caller-selected board.
+    """
+    connection_board = _board_slug_from_connection(conn)
+    if board is None:
+        return connection_board
+    requested_board = _normalize_board_slug(board) or DEFAULT_BOARD
+    if connection_board is not None and requested_board != connection_board:
+        raise ValueError(
+            f"explicit board {requested_board!r} does not match connection board "
+            f"{connection_board!r}"
+        )
+    return requested_board
+
+
+def _policy_board_slug(
+    *,
+    board: Optional[str],
+    conn: Optional[sqlite3.Connection],
+) -> Optional[str]:
+    """Resolve explicit board context before connection-derived identity."""
+    if board is not None:
+        return _normalize_board_slug(board) or DEFAULT_BOARD
+    if conn is not None:
+        return _board_slug_from_connection(conn)
+    return None
+
+
+def _board_kanban_allowed_profiles(
+    *,
+    board: Optional[str] = None,
+    conn: Optional[sqlite3.Connection] = None,
+) -> Optional[frozenset[str]]:
+    """Read one board's optional profile subset from ``board.json``."""
+    slug = _policy_board_slug(board=board, conn=conn)
+    if slug is None:
+        return None
+    metadata_path = board_metadata_path(slug)
+    try:
+        if not metadata_path.is_file():
+            return None
+        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        _log.warning(
+            "kanban board profile policy from %s could not be read (%s); "
+            "rejecting all profile assignments",
+            metadata_path,
+            exc,
+        )
+        return frozenset()
+    if not isinstance(payload, Mapping):
+        _log.warning(
+            "kanban board profile policy source %s is not a mapping; "
+            "rejecting all profile assignments",
+            metadata_path,
+        )
+        return frozenset()
+    if "allowed_profiles" not in payload:
+        return None
+    return _configured_profile_policy(
+        payload.get("allowed_profiles"),
+        source=f"board metadata {metadata_path} (allowed_profiles)",
+    )
+
+
+def _resolve_kanban_allowed_profiles(
+    machine_ceiling: Optional[frozenset[str]],
+    board_subset: Optional[frozenset[str]],
+) -> Optional[frozenset[str]]:
+    """Intersect the machine ceiling with an optional board subset."""
+    if machine_ceiling is None:
+        return board_subset
+    if board_subset is None:
+        return machine_ceiling
+    return machine_ceiling & board_subset
+
+
+def kanban_allowed_profiles(
+    *,
+    board: Optional[str] = None,
+    conn: Optional[sqlite3.Connection] = None,
+) -> Optional[frozenset[str]]:
+    """Return the effective Kanban assignment policy for explicit context.
+
+    With no ``board`` or ``conn``, this remains the legacy machine-ceiling
+    reader. Passing either context additionally applies that board's subset.
+    """
+    machine_ceiling = _machine_kanban_allowed_profiles()
+    if board is None and conn is None:
+        return machine_ceiling
+    board_subset = _board_kanban_allowed_profiles(board=board, conn=conn)
+    return _resolve_kanban_allowed_profiles(machine_ceiling, board_subset)
+
+
+def is_kanban_profile_allowed(
+    profile: str,
+    *,
+    board: Optional[str] = None,
+    conn: Optional[sqlite3.Connection] = None,
+) -> bool:
+    """Return whether *profile* is a member of the effective policy."""
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+    try:
+        canonical = normalize_profile_name(profile)
+        validate_profile_name(canonical)
+    except ValueError:
+        return False
+    allowed = kanban_allowed_profiles(board=board, conn=conn)
+    return allowed is None or canonical in allowed
+
+
+def _normalize_assignee_filter(assignee: str) -> str:
+    """Normalize a read-only assignee filter without applying current policy."""
     from hermes_cli.profiles import normalize_profile_name
 
     return normalize_profile_name(assignee)
+
+
+def _canonical_assignee(
+    assignee: Optional[str],
+    *,
+    board: Optional[str] = None,
+    conn: Optional[sqlite3.Connection] = None,
+) -> Optional[str]:
+    """Canonicalize an assignment and enforce its effective board policy."""
+    if assignee is None:
+        return None
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+    canonical = normalize_profile_name(assignee)
+    validate_profile_name(canonical)
+    allowed = kanban_allowed_profiles(board=board, conn=conn)
+    if allowed is not None and canonical not in allowed:
+        if allowed:
+            allowed_text = ", ".join(sorted(allowed))
+            raise ValueError(
+                f"profile {canonical!r} is not allowed for Kanban assignment; "
+                f"allowed profiles: {allowed_text}"
+            )
+        raise ValueError(
+            f"profile {canonical!r} is not allowed for Kanban assignment; "
+            "no profiles are currently allowed"
+        )
+    return canonical
 
 
 def create_task(
@@ -3223,12 +3608,13 @@ def create_task(
     board can supply the repo and branch convention. Its literal worktree is
     never reused; the new task still gets its own task-id-keyed path.
     """
+    board = _mutation_board_slug(conn, board)
     model_override = (model_override or "").strip() or None
     provider_override = (provider_override or "").strip() or None
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
-    assignee = _canonical_assignee(assignee)
+    assignee = _canonical_assignee(assignee, board=board, conn=conn)
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
@@ -3664,7 +4050,7 @@ def list_tasks(
     params: list[Any] = []
     if assignee is not None:
         query += " AND assignee = ?"
-        params.append(_canonical_assignee(assignee))
+        params.append(_normalize_assignee_filter(assignee))
     if status is not None:
         if status not in VALID_STATUSES:
             raise ValueError(f"status must be one of {sorted(VALID_STATUSES)}")
@@ -3705,7 +4091,7 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
     Refuses to reassign a task that's currently running (claim_lock set).
     Reassign after the current run completes if needed.
     """
-    profile = _canonical_assignee(profile)
+    profile = _canonical_assignee(profile, conn=conn)
     with write_txn(conn):
         row = conn.execute(
             "SELECT status, claim_lock, assignee FROM tasks WHERE id = ?", (task_id,)
@@ -5201,6 +5587,10 @@ def reassign_task(
     Returns True if the reassign landed. ``profile`` may be ``None`` to
     unassign entirely.
     """
+    # Validate against this connection's effective policy before reclaim_task
+    # can terminate a worker, end its current run, or append reclaim events.
+    # assign_task deliberately validates again at the final write boundary.
+    profile = _canonical_assignee(profile, conn=conn)
     if reclaim_first:
         # Safe to call even if nothing to reclaim.
         reclaim_task(conn, task_id, reason=reason or "reassign")
@@ -6504,7 +6894,11 @@ def request_review(
                         "malformed); pass reviewer= explicitly",
                     )
                 reviewer = prior_reviewer
-        reviewer = _canonical_assignee(reviewer) if reviewer is not None else None
+        reviewer = (
+            _canonical_assignee(reviewer, conn=conn)
+            if reviewer is not None
+            else None
+        )
         assignee_sql = ", assignee = ?" if reviewer is not None else ""
         params: tuple[Any, ...]
         if expected_run_id is None:
@@ -6640,9 +7034,10 @@ def request_changes(
         implementer = requested_payload.get("implementer")
         if not isinstance(implementer, str) or not implementer.strip():
             return False, "review handoff has no valid implementer provenance"
+        implementer = _canonical_assignee(implementer, conn=conn)
         reviewer = task_row["assignee"]
         if isinstance(reviewer, str) and reviewer.strip():
-            reviewer = _canonical_assignee(reviewer)
+            reviewer = _normalize_assignee_filter(reviewer)
         else:
             reviewer = None
 
@@ -6905,6 +7300,8 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
         implementer = handoff.get("implementer")
         if not isinstance(implementer, str) or not implementer.strip():
             implementer = None
+        else:
+            implementer = _canonical_assignee(implementer, conn=conn)
         assignee_sql = ", assignee = ?" if implementer else ""
         params: tuple[Any, ...] = (
             (new_status, implementer, task_id)
@@ -7132,7 +7529,7 @@ def specify_triage_task(
     """
     if title is not None and not title.strip():
         raise ValueError("title cannot be blank")
-    assignee = _canonical_assignee(assignee)
+    assignee = _canonical_assignee(assignee, conn=conn)
     with write_txn(conn):
         existing = conn.execute(
             "SELECT title, body, assignee FROM tasks WHERE id = ? AND status = 'triage'",
@@ -7234,7 +7631,7 @@ def decompose_triage_task(
     if not children:
         return None
     if root_assignee is not None:
-        root_assignee = _canonical_assignee(root_assignee)
+        root_assignee = _canonical_assignee(root_assignee, conn=conn)
 
     # Pre-validate the children list shape outside the txn. Cheap checks
     # that don't need DB access. Bad input aborts before we touch the DB.
@@ -7313,7 +7710,7 @@ def decompose_triage_task(
             new_id = _new_task_id()
             title = child["title"].strip()
             body = child.get("body")
-            assignee = _canonical_assignee(child.get("assignee"))
+            assignee = _canonical_assignee(child.get("assignee"), conn=conn)
             # Per-child override wins; otherwise inherit the root's
             # workspace. A child that sets workspace_kind without a path
             # falls back to the root path only when kinds match (so a
@@ -9446,7 +9843,11 @@ def check_respawn_guard(
     return None
 
 
-def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
+def has_spawnable_ready(
+    conn: sqlite3.Connection,
+    *,
+    board: Optional[str] = None,
+) -> bool:
     """Return True iff there is at least one ready+assigned+unclaimed task
     whose assignee maps to a real Hermes profile.
 
@@ -9470,15 +9871,22 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     try:
         from hermes_cli.profiles import profile_exists  # local import: avoids cycle
     except Exception:
-        # Can't introspect — assume spawnable, preserve legacy behavior.
-        return True
+        profile_exists = None  # type: ignore[assignment]
     for row in rows:
-        if profile_exists(row["assignee"]):
+        if not is_kanban_profile_allowed(
+            row["assignee"], board=board, conn=conn
+        ):
+            continue
+        if profile_exists is None or profile_exists(row["assignee"]):
             return True
     return False
 
 
-def has_spawnable_review(conn: sqlite3.Connection) -> bool:
+def has_spawnable_review(
+    conn: sqlite3.Connection,
+    *,
+    board: Optional[str] = None,
+) -> bool:
     """Return True iff there is at least one review+assigned+unclaimed task
     whose assignee maps to a real Hermes profile.
 
@@ -9496,9 +9904,13 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     try:
         from hermes_cli.profiles import profile_exists  # local import: avoids cycle
     except Exception:
-        return True
+        profile_exists = None  # type: ignore[assignment]
     for row in rows:
-        if profile_exists(row["assignee"]):
+        if not is_kanban_profile_allowed(
+            row["assignee"], board=board, conn=conn
+        ):
+            continue
+        if profile_exists is None or profile_exists(row["assignee"]):
             return True
     return False
 
@@ -9545,12 +9957,15 @@ def dispatch_once(
     ``DispatchResult`` with ``skipped_locked=True`` and does no DB writes;
     the holder is already making progress on the same board.
 
-    The lock is keyed off the board's resolved DB path, so unrelated
+    The lock is keyed off the connection's resolved DB path, so unrelated
     boards tick in parallel. See :func:`_dispatch_tick_lock` for the
     cross-process / cross-platform mechanics.
     """
+    board = _mutation_board_slug(conn, board)
     try:
-        db_path = kanban_db_path(board=board)
+        db_path = _connection_main_db_path(conn)
+        if db_path is None:
+            db_path = kanban_db_path(board=board)
     except Exception:
         # Path resolution should never fail, but if it somehow does we
         # must not lose the tick — fall through to an unguarded dispatch
@@ -9734,8 +10149,19 @@ def _dispatch_once_locked(
     _default_assignee_resolved = False
     if _default_assignee:
         try:
+            canonical_default = _canonical_assignee(
+                _default_assignee, board=board, conn=conn
+            )
+            assert canonical_default is not None
+            _default_assignee = canonical_default
             from hermes_cli.profiles import profile_exists as _pe
             _default_assignee_resolved = bool(_pe(_default_assignee))
+        except ValueError:
+            _log.warning(
+                "kanban dispatch: refusing disallowed default_assignee=%r",
+                _default_assignee,
+            )
+            _default_assignee = None
         except Exception:
             # Profiles module not importable (test stubs, exotic envs).
             # Trust the operator's config and try the assignment; the
@@ -9811,6 +10237,16 @@ def _dispatch_once_locked(
             # this distinction to suppress spurious "stuck" warnings on
             # multi-lane setups where the ready queue is steadily full
             # of human-pulled work.
+            result.skipped_nonspawnable.append(row["id"])
+            continue
+        if not is_kanban_profile_allowed(
+            row_assignee, board=board, conn=conn
+        ):
+            _log.warning(
+                "kanban dispatch: refusing task %s assigned to disallowed profile %r",
+                row["id"],
+                row_assignee,
+            )
             result.skipped_nonspawnable.append(row["id"])
             continue
         # Per-profile concurrency cap (#21582): even if there's global
@@ -9959,6 +10395,16 @@ def _dispatch_once_locked(
         except Exception:
             profile_exists = None  # type: ignore[assignment]
         if profile_exists is not None and not profile_exists(row["assignee"]):
+            result.skipped_nonspawnable.append(row["id"])
+            continue
+        if not is_kanban_profile_allowed(
+            row["assignee"], board=board, conn=conn
+        ):
+            _log.warning(
+                "kanban review dispatch: refusing task %s assigned to disallowed profile %r",
+                row["id"],
+                row["assignee"],
+            )
             result.skipped_nonspawnable.append(row["id"])
             continue
         if _per_profile_cap is not None:
@@ -11570,8 +12016,13 @@ def read_worker_log(
 # Assignee enumeration (known profiles + per-profile board stats)
 # ---------------------------------------------------------------------------
 
-def list_profiles_on_disk() -> list[str]:
-    """Return the set of assignee/profile names discovered on disk.
+def list_profiles_on_disk(
+    *,
+    conn: Optional[sqlite3.Connection] = None,
+    board: Optional[str] = None,
+    include_disallowed: bool = False,
+) -> list[str]:
+    """Return assignable profile names discovered on disk.
 
     Includes:
     - named profiles under ``<default-root>/profiles/<name>/config.yaml``
@@ -11579,7 +12030,10 @@ def list_profiles_on_disk() -> list[str]:
 
     Reads profile paths directly so this module has no import dependency on
     ``hermes_cli.profiles`` (which pulls in a large chunk of the CLI startup
-    path).
+    path). Explicit board/connection context applies the effective board
+    policy; no context preserves the legacy machine-ceiling view. Callers that
+    need inventory rather than an assignment roster may set
+    ``include_disallowed=True``.
     """
     try:
         from hermes_constants import get_default_hermes_root
@@ -11602,15 +12056,25 @@ def list_profiles_on_disk() -> list[str]:
         except OSError:
             pass
 
+    if not include_disallowed:
+        allowed = kanban_allowed_profiles(board=board, conn=conn)
+        if allowed is not None:
+            names.intersection_update(allowed)
     return sorted(names)
 
 
-def known_assignees(conn: sqlite3.Connection) -> list[dict]:
-    """Return every assignee name known to the board or on disk.
+def known_assignees(
+    conn: sqlite3.Connection,
+    *,
+    board: Optional[str] = None,
+) -> list[dict]:
+    """Return every effectively allowed assignee known to the board or on disk.
 
     Each entry is ``{"name": str, "on_disk": bool, "counts": {status: n}}``.
-    A name is included when it's a configured profile on disk OR when
-    any non-archived task has it as the assignee. Used by:
+    A name is included when it is allowed by the effective board policy and is
+    a configured profile on disk OR has a non-archived historical assignment.
+    Disallowed historical cards remain visible through :func:`list_tasks` but
+    are intentionally omitted from this assignment roster. Used by:
 
     - ``hermes kanban assignees`` for the terminal.
     - The dashboard assignee dropdown (so a fresh profile appears in
@@ -11618,7 +12082,7 @@ def known_assignees(conn: sqlite3.Connection) -> list[dict]:
     - Router-profile heuristics ("who's overloaded?") without scanning
       the whole board.
     """
-    on_disk = set(list_profiles_on_disk())
+    on_disk = set(list_profiles_on_disk(conn=conn, board=board))
 
     # Count tasks per (assignee, status), excluding archived.
     counts: dict[str, dict[str, int]] = {}
@@ -11629,7 +12093,11 @@ def known_assignees(conn: sqlite3.Connection) -> list[dict]:
     ):
         counts.setdefault(row["assignee"], {})[row["status"]] = int(row["n"])
 
-    names = sorted(on_disk | set(counts.keys()))
+    allowed = kanban_allowed_profiles(board=board, conn=conn)
+    if allowed is None:
+        names = sorted(on_disk | set(counts.keys()))
+    else:
+        names = sorted(on_disk | (set(counts.keys()) & set(allowed)))
     return [
         {
             "name": name,

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -177,65 +177,83 @@ def _load_config() -> dict:
         return {}
 
 
-def _resolve_orchestrator_profile(cfg: dict) -> str:
-    """Resolve which profile owns the root/orchestration task after fan-out.
-
-    Falls back to the active default profile when ``kanban.orchestrator_profile``
-    is unset, so a task is never stranded for lack of an orchestrator.
-    """
+def _resolve_profile_choice(
+    cfg: dict,
+    config_key: str,
+    *,
+    valid_names: set[str],
+) -> Optional[str]:
+    """Resolve a configured route within the installed effective roster."""
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-    explicit = (kanban_cfg.get("orchestrator_profile") or "").strip()
-    if explicit:
-        try:
-            if profiles_mod.profile_exists(explicit):
-                return explicit
-        except Exception:
-            pass
-    # Fall back to the active default profile.
+    explicit = (kanban_cfg.get(config_key) or "").strip()
+    if explicit in valid_names:
+        return explicit
     try:
-        return profiles_mod.get_active_profile_name() or "default"
+        active = profiles_mod.get_active_profile_name() or "default"
     except Exception:
-        return "default"
+        active = "default"
+    if active in valid_names:
+        return active
+    return min(valid_names) if valid_names else None
 
 
-def _resolve_default_assignee(cfg: dict) -> str:
-    """Resolve which profile catches child tasks the orchestrator can't route."""
-    kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-    explicit = (kanban_cfg.get("default_assignee") or "").strip()
-    if explicit:
-        try:
-            if profiles_mod.profile_exists(explicit):
-                return explicit
-        except Exception:
-            pass
-    try:
-        return profiles_mod.get_active_profile_name() or "default"
-    except Exception:
-        return "default"
+def _resolve_orchestrator_profile(
+    cfg: dict,
+    *,
+    valid_names: set[str],
+) -> Optional[str]:
+    """Resolve the root owner within the installed effective roster."""
+    return _resolve_profile_choice(
+        cfg,
+        "orchestrator_profile",
+        valid_names=valid_names,
+    )
 
 
-def _build_roster() -> tuple[list[dict], set[str]]:
-    """Return (roster_for_prompt, valid_assignee_names).
+def _resolve_default_assignee(
+    cfg: dict,
+    *,
+    valid_names: set[str],
+) -> Optional[str]:
+    """Resolve the child fallback within the installed effective roster."""
+    return _resolve_profile_choice(
+        cfg,
+        "default_assignee",
+        valid_names=valid_names,
+    )
+
+
+def _build_roster(
+    *,
+    board: Optional[str] = None,
+    conn=None,
+) -> tuple[list[dict], set[str]]:
+    """Return the prompt roster and installed names allowed by board policy.
 
     Each roster entry is ``{name, description, has_description}``. The
-    valid-set is used after the LLM responds to rewrite invalid
-    assignees to the default fallback.
+    valid-set is used after the LLM responds to rewrite invalid assignees to
+    an installed effective fallback.
     """
     roster: list[dict] = []
     valid: set[str] = set()
     try:
         all_profiles = profiles_mod.list_profiles()
+        allowed = kb.kanban_allowed_profiles(board=board, conn=conn)
     except Exception as exc:
-        logger.warning("decompose: failed to list profiles: %s", exc)
+        logger.warning("decompose: failed to build effective profile roster: %s", exc)
         return roster, valid
-    for p in all_profiles:
-        desc = (p.description or "").strip()
+    for profile in all_profiles:
+        if allowed is not None and profile.name not in allowed:
+            continue
+        desc = (profile.description or "").strip()
         roster.append({
-            "name": p.name,
-            "description": desc or f"(no description; profile named {p.name!r})",
+            "name": profile.name,
+            "description": (
+                desc or f"(no description; profile named {profile.name!r})"
+            ),
             "has_description": bool(desc),
         })
-        valid.add(p.name)
+        valid.add(profile.name)
     return roster, valid
 
 
@@ -273,6 +291,7 @@ def decompose_task(
     *,
     author: Optional[str] = None,
     timeout: Optional[int] = None,
+    board: Optional[str] = None,
 ) -> DecomposeOutcome:
     """Decompose a triage task into a graph of child tasks.
 
@@ -280,22 +299,50 @@ def decompose_task(
     expected failure modes (task not in triage, no aux client
     configured, API error, malformed response, decomposer returned
     fanout=true with empty task list) — those surface via ``ok=False``.
+
+    The board is resolved once at entry and then passed to every connection
+    and policy lookup so a concurrent current-board change cannot alter routing
+    or redirect the eventual mutation.
     """
-    with kb.connect_closing() as conn:
+    effective_board = board or kb.get_current_board()
+    with kb.connect_closing(board=effective_board) as conn:
         task = kb.get_task(conn, task_id)
-    if task is None:
-        return DecomposeOutcome(task_id, False, "unknown task id")
-    if task.status != "triage":
+        if task is None:
+            return DecomposeOutcome(task_id, False, "unknown task id")
+        if task.status != "triage":
+            return DecomposeOutcome(
+                task_id,
+                False,
+                f"task is not in triage (status={task.status!r})",
+            )
+        roster, valid_names = _build_roster(
+            board=effective_board,
+            conn=conn,
+        )
+    if not valid_names:
         return DecomposeOutcome(
-            task_id, False, f"task is not in triage (status={task.status!r})"
+            task_id,
+            False,
+            "no installed profiles are allowed by the effective board policy",
         )
 
     cfg = _load_config()
-    orchestrator = _resolve_orchestrator_profile(cfg)
-    default_assignee = _resolve_default_assignee(cfg)
+    orchestrator = _resolve_orchestrator_profile(
+        cfg,
+        valid_names=valid_names,
+    )
+    default_assignee = _resolve_default_assignee(
+        cfg,
+        valid_names=valid_names,
+    )
+    if orchestrator is None or default_assignee is None:
+        return DecomposeOutcome(
+            task_id,
+            False,
+            "no installed profiles are allowed by the effective board policy",
+        )
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
     auto_promote = bool(kanban_cfg.get("auto_promote_children", True))
-    roster, valid_names = _build_roster()
 
     try:
         from agent.auxiliary_client import call_llm  # type: ignore
@@ -361,15 +408,21 @@ def decompose_task(
             return DecomposeOutcome(
                 task_id, False, "decomposer returned fanout=false with no title/body",
             )
-        with kb.connect_closing() as conn:
-            ok = kb.specify_triage_task(
-                conn,
-                task_id,
-                title=title_val,
-                body=body_val,
-                assignee=assignee_val,
-                author=audit_author,
-            )
+        try:
+            with kb.connect_closing(board=effective_board) as conn:
+                ok = kb.specify_triage_task(
+                    conn,
+                    task_id,
+                    title=title_val,
+                    body=body_val,
+                    assignee=assignee_val,
+                    author=audit_author,
+                )
+        except ValueError as exc:
+            return DecomposeOutcome(task_id, False, f"DB rejected task: {exc}")
+        except Exception as exc:
+            logger.exception("decompose: DB error on task %s", task_id)
+            return DecomposeOutcome(task_id, False, f"DB error: {type(exc).__name__}")
         if not ok:
             return DecomposeOutcome(
                 task_id, False, "task moved out of triage before promotion",
@@ -430,7 +483,7 @@ def decompose_task(
         })
 
     try:
-        with kb.connect_closing() as conn:
+        with kb.connect_closing(board=effective_board) as conn:
             child_ids = kb.decompose_triage_task(
                 conn,
                 task_id,
@@ -456,9 +509,14 @@ def decompose_task(
     )
 
 
-def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
+def list_triage_ids(
+    *,
+    tenant: Optional[str] = None,
+    board: Optional[str] = None,
+) -> list[str]:
     """Return task ids currently in the triage column."""
-    with kb.connect_closing() as conn:
+    effective_board = board or kb.get_current_board()
+    with kb.connect_closing(board=effective_board) as conn:
         rows = kb.list_tasks(
             conn,
             status="triage",

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -198,6 +198,15 @@
     return count && count > 1 ? tx(t, "selectedTasks", "{n} selected tasks", { n: count }) : tx(t, "thisTask", "this task");
   }
 
+  function settleDialogOwner(resolverRef, setDialogState, confirmed, extras) {
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    setDialogState(null);
+    if (!resolve) return false;
+    resolve(Object.assign({ confirmed: confirmed }, extras || {}));
+    return true;
+  }
+
   /**
    * Hook owning the kanban plugin's modal dialog state. Returns
    *   - `request(req)` — imperative API. Resolves to
@@ -226,12 +235,7 @@
     }, []);
 
     const close = React.useCallback(function (confirmed, extras) {
-      const resolve = resolverRef.current;
-      resolverRef.current = null;
-      setDialogState(null);
-      if (resolve) {
-        resolve(Object.assign({ confirmed: confirmed }, extras || {}));
-      }
+      return settleDialogOwner(resolverRef, setDialogState, confirmed, extras);
     }, []);
 
     const onConfirm = React.useCallback(function (maybeSummary) {
@@ -258,11 +262,18 @@
       };
     }, [dialogState, t, onConfirm, onCancel]);
 
-    return { dialogState: dialogState, dialogProps: dialogProps, request: request };
+    return {
+      dialogState: dialogState,
+      dialogProps: dialogProps,
+      request: request,
+      cancel: onCancel,
+    };
   }
 
   const API = "/api/plugins/kanban";
   const MIME_TASK = "text/x-hermes-task";
+  const ASSIGNEE_UNASSIGNED = "__kanban_unassigned__";
+  const ASSIGNEE_DISPATCHER = "__kanban_dispatcher__";
 
   // Docs link — surfaced as a `?` icon next to the board switcher and as
   // `title=` hints on unlabelled controls. Kept in one place so rebrands or
@@ -311,6 +322,119 @@
     if (!board) return url;
     const sep = url.indexOf("?") >= 0 ? "&" : "?";
     return `${url}${sep}board=${encodeURIComponent(board)}`;
+  }
+
+  function effectiveProfileNames(profiles) {
+    return (profiles || []).filter(function (profile) {
+      return profile && profile.effective_allowed;
+    }).map(function (profile) { return profile.name; });
+  }
+
+  function canSubmitAssignee(value, effectiveNames, allowUnassigned) {
+    if (allowUnassigned && value === ASSIGNEE_UNASSIGNED) return true;
+    return (effectiveNames || []).indexOf(value) >= 0;
+  }
+
+  function assignmentPatchValue(value) {
+    return value === ASSIGNEE_UNASSIGNED ? "" : value;
+  }
+
+  function assignmentCreateValue(value) {
+    return value === ASSIGNEE_DISPATCHER ? null : value;
+  }
+
+  function normalizeCreateAssignee(value, effectiveNames) {
+    if (value === ASSIGNEE_DISPATCHER) return value;
+    return (effectiveNames || []).indexOf(value) >= 0
+      ? value
+      : ASSIGNEE_DISPATCHER;
+  }
+
+  function createTaskAssigneeValue(value, effectiveNames) {
+    return assignmentCreateValue(normalizeCreateAssignee(value, effectiveNames));
+  }
+
+  function isExactBoardRequestCurrent(
+    boardRef,
+    generationRef,
+    requestBoard,
+    requestGeneration,
+  ) {
+    return boardRef.current === requestBoard
+      && generationRef.current === requestGeneration;
+  }
+
+  function retryExactBoardLoad(boardRef, requestBoard, setLoading, loadBoard) {
+    if (boardRef.current !== requestBoard) return Promise.resolve(null);
+    setLoading(true);
+    return loadBoard();
+  }
+
+  function taskDrawerIdentity(board, taskId) {
+    return JSON.stringify([
+      board == null ? "" : String(board),
+      taskId == null ? "" : String(taskId),
+    ]);
+  }
+
+  function createTaskRequestState(identity) {
+    return { active: true, identity: identity, generation: 0 };
+  }
+
+  function beginTaskLoad(state, identity) {
+    state.active = true;
+    state.identity = identity;
+    state.generation += 1;
+    return { identity: identity, generation: state.generation };
+  }
+
+  function isTaskLoadCurrent(state, token) {
+    return !!state.active
+      && state.identity === token.identity
+      && state.generation === token.generation;
+  }
+
+  function isTaskIdentityActive(state, identity) {
+    return !!state.active && state.identity === identity;
+  }
+
+  function deactivateTaskRequests(state) {
+    state.active = false;
+    state.generation += 1;
+  }
+
+  function createOperationOwner() {
+    return { serial: 0, token: null };
+  }
+
+  function claimOwnedOperation(owner, operation) {
+    if (owner.token !== null) return null;
+    const token = { id: ++owner.serial, operation: operation };
+    owner.token = token;
+    return token;
+  }
+
+  function ownsOperation(owner, token) {
+    return token !== null && owner.token === token;
+  }
+
+  function operationOwnerIsBusy(owner) {
+    return owner.token !== null;
+  }
+
+  function releaseOwnedOperation(owner, token) {
+    if (!ownsOperation(owner, token)) return false;
+    owner.token = null;
+    return true;
+  }
+
+  function invalidateOperationOwner(owner) {
+    owner.token = null;
+  }
+
+  function settleInlineCreateSubmission(owner, token, succeeded) {
+    if (!releaseOwnedOperation(owner, token)) return false;
+    return !!succeeded;
   }
 
   // The SDK's Select component fires ``onValueChange(value)`` directly
@@ -618,6 +742,9 @@
     const boardData = kanbanBoard;
     const setBoardData = setKanbanBoard;
     const [config, setConfig] = useState(null);
+    const [profiles, setProfiles] = useState([]);
+    const [profilesBoard, setProfilesBoard] = useState(null);
+    const [profilesError, setProfilesError] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
 
@@ -643,9 +770,16 @@
 
     const cursorRef = useRef(0);
     const reloadTimerRef = useRef(null);
-    const wsRef = useRef(null);
-    const wsBackoffRef = useRef(1000);
-    const wsClosedRef = useRef(false);
+    const boardRef = useRef(board);
+    const boardActionGenerationRef = useRef(0);
+    const boardLoadGenerationRef = useRef(0);
+    const boardListGenerationRef = useRef(0);
+    const profilesGenerationRef = useRef(0);
+    boardRef.current = board;
+
+    const effectiveAssignees = useMemo(function () {
+      return profilesBoard === board ? effectiveProfileNames(profiles) : [];
+    }, [profiles, profilesBoard, board]);
 
     // --- load config once ---------------------------------------------------
     useEffect(function () {
@@ -664,32 +798,84 @@
 
     // --- fetch full board ---------------------------------------------------
     const loadBoard = useCallback(() => {
+      const requestBoard = board;
+      if (boardRef.current !== requestBoard) return Promise.resolve(null);
+      const requestGeneration = ++boardLoadGenerationRef.current;
       const qs = new URLSearchParams();
       if (tenantFilter) qs.set("tenant", tenantFilter);
       if (includeArchived) qs.set("include_archived", "true");
       const url = qs.toString() ? `${API}/board?${qs}` : `${API}/board`;
-      return SDK.fetchJSON(withBoard(url, board))
+      return SDK.fetchJSON(withBoard(url, requestBoard))
         .then(function (data) {
+          if (!isExactBoardRequestCurrent(
+            boardRef, boardLoadGenerationRef, requestBoard, requestGeneration,
+          )) return null;
           setBoardData(data);
           cursorRef.current = data.latest_event_id || 0;
           setError(null);
+          return data;
         })
         .catch(function (err) {
+          if (!isExactBoardRequestCurrent(
+            boardRef, boardLoadGenerationRef, requestBoard, requestGeneration,
+          )) return null;
           setError(String(err && err.message ? err.message : err));
+          return null;
         })
-        .finally(function () { setLoading(false); });
+        .finally(function () {
+          if (isExactBoardRequestCurrent(
+            boardRef, boardLoadGenerationRef, requestBoard, requestGeneration,
+          )) setLoading(false);
+        });
     }, [tenantFilter, includeArchived, board]);
+
+    const retryBoardLoad = useCallback(function () {
+      return retryExactBoardLoad(boardRef, board, setLoading, loadBoard);
+    }, [board, loadBoard]);
+
+    const loadProfiles = useCallback(function () {
+      const requestBoard = board;
+      if (boardRef.current !== requestBoard) return Promise.resolve(null);
+      const requestGeneration = ++profilesGenerationRef.current;
+      if (!requestBoard) return Promise.resolve(null);
+      return SDK.fetchJSON(withBoard(`${API}/profiles`, requestBoard))
+        .then(function (data) {
+          if (!isExactBoardRequestCurrent(
+            boardRef, profilesGenerationRef, requestBoard, requestGeneration,
+          )) return null;
+          setProfiles((data && data.profiles) || []);
+          setProfilesBoard(requestBoard);
+          setProfilesError(null);
+          return data;
+        })
+        .catch(function (err) {
+          if (!isExactBoardRequestCurrent(
+            boardRef, profilesGenerationRef, requestBoard, requestGeneration,
+          )) return null;
+          setProfiles([]);
+          setProfilesBoard(requestBoard);
+          setProfilesError(tx(t, "profilesLoadFailed", "Failed to load board profiles: ")
+            + parseApiErrorMessage(err));
+          return null;
+        });
+    }, [board, t]);
 
     // --- load list of boards for the switcher ------------------------------
     const loadBoardList = useCallback(function () {
-      return SDK.fetchJSON(withBoard(`${API}/boards`, board))
+      const requestBoard = board;
+      if (boardRef.current !== requestBoard) return Promise.resolve(null);
+      const requestGeneration = ++boardListGenerationRef.current;
+      return SDK.fetchJSON(withBoard(`${API}/boards`, requestBoard))
         .then(function (data) {
+          if (!isExactBoardRequestCurrent(
+            boardRef, boardListGenerationRef, requestBoard, requestGeneration,
+          )) return null;
           const boards = (data && data.boards) || [];
           const storedBoard = readSelectedBoard();
           setBoardList(boards);
           if (!storedBoard && !board && data && data.current) {
             setBoard(data.current);
-            return;
+            return data;
           }
           // If the stored slug isn't in the list any longer (board was
           // deleted in the CLI while dashboard was open), fall back to
@@ -698,11 +884,13 @@
             setBoard("default");
             writeSelectedBoard("default");
           }
+          return data;
         })
         .catch(function () { /* non-fatal */ });
     }, [board]);
 
     useEffect(function () { loadBoardList(); }, [loadBoardList]);
+    useEffect(function () { loadProfiles(); }, [loadProfiles]);
 
     const scheduleReload = useCallback(function () {
       if (reloadTimerRef.current) return;
@@ -725,9 +913,24 @@
     // --- WebSocket ---------------------------------------------------------
     useEffect(function () {
       if (!boardData) return undefined;
-      wsClosedRef.current = false;
+      const socketBoard = board;
+      let closed = false;
+      let socket = null;
+      let reconnectTimer = null;
+      let backoff = 1000;
+
+      function scheduleReconnect() {
+        if (closed || boardRef.current !== socketBoard || reconnectTimer) return;
+        const delay = Math.min(backoff, 30000);
+        backoff = Math.min(backoff * 2, 30000);
+        reconnectTimer = setTimeout(function () {
+          reconnectTimer = null;
+          openWs();
+        }, delay);
+      }
+
       function openWs() {
-        if (wsClosedRef.current) return;
+        if (closed || boardRef.current !== socketBoard) return;
         // Build the WS URL via the host SDK so the correct auth param is used
         // in BOTH modes: single-use ?ticket= in gated OAuth mode, ?token= in
         // loopback. Reading window.__HERMES_SESSION_TOKEN__ directly (the old
@@ -741,14 +944,18 @@
         // dashboard's own board pin always wins over the server-side
         // ``current`` file — same rationale as ``withBoard()`` above.
         // Regression: #20879.
-        if (board) wsParams.board = board;
+        if (socketBoard) wsParams.board = socketBoard;
         SDK.buildWsUrl(`${API}/events`, wsParams).then(function (url) {
-          if (wsClosedRef.current) return;
+          if (closed || boardRef.current !== socketBoard) return;
           let ws;
-          try { ws = new WebSocket(url); } catch (_e) { return; }
-          wsRef.current = ws;
-          ws.onopen = function () { wsBackoffRef.current = 1000; };
+          try { ws = new WebSocket(url); } catch (_e) { scheduleReconnect(); return; }
+          socket = ws;
+          ws.onopen = function () {
+            if (closed || socket !== ws || boardRef.current !== socketBoard) return;
+            backoff = 1000;
+          };
           ws.onmessage = function (ev) {
+            if (closed || socket !== ws || boardRef.current !== socketBoard) return;
             try {
               const msg = JSON.parse(ev.data);
               if (msg && Array.isArray(msg.events) && msg.events.length > 0) {
@@ -766,31 +973,37 @@
             } catch (_e) { /* ignore */ }
           };
           ws.onclose = function (ev) {
-            if (wsClosedRef.current) return;
+            if (closed || socket !== ws || boardRef.current !== socketBoard) return;
+            socket = null;
             if (ev && ev.code === 1008) {
               setError(tx(t, "wsAuthFailed",
                 "WebSocket auth failed — reload the page to refresh the session token."));
               return;
             }
-            const delay = Math.min(wsBackoffRef.current, 30000);
-            wsBackoffRef.current = Math.min(wsBackoffRef.current * 2, 30000);
-            setTimeout(openWs, delay);
+            scheduleReconnect();
           };
         }).catch(function () {
           // Ticket mint / URL build failed (e.g. session expired). Back off
           // and retry; a hard auth failure surfaces via the 1008 close path.
-          if (wsClosedRef.current) return;
-          const delay = Math.min(wsBackoffRef.current, 30000);
-          wsBackoffRef.current = Math.min(wsBackoffRef.current * 2, 30000);
-          setTimeout(openWs, delay);
+          if (closed || boardRef.current !== socketBoard) return;
+          scheduleReconnect();
         });
       }
       openWs();
       return function () {
-        wsClosedRef.current = true;
-        try { wsRef.current && wsRef.current.close(); } catch (_e) { /* noop */ }
+        closed = true;
+        if (reconnectTimer) clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+        const ws = socket;
+        socket = null;
+        if (ws) {
+          ws.onopen = null;
+          ws.onmessage = null;
+          ws.onclose = null;
+          try { ws.close(); } catch (_e) { /* noop */ }
+        }
       };
-    }, [!!boardData, board, scheduleReload]);
+    }, [!!boardData, board, scheduleReload, t]);
 
     // --- filtering ----------------------------------------------------------
     const filteredBoard = useMemo(function () {
@@ -822,34 +1035,51 @@
     //   taskId  — required when count <= 1 (single-task PATCH endpoint)
     //           — ignored when count >  1 (bulk endpoint uses selectedIds)
     //   summary — completion summary string, or null/undefined to skip
-    const performMoveTask = useCallback(function (taskId, newStatus, count, summary) {
+    const performMoveTask = useCallback(function (
+      taskId,
+      newStatus,
+      count,
+      summary,
+      requestBoard,
+      requestGeneration,
+      requestIds,
+    ) {
+      const actionIsCurrent = function () {
+        return isExactBoardRequestCurrent(
+          boardRef, boardActionGenerationRef, requestBoard, requestGeneration,
+        );
+      };
       const patch = { status: newStatus };
       const finalPatch = summary
         ? Object.assign({}, patch, { result: summary, summary: summary })
         : patch;
       if (count > 1) {
+        const ids = requestIds || [];
+        const idSet = new Set(ids);
         // Bulk path: optimistic UI prepends all moved tasks to dest column.
-        setBoardData(function (b) {
-          if (!b) return b;
-          const moved = [];
-          const columns = b.columns.map(function (col) {
-            const kept = [];
-            for (const tk of col.tasks) {
-              if (selectedIds.has(tk.id)) moved.push(Object.assign({}, tk, { status: newStatus }));
-              else kept.push(tk);
-            }
-            return Object.assign({}, col, { tasks: kept });
+        if (actionIsCurrent()) {
+          setBoardData(function (b) {
+            if (!b || !actionIsCurrent()) return b;
+            const moved = [];
+            const columns = b.columns.map(function (col) {
+              const kept = [];
+              for (const tk of col.tasks) {
+                if (idSet.has(tk.id)) moved.push(Object.assign({}, tk, { status: newStatus }));
+                else kept.push(tk);
+              }
+              return Object.assign({}, col, { tasks: kept });
+            });
+            const dest = columns.find(function (c) { return c.name === newStatus; });
+            if (dest) dest.tasks = moved.concat(dest.tasks);
+            return Object.assign({}, b, { columns });
           });
-          const dest = columns.find(function (c) { return c.name === newStatus; });
-          if (dest) dest.tasks = moved.concat(dest.tasks);
-          return Object.assign({}, b, { columns });
-        });
-        const ids = Array.from(selectedIds);
-        SDK.fetchJSON(withBoard(`${API}/tasks/bulk`, board), {
+        }
+        return SDK.fetchJSON(withBoard(`${API}/tasks/bulk`, requestBoard), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(Object.assign({ ids: ids }, finalPatch)),
         }).then(function (res) {
+          if (!actionIsCurrent()) return res;
           const failed = (res.results || []).filter(function (r) { return !r.ok; });
           if (failed.length > 0) {
             setError(`Bulk move: ${failed.length} of ${res.results.length} failed`);
@@ -860,39 +1090,52 @@
           setSelectedIds(new Set());
           setLastSelectedId(null);
           loadBoard();
+          if (newStatus === "archived") loadBoardList();
+          return res;
         }).catch(function (err) {
+          if (!actionIsCurrent()) return null;
           setError(`Move failed: ${err.message || err}`);
-          setFailedIds(new Set(selectedIds));
+          setFailedIds(new Set(ids));
           loadBoard();
+          return null;
         });
-        return;
       }
       // Single-task path.
-      setBoardData(function (b) {
-        if (!b) return b;
-        let moved = null;
-        const columns = b.columns.map(function (col) {
-          const next = col.tasks.filter(function (tk) {
-            if (tk.id === taskId) { moved = Object.assign({}, tk, { status: newStatus }); return false; }
-            return true;
+      if (actionIsCurrent()) {
+        setBoardData(function (b) {
+          if (!b || !actionIsCurrent()) return b;
+          let moved = null;
+          const columns = b.columns.map(function (col) {
+            const next = col.tasks.filter(function (tk) {
+              if (tk.id === taskId) { moved = Object.assign({}, tk, { status: newStatus }); return false; }
+              return true;
+            });
+            return Object.assign({}, col, { tasks: next });
           });
-          return Object.assign({}, col, { tasks: next });
+          if (moved) {
+            const dest = columns.find(function (c) { return c.name === newStatus; });
+            if (dest) dest.tasks = [moved].concat(dest.tasks);
+          }
+          return Object.assign({}, b, { columns });
         });
-        if (moved) {
-          const dest = columns.find(function (c) { return c.name === newStatus; });
-          if (dest) dest.tasks = [moved].concat(dest.tasks);
-        }
-        return Object.assign({}, b, { columns });
-      });
-      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(taskId)}`, board), {
+      }
+      return SDK.fetchJSON(withBoard(
+        `${API}/tasks/${encodeURIComponent(taskId)}`, requestBoard,
+      ), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(finalPatch),
+      }).then(function (res) {
+        if (!actionIsCurrent()) return res;
+        if (newStatus === "archived") loadBoardList();
+        return res;
       }).catch(function (err) {
+        if (!actionIsCurrent()) return null;
         setError(tx(t, "moveFailed", "Move failed: ") + parseApiErrorMessage(err));
         loadBoard();
+        return null;
       });
-    }, [loadBoard, board, t, selectedIds]);
+    }, [loadBoard, loadBoardList, t]);
 
     // Pre-dispatch dialog step for both moveTask and moveSelected. Drives
     // the new in-app ConfirmDialog instead of window.confirm. The flow:
@@ -941,20 +1184,27 @@
     // Single-task card move. Drives confirmation + completion summary
     // dialogs via the hook, then dispatches via performMoveTask.
     const moveTask = useCallback(function (taskId, newStatus) {
+      const requestBoard = board;
+      const requestGeneration = boardActionGenerationRef.current;
       requestMoveConfirm(newStatus, 1)
         .then(function (r1) {
           if (!r1.confirmed) return null;
           if (newStatus !== "done") {
-            performMoveTask(taskId, newStatus, 1, null);
+            performMoveTask(
+              taskId, newStatus, 1, null, requestBoard, requestGeneration, [taskId],
+            );
             return null;
           }
           return requestCompletionSummary(1).then(function (r2) {
             if (!r2.confirmed) return null;
-            performMoveTask(taskId, newStatus, 1, r2.summary || null);
+            performMoveTask(
+              taskId, newStatus, 1, r2.summary || null,
+              requestBoard, requestGeneration, [taskId],
+            );
           });
         })
         .catch(function () { /* dialog cancelled */ });
-    }, [requestMoveConfirm, requestCompletionSummary, performMoveTask]);
+    }, [board, requestMoveConfirm, requestCompletionSummary, performMoveTask]);
 
     const clearSelected = useCallback(function () {
       setSelectedIds(new Set());
@@ -963,29 +1213,43 @@
     }, []);
     const moveSelected = useCallback(function (newStatus) {
       if (selectedIds.size === 0) return;
-      const count = selectedIds.size;
-      const taskId = Array.from(selectedIds)[0]; // representative id for performMoveTask's single-task branch
+      const requestBoard = board;
+      const requestGeneration = boardActionGenerationRef.current;
+      const requestIds = Array.from(selectedIds);
+      const count = requestIds.length;
+      const taskId = requestIds[0]; // representative id for performMoveTask's single-task branch
       requestMoveConfirm(newStatus, count)
         .then(function (r1) {
           if (!r1.confirmed) return null;
           if (newStatus !== "done") {
-            performMoveTask(taskId, newStatus, count, null);
+            performMoveTask(
+              taskId, newStatus, count, null,
+              requestBoard, requestGeneration, requestIds,
+            );
             return null;
           }
           return requestCompletionSummary(count).then(function (r2) {
             if (!r2.confirmed) return null;
-            performMoveTask(taskId, newStatus, count, r2.summary || null);
+            performMoveTask(
+              taskId, newStatus, count, r2.summary || null,
+              requestBoard, requestGeneration, requestIds,
+            );
           });
         })
         .catch(function () { /* dialog cancelled */ });
-    }, [selectedIds, requestMoveConfirm, requestCompletionSummary, performMoveTask]);
+    }, [selectedIds, board, requestMoveConfirm, requestCompletionSummary, performMoveTask]);
 
     const createTask = useCallback(function (body) {
-      return SDK.fetchJSON(withBoard(`${API}/tasks`, board), {
+      const requestBoard = board;
+      const requestGeneration = boardActionGenerationRef.current;
+      return SDK.fetchJSON(withBoard(`${API}/tasks`, requestBoard), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       }).then(function (res) {
+        if (!isExactBoardRequestCurrent(
+          boardRef, boardActionGenerationRef, requestBoard, requestGeneration,
+        )) return res;
         // Surface dispatcher-presence warnings (e.g. "no gateway is
         // running") via the existing error banner channel. Not fatal —
         // the task was created successfully — but the user should know
@@ -1075,19 +1339,28 @@
 
     const applyBulk = useCallback(function (patch, confirmMsg) {
       if (selectedIds.size === 0) return;
+      const requestBoard = board;
+      const requestGeneration = boardActionGenerationRef.current;
+      const requestIds = Array.from(selectedIds);
+      const requestIdSet = new Set(requestIds);
       const count = selectedIds.size;
       const run = function () {
+        const actionIsCurrent = function () {
+          return isExactBoardRequestCurrent(
+            boardRef, boardActionGenerationRef, requestBoard, requestGeneration,
+          );
+        };
         const finalPatch = patch;
-        const body = Object.assign({ ids: Array.from(selectedIds) }, finalPatch);
+        const body = Object.assign({ ids: requestIds }, finalPatch);
         // Optimistic UI for status moves (same pattern as moveSelected).
-        if (finalPatch.status) {
+        if (finalPatch.status && actionIsCurrent()) {
           setBoardData(function (b) {
-            if (!b) return b;
+            if (!b || !actionIsCurrent()) return b;
             const moved = [];
             const columns = b.columns.map(function (col) {
               const kept = [];
               for (const t of col.tasks) {
-                if (selectedIds.has(t.id)) moved.push(Object.assign({}, t, { status: finalPatch.status }));
+                if (requestIdSet.has(t.id)) moved.push(Object.assign({}, t, { status: finalPatch.status }));
                 else kept.push(t);
               }
               return Object.assign({}, col, { tasks: kept });
@@ -1097,12 +1370,13 @@
             return Object.assign({}, b, { columns });
           });
         }
-        SDK.fetchJSON(withBoard(`${API}/tasks/bulk`, board), {
+        return SDK.fetchJSON(withBoard(`${API}/tasks/bulk`, requestBoard), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         })
           .then(function (res) {
+            if (!actionIsCurrent()) return res;
             const failed = (res.results || []).filter(function (r) { return !r.ok; });
             if (failed.length > 0) {
               setError(tx(t, "bulkFailed", "Bulk: ") +
@@ -1115,35 +1389,49 @@
             setSelectedIds(new Set());
             setLastSelectedId(null);
             loadBoard();
+            if (finalPatch.archive === true || finalPatch.status === "archived") {
+              loadBoardList();
+            }
+            return res;
           })
           .catch(function (e) {
+            if (!actionIsCurrent()) return null;
             setError(String(e.message || e));
-            setFailedIds(new Set(selectedIds));
+            setFailedIds(new Set(requestIds));
             loadBoard();
+            return null;
           });
       };
       if (!confirmMsg) {
-        run();
-        return;
+        return run();
       }
-      kanbanDialogs.request({
+      return kanbanDialogs.request({
         kind: "confirm",
         title: tx(t, "bulkConfirmTitle", "Apply bulk change"),
         description: confirmMsg,
         confirmLabel: tx(t, "apply", "Apply"),
         destructive: false,
       }).then(function (r) {
-        if (r.confirmed) run();
+        if (r.confirmed) return run();
+        return null;
       }).catch(function () { /* cancelled */ });
-    }, [selectedIds, loadBoard, board, t, kanbanDialogs]);
+    }, [selectedIds, loadBoard, loadBoardList, board, t, kanbanDialogs]);
 
     // --- board switching ----------------------------------------------------
     const switchBoard = useCallback(function (nextSlug) {
       if (!nextSlug || nextSlug === board) return;
+      boardRef.current = nextSlug;
+      boardActionGenerationRef.current += 1;
+      boardLoadGenerationRef.current += 1;
+      boardListGenerationRef.current += 1;
+      profilesGenerationRef.current += 1;
       // Optimistic UI: clear the current grid + show loading, reset the
       // event cursor so the WS reopens aligned to the new board's
       // latest_event_id on the next loadBoard.
       setBoardData(null);
+      setProfiles([]);
+      setProfilesBoard(null);
+      setProfilesError(null);
       cursorRef.current = 0;
       setLoading(true);
       setBoard(nextSlug);
@@ -1153,8 +1441,15 @@
       setTenantFilter("");
       setAssigneeFilter("");
       setIncludeArchived(false);
+      setSelectedTaskId(null);
+      setShowNewBoard(false);
+      setShowBoardSettings(false);
+      setTaskEventTick({});
+      setDraggingTaskId(null);
+      setError(null);
+      kanbanDialogs.cancel();
       clearSelected();
-    }, [board, clearSelected]);
+    }, [board, clearSelected, kanbanDialogs]);
 
     const createNewBoard = useCallback(function (payload) {
       return SDK.fetchJSON(`${API}/boards`, {
@@ -1185,15 +1480,23 @@
 
     const deleteBoard = useCallback(function (slug) {
       if (!slug || slug === "default") return Promise.resolve();
+      const requestBoard = board;
+      const requestGeneration = boardActionGenerationRef.current;
       return SDK.fetchJSON(`${API}/boards/${encodeURIComponent(slug)}`, {
         method: "DELETE",
       }).then(function () {
+        if (!isExactBoardRequestCurrent(
+          boardRef, boardActionGenerationRef, requestBoard, requestGeneration,
+        )) return null;
         loadBoardList();
-        if (board === slug) switchBoard("default");
+        if (requestBoard === slug) switchBoard("default");
+        return null;
       });
     }, [board, loadBoardList, switchBoard]);
 
    const deleteTask = useCallback(function (taskId) {
+     const requestBoard = board;
+     const requestGeneration = boardActionGenerationRef.current;
      return kanbanDialogs.request({
        kind: "confirm",
        title: tx(t, "trash.confirmTitle", "Delete task?"),
@@ -1202,22 +1505,36 @@
        destructive: true,
      }).then(function (r) {
        if (!r.confirmed) return null;
-       return SDK.fetchJSON(`${API}/tasks/${encodeURIComponent(taskId)}`, {
+       return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(taskId)}`, requestBoard), {
          method: "DELETE",
        }).then(function () {
+         if (!isExactBoardRequestCurrent(
+           boardRef, boardActionGenerationRef, requestBoard, requestGeneration,
+         )) return null;
          loadBoard();
+         loadBoardList();
          setSelectedIds(function (prev) {
            const next = new Set(prev);
            next.delete(taskId);
            return next;
          });
-       }).catch(function (e) { setError(String(e.message || e)); });
+         return null;
+       }).catch(function (e) {
+         if (!isExactBoardRequestCurrent(
+           boardRef, boardActionGenerationRef, requestBoard, requestGeneration,
+         )) return null;
+         setError(String(e.message || e));
+         return null;
+       });
      }).catch(function () { /* cancelled */ });
-   }, [board, loadBoard, t, kanbanDialogs]);
+   }, [board, loadBoard, loadBoardList, t, kanbanDialogs]);
 
     const deleteSelected = useCallback(function (count) {
       if (selectedIds.size === 0) return Promise.resolve();
-      kanbanDialogs.request({
+      const requestBoard = board;
+      const requestGeneration = boardActionGenerationRef.current;
+      const ids = Array.from(selectedIds);
+      return kanbanDialogs.request({
         kind: "confirm",
         title: tx(t, "trash.confirmManyTitle", "Delete {n} tasks?", { n: count }),
         description: tx(t, "trash.confirmMany", "Permanently delete {n} selected tasks? This cannot be undone.", { n: count }),
@@ -1225,15 +1542,30 @@
         destructive: true,
       }).then(function (r) {
         if (!r.confirmed) return null;
-        const ids = Array.from(selectedIds);
-        setSelectedIds(new Set());
+        if (isExactBoardRequestCurrent(
+          boardRef, boardActionGenerationRef, requestBoard, requestGeneration,
+        )) setSelectedIds(new Set());
         return Promise.all(ids.map(function (id) {
-          return SDK.fetchJSON(`${API}/tasks/${encodeURIComponent(id)}`, { method: "DELETE" });
+          return SDK.fetchJSON(
+            withBoard(`${API}/tasks/${encodeURIComponent(id)}`, requestBoard),
+            { method: "DELETE" },
+          );
         })).then(function () {
+          if (!isExactBoardRequestCurrent(
+            boardRef, boardActionGenerationRef, requestBoard, requestGeneration,
+          )) return null;
           loadBoard();
-        }).catch(function (e) { setError(String(e.message || e)); });
+          loadBoardList();
+          return null;
+        }).catch(function (e) {
+          if (!isExactBoardRequestCurrent(
+            boardRef, boardActionGenerationRef, requestBoard, requestGeneration,
+          )) return null;
+          setError(String(e.message || e));
+          return null;
+        });
       }).catch(function () { /* cancelled */ });
-    }, [selectedIds, board, loadBoard, t, kanbanDialogs]);
+    }, [selectedIds, board, loadBoard, loadBoardList, t, kanbanDialogs]);
 
     // --- render -------------------------------------------------------------
     if (loading && !boardData) {
@@ -1248,6 +1580,13 @@
           h("div", { className: "text-xs text-muted-foreground mt-2" },
             tx(t, "loadFailedHint",
               "The backend auto-creates kanban.db on first read. If this persists, check the dashboard logs.")),
+          h(Button, {
+            type: "button",
+            size: "sm",
+            className: "mt-4",
+            onClick: retryBoardLoad,
+            disabled: loading,
+          }, tx(t, "retry", "Retry")),
         ),
       );
     }
@@ -1280,7 +1619,10 @@
             return updateBoard(board, payload).then(function () { setShowBoardSettings(false); });
           },
         }) : null,
-        h(OrchestrationPanel, null),
+        h(OrchestrationPanel, {
+          board: board,
+          onProfilesReload: loadProfiles,
+        }),
         h(AttentionStrip, {
           boardData,
           onOpen: setSelectedTaskId,
@@ -1293,26 +1635,41 @@
           laneByProfile, setLaneByProfile,
           search, setSearch,
           onNudgeDispatch: function () {
-            SDK.fetchJSON(withBoard(`${API}/dispatch?max=8`, board), { method: "POST" })
-              .then(loadBoard)
-              .catch(function (e) { setError(String(e.message || e)); });
+            const requestBoard = board;
+            const requestGeneration = boardActionGenerationRef.current;
+            SDK.fetchJSON(withBoard(`${API}/dispatch?max=8`, requestBoard), { method: "POST" })
+              .then(function (res) {
+                if (!isExactBoardRequestCurrent(
+                  boardRef, boardActionGenerationRef, requestBoard, requestGeneration,
+                )) return res;
+                return loadBoard().then(function () { return res; });
+              })
+              .catch(function (e) {
+                if (!isExactBoardRequestCurrent(
+                  boardRef, boardActionGenerationRef, requestBoard, requestGeneration,
+                )) return null;
+                setError(String(e.message || e));
+                return null;
+              });
           },
           onRefresh: loadBoard,
         }),
        selectedIds.size > 0 ? h(BulkActionBar, {
          count: selectedIds.size,
-         assignees: (boardData && boardData.assignees) || [],
+         effectiveAssignees: effectiveAssignees,
          onApply: applyBulk,
          onClear: clearSelected,
          onSelectAllVisible: selectAllVisible,
          onDelete: deleteSelected,
        }) : null,
         error ? h("div", { className: "text-xs text-destructive px-2" }, error) : null,
+        profilesError ? h("div", { className: "text-xs text-destructive px-2" }, profilesError) : null,
         h(KanbanDialogs, {
           dialogProps: kanbanDialogs.dialogProps,
           dialogState: kanbanDialogs.dialogState,
         }),
         h(BoardColumns, {
+          key: board,
           board: filteredBoard,
           boardMeta: boardList.find(function (item) { return item.slug === board; }) || null,
           laneByProfile,
@@ -1330,17 +1687,20 @@
           onDeleteSelected: deleteSelected,
           onOpen: setSelectedTaskId,
           onCreate: createTask,
+          effectiveAssignees: effectiveAssignees,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
         }),
         selectedTaskId ? h(TaskDrawer, {
+          key: taskDrawerIdentity(board, selectedTaskId),
           taskId: selectedTaskId,
           boardSlug: board,
           onClose: function () { setSelectedTaskId(null); },
           onOpenTask: setSelectedTaskId,
           onRefresh: loadBoard,
+          onCountsRefresh: loadBoardList,
           renderMarkdown: renderMd,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
-          assignees: (boardData && boardData.assignees) || [],
+          effectiveAssignees: effectiveAssignees,
           eventTick: taskEventTick[selectedTaskId] || 0,
           // Hook for the side-drawer's doPatch to use the same in-app
           // dialog machinery as the column-card flow. TaskDetail also
@@ -1530,11 +1890,15 @@
 
   function DiagnosticCard(props) {
     const { t } = useI18n();
-    const { diag, task, boardSlug, assignees, onRefresh } = props;
+    const { diag, task, boardSlug, effectiveAssignees, onRefresh } = props;
     const [busy, setBusy] = useState(false);
     const [msg, setMsg] = useState(null);
     const [copiedKey, setCopiedKey] = useState(null);
     const [reassignProfile, setReassignProfile] = useState(task.assignee || "");
+
+    useEffect(function () {
+      setReassignProfile(task.assignee || "");
+    }, [task.id, task.assignee]);
 
     const execAction = function (action) {
       if (busy) return;
@@ -1610,14 +1974,15 @@
         return;
       }
       if (action.kind === "reassign") {
-        if (!reassignProfile) {
+        if (!canSubmitAssignee(reassignProfile, effectiveAssignees, true)) {
           setMsg({ ok: false, text: tx(t, "pickProfileFirst", "Pick a profile first.") });
           return;
         }
         setBusy(true); setMsg(null);
         const url = withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/reassign`, boardSlug);
+        const nextProfile = assignmentPatchValue(reassignProfile);
         const body = {
-          profile: reassignProfile || null,
+          profile: nextProfile || null,
           reclaim_first: !!(action.payload && action.payload.reclaim_first),
           reason: `recovery action for ${diag.kind}`,
         };
@@ -1629,7 +1994,7 @@
           setMsg({
             ok: true,
             text: tx(t, "reassignedMessage", "Reassigned {id} to {profile}.",
-              { id: task.id, profile: reassignProfile }),
+              { id: task.id, profile: nextProfile || tx(t, "unassigned", "unassigned") }),
           });
           if (onRefresh) onRefresh();
         }).catch(function (err) {
@@ -1690,8 +2055,15 @@
               value: reassignProfile,
               onChange: function (e) { setReassignProfile(e.target.value); },
             },
-              h("option", { value: "" }, "(unassigned)"),
-              (assignees || []).map(function (a) {
+              h("option", { value: "" }, tx(t, "chooseAssignment", "— choose assignment —")),
+              h("option", { value: ASSIGNEE_UNASSIGNED },
+                tx(t, "unassignAndPark", "Unassign / park")),
+              task.assignee && (effectiveAssignees || []).indexOf(task.assignee) < 0
+                ? h("option", { value: task.assignee, disabled: true },
+                    tx(t, "historicalAssignee", "{name} (not allowed on this board)",
+                      { name: task.assignee }))
+                : null,
+              (effectiveAssignees || []).map(function (a) {
                 return h("option", { key: a, value: a }, a);
               }),
             ),
@@ -1706,7 +2078,8 @@
             busy: busy,
             extra: {
               copied: copiedKey === a.label,
-              disabled: (a.kind === "reassign" && !reassignProfile),
+              disabled: (a.kind === "reassign"
+                && !canSubmitAssignee(reassignProfile, effectiveAssignees, true)),
             },
           });
         }),
@@ -1757,7 +2130,7 @@
                 diag: d,
                 task: props.task,
                 boardSlug: props.boardSlug,
-                assignees: props.assignees,
+                effectiveAssignees: props.effectiveAssignees,
                 onRefresh: props.onRefresh,
               });
             }),
@@ -1791,122 +2164,279 @@
   // auto-generate). Backed by /orchestration + /profiles endpoints.
   // ---------------------------------------------------------------------
 
-  function OrchestrationPanel() {
+  function OrchestrationPanel(props) {
+    const { t } = useI18n();
+    const board = props.board;
     const [expanded, setExpanded] = useState(false);
     const [settings, setSettings] = useState(null);
     const [profiles, setProfiles] = useState([]);
+    const [loadedBoard, setLoadedBoard] = useState(null);
     const [busy, setBusy] = useState({});
     const [msg, setMsg] = useState(null);
+    const [saving, setSaving] = useState(false);
+    const boardRef = useRef(board);
+    const loadVersionRef = useRef(0);
+    const panelGenerationRef = useRef(0);
+    const savingRef = useRef(false);
+    const profileOperationOwnerRef = useRef(createOperationOwner());
+    boardRef.current = board;
 
-    const loadAll = useCallback(function () {
-      Promise.all([
-        SDK.fetchJSON(`${API}/orchestration`),
-        SDK.fetchJSON(`${API}/profiles`),
+    const loadAll = useCallback(function (options) {
+      if (boardRef.current !== board) return Promise.resolve(null);
+      const requestVersion = ++loadVersionRef.current;
+      const keepMessage = !!(options && options.keepMessage);
+      return Promise.all([
+        SDK.fetchJSON(withBoard(`${API}/orchestration`, board)),
+        SDK.fetchJSON(withBoard(`${API}/profiles`, board)),
       ]).then(function (results) {
+        if (requestVersion !== loadVersionRef.current || boardRef.current !== board) {
+          return null;
+        }
         setSettings(results[0] || null);
         setProfiles((results[1] && results[1].profiles) || []);
-        setMsg(null);
+        setLoadedBoard(board);
+        if (!keepMessage) setMsg(null);
+        return results;
       }).catch(function (err) {
-        setMsg({ ok: false, text: "Failed to load: " + (err.message || String(err)) });
+        if (requestVersion !== loadVersionRef.current || boardRef.current !== board) {
+          return null;
+        }
+        setMsg({
+          ok: false,
+          text: tx(t, "orchestrationLoadFailed", "Failed to load orchestration settings: ")
+            + parseApiErrorMessage(err),
+        });
+        return null;
       });
-    }, []);
+    }, [board, t]);
 
     useEffect(function () {
-      // Load on mount so the collapsed pill shows the real mode without
-      // requiring the user to expand the panel first.
-      if (settings === null) loadAll();
-    }, [settings, loadAll]);
+      // Hide the previous board's policy immediately and invalidate its
+      // board-scoped loads. Profile-description writes are global, so their
+      // exact owner token and busy UI survive the board transition until the
+      // write's own finally releases that token.
+      panelGenerationRef.current += 1;
+      loadVersionRef.current += 1;
+      setSettings(null);
+      setProfiles([]);
+      setLoadedBoard(null);
+      setMsg(null);
+      loadAll();
+      return function () {
+        panelGenerationRef.current += 1;
+        loadVersionRef.current += 1;
+      };
+    }, [board, loadAll]);
+
+    // React preserves component state when only props change. Gate every
+    // board-specific value on the board that produced it so one render during
+    // a switch can never flash the previous board's policy.
+    const activeSettings = loadedBoard === board ? settings : null;
+    const activeProfiles = loadedBoard === board ? profiles : [];
 
     const saveSettings = function (patch) {
+      if (savingRef.current) return Promise.resolve(null);
+      savingRef.current = true;
+      setSaving(true);
       setMsg(null);
-      return SDK.fetchJSON(`${API}/orchestration`, {
+      const saveBoard = board;
+      const saveGeneration = panelGenerationRef.current;
+      return SDK.fetchJSON(withBoard(`${API}/orchestration`, saveBoard), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(patch),
       }).then(function (res) {
-        setSettings(res);
-        setMsg({ ok: true, text: "Settings saved." });
-        return res;
+        if (boardRef.current !== saveBoard
+            || panelGenerationRef.current !== saveGeneration) return res;
+        setSettings(null);
+        setProfiles([]);
+        setLoadedBoard(null);
+        setMsg({ ok: true, text: tx(t, "orchestrationSettingsSaved", "Settings saved.") });
+        // Policy changes alter both the settings payload and the per-profile
+        // machine/board/effective flags, so refresh the pair together.
+        return loadAll({ keepMessage: true }).then(function () {
+          if (boardRef.current !== saveBoard
+              || panelGenerationRef.current !== saveGeneration
+              || !props.onProfilesReload) return res;
+          return Promise.resolve(props.onProfilesReload()).then(function () { return res; });
+        });
       }).catch(function (err) {
-        setMsg({ ok: false, text: "Save failed: " + (err.message || String(err)) });
+        if (boardRef.current !== saveBoard
+            || panelGenerationRef.current !== saveGeneration) return null;
+        setMsg({
+          ok: false,
+          text: tx(t, "orchestrationSaveFailed", "Failed to save orchestration settings: ")
+            + parseApiErrorMessage(err),
+        });
+        return null;
+      }).finally(function () {
+        savingRef.current = false;
+        setSaving(false);
       });
     };
 
     const saveProfileDescription = function (name, description) {
-      setBusy(function (b) { return Object.assign({}, b, { [name]: "save" }); });
+      if (savingRef.current) return Promise.resolve(null);
+      const actionBoard = board;
+      const actionGeneration = panelGenerationRef.current;
+      const operationToken = claimOwnedOperation(profileOperationOwnerRef.current, {
+        board: actionBoard, name: name, kind: "save",
+      });
+      if (operationToken === null) return Promise.resolve(null);
+      setBusy({ [name]: "save" });
       return SDK.fetchJSON(`${API}/profiles/${encodeURIComponent(name)}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ description: description }),
       }).then(function () {
-        loadAll();
-        setMsg({ ok: true, text: `Description saved for ${name}.` });
-      }).catch(function (err) {
-        setMsg({ ok: false, text: "Save failed: " + (err.message || String(err)) });
-      }).then(function () {
-        setBusy(function (b) {
-          const next = Object.assign({}, b); delete next[name]; return next;
+        if (boardRef.current !== actionBoard
+            || panelGenerationRef.current !== actionGeneration) return;
+        loadAll({ keepMessage: true });
+        setMsg({
+          ok: true,
+          text: tx(t, "profileDescriptionSaved", "Description saved for {name}.",
+            { name: name }),
         });
+      }).catch(function (err) {
+        if (boardRef.current !== actionBoard
+            || panelGenerationRef.current !== actionGeneration) return;
+        setMsg({
+          ok: false,
+          text: tx(t, "profileDescriptionSaveFailed", "Failed to save profile description: ")
+            + parseApiErrorMessage(err),
+        });
+      }).finally(function () {
+        if (!releaseOwnedOperation(profileOperationOwnerRef.current, operationToken)) return;
+        setBusy({});
+        if (boardRef.current !== actionBoard
+            || panelGenerationRef.current !== actionGeneration) return;
       });
     };
 
     const autoGenerateDescription = function (name, overwrite) {
-      setBusy(function (b) { return Object.assign({}, b, { [name]: "auto" }); });
+      if (savingRef.current) return Promise.resolve(null);
+      const actionBoard = board;
+      const actionGeneration = panelGenerationRef.current;
+      const operationToken = claimOwnedOperation(profileOperationOwnerRef.current, {
+        board: actionBoard, name: name, kind: "auto",
+      });
+      if (operationToken === null) return Promise.resolve(null);
+      setBusy({ [name]: "auto" });
       return SDK.fetchJSON(`${API}/profiles/${encodeURIComponent(name)}/describe-auto`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ overwrite: !!overwrite }),
       }).then(function (res) {
+        if (boardRef.current !== actionBoard
+            || panelGenerationRef.current !== actionGeneration) return;
         if (res && res.ok) {
-          loadAll();
-          setMsg({ ok: true, text: `Auto-generated description for ${name}.` });
+          loadAll({ keepMessage: true });
+          setMsg({
+            ok: true,
+            text: tx(t, "profileDescriptionGenerated",
+              "Auto-generated description for {name}.", { name: name }),
+          });
         } else {
           setMsg({
             ok: false,
-            text: "Auto-generate failed: " + ((res && res.reason) || "unknown error"),
+            text: tx(t, "profileDescriptionGenerateFailed",
+              "Failed to auto-generate profile description: ")
+              + ((res && res.reason) || tx(t, "unknownError", "unknown error")),
           });
         }
       }).catch(function (err) {
-        setMsg({ ok: false, text: "Auto-generate failed: " + (err.message || String(err)) });
-      }).then(function () {
-        setBusy(function (b) {
-          const next = Object.assign({}, b); delete next[name]; return next;
+        if (boardRef.current !== actionBoard
+            || panelGenerationRef.current !== actionGeneration) return;
+        setMsg({
+          ok: false,
+          text: tx(t, "profileDescriptionGenerateFailed",
+            "Failed to auto-generate profile description: ") + parseApiErrorMessage(err),
         });
+      }).finally(function () {
+        if (!releaseOwnedOperation(profileOperationOwnerRef.current, operationToken)) return;
+        setBusy({});
+        if (boardRef.current !== actionBoard
+            || panelGenerationRef.current !== actionGeneration) return;
       });
     };
 
+    const inheritsMachinePolicy = !!(
+      activeSettings && activeSettings.board_allowed_profiles === null
+    );
+    const effectivePolicyEmpty = !!(
+      activeSettings
+      && (activeSettings.effective_allowed_profiles || []).length === 0
+    );
+    const profileDescriptionBusy = operationOwnerIsBusy(profileOperationOwnerRef.current);
+
+    // Convert a displayed selection into an explicit board policy using only
+    // profiles that still pass the machine ceiling. A blocked historical
+    // selection can remain visible, but is never echoed back on a new list.
+    const sanitizeExplicitAllowed = function (names) {
+      const selected = new Set(Array.isArray(names) ? names : []);
+      return activeProfiles.filter(function (p) {
+        return p.machine_allowed && selected.has(p.name);
+      }).map(function (p) { return p.name; });
+    };
+
+    const setPolicyInheritance = function (checked) {
+      if (!activeSettings || savingRef.current) return;
+      const nextAllowed = checked === true
+        ? null
+        : sanitizeExplicitAllowed(activeSettings.effective_allowed_profiles || []);
+      saveSettings({ allowed_profiles: nextAllowed });
+    };
+
+    const setProfileAllowed = function (profile, checked) {
+      if (!activeSettings || savingRef.current || !profile.machine_allowed
+          || inheritsMachinePolicy) return;
+      const source = Array.isArray(activeSettings.board_allowed_profiles)
+        ? activeSettings.board_allowed_profiles
+        : (activeSettings.effective_allowed_profiles || []);
+      const selected = new Set(sanitizeExplicitAllowed(source));
+      if (checked === true) selected.add(profile.name);
+      else selected.delete(profile.name);
+      const nextAllowed = activeProfiles.filter(function (p) {
+        return p.machine_allowed && selected.has(p.name);
+      }).map(function (p) { return p.name; });
+      saveSettings({ allowed_profiles: nextAllowed });
+    };
+
     const headerLabel = expanded
-      ? "▾ Orchestration settings"
-      : "▸ Orchestration settings";
+      ? tx(t, "collapseOrchestrationSettings", "▾ Orchestration settings")
+      : tx(t, "expandOrchestrationSettings", "▸ Orchestration settings");
 
     // Mode pill — always visible (collapsed or expanded). One click flips
     // between Auto and Manual. Auto = dispatcher decomposes new triage tasks
     // every tick. Manual = pre-PR behavior, the user clicks ⚗ Decompose on
     // each triage card (or runs `hermes kanban decompose <id>`) and tasks
     // stay in triage until then.
-    const autoOn = !!(settings && settings.auto_decompose);
-    const modePillTitle = settings === null
-      ? "Loading mode…"
+    const autoOn = !!(activeSettings && activeSettings.auto_decompose);
+    const modePillTitle = activeSettings === null
+      ? tx(t, "orchestrationModeLoading", "Loading mode…")
       : (autoOn
-          ? "Orchestration: Auto — the dispatcher decomposes new triage tasks automatically every tick. Click to switch to Manual (pre-PR behavior)."
-          : "Orchestration: Manual — triage tasks stay in triage until you click ⚗ Decompose on each card. Click to switch to Auto.");
+          ? tx(t, "orchestrationAutoHint", "Orchestration: Auto — the dispatcher decomposes new triage tasks automatically every tick. Click to switch to Manual (pre-PR behavior).")
+          : tx(t, "orchestrationManualHint", "Orchestration: Manual — triage tasks stay in triage until you click ⚗ Decompose on each card. Click to switch to Auto."));
     const modePill = h("button", {
       type: "button",
       onClick: function () {
-        if (settings === null) return;  // not loaded yet
+        if (activeSettings === null || savingRef.current) return;  // not loaded yet
         saveSettings({ auto_decompose: !autoOn });
       },
-      disabled: settings === null,
+      disabled: activeSettings === null || saving,
       title: modePillTitle,
+      "aria-label": modePillTitle,
       className: "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 "
                  + "text-xs font-medium "
                  + (autoOn
                     ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
                     : "border-muted-foreground/30 bg-muted/30 text-muted-foreground"),
     },
-      "Orchestration: ",
+      tx(t, "orchestrationLabel", "Orchestration: "),
       h("span", { className: "ml-1 font-semibold" },
-        settings === null ? "…" : (autoOn ? "Auto" : "Manual"))
+        activeSettings === null
+          ? "…"
+          : (autoOn ? tx(t, "auto", "Auto") : tx(t, "manual", "Manual")))
     );
 
     if (!expanded) {
@@ -1916,13 +2446,14 @@
           type: "button",
           onClick: function () { setExpanded(true); },
           className: "underline text-muted-foreground hover:text-foreground",
-          title: "Configure the kanban orchestrator (profile picker, default assignee, auto-decompose, profile descriptions)",
+          title: tx(t, "configureOrchestrationHint", "Configure the kanban orchestrator (profile picker, default assignee, auto-decompose, profile descriptions)"),
         }, headerLabel),
       );
     }
 
-    const profileOptions = profiles.map(function (p) {
-      const tag = p.is_default ? " (default)" : "";
+    const effectiveNames = effectiveProfileNames(activeProfiles);
+    const profileOptions = activeProfiles.filter(function (p) { return p.effective_allowed; }).map(function (p) {
+      const tag = p.is_default ? tx(t, "defaultProfileTag", " (default)") : "";
       return h(SelectOption, { key: p.name, value: p.name }, p.name + tag);
     });
 
@@ -1935,80 +2466,194 @@
             className: "text-sm font-medium underline-offset-2 hover:underline",
           }, headerLabel),
           modePill,
-          h(Button, { onClick: loadAll, size: "sm" }, "Reload"),
+          h(Button, {
+            onClick: function () { loadAll(); },
+            size: "sm",
+            disabled: saving,
+          }, tx(t, "reload", "Reload")),
         ),
         msg ? h("div", {
           className: msg.ok ? "hermes-kanban-msg-ok" : "hermes-kanban-msg-err",
         }, msg.text) : null,
 
-        settings ? h("div", { className: "grid gap-3 sm:grid-cols-3" },
+        activeSettings ? h("div", { className: "grid gap-3 sm:grid-cols-3" },
           h("div", { className: "flex flex-col gap-1" },
             h(Label, { className: "text-xs text-muted-foreground" },
-              "Orchestrator profile"),
+              tx(t, "orchestratorProfile", "Orchestrator profile")),
             h(Select, Object.assign({
-              value: settings.orchestrator_profile || "",
+              value: activeSettings.orchestrator_profile || "",
               className: "h-8",
+              disabled: saving,
+              "aria-label": tx(t, "orchestratorProfile", "Orchestrator profile"),
             }, selectChangeHandler(function (v) {
+              if (v && effectiveNames.indexOf(v) < 0) return;
               saveSettings({ orchestrator_profile: v });
             })),
               h(SelectOption, { value: "" },
-                "(default: " + (settings.active_profile || "default") + ")"),
+                tx(t, "automaticProfile", "(automatic: {name})", {
+                  name: activeSettings.resolved_orchestrator_profile
+                    || tx(t, "noAllowedProfile", "no allowed profile"),
+                })),
+              activeSettings.orchestrator_profile
+                  && effectiveNames.indexOf(activeSettings.orchestrator_profile) < 0
+                ? h(SelectOption, {
+                    value: activeSettings.orchestrator_profile,
+                    disabled: true,
+                  }, tx(t, "historicalAssignee", "{name} (not allowed on this board)",
+                    { name: activeSettings.orchestrator_profile }))
+                : null,
               profileOptions,
             ),
             h("div", { className: "text-[10px] text-muted-foreground" },
-              "Resolved: " + (settings.resolved_orchestrator_profile || "default")),
+              tx(t, "resolvedProfile", "Resolved: {name}", {
+                name: activeSettings.resolved_orchestrator_profile || tx(t, "none", "none"),
+              })),
             h("div", { className: "text-[10px] text-muted-foreground" },
               "Owns the root task after fan-out (wakes back up to judge completion). Does not drive how tasks split — configure the decomposer model under auxiliary.kanban_decomposer."),
           ),
           h("div", { className: "flex flex-col gap-1" },
             h(Label, { className: "text-xs text-muted-foreground" },
-              "Default assignee"),
+              tx(t, "defaultAssignee", "Default assignee")),
             h(Select, Object.assign({
-              value: settings.default_assignee || "",
+              value: activeSettings.default_assignee || "",
               className: "h-8",
+              disabled: saving,
+              "aria-label": tx(t, "defaultAssignee", "Default assignee"),
             }, selectChangeHandler(function (v) {
+              if (v && effectiveNames.indexOf(v) < 0) return;
               saveSettings({ default_assignee: v });
             })),
               h(SelectOption, { value: "" },
-                "(default: " + (settings.active_profile || "default") + ")"),
+                tx(t, "automaticProfile", "(automatic: {name})", {
+                  name: activeSettings.resolved_default_assignee
+                    || tx(t, "noAllowedProfile", "no allowed profile"),
+                })),
+              activeSettings.default_assignee
+                  && effectiveNames.indexOf(activeSettings.default_assignee) < 0
+                ? h(SelectOption, {
+                    value: activeSettings.default_assignee,
+                    disabled: true,
+                  }, tx(t, "historicalAssignee", "{name} (not allowed on this board)",
+                    { name: activeSettings.default_assignee }))
+                : null,
               profileOptions,
             ),
             h("div", { className: "text-[10px] text-muted-foreground" },
-              "Resolved: " + (settings.resolved_default_assignee || "default")),
+              tx(t, "resolvedProfile", "Resolved: {name}", {
+                name: activeSettings.resolved_default_assignee || tx(t, "none", "none"),
+              })),
           ),
           h("div", { className: "flex flex-col gap-1" },
             h(Label, { className: "text-xs text-muted-foreground" },
-              "Orchestration mode"),
+              tx(t, "orchestrationMode", "Orchestration mode")),
             h("label", { className: "flex items-center gap-2 text-xs h-8" },
               h(Checkbox, {
-                checked: !!settings.auto_decompose,
+                checked: !!activeSettings.auto_decompose,
+                disabled: saving,
+                "aria-label": tx(t, "autoDecomposeTasks", "Auto-decompose triage tasks"),
                 onCheckedChange: function (checked) {
                   saveSettings({ auto_decompose: checked === true });
                 },
               }),
-              "Auto-decompose triage tasks",
+              tx(t, "autoDecomposeTasks", "Auto-decompose triage tasks"),
             ),
             h("div", { className: "text-[10px] text-muted-foreground" },
-              settings.auto_decompose
-                ? "The dispatcher decomposes new triage tasks automatically."
-                : "Triage tasks stay in triage until you click ⚗ Decompose."),
+              activeSettings.auto_decompose
+                ? tx(t, "autoDecomposeOnHint", "The dispatcher decomposes new triage tasks automatically.")
+                : tx(t, "autoDecomposeOffHint", "Triage tasks stay in triage until you click ⚗ Decompose.")),
           ),
         ) : h("div", { className: "text-xs text-muted-foreground" },
-          "Loading…"),
+          tx(t, "loading", "Loading…")),
+
+        activeSettings ? h("div", { className: "border-t pt-3 flex flex-col gap-2" },
+          h(Label, { className: "text-xs text-muted-foreground" },
+            tx(t, "profilesAllowedOnBoard", "Profiles allowed on this board")),
+          h("label", { className: "flex items-center gap-2 text-xs" },
+            h(Checkbox, {
+              checked: inheritsMachinePolicy,
+              disabled: saving,
+              "aria-label": tx(t, "inheritMachinePolicy", "Inherit machine policy"),
+              onCheckedChange: setPolicyInheritance,
+            }),
+            tx(t, "inheritMachinePolicy", "Inherit machine policy"),
+          ),
+          h("div", { className: "text-[10px] text-muted-foreground" },
+            inheritsMachinePolicy
+              ? tx(t, "inheritedProfilePolicyHint", "This board currently follows the machine-wide profile roster. Uncheck to customize it.")
+              : tx(t, "explicitProfilePolicyHint", "The board list can narrow, but never expand, the machine-wide profile roster.")),
+          activeProfiles.length === 0
+            ? h("div", { className: "text-xs text-muted-foreground" },
+                tx(t, "noProfilesInstalled", "No profiles installed."))
+            : h("div", { className: "grid gap-2 sm:grid-cols-2 lg:grid-cols-3" },
+                activeProfiles.map(function (p) {
+                  const blocked = !p.machine_allowed;
+                  const blockedReason = tx(t, "blockedByMachinePolicy",
+                    "blocked by machine policy");
+                  const blockedReasonId = `kanban-machine-policy-${String(p.name)
+                    .replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+                  const selected = inheritsMachinePolicy
+                    ? !!p.effective_allowed
+                    : !!p.board_selected;
+                  return h("label", {
+                    key: p.name,
+                    className: "flex items-center gap-2 rounded border px-2 py-1.5 text-xs "
+                      + (blocked ? "opacity-60" : ""),
+                    title: blocked
+                      ? tx(t, "profileBlockedByMachineTitle",
+                          "{name} is blocked by machine policy", { name: p.name })
+                      : (inheritsMachinePolicy
+                          ? tx(t, "disablePolicyInheritanceHint", "Turn off inheritance to edit this board's roster")
+                          : tx(t, "allowProfileOnBoardHint",
+                              "Allow {name} to run work on this board", { name: p.name })),
+                  },
+                    h(Checkbox, {
+                      checked: selected,
+                      disabled: saving || inheritsMachinePolicy || blocked,
+                      "aria-describedby": blocked ? blockedReasonId : undefined,
+                      "aria-label": blocked
+                        ? `${p.name} — ${blockedReason}`
+                        : tx(t, "allowProfileOnBoardHint",
+                            "Allow {name} to run work on this board", { name: p.name }),
+                      onCheckedChange: function (checked) {
+                        setProfileAllowed(p, checked);
+                      },
+                    }),
+                    h("span", { className: "font-medium" }, p.name),
+                    p.is_default
+                      ? h("span", { className: "text-[10px] text-muted-foreground" },
+                          tx(t, "defaultProfile", "(default)"))
+                      : null,
+                    blocked
+                      ? h("span", {
+                          id: blockedReasonId,
+                          className: "text-[10px] text-destructive",
+                        }, blockedReason)
+                      : null,
+                  );
+                }),
+              ),
+          effectivePolicyEmpty
+            ? h("div", { className: "text-xs text-destructive font-medium" },
+                tx(t, "noWorkersAllowedOnBoard", "No workers can run on this board."))
+            : null,
+        ) : null,
 
         h("div", { className: "border-t pt-3" },
           h(Label, { className: "text-xs text-muted-foreground" },
-            "Profile descriptions"),
+            tx(t, "profileDescriptions", "Profile descriptions")),
           h("div", { className: "text-[10px] text-muted-foreground pb-2" },
-            "Descriptions guide the decomposer's routing. Click ⚗ to auto-generate, or edit and save."),
-          profiles.length === 0
-            ? h("div", { className: "text-xs text-muted-foreground" }, "No profiles installed.")
+            tx(t, "profileDescriptionsHint",
+              "Descriptions guide the decomposer's routing. Click ⚗ to auto-generate, or edit and save.")),
+          activeProfiles.length === 0
+            ? h("div", { className: "text-xs text-muted-foreground" },
+                tx(t, "noProfilesInstalled", "No profiles installed."))
             : h("div", { className: "flex flex-col gap-2" },
-                profiles.map(function (p) {
+                activeProfiles.map(function (p) {
                   return h(ProfileDescriptionRow, {
                     key: p.name,
                     profile: p,
                     busy: busy[p.name] || null,
+                    disabled: saving || profileDescriptionBusy,
                     onSave: saveProfileDescription,
                     onAuto: autoGenerateDescription,
                   });
@@ -2020,47 +2665,60 @@
   }
 
   function ProfileDescriptionRow(props) {
+    const { t } = useI18n();
     const p = props.profile;
     const [draft, setDraft] = useState(p.description || "");
     const busy = props.busy;
+    const disabled = !!props.disabled;
     // Re-sync the local draft if the server-side description changes (e.g.
     // after auto-generate). Cheap because re-runs only happen on prop change.
     useEffect(function () {
       setDraft(p.description || "");
     }, [p.description]);
 
-    const tag = p.description_auto && p.description ? " [auto, review]" : "";
     return h("div", { className: "flex flex-col gap-1 border-l-2 pl-2",
       style: { borderColor: p.description ? "#888" : "#cc6" } },
       h("div", { className: "flex items-center gap-2 text-xs" },
         h("span", { className: "font-medium" }, p.name),
-        p.is_default ? h("span", { className: "text-[10px] text-muted-foreground" }, "(default)") : null,
+        p.is_default ? h("span", { className: "text-[10px] text-muted-foreground" },
+          tx(t, "defaultProfile", "(default)")) : null,
         p.description_auto && p.description
-          ? h("span", { className: "text-[10px] text-yellow-600" }, "auto — review")
+          ? h("span", { className: "text-[10px] text-yellow-600" },
+              tx(t, "autoDescriptionReview", "auto — review"))
           : null,
         !p.description
-          ? h("span", { className: "text-[10px] text-yellow-600" }, "⚠ no description")
+          ? h("span", { className: "text-[10px] text-yellow-600" },
+              tx(t, "noProfileDescription", "⚠ no description"))
           : null,
       ),
       h("div", { className: "flex items-center gap-2" },
         h(Input, {
           value: draft,
           onChange: function (e) { setDraft(e.target.value); },
-          placeholder: "What is this profile good at?",
+          disabled: disabled,
+          placeholder: tx(t, "profileDescriptionPlaceholder", "What is this profile good at?"),
+          "aria-label": tx(t, "profileDescriptionFor", "Description for {name}",
+            { name: p.name }),
           className: "h-7 text-xs flex-1",
         }),
         h(Button, {
           onClick: function () { props.onSave(p.name, draft); },
           size: "sm",
-          disabled: !!busy || draft === (p.description || ""),
-          title: "Save the description above as user-authored",
-        }, busy === "save" ? "Saving…" : "Save"),
+          disabled: disabled || !!busy || draft === (p.description || ""),
+          title: tx(t, "saveProfileDescriptionHint",
+            "Save the description above as user-authored"),
+        }, busy === "save"
+          ? tx(t, "saving", "Saving…")
+          : tx(t, "save", "Save")),
         h(Button, {
           onClick: function () { props.onAuto(p.name, true); },
           size: "sm",
-          disabled: !!busy,
-          title: "Auto-generate a description from this profile's skills and model",
-        }, busy === "auto" ? "Generating…" : "⚗ Auto"),
+          disabled: disabled || !!busy,
+          title: tx(t, "autoGenerateProfileDescriptionHint",
+            "Auto-generate a description from this profile's skills and model"),
+        }, busy === "auto"
+          ? tx(t, "generating", "Generating…")
+          : tx(t, "autoGenerate", "⚗ Auto")),
       ),
     );
   }
@@ -2573,24 +3231,29 @@
         }, tx(t, "setPriority", "Set priority")),
       ),
       h("div", { className: "hermes-kanban-bulk-reassign",
-                 title: "Reassign selected tasks to a different Hermes profile. Pick a profile (or unassign) and click Apply." },
+                 title: tx(t, "bulkReassignHint", "Reassign selected tasks to an allowed Hermes profile, or unassign and park them.") },
         h(Select, Object.assign({
           value: assignee,
           className: "h-7 text-xs",
+          "aria-label": tx(t, "bulkAssignee", "Bulk assignee"),
         }, selectChangeHandler(setAssignee)),
-          h(SelectOption, { value: "" }, "— reassign —"),
-          h(SelectOption, { value: "__none__" }, "(unassign)"),
-          props.assignees.map(function (a) {
+          h(SelectOption, { value: "" }, tx(t, "chooseAssignment", "— choose assignment —")),
+          h(SelectOption, { value: ASSIGNEE_UNASSIGNED },
+            tx(t, "unassignAndPark", "Unassign / park")),
+          (props.effectiveAssignees || []).map(function (a) {
             return h(SelectOption, { key: a, value: a }, a);
           }),
         ),
         h(Button, {
           onClick: function () {
-            if (!assignee) return;
-            props.onApply({ assignee: assignee === "__none__" ? "" : assignee, reclaim_first: reclaimFirst });
+            if (!canSubmitAssignee(assignee, props.effectiveAssignees, true)) return;
+            props.onApply({
+              assignee: assignmentPatchValue(assignee),
+              reclaim_first: reclaimFirst,
+            });
             setAssignee("");
           },
-          disabled: !assignee,
+          disabled: !canSubmitAssignee(assignee, props.effectiveAssignees, true),
           size: "sm",
           title: "Apply the selected assignee to all selected tasks.",
         }, tx(t, "apply", "Apply")),
@@ -2810,6 +3473,7 @@
           onMoveSelected: props.onMoveSelected,
           onOpen: props.onOpen,
           onCreate: props.onCreate,
+          effectiveAssignees: props.effectiveAssignees,
           allTasks: props.allTasks,
         });
       }),
@@ -2920,11 +3584,13 @@
       showCreate ? h(InlineCreate, {
         columnName: props.column.name,
         allTasks: props.allTasks,
+        effectiveAssignees: props.effectiveAssignees,
         defaultWorkspaceKind: (props.boardMeta && props.boardMeta.default_workspace_kind) || "scratch",
         defaultWorkspacePath: (props.boardMeta && props.boardMeta.default_workdir) || "",
         onSubmit: function (body) {
-          props.onCreate(body).then(function () { setShowCreate(false); });
+          return props.onCreate(body);
         },
+        onSuccess: function () { setShowCreate(false); },
         onCancel: function () { setShowCreate(false); },
       }) : null,
       h("div", { className: "hermes-kanban-column-body" },
@@ -3164,7 +3830,7 @@
   function InlineCreate(props) {
     const { t } = useI18n();
     const [title, setTitle] = useState("");
-    const [assignee, setAssignee] = useState("");
+    const [assignee, setAssignee] = useState(ASSIGNEE_DISPATCHER);
     const [priority, setPriority] = useState(0);
     const [parent, setParent] = useState("");
     const [skills, setSkills] = useState("");
@@ -3182,13 +3848,35 @@
     // = backend default.
     const [goalMode, setGoalMode] = useState(false);
     const [goalMaxTurns, setGoalMaxTurns] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState(null);
+    const submitOwnerRef = useRef(createOperationOwner());
+    const effectiveAssignees = props.effectiveAssignees || [];
+    const controlledAssignee = normalizeCreateAssignee(assignee, effectiveAssignees);
+
+    useEffect(function () {
+      if (assignee !== controlledAssignee) setAssignee(controlledAssignee);
+    }, [assignee, controlledAssignee]);
+
+    useEffect(function () {
+      return function () { invalidateOperationOwner(submitOwnerRef.current); };
+    }, []);
 
     const submit = function () {
       const trimmed = title.trim();
-      if (!trimmed) return;
+      if (!trimmed) return Promise.resolve(null);
+      const operationToken = claimOwnedOperation(submitOwnerRef.current, {
+        kind: "create-task",
+      });
+      if (operationToken === null) return Promise.resolve(null);
+      setSubmitting(true);
+      setSubmitError(null);
+      const payloadAssignee = createTaskAssigneeValue(
+        assignee, props.effectiveAssignees || [],
+      );
       const body = {
         title: trimmed,
-        assignee: assignee.trim() || null,
+        assignee: payloadAssignee,
         priority: Number(priority) || 0,
         triage: props.columnName === "triage",
       };
@@ -3215,10 +3903,26 @@
         const gmt = parseInt(goalMaxTurns, 10);
         if (Number.isFinite(gmt) && gmt > 0) body.goal_max_turns = gmt;
       }
-      props.onSubmit(body);
-      setTitle(""); setAssignee(""); setPriority(0); setParent(""); setSkills("");
-      setWorkspaceKind(defaultWorkspaceKind); setWorkspacePath(defaultWorkspacePath);
-      setGoalMode(false); setGoalMaxTurns("");
+      return Promise.resolve().then(function () {
+        return props.onSubmit(body);
+      }).then(function (res) {
+        if (!settleInlineCreateSubmission(submitOwnerRef.current, operationToken, true)) {
+          return res;
+        }
+        setSubmitting(false);
+        setTitle(""); setAssignee(ASSIGNEE_DISPATCHER); setPriority(0); setParent(""); setSkills("");
+        setWorkspaceKind(defaultWorkspaceKind); setWorkspacePath(defaultWorkspacePath);
+        setGoalMode(false); setGoalMaxTurns("");
+        if (props.onSuccess) props.onSuccess(res);
+        return res;
+      }).catch(function (err) {
+        if (!ownsOperation(submitOwnerRef.current, operationToken)) return null;
+        settleInlineCreateSubmission(submitOwnerRef.current, operationToken, false);
+        setSubmitting(false);
+        setSubmitError(tx(t, "taskCreateFailed",
+          "Could not create task. Fix the problem and retry: ") + parseApiErrorMessage(err));
+        return null;
+      });
     };
 
     const showPathInput = workspaceKind !== "scratch";
@@ -3234,8 +3938,12 @@
 
     return h("div", {
       className: "hermes-kanban-dialog-backdrop",
-      onClick: function (e) { if (e.target === e.currentTarget) props.onCancel(); },
-      onKeyDown: function (e) { if (e.key === "Escape") props.onCancel(); },
+      onClick: function (e) {
+        if (!submitting && e.target === e.currentTarget) props.onCancel();
+      },
+      onKeyDown: function (e) {
+        if (!submitting && e.key === "Escape") props.onCancel();
+      },
     },
       h("form", {
         className: "hermes-kanban-dialog hermes-kanban-create-dialog",
@@ -3266,22 +3974,23 @@
               fieldLabel(props.columnName === "triage"
                 ? tx(t, "specifier", "specifier")
                 : tx(t, "assigneeLabel", "Assignee"),
-                tx(t, "assigneeLabelHint", "(blank = dispatcher picks)")),
-              h(Input, {
-                value: assignee,
-                onChange: function (e) { setAssignee(e.target.value); },
-                placeholder: props.columnName === "triage"
-                  ? tx(t, "specifier", "specifier")
-                  : tx(t, "assigneePlaceholder", "assignee"),
+                tx(t, "assigneeLabelHint", "(only profiles allowed on this board)")),
+              h(Select, Object.assign({
+                value: controlledAssignee,
                 className: "h-8 text-sm",
                 title: props.columnName === "triage"
-                  ? "Hermes profile that will spec this task (default: the dispatcher's configured specifier). Leave blank to let the dispatcher pick."
-                  : "Hermes profile to assign. Leave blank and the dispatcher will pick from available profiles when the task is Ready.",
-                style: { textTransform: "none" },
-                autoCapitalize: "none",
-                autoCorrect: "off",
-                spellCheck: false,
-              }),
+                  ? tx(t, "specifierSelectorHint", "Choose an allowed Hermes profile to spec this task, or leave it unassigned for the dispatcher to pick.")
+                  : tx(t, "assigneeSelectorHint", "Choose an allowed Hermes profile, or leave the task unassigned for the dispatcher to pick."),
+                "aria-label": props.columnName === "triage"
+                  ? tx(t, "specifier", "specifier")
+                  : tx(t, "assigneeLabel", "Assignee"),
+              }, selectChangeHandler(setAssignee)),
+                h(SelectOption, { value: ASSIGNEE_DISPATCHER },
+                  tx(t, "unassignedDispatcherPicks", "Unassigned — dispatcher picks")),
+                effectiveAssignees.map(function (name) {
+                  return h(SelectOption, { key: name, value: name }, name);
+                }),
+              ),
             ),
             h("div", { className: "flex flex-col gap-1 w-20" },
               fieldLabel(tx(t, "priority", "Priority")),
@@ -3374,17 +4083,24 @@
             }) : null,
           ),
         ),
+        submitError ? h("div", {
+          className: "text-xs text-destructive",
+          role: "alert",
+        }, submitError) : null,
         h("div", { className: "hermes-kanban-dialog-actions" },
           h(Button, {
             type: "button",
             onClick: props.onCancel,
             size: "sm",
+            disabled: submitting,
           }, tx(t, "cancel", "Cancel")),
           h(Button, {
             type: "submit",
             size: "sm",
-            disabled: !title.trim(),
-          }, tx(t, "create", "Create")),
+            disabled: submitting || !title.trim(),
+          }, submitting
+            ? tx(t, "creating", "Creating…")
+            : tx(t, "create", "Create")),
         ),
       ),
     );
@@ -3397,6 +4113,7 @@
   function TaskDrawer(props) {
     const { t } = useI18n();
     const [data, setData] = useState(null);
+    const [dataIdentity, setDataIdentity] = useState(null);
     const [loading, setLoading] = useState(true);
     const [err, setErr] = useState(null);
     // Surface PATCH failures (e.g. 409 "parent not done") right next to
@@ -3414,19 +4131,65 @@
     const [homeChannels, setHomeChannels] = useState([]);
     const [homeBusy, setHomeBusy] = useState({});
     const boardSlug = props.boardSlug;
+    const drawerIdentity = taskDrawerIdentity(boardSlug, props.taskId);
+    const taskRequestStateRef = useRef(createTaskRequestState(drawerIdentity));
+    const closeRef = useRef(null);
+    const drawerHeadingId = "kanban-task-drawer-heading-"
+      + String(boardSlug || "board").replace(/[^a-zA-Z0-9_-]/g, "-") + "-"
+      + String(props.taskId || "task").replace(/[^a-zA-Z0-9_-]/g, "-");
+
+    const captureTaskRequest = function () {
+      return {
+        board: boardSlug,
+        taskId: props.taskId,
+        identity: drawerIdentity,
+      };
+    };
+    const taskRequestIsCurrent = function (request) {
+      return isTaskIdentityActive(taskRequestStateRef.current, request.identity);
+    };
 
     const load = useCallback(function () {
-      return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}`, boardSlug))
-        .then(function (d) { setData(d); setErr(null); setPatchErr(null); })
-        .catch(function (e) { setErr(String(e.message || e)); })
-        .finally(function () { setLoading(false); });
-    }, [props.taskId, boardSlug]);
+      const request = captureTaskRequest();
+      const loadToken = beginTaskLoad(taskRequestStateRef.current, request.identity);
+      setData(null);
+      setDataIdentity(null);
+      setLoading(true);
+      setErr(null);
+      return SDK.fetchJSON(withBoard(
+        `${API}/tasks/${encodeURIComponent(request.taskId)}`, request.board,
+      )).then(function (d) {
+        if (!isTaskLoadCurrent(taskRequestStateRef.current, loadToken)) return null;
+        if (!d || !d.task
+            || taskDrawerIdentity(request.board, d.task.id) !== request.identity) {
+          setErr(tx(t, "taskIdentityMismatch",
+            "The task response did not match the open drawer. Close it and retry."));
+          return null;
+        }
+        setData(d);
+        setDataIdentity(request.identity);
+        setErr(null);
+        setPatchErr(null);
+        return d;
+      }).catch(function (e) {
+        if (!isTaskLoadCurrent(taskRequestStateRef.current, loadToken)) return null;
+        setErr(String(e.message || e));
+        return null;
+      }).finally(function () {
+        if (isTaskLoadCurrent(taskRequestStateRef.current, loadToken)) setLoading(false);
+      });
+    }, [props.taskId, boardSlug, t]);
 
     const loadHomeChannels = useCallback(function () {
-      const qs = new URLSearchParams({ task_id: props.taskId });
-      const url = withBoard(`${API}/home-channels?${qs}`, boardSlug);
+      const request = captureTaskRequest();
+      const qs = new URLSearchParams({ task_id: request.taskId });
+      const url = withBoard(`${API}/home-channels?${qs}`, request.board);
       return SDK.fetchJSON(url)
-        .then(function (d) { setHomeChannels(d.home_channels || []); })
+        .then(function (d) {
+          if (!taskRequestIsCurrent(request)) return null;
+          setHomeChannels(d.home_channels || []);
+          return d;
+        })
         .catch(function () { /* silent — endpoint optional on older gateways */ });
     }, [props.taskId, boardSlug]);
 
@@ -3436,23 +4199,43 @@
     useEffect(function () { load(); }, [load, props.eventTick]);
     useEffect(function () { loadHomeChannels(); }, [loadHomeChannels]);
     useEffect(function () {
-      function onKey(e) { if (e.key === "Escape" && !editing) props.onClose(); }
+      const requestState = taskRequestStateRef.current;
+      const closeDrawer = props.onClose;
+      const previousFocus = document.activeElement;
+      if (closeRef.current && typeof closeRef.current.focus === "function") {
+        closeRef.current.focus();
+      }
+      function onKey(e) { if (e.key === "Escape") closeDrawer(); }
       window.addEventListener("keydown", onKey);
-      return function () { window.removeEventListener("keydown", onKey); };
-    }, [props.onClose, editing]);
+      return function () {
+        window.removeEventListener("keydown", onKey);
+        deactivateTaskRequests(requestState);
+        if (previousFocus && typeof previousFocus.focus === "function") {
+          try { previousFocus.focus(); } catch (_e) { /* detached focus target */ }
+        }
+      };
+    }, [drawerIdentity]);
 
     const handleComment = function () {
       const body = newComment.trim();
-      if (!body) return;
-      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/comments`, boardSlug), {
+      const request = captureTaskRequest();
+      if (!body || !taskRequestIsCurrent(request)) return Promise.resolve(null);
+      return SDK.fetchJSON(withBoard(
+        `${API}/tasks/${encodeURIComponent(request.taskId)}/comments`, request.board,
+      ), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ body }),
       }).then(function () {
+        if (!taskRequestIsCurrent(request)) return null;
         setNewComment("");
         load();
         props.onRefresh();
-      }).catch(function (e) { setErr(String(e.message || e)); });
+        return null;
+      }).catch(function (e) {
+        if (taskRequestIsCurrent(request)) setErr(String(e.message || e));
+        return null;
+      });
     };
 
     // File upload uses raw fetch (not SDK.fetchJSON, which JSON-encodes)
@@ -3460,14 +4243,18 @@
     // cookie + bearer token, matching the rest of the dashboard.
     const handleUpload = function (fileList) {
       const files = Array.prototype.slice.call(fileList || []);
-      if (!files.length) return;
+      const request = captureTaskRequest();
+      if (!files.length || !taskRequestIsCurrent(request)) return Promise.resolve(null);
       setUploadBusy(true);
       setUploadErr(null);
-      const url = withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/attachments`, boardSlug);
+      const url = withBoard(
+        `${API}/tasks/${encodeURIComponent(request.taskId)}/attachments`, request.board,
+      );
       // Upload sequentially so a partial failure leaves a clear state.
       let chain = Promise.resolve();
       files.forEach(function (f) {
         chain = chain.then(function () {
+          if (!taskRequestIsCurrent(request)) return null;
           const fd = new FormData();
           fd.append("file", f, f.name);
           // SDK.authedFetch handles auth in BOTH modes (loopback token header /
@@ -3484,20 +4271,33 @@
             });
         });
       });
-      chain.then(function () {
+      return chain.then(function () {
+        if (!taskRequestIsCurrent(request)) return null;
         load();
         props.onRefresh();
+        return null;
       }).catch(function (e) {
-        setUploadErr(String(e.message || e));
+        if (taskRequestIsCurrent(request)) setUploadErr(String(e.message || e));
+        return null;
       }).finally(function () {
-        setUploadBusy(false);
+        if (taskRequestIsCurrent(request)) setUploadBusy(false);
       });
     };
 
     const handleDeleteAttachment = function (attachmentId) {
-      return SDK.fetchJSON(withBoard(`${API}/attachments/${attachmentId}`, boardSlug), { method: "DELETE" })
-        .then(function () { load(); props.onRefresh(); })
-        .catch(function (e) { setUploadErr(String(e.message || e)); });
+      const request = captureTaskRequest();
+      if (!taskRequestIsCurrent(request)) return Promise.resolve(null);
+      return SDK.fetchJSON(withBoard(
+        `${API}/attachments/${attachmentId}`, request.board,
+      ), { method: "DELETE" }).then(function () {
+        if (!taskRequestIsCurrent(request)) return null;
+        load();
+        props.onRefresh();
+        return null;
+      }).catch(function (e) {
+        if (taskRequestIsCurrent(request)) setUploadErr(String(e.message || e));
+        return null;
+      });
     };
 
     // doPatch is invoked by the side-drawer's StatusActions (block / unblock
@@ -3515,6 +4315,8 @@
     //    site. The prompt body, validation copy, and requirement are
     //    unchanged from the pre-migration implementation.
     const doPatch = function (patch, opts) {
+      const request = captureTaskRequest();
+      if (!taskRequestIsCurrent(request)) return Promise.resolve(null);
       if (opts && opts.confirm && props.requestDialog) {
         return props.requestDialog({
           kind: "confirm",
@@ -3533,15 +4335,28 @@
       return applyPatch(patch);
 
       function applyPatch(patch) {
+        if (!taskRequestIsCurrent(request)) return Promise.resolve(null);
         const finalPatch = withCompletionSummary(patch);
         if (!finalPatch) return Promise.resolve();
         setPatchErr(null);
-        return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}`, boardSlug), {
+        return SDK.fetchJSON(withBoard(
+          `${API}/tasks/${encodeURIComponent(request.taskId)}`, request.board,
+        ), {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(finalPatch),
-        }).then(function () { load(); props.onRefresh(); })
-          .catch(function (e) { setPatchErr(parseApiErrorMessage(e)); });
+        }).then(function () {
+          if (!taskRequestIsCurrent(request)) return null;
+          load();
+          props.onRefresh();
+          if (finalPatch.status === "archived" && props.onCountsRefresh) {
+            props.onCountsRefresh();
+          }
+          return null;
+        }).catch(function (e) {
+          if (taskRequestIsCurrent(request)) setPatchErr(parseApiErrorMessage(e));
+          return null;
+        });
       }
     };
 
@@ -3573,14 +4388,17 @@
     // comment — or fail with a human-readable reason that the UI
     // surfaces inline without treating it as an HTTP error).
     const doSpecify = function () {
+      const request = captureTaskRequest();
+      if (!taskRequestIsCurrent(request)) return Promise.resolve(null);
       return SDK.fetchJSON(
-        withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/specify`, boardSlug),
+        withBoard(`${API}/tasks/${encodeURIComponent(request.taskId)}/specify`, request.board),
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({}),
         }
       ).then(function (res) {
+        if (!taskRequestIsCurrent(request)) return res;
         load();
         props.onRefresh();
         return res;
@@ -3592,50 +4410,84 @@
     // Refreshes both the drawer (so the user sees the root flip to
     // todo) and the board (so the new children appear in the columns).
     const doDecompose = function () {
+      const request = captureTaskRequest();
+      if (!taskRequestIsCurrent(request)) return Promise.resolve(null);
       return SDK.fetchJSON(
-        withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/decompose`, boardSlug),
+        withBoard(`${API}/tasks/${encodeURIComponent(request.taskId)}/decompose`, request.board),
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({}),
         }
       ).then(function (res) {
+        if (!taskRequestIsCurrent(request)) return res;
         load();
         props.onRefresh();
+        if (props.onCountsRefresh) props.onCountsRefresh();
         return res;
       });
     };
 
     const addLink = function (parentId) {
-      return SDK.fetchJSON(withBoard(`${API}/links`, boardSlug), {
+      const request = captureTaskRequest();
+      if (!taskRequestIsCurrent(request)) return Promise.resolve(null);
+      return SDK.fetchJSON(withBoard(`${API}/links`, request.board), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ parent_id: parentId, child_id: props.taskId }),
-      }).then(function () { load(); props.onRefresh(); })
-        .catch(function (e) { setErr(String(e.message || e)); });
+        body: JSON.stringify({ parent_id: parentId, child_id: request.taskId }),
+      }).then(function () {
+        if (!taskRequestIsCurrent(request)) return null;
+        load(); props.onRefresh(); return null;
+      }).catch(function (e) {
+        if (taskRequestIsCurrent(request)) setErr(String(e.message || e));
+        return null;
+      });
     };
     const removeLink = function (parentId) {
-      const qs = new URLSearchParams({ parent_id: parentId, child_id: props.taskId });
-      return SDK.fetchJSON(withBoard(`${API}/links?${qs}`, boardSlug), { method: "DELETE" })
-        .then(function () { load(); props.onRefresh(); })
-        .catch(function (e) { setErr(String(e.message || e)); });
+      const request = captureTaskRequest();
+      if (!taskRequestIsCurrent(request)) return Promise.resolve(null);
+      const qs = new URLSearchParams({ parent_id: parentId, child_id: request.taskId });
+      return SDK.fetchJSON(withBoard(`${API}/links?${qs}`, request.board), { method: "DELETE" })
+        .then(function () {
+          if (!taskRequestIsCurrent(request)) return null;
+          load(); props.onRefresh(); return null;
+        }).catch(function (e) {
+          if (taskRequestIsCurrent(request)) setErr(String(e.message || e));
+          return null;
+        });
     };
     const addChild = function (childId) {
-      return SDK.fetchJSON(withBoard(`${API}/links`, boardSlug), {
+      const request = captureTaskRequest();
+      if (!taskRequestIsCurrent(request)) return Promise.resolve(null);
+      return SDK.fetchJSON(withBoard(`${API}/links`, request.board), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ parent_id: props.taskId, child_id: childId }),
-      }).then(function () { load(); props.onRefresh(); })
-        .catch(function (e) { setErr(String(e.message || e)); });
+        body: JSON.stringify({ parent_id: request.taskId, child_id: childId }),
+      }).then(function () {
+        if (!taskRequestIsCurrent(request)) return null;
+        load(); props.onRefresh(); return null;
+      }).catch(function (e) {
+        if (taskRequestIsCurrent(request)) setErr(String(e.message || e));
+        return null;
+      });
     };
     const removeChild = function (childId) {
-      const qs = new URLSearchParams({ parent_id: props.taskId, child_id: childId });
-      return SDK.fetchJSON(withBoard(`${API}/links?${qs}`, boardSlug), { method: "DELETE" })
-        .then(function () { load(); props.onRefresh(); })
-        .catch(function (e) { setErr(String(e.message || e)); });
+      const request = captureTaskRequest();
+      if (!taskRequestIsCurrent(request)) return Promise.resolve(null);
+      const qs = new URLSearchParams({ parent_id: request.taskId, child_id: childId });
+      return SDK.fetchJSON(withBoard(`${API}/links?${qs}`, request.board), { method: "DELETE" })
+        .then(function () {
+          if (!taskRequestIsCurrent(request)) return null;
+          load(); props.onRefresh(); return null;
+        }).catch(function (e) {
+          if (taskRequestIsCurrent(request)) setErr(String(e.message || e));
+          return null;
+        });
     };
 
     const toggleHomeSubscription = function (platform, currentlySubscribed) {
+      const request = captureTaskRequest();
+      if (!taskRequestIsCurrent(request)) return Promise.resolve(null);
       // Optimistic flip + busy flag to keep double-clicks idempotent.
       setHomeBusy(function (b) { return Object.assign({}, b, { [platform]: true }); });
       setHomeChannels(function (list) {
@@ -3647,12 +4499,16 @@
       });
       const method = currentlySubscribed ? "DELETE" : "POST";
       const url = withBoard(
-        `${API}/tasks/${encodeURIComponent(props.taskId)}/home-subscribe/${encodeURIComponent(platform)}`,
-        boardSlug,
+        `${API}/tasks/${encodeURIComponent(request.taskId)}/home-subscribe/${encodeURIComponent(platform)}`,
+        request.board,
       );
       return SDK.fetchJSON(url, { method: method })
-        .then(function () { return loadHomeChannels(); })
+        .then(function () {
+          if (!taskRequestIsCurrent(request)) return null;
+          return loadHomeChannels();
+        })
         .catch(function (e) {
+          if (!taskRequestIsCurrent(request)) return null;
           // Revert optimistic flip on failure.
           setHomeChannels(function (list) {
             return list.map(function (h) {
@@ -3662,8 +4518,10 @@
             });
           });
           setErr(String(e.message || e));
+          return null;
         })
         .finally(function () {
+          if (!taskRequestIsCurrent(request)) return;
           setHomeBusy(function (b) {
             const next = Object.assign({}, b);
             delete next[platform];
@@ -3672,14 +4530,22 @@
         });
     };
 
+    const displayedData = dataIdentity === drawerIdentity ? data : null;
     return h("div", { className: "hermes-kanban-drawer-shade", onClick: props.onClose },
       h("div", {
         className: "hermes-kanban-drawer",
+        role: "dialog",
+        "aria-modal": true,
+        "aria-labelledby": drawerHeadingId,
         onClick: function (e) { e.stopPropagation(); },
       },
         h("div", { className: "hermes-kanban-drawer-head" },
-          h("span", { className: "text-xs text-muted-foreground" }, props.taskId),
+          h("h2", {
+            id: drawerHeadingId,
+            className: "text-xs text-muted-foreground",
+          }, tx(t, "taskDrawerHeading", "Task {id}", { id: props.taskId })),
           h("button", {
+            ref: closeRef,
             type: "button",
             onClick: props.onClose,
             className: "hermes-kanban-drawer-close",
@@ -3689,11 +4555,11 @@
         loading ? h("div", { className: "p-4 text-sm text-muted-foreground" },
           tx(t, "loadingDetail", "Loading…")) :
         err ? h("div", { className: "p-4 text-sm text-destructive" }, err) :
-        data ? h(TaskDetail, {
-          data, editing, setEditing,
+        displayedData ? h(TaskDetail, {
+          data: displayedData, editing, setEditing,
           renderMarkdown: props.renderMarkdown,
           allTasks: props.allTasks,
-          assignees: props.assignees || [],
+          effectiveAssignees: props.effectiveAssignees || [],
           boardSlug: boardSlug,
           onPatch: doPatch,
           onSpecify: doSpecify,
@@ -3711,12 +4577,11 @@
           uploadBusy: uploadBusy,
           uploadErr: uploadErr,
           onOpenTask: function (taskId) {
-            props.onClose();
             if (props.onOpenTask) props.onOpenTask(taskId);
           },
-                    requestDialog: props.requestDialog,
+          requestDialog: props.requestDialog,
         }) : null,
-        data ? h("div", { className: "hermes-kanban-drawer-comment-foot" },
+        displayedData ? h("div", { className: "hermes-kanban-drawer-comment-foot" },
           h("div", {
             className: "hermes-kanban-comment-hint text-xs text-muted-foreground",
             title: tx(t, "commentHintTitle",
@@ -3894,7 +4759,11 @@
       ),
       h("div", { className: "hermes-kanban-drawer-meta" },
         h(MetaRow, { label: tx(i18n, "status", "Status"), value: t.status }),
-        h(AssigneeEditor, { task: t, onPatch: props.onPatch }),
+        h(AssigneeEditor, {
+          task: t,
+          effectiveAssignees: props.effectiveAssignees,
+          onPatch: props.onPatch,
+        }),
         h(PriorityEditor, { task: t, onPatch: props.onPatch }),
         h(ModelEditor, { task: t, onPatch: props.onPatch }),
         t.tenant ? h(MetaRow, { label: tx(i18n, "tenant", "Tenant"), value: t.tenant }) : null,
@@ -3923,7 +4792,7 @@
       h(DiagnosticsSection, {
         task: t,
         boardSlug: props.boardSlug,
-        assignees: props.assignees,
+        effectiveAssignees: props.effectiveAssignees,
         diagnostics: t.diagnostics || [],
         onRefresh: props.onRefresh,
       }),
@@ -4238,8 +5107,11 @@
   function AssigneeEditor(props) {
     const { t } = useI18n();
     const [editing, setEditing] = useState(false);
-    const [v, setV] = useState(props.task.assignee || "");
-    useEffect(function () { setV(props.task.assignee || ""); }, [props.task.assignee]);
+    const [v, setV] = useState(props.task.assignee || ASSIGNEE_UNASSIGNED);
+    const effectiveAssignees = props.effectiveAssignees || [];
+    useEffect(function () {
+      setV(props.task.assignee || ASSIGNEE_UNASSIGNED);
+    }, [props.task.assignee]);
     if (!editing) {
       return h("div", { className: "hermes-kanban-meta-row" },
         h("span", { className: "hermes-kanban-meta-label" }, tx(t, "assignee", "Assignee")),
@@ -4251,24 +5123,40 @@
       );
     }
     const save = function () {
-      props.onPatch({ assignee: v.trim() || "" }).then(function () { setEditing(false); });
+      if (!canSubmitAssignee(v, effectiveAssignees, true)) return;
+      props.onPatch({ assignee: assignmentPatchValue(v) })
+        .then(function () { setEditing(false); });
     };
     return h("div", { className: "hermes-kanban-meta-row" },
       h("span", { className: "hermes-kanban-meta-label" }, tx(t, "assignee", "Assignee")),
-      h(Input, {
-        value: v, autoFocus: true,
-        onChange: function (e) { setV(e.target.value); },
-        onKeyDown: function (e) {
-          if (e.key === "Enter") { e.preventDefault(); save(); }
-          if (e.key === "Escape") setEditing(false);
-        },
-        placeholder: tx(t, "emptyAssignee", "(empty = unassign)"),
+      h(Select, Object.assign({
+        value: v,
         className: "h-7 text-xs flex-1",
-        style: { textTransform: "none" },
-        autoCapitalize: "none",
-        autoCorrect: "off",
-        spellCheck: false,
-      }),
+        "aria-label": tx(t, "assignee", "Assignee"),
+      }, selectChangeHandler(setV)),
+        h(SelectOption, { value: ASSIGNEE_UNASSIGNED },
+          tx(t, "unassignAndPark", "Unassign / park")),
+        props.task.assignee && effectiveAssignees.indexOf(props.task.assignee) < 0
+          ? h(SelectOption, { value: props.task.assignee, disabled: true },
+              tx(t, "historicalAssignee", "{name} (not allowed on this board)",
+                { name: props.task.assignee }))
+          : null,
+        effectiveAssignees.map(function (name) {
+          return h(SelectOption, { key: name, value: name }, name);
+        }),
+      ),
+      h(Button, {
+        onClick: save,
+        size: "sm",
+        disabled: !canSubmitAssignee(v, effectiveAssignees, true),
+      }, tx(t, "save", "Save")),
+      h(Button, {
+        onClick: function () {
+          setV(props.task.assignee || ASSIGNEE_UNASSIGNED);
+          setEditing(false);
+        },
+        size: "sm",
+      }, tx(t, "cancel", "Cancel")),
     );
   }
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -36,9 +36,11 @@ the port.
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 import sqlite3
+import threading
 import time
 from dataclasses import asdict
 from pathlib import Path
@@ -54,6 +56,13 @@ from hermes_cli import kanban_diagnostics as kd
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# One process-wide owner for orchestration's cross-file mutation transaction.
+# Config persistence is atomic per save and board metadata persistence is
+# atomic per write, but a mixed request spans both files and may roll config
+# back. Without a lock around the full read/validate/write/rollback sequence,
+# that rollback can overwrite config committed by a newer request.
+_ORCHESTRATION_MUTATION_LOCK = threading.RLock()
 
 
 # ---------------------------------------------------------------------------
@@ -2561,15 +2570,19 @@ def rename_board(slug: str, payload: RenameBoardBody):
                 default_workdir = primary_path
         else:
             project_id = ""  # clear the scope
-    meta = kanban_db.write_board_metadata(
-        normed,
-        name=payload.name,
-        description=payload.description,
-        icon=payload.icon,
-        color=payload.color,
-        default_workdir=default_workdir,
-        project_id=project_id,
-    )
+    # This endpoint and PUT /orchestration both perform read-modify-write on
+    # board.json. Share orchestration's persistence lock so neither can commit
+    # metadata loaded before the other's write.
+    with _ORCHESTRATION_MUTATION_LOCK:
+        meta = kanban_db.write_board_metadata(
+            normed,
+            name=payload.name,
+            description=payload.description,
+            icon=payload.icon,
+            color=payload.color,
+            default_workdir=default_workdir,
+            project_id=project_id,
+        )
     meta["default_workspace_kind"] = _default_workspace_kind(meta)
     _, meta["project_name"], _ = _resolve_project(meta.get("project_id"))
     return {"board": meta}
@@ -2625,20 +2638,54 @@ class DescribeAutoBody(BaseModel):
     overwrite: bool = False
 
 
-@router.get("/profiles")
-def list_profile_roster():
-    """Return every installed profile with its description.
+def _open_policy_board(board: Optional[str]) -> tuple[str, sqlite3.Connection]:
+    """Open the requested/current board and return its canonical identity."""
+    resolved = _resolve_board(board)
+    conn = _conn(board=resolved)
+    try:
+        canonical = kanban_db._policy_board_slug(board=resolved, conn=conn)
+    except Exception:
+        canonical = None
+    if canonical is None:
+        canonical = resolved or kanban_db.get_current_board()
+    return canonical, conn
 
-    Consumed by the dashboard's settings panel (orchestrator picker)
-    and the profile-description editing UI. Profiles without a
-    description still appear here — they're routable on name alone,
-    just less precisely.
-    """
+
+def _installed_profile_names(profiles: list[Any], profiles_mod: Any) -> set[str]:
+    return {profiles_mod.normalize_profile_name(profile.name) for profile in profiles}
+
+
+def _config_shape_error(cfg: object) -> Optional[str]:
+    """Describe a config container that cannot be safely updated."""
+    if not isinstance(cfg, dict):
+        return "config root must be a mapping"
+    if "kanban" in cfg and not isinstance(cfg["kanban"], dict):
+        return "existing kanban section must be a mapping"
+    return None
+
+
+@router.get("/profiles")
+def list_profile_roster(
+    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+):
+    """Return every installed profile with board-scoped policy flags."""
+    canonical_board, conn = _open_policy_board(board)
+    try:
+        machine_allowed = kanban_db.kanban_allowed_profiles()
+        effective_allowed = kanban_db.kanban_allowed_profiles(conn=conn)
+        board_selected = kanban_db._board_kanban_allowed_profiles(
+            board=canonical_board,
+            conn=conn,
+        )
+    finally:
+        conn.close()
+
     try:
         from hermes_cli import profiles as profiles_mod
         profiles = profiles_mod.list_profiles()
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"failed to list profiles: {exc}")
+
     return {
         "profiles": [
             {
@@ -2649,6 +2696,18 @@ def list_profile_roster():
                 "description": p.description or "",
                 "description_auto": bool(p.description_auto),
                 "skill_count": int(p.skill_count or 0),
+                "machine_allowed": (
+                    machine_allowed is None
+                    or profiles_mod.normalize_profile_name(p.name) in machine_allowed
+                ),
+                "board_selected": (
+                    board_selected is None
+                    or profiles_mod.normalize_profile_name(p.name) in board_selected
+                ),
+                "effective_allowed": (
+                    effective_allowed is None
+                    or profiles_mod.normalize_profile_name(p.name) in effective_allowed
+                ),
             }
             for p in profiles
         ],
@@ -2773,120 +2832,378 @@ class OrchestrationSettingsBody(BaseModel):
     default_assignee: Optional[str] = None
     auto_decompose: Optional[bool] = None
     auto_promote_children: Optional[bool] = None
+    allowed_profiles: Optional[list[Any]] = None
+
+
+def _display_selector(value: object) -> str:
+    """Return a stripped selector only when the config leaf is a string."""
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _config_bool(value: object, *, default: bool) -> bool:
+    """Return a config boolean without coercing malformed leaf types."""
+    return value if isinstance(value, bool) else default
+
+
+def _resolve_roster_choice(
+    configured: str,
+    *,
+    installed_effective: list[str],
+    active_profile: str,
+    profiles_mod: Any,
+) -> Optional[str]:
+    """Resolve one global selector against a board's effective roster."""
+    installed_set = set(installed_effective)
+    if configured:
+        try:
+            canonical = profiles_mod.normalize_profile_name(configured)
+            profiles_mod.validate_profile_name(canonical)
+        except ValueError:
+            canonical = ""
+        if canonical in installed_set:
+            return canonical
+    try:
+        active = profiles_mod.normalize_profile_name(active_profile)
+    except ValueError:
+        active = ""
+    if active in installed_set:
+        return active
+    return installed_effective[0] if installed_effective else None
 
 
 @router.get("/orchestration")
-def get_orchestration_settings():
-    """Return the current kanban orchestration knobs from config.yaml
-    plus the resolved effective values (filling in fallbacks)."""
+def get_orchestration_settings(
+    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+):
+    """Return global settings resolved against one board's effective roster."""
+    canonical_board, conn = _open_policy_board(board)
+    try:
+        effective_allowed = kanban_db.kanban_allowed_profiles(conn=conn)
+        board_allowed = kanban_db._board_kanban_allowed_profiles(
+            board=canonical_board,
+            conn=conn,
+        )
+    finally:
+        conn.close()
+
     try:
         from hermes_cli.config import load_config
         cfg = load_config() or {}
     except Exception:
         cfg = {}
-    kanban_cfg = (cfg.get("kanban") or {}) if isinstance(cfg, dict) else {}
-    explicit_orch = (kanban_cfg.get("orchestrator_profile") or "").strip()
-    explicit_default = (kanban_cfg.get("default_assignee") or "").strip()
-    auto_decompose = bool(kanban_cfg.get("auto_decompose", True))
-    auto_promote_children = bool(kanban_cfg.get("auto_promote_children", True))
+    kanban_cfg = cfg.get("kanban") if isinstance(cfg, dict) else None
+    if not isinstance(kanban_cfg, dict):
+        kanban_cfg = {}
+    explicit_orch = _display_selector(kanban_cfg.get("orchestrator_profile"))
+    explicit_default = _display_selector(kanban_cfg.get("default_assignee"))
+    auto_decompose = _config_bool(
+        kanban_cfg.get("auto_decompose"),
+        default=True,
+    )
+    auto_promote_children = _config_bool(
+        kanban_cfg.get("auto_promote_children"),
+        default=True,
+    )
 
-    # Resolve fallbacks the same way the decomposer does.
-    resolved_orch = explicit_orch
-    resolved_default = explicit_default
     try:
         from hermes_cli import profiles as profiles_mod
-        active_default = profiles_mod.get_active_profile_name() or "default"
-        if not resolved_orch or not profiles_mod.profile_exists(resolved_orch):
-            resolved_orch = active_default
-        if not resolved_default or not profiles_mod.profile_exists(resolved_default):
-            resolved_default = active_default
-    except Exception:
-        active_default = "default"
-        if not resolved_orch:
-            resolved_orch = active_default
-        if not resolved_default:
-            resolved_default = active_default
+        profiles = profiles_mod.list_profiles()
+        installed = _installed_profile_names(profiles, profiles_mod)
+        installed_effective = sorted(
+            installed
+            if effective_allowed is None
+            else installed & set(effective_allowed)
+        )
+        active_profile = profiles_mod.get_active_profile_name() or "default"
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"failed to resolve orchestration profiles: {exc}",
+        )
 
     return {
+        "board": canonical_board,
         "orchestrator_profile": explicit_orch,
         "default_assignee": explicit_default,
         "auto_decompose": auto_decompose,
         "auto_promote_children": auto_promote_children,
-        "resolved_orchestrator_profile": resolved_orch,
-        "resolved_default_assignee": resolved_default,
-        "active_profile": active_default,
+        "resolved_orchestrator_profile": _resolve_roster_choice(
+            explicit_orch,
+            installed_effective=installed_effective,
+            active_profile=active_profile,
+            profiles_mod=profiles_mod,
+        ),
+        "resolved_default_assignee": _resolve_roster_choice(
+            explicit_default,
+            installed_effective=installed_effective,
+            active_profile=active_profile,
+            profiles_mod=profiles_mod,
+        ),
+        "active_profile": active_profile,
+        "board_allowed_profiles": (
+            None if board_allowed is None else sorted(board_allowed)
+        ),
+        "effective_allowed_profiles": installed_effective,
     }
 
 
 @router.put("/orchestration")
-def set_orchestration_settings(payload: OrchestrationSettingsBody):
-    """Update the kanban orchestration knobs in ~/.hermes/config.yaml.
+def set_orchestration_settings(
+    payload: OrchestrationSettingsBody,
+    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+):
+    """Update global selectors and/or one board's profile subset atomically."""
+    with _ORCHESTRATION_MUTATION_LOCK:
+        return _set_orchestration_settings_transaction(payload, board)
 
-    Each field is optional — only fields explicitly passed are
-    written. ``orchestrator_profile`` / ``default_assignee`` accept
-    empty strings to clear the override and fall back to the default
-    profile.
-    """
+
+def _set_orchestration_settings_transaction(
+    payload: OrchestrationSettingsBody,
+    board: Optional[str],
+):
+    """Run one serialized config + board metadata mutation transaction."""
+    fields_set = payload.model_fields_set
+    config_field_names = (
+        "orchestrator_profile",
+        "default_assignee",
+        "auto_decompose",
+        "auto_promote_children",
+    )
+    config_write_requested = any(
+        field_name in fields_set and getattr(payload, field_name) is not None
+        for field_name in config_field_names
+    )
+
+    canonical_board, conn = _open_policy_board(board)
     try:
-        from hermes_cli.config import load_config, save_config
-        cfg = load_config() or {}
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"failed to load config: {exc}")
+        machine_allowed = kanban_db.kanban_allowed_profiles()
+        existing_board_allowed = kanban_db._board_kanban_allowed_profiles(
+            board=canonical_board,
+            conn=conn,
+        )
+    finally:
+        conn.close()
 
-    kanban_section = cfg.setdefault("kanban", {})
-    if not isinstance(kanban_section, dict):
-        kanban_section = {}
-        cfg["kanban"] = kanban_section
-
-    # Validate any non-empty profile names exist before saving.
     try:
         from hermes_cli import profiles as profiles_mod
-    except Exception:
-        profiles_mod = None  # type: ignore
+        from hermes_cli import config as config_mod
 
-    if payload.orchestrator_profile is not None:
-        name = (payload.orchestrator_profile or "").strip()
-        if name and profiles_mod is not None:
-            try:
-                if not profiles_mod.profile_exists(name):
-                    raise HTTPException(
-                        status_code=400,
-                        detail=f"profile '{name}' does not exist",
-                    )
-            except HTTPException:
-                raise
-            except Exception:
-                pass  # fail open if the lookup itself errors
-        kanban_section["orchestrator_profile"] = name
-
-    if payload.default_assignee is not None:
-        name = (payload.default_assignee or "").strip()
-        if name and profiles_mod is not None:
-            try:
-                if not profiles_mod.profile_exists(name):
-                    raise HTTPException(
-                        status_code=400,
-                        detail=f"profile '{name}' does not exist",
-                    )
-            except HTTPException:
-                raise
-            except Exception:
-                pass
-        kanban_section["default_assignee"] = name
-
-    if payload.auto_decompose is not None:
-        kanban_section["auto_decompose"] = bool(payload.auto_decompose)
-
-    if payload.auto_promote_children is not None:
-        kanban_section["auto_promote_children"] = bool(payload.auto_promote_children)
-
-    try:
-        save_config(cfg)
+        profiles = profiles_mod.list_profiles()
+        installed = _installed_profile_names(profiles, profiles_mod)
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"failed to save config: {exc}")
+        raise HTTPException(status_code=500, detail=f"failed to load settings: {exc}")
 
-    # Echo back the resolved state (callers usually re-render from it).
-    return get_orchestration_settings()
+    original_cfg: Optional[dict[str, Any]] = None
+    if config_write_requested:
+        # load_config() can return a last-known-good value when config.yaml is
+        # currently malformed. Check the on-disk container as well so a write
+        # cannot replace a fail-closed machine policy with the cached value.
+        config_path = config_mod.get_config_path()
+        try:
+            raw_text = config_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            raw_cfg: object = {}
+        except (OSError, UnicodeError) as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=f"malformed config: config root cannot be read: {exc}",
+            ) from exc
+        else:
+            if not raw_text.strip():
+                raw_cfg = {}
+            else:
+                try:
+                    import yaml
+
+                    raw_cfg = yaml.safe_load(raw_text)
+                except Exception as exc:
+                    raise HTTPException(
+                        status_code=500,
+                        detail=f"malformed config: config root cannot be parsed: {exc}",
+                    ) from exc
+
+        shape_error = _config_shape_error(raw_cfg)
+        if shape_error is not None:
+            raise HTTPException(
+                status_code=500,
+                detail=f"malformed config: {shape_error}",
+            )
+
+        try:
+            loaded_cfg = config_mod.load_config()
+        except Exception as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=f"malformed config: failed to load config: {exc}",
+            ) from exc
+        shape_error = _config_shape_error(loaded_cfg)
+        if shape_error is not None:
+            raise HTTPException(
+                status_code=500,
+                detail=f"malformed config: {shape_error}",
+            )
+        original_cfg = loaded_cfg
+
+    normalized_allowed: Optional[list[str]] = None
+
+    # Validate the prospective board policy without writing it. Installation
+    # is checked before the machine ceiling so an unknown name gets the most
+    # useful error even though it is necessarily absent from a finite ceiling.
+    if "allowed_profiles" in fields_set and payload.allowed_profiles is not None:
+        normalized_allowed = []
+        seen: set[str] = set()
+        for entry in payload.allowed_profiles:
+            if not isinstance(entry, str):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"invalid allowed_profiles entry {entry!r}: expected a profile name",
+                )
+            try:
+                name = profiles_mod.normalize_profile_name(entry)
+                profiles_mod.validate_profile_name(name)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"invalid allowed_profiles entry {entry!r}: {exc}",
+                ) from exc
+            if name not in installed:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"profile '{name}' does not exist",
+                )
+            if machine_allowed is not None and name not in machine_allowed:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"profile '{name}' is not permitted by the machine ceiling "
+                        "(kanban.allowed_profiles)"
+                    ),
+                )
+            if name not in seen:
+                normalized_allowed.append(name)
+                seen.add(name)
+
+    if "allowed_profiles" in fields_set:
+        prospective_board = (
+            None
+            if payload.allowed_profiles is None
+            else frozenset(normalized_allowed or [])
+        )
+    else:
+        prospective_board = existing_board_allowed
+
+    if machine_allowed is None:
+        prospective_effective = prospective_board
+    elif prospective_board is None:
+        prospective_effective = machine_allowed
+    else:
+        prospective_effective = machine_allowed & prospective_board
+    prospective_installed = (
+        installed
+        if prospective_effective is None
+        else installed & set(prospective_effective)
+    )
+
+    # Validate every requested global selector against the prospective roster,
+    # including a new allowed_profiles subset supplied in this same request.
+    selector_updates: dict[str, str] = {}
+    for field_name in ("orchestrator_profile", "default_assignee"):
+        value = getattr(payload, field_name)
+        if field_name not in fields_set or value is None:
+            continue
+        stripped = value.strip()
+        if not stripped:
+            selector_updates[field_name] = ""
+            continue
+        try:
+            name = profiles_mod.normalize_profile_name(stripped)
+            profiles_mod.validate_profile_name(name)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"invalid profile '{stripped}': {exc}",
+            ) from exc
+        if name not in installed:
+            raise HTTPException(
+                status_code=400,
+                detail=f"profile '{name}' does not exist",
+            )
+        if name not in prospective_installed:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"profile '{name}' is not permitted by the effective "
+                    f"policy for board '{canonical_board}'"
+                ),
+            )
+        selector_updates[field_name] = name
+
+    config_updates: dict[str, Any] = dict(selector_updates)
+    if "auto_decompose" in fields_set and payload.auto_decompose is not None:
+        config_updates["auto_decompose"] = bool(payload.auto_decompose)
+    if (
+        "auto_promote_children" in fields_set
+        and payload.auto_promote_children is not None
+    ):
+        config_updates["auto_promote_children"] = bool(payload.auto_promote_children)
+
+    # All validation is complete before either persistence surface is touched.
+    # For mixed requests the config write goes first, so a config failure can
+    # never leave a new board policy behind.
+    config_saved = False
+    if config_updates:
+        assert original_cfg is not None
+        updated_cfg = copy.deepcopy(original_cfg)
+        kanban_section = updated_cfg.setdefault("kanban", {})
+        kanban_section.update(config_updates)
+        try:
+            config_mod.save_config(updated_cfg)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=f"failed to save config: {exc}",
+            ) from exc
+        config_saved = True
+
+    # A board-policy-only request must not rewrite machine config.yaml.
+    if "allowed_profiles" in fields_set:
+        try:
+            kanban_db.write_board_metadata(
+                canonical_board,
+                allowed_profiles=(
+                    None
+                    if payload.allowed_profiles is None
+                    else normalized_allowed
+                ),
+            )
+        except Exception as exc:
+            if config_saved:
+                assert original_cfg is not None
+                try:
+                    config_mod.save_config(original_cfg)
+                except Exception as rollback_exc:
+                    log.exception(
+                        "Failed to roll back config after board policy write failed"
+                    )
+                    raise HTTPException(
+                        status_code=500,
+                        detail=(
+                            f"failed to save board policy: {exc}; "
+                            f"config rollback failed: {rollback_exc}"
+                        ),
+                    ) from exc
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"failed to save board policy: {exc}; config restored",
+                ) from exc
+            if isinstance(exc, ValueError):
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise HTTPException(
+                status_code=500,
+                detail=f"failed to save board policy: {exc}",
+            ) from exc
+
+    return get_orchestration_settings(board=canonical_board)
 
 
 @router.websocket("/events")

--- a/tests/hermes_cli/test_kanban_allowed_profiles.py
+++ b/tests/hermes_cli/test_kanban_allowed_profiles.py
@@ -1,0 +1,986 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for name in (
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_BOARD",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    kb.init_db(board="default")
+    return home
+
+
+def _set_machine_allowed(home: Path, value: object) -> None:
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"kanban": {"allowed_profiles": value}}),
+        encoding="utf-8",
+    )
+
+
+def _set_board_allowed(board: str, value: object) -> None:
+    kb.write_board_metadata(board, allowed_profiles=value)
+
+
+def _set_board_allowed_raw(board: str, value: object) -> None:
+    """Simulate malformed metadata written by hand outside the production API."""
+    path = kb.board_metadata_path(board)
+    payload: dict[str, object] = {}
+    if path.is_file():
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict):
+            payload.update(loaded)
+    payload["allowed_profiles"] = value
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _install_profile(home: Path, name: str) -> None:
+    profile_dir = home / "profiles" / name
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+
+
+def _move_to_review(conn, task_id: str) -> None:
+    conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (task_id,))
+    conn.commit()
+
+
+def _task_mutation_snapshot(conn, task_id: str) -> dict[str, object]:
+    task_row = conn.execute(
+        "SELECT * FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    assert task_row is not None
+    current_run_id = task_row["current_run_id"]
+    current_run_row = (
+        conn.execute(
+            "SELECT * FROM task_runs WHERE id = ?", (current_run_id,)
+        ).fetchone()
+        if current_run_id is not None
+        else None
+    )
+    return {
+        "database_bytes": conn.serialize(),
+        "task": dict(task_row),
+        "current_run": dict(current_run_row) if current_run_row is not None else None,
+        "runs": [
+            dict(row)
+            for row in conn.execute(
+                "SELECT * FROM task_runs WHERE task_id = ? ORDER BY id", (task_id,)
+            )
+        ],
+        "events": [
+            dict(row)
+            for row in conn.execute(
+                "SELECT * FROM task_events WHERE task_id = ? ORDER BY id", (task_id,)
+            )
+        ],
+        "comments": [
+            dict(row)
+            for row in conn.execute(
+                "SELECT * FROM task_comments WHERE task_id = ? ORDER BY id", (task_id,)
+            )
+        ],
+    }
+
+
+def test_board_metadata_profile_policy_roundtrips_without_losing_other_fields(
+    kanban_home: Path,
+) -> None:
+    metadata = kb.create_board(
+        "policy-board",
+        name="Policy Board",
+        description="Keeps its descriptive metadata",
+    )
+
+    assert metadata["allowed_profiles"] is None
+    assert kb.read_board_metadata("policy-board")["allowed_profiles"] is None
+
+    for allowed_profiles in (["alpha", "beta"], []):
+        written = kb.write_board_metadata(
+            "policy-board",
+            allowed_profiles=allowed_profiles,
+        )
+        reloaded = kb.read_board_metadata("policy-board")
+
+        assert written["allowed_profiles"] == allowed_profiles
+        assert reloaded["allowed_profiles"] == allowed_profiles
+        assert reloaded["name"] == "Policy Board"
+        assert reloaded["description"] == "Keeps its descriptive metadata"
+
+
+def test_write_board_metadata_allowed_profiles_uses_three_way_sentinel_and_normalizes(
+    kanban_home: Path,
+) -> None:
+    kb.create_board(
+        "sentinel-policy",
+        name="Sentinel Policy",
+        description="Original description",
+    )
+
+    explicit = kb.write_board_metadata(
+        "sentinel-policy",
+        allowed_profiles=["alpha", "beta"],
+    )
+    assert explicit["allowed_profiles"] == ["alpha", "beta"]
+
+    preserved = kb.write_board_metadata(
+        "sentinel-policy",
+        description="Updated without changing policy",
+    )
+    assert preserved["allowed_profiles"] == ["alpha", "beta"]
+    assert preserved["description"] == "Updated without changing policy"
+    assert kb.read_board_metadata("sentinel-policy")["allowed_profiles"] == [
+        "alpha",
+        "beta",
+    ]
+
+    normalized = kb.write_board_metadata(
+        "sentinel-policy",
+        allowed_profiles=[" Alpha ", "beta", "ALPHA", "Beta"],
+    )
+    assert normalized["allowed_profiles"] == ["alpha", "beta"]
+    assert kb.read_board_metadata("sentinel-policy")["allowed_profiles"] == [
+        "alpha",
+        "beta",
+    ]
+
+    cleared = kb.write_board_metadata(
+        "sentinel-policy",
+        allowed_profiles=None,
+    )
+    assert cleared["allowed_profiles"] is None
+    assert kb.read_board_metadata("sentinel-policy")["allowed_profiles"] is None
+
+
+@pytest.mark.parametrize(
+    "invalid_allowed_profiles",
+    [
+        pytest.param(["alpha", 7], id="non-string-entry"),
+        pytest.param(["alpha", "../escape"], id="invalid-profile-name"),
+    ],
+)
+def test_write_board_metadata_rejects_invalid_allowed_profiles_before_persisting(
+    kanban_home: Path,
+    invalid_allowed_profiles: object,
+) -> None:
+    kb.create_board(
+        "validation-policy",
+        allowed_profiles=["stable-profile"],
+    )
+    metadata_path = kb.board_metadata_path("validation-policy")
+    before = metadata_path.read_bytes()
+
+    with pytest.raises(ValueError):
+        kb.write_board_metadata(
+            "validation-policy",
+            allowed_profiles=invalid_allowed_profiles,
+        )
+
+    assert metadata_path.read_bytes() == before
+    assert kb.read_board_metadata("validation-policy")["allowed_profiles"] == [
+        "stable-profile"
+    ]
+
+
+@pytest.mark.parametrize(
+    "original_bytes",
+    [
+        pytest.param(
+            b'{"allowed_profiles": ["stable-profile"]',
+            id="malformed-json",
+        ),
+        pytest.param(b'["stable-profile"]\n', id="non-mapping-json"),
+    ],
+)
+def test_write_board_metadata_refuses_malformed_existing_metadata(
+    kanban_home: Path,
+    original_bytes: bytes,
+) -> None:
+    metadata_path = kb.board_metadata_path("malformed-metadata")
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_bytes(original_bytes)
+    before = metadata_path.read_bytes()
+
+    assert kb.kanban_allowed_profiles(board="malformed-metadata") == frozenset()
+
+    with pytest.raises(ValueError, match="refusing to update board metadata"):
+        kb.write_board_metadata(
+            "malformed-metadata",
+            description="must not overwrite recoverable bytes",
+        )
+
+    assert metadata_path.read_bytes() == before == original_bytes
+    assert kb.kanban_allowed_profiles(board="malformed-metadata") == frozenset()
+
+
+def test_write_board_metadata_atomic_replace_failure_preserves_existing_file(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import utils
+
+    kb.create_board(
+        "atomic-policy",
+        description="original description",
+        allowed_profiles=["stable-profile"],
+    )
+    metadata_path = kb.board_metadata_path("atomic-policy")
+    before = metadata_path.read_bytes()
+    before_entries = set(metadata_path.parent.iterdir())
+
+    def refuse_replace(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated atomic replace failure")
+
+    monkeypatch.setattr(utils, "atomic_replace", refuse_replace)
+
+    with pytest.raises(OSError, match="simulated atomic replace failure"):
+        kb.write_board_metadata(
+            "atomic-policy",
+            description="unrelated metadata update",
+        )
+
+    assert metadata_path.read_bytes() == before
+    assert kb.kanban_allowed_profiles(board="atomic-policy") == frozenset(
+        {"stable-profile"}
+    )
+    assert set(metadata_path.parent.iterdir()) == before_entries
+
+
+def test_create_board_omitted_allowed_profiles_preserves_existing_policy(
+    kanban_home: Path,
+) -> None:
+    created = kb.create_board(
+        "idempotent-policy",
+        name="Idempotent Policy",
+        allowed_profiles=["alpha", "beta"],
+    )
+    assert created["allowed_profiles"] == ["alpha", "beta"]
+
+    recreated = kb.create_board("idempotent-policy")
+
+    assert recreated["allowed_profiles"] == ["alpha", "beta"]
+    assert kb.read_board_metadata("idempotent-policy")["allowed_profiles"] == [
+        "alpha",
+        "beta",
+    ]
+
+
+def test_allowed_profiles_prefers_explicit_board_then_connection_then_global(
+    kanban_home: Path,
+) -> None:
+    kb.create_board("precedence-a", allowed_profiles=["alpha"])
+    kb.create_board("precedence-b", allowed_profiles=["beta"])
+
+    with kb.connect_closing(board="precedence-a") as conn:
+        kb.set_current_board("precedence-b")
+        assert kb.get_current_board() == "precedence-b"
+        assert kb.kanban_allowed_profiles(conn=conn) == frozenset({"alpha"})
+        assert kb.kanban_allowed_profiles(
+            board="precedence-b",
+            conn=conn,
+        ) == frozenset({"beta"})
+
+
+def test_create_task_rejects_explicit_board_mismatch_without_mutation(
+    kanban_home: Path,
+) -> None:
+    kb.create_board("frontend-policy", allowed_profiles=["frontend-builder"])
+    kb.create_board("systems-policy", allowed_profiles=["systems-builder"])
+
+    with kb.connect_closing(board="frontend-policy") as conn:
+        before = conn.serialize()
+        with pytest.raises(ValueError, match="does not match connection board"):
+            kb.create_task(
+                conn,
+                title="systems policy must not authorize frontend DB writes",
+                assignee="systems-builder",
+                board="systems-policy",
+            )
+
+        assert conn.serialize() == before
+        assert kb.list_tasks(conn) == []
+
+
+def test_create_task_accepts_matching_explicit_connection_board(
+    kanban_home: Path,
+) -> None:
+    kb.create_board("matching-policy", allowed_profiles=["frontend-builder"])
+
+    with kb.connect_closing(board="matching-policy") as conn:
+        task_id = kb.create_task(
+            conn,
+            title="matching explicit board",
+            assignee="Frontend-Builder",
+            board="matching-policy",
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.assignee == "frontend-builder"
+
+
+def test_db_override_connection_keeps_frozen_opening_board_context(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kb.create_board("env-policy", allowed_profiles=["from-env"])
+    kb.create_board("changed-env-policy", allowed_profiles=["from-changed-env"])
+    kb.create_board("explicit-policy", allowed_profiles=["from-explicit"])
+    custom_db = kanban_home.parent / "outside-canonical-tree" / "forced-kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(custom_db))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "env-policy")
+
+    conn = kb.connect()
+    try:
+        db_row = next(
+            row for row in conn.execute("PRAGMA database_list") if row[1] == "main"
+        )
+        assert Path(str(db_row[2])).resolve() == custom_db.resolve()
+        assert kb.kanban_allowed_profiles(conn=conn) == frozenset({"from-env"})
+
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "changed-env-policy")
+        assert kb.kanban_allowed_profiles(conn=conn) == frozenset({"from-env"})
+        assert kb.kanban_allowed_profiles(
+            board="changed-env-policy", conn=conn
+        ) == frozenset({"from-changed-env"})
+
+        env_task_id = kb.create_task(
+            conn,
+            title="frozen env board",
+            assignee="from-env",
+            board="env-policy",
+        )
+        before_mismatch = conn.serialize()
+        with pytest.raises(ValueError, match="does not match connection board"):
+            kb.create_task(
+                conn,
+                title="changed env must not retag an open connection",
+                assignee="from-changed-env",
+                board="changed-env-policy",
+            )
+        assert conn.serialize() == before_mismatch
+        assert {task.id for task in kb.list_tasks(conn)} == {env_task_id}
+
+        with pytest.raises(ValueError, match="does not match connection board"):
+            kb.dispatch_once(conn, board="changed-env-policy", dry_run=True)
+        assert conn.serialize() == before_mismatch
+
+        explicit_conn = kb.connect(board="explicit-policy")
+        try:
+            assert kb.kanban_allowed_profiles(conn=explicit_conn) == frozenset(
+                {"from-explicit"}
+            )
+            assert kb.kanban_allowed_profiles(conn=conn) == frozenset({"from-env"})
+            explicit_task_id = kb.create_task(
+                explicit_conn,
+                title="frozen explicit board",
+                assignee="from-explicit",
+                board="explicit-policy",
+            )
+            before_explicit_mismatch = explicit_conn.serialize()
+            with pytest.raises(ValueError, match="does not match connection board"):
+                kb.create_task(
+                    explicit_conn,
+                    title="env hint must not replace explicit opening hint",
+                    assignee="from-env",
+                    board="env-policy",
+                )
+            assert explicit_conn.serialize() == before_explicit_mismatch
+            assert {task.id for task in kb.list_tasks(explicit_conn)} == {
+                env_task_id,
+                explicit_task_id,
+            }
+        finally:
+            explicit_conn.close()
+    finally:
+        conn.close()
+
+
+def test_canonical_db_path_identity_overrides_conflicting_connection_hint(
+    kanban_home: Path,
+) -> None:
+    kb.create_board("path-identity", allowed_profiles=["path-profile"])
+    kb.create_board("conflicting-hint", allowed_profiles=["hint-profile"])
+
+    conn = kb.connect(
+        db_path=kb.kanban_db_path("path-identity"),
+        board="conflicting-hint",
+    )
+    try:
+        assert kb.kanban_allowed_profiles(conn=conn) == frozenset({"path-profile"})
+        before = conn.serialize()
+        with pytest.raises(ValueError, match="does not match connection board"):
+            kb.create_task(
+                conn,
+                title="hint must not retag canonical path",
+                assignee="hint-profile",
+                board="conflicting-hint",
+            )
+        assert conn.serialize() == before
+
+        task_id = kb.create_task(
+            conn,
+            title="canonical path board remains authoritative",
+            assignee="path-profile",
+            board="path-identity",
+        )
+        assert kb.get_task(conn, task_id) is not None
+    finally:
+        conn.close()
+
+
+def test_unidentified_custom_connection_accepts_explicit_board_context(
+    kanban_home: Path,
+) -> None:
+    kb.create_board("compat-policy", allowed_profiles=["compat-profile"])
+    custom_db = kanban_home.parent / "test-double" / "kanban.db"
+
+    with kb.connect_closing(db_path=custom_db) as conn:
+        task_id = kb.create_task(
+            conn,
+            title="explicit compatibility context",
+            assignee="compat-profile",
+            board="compat-policy",
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.assignee == "compat-profile"
+
+
+@pytest.mark.parametrize(
+    ("machine_allowed", "board_allowed", "expected"),
+    [
+        pytest.param(None, None, None, id="machine-null-board-null-unrestricted"),
+        pytest.param(
+            ["alpha", "beta"],
+            None,
+            frozenset({"alpha", "beta"}),
+            id="machine-list-board-null-machine-ceiling",
+        ),
+        pytest.param(
+            None,
+            ["beta", "gamma"],
+            frozenset({"beta", "gamma"}),
+            id="machine-null-board-list-board-set",
+        ),
+        pytest.param(
+            ["alpha", "beta"],
+            ["beta", "gamma"],
+            frozenset({"beta"}),
+            id="two-lists-intersect",
+        ),
+        pytest.param(
+            None,
+            [],
+            frozenset(),
+            id="explicit-empty-board-allows-none",
+        ),
+        pytest.param(
+            [],
+            None,
+            frozenset(),
+            id="explicit-empty-machine-allows-none",
+        ),
+    ],
+)
+def test_effective_allowed_profiles_follows_two_layer_matrix(
+    kanban_home: Path,
+    machine_allowed: object,
+    board_allowed: object,
+    expected: frozenset[str] | None,
+) -> None:
+    kb.create_board("matrix-board")
+    _set_machine_allowed(kanban_home, machine_allowed)
+    _set_board_allowed("matrix-board", board_allowed)
+
+    with kb.connect_closing(board="matrix-board") as conn:
+        assert kb.kanban_allowed_profiles(conn=conn) == expected
+        for profile in ("alpha", "beta", "gamma", "outside"):
+            assert kb.is_kanban_profile_allowed(profile, conn=conn) is (
+                expected is None or profile in expected
+            )
+
+
+def test_two_boards_use_disjoint_connection_scoped_policies(
+    kanban_home: Path,
+) -> None:
+    _set_machine_allowed(kanban_home, ["alpha", "beta"])
+    kb.create_board("alpha-board")
+    kb.create_board("beta-board")
+    _set_board_allowed("alpha-board", ["alpha"])
+    _set_board_allowed("beta-board", ["beta"])
+
+    with (
+        kb.connect_closing(board="alpha-board") as alpha_conn,
+        kb.connect_closing(board="beta-board") as beta_conn,
+    ):
+        # Deliberately point process-global state at the opposite board. Policy
+        # identity must come from each SQLite connection, not this pointer.
+        kb.set_current_board("beta-board")
+        assert kb.kanban_allowed_profiles(conn=alpha_conn) == frozenset({"alpha"})
+        assert kb.is_kanban_profile_allowed("alpha", conn=alpha_conn)
+        assert not kb.is_kanban_profile_allowed("beta", conn=alpha_conn)
+        alpha_id = kb.create_task(alpha_conn, title="alpha work", assignee="alpha")
+        with pytest.raises(ValueError, match="not allowed for Kanban assignment"):
+            kb.create_task(alpha_conn, title="wrong alpha work", assignee="beta")
+
+        kb.set_current_board("alpha-board")
+        assert kb.kanban_allowed_profiles(conn=beta_conn) == frozenset({"beta"})
+        assert kb.is_kanban_profile_allowed("beta", conn=beta_conn)
+        assert not kb.is_kanban_profile_allowed("alpha", conn=beta_conn)
+        beta_id = kb.create_task(beta_conn, title="beta work", assignee="beta")
+        with pytest.raises(ValueError, match="not allowed for Kanban assignment"):
+            kb.create_task(beta_conn, title="wrong beta work", assignee="alpha")
+
+        alpha_task = kb.get_task(alpha_conn, alpha_id)
+        beta_task = kb.get_task(beta_conn, beta_id)
+        assert alpha_task is not None
+        assert beta_task is not None
+        assert alpha_task.assignee == "alpha"
+        assert beta_task.assignee == "beta"
+
+
+def test_create_and_reassign_enforce_effective_board_policy(
+    kanban_home: Path,
+) -> None:
+    _set_machine_allowed(
+        kanban_home,
+        ["frontend-builder", "systems-builder"],
+    )
+    kb.create_board("frontend")
+    _set_board_allowed("frontend", ["frontend-builder"])
+
+    with kb.connect_closing(board="frontend") as conn:
+        task_id = kb.create_task(
+            conn,
+            title="allowed work",
+            assignee="Frontend-Builder",
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.assignee == "frontend-builder"
+
+        with pytest.raises(ValueError, match="not allowed for Kanban assignment"):
+            kb.create_task(conn, title="blocked work", assignee="systems-builder")
+
+        with pytest.raises(ValueError, match="not allowed for Kanban assignment"):
+            kb.assign_task(conn, task_id, "systems-builder")
+        unchanged = kb.get_task(conn, task_id)
+        assert unchanged is not None
+        assert unchanged.assignee == "frontend-builder"
+
+        unassigned_id = kb.create_task(conn, title="route later")
+        with pytest.raises(ValueError, match="not allowed for Kanban assignment"):
+            kb.assign_task(conn, unassigned_id, "systems-builder")
+        unassigned = kb.get_task(conn, unassigned_id)
+        assert unassigned is not None
+        assert unassigned.assignee is None
+
+        assert kb.assign_task(conn, unassigned_id, "frontend-builder")
+        assigned = kb.get_task(conn, unassigned_id)
+        assert assigned is not None
+        assert assigned.assignee == "frontend-builder"
+        assert kb.assign_task(conn, unassigned_id, None)
+        cleared = kb.get_task(conn, unassigned_id)
+        assert cleared is not None
+        assert cleared.assignee is None
+
+
+def test_reassign_reclaim_rejects_disallowed_profile_without_any_mutation(
+    kanban_home: Path,
+) -> None:
+    kb.create_board("reassign-policy", allowed_profiles=["builder"])
+
+    with kb.connect_closing(board="reassign-policy") as conn:
+        task_id = kb.create_task(conn, title="claimed work", assignee="builder")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        assert claimed.claim_lock is not None
+        assert claimed.current_run_id is not None
+        kb.add_comment(conn, task_id, "operator", "Preserve this comment and run.")
+        before = _task_mutation_snapshot(conn, task_id)
+
+        with pytest.raises(ValueError, match="not allowed for Kanban assignment"):
+            kb.reassign_task(
+                conn,
+                task_id,
+                "systems-builder",
+                reclaim_first=True,
+                reason="must not reclaim before policy validation",
+            )
+
+        assert _task_mutation_snapshot(conn, task_id) == before
+
+
+@pytest.mark.parametrize(
+    "new_profile",
+    [pytest.param("replacement", id="allowed-profile"), pytest.param(None, id="unassign")],
+)
+def test_reassign_reclaim_accepts_allowed_profile_or_unassignment(
+    kanban_home: Path,
+    new_profile: str | None,
+) -> None:
+    kb.create_board(
+        "allowed-reassign-policy",
+        allowed_profiles=["builder", "replacement"],
+    )
+
+    with kb.connect_closing(board="allowed-reassign-policy") as conn:
+        task_id = kb.create_task(conn, title="claimed work", assignee="builder")
+        assert kb.claim_task(conn, task_id) is not None
+
+        assert kb.reassign_task(
+            conn,
+            task_id,
+            new_profile,
+            reclaim_first=True,
+            reason="authorized reassignment",
+        )
+        reassigned = kb.get_task(conn, task_id)
+        assert reassigned is not None
+        assert reassigned.status == "ready"
+        assert reassigned.claim_lock is None
+        assert reassigned.current_run_id is None
+        assert reassigned.assignee == new_profile
+
+
+def test_list_tasks_assignee_filter_returns_historical_disallowed_assignment(
+    kanban_home: Path,
+) -> None:
+    kb.create_board("historical-query", allowed_profiles=["systems-builder"])
+
+    with kb.connect_closing(board="historical-query") as conn:
+        historical_id = kb.create_task(
+            conn,
+            title="historical systems work",
+            assignee="systems-builder",
+        )
+
+    _set_board_allowed("historical-query", ["frontend-builder"])
+    with kb.connect_closing(board="historical-query") as conn:
+        assert not kb.is_kanban_profile_allowed("systems-builder", conn=conn)
+        historical = kb.list_tasks(conn, assignee="systems-builder")
+
+    assert [(task.id, task.title, task.assignee) for task in historical] == [
+        (historical_id, "historical systems work", "systems-builder")
+    ]
+
+
+def test_named_profile_cannot_escape_machine_ceiling(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_machine_allowed(kanban_home, ["systems-builder"])
+    kb.create_board("named-profile-board")
+    _set_board_allowed(
+        "named-profile-board",
+        ["systems-builder", "frank"],
+    )
+
+    named_home = kanban_home / "profiles" / "frank"
+    named_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(named_home))
+
+    # The profile-local home and the board list cannot widen the default-root
+    # machine ceiling.
+    assert kb.kanban_allowed_profiles() == frozenset({"systems-builder"})
+    with kb.connect_closing(board="named-profile-board") as conn:
+        assert kb.kanban_allowed_profiles(conn=conn) == frozenset({"systems-builder"})
+        assert kb.is_kanban_profile_allowed("systems-builder", conn=conn)
+        assert not kb.is_kanban_profile_allowed("frank", conn=conn)
+        with pytest.raises(ValueError, match="not allowed for Kanban assignment"):
+            kb.create_task(conn, title="ceiling bypass", assignee="frank")
+
+
+@pytest.mark.parametrize(
+    ("machine_allowed", "board_allowed", "board_hand_edited"),
+    [
+        pytest.param(
+            "frontend-builder",
+            ["frontend-builder"],
+            False,
+            id="malformed-machine",
+        ),
+        pytest.param(
+            ["frontend-builder"],
+            "frontend-builder",
+            True,
+            id="malformed-board",
+        ),
+        pytest.param(
+            "frontend-builder",
+            "frontend-builder",
+            True,
+            id="malformed-machine-and-board",
+        ),
+        pytest.param(
+            ["frontend-builder", 7],
+            ["frontend-builder"],
+            False,
+            id="malformed-machine-list-entry",
+        ),
+        pytest.param(
+            ["frontend-builder"],
+            ["frontend-builder", 7],
+            True,
+            id="malformed-board-non-string-list-entry",
+        ),
+        pytest.param(
+            ["frontend-builder"],
+            ["frontend-builder", "../escape"],
+            True,
+            id="malformed-board-invalid-profile-name",
+        ),
+    ],
+)
+def test_malformed_policy_layer_fails_closed(
+    kanban_home: Path,
+    machine_allowed: object,
+    board_allowed: object,
+    board_hand_edited: bool,
+) -> None:
+    kb.create_board("malformed-board")
+    _set_machine_allowed(kanban_home, machine_allowed)
+    if board_hand_edited:
+        _set_board_allowed_raw("malformed-board", board_allowed)
+    else:
+        _set_board_allowed("malformed-board", board_allowed)
+
+    with kb.connect_closing(board="malformed-board") as conn:
+        assert kb.kanban_allowed_profiles(conn=conn) == frozenset()
+        with pytest.raises(ValueError, match="no profiles are currently allowed"):
+            kb.create_task(conn, title="blocked", assignee="frontend-builder")
+
+
+def test_known_assignees_uses_connection_effective_policy(
+    kanban_home: Path,
+) -> None:
+    _install_profile(kanban_home, "frontend-builder")
+    _install_profile(kanban_home, "systems-builder")
+    _set_machine_allowed(
+        kanban_home,
+        ["frontend-builder", "systems-builder"],
+    )
+    kb.create_board("roster-board")
+
+    with kb.connect_closing(board="roster-board") as conn:
+        historical_id = kb.create_task(
+            conn,
+            title="historical",
+            assignee="systems-builder",
+        )
+
+    _set_board_allowed("roster-board", ["frontend-builder"])
+    # No-context callers retain the machine-ceiling view, while an explicit
+    # board connection narrows the assignment roster. Task 4 can request the
+    # complete installed-profile inventory without weakening the default.
+    assert kb.list_profiles_on_disk() == ["frontend-builder", "systems-builder"]
+    with kb.connect_closing(board="roster-board") as conn:
+        assert kb.list_profiles_on_disk(conn=conn) == ["frontend-builder"]
+        assert set(kb.list_profiles_on_disk(conn=conn, include_disallowed=True)) == {
+            "default",
+            "frontend-builder",
+            "systems-builder",
+        }
+        assert kb.known_assignees(conn) == [
+            {"name": "frontend-builder", "on_disk": True, "counts": {}},
+        ]
+        visible_tasks = {task.id: task for task in kb.list_tasks(conn)}
+        assert visible_tasks[historical_id].assignee == "systems-builder"
+
+
+def test_tightened_board_policy_blocks_legacy_ready_and_review_dispatch_only_there(
+    kanban_home: Path,
+) -> None:
+    _install_profile(kanban_home, "systems-builder")
+    _install_profile(kanban_home, "rose")
+    _set_machine_allowed(kanban_home, None)
+    kb.create_board("tightened")
+    kb.create_board("unchanged")
+    _set_board_allowed("tightened", None)
+    _set_board_allowed("unchanged", None)
+
+    with kb.connect_closing(board="tightened") as conn:
+        allowed_ready = kb.create_task(
+            conn,
+            title="allowed ready",
+            assignee="systems-builder",
+        )
+        allowed_review = kb.create_task(
+            conn,
+            title="allowed review",
+            assignee="systems-builder",
+        )
+        blocked_ready = kb.create_task(conn, title="legacy ready", assignee="rose")
+        blocked_review = kb.create_task(conn, title="legacy review", assignee="rose")
+        _move_to_review(conn, allowed_review)
+        _move_to_review(conn, blocked_review)
+
+    with kb.connect_closing(board="unchanged") as conn:
+        unchanged_ready = kb.create_task(conn, title="ready elsewhere", assignee="rose")
+        unchanged_review = kb.create_task(conn, title="review elsewhere", assignee="rose")
+        _move_to_review(conn, unchanged_review)
+
+    # Tighten only one board after the assignments already exist.
+    _set_board_allowed("tightened", ["systems-builder"])
+
+    with kb.connect_closing(board="tightened") as conn:
+        kb.set_current_board("unchanged")
+        tightened_result = kb.dispatch_once(conn, dry_run=True)
+
+    with kb.connect_closing(board="unchanged") as conn:
+        kb.set_current_board("tightened")
+        unchanged_result = kb.dispatch_once(conn, dry_run=True)
+
+    assert {task_id for task_id, _, _ in tightened_result.spawned} == {
+        allowed_ready,
+        allowed_review,
+    }
+    assert set(tightened_result.skipped_nonspawnable) == {
+        blocked_ready,
+        blocked_review,
+    }
+    assert {task_id for task_id, _, _ in unchanged_result.spawned} == {
+        unchanged_ready,
+        unchanged_review,
+    }
+    assert unchanged_result.skipped_nonspawnable == []
+
+
+def test_dispatch_rejects_explicit_board_mismatch_without_mutation(
+    kanban_home: Path,
+) -> None:
+    _install_profile(kanban_home, "systems-builder")
+    kb.create_board("dispatch-frontend", allowed_profiles=["frontend-builder"])
+    kb.create_board("dispatch-systems", allowed_profiles=["systems-builder"])
+
+    spawned: list[str] = []
+    with kb.connect_closing(board="dispatch-frontend") as conn:
+        task_id = kb.create_task(conn, title="route only on the connected board")
+        before = _task_mutation_snapshot(conn, task_id)
+
+        with pytest.raises(ValueError, match="does not match connection board"):
+            kb.dispatch_once(
+                conn,
+                board="dispatch-systems",
+                default_assignee="systems-builder",
+                spawn_fn=lambda task, _workspace: spawned.append(task.id),
+            )
+
+        assert spawned == []
+        assert _task_mutation_snapshot(conn, task_id) == before
+
+
+def _review_state_snapshot(conn, task_id: str) -> dict[str, object]:
+    return {
+        "task": dict(conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()),
+        "runs": [
+            dict(row)
+            for row in conn.execute(
+                "SELECT * FROM task_runs WHERE task_id = ? ORDER BY id", (task_id,)
+            )
+        ],
+        "events": [
+            dict(row)
+            for row in conn.execute(
+                "SELECT * FROM task_events WHERE task_id = ? ORDER BY id", (task_id,)
+            )
+        ],
+    }
+
+
+@pytest.mark.parametrize("use_provenance", [False, True], ids=["explicit", "provenance"])
+def test_review_handoff_rejects_disallowed_reviewer_without_mutation(
+    kanban_home: Path,
+    use_provenance: bool,
+) -> None:
+    kb.create_board("review-handoff-policy", allowed_profiles=["builder", "reviewer"])
+
+    with kb.connect_closing(board="review-handoff-policy") as conn:
+        task_id = kb.create_task(conn, title="review policy", assignee="builder")
+        implementation = kb.claim_task(conn, task_id)
+        assert implementation is not None
+
+        if use_provenance:
+            assert kb.request_review(
+                conn,
+                task_id,
+                reviewer="reviewer",
+                expected_run_id=implementation.current_run_id,
+            )
+            review = kb.claim_review_task(conn, task_id)
+            assert review is not None
+            assert kb.request_changes(
+                conn,
+                task_id,
+                reason="revise",
+                expected_run_id=review.current_run_id,
+            ) == (True, "builder")
+            implementation = kb.claim_task(conn, task_id)
+            assert implementation is not None
+
+        _set_board_allowed("review-handoff-policy", ["builder"])
+        before = _review_state_snapshot(conn, task_id)
+
+        with pytest.raises(ValueError, match="not allowed for Kanban assignment"):
+            kb.request_review(
+                conn,
+                task_id,
+                reviewer=None if use_provenance else "reviewer",
+                expected_run_id=implementation.current_run_id,
+            )
+
+        assert _review_state_snapshot(conn, task_id) == before
+
+
+def test_request_changes_rejects_disallowed_implementer_without_mutation(
+    kanban_home: Path,
+) -> None:
+    kb.create_board(
+        "changes-restoration-policy",
+        allowed_profiles=["builder", "reviewer"],
+    )
+
+    with kb.connect_closing(board="changes-restoration-policy") as conn:
+        task_id = kb.create_task(conn, title="restore policy", assignee="builder")
+        implementation = kb.claim_task(conn, task_id)
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            task_id,
+            reviewer="reviewer",
+            expected_run_id=implementation.current_run_id,
+        )
+        review = kb.claim_review_task(conn, task_id)
+        assert review is not None
+
+        _set_board_allowed("changes-restoration-policy", ["reviewer"])
+        before = _review_state_snapshot(conn, task_id)
+
+        with pytest.raises(ValueError, match="not allowed for Kanban assignment"):
+            kb.request_changes(
+                conn,
+                task_id,
+                reason="restore the original implementer",
+                expected_run_id=review.current_run_id,
+            )
+
+        assert _review_state_snapshot(conn, task_id) == before

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -161,3 +161,231 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+def test_decompose_routes_each_explicit_board_by_its_effective_profile_policy(
+    kanban_home,
+):
+    kb.create_board(
+        "alpha-board",
+        allowed_profiles=["alpha-orchestrator", "alpha-worker"],
+    )
+    kb.create_board(
+        "beta-board",
+        allowed_profiles=["beta-orchestrator", "beta-worker"],
+    )
+    with kb.connect(board="alpha-board") as conn:
+        alpha_tid = kb.create_task(conn, title="alpha work", triage=True)
+    with kb.connect(board="beta-board") as conn:
+        beta_tid = kb.create_task(conn, title="beta work", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "one routed child",
+        "tasks": [{
+            "title": "do it",
+            "body": "board-scoped work",
+            "assignee": "not-installed",
+            "parents": [],
+        }],
+    })
+    installed = [
+        "global-active",
+        "alpha-orchestrator",
+        "alpha-worker",
+        "beta-orchestrator",
+        "beta-worker",
+    ]
+    config = {
+        "kanban": {
+            "orchestrator_profile": "beta-orchestrator",
+            "default_assignee": "beta-worker",
+        }
+    }
+    prompts: list[str] = []
+
+    def call_llm_for(board_to_switch_to: str):
+        def _call_llm(**kwargs):
+            prompts.append(kwargs["messages"][1]["content"])
+            kb.set_current_board(board_to_switch_to)
+            return _fake_aux_response(llm_payload)
+
+        return _call_llm
+
+    patches = _patch_list_profiles(installed)
+    for profile_patch in patches:
+        profile_patch.start()
+    try:
+        with patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value=config,
+        ), patch(
+            "agent.auxiliary_client.call_llm",
+            side_effect=call_llm_for("beta-board"),
+        ):
+            alpha_outcome = decomp.decompose_task(
+                alpha_tid,
+                board="alpha-board",
+                author="me",
+            )
+        with patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value=config,
+        ), patch(
+            "agent.auxiliary_client.call_llm",
+            side_effect=call_llm_for("alpha-board"),
+        ):
+            beta_outcome = decomp.decompose_task(
+                beta_tid,
+                board="beta-board",
+                author="me",
+            )
+    finally:
+        for profile_patch in patches:
+            profile_patch.stop()
+
+    assert alpha_outcome.ok, alpha_outcome.reason
+    assert beta_outcome.ok, beta_outcome.reason
+    assert alpha_outcome.child_ids
+    assert beta_outcome.child_ids
+    assert len(prompts) == 2
+    assert "alpha-orchestrator" in prompts[0]
+    assert "alpha-worker" in prompts[0]
+    assert "beta-orchestrator" not in prompts[0]
+    assert "beta-worker" not in prompts[0]
+    assert "beta-orchestrator" in prompts[1]
+    assert "beta-worker" in prompts[1]
+    assert "alpha-orchestrator" not in prompts[1]
+    assert "alpha-worker" not in prompts[1]
+
+    with kb.connect(board="alpha-board") as conn:
+        alpha_root = kb.get_task(conn, alpha_tid)
+        alpha_child = kb.get_task(conn, alpha_outcome.child_ids[0])
+    with kb.connect(board="beta-board") as conn:
+        beta_root = kb.get_task(conn, beta_tid)
+        beta_child = kb.get_task(conn, beta_outcome.child_ids[0])
+
+    # Alpha's configured choices are excluded, so both routes use the first
+    # installed effective profile. Beta's configured choices are effective.
+    assert alpha_root is not None
+    assert alpha_child is not None
+    assert beta_root is not None
+    assert beta_child is not None
+    assert alpha_root.assignee == "alpha-orchestrator"
+    assert alpha_child.assignee == "alpha-orchestrator"
+    assert beta_root.assignee == "beta-orchestrator"
+    assert beta_child.assignee == "beta-worker"
+
+
+def test_decompose_empty_effective_roster_is_non_ok_without_mutation(kanban_home):
+    kb.create_board("empty-board", allowed_profiles=["existing"])
+    with kb.connect(board="empty-board") as conn:
+        tid = kb.create_task(
+            conn,
+            title="must stay triage",
+            body="must stay unchanged",
+            assignee="existing",
+            triage=True,
+        )
+    kb.write_board_metadata("empty-board", allowed_profiles=[])
+    with kb.connect(board="empty-board") as conn:
+        before_root = kb.get_task(conn, tid)
+        before_task_ids = [task.id for task in kb.list_tasks(conn, limit=100)]
+        before_comment_ids = [comment.id for comment in kb.list_comments(conn, tid)]
+        before_event_ids = [event.id for event in kb.list_events(conn, tid)]
+
+    patches = _patch_list_profiles(["global-active", "existing"])
+    for profile_patch in patches:
+        profile_patch.start()
+    try:
+        with patch("agent.auxiliary_client.call_llm") as call_llm:
+            outcome = decomp.decompose_task(
+                tid,
+                board="empty-board",
+                author="me",
+            )
+    finally:
+        for profile_patch in patches:
+            profile_patch.stop()
+
+    assert outcome.ok is False
+    assert "no installed profiles" in outcome.reason.lower()
+    call_llm.assert_not_called()
+    with kb.connect(board="empty-board") as conn:
+        root = kb.get_task(conn, tid)
+        tasks = kb.list_tasks(conn, limit=100)
+        comments = kb.list_comments(conn, tid)
+        events = kb.list_events(conn, tid)
+    assert root == before_root
+    assert [task.id for task in tasks] == before_task_ids == [tid]
+    assert [comment.id for comment in comments] == before_comment_ids
+    assert [event.id for event in events] == before_event_ids
+
+
+def test_decompose_single_task_policy_race_is_non_ok_without_mutation(kanban_home):
+    board = "policy-race-board"
+    allowed_profile = "policy-worker"
+    kb.create_board(board, allowed_profiles=[allowed_profile])
+    with kb.connect(board=board) as conn:
+        tid = kb.create_task(
+            conn,
+            title="rough title",
+            body="rough body",
+            triage=True,
+        )
+        before_root = kb.get_task(conn, tid)
+        before_task_count = len(kb.list_tasks(conn, limit=100))
+        before_comments = kb.list_comments(conn, tid)
+        before_events = kb.list_events(conn, tid)
+    assert before_root is not None
+    before_task_state = (
+        before_root.status,
+        before_root.title,
+        before_root.body,
+        before_root.assignee,
+        before_root.current_run_id,
+    )
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit",
+        "title": "tightened title",
+        "body": "tightened body",
+        "assignee": allowed_profile,
+    })
+
+    def tighten_policy_then_return(**_kwargs):
+        kb.write_board_metadata(board, allowed_profiles=[])
+        return _fake_aux_response(llm_payload)
+
+    patches = _patch_list_profiles([allowed_profile])
+    for profile_patch in patches:
+        profile_patch.start()
+    try:
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            side_effect=tighten_policy_then_return,
+        ):
+            outcome = decomp.decompose_task(tid, board=board, author="me")
+    finally:
+        for profile_patch in patches:
+            profile_patch.stop()
+
+    assert outcome.ok is False
+    assert outcome.reason.startswith("DB rejected task: ")
+    assert "not allowed" in outcome.reason.lower()
+    with kb.connect(board=board) as conn:
+        root = kb.get_task(conn, tid)
+        task_count = len(kb.list_tasks(conn, limit=100))
+        comments = kb.list_comments(conn, tid)
+        events = kb.list_events(conn, tid)
+    assert root is not None
+    assert (
+        root.status,
+        root.title,
+        root.body,
+        root.assignee,
+        root.current_run_id,
+    ) == before_task_state
+    assert root == before_root
+    assert task_count == before_task_count == 1
+    assert comments == before_comments
+    assert events == before_events

--- a/tests/plugins/kanban/dashboard_orchestration_bundle_harness.mjs
+++ b/tests/plugins/kanban/dashboard_orchestration_bundle_harness.mjs
@@ -1,0 +1,406 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const harnessDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(harnessDir, "..", "..", "..");
+const require = createRequire(pathToFileURL(join(repoRoot, "package.json")));
+
+function failAbsentRuntime(message) {
+  throw new Error(`declared Playwright runtime is absent: ${message}`);
+}
+
+let playwright;
+try {
+  playwright = require("@playwright/test");
+} catch (error) {
+  if (error && error.code === "MODULE_NOT_FOUND") {
+    failAbsentRuntime("@playwright/test is not installed");
+  }
+  throw error;
+}
+
+const { chromium, expect } = playwright;
+const chromiumPath = chromium.executablePath();
+if (!chromiumPath || !existsSync(chromiumPath)) {
+  failAbsentRuntime(`Chromium executable not found at ${chromiumPath || "<unset>"}`);
+}
+
+const { buildSync } = require("esbuild");
+const bundlePath = join(
+  repoRoot,
+  "plugins",
+  "kanban",
+  "dashboard",
+  "dist",
+  "index.js",
+);
+
+const hostSource = String.raw`
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+
+function elementComponent(tag, omitted) {
+  return function HostComponent(props) {
+    const clean = {};
+    const children = props.children;
+    for (const key of Object.keys(props)) {
+      if (key === "children" || omitted.indexOf(key) !== -1) continue;
+      clean[key] = props[key];
+    }
+    if (tag === "button" && !clean.type) clean.type = "button";
+    return React.createElement(tag, clean, children);
+  };
+}
+
+const Card = elementComponent("div", []);
+const CardContent = elementComponent("div", []);
+const Badge = elementComponent("span", ["variant"]);
+const Button = elementComponent("button", ["size", "variant"]);
+const Input = elementComponent("input", []);
+const Label = elementComponent("label", []);
+const Select = elementComponent("select", ["onValueChange"]);
+const SelectOption = elementComponent("option", []);
+
+function deferred() {
+  let resolvePromise;
+  let rejectPromise;
+  const promise = new Promise(function (resolve, reject) {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return { promise: promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+const alphaSettingsGate = deferred();
+const alphaProfilesGate = deferred();
+let betaOrchestrationLoads = 0;
+let betaAllowed = ["beta", "blocked"];
+let pendingPut = null;
+let putRecord = null;
+const calls = [];
+
+const boards = [
+  { slug: "alpha", name: "Alpha", total: 1, counts: {} },
+  { slug: "beta", name: "Beta", total: 1, counts: {} },
+];
+const emptyBoard = {
+  columns: ["triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done"].map(
+    function (name) { return { name: name, tasks: [] }; }
+  ),
+  tenants: [],
+  assignees: [],
+  latest_event_id: 0,
+  now: 1,
+};
+
+function alphaSettings() {
+  return {
+    board: "alpha",
+    orchestrator_profile: "alpha-stale",
+    default_assignee: "alpha-stale",
+    auto_decompose: true,
+    auto_promote_children: true,
+    resolved_orchestrator_profile: "alpha-stale",
+    resolved_default_assignee: "alpha-stale",
+    active_profile: "alpha-stale",
+    board_allowed_profiles: ["alpha-stale"],
+    effective_allowed_profiles: ["alpha-stale"],
+  };
+}
+
+function betaSettings() {
+  const effective = betaAllowed.filter(function (name) { return name === "beta"; });
+  return {
+    board: "beta",
+    orchestrator_profile: "",
+    default_assignee: "",
+    auto_decompose: true,
+    auto_promote_children: false,
+    resolved_orchestrator_profile: effective[0] || null,
+    resolved_default_assignee: effective[0] || null,
+    active_profile: "beta",
+    board_allowed_profiles: betaAllowed.slice(),
+    effective_allowed_profiles: effective,
+  };
+}
+
+function alphaProfiles() {
+  return {
+    profiles: [{
+      name: "alpha-stale",
+      is_default: false,
+      description: "stale alpha response",
+      description_auto: false,
+      skill_count: 0,
+      machine_allowed: true,
+      board_selected: true,
+      effective_allowed: true,
+    }],
+  };
+}
+
+function betaProfiles() {
+  return {
+    profiles: [
+      {
+        name: "beta",
+        is_default: false,
+        description: "beta worker",
+        description_auto: false,
+        skill_count: 0,
+        machine_allowed: true,
+        board_selected: betaAllowed.indexOf("beta") !== -1,
+        effective_allowed: betaAllowed.indexOf("beta") !== -1,
+      },
+      {
+        name: "blocked",
+        is_default: false,
+        description: "historical blocked worker",
+        description_auto: false,
+        skill_count: 0,
+        machine_allowed: false,
+        board_selected: betaAllowed.indexOf("blocked") !== -1,
+        effective_allowed: false,
+      },
+    ],
+  };
+}
+
+function fetchJSON(url, options) {
+  const request = options || {};
+  const method = request.method || "GET";
+  const parsed = new URL(url, window.location.origin);
+  const board = parsed.searchParams.get("board");
+  const body = request.body ? JSON.parse(request.body) : null;
+  calls.push({ url: url, method: method, body: body });
+
+  if (parsed.pathname.endsWith("/config")) {
+    return Promise.resolve({
+      render_markdown: true,
+      lane_by_profile: false,
+      include_archived_by_default: false,
+    });
+  }
+  if (parsed.pathname.endsWith("/boards")) {
+    return Promise.resolve({ boards: boards, current: "alpha" });
+  }
+  if (parsed.pathname.endsWith("/board")) {
+    return Promise.resolve(emptyBoard);
+  }
+  if (parsed.pathname.endsWith("/profiles")) {
+    if (board === "alpha") return alphaProfilesGate.promise;
+    if (board === "beta") return Promise.resolve(betaProfiles());
+  }
+  if (parsed.pathname.endsWith("/orchestration")) {
+    if (method === "PUT") {
+      putRecord = { url: url, body: body };
+      pendingPut = deferred();
+      return pendingPut.promise.then(function () {
+        betaAllowed = body.allowed_profiles.slice();
+        return betaSettings();
+      });
+    }
+    if (board === "alpha") return alphaSettingsGate.promise;
+    if (board === "beta") {
+      betaOrchestrationLoads += 1;
+      if (betaOrchestrationLoads === 1) {
+        return Promise.reject(new Error(
+          '503: {"detail":"planned beta load failure"}'
+        ));
+      }
+      return Promise.resolve(betaSettings());
+    }
+  }
+  if (parsed.pathname.endsWith("/dispatch/nudge")) {
+    return Promise.resolve({ ok: true });
+  }
+  return Promise.reject(new Error("unexpected harness request: " + method + " " + url));
+}
+
+class HarnessWebSocket {
+  constructor() {
+    const self = this;
+    queueMicrotask(function () {
+      if (self.onopen) self.onopen({});
+    });
+  }
+  close() {}
+}
+window.WebSocket = HarnessWebSocket;
+
+window.__KANBAN_HARNESS__ = {
+  calls: calls,
+  currentBoard: function () {
+    return window.localStorage.getItem("hermes.kanban.selectedBoard");
+  },
+  resolveAlpha: function () {
+    alphaSettingsGate.resolve(alphaSettings());
+    alphaProfilesGate.resolve(alphaProfiles());
+  },
+  resolvePut: function () {
+    if (!pendingPut) throw new Error("no orchestration PUT is pending");
+    pendingPut.resolve();
+  },
+  putRecord: function () { return putRecord; },
+};
+
+window.__HERMES_PLUGIN_SDK__ = {
+  React: React,
+  components: {
+    Card: Card,
+    CardContent: CardContent,
+    Badge: Badge,
+    Button: Button,
+    Input: Input,
+    Label: Label,
+    Select: Select,
+    SelectOption: SelectOption,
+  },
+  hooks: {
+    useState: React.useState,
+    useEffect: React.useEffect,
+    useCallback: React.useCallback,
+    useMemo: React.useMemo,
+    useRef: React.useRef,
+  },
+  utils: {
+    cn: function () {
+      return Array.prototype.slice.call(arguments).filter(Boolean).join(" ");
+    },
+    timeAgo: function () { return "now"; },
+  },
+  fetchJSON: fetchJSON,
+  buildWsUrl: function () { return Promise.resolve("ws://kanban.test/events"); },
+  useI18n: (function () {
+    const value = { t: { kanban: null }, locale: "en" };
+    return function () { return value; };
+  })(),
+};
+
+window.__HERMES_PLUGINS__ = {
+  register: function (name, Component) {
+    if (name !== "kanban") throw new Error("unexpected plugin registration: " + name);
+    window.__REGISTERED_KANBAN_COMPONENT__ = Component;
+    createRoot(document.getElementById("root")).render(React.createElement(Component));
+  },
+};
+`;
+
+const hostBundle = buildSync({
+  absWorkingDir: repoRoot,
+  bundle: true,
+  define: { "process.env.NODE_ENV": '"production"' },
+  format: "iife",
+  platform: "browser",
+  stdin: {
+    contents: hostSource,
+    loader: "js",
+    resolveDir: repoRoot,
+    sourcefile: "dashboard-orchestration-harness-host.js",
+  },
+  target: "chrome120",
+  write: false,
+}).outputFiles[0].text;
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  page.setDefaultTimeout(5_000);
+  const pageErrors = [];
+  page.on("pageerror", (error) => pageErrors.push(error));
+
+  try {
+    await page.route("http://kanban.test/**", async (route) => {
+      await route.fulfill({
+        body: "<!doctype html><html><body><div id=\"root\"></div></body></html>",
+        contentType: "text/html",
+        status: 200,
+      });
+    });
+    await page.goto("http://kanban.test/");
+    await page.evaluate(() => {
+      window.localStorage.setItem("hermes.kanban.selectedBoard", "alpha");
+    });
+    await page.addScriptTag({ content: hostBundle });
+    await page.addScriptTag({ path: bundlePath });
+
+    const boardSwitcher = page.getByLabel("Switch kanban board");
+    await expect(boardSwitcher).toBeVisible();
+    await expect(boardSwitcher).toHaveValue("alpha");
+    await boardSwitcher.selectOption("beta");
+    await expect(boardSwitcher).toHaveValue("beta");
+    await expect.poll(
+      () => page.evaluate(() => window.__KANBAN_HARNESS__.currentBoard())
+    ).toBe("beta");
+
+    await page.getByRole("button", { name: "▸ Orchestration settings" }).evaluate(
+      (button) => button.click()
+    );
+    await expect(page.getByText(
+      "Failed to load orchestration settings: planned beta load failure"
+    )).toBeVisible();
+
+    await page.getByRole("button", { name: "Reload" }).click();
+    await expect(page.getByText("Profiles allowed on this board")).toBeVisible();
+    await expect(page.getByText(
+      "Failed to load orchestration settings: planned beta load failure"
+    )).toHaveCount(0);
+
+    const blockedCheckbox = page.getByRole("checkbox", {
+      name: "blocked — blocked by machine policy",
+    });
+    await expect(blockedCheckbox).toBeVisible();
+    await expect(blockedCheckbox).toBeDisabled();
+    await expect(page.getByText("blocked by machine policy", { exact: true })).toBeVisible();
+
+    const betaCheckbox = page.getByRole("checkbox", {
+      name: "Allow beta to run work on this board",
+    });
+    await expect(betaCheckbox).toBeVisible();
+    await expect(betaCheckbox).toBeEnabled();
+    await expect(betaCheckbox).toBeChecked();
+
+    await page.evaluate(() => window.__KANBAN_HARNESS__.resolveAlpha());
+    await page.evaluate(() => new Promise((resolvePromise) => setTimeout(resolvePromise, 0)));
+    await expect(page.getByText("alpha-stale", { exact: true })).toHaveCount(0);
+    await expect(betaCheckbox).toBeVisible();
+    await expect(betaCheckbox).toBeChecked();
+
+    await betaCheckbox.click();
+    await expect.poll(
+      () => page.evaluate(() => window.__KANBAN_HARNESS__.putRecord())
+    ).not.toBeNull();
+    const putRecord = await page.evaluate(() => window.__KANBAN_HARNESS__.putRecord());
+    assert.deepEqual(putRecord, {
+      url: "/api/plugins/kanban/orchestration?board=beta",
+      body: { allowed_profiles: [] },
+    });
+    await expect(betaCheckbox).toBeDisabled();
+    await expect(page.getByLabel("Inherit machine policy")).toBeDisabled();
+
+    await page.evaluate(() => window.__KANBAN_HARNESS__.resolvePut());
+    await expect(page.getByText("No workers can run on this board.")).toBeVisible();
+    await expect(betaCheckbox).toBeEnabled();
+    await expect(betaCheckbox).not.toBeChecked();
+    await expect(page.getByText("Settings saved.")).toBeVisible();
+
+    assert.equal(pageErrors.length, 0, pageErrors.map((error) => error.stack).join("\n"));
+    process.stdout.write(JSON.stringify({
+      ok: true,
+      board: "beta",
+      put_url: putRecord.url,
+      put_body: putRecord.body,
+      checks: 6,
+    }) + "\n");
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error && error.stack ? error.stack : error}\n`);
+  process.exitCode = 1;
+});

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -770,19 +772,61 @@ def test_dashboard_done_actions_prompt_for_completion_summary():
     )
 
 
-def test_dashboard_cancel_keeps_task_in_old_status(client):
-    """Behavioral: the cancel branch of the dispatch path (no PATCH/DELETE
-    issued) must leave the task in its previous status. The cancel guard
-    lives in the bundle; this test pins the backend contract that the guard
-    relies on.
-    """
-    t = client.post("/api/plugins/kanban/tasks",
-                    json={"title": "x"}).json()["task"]
-    # Tasks land in ``ready`` by default. No PATCH issued — simulating the
-    # cancel branch in the bundle.
-    assert t["status"] == "ready"
-    r = client.get(f"/api/plugins/kanban/tasks/{t['id']}")
-    assert r.json()["task"]["status"] == "ready"
+def test_dashboard_cancel_keeps_task_dispatch_suppressed():
+    """Execute the production-used dialog-owner cancel path."""
+    js = _dashboard_bundle_source()
+    helper_source = js[
+        js.index("function settleDialogOwner"):
+        js.index("function useKanbanDialogs")
+    ]
+    hook = js[
+        js.index("function useKanbanDialogs"):
+        js.index("const API =", js.index("function useKanbanDialogs"))
+    ]
+    assert (
+        "return settleDialogOwner(resolverRef, setDialogState, confirmed, extras);"
+        in hook
+    )
+    assert (
+        "const onCancel = React.useCallback(function () { close(false, null); }"
+        in hook
+    )
+
+    probe = helper_source + """
+const resolverRef = {current: null};
+let dialogState = {kind: "confirm"};
+let requests = 0;
+const pending = new Promise(function (resolve) { resolverRef.current = resolve; });
+const settled = settleDialogOwner(
+  resolverRef,
+  function (next) { dialogState = next; },
+  false,
+  null
+);
+pending.then(function (result) {
+  if (result.confirmed) requests += 1;
+  console.log(JSON.stringify({
+    settled,
+    confirmed: result.confirmed,
+    ownerReleased: resolverRef.current === null,
+    dialogState,
+    requests
+  }));
+});
+"""
+    completed = subprocess.run(
+        ["node", "-e", probe],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(completed.stdout) == {
+        "settled": True,
+        "confirmed": False,
+        "ownerReleased": True,
+        "dialogState": None,
+        "requests": 0,
+    }
 
 
 def test_dashboard_confirm_dispatches_expected_patch_body(client):
@@ -1225,8 +1269,1407 @@ def test_specify_happy_path(client, monkeypatch):
     assert "**Goal**" in (detail["body"] or "")
 
 
+def _dashboard_bundle_source():
+    repo_root = Path(__file__).resolve().parents[2]
+    return (
+        repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    ).read_text(encoding="utf-8")
+
+
+def test_dashboard_orchestration_policy_lifecycle_in_shipped_bundle():
+    """Exercise the real registered bundle in headless Chromium."""
+    repo_root = Path(__file__).resolve().parents[2]
+    harness = (
+        repo_root
+        / "tests"
+        / "plugins"
+        / "kanban"
+        / "dashboard_orchestration_bundle_harness.mjs"
+    )
+    node = shutil.which("node")
+    assert node is not None, "declared Playwright runtime is absent: node not found"
+
+    completed = subprocess.run(
+        [node, str(harness)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, (
+        f"bundle harness failed ({completed.returncode})\n"
+        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+    assert json.loads(completed.stdout) == {
+        "ok": True,
+        "board": "beta",
+        "put_url": "/api/plugins/kanban/orchestration?board=beta",
+        "put_body": {"allowed_profiles": []},
+        "checks": 6,
+    }
+
+
+def test_dashboard_task_deletes_pin_the_board_captured_before_confirmation():
+    js = _dashboard_bundle_source()
+    single_start = js.index("const deleteTask = useCallback")
+    bulk_start = js.index("const deleteSelected = useCallback", single_start)
+    render_start = js.index("// --- render", bulk_start)
+    single = js[single_start:bulk_start]
+    bulk = js[bulk_start:render_start]
+
+    assert single.index("const requestBoard = board;") < single.index(
+        "kanbanDialogs.request({"
+    )
+    assert single.index(
+        "const requestGeneration = boardActionGenerationRef.current;"
+    ) < single.index("kanbanDialogs.request({")
+    assert (
+        "SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(taskId)}`, "
+        "requestBoard), {"
+    ) in single
+    assert "method: \"DELETE\"" in single
+    assert single.count("isExactBoardRequestCurrent(") == 2
+
+    assert bulk.index("const requestBoard = board;") < bulk.index(
+        "kanbanDialogs.request({"
+    )
+    assert bulk.index(
+        "const requestGeneration = boardActionGenerationRef.current;"
+    ) < bulk.index("kanbanDialogs.request({")
+    assert bulk.index("const ids = Array.from(selectedIds);") < bulk.index(
+        "kanbanDialogs.request({"
+    )
+    assert (
+        "withBoard(`${API}/tasks/${encodeURIComponent(id)}`, requestBoard)"
+    ) in bulk
+    assert "SDK.fetchJSON(`${API}/tasks/" not in single + bulk
+    assert bulk.count("isExactBoardRequestCurrent(") == 3
+
+
+def test_dashboard_board_delete_completion_is_generation_local():
+    js = _dashboard_bundle_source()
+    start = js.index("const deleteBoard = useCallback")
+    end = js.index("const deleteTask = useCallback", start)
+    delete_board = js[start:end]
+
+    assert delete_board.index("const requestBoard = board;") < delete_board.index(
+        "SDK.fetchJSON("
+    )
+    assert delete_board.index(
+        "const requestGeneration = boardActionGenerationRef.current;"
+    ) < delete_board.index("SDK.fetchJSON(")
+    guard = delete_board.index("if (!isExactBoardRequestCurrent(")
+    assert guard < delete_board.index("loadBoardList();")
+    assert guard < delete_board.index('switchBoard("default");')
+    assert "if (requestBoard === slug)" in delete_board
+
+
+def test_dashboard_exact_board_request_helper_rejects_deferred_a_completion():
+    js = _dashboard_bundle_source()
+    helper_source = js[
+        js.index("const ASSIGNEE_UNASSIGNED"):
+        js.index("// The SDK's Select component")
+    ]
+    probe = helper_source + """
+const boardRef = {current: "board-a"};
+const generationRef = {current: 7};
+const requestBoard = boardRef.current;
+const requestGeneration = generationRef.current;
+const mutations = {success: 0, catch: 0, finally: 0, load: 0};
+function settle(kind) {
+  if (!isExactBoardRequestCurrent(
+    boardRef, generationRef, requestBoard, requestGeneration
+  )) return;
+  mutations[kind] += 1;
+  mutations.load += 1;
+}
+boardRef.current = "board-b";
+generationRef.current += 1;
+settle("success");
+settle("catch");
+settle("finally");
+const afterB = isExactBoardRequestCurrent(
+  boardRef, generationRef, requestBoard, requestGeneration
+);
+boardRef.current = "board-a";
+const afterReturnToA = isExactBoardRequestCurrent(
+  boardRef, generationRef, requestBoard, requestGeneration
+);
+console.log(JSON.stringify({afterB, afterReturnToA, mutations}));
+"""
+    completed = subprocess.run(
+        ["node", "-e", probe],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(completed.stdout) == {
+        "afterB": False,
+        "afterReturnToA": False,
+        "mutations": {"success": 0, "catch": 0, "finally": 0, "load": 0},
+    }
+
+
+def test_dashboard_exact_drawer_load_helper_rejects_stale_task_and_board():
+    js = _dashboard_bundle_source()
+    helper_source = js[
+        js.index("const ASSIGNEE_UNASSIGNED"):
+        js.index("// The SDK's Select component")
+    ]
+    probe = helper_source + """
+const identityA = taskDrawerIdentity("board-a", "task-1");
+const identityB = taskDrawerIdentity("board-a", "task-2");
+const identityOtherBoard = taskDrawerIdentity("board-b", "task-2");
+const state = createTaskRequestState(identityA);
+const loadA = beginTaskLoad(state, identityA);
+let rendered = null;
+let staleWrites = 0;
+
+// Linked navigation can batch close/open. Starting B must invalidate A even
+// when the component has not unmounted yet.
+const loadB = beginTaskLoad(state, identityB);
+if (isTaskLoadCurrent(state, loadB)) rendered = "task-2";
+if (isTaskLoadCurrent(state, loadA)) {
+  rendered = "task-1";
+  staleWrites += 1;
+}
+const oldIdentityActive = isTaskIdentityActive(state, identityA);
+const currentIdentityActive = isTaskIdentityActive(state, identityB);
+deactivateTaskRequests(state);
+if (isTaskLoadCurrent(state, loadB)) staleWrites += 1;
+
+console.log(JSON.stringify({
+  identitiesDiffer: identityA !== identityB && identityB !== identityOtherBoard,
+  rendered,
+  staleWrites,
+  oldIdentityActive,
+  currentIdentityActive,
+  activeAfterUnmount: isTaskIdentityActive(state, identityB)
+}));
+"""
+    completed = subprocess.run(
+        ["node", "-e", probe],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(completed.stdout) == {
+        "identitiesDiffer": True,
+        "rendered": "task-2",
+        "staleWrites": 0,
+        "oldIdentityActive": False,
+        "currentIdentityActive": True,
+        "activeAfterUnmount": False,
+    }
+
+
+def test_dashboard_owned_operation_helper_serializes_and_is_stale_safe():
+    js = _dashboard_bundle_source()
+    helper_source = js[
+        js.index("const ASSIGNEE_UNASSIGNED"):
+        js.index("// The SDK's Select component")
+    ]
+    probe = helper_source + """
+const owner = createOperationOwner();
+let profileRequests = 0;
+function beginProfileWrite(board, name, kind) {
+  const token = claimOwnedOperation(owner, {board, name, kind});
+  if (token === null) return null;
+  profileRequests += 1;
+  return token;
+}
+const saveA = beginProfileWrite("a", "alpha", "save");
+const busyOnA = operationOwnerIsBusy(owner);
+// A board transition does not touch the owner: profile endpoints are global.
+const autoBWhileABusy = beginProfileWrite("b", "beta", "auto");
+const requestsWhileABusy = profileRequests;
+const busyOnB = operationOwnerIsBusy(owner);
+const releaseA = releaseOwnedOperation(owner, saveA);
+const nextSaveB = beginProfileWrite("b", "beta", "save");
+const staleReleaseA = releaseOwnedOperation(owner, saveA);
+const bStillOwned = ownsOperation(owner, nextSaveB);
+const releaseB = releaseOwnedOperation(owner, nextSaveB);
+
+const createOwner = createOperationOwner();
+const form = {title: "retry me", workspace: "/repo", assignee: "builder"};
+const firstCreate = claimOwnedOperation(createOwner, {kind: "create-task"});
+const duplicateCreate = claimOwnedOperation(createOwner, {kind: "create-task"});
+const resetAfterReject = settleInlineCreateSubmission(createOwner, firstCreate, false);
+if (resetAfterReject) Object.keys(form).forEach((key) => { form[key] = ""; });
+const retryCreate = claimOwnedOperation(createOwner, {kind: "create-task"});
+const resetAfterSuccess = settleInlineCreateSubmission(createOwner, retryCreate, true);
+const preservedForRetry = Object.assign({}, form);
+if (resetAfterSuccess) Object.keys(form).forEach((key) => { form[key] = ""; });
+
+console.log(JSON.stringify({
+  saveClaimed: saveA !== null,
+  busyOnA,
+  secondBoardWriteBlocked: autoBWhileABusy === null,
+  requestsWhileABusy,
+  busyOnB,
+  releaseA,
+  nextBoardWriteAllowed: nextSaveB !== null,
+  profileRequests,
+  staleReleaseA,
+  bStillOwned,
+  releaseB,
+  busyAfterB: operationOwnerIsBusy(owner),
+  duplicateCreateBlocked: duplicateCreate === null,
+  resetAfterReject,
+  preservedForRetry,
+  retryClaimed: retryCreate !== null,
+  resetAfterSuccess,
+  formAfterSuccess: form
+}));
+"""
+    completed = subprocess.run(
+        ["node", "-e", probe],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(completed.stdout) == {
+        "saveClaimed": True,
+        "busyOnA": True,
+        "secondBoardWriteBlocked": True,
+        "requestsWhileABusy": 1,
+        "busyOnB": True,
+        "releaseA": True,
+        "nextBoardWriteAllowed": True,
+        "profileRequests": 2,
+        "staleReleaseA": False,
+        "bStillOwned": True,
+        "releaseB": True,
+        "busyAfterB": False,
+        "duplicateCreateBlocked": True,
+        "resetAfterReject": False,
+        "preservedForRetry": {
+            "title": "retry me",
+            "workspace": "/repo",
+            "assignee": "builder",
+        },
+        "retryClaimed": True,
+        "resetAfterSuccess": True,
+        "formAfterSuccess": {"title": "", "workspace": "", "assignee": ""},
+    }
+
+
+def test_dashboard_drawer_identity_and_accessibility_wiring():
+    js = _dashboard_bundle_source()
+    page = js[
+        js.index("function KanbanPage()"):
+        js.index("function collectDiagTasks")
+    ]
+    drawer = js[js.index("function TaskDrawer"):js.index("function _fmtBytes")]
+
+    assert "key: taskDrawerIdentity(board, selectedTaskId)" in page
+    assert drawer.index("setData(null);") < drawer.index("SDK.fetchJSON(")
+    assert "const loadToken = beginTaskLoad(" in drawer
+    assert "taskDrawerIdentity(request.board, d.task.id) !== request.identity" in drawer
+    assert "const displayedData = dataIdentity === drawerIdentity ? data : null;" in drawer
+    assert "if (props.onOpenTask) props.onOpenTask(taskId);" in drawer
+    linked_open = drawer[drawer.index("onOpenTask: function (taskId)"):]
+    linked_open = linked_open[:linked_open.index("requestDialog:")]
+    assert "props.onClose()" not in linked_open
+
+    for contract in (
+        'role: "dialog"',
+        '"aria-modal": true',
+        '"aria-labelledby": drawerHeadingId',
+        'id: drawerHeadingId',
+        "ref: closeRef",
+        "closeRef.current.focus();",
+        'if (e.key === "Escape") closeDrawer();',
+        "previousFocus.focus();",
+    ):
+        assert contract in drawer
+
+
+def test_dashboard_count_changing_task_actions_refresh_board_counts():
+    js = _dashboard_bundle_source()
+    page = js[
+        js.index("function KanbanPage()"):
+        js.index("function collectDiagTasks")
+    ]
+    drawer = js[js.index("function TaskDrawer"):js.index("function _fmtBytes")]
+
+    create = page[page.index("const createTask"):page.index("const toggleSelected")]
+    assert create.index("if (!isExactBoardRequestCurrent(") < create.index(
+        "loadBoardList();"
+    )
+
+    move = page[page.index("const performMoveTask"):page.index(
+        "// Pre-dispatch dialog step"
+    )]
+    assert move.count('if (newStatus === "archived") loadBoardList();') == 2
+
+    bulk = page[page.index("const applyBulk"):page.index("// --- board switching")]
+    assert "finalPatch.archive === true || finalPatch.status === \"archived\"" in bulk
+    assert bulk.index("if (!actionIsCurrent()) return res;") < bulk.index(
+        "loadBoardList();"
+    )
+
+    single_delete = page[page.index("const deleteTask"):page.index(
+        "const deleteSelected"
+    )]
+    bulk_delete = page[page.index("const deleteSelected"):page.index("// --- render")]
+    for delete_path in (single_delete, bulk_delete):
+        assert delete_path.index("if (!isExactBoardRequestCurrent(") < (
+            delete_path.index("loadBoardList();")
+        )
+
+    assert "onCountsRefresh: loadBoardList" in page
+    assert 'finalPatch.status === "archived" && props.onCountsRefresh' in drawer
+    assert "if (props.onCountsRefresh) props.onCountsRefresh();" in drawer
+
+
+def test_dashboard_inline_create_waits_for_success_and_surfaces_rejection():
+    js = _dashboard_bundle_source()
+    column = js[js.index("function BoardColumn"):js.index("function TaskCard")]
+    inline = js[js.index("function InlineCreate"):js.index("function TaskDrawer")]
+
+    assert "return props.onCreate(body);" in column
+    assert "onSuccess: function () { setShowCreate(false); }" in column
+    assert "const operationToken = claimOwnedOperation(" in inline
+    assert "if (operationToken === null) return Promise.resolve(null);" in inline
+    assert inline.index("return props.onSubmit(body);") < inline.index(
+        "setTitle(\"\")"
+    )
+    assert "settleInlineCreateSubmission(" in inline
+    assert "setSubmitError(tx(t, \"taskCreateFailed\"" in inline
+    assert 'role: "alert"' in inline
+    assert "disabled: submitting || !title.trim()" in inline
+
+
+def test_dashboard_task_and_bulk_completions_use_exact_board_identity():
+    js = _dashboard_bundle_source()
+    page = js[
+        js.index("function KanbanPage()"):
+        js.index("function collectDiagTasks")
+    ]
+    move = page[
+        page.index("const performMoveTask"):
+        page.index("// Pre-dispatch dialog step")
+    ]
+    apply_bulk = page[
+        page.index("const applyBulk"):
+        page.index("// --- board switching")
+    ]
+
+    assert "withBoard(`${API}/tasks/bulk`, requestBoard)" in move
+    assert "`${API}/tasks/${encodeURIComponent(taskId)}`, requestBoard" in move
+    assert move.count("if (!actionIsCurrent())") >= 3
+    assert "if (!b || !actionIsCurrent()) return b;" in move
+
+    assert "const requestBoard = board;" in apply_bulk
+    assert "const requestGeneration = boardActionGenerationRef.current;" in apply_bulk
+    assert "withBoard(`${API}/tasks/bulk`, requestBoard)" in apply_bulk
+    assert apply_bulk.count("if (!actionIsCurrent())") == 2
+    assert "if (!b || !actionIsCurrent()) return b;" in apply_bulk
+
+
+def test_dashboard_create_and_nudge_callbacks_pin_exact_board_identity():
+    js = _dashboard_bundle_source()
+    page = js[
+        js.index("function KanbanPage()"):
+        js.index("function collectDiagTasks")
+    ]
+    create = page[
+        page.index("const createTask = useCallback"):
+        page.index("const toggleSelected", page.index("const createTask = useCallback"))
+    ]
+    toolbar = page[
+        page.index("onNudgeDispatch: function ()"):
+        page.index("onRefresh: loadBoard", page.index("onNudgeDispatch: function ()"))
+    ]
+
+    # Both requests capture identity before dispatch and pin the HTTP URL to it.
+    for callback in (create, toolbar):
+        assert callback.index("const requestBoard = board;") < callback.index(
+            "SDK.fetchJSON("
+        )
+        assert callback.index(
+            "const requestGeneration = boardActionGenerationRef.current;"
+        ) < callback.index("SDK.fetchJSON(")
+        assert (
+            "boardRef, boardActionGenerationRef, requestBoard, requestGeneration,"
+        ) in callback
+    assert "withBoard(`${API}/tasks`, requestBoard)" in create
+    assert "withBoard(`${API}/dispatch?max=8`, requestBoard)" in toolbar
+
+    # Create success cannot publish A's warning or reload callbacks onto B.
+    create_guard = create.index("if (!isExactBoardRequestCurrent(")
+    assert create_guard < create.index("setError(")
+    assert create_guard < create.index("loadBoard();")
+    assert create_guard < create.index("loadBoardList();")
+
+    # Nudge success and error each independently reject stale A completion.
+    assert toolbar.count("if (!isExactBoardRequestCurrent(") == 2
+    success_guard = toolbar.index("if (!isExactBoardRequestCurrent(")
+    error_guard = toolbar.index("if (!isExactBoardRequestCurrent(", success_guard + 1)
+    assert success_guard < toolbar.index("loadBoard()")
+    assert error_guard < toolbar.index("setError(")
+
+
+def test_dashboard_board_load_and_websocket_are_generation_local():
+    js = _dashboard_bundle_source()
+    page = js[
+        js.index("function KanbanPage()"):
+        js.index("function collectDiagTasks")
+    ]
+
+    # Full-board and page-level profile loads reject stale success/error/finally.
+    assert "const boardActionGenerationRef = useRef(0);" in page
+    assert "const boardLoadGenerationRef = useRef(0);" in page
+    assert "const profilesGenerationRef = useRef(0);" in page
+    assert page.count(
+        "boardRef, boardLoadGenerationRef, requestBoard, requestGeneration,"
+    ) == 3
+    assert "SDK.fetchJSON(withBoard(`${API}/profiles`, requestBoard))" in page
+    assert page.count(
+        "boardRef, profilesGenerationRef, requestBoard, requestGeneration,"
+    ) == 2
+
+    # Each WS effect owns its close flag, socket, timer, and backoff.
+    for contract in (
+        "let closed = false;",
+        "let socket = null;",
+        "let reconnectTimer = null;",
+        "let backoff = 1000;",
+        "if (closed || boardRef.current !== socketBoard) return;",
+        "if (reconnectTimer) clearTimeout(reconnectTimer);",
+        "try { ws.close(); } catch (_e) { /* noop */ }",
+    ):
+        assert contract in page
+    assert "wsClosedRef" not in page
+    assert "wsBackoffRef" not in page
+    assert "wsRef" not in page
+
+    # The visible error-only state retries through the production exact-board
+    # helper. A callback retained from A cannot start loading after B is active.
+    error_render = page[
+        page.index("if (error && !boardData)"):
+        page.index("if (!filteredBoard)")
+    ]
+    assert "h(Button, {" in error_render
+    assert "onClick: retryBoardLoad," in error_render
+    assert 'tx(t, "retry", "Retry")' in error_render
+    assert (
+        "return retryExactBoardLoad(boardRef, board, setLoading, loadBoard);"
+        in page
+    )
+
+    helper_source = js[
+        js.index("const ASSIGNEE_UNASSIGNED"):
+        js.index("// The SDK's Select component")
+    ]
+    probe = helper_source + """
+const retryBoardRef = {current: "board-a"};
+const loadingFor = [];
+const requests = [];
+function retry(capturedBoard) {
+  return retryExactBoardLoad(
+    retryBoardRef,
+    capturedBoard,
+    function () { loadingFor.push(capturedBoard); },
+    function () {
+      requests.push(capturedBoard);
+      return Promise.resolve({board: capturedBoard});
+    }
+  );
+}
+const staleRetryA = function () { return retry("board-a"); };
+retryBoardRef.current = "board-b";
+Promise.all([staleRetryA(), retry("board-b")]).then(function (results) {
+  console.log(JSON.stringify({loadingFor, requests, results}));
+});
+"""
+    completed = subprocess.run(
+        ["node", "-e", probe],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(completed.stdout) == {
+        "loadingFor": ["board-b"],
+        "requests": ["board-b"],
+        "results": [None, {"board": "board-b"}],
+    }
+
+    # A switch invalidates work and clears every board-local interaction surface.
+    switch = page[page.index("const switchBoard"):page.index("const createNewBoard")]
+    for contract in (
+        "boardActionGenerationRef.current += 1;",
+        "boardLoadGenerationRef.current += 1;",
+        "profilesGenerationRef.current += 1;",
+        "setSelectedTaskId(null);",
+        "setShowNewBoard(false);",
+        "setShowBoardSettings(false);",
+        "setTaskEventTick({});",
+        "kanbanDialogs.cancel();",
+        "clearSelected();",
+    ):
+        assert contract in switch
+    assert "key: board" in page
+
+
+def test_dashboard_effective_roster_drives_every_assignment_surface():
+    js = _dashboard_bundle_source()
+
+    # Execute the production-used pure roster/sentinel helpers, rather than
+    # only proving their names are present in the bundle.
+    helper_source = js[
+        js.index("const ASSIGNEE_UNASSIGNED"):
+        js.index("// The SDK's Select component")
+    ]
+    probe = helper_source + """
+const names = effectiveProfileNames([
+  {name: "alpha", effective_allowed: true},
+  {name: "historical", effective_allowed: false}
+]);
+console.log(JSON.stringify({
+  names,
+  allowed: canSubmitAssignee("alpha", names, true),
+  historical: canSubmitAssignee("historical", names, true),
+  unassigned: canSubmitAssignee(ASSIGNEE_UNASSIGNED, names, true),
+  patchNone: assignmentPatchValue(ASSIGNEE_UNASSIGNED),
+  createAuto: assignmentCreateValue(ASSIGNEE_DISPATCHER),
+  normalizedAllowed: normalizeCreateAssignee("alpha", names),
+  normalizedStale: normalizeCreateAssignee("historical", names),
+  allowedPayload: {assignee: createTaskAssigneeValue("alpha", names)},
+  stalePayload: {assignee: createTaskAssigneeValue("historical", names)},
+  dispatcherPayload: {assignee: createTaskAssigneeValue(ASSIGNEE_DISPATCHER, names)},
+  sentinelsDiffer: ASSIGNEE_UNASSIGNED !== ASSIGNEE_DISPATCHER
+}));
+"""
+    completed = subprocess.run(
+        ["node", "-e", probe],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(completed.stdout) == {
+        "names": ["alpha"],
+        "allowed": True,
+        "historical": False,
+        "unassigned": True,
+        "patchNone": "",
+        "createAuto": None,
+        "normalizedAllowed": "alpha",
+        "normalizedStale": "__kanban_dispatcher__",
+        "allowedPayload": {"assignee": "alpha"},
+        "stalePayload": {"assignee": None},
+        "dispatcherPayload": {"assignee": None},
+        "sentinelsDiffer": True,
+    }
+
+    # Page roster flows through bulk, drawer/diagnostics, and create columns.
+    assert "return profilesBoard === board ? effectiveProfileNames(profiles) : [];" in js
+    assert js.count("effectiveAssignees: effectiveAssignees") >= 3
+    assert "effectiveAssignees: props.effectiveAssignees" in js
+
+    inline = js[js.index("function InlineCreate"):js.index("function TaskDrawer")]
+    assert "useState(ASSIGNEE_DISPATCHER)" in inline
+    assert "const controlledAssignee = normalizeCreateAssignee(" in inline
+    assert "if (assignee !== controlledAssignee) setAssignee(controlledAssignee);" in inline
+    assert "value: controlledAssignee" in inline
+    assert "const payloadAssignee = createTaskAssigneeValue(" in inline
+    assert "assignee, props.effectiveAssignees || []," in inline
+    assert "assignee: payloadAssignee" in inline
+    assert "props.effectiveAssignees || []" in inline
+    assert "assignee.trim()" not in inline
+
+    diagnostic = js[js.index("function DiagnosticCard"):js.index("function DiagnosticsSection")]
+    assert "value: ASSIGNEE_UNASSIGNED" in diagnostic
+    assert "profile: nextProfile || null" in diagnostic
+    assert "canSubmitAssignee(reassignProfile, effectiveAssignees, true)" in diagnostic
+
+    drawer = js[js.index("function AssigneeEditor"):js.index("function PriorityEditor")]
+    assert "value: ASSIGNEE_UNASSIGNED" in drawer
+    assert "disabled: true" in drawer
+    assert "assignee: assignmentPatchValue(v)" in drawer
+    assert "h(Input" not in drawer
+
+
 # ---------------------------------------------------------------------------
-# Final result visibility for Done cards
+# Board-scoped profile policy and orchestration settings
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def policy_boards(kanban_home):
+    profiles_root = kanban_home / "profiles"
+    for name in ("alpha", "beta", "blocked"):
+        (profiles_root / name).mkdir(parents=True)
+
+    kb.create_board("board-a", name="Board A")
+    kb.create_board("board-b", name="Board B")
+    kb.write_board_metadata("board-a", allowed_profiles=["alpha"])
+    kb.write_board_metadata("board-b", allowed_profiles=["beta"])
+
+    config_path = kanban_home / "config.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "kanban": {
+                    "allowed_profiles": ["default", "alpha", "beta"],
+                    "orchestrator_profile": "alpha",
+                    "default_assignee": "beta",
+                    "auto_decompose": True,
+                    "auto_promote_children": False,
+                },
+                "policy_test_sentinel": {"preserve": True},
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "home": kanban_home,
+        "config_path": config_path,
+        "board_a_path": kb.board_metadata_path("board-a"),
+        "board_b_path": kb.board_metadata_path("board-b"),
+    }
+
+
+def _profile_policy_flags(response):
+    assert response.status_code == 200, response.text
+    return {
+        profile["name"]: {
+            "machine_allowed": profile["machine_allowed"],
+            "board_selected": profile["board_selected"],
+            "effective_allowed": profile["effective_allowed"],
+        }
+        for profile in response.json()["profiles"]
+    }
+
+
+def test_profiles_are_all_visible_with_board_scoped_policy_flags(
+    client, policy_boards,
+):
+    # A raw board subset can select a machine-blocked profile. It remains
+    # visible and selected, but can never become effectively assignable.
+    kb.write_board_metadata(
+        "board-a",
+        allowed_profiles=["alpha", "blocked"],
+    )
+
+    assert _profile_policy_flags(
+        client.get("/api/plugins/kanban/profiles?board=board-a")
+    ) == {
+        "default": {
+            "machine_allowed": True,
+            "board_selected": False,
+            "effective_allowed": False,
+        },
+        "alpha": {
+            "machine_allowed": True,
+            "board_selected": True,
+            "effective_allowed": True,
+        },
+        "beta": {
+            "machine_allowed": True,
+            "board_selected": False,
+            "effective_allowed": False,
+        },
+        "blocked": {
+            "machine_allowed": False,
+            "board_selected": True,
+            "effective_allowed": False,
+        },
+    }
+    assert _profile_policy_flags(
+        client.get("/api/plugins/kanban/profiles?board=board-b")
+    ) == {
+        "default": {
+            "machine_allowed": True,
+            "board_selected": False,
+            "effective_allowed": False,
+        },
+        "alpha": {
+            "machine_allowed": True,
+            "board_selected": False,
+            "effective_allowed": False,
+        },
+        "beta": {
+            "machine_allowed": True,
+            "board_selected": True,
+            "effective_allowed": True,
+        },
+        "blocked": {
+            "machine_allowed": False,
+            "board_selected": False,
+            "effective_allowed": False,
+        },
+    }
+
+    # Omitting board follows the current board selected by the connection.
+    kb.set_current_board("board-b")
+    assert _profile_policy_flags(
+        client.get("/api/plugins/kanban/profiles")
+    ) == _profile_policy_flags(
+        client.get("/api/plugins/kanban/profiles?board=board-b")
+    )
+
+
+def test_get_orchestration_reports_raw_effective_and_resolved_per_board(
+    client, policy_boards,
+):
+    board_a = client.get(
+        "/api/plugins/kanban/orchestration?board=board-a"
+    )
+    assert board_a.status_code == 200, board_a.text
+    assert board_a.json() == {
+        "board": "board-a",
+        "orchestrator_profile": "alpha",
+        "default_assignee": "beta",
+        "auto_decompose": True,
+        "auto_promote_children": False,
+        "resolved_orchestrator_profile": "alpha",
+        "resolved_default_assignee": "alpha",
+        "active_profile": "default",
+        "board_allowed_profiles": ["alpha"],
+        "effective_allowed_profiles": ["alpha"],
+    }
+
+    board_b = client.get(
+        "/api/plugins/kanban/orchestration?board=board-b"
+    )
+    assert board_b.status_code == 200, board_b.text
+    assert board_b.json()["board"] == "board-b"
+    assert board_b.json()["board_allowed_profiles"] == ["beta"]
+    assert board_b.json()["effective_allowed_profiles"] == ["beta"]
+    assert board_b.json()["resolved_orchestrator_profile"] == "beta"
+    assert board_b.json()["resolved_default_assignee"] == "beta"
+
+    kb.write_board_metadata("board-a", allowed_profiles=[])
+    empty = client.get(
+        "/api/plugins/kanban/orchestration?board=board-a"
+    )
+    assert empty.status_code == 200, empty.text
+    assert empty.json()["board_allowed_profiles"] == []
+    assert empty.json()["effective_allowed_profiles"] == []
+    assert empty.json()["resolved_orchestrator_profile"] is None
+    assert empty.json()["resolved_default_assignee"] is None
+
+    kb.set_current_board("board-b")
+    current = client.get("/api/plugins/kanban/orchestration")
+    assert current.status_code == 200, current.text
+    assert current.json()["board"] == "board-b"
+    assert current.json()["effective_allowed_profiles"] == ["beta"]
+
+
+def test_get_policy_endpoints_fail_closed_for_non_mapping_kanban_config(
+    client, policy_boards,
+):
+    config_path = policy_boards["config_path"]
+    board_path = policy_boards["board_a_path"]
+    config_path.write_text(
+        json.dumps(
+            {
+                "kanban": ["not", "a", "mapping"],
+                "policy_test_sentinel": {"preserve": True},
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config_before = config_path.read_bytes()
+    board_before = board_path.read_bytes()
+
+    roster = client.get("/api/plugins/kanban/profiles?board=board-a")
+    assert roster.status_code == 200, roster.text
+    assert all(
+        not profile["machine_allowed"] and not profile["effective_allowed"]
+        for profile in roster.json()["profiles"]
+    )
+
+    settings = client.get(
+        "/api/plugins/kanban/orchestration?board=board-a"
+    )
+    assert settings.status_code == 200, settings.text
+    assert settings.json()["orchestrator_profile"] == ""
+    assert settings.json()["default_assignee"] == ""
+    assert settings.json()["auto_decompose"] is True
+    assert settings.json()["auto_promote_children"] is True
+    assert settings.json()["board_allowed_profiles"] == ["alpha"]
+    assert settings.json()["effective_allowed_profiles"] == []
+    assert settings.json()["resolved_orchestrator_profile"] is None
+    assert settings.json()["resolved_default_assignee"] is None
+    assert config_path.read_bytes() == config_before
+    assert board_path.read_bytes() == board_before
+
+
+def test_get_orchestration_uses_safe_defaults_for_malformed_config_leaves(
+    client, policy_boards,
+):
+    config_path = policy_boards["config_path"]
+    board_path = policy_boards["board_a_path"]
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["kanban"].update(
+        {
+            "orchestrator_profile": [],
+            "default_assignee": {"profile": "beta"},
+            "auto_decompose": "false",
+        }
+    )
+    config_path.write_text(
+        json.dumps(config, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    config_before = config_path.read_bytes()
+    board_before = board_path.read_bytes()
+    other_board_before = policy_boards["board_b_path"].read_bytes()
+
+    response = client.get(
+        "/api/plugins/kanban/orchestration?board=board-a"
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "board": "board-a",
+        "orchestrator_profile": "",
+        "default_assignee": "",
+        "auto_decompose": True,
+        "auto_promote_children": False,
+        "resolved_orchestrator_profile": "alpha",
+        "resolved_default_assignee": "alpha",
+        "active_profile": "default",
+        "board_allowed_profiles": ["alpha"],
+        "effective_allowed_profiles": ["alpha"],
+    }
+    assert config_path.read_bytes() == config_before
+    assert board_path.read_bytes() == board_before
+    assert policy_boards["board_b_path"].read_bytes() == other_board_before
+
+
+def test_put_preserves_unrelated_malformed_config_leaves(
+    client, policy_boards,
+):
+    from hermes_cli.config import read_raw_config
+
+    config_path = policy_boards["config_path"]
+    board_path = policy_boards["board_a_path"]
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["kanban"].update(
+        {
+            "orchestrator_profile": [],
+            "default_assignee": {"profile": "beta"},
+            "auto_decompose": "false",
+        }
+    )
+    config_path.write_text(
+        json.dumps(config, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    board_before = board_path.read_bytes()
+    other_board_before = policy_boards["board_b_path"].read_bytes()
+
+    response = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={"auto_promote_children": True},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["orchestrator_profile"] == ""
+    assert response.json()["default_assignee"] == ""
+    assert response.json()["auto_decompose"] is True
+    assert response.json()["auto_promote_children"] is True
+    assert response.json()["resolved_orchestrator_profile"] == "alpha"
+    assert response.json()["resolved_default_assignee"] == "alpha"
+    assert response.json()["effective_allowed_profiles"] == ["alpha"]
+
+    config["kanban"]["auto_promote_children"] = True
+    saved_config = read_raw_config()
+    assert isinstance(saved_config.pop("_config_version"), int)
+    assert saved_config == config
+    assert board_path.read_bytes() == board_before
+    assert policy_boards["board_b_path"].read_bytes() == other_board_before
+
+
+def test_put_allowed_profiles_tri_state_isolated_and_config_write_free(
+    client, policy_boards,
+):
+    config_path = policy_boards["config_path"]
+    board_b_path = policy_boards["board_b_path"]
+    original_config = config_path.read_bytes()
+    original_board_b = board_b_path.read_bytes()
+
+    selected = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={"allowed_profiles": [" Alpha ", "alpha"]},
+    )
+    assert selected.status_code == 200, selected.text
+    assert selected.json()["board_allowed_profiles"] == ["alpha"]
+    assert kb.read_board_metadata("board-a")["allowed_profiles"] == ["alpha"]
+    assert config_path.read_bytes() == original_config
+    assert board_b_path.read_bytes() == original_board_b
+
+    inherited = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={"allowed_profiles": None},
+    )
+    assert inherited.status_code == 200, inherited.text
+    assert inherited.json()["board_allowed_profiles"] is None
+    assert inherited.json()["effective_allowed_profiles"] == [
+        "alpha",
+        "beta",
+        "default",
+    ]
+    assert config_path.read_bytes() == original_config
+    assert board_b_path.read_bytes() == original_board_b
+
+    empty = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={"allowed_profiles": []},
+    )
+    assert empty.status_code == 200, empty.text
+    assert empty.json()["board_allowed_profiles"] == []
+    assert config_path.read_bytes() == original_config
+    assert board_b_path.read_bytes() == original_board_b
+
+    # Omitting allowed_profiles preserves the explicit empty board policy.
+    global_update = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={"auto_decompose": False},
+    )
+    assert global_update.status_code == 200, global_update.text
+    assert kb.read_board_metadata("board-a")["allowed_profiles"] == []
+    assert kb.read_board_metadata("board-b")["allowed_profiles"] == ["beta"]
+
+    # A no-board PUT follows the connection/current board instead of default.
+    config_after_global_update = config_path.read_bytes()
+    kb.set_current_board("board-b")
+    current_update = client.put(
+        "/api/plugins/kanban/orchestration",
+        json={"allowed_profiles": ["alpha"]},
+    )
+    assert current_update.status_code == 200, current_update.text
+    assert current_update.json()["board"] == "board-b"
+    assert kb.read_board_metadata("board-a")["allowed_profiles"] == []
+    assert kb.read_board_metadata("board-b")["allowed_profiles"] == ["alpha"]
+    assert config_path.read_bytes() == config_after_global_update
+
+
+def test_put_keeps_global_writes_and_scopes_new_policy_to_requested_board(
+    client, policy_boards,
+):
+    board_b_before = policy_boards["board_b_path"].read_bytes()
+
+    response = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={
+            "allowed_profiles": [" Beta ", "beta"],
+            "orchestrator_profile": "BETA",
+            "default_assignee": "beta",
+            "auto_decompose": False,
+            "auto_promote_children": True,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["board_allowed_profiles"] == ["beta"]
+    assert response.json()["resolved_orchestrator_profile"] == "beta"
+    assert response.json()["resolved_default_assignee"] == "beta"
+    assert response.json()["auto_decompose"] is False
+    assert response.json()["auto_promote_children"] is True
+    assert kb.read_board_metadata("board-a")["allowed_profiles"] == ["beta"]
+    assert policy_boards["board_b_path"].read_bytes() == board_b_before
+
+    from hermes_cli.config import load_config
+
+    kanban_config = load_config()["kanban"]
+    assert kanban_config["allowed_profiles"] == ["default", "alpha", "beta"]
+    assert kanban_config["orchestrator_profile"] == "beta"
+    assert kanban_config["default_assignee"] == "beta"
+    assert kanban_config["auto_decompose"] is False
+    assert kanban_config["auto_promote_children"] is True
+
+
+@pytest.mark.parametrize(
+    ("allowed_profiles", "detail_fragment"),
+    [
+        (["bad/name"], "invalid"),
+        ([123], "invalid"),
+        (["missing"], "does not exist"),
+        (["blocked"], "machine ceiling"),
+    ],
+)
+def test_put_rejects_invalid_uninstalled_or_machine_blocked_board_profiles(
+    client, policy_boards, allowed_profiles, detail_fragment,
+):
+    board_path = policy_boards["board_a_path"]
+    config_path = policy_boards["config_path"]
+    board_before = board_path.read_bytes()
+    config_before = config_path.read_bytes()
+
+    response = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={"allowed_profiles": allowed_profiles},
+    )
+
+    assert response.status_code == 400, response.text
+    assert detail_fragment in response.json()["detail"].lower()
+    assert board_path.read_bytes() == board_before
+    assert config_path.read_bytes() == config_before
+
+
+@pytest.mark.parametrize("selector", ["orchestrator_profile", "default_assignee"])
+def test_put_rejects_selector_disallowed_by_prospective_board_policy_atomically(
+    client, policy_boards, selector,
+):
+    board_path = policy_boards["board_a_path"]
+    config_path = policy_boards["config_path"]
+    board_before = board_path.read_bytes()
+    config_before = config_path.read_bytes()
+
+    response = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={"allowed_profiles": ["beta"], selector: "alpha"},
+    )
+
+    assert response.status_code == 400, response.text
+    assert "board" in response.json()["detail"].lower()
+    assert board_path.read_bytes() == board_before
+    assert config_path.read_bytes() == config_before
+
+
+def test_policy_endpoints_reject_unknown_board_without_mutation(
+    client, policy_boards,
+):
+    config_path = policy_boards["config_path"]
+    config_before = config_path.read_bytes()
+
+    for method, path, kwargs in (
+        ("get", "/api/plugins/kanban/profiles?board=unknown", {}),
+        ("get", "/api/plugins/kanban/orchestration?board=unknown", {}),
+        (
+            "put",
+            "/api/plugins/kanban/orchestration?board=unknown",
+            {"json": {"allowed_profiles": ["alpha"]}},
+        ),
+    ):
+        response = getattr(client, method)(path, **kwargs)
+        assert response.status_code == 404, response.text
+
+    assert not kb.board_exists("unknown")
+    assert config_path.read_bytes() == config_before
+
+
+@pytest.mark.parametrize(
+    ("malformed_config", "detail_fragment"),
+    [
+        (["not", "a", "mapping"], "root"),
+        ({"kanban": ["not", "a", "mapping"]}, "kanban"),
+    ],
+)
+def test_put_refuses_malformed_global_config_before_any_mixed_write(
+    client, policy_boards, malformed_config, detail_fragment,
+):
+    config_path = policy_boards["config_path"]
+    board_path = policy_boards["board_a_path"]
+    config_path.write_text(
+        json.dumps(malformed_config, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    config_before = config_path.read_bytes()
+    board_before = board_path.read_bytes()
+
+    response = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={"allowed_profiles": [], "auto_decompose": False},
+    )
+
+    assert response.status_code == 500, response.text
+    detail = response.json()["detail"].lower()
+    assert "malformed config" in detail
+    assert detail_fragment in detail
+    assert config_path.read_bytes() == config_before
+    assert board_path.read_bytes() == board_before
+
+
+def test_policy_only_put_remains_config_write_free_with_malformed_global_config(
+    client, policy_boards,
+):
+    config_path = policy_boards["config_path"]
+    config_path.write_text('["malformed-root"]\n', encoding="utf-8")
+    config_before = config_path.read_bytes()
+
+    response = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={"allowed_profiles": []},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["board_allowed_profiles"] == []
+    assert config_path.read_bytes() == config_before
+    assert kb.read_board_metadata("board-a")["allowed_profiles"] == []
+
+
+def test_malformed_board_policy_is_reported_and_validated_fail_closed(
+    client, policy_boards,
+):
+    board_path = policy_boards["board_a_path"]
+    config_path = policy_boards["config_path"]
+    malformed_metadata = {
+        "slug": "board-a",
+        "name": "Board A",
+        "allowed_profiles": "alpha",
+        "policy_test_sentinel": {"preserve": True},
+    }
+    board_path.write_text(
+        json.dumps(malformed_metadata, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    roster = client.get("/api/plugins/kanban/profiles?board=board-a")
+    assert roster.status_code == 200, roster.text
+    assert all(
+        not profile["board_selected"] and not profile["effective_allowed"]
+        for profile in roster.json()["profiles"]
+    )
+
+    settings = client.get(
+        "/api/plugins/kanban/orchestration?board=board-a"
+    )
+    assert settings.status_code == 200, settings.text
+    assert settings.json()["board_allowed_profiles"] == []
+    assert settings.json()["effective_allowed_profiles"] == []
+
+    board_before = board_path.read_bytes()
+    config_before = config_path.read_bytes()
+    rejected = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={"orchestrator_profile": "alpha"},
+    )
+    assert rejected.status_code == 400, rejected.text
+    assert "effective policy" in rejected.json()["detail"].lower()
+    assert board_path.read_bytes() == board_before
+    assert config_path.read_bytes() == config_before
+
+    repaired = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={"allowed_profiles": ["alpha"]},
+    )
+    assert repaired.status_code == 200, repaired.text
+    assert repaired.json()["board_allowed_profiles"] == ["alpha"]
+    assert kb.read_board_metadata("board-a")["policy_test_sentinel"] == {
+        "preserve": True,
+    }
+    assert config_path.read_bytes() == config_before
+
+
+def test_mixed_put_saves_config_before_board_and_leaves_board_on_config_failure(
+    client, policy_boards, monkeypatch,
+):
+    from hermes_cli import config as config_mod
+
+    config_path = policy_boards["config_path"]
+    board_path = policy_boards["board_a_path"]
+    config_before = config_path.read_bytes()
+    board_before = board_path.read_bytes()
+    calls = []
+
+    def fail_config_save(_cfg):
+        calls.append("config")
+        raise OSError("config save exploded")
+
+    def unexpected_board_write(*_args, **_kwargs):
+        calls.append("board")
+        raise AssertionError("board write ran before config save completed")
+
+    monkeypatch.setattr(config_mod, "save_config", fail_config_save)
+    monkeypatch.setattr(kb, "write_board_metadata", unexpected_board_write)
+
+    response = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={
+            "allowed_profiles": ["beta"],
+            "orchestrator_profile": "beta",
+        },
+    )
+
+    assert response.status_code == 500, response.text
+    assert "failed to save config" in response.json()["detail"].lower()
+    assert calls == ["config"]
+    assert config_path.read_bytes() == config_before
+    assert board_path.read_bytes() == board_before
+
+
+def test_mixed_put_rolls_config_back_when_board_write_fails(
+    client, policy_boards, monkeypatch,
+):
+    from hermes_cli import config as config_mod
+
+    original_save_config = config_mod.save_config
+    original_config = config_mod.load_config()
+    board_path = policy_boards["board_a_path"]
+    board_before = board_path.read_bytes()
+    calls = []
+
+    def recording_save(cfg):
+        calls.append("config")
+        original_save_config(cfg)
+
+    def fail_board_write(*_args, **_kwargs):
+        calls.append("board")
+        assert config_mod.load_config()["kanban"]["orchestrator_profile"] == "beta"
+        raise OSError("board write exploded")
+
+    monkeypatch.setattr(config_mod, "save_config", recording_save)
+    monkeypatch.setattr(kb, "write_board_metadata", fail_board_write)
+
+    response = client.put(
+        "/api/plugins/kanban/orchestration?board=board-a",
+        json={
+            "allowed_profiles": ["beta"],
+            "orchestrator_profile": "beta",
+        },
+    )
+
+    assert response.status_code == 500, response.text
+    assert "config restored" in response.json()["detail"].lower()
+    assert calls == ["config", "board", "config"]
+    assert config_mod.load_config() == original_config
+    assert board_path.read_bytes() == board_before
+
+
+def test_mixed_put_reports_config_rollback_failure(
+    client, policy_boards, monkeypatch, caplog,
+):
+    from hermes_cli import config as config_mod
+
+    original_save_config = config_mod.save_config
+    board_path = policy_boards["board_a_path"]
+    board_before = board_path.read_bytes()
+    save_calls = 0
+
+    def fail_second_save(cfg):
+        nonlocal save_calls
+        save_calls += 1
+        if save_calls == 2:
+            raise OSError("rollback exploded")
+        original_save_config(cfg)
+
+    def fail_board_write(*_args, **_kwargs):
+        raise OSError("board write exploded")
+
+    monkeypatch.setattr(config_mod, "save_config", fail_second_save)
+    monkeypatch.setattr(kb, "write_board_metadata", fail_board_write)
+
+    with caplog.at_level("ERROR"):
+        response = client.put(
+            "/api/plugins/kanban/orchestration?board=board-a",
+            json={
+                "allowed_profiles": ["beta"],
+                "orchestrator_profile": "beta",
+            },
+        )
+
+    assert response.status_code == 500, response.text
+    detail = response.json()["detail"].lower()
+    assert "board write exploded" in detail
+    assert "rollback failed" in detail
+    assert "rollback exploded" in detail
+    assert "rollback exploded" in caplog.text
+    assert save_calls == 2
+    assert board_path.read_bytes() == board_before
+
+
+def test_mixed_put_transaction_serializes_rollback_before_later_success(
+    client, policy_boards, monkeypatch,
+):
+    """A failed mixed write cannot roll stale config over a later success."""
+    from hermes_cli import config as config_mod
+
+    original_save_config = config_mod.save_config
+    original_write_board_metadata = kb.write_board_metadata
+    first_save_entered = threading.Event()
+    release_first_save = threading.Event()
+    second_save_entered = threading.Event()
+    second_start = threading.Barrier(2)
+    responses = {}
+    save_calls = []
+    board_calls = []
+
+    def controlled_save(cfg):
+        kanban_cfg = cfg["kanban"]
+        profile = kanban_cfg["orchestrator_profile"]
+        auto_decompose = kanban_cfg["auto_decompose"]
+        save_calls.append((profile, auto_decompose))
+        if profile == "beta":
+            first_save_entered.set()
+            assert release_first_save.wait(5), "timed out releasing first config save"
+        elif profile == "alpha" and auto_decompose is False:
+            second_save_entered.set()
+        original_save_config(cfg)
+
+    def fail_first_board_write(*args, **kwargs):
+        allowed = kwargs.get("allowed_profiles")
+        board_calls.append(tuple(allowed) if allowed is not None else None)
+        if allowed == ["beta"]:
+            raise OSError("first board write exploded")
+        return original_write_board_metadata(*args, **kwargs)
+
+    def run_first_request():
+        responses["first"] = TestClient(client.app).put(
+            "/api/plugins/kanban/orchestration?board=board-a",
+            json={
+                "allowed_profiles": ["beta"],
+                "orchestrator_profile": "beta",
+            },
+        )
+
+    def run_second_request():
+        second_start.wait()
+        responses["second"] = TestClient(client.app).put(
+            "/api/plugins/kanban/orchestration?board=board-a",
+            json={
+                "allowed_profiles": ["alpha"],
+                "orchestrator_profile": "alpha",
+                "auto_decompose": False,
+            },
+        )
+
+    monkeypatch.setattr(config_mod, "save_config", controlled_save)
+    monkeypatch.setattr(kb, "write_board_metadata", fail_first_board_write)
+
+    first_thread = threading.Thread(target=run_first_request, name="first-mixed-put")
+    second_thread = threading.Thread(target=run_second_request, name="second-mixed-put")
+    first_thread.start()
+    try:
+        assert first_save_entered.wait(5), "first request never entered config save"
+        second_thread.start()
+        second_start.wait()
+        assert not second_save_entered.wait(0.5), (
+            "second request entered config save while the first mixed transaction "
+            "was blocked"
+        )
+    finally:
+        release_first_save.set()
+        first_thread.join(5)
+        if second_thread.ident is not None:
+            second_thread.join(5)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert responses["first"].status_code == 500, responses["first"].text
+    assert "config restored" in responses["first"].json()["detail"].lower()
+    assert responses["second"].status_code == 200, responses["second"].text
+    assert save_calls == [
+        ("beta", True),
+        ("alpha", True),
+        ("alpha", False),
+    ]
+    assert board_calls == [("beta",), ("alpha",)]
+    assert config_mod.load_config()["kanban"]["orchestrator_profile"] == "alpha"
+    assert config_mod.load_config()["kanban"]["auto_decompose"] is False
+    assert kb.read_board_metadata("board-a")["allowed_profiles"] == ["alpha"]
+
+    plugin_module = sys.modules["hermes_dashboard_plugin_kanban_test"]
+    transaction_lock = plugin_module._ORCHESTRATION_MUTATION_LOCK
+    assert transaction_lock.acquire(blocking=False), (
+        "orchestration transaction lock remained held after the board-write exception"
+    )
+    transaction_lock.release()

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -153,6 +153,11 @@ matters.
   inherits (git repo → preserved worktree, plain dir → preserved
   directory); each task can still override it at creation time. Clearing
   the field reverts new tasks to disposable scratch workspaces.
+- **Orchestration settings** — expand the panel to set **Profiles allowed
+  on this board**. You can inherit the machine ceiling, select profiles
+  from an explicit checklist, or explicitly allow none. Profiles excluded
+  by the machine ceiling remain visible but disabled because a board cannot
+  re-enable them.
 - **Archive** — only shown on non-`default` boards. Confirms, then moves
   the board dir to `boards/_archived/`.
 
@@ -601,7 +606,7 @@ The kanban board has two ways to handle a task you drop into the Triage column:
 
 Flip between the two modes from the **Orchestration: Auto/Manual** pill at the top of the kanban page (emerald = Auto, muted gray = Manual), or by editing `config.yaml` directly. Both modes coexist with `hermes kanban specify` — that's still available as a single-task spec rewrite when you don't want fan-out.
 
-The decomposer's routing decisions depend on profile descriptions, which is a per-profile labeling primitive you set with `hermes profile create --description "..."`, `hermes profile describe <name> --text "..."`, `hermes profile describe <name> --auto` (LLM-generates from the profile's installed skills + model), or the dashboard's per-profile editor in the expanded **Orchestration settings** panel. Profiles without a description still appear in the roster — they're routable by name, just less precisely. The decomposer NEVER lands a child task with `assignee=None`: when the LLM picks an unknown profile, the child gets routed to `kanban.default_assignee` (or the active default profile if that's unset).
+The decomposer's routing decisions depend on profile descriptions, which is a per-profile labeling primitive you set with `hermes profile create --description "..."`, `hermes profile describe <name> --text "..."`, `hermes profile describe <name> --auto` (LLM-generates from the profile's installed skills + model), or the dashboard's per-profile editor in the expanded **Orchestration settings** panel. Profiles without a description still appear in the roster — they're routable by name, just less precisely. Routing and assignment use the active board's effective profile set: the machine ceiling intersected with the board's selection. The decomposer NEVER lands a child task with `assignee=None`: when the LLM picks an unknown profile, it tries `kanban.default_assignee` (or the active default profile if that's unset), subject to the same effective board policy.
 
 `kanban.orchestrator_profile` does not load that profile's prompt, skills, or custom logic into the decomposition call. It controls who owns the root/orchestration task after fan-out. To change the decomposer's model/provider, configure `auxiliary.kanban_decomposer`. To use a profile's custom task-splitting logic instead of the built-in decomposer, switch to Manual mode and have that profile create or decompose tasks explicitly.
 
@@ -609,6 +614,7 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 
 | Key | Default | Purpose |
 |---|---|---|
+| `allowed_profiles` | `null` | Machine-wide Kanban safety ceiling that boards may inherit or narrow. `null` is unrestricted; `[]` permits no profiles. No board or named profile can widen this ceiling. |
 | `auto_decompose` | `true` | Dispatcher auto-runs the built-in decomposer for Triage tasks every tick. It does not gate profile-driven `kanban_create` calls or creator wake turns. |
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
@@ -622,6 +628,39 @@ And the two auxiliary LLM slots:
 |---|---|
 | `auxiliary.kanban_decomposer` | Model that produces the task graph (called by Decompose). Set `provider`/`model` to override the main chat model. |
 | `auxiliary.profile_describer` | Model that auto-generates profile descriptions (called by `hermes profile describe --auto`). |
+
+### Profile assignment policy
+
+`kanban.allowed_profiles` in shared `~/.hermes/config.yaml` sets the machine
+safety ceiling. Each board may persist its own `allowed_profiles` selection
+in that board's `board.json` under Hermes home. Among installed profiles, the
+effective assignment set is the machine ceiling intersected with the board
+selection:
+
+| Machine `kanban.allowed_profiles` | Board `allowed_profiles` | Effective assignment set |
+|---|---|---|
+| `null` | absent or `null` | All installed profiles |
+| `null` | `[]` | No profiles |
+| `null` | Nonempty list | The board list |
+| Nonempty list | absent or `null` | The machine list |
+| Nonempty list | `[]` | No profiles |
+| Nonempty list | Nonempty list | Profiles present in both lists |
+| `[]` | Any value | No profiles |
+
+An absent board field therefore preserves existing-board behavior and needs
+no migration. The effective set is enforced for creation, reassignment,
+triage and decomposition, review handoff and restoration, dashboard rosters
+and selectors, and both normal and review dispatch. Named-profile configs and
+gateways cannot bypass the shared machine ceiling. Tightening either layer
+does not hide historical cards, but a card assigned to a now-excluded profile
+will not dispatch until it is reassigned or the policy changes.
+
+#### Update durability
+
+Policy state lives under Hermes home: the machine ceiling in `config.yaml`
+and each board selection in its `board.json`. Hermes source updates do not
+overwrite these files. This persistence guarantee covers policy data only;
+source-code and update integration are separate concerns.
 
 ### Architecture
 
@@ -663,11 +702,11 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 | `POST` | `/tasks/:id/comments` | Append a comment |
 | `POST` | `/tasks/:id/specify` | Run the triage specifier — auxiliary LLM fleshes out the task body and promotes it from `triage` to `todo`. Returns `{ok, task_id, reason, new_title}`; `ok=false` with a human-readable reason on "not in triage" / no aux client / LLM error is a 200, not a 4xx |
 | `POST` | `/tasks/:id/decompose` | Run the kanban decomposer — auxiliary LLM produces a task graph and the helper atomically creates the children + links the root + flips `triage → todo`. Returns `{ok, task_id, reason, fanout, child_ids, new_title}`. Same 200-on-LLM-error convention as `/specify`. |
-| `GET` | `/profiles` | List installed profiles with their descriptions (consumed by the dashboard's profile-description editor and the orchestrator picker). |
+| `GET` | `/profiles?board=<slug>` | List every installed profile with its description plus machine-ceiling, board-selection, and effective-eligibility flags for the selected board. |
 | `PATCH` | `/profiles/:name` | Set or clear a profile's description (user-authored — `description_auto: false`). Returns `{ok, profile, description}`. |
 | `POST` | `/profiles/:name/describe-auto` | Generate a description for a profile via `auxiliary.profile_describer`. Persists with `description_auto: true` so the dashboard can surface a "review" badge. |
-| `GET` | `/orchestration` | Read the kanban orchestration settings (`orchestrator_profile`, `default_assignee`, `auto_decompose`) plus the *resolved* effective values after fallbacks. |
-| `PUT` | `/orchestration` | Update one or more of the three orchestration keys in `config.yaml`. Validates that non-empty profile names actually exist. |
+| `GET` | `/orchestration?board=<slug>` | Read the global orchestration settings and resolved fallbacks, plus the board's `allowed_profiles` policy and effective profile list. |
+| `PUT` | `/orchestration?board=<slug>` | Update orchestration settings. `allowed_profiles: null` makes this board inherit the machine ceiling; a list stores an explicit board selection, including `[]` for allow none. Other orchestration keys remain global. |
 | `POST` | `/links` | Add a dependency (`parent_id` → `child_id`) |
 | `DELETE` | `/links?parent_id=…&child_id=…` | Remove a dependency |
 | `POST` | `/dispatch?max=…&dry_run=…` | Nudge the dispatcher — skip the 60 s wait |


### PR DESCRIPTION
## What does this PR do?

Adds an optional per-board Kanban assignment policy while preserving `kanban.allowed_profiles` as the administrator-controlled machine safety ceiling.

Each board can persist `allowed_profiles` in `board.json`:

- absent or `null`: inherit the machine ceiling
- `[]`: deny all new assignments
- non-empty list: allow only the intersection with the machine ceiling

Existing boards require no migration. Malformed policy fails closed, historical cards remain visible, and unassignment stays legal.

## Related Issue

No matching open issue, open PR, or merged PR was found after searching for Kanban board/profile policy terms.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added tri-state `allowed_profiles` persistence to board metadata with strict validation and atomic writes.
- Resolved effective policy from the shared machine ceiling and connection-scoped board identity.
- Enforced policy before assignment, reassignment/reclaim, decomposition, review handoff/restoration, default routing, and normal/review dispatch.
- Added board-scoped dashboard API fields and serialized mixed config/board writes with rollback safety.
- Added canonical desktop and shipped legacy-dashboard controls for inherit, explicit selection, and allow-none modes.
- Kept machine-blocked profiles visible but disabled and preserved single/bulk unassignment on deny-all boards.
- Added race/stale-response protections across board switching and mutations.
- Added Python, React/Vitest, and real shipped-bundle Playwright regression coverage.
- Documented policy semantics, REST behavior, persistence, and the example config key.

## How to Test

1. Run the focused backend/API suites:
   `pytest -q tests/hermes_cli/test_kanban_allowed_profiles.py tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py tests/plugins/test_kanban_dashboard_plugin.py`
2. Run the review/dispatch sibling suites listed in the changed tests.
3. In `apps/desktop`, run:
   `npx vitest run --project ui src/plugins/kanban/orchestration.test.tsx`
   `npm run typecheck`
   `npm run build`
4. Run Ruff, `py_compile`, Node syntax checks, ESLint, Prettier, and `git diff --check` on the changed files.

Verified on the rebased upstream tree:

- Python: 232 passed, 1 optional-ACP skip
- Desktop Vitest: 33 passed
- Three TypeScript configs, ESLint, Prettier, and production build: passed
- Ruff, `py_compile`, Node syntax, and diff checks: passed
- Shipped legacy bundle in Chromium: 6 behavioral checks passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs/issues and found no duplicate
- [x] This PR contains only changes related to this feature
- [ ] I ran the complete `pytest tests/ -q` repository suite (focused and sibling suites above were run instead)
- [x] I added behavioral tests for the changes
- [x] I tested on macOS

### Documentation & Housekeeping

- [x] I updated the relevant user documentation
- [x] I updated `cli-config.yaml.example`
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A; architecture and workflows are unchanged
- [x] I considered cross-platform impact; production changes use existing Python/SQLite/React abstractions
- [x] Tool descriptions/schemas are N/A

## Screenshots / Logs

Real shipped-bundle Playwright result:

```json
{"ok":true,"board":"beta","put_url":"/api/plugins/kanban/orchestration?board=beta","put_body":{"allowed_profiles":[]},"checks":6}
```
