### PR TITLE
fix(dashboard): restore Shift+Enter newline in the embedded TUI

### DIFF
--- a/web/src/lib/pty-keyboard-shortcuts.test.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.test.ts
@@ -44,6 +44,32 @@ describe('resolvePtyKeyboardShortcut', () => {
       resolvePtyKeyboardShortcut(key({ ctrlKey: true, key: 'Delete' }), false, false),
     ).toBe('delete-word-forward')
   })
+
+  it('maps Shift+Enter to newline insertion', () => {
+    expect(
+      resolvePtyKeyboardShortcut(key({ shiftKey: true, key: 'Enter' }), false, false),
+    ).toBe('insert-newline')
+  })
+
+  it('maps Alt+Enter to newline insertion', () => {
+    expect(
+      resolvePtyKeyboardShortcut(key({ altKey: true, key: 'Enter' }), false, false),
+    ).toBe('insert-newline')
+  })
+
+  it('leaves plain Enter to xterm (submit)', () => {
+    expect(resolvePtyKeyboardShortcut(key({ key: 'Enter' }), false, false)).toBe('pass')
+  })
+
+  it('does not hijack Ctrl+Shift+Enter', () => {
+    expect(
+      resolvePtyKeyboardShortcut(
+        key({ ctrlKey: true, shiftKey: true, key: 'Enter' }),
+        false,
+        false,
+      ),
+    ).toBe('pass')
+  })
 })
 
 describe('sendPtyShortcutSequence', () => {

--- a/web/src/lib/pty-keyboard-shortcuts.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.ts
@@ -6,6 +6,7 @@ export type PtyKeyboardShortcut =
   | "copy"
   | "delete-word-backward"
   | "delete-word-forward"
+  | "insert-newline"
   | "pass";
 
 export function resolvePtyKeyboardShortcut(
@@ -40,6 +41,15 @@ export function resolvePtyKeyboardShortcut(
     ev.key === "Delete"
   ) {
     return "delete-word-forward";
+  }
+
+  if (
+    ((ev.shiftKey && !ev.altKey) || (ev.altKey && !ev.shiftKey)) &&
+    !ev.ctrlKey &&
+    !ev.metaKey &&
+    ev.key === "Enter"
+  ) {
+    return "insert-newline";
   }
 
   return "pass";

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -723,6 +723,27 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         return false;
       }
 
+      // Shift+Enter / Alt+Enter → insert newline in the composer. xterm.js
+      // sends a bare \r for Enter regardless of held modifiers, so the TUI
+      // can never tell Shift/Alt+Enter apart from plain Enter (which submits
+      // the draft). Send the kitty-protocol CSI-u encoding the TUI's parser
+      // already decodes: ESC[13;2u = Shift+Enter, ESC[13;3u = Alt+Enter.
+      if (shortcut === "insert-newline") {
+        // During IME composition, Enter confirms the composed text; let it
+        // through so CJK input keeps working.
+        if (ev.isComposing) {
+          return true;
+        }
+
+        ev.preventDefault();
+        sendPtyShortcutSequence(
+          wsRef.current,
+          ptyStateRef.current,
+          ev.shiftKey ? "\x1b[13;2u" : "\x1b[13;3u",
+        );
+        return false;
+      }
+
       if (pasteModifier && ev.key.toLowerCase() === "v") {
         // preventDefault suppresses the DOM paste event, so image paste must
         // be handled here via clipboard.read() — readText() alone misses


### PR DESCRIPTION
## Problem

The TUI's hotkey reference documents **Shift+Enter / Alt+Enter -> insert newline** (`ui-tui/src/content/hotkeys.ts`), and the composer implements it: a return keypress with `shift || ctrl || meta` inserts `\n`, otherwise it submits (`ui-tui/src/components/textInput.tsx`).

In the web dashboard this documented shortcut can never work: xterm.js sends a bare `\r` for Enter regardless of held modifiers (the same reason Ctrl+Backspace needed the `\x17` bridge below), so every Enter arrives as a plain return and submits the draft. Today the only dashboard workarounds are the `\`+Enter continuation or pasting pre-formatted text.

## Fix

Intercept Shift+Enter / Alt+Enter in the dashboard's `attachCustomKeyEventHandler` and send the kitty-protocol CSI-u encodings (`ESC[13;2u` / `ESC[13;3u`) straight to the PTY. The TUI's input parser already decodes CSI-u (`ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts` `CSI_U_RE`) into shift/meta+return, so the existing newline branch fires with **zero TUI changes**. This mirrors the existing Ctrl+Backspace -> `\x17` / Ctrl+Delete -> `\x1bd` dashboard shortcuts.

IME composition (`ev.isComposing`) passes through untouched so CJK input is unaffected.

## Changes

- `web/src/lib/pty-keyboard-shortcuts.ts` — new `insert-newline` shortcut (Shift/Alt+Enter without Ctrl/Meta).
- `web/src/pages/ChatPage.tsx` — intercept, IME guard, send the CSI-u sequence.
- `web/src/lib/pty-keyboard-shortcuts.test.ts` — 4 new cases.

## Verification

- `npx vitest run src/lib/pty-keyboard-shortcuts.test.ts` — 14/14 pass
- `npm run typecheck` — clean; `npm run lint` — 0 errors (26 pre-existing warnings elsewhere, untouched)
- `npm run build` — succeeds
- Manual E2E on a live dashboard (Windows/ConPTY): Shift+Enter and Alt+Enter insert a newline, plain Enter submits, IME commit unaffected
