### PR TITLE
fix(slack): drop markdown_text from native task-card appendStream payload

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2640,8 +2640,13 @@ class SlackAdapter(BasePlatformAdapter):
                     "ts": stream.stream_ts,
                     "chunks": chunks,
                 }
-                if fallback_text:
-                    append_payload["markdown_text"] = fallback_text
+                # Do NOT attach markdown_text here: chat.appendStream
+                # rejects a request carrying both markdown_text and chunks
+                # with `cannot_provide_both_markdown_text_and_chunks`, which
+                # made every native task-card update fail and downgraded
+                # each turn to the plain-text fallback (#87743). The chunks
+                # are the native rendering; the caller keeps its own
+                # editable-text fallback rail for when this call fails.
                 await client.api_call("chat.appendStream", json=append_payload)
                 return SendResult(success=True, message_id=stream.stream_ts)
             except Exception as exc:  # pragma: no cover - defensive logging

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2564,7 +2564,15 @@ class SlackAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         fallback_text: Optional[str] = None,
     ) -> SendResult:
-        """Start or update a Slack-native plan/task progress stream."""
+        """Start or update a Slack-native plan/task progress stream.
+
+        ``fallback_text`` is accepted for call-site compatibility but is
+        deliberately NOT used: chat.appendStream rejects markdown_text
+        alongside chunks (#87743), and the gateway caller keeps its own
+        editable-text fallback rail (``_send_or_edit_fallback``) that
+        activates when this native call itself fails — so the text has no
+        legitimate place on the append payload.
+        """
         if not self._app:
             return SendResult(success=False, error="Not connected")
         if not tasks:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4681,3 +4681,42 @@ class TestNativeTaskCardProgress:
             "chat.stopStream",
         ]
         assert adapter._native_task_card_streams == {}
+
+    @pytest.mark.asyncio
+    async def test_append_payload_never_mixes_markdown_text_with_chunks(
+        self, adapter
+    ):
+        """#87743: chat.appendStream rejects a request carrying both
+        markdown_text and chunks (`cannot_provide_both_markdown_text_and_chunks`),
+        which made every native task-card update fail and silently downgraded
+        each turn to the plain-text fallback. The fallback_text must never be
+        attached to the chunks payload."""
+        client = adapter._app.client
+
+        async def api_call(method, *, json):
+            if method == "chat.startStream":
+                return {"ts": "stream-1"}
+            return {"ok": True}
+
+        client.api_call.side_effect = api_call
+
+        result = await adapter.send_native_task_card_progress(
+            "C1",
+            [{"id": "call-1", "title": "terminal", "status": "in_progress"}],
+            metadata={"thread_id": "thread-1"},
+            fallback_text="fallback progress text",
+        )
+
+        assert result.success is True
+        append_calls = [
+            call
+            for call in client.api_call.await_args_list
+            if call.args[0] == "chat.appendStream"
+        ]
+        assert append_calls, "expected an appendStream call"
+        payload = append_calls[0].kwargs["json"]
+        assert "chunks" in payload
+        assert "markdown_text" not in payload, (
+            "appendStream must not mix markdown_text with chunks — Slack "
+            "rejects the pair and the whole native card fails (#87743)"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes the opt-in Slack native task cards never rendering (#87743). Every `chat.appendStream` call in `send_native_task_card_progress` failed with Slack API error `cannot_provide_both_markdown_text_and_chunks`, because the append payload attached `markdown_text` (the caller's `fallback_text`) alongside the `chunks` array — Slack rejects that combination outright. Each failed update was swallowed by the defensive `except` and the turn downgraded to the continuously-edited plain-text progress message, so the native card rail (shipped in #85476/#59010) never appeared for any user who enabled it.

The fix removes the `markdown_text` injection from the chunks payload. The field was both rejected and redundant: the gateway caller (`gateway/run.py::_publish_native_progress`) already keeps its own independent editable-text fallback rail (`_send_or_edit_fallback`) that activates precisely when this native call fails, so the fallback text never needed to ride on the append request. The draft-stream appendStream site in the same adapter (which sends `markdown_text` alone, no chunks) is the correct contrast and is unchanged.

## Related Issue

Fixes #87743

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/adapter.py` — `send_native_task_card_progress`: no longer adds `markdown_text` to the `chat.appendStream` payload when `fallback_text` is provided; comment documents the API constraint (#87743) and why the caller's separate fallback rail makes the field redundant.
- `tests/gateway/test_slack.py` — new `test_append_payload_never_mixes_markdown_text_with_chunks` in `TestNativeTaskCardProgress`: drives the adapter with `fallback_text` set and asserts the appendStream payload contains `chunks` and never `markdown_text`.

## How to Test

1. `uv run --extra acp pytest tests/gateway/test_slack.py -k TestNativeTaskCardProgress -q` — should pass (5 tests).
2. Observed result: `5 passed` (4 pre-existing + 1 new).
3. Observed result with the adapter change reverted: `test_append_payload_never_mixes_markdown_text_with_chunks` fails — the payload carries both keys, reproducing the report's API error.
4. Live: with `platforms.slack.extra.native_task_cards: true`, a tool-call turn now renders the Slack-native plan/task card (no `cannot_provide_both_markdown_text_and_chunks` in `gateway.log`, no downgrade to the plain-text message).

Note: `test_batch_download_blocks_connect_time_rebind` in `TestSendMultipleImagesSSRFGuards` fails on this checkout with and without this change (verified by stashing) — pre-existing, unrelated.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
