### PR TITLE
fix: keep launchd gateway child supervisor-marked

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4474,16 +4474,19 @@ def _launchd_unsupported_marker_exists() -> bool:
 
 
 def _gateway_run_command() -> list[str]:
-    """Build the `python -m hermes_cli.main [--profile X] gateway run --replace` argv.
+    """Build the `python -m hermes_cli.main [--profile X] gateway run` argv.
 
     Profile-aware: honors the active HERMES_HOME via `_profile_arg()` so the
     detached fallback launches into the same profile as the CLI invocation.
+    The explicit ``--external-supervisor`` marker is required for launchd's
+    stderr timestamp wrapper: the nested gateway child must still recognize
+    that it is supervisor-managed before ``--replace`` restarts it.
     """
     cmd = [get_python_path(), "-m", "hermes_cli.main"]
     profile_arg = _profile_arg()
     if profile_arg:
         cmd.extend(profile_arg.split())
-    cmd.extend(["gateway", "run", "--replace"])
+    cmd.extend(["gateway", "run", "--external-supervisor", "--replace"])
     return cmd
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1296,8 +1296,8 @@ class TestProfileArg:
             "mybot",
             "gateway",
             "run",
-            "--replace",
             "--external-supervisor",
+            "--replace",
         ]
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- make `_gateway_run_command()` emit `gateway run --external-supervisor --replace`
- keep regenerated launchd ProgramArguments supervisor-marked when wrapped by stderr timestamping
- update the launchd plist expectation for the corrected argument order

## Why
On macOS launchd installs, the gateway is started through the stderr timestamp wrapper. When `hermes update --backup --yes` restarts the gateway from inside the running gateway/cron process, the nested gateway child must explicitly see `--external-supervisor`; otherwise it can mistake itself for a duplicate foreground gateway and refuse startup, causing a launchd respawn/duplicate-guard loop.

The generated plist is the durable choke point: hand-editing a LaunchAgent can be reverted by `hermes gateway start/restart`, so the generator itself should emit the supervisor marker in the nested gateway command.

## Validation
- `git diff --check`
- `/Users/horatio/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/gateway.py`
- direct Python assertion: `_gateway_run_command()` tail is `['gateway', 'run', '--external-supervisor', '--replace']`
- direct plist assertion: `generate_launchd_plist()` ProgramArguments tail is `['gateway', 'run', '--external-supervisor', '--replace']`
- isolated targeted pytest: `1 passed, 81 deselected`

Targeted pytest used pytest installed into an isolated temporary target, not the production Hermes venv.