### PR TITLE
fix(agent): forbid kanban workers from creating chat sessions

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -336,7 +336,14 @@ KANBAN_GUIDANCE = (
     "specialist profile.\n"
     "- Do not call `delegate_task` as a board substitute. `delegate_task` is "
     "for short reasoning subtasks inside your own run; board tasks are for "
-    "cross-agent handoffs that outlive one API loop."
+    "cross-agent handoffs that outlive one API loop.\n"
+    "- Do NOT create new chat sessions to deliver results (no `hermes chat -q`, "
+    "no desktop/gateway session creation, no 'deliver this in a new session' "
+    "step). Every task's output is collected into ONE canonical session per "
+    "root task automatically — extra sessions fragment that record. Attach "
+    "real files with `kanban_attach` and write the summary into "
+    "`kanban_complete`; that is the deliverable and it lands in the canonical "
+    "session on its own."
 )
 
 TOOL_USE_ENFORCEMENT_GUIDANCE = (


### PR DESCRIPTION
## What

Kanban workers occasionally deliver results by creating a new chat session (`hermes chat -q`, a desktop session, or an explicit "deliver this in a new session" step). Every such session lands in the user's session list as a separate one-off, so a single job can scatter its output across several sessions on top of the worker-run rows.

## Change

Adds a Do-NOT rule to `KANBAN_GUIDANCE` in `agent/prompt_builder.py`: workers must never create chat sessions to deliver results. Attach real files with `kanban_attach` and write the summary into `kanban_complete` — the board's canonical-session collector picks that up automatically, keeping one session per root task.

## Verification

- `python3 -m py_compile agent/prompt_builder.py` — clean
- No behavior change outside the worker prompt block

Authored with agent assistance (Hermes).
