### PR TITLE
fix(desktop): surface real gh stderr in Review pane PR create errors

### DIFF
--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -4,9 +4,18 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { afterEach, test } from 'vitest'
+import { afterEach, test, vi } from 'vitest'
 
-import { gitFor, repoStatus, resolveRenamePath, REVIEW_FILE_CAP, reviewList } from './git-review-ops'
+import { gitFor, repoStatus, resolveRenamePath, REVIEW_FILE_CAP, reviewCreatePr, reviewList } from './git-review-ops'
+
+// `runGh` shells to the `gh` CLI via execFile. Mock it so reviewCreatePr's gh
+// invocation is controllable (real `gh` may be absent or slow in CI) while the
+// repo setup below still uses the real execFileSync.
+vi.mock('node:child_process', async importOriginal => {
+  const actual = await importOriginal<{ execFile: unknown; execFileSync: unknown }>()
+
+  return { ...actual, execFile: vi.fn() }
+})
 
 const tempDirs: string[] = []
 
@@ -116,4 +125,45 @@ test('reviewList caps the file payload returned to the renderer', async () => {
   const result = await reviewList(dir, 'uncommitted', null, 'git')
 
   assert.equal(result.files.length, REVIEW_FILE_CAP)
+})
+
+const mockExecFile = vi.mocked(await import('node:child_process')).execFile
+
+type ExecFileCallback = (error: Error | null, stdout?: string, stderr?: string) => void
+
+// `execFile` has overloaded declarations returning ChildProcess; the mock
+// implementation only needs to drive its callback, so view it as a plain
+// callable and set the implementation through the Mock typing.
+function failGh(stderr: string): void {
+  ;(
+    mockExecFile as unknown as {
+      mockImplementation: (
+        impl: (file: string, args: string[], options: object, callback: ExecFileCallback) => void
+      ) => unknown
+    }
+  ).mockImplementation((_bin: string, _args: string[], _opts: object, callback: ExecFileCallback) => {
+    const error = new Error('command failed')
+
+    if (stderr) {
+      ;(error as Error & { stderr?: string }).stderr = stderr
+    }
+
+    callback(error, '', stderr)
+  })
+}
+
+test('reviewCreatePr surfaces gh stderr when pr create fails', async () => {
+  const dir = makeRepo()
+
+  failGh('no commits between main and feature')
+
+  await assert.rejects(reviewCreatePr(dir, 'git', 'gh'), /no commits between main and feature/)
+})
+
+test('reviewCreatePr falls back to the generic message when gh reports no stderr', async () => {
+  const dir = makeRepo()
+
+  failGh('')
+
+  await assert.rejects(reviewCreatePr(dir, 'git', 'gh'), /is gh installed and authenticated\?/)
 })

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -30,15 +30,16 @@ function ghEnv(ghBin) {
   return { ...process.env, PATH: [...extra, process.env.PATH].filter(Boolean).join(path.delimiter) }
 }
 
-// Run the `gh` CLI in a repo. Resolves { ok, stdout } so callers branch on
-// availability/auth without a throw. gh missing/unauthed → ok:false.
-function runGh(args, cwd, ghBin): Promise<{ ok: boolean; stdout: string }> {
+// Run the `gh` CLI in a repo. Resolves { ok, stdout, stderr } so callers branch
+// on availability/auth without a throw. gh missing/unauthed → ok:false.
+function runGh(args, cwd, ghBin): Promise<{ ok: boolean; stdout: string; stderr: string }> {
   return new Promise(resolve => {
     execFile(
       ghBin || 'gh',
       args,
       { cwd, env: ghEnv(ghBin), windowsHide: true, timeout: 30_000, maxBuffer: 8 * 1024 * 1024 },
-      (err, stdout) => resolve({ ok: !err, stdout: String(stdout || '') })
+      (err, stdout, stderr) =>
+        resolve({ ok: !err, stdout: String(stdout || ''), stderr: String(err?.stderr ?? stderr ?? '') })
     )
   })
 }
@@ -770,7 +771,12 @@ async function reviewCreatePr(repoPath, gitBin, ghBin) {
   const created = await runGh(['pr', 'create', '--fill'], cwd, ghBin)
 
   if (!created.ok) {
-    throw new Error('gh pr create failed (is gh installed and authenticated?)')
+    // gh's own stderr says why the create failed (e.g. "no commits between
+    // main and feature", missing auth, a repo in an uncreatable state). Surface
+    // it instead of the generic fallback, which lied whenever gh was fine.
+    const reason = created.stderr.trim() || 'is gh installed and authenticated?'
+
+    throw new Error(`gh pr create failed: ${reason}`)
   }
 
   const url = created.stdout.trim().split('\n').filter(Boolean).pop() || ''


### PR DESCRIPTION
Fixes #87731.

The Review pane's Create-PR button always reported the generic `gh pr create failed (is gh installed and authenticated?)` toast even when gh was installed and authenticated, because `runGh` discarded stderr and `reviewCreatePr` mapped every non-zero exit to that one message.

Changes:
- `runGh` now captures stderr (from both the error object and the callback's stderr arg) and returns it alongside `ok`/`stdout`.
- `reviewCreatePr` throws `gh pr create failed: <real stderr>` when gh exits non-zero, falling back to the generic message only when stderr is empty. The renderer's existing `notifyError` path surfaces the thrown message, so users now see the actual reason (e.g. `no commits between main and feature`) instead of a lie.

Tests:
- `reviewCreatePr` surfaces gh stderr on failure.
- `reviewCreatePr` falls back to the generic message when stderr is empty.

Verified: electron vitest suite passes, `tsc -p tsconfig.electron.json --noEmit` clean, eslint + prettier clean on touched files.