### PR TITLE
fix(slack): restore native task cards for tool progress

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2638,9 +2638,10 @@ class SlackAdapter(BasePlatformAdapter):
                 append_payload: Dict[str, Any] = {
                     "channel": chat_id,
                     "ts": stream.stream_ts,
-                    "chunks": chunks,
                 }
-                if fallback_text:
+                if chunks:
+                    append_payload["chunks"] = chunks
+                elif fallback_text:
                     append_payload["markdown_text"] = fallback_text
                 await client.api_call("chat.appendStream", json=append_payload)
                 return SendResult(success=True, message_id=stream.stream_ts)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4574,6 +4574,26 @@ class TestNativeTaskCardProgress:
         ).native_task_cards_enabled() is False
 
     @pytest.mark.asyncio
+    async def test_task_chunks_exclude_markdown_fallback(self, adapter):
+        client = adapter._app.client
+        client.api_call.side_effect = [
+            {"ts": "stream-1"},
+            {"ok": True},
+        ]
+
+        result = await adapter.send_native_task_card_progress(
+            "C1",
+            [{"id": "call-1", "title": "terminal", "status": "in_progress"}],
+            metadata={"thread_id": "thread-1"},
+            fallback_text="Working: terminal",
+        )
+
+        assert result.success is True
+        append_payload = client.api_call.await_args_list[1].kwargs["json"]
+        assert append_payload["chunks"]
+        assert "markdown_text" not in append_payload
+
+    @pytest.mark.asyncio
     async def test_native_updates_are_serialized_and_workspace_scoped(self, adapter):
         team_client = AsyncMock()
         start_count = 0


### PR DESCRIPTION
## What does this PR do?

Slack native task cards currently fail on every tool-progress update because the adapter sends both `chunks` and `markdown_text` to `chat.appendStream`. Slack rejects that payload with `cannot_provide_both_markdown_text_and_chunks`, so users who opt into native task cards only receive the editable-text fallback.

### Symptom

With `platforms.slack.extra.native_task_cards` enabled, a turn containing tool calls cannot render its native plan/task card and logs Slack's `cannot_provide_both_markdown_text_and_chunks` API error.

### Impact

The opt-in native task-card feature is unusable for affected Slack users: every task-card update is rejected before rendering and downgraded to plain editable text.

### Bug Cause

**Trigger:** `plugins/platforms/slack/adapter.py` / `send_native_task_card_progress()` when the gateway supplies task rows and fallback text.

**Causal chain:**
1. The gateway sends a non-empty task list and fallback text for tool progress.
2. The adapter builds non-empty task-card `chunks` and also adds `markdown_text` to the same `chat.appendStream` payload.
3. Slack rejects the mutually exclusive fields, preventing the native card from rendering.

**Why it is wrong:** Slack accepts either structured chunks or markdown text for an append operation, not both.

**Working sibling / contrast:** Ordinary native streaming appends only `markdown_text`; task-card appends should prioritize their structured chunks instead.

**Ruled out:** Client rendering and workspace routing are not causes because Slack rejects the request at the API payload boundary.

### Fix

Give structured task-card chunks priority and only add fallback markdown when no chunks are available. The regression test exercises the real adapter payload construction and asserts that a non-empty `chunks` payload excludes `markdown_text`.

## Related Issue

Closes #87743

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/adapter.py` - keep `chat.appendStream` task-card payload fields mutually exclusive.
- `tests/gateway/test_slack.py` - cover the structured-chunks versus fallback-markdown invariant.

## How to Test

1. Enable Slack native task cards and trigger a turn with a tool call.
2. Confirm `chat.appendStream` receives structured `chunks` without `markdown_text` and the request is not rejected with `cannot_provide_both_markdown_text_and_chunks`.
3. Run the related automated tests:

```bash
scripts/run_tests.sh tests/gateway/test_slack.py
scripts/run_tests.sh tests/gateway/test_run_progress_topics.py -k native
```

Local result: 166 Slack tests passed and 3 native progress-topic tests passed. Phase B independently re-ran the targeted regression test and it passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior now matches the existing Slack messaging documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - payload construction is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool schema changed

## Screenshots / Logs

The issue contains the captured Slack API rejection. Automated coverage verifies the corrected request payload.
