### PR TITLE
perf(desktop): make transcript updates incremental

### DIFF
--- a/apps/desktop/scripts/startup-graph.test.mjs
+++ b/apps/desktop/scripts/startup-graph.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, beforeAll, test } from 'vitest'
+
+const desktopRoot = path.resolve(import.meta.dirname, '..')
+const repoRoot = path.resolve(desktopRoot, '../..')
+const viteBin = path.join(repoRoot, 'node_modules/vite/bin/vite.js')
+const output = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-startup-graph-'))
+let html = ''
+let manifest = {}
+let preloads = []
+
+beforeAll(() => {
+  execFileSync(process.execPath, [viteBin, 'build', '--outDir', output, '--emptyOutDir'], {
+    cwd: desktopRoot,
+    env: { ...process.env, VITE_CONFIG_NATIVE_IGNORE_WARNING: 'true' },
+    stdio: 'pipe'
+  })
+  html = fs.readFileSync(path.join(output, 'index.html'), 'utf8')
+  manifest = JSON.parse(fs.readFileSync(path.join(output, '.vite/manifest.json'), 'utf8'))
+  preloads = [...html.matchAll(/<link\s+rel="modulepreload"[^>]+href="([^"]+)"/g)].map(match => match[1])
+}, 30_000)
+
+afterAll(() => fs.rmSync(output, { recursive: true, force: true }))
+
+test('initial renderer modulepreloads stay relative and within the startup budget', () => {
+  assert.ok(preloads.length > 0, 'production index should preload its static entry dependencies')
+  assert.ok(preloads.every(href => href.startsWith('./assets/')), 'modulepreloads must remain valid under file://')
+
+  const bytes = preloads.reduce((total, href) => total + fs.statSync(path.join(output, href.slice(2))).size, 0)
+  assert.ok(preloads.length <= 120, `initial modulepreload count ${preloads.length} exceeds 120`)
+  assert.ok(bytes <= 3_000_000, `initial modulepreload bytes ${bytes} exceeds 3,000,000`)
+})
+
+test('interaction-only rendering features are absent from initial modulepreloads', () => {
+  const forbidden = /(?:katex|shiki|mermaid|code-editor|session-export|(?:create|rename|delete)-profile-dialog|edit-soul-dialog|pet-gallery)-/i
+  assert.deepEqual(preloads.filter(href => forbidden.test(href)), [])
+})
+
+test('math, editor, export, profile dialogs, and gallery remain emitted as lazy features', () => {
+  const emitted = Object.values(manifest).map(entry => entry.file)
+  for (const feature of ['katex-', 'code-editor-', 'session-export-', 'rename-profile-dialog-', 'pet-gallery-']) {
+    assert.ok(emitted.some(file => file.includes(feature)), `${feature} feature chunk was not emitted`)
+  }
+})

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -8,10 +8,14 @@ import { useLocation } from 'react-router'
 
 import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
 import { Thread } from '@/components/assistant-ui/thread'
+import {
+  TranscriptLayoutProvider,
+  useTranscriptLayoutIndex
+} from '@/components/assistant-ui/thread/transcript-layout'
 import { TranscriptWindowProvider } from '@/components/assistant-ui/thread/transcript-window'
 import { Backdrop } from '@/components/Backdrop'
 import { COMPOSER_HEART_CONFIG, HeartField } from '@/components/chat/vibe-hearts'
-import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
+import { usePaneLifecycle, usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { $sessionTileDragging, $sessionTileEdgeHover } from '@/components/pane-shell/tree/store'
 import { PromptOverlays } from '@/components/prompt-overlays'
 import { Button } from '@/components/ui/button'
@@ -30,6 +34,7 @@ import { $pinnedSessionIds } from '@/store/layout'
 import { $petActive } from '@/store/pet'
 import { $petOverlayActive } from '@/store/pet-overlay'
 import { $activeGatewayProfile, $gatewaySwapTarget, $profiles } from '@/store/profile'
+import { useRuntimeTranscript } from '@/store/runtime-session-stores'
 import {
   $contextSuggestions,
   $freshDraftReady,
@@ -233,8 +238,12 @@ function ChatRuntimeBoundary({
 }: ChatRuntimeBoundaryProps) {
   const view = useSessionView()
   const runtimeId = useStore(view.$runtimeId)
+  const visible = usePaneVisible()
+  const runtimeTranscript = useRuntimeTranscript(runtimeId, visible)
   const storeMessages = useMessagesWhileVisible(view.$messages)
-  const messages = suppressMessages ? NO_MESSAGES : storeMessages
+  // A bound runtime reads its independently publishable transcript channel.
+  // The view atom remains the draft/cold-resume fallback before that binding.
+  const messages = suppressMessages ? NO_MESSAGES : runtimeId ? runtimeTranscript.messages : storeMessages
 
   const [windowPages, setWindowPages] = useState(1)
   const [windowSessionKey, setWindowSessionKey] = useState(runtimeId)
@@ -258,7 +267,12 @@ function ChatRuntimeBoundary({
     return next.window
   }, [messages, windowPages])
 
-  const runtimeMessageRepository = useRuntimeMessageRepository(windowedMessages)
+  const runtimeMessageRepository = useRuntimeMessageRepository(windowedMessages, runtimeTranscript.operation.kind)
+
+  const transcriptLayout = useTranscriptLayoutIndex(
+    runtimeMessageRepository.messages.map(item => item.message),
+    runtimeMessageRepository.operation
+  )
 
   const storedId = useStore(view.$storedId)
   // Subscribed (not read imperatively) so the "Show earlier" affordance
@@ -312,7 +326,9 @@ function ChatRuntimeBoundary({
 
   return (
     <TranscriptWindowProvider value={transcriptWindow}>
-      <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>
+      <TranscriptLayoutProvider value={transcriptLayout}>
+        <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>
+      </TranscriptLayoutProvider>
     </TranscriptWindowProvider>
   )
 }
@@ -354,6 +370,7 @@ export const ChatView = memo(function ChatView({
   // The view this surface renders: the primary route-driven session (global
   // atoms) or a tile's session slice — same component either way.
   const view = useSessionView()
+  const paneLifecycle = usePaneLifecycle()
   const composerScope = useComposerScope()
   const isPrimary = view.kind === 'primary'
   const activeSessionId = useStore(view.$runtimeId)
@@ -592,19 +609,21 @@ export const ChatView = memo(function ChatView({
           data-slot="composer-bounds"
           {...dropHandlers}
         >
-          <Thread
-            clampToComposer={showChatBar}
-            cwd={currentCwd}
-            gateway={gateway}
-            intro={showIntro ? { personality: introPersonality, seed: introSeed } : undefined}
-            loading={threadLoading}
-            onBranchInNewChat={onBranchInNewChat}
-            onCancel={haltRun}
-            onDismissError={onDismissError}
-            onRestoreToMessage={onRestoreToMessage}
-            sessionId={activeSessionId}
-            sessionKey={threadKey}
-          />
+          {paneLifecycle === 'visible' && (
+            <Thread
+              clampToComposer={showChatBar}
+              cwd={currentCwd}
+              gateway={gateway}
+              intro={showIntro ? { personality: introPersonality, seed: introSeed } : undefined}
+              loading={threadLoading}
+              onBranchInNewChat={onBranchInNewChat}
+              onCancel={haltRun}
+              onDismissError={onDismissError}
+              onRestoreToMessage={onRestoreToMessage}
+              sessionId={activeSessionId}
+              sessionKey={threadKey}
+            />
+          )}
           {resumeExhausted && routedSessionId && (
             <div className="absolute inset-0 z-10 grid place-items-center bg-(--ui-chat-surface-background) px-8 py-10">
               <ErrorState

--- a/apps/desktop/src/app/chat/runtime-repository.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.ts
@@ -23,7 +23,13 @@ const FALLBACK_STATUS = getAutoStatus(false, false, false, false, undefined)
  * cache miss keeps identity stable for settled turns, which is what lets the
  * runtime reconcile detect that only the tail moved.
  */
-export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMessageRepository {
+export type RuntimeRepositoryOperation = 'append' | 'finalize-tail' | 'replace-tail' | 'reset'
+export type RuntimeMessageRepository = ExportedMessageRepository & { operation: RuntimeRepositoryOperation }
+
+export function useRuntimeMessageRepository(
+  messages: ChatMessage[],
+  operation: RuntimeRepositoryOperation = 'reset'
+): RuntimeMessageRepository {
   const cacheRef = useRef(new WeakMap<ChatMessage, ThreadMessage>())
   const toolMergeCacheRef = useRef(createToolMergeCache())
 
@@ -73,6 +79,6 @@ export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMe
       }
     }
 
-    return { headId, messages: items }
-  }, [messages])
+    return { headId, messages: items, operation }
+  }, [messages, operation])
 }

--- a/apps/desktop/src/app/chat/sidebar/edit-soul-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/edit-soul-dialog.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react'
+
+import { CodeEditor } from '@/components/chat/code-editor'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { getProfileSoul, updateProfileSoul } from '@/hermes'
+import { useI18n } from '@/i18n'
+import { notify, notifyError } from '@/store/notifications'
+
+export function EditSoulDialog({ onClose, profileName }: { onClose: () => void; profileName: string }) {
+  const { t } = useI18n()
+  const p = t.profiles
+  const [content, setContent] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setContent('')
+    getProfileSoul(profileName)
+      .then(soul => !cancelled && setContent(soul.content))
+      .catch(err => !cancelled && notifyError(err, p.failedLoadSoul))
+      .finally(() => !cancelled && setLoading(false))
+
+    return () => void (cancelled = true)
+  }, [p, profileName])
+
+  const save = async () => {
+    setSaving(true)
+
+    try {
+      await updateProfileSoul(profileName, content)
+      notify({ kind: 'success', title: p.soulSaved, message: profileName })
+      onClose()
+    } catch (err) {
+      notifyError(err, p.failedSaveSoul)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog onOpenChange={open => !open && !saving && onClose()} open>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader><DialogTitle>{profileName} · SOUL.md</DialogTitle></DialogHeader>
+        <div className="h-80">
+          {!loading && <CodeEditor filePath="SOUL.md" framed initialValue={content} onCancel={() => !saving && onClose()} onChange={setContent} onSave={() => void save()} />}
+        </div>
+        <DialogFooter>
+          <Button disabled={saving} onClick={onClose} type="button" variant="ghost">{t.common.cancel}</Button>
+          <Button disabled={saving || loading} onClick={() => void save()}>{saving ? p.saving : p.saveSoul}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -19,20 +19,17 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useStore } from '@nanostores/react'
-import { useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 
-import { CodeEditor } from '@/components/chat/code-editor'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { ColorSwatches } from '@/components/ui/color-swatches'
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { ProfileGlyph } from '@/components/ui/profile-glyph'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tip, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { getProfileSoul, updateProfileSoul } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { PROFILE_SWATCHES, profileColorSoft, resolveProfileColor } from '@/lib/profile-color'
@@ -43,7 +40,6 @@ import {
   reorderStepHaptic
 } from '@/lib/reorder'
 import { cn } from '@/lib/utils'
-import { notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
   $profileColors,
@@ -60,16 +56,17 @@ import {
   setShowAllProfiles,
   sortByProfileOrder
 } from '@/store/profile'
-import { runExportProfileFlow, runImportProfileFlow } from '@/store/profile-share'
 import type { ProfileInfo } from '@/types/hermes'
 
-import { CreateProfileDialog } from '../../profiles/create-profile-dialog'
-import { DeleteProfileDialog } from '../../profiles/delete-profile-dialog'
-import { RenameProfileDialog } from '../../profiles/rename-profile-dialog'
 import { PROFILES_ROUTE, SETTINGS_ROUTE } from '../../routes'
 
 import { useProfilePrewarm } from './use-profile-prewarm'
 import { useProfileRailRefreshOnActive } from './use-profile-rail-refresh-on-active'
+
+const CreateProfileDialog = lazy(() => import('../../profiles/create-profile-dialog').then(m => ({ default: m.CreateProfileDialog })))
+const DeleteProfileDialog = lazy(() => import('../../profiles/delete-profile-dialog').then(m => ({ default: m.DeleteProfileDialog })))
+const RenameProfileDialog = lazy(() => import('../../profiles/rename-profile-dialog').then(m => ({ default: m.RenameProfileDialog })))
+const EditSoulDialog = lazy(() => import('./edit-soul-dialog').then(m => ({ default: m.EditSoulDialog })))
 
 const RAIL_GAP = 4 // px — matches gap-1 between squares.
 
@@ -332,109 +329,27 @@ export function ProfileRail() {
 
       {/* Land in the new profile on a fresh chat (selectProfile triggers the
           new-session reset), not stuck on the session you were just in. */}
-      <CreateProfileDialog
-        onClose={() => setCreateOpen(false)}
-        onCreated={async name => {
-          await refreshActiveProfile()
-          selectProfile(name)
-        }}
-        open={createOpen}
-        profiles={profiles}
-      />
-
-      <RenameProfileDialog
-        currentName={pendingRename?.name ?? ''}
-        onClose={() => setPendingRename(null)}
-        onRenamed={refreshActiveProfile}
-        open={pendingRename !== null}
-      />
-
-      <DeleteProfileDialog
-        onClose={() => setPendingDelete(null)}
-        onDeleted={refreshActiveProfile}
-        open={pendingDelete !== null}
-        profile={pendingDelete}
-      />
-
-      <EditSoulDialog onClose={() => setPendingSoul(null)} profileName={pendingSoul} />
+      <Suspense fallback={null}>
+        {createOpen && (
+          <CreateProfileDialog
+            onClose={() => setCreateOpen(false)}
+            onCreated={async name => {
+              await refreshActiveProfile()
+              selectProfile(name)
+            }}
+            open
+            profiles={profiles}
+          />
+        )}
+        {pendingRename && (
+          <RenameProfileDialog currentName={pendingRename.name} onClose={() => setPendingRename(null)} onRenamed={refreshActiveProfile} open />
+        )}
+        {pendingDelete && (
+          <DeleteProfileDialog onClose={() => setPendingDelete(null)} onDeleted={refreshActiveProfile} open profile={pendingDelete} />
+        )}
+        {pendingSoul && <EditSoulDialog onClose={() => setPendingSoul(null)} profileName={pendingSoul} />}
+      </Suspense>
     </div>
-  )
-}
-
-// Right-click → Edit SOUL.md for a sidebar profile — the same in-app markdown
-// editor as the memory-graph node edit, so a profile's persona is editable
-// without opening the Manage overlay.
-function EditSoulDialog({ onClose, profileName }: { onClose: () => void; profileName: null | string }) {
-  const { t } = useI18n()
-  const p = t.profiles
-  const [content, setContent] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [saving, setSaving] = useState(false)
-
-  useEffect(() => {
-    if (!profileName) {
-      return
-    }
-
-    let cancelled = false
-    setLoading(true)
-    setContent('')
-
-    getProfileSoul(profileName)
-      .then(soul => !cancelled && setContent(soul.content))
-      .catch(err => !cancelled && notifyError(err, p.failedLoadSoul))
-      .finally(() => !cancelled && setLoading(false))
-
-    return () => void (cancelled = true)
-  }, [p, profileName])
-
-  const save = async () => {
-    if (!profileName) {
-      return
-    }
-
-    setSaving(true)
-
-    try {
-      await updateProfileSoul(profileName, content)
-      notify({ kind: 'success', title: p.soulSaved, message: profileName })
-      onClose()
-    } catch (err) {
-      notifyError(err, p.failedSaveSoul)
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  return (
-    <Dialog onOpenChange={open => !open && !saving && onClose()} open={profileName !== null}>
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>{profileName} · SOUL.md</DialogTitle>
-        </DialogHeader>
-        <div className="h-80">
-          {!loading && profileName && (
-            <CodeEditor
-              filePath="SOUL.md"
-              framed
-              initialValue={content}
-              key={profileName}
-              onCancel={() => !saving && onClose()}
-              onChange={setContent}
-              onSave={() => void save()}
-            />
-          )}
-        </div>
-        <DialogFooter>
-          <Button disabled={saving} onClick={onClose} type="button" variant="ghost">
-            {t.common.cancel}
-          </Button>
-          <Button disabled={saving || loading} onClick={() => void save()}>
-            {saving ? p.saving : p.saveSoul}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   )
 }
 
@@ -463,7 +378,7 @@ function ImportProfileButton({ label }: { label: string }) {
       <button
         aria-label={label}
         className="grid size-5 shrink-0 place-items-center rounded-[3px] text-(--ui-text-tertiary) opacity-55 transition hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100"
-        onClick={() => void runImportProfileFlow()}
+        onClick={() => void import('@/store/profile-share').then(m => m.runImportProfileFlow())}
         type="button"
       >
         <Codicon name="cloud-download" size="0.75rem" />
@@ -722,7 +637,7 @@ function ProfileSquare({
             <Codicon name="edit" size="0.875rem" />
             <span>{p.editSoul}</span>
           </ContextMenuItem>
-          <ContextMenuItem onSelect={() => void runExportProfileFlow(label)}>
+          <ContextMenuItem onSelect={() => void import('@/store/profile-share').then(m => m.runExportProfileFlow(label))}>
             <Codicon name="package" size="0.875rem" />
             <span>{p.exportProfile}</span>
           </ContextMenuItem>

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -35,7 +35,6 @@ import { renameSession } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { PROFILE_SWATCHES } from '@/lib/profile-color'
-import { exportSession } from '@/lib/session-export'
 import { activeGateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
@@ -360,7 +359,7 @@ function useSessionActions({
       label: r.export,
       onSelect: () => {
         triggerHaptic('selection')
-        void exportSession(sessionId, { profile, title })
+        void import('@/lib/session-export').then(({ exportSession }) => exportSession(sessionId, { profile, title }))
       }
     })
   ]

--- a/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react'
 
 import { setPetActivity } from '@/store/pet'
-import { setPetScale } from '@/store/pet-gallery'
 import { setPetOverlayOpenAppHandler, setPetOverlayScaleHandler, setPetOverlaySubmitHandler } from '@/store/pet-overlay'
+import { setPetScale } from '@/store/pet-scale'
 import { $sessions } from '@/store/session'
 import { $attentionSessionIds } from '@/store/session-states'
 import { isAuxiliaryWindow } from '@/store/windows'

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -83,7 +83,6 @@ import { useHudHandoff } from '../hud/handoff'
 import { ModelPickerOverlay } from '../model-picker-overlay'
 import { ModelVisibilityOverlay } from '../model-visibility-overlay'
 import { mainChatOccupied, openSession } from '../open-session'
-import { PetGenerateOverlay } from '../pet-generate/pet-generate-overlay'
 import { FileActionDialogs } from '../right-sidebar/file-actions'
 import { RemoteFolderPicker } from '../right-sidebar/files/remote-picker'
 import { resetProjectTreeState } from '../right-sidebar/files/use-project-tree'
@@ -147,6 +146,11 @@ const CronView = lazy(async () => ({ default: (await import('../cron')).CronView
 const WebhooksView = lazy(async () => ({ default: (await import('../webhooks')).WebhooksView }))
 const ProfilesView = lazy(async () => ({ default: (await import('../profiles')).ProfilesView }))
 const SettingsView = lazy(async () => ({ default: (await import('../settings')).SettingsView }))
+
+const PetGenerateOverlay = lazy(async () => ({
+  default: (await import('../pet-generate/pet-generate-overlay')).PetGenerateOverlay
+}))
+
 const StarmapView = lazy(async () => ({ default: (await import('../starmap')).StarmapView }))
 
 // Surfaces (the four wired panes), the render context + WiredPane, and the
@@ -1075,7 +1079,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       <GatewayConnectingOverlay />
       <BootFailureOverlay />
       <CommandPalette />
-      <PetGenerateOverlay />
+      <Suspense fallback={null}>
+        <PetGenerateOverlay />
+      </Suspense>
       <SessionSwitcher />
       <FileActionDialogs />
       <McpInstallDeepLinkDialog />

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -21,8 +21,8 @@ import { setComposerDraft } from '@/store/composer'
 import { enqueueQueuedPrompt } from '@/store/composer-queue'
 import { applyGoalStatusText } from '@/store/goals'
 import { dismissNotification, notify, notifyError } from '@/store/notifications'
-import { setPetScale } from '@/store/pet-gallery'
 import { $petGenInput, openPetGenerate } from '@/store/pet-generate'
+import { setPetScale } from '@/store/pet-scale'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import {
   $connection,

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -340,7 +340,7 @@ export function useSessionStateCache({
       // Publishing to $sessionStates automatically fires transition side-effects
       // (watchdog, settle grace, unread marker, compression id rotation) inside
       // publishSessionState — no manual transition call needed.
-      publishSessionState(sessionId, next)
+      publishSessionState(sessionId, next, previous)
       sessionStateCache.prune()
       syncSessionStateToView(sessionId, next)
 

--- a/apps/desktop/src/components/assistant-ui/markdown-math.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-math.ts
@@ -1,0 +1,5 @@
+import 'katex/dist/katex.min.css'
+
+import { createMemoizedMathPlugin } from '@/lib/katex-memo'
+
+export const mathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -17,7 +17,6 @@ import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { detectArtifact } from '@/lib/artifact-detect'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
-import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
@@ -38,20 +37,39 @@ import { cn } from '@/lib/utils'
 import { ArtifactCard } from './artifact-card'
 import { SessionRefLink } from './directive-text'
 import { detectEmbed, extractAlert, MarkdownAlert, RichCodeBlock, UrlEmbed } from './embeds'
+import type { mathPlugin as streamdownMath } from './markdown-math'
 
-// Math rendering plugin (KaTeX). Configured once at module scope — the
-// plugin is stateless beyond its internal cache so re-creating per-render
-// would needlessly thrash. We use a memoizing wrapper around rehype-katex
-// (see lib/katex-memo.ts) so that during streaming we re-katex only the
-// equations whose source actually changed since the last token. With the
-// stock @streamdown/math plugin every equation re-renders on every token,
-// which throttles UI updates badly for math-heavy responses; the memoized
-// plugin keeps the steady-state work proportional to "new equations
-// arriving" rather than "equations × tokens-per-second".
-//
-// `singleDollarTextMath: true` enables `$x^2$` for inline math (de-facto
-// LLM convention). The default false-setting only accepts `$$...$$`.
-const mathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
+type MathPlugin = typeof streamdownMath
+let mathPluginCache: MathPlugin | null = null
+
+// Keep ordinary prose off the KaTeX graph. The signal is intentionally broad:
+// false positives only defer-load math for unusual dollar-heavy prose, while a
+// false negative would leave visible TeX unrendered.
+function containsMath(text: string): boolean {
+  return /\$\$|\\[([]|```\s*math\b|\[math\]|\$[^\s$][^\n$]*\$/m.test(text)
+}
+
+function useMathPlugin(text: string): MathPlugin | null {
+  const needed = containsMath(text)
+  const [plugin, setPlugin] = useState(mathPluginCache)
+
+  useEffect(() => {
+    if (!needed || plugin) {return}
+
+    let cancelled = false
+    void import('./markdown-math').then(module => {
+      mathPluginCache = module.mathPlugin
+
+      if (!cancelled) {setPlugin(module.mathPlugin)}
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [needed, plugin])
+
+  return needed ? plugin : null
+}
 
 // `@streamdown/code` statically imports ALL of shiki (every grammar + theme —
 // the single largest chunk in the renderer), so it must never sit on the
@@ -476,7 +494,8 @@ function MarkdownTextSurface({
   // `SyntaxHighlighter` below when `isStreaming` is true, and the code plugin
   // itself arrives async (useCodePlugin) so shiki never blocks cold start.
   const code = useCodePlugin()
-  const plugins = useMemo(() => (code ? { math: mathPlugin, code } : { math: mathPlugin }), [code])
+  const math = useMathPlugin(text)
+  const plugins = useMemo(() => ({ ...(code ? { code } : {}), ...(math ? { math } : {}) }), [code, math])
 
   const components = useMemo(
     () =>

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -91,9 +91,10 @@ const signature = (rows: [string, string, number][]) =>
   rows.map(([id, role, weight], index) => `${index}:${id}:${role}:${weight}`).join('\n')
 
 describe('transcriptPaneBudget', () => {
-  it('uses a fixed live-tail budget while hidden instead of charging every mounted transcript', () => {
+  it('gives hidden transcripts zero mounted budget', () => {
     expect(transcriptPaneBudget(1, true)).toBe(HIDDEN_TRANSCRIPT_RENDER_BUDGET)
     expect(transcriptPaneBudget(4, true)).toBe(HIDDEN_TRANSCRIPT_RENDER_BUDGET)
+    expect(HIDDEN_TRANSCRIPT_RENDER_BUDGET).toBe(0)
     expect(transcriptPaneBudget(1, false)).toBeGreaterThan(HIDDEN_TRANSCRIPT_RENDER_BUDGET)
   })
 })
@@ -115,8 +116,8 @@ describe('buildGroups', () => {
     )
 
     expect(groups).toEqual([
-      { id: 'u1', indices: [0, 1, 2], kind: 'turn', weight: 7 },
-      { id: 'u2', indices: [3, 4], kind: 'turn', weight: 4 }
+      { endIndex: 2, id: 'u1', kind: 'turn', messageIds: ['u1', 'a1', 'a2'], weight: 7 },
+      { endIndex: 4, id: 'u2', kind: 'turn', messageIds: ['u2', 'a3'], weight: 4 }
     ])
   })
 
@@ -131,16 +132,16 @@ describe('buildGroups', () => {
     )
 
     expect(groups).toEqual([
-      { id: 's1', index: 0, kind: 'standalone', weight: 1 },
-      { id: 'a0', index: 1, kind: 'standalone', weight: 2 },
-      { id: 'u1', indices: [2, 3], kind: 'turn', weight: 6 }
+      { endIndex: 0, id: 's1', kind: 'standalone', messageId: 's1', weight: 1 },
+      { endIndex: 1, id: 'a0', kind: 'standalone', messageId: 'a0', weight: 2 },
+      { endIndex: 3, id: 'u1', kind: 'turn', messageIds: ['u1', 'a1'], weight: 6 }
     ])
   })
 
   it('defaults a missing/zero weight to 1', () => {
     const groups = buildGroups('0:a:assistant:0')
 
-    expect(groups).toEqual([{ id: 'a', index: 0, kind: 'standalone', weight: 1 }])
+    expect(groups).toEqual([{ endIndex: 0, id: 'a', kind: 'standalone', messageId: 'a', weight: 1 }])
   })
 })
 
@@ -192,7 +193,13 @@ describe('resolveThreadScrollTarget', () => {
 })
 
 describe('firstVisibleGroupIndex', () => {
-  const group = (id: string, weight: number): MessageGroup => ({ id, index: 0, kind: 'standalone', weight })
+  const group = (id: string, weight: number): MessageGroup => ({
+    endIndex: 0,
+    id,
+    kind: 'standalone',
+    messageId: id,
+    weight
+  })
 
   it('shows everything when total weight fits the budget', () => {
     const groups = [group('a', 10), group('b', 10), group('c', 10)]
@@ -234,7 +241,13 @@ describe('firstVisibleGroupIndex', () => {
 })
 
 describe('liveTailStart', () => {
-  const group = (id: string, weight: number): MessageGroup => ({ id, index: 0, kind: 'standalone', weight })
+  const group = (id: string, weight: number): MessageGroup => ({
+    endIndex: 0,
+    id,
+    kind: 'standalone',
+    messageId: id,
+    weight
+  })
 
   it('keeps the newest turns rendered until the parts budget is spent', () => {
     // 10 turns x 10 parts. A 40-part tail covers the newest 4-5 turns.

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -32,12 +32,13 @@ import { isSecondaryWindow } from '@/store/windows'
 
 import { MessageRenderBoundary } from '../message-render-boundary'
 
+import { useTranscriptLayout } from './transcript-layout'
 import { resolveShowEarlierAction, useTranscriptWindow } from './transcript-window'
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
-export type MessageGroup = { id: string; weight: number } & (
-  { index: number; kind: 'standalone' } | { indices: number[]; kind: 'turn' }
+export type MessageGroup = { endIndex: number; id: string; weight: number } & (
+  { kind: 'standalone'; messageId: string } | { kind: 'turn'; messageIds: string[] }
 )
 
 // DOM is bounded by a render-cost budget, not a message/turn count. The
@@ -96,10 +97,10 @@ const MIN_VISIBLE_GROUPS = 8
 // interruptibly, so the only thing a smaller budget changes is how much work
 // blocks the click-to-paint path.
 const FIRST_PAINT_BUDGET = 20
-// A hot-hidden transcript is retained for instant tab return, but keeping its
-// full scrollback mounted defeats the bounded pane cache. Preserve only the
-// live tail while hidden; revealing it resumes stepped backfill.
-export const HIDDEN_TRANSCRIPT_RENDER_BUDGET = 40
+// Chat panes retain their lightweight shell while hidden, but mount no
+// transcript rows. The owning ChatView unmounts Thread; this zero is the
+// defensive budget if a nonstandard surface keeps the list mounted.
+export const HIDDEN_TRANSCRIPT_RENDER_BUDGET = 0
 
 export const transcriptPaneBudget = (mountedPanes: number, hidden: boolean): number =>
   hidden
@@ -195,20 +196,20 @@ export function buildGroups(signature: string): MessageGroup[] {
     const message = messages[i]
 
     if (message.role !== 'user') {
-      groups.push({ id: message.id, index: message.index, kind: 'standalone', weight: message.weight })
+      groups.push({ endIndex: message.index, id: message.id, kind: 'standalone', messageId: message.id, weight: message.weight })
 
       continue
     }
 
-    const indices = [message.index]
+    const messageIds = [message.id]
     let weight = message.weight
 
     while (i + 1 < messages.length && messages[i + 1].role !== 'user') {
       weight += messages[++i].weight
-      indices.push(messages[i].index)
+      messageIds.push(messages[i].id)
     }
 
-    groups.push({ id: message.id, indices, kind: 'turn', weight })
+    groups.push({ endIndex: messages[i].index, id: message.id, kind: 'turn', messageIds, weight })
   }
 
   return groups
@@ -344,12 +345,12 @@ const TurnRow = memo(function TurnRow({ components, group, resetKey, virtualized
             className="composer-human-ai-pair-container relative flex min-w-0 flex-col gap-(--conversation-turn-gap)"
             data-slot="aui_turn-pair"
           >
-            {group.indices.map(index => (
-              <ThreadPrimitive.MessageByIndex components={components} index={index} key={index} />
+            {group.messageIds.map(messageId => (
+              <ThreadPrimitive.Unstable_MessageById components={components} key={messageId} messageId={messageId} />
             ))}
           </div>
         ) : (
-          <ThreadPrimitive.MessageByIndex components={components} index={group.index} />
+          <ThreadPrimitive.Unstable_MessageById components={components} messageId={group.messageId} />
         )}
       </MessageRenderBoundary>
     </div>
@@ -363,27 +364,22 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   loadingIndicator,
   sessionKey
 }) => {
-  // TWO signatures, deliberately split. The STRUCTURAL one (ids/roles/count)
-  // changes only when messages are added/removed/swapped — it keys the error
-  // boundaries and the row identity. The WEIGHT one (parts + character cost)
-  // ticks while a streaming turn appends content — it feeds only the render
-  // budget. Folding weights into the structural key handed every boundary a
-  // new resetKey per appended part, which reconciled every turn's subtree on
-  // every tick (measured: 540 wasted Block renders per explain() sample with
-  // two threads streaming).
-  const structuralSignature = useAuiState(s =>
-    s.thread.messages.map((message, index) => `${index}:${message.id}:${message.role}`).join('\n')
+  const transcriptLayout = useTranscriptLayout()
+
+  // Standalone Thread tests and third-party surfaces do not install Hermes'
+  // projection provider. Keep a compatibility projection there; production
+  // chat always receives the incremental layout and never runs this selector.
+  const fallbackSignature = useAuiState(s =>
+    transcriptLayout
+      ? ''
+      : s.thread.messages
+          .map((message, index) => `${index}:${message.id}:${message.role}:${messagePaintWeight(message.content)}`)
+          .join('\n')
   )
 
-  const weightSignature = useAuiState(s =>
-    s.thread.messages.map(message => messagePaintWeight(message.content)).join(',')
-  )
-
+  const fallbackGroups = useMemo(() => buildGroups(fallbackSignature), [fallbackSignature])
+  const groups = transcriptLayout?.groups ?? fallbackGroups
   const { t } = useI18n()
-  // Row structure is memoized on the STRUCTURAL signature only, so streaming
-  // part-appends can't churn group identity (that would defeat the rows memo
-  // below on every tick). Weights are folded in separately for the budget.
-  const groups = useMemo(() => buildGroups(structuralSignature), [structuralSignature])
   const renderEmpty = groups.length === 0 && Boolean(emptyPlaceholder)
 
   // use-stick-to-bottom owns scrollTop (single writer): follow while locked,
@@ -504,20 +500,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     return () => cancelAnimationFrame(rafId)
   }, [anchorBeforePrepend, paneBudget, renderBudget])
 
-  // Weights (part count + visible character cost) fold into the BUDGET only.
-  // Group identity stays structural, so a streaming append re-runs this cheap
-  // sum — not the row JSX. Settled content hits messagePaintWeight's WeakMap.
-  const weightedGroups = useMemo(() => {
-    const weights = weightSignature.split(',').map(w => Number(w) || 1)
-
-    return groups.map(group => ({
-      ...group,
-      weight:
-        group.kind === 'turn'
-          ? group.indices.reduce((sum, index) => sum + (weights[index] ?? 1), 0)
-          : (weights[group.index] ?? 1)
-    }))
-  }, [groups, weightSignature])
+  const weightedGroups = groups
 
   // The turn floor applies to a real page only. During the first-paint budget
   // the point is a small synchronous commit; forcing 8 turns into it would put
@@ -727,11 +710,13 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
           components={components}
           group={group}
           key={group.id}
-          resetKey={structuralSignature}
+          resetKey={
+            group.kind === 'turn' ? `${group.id}:${group.messageIds.join(',')}` : group.id
+          }
           virtualized={indexInVisible < tailStart}
         />
       )),
-    [visibleGroups, components, structuralSignature, tailStart]
+    [visibleGroups, components, tailStart]
   )
 
   return (

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-layout.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-layout.test.tsx
@@ -1,0 +1,47 @@
+import { fromThreadMessageLike, getAutoStatus } from '@assistant-ui/core/internal'
+import type { ThreadMessage } from '@assistant-ui/react'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { useTranscriptLayoutIndex } from './transcript-layout'
+
+const STATUS = getAutoStatus(false, false, false, false, undefined)
+
+const message = (id: string, role: 'assistant' | 'user', text: string): ThreadMessage =>
+  fromThreadMessageLike({ role, content: [{ type: 'text', text }] }, id, STATUS)
+
+describe('useTranscriptLayoutIndex', () => {
+  it('preserves settled group identity and rebuilds only the changed tail', () => {
+    const settledUser = message('u1', 'user', 'one')
+    const settledAssistant = message('a1', 'assistant', 'reply')
+    const tailUser = message('u2', 'user', 'two')
+    const tail = message('a2', 'assistant', 'a')
+    let messages = [settledUser, settledAssistant, tailUser, tail]
+    let operation: 'replace-tail' | 'reset' = 'reset'
+    const { result, rerender } = renderHook(() => useTranscriptLayoutIndex(messages, operation))
+    const settledGroup = result.current.groups[0]
+    const oldTailGroup = result.current.groups[1]
+
+    act(() => {
+      messages = [settledUser, settledAssistant, tailUser, message('a2', 'assistant', 'ab')]
+      operation = 'replace-tail'
+      rerender()
+    })
+
+    expect(result.current.groups[0]).toBe(settledGroup)
+    expect(result.current.groups[1]).not.toBe(oldTailGroup)
+    expect(result.current.groups[1].id).toBe('u2')
+  })
+
+  it('handles reset, compression, and branch replacements from the changed prefix', () => {
+    let messages = [message('u1', 'user', 'one'), message('a1', 'assistant', 'reply')]
+    const { result, rerender } = renderHook(() => useTranscriptLayoutIndex(messages))
+
+    act(() => {
+      messages = [message('compressed', 'assistant', 'summary'), message('u2', 'user', 'branch')]
+      rerender()
+    })
+
+    expect(result.current.groups.map(group => group.id)).toEqual(['compressed', 'u2'])
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-layout.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-layout.tsx
@@ -1,0 +1,110 @@
+import type { ThreadMessage } from '@assistant-ui/react'
+import { createContext, type ReactNode, useContext, useRef } from 'react'
+
+import { messagePaintWeight } from '@/lib/render-weight'
+
+import type { MessageGroup } from './list'
+
+export interface TranscriptLayoutSnapshot {
+  groups: readonly MessageGroup[]
+}
+
+const EMPTY_LAYOUT: TranscriptLayoutSnapshot = { groups: [] }
+const TranscriptLayoutContext = createContext<TranscriptLayoutSnapshot | null>(null)
+
+export function TranscriptLayoutProvider({ children, value }: { children: ReactNode; value: TranscriptLayoutSnapshot }) {
+  return <TranscriptLayoutContext.Provider value={value}>{children}</TranscriptLayoutContext.Provider>
+}
+
+export const useTranscriptLayout = () => useContext(TranscriptLayoutContext)
+
+/** Persistent grouping index. A streaming update replaces only the final
+ * message, so settled group objects stay identical and work starts at the
+ * changed tail rather than scanning or signing the complete transcript. */
+export function useTranscriptLayoutIndex(
+  messages: readonly ThreadMessage[],
+  operation: 'append' | 'finalize-tail' | 'replace-tail' | 'reset' = 'reset'
+): TranscriptLayoutSnapshot {
+  const previousRef = useRef<{ messages: readonly ThreadMessage[]; snapshot: TranscriptLayoutSnapshot }>({
+    messages: [],
+    snapshot: EMPTY_LAYOUT
+  })
+
+  const previous = previousRef.current
+  let shared: number
+
+  if (
+    operation === 'append' &&
+    messages.length === previous.messages.length + 1 &&
+    messages.at(-2) === previous.messages.at(-1)
+  ) {
+    shared = previous.messages.length
+  } else if (
+    (operation === 'replace-tail' || operation === 'finalize-tail') &&
+    messages.length === previous.messages.length &&
+    messages.length > 0 &&
+    messages.at(-1)?.id === previous.messages.at(-1)?.id
+  ) {
+    shared = messages.length - 1
+  } else {
+    shared = 0
+    const limit = Math.min(previous.messages.length, messages.length)
+
+    while (shared < limit && previous.messages[shared] === messages[shared]) {
+      shared += 1
+    }
+  }
+
+  if (shared === messages.length && shared === previous.messages.length) {
+    return previous.snapshot
+  }
+
+  // A changed assistant tail belongs to its preceding user group. Rebuild from
+  // that boundary; append-only transcripts usually rebuild one group.
+  let rebuildMessage = shared
+
+  while (rebuildMessage > 0 && messages[rebuildMessage]?.role !== 'user') {
+    rebuildMessage -= 1
+  }
+
+  let keepGroups = 0
+
+  while (keepGroups < previous.snapshot.groups.length) {
+    const group = previous.snapshot.groups[keepGroups]
+
+    if (group.endIndex >= rebuildMessage) {
+      break
+    }
+
+    keepGroups += 1
+  }
+
+  const groups = previous.snapshot.groups.slice(0, keepGroups) as MessageGroup[]
+
+  for (let index = rebuildMessage; index < messages.length; index += 1) {
+    const message = messages[index]
+    const weight = messagePaintWeight(message.content)
+
+    if (message.role !== 'user') {
+      groups.push({ endIndex: index, id: message.id, kind: 'standalone', messageId: message.id, weight })
+
+      continue
+    }
+
+    const messageIds = [message.id]
+    let groupWeight = weight
+
+    while (index + 1 < messages.length && messages[index + 1].role !== 'user') {
+      index += 1
+      messageIds.push(messages[index].id)
+      groupWeight += messagePaintWeight(messages[index].content)
+    }
+
+    groups.push({ endIndex: index, id: message.id, kind: 'turn', messageIds, weight: groupWeight })
+  }
+
+  const snapshot = { groups }
+  previousRef.current = { messages, snapshot }
+
+  return snapshot
+}

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -20,8 +20,8 @@ import {
   petProfile,
   setPetInfo
 } from '@/store/pet'
-import { resetPetGallery, setPetScale } from '@/store/pet-gallery'
 import { $petOverlayActive, initPetOverlayBridge, popOutPet, restorePetOverlay } from '@/store/pet-overlay'
+import { setPetScale } from '@/store/pet-scale'
 import { $gatewayState } from '@/store/session'
 import { isSecondaryWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
@@ -273,7 +273,7 @@ export function FloatingPet() {
   // profile's pet (its config + pets dir resolve per-profile on the backend).
   useOnProfileSwitch(() => {
     setPetInfo({ enabled: false })
-    resetPetGallery()
+    void import('@/store/pet-gallery').then(({ resetPetGallery }) => resetPetGallery())
   })
 
   // Wire the overlay control channel once, only in the primary window — the

--- a/apps/desktop/src/components/pet/use-pet-zoom-gesture.ts
+++ b/apps/desktop/src/components/pet/use-pet-zoom-gesture.ts
@@ -1,7 +1,7 @@
 import { type RefObject, useEffect } from 'react'
 
 import { $petInfo } from '@/store/pet'
-import { nextScaleFromWheel, PET_SCALE_DEFAULT } from '@/store/pet-gallery'
+import { nextScaleFromWheel, PET_SCALE_DEFAULT } from '@/store/pet-scale'
 
 /** Where the gesture happened + how much it scaled — lets callers zoom toward the
  *  cursor (keep the pixel under it fixed) instead of growing from a corner. */

--- a/apps/desktop/src/lib/incremental-external-store-runtime.test.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.test.ts
@@ -32,8 +32,11 @@ function chain(messages: ThreadMessage[]) {
   }))
 }
 
-function exported(items: { message: ThreadMessage; parentId: string | null }[]): ExportedMessageRepository {
-  return { headId: items.at(-1)?.message.id ?? null, messages: items }
+function exported(
+  items: { message: ThreadMessage; parentId: string | null }[],
+  operation: 'append' | 'finalize-tail' | 'replace-tail' | 'reset' = 'reset'
+): ExportedMessageRepository {
+  return { headId: items.at(-1)?.message.id ?? null, messages: items, operation } as ExportedMessageRepository
 }
 
 describe('syncRepositoryIncrementally', () => {
@@ -43,19 +46,25 @@ describe('syncRepositoryIncrementally', () => {
     const runtime = runtimeWith(items)
     const repository = (runtime as unknown as { repository: MessageRepository }).repository
 
+    // Seed the persistent incoming index. Subsequent publications use explicit
+    // tail operations and must not export/scan the repository.
+    syncRepositoryIncrementally(runtime, exported(items))
+
     const addOrUpdate = vi.spyOn(repository, 'addOrUpdateMessage')
     const resetHead = vi.spyOn(repository, 'resetHead')
+    const exportRepository = vi.spyOn(repository, 'export')
 
     // One streamed delta: the tail grows, every settled message keeps identity.
     const nextTail = message('m-199', 'body 199 + delta')
     const nextItems = [...items.slice(0, -1), { message: nextTail, parentId: 'm-198' }]
 
-    const result = syncRepositoryIncrementally(runtime, exported(nextItems))
+    const result = syncRepositoryIncrementally(runtime, exported(nextItems, 'replace-tail'))
 
     expect(addOrUpdate).toHaveBeenCalledTimes(1)
     expect(addOrUpdate).toHaveBeenCalledWith('m-198', nextTail)
     // The head did not move, so the descendant-pruning reset is skipped.
     expect(resetHead).not.toHaveBeenCalled()
+    expect(exportRepository).not.toHaveBeenCalled()
     expect(result).toHaveLength(200)
     expect(result.at(-1)).toBe(nextTail)
   })
@@ -65,13 +74,16 @@ describe('syncRepositoryIncrementally', () => {
     const runtime = runtimeWith(items)
     const repository = (runtime as unknown as { repository: MessageRepository }).repository
 
+    syncRepositoryIncrementally(runtime, exported(items))
     const addOrUpdate = vi.spyOn(repository, 'addOrUpdateMessage')
     const deleteMessage = vi.spyOn(repository, 'deleteMessage')
+    const exportRepository = vi.spyOn(repository, 'export')
 
-    syncRepositoryIncrementally(runtime, exported(items))
+    syncRepositoryIncrementally(runtime, exported(items, 'replace-tail'))
 
     expect(addOrUpdate).not.toHaveBeenCalled()
     expect(deleteMessage).not.toHaveBeenCalled()
+    expect(exportRepository).not.toHaveBeenCalled()
   })
 
   it('appends a new message through the full path', () => {
@@ -79,10 +91,14 @@ describe('syncRepositoryIncrementally', () => {
     const items = chain([first])
     const runtime = runtimeWith(items)
 
+    syncRepositoryIncrementally(runtime, exported(items))
+    const repository = (runtime as unknown as { repository: MessageRepository }).repository
+    const exportRepository = vi.spyOn(repository, 'export')
     const second = message('b', 'two')
-    const result = syncRepositoryIncrementally(runtime, exported(chain([first, second])))
+    const result = syncRepositoryIncrementally(runtime, exported(chain([first, second]), 'append'))
 
     expect(result.map(item => item.id)).toEqual(['a', 'b'])
+    expect(exportRepository).not.toHaveBeenCalled()
   })
 
   it('honours an authoritative deletion', () => {

--- a/apps/desktop/src/lib/incremental-external-store-runtime.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.ts
@@ -48,29 +48,65 @@ const getThreadListAdapter = (store: ExternalStoreAdapter) => store.adapters?.th
  * incoming message has no repository entry yet), so the caller falls back to
  * the full rebuild rather than guessing.
  */
-function applyChangedMessages(
-  repository: ExternalStoreThreadRuntimeCore['repository'],
-  existing: readonly { message: ThreadMessage; parentId: string | null }[],
+interface RepositorySyncState {
   incoming: readonly { message: ThreadMessage; parentId: string | null }[]
+}
+
+type OperationRepository = NonNullable<ExternalStoreAdapter['messageRepository']> & {
+  operation?: 'append' | 'finalize-tail' | 'replace-tail' | 'reset'
+}
+
+const syncStates = new WeakMap<object, RepositorySyncState>()
+
+/** The explicit steady-state operations: append one row or replace the live
+ * tail. Both are O(1); resets/reparents/compression intentionally use rebuild. */
+function applyTailOperation(
+  repository: ExternalStoreThreadRuntimeCore['repository'],
+  previous: RepositorySyncState | undefined,
+  incoming: readonly { message: ThreadMessage; parentId: string | null }[],
+  operation: OperationRepository['operation']
 ): boolean {
-  if (existing.length !== incoming.length) {
+  const before = previous?.incoming
+
+  if (!before) {
     return false
   }
 
-  const existingById = new Map(existing.map(item => [item.message.id, item]))
+  if (
+    operation === 'append' &&
+    incoming.length === before.length + 1 &&
+    incoming.at(-2)?.message === before.at(-1)?.message
+  ) {
+    const appended = incoming.at(-1)!
+    repository.addOrUpdateMessage(appended.parentId, appended.message)
 
-  for (const item of incoming) {
-    const current = existingById.get(item.message.id)
+    return true
+  }
 
-    if (!current) {
-      return false
-    }
+  if (
+    (operation !== 'replace-tail' && operation !== 'finalize-tail') ||
+    incoming.length !== before.length ||
+    incoming.length === 0
+  ) {
+    return false
+  }
 
-    // Reference identity, not deep equality: the conversion cache guarantees a
-    // stable object for an unchanged turn, and a changed turn is a new object.
-    if (current.message !== item.message || current.parentId !== item.parentId) {
-      repository.addOrUpdateMessage(item.parentId, item.message)
-    }
+  const oldTail = before.at(-1)!
+  const nextTail = incoming.at(-1)!
+
+  // Endpoint identity proves this is the same branch. Structural operations
+  // (reset/compression/reparent) change an endpoint/parent and take the safe
+  // rebuild path; token/tool/error settlement replaces only this tail object.
+  if (
+    before[0]?.message.id !== incoming[0]?.message.id ||
+    oldTail.message.id !== nextTail.message.id ||
+    oldTail.parentId !== nextTail.parentId
+  ) {
+    return false
+  }
+
+  if (oldTail.message !== nextTail.message) {
+    repository.addOrUpdateMessage(nextTail.parentId, nextTail.message)
   }
 
   return true
@@ -82,8 +118,24 @@ export function syncRepositoryIncrementally(
 ): readonly ThreadMessage[] {
   const repository = (runtime as unknown as { repository: ExternalStoreThreadRuntimeCore['repository'] }).repository
   const incoming = messageRepository.messages
-  const existing = repository.export().messages
+  const operation = (messageRepository as OperationRepository).operation
+  const previous = syncStates.get(runtime as unknown as object)
   const headId = messageRepository.headId ?? incoming.at(-1)?.message.id ?? null
+
+  // The steady path must not call export(): assistant-ui's export walks the
+  // complete repository. Persistent incoming indexes tell us exactly whether
+  // this publication is a tail patch/append before any whole-transcript work.
+  if (applyTailOperation(repository, previous, incoming, operation)) {
+    syncStates.set(runtime as unknown as object, { incoming })
+
+    if (repository.headId !== headId) {
+      repository.resetHead(headId)
+    }
+
+    return repository.getMessages()
+  }
+
+  const existing = repository.export().messages
 
   // A thread switch swaps in a fully-DISJOINT transcript (no id carries over).
   // Reconciling two unrelated trees in place — grafting the new chain onto the
@@ -91,17 +143,6 @@ export function syncRepositoryIncrementally(
   // to preserve: clear the tree first (leaves→root), then rebuild clean.
   const incomingIds = new Set(incoming.map(({ message }) => message.id))
   const disjoint = existing.length > 0 && !existing.some(({ message }) => incomingIds.has(message.id))
-
-  // Steady-state streaming: same message set, one item changed. Skip the
-  // whole-transcript rewrite, the prune scan, and the second export. resetHead
-  // deletes the head's descendants, so it only runs when the head really moved.
-  if (!disjoint && applyChangedMessages(repository, existing, incoming)) {
-    if (repository.headId !== headId) {
-      repository.resetHead(headId)
-    }
-
-    return repository.getMessages()
-  }
 
   if (disjoint) {
     for (const { message } of [...existing].reverse()) {
@@ -120,6 +161,7 @@ export function syncRepositoryIncrementally(
   }
 
   repository.resetHead(headId)
+  syncStates.set(runtime as unknown as object, { incoming })
 
   return repository.getMessages()
 }

--- a/apps/desktop/src/store/pet-gallery.ts
+++ b/apps/desktop/src/store/pet-gallery.ts
@@ -371,55 +371,7 @@ export function setPetEnabled(
   })
 }
 
-// Pet scale bounds — mirror `agent/pet/constants.py` (MIN_SCALE / MAX_SCALE) so
-// the slider and the server clamp to the same range.
-export const PET_SCALE_MIN = 0.1
-export const PET_SCALE_MAX = 3.0
-export const PET_SCALE_DEFAULT = 0.33
-export const clampPetScale = (n: number) => Math.max(PET_SCALE_MIN, Math.min(PET_SCALE_MAX, n))
-
-// Wheel → scale. Multiplicative so one notch feels the same at any size. Tuned
-// for a discrete mouse-wheel notch (deltaY ≈ ±100); trackpad two-finger scroll
-// (smaller deltas) just resizes more gently, which is fine.
-const WHEEL_SCALE_K = 0.0015
-
-/**
- * Next pet scale for one mouse-wheel step over the pet. Scrolling up (deltaY < 0)
- * grows it, scrolling down shrinks it; the result is clamped to the slider's range.
- */
-export function nextScaleFromWheel(current: number | undefined, deltaY: number): number {
-  const base = current ?? PET_SCALE_DEFAULT
-
-  return clampPetScale(base * Math.exp(-deltaY * WHEEL_SCALE_K))
-}
-
-let scalePersist: ReturnType<typeof setTimeout> | undefined
-
-/**
- * Resize the floating pet. Updates `$petInfo` synchronously so the on-screen pet
- * (and the slider) react on the same frame, then debounce-persists to
- * `display.pet.scale` so a slider drag fires one RPC, not one per pixel. No poll
- * or event needed — the pet already renders from `$petInfo.scale`.
- */
-export function setPetScale(request: GatewayRequest, scale: number): void {
-  const next = clampPetScale(scale)
-
-  setPetInfo({ ...$petInfo.get(), scale: next })
-
-  clearTimeout(scalePersist)
-  scalePersist = setTimeout(() => {
-    petRpc<{ ok: boolean; scale?: number }>(request, 'pet.scale', { scale: next })
-      .then(result => {
-        // Reconcile with the server's clamp (cheap; only matters at the bounds).
-        if (typeof result?.scale === 'number' && result.scale !== $petInfo.get().scale) {
-          setPetInfo({ ...$petInfo.get(), scale: result.scale })
-        }
-      })
-      .catch(() => {
-        // Cosmetic — the pet already resized; persistence self-heals next write.
-      })
-  }, 200)
-}
+export { clampPetScale, nextScaleFromWheel, PET_SCALE_DEFAULT, PET_SCALE_MAX, PET_SCALE_MIN, setPetScale } from './pet-scale'
 
 /** Export a pet as a `.zip` (pet.json + spritesheet) and save it via the browser. */
 export async function exportPet(request: GatewayRequest, slug: string, fallback: string): Promise<boolean> {

--- a/apps/desktop/src/store/pet-scale.ts
+++ b/apps/desktop/src/store/pet-scale.ts
@@ -1,0 +1,36 @@
+import { $petInfo, petProfile, setPetInfo } from '@/store/pet'
+
+export type GatewayRequest = <T>(
+  method: string,
+  params?: Record<string, unknown>,
+  timeoutMs?: number,
+  signal?: AbortSignal
+) => Promise<T>
+
+export const PET_SCALE_MIN = 0.1
+export const PET_SCALE_MAX = 3.0
+export const PET_SCALE_DEFAULT = 0.33
+export const clampPetScale = (n: number) => Math.max(PET_SCALE_MIN, Math.min(PET_SCALE_MAX, n))
+
+const WHEEL_SCALE_K = 0.0015
+
+export function nextScaleFromWheel(current: number | undefined, deltaY: number): number {
+  return clampPetScale((current ?? PET_SCALE_DEFAULT) * Math.exp(-deltaY * WHEEL_SCALE_K))
+}
+
+let scalePersist: ReturnType<typeof setTimeout> | undefined
+
+export function setPetScale(request: GatewayRequest, scale: number): void {
+  const next = clampPetScale(scale)
+  setPetInfo({ ...$petInfo.get(), scale: next })
+  clearTimeout(scalePersist)
+  scalePersist = setTimeout(() => {
+    request<{ ok: boolean; scale?: number }>('pet.scale', { profile: petProfile(), scale: next })
+      .then(result => {
+        if (typeof result?.scale === 'number' && result.scale !== $petInfo.get().scale) {
+          setPetInfo({ ...$petInfo.get(), scale: result.scale })
+        }
+      })
+      .catch(() => undefined)
+  }, 200)
+}

--- a/apps/desktop/src/store/runtime-session-stores.test.ts
+++ b/apps/desktop/src/store/runtime-session-stores.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+
+import {
+  clearRuntimeStores,
+  publishRuntimeState,
+  runtimeStatusStore,
+  runtimeTranscriptStore
+} from './runtime-session-stores'
+
+describe('runtime session stores', () => {
+  it('publishes a token delta only to the target transcript subscriber', () => {
+    clearRuntimeStores()
+    const aStatus = vi.fn()
+    const aTranscript = vi.fn()
+    const bTranscript = vi.fn()
+
+    const unlisten = [
+      runtimeStatusStore('a').listen(aStatus),
+      runtimeTranscriptStore('a').listen(aTranscript),
+      runtimeTranscriptStore('b').listen(bTranscript)
+    ]
+
+    aStatus.mockClear()
+    aTranscript.mockClear()
+    bTranscript.mockClear()
+
+    const first = createClientSessionState()
+    first.messages = [{ id: 'tail', role: 'assistant', parts: [{ type: 'text', text: 'a' }], pending: true }]
+    publishRuntimeState('a', null, first)
+    aStatus.mockClear()
+    aTranscript.mockClear()
+
+    const next = {
+      ...first,
+      messages: [{ ...first.messages[0], parts: [{ type: 'text' as const, text: 'ab' }] }]
+    }
+
+    publishRuntimeState('a', first, next)
+
+    expect(aTranscript).toHaveBeenCalledTimes(1)
+    expect(aStatus).not.toHaveBeenCalled()
+    expect(bTranscript).not.toHaveBeenCalled()
+    unlisten.forEach(stop => stop())
+  })
+
+  it('keeps settled message identity across a tail replacement', () => {
+    clearRuntimeStores()
+    const settled = { id: 'settled', role: 'user' as const, parts: [{ type: 'text' as const, text: 'prompt' }] }
+    const first = createClientSessionState()
+    first.messages = [settled, { id: 'tail', role: 'assistant', parts: [{ type: 'text', text: 'a' }] }]
+    publishRuntimeState('a', null, first)
+
+    const next = {
+      ...first,
+      messages: [settled, { ...first.messages[1], parts: [{ type: 'text' as const, text: 'ab' }] }]
+    }
+
+    publishRuntimeState('a', first, next)
+
+    expect(runtimeTranscriptStore('a').get().messages[0]).toBe(settled)
+    expect(runtimeTranscriptStore('a').get().operation).toMatchObject({ kind: 'replace-tail', message: next.messages[1] })
+  })
+
+  it('classifies append, finalize, and structural reset operations', () => {
+    clearRuntimeStores()
+    const user = { id: 'user', role: 'user' as const, parts: [{ type: 'text' as const, text: 'prompt' }] }
+
+    const pending = {
+      id: 'tail',
+      role: 'assistant' as const,
+      parts: [{ type: 'text' as const, text: 'answer' }],
+      pending: true
+    }
+
+    const first = { ...createClientSessionState(), messages: [user] }
+    publishRuntimeState('a', null, first)
+
+    const appended = { ...first, messages: [user, pending] }
+    publishRuntimeState('a', first, appended)
+    expect(runtimeTranscriptStore('a').get().operation).toEqual({ kind: 'append', message: pending })
+
+    const final = { ...appended, messages: [user, { ...pending, pending: false }] }
+    publishRuntimeState('a', appended, final)
+    expect(runtimeTranscriptStore('a').get().operation.kind).toBe('finalize-tail')
+
+    const branch = { ...final, messages: [{ ...user, id: 'branch-user' }] }
+    publishRuntimeState('a', final, branch)
+    expect(runtimeTranscriptStore('a').get().operation).toEqual({ kind: 'reset', messages: branch.messages })
+  })
+})

--- a/apps/desktop/src/store/runtime-session-stores.ts
+++ b/apps/desktop/src/store/runtime-session-stores.ts
@@ -1,0 +1,149 @@
+import { atom, type ReadableAtom } from 'nanostores'
+import { useCallback, useSyncExternalStore } from 'react'
+
+import type { ClientSessionState } from '@/app/types'
+import type { ChatMessage } from '@/lib/chat-messages'
+
+export type RuntimeSessionStatus = Omit<ClientSessionState, 'messages'>
+export type RuntimeTranscriptOperation =
+  | { kind: 'append'; message: ChatMessage }
+  | { kind: 'finalize-tail' | 'replace-tail'; message: ChatMessage }
+  | { kind: 'reset'; messages: ChatMessage[] }
+
+export interface RuntimeTranscriptSnapshot {
+  messages: ChatMessage[]
+  operation: RuntimeTranscriptOperation
+}
+
+const EMPTY_MESSAGES: ChatMessage[] = []
+
+const EMPTY_TRANSCRIPT: RuntimeTranscriptSnapshot = {
+  messages: EMPTY_MESSAGES,
+  operation: { kind: 'reset', messages: EMPTY_MESSAGES }
+}
+
+const runtimeStatuses = new Map<string, ReturnType<typeof atom<RuntimeSessionStatus | undefined>>>()
+const runtimeTranscripts = new Map<string, ReturnType<typeof atom<RuntimeTranscriptSnapshot>>>()
+
+const withoutMessages = ({ messages: _messages, ...status }: ClientSessionState): RuntimeSessionStatus => status
+
+function statusStore(runtimeId: string) {
+  let store = runtimeStatuses.get(runtimeId)
+
+  if (!store) {
+    store = atom<RuntimeSessionStatus | undefined>()
+    runtimeStatuses.set(runtimeId, store)
+  }
+
+  return store
+}
+
+export function runtimeStatusStore(runtimeId: string): ReadableAtom<RuntimeSessionStatus | undefined> {
+  return statusStore(runtimeId)
+}
+
+export function runtimeTranscriptStore(runtimeId: string): ReadableAtom<RuntimeTranscriptSnapshot> {
+  let store = runtimeTranscripts.get(runtimeId)
+
+  if (!store) {
+    store = atom<RuntimeTranscriptSnapshot>(EMPTY_TRANSCRIPT)
+    runtimeTranscripts.set(runtimeId, store)
+  }
+
+  return store
+}
+
+/** Publish one runtime only. Transcript and status are independent channels so
+ * a token delta cannot wake status consumers or another runtime's transcript. */
+export function publishRuntimeState(runtimeId: string, previous: ClientSessionState | null, state: ClientSessionState) {
+  if (!previous || statusChanged(previous, state)) {
+    statusStore(runtimeId).set(withoutMessages(state))
+  }
+
+  publishRuntimeTranscript(runtimeId, previous?.messages ?? null, state.messages)
+}
+
+export function useRuntimeTranscript(runtimeId: string | null, enabled = true): RuntimeTranscriptSnapshot {
+  const store = runtimeId ? runtimeTranscriptStore(runtimeId) : null
+
+  const subscribe = useCallback(
+    (listener: () => void) => (store && enabled ? store.listen(listener) : () => undefined),
+    [enabled, store]
+  )
+
+  return useSyncExternalStore(subscribe, () => store?.get() ?? EMPTY_TRANSCRIPT)
+}
+
+function transcriptOperation(previous: ChatMessage[] | null, messages: ChatMessage[]): RuntimeTranscriptOperation {
+  if (previous && messages.length === previous.length + 1 && messages.at(-2) === previous.at(-1)) {
+    return { kind: 'append', message: messages.at(-1)! }
+  }
+
+  if (previous && messages.length === previous.length && messages.length > 0) {
+    const oldTail = previous.at(-1)!
+    const nextTail = messages.at(-1)!
+    const samePrefix = messages.length === 1 || messages.at(-2) === previous.at(-2)
+
+    if (samePrefix && oldTail.id === nextTail.id) {
+      return {
+        kind: oldTail.pending && !nextTail.pending ? 'finalize-tail' : 'replace-tail',
+        message: nextTail
+      }
+    }
+  }
+
+  return { kind: 'reset', messages }
+}
+
+export function publishRuntimeTranscript(runtimeId: string, previous: ChatMessage[] | null, messages: ChatMessage[]) {
+  const transcript = runtimeTranscriptStore(runtimeId) as ReturnType<typeof atom<RuntimeTranscriptSnapshot>>
+
+  if (transcript.get().messages !== messages) {
+    transcript.set({ messages, operation: transcriptOperation(previous, messages) })
+  }
+}
+
+export function releaseRuntimeTranscript(runtimeId: string) {
+  const transcript = runtimeTranscripts.get(runtimeId)
+  const snapshot = transcript?.get()
+
+  // Test/module hot-reload isolation can leave the pre-normalization array
+  // shape in this module-level map. Treat it as an occupied transcript and
+  // normalize it instead of throwing during lifecycle cleanup.
+  if (snapshot && (Array.isArray(snapshot) || (Array.isArray(snapshot.messages) && snapshot.messages.length > 0))) {
+    transcript!.set(EMPTY_TRANSCRIPT)
+  }
+}
+
+export function dropRuntimeStores(runtimeId: string) {
+  runtimeStatuses.get(runtimeId)?.set(undefined)
+  runtimeTranscripts.get(runtimeId)?.set(EMPTY_TRANSCRIPT)
+  runtimeStatuses.delete(runtimeId)
+  runtimeTranscripts.delete(runtimeId)
+}
+
+export function clearRuntimeStores() {
+  for (const status of runtimeStatuses.values()) {
+    status.set(undefined)
+  }
+
+  for (const transcript of runtimeTranscripts.values()) {
+    transcript.set(EMPTY_TRANSCRIPT)
+  }
+
+  runtimeStatuses.clear()
+  runtimeTranscripts.clear()
+}
+
+function statusChanged(previous: ClientSessionState, next: ClientSessionState): boolean {
+  const previousStatus = previous as unknown as Record<string, unknown>
+  const nextStatus = next as unknown as Record<string, unknown>
+
+  for (const key of Object.keys(nextStatus)) {
+    if (key !== 'messages' && previousStatus[key] !== nextStatus[key]) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClientSessionState } from '@/app/types'
 import { findGroupOfPane, group, split } from '@/components/pane-shell/tree/model'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { $selectedStoredSessionId } from '@/store/session'
 import type { SessionTile } from '@/store/session-states'
 import {
@@ -12,6 +13,7 @@ import {
   focusedSessionNeedsRoute,
   markSelectionRestore,
   orderTilesByTree,
+  publishSessionState,
   releaseSessionTranscript,
   resetTileRuntimeBindings,
   selectionHomesToWorkspace,
@@ -49,6 +51,30 @@ describe('resetTileRuntimeBindings', () => {
 
     expect(() => resetTileRuntimeBindings()).not.toThrow()
     expect($sessionTiles.get()[0]?.runtimeId).toBeUndefined()
+  })
+})
+
+describe('publishSessionState', () => {
+  afterEach(() => {
+    $sessionStates.set({})
+  })
+
+  it('does not republish the global lifecycle index for a token-only update', () => {
+    const first = createClientSessionState()
+    first.busy = true
+    first.messages = [{ id: 'tail', role: 'assistant', parts: [{ type: 'text', text: 'a' }] }]
+    publishSessionState('runtime', first)
+    const listener = vi.fn()
+    const unlisten = $sessionStates.listen(listener)
+    listener.mockClear()
+
+    publishSessionState('runtime', {
+      ...first,
+      messages: [{ ...first.messages[0], parts: [{ type: 'text', text: 'ab' }] }]
+    })
+
+    expect(listener).not.toHaveBeenCalled()
+    unlisten()
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -36,6 +36,12 @@ import type { SessionInfo } from '@/types/hermes'
 import { $activeGatewayProfile, normalizeProfileKey } from './profile'
 import { clearAllProviderWaits, clearSessionProviderWait } from './provider-wait'
 import {
+  clearRuntimeStores,
+  dropRuntimeStores,
+  publishRuntimeState,
+  releaseRuntimeTranscript
+} from './runtime-session-stores'
+import {
   $activeSessionId,
   $lastReadAtBySessionId,
   $selectedStoredSessionId,
@@ -292,23 +298,46 @@ function evictable(runtimeId: string, state: ClientSessionState): boolean {
  *  effects still fire, so lightweight status and the unread dot survive. A
  *  FIRST publish always lands in full because a resume can publish its idle
  *  state a beat before `$activeSessionId` / the tile binding points at it. */
-export function publishSessionState(runtimeId: string, state: ClientSessionState) {
+export function publishSessionState(
+  runtimeId: string,
+  state: ClientSessionState,
+  previousState?: ClientSessionState | null
+) {
   const current = $sessionStates.get()
-  const prev = current[runtimeId] ?? null
+  const published = current[runtimeId] ?? null
+  const prev = previousState === undefined ? published : previousState
 
   if (prev === state) {
     return
   }
 
-  if (prev && evictable(runtimeId, state)) {
+  publishRuntimeState(runtimeId, prev, state)
+
+  if (published && prev && evictable(runtimeId, state)) {
     handleTransition(prev, state, runtimeId)
     releaseSessionTranscript(runtimeId, state)
 
     return
   }
 
-  $sessionStates.set({ ...current, [runtimeId]: state })
-  handleTransition(prev, state, runtimeId)
+  // Compatibility/status index. Do not republish it for a transcript-only
+  // update: lifecycle consumers wake only on actual status edges, while the
+  // target runtime's transcript channel above receives every token delta.
+  const statusChanged =
+    !published ||
+    !prev ||
+    Object.keys(state).some(
+      key => key !== 'messages' && state[key as keyof ClientSessionState] !== prev[key as keyof ClientSessionState]
+    )
+
+  if (statusChanged) {
+    $sessionStates.set({ ...current, [runtimeId]: state })
+    handleTransition(prev, state, runtimeId)
+  } else if (state.busy) {
+    // Stream activity refreshes only this runtime's silence watchdog. Global
+    // lifecycle memberships do not recompute until a real status edge.
+    armWatchdog(runtimeId)
+  }
 }
 
 /** Keep the cheap status projection for a cold session while releasing its
@@ -332,6 +361,7 @@ export function releaseSessionTranscript(runtimeId: string, state?: ClientSessio
   const lightweight =
     Array.isArray(retained.messages) && retained.messages.length === 0 ? retained : { ...retained, messages: [] }
 
+  releaseRuntimeTranscript(runtimeId)
   $sessionStates.set({ ...current, [runtimeId]: lightweight })
 }
 
@@ -343,6 +373,7 @@ export function dropSessionState(runtimeId: string) {
   clearWatchdog(runtimeId)
   clearSessionProviderWait(runtimeId)
   sessionScopeByRuntimeId.delete(runtimeId)
+  dropRuntimeStores(runtimeId)
 
   const current = $sessionStates.get()
   setSessionStalled(current[runtimeId]?.storedSessionId, false)
@@ -370,6 +401,7 @@ export function clearAllSessionStates() {
   clearAllProviderWaits()
   sessionScopeByRuntimeId.clear()
   $stalledSessionIds.set([])
+  clearRuntimeStores()
   $sessionStates.set({})
 }
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1,7 +1,6 @@
 @import 'tailwindcss';
 @plugin '@tailwindcss/typography';
 @import 'tw-shimmer';
-@import 'katex/dist/katex.min.css';
 @import '@vscode/codicons/dist/codicon.css';
 
 /* Titlebar clusters: 24×24 hit targets, 13.9px glyphs. codicon.css is

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
-import path from 'path'
 import fs from 'fs'
 import { createRequire } from 'module'
+import path from 'path'
+
+import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
 
 // `hgui` symlinks a worktree's node_modules to the main checkout. Vite realpaths
 // those before enforcing server.fs.allow, so codicon/font assets resolve outside
@@ -68,9 +69,10 @@ const emojibaseAssets = () => ({
   }) {
     server.middlewares.use('/emojibase', (req, res, next) => {
       const rel = (req.url ?? '').split('?')[0].replace(/^\/+/, '')
-      if (!emojibaseDir || !EMOJIBASE_PATH.test(rel)) return next()
+
+      if (!emojibaseDir || !EMOJIBASE_PATH.test(rel)) {return next()}
       fs.readFile(path.join(emojibaseDir, rel), (err: unknown, buf: Buffer) => {
-        if (err) return next()
+        if (err) {return next()}
         res.setHeader('Content-Type', 'application/json')
         res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
         res.end(buf)
@@ -78,7 +80,8 @@ const emojibaseAssets = () => ({
     })
   },
   generateBundle(this: { emitFile: (asset: { type: 'asset'; fileName: string; source: Uint8Array }) => void }) {
-    if (!emojibaseDir) return
+    if (!emojibaseDir) {return}
+
     for (const rel of ['en/data.json', 'en/messages.json', 'en/shortcodes/emojibase.json']) {
       this.emitFile({
         type: 'asset',
@@ -118,6 +121,22 @@ export default defineConfig(({ command }) => ({
     // a handful of named vendor chunks loaded on first use, app-level dynamic
     // imports stay lazy, and the file count stays in the tens.
     chunkSizeWarningLimit: 25000,
+    manifest: true,
+    // Electron loads the renderer from file://. Keep Vite's relative dependency
+    // paths untouched (rather than resolving them as web URLs), while avoiding
+    // speculative boot fetches for interaction-only feature chunks. Dynamic
+    // imports still receive their normal dependency preloads on first use.
+    modulePreload: {
+      resolveDependencies: (filename, dependencies, context) =>
+        context.hostId.endsWith('index.html')
+          ? dependencies.filter(
+              dependency =>
+                !/(?:^|\/)(?:katex|shiki|mermaid|code-editor|session-export|(?:create|rename|delete)-profile-dialog|edit-soul-dialog|pet-gallery)-/i.test(
+                  dependency
+                )
+            )
+          : dependencies
+    },
     rolldownOptions: {
       output: {
         advancedChunks: {


### PR DESCRIPTION
## Summary

Make desktop transcript updates incremental: isolate session streams, patch only the changing transcript tail, and keep heavy optional features off startup so active conversations stay responsive.

This PR is **incremental-only**. The earlier lifecycle-cache commit (`ac7ab3bdf`, "bound long-running app resource use") already landed upstream via #86587 and is **not** in this unique range.

## Unique range

- **1 commit** on `main`: `perf(desktop): make transcript updates incremental`
- New files include `runtime-session-stores.ts` and `transcript-layout.tsx` (still missing on `main`)
- 28 files changed

## Rebase

- **Base:** `upstream/main` `7095e23eb2066fe9a2f93b99cdbfe0e2b5ece397`
- **Old HEAD:** `eb58357c69c51911e231375f8146113cd76f987f`
- **New HEAD:** `f7f9c4d36fa58c29e73d6691951ea5fa29f91649`
- **Safety ref:** `refs/safety/perf-desktop-incremental-rendering-pre-rebase-eb58357c6` → `eb58357c69c51911e231375f8146113cd76f987f`
- Replay: `git rebase --onto upstream/main ac7ab3bdf perf/desktop-incremental-rendering`
- Conflicts resolved in `profile-switcher.tsx` (keep incremental lazy dialogs + main `SETTINGS_ROUTE`), `session-states.ts` (keep both `clearSessionProviderWait` and `dropRuntimeStores`), `vite.config.ts` (union of main `createRequire` + incremental path/plugin imports). No `git add -A`.

## Local gates

- `git diff --check upstream/main...HEAD` — clean
- Focused vitest (requested files): **4 files / 15 tests passed**
  - `incremental-external-store-runtime.test.ts`
  - `runtime-session-stores.test.ts`
  - `transcript-layout.test.tsx`
  - `startup-graph.test.mjs`
- Additional unique-diff tests: **2 files / 46 tests passed**
  - `thread/list.test.ts`
  - `session-states.test.ts`

## Notes

- Fork PR `aleksclark/hermes-agent#1` targeted `perf/desktop-lifecycle-cache` and was conflicting; it will be closed as superseded by this focused upstream PR against `main`.
