### PR TITLE
feat: add --duration to `hermes sessions list`

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12783,6 +12783,11 @@ def main():
         "--limit", type=int, default=20, help="Max sessions to show"
     )
     sessions_list.add_argument(
+        "--duration", action="store_true",
+        help="Show wall-clock session duration (from started_at to ended_at, "
+             "or to now if the session is still active)"
+    )
+    sessions_list.add_argument(
         "--workspace",
         metavar="NEEDLE",
         help="Only sessions in one workspace: a git repo root or project dir "

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -21,6 +21,7 @@ time — no import cycle).
 
 import os
 import sys
+import time
 from pathlib import Path
 
 
@@ -37,6 +38,30 @@ def get_hermes_home():
 
 def _relative_time(ts):
     return _m()._relative_time(ts)
+
+
+def _duration_label(s):
+    """Wall-clock session duration from started_at to ended_at.
+
+    Active sessions (ended_at is None) count up to now. Returns a compact
+    label: '42s', '5m 09s', '1h 02m', '1d 04h', or '—' when started_at is
+    missing.
+    """
+    sa, ea = s.get("started_at"), s.get("ended_at")
+    if sa is None:
+        return "—"
+    dur = (ea if ea is not None else time.time()) - sa
+    secs = int(dur)
+    if secs < 60:
+        return f"{secs}s"
+    m, s_rem = divmod(secs, 60)
+    if m < 60:
+        return f"{m}m {s_rem:02d}s"
+    h, m = divmod(m, 60)
+    if h < 24:
+        return f"{h}h {m:02d}m"
+    d, h = divmod(h, 24)
+    return f"{d}d {h:02d}h"
 
 
 def _session_browse_picker(sessions, session_db=None):
@@ -355,30 +380,58 @@ def cmd_sessions(args, sessions_parser=None):
         has_ws = bool(_ws_filter) or any(_ws_key(s) for s in sessions)
         has_titles = any(s.get("title") for s in sessions)
 
+        # Duration column: wall-clock from started_at to ended_at (or now if the
+        # session is still active). Opt-in via --duration so existing column
+        # layouts / scripts parsing the output are untouched.
+        _show_dur = bool(getattr(args, "duration", False))
+
         if has_ws:
             if has_titles:
-                print(f"{'Title':<28} {'Workspace':<18} {'Last Active':<13} {'ID'}")
-                print("─" * 110)
+                if _show_dur:
+                    print(f"{'Duration':<9} {'Title':<28} {'Workspace':<18} {'Last Active':<13} {'ID'}")
+                    print("─" * 120)
+                else:
+                    print(f"{'Title':<28} {'Workspace':<18} {'Last Active':<13} {'ID'}")
+                    print("─" * 110)
             else:
-                print(f"{'Preview':<38} {'Workspace':<18} {'Last Active':<13} {'Src':<6} {'ID'}")
-                print("─" * 100)
+                if _show_dur:
+                    print(f"{'Duration':<9} {'Preview':<38} {'Workspace':<18} {'Last Active':<13} {'Src':<6} {'ID'}")
+                    print("─" * 110)
+                else:
+                    print(f"{'Preview':<38} {'Workspace':<18} {'Last Active':<13} {'Src':<6} {'ID'}")
+                    print("─" * 100)
             for s in sessions:
                 last_active = _relative_time(s.get("last_active"))
                 ws = _ws_label(s)[:16]
+                dur = _duration_label(s)
                 if has_titles:
                     title = (s.get("title") or "—")[:26]
-                    print(f"{title:<28} {ws:<18} {last_active:<13} {s['id']}")
+                    if _show_dur:
+                        print(f"{dur:<9} {title:<28} {ws:<18} {last_active:<13} {s['id']}")
+                    else:
+                        print(f"{title:<28} {ws:<18} {last_active:<13} {s['id']}")
                 else:
                     preview = s.get("preview", "")[:36]
-                    print(f"{preview:<38} {ws:<18} {last_active:<13} {s['source']:<6} {s['id']}")
+                    if _show_dur:
+                        print(f"{dur:<9} {preview:<38} {ws:<18} {last_active:<13} {s['source']:<6} {s['id']}")
+                    else:
+                        print(f"{preview:<38} {ws:<18} {last_active:<13} {s['source']:<6} {s['id']}")
             return
 
         if has_titles:
-            print(f"{'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-            print("─" * 110)
+            if _show_dur:
+                print(f"{'Duration':<9} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
+                print("─" * 120)
+            else:
+                print(f"{'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
+                print("─" * 110)
         else:
-            print(f"{'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
-            print("─" * 95)
+            if _show_dur:
+                print(f"{'Duration':<9} {'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
+                print("─" * 105)
+            else:
+                print(f"{'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
+                print("─" * 95)
         for s in sessions:
             last_active = _relative_time(s.get("last_active"))
             preview = (
@@ -386,13 +439,20 @@ def cmd_sessions(args, sessions_parser=None):
                 if has_titles
                 else s.get("preview", "")[:48]
             )
+            dur = _duration_label(s)
             if has_titles:
                 title = (s.get("title") or "—")[:30]
                 sid = s["id"]
-                print(f"{title:<32} {preview:<40} {last_active:<13} {sid}")
+                if _show_dur:
+                    print(f"{dur:<9} {title:<32} {preview:<40} {last_active:<13} {sid}")
+                else:
+                    print(f"{title:<32} {preview:<40} {last_active:<13} {sid}")
             else:
                 sid = s["id"]
-                print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+                if _show_dur:
+                    print(f"{dur:<9} {preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+                else:
+                    print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
 
     elif action == "export":
         from hermes_cli.session_filters import (

--- a/tests/hermes_cli/test_sessions_list_duration.py
+++ b/tests/hermes_cli/test_sessions_list_duration.py
@@ -1,0 +1,106 @@
+"""Tests for `hermes sessions list --duration`.
+
+Behavior-contract style: assert the Duration label formatting and that the
+column appears only when --duration is passed. Uses a temp HERMES_HOME with a
+seeded SessionDB so no real data is touched.
+"""
+import os
+import time
+
+import pytest
+
+
+def _make_session(title, started_at, ended_at, source="cli", sid="s1"):
+    return {
+        "id": sid,
+        "source": source,
+        "model": "x",
+        "title": title,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "message_count": 1,
+        "preview": "hello world this is a preview",
+        "last_active": ended_at if ended_at else started_at,
+    }
+
+
+def test_duration_label_formatting():
+    from hermes_cli import sessions_cmd
+
+    # ended session: 1h 2m 3s
+    s = _make_session("t", 1_000_000, 1_000_000 + 3723)
+    assert sessions_cmd._duration_label(s) == "1h 02m"
+
+    # ended session: 5m 09s
+    s = _make_session("t", 1_000_000, 1_000_000 + 309)
+    assert sessions_cmd._duration_label(s) == "5m 09s"
+
+    # short session: seconds only
+    s = _make_session("t", 1_000_000, 1_000_000 + 42)
+    assert sessions_cmd._duration_label(s) == "42s"
+
+    # multi-day
+    s = _make_session("t", 1_000_000, 1_000_000 + 60 * 60 * 25 + 3 * 3600 + 7 * 60)
+    assert sessions_cmd._duration_label(s) == "1d 04h"
+
+    # active session (ended_at None): uses now, so duration >= started->now
+    s = _make_session("t", time.time() - 120, None)
+    assert sessions_cmd._duration_label(s) == "2m 00s"
+
+    # missing started_at: defensive dash
+    s = _make_session("t", None, None)
+    assert sessions_cmd._duration_label(s) == "—"
+
+
+def test_list_duration_column_appears(monkeypatch, capsys):
+    from hermes_cli import sessions_cmd
+
+    now = time.time()
+    rows = [
+        _make_session("Alpha", now - 3600, now - 60, sid="a"),
+        _make_session("Beta", now - 120, None, sid="b"),
+    ]
+
+    class _FakeDB:
+        def list_sessions_rich(self, **kwargs):
+            return rows
+
+    import hermes_state
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: _FakeDB())
+
+    class _Args:
+        sessions_action = "list"
+        source = None
+        limit = 20
+        workspace = None
+        duration = True
+
+    sessions_cmd.cmd_sessions(_Args())
+    out = capsys.readouterr().out
+    assert "Duration" in out
+    assert "1h" in out  # Alpha
+    assert "2m" in out  # Beta (active)
+
+
+def test_list_duration_column_absent_by_default(monkeypatch, capsys):
+    from hermes_cli import sessions_cmd
+
+    now = time.time()
+    rows = [_make_session("Alpha", now - 3600, now - 60, sid="a")]
+
+    class _FakeDB:
+        def list_sessions_rich(self, **kwargs):
+            return rows
+
+    monkeypatch.setattr(sessions_cmd, "SessionDB", lambda: _FakeDB())
+
+    class _Args:
+        sessions_action = "list"
+        source = None
+        limit = 20
+        workspace = None
+        duration = False
+
+    sessions_cmd.cmd_sessions(_Args())
+    out = capsys.readouterr().out
+    assert "Duration" not in out


### PR DESCRIPTION
What Adds an opt-in --duration flag to hermes sessions list that shows each session's wall-clock duration (from started_at to ended_at, or to now if the session is still active) as a new Duration column.

Why The session store already records started_at/ended_at, but sessions list only surfaces "Last Active" — users can't see how long a session was open. This surfaces existing data with no schema change.

How

main.py: new --duration argparse flag on the list subcommand.
sessions_cmd.py: module-level _duration_label() + column injected into all four list layouts, gated on the flag. Default output is byte-identical when the flag is off, so scripts parsing existing columns are unaffected.
Test: tests/hermes_cli/test_sessions_list_duration.py covers label formatting (seconds/minutes/hours/days/active/missing) and that the column appears only with --duration.
Follow-ups (not in this PR): always-on default, daily/weekly aggregate totals, and a desktop sidebar column.