### PR TITLE
fix(gateway): stop sending markdown_text alongside chunks in Slack chat.appendStream

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4430,7 +4430,6 @@ class TurnRunner:
                     title="Hermes is working",
                     reply_to=ctx._progress_reply_to,
                     metadata=ctx._progress_metadata,
-                    fallback_text=_fallback_text(),
                 )
                 if getattr(result, "success", False):
                     return

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2640,7 +2640,11 @@ class SlackAdapter(BasePlatformAdapter):
                     "ts": stream.stream_ts,
                     "chunks": chunks,
                 }
-                if fallback_text:
+                # chat.appendStream rejects payloads containing both chunks
+                # and markdown_text (cannot_provide_both_markdown_text_and_chunks).
+                # The task-card chunks are the primary payload, so only send
+                # markdown_text when there are no chunks to attach.
+                if fallback_text and not chunks:
                     append_payload["markdown_text"] = fallback_text
                 await client.api_call("chat.appendStream", json=append_payload)
                 return SendResult(success=True, message_id=stream.stream_ts)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2562,9 +2562,13 @@ class SlackAdapter(BasePlatformAdapter):
         title: str = "Hermes is working",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
-        fallback_text: Optional[str] = None,
     ) -> SendResult:
-        """Start or update a Slack-native plan/task progress stream."""
+        """Start or update a Slack-native plan/task progress stream.
+
+        This path sends structured plan/task chunks only. Slack rejects
+        ``markdown_text`` alongside ``chunks``; the gateway owns a separate
+        editable-text fallback rail for native stream failures.
+        """
         if not self._app:
             return SendResult(success=False, error="Not connected")
         if not tasks:
@@ -2640,12 +2644,6 @@ class SlackAdapter(BasePlatformAdapter):
                     "ts": stream.stream_ts,
                     "chunks": chunks,
                 }
-                # chat.appendStream rejects payloads containing both chunks
-                # and markdown_text (cannot_provide_both_markdown_text_and_chunks).
-                # The task-card chunks are the primary payload, so only send
-                # markdown_text when there are no chunks to attach.
-                if fallback_text and not chunks:
-                    append_payload["markdown_text"] = fallback_text
                 await client.api_call("chat.appendStream", json=append_payload)
                 return SendResult(success=True, message_id=stream.stream_ts)
             except Exception as exc:  # pragma: no cover - defensive logging

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -246,14 +246,12 @@ class NativeTaskCardAdapter(ProgressCaptureAdapter):
         title,
         reply_to=None,
         metadata=None,
-        fallback_text=None,
     ) -> SendResult:
         self.native_updates.append(
             {
                 "chat_id": chat_id,
                 "tasks": [dict(task) for task in tasks],
                 "metadata": dict(metadata or {}),
-                "fallback_text": fallback_text,
             }
         )
         return SendResult(success=True, message_id="native-stream-1")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4681,3 +4681,25 @@ class TestNativeTaskCardProgress:
             "chat.stopStream",
         ]
         assert adapter._native_task_card_streams == {}
+
+    @pytest.mark.asyncio
+    async def test_append_stream_never_combines_chunks_and_markdown_text(self, adapter):
+        # Slack rejects chat.appendStream payloads containing both fields with
+        # cannot_provide_both_markdown_text_and_chunks, which silently forced
+        # every native task card onto the plain-text fallback path.
+        client = adapter._app.client
+        client.api_call.side_effect = [{"ts": "stream-1"}, {"ok": True}]
+
+        result = await adapter.send_native_task_card_progress(
+            "C1",
+            [{"id": "call-1", "title": "terminal", "status": "in_progress"}],
+            metadata={"thread_id": "thread-1"},
+            fallback_text="Hermes is working\n- terminal - running",
+        )
+
+        assert result.success
+        append_call = client.api_call.await_args_list[-1]
+        assert append_call.args[0] == "chat.appendStream"
+        payload = append_call.kwargs["json"]
+        assert payload["chunks"]
+        assert "markdown_text" not in payload

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4683,7 +4683,9 @@ class TestNativeTaskCardProgress:
         assert adapter._native_task_card_streams == {}
 
     @pytest.mark.asyncio
-    async def test_append_stream_never_combines_chunks_and_markdown_text(self, adapter):
+    async def test_native_task_card_append_uses_chunks_without_markdown_text(
+        self, adapter
+    ):
         # Slack rejects chat.appendStream payloads containing both fields with
         # cannot_provide_both_markdown_text_and_chunks, which silently forced
         # every native task card onto the plain-text fallback path.
@@ -4694,12 +4696,16 @@ class TestNativeTaskCardProgress:
             "C1",
             [{"id": "call-1", "title": "terminal", "status": "in_progress"}],
             metadata={"thread_id": "thread-1"},
-            fallback_text="Hermes is working\n- terminal - running",
         )
 
-        assert result.success
-        append_call = client.api_call.await_args_list[-1]
-        assert append_call.args[0] == "chat.appendStream"
-        payload = append_call.kwargs["json"]
-        assert payload["chunks"]
-        assert "markdown_text" not in payload
+        assert result.success is True
+        append_calls = [
+            call
+            for call in client.api_call.await_args_list
+            if call.args[0] == "chat.appendStream"
+        ]
+        assert append_calls
+        for append_call in append_calls:
+            payload = append_call.kwargs["json"]
+            assert payload["chunks"]
+            assert "markdown_text" not in payload


### PR DESCRIPTION
## What does this PR do?

Fixes opt-in Slack native task cards (`platforms.slack.extra.native_task_cards: true`, shipped in #85476), which currently never render. `send_native_task_card_progress()` sends both structured `chunks` and caller-supplied `fallback_text` as `markdown_text` in one `chat.appendStream` request. Slack treats those fields as mutually exclusive and rejects every update with `cannot_provide_both_markdown_text_and_chunks`, so the gateway silently downgrades to its editable plain-text fallback on every turn.

This PR makes the ownership boundary explicit:

- the Slack native-card adapter sends structured plan/task `chunks` only;
- the gateway retains its existing, independent editable-text fallback rail for native stream failures;
- the now-invalid `fallback_text` parameter is removed from the native-card adapter call end-to-end rather than retained as dead or unreachable API surface.

## Related Issue

Fixes #87743

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/adapter.py` — make `send_native_task_card_progress()` a chunks-only path; remove the invalid `fallback_text` parameter and document the Slack API constraint/fallback ownership
- `gateway/run.py` — stop passing fallback text into the native-card adapter; `_send_or_edit_fallback()` remains the owner of text fallback rendering
- `tests/gateway/test_slack.py` — add an adapter regression test asserting the `chat.appendStream` task-card payload contains `chunks` and excludes `markdown_text`
- `tests/gateway/test_run_progress_topics.py` — keep the native-card test double aligned with the production signature; the existing `test_slack_native_failure_keeps_editing_one_live_text_fallback` continues to verify that native failure produces and updates one text fallback message

## Relationship to concurrent PRs

After this report was filed, #87746 and #87752 independently proposed the same payload repair. This version incorporates the useful distinctions surfaced by those implementations and their review comments:

- `chunks` is unconditionally non-empty in this path (it always begins with a `plan_update` chunk), so an empty-chunks `markdown_text` branch cannot be reached;
- keeping `fallback_text` as an intentionally-unused parameter leaves misleading dead API surface;
- removing the parameter and its caller argument makes the two rendering rails explicit, while the existing gateway-level fallback test proves plain-text degradation still works.

Only one of the three duplicate fixes should merge; this PR is intentionally self-contained so maintainers can choose the preferred shape.

## How to Test

1. Configure a Slack app with Agents & AI Apps enabled, set `platforms.slack.extra.native_task_cards: true`, and start the gateway.
2. Send the bot a message that triggers tool calls.
3. **Before:** the gateway logs `cannot_provide_both_markdown_text_and_chunks`, then falls back to one edited text update; no card appears.
4. **After:** native task-card updates are accepted and render; if the native stream itself fails, the separate editable-text fallback still takes over.

Automated verification:

```bash
HERMES_PYTHON=/path/to/hermes/venv/bin/python \
  scripts/run_tests.sh -q \
  tests/gateway/test_slack.py \
  tests/gateway/test_run_progress_topics.py
```

Result: **193 passed, 0 failed**. The regression test was also verified RED against the unfixed payload and GREEN with the fix.

A full canonical suite was run locally. The checkout has unrelated environment/baseline failures in areas such as Daytona, video generation, memory providers, and CLI updater tests; representative failing files produced identical results against pristine `origin/main`. No new failures were introduced by this change. Upstream CI remains authoritative for the full matrix.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and compared the concurrent duplicates noted above
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite run, but unrelated baseline/environment failures remain as documented above
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04.4 LTS with Python 3.11.15

### Documentation & Housekeeping
- [x] Relevant docs update — N/A; behavior now matches the existing Slack messaging docs, and the method docstring documents the API constraint
- [x] `cli-config.yaml.example` update — N/A; no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture/workflow change
- [x] Cross-platform impact considered — payload/signature change only; no OS interaction
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

Production gateway log before the fix:

```text
2026-08-16 14:53:03,014 ERROR hermes_plugins.slack_platform.adapter: [Slack] Native task-card progress error: The request to the Slack API failed. (url: https://slack.com/api/chat.appendStream, status: 200)
The server responded with: {'ok': False, 'error': 'cannot_provide_both_markdown_text_and_chunks'}
  File "plugins/platforms/slack/adapter.py", line 2645, in send_native_task_card_progress
    await client.api_call("chat.appendStream", json=append_payload)
2026-08-16 14:53:03,018 WARNING gateway.run: Slack native task-card progress failed; falling back to an editable text update
```

**Production validation:** with the payload fix applied to a live gateway, the `cannot_provide_both_markdown_text_and_chunks` error stopped and consecutive card updates succeeded where previously every turn failed.

One separate follow-up was observed on a long-running turn: Slack eventually returned `message_not_in_streaming_state`. That is Slack's undocumented server-side stream expiry (see slackapi/python-slack-sdk#1859 and vercel/chat#607), not the mixed-payload bug. The existing editable-text fallback handles it gracefully; stream rotation/keepalive belongs in a separate change.
