### PR TITLE
fix(cron): scrub Kanban worker env from non-dispatcher subprocess spawns

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4321,10 +4321,14 @@ def run_job(
             _job_workdir = None
 
         try:
-            # This subprocess is spawned before the non-dispatcher marker
-            # further down in run_job() is entered — wrap it explicitly so the
-            # kanban env scrub (tools/environments/local.py) fires here too,
-            # not just for the agent path's tool loop (#87725).
+            # This subprocess is spawned before the non-dispatcher marker set
+            # later in run_job() (for the agent path's tool loop, which was
+            # already correctly covered) is entered — wrap it explicitly here
+            # too so the kanban env scrub (tools/environments/local.py) fires
+            # for this early script-launch path as well (#87725). This
+            # ``with`` fully exits (ContextVar reset) before that later marker
+            # is entered, so the two are sequential, not nested — no token
+            # ordering hazard.
             with non_dispatcher_owned_context():
                 ok, output = _run_job_script_with_claim_heartbeat(
                     job, script_path, workdir=_job_workdir, cancel_event=cancel_event,
@@ -4540,6 +4544,8 @@ def run_job(
     if script_path:
         # Same as the no_agent path above: this runs before the non-dispatcher
         # marker is entered later in run_job(), so wrap it explicitly (#87725).
+        # Sequential, not nested, with that later token-based entry — see the
+        # comment on the no_agent path's wrap above.
         with non_dispatcher_owned_context():
             prerun_script = _run_job_script_with_claim_heartbeat(
                 job, script_path, cancel_event=cancel_event,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -58,6 +58,7 @@ from agent.interrupt_compat import request_hard_interrupt
 from agent.delegation_context import (
     enter_non_dispatcher_owned_context,
     exit_non_dispatcher_owned_context,
+    non_dispatcher_owned_context,
 )
 
 logger = logging.getLogger(__name__)
@@ -4320,9 +4321,14 @@ def run_job(
             _job_workdir = None
 
         try:
-            ok, output = _run_job_script_with_claim_heartbeat(
-                job, script_path, workdir=_job_workdir, cancel_event=cancel_event,
-            )
+            # This subprocess is spawned before the non-dispatcher marker
+            # further down in run_job() is entered — wrap it explicitly so the
+            # kanban env scrub (tools/environments/local.py) fires here too,
+            # not just for the agent path's tool loop (#87725).
+            with non_dispatcher_owned_context():
+                ok, output = _run_job_script_with_claim_heartbeat(
+                    job, script_path, workdir=_job_workdir, cancel_event=cancel_event,
+                )
         except Exception as exc:
             logger.exception(
                 "Job '%s': script execution raised unexpectedly", job_id,
@@ -4532,9 +4538,12 @@ def run_job(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(
-            job, script_path, cancel_event=cancel_event,
-        )
+        # Same as the no_agent path above: this runs before the non-dispatcher
+        # marker is entered later in run_job(), so wrap it explicitly (#87725).
+        with non_dispatcher_owned_context():
+            prerun_script = _run_job_script_with_claim_heartbeat(
+                job, script_path, cancel_event=cancel_event,
+            )
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(

--- a/tests/cron/test_cron_kanban_env_isolation.py
+++ b/tests/cron/test_cron_kanban_env_isolation.py
@@ -428,10 +428,13 @@ class TestSubprocessEnvScrub:
         import cron.scheduler as sched
 
         captured_env: dict = {}
+        observed: dict = {}
 
         def fake_run_job_script(script_path, workdir=None, cancel_event=None):
+            from agent.delegation_context import is_dispatcher_owned_worker_context
             from tools.environments.local import build_subprocess_env
             captured_env.update(build_subprocess_env())
+            observed["dispatcher_owned_during_script"] = is_dispatcher_owned_worker_context()
             return True, "ok"
 
         monkeypatch.setattr(sched, "_run_job_script", fake_run_job_script)
@@ -446,6 +449,9 @@ class TestSubprocessEnvScrub:
         assert captured_env, "fake script runner was never invoked"
         assert "HERMES_KANBAN_TASK" not in captured_env
         assert "HERMES_KANBAN_CLAIM_LOCK" not in captured_env
+        # The wrap in run_job() must cover the whole _run_job_script_with_claim_heartbeat
+        # call, not just leave the marker to be inferred from the scrubbed env.
+        assert observed["dispatcher_owned_during_script"] is False
 
     def test_prerun_script_subprocess_env_is_scrubbed(self, monkeypatch, worker_env):
         """Integration: the wake-gate pre-check script also builds its
@@ -453,10 +459,13 @@ class TestSubprocessEnvScrub:
         import cron.scheduler as sched
 
         captured_env: dict = {}
+        observed: dict = {}
 
         def fake_run_job_script(script_path, workdir=None, cancel_event=None):
+            from agent.delegation_context import is_dispatcher_owned_worker_context
             from tools.environments.local import build_subprocess_env
             captured_env.update(build_subprocess_env())
+            observed["dispatcher_owned_during_script"] = is_dispatcher_owned_worker_context()
             return True, '{"wakeAgent": false}'
 
         monkeypatch.setattr(sched, "_run_job_script", fake_run_job_script)
@@ -471,6 +480,7 @@ class TestSubprocessEnvScrub:
         assert captured_env, "fake script runner was never invoked"
         assert "HERMES_KANBAN_TASK" not in captured_env
         assert "HERMES_KANBAN_CLAIM_LOCK" not in captured_env
+        assert observed["dispatcher_owned_during_script"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_cron_kanban_env_isolation.py
+++ b/tests/cron/test_cron_kanban_env_isolation.py
@@ -375,6 +375,105 @@ class TestRunJobKanbanIsolation:
 
 
 # ---------------------------------------------------------------------------
+# Subprocess env scrub (the ContextVar marks in-process code, but any
+# subprocess a non-dispatcher-owned cron job spawns must not inherit the
+# dispatcher's HERMES_KANBAN_* vars either).
+# ---------------------------------------------------------------------------
+
+class TestSubprocessEnvScrub:
+    def test_build_subprocess_env_leaks_kanban_by_default(self, worker_env):
+        """Baseline: a normal (dispatcher-owned) subprocess legitimately sees
+        the worker's own kanban env — this is not the bug."""
+        from tools.environments.local import build_subprocess_env
+
+        env = build_subprocess_env()
+        assert env.get("HERMES_KANBAN_TASK") == "t_worker_real_task"
+
+    def test_build_subprocess_env_scrubs_inside_non_dispatcher_context(self, worker_env):
+        from agent.delegation_context import non_dispatcher_owned_context
+        from tools.environments.local import build_subprocess_env
+
+        with non_dispatcher_owned_context():
+            env = build_subprocess_env()
+
+        assert "HERMES_KANBAN_TASK" not in env
+        assert "HERMES_KANBAN_RUN_ID" not in env
+        assert "HERMES_KANBAN_CLAIM_LOCK" not in env
+        assert "HERMES_KANBAN_BOARD" not in env
+        assert "HERMES_KANBAN_WORKSPACE" not in env
+
+    def test_hermes_subprocess_env_scrubs_inside_non_dispatcher_context(self, worker_env):
+        from agent.delegation_context import non_dispatcher_owned_context
+        from tools.environments.local import hermes_subprocess_env
+
+        with non_dispatcher_owned_context():
+            env = hermes_subprocess_env()
+
+        assert "HERMES_KANBAN_TASK" not in env
+
+    def test_delegated_child_scrub_still_works(self, worker_env):
+        """The pre-existing delegate_task scrub path must be unaffected."""
+        from agent.delegation_context import delegated_child_context
+        from tools.environments.local import build_subprocess_env
+
+        with delegated_child_context():
+            env = build_subprocess_env()
+
+        assert "HERMES_KANBAN_TASK" not in env
+
+    def test_no_agent_script_subprocess_env_is_scrubbed(self, monkeypatch, worker_env):
+        """Integration: run_job's no_agent script-launch path builds its
+        subprocess env BEFORE the non-dispatcher marker is entered later in
+        run_job — the scrub must not depend on that ordering."""
+        import cron.scheduler as sched
+
+        captured_env: dict = {}
+
+        def fake_run_job_script(script_path, workdir=None, cancel_event=None):
+            from tools.environments.local import build_subprocess_env
+            captured_env.update(build_subprocess_env())
+            return True, "ok"
+
+        monkeypatch.setattr(sched, "_run_job_script", fake_run_job_script)
+
+        job = {
+            "id": "no-agent-kanban", "name": "no-agent-kanban-job",
+            "no_agent": True, "script": "dummy.py", "workdir": None,
+        }
+        success, *_ = sched.run_job(job)
+
+        assert success is True
+        assert captured_env, "fake script runner was never invoked"
+        assert "HERMES_KANBAN_TASK" not in captured_env
+        assert "HERMES_KANBAN_CLAIM_LOCK" not in captured_env
+
+    def test_prerun_script_subprocess_env_is_scrubbed(self, monkeypatch, worker_env):
+        """Integration: the wake-gate pre-check script also builds its
+        subprocess env before the marker is entered further down in run_job."""
+        import cron.scheduler as sched
+
+        captured_env: dict = {}
+
+        def fake_run_job_script(script_path, workdir=None, cancel_event=None):
+            from tools.environments.local import build_subprocess_env
+            captured_env.update(build_subprocess_env())
+            return True, '{"wakeAgent": false}'
+
+        monkeypatch.setattr(sched, "_run_job_script", fake_run_job_script)
+
+        job = {
+            "id": "prerun-kanban", "name": "prerun-kanban-job",
+            "script": "dummy.py", "workdir": None, "schedule_display": "manual",
+        }
+        success, *_ = sched.run_job(job)
+
+        assert success is True
+        assert captured_env, "fake script runner was never invoked"
+        assert "HERMES_KANBAN_TASK" not in captured_env
+        assert "HERMES_KANBAN_CLAIM_LOCK" not in captured_env
+
+
+# ---------------------------------------------------------------------------
 # Drift guard
 # ---------------------------------------------------------------------------
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -514,14 +514,25 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
 
 
 def _scrub_delegated_child_kanban_env(env: dict[str, str]) -> dict[str, str]:
-    """Strip dispatcher-owned Kanban env from delegate_task child subprocesses."""
+    """Strip dispatcher-owned Kanban env from non-dispatcher-owned subprocesses.
+
+    Covers both delegate_task children (``is_delegated_child_process_context``,
+    including the cross-process env-marker case) and cron jobs fired in-process
+    from a kanban worker (``is_dispatcher_owned_worker_context`` is False) — see
+    ``agent.delegation_context.is_dispatcher_owned_worker_context``, "the single
+    predicate every HERMES_KANBAN_* identity gate should use." This function
+    predates that unifying predicate (added in #79657) and was never migrated
+    to it, so non-dispatcher cron subprocesses kept inheriting the worker's
+    Kanban identity (#87725).
+    """
     try:
         from agent.delegation_context import (
             is_delegated_child_process_context,
+            is_dispatcher_owned_worker_context,
             scrub_kanban_env,
         )
 
-        if is_delegated_child_process_context():
+        if is_delegated_child_process_context() or not is_dispatcher_owned_worker_context():
             return scrub_kanban_env(env)
     except Exception:
         pass


### PR DESCRIPTION
## What does this PR do?

Closes a Kanban-authority leak in cron's non-dispatcher isolation. Cron jobs can be fired *in-process* from inside a Kanban worker (`cronjob(action="run")` calls `run_job()` in the worker's own process, where `HERMES_KANBAN_*` is legitimately set). `run_job()` marks itself non-dispatcher-owned via `enter_non_dispatcher_owned_context()` / `is_dispatcher_owned_worker_context()` so it isn't misidentified as the worker in-process — but that identity fix never extended to **subprocesses** the cron job spawns.

Root cause: `_scrub_delegated_child_kanban_env()` in `tools/environments/local.py` (the sole chokepoint for `build_subprocess_env()` / `hermes_subprocess_env()`) only ever checked the older `is_delegated_child_process_context()` (for `delegate_task` children). It was never migrated to also check `is_dispatcher_owned_worker_context()` — "the single predicate every `HERMES_KANBAN_*` identity gate should use" per its own docstring — after that predicate was introduced. So any subprocess a non-dispatcher-owned cron job spawned (script jobs, terminal calls, browser/tts/lazy-deps helpers, etc.) still inherited the worker's `HERMES_KANBAN_*` env for its full duration.

On top of that, two specific spawn sites in `cron/scheduler.py`'s `run_job()` — the `no_agent` script-launch path and the wake-gate prerun-script path — build their subprocess env *before* the existing `enter_non_dispatcher_owned_context()` call further down in the function, so even a corrected predicate wouldn't have covered them without also wrapping those two call sites explicitly.

**Fix:**
1. `tools/environments/local.py`: `_scrub_delegated_child_kanban_env()` now also scrubs when `not is_dispatcher_owned_worker_context()`, alongside the existing delegated-child check.
2. `cron/scheduler.py`: wrap the two early script-launch call sites with `non_dispatcher_owned_context()` so their subprocess env is built while the marker is active.

No behavior changes to any dispatcher-owned (normal worker) or delegated-child path — the new condition only fires when one of the two ContextVars is actually set.

**Note for maintainers:** open PR #81843 edits the same `_scrub_delegated_child_kanban_env` function (for a different, unrelated gap — terminal-spawned subprocess isolation from delegate_task children). The two patches don't touch the same lines but whichever lands second will need a small rebase.

## Related Issue

Fixes #87725

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/local.py`: `_scrub_delegated_child_kanban_env()` now scrubs Kanban env when `is_dispatcher_owned_worker_context()` is False, not just for delegated children.
- `cron/scheduler.py`: wrap the `no_agent` script-launch call and the wake-gate prerun-script call in `non_dispatcher_owned_context()`.
- `tests/cron/test_cron_kanban_env_isolation.py`: new `TestSubprocessEnvScrub` class — 6 tests covering the direct predicate gap (`build_subprocess_env`/`hermes_subprocess_env` inside `non_dispatcher_owned_context()`), the pre-existing delegated-child path (unaffected), and both `run_job()` script-launch sites via a fake `_run_job_script` that captures the env it was actually given.

## How to Test

1. Reproduction (pre-fix): inside `non_dispatcher_owned_context()`, call `tools.environments.local.build_subprocess_env()` — `HERMES_KANBAN_TASK`/`_RUN_ID`/`_CLAIM_LOCK`/etc. are present in the returned env despite the context marking this execution as not dispatcher-owned.
2. RED → GREEN: `pytest tests/cron/test_cron_kanban_env_isolation.py -q -k TestSubprocessEnvScrub` — 4 of the 6 new tests fail against the pre-fix code (verified by stashing the two production-file changes) and pass after the fix; the other 2 assert unchanged baseline behavior (dispatcher-owned and delegated-child paths still work as before).
3. Full regression run: `pytest tests/cron/test_cron_kanban_env_isolation.py -q` → 24 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/test_cron_kanban_env_isolation.py -q` and all tests pass (24 passed). I also ran `pytest tests/cron/ -q` (690 passed, 20 skipped, 7 pre-existing failures unrelated to this change — Windows POSIX-permission assertions in `test_file_permissions.py` and a tilde-expansion assertion in `test_cron_workdir.py`, all reproduced identically on `origin/main` without this patch) and `pytest tests/tools/test_delegate.py tests/tools/test_delegate_kanban_isolation.py tests/tools/test_delegate_cron_sync_fallback.py tests/test_delegate_cascade_49148.py tests/agent/test_subprocess_env_guard.py tests/cron/test_cron_script.py tests/tools/test_build_subprocess_env.py tests/tools/test_env_passthrough.py -q` (133 passed, 1 skipped). I did **not** run the full `tests/` suite (not attempted; only the modules above and directly-adjacent ones).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring on the changed function updated; no user-facing docs affected)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — ran `scripts/check-windows-footguns.py` against the changed files, no findings
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool schema changed)

## Update (2026-08-16): addressed AI review feedback

- **Confirmed, no code change:** `non_dispatcher_owned_context()` restores via `ContextVar.reset(token)` in a `finally`, and the two new wraps fully exit before the existing later token-based `enter_non_dispatcher_owned_context()` call — they're sequential, not nested, so there's no token-restore hazard. Added an explicit comment saying so at both wrap sites.
- **Confirmed, no code change:** `scrub_kanban_env()` only ever pops the `KANBAN_ENV_KEYS` tuple and sets the delegated-child marker — nothing else. In a plain (non-cron, non-delegated) process `is_dispatcher_owned_worker_context()` defaults to `True`, so the new `not is_dispatcher_owned_worker_context()` condition is `False` and normal subprocess spawns take the same no-op path as before.
- **Added:** a new assertion in both `test_no_agent_script_subprocess_env_is_scrubbed` and `test_prerun_script_subprocess_env_is_scrubbed` that `is_dispatcher_owned_worker_context()` is `False` *during* the script call itself (not just inferred from the scrubbed env), confirming the wrap covers the whole `_run_job_script_with_claim_heartbeat` call as requested.
- **Not changed:** the "extract a single wrapper" suggestion — two `with non_dispatcher_owned_context():` one-liners at genuinely different call sites didn't seem worth an extraction; happy to do it if a maintainer prefers.

## Screenshots / Logs

N/A

