### PR TITLE
fix(update): reload _subprocess_compat and dashboard_procs after git pull

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -87,7 +87,7 @@ def _reload_updated_runtime_modules() -> None:
 
 
 def _reload_config_modules() -> None:
-    """Force-reload config modules from disk after git pull.
+    """Force-reload modules from disk after git pull.
 
     ``hermes update`` runs in the PRE-pull Python process. After ``git pull``
     updates the source files on disk, modules already in ``sys.modules``
@@ -99,17 +99,31 @@ def _reload_config_modules() -> None:
     This function force-reloads ``hermes_cli.config_defaults``,
     ``hermes_cli.config``, and ``hermes_cli.config_migrations`` from disk
     so subsequent imports read the UPDATED code.
+
+    It also reloads ``hermes_cli._subprocess_compat`` and
+    ``hermes_cli.dashboard_procs`` so that post-update dashboard cleanup
+    (``_finish_dashboard_update_cleanup`` → ``_scan_dashboard_processes``)
+    uses the freshly-pulled code. Without this, a new symbol added to
+    ``_subprocess_compat`` (e.g. ``bounded_probe_run``) is invisible to the
+    cached module object, causing ``ImportError`` during the cleanup step
+    that runs later in the same process.
     """
     import importlib
 
     importlib.invalidate_caches()
-    for mod_name in ("hermes_cli.config_defaults", "hermes_cli.config", "hermes_cli.config_migrations"):
+    for mod_name in (
+        "hermes_cli.config_defaults",
+        "hermes_cli.config",
+        "hermes_cli.config_migrations",
+        "hermes_cli._subprocess_compat",
+        "hermes_cli.dashboard_procs",
+    ):
         mod = sys.modules.get(mod_name)
         if mod is not None:
             try:
                 importlib.reload(mod)
             except Exception as exc:
-                logger.debug("Could not reload %s for fresh config check: %s", mod_name, exc)
+                logger.debug("Could not reload %s for fresh post-update code: %s", mod_name, exc)
 
 
 def _run_config_check_fresh() -> tuple:


### PR DESCRIPTION
# `hermes update` crashes with `ImportError: cannot import name 'bounded_probe_run'` during dashboard cleanup on Windows

## Summary

`hermes update` successfully completes the code update (git pull, pip install, web UI build, gateway restart), but crashes at the very last step — dashboard process cleanup — with:

```
ImportError: cannot import name 'bounded_probe_run' from 'hermes_cli._subprocess_compat'
```

This is because the update process runs in a single Python process that loaded modules **before** `git pull` updated them on disk. The existing `_reload_config_modules()` function reloads config modules but does **not** reload `_subprocess_compat` or `dashboard_procs`, so the cleanup step uses stale module state.

## Environment

- **OS**: Windows 11
- **Python**: 3.11.15 (hermes-agent venv) / 3.12.13 (desktop runtime venv)
- **Hermes**: 0.20.0 → 0.20.1
- **Install mode**: editable (`pip install -e .`)
- **Commit at time of crash**: `4e3de140c` (introduces `bounded_probe_run` in `_subprocess_compat.py` and the `from hermes_cli._subprocess_compat import bounded_probe_run` import in `dashboard_procs.py:87`)

## Traceback

```
Traceback (most recent call last):
  File "hermes_cli\main.py", line 13470, in main
  File "hermes_cli\main.py", line 9779, in cmd_update
  File "hermes_cli\update_cmd.py", line 6380, in _cmd_update_impl
    print("  flap loops. Remove them with:")
  File "hermes_cli\update_cmd.py", line 629, in _finish_dashboard_update_cleanup
    stop_result = _m()._kill_stale_dashboard_processes(restart_managed=True)
  File "hermes_cli\dashboard_procs.py", line 346, in _kill_stale_dashboard_processes
    pids = _m()._find_stale_dashboard_pids(exclude_pids=exclude)
  File "hermes_cli\main.py", line 7886, in _find_stale_dashboard_pids
    packaged_executable = _desktop_packaged_executable(desktop_dir)
  File "hermes_cli\dashboard_procs.py", line 87, in _scan_dashboard_processes
    from hermes_cli._subprocess_compat import bounded_probe_run
ImportError: cannot import name 'bounded_probe_run' from 'hermes_cli._subprocess_compat'
```

## Root Cause

`hermes update` runs entirely in one Python process:

1. **T1** — Process starts; modules loaded into `sys.modules` (old versions from before pull).
2. **T2** — `git pull` replaces `.py` files on disk with new versions.
3. **T3** — `_reload_config_modules()` reloads `hermes_cli.config_defaults`, `hermes_cli.config`, `hermes_cli.config_migrations` — but **not** `hermes_cli._subprocess_compat` or `hermes_cli.dashboard_procs`.
4. **T4** — Gateway restart succeeds (spawns new child processes that load updated code).
5. **T5** — `_finish_dashboard_update_cleanup()` → `_kill_stale_dashboard_processes()` → `_find_stale_dashboard_pids()` → `_scan_dashboard_processes()`.
6. At `dashboard_procs.py:87`, the **new** code does `from hermes_cli._subprocess_compat import bounded_probe_run`, but the module object in `sys.modules` is the **old** version (loaded at T1) that doesn't have `bounded_probe_run`. → `ImportError`.

The function-level import at `dashboard_procs.py:87` is correct design (lazy import to avoid circular dependencies). The problem is that Python's `from X import Y` checks `sys.modules` first — if `X` is cached (stale), it never reads the updated file from disk.

This only manifests when the commit being pulled **adds a new symbol** to `_subprocess_compat` that `dashboard_procs` then tries to import. Commit `4e3de140c` added `bounded_probe_run` to `_subprocess_compat` and the corresponding import in `dashboard_procs._scan_dashboard_processes` — exactly this pattern.

## Suggested Fix

Extend `_reload_config_modules()` in `update_cmd.py` to also reload `hermes_cli._subprocess_compat` and `hermes_cli.dashboard_procs`:

```python
def _reload_config_modules() -> None:
    """Force-reload modules from disk after git pull.

    ``hermes update`` runs in the PRE-pull Python process. After ``git pull``
    updates the source files on disk, modules already in ``sys.modules``
    still hold the OLD code. Function-level imports return the cached module,
    so ``DEFAULT_CONFIG["_config_version"]`` is the OLD value and
    ``check_config_version()`` reports ``(33, 33)`` — "up to date" — even
    though the freshly-pulled code has v34 with a migration to run.

    This function force-reloads ``hermes_cli.config_defaults``,
    ``hermes_cli.config``, and ``hermes_cli.config_migrations`` from disk
    so subsequent imports read the UPDATED code.

    It also reloads ``hermes_cli._subprocess_compat`` and
    ``hermes_cli.dashboard_procs`` so that post-update dashboard cleanup
    (``_finish_dashboard_update_cleanup`` → ``_scan_dashboard_processes``)
    uses the freshly-pulled code. Without this, a new symbol added to
    ``_subprocess_compat`` (e.g. ``bounded_probe_run``) is invisible to the
    cached module object, causing ``ImportError`` during the cleanup step
    that runs later in the same process.
    """
    import importlib

    importlib.invalidate_caches()
    for mod_name in (
        "hermes_cli.config_defaults",
        "hermes_cli.config",
        "hermes_cli.config_migrations",
        "hermes_cli._subprocess_compat",
        "hermes_cli.dashboard_procs",
    ):
        mod = sys.modules.get(mod_name)
        if mod is not None:
            try:
                importlib.reload(mod)
            except Exception as exc:
                logger.debug("Could not reload %s for fresh post-update code: %s", mod_name, exc)
```

This follows the exact pattern already established by `_reload_config_modules()` — no new mechanism, just extending the reload list.

### Alternative considered

- **Subprocess relaunch**: Re-launch a fresh `hermes` process after `git pull` to execute the cleanup. This is structurally cleaner but much more invasive (state passing, process management, user experience during the restart). The `importlib.reload` approach is minimal and consistent with the existing codebase pattern.
- **try/except around `_finish_dashboard_update_cleanup`**: Silences the error but leaves stale dashboard processes running. Not a real fix.

## Impact

- The update itself **succeeds** — code, dependencies, web UI, and gateway are all updated correctly.
- Only the dashboard process cleanup fails; the user sees a traceback and the update script exits non-zero.
- The error is **not persistent** — subsequent `hermes` commands work fine because they start a new process that loads the updated code.
- But it makes `hermes update` appear to have failed, which is confusing.

## Reproduction

1. Be on an older commit (before `4e3de140c`) that doesn't have `bounded_probe_run` in `_subprocess_compat`.
2. Run `hermes update` on Windows (where `_scan_dashboard_processes` takes the `sys.platform == "win32"` branch with the `bounded_probe_run` import).
3. The update will succeed but the cleanup will crash with `ImportError`.