### PR TITLE
feat(cli): profile display_name, separate from internal id (#45624)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
@@ -49,6 +49,7 @@ vi.mock('@/store/profile', () => ({
   $profileScope: atom('default'),
   ALL_PROFILES: '*',
   normalizeProfileKey: (name: string) => name,
+  profileLabel: (profile: { display_name?: string; name: string }) => profile.name,
   refreshActiveProfile: vi.fn().mockResolvedValue(undefined),
   selectProfile: vi.fn(),
   setProfileColor: vi.fn(),

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -53,6 +53,7 @@ import {
   $profileScope,
   ALL_PROFILES,
   normalizeProfileKey,
+  profileLabel,
   refreshActiveProfile,
   selectProfile,
   setProfileColor,
@@ -237,7 +238,7 @@ export function ProfileRail() {
           <ProfilePill
             active={isAll || onDefault}
             glyph={isAll ? 'layers' : 'home'}
-            label={onDefault ? p.showAllProfiles : p.switchToProfile(defaultProfile.name)}
+            label={onDefault ? p.showAllProfiles : p.switchToProfile(profileLabel(defaultProfile))}
             onSelect={() => (onDefault ? setShowAllProfiles(true) : selectProfile(defaultProfile.name))}
           />
         ) : (
@@ -249,7 +250,7 @@ export function ProfileRail() {
         <ProfilePill
           active
           glyph="home"
-          label={defaultProfile.name}
+          label={profileLabel(defaultProfile)}
           onSelect={() => selectProfile(defaultProfile.name)}
         />
       )}
@@ -291,7 +292,7 @@ export function ProfileRail() {
                       active={!isAll && normalizeProfileKey(profile.name) === activeKey}
                       color={resolveProfileColor(profile.name, colors)}
                       key={profile.name}
-                      label={profile.name}
+                      label={profileLabel(profile)}
                       onDelete={() => setPendingDelete(profile)}
                       onEditSoul={() => setPendingSoul(profile.name)}
                       onRecolor={color => setProfileColor(profile.name, color)}
@@ -498,6 +499,7 @@ function ProfileDropdown({
           <ProfileDropdownItem
             color={resolveProfileColor(profile.name, colors)}
             key={profile.name}
+            label={profileLabel(profile)}
             name={profile.name}
           />
         ))}
@@ -508,14 +510,14 @@ function ProfileDropdown({
 
 // One dropdown row per profile — its own component so each row can own a
 // hover-intent prewarm timer (see useProfilePrewarm).
-function ProfileDropdownItem({ color, name }: { color: null | string; name: string }) {
+function ProfileDropdownItem({ color, label, name }: { color: null | string; label: string; name: string }) {
   const { cancelPrewarm, startPrewarm } = useProfilePrewarm(name)
 
   return (
     <SelectItem onPointerEnter={startPrewarm} onPointerLeave={cancelPrewarm} value={name}>
       <span className="flex min-w-0 items-center gap-1.5">
         <ProfileGlyph aria-hidden="true" color={color} isDefault={false} name={name} />
-        <span className="truncate">{name}</span>
+        <span className="truncate">{label}</span>
       </span>
     </SelectItem>
   )

--- a/apps/desktop/src/app/profiles/index.test.tsx
+++ b/apps/desktop/src/app/profiles/index.test.tsx
@@ -52,6 +52,11 @@ vi.mock('@/store/profile', () => ({
   $activeGatewayProfile: activeGateway,
   $profileColors,
   normalizeProfileKey: (name: null | string | undefined) => (name ?? '').trim() || 'default',
+  profileLabel: (profile: { display_name?: string; name: string }) => {
+    const display = (profile.display_name ?? '').trim()
+
+    return display && display !== profile.name ? `${display} (${profile.name})` : profile.name
+  },
   refreshProfiles: vi.fn(async () => [] as ProfileInfo[]),
   selectProfile: vi.fn(),
   setActiveProfile: vi.fn()

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -13,7 +13,7 @@ import { AlertTriangle, Save } from '@/lib/icons'
 import { resolveProfileColor } from '@/lib/profile-color'
 import { normalize } from '@/lib/text'
 import { notify, notifyError } from '@/store/notifications'
-import { $profileColors, refreshProfiles } from '@/store/profile'
+import { $profileColors, profileLabel, refreshProfiles } from '@/store/profile'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import {
@@ -212,10 +212,10 @@ function ProfileRow({
         />
       }
       menuItems={menuItems}
-      menuLabel={profile.name}
+      menuLabel={profileLabel(profile)}
       onSelect={onSelect}
       rowKey={profile.name}
-      title={profile.name}
+      title={profileLabel(profile)}
     />
   )
 }
@@ -229,7 +229,7 @@ function ProfileDetail({ profile }: { profile: ProfileInfo }) {
       <header className="space-y-3">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <h3 className="text-[0.95rem] font-semibold tracking-tight text-foreground">{profile.name}</h3>
+            <h3 className="text-[0.95rem] font-semibold tracking-tight text-foreground">{profileLabel(profile)}</h3>
             {profile.is_default && <PanelPill tone="good">{p.defaultBadge}</PanelPill>}
             {profile.has_env && <PanelPill tone="muted">.env</PanelPill>}
           </div>

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -25,6 +25,16 @@ export function normalizeProfileKey(name: string | null | undefined): string {
   return value || 'default'
 }
 
+// Presentation-only label for a profile: "display_name (name)" when a
+// display_name is set (e.g. the renamed default profile), else the bare
+// canonical name. Never used for comparison or routing — canonical `name`
+// remains the identity everywhere.
+export function profileLabel(profile: Pick<ProfileInfo, 'display_name' | 'name'>): string {
+  const display = (profile.display_name ?? '').trim()
+
+  return display && display !== profile.name ? `${display} (${profile.name})` : profile.name
+}
+
 // The profile the running local backend is actually scoped to (mirrors
 // /api/profiles/active `current`). "default" is the root ~/.hermes. This is the
 // display source of truth for the statusbar pill; the desktop's *stored*

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -920,6 +920,7 @@ export interface ProfileCreatePayload {
 }
 
 export interface ProfileInfo {
+  display_name?: string
   has_env: boolean
   is_default: boolean
   model: null | string

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9968,9 +9968,21 @@ def cmd_profile(args):
 
     if action is None:
         # Bare `hermes profile` — show current profile status
+        from hermes_cli.profiles import (
+            format_profile_label,
+            get_profile_dir,
+            read_profile_meta,
+        )
+
         profile_name = get_active_profile_name()
         dhh = display_hermes_home()
-        print(f"\nActive profile: {profile_name}")
+        try:
+            _display = read_profile_meta(get_profile_dir(profile_name)).get(
+                "display_name", ""
+            )
+        except Exception:
+            _display = ""
+        print(f"\nActive profile: {format_profile_label(profile_name, _display)}")
         print(f"Path:           {dhh}")
 
         profiles = list_profiles()
@@ -9993,6 +10005,8 @@ def cmd_profile(args):
         return
 
     if action == "list":
+        from hermes_cli.profiles import format_profile_label
+
         profiles = list_profiles()
         active = get_active_profile_name()
 
@@ -10016,7 +10030,7 @@ def cmd_profile(args):
                 if (p.name == active or (active == "default" and p.is_default))
                 else "  "
             )
-            name = p.name
+            name = format_profile_label(p.name, getattr(p, "display_name", ""))
             model = (p.model or "—")[:26]
             gw = "running" if p.gateway_running else "stopped"
             alias = (p.alias_name or p.name) if p.alias_path else "—"
@@ -10275,6 +10289,9 @@ def cmd_profile(args):
             _read_distribution_meta,
             _get_wrapper_dir,
             find_alias_for_profile,
+            format_profile_label,
+            normalize_profile_name,
+            read_profile_meta,
         )
 
         if not profile_exists(name):
@@ -10286,8 +10303,9 @@ def cmd_profile(args):
         skills = _count_skills(profile_dir)
         dist_name, dist_version, dist_source = _read_distribution_meta(profile_dir)
         alias_name = find_alias_for_profile(name)
+        display_name = read_profile_meta(profile_dir).get("display_name", "")
 
-        print(f"\nProfile: {name}")
+        print(f"\nProfile: {format_profile_label(normalize_profile_name(name), display_name)}")
         print(f"Path:    {profile_dir}")
         if model:
             print(f"Model:   {model}" + (f" ({provider})" if provider else ""))
@@ -10348,12 +10366,17 @@ def cmd_profile(args):
                     print(f"⚠ {_get_wrapper_dir()} is not in your PATH.")
 
     elif action == "rename":
-        from hermes_cli.profiles import rename_profile
+        from hermes_cli.profiles import normalize_profile_name, rename_profile
 
         try:
             new_dir = rename_profile(args.old_name, args.new_name)
-            print(f"\nProfile renamed: {args.old_name} → {args.new_name}")
-            print(f"Path: {new_dir}\n")
+            if normalize_profile_name(args.old_name) == "default":
+                # Display name set; canonical id untouched (printed by
+                # rename_profile). Nothing else to report.
+                print()
+            else:
+                print(f"\nProfile renamed: {args.old_name} → {args.new_name}")
+                print(f"Path: {new_dir}\n")
         except (ValueError, FileExistsError, FileNotFoundError) as e:
             print(f"Error: {e}")
             sys.exit(1)

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -657,6 +657,12 @@ class ProfileInfo:
     # surfaces a "review" badge in this case so the user can edit or
     # accept.
     description_auto: bool = False
+    # Optional user-facing display name, persisted in
+    # ``<profile_dir>/profile.yaml``. Presentation-only: every code path
+    # that resolves, compares, or spawns profiles keeps using the
+    # canonical ``name``. Empty when unset — surfaces fall back to
+    # ``name`` exactly as before (see format_profile_label).
+    display_name: str = ""
 
 
 def _read_distribution_meta(profile_dir: Path) -> tuple:
@@ -823,25 +829,27 @@ def _profile_yaml_path(profile_dir: Path) -> Path:
 def read_profile_meta(profile_dir: Path) -> dict:
     """Read ``<profile_dir>/profile.yaml`` and return a dict.
 
-    Returns ``{"description": "", "description_auto": False}`` when the
-    file is missing or unreadable. Never raises — a corrupt
-    profile.yaml on an unrelated profile must not break
-    ``hermes profile list``.
+    Returns ``{"description": "", "description_auto": False,
+    "display_name": ""}`` when the file is missing or unreadable.
+    Never raises — a corrupt profile.yaml on an unrelated profile
+    must not break ``hermes profile list``.
     """
+    _empty = {"description": "", "description_auto": False, "display_name": ""}
     path = _profile_yaml_path(profile_dir)
     if not path.is_file():
-        return {"description": "", "description_auto": False}
+        return dict(_empty)
     try:
         import yaml
         with open(path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
     except Exception:
-        return {"description": "", "description_auto": False}
+        return dict(_empty)
     if not isinstance(data, dict):
-        return {"description": "", "description_auto": False}
+        return dict(_empty)
     return {
         "description": str(data.get("description") or "").strip(),
         "description_auto": bool(data.get("description_auto", False)),
+        "display_name": str(data.get("display_name") or "").strip(),
     }
 
 
@@ -850,6 +858,7 @@ def write_profile_meta(
     *,
     description: Optional[str] = None,
     description_auto: Optional[bool] = None,
+    display_name: Optional[str] = None,
 ) -> None:
     """Update ``<profile_dir>/profile.yaml`` in place.
 
@@ -874,12 +883,76 @@ def write_profile_meta(
         existing["description"] = description.strip()
     if description_auto is not None:
         existing["description_auto"] = bool(description_auto)
+    if display_name is not None:
+        # Empty string clears the display name (falls back to canonical id).
+        cleaned = display_name.strip()
+        if cleaned:
+            existing["display_name"] = cleaned
+        else:
+            existing.pop("display_name", None)
     # Atomic write: bare open("w") truncates before the dump, and the read
     # path above swallows parse errors as {}, so a crashed write would
     # silently drop unspecified fields on the next call (#51356, #16743).
     from utils import atomic_yaml_write
 
     atomic_yaml_write(path, existing, sort_keys=False)
+
+
+# Display names share the profile-id length cap but none of its charset
+# restrictions: they are presentation-only (never a directory name, wrapper
+# filename, or argv token), so Unicode is fine (#45624 requests a Chinese
+# display name).
+_DISPLAY_NAME_MAX_LEN = 64
+
+
+def validate_display_name(name: str) -> str:
+    """Validate and return a cleaned profile display name.
+
+    Raises ``ValueError`` for empty/whitespace-only input or over-length
+    names. Display names are presentation-only, so any printable Unicode
+    is accepted; only the length is capped (matches the profile-id cap).
+    """
+    cleaned = (name or "").strip()
+    if not cleaned:
+        raise ValueError("Display name cannot be empty.")
+    if len(cleaned) > _DISPLAY_NAME_MAX_LEN:
+        raise ValueError(
+            f"Display name too long ({len(cleaned)} chars). "
+            f"Maximum is {_DISPLAY_NAME_MAX_LEN}."
+        )
+    return cleaned
+
+
+def set_profile_display_name(profile_name: str, display_name: str) -> str:
+    """Set (or clear) a profile's user-facing display name.
+
+    ``display_name`` of ``""`` clears it. Returns the cleaned value that
+    was stored (``""`` when cleared). Presentation-only: the canonical
+    profile id is untouched.
+    """
+    canon = normalize_profile_name(profile_name)
+    validate_profile_name(canon)
+    profile_dir = get_profile_dir(canon)
+    if not profile_dir.is_dir():
+        raise FileNotFoundError(f"Profile '{canon}' does not exist.")
+    cleaned = (display_name or "").strip()
+    if cleaned:
+        cleaned = validate_display_name(cleaned)
+    write_profile_meta(profile_dir, display_name=cleaned)
+    return cleaned
+
+
+def format_profile_label(name: str, display_name: Optional[str]) -> str:
+    """Render a profile for display: ``display_name (canonical_id)``.
+
+    Falls back to the bare canonical id when no display name is set or
+    when it equals the id — byte-for-byte what surfaces printed before
+    display names existed.
+    """
+    dn = (display_name or "").strip()
+    if dn and dn != name:
+        return f"{dn} ({name})"
+    return name
 
 
 # ---------------------------------------------------------------------------
@@ -911,6 +984,7 @@ def list_profiles() -> List[ProfileInfo]:
             distribution_source=dist_source,
             description=meta.get("description", ""),
             description_auto=meta.get("description_auto", False),
+            display_name=meta.get("display_name", ""),
         ))
 
     # Named profiles
@@ -953,6 +1027,7 @@ def list_profiles() -> List[ProfileInfo]:
                 distribution_source=dist_source,
                 description=meta.get("description", ""),
                 description_auto=meta.get("description_auto", False),
+                display_name=meta.get("display_name", ""),
             ))
 
     return profiles
@@ -2299,15 +2374,30 @@ def _migrate_honcho_profile_host(old_name: str, new_name: str, new_dir: Path) ->
 def rename_profile(old_name: str, new_name: str) -> Path:
     """Rename a profile: directory, wrapper script, service, active_profile.
 
-    Returns the new profile directory.
+    The default profile cannot be renamed (its home IS the installation
+    root), so renaming it sets a presentation-only ``display_name`` in
+    ``~/.hermes/profile.yaml`` instead — the canonical id stays
+    ``"default"`` and every resolution path is untouched.
+
+    Returns the (new) profile directory.
     """
     old_canon = normalize_profile_name(old_name)
-    new_canon = normalize_profile_name(new_name)
     validate_profile_name(old_canon)
-    validate_profile_name(new_canon)
 
     if old_canon == "default":
-        raise ValueError("Cannot rename the default profile.")
+        # Presentation-only: the default profile keeps its canonical id.
+        cleaned = validate_display_name(new_name)
+        default_home = _get_default_hermes_home()
+        if not default_home.is_dir():
+            raise FileNotFoundError("Default profile directory does not exist.")
+        write_profile_meta(default_home, display_name=cleaned)
+        print(f"✓ Display name set: {cleaned} (default)")
+        print("  Display name set; canonical id remains 'default'.")
+        return default_home
+
+    new_canon = normalize_profile_name(new_name)
+    validate_profile_name(new_canon)
+
     if new_canon == "default":
         raise ValueError("Cannot rename to 'default' — it is reserved.")
 

--- a/hermes_cli/slash_exec.py
+++ b/hermes_cli/slash_exec.py
@@ -100,9 +100,26 @@ def _exec_profile(ctx: CommandContext) -> CommandReply:
 
         home_display = display_hermes_home()
 
+    # Presentation-only display name (profile.yaml). Failures never break
+    # /profile — fall back to the bare canonical id.
+    profile_label = profile_name
+    try:
+        from hermes_cli.profiles import (
+            format_profile_label,
+            get_profile_dir,
+            read_profile_meta,
+        )
+
+        display = read_profile_meta(get_profile_dir(profile_name)).get(
+            "display_name", ""
+        )
+        profile_label = format_profile_label(profile_name, display)
+    except Exception:
+        pass
+
     return CommandReply(
-        f"Profile: {profile_name}\nHome: {home_display}",
-        data={"profile": profile_name, "home": home_display},
+        f"Profile: {profile_label}\nHome: {home_display}",
+        data={"profile": profile_label, "home": home_display},
     )
 
 

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -120,9 +120,16 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
         help="Custom alias name (default: profile name)",
     )
 
-    profile_rename = profile_subparsers.add_parser("rename", help="Rename a profile")
+    profile_rename = profile_subparsers.add_parser(
+        "rename",
+        help="Rename a profile (for 'default': sets a display name only)",
+    )
     profile_rename.add_argument("old_name", help="Current profile name")
-    profile_rename.add_argument("new_name", help="New profile name")
+    profile_rename.add_argument(
+        "new_name",
+        help="New profile name (for 'default': a display name; the "
+        "canonical id stays 'default')",
+    )
 
     profile_export = profile_subparsers.add_parser(
         "export", help="Export a profile to archive"

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -1010,6 +1010,19 @@ async def rename_profile_endpoint(name: str, body: ProfileRename):
     except Exception as e:
         _log.exception("PATCH /api/profiles/%s failed", name)
         raise HTTPException(status_code=500, detail=str(e))
+    try:
+        is_default = profiles_mod.normalize_profile_name(name) == "default"
+    except ValueError:
+        is_default = False
+    if is_default:
+        # Presentation-only: the canonical id stays "default"; the new
+        # name landed as display_name in profile.yaml.
+        return {
+            "ok": True,
+            "name": "default",
+            "display_name": body.new_name.strip(),
+            "path": str(path),
+        }
     return {"ok": True, "name": body.new_name, "path": str(path)}
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14366,6 +14366,7 @@ def _profile_to_dict(info) -> Dict[str, Any]:
         "gateway_running": bool(_profile_attr(info, "gateway_running", False)),
         "description": _profile_attr(info, "description", "") or "",
         "description_auto": bool(_profile_attr(info, "description_auto", False)),
+        "display_name": _profile_attr(info, "display_name", "") or "",
         "distribution_name": _profile_attr(info, "distribution_name"),
         "distribution_version": _profile_attr(info, "distribution_version"),
         "distribution_source": _profile_attr(info, "distribution_source"),

--- a/tests/hermes_cli/test_profile_display_name.py
+++ b/tests/hermes_cli/test_profile_display_name.py
@@ -1,0 +1,252 @@
+"""Tests for the profile display_name feature (#45624).
+
+display_name is a presentation-only field in <profile_dir>/profile.yaml.
+The canonical profile id ("default" for ~/.hermes) is never touched:
+resolution, comparison, and spawn paths must be provably unaffected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from hermes_cli import profiles
+from hermes_cli.profiles import (
+    create_profile,
+    format_profile_label,
+    get_profile_dir,
+    list_profiles,
+    profile_exists,
+    read_profile_meta,
+    rename_profile,
+    resolve_profile_env,
+    set_profile_display_name,
+    validate_display_name,
+    write_profile_meta,
+)
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    """Isolated environment: Path.home() and HERMES_HOME under tmp_path."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    return tmp_path
+
+
+# ===================================================================
+# Metadata plumbing (read/write_profile_meta)
+# ===================================================================
+
+class TestDisplayNameMeta:
+    def test_write_and_read_round_trip(self, profile_env):
+        home = profile_env / ".hermes"
+        write_profile_meta(home, display_name="Harumesu")
+        meta = read_profile_meta(home)
+        assert meta["display_name"] == "Harumesu"
+
+    def test_missing_file_defaults_empty(self, profile_env):
+        home = profile_env / ".hermes"
+        assert read_profile_meta(home)["display_name"] == ""
+
+    def test_preserves_description_fields(self, profile_env):
+        home = profile_env / ".hermes"
+        write_profile_meta(home, description="ops agent", description_auto=False)
+        write_profile_meta(home, display_name="Harumesu")
+        meta = read_profile_meta(home)
+        assert meta["description"] == "ops agent"
+        assert meta["description_auto"] is False
+        assert meta["display_name"] == "Harumesu"
+
+    def test_empty_string_clears_display_name(self, profile_env):
+        home = profile_env / ".hermes"
+        write_profile_meta(home, display_name="Harumesu")
+        write_profile_meta(home, display_name="")
+        meta = read_profile_meta(home)
+        assert meta["display_name"] == ""
+        # The key is removed from the file entirely, not left as "".
+        data = yaml.safe_load((home / "profile.yaml").read_text())
+        assert "display_name" not in data
+
+    def test_unicode_round_trips(self, profile_env):
+        home = profile_env / ".hermes"
+        write_profile_meta(home, display_name="小助手")
+        assert read_profile_meta(home)["display_name"] == "小助手"
+        # And through the raw file: valid UTF-8 YAML.
+        data = yaml.safe_load(
+            (home / "profile.yaml").read_text(encoding="utf-8")
+        )
+        assert data["display_name"] == "小助手"
+
+
+# ===================================================================
+# Validation
+# ===================================================================
+
+class TestValidateDisplayName:
+    def test_strips_whitespace(self):
+        assert validate_display_name("  Harumesu  ") == "Harumesu"
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValueError):
+            validate_display_name("")
+
+    def test_rejects_whitespace_only(self):
+        with pytest.raises(ValueError):
+            validate_display_name("   ")
+
+    def test_rejects_over_length(self):
+        with pytest.raises(ValueError):
+            validate_display_name("x" * 65)
+
+    def test_accepts_max_length(self):
+        assert validate_display_name("x" * 64) == "x" * 64
+
+    def test_accepts_unicode(self):
+        assert validate_display_name("小助手") == "小助手"
+
+
+# ===================================================================
+# rename_profile: default-profile branch sets display name
+# ===================================================================
+
+class TestRenameDefaultSetsDisplayName:
+    def test_default_rename_sets_display_name(self, profile_env, capsys):
+        home = profile_env / ".hermes"
+        result = rename_profile("default", "Harumesu")
+        assert result == home  # returns the (unchanged) default home
+        meta = read_profile_meta(home)
+        assert meta["display_name"] == "Harumesu"
+        out = capsys.readouterr().out
+        assert "canonical id remains 'default'" in out
+
+    def test_default_home_dir_not_renamed(self, profile_env):
+        home = profile_env / ".hermes"
+        rename_profile("default", "Harumesu")
+        assert home.is_dir()
+
+    def test_default_still_default_in_list(self, profile_env):
+        rename_profile("default", "Harumesu")
+        infos = {p.name: p for p in list_profiles()}
+        assert "default" in infos
+        assert infos["default"].is_default is True
+        assert infos["default"].display_name == "Harumesu"
+
+    def test_default_rename_rejects_empty(self, profile_env):
+        with pytest.raises(ValueError):
+            rename_profile("default", "   ")
+
+    def test_default_rename_rejects_over_length(self, profile_env):
+        with pytest.raises(ValueError):
+            rename_profile("default", "x" * 65)
+
+    def test_rename_to_default_still_reserved(self, profile_env):
+        create_profile("worker", no_alias=True)
+        with pytest.raises(ValueError, match="reserved"):
+            rename_profile("worker", "default")
+
+    def test_named_profile_rename_still_real(self, profile_env):
+        tmp_path = profile_env
+        create_profile("oldname", no_alias=True)
+        with patch(
+            "hermes_cli.profiles.check_alias_collision", return_value="skip"
+        ):
+            new_dir = rename_profile("oldname", "newname")
+        assert not (tmp_path / ".hermes" / "profiles" / "oldname").is_dir()
+        assert new_dir == tmp_path / ".hermes" / "profiles" / "newname"
+
+    def test_named_profile_display_name_survives_rename(self, profile_env):
+        tmp_path = profile_env
+        create_profile("oldname", no_alias=True)
+        old_dir = tmp_path / ".hermes" / "profiles" / "oldname"
+        write_profile_meta(old_dir, display_name="Old Friend")
+        with patch(
+            "hermes_cli.profiles.check_alias_collision", return_value="skip"
+        ):
+            new_dir = rename_profile("oldname", "newname")
+        assert read_profile_meta(new_dir)["display_name"] == "Old Friend"
+
+
+# ===================================================================
+# set_profile_display_name (direct setter)
+# ===================================================================
+
+class TestSetProfileDisplayName:
+    def test_sets_for_default(self, profile_env):
+        home = profile_env / ".hermes"
+        assert set_profile_display_name("default", "Harumesu") == "Harumesu"
+        assert read_profile_meta(home)["display_name"] == "Harumesu"
+
+    def test_sets_for_named_profile(self, profile_env):
+        create_profile("worker", no_alias=True)
+        set_profile_display_name("worker", "Workhorse")
+        assert (
+            read_profile_meta(get_profile_dir("worker"))["display_name"]
+            == "Workhorse"
+        )
+
+    def test_clear_with_empty_string(self, profile_env):
+        home = profile_env / ".hermes"
+        set_profile_display_name("default", "Harumesu")
+        assert set_profile_display_name("default", "") == ""
+        assert read_profile_meta(home)["display_name"] == ""
+
+    def test_missing_profile_raises(self, profile_env):
+        with pytest.raises(FileNotFoundError):
+            set_profile_display_name("ghost", "Boo")
+
+
+# ===================================================================
+# Rendering fallback (format_profile_label)
+# ===================================================================
+
+class TestFormatProfileLabel:
+    def test_display_name_with_canonical_id(self):
+        assert format_profile_label("default", "Harumesu") == "Harumesu (default)"
+
+    def test_unset_falls_back_to_bare_name(self):
+        # Byte-for-byte the pre-feature rendering for a no-meta profile.
+        assert format_profile_label("default", "") == "default"
+        assert format_profile_label("default", None) == "default"
+
+    def test_same_as_id_collapses(self):
+        assert format_profile_label("worker", "worker") == "worker"
+
+    def test_unicode(self):
+        assert format_profile_label("default", "小助手") == "小助手 (default)"
+
+
+# ===================================================================
+# Resolution is provably unaffected
+# ===================================================================
+
+class TestResolutionUnaffected:
+    def test_get_profile_dir_ignores_display_name(self, profile_env):
+        home = profile_env / ".hermes"
+        rename_profile("default", "Harumesu")
+        assert get_profile_dir("default") == home
+        # The display name is NOT a resolvable profile id.
+        assert get_profile_dir("harumesu") != home
+
+    def test_profile_exists_ignores_display_name(self, profile_env):
+        rename_profile("default", "Harumesu")
+        assert profile_exists("default") is True
+        assert profile_exists("harumesu") is False
+
+    def test_resolve_profile_env_ignores_display_name(self, profile_env):
+        home = profile_env / ".hermes"
+        rename_profile("default", "Harumesu")
+        assert resolve_profile_env("default") == str(home)
+        with pytest.raises(FileNotFoundError):
+            resolve_profile_env("harumesu")
+
+    def test_list_profiles_canonical_name_unchanged(self, profile_env):
+        rename_profile("default", "Harumesu")
+        default_info = next(p for p in list_profiles() if p.is_default)
+        assert default_info.name == "default"
+        assert default_info.display_name == "Harumesu"

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -125,6 +125,7 @@ def _(rid, params: dict) -> dict:
                 "model": p.model,
                 "provider": p.provider,
                 "description": getattr(p, "description", "") or "",
+                "display_name": getattr(p, "display_name", "") or "",
                 "skill_count": getattr(p, "skill_count", 0) or 0,
             }
             if include_sessions:

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2180,6 +2180,7 @@ export interface ProfileInfo {
   gateway_running: boolean;
   description: string;
   description_auto: boolean;
+  display_name?: string;
   distribution_name: string | null;
   distribution_version: string | null;
   distribution_source: string | null;

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1092,7 +1092,9 @@ export default function ProfilesPage() {
                       <div className="flex items-start gap-2">
                         <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
                           <span className="font-medium text-sm truncate">
-                            {p.name}
+                            {p.display_name && p.display_name !== p.name
+                              ? `${p.display_name} (${p.name})`
+                              : p.name}
                           </span>
 
                           {active && (

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -247,6 +247,33 @@ hermes profile import coder.tar.gz   # install an archive as a new profile
 
 In chat, the same two live as `/export` and `/import` — and in the desktop app as **⌘K → Export/Import profile…**. See [Sharing a profile](#sharing-a-profile).
 
+### Naming the default profile
+
+The default profile's internal ID is always `default` — it can't be renamed
+because `~/.hermes` is the installation root. But you can give it a
+**display name**, which every UI surface shows in place of the bare ID:
+
+```bash
+hermes profile rename default Harumesu
+```
+
+```
+ Profile           Model              Gateway   ...
+ ─────────────     ──────────────     ───────
+◆Harumesu (default)  claude-...       running
+```
+
+The display name appears in `hermes profile list`, `hermes profile show`,
+the `/profile` chat command, and the dashboard. It is presentation-only:
+`-p default`, service names, cron jobs, and every other reference keep
+using the canonical `default` ID. Unicode names are fine (e.g.
+`hermes profile rename default 小助手`).
+
+The name is stored as `display_name` in `~/.hermes/profile.yaml`. Remove
+that line (or set an empty value) to revert to the plain `default` label.
+Named profiles can also carry a `display_name` in their `profile.yaml`;
+`rename` for them still performs a real rename.
+
 ## Deleting a profile
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Gives profiles an optional, user-facing **display name** that UI surfaces show alongside the internal profile ID — so the default profile can appear as `Harumesu (default)` (or `小助手 (default)`) instead of the bare `default`.

The display name is **presentation-only**. It lives as an optional `display_name` key in the existing `<profile_dir>/profile.yaml` (same file and plumbing as the `description` field). No code path resolves, compares, or spawns profiles by display name: `-p default`, `get_profile_dir`, `profile_exists`, `resolve_profile_env`, gateway service labels, and cron all keep using canonical IDs, and the tests prove it.

This deliberately avoids the shape of the earlier closed PR #21134, which routed a default-profile alias through `normalize_profile_name` and changed identity resolution. Here identity resolution is untouched.

`hermes profile rename default <name>` — which previously refused with `Cannot rename the default profile.` — now sets the display name for the default profile (and says so: `display name set; canonical id remains 'default'`). Named profiles keep real rename behaviour, and `rename <x> default` remains reserved.

## Related Issue

Fixes #45624

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/profiles.py`
  - `ProfileInfo.display_name` field (defaults `""`)
  - `read_profile_meta` / `write_profile_meta`: read/persist `display_name` (empty value removes the key)
  - `validate_display_name`: strip, reject empty, cap at 64 chars (matches profile-id cap); Unicode allowed
  - `set_profile_display_name`: direct setter (empty string clears)
  - `format_profile_label`: renders `display_name (canonical_id)`, byte-for-byte fallback to the bare ID when unset
  - `rename_profile`: default-profile branch sets the display name instead of raising; named-profile rename unchanged
- `hermes_cli/main.py`: `profile list`, `profile show`, bare `hermes profile`, and the `rename` handler render/report the display name
- `hermes_cli/slash_exec.py`: `/profile` shows the display label (failure-safe fallback to bare ID)
- `hermes_cli/web_server.py`: `_profile_to_dict` gains additive `display_name` field (dashboard API)
- `hermes_cli/web_routers/profiles.py`: rename endpoint returns `{name: "default", display_name: ...}` for the default-profile case instead of claiming a rename
- `hermes_cli/subcommands/profile.py`: help text for `rename` documents the default-profile behaviour
- `tui_gateway/methods_profiles.py`: additive `display_name` in the profile listing payload
- `website/docs/user-guide/profiles.md`: new "Naming the default profile" section
- `tests/hermes_cli/test_profile_display_name.py`: 31 new tests (metadata round-trip incl. Unicode, validation, default rename branch, named rename unaffected, rendering fallback, resolution provably untouched)

## How to Test

1. `hermes profile rename default Harumesu`
   ```
   ✓ Display name set: Harumesu (default)
     Display name set; canonical id remains 'default'.
   ```
2. `hermes profile list` → the default row shows `◆Harumesu (default)`; `hermes profile show default` and `/profile` agree.
3. `hermes -p default chat` still resolves normally; `~/.hermes/profile.yaml` gains only a `display_name: Harumesu` line — remove it to revert.
4. `pytest tests/hermes_cli/test_profile_display_name.py tests/hermes_cli/test_profiles.py tests/hermes_cli/test_profile_describer.py -q`

Live output from my install (macOS 26.6.1):

```
$ hermes profile rename default Harumesu
✓ Display name set: Harumesu (default)
  Display name set; canonical id remains 'default'.

$ hermes profile list
 Profile          Model                        Gateway      Alias        Distribution
 ───────────────    ───────────────────────────    ───────────    ───────────    ────────────────────
 ◆Harumesu (default) claude-fable-5               stopped      —            —

$ hermes profile show default
Profile: Harumesu (default)
Path:    /Users/yxssxn/.hermes
Model:   claude-fable-5 (claude-sub)
...

$ grep display_name ~/.hermes/profile.yaml
display_name: Harumesu

$ hermes -p default chat -q 'reply with exactly: ok'   # resolution unaffected
Messages:       2 (1 user, 0 tool calls)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #45624 is open with no implementing PR; closed #21134 used a different (identity-resolution) mechanism; #48596/#48671 are adjacent but non-colliding
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `website/docs/user-guide/profiles.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config.yaml key; metadata lives in `profile.yaml`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python metadata + rendering, no OS-specific paths; display names never become filenames or argv tokens, so Windows-safe
