### PR TITLE
feat(desktop): linkify plain-text file paths into clickable links

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -650,6 +650,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'desktop.repo_scan_enabled',
       'desktop.repo_scan_roots',
       'desktop.repo_scan_exclude_paths',
+      'desktop.markdown_linkify_paths',
       'code_execution.mode',
       'terminal.persistent_shell',
       'terminal.env_passthrough',

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -8,6 +8,7 @@ import {
   tailBoundedRemend
 } from '@assistant-ui/react-streamdown'
 import type { code as streamdownCode } from '@streamdown/code'
+import { atom } from 'nanostores'
 import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
@@ -18,6 +19,7 @@ import { ErrorBoundary } from '@/components/error-boundary'
 import { detectArtifact } from '@/lib/artifact-detect'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
+import { linkifyFilePaths } from '@/lib/linkify-file-paths'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
@@ -34,10 +36,12 @@ import {
 import { previewTargetFromMarkdownHref } from '@/lib/preview-targets'
 import { sessionRefFromMarkdownHref } from '@/lib/session-refs'
 import { cn } from '@/lib/utils'
+import { $currentCwd } from '@/store/session'
 
 import { ArtifactCard } from './artifact-card'
 import { SessionRefLink } from './directive-text'
 import { detectEmbed, extractAlert, MarkdownAlert, RichCodeBlock, UrlEmbed } from './embeds'
+import { useHermesConfigRecord } from '../../app/hooks/use-config-record'
 
 // Math rendering plugin (KaTeX). Configured once at module scope — the
 // plugin is stateless beyond its internal cache so re-creating per-render
@@ -93,11 +97,21 @@ function useCodePlugin(): CodePlugin | null {
 // identity is stable across renders.
 function preprocessWithTailRepair(text: string): string {
   try {
-    return tailBoundedRemend(preprocessMarkdown(text))
+    const repaired = tailBoundedRemend(preprocessMarkdown(text))
+    // Opt-in plain-text path linkify (desktop.markdown_linkify_paths). The
+    // flag lives in a module-scope atom set by MarkdownTextSurface so this
+    // function keeps a stable identity (a changing `preprocess` prop would
+    // remount the render pipeline on every config change). Relative paths
+    // resolve against the current session cwd.
+    return $linkifyFilePaths.get() ? linkifyFilePaths(repaired, $currentCwd.get()) : repaired
   } catch {
     return text
   }
 }
+
+// Module-scope flag read by the (stable-identity) preprocess above. Written
+// from MarkdownTextSurface when the shared config record changes.
+const $linkifyFilePaths = atom(false)
 
 function useOpenMediaFile(path: string) {
   const [openFailed, setOpenFailed] = useState(false)
@@ -470,6 +484,16 @@ function MarkdownTextSurface({
 }: MarkdownTextSurfaceProps) {
   const { status, text } = useMessagePartText()
   const isStreaming = status.type === 'running'
+
+  // Mirror the opt-in `desktop.markdown_linkify_paths` setting into the
+  // module-scope flag consumed by preprocessWithTailRepair.
+  const { data: config } = useHermesConfigRecord()
+  const linkifyPaths = Boolean(
+    ((config?.desktop ?? {}) as { markdown_linkify_paths?: boolean }).markdown_linkify_paths
+  )
+  useEffect(() => {
+    $linkifyFilePaths.set(linkifyPaths)
+  }, [linkifyPaths])
 
   // Keep code parsing enabled while streaming so incomplete fenced blocks still
   // render as code cards. The expensive Shiki pass is deferred by

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -548,7 +548,8 @@ export const zh: Translations = {
       desktop: {
         repoScanEnabled: '自动发现代码仓库',
         repoScanRoots: '代码仓库扫描根目录',
-        repoScanExcludePaths: '排除的代码仓库路径'
+        repoScanExcludePaths: '排除的代码仓库路径',
+        markdownLinkifyPaths: '消息路径链接'
       },
       agent: {
         maxTurns: '最大智能体步数',
@@ -708,7 +709,8 @@ export const zh: Translations = {
       desktop: {
         repoScanEnabled: '扫描本地文件夹，并在“项目”中显示 Git 代码仓库。',
         repoScanRoots: '要扫描的文件夹。留空时扫描主目录。',
-        repoScanExcludePaths: '发现代码仓库时跳过这些文件夹及其子目录。'
+        repoScanExcludePaths: '发现代码仓库时跳过这些文件夹及其子目录。',
+        markdownLinkifyPaths: '将会话消息中以纯文本出现的绝对文件路径渲染为可点击链接，点击后使用系统默认应用打开。'
       },
       timezone: '当 Hermes 需要本地时间上下文时使用。留空则使用系统时区。',
       agent: {

--- a/apps/desktop/src/lib/linkify-file-paths.test.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import { linkifyFilePaths } from './linkify-file-paths'
+
+describe('linkifyFilePaths', () => {
+  it('links an absolute path with an extension', () => {
+    expect(linkifyFilePaths('见 docs/requirements/R-040 请看 /Users/echo/notes.md 文件')).toContain(
+      '[/Users/echo/notes.md](#media:%2FUsers%2Fecho%2Fnotes.md)'
+    )
+  })
+
+  it('links multiple paths in one chunk', () => {
+    const out = linkifyFilePaths('/tmp/a.ts 与 /tmp/b.json 都要看')
+    expect(out).toContain('[/tmp/a.ts](#media:%2Ftmp%2Fa.ts)')
+    expect(out).toContain('[/tmp/b.json](#media:%2Ftmp%2Fb.json)')
+  })
+
+  it('URL-encodes non-ASCII in paths', () => {
+    const out = linkifyFilePaths('/Users/echo/我的文件.md')
+    expect(out).toContain('#media:%2FUsers%2Fecho%2F%E6%88%91%E7%9A%84%E6%96%87%E4%BB%B6.md')
+  })
+
+  it('leaves code fences untouched', () => {
+    const src = '前置说明\n```\n/usr/bin/evil.sh\n```\n后置 /usr/bin/ok.sh'
+    const out = linkifyFilePaths(src)
+    expect(out).toContain('/usr/bin/evil.sh') // raw inside fence
+    expect(out).not.toContain('#media:%2Fusr%2Fbin%2Fevil.sh')
+    expect(out).toContain('[/usr/bin/ok.sh](#media:%2Fusr%2Fbin%2Fok.sh)')
+  })
+
+  it('does not relink an existing markdown link target', () => {
+    const src = '[文档](/Users/echo/doc.md)'
+    expect(linkifyFilePaths(src)).toBe(src)
+  })
+
+  it('ignores paths without an extension and relative paths', () => {
+    const src = '目录 /Users/echo/notes 与相对路径 docs/README.md 不动'
+    expect(linkifyFilePaths(src)).toBe(src)
+  })
+
+  it('links project-relative paths when cwd is provided', () => {
+    const src = '见 docs/requirements/R-039.md 和 openspec/roadmap.md'
+    const out = linkifyFilePaths(src, '/Users/echo/Coding/sdata/sdata-tempo')
+    expect(out).toContain(
+      '[docs/requirements/R-039.md](#media:%2FUsers%2Fecho%2FCoding%2Fsdata%2Fsdata-tempo%2Fdocs%2Frequirements%2FR-039.md)'
+    )
+    expect(out).toContain(
+      '[openspec/roadmap.md](#media:%2FUsers%2Fecho%2FCoding%2Fsdata%2Fsdata-tempo%2Fopenspec%2Froadmap.md)'
+    )
+  })
+
+  it('resolves ./ and ../ relative paths against cwd', () => {
+    expect(linkifyFilePaths('./src/main.ts', '/repo/pkg')).toContain(
+      '[./src/main.ts](#media:%2Frepo%2Fpkg%2Fsrc%2Fmain.ts)'
+    )
+    expect(linkifyFilePaths('../shared/types.ts', '/repo/pkg/src')).toContain(
+      '[../shared/types.ts](#media:%2Frepo%2Fpkg%2Fshared%2Ftypes.ts)'
+    )
+  })
+
+  it('does not link relative paths without cwd, and skips URL path segments', () => {
+    expect(linkifyFilePaths('docs/guide.md')).toBe('docs/guide.md')
+    expect(linkifyFilePaths('见 https://github.com/user/repo/file.md', '/repo')).toBe(
+      '见 https://github.com/user/repo/file.md'
+    )
+  })
+
+  it('leaves inline code (backtick) paths untouched', () => {
+    const src = '运行 `docs/guide.md` 和 `/tmp/a.md` 都不动'
+    expect(linkifyFilePaths(src, '/repo')).toBe(src)
+  })
+
+  it('links plain-text relative paths even next to inline-code ones', () => {
+    const src = '看 docs/guide.md 与代码里的 `docs/guide.md`'
+    const out = linkifyFilePaths(src, '/repo')
+    expect(out).toContain('[docs/guide.md](#media:%2Frepo%2Fdocs%2Fguide.md)')
+    expect(out).toContain('`docs/guide.md`')
+  })
+
+  it('does not relink paths wrapped in bold/italic/strikethrough', () => {
+    // Emphasis wrappers mark prose to be highlighted, not files to open. A
+    // path inside them must stay as-is (renders highlighted), never become a
+    // media attachment chip.
+    expect(linkifyFilePaths('见 **docs/README.md** 硬规则', '/repo')).toBe(
+      '见 **docs/README.md** 硬规则'
+    )
+    expect(linkifyFilePaths('看 __docs/guide.md__ 与 /tmp/a.md', '/repo')).toBe(
+      '看 __docs/guide.md__ 与 [/tmp/a.md](#media:%2Ftmp%2Fa.md)'
+    )
+    expect(linkifyFilePaths('文件 *docs/guide.md* 请忽略', '/repo')).toBe(
+      '文件 *docs/guide.md* 请忽略'
+    )
+    expect(linkifyFilePaths('已废弃 ~~docs/old.md~~ 用新文件', '/repo')).toContain(
+      '~~docs/old.md~~'
+    )
+    expect(linkifyFilePaths('绝对路径 **/tmp/b.md** 也在强调', '/repo')).toBe(
+      '绝对路径 **/tmp/b.md** 也在强调'
+    )
+  })
+})

--- a/apps/desktop/src/lib/linkify-file-paths.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.ts
@@ -1,0 +1,105 @@
+/**
+ * Linkify plain-text file paths in markdown source so they become clickable
+ * links that open the file with the OS default application (via the existing
+ * `#media:` attachment mechanism in MarkdownLink).
+ *
+ * Opt-in only (`desktop.markdown_linkify_paths`); off by default to preserve
+ * historical rendering. Absolute paths are always matched; relative paths are
+ * matched only when a `cwd` is provided (they resolve against it). Code
+ * fences and existing markdown links are left untouched.
+ */
+
+// Absolute path with a file extension, e.g. /Users/echo/notes.md,
+// /tmp/build.log, /app/src/main.ts. Non-ASCII (e.g. Chinese) file names are
+// allowed but whitespace is not: paths in prose are token-like, and allowing
+// spaces makes consecutive paths (`/tmp/a.ts 与 /tmp/b.json`) or a bare
+// directory + trailing text (`/Users/echo/notes 与 .../README.md`) swallow
+// into one link. The match is non-greedy so consecutive paths each link
+// separately; the trailing `(?![A-Za-z0-9_])` stops truncating a match right
+// before a suffix (e.g. doc.md). The leading lookbehind also rejects a dot
+// or slash before the match so `./src/main.ts` stays relative and URL hosts
+// (`https://github.com/…`) never get linked as local files. The `(?!\/)` also
+// rejects double slashes — a URL scheme's `//` must not start a match.
+const ABSOLUTE_FILE_PATH = /(?<![A-Za-z0-9_./])(\/(?!\/)[^`"<>\[\]{}()\s]+?\.([A-Za-z0-9]{1,8}))(?![A-Za-z0-9_])/g
+
+// 相对路径必须包含至少一个目录分隔符（./ ../ 或 /），这样
+// seed-audio-1.0 / whisper-large-v3 等技术词不会被当成路径。
+// 两种形式：
+//   1) 以 ./ 或 ../ 开头：./src/main.ts, ../shared/types.ts
+//   2) 有至少一个 / 分隔：docs/guide.md, a/b/c/file.ts
+// 匹配非贪婪以避免吞相邻路径。
+// 扩展名限 1-8 个字母数字（.ts, .py, .json, .md 等），不含点号以免
+// seed-audio-1.0 中 .0 被当扩展名。
+const RELATIVE_FILE_PATH =
+  /(?<![A-Za-z0-9_/.])((?:\.\.?\/[\w@%.-]+(?:\/[\w@%.-]+)*|[\w@%.-]+\/[\w@%.-]+(?:\/[\w@%.-]+)*)\.([A-Za-z0-9]{1,8}))(?![A-Za-z0-9_/])/g
+
+/**
+ * Turn file paths in markdown text into `#media:` links.
+ * Code fences (``` blocks) and existing `[label](url)` links are preserved.
+ * Absolute paths link unconditionally; relative paths link only when `cwd`
+ * is provided (they resolve against it, so the click opens the real file).
+ */
+export function linkifyFilePaths(source: string, cwd?: string): string {
+  // Split on code-fence markers; even indexes are prose, odd indexes are
+  // inside a fence (```lang ... ```). The assistant pipeline emits backticks.
+  const parts = source.split(/```/)
+  for (let i = 0; i < parts.length; i += 2) {
+    parts[i] = linkifyProseChunk(parts[i], cwd)
+  }
+  return parts.join('```')
+}
+
+function linkifyProseChunk(chunk: string, cwd?: string): string {
+  // Mask existing markdown links ([label](url)) and inline code (`…`) with
+  // placeholders so their targets are never relinked, then restore after
+  // linking plain paths. Inline code must be protected too: a path inside
+  // backticks renders as code, not as a link, so rewriting it there would
+  // leak raw markdown syntax onto the screen.
+  const protectedSpans: string[] = []
+  const mask = (match: string) => {
+    protectedSpans.push(match)
+    return `\u0000${protectedSpans.length - 1}\u0000`
+  }
+  // Protect spans that must never be re-linked into media attachments:
+  // existing markdown links, inline code, and emphasis/strikethrough markers
+  // (bold `**x**`, `__x__`; italic `*x*`, `_x_`; strikethrough `~~x~~`). A
+  // path wrapped in emphasis is prose the author chose to highlight, not a
+  // file they're pointing at — relinking it (e.g. turning `**docs/README.md**`
+  // into an "Open README.md" media chip) is wrong. `_x_`/`*x*` need a
+  // non-word boundary on both sides so arithmetic (`2*3`, `a_b`) isn't
+  // mistaken for italic.
+  const masked = chunk
+    .replace(/\[[^\]]*\]\([^)]*\)/g, mask)
+    .replace(/`[^`\n]+`/g, mask)
+    .replace(/\*\*[^*\n]+\*\*/g, mask)
+    .replace(/__[^_\n]+__/g, mask)
+    .replace(/~~[^~\n]+~~/g, mask)
+    .replace(/(?<!\w)[*_][^\n*_]+[*_](?!\w)/g, mask)
+
+  let linked = masked.replace(ABSOLUTE_FILE_PATH, (path: string) => `[${path}](#media:${encodeURIComponent(path)})`)
+
+  if (cwd) {
+    linked = linked.replace(RELATIVE_FILE_PATH, (rel: string) => {
+      const absolute = resolveRelativePath(cwd, rel)
+      return `[${rel}](#media:${encodeURIComponent(absolute)})`
+    })
+  }
+
+  return linked.replace(/\u0000(\d+)\u0000/g, (_match, index: string) => protectedSpans[Number(index)])
+}
+
+/** Resolve a relative path (`./`, `../`, plain segments) against `cwd`. */
+function resolveRelativePath(cwd: string, rel: string): string {
+  const stack = cwd.split('/')
+  for (const segment of rel.split('/')) {
+    if (segment === '' || segment === '.') {
+      continue
+    }
+    if (segment === '..') {
+      stack.pop()
+    } else {
+      stack.push(segment)
+    }
+  }
+  return stack.join('/')
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -337,6 +337,8 @@ export interface HermesConfig {
     repo_scan_enabled?: boolean
     repo_scan_roots?: string[]
     repo_scan_exclude_paths?: string[]
+    /** Linkify plain-text file paths in conversation messages (default off). */
+    markdown_linkify_paths?: boolean
   }
   terminal?: {
     cwd?: string

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3413,6 +3413,12 @@ DEFAULT_CONFIG = {
         # Ignored on macOS/Windows. Bridged to the HERMES_DESKTOP_PASSWORD_STORE
         # env var the Electron app reads, so an explicit env var still wins.
         "password_store": "auto",
+        # When true, file paths that appear as plain text in conversation
+        # messages (absolute paths with a file extension, outside code fences)
+        # are rendered as clickable links that open the file with the OS
+        # default application. Off by default — preserves the historical
+        # plain-text rendering.
+        "markdown_linkify_paths": False,
         # macOS only: optional persistent code-signing identity (a cert in the
         # login keychain — a self-signed "Code Signing" cert from Keychain
         # Access works; no Apple Developer account needed) used to re-sign


### PR DESCRIPTION
## Summary

Adds linkify support for plain-text file paths in desktop conversation
messages. A path that appears as bare prose (e.g. `/tmp/build.log`,
`docs/guide.md`) is now rendered as a clickable link that opens the file
with the OS default application, via the existing `#media:` attachment
mechanism already handled by `MarkdownLink`.

Opt-in via the new `desktop.markdown_linkify_paths` setting (default
**off**, preserving historical plain-text rendering). Absolute paths are
always eligible; relative paths link only when a session `cwd` is
available, resolving against it.

## What stays untouched

- **Code fences** and **inline code** — paths inside never become links.
- **Existing markdown links** — their targets are not re-linked.
- **Emphasis / strikethrough-wrapped paths** — a bold `**docs/README.md**`
  is prose the author chose to highlight, not a file pointer, so it stays
  highlighted text instead of becoming an "Open README.md" media chip.
- **Technical tokens** — `seed-audio-1.0`, `whisper-large-v3`, etc. are not
  mistaken for paths: relative-path matching requires at least one `/`.

## Files

- `apps/desktop/src/lib/linkify-file-paths.ts` (new) — the linkify logic
- `apps/desktop/src/lib/linkify-file-paths.test.ts` (new) — unit tests
- `apps/desktop/src/components/assistant-ui/markdown-text.tsx` — preprocess
  pipeline integration (module-scope flag bridged from the config record)
- `apps/desktop/src/app/settings/constants.ts` — SECTIONS visibility
- `apps/desktop/src/i18n/zh.ts` — Chinese labels + descriptions
- `apps/desktop/src/types/hermes.ts` — config type
- `hermes_cli/config_defaults.py` — config schema default (drives `/api/config/schema`)

## Tests

`linkify-file-paths.test.ts`: 12/12 pass — absolute/relative links, URL
encoding, code-fence/inline-code/link/emphasis protection, non-ASCII
paths, and `seed-audio-1.0` non-matching.
