### PR TITLE
feat(infra): add cursor-acp provider adapter for tool-using Hermes seats

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -760,8 +760,9 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
+        and agent.provider not in {"copilot-acp", "cursor-acp"}
         and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and not str(agent.base_url or "").lower().startswith("acp://cursor")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (
@@ -1224,7 +1225,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in {"copilot-acp", "cursor-acp"}:
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2494,6 +2494,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
+    if agent.provider == "cursor-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://cursor"):
+        from agent.cursor_acp_client import CursorACPClient
+
+        client = CursorACPClient(**client_kwargs)
+        _ra().logger.info(
+            "Cursor ACP client created (%s, shared=%s) %s",
+            reason,
+            shared,
+            agent._client_log_context(),
+        )
+        return client
     if agent.provider == "gemini":
         from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -575,6 +575,8 @@ _PROVIDER_ALIASES = {
     "github-models": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "cursor-acp-agent": "cursor-acp",
+    "cursor-agent-acp": "cursor-acp",
     "tencent": "tencent-tokenhub",
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
@@ -2345,6 +2347,12 @@ def _maybe_wrap_anthropic(
     try:
         from agent.copilot_acp_client import CopilotACPClient
         if _safe_isinstance(client_obj, CopilotACPClient):
+            return client_obj
+    except ImportError:
+        pass
+    try:
+        from agent.cursor_acp_client import CursorACPClient
+        if _safe_isinstance(client_obj, CursorACPClient):
             return client_obj
     except ImportError:
         pass
@@ -6011,6 +6019,12 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
             return sync_client, model
     except ImportError:
         pass
+    try:
+        from agent.cursor_acp_client import CursorACPClient
+        if isinstance(sync_client, CursorACPClient):
+            return sync_client, model
+    except ImportError:
+        pass
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -6768,31 +6782,43 @@ def resolve_provider_client(
             or _read_main_model_for_aux(),
             provider,
         )
-        if provider == "copilot-acp":
+        if provider in {"copilot-acp", "cursor-acp"}:
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None
             args = list(creds.get("args") or [])
             if not final_model:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
+                    "resolve_provider_client: %s requested but no model "
+                    "was provided or configured",
+                    provider,
                 )
                 return None, None
             if not api_key or not base_url:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
+                    "resolve_provider_client: %s requested but external "
+                    "process credentials are incomplete",
+                    provider,
                 )
                 return None, None
-            from agent.copilot_acp_client import CopilotACPClient
+            if provider == "cursor-acp":
+                from agent.cursor_acp_client import CursorACPClient
 
-            client = CopilotACPClient(
-                api_key=api_key,
-                base_url=base_url,
-                command=command,
-                args=args,
-            )
+                client = CursorACPClient(
+                    api_key=api_key,
+                    base_url=base_url,
+                    command=command,
+                    args=args,
+                )
+            else:
+                from agent.copilot_acp_client import CopilotACPClient
+
+                client = CopilotACPClient(
+                    api_key=api_key,
+                    base_url=base_url,
+                    command=command,
+                    args=args,
+                )
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
@@ -7971,6 +7997,7 @@ def _resolve_task_provider_model(
                 "anthropic",
                 "copilot",
                 "copilot-acp",
+                "cursor-acp",
                 "minimax-oauth",
                 "nous",
                 "openai-codex",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2880,8 +2880,9 @@ def run_conversation(
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider in {"copilot-acp"}
+                    agent.provider in {"copilot-acp", "cursor-acp"}
                     or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    or str(agent.base_url or "").lower().startswith("acp://cursor")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/cursor_acp_client.py
+++ b/agent/cursor_acp_client.py
@@ -1,0 +1,817 @@
+"""OpenAI-compatible shim that forwards Hermes requests to `cursor-agent acp`.
+
+Cursor's HTTP OpenAI shim (`cur-*` on :8317/:8321) correctly rejects tool
+schemas. This adapter is the execution path: it talks JSON-RPC ACP over
+stdio, injects Hermes tool schemas into the prompt, and rebuilds OpenAI
+`tool_calls` from `<tool_call>{...}</tool_call>` blocks.
+
+Transport (verified 2026-08-16): `cursor-agent acp` — initialize →
+authenticate(cursor_login) → session/new → session/set_model →
+session/prompt. Do not fall back to `cursor-agent -p`; ACP works.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import re
+import subprocess
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+
+from agent.file_safety import get_read_block_error, get_write_denied_error, is_write_approval_required
+from agent.redact import redact_sensitive_text
+from tools.environments.local import hermes_subprocess_env
+
+ACP_MARKER_BASE_URL = "acp://cursor"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+_DEFAULT_COMMAND = "cursor-agent"
+_DEFAULT_ARGS = ["acp"]
+
+_TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+_TOOL_CALL_JSON_RE = re.compile(
+    r'\{\s*"id"\s*:\s*"[^"]+"\s*,\s*"type"\s*:\s*"function"\s*,\s*"function"\s*:\s*\{.*?\}\s*\}',
+    re.DOTALL,
+)
+
+_CLI_SUFFIXES = (
+    "-high-fast",
+    "-xhigh-fast",
+    "-low-fast",
+    "-medium-fast",
+    "-xhigh",
+    "-high",
+    "-medium",
+    "-low",
+    "-fast",
+)
+
+
+class CursorACPToolCallParseError(ValueError):
+    """A `<tool_call>` block was present but could not be recovered."""
+
+
+def _resolve_command() -> str:
+    return _DEFAULT_COMMAND
+
+
+def _resolve_args() -> list[str]:
+    return list(_DEFAULT_ARGS)
+
+
+def _resolve_home_dir() -> str:
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return home
+    expanded = os.path.expanduser("~")
+    if expanded and expanded != "~":
+        return expanded
+    try:
+        import pwd
+
+        resolved = pwd.getpwuid(os.getuid()).pw_dir.strip()
+        if resolved:
+            return resolved
+    except Exception:
+        pass
+    return "/tmp"
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    env = hermes_subprocess_env(inherit_credentials=True)
+    home = _resolve_home_dir()
+    env["HOME"] = home
+    from hermes_constants import apply_subprocess_home_env
+
+    apply_subprocess_home_env(env)
+    return env
+
+
+def _jsonrpc_error(message_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _permission_denied(message_id: Any) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "result": {"outcome": {"outcome": "cancelled"}},
+    }
+
+
+def _format_messages_as_prompt(
+    messages: list[dict[str, Any]],
+    model: str | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = None,
+) -> str:
+    sections: list[str] = [
+        "You are being used as the active ACP agent backend for Hermes.",
+        "Use ACP capabilities to complete tasks.",
+        "IMPORTANT: If you take an action with a tool, you MUST output tool calls using <tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
+        "If no tool is needed, answer normally.",
+    ]
+    if model:
+        sections.append(f"Hermes requested model hint: {model}")
+
+    if isinstance(tools, list) and tools:
+        tool_specs: list[dict[str, Any]] = []
+        for t in tools:
+            if not isinstance(t, dict):
+                continue
+            fn = t.get("function") or {}
+            if not isinstance(fn, dict):
+                continue
+            name = fn.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            tool_specs.append(
+                {
+                    "name": name.strip(),
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }
+            )
+        if tool_specs:
+            sections.append(
+                "Available tools (OpenAI function schema). "
+                "When using a tool, emit ONLY <tool_call>{...}</tool_call> with one JSON object "
+                "containing id/type/function{name,arguments}. arguments must be a JSON string.\n"
+                + json.dumps(tool_specs, ensure_ascii=False)
+            )
+
+    if tool_choice is not None:
+        sections.append(f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False)}")
+
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        if role == "tool":
+            role = "tool"
+        elif role not in {"system", "user", "assistant"}:
+            role = "context"
+
+        content = message.get("content")
+        rendered = _render_message_content(content)
+        tool_calls = message.get("tool_calls")
+        if not rendered and isinstance(tool_calls, list) and tool_calls:
+            rendered = json.dumps(tool_calls, ensure_ascii=False)
+        if not rendered:
+            continue
+
+        label = {
+            "system": "System",
+            "user": "User",
+            "assistant": "Assistant",
+            "tool": "Tool",
+            "context": "Context",
+        }.get(role, role.title())
+        transcript.append(f"{label}:\n{rendered}")
+
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+
+    sections.append("Continue the conversation from the latest user request.")
+    return "\n\n".join(section.strip() for section in sections if section and section.strip())
+
+
+def _render_message_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        if "text" in content:
+            return str(content.get("text") or "").strip()
+        if "content" in content and isinstance(content.get("content"), str):
+            return str(content.get("content") or "").strip()
+        return json.dumps(content, ensure_ascii=True)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+        return "\n".join(parts).strip()
+    return str(content).strip()
+
+
+def _build_openai_tool_call(
+    *,
+    call_id: str,
+    name: str,
+    arguments: str,
+) -> ChatCompletionMessageToolCall:
+    return ChatCompletionMessageToolCall(
+        id=call_id,
+        call_id=call_id,
+        response_item_id=None,
+        type="function",
+        function=Function(name=name, arguments=arguments),
+    )
+
+
+def _completion_to_stream_chunks(completion: SimpleNamespace) -> list[SimpleNamespace]:
+    choice = completion.choices[0]
+    message = choice.message
+    tool_call_deltas = None
+    if message.tool_calls:
+        tool_call_deltas = []
+        for index, tool_call in enumerate(message.tool_calls):
+            tool_call_deltas.append(
+                SimpleNamespace(
+                    index=index,
+                    id=getattr(tool_call, "id", None),
+                    type=getattr(tool_call, "type", "function"),
+                    function=SimpleNamespace(
+                        name=getattr(tool_call.function, "name", None),
+                        arguments=getattr(tool_call.function, "arguments", None),
+                    ),
+                )
+            )
+
+    delta = SimpleNamespace(
+        role="assistant",
+        content=message.content or None,
+        tool_calls=tool_call_deltas,
+        reasoning_content=message.reasoning_content,
+        reasoning=message.reasoning,
+    )
+    data_chunk = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                index=0,
+                delta=delta,
+                finish_reason=choice.finish_reason,
+            )
+        ],
+        model=completion.model,
+        usage=None,
+    )
+    usage_chunk = SimpleNamespace(
+        choices=[],
+        model=completion.model,
+        usage=completion.usage,
+    )
+    return [data_chunk, usage_chunk]
+
+
+def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessageToolCall], str]:
+    if not isinstance(text, str) or not text.strip():
+        return [], ""
+
+    open_count = text.count("<tool_call>")
+    close_count = text.count("</tool_call>")
+    if open_count != close_count:
+        raise CursorACPToolCallParseError(
+            "truncated <tool_call> block: opening and closing tags do not match"
+        )
+
+    extracted: list[ChatCompletionMessageToolCall] = []
+    consumed_spans: list[tuple[int, int]] = []
+
+    def _parse_tool_call(raw_json: str) -> ChatCompletionMessageToolCall:
+        try:
+            obj = json.loads(raw_json)
+        except Exception as exc:
+            raise CursorACPToolCallParseError(
+                f"malformed <tool_call> JSON: {exc}"
+            ) from exc
+        if not isinstance(obj, dict):
+            raise CursorACPToolCallParseError("malformed <tool_call> payload: expected object")
+        fn = obj.get("function")
+        if not isinstance(fn, dict):
+            raise CursorACPToolCallParseError("malformed <tool_call> payload: missing function")
+        fn_name = fn.get("name")
+        if not isinstance(fn_name, str) or not fn_name.strip():
+            raise CursorACPToolCallParseError("malformed <tool_call> payload: missing function.name")
+        fn_args = fn.get("arguments", "{}")
+        if not isinstance(fn_args, str):
+            fn_args = json.dumps(fn_args, ensure_ascii=False)
+        call_id = obj.get("id")
+        if not isinstance(call_id, str) or not call_id.strip():
+            call_id = f"acp_call_{len(extracted) + 1}"
+        return _build_openai_tool_call(
+            call_id=call_id,
+            name=fn_name.strip(),
+            arguments=fn_args,
+        )
+
+    for match in _TOOL_CALL_BLOCK_RE.finditer(text):
+        extracted.append(_parse_tool_call(match.group(1)))
+        consumed_spans.append((match.start(), match.end()))
+
+    if open_count and len(extracted) != open_count:
+        raise CursorACPToolCallParseError(
+            "malformed <tool_call> block: could not parse every tagged payload"
+        )
+
+    if not extracted:
+        for match in _TOOL_CALL_JSON_RE.finditer(text):
+            try:
+                extracted.append(_parse_tool_call(match.group(0)))
+            except CursorACPToolCallParseError:
+                continue
+            consumed_spans.append((match.start(), match.end()))
+
+    if not consumed_spans:
+        return extracted, text.strip()
+
+    consumed_spans.sort()
+    merged: list[tuple[int, int]] = []
+    for start, end in consumed_spans:
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+
+    parts: list[str] = []
+    cursor = 0
+    for start, end in merged:
+        if cursor < start:
+            parts.append(text[cursor:start])
+        cursor = max(cursor, end)
+    if cursor < len(text):
+        parts.append(text[cursor:])
+
+    cleaned = "\n".join(p.strip() for p in parts if p and p.strip()).strip()
+    return extracted, cleaned
+
+
+def resolve_cursor_acp_model_id(
+    requested: str | None,
+    available: list[dict[str, Any]] | None,
+) -> str | None:
+    """Map a Hermes/CLI model id onto a Cursor ACP `modelId`.
+
+    Cursor ACP advertises parameterized ids such as
+    ``gemini-3.7-flash[effort=high]``. Hermes seats ask for CLI names such as
+    ``gemini-3.7-flash-high`` / ``gpt-5.6-sol-high``. Exact `modelId` and
+    `name` win; otherwise a suffix-stripped stem is matched.
+    """
+    req = (requested or "").strip()
+    if not req:
+        return None
+    rows: list[tuple[str, str]] = []
+    for item in available or []:
+        if not isinstance(item, dict):
+            continue
+        model_id = str(item.get("modelId") or "").strip()
+        name = str(item.get("name") or "").strip()
+        if model_id:
+            rows.append((model_id, name))
+            if model_id == req or name == req:
+                return model_id
+
+    stem = req
+    for suffix in _CLI_SUFFIXES:
+        if stem.endswith(suffix):
+            stem = stem[: -len(suffix)]
+            break
+    if stem:
+        for model_id, name in rows:
+            if name == stem or model_id == stem or model_id.startswith(stem + "["):
+                return model_id
+    return None
+
+
+def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
+    candidate = Path(path_text)
+    if not candidate.is_absolute():
+        raise PermissionError("ACP file-system paths must be absolute.")
+    resolved = candidate.resolve()
+    root = Path(cwd).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise PermissionError(f"Path '{resolved}' is outside the session cwd '{root}'.") from exc
+    return resolved
+
+
+class _ACPChatCompletions:
+    def __init__(self, client: "CursorACPClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ACPChatNamespace:
+    def __init__(self, client: "CursorACPClient"):
+        self.completions = _ACPChatCompletions(client)
+
+
+class CursorACPClient:
+    """Minimal OpenAI-client-compatible facade for Cursor ACP."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "cursor-acp"
+        self.base_url = base_url or ACP_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._acp_command = acp_command or command or _resolve_command()
+        self._acp_args = list(acp_args or args or _resolve_args())
+        self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self.chat = _ACPChatNamespace(self)
+        self.is_closed = False
+        self._active_process: subprocess.Popen[str] | None = None
+        self._active_process_lock = threading.Lock()
+
+    def close(self) -> None:
+        proc: subprocess.Popen[str] | None
+        with self._active_process_lock:
+            proc = self._active_process
+            self._active_process = None
+        self.is_closed = True
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        stream: bool = False,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(
+            messages or [],
+            model=model,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        if timeout is None:
+            effective_timeout = _DEFAULT_TIMEOUT_SECONDS
+        elif isinstance(timeout, (int, float)):
+            effective_timeout = float(timeout)
+        else:
+            candidates = [
+                getattr(timeout, attr, None)
+                for attr in ("read", "write", "connect", "pool", "timeout")
+            ]
+            numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+            effective_timeout = max(numeric) if numeric else _DEFAULT_TIMEOUT_SECONDS
+
+        response_text, reasoning_text = self._run_prompt(
+            prompt_text,
+            timeout_seconds=effective_timeout,
+            model=model,
+        )
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+        usage = SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=reasoning_text or None,
+            reasoning_content=reasoning_text or None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        completion = SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or "cursor-acp",
+        )
+        if stream:
+            return _completion_to_stream_chunks(completion)
+        return completion
+
+    def _run_prompt(
+        self,
+        prompt_text: str,
+        *,
+        timeout_seconds: float,
+        model: str | None = None,
+    ) -> tuple[str, str]:
+        try:
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
+            proc = subprocess.Popen(
+                [self._acp_command] + self._acp_args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                bufsize=1,
+                cwd=self._acp_cwd,
+                env=_build_subprocess_env(),
+                creationflags=windows_hide_flags(),
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start Cursor ACP command '{self._acp_command}'. "
+                "Install the Cursor CLI and run `cursor-agent login`, then retry."
+            ) from exc
+
+        if proc.stdin is None or proc.stdout is None:
+            proc.kill()
+            raise RuntimeError("Cursor ACP process did not expose stdin/stdout pipes.")
+
+        self.is_closed = False
+        with self._active_process_lock:
+            self._active_process = proc
+
+        inbox: queue.Queue[dict[str, Any]] = queue.Queue()
+        stderr_tail: deque[str] = deque(maxlen=40)
+
+        def _stdout_reader() -> None:
+            if proc.stdout is None:
+                return
+            for line in proc.stdout:
+                try:
+                    inbox.put(json.loads(line))
+                except Exception:
+                    inbox.put({"raw": line.rstrip("\n")})
+
+        def _stderr_reader() -> None:
+            if proc.stderr is None:
+                return
+            for line in proc.stderr:
+                stderr_tail.append(line.rstrip("\n"))
+
+        threading.Thread(target=_stdout_reader, daemon=True).start()
+        threading.Thread(target=_stderr_reader, daemon=True).start()
+
+        next_id = 0
+
+        def _request(
+            method: str,
+            params: dict[str, Any],
+            *,
+            text_parts: list[str] | None = None,
+            reasoning_parts: list[str] | None = None,
+        ) -> Any:
+            nonlocal next_id
+            next_id += 1
+            request_id = next_id
+            payload = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            }
+            proc.stdin.write(json.dumps(payload) + "\n")
+            proc.stdin.flush()
+
+            deadline = time.monotonic() + timeout_seconds
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    break
+                try:
+                    msg = inbox.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+
+                if self._handle_server_message(
+                    msg,
+                    process=proc,
+                    cwd=self._acp_cwd,
+                    text_parts=text_parts,
+                    reasoning_parts=reasoning_parts,
+                ):
+                    continue
+
+                if msg.get("id") != request_id:
+                    continue
+                if "error" in msg:
+                    err = msg.get("error") or {}
+                    raise RuntimeError(
+                        f"Cursor ACP {method} failed: {err.get('message') or err}"
+                    )
+                return msg.get("result")
+
+            stderr_text = "\n".join(stderr_tail).strip()
+            if proc.poll() is not None and stderr_text:
+                lower = stderr_text.lower()
+                if "login" in lower or "unauthor" in lower or "auth" in lower:
+                    raise RuntimeError(
+                        "Cursor ACP process exited before completing the handshake. "
+                        "Run `cursor-agent login` and retry.\n"
+                        f"Original error:\n{stderr_text}"
+                    )
+                raise RuntimeError(f"Cursor ACP process exited early: {stderr_text}")
+            raise TimeoutError(f"Timed out waiting for Cursor ACP response to {method}.")
+
+        try:
+            init_result = _request(
+                "initialize",
+                {
+                    "protocolVersion": 1,
+                    "clientCapabilities": {
+                        "fs": {
+                            "readTextFile": True,
+                            "writeTextFile": True,
+                        }
+                    },
+                    "clientInfo": {
+                        "name": "hermes-agent",
+                        "title": "Hermes Agent",
+                        "version": "0.0.0",
+                    },
+                },
+            ) or {}
+            auth_methods = init_result.get("authMethods") if isinstance(init_result, dict) else None
+            method_id = "cursor_login"
+            if isinstance(auth_methods, list):
+                ids = [
+                    str(item.get("id") or "").strip()
+                    for item in auth_methods
+                    if isinstance(item, dict)
+                ]
+                if "cursor_login" in ids:
+                    method_id = "cursor_login"
+                elif ids:
+                    method_id = ids[0]
+            try:
+                _request("authenticate", {"methodId": method_id})
+            except RuntimeError as exc:
+                raise RuntimeError(
+                    "Cursor ACP authentication failed. "
+                    "Run `cursor-agent login` and retry. "
+                    f"Original error: {exc}"
+                ) from exc
+
+            session = _request(
+                "session/new",
+                {
+                    "cwd": self._acp_cwd,
+                    "mcpServers": [],
+                },
+            ) or {}
+            session_id = str(session.get("sessionId") or "").strip()
+            if not session_id:
+                raise RuntimeError("Cursor ACP did not return a sessionId.")
+
+            available = []
+            models = session.get("models") if isinstance(session, dict) else None
+            if isinstance(models, dict):
+                raw_available = models.get("availableModels")
+                if isinstance(raw_available, list):
+                    available = [item for item in raw_available if isinstance(item, dict)]
+            resolved = resolve_cursor_acp_model_id(model, available)
+            if model and available and resolved is None:
+                raise RuntimeError(
+                    f"Cursor ACP does not advertise model {model!r}. "
+                    "Use a Cursor CLI id such as gpt-5.6-sol-high or gemini-3.7-flash-high."
+                )
+            if resolved:
+                _request(
+                    "session/set_model",
+                    {"sessionId": session_id, "modelId": resolved},
+                )
+
+            text_parts: list[str] = []
+            reasoning_parts: list[str] = []
+            _request(
+                "session/prompt",
+                {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": prompt_text}],
+                },
+                text_parts=text_parts,
+                reasoning_parts=reasoning_parts,
+            )
+            return "".join(text_parts), "".join(reasoning_parts)
+        finally:
+            self.close()
+
+    def _handle_server_message(
+        self,
+        msg: dict[str, Any],
+        *,
+        process: subprocess.Popen[str],
+        cwd: str,
+        text_parts: list[str] | None,
+        reasoning_parts: list[str] | None,
+    ) -> bool:
+        method = msg.get("method")
+        if not isinstance(method, str):
+            return False
+
+        if method == "session/update":
+            params = msg.get("params") or {}
+            update = params.get("update") or {}
+            kind = str(update.get("sessionUpdate") or "").strip()
+            content = update.get("content") or {}
+            chunk_text = ""
+            if isinstance(content, dict):
+                chunk_text = str(content.get("text") or "")
+            if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
+                text_parts.append(chunk_text)
+            elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:
+                reasoning_parts.append(chunk_text)
+            return True
+
+        if process.stdin is None:
+            return True
+
+        message_id = msg.get("id")
+        params = msg.get("params") or {}
+
+        if method == "session/request_permission":
+            response = _permission_denied(message_id)
+        elif method == "fs/read_text_file":
+            try:
+                path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
+                block_error = get_read_block_error(str(path))
+                if block_error:
+                    raise PermissionError(block_error)
+                try:
+                    content = path.read_text(encoding="utf-8")
+                except FileNotFoundError:
+                    content = ""
+                line = params.get("line")
+                limit = params.get("limit")
+                if isinstance(line, int) and line > 1:
+                    lines = content.splitlines(keepends=True)
+                    start = line - 1
+                    end = start + limit if isinstance(limit, int) and limit > 0 else None
+                    content = "".join(lines[start:end])
+                if content:
+                    content = redact_sensitive_text(content, force=True)
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": {"content": content},
+                }
+            except Exception as exc:
+                response = _jsonrpc_error(message_id, -32602, str(exc))
+        elif method == "fs/write_text_file":
+            try:
+                path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
+                denied = get_write_denied_error(str(path))
+                if denied:
+                    raise PermissionError(denied)
+                if is_write_approval_required(str(path)):
+                    raise PermissionError(
+                        f"Write denied: '{path}' requires interactive approval "
+                        "and cannot be written through the ACP file bridge."
+                    )
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(str(params.get("content") or ""), encoding="utf-8")
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": None,
+                }
+            except Exception as exc:
+                response = _jsonrpc_error(message_id, -32602, str(exc))
+        else:
+            response = _jsonrpc_error(
+                message_id,
+                -32601,
+                f"ACP client method '{method}' is not supported by Hermes yet.",
+            )
+
+        process.stdin.write(json.dumps(response) + "\n")
+        process.stdin.flush()
+        return True

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -134,6 +134,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_CURSOR_ACP_BASE_URL = "acp://cursor"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 DEFAULT_ACTUAL_BASE_URL = "https://api.actual.inc/v1"
 DEFAULT_ACTUAL_LOCAL_BASE_URL = "http://127.0.0.1:8080/v1"
@@ -304,6 +305,12 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "cursor-acp": ProviderConfig(
+        id="cursor-acp",
+        name="Cursor ACP",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_CURSOR_ACP_BASE_URL,
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -2110,6 +2117,7 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        "cursor-acp-agent": "cursor-acp", "cursor-agent-acp": "cursor-acp",
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
@@ -7117,12 +7125,15 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
-def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
-    """Status snapshot for providers that run a local subprocess."""
-    pconfig = PROVIDER_REGISTRY.get(provider_id)
-    if not pconfig or pconfig.auth_type != "external_process":
-        return {"configured": False}
+def _external_process_launch(provider_id: str) -> tuple[str, list[str]]:
+    """Return (command, args) for an external-process provider.
 
+    Copilot ACP keeps the existing HERMES_COPILOT_ACP_* / COPILOT_CLI_PATH
+    contract. Cursor ACP launches `cursor-agent acp` and does not reuse
+    those Copilot-only env vars.
+    """
+    if provider_id == "cursor-acp":
+        return "cursor-agent", ["acp"]
     command = (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
         or os.getenv("COPILOT_CLI_PATH", "").strip()
@@ -7130,6 +7141,16 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     )
     raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    return command, args
+
+
+def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
+    """Status snapshot for providers that run a local subprocess."""
+    pconfig = PROVIDER_REGISTRY.get(provider_id)
+    if not pconfig or pconfig.auth_type != "external_process":
+        return {"configured": False}
+
+    command, args = _external_process_launch(provider_id)
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
@@ -7164,7 +7185,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    if target in {"copilot-acp", "cursor-acp"}:
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -7354,15 +7375,16 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    command, args = _external_process_launch(provider_id)
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
+        if provider_id == "cursor-acp":
+            raise AuthError(
+                f"Could not find the Cursor CLI command '{command}'. "
+                "Install cursor-agent and run `cursor-agent login`.",
+                provider=provider_id,
+                code="missing_cursor_cli",
+            )
         raise AuthError(
             f"Could not find the Copilot CLI command '{command}'. "
             "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
@@ -7372,7 +7394,7 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -804,6 +804,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_cursor_acp,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock_api_key,
@@ -3887,6 +3888,8 @@ def select_provider_and_model(args=None):
         _model_flow_minimax_oauth(config, current_model, args=args)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "cursor-acp":
+        _model_flow_cursor_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -11292,7 +11295,7 @@ def _build_provider_choices() -> list[str]:
     except Exception:
         # Fallback: static list guarantees the CLI always works
         return [
-            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "copilot",
+            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "cursor-acp", "copilot",
             "anthropic", "gemini", "vertex", "xai", "bedrock", "azure-foundry",
             "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn",
             "stepfun", "minimax", "minimax-cn", "kilocode", "novita", "xiaomi", "arcee",

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -82,6 +82,7 @@ _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
 _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
     "copilot",
     "copilot-acp",
+    "cursor-acp",
     "openai-codex",
 })
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2023,6 +2023,76 @@ def _model_flow_copilot_acp(config, current_model=""):
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
 
+def _model_flow_cursor_acp(config, current_model=""):
+    """Cursor ACP flow using the local `cursor-agent acp` CLI."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "cursor-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = (
+        status.get("resolved_command") or status.get("command") or "cursor-agent"
+    )
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Cursor ACP delegates Hermes turns to `cursor-agent acp`.")
+    print("  Hermes starts its own ACP subprocess for each request.")
+    print("  Selected model is mapped onto Cursor's ACP modelId list.")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print("  Install cursor-agent and run `cursor-agent login`.")
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+    model_list = list(_PROVIDER_MODELS.get("cursor-acp", []))
+    if model_list:
+        selected = _prompt_model_selection(
+            model_list,
+            current_model=current_model,
+            confirm_provider=provider_id,
+            confirm_base_url=effective_base,
+        )
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+    save_config(cfg)
+    deactivate_provider()
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -337,6 +337,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "cursor-acp": [
+        "gpt-5.6-sol-high",
+        "gemini-3.7-flash-high",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -1166,6 +1170,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("cursor-acp",     "Cursor ACP",               "Cursor ACP (Spawns cursor-agent acp)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("vertex",         "Google Vertex AI",         "Google Vertex AI (Gemini via GCP; OAuth2 service account or ADC, GCP billing/quotas)"),
@@ -1329,6 +1334,8 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "cursor-acp-agent": "cursor-acp",
+    "cursor-agent-acp": "cursor-acp",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
@@ -3161,6 +3168,8 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             pass
         if normalized == "copilot-acp":
             return list(_PROVIDER_MODELS.get("copilot", []))
+    if normalized == "cursor-acp":
+        return list(_PROVIDER_MODELS.get("cursor-acp", []))
     if normalized == "nous":
         # Try live Nous Portal /models endpoint
         try:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "cursor-acp": HermesOverlay(
+        transport="openai_chat",
+        auth_type="external_process",
+        base_url_override="acp://cursor",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -415,6 +420,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "ChatGPT or Codex Subscription",
     "copilot-acp": "GitHub Copilot ACP",
+    "cursor-acp": "Cursor ACP",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -2078,10 +2078,10 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "cursor-acp"}:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -74,6 +74,10 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "cursor-acp": [
+        "gpt-5.6-sol-high",
+        "gemini-3.7-flash-high",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",

--- a/plugins/model-providers/cursor-acp/__init__.py
+++ b/plugins/model-providers/cursor-acp/__init__.py
@@ -1,0 +1,39 @@
+"""Cursor ACP provider profile.
+
+cursor-acp uses an external ACP subprocess (`cursor-agent acp`) — NOT the
+HTTP `cur-*` shim on :8317/:8321. That shim correctly returns HTTP 400
+`unsupported_tools` for any request carrying a tool schema. This provider
+is the tool-using execution path.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class CursorACPProfile(ProviderProfile):
+    """Cursor ACP — external process, no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is handled by the ACP subprocess."""
+        return None
+
+
+cursor_acp = CursorACPProfile(
+    name="cursor-acp",
+    aliases=("cursor-acp-agent", "cursor-agent-acp"),
+    display_name="Cursor ACP",
+    description="Cursor ACP (Spawns cursor-agent acp)",
+    api_mode="chat_completions",
+    env_vars=(),
+    base_url="acp://cursor",
+    auth_type="external_process",
+    fallback_models=("gpt-5.6-sol-high", "gemini-3.7-flash-high"),
+)
+
+register_provider(cursor_acp)

--- a/plugins/model-providers/cursor-acp/plugin.yaml
+++ b/plugins/model-providers/cursor-acp/plugin.yaml
@@ -1,0 +1,5 @@
+name: cursor-acp-provider
+kind: model-provider
+version: 1.0.0
+description: Cursor via ACP subprocess (cursor-agent acp)
+author: Nous Research

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -506,6 +506,11 @@ class TestNormalizeAuxProvider:
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
 
+    def test_maps_cursor_acp_aliases(self):
+        assert _normalize_aux_provider("cursor-acp") == "cursor-acp"
+        assert _normalize_aux_provider("cursor-acp-agent") == "cursor-acp"
+        assert _normalize_aux_provider("cursor-agent-acp") == "cursor-acp"
+
 
 class TestReadCodexAccessToken:
     def test_valid_auth_store(self, tmp_path, monkeypatch):

--- a/tests/agent/test_cursor_acp_client.py
+++ b/tests/agent/test_cursor_acp_client.py
@@ -1,0 +1,266 @@
+"""Unit tests for the Cursor ACP OpenAI-compatible shim.
+
+These cover the contract Hermes needs to drive `cursor-agent acp` as a
+tool-using seat: tool-schema injection, <tool_call> extraction (including
+malformed / truncated / multiple blocks), plain-prose responses, and
+CLI-name → ACP model-id mapping.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.cursor_acp_client import (
+    ACP_MARKER_BASE_URL,
+    CursorACPClient,
+    CursorACPToolCallParseError,
+    _extract_tool_calls_from_text,
+    _format_messages_as_prompt,
+    resolve_cursor_acp_model_id,
+)
+
+
+READ_FILE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "read_file",
+        "description": "Read a file from disk",
+        "parameters": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    },
+}
+
+WRITE_FILE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "write_file",
+        "description": "Write a file",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "content": {"type": "string"},
+            },
+            "required": ["path", "content"],
+        },
+    },
+}
+
+
+def _tool_block(call_id: str, name: str, arguments: dict) -> str:
+    payload = {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": json.dumps(arguments, separators=(",", ":")),
+        },
+    }
+    return f"<tool_call>{json.dumps(payload, separators=(',', ':'))}</tool_call>"
+
+
+class TestFormatMessagesAsPrompt:
+    def test_injects_tool_schema_and_tool_call_contract(self) -> None:
+        prompt = _format_messages_as_prompt(
+            [{"role": "user", "content": "Read /etc/hostname"}],
+            model="gpt-5.6-sol-high",
+            tools=[READ_FILE_TOOL],
+            tool_choice="auto",
+        )
+        assert "You are being used as the active ACP agent backend for Hermes." in prompt
+        assert "<tool_call>" in prompt
+        assert "</tool_call>" in prompt
+        assert "read_file" in prompt
+        assert "Read a file from disk" in prompt
+        assert "Hermes requested model hint: gpt-5.6-sol-high" in prompt
+        assert "User:" in prompt
+        assert "Read /etc/hostname" in prompt
+        assert "Available tools (OpenAI function schema)" in prompt
+
+    def test_renders_tool_role_transcript_for_multi_turn(self) -> None:
+        prompt = _format_messages_as_prompt(
+            [
+                {"role": "user", "content": "Read /etc/hostname then summarize it"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": '{"path":"/etc/hostname"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "content": "maximus-host",
+                },
+            ],
+            tools=[READ_FILE_TOOL],
+        )
+        assert "Tool:" in prompt
+        assert "maximus-host" in prompt
+        assert "User:" in prompt
+
+
+class TestExtractToolCallsFromText:
+    def test_parses_single_tool_call_block(self) -> None:
+        raw = _tool_block("call_1", "read_file", {"path": "/etc/hostname"})
+        calls, cleaned = _extract_tool_calls_from_text(raw)
+        assert len(calls) == 1
+        assert calls[0].id == "call_1"
+        assert calls[0].type == "function"
+        assert calls[0].function.name == "read_file"
+        assert json.loads(calls[0].function.arguments) == {"path": "/etc/hostname"}
+        assert cleaned == ""
+
+    def test_parses_multiple_tool_call_blocks(self) -> None:
+        raw = (
+            _tool_block("call_1", "read_file", {"path": "/etc/hostname"})
+            + "\n"
+            + _tool_block("call_2", "write_file", {"path": "/tmp/out", "content": "x"})
+        )
+        calls, cleaned = _extract_tool_calls_from_text(raw)
+        assert [c.function.name for c in calls] == ["read_file", "write_file"]
+        assert [c.id for c in calls] == ["call_1", "call_2"]
+        assert json.loads(calls[1].function.arguments)["path"] == "/tmp/out"
+        assert cleaned == ""
+
+    def test_plain_prose_returns_no_tool_calls(self) -> None:
+        prose = "The hostname is maximus-host. No further action needed."
+        calls, cleaned = _extract_tool_calls_from_text(prose)
+        assert calls == []
+        assert cleaned == prose
+
+    def test_malformed_json_inside_block_does_not_crash_or_drop_silently(self) -> None:
+        raw = "<tool_call>{not-json}</tool_call>"
+        with pytest.raises(CursorACPToolCallParseError, match="malformed"):
+            _extract_tool_calls_from_text(raw)
+
+    def test_truncated_tool_call_block_does_not_crash_or_drop_silently(self) -> None:
+        raw = (
+            '<tool_call>{"id":"call_1","type":"function",'
+            '"function":{"name":"read_file","arguments":"{\\"path\\":\\"/etc/hostname\\"}"'
+        )
+        with pytest.raises(CursorACPToolCallParseError, match="truncated"):
+            _extract_tool_calls_from_text(raw)
+
+    def test_mixed_valid_and_malformed_does_not_silently_drop(self) -> None:
+        raw = (
+            _tool_block("call_1", "read_file", {"path": "/etc/hostname"})
+            + "\n<tool_call>{broken}</tool_call>"
+        )
+        with pytest.raises(CursorACPToolCallParseError, match="malformed"):
+            _extract_tool_calls_from_text(raw)
+
+    def test_object_arguments_are_serialized(self) -> None:
+        raw = (
+            '<tool_call>{"id":"call_obj","type":"function",'
+            '"function":{"name":"read_file","arguments":{"path":"/etc/hostname"}}}'
+            "</tool_call>"
+        )
+        calls, _cleaned = _extract_tool_calls_from_text(raw)
+        assert len(calls) == 1
+        assert json.loads(calls[0].function.arguments) == {"path": "/etc/hostname"}
+
+
+class TestResolveCursorAcpModelId:
+    AVAILABLE = [
+        {"modelId": "default[]", "name": "Auto"},
+        {
+            "modelId": "gpt-5.6-sol[context=272k,reasoning=medium,fast=false]",
+            "name": "gpt-5.6-sol",
+        },
+        {"modelId": "gemini-3.7-flash[effort=high]", "name": "gemini-3.7-flash"},
+    ]
+
+    def test_maps_cli_high_alias_to_available_gemini_id(self) -> None:
+        assert (
+            resolve_cursor_acp_model_id("gemini-3.7-flash-high", self.AVAILABLE)
+            == "gemini-3.7-flash[effort=high]"
+        )
+
+    def test_maps_cli_high_alias_to_available_sol_family(self) -> None:
+        assert (
+            resolve_cursor_acp_model_id("gpt-5.6-sol-high", self.AVAILABLE)
+            == "gpt-5.6-sol[context=272k,reasoning=medium,fast=false]"
+        )
+
+    def test_exact_model_id_passthrough(self) -> None:
+        assert (
+            resolve_cursor_acp_model_id(
+                "gemini-3.7-flash[effort=high]", self.AVAILABLE
+            )
+            == "gemini-3.7-flash[effort=high]"
+        )
+
+    def test_unknown_model_returns_none(self) -> None:
+        assert resolve_cursor_acp_model_id("not-a-real-model", self.AVAILABLE) is None
+
+
+class TestCursorACPClientShape:
+    def test_marker_base_url(self) -> None:
+        client = CursorACPClient()
+        assert ACP_MARKER_BASE_URL == "acp://cursor"
+        assert client.base_url == "acp://cursor"
+        assert client.api_key == "cursor-acp"
+
+    def test_default_launch_is_cursor_agent_acp(self) -> None:
+        client = CursorACPClient()
+        assert client._acp_command == "cursor-agent"
+        assert client._acp_args == ["acp"]
+
+    def test_create_completion_parses_tool_call(self) -> None:
+        client = CursorACPClient()
+        raw = _tool_block("call_1", "read_file", {"path": "/etc/hostname"})
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(client, "_run_prompt", lambda *_a, **_k: (raw, ""))
+            completion = client.chat.completions.create(
+                model="gpt-5.6-sol-high",
+                messages=[{"role": "user", "content": "read hostname"}],
+                tools=[READ_FILE_TOOL],
+            )
+        assert completion.choices[0].finish_reason == "tool_calls"
+        tool_calls = completion.choices[0].message.tool_calls
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "read_file"
+        assert completion.choices[0].message.content == ""
+
+    def test_create_completion_plain_prose(self) -> None:
+        client = CursorACPClient()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                client,
+                "_run_prompt",
+                lambda *_a, **_k: ("hostname is maximus-host", ""),
+            )
+            completion = client.chat.completions.create(
+                model="gemini-3.7-flash-high",
+                messages=[{"role": "user", "content": "what is the hostname?"}],
+            )
+        assert completion.choices[0].finish_reason == "stop"
+        assert completion.choices[0].message.tool_calls == []
+        assert "maximus-host" in completion.choices[0].message.content
+
+    def test_missing_cli_is_actionable(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "agent.cursor_acp_client.subprocess.Popen",
+            lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError("missing")),
+        )
+        client = CursorACPClient(
+            acp_command="cursor-agent-missing",
+            acp_args=["acp"],
+            acp_cwd=str(tmp_path),
+        )
+        with pytest.raises(RuntimeError, match="cursor-agent login"):
+            client._run_prompt("hello", timeout_seconds=1)

--- a/tests/agent/test_cursor_acp_client.py
+++ b/tests/agent/test_cursor_acp_client.py
@@ -264,3 +264,50 @@ class TestCursorACPClientShape:
         )
         with pytest.raises(RuntimeError, match="cursor-agent login"):
             client._run_prompt("hello", timeout_seconds=1)
+
+    def test_authenticate_failure_is_actionable(self, tmp_path) -> None:
+        """A live ACP process that rejects cursor_login must not fall back to prose."""
+        server = tmp_path / "fake_unauth_acp.py"
+        server.write_text(
+            "import json, sys\n"
+            "\n"
+            "def send(obj):\n"
+            "    sys.stdout.write(json.dumps(obj) + '\\n')\n"
+            "    sys.stdout.flush()\n"
+            "\n"
+            "for line in sys.stdin:\n"
+            "    msg = json.loads(line)\n"
+            "    method = msg.get('method')\n"
+            "    mid = msg.get('id')\n"
+            "    if method == 'initialize':\n"
+            "        send({\n"
+            "            'jsonrpc': '2.0',\n"
+            "            'id': mid,\n"
+            "            'result': {\n"
+            "                'protocolVersion': 1,\n"
+            "                'authMethods': [{'id': 'cursor_login'}],\n"
+            "            },\n"
+            "        })\n"
+            "    elif method == 'authenticate':\n"
+            "        send({\n"
+            "            'jsonrpc': '2.0',\n"
+            "            'id': mid,\n"
+            "            'error': {'code': -32000, 'message': 'Not logged in'},\n"
+            "        })\n"
+            "    else:\n"
+            "        send({\n"
+            "            'jsonrpc': '2.0',\n"
+            "            'id': mid,\n"
+            "            'error': {'code': -32601, 'message': method},\n"
+            "        })\n",
+            encoding="utf-8",
+        )
+        import sys
+
+        client = CursorACPClient(
+            acp_command=sys.executable,
+            acp_args=[str(server)],
+            acp_cwd=str(tmp_path),
+        )
+        with pytest.raises(RuntimeError, match="authentication failed"):
+            client._run_prompt("hello", timeout_seconds=5)

--- a/tests/agent/test_cursor_acp_routing.py
+++ b/tests/agent/test_cursor_acp_routing.py
@@ -1,0 +1,115 @@
+"""Provider + alias resolution for cursor-acp / acp://cursor."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.auxiliary_client import _normalize_aux_provider
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    resolve_external_process_provider_credentials,
+    resolve_provider,
+)
+
+
+class TestCursorACPAliases:
+    def test_normalize_aux_provider_aliases(self) -> None:
+        assert _normalize_aux_provider("cursor-acp") == "cursor-acp"
+        assert _normalize_aux_provider("cursor-acp-agent") == "cursor-acp"
+        assert _normalize_aux_provider("cursor-agent-acp") == "cursor-acp"
+
+    def test_resolve_provider_aliases(self) -> None:
+        assert resolve_provider("cursor-acp") == "cursor-acp"
+        assert resolve_provider("cursor-acp-agent") == "cursor-acp"
+        assert resolve_provider("cursor-agent-acp") == "cursor-acp"
+
+    def test_registry_entry(self) -> None:
+        assert "cursor-acp" in PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["cursor-acp"]
+        assert pconfig.auth_type == "external_process"
+        assert pconfig.inference_base_url == "acp://cursor"
+        assert pconfig.id == "cursor-acp"
+
+
+class TestCursorACPRuntimeResolution:
+    def test_resolve_runtime_provider(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "hermes_cli.auth.shutil.which",
+            lambda command: f"/usr/local/bin/{command}",
+        )
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="cursor-acp")
+        assert result["provider"] == "cursor-acp"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "cursor-acp"
+        assert result["base_url"] == "acp://cursor"
+        assert result["command"] == "/usr/local/bin/cursor-agent"
+        assert result["args"] == ["acp"]
+
+    def test_missing_cli_is_actionable(self, monkeypatch) -> None:
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: None)
+        with pytest.raises(Exception, match="cursor-agent"):
+            resolve_external_process_provider_credentials("cursor-acp")
+
+
+class TestCursorACPClientRouting:
+    def test_runtime_helper_builds_cursor_client(self) -> None:
+        from agent.agent_runtime_helpers import create_openai_client
+
+        agent = SimpleNamespace(
+            provider="cursor-acp",
+            _client_log_context=lambda: "",
+        )
+        with (
+            patch("agent.cursor_acp_client.CursorACPClient") as mock_cls,
+            patch("agent.agent_runtime_helpers._ra") as mock_ra,
+            patch("agent.auxiliary_client._validate_proxy_env_urls"),
+            patch("agent.auxiliary_client._validate_base_url"),
+            patch("agent.ssl_verify.resolve_httpx_verify", return_value=True),
+        ):
+            mock_ra.return_value = SimpleNamespace(
+                logger=SimpleNamespace(info=lambda *a, **k: None)
+            )
+            fake = MagicMock()
+            mock_cls.return_value = fake
+            client = create_openai_client(
+                agent,
+                {"api_key": "cursor-acp", "base_url": "acp://cursor"},
+                reason="test",
+                shared=False,
+            )
+        assert client is fake
+        mock_cls.assert_called_once()
+
+    def test_base_url_sentinel_routes_without_provider_name(self) -> None:
+        from agent.agent_runtime_helpers import create_openai_client
+
+        agent = SimpleNamespace(
+            provider="custom",
+            _client_log_context=lambda: "",
+        )
+        with (
+            patch("agent.cursor_acp_client.CursorACPClient") as mock_cls,
+            patch("agent.agent_runtime_helpers._ra") as mock_ra,
+            patch("agent.auxiliary_client._validate_proxy_env_urls"),
+            patch("agent.auxiliary_client._validate_base_url"),
+            patch("agent.ssl_verify.resolve_httpx_verify", return_value=True),
+            patch("openai.OpenAI") as mock_openai,
+        ):
+            mock_ra.return_value = SimpleNamespace(
+                logger=SimpleNamespace(info=lambda *a, **k: None)
+            )
+            fake = MagicMock()
+            mock_cls.return_value = fake
+            client = create_openai_client(
+                agent,
+                {"api_key": "cursor-acp", "base_url": "acp://cursor"},
+                reason="test",
+                shared=False,
+            )
+        assert client is fake
+        mock_openai.assert_not_called()

--- a/tests/agent/test_proxy_and_url_validation.py
+++ b/tests/agent/test_proxy_and_url_validation.py
@@ -39,6 +39,7 @@ def test_proxy_env_rejects_malformed_port(monkeypatch, key):
     "https://api.example.com/v1",
     "http://127.0.0.1:6153/v1",
     "acp://copilot",
+    "acp://cursor",
     "",
     None,
 ])

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -31,6 +31,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("cursor-acp", "Cursor ACP", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
@@ -106,6 +107,7 @@ class TestProviderRegistry:
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
+        assert PROVIDER_REGISTRY["cursor-acp"].inference_base_url == "acp://cursor"
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["stepfun"].inference_base_url == STEPFUN_STEP_PLAN_INTL_BASE_URL
@@ -227,6 +229,11 @@ class TestResolveProvider:
     def test_alias_github_copilot_acp(self):
         assert resolve_provider("github-copilot-acp") == "copilot-acp"
         assert resolve_provider("copilot-acp-agent") == "copilot-acp"
+
+    def test_alias_cursor_acp(self):
+        assert resolve_provider("cursor-acp") == "cursor-acp"
+        assert resolve_provider("cursor-acp-agent") == "cursor-acp"
+        assert resolve_provider("cursor-agent-acp") == "cursor-acp"
 
     def test_explicit_huggingface(self):
         assert resolve_provider("huggingface") == "huggingface"
@@ -500,6 +507,23 @@ class TestRuntimeProviderResolution:
         assert result["base_url"] == "acp://copilot"
         assert result["command"] == "/usr/local/bin/copilot"
         assert result["args"] == ["--acp", "--stdio", "--debug"]
+
+    def test_runtime_cursor_acp_uses_process_runtime(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.auth.shutil.which",
+            lambda command: f"/usr/local/bin/{command}",
+        )
+
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="cursor-acp")
+
+        assert result["provider"] == "cursor-acp"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "cursor-acp"
+        assert result["base_url"] == "acp://cursor"
+        assert result["command"] == "/usr/local/bin/cursor-agent"
+        assert result["args"] == ["acp"]
 
 
 # =============================================================================

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -94,6 +94,7 @@ class TestProviderLabel:
         assert provider_label("stepfun") == "StepFun Step Plan"
         assert provider_label("copilot") == "GitHub Copilot"
         assert provider_label("copilot-acp") == "GitHub Copilot ACP"
+        assert provider_label("cursor-acp") == "Cursor ACP"
         assert provider_label("auto") == "Auto"
 
 


### PR DESCRIPTION
## Summary

- Adds additive provider `cursor-acp` (`acp://cursor`) so Cursor models can back a tool-using Hermes seat.
- Transport is `cursor-agent acp` (JSON-RPC over stdio), modeled on `copilot-acp`. Hermes injects the OpenAI tool schema as text and rebuilds `tool_calls` from `<tool_call>` blocks.
- The `:8317`/`:8321` `cur-*` HTTP shim is unchanged and still returns HTTP 400 `unsupported_tools`. CLIProxy is untouched. OpenClaw is not a dependency.

## Motivation

`cur-*` ids reach Cursor through an OpenAI-compatible shim that correctly refuses tool schemas. Cursor runs its own agent loop and returns finished prose, so a Hermes worker that sends tools on message one dies at `Messages: 1 (0 tool calls)`. This adapter is the execution path; the HTTP shim stays a review-only lane.

Hermes Agent trunk is `main` (not `development`).

## Changes

- New `agent/cursor_acp_client.py` + `plugins/model-providers/cursor-acp/`
- Wire-in at the same sites as Copilot ACP: `create_openai_client`, auxiliary aliases / isinstance / external-process resolve, auth/runtime credentials, conversation-loop non-streaming, Responses-API exclusion, catalogs, setup flow
- CLI model ids `gpt-5.6-sol-high` / `gemini-3.7-flash-high` map onto Cursor ACP `modelId`s
- Malformed / truncated tagged `<tool_call>` blocks fail closed
- Missing CLI or failed `cursor_login` raises an actionable `RuntimeError`

## Test Plan

- [x] Unit tests: parse, malformed/truncated/multi-block, prose, aliases, routing (344 related tests green; 19 client + 7 routing)
- [x] Live single-turn: ACP prompt emits `read_file` `<tool_call>`
- [x] Live multi-turn: second ACP turn consumes tool result and answers `HOST=maximus-work`
- [x] Throwaway profile seat `t460-cursor-acp-seat`: session `20260816_164701_69a67e`, `Messages: 14 (2 user, 10 tool calls)` — not `Messages: 1 (0 tool calls)`
- [x] Negative: `POST :8317/v1/chat/completions` with tools still `400 unsupported_tools`
- [x] Copilot ACP tests still green (56 tests)
- [x] Missing binary / failed authenticate produce actionable errors (not hang / not silent prose)

## Notes for Reviewers

- Additive only. Copilot ACP env contract (`HERMES_COPILOT_ACP_*`) is not reused for Cursor.
- `HOME=/tmp/...` still authenticated on this host (Cursor login is not HOME-isolated). Unauth proof used a fake ACP server returning `Not logged in`.
- Stop at draft. Do not mark ready or merge.
- Card `t_460cb0e6`.