### PR TITLE
fix(tools): fail closed on computer_use approval when no callback is wired

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -18,11 +18,19 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _reset_backend():
-    """Tear down the cached backend between tests."""
+    """Tear down the cached backend between tests.
+
+    Also bypasses computer_use approval by default: this file's tests exercise
+    schema/dispatch/routing/capture behavior, not approval semantics (that's
+    covered by test_computer_use_approval_isolation.py and the Phase C tests
+    in test_computer_use_delivery_ladder.py) — without an explicit bypass,
+    every destructive-action dispatch here would now fail closed (#87724).
+    """
     from tools.computer_use.tool import reset_backend_for_tests
     reset_backend_for_tests()
     # Force the noop backend.
-    with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "noop"}, clear=False):
+    with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "noop"}, clear=False), \
+         patch("tools.approval.is_approval_bypass_active_for_session", return_value=True):
         yield
     reset_backend_for_tests()
 
@@ -166,6 +174,69 @@ class TestDispatch:
         # No follow-up capture should have been issued.
         capture_calls = [c for c in noop_backend.calls if c[0] == "capture"]
         assert len(capture_calls) == 0, "capture must not be called after a failed action"
+
+
+# ---------------------------------------------------------------------------
+# Approval fail-closed (#87724): headless dispatch (cron, bot-platform
+# gateways, ACP) never calls set_approval_callback(), so a destructive action
+# must not silently execute just because no callback is wired.
+# ---------------------------------------------------------------------------
+
+class TestHeadlessApprovalFailClosed:
+    def test_destructive_action_denied_with_no_callback_and_no_bypass(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+
+        with patch("tools.approval.is_approval_bypass_active_for_session",
+                    return_value=False):
+            out = handle_computer_use({"action": "click", "element": 3})
+
+        parsed = json.loads(out)
+        assert parsed.get("error"), out
+        assert not noop_backend.calls, (
+            "backend must not be invoked when approval cannot be resolved"
+        )
+
+    def test_destructive_action_allowed_when_bypass_active(self, noop_backend):
+        """Explicit unattended opt-in (/yolo, approvals.mode: off) must still
+        work in headless dispatch — this is not a blanket lockout."""
+        from tools.computer_use.tool import handle_computer_use
+
+        with patch("tools.approval.is_approval_bypass_active_for_session",
+                    return_value=True):
+            out = handle_computer_use({"action": "click", "element": 3})
+
+        parsed = json.loads(out)
+        assert "error" not in parsed, out
+        assert any(c[0] == "click" for c in noop_backend.calls)
+
+    def test_safe_action_unaffected_by_missing_callback(self, noop_backend):
+        """Read-only actions were never gated and must stay ungated."""
+        from tools.computer_use.tool import handle_computer_use
+
+        with patch("tools.approval.is_approval_bypass_active_for_session",
+                    return_value=False):
+            out = handle_computer_use({"action": "capture", "mode": "ax"})
+
+        parsed = json.loads(out)
+        assert "error" not in parsed, out
+
+    def test_callback_still_takes_precedence_over_bypass_check(self, noop_backend):
+        """When a callback IS wired (CLI), it decides — the bypass check is
+        only the no-callback fallback path, not a replacement for it."""
+        from tools.computer_use.tool import handle_computer_use, set_approval_callback
+
+        try:
+            set_approval_callback(lambda action, args, summary: "deny")
+            with patch("tools.approval.is_approval_bypass_active_for_session",
+                        return_value=True):
+                out = handle_computer_use({"action": "click", "element": 3})
+        finally:
+            set_approval_callback(None)
+
+        parsed = json.loads(out)
+        assert parsed.get("error") == "denied by user"
+        assert not noop_backend.calls
+
 
 # ---------------------------------------------------------------------------
 # Safety guards (type / key block lists)

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -237,6 +237,48 @@ class TestHeadlessApprovalFailClosed:
         parsed = json.loads(out)
         assert "error" not in parsed, out
 
+    def test_cron_mode_approve_allows_destructive_action(self, monkeypatch):
+        """approvals.cron_mode: approve must auto-approve computer_use exactly
+        like it already does for a flagged dangerous shell command — the
+        no-callback fallback isn't limited to the global bypass.
+
+        Fetches the backend AFTER setting the cron/bypass state (rather than
+        via the ``noop_backend`` fixture, captured earlier): permission mode
+        is part of the backend cache key, so changing it here can rebuild a
+        fresh backend instance and a pre-captured reference would go stale.
+        """
+        import tools.approval as approval_module
+        from tools.computer_use import tool as cu_tool
+
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.setattr(approval_module, "_get_cron_approval_mode", lambda: "approve")
+        with patch("tools.approval.is_approval_bypass_active_for_session",
+                    return_value=False):
+            backend = cu_tool._get_backend()
+            out = cu_tool.handle_computer_use({"action": "click", "element": 3})
+
+        parsed = json.loads(out)
+        assert "error" not in parsed, out
+        assert any(c[0] == "click" for c in backend.calls)
+
+    def test_cron_mode_deny_blocks_with_config_hint(self, monkeypatch):
+        """approvals.cron_mode: deny (the default) still blocks, with a
+        message pointing at the config key instead of a generic error."""
+        import tools.approval as approval_module
+        from tools.computer_use import tool as cu_tool
+
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.setattr(approval_module, "_get_cron_approval_mode", lambda: "deny")
+        with patch("tools.approval.is_approval_bypass_active_for_session",
+                    return_value=False):
+            backend = cu_tool._get_backend()
+            out = cu_tool.handle_computer_use({"action": "click", "element": 3})
+
+        parsed = json.loads(out)
+        assert parsed.get("code") == "approval_unavailable", out
+        assert "cron_mode" in parsed.get("error", ""), out
+        assert not backend.calls
+
     def test_callback_still_takes_precedence_over_bypass_check(self, noop_backend):
         """When a callback IS wired (CLI), it decides — the bypass check is
         only the no-callback fallback path, not a replacement for it."""

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -192,9 +192,26 @@ class TestHeadlessApprovalFailClosed:
 
         parsed = json.loads(out)
         assert parsed.get("error"), out
+        assert parsed.get("code") == "approval_unavailable", out
         assert not noop_backend.calls, (
             "backend must not be invoked when approval cannot be resolved"
         )
+
+    def test_bypass_check_failure_fails_closed_and_logs(self, noop_backend, caplog):
+        """A broken bypass check (e.g. a renamed function) must still deny —
+        and log, so the failure is diagnosable instead of a silent deny."""
+        import logging
+        from tools.computer_use.tool import handle_computer_use
+
+        with patch("tools.approval.is_approval_bypass_active_for_session",
+                    side_effect=RuntimeError("boom")), \
+             caplog.at_level(logging.WARNING, logger="tools.computer_use.tool"):
+            out = handle_computer_use({"action": "click", "element": 3})
+
+        parsed = json.loads(out)
+        assert parsed.get("error"), out
+        assert not noop_backend.calls
+        assert any("approval-bypass check failed" in r.message for r in caplog.records)
 
     def test_destructive_action_allowed_when_bypass_active(self, noop_backend):
         """Explicit unattended opt-in (/yolo, approvals.mode: off) must still

--- a/tests/tools/test_computer_use_approval_isolation.py
+++ b/tests/tools/test_computer_use_approval_isolation.py
@@ -59,12 +59,21 @@ def test_a_forgets_a_poisoned_approval_callback():
     # no reset — the autouse fixture must clean this up
 
 
-def test_b_still_dispatches_with_default_allow():
+def test_b_still_dispatches_with_bypass_allow(monkeypatch):
     """Without the isolation fixture this fails: the stale callback raises
     (arity), ``_request_approval`` converts that into a deny, and the
-    backend never sees the click."""
+    backend never sees the click.
+
+    No callback is wired here (the isolation fixture cleared it), so this
+    relies on an explicit approval bypass rather than the removed no-callback
+    default-allow (#87724) — the isolation property under test (a leaked
+    callback from test A must not poison this test) is orthogonal to that.
+    """
     from tools.computer_use import tool as cu_tool
 
+    monkeypatch.setattr(
+        "tools.approval.is_approval_bypass_active_for_session", lambda key: True
+    )
     backend = _install_backend(cu_tool)
     result = cu_tool.handle_computer_use({"action": "click", "element": 3})
     call_names = [c[0] for c in backend.calls]

--- a/tests/tools/test_computer_use_delivery_ladder.py
+++ b/tests/tools/test_computer_use_delivery_ladder.py
@@ -223,7 +223,8 @@ def test_bad_delivery_mode_rejected():
 def test_dispatcher_threads_delivery_mode_to_backend():
     """End-to-end through the tool dispatcher with the noop backend."""
     from tools.computer_use import tool as cu
-    with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "noop"}, clear=False):
+    with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "noop"}, clear=False), \
+         patch("tools.approval.is_approval_bypass_active_for_session", return_value=True):
         cu.reset_backend_for_tests()
         be = cu._get_backend()
         cu.handle_computer_use({"action": "click", "element": 5,

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -589,10 +589,17 @@ def _request_approval(action: str, args: Dict[str, Any],
             if current_key and is_approval_bypass_active_for_session(current_key):
                 return None
         except Exception:
-            # Approval state must fail closed if it cannot be resolved.
-            pass
+            # Approval state must fail closed if it cannot be resolved, but a
+            # broken bypass check (e.g. a renamed function) should not fail
+            # silently — log it so the underlying error is diagnosable.
+            logger.warning(
+                "computer_use approval-bypass check failed for action %r; "
+                "failing closed",
+                action, exc_info=True,
+            )
         return json.dumps({
             "error": "approval required but no approval mechanism is available",
+            "code": "approval_unavailable",
             "hint": "computer_use needs interactive CLI approval or an explicit "
                     "unattended-mode opt-in (/yolo, or the configured bypass) "
                     "before destructive actions can run in this context.",

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -573,10 +573,10 @@ def _request_approval(action: str, args: Dict[str, Any],
         # or ACP, none of which call set_approval_callback(). There is no
         # other approval gate for computer_use (tools/approval.py's dangerous-
         # command system is terminal/shell-specific and never inspects this
-        # tool): only proceed if the user explicitly opted into unattended
-        # operation for this session (the same YOLO/bypass check
-        # _cua_permission_mode above uses), otherwise fail closed instead of
-        # silently allowing destructive actions (#87724).
+        # tool).
+        #
+        # First honor the global bypass (mirrors _cua_permission_mode above):
+        # --yolo / a session's /yolo toggle / approvals.mode: off.
         try:
             from tools.approval import (
                 get_current_session_key,
@@ -589,20 +589,45 @@ def _request_approval(action: str, args: Dict[str, Any],
             if current_key and is_approval_bypass_active_for_session(current_key):
                 return None
         except Exception:
-            # Approval state must fail closed if it cannot be resolved, but a
-            # broken bypass check (e.g. a renamed function) should not fail
-            # silently — log it so the underlying error is diagnosable.
+            # A broken bypass check (e.g. a renamed function) must not fail
+            # silently — log it, then fall through to the escalation gate
+            # below, which fails closed on its own if nothing else applies.
             logger.warning(
                 "computer_use approval-bypass check failed for action %r; "
+                "falling through to the escalation gate",
+                action, exc_info=True,
+            )
+
+        # No global bypass — escalate through the same human-approval gate a
+        # Tier-2 dangerous shell command uses (tools.approval.request_tool_approval
+        # -> _run_approval_gate), instead of failing closed outright. This
+        # honors approvals.cron_mode / approvals.single_query_mode and does a
+        # real interactive gateway round-trip (Discord/Telegram/Slack) when
+        # one is available, exactly like a dangerous shell command already
+        # does in the same contexts. It fails closed on its own when none of
+        # those apply — no fail-open regression (#87724).
+        try:
+            from tools.approval import request_tool_approval
+
+            verdict = request_tool_approval(
+                "computer_use",
+                _summarize_action(action, args),
+                rule_key=f"computer_use:{scope_key[0]}:{scope_key[1]}",
+            )
+        except Exception:
+            logger.warning(
+                "computer_use approval escalation failed for action %r; "
                 "failing closed",
                 action, exc_info=True,
             )
+            verdict = {"approved": False, "message": None}
+        if verdict.get("approved"):
+            return None
         return json.dumps({
-            "error": "approval required but no approval mechanism is available",
+            "error": verdict.get("message") or (
+                "approval required but no approval mechanism is available"
+            ),
             "code": "approval_unavailable",
-            "hint": "computer_use needs interactive CLI approval or an explicit "
-                    "unattended-mode opt-in (/yolo, or the configured bypass) "
-                    "before destructive actions can run in this context.",
             "action": action,
         })
     summary = _summarize_action(action, args)

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -569,9 +569,35 @@ def _request_approval(action: str, args: Dict[str, Any],
             return None
     cb = _approval_callback
     if cb is None:
-        # No CLI approval wired — default allow. Gateway approval is handled
-        # one layer out via the normal tool-approval infra.
-        return None
+        # No CLI approval callback wired — e.g. cron, bot-platform gateways,
+        # or ACP, none of which call set_approval_callback(). There is no
+        # other approval gate for computer_use (tools/approval.py's dangerous-
+        # command system is terminal/shell-specific and never inspects this
+        # tool): only proceed if the user explicitly opted into unattended
+        # operation for this session (the same YOLO/bypass check
+        # _cua_permission_mode above uses), otherwise fail closed instead of
+        # silently allowing destructive actions (#87724).
+        try:
+            from tools.approval import (
+                get_current_session_key,
+                is_approval_bypass_active_for_session,
+            )
+
+            if is_approval_bypass_active_for_session(session_id):
+                return None
+            current_key = get_current_session_key(default="")
+            if current_key and is_approval_bypass_active_for_session(current_key):
+                return None
+        except Exception:
+            # Approval state must fail closed if it cannot be resolved.
+            pass
+        return json.dumps({
+            "error": "approval required but no approval mechanism is available",
+            "hint": "computer_use needs interactive CLI approval or an explicit "
+                    "unattended-mode opt-in (/yolo, or the configured bypass) "
+                    "before destructive actions can run in this context.",
+            "action": action,
+        })
     summary = _summarize_action(action, args)
     try:
         verdict = cb(action, args, summary)


### PR DESCRIPTION
## What does this PR do?

Fixes a fail-open approval default in `computer_use`. `_request_approval()` in `tools/computer_use/tool.py` returned `None` (allow) unconditionally whenever no CLI approval callback was wired:

```python
cb = _approval_callback
if cb is None:
    # No CLI approval wired — default allow. Gateway approval is handled
    # one layer out via the normal tool-approval infra.
    return None
```

The interactive CLI (`cli.py`) is the *only* call site that ever wires a real callback via `set_approval_callback`. Cron jobs, every bot-platform gateway (`computer_use` lives in `_HERMES_CORE_TOOLS`, shared by `hermes-cron` and the messaging toolsets per `toolsets.py`), and ACP sessions never call it, so any of those contexts could execute destructive actions (click, type, drag, key combos) with zero confirmation. The comment's claim of an "outer gateway layer" handling approval isn't evidenced anywhere: `tools/registry.py`'s `dispatch()` has no generic approval gate, and `tools/approval.py` (the real dangerous-command-detection system) never references `computer_use`.

Reproduced live against the test noop backend: with `_approval_callback` at its default `None`, a `click` action executed successfully — no prompt, no error.

**Fix:** when `cb is None`, check `is_approval_bypass_active_for_session()` across both session-identity namespaces (DB `session_id` and gateway `session_key`) — the exact same bypass check `_cua_permission_mode()` already performs a few lines above in the same file, for the same reason. If the user has explicitly opted into unattended operation (`/yolo`, `HERMES_YOLO_MODE`, or `approvals.mode: off`), the action still proceeds exactly as before. Otherwise it now fails closed with an explicit error instead of silently allowing.

Read-only actions (`_SAFE_ACTIONS`: capture, wait, list_apps, list_windows, cua_browser_state) never reach `_request_approval` at all and are unaffected. A wired CLI callback still takes precedence over the bypass check (covered by a new test) — this only changes the no-callback fallback.

**Note for maintainers:** open PR #85075 ("honor approval bypass mode") touches the same function for a different gap (making bypass suppress even a *wired* callback). The two changes are logically compatible but will likely need a small rebase against each other depending on merge order.

## Related Issue

Fixes #87724

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/computer_use/tool.py`: `_request_approval()` — when no callback is wired, check the approval-bypass helper (both session namespaces) instead of unconditionally allowing; fail closed with a JSON error otherwise.
- `tests/tools/test_computer_use.py`: new `TestHeadlessApprovalFailClosed` class (4 tests — deny with no callback/no bypass, allow with bypass active, safe actions unaffected, wired callback still takes precedence over bypass). Also updated the file's autouse `_reset_backend` fixture to mock bypass-active by default, since this file's ~110 other tests exercise dispatch/routing/capture behavior, not approval semantics, and previously relied implicitly on the removed default-allow.
- `tests/tools/test_computer_use_approval_isolation.py`: updated `test_b_still_dispatches_with_default_allow` (renamed `..._with_bypass_allow`) to explicitly mock the bypass instead of relying on the removed default, preserving its actual intent (a leaked approval callback from a prior test must not poison this one).
- `tests/tools/test_computer_use_delivery_ladder.py`: same explicit-bypass update for one dispatch-focused test that didn't wire a callback.

## How to Test

1. Reproduction (pre-fix): with `tools.computer_use.tool._approval_callback` at its default `None` and no bypass configured, `handle_computer_use({"action": "click", ...})` executes the click against the backend with no confirmation.
2. RED → GREEN: `pytest tests/tools/test_computer_use.py -q -k TestHeadlessApprovalFailClosed` — the deny-path test fails pre-fix (verified by stashing the production-file change) and passes post-fix; the other 3 new tests pass in both states (they document unaffected/unchanged behavior — bypass-allow, safe actions, callback precedence).
3. Mutation check: inverting the new bypass condition causes 4 tests to fail (the new deny/allow tests plus the two updated regression tests), confirming the tests aren't vacuous.
4. Full suite: `pytest tests/tools/test_computer_use.py tests/tools/test_computer_use_approval_isolation.py tests/tools/test_computer_use_delivery_ladder.py tests/tools/test_computer_use_*.py -q` → 255 passed, 2 skipped, 3 failed (all 3 pre-existing/unrelated — `test_cua_driver_cmd_env_override_is_resolved_dynamically`, `test_cli_fallback_reads_screenshot_from_file`, `test_linux_default_capture_skips_gnome_shell_helper` — reproduced identically on `origin/main` without this patch).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_computer_use*.py -q` and all tests pass except 3 pre-existing, unrelated baseline failures (see above; independently confirmed present on `origin/main` without this patch).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment explaining the new fallback; no user-facing docs affected)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config keys; reuses the existing `approvals.mode`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — ran `scripts/check-windows-footguns.py`; the one hit reported is pre-existing, untouched code, not part of this diff
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool schema changed, only internal approval logic)

## Update (2026-08-16): addressed AI review feedback

- **Fixed:** the `except Exception: pass` around the bypass check now `logger.warning(..., exc_info=True)` before failing closed, so a future programming error there (e.g. a renamed function) is diagnosable instead of an invisible silent deny.
- **Fixed:** added `"code": "approval_unavailable"` to the fail-closed deny payload, matching the existing `"code"` convention this same function already uses (`bring_to_front_requires_foreground`), so callers can branch on a stable code instead of the error string.
- **Confirmed, no code change:** this is the only approval gate for `computer_use` in headless contexts — `tools/registry.py`'s `dispatch()` has no generic gate, and `tools/approval.py` never references `computer_use`. Every documented unattended opt-in (`--yolo`/`HERMES_YOLO_MODE`, gateway `/yolo`, `approvals.mode: off`) already flows through `is_approval_bypass_active_for_session()` (unmodified by this patch), so none of those paths are affected.
- **Confirmed, no code change:** the double bypass check (`session_id`, then `get_current_session_key()`) is intentional, not redundant — it mirrors the exact pattern `_cua_permission_mode()` already uses a few lines above for the same documented reason (Hermes has two session-identity namespaces: the DB `session_id` and the gateway `/yolo` `session_key`; checking only one would make gateway `/yolo` silently invisible to computer_use).
- Added a new test (`test_bypass_check_failure_fails_closed_and_logs`) covering the new logging behavior and the `code` field.

## Update (2026-08-17): adopted @jackulau's routing-through-`request_tool_approval` suggestion

@jackulau opened #87782 for the same bug ~43 minutes after this PR and reviewed this one properly instead of just flagging the collision. Their diagnosis (`"one layer out"` is unevidenced, no generic gate in `registry.dispatch`, `tools/approval.py` never inspects `computer_use`) independently matches mine exactly. They also found a real gap in my fix: the global-bypass-only fallback ignores `approvals.cron_mode`, `approvals.single_query_mode`, and the interactive gateway approval round-trip (Discord/Telegram/Slack buttons) that dangerous shell commands already get via `tools.approval.request_tool_approval()` — so a cron operator with `cron_mode: approve`, or a reachable gateway user, would now get denied outright instead of getting the same treatment a flagged shell command gets.

I verified this independently and it holds up, so I've adopted it directly into this PR instead of leaving it to a competing PR:

- The `cb is None` branch now: (1) checks the global bypass first — unchanged, and still necessary, since `request_tool_approval`'s own gate (`_run_approval_gate`) only checks `--yolo`/session-yolo, **not** `approvals.mode: off`, so removing this step would silently break `mode: off` users; (2) falls through to `tools.approval.request_tool_approval("computer_use", <summary>, rule_key=f"computer_use:{action}:{delivery_mode}")` instead of failing closed outright. The `rule_key` preserves the existing `(action, delivery_mode)` scope (#67052) in the shared allowlist.
- This restores `cron_mode: approve`/`deny`, `single_query_mode`, and the real gateway prompt round-trip for `computer_use`, while still failing closed on its own for the genuine no-human case — no fail-open regression. New tests (`test_cron_mode_approve_allows_destructive_action`, `test_cron_mode_deny_blocks_with_config_hint`) confirm both directions end to end.
- One nuance flagged by an independent adversarial review of this change: `request_tool_approval`'s persistence lives in `tools.approval`'s own approved-pattern store, separate from `computer_use`'s own `_always_allow`/`_session_auto_approve` dicts. Not a correctness bug (the `tools.approval` cache still short-circuits repeat calls before re-prompting), just a second, parallel cache rather than a shared one — noted, not changed, since fixing it would mean touching the shared `_run_approval_gate` contract for a cosmetic gain.

@jackulau — thank you for the honest disclosure and the actually-useful review instead of just a collision flag. I've folded the routing change in here per your offer; happy to close this out however the maintainers prefer.

## Screenshots / Logs

N/A


