### PR TITLE
fix(desktop): keep active Goals visible in sidebar

### DIFF
--- a/apps/desktop/src/store/session-dot-state.test.ts
+++ b/apps/desktop/src/store/session-dot-state.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type { SessionInfo } from '@/types/hermes'
 
+import { $goalsBySession, setSessionGoal } from './goals'
 import { $sessions, $unreadFinishedSessionIds, setSessions } from './session'
 import { $delegatingSessionIds, $sessionDotStateById, hasLiveTurn, showsRunningArc } from './session-dot-state'
 import { clearAllSessionStates, publishSessionState } from './session-states'
@@ -88,6 +89,45 @@ describe('$delegatingSessionIds', () => {
 
 const storedRow = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
   ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
+
+describe('standing Goals', () => {
+  beforeEach(() => {
+    clearAllSessionStates()
+    $goalsBySession.set({})
+    $sessions.set([storedRow('s1')])
+  })
+
+  afterEach(() => {
+    clearAllSessionStates()
+    $goalsBySession.set({})
+    $sessions.set([])
+  })
+
+  it('keeps an active Goal visible as background work', () => {
+    setSessionGoal('s1', { status: 'active', title: 'ship the feature', updatedAt: 0 })
+
+    expect($sessionDotStateById.get()['s1']).toBe('background')
+  })
+
+  it('keeps a waiting Goal visible as background work', () => {
+    setSessionGoal('s1', { status: 'waiting', title: 'ship the feature', updatedAt: 0 })
+
+    expect($sessionDotStateById.get()['s1']).toBe('background')
+  })
+
+  it('lets a live turn outrank a standing Goal', () => {
+    setSessionGoal('s1', { status: 'active', title: 'ship the feature', updatedAt: 0 })
+    publishSessionState('runtime-1', { ...createClientSessionState('s1'), busy: true })
+
+    expect($sessionDotStateById.get()['s1']).toBe('working')
+  })
+
+  it('drops a paused Goal back to the idle state', () => {
+    setSessionGoal('s1', { status: 'paused', title: 'ship the feature', updatedAt: 0 })
+
+    expect($sessionDotStateById.get()['s1'] ?? 'idle').toBe('idle')
+  })
+})
 
 describe('persisted unread (backend watermark)', () => {
   beforeEach(() => {

--- a/apps/desktop/src/store/session-dot-state.test.ts
+++ b/apps/desktop/src/store/session-dot-state.test.ts
@@ -115,6 +115,14 @@ describe('standing Goals', () => {
     expect($sessionDotStateById.get()['s1']).toBe('background')
   })
 
+  it('bridges a runtime Goal to its stored sidebar session', () => {
+    publishSessionState('runtime-1', { ...createClientSessionState('stored-1'), busy: false })
+    $sessions.set([storedRow('stored-1')])
+    setSessionGoal('runtime-1', { status: 'active', title: 'ship the feature', updatedAt: 0 })
+
+    expect($sessionDotStateById.get()['stored-1']).toBe('background')
+  })
+
   it('lets a live turn outrank a standing Goal', () => {
     setSessionGoal('s1', { status: 'active', title: 'ship the feature', updatedAt: 0 })
     publishSessionState('runtime-1', { ...createClientSessionState('s1'), busy: true })

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -100,33 +100,40 @@ export const sessionStatusRank = (state?: SessionDotState): number => STATUS_RAN
 
 let dotStates: Readonly<Record<string, SessionDotState>> = {}
 
+let standingGoalIds: readonly string[] = []
+const $standingGoalSessionIds = computed(
+  [$goalsBySession, $sessionStates, $sessions],
+  (goals, sessionStates, sessions) => {
+    const ids = new Set<string>()
+
+    for (const [runtimeId, goal] of Object.entries(goals)) {
+      if (goal.status !== 'active' && goal.status !== 'waiting') {
+        continue
+      }
+
+      for (const alias of lineageAliases(sessionStates[runtimeId]?.storedSessionId ?? runtimeId, sessions)) {
+        ids.add(alias)
+      }
+    }
+
+    return (standingGoalIds = stableArray(standingGoalIds, [...ids]))
+  }
+)
+
 export const $sessionDotStateById = computed(
   [
     $attentionSessionIds,
-    $goalsBySession,
+    $standingGoalSessionIds,
     $workingSessionIds,
     $stalledSessionIds,
     $backgroundRunningSessionIds,
     $delegatingSessionIds,
     $unreadFinishedSessionIds,
     $draftSessionIds,
-    $sessionStates,
     $sessions,
     $unreadWriteGuard
   ],
-  (
-    attention,
-    goals,
-    working,
-    stalled,
-    background,
-    delegating,
-    unread,
-    draft,
-    sessionStates,
-    sessions,
-    unreadWriteGuard
-  ) => {
+  (attention, standingGoals, working, stalled, background, delegating, unread, draft, sessions, unreadWriteGuard) => {
     const next: Record<string, SessionDotState> = {}
 
     const claim = (ids: readonly string[], state: SessionDotState) => {
@@ -175,19 +182,7 @@ export const $sessionDotStateById = computed(
     // A standing Goal can keep working between model turns. Treat it as
     // background work so the sidebar does not fall back to an idle dot while
     // the Goal remains active; a live turn below still upgrades it to working.
-    const standingGoalIds = new Set<string>()
-
-    for (const [runtimeId, goal] of Object.entries(goals)) {
-      if (goal.status !== 'active' && goal.status !== 'waiting') {
-        continue
-      }
-
-      for (const alias of lineageAliases(sessionStates[runtimeId]?.storedSessionId ?? runtimeId, sessions)) {
-        standingGoalIds.add(alias)
-      }
-    }
-
-    claim([...standingGoalIds], 'background')
+    claim(standingGoals, 'background')
     claim(background, 'background')
     // Async delegation: the parent turn has ended but its subagents are still
     // running, so the session's work continues in child sessions. Same visual

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -28,6 +28,7 @@ import { computed } from 'nanostores'
 import { stableArray, stableRecord } from '@/lib/stable-array'
 
 import { $backgroundRunningSessionIds } from './composer-status'
+import { $goalsBySession } from './goals'
 import { $sessions, $unreadFinishedSessionIds, lineageAliases } from './session'
 import {
   $attentionSessionIds,
@@ -102,6 +103,7 @@ let dotStates: Readonly<Record<string, SessionDotState>> = {}
 export const $sessionDotStateById = computed(
   [
     $attentionSessionIds,
+    $goalsBySession,
     $workingSessionIds,
     $stalledSessionIds,
     $backgroundRunningSessionIds,
@@ -111,7 +113,7 @@ export const $sessionDotStateById = computed(
     $sessions,
     $unreadWriteGuard
   ],
-  (attention, working, stalled, background, delegating, unread, draft, sessions, unreadWriteGuard) => {
+  (attention, goals, working, stalled, background, delegating, unread, draft, sessions, unreadWriteGuard) => {
     const next: Record<string, SessionDotState> = {}
 
     const claim = (ids: readonly string[], state: SessionDotState) => {
@@ -157,6 +159,15 @@ export const $sessionDotStateById = computed(
 
     claim(persistedUnread, 'unread')
 
+    // A standing Goal can keep working between model turns. Treat it as
+    // background work so the sidebar does not fall back to an idle dot while
+    // the Goal remains active; a live turn below still upgrades it to working.
+    claim(
+      Object.entries(goals)
+        .filter(([, goal]) => goal.status === 'active' || goal.status === 'waiting')
+        .map(([id]) => id),
+      'background'
+    )
     claim(background, 'background')
     // Async delegation: the parent turn has ended but its subagents are still
     // running, so the session's work continues in child sessions. Same visual

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -110,10 +110,23 @@ export const $sessionDotStateById = computed(
     $delegatingSessionIds,
     $unreadFinishedSessionIds,
     $draftSessionIds,
+    $sessionStates,
     $sessions,
     $unreadWriteGuard
   ],
-  (attention, goals, working, stalled, background, delegating, unread, draft, sessions, unreadWriteGuard) => {
+  (
+    attention,
+    goals,
+    working,
+    stalled,
+    background,
+    delegating,
+    unread,
+    draft,
+    sessionStates,
+    sessions,
+    unreadWriteGuard
+  ) => {
     const next: Record<string, SessionDotState> = {}
 
     const claim = (ids: readonly string[], state: SessionDotState) => {
@@ -162,12 +175,19 @@ export const $sessionDotStateById = computed(
     // A standing Goal can keep working between model turns. Treat it as
     // background work so the sidebar does not fall back to an idle dot while
     // the Goal remains active; a live turn below still upgrades it to working.
-    claim(
-      Object.entries(goals)
-        .filter(([, goal]) => goal.status === 'active' || goal.status === 'waiting')
-        .map(([id]) => id),
-      'background'
-    )
+    const standingGoalIds = new Set<string>()
+
+    for (const [runtimeId, goal] of Object.entries(goals)) {
+      if (goal.status !== 'active' && goal.status !== 'waiting') {
+        continue
+      }
+
+      for (const alias of lineageAliases(sessionStates[runtimeId]?.storedSessionId ?? runtimeId, sessions)) {
+        standingGoalIds.add(alias)
+      }
+    }
+
+    claim([...standingGoalIds], 'background')
     claim(background, 'background')
     // Async delegation: the parent turn has ended but its subagents are still
     // running, so the session's work continues in child sessions. Same visual

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -100,6 +100,8 @@ export const sessionStatusRank = (state?: SessionDotState): number => STATUS_RAN
 
 let dotStates: Readonly<Record<string, SessionDotState>> = {}
 
+// Module-level on purpose: stableArray needs the previous result to preserve
+// identity when unrelated stream updates re-evaluate this projection.
 let standingGoalIds: readonly string[] = []
 const $standingGoalSessionIds = computed(
   [$goalsBySession, $sessionStates, $sessions],


### PR DESCRIPTION
## What does this PR do?

Standing Goals can continue across turns, but the Desktop sidebar status projection did not consume Goal state. When a foreground turn yielded while a Goal remained `active` or `waiting`, its sidebar row could appear idle even though the Goal was still running.

This PR adds a stable standing-Goal projection, bridges runtime session IDs through stored-session IDs and lineage aliases, and applies the existing `background` sidebar state without overriding more specific live states (`working`, `stalled`, or `needs-input`). It changes only status presentation; Goal execution is unchanged.

## Related Issue

No linked issue. The bug was reproduced in a live local Desktop session, and no matching existing issue or PR was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/session-dot-state.ts`
  - Project `active` and `waiting` Goals to the existing `background` sidebar state.
  - Resolve runtime Goal IDs through stored-session IDs and lineage aliases.
  - Keep the derived Goal projection stable across unrelated stream updates.
  - Preserve the existing priority order: `background` < `working` < `stalled` < `needs-input`.
- `apps/desktop/src/store/session-dot-state.test.ts`
  - Add regression coverage for active/waiting Goals, paused Goals, runtime-to-stored identity bridging, and live-turn precedence.

## How to Test

1. In Desktop, start a standing Goal and let a foreground turn finish while the Goal remains `active` or `waiting`.
2. Confirm that the sidebar row remains in the background-running state. A live turn should still show `working`; a stalled turn should show `stalled`; attention should show `needs-input`; a paused or completed Goal should not claim activity on its own.
3. Run the focused checks from `apps/desktop`:

```bash
npm run test:ui -- src/store/session-dot-state.test.ts
npm run typecheck
npm run lint -- --quiet
npx prettier --check src/store/session-dot-state.ts src/store/session-dot-state.test.ts
npm run test:desktop:platforms
```

## Validation

| Check | Result |
|---|---|
| Focused sidebar-state tests | 19 passed |
| TypeScript checks | Passed (renderer, Electron, and E2E) |
| ESLint | Passed |
| Prettier | Passed |
| Desktop platform tests | 1,233 passed, 2 skipped |
| Full UI suite | 4,492/4,493 tests passed across 480/481 files; the sole failure was an unrelated JST midnight boundary assertion in `session-row.test.tsx` (`Today` vs `Yesterday`) |
| Contributor attribution audit | Passed |
| `git diff --check` | Passed |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched open and closed issues/PRs and found no duplicate
- [x] My PR contains only changes related to this fix
- [x] Python tests are N/A for this Desktop TypeScript-only change; applicable npm checks are listed above
- [x] I've added regression tests for the bug
- [x] Tested on macOS 26.5.1 (arm64)

### Documentation & Housekeeping

- [x] Documentation update: N/A — no user-facing API, configuration, or workflow changed
- [x] `cli-config.yaml.example`: N/A — no configuration keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or contributor workflow changed
- [x] Cross-platform impact considered — the change is platform-neutral state-store logic
- [x] Tool descriptions/schemas: N/A — no tool behavior changed

## Screenshots / Logs

Not applicable; this changes status projection rather than visual styling, and the behavior is covered by focused store tests.
