### PR TITLE
fix(cli): reject bracket index syntax in hermes config set instead of writing junk keys (#87689)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1012,7 +1012,19 @@ def _set_nested(config, dotted_key: str, value):
     replaced any non-dict value (including lists) with ``{}``, silently
     destroying list-typed config like ``custom_providers`` whenever a
     caller used an indexed path.
+
+    Rejects bracket index syntax (``name[N]``, e.g. ``pre_llm_call[1]``):
+    bracket segments can never resolve here (we split on ``.`` only), so
+    they would silently fall through to plain dict assignment and create a
+    literal junk key next to the real list (#87689).  The failure must be
+    explicit, not a confident no-op.
     """
+    if "[" in dotted_key or "]" in dotted_key:
+        raise ValueError(
+            f"Cannot set key {dotted_key!r}: bracket index syntax ('name[N]') "
+            f"is not supported. Use numeric dotted segments "
+            f"(e.g. 'custom_providers.0.api_key') or edit config.yaml directly."
+        )
     parts = dotted_key.split(".")
     current = config
     for part in parts[:-1]:
@@ -1092,6 +1104,15 @@ def _get_nested(config, dotted_key: str):
 
 def _unset_nested(config, dotted_key: str) -> bool:
     """Remove a dotted-path value from nested dict/list config data."""
+    # Symmetric with _set_nested (#87689): bracket index syntax can never
+    # resolve here, so reject it instead of treating ``name[N]`` as a
+    # literal dict key.
+    if "[" in dotted_key or "]" in dotted_key:
+        raise ValueError(
+            f"Cannot unset key {dotted_key!r}: bracket index syntax ('name[N]') "
+            f"is not supported. Use numeric dotted segments "
+            f"(e.g. 'custom_providers.0.api_key') or edit config.yaml directly."
+        )
     parts = dotted_key.split(".")
     if not parts:
         return False
@@ -5202,6 +5223,29 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     return True, None
 
 
+def _reject_bracket_index_syntax(key: str, verb: str) -> None:
+    """Reject bracket index syntax (``name[N]``) in config set/unset keys.
+
+    Before #87689, ``hermes config set hooks.pre_llm_call[1].command ...``
+    reported ``✓ Set`` and wrote a literal ``pre_llm_call[1]`` dict key next
+    to the real list — completely inert at runtime, so the operator's guard
+    hook never fired.  Bracket segments can never resolve: the nested
+    navigators split on ``.`` only, so the bracketed segment falls through
+    to plain dict assignment.  Reject up front with an explicit error
+    instead of writing a junk key.
+    """
+    if "[" in key or "]" in key:
+        print(
+            f"✗ Cannot {verb} '{key}': bracket index syntax ('name[N]') is not "
+            f"supported by 'hermes config {verb}'.\n"
+            f"  Use the numeric dotted-path form to address a list element,\n"
+            f"  e.g. 'hermes config {verb} hooks.pre_llm_call.1.command <value>',\n"
+            f"  or edit config.yaml directly.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 def set_config_value(key: str, value: str, force: bool = False):
     """Set a configuration value.
 
@@ -5216,6 +5260,9 @@ def set_config_value(key: str, value: str, force: bool = False):
             refused (bare ``model`` is redirected to ``model.default``). The
             CLI exposes this via ``hermes config set --force``.
     """
+    # Reject bracket index syntax before anything is routed or written —
+    # the failure must be explicit, never a silent literal junk key (#87689).
+    _reject_bracket_index_syntax(key, "set")
     if is_managed():
         managed_error("set configuration values")
         return
@@ -5443,6 +5490,8 @@ def get_config_value(key: str, *, as_json: bool = False):
 
 def unset_config_value(key: str):
     """Remove a user-set configuration or .env value."""
+    # Symmetric with set_config_value (#87689).
+    _reject_bracket_index_syntax(key, "unset")
     if is_managed():
         managed_error("unset configuration values")
         return

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -11,6 +11,7 @@ from hermes_cli.config import (
     config_command,
     cron_model_drift_guard_enabled,
     set_config_value,
+    unset_config_value,
 )
 
 
@@ -284,6 +285,99 @@ class TestListNavigation:
         assert isinstance(allowlist, list)
         assert allowlist[0] == {"name": "alice", "role": "admin"}
         assert allowlist[1] == {"name": "bob", "role": "admin"}
+
+
+# ---------------------------------------------------------------------------
+# Bracket index syntax — regression tests for #87689
+# ---------------------------------------------------------------------------
+
+class TestBracketIndexRejection:
+    """hermes config set/unset must reject bracket index syntax ('name[N]')
+    with a clear error instead of silently writing a literal junk key next
+    to the real list.  Before #87689, `hooks.pre_llm_call[1].command`
+    reported `✓ Set` and created a top-level `pre_llm_call[1]` key that is
+    completely inert at runtime — the operator's hook never fired.
+    """
+
+    HOOKS_CONFIG = (
+        "hooks:\n"
+        "  pre_llm_call:\n"
+        "    - command: existing.py\n"
+        "      timeout: 3\n"
+    )
+
+    def _write_config(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(self.HOOKS_CONFIG)
+
+    def test_bracket_index_set_is_rejected_with_clear_error(
+        self, _isolated_hermes_home, capsys
+    ):
+        self._write_config(_isolated_hermes_home)
+
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("hooks.pre_llm_call[1].command", "/path/new.py")
+        assert exc.value.code == 1
+
+        err = capsys.readouterr().err
+        assert "bracket index syntax" in err
+        assert "hooks.pre_llm_call[1].command" in err
+        assert "hooks.pre_llm_call.1.command" in err  # points at supported syntax
+
+    def test_bracket_index_set_writes_no_junk_key(self, _isolated_hermes_home):
+        """The rejected write must not create a literal 'pre_llm_call[1]' key."""
+        self._write_config(_isolated_hermes_home)
+
+        with pytest.raises(SystemExit):
+            set_config_value("hooks.pre_llm_call[1].command", "/path/new.py")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        # The real list is untouched and no junk sibling key was added.
+        assert reloaded == {
+            "hooks": {
+                "pre_llm_call": [{"command": "existing.py", "timeout": 3}],
+            }
+        }
+        assert "pre_llm_call[1]" not in reloaded["hooks"]
+
+    def test_dotted_numeric_index_still_works(self, _isolated_hermes_home):
+        """The supported numeric dotted-path form must keep working."""
+        self._write_config(_isolated_hermes_home)
+
+        set_config_value("hooks.pre_llm_call.0.command", "/path/new.py")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["hooks"]["pre_llm_call"][0]["command"] == "/path/new.py"
+        assert reloaded["hooks"]["pre_llm_call"][0]["timeout"] == 3
+        assert "pre_llm_call[1]" not in reloaded["hooks"]
+
+    def test_bracket_index_unset_is_rejected(self, _isolated_hermes_home, capsys):
+        self._write_config(_isolated_hermes_home)
+
+        with pytest.raises(SystemExit) as exc:
+            unset_config_value("hooks.pre_llm_call[1].command")
+        assert exc.value.code == 1
+
+        err = capsys.readouterr().err
+        assert "bracket index syntax" in err
+        assert "hooks.pre_llm_call[1].command" in err
+
+    def test_nested_helper_rejects_bracket_segments(self):
+        """_set_nested/_unset_nested raise for programmatic callers too."""
+        from hermes_cli.config import _set_nested, _unset_nested
+
+        cfg = {
+            "hooks": {
+                "pre_llm_call": [{"command": "existing.py", "timeout": 3}],
+            }
+        }
+        with pytest.raises(ValueError, match="bracket index syntax"):
+            _set_nested(cfg, "hooks.pre_llm_call[1].command", "new.py")
+        with pytest.raises(ValueError, match="bracket index syntax"):
+            _unset_nested(cfg, "hooks.pre_llm_call[1].command")
+        # No junk key was created by the failed calls.
+        assert "pre_llm_call[1]" not in cfg["hooks"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`hermes config set` accepts bracket-style list indices like `hooks.pre_llm_call[1].command`, reports `✓ Set`, and writes a **literal top-level key named `pre_llm_call[1]`** next to the real list. Nothing warns the user. The config parses fine, the setting appears in `hermes config get`, and it is completely inert at runtime — a silent false sense of security, especially for security-sensitive hooks.

## Reproduction (before fix)

```
$ hermes config set hooks.pre_llm_call[1].command /path/new.py
✓ Set hooks.pre_llm_call[1].command = /path/new.py in .../config.yaml
```

config.yaml then contains the junk key `pre_llm_call[1]: {command: /path/new.py}` next to the real list.

## Fix

`hermes_cli/config.py`:
- **`_set_nested`** — guard at top: segment containing `[`/`]` raises a clear `ValueError` (protects programmatic callers, incl. the setup wizard).
- **`_unset_nested`** — same guard for symmetry (get/unset).
- **`_reject_bracket_index_syntax(key, verb)`** (new) — CLI helper printing an explicit error to stderr + `sys.exit(1)`, pointing to supported syntax (`hooks.pre_llm_call.1.command`) or direct config.yaml editing.
- **`set_config_value` / `unset_config_value`** — call the helper before any routing/writing.

## After fix

```
✗ Cannot set 'hooks.pre_llm_call[1].command': bracket index syntax ('name[N]') is not supported by 'hermes config set'.
```

## Tests

`tests/hermes_cli/test_set_config_value.py` (+94 lines): regression cases for (a) bracket index rejected with clear error, (b) normal dotted path still works.

## Verification

`uv run pytest tests/hermes_cli/test_set_config_value.py` — all passing.