### PR TITLE
feat(desktop): add colorblind-friendly diff colors option

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -4,6 +4,7 @@ import type { CSSProperties, ReactElement, PointerEvent as ReactPointerEvent } f
 
 import { SessionDraftTitle } from '@/app/chat/session-draft-title'
 import { SessionStatusDot } from '@/app/chat/session-status-dot'
+import { useColorblindMode } from '@/app/hooks/use-colorblind-mode'
 import { PALETTE_AREA, type PaletteContribution, paletteToggle } from '@/app/command-palette/contrib'
 import { type StatusbarItem } from '@/app/shell/statusbar-controls'
 import { InlinePreviewDirective } from '@/components/assistant-ui/inline-preview-directive'
@@ -823,6 +824,11 @@ function TitlebarSlot({ area, className, style }: TitlebarSlotProps) {
 export function ContribController() {
   const sidebarOpen = useStore($sidebarOpen)
   const statusbarVisible = useStore($statusbarVisible)
+
+  // Opt-in colorblind mode: sets html[data-colorblind] so styles.css can swap
+  // the diff palette to blue/orange. Hook runs before the HUD branch so the
+  // attribute applies in every window mode.
+  useColorblindMode()
 
   // HUD mode is the SAME app with its frame removed: the wiring (gateway,
   // sessions, streams, submit) mounts identically, and only the shell around

--- a/apps/desktop/src/app/hooks/use-colorblind-mode.test.tsx
+++ b/apps/desktop/src/app/hooks/use-colorblind-mode.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useColorblindMode } from './use-colorblind-mode'
+
+const mocks = vi.hoisted(() => ({
+  loadedConfig: {} as Record<string, unknown>
+}))
+
+vi.mock('./use-config-record', () => ({
+  useHermesConfigRecord: () => ({ data: mocks.loadedConfig })
+}))
+
+describe('useColorblindMode', () => {
+  beforeEach(() => {
+    delete document.documentElement.dataset.colorblind
+  })
+
+  afterEach(() => {
+    cleanup()
+    delete document.documentElement.dataset.colorblind
+  })
+
+  it('leaves the attribute off when colorblind_mode is unset or false', () => {
+    mocks.loadedConfig = {}
+    renderHook(() => useColorblindMode())
+    expect(document.documentElement.dataset.colorblind).toBeUndefined()
+
+    mocks.loadedConfig = { desktop: { colorblind_mode: false } }
+    renderHook(() => useColorblindMode())
+    expect(document.documentElement.dataset.colorblind).toBeUndefined()
+  })
+
+  it('sets html[data-colorblind="true"] when colorblind_mode is on', () => {
+    mocks.loadedConfig = { desktop: { colorblind_mode: true } }
+    renderHook(() => useColorblindMode())
+    expect(document.documentElement.dataset.colorblind).toBe('true')
+  })
+
+  it('removes the attribute when the toggle turns back off', () => {
+    mocks.loadedConfig = { desktop: { colorblind_mode: true } }
+    const { rerender } = renderHook(() => useColorblindMode())
+    expect(document.documentElement.dataset.colorblind).toBe('true')
+
+    mocks.loadedConfig = { desktop: { colorblind_mode: false } }
+    rerender()
+    expect(document.documentElement.dataset.colorblind).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/hooks/use-colorblind-mode.ts
+++ b/apps/desktop/src/app/hooks/use-colorblind-mode.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+
+import { useHermesConfigRecord } from './use-config-record'
+
+/**
+ * Bridges the `desktop.colorblind_mode` config toggle to a data attribute on
+ * <html>. When enabled, `html[data-colorblind='true']` switches diff colors
+ * to a colorblind-safe blue (add) / orange (remove) pair — see the matching
+ * rules in styles.css. Off by default, so the default green/red diff palette
+ * stays untouched until the user opts in.
+ */
+export function useColorblindMode() {
+  const { data: config } = useHermesConfigRecord()
+  const desktopCfg = (config?.desktop ?? {}) as { colorblind_mode?: boolean }
+  const enabled = desktopCfg.colorblind_mode ?? false
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (enabled) {
+      root.dataset.colorblind = 'true'
+    } else {
+      delete root.dataset.colorblind
+    }
+  }, [enabled])
+}

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -645,7 +645,7 @@ export const SECTIONS: DesktopConfigSection[] = [
     id: 'appearance',
     label: 'Appearance',
     icon: Palette,
-    keys: []
+    keys: ['desktop.colorblind_mode']
   },
   {
     id: 'workspace',

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -386,7 +386,8 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   desktop: {
     repoScanEnabled: 'Automatic Repository Discovery',
     repoScanRoots: 'Repository Discovery Roots',
-    repoScanExcludePaths: 'Excluded Repository Paths'
+    repoScanExcludePaths: 'Excluded Repository Paths',
+    colorblindMode: 'Colorblind-Friendly Diff Colors'
   },
   agent: {
     maxTurns: 'Max Agent Steps',
@@ -553,7 +554,8 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   desktop: {
     repoScanEnabled: 'Scan local folders for Git repositories to show in Projects.',
     repoScanRoots: 'Folders to scan. Leave empty to scan your home directory.',
-    repoScanExcludePaths: 'Folders and their descendants to skip during repository discovery.'
+    repoScanExcludePaths: 'Folders and their descendants to skip during repository discovery.',
+    colorblindMode: 'When enabled, added lines in a diff use blue and removed lines use orange instead of the default red/green, so colorblind users can still tell them apart.'
   },
   timezone: 'IANA timezone identifier. Blank uses the system timezone.',
   browser: {

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -585,10 +585,10 @@ function ToolEntry({ part }: ToolEntryProps) {
             {showDiffStats && diffStats && (
               <span className="flex shrink-0 items-center gap-1 font-mono text-[0.625rem] tabular-nums">
                 {diffStats.added > 0 && (
-                  <span className="text-emerald-600 dark:text-emerald-400">+{diffStats.added}</span>
+                  <span className="text-(--ui-diff-add-foreground)">+{diffStats.added}</span>
                 )}
                 {diffStats.removed > 0 && (
-                  <span className="text-rose-600 dark:text-rose-400">−{diffStats.removed}</span>
+                  <span className="text-(--ui-diff-remove-foreground)">−{diffStats.removed}</span>
                 )}
               </span>
             )}

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -3,6 +3,7 @@
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
 import { type FC, lazy, Suspense, useMemo } from 'react'
 
+import { useHermesConfigRecord } from '@/app/hooks/use-config-record'
 import { CodeCard, CodeCardBody } from '@/components/chat/code-card'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 // Theme constants live in shiki-config (dependency-free) so the lazy shiki
@@ -31,6 +32,27 @@ interface HermesSyntaxHighlighterProps extends SyntaxHighlighterProps {
   defer?: boolean
 }
 
+/**
+ * Diff-language tokens in the GitHub themes are hard-coded green (added) /
+ * red (removed). Shiki paints them as inline styles, so the `--ui-diff-*`
+ * CSS variable overrides can't reach them. In colorblind mode
+ * (desktop.colorblind_mode) remap the four palette entries (light + dark) to
+ * the same blue/orange pair the CSS overrides use, so a fenced ```diff block
+ * in the stream reads like every other diff. Values mirror the
+ * `:root[data-colorblind='true']` rules in styles.css.
+ */
+const SHIKI_COLORBLIND_REPLACEMENTS: Record<string, Record<string, string>> = {
+  // Keys must be lowercase — shiki looks replacements up via
+  // `color.toLowerCase()`, so mixed-case entries silently no-op.
+  'github-light-default': {
+    '#116329': '#0a6cd2', // diff added (green → blue)
+    '#82071e': '#c2570a' // diff removed (red → orange)
+  },
+  'github-dark-dimmed': {
+    '#8ddb8c': '#a8c8ff', // diff added (green → blue)
+    '#ff938a': '#ffc9a3' // diff removed (red → orange)
+  }
+}
 const MAX_HIGHLIGHT_CHARS = 150_000
 const MAX_HIGHLIGHT_LINES = 3_000
 const CHUNK_LINES = 200
@@ -123,6 +145,27 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
   defer = false
 }) => {
   const { t } = useI18n()
+  const { data: config } = useHermesConfigRecord()
+  const colorblind = ((config?.desktop ?? {}) as { colorblind_mode?: boolean }).colorblind_mode ?? false
+  // Diff-language tokens are hard-coded red/green in the GitHub themes; only
+  // remap them (to blue/orange) while colorblind mode is on. The light theme
+  // keeps its comment-contrast bump, so spread both tables.
+  const colorReplacements = useMemo(() => {
+    if (!colorblind) {
+      return SHIKI_COLOR_REPLACEMENTS
+    }
+
+    return {
+      'github-light-default': {
+        ...SHIKI_COLOR_REPLACEMENTS['github-light-default'],
+        ...SHIKI_COLORBLIND_REPLACEMENTS['github-light-default']
+      },
+      'github-dark-dimmed': {
+        ...SHIKI_COLORBLIND_REPLACEMENTS['github-dark-dimmed']
+      }
+    }
+  }, [colorblind])
+
   const trimmed = (code ?? '').replace(/^\n+/, '').trimEnd()
 
   // Streaming may hand us empty/incomplete fences — render nothing rather
@@ -153,7 +196,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
             {plain ? (
               <PlainCode code={trimmed} />
             ) : (
-              <LazyShiki code={trimmed} colorReplacements={SHIKI_COLOR_REPLACEMENTS} language={language || 'text'} />
+              <LazyShiki code={trimmed} colorReplacements={colorReplacements} language={language || 'text'} />
             )}
           </Pre>
         </ExpandableBlock>

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -664,7 +664,8 @@ export const zh: Translations = {
       desktop: {
         repoScanEnabled: '自动发现代码仓库',
         repoScanRoots: '代码仓库扫描根目录',
-        repoScanExcludePaths: '排除的代码仓库路径'
+        repoScanExcludePaths: '排除的代码仓库路径',
+        colorblindMode: '红绿色弱模式'
       },
       agent: {
         maxTurns: '最大智能体步数',
@@ -824,7 +825,8 @@ export const zh: Translations = {
       desktop: {
         repoScanEnabled: '扫描本地文件夹，并在“项目”中显示 Git 代码仓库。',
         repoScanRoots: '要扫描的文件夹。留空时扫描主目录。',
-        repoScanExcludePaths: '发现代码仓库时跳过这些文件夹及其子目录。'
+        repoScanExcludePaths: '发现代码仓库时跳过这些文件夹及其子目录。',
+        colorblindMode: '开启后，文件差异（diff）中的新增行使用蓝色、删除行使用橙色，替代默认的红绿色，让红绿色弱用户也能清楚区分。'
       },
       timezone: '当 Hermes 需要本地时间上下文时使用。留空则使用系统时区。',
       agent: {

--- a/apps/desktop/src/lib/ansi.ts
+++ b/apps/desktop/src/lib/ansi.ts
@@ -145,17 +145,22 @@ const TAILWIND_BY_COLOR: Record<AnsiColor, string> = {
   // Tuned for legibility against the muted bg-(--ui-bg-tertiary) surface used
   // in tool cards. We don't paint pure ANSI colors (#000, #fff) because they
   // disappear into the surface.
+  //
+  // red / green / bright-red / bright-green ride CSS variables
+  // (--ui-ansi-*) so colorblind mode (desktop.colorblind_mode) can swap the
+  // pair to blue/orange — git diff paints +/− lines with exactly these SGR
+  // codes, and the default values below match the old hard-coded classes.
   black: 'text-zinc-700 dark:text-zinc-300',
-  red: 'text-red-700 dark:text-red-300',
-  green: 'text-emerald-700 dark:text-emerald-300',
+  red: 'text-(--ui-ansi-red)',
+  green: 'text-(--ui-ansi-green)',
   yellow: 'text-amber-700 dark:text-amber-300',
   blue: 'text-blue-700 dark:text-blue-300',
   magenta: 'text-fuchsia-700 dark:text-fuchsia-300',
   cyan: 'text-cyan-700 dark:text-cyan-300',
   white: 'text-zinc-600 dark:text-zinc-200',
   'bright-black': 'text-zinc-500 dark:text-zinc-400',
-  'bright-red': 'text-rose-600 dark:text-rose-300',
-  'bright-green': 'text-emerald-600 dark:text-emerald-200',
+  'bright-red': 'text-(--ui-ansi-bright-red)',
+  'bright-green': 'text-(--ui-ansi-bright-green)',
   'bright-yellow': 'text-amber-600 dark:text-amber-200',
   'bright-blue': 'text-sky-600 dark:text-sky-300',
   'bright-magenta': 'text-pink-600 dark:text-pink-300',

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -240,6 +240,45 @@
     --ui-diff-remove-background: color-mix(in srgb, var(--ui-red) 12%, transparent);
     --ui-diff-remove-foreground: color-mix(in srgb, var(--ui-red) 70%, #000);
 
+    /* Colorblind mode (desktop.colorblind_mode): blue add / orange remove —
+       a pair that stays clearly separable under red-green color vision
+       deficiency (the two hues land on opposite sides of the
+       deuteranopia/protanopia confusion axis). Opt-in: the default green/red
+       palette above applies unless html carries [data-colorblind='true'],
+       which useColorblindMode() toggles from the config. */
+    :root[data-colorblind='true']:not(.dark) {
+      --ui-diff-add-border: #0a6cd2;
+      --ui-diff-add-background: color-mix(in srgb, #0a6cd2 20%, transparent);
+      --ui-diff-add-foreground: #0a6cd2;
+      --ui-diff-remove-border: #c2570a;
+      --ui-diff-remove-background: color-mix(in srgb, #c2570a 20%, transparent);
+      --ui-diff-remove-foreground: #c2570a;
+    }
+    :root[data-colorblind='true'].dark {
+      --ui-diff-add-border: #5f9ef8;
+      --ui-diff-add-background: color-mix(in srgb, #5f9ef8 22%, transparent);
+      --ui-diff-add-foreground: #a8c8ff;
+      --ui-diff-remove-border: #ff9e64;
+      --ui-diff-remove-background: color-mix(in srgb, #ff9e64 22%, transparent);
+      --ui-diff-remove-foreground: #ffc9a3;
+    }
+    /* Review file-tree status glyphs (A/D icons) and the +n/−n counters use
+       the semantic green/red text classes directly; recolor them inside
+       review rows only so the whole diff surface speaks one color language
+       without touching app-wide green/red usage (errors, PR badges, …). */
+    :root[data-colorblind='true'] .group\/review-row .text-\(--ui-green\) {
+      color: #0a6cd2;
+    }
+    :root[data-colorblind='true'] .group\/review-row .text-\(--ui-red\) {
+      color: #c2570a;
+    }
+    :root[data-colorblind='true'].dark .group\/review-row .text-\(--ui-green\) {
+      color: #5f9ef8;
+    }
+    :root[data-colorblind='true'].dark .group\/review-row .text-\(--ui-red\) {
+      color: #ff9e64;
+    }
+
     /* Overlay ladder. DESIGN.md: app-wide surfaces must not compete through
        ad-hoc z-index literals — pick the rung that describes the surface.
        Values are deliberately sparse so a one-off can slot between two rungs

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -267,16 +267,16 @@
        review rows only so the whole diff surface speaks one color language
        without touching app-wide green/red usage (errors, PR badges, …). */
     :root[data-colorblind='true'] .group\/review-row .text-\(--ui-green\) {
-      color: #0a6cd2;
+      color: var(--ui-diff-add-foreground);
     }
     :root[data-colorblind='true'] .group\/review-row .text-\(--ui-red\) {
-      color: #c2570a;
+      color: var(--ui-diff-remove-foreground);
     }
     :root[data-colorblind='true'].dark .group\/review-row .text-\(--ui-green\) {
-      color: #5f9ef8;
+      color: var(--ui-diff-add-foreground);
     }
     :root[data-colorblind='true'].dark .group\/review-row .text-\(--ui-red\) {
-      color: #ff9e64;
+      color: var(--ui-diff-remove-foreground);
     }
 
     /* Overlay ladder. DESIGN.md: app-wide surfaces must not compete through

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -240,42 +240,58 @@
     --ui-diff-remove-background: color-mix(in srgb, var(--ui-red) 12%, transparent);
     --ui-diff-remove-foreground: color-mix(in srgb, var(--ui-red) 70%, #000);
 
+    /* ANSI output (terminal cards): git diff paints +/- lines with ANSI SGR
+       colors that `ansiColorClass` maps to these tokens, so colorblind mode
+       can swap red/green to the blue/orange pair there too. */
+    --ui-ansi-red: #b91c1c;
+    --ui-ansi-green: #047857;
+    --ui-ansi-bright-red: #e11d48;
+    --ui-ansi-bright-green: #059669;
+
     /* Colorblind mode (desktop.colorblind_mode): blue add / orange remove —
        a pair that stays clearly separable under red-green color vision
        deficiency (the two hues land on opposite sides of the
        deuteranopia/protanopia confusion axis). Opt-in: the default green/red
        palette above applies unless html carries [data-colorblind='true'],
        which useColorblindMode() toggles from the config. */
-    :root[data-colorblind='true']:not(.dark) {
+    &:root[data-colorblind='true']:not(.dark) {
       --ui-diff-add-border: #0a6cd2;
       --ui-diff-add-background: color-mix(in srgb, #0a6cd2 20%, transparent);
       --ui-diff-add-foreground: #0a6cd2;
       --ui-diff-remove-border: #c2570a;
       --ui-diff-remove-background: color-mix(in srgb, #c2570a 20%, transparent);
       --ui-diff-remove-foreground: #c2570a;
+      --ui-ansi-red: #c2570a;
+      --ui-ansi-green: #0a6cd2;
+      --ui-ansi-bright-red: #c2570a;
+      --ui-ansi-bright-green: #0a6cd2;
     }
-    :root[data-colorblind='true'].dark {
+    &:root[data-colorblind='true'].dark {
       --ui-diff-add-border: #5f9ef8;
       --ui-diff-add-background: color-mix(in srgb, #5f9ef8 22%, transparent);
       --ui-diff-add-foreground: #a8c8ff;
       --ui-diff-remove-border: #ff9e64;
       --ui-diff-remove-background: color-mix(in srgb, #ff9e64 22%, transparent);
       --ui-diff-remove-foreground: #ffc9a3;
+      --ui-ansi-red: #ffc9a3;
+      --ui-ansi-green: #a8c8ff;
+      --ui-ansi-bright-red: #ffc9a3;
+      --ui-ansi-bright-green: #a8c8ff;
     }
     /* Review file-tree status glyphs (A/D icons) and the +n/−n counters use
        the semantic green/red text classes directly; recolor them inside
        review rows only so the whole diff surface speaks one color language
        without touching app-wide green/red usage (errors, PR badges, …). */
-    :root[data-colorblind='true'] .group\/review-row .text-\(--ui-green\) {
+    &:root[data-colorblind='true'] .group\/review-row .text-\(--ui-green\) {
       color: var(--ui-diff-add-foreground);
     }
-    :root[data-colorblind='true'] .group\/review-row .text-\(--ui-red\) {
+    &:root[data-colorblind='true'] .group\/review-row .text-\(--ui-red\) {
       color: var(--ui-diff-remove-foreground);
     }
-    :root[data-colorblind='true'].dark .group\/review-row .text-\(--ui-green\) {
+    &:root[data-colorblind='true'].dark .group\/review-row .text-\(--ui-green\) {
       color: var(--ui-diff-add-foreground);
     }
-    :root[data-colorblind='true'].dark .group\/review-row .text-\(--ui-red\) {
+    &:root[data-colorblind='true'].dark .group\/review-row .text-\(--ui-red\) {
       color: var(--ui-diff-remove-foreground);
     }
 
@@ -602,6 +618,10 @@
     --ui-cyan: #6f9ba6;
     --ui-diff-add-foreground: color-mix(in srgb, var(--ui-green) 62%, #fff);
     --ui-diff-remove-foreground: color-mix(in srgb, var(--ui-red) 62%, #fff);
+    --ui-ansi-red: #fca5a5;
+    --ui-ansi-green: #6ee7b7;
+    --ui-ansi-bright-red: #fda4af;
+    --ui-ansi-bright-green: #a7f3d0;
 
     --sidebar-edge-border: color-mix(in srgb, var(--ui-base) 12%, transparent);
     --composer-ring-strength: 1.3;

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -352,6 +352,8 @@ export interface HermesConfig {
     repo_scan_enabled?: boolean
     repo_scan_roots?: string[]
     repo_scan_exclude_paths?: string[]
+    /** Colorblind-friendly diff colors (blue/orange instead of green/red). */
+    colorblind_mode?: boolean
   }
   terminal?: {
     cwd?: string

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2265,6 +2265,11 @@ DEFAULT_CONFIG = {
         # gnome-libsecret|kwallet|kwallet5|kwallet6|basic force one (basic = unencrypted). Bridged
         # to HERMES_DESKTOP_PASSWORD_STORE; ignored off-Linux.
         "password_store": "auto",
+        # Colorblind-friendly diff colors: when true, file diffs use a
+        # blue (add) / orange (remove) pair that stays clearly separable
+        # under red-green color vision deficiency, instead of the default
+        # green/red. Off by default — preserves the default palette.
+        "colorblind_mode": False,
         # macOS only: code-signing identity (login-keychain cert; self-signed works) to re-sign
         # locally rebuilt apps so the Designated Requirement — and thus TCC grants — survives
         # updates. Empty = default ad-hoc identifier-pinned signing.


### PR DESCRIPTION
## Summary
Adds an opt-in **colorblind mode** for the desktop app. When enabled, file diffs use a blue (add) / orange (remove) pair instead of the default green/red — colors that stay clearly separable under red-green color vision deficiency (deuteranopia / protanopia), where red vs green is exactly the pair that blurs together.

## Motivation
Red-green color vision deficiency affects ~8% of men. Diff lines in the desktop app have their leading +/- marker stripped and read by color alone, so the default green/red tint is the least accessible part of the UI for those users. The existing approach required users to inject their own CSS via a desktop plugin; this makes the fix first-class and configurable.

## Changes
- **`hermes_cli/config_defaults.py`**: new `desktop.colorblind_mode` key, default `False` (auto-surfaced in the config schema).
- **`apps/desktop/src/styles.css`**: `html[data-colorblind='true']` overrides the `--ui-diff-add/remove-*` tokens to the blue/orange pair (light + dark variants), plus the review file-tree status glyphs and +n/−n diff counters inside review rows — scoped so app-wide green/red usage (errors, PR badges) is untouched.
- **`apps/desktop/src/app/hooks/use-colorblind-mode.ts`** (new): bridges the config toggle to the `data-colorblind` attribute on `<html>`, mounted in `ContribController` so it applies in every window mode (main + HUD).
- **`apps/desktop/src/app/settings/constants.ts`**: `Appearance` section now exposes the field.
- **`apps/desktop/src/i18n/zh.ts`**: Chinese label + description (设置 → 配置 → 外观 → 红绿色弱模式).
- **`apps/desktop/src/types/hermes.ts`**: typed `colorblind_mode` field.
- **`use-colorblind-mode.test.tsx`** (new): 3 tests covering attribute set / unset / toggle-off.

## Behavior
- **Default unchanged**: `colorblind_mode` is off by default; the green/red diff palette renders exactly as before unless the user opts in.
- Colors in colorblind mode: light `add #0a6cd2 / remove #c2570a`; dark `add #5f9ef8 / remove #ff9e64`; background tint raised to 20–22% for stronger blocks.

## Testing
- `tsc -p tsconfig.json --noEmit` — clean
- `vitest run src/app/hooks/use-colorblind-mode.test.tsx` — 3/3 passed
- Schema probe: `desktop.colorblind_mode` present in `_build_schema_from_config(DEFAULT_CONFIG)` (type boolean)
- Local build (`npm run build` + electron-builder) verified; toggle verified in the built app