### PR TITLE
fix(desktop): clear messaging sessions optimistically on archive and delete

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -2665,4 +2665,41 @@ describe('archive/delete of a messaging-platform row (issue #87716)', () => {
     expect(idsIn($sessions.get())).toEqual([row.id])
     expect(idsIn($messagingSessions.get())).toEqual([])
   })
+
+  it('rolls a failed delete back into the messaging slice, not into recents', async () => {
+    // Delete rolls back through the same helper as archive but from a
+    // different catch, so the routing has to be pinned separately: an archive
+    // that restores correctly proves nothing about the delete path.
+    const row = feishuRow()
+
+    setMessagingSessions([row])
+    vi.mocked(deleteSession).mockRejectedValue(new Error('gateway unreachable'))
+
+    const actions = await mountSidebarActions()
+
+    await act(async () => {
+      await actions.removeSession(row.id)
+    })
+
+    expect(idsIn($messagingSessions.get())).toEqual([row.id])
+    // Into recents it would be filtered out by SIDEBAR_EXCLUDED_SOURCES on the
+    // next refresh, so the row that survived the failed delete disappears anyway.
+    expect(idsIn($sessions.get())).toEqual([])
+  })
+
+  it('still rolls a failed delete of a local row back into recents', async () => {
+    const row = storedSession({ id: 'stored-desktop-2', source: 'desktop' })
+
+    setSessions([row])
+    vi.mocked(deleteSession).mockRejectedValue(new Error('gateway unreachable'))
+
+    const actions = await mountSidebarActions()
+
+    await act(async () => {
+      await actions.removeSession(row.id)
+    })
+
+    expect(idsIn($sessions.get())).toEqual([row.id])
+    expect(idsIn($messagingSessions.get())).toEqual([])
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -52,6 +52,7 @@ import {
   setTurnStartedAt
 } from '@/store/session'
 import { $sessionTiles } from '@/store/session-states'
+import { $archivedSessions } from '@/store/sidebar-archive'
 
 import sessionResumeActiveTurn from '../../../../../../tests/fixtures/session-resume-active-turn.json'
 import { deferred } from '../../../test/deferred'
@@ -2586,12 +2587,14 @@ describe('archive/delete of a messaging-platform row (issue #87716)', () => {
   beforeEach(() => {
     setSessions([])
     setMessagingSessions([])
+    $archivedSessions.set([])
   })
 
   afterEach(() => {
     cleanup()
     setSessions([])
     setMessagingSessions([])
+    $archivedSessions.set([])
     vi.mocked(deleteSession).mockReset()
     vi.mocked(setSessionArchived).mockReset()
   })
@@ -2700,6 +2703,29 @@ describe('archive/delete of a messaging-platform row (issue #87716)', () => {
     })
 
     expect(idsIn($sessions.get())).toEqual([row.id])
+    expect(idsIn($messagingSessions.get())).toEqual([])
+  })
+
+  it('rolls a failed delete of an archived row back into the archived view only', async () => {
+    // The third slice. `restoreSidebarSession` routes between the two LIVE
+    // slices and knows nothing about the archived store, which is restored
+    // from its own `previousArchived` snapshot instead. Running both would put
+    // the row back in recents as well, so the row would appear twice until the
+    // next refresh and then vanish from the Archived filter it was deleted
+    // from. Pin that the archived case restores in exactly one place.
+    const row = storedSession({ id: 'stored-archived-1', source: 'desktop', title: 'Archived thread' })
+
+    $archivedSessions.set([row])
+    vi.mocked(deleteSession).mockRejectedValue(new Error('gateway unreachable'))
+
+    const actions = await mountSidebarActions()
+
+    await act(async () => {
+      await actions.removeSession(row.id)
+    })
+
+    expect(idsIn($archivedSessions.get())).toEqual([row.id])
+    expect(idsIn($sessions.get())).toEqual([])
     expect(idsIn($messagingSessions.get())).toEqual([])
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -7,11 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
 import {
+  deleteSession,
   getAllSessionMessages,
   getLatestSessionMessages,
   getSession,
   type SessionInfo,
-  type SessionResumeResponse
+  type SessionResumeResponse,
+  setSessionArchived
 } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
@@ -26,9 +28,11 @@ import {
   $currentProvider,
   $currentReasoningEffort,
   $messages,
+  $messagingSessions,
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
   $selectedStoredSessionId,
+  $sessions,
   $turnStartedAt,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
@@ -40,6 +44,7 @@ import {
   setCurrentProvider,
   setCurrentReasoningEffort,
   setMessages,
+  setMessagingSessions,
   setNewChatWorkspaceTarget,
   setResumeFailedSessionId,
   setSelectedStoredSessionId,
@@ -82,7 +87,7 @@ const RUNTIME_SESSION_ID = 'rt-new-001'
 
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
-  'createBackendSessionForSend' | 'selectSidebarItem' | 'startFreshSessionDraft'
+  'archiveSession' | 'createBackendSessionForSend' | 'removeSession' | 'selectSidebarItem' | 'startFreshSessionDraft'
 >
 
 function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
@@ -2539,5 +2544,125 @@ describe('selectSidebarItem', () => {
     expect(navigate).toHaveBeenCalledWith('/skills', undefined)
     expect(noteActiveTreeGroup).toHaveBeenCalledWith(null)
     expect(revealTreePane).toHaveBeenCalledWith('workspace')
+  })
+})
+
+describe('archive/delete of a messaging-platform row (issue #87716)', () => {
+  // The sidebar is two disjoint atoms: recents are fetched with
+  // SIDEBAR_EXCLUDED_SOURCES (every messaging source spread in) and the messaging
+  // sections are fetched into $messagingSessions. So a Feishu row is never in
+  // $sessions, and a $sessions-only lookup does not miss it by accident — it
+  // misses it every time.
+  function feishuRow(): SessionInfo {
+    return storedSession({
+      _lineage_root_id: 'root-feishu-1',
+      id: 'stored-feishu-1',
+      profile: 'work',
+      source: 'feishu',
+      title: 'Feishu thread'
+    })
+  }
+
+  function idsIn(rows: SessionInfo[]): string[] {
+    return rows.map(row => row.id)
+  }
+
+  async function mountSidebarActions(): Promise<HarnessHandle> {
+    const held: { current: HarnessHandle | null } = { current: null }
+
+    render(
+      <Harness
+        onReady={value => {
+          held.current = value
+        }}
+        requestGateway={vi.fn(async () => ({}) as never)}
+      />
+    )
+    await waitFor(() => expect(held.current).not.toBeNull())
+
+    return held.current as HarnessHandle
+  }
+
+  beforeEach(() => {
+    setSessions([])
+    setMessagingSessions([])
+  })
+
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    setMessagingSessions([])
+    vi.mocked(deleteSession).mockReset()
+    vi.mocked(setSessionArchived).mockReset()
+  })
+
+  it('archiving drops the row from the messaging slice, not only from recents', async () => {
+    const row = feishuRow()
+
+    setMessagingSessions([row])
+    vi.mocked(setSessionArchived).mockResolvedValue(undefined as never)
+
+    const actions = await mountSidebarActions()
+
+    await act(async () => {
+      await actions.archiveSession(row.id)
+    })
+
+    // Filtering $sessions alone leaves the row on screen until the next
+    // refresh lands, which is the reported 2-4s of stale sidebar.
+    expect(idsIn($messagingSessions.get())).toEqual([])
+  })
+
+  it('deleting routes the RPC through the profile of the row being deleted', async () => {
+    const row = feishuRow()
+
+    setMessagingSessions([row])
+    vi.mocked(deleteSession).mockResolvedValue(undefined as never)
+
+    const actions = await mountSidebarActions()
+
+    await act(async () => {
+      await actions.removeSession(row.id)
+    })
+
+    expect(idsIn($messagingSessions.get())).toEqual([])
+    // The lookup does more than find the row to hide: the caller reads its
+    // profile to pick the gateway. A $sessions-only lookup sends undefined here
+    // and the delete goes to whichever profile happens to be active.
+    expect(deleteSession).toHaveBeenCalledWith(row.id, 'work')
+  })
+
+  it('rolls a failed archive back into the messaging slice, not into recents', async () => {
+    const row = feishuRow()
+
+    setMessagingSessions([row])
+    vi.mocked(setSessionArchived).mockRejectedValue(new Error('gateway unreachable'))
+
+    const actions = await mountSidebarActions()
+
+    await act(async () => {
+      await actions.archiveSession(row.id)
+    })
+
+    expect(idsIn($messagingSessions.get())).toEqual([row.id])
+    // Restoring into recents would look like a working rollback and then lose
+    // the row a second time, silently, on the next refreshSessions.
+    expect(idsIn($sessions.get())).toEqual([])
+  })
+
+  it('still rolls a failed archive of a local row back into recents', async () => {
+    const row = storedSession({ id: 'stored-desktop-1', source: 'desktop' })
+
+    setSessions([row])
+    vi.mocked(setSessionArchived).mockRejectedValue(new Error('gateway unreachable'))
+
+    const actions = await mountSidebarActions()
+
+    await act(async () => {
+      await actions.archiveSession(row.id)
+    })
+
+    expect(idsIn($sessions.get())).toEqual([row.id])
+    expect(idsIn($messagingSessions.get())).toEqual([])
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -60,6 +60,7 @@ import {
   setFreshDraftReady,
   setIntroSeed,
   setMessages,
+  setMessagingSessions,
   setNewChatWorkspaceTarget,
   setResumeExhaustedSessionId,
   setResumeFailedSessionId,
@@ -98,6 +99,7 @@ import {
   type BranchMessage,
   chatMessageArraysEquivalent,
   dedupeInflightUserAgainstTranscript,
+  findSidebarSession,
   goneSessionVerdict,
   isSessionGoneError,
   overlayConcurrentMessageChanges,
@@ -108,6 +110,7 @@ import {
   resolveResumedBusy,
   resolveSessionProfile,
   resolveStoredSession,
+  restoreSidebarSession,
   selectBranchMessages,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
@@ -1724,14 +1727,23 @@ export function useSessionActions({
     async (storedSessionId: string) => {
       clearNotifications()
 
-      // The row may live in the main list OR the archived view's own store
-      // (archived rows are excluded from $sessions by design). Resolve from
-      // both so deleting from the Archived filter evicts the row instead of
-      // leaving a ghost that resumes into a dead id (infinite spinner).
-      const removedFromMain = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+      // The row may live in the recents list, the messaging list, or the
+      // archived view's own store -- three disjoint atoms, none of which is a
+      // superset of another. `findSidebarSession` covers the two live ones
+      // (messaging rows are never in $sessions); archived rows are excluded
+      // from both by design. Resolve from all three so deleting from any
+      // filter evicts the row instead of leaving a ghost that resumes into a
+      // dead id (infinite spinner), and so the profile that routes the RPC and
+      // the _lineage_root_id the tombstone matches on are actually found.
+      //
+      // Kept separate from `removed` because only a LIVE row is restored by
+      // `restoreSidebarSession` on rollback -- the archived case is covered by
+      // the `$archivedSessions.set(previousArchived)` snapshot restore below,
+      // and running both would put an archived row back into recents.
+      const removedFromLive = findSidebarSession(storedSessionId)
 
       const removed =
-        removedFromMain ?? $archivedSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+        removedFromLive ?? $archivedSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
 
       const wasSelected = selectedStoredSessionId === storedSessionId
       const closingRuntimeId = wasSelected ? activeSessionId : null
@@ -1744,6 +1756,7 @@ export function useSessionActions({
       const removedIds = [storedSessionId, removed?.id, removed?._lineage_root_id]
 
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+      setMessagingSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
       $archivedSessions.set(previousArchived.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
       // Evict from the project tree's optimistic layer too (the backend snapshot
       // still lists it until its next refresh), so grouped + flat views drop the
@@ -1788,8 +1801,8 @@ export function useSessionActions({
           dropSessionState(tiledRuntimeId)
         }
       } catch (err) {
-        if (removedFromMain) {
-          setSessions(prev => [removedFromMain, ...prev])
+        if (removedFromLive) {
+          restoreSidebarSession(removedFromLive)
         }
 
         // Restore the archived-view row too (no-op when it wasn't archived).
@@ -1802,7 +1815,7 @@ export function useSessionActions({
           setFreshDraftReady(false)
           setSelectedStoredSessionId(storedSessionId)
           selectedStoredSessionIdRef.current = storedSessionId
-          const stored = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+          const stored = findSidebarSession(storedSessionId)
 
           if (stored) {
             applyStoredUsage(stored)
@@ -1843,7 +1856,7 @@ export function useSessionActions({
     async (storedSessionId: string) => {
       clearNotifications()
 
-      const archived = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+      const archived = findSidebarSession(storedSessionId)
       const wasSelected = selectedStoredSessionId === storedSessionId
       const previousPinned = $pinnedSessionIds.get()
       // Pins are keyed on the durable lineage-root id; the stored id may be the
@@ -1853,6 +1866,7 @@ export function useSessionActions({
 
       // Soft-hide: drop from the sidebar immediately, keep the data.
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+      setMessagingSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
       tombstoneSessions(archivedIds)
       beginSessionMutation(archivedIds)
       $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
@@ -1879,7 +1893,7 @@ export function useSessionActions({
         notify({ durationMs: 2_000, kind: 'success', message: copy.archived })
       } catch (err) {
         if (archived) {
-          setSessions(prev => [archived, ...prev.filter(session => !sessionMatchesStoredId(session, storedSessionId))])
+          restoreSidebarSession(archived)
         }
 
         untombstoneSessions(archivedIds)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -4,6 +4,7 @@ import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { parseErrorSurface } from '@/lib/error-surface'
+import { isMessagingSource } from '@/lib/session-source'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
@@ -24,6 +25,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
+  setMessagingSessions,
   setSessions,
   setWorkspaceCwdOwner,
   setYoloActive
@@ -1301,6 +1303,41 @@ function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
       return (existing._lineage_root_id ?? existing.id) !== lineage
     })
   ])
+}
+
+/** The sidebar row for a stored id, from whichever slice actually holds it.
+ *
+ * The sidebar is two disjoint atoms, not one: `refreshSessions` fetches recents
+ * with `SIDEBAR_EXCLUDED_SOURCES` (which spreads in every messaging source), and
+ * `refreshMessagingSessions` fetches the inverse into `$messagingSessions`. So a
+ * Feishu/Discord/Telegram row is NEVER in `$sessions`, and a lookup that reads
+ * only `$sessions` does not return undefined by accident for those rows — it
+ * returns undefined always.
+ *
+ * That matters beyond the row itself: callers derive the session's `profile`
+ * (which routes the RPC), its `_lineage_root_id` (which the tombstone needs to
+ * match a compressed row) and their own rollback snapshot from this lookup.
+ * `resolveStoredSession` below already reads all three slices for exactly this
+ * reason — see its multi-profile note.
+ */
+export function findSidebarSession(storedSessionId: string): SessionInfo | undefined {
+  return (
+    $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
+    $messagingSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+  )
+}
+
+/** Put a row back in the slice it came from, after a failed archive/delete.
+ *
+ * Restoring into `$sessions` unconditionally would move a messaging row into
+ * the recents list, where it does not belong and where the next
+ * `refreshSessions` would drop it again — a rollback that looks like it worked
+ * and then silently loses the row a second time.
+ */
+export function restoreSidebarSession(session: SessionInfo): void {
+  const setSlice = isMessagingSource(session.source) ? setMessagingSessions : setSessions
+
+  setSlice(prev => [session, ...prev.filter(existing => existing.id !== session.id)])
 }
 
 export async function resolveStoredSession(storedSessionId: string): Promise<SessionInfo | undefined> {


### PR DESCRIPTION
## What does this PR do?

Archiving or deleting a messaging-platform session (Telegram, Discord, Feishu, Slack, ...) left the row in the sidebar until the next refresh landed, the 2-4s of stale UI in the report.

The sidebar is two disjoint atoms, not one. `refreshSessions` fetches recents with `SIDEBAR_EXCLUDED_SOURCES`, which spreads in every id from `MESSAGING_SESSION_SOURCE_IDS`, and `refreshMessagingSessions` fetches the inverse into `$messagingSessions`. `archiveSession` and `removeSession` optimistically filtered `$sessions` only, so for a messaging row the optimistic clear was a no-op.

**The lookup in front of that filter has the same blind spot, and it is the more damaging half.** Both actions start with

```ts
const removed = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
```

and then derive three separate things from it:

- `removed?.profile`, which routes the RPC (`deleteSession(id, profile)` / `setSessionArchived(id, true, profile)`)
- `removed?._lineage_root_id`, which the tombstone needs to match a compressed row
- `removed` itself, which is the snapshot the `catch` restores from

For a messaging row that lookup does not return `undefined` by accident, it returns `undefined` **always**. So the delete goes out with no profile, the tombstone covers only the stored id, and `if (removed) { ... }` in the rollback is dead code: a failed archive tears the row out of the UI and never puts it back. Adding the optimistic `$messagingSessions` clear on its own would have made that last one worse, since it would start actually removing the row it cannot restore.

So the fix is two small helpers in `utils.ts` rather than a second `setSessions` call:

- `findSidebarSession(storedSessionId)` reads `$sessions` and falls back to `$messagingSessions`. `resolveStoredSession` in the same file already reads all three slices for exactly this reason, so this follows the local precedent.
- `restoreSidebarSession(session)` puts a row back in the slice it came from, keyed on `isMessagingSource(session.source)`. Restoring into `$sessions` unconditionally would relocate a messaging row into recents, where it does not render and where the next `refreshSessions` would drop it again: a rollback that looks like it worked and then silently loses the row a second time.

### Answering the two things I said I would check on the issue

**`deleteSession` has the identical omission.** Confirmed and fixed here. `removeSession` is that path (`session-actions-menu` and the tile menu both route delete through it), and it had all four symptoms above, not just the visible one.

**Does the tombstone cover messaging ingestion, or only recents?** It covers all of it, so the optimistic clear is safe and no re-add race remains. `dropTombstoned` is applied at every ingestion point in `use-session-list-actions.ts`: lines 139 and 192 on the messaging paths, 276 and 321 on the recents paths. That was the condition I flagged as the reason a clear alone might not be enough; it does not apply.

## Related Issue

Fixes #87716

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts`: added `findSidebarSession` (both-slice lookup) and `restoreSidebarSession` (slice-preserving rollback), with comments explaining why the two atoms are disjoint.
- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`: `removeSession` and `archiveSession` now look the row up with `findSidebarSession`, also filter `$messagingSessions` optimistically, and roll back through `restoreSidebarSession`. The `wasSelected` re-lookup in `removeSession`'s `catch` uses the same helper, so a messaging row now restores its usage counters too.
- `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx`: 4 regression tests.

## How to Test

1. Connect a messaging platform, so the sidebar shows a section fed by `$messagingSessions` (Feishu in the report).
2. Archive or delete one of those rows. Before: it stays visible until the next refresh. After: it disappears on click.
3. To see the rollback half, make the RPC fail (stop the gateway, or point the profile at a dead backend) and archive a messaging row. Before: the row vanishes from the UI and the error toast fires, but it is never restored. After: it comes back into its own section, not into recents.

The 4 new tests cover the same ground:

- `archiving drops the row from the messaging slice, not only from recents` fails on `main` with the row still in `$messagingSessions`.
- `deleting routes the RPC through the profile of the row being deleted` fails on `main` with `deleteSession` called as `(id, undefined)` instead of `(id, 'work')`. This is the silent half of the bug, and the reason it is worth a test rather than a comment.
- `rolls a failed archive back into the messaging slice, not into recents` pins `restoreSidebarSession`'s routing.
- `still rolls a failed archive of a local row back into recents` is the non-regression guard for the desktop/CLI path.

Note on verification: I could not run vitest locally in this checkout, so CI is the gate on these. `scripts/check-windows-footguns.py --all` passes (973 files scanned).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- N/A: no Python in this change. The relevant suite is vitest, which I could not run in this checkout, so CI is the gate on the 4 new tests. Saying so rather than checking a box I did not earn. -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 <!-- static verification only: check-windows-footguns.py --all passes, and the behaviour claims above are derived from the source plus the new tests, not from a manual run of the desktop app -->



### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
