### PR TITLE
fix(honcho): adopt externally rotated OAuth tokens

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -947,6 +947,7 @@ _honcho_client_slot: SingletonSlot = SingletonSlot()
 import threading as _threading
 
 _client_slots: dict[tuple, SingletonSlot] = {}
+_client_oauth_sync_locks: dict[tuple, _threading.Lock] = {}
 _client_slots_lock = _threading.Lock()
 
 
@@ -1078,9 +1079,19 @@ def _slot_for(key: tuple) -> SingletonSlot:
             ]
             for k in stale:
                 _client_slots.pop(k, None)
+                _client_oauth_sync_locks.pop(k, None)
             slot = SingletonSlot()
             _client_slots[key] = slot
+        _client_oauth_sync_locks.setdefault(key, _threading.Lock())
         return slot
+
+
+def _oauth_sync_lock_for(key: tuple):
+    """Return the per-client-identity lock for read/compare/apply token sync."""
+    with _client_slots_lock:
+        return _client_oauth_sync_locks.setdefault(key, _threading.Lock())
+
+
 # Memo for the honcho.json-derived timeout, keyed PER CONFIG PATH on the
 # file's mtime_ns so the staleness check on every get_honcho_client() call
 # costs one stat() instead of a JSON parse. Path-keyed because multi-profile
@@ -1185,11 +1196,16 @@ def _refresh_cached_oauth(
     config: HonchoClientConfig | None,
     slot: SingletonSlot | None = None,
 ) -> None:
-    """Rotate the cached client's Bearer in place when its OAuth token is stale.
+    """Keep the cached client's Bearer aligned with the persisted OAuth token.
+
+    ``ensure_fresh_token`` returns ``refreshed=False`` both when no refresh was
+    needed and when another process already rotated the grant on disk. The
+    latter still requires updating this process's cached SDK client, so compare
+    the returned token with the live client instead of relying on that flag.
 
     If the SDK shape changed and the in-place rotation can't apply, the
     client's own slot is reset so the next acquisition rebuilds with the
-    fresh token.
+    persisted token.
     """
     try:
         from plugins.memory.honcho import oauth
@@ -1200,8 +1216,10 @@ def _refresh_cached_oauth(
         else:
             host = resolve_active_host()
             path = resolve_config_path()
-        token, refreshed = oauth.ensure_fresh_token(path, host)
-        if refreshed and token and not oauth.apply_token_to_client(client, token):
+        token, _refreshed = oauth.ensure_fresh_token(path, host)
+        http = getattr(client, "_http", None)
+        live_token = getattr(http, "api_key", None)
+        if token and token != live_token and not oauth.apply_token_to_client(client, token):
             if slot is not None:
                 slot.reset()
     except Exception:
@@ -1228,13 +1246,14 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
     """
     key = _client_cache_key(config)
     slot = _slot_for(key)
-    cached = slot.peek()
-    if cached is not None:
-        _refresh_cached_oauth(cached, config, slot)
-        refreshed = slot.peek()
-        if refreshed is not None:
-            return refreshed
-        # Slot was reset by a failed in-place rotation — rebuild below.
+    with _oauth_sync_lock_for(key):
+        cached = slot.peek()
+        if cached is not None:
+            _refresh_cached_oauth(cached, config, slot)
+            refreshed = slot.peek()
+            if refreshed is not None:
+                return refreshed
+            # Slot was reset by a failed in-place rotation — rebuild below.
 
     if config is None:
         config = HonchoClientConfig.from_global_config()
@@ -1363,5 +1382,6 @@ def reset_honcho_client() -> None:
     """Reset all cached Honcho clients (tests, OAuth re-login)."""
     with _client_slots_lock:
         _client_slots.clear()
+        _client_oauth_sync_locks.clear()
     _honcho_client_slot.reset()
     _honcho_json_timeout_memo.clear()

--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -138,15 +138,29 @@ def _config_refresh_lock(path: Path):
                 pass
             fh.close()
 
-# In-memory expiry cache keyed by (config path, host) → (expires_at, access).
-# Lets the hot path (every memory access calls this) skip the honcho.json read
-# while the token is comfortably live; disk is only touched near expiry, on a
-# cache miss, or when an explicit ``raw`` is supplied. Single-key dict ops are
-# atomic under the GIL, so no separate lock is needed. An access token stays
-# valid until its own expiry regardless of out-of-band rotation, so a stale
-# cache entry can't break auth — it just defers picking up external changes
-# until the token nears expiry and disk is read again.
-_expiry_cache: dict[tuple[str, str], tuple[float, str]] = {}
+# In-memory expiry cache keyed by (config path, host) →
+# (expires_at, access, config fingerprint). Every memory access stats the small
+# config file but avoids parsing it while both the token and fingerprint are
+# unchanged. The fingerprint is necessary because another process can rotate
+# the same grant and atomically replace the credential file before this
+# process's cached access token reaches its local expiry.
+_ConfigFingerprint = tuple[int, int, int, int]
+_expiry_cache: dict[
+    tuple[str, str], tuple[float, str, _ConfigFingerprint | None]
+] = {}
+
+
+def _fingerprint_from_stat(st: os.stat_result) -> _ConfigFingerprint:
+    return (st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
+
+
+def _config_fingerprint(path: Path) -> _ConfigFingerprint | None:
+    """Return a cheap identity for detecting atomic out-of-process rewrites."""
+    try:
+        st = path.stat()
+    except OSError:
+        return None
+    return _fingerprint_from_stat(st)
 
 # Permanently rejected grants: (config path, host) → sha256 of the dead refresh token; a re-login rotates the token, so the digest check self-clears.
 _dead_grants: dict[tuple[str, str], str] = {}
@@ -442,19 +456,48 @@ def _read_config(path: Path) -> dict[str, Any]:
         return {}
 
 
-def _atomic_write_config(path: Path, raw: dict[str, Any]) -> None:
-    """Write ``raw`` to ``path`` atomically, preserving 0600 on the new file."""
+def _read_config_snapshot(
+    path: Path,
+) -> tuple[dict[str, Any], _ConfigFingerprint | None]:
+    """Read JSON and fingerprint the same opened file version.
+
+    An atomic replacement after ``open`` does not change the file descriptor,
+    so ``fstat`` keeps the parsed credential and cached fingerprint aligned.
+    """
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+            try:
+                fingerprint = _fingerprint_from_stat(os.fstat(fh.fileno()))
+            except OSError:
+                fingerprint = None
+        return raw, fingerprint
+    except (OSError, json.JSONDecodeError):
+        return {}, None
+
+
+def _atomic_write_config(
+    path: Path, raw: dict[str, Any]
+) -> _ConfigFingerprint | None:
+    """Write ``raw`` atomically and return the written file's fingerprint."""
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f".{path.name}.tmp")
     text = json.dumps(raw, indent=2) + "\n"
     fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    fingerprint = None
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(text)
+            fh.flush()
+            try:
+                fingerprint = _fingerprint_from_stat(os.fstat(fh.fileno()))
+            except OSError:
+                pass
     except Exception:
         tmp.unlink(missing_ok=True)
         raise
     os.replace(tmp, path)
+    return fingerprint
 
 
 def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
@@ -474,8 +517,12 @@ def _persist_credential(path: Path, host: str, cred: OAuthCredential) -> None:
     block = hosts.setdefault(host, {})
     block["apiKey"] = cred.access_token
     block["oauth"] = cred.oauth_block()
-    _atomic_write_config(path, raw)
-    _expiry_cache[(str(path), host)] = (cred.expires_at, cred.access_token)
+    fingerprint = _atomic_write_config(path, raw)
+    _expiry_cache[(str(path), host)] = (
+        cred.expires_at,
+        cred.access_token,
+        fingerprint,
+    )
     _dead_grants.pop((str(path), host), None)
     _refresh_failure_at.pop((str(path), host), None)
 
@@ -500,20 +547,36 @@ def ensure_fresh_token(
     key = (str(path), host)
 
     # Hot path: trust the cached expiry while the token is well clear of the
-    # skew window — no disk read. Bypassed when an explicit ``raw`` is supplied.
+    # skew window and the credential file is unchanged. A stat catches atomic
+    # rotation by another process without parsing JSON on every memory call.
+    # Bypassed when an explicit ``raw`` is supplied.
     if raw is None:
         cached = _expiry_cache.get(key)
-        if cached is not None and now < cached[0] - _REFRESH_SKEW_SECONDS:
+        if (
+            cached is not None
+            and cached[2] is not None
+            and cached[2] == _config_fingerprint(path)
+            and now < cached[0] - _REFRESH_SKEW_SECONDS
+        ):
             return cached[1], False
 
-    source = raw if raw is not None else _read_config(path)
+    if raw is None:
+        source, source_fingerprint = _read_config_snapshot(path)
+    else:
+        # Explicit snapshots are not tied to a verifiable on-disk version, so
+        # never let them enable the normal cache hot path.
+        source, source_fingerprint = raw, None
     block = (source.get("hosts") or {}).get(host) or {}
     cred = OAuthCredential.from_host_block(block)
     if cred is None:
         _expiry_cache.pop(key, None)
         return None, False
 
-    _expiry_cache[key] = (cred.expires_at, cred.access_token)
+    _expiry_cache[key] = (
+        cred.expires_at,
+        cred.access_token,
+        source_fingerprint,
+    )
     if not cred.is_expired(now=now):
         return cred.access_token, False
     if _in_failure_cooldown(key):
@@ -523,9 +586,15 @@ def ensure_fresh_token(
     with _refresh_lock, _config_refresh_lock(path):
         # Re-read under both locks: another thread or process may have just
         # rotated the token — adopt theirs instead of replaying the old one.
-        fresh_block = (_read_config(path).get("hosts") or {}).get(host) or {}
+        fresh_source, fresh_fingerprint = _read_config_snapshot(path)
+        fresh_block = (fresh_source.get("hosts") or {}).get(host) or {}
         current = OAuthCredential.from_host_block(fresh_block) or cred
         if not current.is_expired(now=now):
+            _expiry_cache[key] = (
+                current.expires_at,
+                current.access_token,
+                fresh_fingerprint,
+            )
             return current.access_token, current.access_token != cred.access_token
         if _grant_is_dead(key, current):
             return current.access_token, False
@@ -547,7 +616,8 @@ def force_refresh_token(path: Path, host: str) -> str | None:
     now = time.time()
     key = (str(path), host)
     with _refresh_lock, _config_refresh_lock(path):
-        block = (_read_config(path).get("hosts") or {}).get(host) or {}
+        source, source_fingerprint = _read_config_snapshot(path)
+        block = (source.get("hosts") or {}).get(host) or {}
         cred = OAuthCredential.from_host_block(block)
         if cred is None:
             _expiry_cache.pop(key, None)
@@ -561,7 +631,11 @@ def force_refresh_token(path: Path, host: str) -> str | None:
         cached = _expiry_cache.get(key)
         # Another thread or process already rotated: adopt the newer on-disk token.
         if cached is not None and cred.access_token != cached[1] and not cred.is_expired(now=now):
-            _expiry_cache[key] = (cred.expires_at, cred.access_token)
+            _expiry_cache[key] = (
+                cred.expires_at,
+                cred.access_token,
+                source_fingerprint,
+            )
             return cred.access_token
         rotated = _rotate_and_persist(path, host, key, cred, now=now, op_label="forced refresh")
         if rotated is None:
@@ -614,14 +688,18 @@ def install_grant(
         cred.consent_peer_name = granted_config.get("peerName")
         if apply_config:
             _deep_merge(raw, granted_config)
-    _expiry_cache[(str(path), host)] = (cred.expires_at, cred.access_token)
     _dead_grants.pop((str(path), host), None)
     _refresh_failure_at.pop((str(path), host), None)
     hosts = raw.setdefault("hosts", {})
     block = hosts.setdefault(host, {})
     block["apiKey"] = cred.access_token
     block["oauth"] = cred.oauth_block()
-    _atomic_write_config(path, raw)
+    fingerprint = _atomic_write_config(path, raw)
+    _expiry_cache[(str(path), host)] = (
+        cred.expires_at,
+        cred.access_token,
+        fingerprint,
+    )
     return cred
 
 

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -4,14 +4,17 @@ import importlib.util
 import json
 import os
 import sys
+import threading
 import types
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch, MagicMock
 
 from hermes_cli.profiles import _get_default_hermes_home
 
 import pytest
 
+from plugins.memory.honcho import client as honcho_client
 from plugins.memory.honcho.client import (
     HonchoClientConfig,
     get_honcho_client,
@@ -649,6 +652,214 @@ class TestResetHonchoClient:
         assert mod._honcho_client_slot.peek() is not None
         reset_honcho_client()
         assert mod._honcho_client_slot.peek() is None
+
+
+class TestCachedOAuthRotation:
+    def test_adopts_token_rotated_by_another_process(self, tmp_path, monkeypatch):
+        """A persisted token must rotate the matching cached SDK client."""
+        config_path = tmp_path / "honcho.json"
+        http = types.SimpleNamespace(api_key="hch-at-old")
+        sdk_client = cast(Any, types.SimpleNamespace(_http=http))
+        config = HonchoClientConfig(host="hermes", config_path=config_path)
+
+        ensure = MagicMock(return_value=("hch-at-external", False))
+        monkeypatch.setattr(
+            "plugins.memory.honcho.oauth.ensure_fresh_token",
+            ensure,
+        )
+
+        honcho_client._refresh_cached_oauth(sdk_client, config)
+
+        ensure.assert_called_once_with(config_path, "hermes")
+        assert http.api_key == "hch-at-external"
+
+    def test_does_not_reapply_matching_token(self, tmp_path, monkeypatch):
+        """The normal fresh-token path leaves the cached client untouched."""
+        config_path = tmp_path / "honcho.json"
+        http = types.SimpleNamespace(api_key="hch-at-current")
+        sdk_client = cast(Any, types.SimpleNamespace(_http=http))
+        config = HonchoClientConfig(host="hermes", config_path=config_path)
+        apply = MagicMock(return_value=True)
+
+        monkeypatch.setattr(
+            "plugins.memory.honcho.oauth.ensure_fresh_token",
+            lambda *args, **kwargs: ("hch-at-current", False),
+        )
+        monkeypatch.setattr(
+            "plugins.memory.honcho.oauth.apply_token_to_client",
+            apply,
+        )
+
+        honcho_client._refresh_cached_oauth(sdk_client, config)
+
+        apply.assert_not_called()
+
+    def test_cached_sync_runs_inside_per_identity_lock(self, tmp_path, monkeypatch):
+        """The persisted-token read/compare/apply sequence must be atomic."""
+        config = HonchoClientConfig(
+            host="hermes",
+            api_key="hch-at-old",
+            config_path=tmp_path / "honcho.json",
+        )
+        sdk_client = cast(
+            Any,
+            types.SimpleNamespace(
+                _http=types.SimpleNamespace(api_key="hch-at-old")
+            ),
+        )
+        key = honcho_client._client_cache_key(config)
+        slot = honcho_client._slot_for(key)
+        slot.get(lambda: sdk_client)
+
+        class TrackingLock:
+            active = False
+
+            def __enter__(self):
+                self.active = True
+
+            def __exit__(self, *exc_info):
+                self.active = False
+
+        sync_lock = TrackingLock()
+        monkeypatch.setattr(
+            honcho_client,
+            "_oauth_sync_lock_for",
+            lambda cache_key: sync_lock,
+        )
+
+        def assert_locked(*args):
+            assert sync_lock.active
+
+        monkeypatch.setattr(
+            honcho_client, "_refresh_cached_oauth", assert_locked
+        )
+        try:
+            assert get_honcho_client(config) is sdk_client
+        finally:
+            reset_honcho_client()
+
+    def test_concurrent_sync_cannot_regress_to_older_observation(
+        self, tmp_path, monkeypatch
+    ):
+        """A delayed B observation must not overwrite a later persisted C."""
+        config = HonchoClientConfig(
+            host="hermes",
+            api_key="hch-at-old",
+            config_path=tmp_path / "honcho.json",
+        )
+        http = types.SimpleNamespace(api_key="hch-at-old")
+        sdk_client = cast(Any, types.SimpleNamespace(_http=http))
+        key = honcho_client._client_cache_key(config)
+        honcho_client._slot_for(key).get(lambda: sdk_client)
+
+        ensure_calls = 0
+        ensure_lock = threading.Lock()
+        first_apply_entered = threading.Event()
+        allow_first_apply = threading.Event()
+        second_applied = threading.Event()
+
+        def ensure(*args, **kwargs):
+            nonlocal ensure_calls
+            with ensure_lock:
+                ensure_calls += 1
+                return (f"hch-at-{'B' if ensure_calls == 1 else 'C'}", False)
+
+        def apply(client, token):
+            if token == "hch-at-B":
+                first_apply_entered.set()
+                assert allow_first_apply.wait(timeout=2)
+            client._http.api_key = token
+            if token == "hch-at-C":
+                second_applied.set()
+            return True
+
+        monkeypatch.setattr(
+            "plugins.memory.honcho.oauth.ensure_fresh_token", ensure
+        )
+        monkeypatch.setattr(
+            "plugins.memory.honcho.oauth.apply_token_to_client", apply
+        )
+
+        errors = []
+
+        def acquire_client():
+            try:
+                get_honcho_client(config)
+            except Exception as exc:  # pragma: no cover - asserted below
+                errors.append(exc)
+
+        first = threading.Thread(target=acquire_client)
+        second = threading.Thread(target=acquire_client)
+        try:
+            first.start()
+            assert first_apply_entered.wait(timeout=2)
+            second.start()
+            assert not second_applied.wait(timeout=0.25)
+            allow_first_apply.set()
+            first.join(timeout=2)
+            second.join(timeout=2)
+
+            assert not first.is_alive() and not second.is_alive()
+            assert errors == []
+            assert ensure_calls == 2
+            assert http.api_key == "hch-at-C"
+        finally:
+            allow_first_apply.set()
+            first.join(timeout=2)
+            second.join(timeout=2)
+            reset_honcho_client()
+
+    def test_failed_in_place_rotation_resets_only_matching_slot(
+        self, tmp_path, monkeypatch
+    ):
+        first_config = HonchoClientConfig(
+            host="hermes",
+            api_key="hch-at-first",
+            config_path=tmp_path / "first.json",
+        )
+        second_config = HonchoClientConfig(
+            host="hermes_other",
+            api_key="hch-at-second",
+            config_path=tmp_path / "second.json",
+        )
+        first_client = cast(
+            Any,
+            types.SimpleNamespace(
+                _http=types.SimpleNamespace(api_key="hch-at-first")
+            ),
+        )
+        second_client = cast(
+            Any,
+            types.SimpleNamespace(
+                _http=types.SimpleNamespace(api_key="hch-at-second")
+            ),
+        )
+        first_slot = honcho_client._slot_for(
+            honcho_client._client_cache_key(first_config)
+        )
+        second_slot = honcho_client._slot_for(
+            honcho_client._client_cache_key(second_config)
+        )
+        first_slot.get(lambda: first_client)
+        second_slot.get(lambda: second_client)
+
+        monkeypatch.setattr(
+            "plugins.memory.honcho.oauth.ensure_fresh_token",
+            lambda *args, **kwargs: ("hch-at-replacement", False),
+        )
+        monkeypatch.setattr(
+            "plugins.memory.honcho.oauth.apply_token_to_client",
+            lambda *args, **kwargs: False,
+        )
+        try:
+            honcho_client._refresh_cached_oauth(
+                first_client, first_config, first_slot
+            )
+
+            assert first_slot.peek() is None
+            assert second_slot.peek() is second_client
+        finally:
+            reset_honcho_client()
 
 
 class TestDialecticDepthParsing:

--- a/tests/honcho_plugin/test_oauth.py
+++ b/tests/honcho_plugin/test_oauth.py
@@ -1,6 +1,7 @@
 """Tests for plugins/memory/honcho/oauth.py — OAuth grant storage + refresh."""
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -74,6 +75,89 @@ class TestEnsureFreshToken:
         )
         token, refreshed = oauth.ensure_fresh_token(path, "hermes", now=0)
         assert token == "hch-at-old" and refreshed is False
+
+    def test_fresh_cache_adopts_atomic_out_of_process_rotation(
+        self, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "honcho.json"
+        _write(path, {"hosts": {"hermes": _host_block(expires_at=10_000)}})
+        oauth._expiry_cache.clear()
+        oauth.ensure_fresh_token(path, "hermes", now=0)
+
+        rotated = _host_block(expires_at=20_000)
+        rotated["apiKey"] = "hch-at-external"
+        replacement = tmp_path / "honcho.json.next"
+        _write(replacement, {"hosts": {"hermes": rotated}})
+        replacement.replace(path)
+        monkeypatch.setattr(
+            oauth,
+            "_http_post_form_status",
+            lambda *a, **k: pytest.fail("fresh external token must not refresh again"),
+        )
+
+        token, refreshed = oauth.ensure_fresh_token(path, "hermes", now=100)
+
+        assert token == "hch-at-external" and refreshed is False
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="Windows does not replace a destination while it is open",
+    )
+    def test_config_snapshot_fingerprints_the_opened_file(self, tmp_path, monkeypatch):
+        path = tmp_path / "honcho.json"
+        _write(path, {"version": "opened"})
+        opened_fingerprint = oauth._fingerprint_from_stat(path.stat())
+        replacement = tmp_path / "honcho.json.next"
+        _write(replacement, {"version": "replacement"})
+
+        real_load = oauth.json.load
+
+        def load_then_replace(*args, **kwargs):
+            result = real_load(*args, **kwargs)
+            replacement.replace(path)
+            return result
+
+        monkeypatch.setattr(oauth.json, "load", load_then_replace)
+
+        raw, fingerprint = oauth._read_config_snapshot(path)
+
+        assert raw == {"version": "opened"}
+        assert fingerprint == opened_fingerprint
+        assert fingerprint != oauth._fingerprint_from_stat(path.stat())
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="Windows does not replace a destination while it is open",
+    )
+    def test_rotation_during_config_parse_does_not_cache_stale_token(
+        self, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "honcho.json"
+        _write(path, {"hosts": {"hermes": _host_block(expires_at=10_000)}})
+        rotated = _host_block(expires_at=20_000)
+        rotated["apiKey"] = "hch-at-external"
+        replacement = tmp_path / "honcho.json.next"
+        _write(replacement, {"hosts": {"hermes": rotated}})
+        oauth._expiry_cache.clear()
+
+        real_load = oauth.json.load
+        replaced = False
+
+        def load_then_replace(*args, **kwargs):
+            nonlocal replaced
+            result = real_load(*args, **kwargs)
+            if not replaced:
+                replacement.replace(path)
+                replaced = True
+            return result
+
+        monkeypatch.setattr(oauth.json, "load", load_then_replace)
+
+        first, _ = oauth.ensure_fresh_token(path, "hermes", now=100)
+        second, refreshed = oauth.ensure_fresh_token(path, "hermes", now=100)
+
+        assert first == "hch-at-old"
+        assert second == "hch-at-external" and refreshed is False
 
 
     def test_expired_token_refreshes_and_persists_rotation(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- bind Honcho's OAuth expiry-cache entries to the credential-file version they were parsed from, so an atomic rotation by another process invalidates the local hot-path cache;
- read and fingerprint the same opened config-file version to close the parse/replacement TOCTOU window;
- retain writer fingerprints after local token persistence and grant installation; and
- synchronize each cached SDK client's live Bearer with the persisted token even when this process did not perform the refresh, serializing the read/compare/apply sequence per client identity so an older observation cannot overwrite a newer token.

This is the separate lower-level OAuth follow-up requested in #72761. It stays within `plugins/memory/honcho/oauth.py` plus the existing cached-client synchronization hook; it does not change #72761's gateway/client cache-invalidation boundary, current per-identity client caching, or bound config-path resolution.

## Regression coverage

The deterministic regressions cover:

1. adopting an access token atomically persisted by another process;
2. reading and fingerprinting the same opened credential-file version;
3. reproducing a replacement during JSON parsing without caching the stale token against the replacement file; and
4. synchronizing an already-cached SDK client with the persisted token when `ensure_fresh_token()` reports that no local refresh occurred.

Additional regressions cover concurrent B→C ordering, matching-token no-op behavior, and isolation when a failed in-place update resets one identity's client slot.

## Validation

- `scripts/run_tests.sh tests/honcho_plugin/test_oauth.py tests/honcho_plugin/test_client.py tests/honcho_plugin/test_client_identity_isolation.py -q` — 83 passed
- `scripts/run_tests.sh tests/honcho_plugin -q -k 'not test_cache_busting_signature_reflects_pin_peer_name'` — 337 passed
- concurrent stale-observation regression — 20/20 repeated passes
- unfiltered Honcho suite — 337 passed, 1 pre-existing current-`main` failure in `test_cache_busting_signature_reflects_pin_peer_name`; reproduced unchanged on a pristine `origin/main` worktree
- Focused Ruff — passed
- Ruff/Ty diff against `origin/main` — no new diagnostics
- `git diff --check` — passed

## Scope note

This PR does not address the separate synthetic comparison-time/expiry-mint-time behavior in `_exchange_refresh_token()`.
