### PR TITLE
fix(desktop): declare repository so electron-builder detects it in workspace builds

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,6 +5,10 @@
   "version": "0.17.0",
   "description": "Native desktop shell for Hermes Agent.",
   "author": "Nous Research",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NousResearch/Hermes-Agent.git"
+  },
   "type": "module",
   "main": "dist/electron-main.mjs",
   "engines": {


### PR DESCRIPTION
## Bug Description

`hermes desktop` fails during packaging with:

```
⨯ Cannot detect repository by .git/config. Please specify "repository" in the package.json
```

This happens on any build from a git checkout of the monorepo (npm workspace layout).

## Root Cause

electron-builder 26.15.x resolves the repository for the auto-update publish config from `packager.repositoryInfo` (app-builder-lib `util/repositoryInfo.js`). It falls back to reading `.git/config` relative to the builder's projectDir — which in an npm workspace is `apps/desktop/.git/config`, and that file does not exist (the `.git` dir lives at the workspace root). Since `apps/desktop/package.json` declares no `repository` field, the resolution returns null and `getAppUpdatePublishConfiguration` throws (PublishManager.ts, `errorIfCannot=true` path) even for a local `--dir` build.

## Fix

Declare the `repository` in `apps/desktop/package.json` (same URL the root package.json already uses). hosted-git-info parses it and the publish config resolves; nothing is published from a local `--dir` build, so this only satisfies the detection.

## How to Verify

1. `git clone` the repo (fresh checkout, not a published tarball)
2. `cd apps/desktop && npm install` (or workspace install at root)
3. `npm run pack -- --dir` (or `hermes desktop --force-build`)
4. Before: fails with `Cannot detect repository by .git/config`; after: packaging completes and the app launches

## Test Plan

- [ ] No new test added — build-time config fix, verified manually (packaging completes, app launches)
- [ ] Existing tests still pass (no code change)
- [x] Manual verification of the fix

## Risk Assessment

Low — declarative metadata only; no runtime code path changes. The field matches the root package.json's repository URL. Blast radius is limited to electron-builder's publish-config resolution during packaging.