### PR TITLE
fix(computer_use): stop approval failing open when no CLI callback is wired

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1692,6 +1692,25 @@ def _isolate_computer_use_approval_state():
         pass
 
 
+@pytest.fixture
+def approve_computer_use():
+    """Approve computer_use destructive actions for this test.
+
+    A destructive action with no approval callback registered no longer
+    defaults to allow: ``_request_approval`` routes it to
+    ``tools.approval.request_tool_approval``, which fails closed when no
+    human is present — which is every pytest run. Request this fixture in
+    tests that exercise dispatch/plumbing rather than the gate itself, so
+    the approval is stated at the call site instead of being an accident of
+    the default. Cleared by ``_isolate_computer_use_approval_state`` above.
+    """
+    from tools.computer_use import tool as _cu_tool
+
+    _cu_tool.set_approval_callback(lambda action, args, summary: "approve_once")
+
+    return _cu_tool
+
+
 @pytest.fixture(autouse=True)
 def _moa_caches_isolated():
     """Clear module-level MoA cold-start caches before each test.

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -102,7 +102,7 @@ class TestDispatch:
         assert "error" in parsed
 
 
-    def test_type_action_routes_to_type_text_backend(self, noop_backend):
+    def test_type_action_routes_to_type_text_backend(self, noop_backend, approve_computer_use):
         """type action must call backend.type_text, not type_text_chars (issue #24170, bug 3)."""
         from tools.computer_use.tool import handle_computer_use
         out = handle_computer_use({"action": "type", "text": "hello"})
@@ -113,7 +113,7 @@ class TestDispatch:
         type_kw = next(c[1] for c in noop_backend.calls if c[0] == "type")
         assert type_kw["text"] == "hello"
 
-    def test_drag_action_routes_to_backend_by_element(self, noop_backend):
+    def test_drag_action_routes_to_backend_by_element(self, noop_backend, approve_computer_use):
         """drag action must dispatch to backend.drag with element indices (issue #24170, bug 4)."""
         from tools.computer_use.tool import handle_computer_use
         out = handle_computer_use({
@@ -142,7 +142,7 @@ class TestDispatch:
             "mode": "ax", "app": None, "pid": 23502, "window_id": 58720504,
         }
 
-    def test_capture_after_skipped_when_action_failed(self, noop_backend):
+    def test_capture_after_skipped_when_action_failed(self, noop_backend, approve_computer_use):
         """capture_after must not fire when res.ok=False (regression guard).
 
         A follow-up screenshot after a failed action shows the screen in a
@@ -205,7 +205,7 @@ class TestSafetyGuards:
             assert "error" in parsed, keys
             assert "blocked key combo" in parsed["error"], keys
 
-    def test_safe_key_combos_pass(self, noop_backend):
+    def test_safe_key_combos_pass(self, noop_backend, approve_computer_use):
         # Non-destructive combos, including hyphen notation and the literal '-'
         # zoom key, must not be caught by the widened separator.
         from tools.computer_use.tool import handle_computer_use
@@ -213,7 +213,7 @@ class TestSafetyGuards:
             parsed = json.loads(handle_computer_use({"action": "key", "keys": keys}))
             assert "error" not in parsed, keys
 
-    def test_type_with_empty_string_is_allowed(self, noop_backend):
+    def test_type_with_empty_string_is_allowed(self, noop_backend, approve_computer_use):
         from tools.computer_use.tool import handle_computer_use
         out = handle_computer_use({"action": "type", "text": ""})
         parsed = json.loads(out)
@@ -799,7 +799,7 @@ class TestCaptureAfterAppContext:
     the preceding capture/focus_app call, rather than the frontmost window.
     """
 
-    def test_capture_after_uses_last_app(self):
+    def test_capture_after_uses_last_app(self, approve_computer_use):
         """capture_after=True should pass _last_app to the follow-up capture."""
         from tools.computer_use.backend import ActionResult, CaptureResult
         from tools.computer_use import tool as cu_tool
@@ -865,7 +865,7 @@ class TestCaptureAfterAppContext:
             f"Expected follow-up capture with app='Calculator', got {captured_app_args[0]!r}"
         )
 
-    def test_capture_after_without_prior_app_uses_none(self):
+    def test_capture_after_without_prior_app_uses_none(self, approve_computer_use):
         """When no app context is set, follow-up capture uses app=None (frontmost)."""
         from tools.computer_use.backend import ActionResult, CaptureResult
         from tools.computer_use import tool as cu_tool

--- a/tests/tools/test_computer_use_approval_isolation.py
+++ b/tests/tools/test_computer_use_approval_isolation.py
@@ -6,8 +6,8 @@ stores are module-globals. Without the autouse reset fixture in
 changes the behavior of every later computer-use test in the process:
 a raising callback becomes ``verdict = "deny"`` (dispatch tests see an
 empty backend call list), a blocking callback hangs the run. The pair
-below simulates the forgetful test and asserts the next test still sees
-default-allow behavior.
+below simulates the forgetful test and asserts the next test starts with
+no callback installed.
 """
 
 import json
@@ -59,12 +59,25 @@ def test_a_forgets_a_poisoned_approval_callback():
     # no reset — the autouse fixture must clean this up
 
 
-def test_b_still_dispatches_with_default_allow():
-    """Without the isolation fixture this fails: the stale callback raises
-    (arity), ``_request_approval`` converts that into a deny, and the
-    backend never sees the click."""
+def test_b_starts_from_a_cleared_approval_callback():
+    """Without the isolation fixture this fails on the first assert: the
+    stale callback from test A is still installed.
+
+    The leak is asserted directly rather than inferred from the dispatch
+    outcome. It used to be inferrable, because a missing callback meant
+    default-allow and a leaked one meant deny — but a missing callback now
+    routes to ``tools.approval.request_tool_approval``, which fails closed
+    under pytest, so both states block the click and the outcome no longer
+    tells them apart. The dispatch half is kept below (under a callback this
+    test installs itself, AFTER the assert) so the file still exercises the
+    path the fixture protects."""
     from tools.computer_use import tool as cu_tool
 
+    assert cu_tool._approval_callback is None, (
+        "test A's approval callback leaked past the isolation fixture"
+    )
+
+    cu_tool.set_approval_callback(lambda action, args, summary: "approve_once")
     backend = _install_backend(cu_tool)
     result = cu_tool.handle_computer_use({"action": "click", "element": 3})
     call_names = [c[0] for c in backend.calls]

--- a/tests/tools/test_computer_use_delivery_ladder.py
+++ b/tests/tools/test_computer_use_delivery_ladder.py
@@ -220,7 +220,7 @@ def test_bad_delivery_mode_rejected():
     assert res.code == "bad_delivery_mode"
 
 
-def test_dispatcher_threads_delivery_mode_to_backend():
+def test_dispatcher_threads_delivery_mode_to_backend(approve_computer_use):
     """End-to-end through the tool dispatcher with the noop backend."""
     from tools.computer_use import tool as cu
     with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "noop"}, clear=False):

--- a/tests/tools/test_computer_use_headless_approval.py
+++ b/tests/tools/test_computer_use_headless_approval.py
@@ -1,0 +1,276 @@
+"""computer_use must not fail open when no CLI approval callback is wired.
+
+``_request_approval`` used to ``return None`` (allow) whenever
+``_approval_callback`` was unset, on the reasoning that "Gateway approval is
+handled one layer out via the normal tool-approval infra". Nothing routes
+``computer_use`` into that infra: ``ToolRegistry.dispatch`` calls the handler
+directly, ``model_tools``' pre-dispatch hook covers ACP *edit* approval only,
+and ``tools.approval``'s own gate is command-shaped, so it never sees a tool
+call that carries no command string. The only reachable path into
+``request_tool_approval`` is a plugin ``pre_tool_call`` rule naming the tool,
+which the default install does not have (issue #87724).
+
+So every non-CLI entry point — gateway, cron, ``-q``, a bare script — could
+click, drag, type and raise windows on a real desktop with no human asked.
+These tests pin the routed behavior at the dispatch level rather than against
+the callback, since the callback is exactly the thing that is absent in the
+contexts that matter.
+"""
+
+import json
+
+import pytest
+
+import tools.approval as approval
+
+
+@pytest.fixture(autouse=True)
+def _isolate_approval_state(monkeypatch):
+    """Clean session key, empty allowlists, no yolo, no thread callback.
+
+    Mirrors ``tests/tools/test_request_tool_approval.py`` so both entry
+    points into the shared gate are set up identically.
+    """
+    monkeypatch.setattr(
+        approval, "get_current_session_key",
+        lambda default="default": "test-session",
+    )
+    monkeypatch.setattr(approval, "is_approved", lambda sk, pk: False)
+    monkeypatch.setattr(approval, "is_current_session_yolo_enabled", lambda: False)
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False, raising=False)
+    monkeypatch.setattr(
+        "tools.terminal_tool._get_approval_callback", lambda: None, raising=False
+    )
+    yield
+
+
+def _headless(monkeypatch):
+    """No interactive CLI, no gateway, no cron: the bare-script context."""
+    monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+    monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+    monkeypatch.setattr(approval, "_is_cron_approval_context", lambda: False)
+    monkeypatch.setattr(
+        approval, "_is_single_query_approval_context", lambda: False, raising=False
+    )
+
+
+class _RecordingBackend:
+    """Minimal backend that records the calls it is asked to make."""
+
+    def __init__(self):
+        self.calls = []
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def is_available(self):
+        return True
+
+    def click(self, **kw):
+        from tools.computer_use.backend import ActionResult
+
+        self.calls.append(("click", kw))
+
+        return ActionResult(ok=True, action="click")
+
+
+@pytest.fixture
+def backend():
+    from tools.computer_use import tool as cu_tool
+
+    be = _RecordingBackend()
+    cu_tool.reset_backend_for_tests()
+    cu_tool._backend = be
+    yield be
+    cu_tool.reset_backend_for_tests()
+
+
+def _click(args=None):
+    """Dispatch a click the way the model does: through the registry."""
+    import tools.computer_use_tool  # noqa: F401  (registers the tool)
+    from tools.registry import registry
+
+    payload = {"action": "click", "element": 3}
+    payload.update(args or {})
+    out = registry.dispatch("computer_use", payload)
+
+    return json.loads(out) if isinstance(out, str) else out
+
+
+def test_registry_dispatch_is_gated_when_no_human_is_present(backend, monkeypatch):
+    """The reported bug, at the layer the reporter checked.
+
+    Nothing between the model and ``handle_computer_use`` asks anyone, so if
+    this dispatch reaches the backend, the click happened on a real desktop
+    with nobody consulted.
+    """
+    _headless(monkeypatch)
+
+    parsed = _click()
+
+    assert [name for name, _ in backend.calls] == [], (
+        "a destructive action reached the backend with no approval callback "
+        "registered and no human present to approve it"
+    )
+    assert "error" in parsed
+    assert "approval" in parsed["error"].lower() or "BLOCKED" in parsed["error"]
+
+
+def test_cron_deny_mode_blocks_the_click(backend, monkeypatch):
+    """Parity with dangerous shell commands, which cron_mode already governs."""
+    _headless(monkeypatch)
+    monkeypatch.setattr(approval, "_is_cron_approval_context", lambda: True)
+    monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "deny")
+
+    parsed = _click()
+
+    assert [name for name, _ in backend.calls] == []
+    assert "cron" in parsed["error"].lower()
+
+
+def test_cron_approve_mode_allows_the_click(backend, monkeypatch):
+    """The other half of the same knob: an operator who opted in still runs.
+
+    Worth pinning next to the deny case, because a fail-closed change that
+    also broke ``cron_mode: approve`` would look correct from the deny test
+    alone.
+    """
+    _headless(monkeypatch)
+    monkeypatch.setattr(approval, "_is_cron_approval_context", lambda: True)
+    monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "approve")
+
+    parsed = _click()
+
+    assert [name for name, _ in backend.calls] == ["click"]
+    assert "error" not in parsed
+
+
+def test_gateway_context_queues_a_pending_approval(backend, monkeypatch):
+    """The behavior the old comment promised but nothing delivered.
+
+    With no notify callback attached (an API-server session with no chat
+    surface), the shared gate queues the action for ``/approve`` review
+    instead of running it.
+    """
+    _headless(monkeypatch)
+    monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+    submitted = []
+    monkeypatch.setattr(
+        approval, "submit_pending",
+        lambda session_key, data: submitted.append((session_key, data)),
+    )
+
+    _click()
+
+    assert [name for name, _ in backend.calls] == []
+    assert submitted, "the gateway never saw the action it was said to gate"
+    assert submitted[0][1]["pattern_key"] == (
+        "plugin_rule:computer_use:click:background"
+    )
+
+
+def test_foreground_keeps_its_own_approval_scope(backend, monkeypatch):
+    """#67052's separation must survive the trip through the shared gate.
+
+    A background approval must not silently authorize the foreground form of
+    the same action, so the two have to reach ``request_tool_approval`` under
+    different allowlist keys.
+    """
+    _headless(monkeypatch)
+    monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+    submitted = []
+    monkeypatch.setattr(
+        approval, "submit_pending",
+        lambda session_key, data: submitted.append(data["pattern_key"]),
+    )
+
+    _click()
+    _click({"delivery_mode": "foreground"})
+
+    assert submitted == [
+        "plugin_rule:computer_use:click:background",
+        "plugin_rule:computer_use:click:foreground",
+    ]
+
+
+def test_bring_to_front_is_gated_separately_from_the_input(backend, monkeypatch):
+    """``focus_app(raise_window=True)`` takes the second rung.
+
+    It is the rung most obviously wrong to auto-allow headlessly: a visible
+    focus change with, by definition, nobody watching the screen. The input
+    rung is pre-approved here so the run actually reaches the second one.
+    """
+    _headless(monkeypatch)
+    monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+    monkeypatch.setattr(
+        approval, "is_approved",
+        lambda sk, pk: pk == "plugin_rule:computer_use:focus_app:background",
+    )
+    submitted = []
+    monkeypatch.setattr(
+        approval, "submit_pending",
+        lambda session_key, data: submitted.append(data["pattern_key"]),
+    )
+
+    import tools.computer_use_tool  # noqa: F401
+    from tools.registry import registry
+
+    registry.dispatch(
+        "computer_use", {"action": "focus_app", "app": "Mail", "raise_window": True}
+    )
+
+    assert submitted == ["plugin_rule:computer_use:bring_to_front:background"], (
+        "raising a window inherited the input approval instead of taking its "
+        "own rung"
+    )
+
+
+def test_yolo_still_bypasses_the_gate(backend, monkeypatch):
+    """No change for a user who explicitly opted into unattended operation."""
+    _headless(monkeypatch)
+    monkeypatch.setattr(approval, "is_current_session_yolo_enabled", lambda: True)
+
+    parsed = _click()
+
+    assert [name for name, _ in backend.calls] == ["click"]
+    assert "error" not in parsed
+
+
+def test_registered_cli_callback_path_is_unchanged(backend, monkeypatch):
+    """The interactive CLI is untouched: its callback still decides.
+
+    ``request_tool_approval`` is only consulted on the branch that used to
+    return None, so a denial here must still come back as the callback's
+    verdict and never reach the shared gate.
+    """
+    from tools.computer_use import tool as cu_tool
+
+    _headless(monkeypatch)
+    monkeypatch.setattr(
+        approval, "request_tool_approval",
+        lambda *a, **k: pytest.fail("registered callback must decide on its own"),
+    )
+    cu_tool.set_approval_callback(lambda action, args, summary: "deny")
+
+    parsed = _click()
+
+    assert [name for name, _ in backend.calls] == []
+    assert parsed["error"] == "denied by user"
+
+
+def test_gate_failure_is_not_consent(backend, monkeypatch):
+    """An approval gate that cannot run must block, not shrug and continue."""
+    _headless(monkeypatch)
+
+    def _explode(*a, **k):
+        raise RuntimeError("approval store unreadable")
+
+    monkeypatch.setattr(approval, "request_tool_approval", _explode)
+
+    parsed = _click()
+
+    assert [name for name, _ in backend.calls] == []
+    assert "approval gate unavailable" in parsed["error"]

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -569,9 +569,12 @@ def _request_approval(action: str, args: Dict[str, Any],
             return None
     cb = _approval_callback
     if cb is None:
-        # No CLI approval wired — default allow. Gateway approval is handled
-        # one layer out via the normal tool-approval infra.
-        return None
+        # No CLI callback registered. Nothing upstream gates computer_use by
+        # name — ToolRegistry.dispatch calls the handler directly, and
+        # model_tools' pre-dispatch hook only covers ACP *edit* approval — so
+        # returning None here is the whole decision, not a deferral to another
+        # layer. Route it to the generic human gate instead.
+        return _request_generic_approval(action, args, scope_key)
     summary = _summarize_action(action, args)
     try:
         verdict = cb(action, args, summary)
@@ -595,6 +598,53 @@ def _request_approval(action: str, args: Dict[str, Any],
             "action": action,
         })
     return json.dumps({"error": "denied by user", "action": action})
+
+
+def _request_generic_approval(action: str, args: Dict[str, Any],
+                              scope_key: Tuple[str, str]) -> Optional[str]:
+    """Gate a destructive action through the shared human-approval gate.
+
+    Reached only when no CLI approval callback is registered, which is every
+    non-CLI entry point: the gateway, cron jobs, ``-q`` single-query runs and
+    bare scripts. ``request_tool_approval`` is the same gate a plugin
+    ``pre_tool_call`` escalation uses, so computer_use inherits the policy it
+    already implements rather than inventing a second one: yolo bypasses,
+    the gateway submits a pending approval and waits, cron honors
+    ``approvals.cron_mode``, ``-q`` honors ``approvals.single_query_mode``,
+    and any other context with no human present fails CLOSED.
+
+    ``rule_key`` carries this call's approval scope, so the ``[a]lways``
+    allowlist has the same grain as the in-process ``_always_allow`` set: an
+    unlock for a background click does not silently cover the foreground form
+    of the same action (#67052), and the separate ``bring_to_front`` rung
+    stays separate.
+    """
+    # Call-time import: tools.approval reaches back into tools.computer_use
+    # (release_computer_use_session), so keep the edge one-directional at
+    # import time.
+    from tools.approval import request_tool_approval
+
+    summary = _summarize_action(action, args)
+    try:
+        verdict = request_tool_approval(
+            "computer_use",
+            f"desktop control: {summary}",
+            rule_key=f"computer_use:{scope_key[0]}:{scope_key[1]}",
+        )
+    except Exception as e:
+        # Fail closed. An approval gate that cannot run is not consent, and
+        # this branch only executes where no human is watching the screen.
+        logger.warning("computer_use approval gate unavailable: %s", e)
+        return json.dumps({
+            "error": f"approval gate unavailable, refusing to act: {e}",
+            "action": action,
+        })
+    if verdict.get("approved"):
+        return None
+    return json.dumps({
+        "error": verdict.get("message") or "denied by user",
+        "action": action,
+    })
 
 
 def _summarize_action(action: str, args: Dict[str, Any]) -> str:


### PR DESCRIPTION
## What does this PR do?

`computer_use`'s destructive-action gate failed open whenever no CLI approval callback was registered:

```python
    cb = _approval_callback
    if cb is None:
        # No CLI approval wired — default allow. Gateway approval is handled
        # one layer out via the normal tool-approval infra.
        return None
```

The second sentence is what makes this safe, and it is not true by default. The chain, checked against `56526bc0d`:

1. The generic per-tool human gate is `tools.approval.request_tool_approval`. Its only non-test caller is `hermes_cli/plugins.py:2522`, reached when a plugin `pre_tool_call` hook returns `{"action": "approve"}`.
2. `ToolRegistry.dispatch` calls `entry.handler(args, **kwargs)` with no approval step of its own.
3. `model_tools.py`'s pre-dispatch path gates ACP *edit* approval (`maybe_require_edit_approval`, file mutations only) and sets approval observability context. There is no tool-name-keyed check for `computer_use`.
4. `tools/approval.py`'s own gate is command-shaped (`detect_hardline_command`, `check_dangerous_command`, `_SENSITIVE_WRITE_TARGET`). `computer_use` never presents a command string to it.

So the "one layer out" protection exists, but nothing routes `computer_use` into it. An operator who installed a plugin rule naming the tool is covered; a default install is not. Every non-CLI entry point (gateway, cron, `-q`, a bare script) could click, drag, type and press keys on a real desktop with nobody asked.

**The `bring_to_front` rung goes with it, and that is the part worth a second look.** #67052 deliberately keeps persistent focus in a *separate* approval scope from the input itself, on the reasoning that a background approval must not silently authorize a visible focus change. Both rungs call `_request_approval`, so with no callback both returned `None`: the distinction that issue paid for was absent precisely where nobody is watching the screen.

### The fix

The `cb is None` branch now calls `request_tool_approval` instead of returning `None`. This makes the existing comment true rather than replacing it with a new policy, and `computer_use` inherits the contexts that function already handles:

| context | before | after |
|---|---|---|
| interactive CLI (callback registered) | callback decides | unchanged, this branch is not reached |
| `--yolo` | allowed | allowed (the shared gate bypasses first) |
| gateway | **allowed silently** | notify round-trip, or a pending approval for `/approve` |
| cron | **allowed silently** | honors `approvals.cron_mode` |
| `-q` single query | **allowed silently** | honors `approvals.single_query_mode` |
| bare script / SDK embed | **allowed silently** | fails closed |

`rule_key` carries the existing `(action, delivery_mode)` scope key, so the `[a]lways` allowlist keeps exactly the grain `_always_allow` already had: an unlock for a background click does not cover the foreground form, and `bring_to_front` stays on its own rung.

**The one thing that changes for existing users**, flagged deliberately rather than buried: a gateway session that used to run `computer_use` headlessly now waits on a pending approval. That is what a dangerous shell command already does in the same context, so I believe it is the right default, but it is a behavior change and a maintainer may want a different call for the gateway specifically. Happy to gate it on a config key instead if you prefer.

### About the existing tests

Seven existing tests dispatched a destructive action and relied on this fail-open to reach the backend. They assert dispatch *plumbing* (does `type` route to `type_text`, does `delivery_mode` thread through), not approval policy, so they now request a small `approve_computer_use` fixture. That states the approval at the call site instead of inheriting it from a default, which is the point.

`tests/tools/test_computer_use_approval_isolation.py` needed a real rethink rather than a fixture. It inferred "did a callback leak?" from the dispatch outcome: no callback meant allow, a leaked broken one meant deny. Both states block now, so the outcome no longer distinguishes them and the test would have passed for the wrong reason. It asserts the cleared callback directly, then installs its own callback to keep exercising the dispatch path the fixture protects.

## Related Issue

Fixes #87724

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/computer_use/tool.py`: the `cb is None` branch calls the new `_request_generic_approval`, which routes to `tools.approval.request_tool_approval` with the call's scope as `rule_key`, maps the verdict back to the tool's error contract, and fails closed if the gate itself raises. Call-time import, since `tools.approval` already reaches back into `tools.computer_use` for `release_computer_use_session`.
- `tests/tools/test_computer_use_headless_approval.py`: new, 9 tests.
- `tests/conftest.py`: `approve_computer_use` fixture (opt-in, not autouse), next to the existing computer-use approval isolation fixture.
- `tests/tools/test_computer_use.py`, `test_computer_use_delivery_ladder.py`: 6 dispatch tests request that fixture.
- `tests/tools/test_computer_use_approval_isolation.py`: asserts the cleared callback directly, per above.

## How to Test

```
pytest tests/tools/test_computer_use_headless_approval.py -q
```

6 of the 9 fail on `main`, all with the same shape: the click reaches the recording backend.

```
AssertionError: assert ['click'] == []
```

The other 3 pass on `main` on purpose, since they are the non-regression guards (`cron_mode: approve` still runs, `--yolo` still bypasses, a registered CLI callback still decides on its own and never reaches the shared gate).

Verified on Windows 11 with the venv interpreter:

- `tests/tools/test_computer_use.py`, `test_computer_use_approval_isolation.py`, `test_computer_use_delivery_ladder.py`, `test_computer_use_cua_0_9.py`, `test_computer_use_headless_approval.py`, `test_approval.py`, `test_request_tool_approval.py`, `tests/acp/test_approval_isolation.py`: **264 passed, 5 failed**, and all 5 fail identically on clean `upstream/main` on this host (`test_cua_driver_cmd_env_override_is_resolved_dynamically`, `test_cli_fallback_reads_screenshot_from_file`, `test_linux_default_capture_skips_gnome_shell_helper`, and 2 in `TestDetectDangerousRm`).
- `tests/computer_use/` plus the other 12 `test_computer_use_*` files and `test_zombie_process_cleanup.py`: **169 passed**, 3 pre-existing failures (2 WSL manifest, 1 `signal.SIGKILL` on Windows). `test_timed_out_child_keeps_relay_session_until_its_turn_exits` is order-dependent and fails on clean `main` in the same subset, so it is not from this change.
- `ruff check` clean. `ruff format --diff` wants to explode the two-argument-per-line `monkeypatch.setattr(...)` calls in the new test file, but the neighbouring `tests/tools/test_request_tool_approval.py` has 28 of the same hunks against it, so I matched the local idiom rather than making the new file look unlike the file it mirrors. Say the word if you would rather have it formatted.
- `scripts/check-windows-footguns.py --all` clean (973 files).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate <!-- #81668 moves _approval_callback to a ContextVar and does not touch the `cb is None` branch, so the two should not collide; whichever lands second wants a trivial rebase -->
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass <!-- the affected suites, listed above, with every failure shown to be pre-existing on this host -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- the stale comment this issue is about is replaced with an accurate one, and the new helper carries the policy in its docstring -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A <!-- no new keys; this reuses approvals.cron_mode / approvals.single_query_mode -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- no platform-specific code paths touched -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A <!-- the schema is unchanged; the gate is not model-visible except through the denial message -->
