### PR TITLE
fix(gateway): flush an adapter's pending messages even when the teardown budget cuts the drain

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6960,6 +6960,18 @@ class BasePlatformAdapter(ABC):
         (typing-task cleanup, on_processing_complete hook) can't stall the
         whole shutdown path.  Stragglers are released from our tracking and
         allowed to finish unwinding on their own.
+
+        The settle tail runs in a ``finally`` so a cancellation landing
+        anywhere in the drain above can NEVER skip it.  The caller
+        (``GatewayRunner._bounded_adapter_teardown`` via
+        ``_await_adapter_cleanup_with_timeout``) cancels this coroutine
+        outright once its per-adapter budget
+        (``HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT``, default 5s) expires,
+        so without the ``finally`` the #72680 flush below never runs and a
+        queued follow-up is lost with no on-disk recovery copy.  The tail is
+        deliberately await-free: awaiting during cancellation would raise
+        immediately and re-truncate it.  ``CancelledError`` is not caught, so
+        cancellation still propagates to the caller.
         """
         # Loop until no new tasks appear.  Without this, a message
         # arriving during the `await asyncio.gather` below would spawn
@@ -6971,45 +6983,47 @@ class BasePlatformAdapter(ABC):
         # until it completes on its own.  Retrying the drain until the
         # task set stabilizes closes the window.
         MAX_DRAIN_ROUNDS = 5
-        for _ in range(MAX_DRAIN_ROUNDS):
-            tasks = [task for task in self._background_tasks if not task.done()]
-            if not tasks:
-                break
-            for task in tasks:
-                self._expected_cancelled_tasks.add(task)
-                task.cancel()
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(
-                        *(asyncio.shield(t) for t in tasks),
-                        return_exceptions=True,
-                    ),
-                    timeout=5.0,
-                )
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "[%s] %d background task(s) did not exit within 5s; "
-                    "releasing tracking and letting them unwind in the background",
-                    self.name, len([t for t in tasks if not t.done()]),
-                )
-                break
-            # Loop: late-arrival tasks spawned during the gather above
-            # will be in self._background_tasks now.  Re-check.
-        self._background_tasks.clear()
-        self._expected_cancelled_tasks.clear()
-        self._session_tasks.clear()
-        # Flush pending messages to disk before clearing (#72680).
         try:
-            from gateway.shutdown_flush import flush_pending_to_file
-            flush_pending_to_file(self._pending_messages, reason="adapter_shutdown")
-        except Exception:
-            pass
-        self._pending_messages.clear()
-        self._active_sessions.clear()
-        for state in list(self._text_debounce_store().values()):
-            if state.task is not None and not state.task.done():
-                state.task.cancel()
-        self._text_debounce_store().clear()
+            for _ in range(MAX_DRAIN_ROUNDS):
+                tasks = [task for task in self._background_tasks if not task.done()]
+                if not tasks:
+                    break
+                for task in tasks:
+                    self._expected_cancelled_tasks.add(task)
+                    task.cancel()
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(
+                            *(asyncio.shield(t) for t in tasks),
+                            return_exceptions=True,
+                        ),
+                        timeout=5.0,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "[%s] %d background task(s) did not exit within 5s; "
+                        "releasing tracking and letting them unwind in the background",
+                        self.name, len([t for t in tasks if not t.done()]),
+                    )
+                    break
+                # Loop: late-arrival tasks spawned during the gather above
+                # will be in self._background_tasks now.  Re-check.
+        finally:
+            self._background_tasks.clear()
+            self._expected_cancelled_tasks.clear()
+            self._session_tasks.clear()
+            # Flush pending messages to disk before clearing (#72680).
+            try:
+                from gateway.shutdown_flush import flush_pending_to_file
+                flush_pending_to_file(self._pending_messages, reason="adapter_shutdown")
+            except Exception:
+                pass
+            self._pending_messages.clear()
+            self._active_sessions.clear()
+            for state in list(self._text_debounce_store().values()):
+                if state.task is not None and not state.task.done():
+                    state.task.cancel()
+            self._text_debounce_store().clear()
 
     def has_pending_interrupt(self, session_key: str) -> bool:
         """Check if there's a pending interrupt for a session."""

--- a/tests/gateway/test_cancel_background_drain.py
+++ b/tests/gateway/test_cancel_background_drain.py
@@ -229,6 +229,65 @@ async def test_cancellation_still_propagates_to_caller(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_timely_teardown_flushes_pending_exactly_once(tmp_path, monkeypatch):
+    """Moving the tail into a finally must not double-flush the timely path.
+
+    A clean teardown already flushed correctly before this change (#72680);
+    guard that it still writes exactly one payload per pending slot.
+    """
+    flush_dir = _redirect_flush_dir(tmp_path, monkeypatch)
+    adapter = _make_adapter()
+    sk = build_session_key(
+        SessionSource(platform=Platform.TELEGRAM, chat_id="42", chat_type="dm")
+    )
+    adapter._pending_messages[sk] = _event("queued follow-up")
+
+    await adapter.cancel_background_tasks()
+
+    payloads = _flushed_payloads(flush_dir)
+    assert len(payloads) == 1
+    assert payloads[0]["data"]["text"] == "queued follow-up"
+    assert adapter._pending_messages == {}
+    assert adapter._active_sessions == {}
+    assert adapter._background_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_second_teardown_pass_after_cancellation_is_safe(tmp_path, monkeypatch):
+    """A retried teardown after a cancelled pass must not raise or re-flush.
+
+    ``_bounded_adapter_teardown`` keeps making forward progress after a
+    timeout, so the adapter can see a second cleanup call.  The first pass
+    already drained the pending slots, so the second must be a no-op.
+    """
+    flush_dir = _redirect_flush_dir(tmp_path, monkeypatch)
+    adapter = _make_adapter()
+    sk = build_session_key(
+        SessionSource(platform=Platform.TELEGRAM, chat_id="42", chat_type="dm")
+    )
+    adapter._pending_messages[sk] = _event("queued follow-up")
+
+    resume = asyncio.Event()
+    draining, stubborn_task = await _stall_until_drain(adapter, resume)
+
+    cancel_task = asyncio.create_task(adapter.cancel_background_tasks())
+    await asyncio.wait_for(draining.wait(), timeout=1.0)
+    cancel_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancel_task
+
+    assert len(_flushed_payloads(flush_dir)) == 1
+
+    resume.set()
+    await asyncio.gather(stubborn_task, return_exceptions=True)
+
+    # Second pass: nothing left to flush, and it must complete cleanly.
+    await adapter.cancel_background_tasks()
+    assert len(_flushed_payloads(flush_dir)) == 1
+    assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
 async def test_cancel_background_tasks_handles_no_tasks():
     """Regression guard: no tasks, no hang, no error."""
     adapter = _make_adapter()

--- a/tests/gateway/test_cancel_background_drain.py
+++ b/tests/gateway/test_cancel_background_drain.py
@@ -9,6 +9,7 @@ untracked against a disconnecting adapter.
 """
 
 import asyncio
+import json
 from unittest.mock import AsyncMock
 
 import pytest
@@ -116,6 +117,115 @@ async def test_cancel_background_tasks_drains_late_arrivals():
         "the re-drain loop is missing and the task leaked"
     )
     assert adapter._background_tasks == set()
+
+
+def _redirect_flush_dir(tmp_path, monkeypatch):
+    """Point the #72680 pending-message spool at a temp dir."""
+    flush_dir = tmp_path / "pending_messages"
+    flush_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr("gateway.shutdown_flush._get_flush_dir", lambda: flush_dir)
+    return flush_dir
+
+
+def _flushed_payloads(flush_dir):
+    return [
+        json.loads(p.read_text(encoding="utf-8"))
+        for p in sorted(flush_dir.glob("*.json"))
+    ]
+
+
+async def _stall_until_drain(adapter, resume):
+    """Add a background task that resists cancellation until ``resume`` is set.
+
+    Returns an Event that fires once the task has entered its cancellation
+    handler — i.e. once ``cancel_background_tasks`` is parked in the drain
+    ``wait_for``, which is the exact window the teardown budget expires in.
+    """
+    draining = asyncio.Event()
+
+    async def stubborn():
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            draining.set()
+            # Shielded, so the drain's gather cannot complete until the
+            # test releases us — holding the coroutine inside the loop.
+            await asyncio.shield(resume.wait())
+            raise
+
+    task = asyncio.create_task(stubborn())
+    await asyncio.sleep(0)  # let it reach the sleep
+    adapter._background_tasks.add(task)
+    return draining, task
+
+
+@pytest.mark.asyncio
+async def test_pending_flush_survives_teardown_budget_cancellation(tmp_path, monkeypatch):
+    """The #72680 flush must still run when the teardown budget cancels the drain.
+
+    ``GatewayRunner._bounded_adapter_teardown`` wraps this coroutine in
+    ``_await_adapter_cleanup_with_timeout``, which calls ``task.cancel()``
+    once ``HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT`` expires.  If the
+    settle tail is not in a ``finally``, that cancellation skips the flush
+    and the queued follow-up is lost with no on-disk recovery copy.
+    """
+    flush_dir = _redirect_flush_dir(tmp_path, monkeypatch)
+    adapter = _make_adapter()
+    sk = build_session_key(
+        SessionSource(platform=Platform.TELEGRAM, chat_id="42", chat_type="dm")
+    )
+    adapter._pending_messages[sk] = _event("queued follow-up")
+
+    resume = asyncio.Event()
+    draining, stubborn_task = await _stall_until_drain(adapter, resume)
+
+    cancel_task = asyncio.create_task(adapter.cancel_background_tasks())
+    await asyncio.wait_for(draining.wait(), timeout=1.0)
+
+    # The teardown budget expires: the runner cancels the cleanup coroutine
+    # outright while it is still parked in the drain.
+    cancel_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancel_task
+
+    payloads = _flushed_payloads(flush_dir)
+    assert len(payloads) == 1, (
+        "pending message was NOT flushed to disk when the teardown budget "
+        "cancelled the drain — the settle tail is not running in a finally"
+    )
+    assert payloads[0]["session_key"] == sk
+    assert payloads[0]["reason"] == "adapter_shutdown"
+    assert payloads[0]["data"]["text"] == "queued follow-up"
+    assert adapter._pending_messages == {}
+
+    resume.set()
+    await asyncio.gather(stubborn_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_still_propagates_to_caller(tmp_path, monkeypatch):
+    """The finally must not swallow CancelledError.
+
+    ``_await_adapter_cleanup_with_timeout`` relies on the cancellation
+    completing; a swallowed CancelledError would turn a bounded teardown
+    back into an unbounded one.
+    """
+    _redirect_flush_dir(tmp_path, monkeypatch)
+    adapter = _make_adapter()
+
+    resume = asyncio.Event()
+    draining, stubborn_task = await _stall_until_drain(adapter, resume)
+
+    cancel_task = asyncio.create_task(adapter.cancel_background_tasks())
+    await asyncio.wait_for(draining.wait(), timeout=1.0)
+    cancel_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await cancel_task
+    assert cancel_task.cancelled()
+
+    resume.set()
+    await asyncio.gather(stubborn_task, return_exceptions=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

`BasePlatformAdapter.cancel_background_tasks()` runs a bounded drain loop and then performs its entire settle tail — the three tracking `clear()` calls, the #72680 `flush_pending_to_file()` block, `_pending_messages.clear()`, `_active_sessions.clear()`, and the text-debounce cancel/clear — *after* the loop and **not** in a `finally`.

That tail is only reached if the coroutine runs to completion, and on the shutdown path it frequently does not. `GatewayRunner._bounded_adapter_teardown` awaits it through `_await_adapter_cleanup_with_timeout`, which cancels it outright at the deadline:

```python
task = asyncio.ensure_future(awaitable)
try:
    done, _pending = await asyncio.wait({task}, timeout=timeout)
except asyncio.CancelledError:
    task.cancel()
    ...
    raise
if task in done:
    await task
    return True

task.cancel()
task.add_done_callback(consume_detached_task_result)
return False
```

with `timeout = self._adapter_disconnect_timeout_secs()` (default 5.0s, operator-tunable via `HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT`). When that budget expires while the drain is still unwinding a slow task, `CancelledError` lands inside the loop and **the whole tail is skipped — including the flush.**

**The remedy already exists in this repo, one layer down.** `RelayTransport.disconnect()` in `gateway/relay/ws_transport.py` has the same structure — a bounded drain followed by a settle step, under the same cancelling caller — and it puts the settle step in a `finally` for precisely this reason:

```python
finally:
    # Fail any in-flight outbound waiters so callers don't hang.
    # Runs in a finally so a cancellation landing anywhere in the
    # drain/teardown above (the runner's wait_for budget, an outer
    # cleanup deadline) can NEVER leave a registered future
    # unresolved — a stranded waiter would otherwise block until
    # _OUTBOUND_TIMEOUT_S (30s). Idempotent: done futures are
    # skipped, so a second disconnect() pass is safe.
```

This PR argues only that the adapter teardown path was missed. It applies the same structure there.

**User-visible symptom:** a follow-up message queued while a session is busy is neither answered nor written to `<hermes_home>/pending_messages/` when the gateway is stopped while an adapter is slow to unwind. The recovery file #72680 added is silently absent, and nothing downstream covers it — `run.py`'s own `flush_pending_to_file` call flushes the *runner's* `_pending_messages` (documented write-only: "The actual interrupt message is delivered via `adapter._pending_messages`"), and `self.adapters.clear()` then drops the adapter.

**Blast radius, stated honestly:** this needs a slow-cancelling adapter background task at shutdown *and* a non-empty `_pending_messages`. A clean shutdown flushes correctly today and is unaffected. It becomes reliable rather than marginal for adapters that need 2+ drain rounds, and for any operator who lowered `HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT` below 5s to stay inside systemd's `TimeoutStopSec` — the knob `_bounded_adapter_teardown`'s own docstring recommends.

Two constraints were deliberate, because getting either wrong reintroduces the bug:

- **The `finally` body contains no `await`.** Awaiting inside a `finally` during cancellation can raise immediately and re-truncate the tail. The existing tail was already await-free (`flush_pending_to_file` is synchronous); it stays that way.
- **`CancelledError` is not caught.** A bare `finally` re-raises, so cancellation still propagates and the runner's teardown stays bounded. Swallowing it would turn a bounded teardown back into the unbounded wait `_await_adapter_cleanup_with_timeout` exists to prevent.

**Sibling-site sweep.** `cancel_background_tasks` has exactly two definitions: this one and `DiscordAdapter`'s override. The override is deliberately **excluded**, and not by oversight — it already clamps its own text-batch flush deadline strictly below the gateway budget (`max(0.5, budget * 0.2)` of headroom, capped at 90% of budget) specifically so "the gateway's outer `wait_for` can't hard-cancel us mid-flush", per its own docstring. Its tail's load-bearing statement is `await super().cancel_background_tasks()`, so the no-await `finally` used here cannot be transplanted onto it; making that path cancellation-proof needs either a shield or a duplicated synchronous flush, both of which change teardown ordering and are a design call rather than a bug fix. The other two `flush_pending_to_file` call sites (`gateway/run.py`, and `shutdown_flush.py` itself) operate on the runner's separate dict and are structurally different.

## Related Issue

No open issue — found by inspection of the teardown path.

Restores, under cancellation, the flush added for #72680 (closed; the timely path it fixed still behaves exactly as before).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py` — `cancel_background_tasks()`: wrap the `MAX_DRAIN_ROUNDS` drain loop in `try:` and move the entire settle tail into `finally:`. The only logic change is the `try:`/`finally:` pair; everything else in the diff is re-indentation (`git diff -w` shows just those two lines plus the docstring). The flush is **not** hoisted above the loop — late-arriving tasks legitimately add to `_pending_messages` during the drain, which is what the loop's own retry comment exists for, so `finally` is the only placement that captures both the timely and the cancelled path.
- `gateway/platforms/base.py` — docstring: record the invariant, the cancelling caller, and why the tail must stay await-free.
- `tests/gateway/test_cancel_background_drain.py` — four regression tests added to the existing file.

## How to Test

```
pytest tests/gateway/test_cancel_background_drain.py -v
```

Red-before / green-after, with the production file reverted via `git checkout origin/main -- gateway/platforms/base.py` (the test file untouched):

| Test | On `origin/main` | With this PR |
|---|---|---|
| `test_pending_flush_survives_teardown_budget_cancellation` | **FAILS** — `assert 0 == 1`, zero payloads written | passes |
| `test_second_teardown_pass_after_cancellation_is_safe` | **FAILS** — same, no payload from the cancelled first pass | passes |
| `test_cancellation_still_propagates_to_caller` | passes | passes |
| `test_timely_teardown_flushes_pending_exactly_once` | passes | passes |
| 3 pre-existing tests in the file | pass | pass |

Totals: **2 failed, 5 passed** before; **7 passed** after.

The last two pass in both directions by design — they are guards that this change does not *introduce* a regression (a swallowed `CancelledError`, or a second flush on the timely path), not reproductions of the original bug.

Adjacent suites, all green with the fix (50 passed; 43 of these exist on `main` and pass there too, so no baseline drift):

```
pytest tests/gateway/test_bounded_adapter_teardown.py tests/gateway/test_gateway_shutdown.py \
       tests/gateway/test_discord_pending_text_batch_shutdown.py tests/gateway/test_shutdown_flush.py \
       tests/gateway/test_pending_drain_no_recursion.py tests/gateway/test_pending_drain_race.py \
       tests/gateway/test_startup_restart_race.py tests/gateway/test_duplicate_reply_suppression.py \
       tests/gateway/test_relay_teardown_drain.py tests/gateway/test_base_topic_sessions.py \
       tests/gateway/test_cancel_background_drain.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the focused and adjacent gateway suites listed above (50 tests) rather than the full suite; not claiming a full-suite run I didn't do.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring updated to record the invariant
- [x] N/A — no config keys added or changed (`cli-config.yaml.example` untouched)
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — the change is pure `asyncio` control flow with no platform-specific behaviour; the `finally` semantics are identical on Windows and macOS
- [x] N/A — no tool behaviour changed
