### PR TITLE
fix(desktop): keep local packaging from entering publish mode

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7818,6 +7818,9 @@ def cmd_gui(args: argparse.Namespace):
                       "(CSC_IDENTITY_AUTO_DISCOVERY=false)")
             npm_build_env = _npm_lifecycle_env(env)
             if not source_mode:
+                # electron-builder treats CI as an implicit request to publish;
+                # local `pack` builds must only produce the unpacked app.
+                npm_build_env.pop("CI", None)
                 # A running desktop instance launched from release/win-unpacked
                 # holds Hermes.exe locked on Windows, so the pack can't replace
                 # it ("Access is denied" / ERR_ELECTRON_BUILDER_CANNOT_EXECUTE).

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -101,17 +101,20 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     root = _make_desktop_tree(tmp_path)
     desktop_dir = root / "apps" / "desktop"
     monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.setenv("ESBUILD_BINARY_PATH", "/opt/esbuild-0.28.2")
     packaged_exe = _make_packaged_executable(root, monkeypatch)
 
     install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
     pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
     launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
 
-    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok) as mock_install, \
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._ensure_desktop_exe_launchable", return_value=(packaged_exe, False)), \
          patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.main._register_linux_desktop_entry"), \
          patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
@@ -128,6 +131,9 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     assert install_env is not None and "PATH" in install_env
     assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
     assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
+    pack_env = mock_run.call_args_list[0].kwargs["env"]
+    assert "CI" not in pack_env
+    assert "ESBUILD_BINARY_PATH" not in pack_env
     assert mock_run.call_args_list[1].args[0] == [str(packaged_exe)]
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 


### PR DESCRIPTION
## What does this PR do?

Local Desktop packaging no longer inherits the synthetic `CI=1` value used by shared npm lifecycle helpers. This keeps `hermes desktop --force-build --build-only` in local pack mode instead of letting Electron Builder enter implicit publishing and fail while resolving repository metadata.

### Symptom

A local `hermes desktop --force-build --build-only` run reaches Electron Builder successfully, then reports implicit publishing from CI detection and can fail with `Cannot detect repository by .git/config` instead of producing the unpacked Desktop artifact.

### Impact

Developers and users rebuilding the packaged Desktop locally can lose the expected local artifact even though dependency installation and the application build itself succeeded.

### Bug Cause

**Trigger:** `hermes_cli/main.py:cmd_gui` passes `_npm_lifecycle_env(env)` to the packaged `npm run pack` subprocess.

**Causal chain:**
1. A user requests a local packaged Desktop rebuild.
2. The shared npm lifecycle helper adds `CI=1` to the pack subprocess environment.
3. Electron Builder interprets CI as an implicit publish policy and enters repository-dependent publishing logic, so a local-only package can fail before the artifact is accepted.

**Why it is wrong:** The shared helper's non-interactive CI setting is appropriate for dependency and source build lifecycle commands, but a local Electron Builder pack must not opt into publishing implicitly.

**Working sibling / contrast:** The same Electron Builder command completes and produces the unpacked artifact when CI is absent. Source-mode Desktop builds and the TUI/web npm lifecycle paths do not invoke the local packaged-app publisher and retain the shared helper behavior.

**Ruled out:** Invalid Git metadata and `ESBUILD_BINARY_PATH` were not the root cause. The base pack reproduced implicit publishing when CI reached Electron Builder, while the fixed command completed with an intentionally invalid esbuild override because that override remained scrubbed.

### Fix

Remove `CI` only from the environment used by packaged Desktop builds after applying the shared lifecycle cleanup. Reuse that sanitized environment for the existing retry path, and assert that both `CI` and `ESBUILD_BINARY_PATH` are absent from the real pack subprocess environment.

## Related Issue

Closes #87758

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` - remove synthetic CI detection from local packaged Desktop builds while preserving the shared environment cleanup.
- `tests/hermes_cli/test_gui_command.py` - verify the pack subprocess receives neither `CI` nor `ESBUILD_BINARY_PATH`.

## How to Test

1. Set `CI=1` and an invalid `ESBUILD_BINARY_PATH`, then run `uv run python -m hermes_cli.main desktop --force-build --build-only`.
2. Confirm Electron Builder does not report implicit publishing and produces `apps/desktop/release/win-unpacked/Hermes.exe`.
3. Run the related test file:

```bash
scripts/run_tests.sh tests/hermes_cli/test_gui_command.py
```

Result: 20 passed, 11 skipped on Windows. A second real packaged build also accepted the content stamp and existing artifact.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A because this restores the existing local-build contract
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the environment fix applies to local packaged builds on every host
- [x] Tool description/schema updates are N/A because no model tool behavior changed

## Screenshots / Logs

The real environment reproduction reported `Implicit publishing triggered by CI detection` before the fix. At the fixed tip, the same local packaged build completed without that line, produced the Windows unpacked executable, and accepted the follow-up content stamp.
