### PR TITLE
fix(slack): roll over full progress messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2711,6 +2711,10 @@ class SendResult:
     # ``None`` (unset / not classified).  Producers should set this via
     # :func:`classify_send_error`.
     error_kind: Optional[str] = None
+    # True when a non-idempotent outbound operation reached the wire but its
+    # acknowledgement was lost, so delivery may already have happened. Callers
+    # must not retry such a result unless the operation itself is idempotent.
+    ambiguous: bool = False
 
 
 # Machine-readable send-failure categories.  Kept platform-neutral so every
@@ -2790,7 +2794,11 @@ def classify_send_error(exc: Optional[BaseException], error_text: str = "") -> s
     blob = _error_blob(exc, error_text)
     if not blob.strip():
         return "unknown"
-    if "message_too_long" in blob or "too long" in blob or "message is too long" in blob:
+    if (
+        "message_too_long" in blob
+        or "msg_too_long" in blob
+        or "message is too long" in blob
+    ):
         return "too_long"
     if (
         "can't parse entities" in blob
@@ -5893,6 +5901,11 @@ class BasePlatformAdapter(ABC):
         if result.success:
             return result
 
+        # A non-idempotent send with an unknown ACK outcome may already be
+        # visible. Ambiguity dominates retry and formatting classifications.
+        if result.ambiguous:
+            return result
+
         error_str = result.error or ""
         is_network = result.retryable or self._is_retryable_error(error_str)
 
@@ -5925,6 +5938,8 @@ class BasePlatformAdapter(ABC):
                 )
                 if result.success:
                     logger.info("[%s] Send succeeded on retry %d", self.name, attempt)
+                    return result
+                if result.ambiguous:
                     return result
                 error_str = result.error or ""
                 if result.retry_after is not None:

--- a/gateway/progress_delivery.py
+++ b/gateway/progress_delivery.py
@@ -1,0 +1,475 @@
+"""Stateful delivery helpers for editable tool-progress bubbles.
+
+The gateway turn loop owns queueing, throttling, and typing indicators.  This
+module owns the mutable message ledger and the rollover/final-drain operations
+that must agree about which content is confirmed visible, still pending, or
+ACK-ambiguous.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from typing import Any
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    _custom_unit_to_cp,
+    classify_send_error,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ProgressDeliveryState:
+    """Own one turn's editable progress-bubble ledger and transitions."""
+
+    def __init__(self, ctx: Any, adapter: Any) -> None:
+        self.ctx = ctx
+        self.adapter = adapter
+        self.progress_lines: list[Any] = []
+        self.delivered_progress_lines: list[Any] = []
+        self.progress_msg_id: str | None = None
+        self.pending_ambiguous_edit: tuple[str, str, list[Any]] | None = None
+        self.can_edit = ctx.progress_grouping != "separate"
+        self.last_edit_ts = 0.0
+
+        self.progress_len_fn = (
+            adapter.message_len_fn if isinstance(adapter, BasePlatformAdapter) else len
+        )
+        try:
+            raw_progress_limit = int(
+                getattr(adapter, "MAX_MESSAGE_LENGTH", 4000) or 4000
+            )
+        except Exception:
+            raw_progress_limit = 4000
+        if isinstance(adapter, BasePlatformAdapter):
+            try:
+                raw_progress_limit = int(
+                    adapter.max_message_length_for_chat(ctx.source.chat_id) or 4000
+                )
+                self.progress_len_fn = adapter.message_len_fn_for_chat(
+                    ctx.source.chat_id
+                )
+            except Exception:
+                pass
+        self.text_limit = max(
+            1,
+            raw_progress_limit - (64 if raw_progress_limit > 128 else 0),
+        )
+
+        self.edit_accepts_metadata = False
+        if ctx._progress_metadata:
+            try:
+                edit_params = inspect.signature(adapter.edit_message).parameters
+                self.edit_accepts_metadata = "metadata" in edit_params or any(
+                    param.kind is inspect.Parameter.VAR_KEYWORD
+                    for param in edit_params.values()
+                )
+            except (TypeError, ValueError):
+                self.edit_accepts_metadata = False
+
+    @property
+    def adapter_name(self) -> str:
+        return str(getattr(self.adapter, "name", "unknown"))
+
+    @staticmethod
+    def progress_text(lines: list[Any]) -> str:
+        return "\n".join(str(line) for line in lines)
+
+    def split_line(self, line: Any) -> list[str]:
+        """Split one logical line without changing its visible content."""
+        remaining = str(line)
+        chunks: list[str] = []
+        while self.progress_len_fn(remaining) > self.text_limit:
+            split_at = (
+                self.text_limit
+                if self.progress_len_fn is len
+                else _custom_unit_to_cp(
+                    remaining,
+                    self.text_limit,
+                    self.progress_len_fn,
+                )
+            )
+            split_at = max(1, split_at)
+            chunks.append(remaining[:split_at])
+            remaining = remaining[split_at:]
+        chunks.append(remaining)
+        return chunks
+
+    def split_groups(self, lines: list[Any]) -> list[list[Any]]:
+        """Partition progress lines into platform-sized editable bubbles."""
+        groups: list[list[Any]] = []
+        current: list[Any] = []
+        for raw_line in lines:
+            parts = self.split_line(raw_line)
+            if len(parts) > 1:
+                if current:
+                    groups.append(current)
+                groups.extend([[part] for part in parts[:-1]])
+                current = [parts[-1]]
+                continue
+            line = parts[0]
+            candidate = current + [line]
+            if (
+                current
+                and self.progress_len_fn(self.progress_text(candidate))
+                > self.text_limit
+            ):
+                groups.append(current)
+                current = [line]
+            else:
+                current = candidate
+        if current:
+            groups.append(current)
+        return groups
+
+    def track_result(self, result: Any) -> None:
+        if (
+            self.ctx._cleanup_progress
+            and getattr(result, "success", False)
+            and getattr(result, "message_id", None)
+        ):
+            self.ctx._cleanup_msg_ids.append(str(result.message_id))
+
+    async def send_text(self, text: str) -> Any:
+        result = await self.adapter.send(
+            chat_id=self.ctx.source.chat_id,
+            content=text,
+            reply_to=self.ctx._progress_reply_to,
+            metadata=self.ctx._progress_metadata,
+        )
+        self.track_result(result)
+        return result
+
+    async def edit_message(self, message_id: str, content: str) -> Any:
+        kwargs: dict[str, Any] = {
+            "chat_id": self.ctx.source.chat_id,
+            "message_id": message_id,
+            "content": content,
+        }
+        if getattr(self.adapter, "REQUIRES_EDIT_FINALIZE", False):
+            kwargs["finalize"] = True
+        if self.edit_accepts_metadata:
+            kwargs["metadata"] = self.ctx._progress_metadata
+        return await self.adapter.edit_message(**kwargs)
+
+    @staticmethod
+    def edit_was_too_long(result: Any) -> bool:
+        error_kind = getattr(result, "error_kind", None)
+        if error_kind is not None:
+            return error_kind == "too_long"
+        return (
+            classify_send_error(
+                None,
+                getattr(result, "error", "") or "",
+            )
+            == "too_long"
+        )
+
+    def undelivered_lines(self) -> list[Any]:
+        """Return content added or changed since the last successful edit."""
+        shared = 0
+        shared_limit = min(len(self.progress_lines), len(self.delivered_progress_lines))
+        while (
+            shared < shared_limit
+            and self.progress_lines[shared] == self.delivered_progress_lines[shared]
+        ):
+            shared += 1
+        return self.progress_lines[shared:]
+
+    def reset_dedup(self) -> None:
+        self.ctx.last_progress_msg[0] = None
+        self.ctx.repeat_count[0] = 0
+
+    def clear_bubble(self, *, disable_edit: bool = False) -> None:
+        self.progress_msg_id = None
+        self.progress_lines = []
+        self.delivered_progress_lines = []
+        self.pending_ambiguous_edit = None
+        if disable_edit:
+            self.can_edit = False
+        self.reset_dedup()
+
+    def drop_attempted_send(
+        self,
+        *,
+        sent_all: bool,
+        attempted_line: Any = None,
+    ) -> None:
+        """Remove a non-idempotent send once its outcome can be ambiguous."""
+        self.progress_msg_id = None
+        if sent_all:
+            self.progress_lines = []
+            self.delivered_progress_lines = []
+        elif self.progress_lines and self.progress_lines[-1] == attempted_line:
+            self.progress_lines.pop()
+            shared = 0
+            shared_limit = min(
+                len(self.progress_lines), len(self.delivered_progress_lines)
+            )
+            while (
+                shared < shared_limit
+                and self.progress_lines[shared] == self.delivered_progress_lines[shared]
+            ):
+                shared += 1
+            self.delivered_progress_lines = self.delivered_progress_lines[:shared]
+        if not self.progress_lines:
+            self.reset_dedup()
+
+    async def start_fresh_bubbles(self, lines: list[Any]) -> bool:
+        """Send pending lines as new bubbles and keep the newest editable."""
+        groups = self.split_groups(lines)
+        if not groups:
+            return False
+
+        self.progress_msg_id = None
+        self.delivered_progress_lines = []
+        for index, group in enumerate(groups):
+            self.progress_lines = [
+                line for remaining_group in groups[index:] for line in remaining_group
+            ]
+            self.progress_msg_id = None
+            self.delivered_progress_lines = []
+            try:
+                result = await self.send_text(self.progress_text(group))
+            except asyncio.CancelledError:
+                self.progress_lines = [
+                    line
+                    for remaining_group in groups[index + 1 :]
+                    for line in remaining_group
+                ]
+                self.progress_msg_id = None
+                self.delivered_progress_lines = []
+                if not self.progress_lines:
+                    self.reset_dedup()
+                raise
+            except Exception:
+                logger.warning(
+                    "[%s] Progress continuation send raised with unknown "
+                    "outcome; suppressing duplicate retry",
+                    self.adapter_name,
+                    exc_info=True,
+                )
+                self.progress_lines = [
+                    line
+                    for remaining_group in groups[index + 1 :]
+                    for line in remaining_group
+                ]
+                self.progress_msg_id = None
+                self.delivered_progress_lines = []
+                if not self.progress_lines:
+                    self.reset_dedup()
+                return False
+            if not result.success:
+                if getattr(result, "ambiguous", False):
+                    logger.warning(
+                        "[%s] Progress continuation outcome is ambiguous; "
+                        "suppressing duplicate retry",
+                        self.adapter_name,
+                    )
+                    self.progress_lines = [
+                        line
+                        for remaining_group in groups[index + 1 :]
+                        for line in remaining_group
+                    ]
+                    self.progress_msg_id = None
+                    self.delivered_progress_lines = []
+                    if not self.progress_lines:
+                        self.reset_dedup()
+                    return False
+                self.progress_lines = [
+                    line
+                    for remaining_group in groups[index:]
+                    for line in remaining_group
+                ]
+                self.progress_msg_id = None
+                self.delivered_progress_lines = []
+                return False
+            if not result.message_id:
+                self.progress_msg_id = None
+                self.progress_lines = []
+                self.delivered_progress_lines = []
+                if index == len(groups) - 1:
+                    self.reset_dedup()
+                continue
+            self.progress_msg_id = result.message_id
+            self.progress_lines = list(group)
+            self.delivered_progress_lines = list(group)
+        return True
+
+    async def flush_fresh_with_retry(
+        self,
+        lines: list[Any] | None = None,
+    ) -> bool:
+        """Give a final fresh-send flush one bounded retry."""
+        initial_lines = list(self.progress_lines if lines is None else lines)
+        if not initial_lines:
+            return True
+        sent = await self.start_fresh_bubbles(initial_lines)
+        if sent or not self.progress_lines:
+            return sent
+        return await self.start_fresh_bubbles(list(self.progress_lines))
+
+    async def continue_after_too_long(
+        self,
+        *,
+        retry_failed_send: bool = False,
+    ) -> bool:
+        """Freeze the full bubble and move only unseen content to a fresh one."""
+        pending = self.undelivered_lines()
+        if not pending:
+            self.clear_bubble()
+            return True
+        if retry_failed_send:
+            return await self.flush_fresh_with_retry(pending)
+        return await self.start_fresh_bubbles(pending)
+
+    async def settle_pending_ambiguous_edit(self) -> bool:
+        """Retry an ACK-lost edit without changing its identity or payload."""
+        if self.pending_ambiguous_edit is None:
+            return True
+        message_id, payload, tentative_lines = self.pending_ambiguous_edit
+        try:
+            result = await self.edit_message(message_id, payload)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "[%s] Pending progress edit retry raised with unknown outcome",
+                self.adapter_name,
+                exc_info=True,
+            )
+            return False
+        if result.success:
+            self.delivered_progress_lines = list(tentative_lines)
+            self.pending_ambiguous_edit = None
+            return True
+        logger.warning(
+            "[%s] Pending progress edit remains unresolved; retaining exact payload",
+            self.adapter_name,
+        )
+        return False
+
+    async def settle_edit_during_drain(self) -> bool:
+        """Finish one pending edit safely before a cancellation boundary."""
+        if not (self.can_edit and self.progress_lines and self.progress_msg_id):
+            return True
+        if self.pending_ambiguous_edit is not None:
+            tentative_lines = list(self.pending_ambiguous_edit[2])
+            if not await self.settle_pending_ambiguous_edit():
+                # The exact edit may have landed, so never replay its payload as
+                # a fresh bubble.  Later lines were not part of that attempt and
+                # remain safe to deliver as a fresh suffix.
+                self.delivered_progress_lines = tentative_lines
+                self.pending_ambiguous_edit = None
+                pending = self.undelivered_lines()
+                if pending:
+                    await self.flush_fresh_with_retry(pending)
+                return not self.undelivered_lines()
+
+        full_text = self.progress_text(self.progress_lines)
+        saw_ambiguous = False
+        result = None
+        try:
+            result = await self.edit_message(self.progress_msg_id, full_text)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            saw_ambiguous = True
+            logger.warning(
+                "[%s] Progress drain edit raised with unknown outcome",
+                self.adapter_name,
+                exc_info=True,
+            )
+
+        saw_ambiguous = saw_ambiguous or bool(getattr(result, "ambiguous", False))
+        if result is None or (
+            not result.success
+            and (saw_ambiguous or getattr(result, "retryable", False))
+        ):
+            try:
+                result = await self.edit_message(self.progress_msg_id, full_text)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "[%s] Progress drain edit retry raised with unknown outcome",
+                    self.adapter_name,
+                    exc_info=True,
+                )
+                return True
+            saw_ambiguous = saw_ambiguous or bool(getattr(result, "ambiguous", False))
+
+        if result.success:
+            self.delivered_progress_lines = list(self.progress_lines)
+            return True
+        if saw_ambiguous:
+            logger.warning(
+                "[%s] Progress drain edit remained ambiguous; "
+                "suppressing fresh fallback",
+                self.adapter_name,
+            )
+            return True
+        if self.edit_was_too_long(result):
+            await self.continue_after_too_long(retry_failed_send=True)
+            return not self.undelivered_lines()
+
+        pending = self.undelivered_lines()
+        if pending:
+            await self.flush_fresh_with_retry(pending)
+        return not self.undelivered_lines()
+
+    async def roll_overflow_if_needed(self) -> bool:
+        """Split an overflowing buffer while preserving delivery boundaries."""
+        if self.pending_ambiguous_edit is not None:
+            if not await self.settle_pending_ambiguous_edit():
+                return True
+        if not self.progress_lines or not self.can_edit:
+            return False
+        groups = self.split_groups(self.progress_lines)
+        if len(groups) <= 1:
+            return False
+
+        first_text = self.progress_text(groups[0])
+        if self.progress_msg_id is not None:
+            result = await self.edit_message(self.progress_msg_id, first_text)
+            if not result.success:
+                if getattr(result, "ambiguous", False):
+                    self.pending_ambiguous_edit = (
+                        self.progress_msg_id,
+                        first_text,
+                        list(groups[0]),
+                    )
+                    self.delivered_progress_lines = list(groups[0])
+                    logger.warning(
+                        "[%s] Progress overflow edit outcome is ambiguous; "
+                        "retaining exact edit payload",
+                        self.adapter_name,
+                    )
+                    return True
+                if self.edit_was_too_long(result):
+                    logger.info(
+                        "[%s] Progress bubble hit the platform edit limit; "
+                        "starting a fresh editable bubble",
+                        self.adapter_name,
+                    )
+                    return await self.continue_after_too_long()
+                if getattr(result, "retryable", False):
+                    logger.debug(
+                        "[%s] Transient overflow edit failure — keeping can_edit=True",
+                        self.adapter_name,
+                    )
+                    return True
+                self.can_edit = False
+                return False
+            self.delivered_progress_lines = list(groups[0])
+        else:
+            await self.start_fresh_bubbles([line for group in groups for line in group])
+            return True
+
+        remaining_lines = [line for group in groups[1:] for line in group]
+        if remaining_lines:
+            await self.start_fresh_bubbles(remaining_lines)
+        return True

--- a/gateway/progress_delivery.py
+++ b/gateway/progress_delivery.py
@@ -434,7 +434,27 @@ class ProgressDeliveryState:
 
         first_text = self.progress_text(groups[0])
         if self.progress_msg_id is not None:
-            result = await self.edit_message(self.progress_msg_id, first_text)
+            try:
+                result = await self.edit_message(self.progress_msg_id, first_text)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # The overflow edit may already be visible even though its
+                # acknowledgement failed. Preserve the exact operation so no
+                # wider edit or fresh suffix can replay these lines.
+                self.pending_ambiguous_edit = (
+                    self.progress_msg_id,
+                    first_text,
+                    list(groups[0]),
+                )
+                self.delivered_progress_lines = list(groups[0])
+                logger.warning(
+                    "[%s] Progress overflow edit raised with unknown outcome; "
+                    "retaining exact edit payload",
+                    self.adapter_name,
+                    exc_info=True,
+                )
+                return True
             if not result.success:
                 if getattr(result, "ambiguous", False):
                     self.pending_ambiguous_edit = (

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -1879,6 +1879,7 @@ class RelayAdapter(BasePlatformAdapter):
             message_id=result.get("message_id"),
             error=result.get("error"),
             raw_response=result,
+            ambiguous=bool(result.get("ambiguous")),
         )
 
     def _format_hints(
@@ -2087,6 +2088,7 @@ class RelayAdapter(BasePlatformAdapter):
             success=bool(result.get("success")),
             message_id=result.get("message_id"),
             error=result.get("error"),
+            ambiguous=bool(result.get("ambiguous")),
         )
 
     def auto_thread_info_for_chat(
@@ -2303,6 +2305,10 @@ class RelayAdapter(BasePlatformAdapter):
             success=bool(result.get("success")),
             message_id=result.get("message_id") or message_id,
             error=result.get("error"),
+            retryable=bool(result.get("retryable")),
+            retry_after=result.get("retry_after"),
+            error_kind=result.get("error_kind"),
+            ambiguous=bool(result.get("ambiguous")),
         )
 
     async def delete_message(

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -893,6 +893,8 @@ class WebSocketRelayTransport:
                 "success": False,
                 "error": "relay outbound timed out",
                 "ambiguous": True,
+                "retryable": True,
+                "error_kind": "transient",
             }
         except Exception as exc:  # noqa: BLE001 - a dead socket is a failed send, not a raise
             # No `is None` check can close the window where the socket dies
@@ -915,6 +917,8 @@ class WebSocketRelayTransport:
             }
             if frame_sent:
                 result["ambiguous"] = True
+                result["retryable"] = True
+                result["error_kind"] = "transient"
             return result
         finally:
             self._pending.pop(request_id, None)
@@ -1008,7 +1012,13 @@ class WebSocketRelayTransport:
             for _rid, fut in list(self._pending.items()):
                 if not fut.done():
                     fut.set_result(
-                        {"success": False, "error": "relay transport connection lost"}
+                        {
+                            "success": False,
+                            "error": "relay transport connection lost",
+                            "ambiguous": True,
+                            "retryable": True,
+                            "error_kind": "transient",
+                        }
                     )
             self._pending.clear()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5501,7 +5501,32 @@ class TurnRunner:
                 if state.can_edit and state.progress_msg_id is not None:
                     # Try to edit the existing progress message
                     full_text = "\n".join(state.progress_lines)
-                    result = await state.edit_message(state.progress_msg_id, full_text)
+                    try:
+                        result = await state.edit_message(
+                            state.progress_msg_id, full_text
+                        )
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        # Entering edit_message() makes an untyped exception
+                        # ACK-ambiguous: the edit may already be visible. Retry
+                        # the exact same idempotent edit before incorporating
+                        # later lines, just as for a typed ambiguous result.
+                        state.pending_ambiguous_edit = (
+                            state.progress_msg_id,
+                            full_text,
+                            list(state.progress_lines),
+                        )
+                        state.delivered_progress_lines = list(
+                            state.progress_lines
+                        )
+                        logger.warning(
+                            "[%s] Progress edit raised with unknown outcome; "
+                            "retaining exact edit payload",
+                            getattr(adapter, "name", "unknown"),
+                            exc_info=True,
+                        )
+                        continue
                     if not result.success:
                         _err = (getattr(result, "error", "") or "").lower()
                         if getattr(result, "ambiguous", False):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3154,6 +3154,7 @@ from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.turn_context import TurnContext
+from gateway.progress_delivery import ProgressDeliveryState as _ProgressDeliveryState
 from gateway.platforms.base import (
     BasePlatformAdapter,
     EphemeralReply,
@@ -3201,6 +3202,8 @@ from gateway.whatsapp_identity import (
 
 
 logger = logging.getLogger(__name__)
+
+_PROGRESS_FINALIZE_TIMEOUT = 5.0
 
 
 # Ceiling for the shutdown quiesce of the gateway-owned thread pool. Drain has
@@ -5387,146 +5390,8 @@ class TurnRunner:
                     break
             return
 
-        progress_lines = []      # Accumulated tool lines for the CURRENT editable bubble
-        progress_msg_id = None   # ID of the current progress message to edit
-        can_edit = ctx.progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
-        _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
-        _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
-
-        _progress_len_fn = (
-            adapter.message_len_fn
-            if isinstance(adapter, BasePlatformAdapter)
-            else len
-        )
-        try:
-            _raw_progress_limit = int(getattr(adapter, "MAX_MESSAGE_LENGTH", 4000) or 4000)
-        except Exception:
-            _raw_progress_limit = 4000
-        # Per-chat resolution (relay adapter fronting N platforms): the cap
-        # and length unit follow the chat's underlying platform. Native
-        # adapters return their scalar/property unchanged.
-        if isinstance(adapter, BasePlatformAdapter):
-            try:
-                _raw_progress_limit = int(
-                    adapter.max_message_length_for_chat(ctx.source.chat_id) or 4000
-                )
-                _progress_len_fn = adapter.message_len_fn_for_chat(ctx.source.chat_id)
-            except Exception:
-                pass
-        # Leave a little room for platform quirks / formatting.  For tiny
-        # test adapters keep the limit usable instead of clamping to 500+.
-        _PROGRESS_TEXT_LIMIT = max(
-            1,
-            _raw_progress_limit - (64 if _raw_progress_limit > 128 else 0),
-        )
-
-        # Detect whether the adapter's edit_message accepts metadata so
-        # overflow edits preserve Telegram topic/thread routing (#27487).
-        _edit_accepts_metadata = False
-        if ctx._progress_metadata:
-            try:
-                _edit_params = inspect.signature(adapter.edit_message).parameters
-                _edit_accepts_metadata = (
-                    "metadata" in _edit_params
-                    or any(
-                        param.kind is inspect.Parameter.VAR_KEYWORD
-                        for param in _edit_params.values()
-                    )
-                )
-            except (TypeError, ValueError):
-                _edit_accepts_metadata = False
-
-        async def _edit_progress_message(message_id: str, content: str):
-            kwargs = {
-                "chat_id": ctx.source.chat_id,
-                "message_id": message_id,
-                "content": content,
-            }
-            if getattr(adapter, "REQUIRES_EDIT_FINALIZE", False):
-                kwargs["finalize"] = True
-            if _edit_accepts_metadata:
-                kwargs["metadata"] = ctx._progress_metadata
-            return await adapter.edit_message(**kwargs)
-
-        def _progress_text(lines: list) -> str:
-            return "\n".join(str(line) for line in lines)
-
-        def _split_progress_groups(lines: list) -> list[list]:
-            """Partition progress lines into platform-sized editable bubbles."""
-            groups: list[list] = []
-            current: list = []
-            for line in lines:
-                candidate = current + [line]
-                if current and _progress_len_fn(_progress_text(candidate)) > _PROGRESS_TEXT_LIMIT:
-                    groups.append(current)
-                    current = [line]
-                else:
-                    current = candidate
-            if current:
-                groups.append(current)
-            return groups
-
-        def _track_progress_result(result) -> None:
-            if (
-                ctx._cleanup_progress
-                and getattr(result, "success", False)
-                and getattr(result, "message_id", None)
-            ):
-                ctx._cleanup_msg_ids.append(str(result.message_id))
-
-        async def _send_progress_text(text: str):
-            result = await adapter.send(
-                chat_id=ctx.source.chat_id,
-                content=text,
-                reply_to=ctx._progress_reply_to,
-                metadata=ctx._progress_metadata,
-            )
-            _track_progress_result(result)
-            return result
-
-        async def _roll_progress_overflow_if_needed() -> bool:
-            """Start fresh editable progress bubbles before a bubble exceeds limit.
-
-                Returns True when it delivered/split the current buffer, or when
-                a transient edit failure left the buffer and message identity
-                intact for a later retry.  In either case the caller should skip
-                the normal send/edit path for this tick.
-                """
-            nonlocal progress_msg_id, progress_lines, can_edit
-            if not progress_lines or not can_edit:
-                return False
-            groups = _split_progress_groups(progress_lines)
-            if len(groups) <= 1:
-                return False
-
-            first_text = _progress_text(groups[0])
-            if progress_msg_id is not None:
-                result = await _edit_progress_message(progress_msg_id, first_text)
-                if not result.success:
-                    if getattr(result, "retryable", False):
-                        logger.debug(
-                            "[%s] Transient overflow edit failure — keeping can_edit=True",
-                            adapter.name,
-                        )
-                        return True
-                    can_edit = False
-                    # Fall back to the existing non-edit behavior below.
-                    return False
-            else:
-                result = await _send_progress_text(first_text)
-                if result.success and result.message_id:
-                    progress_msg_id = result.message_id
-
-            for group in groups[1:]:
-                result = await _send_progress_text(_progress_text(group))
-                if result.success and result.message_id:
-                    progress_msg_id = result.message_id
-
-            # The newest continuation is now the only mutable bubble.  Keep
-            # just its lines so subsequent edits update it instead of
-            # replaying the full historical transcript into new messages.
-            progress_lines = groups[-1]
-            return True
+        state = _ProgressDeliveryState(ctx, adapter)
+        progress_edit_interval = 1.5
 
         while True:
             try:
@@ -5559,9 +5424,9 @@ class TurnRunner:
                 # Handle dedup messages: update last line with repeat counter
                 if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                     _, base_msg, count = raw
-                    if progress_lines:
-                        progress_lines[-1] = f"{base_msg} (×{count + 1})"
-                    msg = progress_lines[-1] if progress_lines else base_msg
+                    if state.progress_lines:
+                        state.progress_lines[-1] = f"{base_msg} (×{count + 1})"
+                    msg = state.progress_lines[-1] if state.progress_lines else base_msg
                 elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                     # Content bubble just landed on the platform — close off
                     # the current tool-progress bubble so the next tool
@@ -5571,17 +5436,47 @@ class TurnRunner:
                     # order. Mirrors GatewayStreamConsumer.on_segment_break
                     # on the content side. (Issue: tool + content
                     # linearization regression after PR #7885.)
-                    progress_msg_id = None
-                    progress_lines = []
+                    boundary_settled = True
+                    if state.can_edit and state.progress_lines and state.progress_msg_id:
+                        boundary_settled = await state.settle_edit_during_drain()
+                    else:
+                        pending = state.undelivered_lines()
+                        if pending:
+                            await state.flush_fresh_with_retry(pending)
+                            boundary_settled = not state.undelivered_lines()
+                    if not boundary_settled:
+                        # Both bounded attempts failed. Keep the exact tail
+                        # pending so a later tick or cancellation drain can
+                        # retry it instead of silently discarding progress.
+                        ctx.last_progress_msg[0] = None
+                        ctx.repeat_count[0] = 0
+                        continue
+                    state.progress_msg_id = None
+                    state.progress_lines = []
+                    state.delivered_progress_lines = []
                     ctx.last_progress_msg[0] = None
                     ctx.repeat_count[0] = 0
                     continue
                 else:
                     msg = raw
-                    progress_lines.append(msg)
+                    if state.pending_ambiguous_edit is not None:
+                        if not await state.settle_pending_ambiguous_edit():
+                            state.progress_lines.append(msg)
+                            continue
+                    if not state.can_edit and state.undelivered_lines():
+                        # Preserve FIFO order after a definite fallback-send
+                        # failure: settle the retained head before a later line
+                        # is allowed to become visible.
+                        await state.flush_fresh_with_retry(
+                            state.undelivered_lines()
+                        )
+                        if state.undelivered_lines():
+                            state.progress_lines.append(msg)
+                            continue
+                    state.progress_lines.append(msg)
 
-                if await _roll_progress_overflow_if_needed():
-                    _last_edit_ts = time.monotonic()
+                if await state.roll_overflow_if_needed():
+                    state.last_edit_ts = time.monotonic()
                     await asyncio.sleep(0.3)
                     if ctx._run_still_current():
                         await adapter.send_typing(ctx.source.chat_id, metadata=ctx._progress_metadata)
@@ -5592,7 +5487,7 @@ class TurnRunner:
                 # (grammY auto-retry pattern: proactively rate-limit
                 # instead of reacting to 429s.)
                 _now = time.monotonic()
-                _remaining = _PROGRESS_EDIT_INTERVAL - (_now - _last_edit_ts)
+                _remaining = progress_edit_interval - (_now - state.last_edit_ts)
                 if _remaining > 0:
                     # Wait out the throttle interval, then loop back to
                     # drain any additional queued messages before sending
@@ -5603,69 +5498,178 @@ class TurnRunner:
                 if not ctx._run_still_current():
                     return
 
-                if can_edit and progress_msg_id is not None:
+                if state.can_edit and state.progress_msg_id is not None:
                     # Try to edit the existing progress message
-                    full_text = "\n".join(progress_lines)
-                    result = await _edit_progress_message(progress_msg_id, full_text)
+                    full_text = "\n".join(state.progress_lines)
+                    result = await state.edit_message(state.progress_msg_id, full_text)
                     if not result.success:
                         _err = (getattr(result, "error", "") or "").lower()
+                        if getattr(result, "ambiguous", False):
+                            state.pending_ambiguous_edit = (
+                                state.progress_msg_id,
+                                full_text,
+                                list(state.progress_lines),
+                            )
+                            state.delivered_progress_lines = list(state.progress_lines)
+                            # Editing the same message is idempotent. Keep its
+                            # exact identity and payload for the next retry.
+                            logger.warning(
+                                "[%s] Progress edit outcome is ambiguous; "
+                                "retaining exact edit payload",
+                                getattr(adapter, "name", "unknown"),
+                            )
+                            continue
+                        # A full-bubble rejection means this message is simply
+                        # out of room; editing itself still works on a fresh one.
+                        if state.edit_was_too_long(result):
+                            logger.info(
+                                "[%s] Progress bubble hit the platform edit limit; "
+                                "starting a fresh editable bubble",
+                                getattr(adapter, "name", "unknown"),
+                            )
+                            await state.continue_after_too_long()
                         # Transient network errors (ConnectError, timeouts)
                         # must not permanently disable progress-message
                         # editing — the next cycle can catch up.  Only
                         # permanent failures (flood control, message not
-                        # found, permissions) should set can_edit = False.
-                        if getattr(result, "retryable", False):
+                        # found, permissions) should disable editing.
+                        elif getattr(result, "retryable", False):
                             logger.debug(
                                 "[%s] Transient edit failure — keeping can_edit=True",
                                 adapter.name,
                             )
                             continue
-                        if "flood" in _err or "retry after" in _err:
-                            # Flood control hit — backoff but keep editing.
-                            # Only disable edits for non-recoverable errors.
-                            logger.info(
-                                "[%s] Progress edit flood control, backing off",
-                                adapter.name,
-                            )
-                            _last_edit_ts = time.monotonic()
                         else:
-                            can_edit = False
-                        _flood_result = await adapter.send(
-                            chat_id=ctx.source.chat_id,
-                            content=msg,
-                            reply_to=ctx._progress_reply_to,
-                            metadata=ctx._progress_metadata,
-                        )
-                        if (
-                            ctx._cleanup_progress
-                            and getattr(_flood_result, "success", False)
-                            and getattr(_flood_result, "message_id", None)
-                        ):
-                            ctx._cleanup_msg_ids.append(str(_flood_result.message_id))
-                else:
-                    if can_edit:
-                        # First tool: send all accumulated text as new message
-                        full_text = "\n".join(progress_lines)
-                        result = await adapter.send(
-                            chat_id=ctx.source.chat_id,
-                            content=full_text,
-                            reply_to=ctx._progress_reply_to,
-                            metadata=ctx._progress_metadata,
-                        )
+                            if "flood" in _err or "retry after" in _err:
+                                # Flood control hit — backoff but keep editing.
+                                # Only disable edits for non-recoverable errors.
+                                logger.info(
+                                    "[%s] Progress edit flood control, backing off",
+                                    adapter.name,
+                                )
+                                state.last_edit_ts = time.monotonic()
+                            else:
+                                state.can_edit = False
+                            fallback_lines = state.undelivered_lines() or [msg]
+                            try:
+                                _flood_result = await adapter.send(
+                                    chat_id=ctx.source.chat_id,
+                                    content=state.progress_text(fallback_lines),
+                                    reply_to=ctx._progress_reply_to,
+                                    metadata=ctx._progress_metadata,
+                                )
+                            except asyncio.CancelledError:
+                                # The fallback is non-idempotent and may already
+                                # be visible. Freeze the complete attempted tail.
+                                state.drop_attempted_send(sent_all=True)
+                                state.can_edit = False
+                                raise
+                            except Exception:
+                                # An untyped exception may follow a successful
+                                # write. Freeze the attempted fallback instead
+                                # of replaying a possibly-visible tail.
+                                state.drop_attempted_send(sent_all=True)
+                                state.can_edit = False
+                                logger.warning(
+                                    "[%s] Progress fallback send raised with "
+                                    "unknown outcome; suppressing duplicate retry",
+                                    getattr(adapter, "name", "unknown"),
+                                    exc_info=True,
+                                )
+                                continue
+                            if (
+                                not _flood_result.success
+                                and getattr(_flood_result, "ambiguous", False)
+                            ):
+                                # Any of ``fallback_lines`` may have landed.
+                                # Never replay the old visible prefix or this tail.
+                                state.progress_msg_id = None
+                                state.progress_lines = []
+                                state.delivered_progress_lines = []
+                                state.can_edit = False
+                                ctx.last_progress_msg[0] = None
+                                ctx.repeat_count[0] = 0
+                            elif _flood_result.success:
+                                if state.can_edit and _flood_result.message_id:
+                                    # Continue editing the fresh fallback bubble,
+                                    # whose ledger contains only what it rendered.
+                                    state.progress_msg_id = _flood_result.message_id
+                                    state.progress_lines = list(fallback_lines)
+                                    state.delivered_progress_lines = list(fallback_lines)
+                                else:
+                                    # Visible but not safely editable. Freeze both
+                                    # the old bubble and the complete fallback tail.
+                                    state.progress_msg_id = None
+                                    state.progress_lines = []
+                                    state.delivered_progress_lines = []
+                                    state.can_edit = False
+                                    ctx.last_progress_msg[0] = None
+                                    ctx.repeat_count[0] = 0
+                            if (
+                                ctx._cleanup_progress
+                                and getattr(_flood_result, "success", False)
+                                and getattr(_flood_result, "message_id", None)
+                            ):
+                                ctx._cleanup_msg_ids.append(str(_flood_result.message_id))
                     else:
-                        # Editing unsupported: send just this line
+                        state.delivered_progress_lines = list(state.progress_lines)
+                else:
+                    sent_all = state.can_edit
+                    content_to_send = "\n".join(state.progress_lines) if sent_all else msg
+                    try:
                         result = await adapter.send(
                             chat_id=ctx.source.chat_id,
-                            content=msg,
+                            content=content_to_send,
                             reply_to=ctx._progress_reply_to,
                             metadata=ctx._progress_metadata,
                         )
-                    if result.success and result.message_id:
-                        progress_msg_id = result.message_id
-                        if ctx._cleanup_progress:
-                            ctx._cleanup_msg_ids.append(str(result.message_id))
+                    except asyncio.CancelledError:
+                        state.drop_attempted_send(
+                            sent_all=sent_all, attempted_line=msg
+                        )
+                        raise
+                    except Exception:
+                        # Entering adapter.send() makes an untyped exception
+                        # ACK-ambiguous. Remove only this attempted payload so
+                        # later progress cannot replay it.
+                        state.drop_attempted_send(
+                            sent_all=sent_all, attempted_line=msg
+                        )
+                        logger.warning(
+                            "[%s] Progress send raised with unknown outcome; "
+                            "suppressing duplicate retry",
+                            getattr(adapter, "name", "unknown"),
+                            exc_info=True,
+                        )
+                        continue
+                    if not result.success and getattr(result, "ambiguous", False):
+                        state.drop_attempted_send(
+                            sent_all=sent_all, attempted_line=msg
+                        )
+                    if result.success:
+                        if result.message_id:
+                            if state.can_edit:
+                                state.progress_msg_id = result.message_id
+                                state.delivered_progress_lines = list(state.progress_lines)
+                            if ctx._cleanup_progress:
+                                ctx._cleanup_msg_ids.append(str(result.message_id))
+                        elif state.can_edit:
+                            # The bubble is visible but cannot be edited.
+                            # Freeze it so later progress is not replayed.
+                            state.progress_msg_id = None
+                            state.progress_lines = []
+                            state.delivered_progress_lines = []
+                            ctx.last_progress_msg[0] = None
+                            ctx.repeat_count[0] = 0
+                        if not state.can_edit:
+                            # Separate mode posts only ``msg`` as its own bubble.
+                            # Remove that confirmed-visible line from the pending
+                            # buffer so a later content reset cannot replay it.
+                            state.drop_attempted_send(
+                                sent_all=False, attempted_line=msg
+                            )
 
-                _last_edit_ts = time.monotonic()
+                state.last_edit_ts = time.monotonic()
 
                 # Restore typing indicator
                 await asyncio.sleep(0.3)
@@ -5681,38 +5685,47 @@ class TurnRunner:
                         raw = ctx.progress_queue.get_nowait()
                         if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                             _, base_msg, count = raw
-                            if progress_lines:
-                                progress_lines[-1] = f"{base_msg} (×{count + 1})"
-                                await _roll_progress_overflow_if_needed()
+                            if state.progress_lines:
+                                state.progress_lines[-1] = f"{base_msg} (×{count + 1})"
+                                await state.roll_overflow_if_needed()
                         elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                             # Content-bubble marker during drain: close off
                             # the current progress bubble and start a fresh
                             # one for any tool lines that arrived after.
-                            await _roll_progress_overflow_if_needed()
-                            if can_edit and progress_lines and progress_msg_id:
-                                _pending_text = _progress_text(progress_lines)
-                                try:
-                                    await _edit_progress_message(progress_msg_id, _pending_text)
-                                except Exception:
-                                    pass
-                            progress_msg_id = None
-                            progress_lines = []
+                            await state.roll_overflow_if_needed()
+                            boundary_settled = True
+                            if state.can_edit and state.progress_lines and state.progress_msg_id:
+                                boundary_settled = (
+                                    await state.settle_edit_during_drain()
+                                )
+                            elif state.progress_lines:
+                                await state.flush_fresh_with_retry(
+                                    state.undelivered_lines()
+                                )
+                                boundary_settled = not state.undelivered_lines()
+                            if not boundary_settled:
+                                # Preserve the exact tail for the final drain
+                                # rather than clearing it at this reset marker.
+                                continue
+                            state.progress_msg_id = None
+                            state.progress_lines = []
+                            state.delivered_progress_lines = []
                             ctx.last_progress_msg[0] = None
                             ctx.repeat_count[0] = 0
                         else:
-                            progress_lines.append(raw)
-                            await _roll_progress_overflow_if_needed()
+                            state.progress_lines.append(raw)
+                            await state.roll_overflow_if_needed()
                     except Exception:
                         break
                 # Final edit with all remaining tools (only if editing works)
-                if can_edit and progress_lines and progress_msg_id:
-                    await _roll_progress_overflow_if_needed()
-                if can_edit and progress_lines and progress_msg_id:
-                    full_text = _progress_text(progress_lines)
-                    try:
-                        await _edit_progress_message(progress_msg_id, full_text)
-                    except Exception:
-                        pass
+                if state.can_edit and state.progress_lines and state.progress_msg_id:
+                    await state.roll_overflow_if_needed()
+                if state.can_edit and state.progress_lines and state.progress_msg_id:
+                    await state.settle_edit_during_drain()
+                elif state.progress_lines:
+                    await state.flush_fresh_with_retry(
+                        state.undelivered_lines()
+                    )
                 return
             except Exception as e:
                 logger.error("Progress message error: %s", e)
@@ -6046,6 +6059,11 @@ class TurnRunner:
                             on_missing_cursor="raise",
                         )
                     )
+
+                    async def _wait_for_progress_before_final_delivery() -> None:
+                        if ctx._progress_finalization_ready is not None:
+                            await ctx._progress_finalization_ready.wait()
+
                     _stream_consumer = GatewayStreamConsumer(
                         adapter=_adapter,
                         chat_id=ctx.source.chat_id,
@@ -6057,6 +6075,9 @@ class TurnRunner:
                             else None
                         ),
                         on_before_finalize=_pause_typing_before_finalize,
+                        on_before_final_delivery=(
+                            _wait_for_progress_before_final_delivery
+                        ),
                         initial_reply_to_id=ctx.event_message_id,
                         run_still_current=ctx._run_still_current,
                     )
@@ -31844,6 +31865,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         turn_ctx.tools_holder = tools_holder
         turn_ctx.stream_consumer_holder = stream_consumer_holder
         turn_ctx.streaming_tts_consumer_holder = streaming_tts_consumer_holder
+        turn_ctx._progress_finalization_ready = asyncio.Event()
         
         # Bridge sync step_callback → async hooks.emit for agent:step events
         _loop_for_step = asyncio.get_running_loop()
@@ -31952,6 +31974,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         progress_task = None
         if needs_progress_queue:
             progress_task = asyncio.create_task(send_progress_messages())
+
+        progress_drain_complete = False
+
+        async def _drain_progress_before_finalization() -> None:
+            """Boundedly drain progress once, then release streamed finalization."""
+            nonlocal progress_drain_complete
+            if progress_drain_complete:
+                return
+            progress_drain_complete = True
+            try:
+                if progress_task:
+                    progress_task.cancel()
+                    completed = await self._await_adapter_cleanup_with_timeout(
+                        progress_task, _PROGRESS_FINALIZE_TIMEOUT
+                    )
+                    if not completed:
+                        logger.warning(
+                            "Timed out after %.1fs finalizing progress; continuing turn cleanup",
+                            _PROGRESS_FINALIZE_TIMEOUT,
+                        )
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug(
+                    "progress task failed during turn cleanup",
+                    exc_info=True,
+                )
+            finally:
+                turn_ctx._progress_finalization_ready.set()
+
+        if progress_task is None:
+            progress_drain_complete = True
+            turn_ctx._progress_finalization_ready.set()
 
         # Start the tool-call log writer when tool_progress == "log".
         log_task = None
@@ -32556,6 +32611,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             result = result_holder[0]
             adapter = self._adapter_for_source(source)
 
+            # run_sync may already have signalled the stream consumer's finish
+            # queue. Its pre-finalize barrier holds the visible final edit until
+            # every bounded progress retry has either landed or timed out.
+            await _drain_progress_before_finalization()
+
             # Finalize the streaming-TTS consumer (#60671).
             #
             # finish() is called from the outer event-loop thread (not the
@@ -32895,12 +32955,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:
             # Stop progress sender, interrupt monitor, and notification task
-            if progress_task:
-                progress_task.cancel()
             if log_task:
                 log_task.cancel()
             interrupt_monitor.cancel()
             _notify_task.cancel()
+
+            await _drain_progress_before_finalization()
 
             # Wait for stream consumer to finish its final edit
             if stream_task:
@@ -32956,7 +33016,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._update_runtime_status("draining")
             
             # Wait for cancelled tasks
-            for task in [progress_task, log_task, interrupt_monitor, tracking_task, _notify_task]:
+            for task in [log_task, interrupt_monitor, tracking_task, _notify_task]:
                 if task:
                     try:
                         await task

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -241,6 +241,7 @@ class GatewayStreamConsumer:
         metadata: Optional[dict] = None,
         on_new_message: Optional[callable] = None,
         on_before_finalize: Optional[Callable[[], Any]] = None,
+        on_before_final_delivery: Optional[Callable[[], Any]] = None,
         initial_reply_to_id: Optional[str] = None,
         run_still_current: Optional[Callable[[], bool]] = None,
     ):
@@ -260,6 +261,10 @@ class GatewayStreamConsumer:
         # Gateway callers use this to pause typing refreshes before a slow
         # final rich-text edit (Telegram MarkdownV2 finalize, etc.).
         self._on_before_finalize = on_before_finalize
+        # Fired once before any turn-final content can become visible. This is
+        # separate because the finalize hook intentionally follows an initial
+        # preview send for adapters that require a final edit.
+        self._on_before_final_delivery = on_before_final_delivery
         self._initial_reply_to_id = initial_reply_to_id
 
         # Per-turn identifier: uniquely identifies this consumer's stream turn.
@@ -431,6 +436,12 @@ class GatewayStreamConsumer:
         self._tool_progress_lines: list[str] = []
         self._tool_progress_active: bool = False
 
+        self._before_final_delivery_notified = False
+        # A tool/segment boundary separates visible preamble from the answer
+        # that follows tool progress.  Once armed, the first progressive frame
+        # of that post-tool segment must pass the same progress-drain barrier as
+        # the terminal finalize frame; waiting only for _DONE is too late.
+        self._post_segment_delivery_barrier_armed = False
 
     def _stream_is_message(self) -> bool:
         """Whether THIS chat's transport treats the stream as the message.
@@ -544,6 +555,20 @@ class GatewayStreamConsumer:
             return
         try:
             result = self._on_before_finalize()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            pass
+
+    async def _notify_before_final_delivery(self) -> None:
+        """Run the final-delivery barrier exactly once, swallowing hook errors."""
+        if self._before_final_delivery_notified:
+            return
+        self._before_final_delivery_notified = True
+        if self._on_before_final_delivery is None:
+            return
+        try:
+            result = self._on_before_final_delivery()
             if inspect.isawaitable(result):
                 await result
         except Exception:
@@ -1497,6 +1522,12 @@ class GatewayStreamConsumer:
                     ):
                         await self._suppress_silence_marker()
                         return
+                    if (
+                        self._accumulated
+                        or self._message_id is not None
+                        or self._already_sent
+                    ):
+                        await self._notify_before_final_delivery()
 
                 # Decide whether to flush an edit
                 now = time.monotonic()
@@ -1551,7 +1582,17 @@ class GatewayStreamConsumer:
                     )
                 ):
                     should_edit = False
-                if should_edit and (self._accumulated or (self._use_native_streaming and self._tool_progress_active)):
+                if should_edit and (
+                    self._accumulated
+                    or (self._use_native_streaming and self._tool_progress_active)
+                ):
+                    if (
+                        self._post_segment_delivery_barrier_armed
+                        and not got_segment_break
+                        and commentary_text is None
+                    ):
+                        await self._notify_before_final_delivery()
+                        self._post_segment_delivery_barrier_armed = False
                     # Split overflow: if accumulated text exceeds the platform
                     # limit, split into properly sized chunks.
                     # Native streaming bypasses this entirely — the adapter's
@@ -1739,7 +1780,11 @@ class GatewayStreamConsumer:
                         self._tool_progress_active = False
 
                 if got_done:
-                    if self._accumulated or self._message_id is not None or self._already_sent:
+                    if (
+                        self._accumulated
+                        or self._message_id is not None
+                        or self._already_sent
+                    ):
                         await self._notify_before_finalize()
                     # Final edit without cursor. If progressive editing failed
                     # mid-stream, send a single continuation/fallback message
@@ -1975,6 +2020,7 @@ class GatewayStreamConsumer:
                         ):
                             await self._flush_segment_tail_on_edit_failure()
                         self._reset_segment_state(preserve_no_edit=True)
+                    self._post_segment_delivery_barrier_armed = True
 
                 # Flush barrier satisfied: the buffered segment (if any) has now
                 # been finalized and delivered above, so wake the thread blocked

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -118,6 +118,7 @@ class TurnContext:
     tools_holder: list = field(default_factory=lambda: [None])
     stream_consumer_holder: list = field(default_factory=lambda: [None])
     streaming_tts_consumer_holder: list = field(default_factory=lambda: [None])
+    _progress_finalization_ready: Any = None
 
     # --- voice-ack wiring --------------------------------------------------
     _voice_ack_fired: list = field(default_factory=lambda: [False])

--- a/tests/gateway/relay/test_relay_ack_ambiguity.py
+++ b/tests/gateway/relay/test_relay_ack_ambiguity.py
@@ -32,6 +32,7 @@ class AckLossTransport:
         self.ops = []
         self.lose_acks_for = set(lose_acks_for)
         self.lose_times = dict(lose_times or {})  # key -> remaining losses
+        self._identities = []
         self._n = 0
 
     def _lost(self, key):
@@ -93,6 +94,33 @@ class TestSealAckLoss:
 
 
 class TestFrameAckLoss:
+    @pytest.mark.asyncio
+    async def test_plain_send_preserves_transport_ambiguity(self):
+        """Relay send results expose ACK-loss ambiguity to gateway callers."""
+        adapter, _ = _connected_adapter()
+        adapter._transport = AckLossTransport(lose_acks_for=("send",))
+
+        result = await adapter.send("C1", "progress continuation")
+
+        assert result.success is False
+        assert result.ambiguous is True
+        assert result.error == "relay outbound timed out"
+
+    @pytest.mark.asyncio
+    async def test_explicit_platform_send_preserves_transport_ambiguity(self):
+        """Persisted/scheduled relay sends keep the same ambiguity contract."""
+        adapter, _ = _connected_adapter()
+        transport = AckLossTransport(lose_acks_for=("send",))
+        transport._identities = [("slack", "bot-1")]
+        adapter._transport = transport
+
+        result = await adapter.send_for_platform(
+            "slack", "C1", "progress continuation"
+        )
+
+        assert result.success is False
+        assert result.ambiguous is True
+
     @pytest.mark.asyncio
     async def test_lost_frame_ack_keeps_interception_armed(self):
         """THE round-2 regression: a timeout-shaped frame result must not

--- a/tests/gateway/relay/test_relay_adapter.py
+++ b/tests/gateway/relay/test_relay_adapter.py
@@ -108,6 +108,36 @@ class _CaptureTransport:
         return {"success": True, "message_id": "m1"}
 
 
+class _AmbiguousEditTransport(_CaptureTransport):
+    async def send_outbound(self, action, *, platform=None):
+        self.sent = action
+        self.sent_platform = platform
+        return {
+            "success": False,
+            "message_id": action.get("message_id"),
+            "error": "relay outbound timed out",
+            "ambiguous": True,
+            "retryable": True,
+            "error_kind": "transient",
+        }
+
+
+@pytest.mark.asyncio
+async def test_edit_preserves_typed_relay_ack_ambiguity():
+    transport = _AmbiguousEditTransport()
+    adapter = RelayAdapter(
+        PlatformConfig(), make_desc(platform="slack"), transport=transport
+    )
+
+    result = await adapter.edit_message("C1", "171.01", "updated")
+
+    assert result.success is False
+    assert result.message_id == "171.01"
+    assert result.ambiguous is True
+    assert result.retryable is True
+    assert result.error_kind == "transient"
+
+
 def _make_event(chat_id="chan-1", scope_id="scope-9"):
     from gateway.platforms.base import MessageEvent, MessageType
     from gateway.session import SessionSource

--- a/tests/gateway/relay/test_ws_transport_hardening.py
+++ b/tests/gateway/relay/test_ws_transport_hardening.py
@@ -83,7 +83,13 @@ async def test_read_loop_exit_fails_pending_futures_promptly():
     fake.drop.set()
 
     result = await asyncio.wait_for(send_task, timeout=2.0)
-    assert result == {"success": False, "error": "relay transport connection lost"}
+    assert result == {
+        "success": False,
+        "error": "relay transport connection lost",
+        "ambiguous": True,
+        "retryable": True,
+        "error_kind": "transient",
+    }
     assert t._pending == {}
     await t._reader
 
@@ -277,7 +283,13 @@ async def test_read_loop_without_socket_still_fails_pending():
     await t._read_loop()  # must not raise
 
     assert fut.done()
-    assert fut.result() == {"success": False, "error": "relay transport connection lost"}
+    assert fut.result() == {
+        "success": False,
+        "error": "relay transport connection lost",
+        "ambiguous": True,
+        "retryable": True,
+        "error_kind": "transient",
+    }
     assert t._pending == {}
 
 

--- a/tests/gateway/test_progress_delivery_state.py
+++ b/tests/gateway/test_progress_delivery_state.py
@@ -1,0 +1,144 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.platforms.base import SendResult
+from gateway.progress_delivery import ProgressDeliveryState
+
+
+class _SmallProgressAdapter:
+    MAX_MESSAGE_LENGTH = 10
+
+
+class _CaptureProgressAdapter(_SmallProgressAdapter):
+    def __init__(self, results: list[SendResult]) -> None:
+        self.results = list(results)
+        self.sent: list[str] = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(content)
+        return self.results.pop(0)
+
+
+class _AmbiguousEditCaptureAdapter(_CaptureProgressAdapter):
+    def __init__(self, send_results: list[SendResult]) -> None:
+        super().__init__(send_results)
+        self.edited: list[str] = []
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edited.append(content)
+        return SendResult(
+            success=False,
+            error="ack lost",
+            retryable=True,
+            ambiguous=True,
+        )
+
+
+def _state(adapter=None) -> ProgressDeliveryState:
+    context = SimpleNamespace(
+        progress_grouping="grouped",
+        source=SimpleNamespace(chat_id="chat-1"),
+        _progress_metadata=None,
+        _progress_reply_to=None,
+        _cleanup_progress=False,
+        _cleanup_msg_ids=[],
+        last_progress_msg=[None],
+        repeat_count=[0],
+    )
+    return ProgressDeliveryState(context, adapter or _SmallProgressAdapter())
+
+
+def test_progress_delivery_state_splits_groups_at_platform_boundary() -> None:
+    state = _state()
+
+    assert state.split_groups(["abcdef", "ghij"]) == [["abcdef"], ["ghij"]]
+
+    chunks = state.split_line("klmnopqrstuv")
+    assert chunks == ["klmnopqrst", "uv"]
+    assert "".join(chunks) == "klmnopqrstuv"
+    assert all(len(chunk) <= state.text_limit for chunk in chunks)
+
+
+def test_progress_delivery_state_tracks_only_undelivered_suffix() -> None:
+    state = _state()
+    state.progress_lines = ["first", "second", "third"]
+    state.delivered_progress_lines = ["first", "second"]
+
+    assert state.undelivered_lines() == ["third"]
+
+
+def test_progress_delivery_state_drops_only_attempted_separate_send() -> None:
+    state = _state()
+    state.can_edit = False
+    state.progress_lines = ["first", "second"]
+    state.delivered_progress_lines = ["first"]
+
+    state.drop_attempted_send(sent_all=False, attempted_line="second")
+
+    assert state.progress_lines == ["first"]
+    assert state.delivered_progress_lines == ["first"]
+    assert state.progress_msg_id is None
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_fresh_send_retains_only_never_attempted_groups() -> None:
+    adapter = _CaptureProgressAdapter([
+        SendResult(
+            success=False,
+            error="ack lost",
+            retryable=True,
+            ambiguous=True,
+        )
+    ])
+    state = _state(adapter)
+
+    assert not await state.start_fresh_bubbles(["abcdef", "ghij"])
+
+    assert adapter.sent == ["abcdef"]
+    assert state.progress_lines == ["ghij"]
+    assert state.delivered_progress_lines == []
+    assert state.progress_msg_id is None
+
+
+@pytest.mark.asyncio
+async def test_too_long_continuation_sends_only_undelivered_suffix() -> None:
+    adapter = _CaptureProgressAdapter([
+        SendResult(success=True, message_id="new-bubble")
+    ])
+    state = _state(adapter)
+    state.progress_msg_id = "full-bubble"
+    state.progress_lines = ["first", "second"]
+    state.delivered_progress_lines = ["first"]
+
+    assert await state.continue_after_too_long()
+
+    assert adapter.sent == ["second"]
+    assert state.progress_lines == ["second"]
+    assert state.delivered_progress_lines == ["second"]
+    assert state.progress_msg_id == "new-bubble"
+
+
+@pytest.mark.asyncio
+async def test_drain_preserves_suffix_after_ambiguous_edit_retry() -> None:
+    adapter = _AmbiguousEditCaptureAdapter([
+        SendResult(success=True, message_id="suffix-bubble")
+    ])
+    state = _state(adapter)
+    state.progress_msg_id = "existing-bubble"
+    state.progress_lines = ["first", "second", "third"]
+    state.delivered_progress_lines = ["first", "second"]
+    state.pending_ambiguous_edit = (
+        "existing-bubble",
+        "first\nsecond",
+        ["first", "second"],
+    )
+
+    assert await state.settle_edit_during_drain()
+
+    assert adapter.edited == ["first\nsecond"]
+    assert adapter.sent == ["third"]
+    assert state.progress_lines == ["third"]
+    assert state.delivered_progress_lines == ["third"]
+    assert state.progress_msg_id == "suffix-bubble"
+    assert state.pending_ambiguous_edit is None

--- a/tests/gateway/test_progress_delivery_state.py
+++ b/tests/gateway/test_progress_delivery_state.py
@@ -35,6 +35,16 @@ class _AmbiguousEditCaptureAdapter(_CaptureProgressAdapter):
         )
 
 
+class _RaisingOverflowEditAdapter(_CaptureProgressAdapter):
+    def __init__(self) -> None:
+        super().__init__([])
+        self.edited: list[str] = []
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edited.append(content)
+        raise RuntimeError("response decode failed after visible edit")
+
+
 def _state(adapter=None) -> ProgressDeliveryState:
     context = SimpleNamespace(
         progress_grouping="grouped",
@@ -142,3 +152,22 @@ async def test_drain_preserves_suffix_after_ambiguous_edit_retry() -> None:
     assert state.delivered_progress_lines == ["third"]
     assert state.progress_msg_id == "suffix-bubble"
     assert state.pending_ambiguous_edit is None
+
+
+@pytest.mark.asyncio
+async def test_raising_overflow_edit_retains_exact_ambiguous_operation() -> None:
+    adapter = _RaisingOverflowEditAdapter()
+    state = _state(adapter)
+    state.progress_msg_id = "existing-bubble"
+    state.progress_lines = ["abcdef", "ghij"]
+
+    assert await state.roll_overflow_if_needed()
+
+    assert adapter.edited == ["abcdef"]
+    assert adapter.sent == []
+    assert state.pending_ambiguous_edit == (
+        "existing-bubble",
+        "abcdef",
+        ["abcdef"],
+    )
+    assert state.delivered_progress_lines == ["abcdef"]

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -2,9 +2,12 @@
 
 import asyncio
 import importlib
+import queue
 import sys
+import threading
 import time
 import types
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
 import pytest
@@ -13,6 +16,27 @@ import gateway.platforms.base as base_platform
 from gateway.config import Platform, PlatformConfig, StreamingConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
 from gateway.session import SessionSource
+
+
+_single_progress_sent = threading.Event()
+_overflow_initial_sent = threading.Event()
+_overflow_send_failed = threading.Event()
+_overflow_missing_id_seen = threading.Event()
+_initial_send_failed = threading.Event()
+_initial_no_id_delivered = threading.Event()
+_retryable_overflow_initial_sent = threading.Event()
+_retryable_overflow_edit_failed = threading.Event()
+_cancelled_overflow_initial_sent = threading.Event()
+_cancelled_overflow_send_started = threading.Event()
+_interim_content_sent = threading.Event()
+_retained_tail_flushed = threading.Event()
+_grouped_initial_sent = threading.Event()
+_grouped_continuation_edited = threading.Event()
+_ordering_draft_sent = threading.Event()
+_ordering_initial_progress_failed = threading.Event()
+_ordering_progress_retry_started = threading.Event()
+_ordering_progress_retry_release = threading.Event()
+_ordering_final_sent = threading.Event()
 
 
 class ProgressCaptureAdapter(BasePlatformAdapter):
@@ -180,6 +204,12 @@ class RetryableOverflowEditProgressAdapter(SmallLimitProgressAdapter):
         super().__init__(platform=platform)
         self.retryable_edit_failures = 0
 
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        result = await super().send(chat_id, content, reply_to, metadata)
+        if len(self.sent) == 1:
+            _retryable_overflow_initial_sent.set()
+        return result
+
     async def edit_message(self, chat_id, message_id, content) -> SendResult:
         if self.retryable_edit_failures == 0:
             self.retryable_edit_failures += 1
@@ -190,6 +220,7 @@ class RetryableOverflowEditProgressAdapter(SmallLimitProgressAdapter):
                     "content": content,
                 }
             )
+            _retryable_overflow_edit_failed.set()
             return SendResult(
                 success=False,
                 error="temporary network failure",
@@ -197,6 +228,415 @@ class RetryableOverflowEditProgressAdapter(SmallLimitProgressAdapter):
                 error_kind="transient",
             )
         return await super().edit_message(chat_id, message_id, content)
+
+
+class AmbiguousOverflowEditProgressAdapter(SmallLimitProgressAdapter):
+    """Keep every overflow edit ACK-ambiguous to test stable retries."""
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        result = await super().send(chat_id, content, reply_to, metadata)
+        if len(self.sent) == 1:
+            _retryable_overflow_initial_sent.set()
+        return result
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {"chat_id": chat_id, "message_id": message_id, "content": content}
+        )
+        _retryable_overflow_edit_failed.set()
+        return SendResult(
+            success=False,
+            error="relay acknowledgement timed out",
+            retryable=True,
+            error_kind="transient",
+            ambiguous=True,
+        )
+
+
+class TooLongOverflowEditProgressAdapter(SmallLimitProgressAdapter):
+    """Reject the first progress edit with Slack's size-limit error."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.too_long_edit_failures = 0
+        self.visible = {}
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        result = await super().send(chat_id, content, reply_to, metadata)
+        if result.success and result.message_id:
+            self.sent[-1]["message_id"] = result.message_id
+            self.visible[result.message_id] = content
+            if len(self.sent) == 1:
+                _grouped_initial_sent.set()
+        return result
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        if self.too_long_edit_failures == 0:
+            self.too_long_edit_failures += 1
+            self.edits.append(
+                {
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "content": content,
+                }
+            )
+            return SendResult(success=False, error="Slack API error: msg_too_long")
+        result = await super().edit_message(chat_id, message_id, content)
+        if result.success:
+            self.visible[message_id] = content
+            if message_id != "progress-1":
+                _grouped_continuation_edited.set()
+        return result
+
+
+class TooLongFinalEditProgressAdapter(SmallLimitProgressAdapter):
+    """Synchronize one delivered line, then reject its identical final edit."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.too_long_edit_failures = 0
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        result = await super().send(chat_id, content, reply_to, metadata)
+        _single_progress_sent.set()
+        return result
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.too_long_edit_failures += 1
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        return SendResult(success=False, error="Slack API error: msg_too_long")
+
+
+class TypedTransientTooLongEditProgressAdapter(SmallLimitProgressAdapter):
+    """Return a typed transient whose detail happens to say ``too long``."""
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        result = await super().send(chat_id, content, reply_to, metadata)
+        _single_progress_sent.set()
+        return result
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        return SendResult(
+            success=False,
+            error="relay request took too long awaiting acknowledgement",
+            retryable=True,
+            error_kind="transient",
+        )
+
+
+class AmbiguousEditProgressAdapter(SmallLimitProgressAdapter):
+    """Lose an edit ACK without classifying the result as retryable."""
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        result = await super().send(chat_id, content, reply_to, metadata)
+        _single_progress_sent.set()
+        return result
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        return SendResult(
+            success=False,
+            error="relay outbound timed out",
+            ambiguous=True,
+        )
+
+
+class RetryFreshSendAfterTooLongAdapter(SmallLimitProgressAdapter):
+    """Fail the first continuation send after a final ``msg_too_long`` edit."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.send_attempts = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.send_attempts.append(content)
+        if len(self.send_attempts) == 2:
+            return SendResult(
+                success=False,
+                error="temporary continuation send failure",
+                retryable=True,
+                error_kind="transient",
+            )
+        result = await super().send(chat_id, content, reply_to, metadata)
+        if len(self.send_attempts) == 1:
+            _single_progress_sent.set()
+        return result
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        return SendResult(success=False, error="Slack API error: msg_too_long")
+
+
+class RaisingFreshSendAfterTooLongAdapter(RetryFreshSendAfterTooLongAdapter):
+    """Post the first continuation, then raise before its ACK can be decoded."""
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.send_attempts.append(content)
+        if len(self.send_attempts) == 2:
+            self.sent.append(
+                {
+                    "chat_id": chat_id,
+                    "content": content,
+                    "reply_to": reply_to,
+                    "metadata": metadata,
+                }
+            )
+            raise RuntimeError("temporary continuation send exception")
+        result = await SmallLimitProgressAdapter.send(
+            self, chat_id, content, reply_to, metadata
+        )
+        if len(self.send_attempts) == 1:
+            _single_progress_sent.set()
+        return result
+
+
+class AmbiguousFreshSendAfterTooLongAdapter(RetryFreshSendAfterTooLongAdapter):
+    """Lose the ACK for the first non-idempotent continuation send."""
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.send_attempts.append(content)
+        if len(self.send_attempts) == 2:
+            return SendResult(
+                success=False,
+                error="relay outbound timed out",
+                ambiguous=True,
+            )
+        result = await SmallLimitProgressAdapter.send(
+            self, chat_id, content, reply_to, metadata
+        )
+        if len(self.send_attempts) == 1:
+            _single_progress_sent.set()
+        return result
+
+
+class FailedOverflowGroupAdapter(SmallLimitProgressAdapter):
+    """Fail one overflow group and expose the successfully visible messages."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.send_attempts = []
+        self.visible = {}
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.send_attempts.append(content)
+        if content == "content between progress groups":
+            result = await SmallLimitProgressAdapter.send(
+                self, chat_id, content, reply_to, metadata
+            )
+            if result.success:
+                _interim_content_sent.set()
+            return result
+        if len(self.send_attempts) == 2:
+            _overflow_send_failed.set()
+            return SendResult(
+                success=False,
+                error="temporary overflow group failure",
+                retryable=True,
+                error_kind="transient",
+            )
+        result = await super().send(chat_id, content, reply_to, metadata)
+        if result.success and result.message_id:
+            self.visible[result.message_id] = content
+            if _interim_content_sent.is_set():
+                _retained_tail_flushed.set()
+        if len(self.send_attempts) == 1:
+            _overflow_initial_sent.set()
+        return result
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        result = await super().edit_message(chat_id, message_id, content)
+        if result.success:
+            self.visible[message_id] = content
+        return result
+
+
+class MissingIdOverflowGroupAdapter(SmallLimitProgressAdapter):
+    """Deliver one continuation successfully without an editable message ID."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.send_attempts = []
+        self.visible = {}
+        self.visible_without_ids = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.send_attempts.append(content)
+        if len(self.send_attempts) == 2:
+            self.visible_without_ids.append(content)
+            _overflow_missing_id_seen.set()
+            return SendResult(success=True, message_id=None)
+        result = await super().send(chat_id, content, reply_to, metadata)
+        if result.success and result.message_id:
+            self.visible[result.message_id] = content
+        if len(self.send_attempts) == 1:
+            _overflow_initial_sent.set()
+        return result
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        result = await super().edit_message(chat_id, message_id, content)
+        if result.success:
+            self.visible[message_id] = content
+        return result
+
+
+class CancelledOverflowGroupAdapter(SmallLimitProgressAdapter):
+    """Pause an overflow split after one successful no-ID continuation."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.send_attempts = []
+        self.visible = {}
+        self.visible_without_ids = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.send_attempts.append(content)
+        attempt = len(self.send_attempts)
+        if attempt == 2:
+            self.visible_without_ids.append(content)
+            return SendResult(success=True, message_id=None)
+        if attempt == 3:
+            # The relay frame reached the wire before cancellation interrupted
+            # its acknowledgement wait.  Treat this as possibly visible.
+            self.visible_without_ids.append(content)
+            _cancelled_overflow_send_started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("blocked continuation send should be cancelled")
+        result = await super().send(chat_id, content, reply_to, metadata)
+        if result.success and result.message_id:
+            self.visible[result.message_id] = content
+        if attempt == 1:
+            _cancelled_overflow_initial_sent.set()
+        return result
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        result = await super().edit_message(chat_id, message_id, content)
+        if result.success:
+            self.visible[message_id] = content
+        return result
+
+
+class WedgedCancellationDrainAdapter(SmallLimitProgressAdapter):
+    """Hang until a bounded cleanup wait cancels the finalizer send."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.send_attempts = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.send_attempts.append(content)
+        if len(self.send_attempts) == 1:
+            _initial_send_failed.set()
+            return SendResult(
+                success=False,
+                error="temporary progress send failure",
+                retryable=True,
+                error_kind="transient",
+            )
+        await asyncio.Event().wait()
+        raise AssertionError("wedged finalizer send should be cancelled")
+
+
+class OrderedFinalProgressAdapter(ProgressCaptureAdapter):
+    """Capture whether cancellation progress drains before streamed final text."""
+
+    def __init__(self, platform=Platform.SLACK):
+        super().__init__(platform=platform)
+        self.send_attempts = []
+        self.visible_order = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.send_attempts.append(content)
+        if "ordering progress" in content and not _ordering_initial_progress_failed.is_set():
+            _ordering_initial_progress_failed.set()
+            return SendResult(
+                success=False,
+                error="temporary progress send failure",
+                retryable=True,
+                error_kind="transient",
+            )
+        if "ordering progress" in content:
+            _ordering_progress_retry_started.set()
+            while not _ordering_progress_retry_release.is_set():
+                await asyncio.sleep(0)
+        if "ordering progress" in content:
+            self.visible_order.append("progress")
+        elif "draft" in content:
+            self.visible_order.append("draft")
+            _ordering_draft_sent.set()
+        elif content == "done":
+            self.visible_order.append("final")
+            _ordering_final_sent.set()
+        return await super().send(chat_id, content, reply_to, metadata)
+
+    async def edit_message(self, chat_id, message_id, content, **kwargs) -> SendResult:
+        result = await super().edit_message(chat_id, message_id, content)
+        if result.success and content == "done":
+            self.visible_order.append("final")
+            _ordering_final_sent.set()
+        return result
+
+
+class RetryNoIdDrainAdapter(SmallLimitProgressAdapter):
+    """Fail the initial send and first cancellation-drain retry."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.send_attempts = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.send_attempts.append(content)
+        if len(self.send_attempts) <= 2:
+            if len(self.send_attempts) == 1:
+                _initial_send_failed.set()
+            return SendResult(
+                success=False,
+                error="temporary progress send failure",
+                retryable=True,
+                error_kind="transient",
+            )
+        return await super().send(chat_id, content, reply_to, metadata)
+
+
+class SuccessfulInitialNoIdAdapter(SmallLimitProgressAdapter):
+    """Deliver the first progress bubble without returning an editable ID."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.send_attempts = []
+        self.visible_without_ids = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.send_attempts.append(content)
+        if len(self.send_attempts) == 1:
+            self.visible_without_ids.append(content)
+            _initial_no_id_delivered.set()
+            return SendResult(success=True, message_id=None)
+        return await super().send(chat_id, content, reply_to, metadata)
 
 
 class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
@@ -448,6 +888,270 @@ class DelayedInterimAgent:
         time.sleep(0.45)
         self.interim_assistant_callback("second interim")
         time.sleep(0.1)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class GroupedProgressLinesAgent:
+    """Emit short lines so several fit in each continuation bubble."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        callback("tool.started", "terminal", "grouped-seed", {})
+        assert _grouped_initial_sent.wait(timeout=2)
+        for index in range(1, 9):
+            callback("tool.started", "terminal", f"grouped-item-{index}", {})
+        assert _grouped_continuation_edited.wait(timeout=4)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 9,
+        }
+
+
+class SingleProgressLineAgent:
+    """Leave one already-delivered line for the cancellation finalizer."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        callback("tool.started", "terminal", "only command", {})
+        assert _single_progress_sent.wait(timeout=2)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class PendingProgressLineAgent:
+    """Queue one unseen line immediately before cancellation finalization."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        callback("tool.started", "terminal", "first command", {})
+        assert _single_progress_sent.wait(timeout=2)
+        callback("tool.started", "terminal", "second command", {})
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class OrderedFinalProgressAgent:
+    """Finish a streamed answer while one definite progress failure is pending."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        progress = self.tool_progress_callback
+        assert progress is not None
+        if self.stream_delta_callback:
+            self.stream_delta_callback("draft")
+            assert _ordering_draft_sent.wait(timeout=2)
+        progress("tool.started", "terminal", "ordering progress", {})
+        assert _ordering_initial_progress_failed.wait(timeout=2)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class RetryableOverflowLinesAgent:
+    """Drive a transient overflow edit using acknowledgements, not sleeps."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        callback("tool.started", "terminal", "first-short", {})
+        assert _retryable_overflow_initial_sent.wait(timeout=2)
+        for index in range(1, 8):
+            callback(
+                "tool.started",
+                "terminal",
+                f"overflow-line-{index}-" + ("x" * 45),
+                {},
+            )
+        assert _retryable_overflow_edit_failed.wait(timeout=4)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class OverflowSendFailureAgent:
+    """Force a grouped overflow send, then return after one group fails."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        callback("tool.started", "terminal", "base command", {})
+        assert _overflow_initial_sent.wait(timeout=2)
+        for index in range(1, 7):
+            callback(
+                "tool.started",
+                "terminal",
+                f"overflow-item-{index}-" + ("x" * 45),
+                {},
+            )
+        assert _overflow_send_failed.wait(timeout=4)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class OverflowSendFailureThenInterimAgent:
+    """Land content after a grouped overflow leaves an undelivered tail."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        progress = self.tool_progress_callback
+        interim = self.interim_assistant_callback
+        assert progress is not None
+        assert interim is not None
+        progress("tool.started", "terminal", "reset-base", {})
+        assert _overflow_initial_sent.wait(timeout=2)
+        for index in range(1, 7):
+            progress(
+                "tool.started",
+                "terminal",
+                f"reset-item-{index}-" + ("x" * 45),
+                {},
+            )
+        assert _overflow_send_failed.wait(timeout=4)
+        interim("content between progress groups")
+        assert _interim_content_sent.wait(timeout=2)
+        assert _retained_tail_flushed.wait(timeout=2)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class OverflowMissingIdAgent:
+    """Force grouped overflow and wait for a successful no-ID continuation."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        callback("tool.started", "terminal", "base command", {})
+        assert _overflow_initial_sent.wait(timeout=2)
+        for index in range(1, 7):
+            callback(
+                "tool.started",
+                "terminal",
+                f"no-id-item-{index}-" + ("x" * 45),
+                {},
+            )
+        assert _overflow_missing_id_seen.wait(timeout=4)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class CancelledOverflowGroupAgent:
+    """Finish while a later continuation group is still being sent."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        callback("tool.started", "terminal", "cancel-base", {})
+        assert _cancelled_overflow_initial_sent.wait(timeout=2)
+        for index in range(1, 7):
+            callback(
+                "tool.started",
+                "terminal",
+                f"cancel-item-{index}-" + ("x" * 45),
+                {},
+            )
+        assert _cancelled_overflow_send_started.wait(timeout=4)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class FailedInitialProgressSendAgent:
+    """Return once the initial progress send has failed without an ID."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        callback("tool.started", "terminal", "retry me", {})
+        assert _initial_send_failed.wait(timeout=2)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class InitialNoIdThenProgressAgent:
+    """Emit another line after a successful uneditable initial delivery."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        callback("tool.started", "terminal", "first no-id command", {})
+        assert _initial_no_id_delivered.wait(timeout=2)
+        callback("tool.started", "terminal", "second command", {})
         return {
             "final_response": "done",
             "messages": [],
@@ -1057,6 +1761,58 @@ async def _run_with_agent(
     return adapter, result
 
 
+@asynccontextmanager
+async def _running_progress_worker(adapter, *, grouping="accumulate"):
+    """Run the direct progress worker with the shared minimal test context."""
+    gateway_run = importlib.import_module("gateway.run")
+    progress_queue = queue.Queue()
+    ctx = SimpleNamespace(
+        progress_queue=progress_queue,
+        _native_slack_task_cards=False,
+        source=SimpleNamespace(chat_id="C123"),
+        progress_grouping=grouping,
+        _run_still_current=lambda: True,
+        _progress_reply_to=None,
+        _progress_metadata=None,
+        _cleanup_progress=False,
+        _cleanup_msg_ids=[],
+        agent_holder=[],
+        last_progress_msg=[None],
+        repeat_count=[0],
+    )
+    runner = SimpleNamespace(_adapter_for_source=lambda source: adapter)
+    task = asyncio.create_task(
+        gateway_run.TurnRunner(runner, ctx).send_progress_messages()
+    )
+    try:
+        yield progress_queue, task
+    finally:
+        if not task.done():
+            task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_oversized_single_progress_line_is_split_before_adapter_delivery():
+    adapter = SmallLimitProgressAdapter(platform=Platform.SLACK)
+    progress_line = "x" * (adapter.MAX_MESSAGE_LENGTH + 50)
+
+    async with _running_progress_worker(adapter) as (progress_queue, _task):
+        progress_queue.put(progress_line)
+        for _ in range(100):
+            if sum(len(call["content"]) for call in adapter.sent) >= len(progress_line):
+                break
+            await asyncio.sleep(0.01)
+
+    sent_chunks = [call["content"] for call in adapter.sent]
+    assert "".join(sent_chunks) == progress_line
+    assert adapter.oversized_sends == []
+    assert adapter.oversized_edits == []
+
+
 @pytest.mark.asyncio
 async def test_slack_native_progress_correlates_concurrent_duplicate_tools_by_id(
     monkeypatch, tmp_path
@@ -1134,10 +1890,11 @@ async def test_slack_native_failure_keeps_editing_one_live_text_fallback(
 @pytest.mark.asyncio
 async def test_retryable_overflow_edit_keeps_editable_bubble_identity(monkeypatch, tmp_path):
     """A transient split edit must retain can_edit and the current message ID."""
+    _retryable_overflow_initial_sent.clear()
     adapter, result = await _run_with_agent(
         monkeypatch,
         tmp_path,
-        ManyProgressLinesAgent,
+        RetryableOverflowLinesAgent,
         session_id="sess-progress-retry-overflow-same-message",
         config_data={
             "display": {
@@ -1160,6 +1917,1020 @@ async def test_retryable_overflow_edit_keeps_editable_bubble_identity(monkeypatc
     assert any(call["message_id"] == "progress-1" for call in adapter.edits[1:])
     assert adapter.oversized_sends == []
     assert adapter.oversized_edits == []
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_overflow_edit_retries_exact_payload(monkeypatch, tmp_path):
+    """Later lines must not mutate an unresolved same-ID edit retry."""
+    _retryable_overflow_initial_sent.clear()
+    _retryable_overflow_edit_failed.clear()
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        RetryableOverflowLinesAgent,
+        session_id="sess-progress-ambiguous-overflow-stable-payload",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="direct",
+        thread_id="1700000000.000100",
+        adapter_cls=AmbiguousOverflowEditProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.edits) >= 2
+    assert {edit["message_id"] for edit in adapter.edits} == {"progress-1"}
+    assert {edit["content"] for edit in adapter.edits} == {
+        adapter.edits[0]["content"]
+    }
+
+
+@pytest.mark.asyncio
+async def test_too_long_overflow_edit_starts_fresh_editable_bubble(
+    monkeypatch, tmp_path
+):
+    """Slack ``msg_too_long`` should roll over, not disable edits for the turn."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        GroupedProgressLinesAgent,
+        session_id="sess-progress-too-long-overflow-rollover",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+                "tool_preview_length": 60,
+            }
+        },
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="direct",
+        thread_id="1700000000.000100",
+        adapter_cls=TooLongOverflowEditProgressAdapter,
+    )
+    assert isinstance(adapter, TooLongOverflowEditProgressAdapter)
+
+    assert result["final_response"] == "done"
+    assert adapter.too_long_edit_failures == 1
+    assert adapter.edits[0]["message_id"] == "progress-1"
+    continuation_ids = {call["message_id"] for call in adapter.sent[1:]}
+    assert any(call["message_id"] in continuation_ids for call in adapter.edits[1:]), (
+        "expected later progress to edit a fresh continuation bubble"
+    )
+    assert len(adapter.sent) < 9, "progress fell back to one fresh send per tool line"
+    assert any("\n" in call["content"] for call in adapter.sent[1:])
+    visible_text = "\n".join(adapter.visible.values())
+    assert visible_text.count("grouped-seed") == 1
+    for index in range(1, 9):
+        assert visible_text.count(f"grouped-item-{index}") == 1
+    assert adapter.oversized_sends == []
+    assert adapter.oversized_edits == []
+
+
+@pytest.mark.asyncio
+async def test_identical_final_too_long_edit_does_not_duplicate_delivered_line(
+    monkeypatch, tmp_path
+):
+    """A no-op final edit rejection must freeze the bubble without resending it."""
+    _single_progress_sent.clear()
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        SingleProgressLineAgent,
+        session_id="sess-progress-too-long-identical-final",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="direct",
+        thread_id="1700000000.000100",
+        adapter_cls=TooLongFinalEditProgressAdapter,
+    )
+    assert isinstance(adapter, TooLongFinalEditProgressAdapter)
+
+    assert result["final_response"] == "done"
+    assert adapter.too_long_edit_failures == 1
+    sent_contents = [call["content"] for call in adapter.sent]
+    assert len(sent_contents) == 1
+    assert sent_contents[0].endswith("Running only command")
+
+
+@pytest.mark.asyncio
+async def test_typed_transient_edit_error_text_does_not_trigger_size_rollover(
+    monkeypatch, tmp_path
+):
+    """A populated error_kind is authoritative over ambiguous human text."""
+    _single_progress_sent.clear()
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        PendingProgressLineAgent,
+        session_id="sess-progress-typed-transient-not-overflow",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="direct",
+        thread_id="1700000000.000100",
+        adapter_cls=TypedTransientTooLongEditProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert isinstance(adapter, TypedTransientTooLongEditProgressAdapter)
+    assert len(adapter.edits) == 2
+    assert adapter.edits[0]["content"] == adapter.edits[1]["content"]
+    sent_contents = [call["content"] for call in adapter.sent]
+    assert len(sent_contents) == 2
+    assert sent_contents[0].endswith("Running first command")
+    assert sent_contents[1].endswith("Running second command"), (
+        "only the unseen tail may be fresh-sent after bounded transient edit retries"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_edit_does_not_fall_back_to_fresh_send(monkeypatch, tmp_path):
+    """An ACK-lost edit may have landed and must never trigger a duplicate bubble."""
+    _single_progress_sent.clear()
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        PendingProgressLineAgent,
+        session_id="sess-progress-ambiguous-edit",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="direct",
+        thread_id="1700000000.000100",
+        adapter_cls=AmbiguousEditProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.edits) == 2
+    assert adapter.edits[0]["content"] == adapter.edits[1]["content"]
+    assert len(adapter.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_content_reset_retries_ambiguous_edit_in_place(monkeypatch):
+    """A reset settles an ACK-lost edit before opening a fresh bubble."""
+    gateway_run = importlib.import_module("gateway.run")
+    clock = [0.0]
+
+    def monotonic():
+        clock[0] += 2.0
+        return clock[0]
+
+    monkeypatch.setattr(gateway_run.time, "monotonic", monotonic)
+    adapter = ProgressCaptureAdapter(platform=Platform.SLACK)
+    first_sent = asyncio.Event()
+    first_edit_attempted = asyncio.Event()
+    edit_retry_succeeded = asyncio.Event()
+    third_sent = asyncio.Event()
+    original_send = adapter.send
+
+    async def tracking_send(chat_id, content, reply_to=None, metadata=None):
+        result = await original_send(chat_id, content, reply_to, metadata)
+        if content == "first":
+            first_sent.set()
+        elif content == "third":
+            third_sent.set()
+        return result
+
+    async def ambiguous_then_successful_edit(chat_id, message_id, content):
+        adapter.edits.append(
+            {"chat_id": chat_id, "message_id": message_id, "content": content}
+        )
+        if len(adapter.edits) == 1:
+            first_edit_attempted.set()
+            return SendResult(
+                success=False,
+                error="relay acknowledgement timed out",
+                retryable=True,
+                error_kind="transient",
+                ambiguous=True,
+            )
+        edit_retry_succeeded.set()
+        return SendResult(success=True, message_id=message_id)
+
+    adapter.send = tracking_send
+    adapter.edit_message = ambiguous_then_successful_edit
+    async with _running_progress_worker(adapter) as (progress_queue, _task):
+        progress_queue.put("first")
+        await asyncio.wait_for(first_sent.wait(), timeout=2)
+        progress_queue.put("second")
+        await asyncio.wait_for(first_edit_attempted.wait(), timeout=2)
+        progress_queue.put(("__reset__",))
+        await asyncio.wait_for(edit_retry_succeeded.wait(), timeout=2)
+        progress_queue.put("third")
+        await asyncio.wait_for(third_sent.wait(), timeout=2)
+
+    assert [call["content"] for call in adapter.sent] == ["first", "third"]
+    assert [edit["content"] for edit in adapter.edits[:2]] == [
+        "first\nsecond",
+        "first\nsecond",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("adapter_cls", "attempt_count", "visible_count"),
+    [
+        (RetryFreshSendAfterTooLongAdapter, 3, 2),
+        (RaisingFreshSendAfterTooLongAdapter, 2, 2),
+        (AmbiguousFreshSendAfterTooLongAdapter, 2, 1),
+    ],
+)
+@pytest.mark.asyncio
+async def test_continuation_send_outcome_controls_bounded_retry(
+    monkeypatch, tmp_path, adapter_cls, attempt_count, visible_count
+):
+    """Retry definite failures once, but never replay an ambiguous send."""
+    _single_progress_sent.clear()
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        PendingProgressLineAgent,
+        session_id=f"sess-progress-{adapter_cls.__name__}",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="direct",
+        thread_id="1700000000.000100",
+        adapter_cls=adapter_cls,
+    )
+
+    assert result["final_response"] == "done"
+    send_attempts = getattr(adapter, "send_attempts")
+    assert len(send_attempts) == attempt_count
+    assert send_attempts[1].endswith("Running second command")
+    if attempt_count == 3:
+        assert send_attempts[1] == send_attempts[2]
+    successful_contents = [call["content"] for call in adapter.sent]
+    assert len(successful_contents) == visible_count
+    assert successful_contents[0].endswith("Running first command")
+    if visible_count == 2:
+        assert successful_contents[1].endswith("Running second command")
+
+
+@pytest.mark.parametrize("outcome", ["ambiguous", "cancelled", "raised"])
+@pytest.mark.asyncio
+async def test_unknown_initial_send_is_never_replayed(monkeypatch, outcome):
+    """An attempted non-idempotent send is never replayed after an unknown outcome."""
+    gateway_run = importlib.import_module("gateway.run")
+    clock = [0.0]
+
+    def monotonic():
+        clock[0] += 2.0
+        return clock[0]
+
+    monkeypatch.setattr(gateway_run.time, "monotonic", monotonic)
+    adapter = ProgressCaptureAdapter(platform=Platform.SLACK)
+    send_attempts = []
+    first_attempted = asyncio.Event()
+    second_attempted = asyncio.Event()
+
+    async def unknown_send(chat_id, content, reply_to=None, metadata=None):
+        send_attempts.append(content)
+        if len(send_attempts) == 1:
+            first_attempted.set()
+        else:
+            second_attempted.set()
+        if outcome == "cancelled":
+            await asyncio.Event().wait()
+        if outcome == "raised" and len(send_attempts) == 1:
+            raise RuntimeError("response decode failed after send became visible")
+        return SendResult(
+            success=False,
+            error="relay outbound timed out",
+            ambiguous=True,
+        )
+
+    adapter.send = unknown_send
+    async with _running_progress_worker(adapter) as (progress_queue, task):
+        progress_queue.put("first")
+        await asyncio.wait_for(first_attempted.wait(), timeout=2)
+        if outcome == "raised":
+            progress_queue.put("second")
+            await asyncio.wait_for(second_attempted.wait(), timeout=2)
+        else:
+            await asyncio.sleep(0)
+            task.cancel()
+
+    assert send_attempts == (["first", "second"] if outcome == "raised" else ["first"])
+
+
+@pytest.mark.asyncio
+async def test_separate_progress_is_not_replayed_after_content_reset(monkeypatch):
+    """A reset must not resend a separate progress line that is already visible."""
+    gateway_run = importlib.import_module("gateway.run")
+    clock = [0.0]
+
+    def monotonic():
+        clock[0] += 2.0
+        return clock[0]
+
+    monkeypatch.setattr(gateway_run.time, "monotonic", monotonic)
+    adapter = ProgressCaptureAdapter(platform=Platform.SLACK)
+    first_sent = asyncio.Event()
+    second_sent = asyncio.Event()
+    original_send = adapter.send
+
+    async def tracking_send(chat_id, content, reply_to=None, metadata=None):
+        result = await original_send(chat_id, content, reply_to, metadata)
+        if content == "first":
+            first_sent.set()
+        elif content == "second":
+            second_sent.set()
+        return result
+
+    adapter.send = tracking_send
+    async with _running_progress_worker(adapter, grouping="separate") as (
+        progress_queue,
+        _task,
+    ):
+        progress_queue.put("first")
+        await asyncio.wait_for(first_sent.wait(), timeout=2)
+        progress_queue.put(("__reset__",))
+        progress_queue.put("second")
+        await asyncio.wait_for(second_sent.wait(), timeout=2)
+
+    sent_contents = [call["content"] for call in adapter.sent]
+    assert sent_contents.count("first") == 1
+
+
+@pytest.mark.parametrize("edit_failure", ["not_found", "flood"])
+@pytest.mark.parametrize("fallback_outcome", ["success", "ambiguous", "raised"])
+@pytest.mark.asyncio
+async def test_edit_fallback_is_not_replayed_after_content_reset(
+    monkeypatch,
+    fallback_outcome,
+    edit_failure,
+):
+    """A visible or unknown fresh fallback must leave the replay ledger."""
+    gateway_run = importlib.import_module("gateway.run")
+    clock = [0.0]
+
+    def monotonic():
+        clock[0] += 2.0
+        return clock[0]
+
+    monkeypatch.setattr(gateway_run.time, "monotonic", monotonic)
+    adapter = ProgressCaptureAdapter(platform=Platform.SLACK)
+    first_sent = asyncio.Event()
+    fallback_sent = asyncio.Event()
+    third_sent = asyncio.Event()
+    fourth_sent = asyncio.Event()
+    send_attempts = []
+    original_send = adapter.send
+
+    async def tracking_send(chat_id, content, reply_to=None, metadata=None):
+        send_attempts.append(content)
+        if content == "second" and fallback_outcome == "ambiguous":
+            fallback_sent.set()
+            return SendResult(
+                success=False,
+                error="relay acknowledgement timed out",
+                error_kind="transient",
+                retryable=True,
+                ambiguous=True,
+            )
+        result = await original_send(chat_id, content, reply_to, metadata)
+        if content == "first":
+            first_sent.set()
+        elif content == "second":
+            fallback_sent.set()
+        elif "third" in content.splitlines():
+            third_sent.set()
+        elif "fourth" in content.splitlines():
+            fourth_sent.set()
+        if content == "second" and fallback_outcome == "raised":
+            raise RuntimeError("response decode failed after fallback became visible")
+        return result
+
+    async def permanently_failing_edit(chat_id, message_id, content):
+        adapter.edits.append(
+            {"chat_id": chat_id, "message_id": message_id, "content": content}
+        )
+        if edit_failure == "flood":
+            return SendResult(
+                success=False,
+                error="flood control: retry after 1",
+                error_kind="rate_limit",
+            )
+        return SendResult(
+            success=False,
+            error="message not found",
+            error_kind="not_found",
+        )
+
+    adapter.send = tracking_send
+    adapter.edit_message = permanently_failing_edit
+    async with _running_progress_worker(adapter) as (progress_queue, _task):
+        progress_queue.put("first")
+        await asyncio.wait_for(first_sent.wait(), timeout=2)
+        progress_queue.put("second")
+        await asyncio.wait_for(fallback_sent.wait(), timeout=2)
+        progress_queue.put("third")
+        await asyncio.wait_for(third_sent.wait(), timeout=2)
+        progress_queue.put(("__reset__",))
+        progress_queue.put("fourth")
+        await asyncio.wait_for(fourth_sent.wait(), timeout=2)
+
+    visible_lines = "\n".join(send_attempts).splitlines()
+    assert visible_lines.count("first") == 1
+    assert visible_lines.count("second") == 1
+    assert visible_lines.count("third") == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_edit_fallback_blocks_later_progress_until_retried(monkeypatch):
+    """A definite failed fallback remains ahead of later progress lines."""
+    gateway_run = importlib.import_module("gateway.run")
+    clock = [0.0]
+
+    def monotonic():
+        clock[0] += 2.0
+        return clock[0]
+
+    monkeypatch.setattr(gateway_run.time, "monotonic", monotonic)
+    adapter = ProgressCaptureAdapter(platform=Platform.SLACK)
+    first_sent = asyncio.Event()
+    fallback_failed = asyncio.Event()
+    third_sent = asyncio.Event()
+    send_attempts = []
+    original_send = adapter.send
+
+    async def fail_fallback_once(chat_id, content, reply_to=None, metadata=None):
+        send_attempts.append(content)
+        if content == "second" and send_attempts.count("second") == 1:
+            fallback_failed.set()
+            return SendResult(
+                success=False,
+                error="temporary progress send failure",
+                retryable=True,
+                error_kind="transient",
+            )
+        result = await original_send(chat_id, content, reply_to, metadata)
+        if content == "first":
+            first_sent.set()
+        elif content == "third":
+            third_sent.set()
+        return result
+
+    async def permanently_failing_edit(chat_id, message_id, content):
+        adapter.edits.append(
+            {"chat_id": chat_id, "message_id": message_id, "content": content}
+        )
+        return SendResult(
+            success=False,
+            error="message not found",
+            error_kind="not_found",
+        )
+
+    adapter.send = fail_fallback_once
+    adapter.edit_message = permanently_failing_edit
+    async with _running_progress_worker(adapter) as (progress_queue, _task):
+        progress_queue.put("first")
+        await asyncio.wait_for(first_sent.wait(), timeout=2)
+        progress_queue.put("second")
+        await asyncio.wait_for(fallback_failed.wait(), timeout=2)
+        progress_queue.put("third")
+        await asyncio.wait_for(third_sent.wait(), timeout=2)
+
+    assert send_attempts == ["first", "second", "second", "third"]
+
+
+@pytest.mark.asyncio
+async def test_failed_separate_progress_blocks_newer_line_until_retry(monkeypatch):
+    """Separate-mode retries preserve FIFO order after a definite failure."""
+    gateway_run = importlib.import_module("gateway.run")
+    clock = [0.0]
+
+    def monotonic():
+        clock[0] += 2.0
+        return clock[0]
+
+    monkeypatch.setattr(gateway_run.time, "monotonic", monotonic)
+    adapter = ProgressCaptureAdapter(platform=Platform.SLACK)
+    older_failed = asyncio.Event()
+    newer_sent = asyncio.Event()
+    send_attempts = []
+
+    async def fail_older_once(chat_id, content, reply_to=None, metadata=None):
+        send_attempts.append(content)
+        if len(send_attempts) == 1:
+            older_failed.set()
+            return SendResult(
+                success=False,
+                error="temporary progress send failure",
+                retryable=True,
+                error_kind="transient",
+            )
+        if content == "newer":
+            newer_sent.set()
+        return SendResult(success=True, message_id=f"progress-{len(send_attempts)}")
+
+    adapter.send = fail_older_once
+    async with _running_progress_worker(adapter, grouping="separate") as (
+        progress_queue,
+        _task,
+    ):
+        progress_queue.put("older")
+        await asyncio.wait_for(older_failed.wait(), timeout=2)
+        progress_queue.put("newer")
+        await asyncio.wait_for(newer_sent.wait(), timeout=2)
+
+    assert send_attempts == ["older", "older", "newer"]
+
+
+@pytest.mark.asyncio
+async def test_failed_separate_progress_is_retried_during_cancellation_drain(
+    monkeypatch,
+):
+    """A definite failed separate send remains pending for the bounded drain."""
+    gateway_run = importlib.import_module("gateway.run")
+    clock = [0.0]
+
+    def monotonic():
+        clock[0] += 2.0
+        return clock[0]
+
+    monkeypatch.setattr(gateway_run.time, "monotonic", monotonic)
+    adapter = ProgressCaptureAdapter(platform=Platform.SLACK)
+    send_attempts = []
+    first_failed = asyncio.Event()
+
+    async def fail_once(chat_id, content, reply_to=None, metadata=None):
+        send_attempts.append(content)
+        if len(send_attempts) == 1:
+            first_failed.set()
+            return SendResult(
+                success=False,
+                error="temporary progress send failure",
+                retryable=True,
+                error_kind="transient",
+            )
+        return SendResult(success=True, message_id="progress-retry")
+
+    adapter.send = fail_once
+    async with _running_progress_worker(adapter, grouping="separate") as (
+        progress_queue,
+        task,
+    ):
+        progress_queue.put("first")
+        await asyncio.wait_for(first_failed.wait(), timeout=2)
+        await asyncio.sleep(0)
+        task.cancel()
+
+    assert send_attempts == ["first", "first"]
+
+
+@pytest.mark.parametrize("reset_before_cancel", [False, True])
+@pytest.mark.asyncio
+async def test_cancellation_drain_fresh_sends_unseen_tail_after_definite_edit_failure(
+    monkeypatch,
+    reset_before_cancel,
+):
+    """A definite drain edit failure must not discard unseen progress."""
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run.time, "monotonic", lambda: 2.0)
+    adapter = ProgressCaptureAdapter(platform=Platform.SLACK)
+    first_sent = asyncio.Event()
+    original_send = adapter.send
+
+    async def tracking_send(chat_id, content, reply_to=None, metadata=None):
+        result = await original_send(chat_id, content, reply_to, metadata)
+        if content == "first":
+            first_sent.set()
+        return result
+
+    async def missing_edit(chat_id, message_id, content):
+        adapter.edits.append(
+            {"chat_id": chat_id, "message_id": message_id, "content": content}
+        )
+        return SendResult(
+            success=False,
+            error="message not found",
+            error_kind="not_found",
+        )
+
+    adapter.send = tracking_send
+    adapter.edit_message = missing_edit
+    async with _running_progress_worker(adapter) as (progress_queue, task):
+        progress_queue.put("first")
+        await asyncio.wait_for(first_sent.wait(), timeout=2)
+        progress_queue.put("second")
+        if reset_before_cancel:
+            progress_queue.put(("__reset__",))
+        task.cancel()
+
+    assert [call["content"] for call in adapter.sent] == ["first", "second"]
+    assert adapter.edits[-1]["content"] == "first\nsecond"
+
+
+@pytest.mark.parametrize(
+    ("first_failure", "second_failure"),
+    [
+        ("ambiguous", None),
+        ("transient", None),
+        ("exception", None),
+        ("ambiguous", "ambiguous"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_cancellation_drain_retries_idempotent_edit_before_fallback(
+    monkeypatch,
+    first_failure,
+    second_failure,
+):
+    """Drain retries edits in place and never fresh-sends unresolved ambiguity."""
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run.time, "monotonic", lambda: 2.0)
+    adapter = ProgressCaptureAdapter(platform=Platform.SLACK)
+    first_sent = asyncio.Event()
+    original_send = adapter.send
+
+    async def tracking_send(chat_id, content, reply_to=None, metadata=None):
+        result = await original_send(chat_id, content, reply_to, metadata)
+        if content == "first":
+            first_sent.set()
+        return result
+
+    failures = [first_failure, second_failure]
+
+    async def retrying_edit(chat_id, message_id, content):
+        adapter.edits.append(
+            {"chat_id": chat_id, "message_id": message_id, "content": content}
+        )
+        failure = failures[len(adapter.edits) - 1]
+        if failure == "ambiguous":
+            return SendResult(
+                success=False,
+                error="relay acknowledgement timed out",
+                error_kind="transient",
+                retryable=True,
+                ambiguous=True,
+            )
+        if failure == "transient":
+            return SendResult(
+                success=False,
+                error="temporary network failure",
+                error_kind="transient",
+                retryable=True,
+            )
+        if failure == "exception":
+            raise RuntimeError("edit acknowledgement unavailable")
+        return SendResult(success=True, message_id=message_id)
+
+    adapter.send = tracking_send
+    adapter.edit_message = retrying_edit
+    async with _running_progress_worker(adapter) as (progress_queue, task):
+        progress_queue.put("first")
+        await asyncio.wait_for(first_sent.wait(), timeout=2)
+        progress_queue.put("second")
+        task.cancel()
+
+    assert [call["content"] for call in adapter.sent] == ["first"]
+    assert [edit["content"] for edit in adapter.edits] == [
+        "first\nsecond",
+        "first\nsecond",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_overflow_group_is_retained_and_retried(monkeypatch, tmp_path):
+    """A failed overflow group must stop the split and preserve the exact tail."""
+    _overflow_initial_sent.clear()
+    _overflow_send_failed.clear()
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        OverflowSendFailureAgent,
+        session_id="sess-progress-overflow-group-retry",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            },
+            "tool_preview_length": 60,
+        },
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="direct",
+        thread_id="1700000000.000100",
+        adapter_cls=FailedOverflowGroupAdapter,
+    )
+    assert isinstance(adapter, FailedOverflowGroupAdapter)
+
+    assert result["final_response"] == "done"
+    assert len(adapter.send_attempts) >= 3
+    assert adapter.send_attempts[2].splitlines()[0] == adapter.send_attempts[1]
+    visible_text = "\n".join(adapter.visible.values())
+    ordered_tokens = ["base command", *(f"overflow-item-{index}-" for index in range(1, 7))]
+    assert [visible_text.count(token) for token in ordered_tokens] == [1] * len(
+        ordered_tokens
+    )
+    assert [visible_text.index(token) for token in ordered_tokens] == sorted(
+        visible_text.index(token) for token in ordered_tokens
+    )
+
+
+@pytest.mark.asyncio
+async def test_content_reset_flushes_retained_failed_overflow_tail(monkeypatch, tmp_path):
+    """A content-bubble reset must not discard a failed continuation tail."""
+    _overflow_initial_sent.clear()
+    _overflow_send_failed.clear()
+    _interim_content_sent.clear()
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        OverflowSendFailureThenInterimAgent,
+        session_id="sess-progress-reset-retained-tail",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": True,
+            },
+            "tool_preview_length": 60,
+        },
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="direct",
+        thread_id="1700000000.000100",
+        adapter_cls=FailedOverflowGroupAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert isinstance(adapter, FailedOverflowGroupAdapter)
+    visible_text = "\n".join(adapter.visible.values())
+    ordered_tokens = ["reset-base", *(f"reset-item-{index}-" for index in range(1, 7))]
+    assert [visible_text.count(token) for token in ordered_tokens] == [1] * len(
+        ordered_tokens
+    )
+
+
+@pytest.mark.asyncio
+async def test_successful_overflow_group_without_id_is_not_retried(monkeypatch, tmp_path):
+    """Success without an ID is visible but frozen, not pending for resubmission."""
+    _overflow_initial_sent.clear()
+    _overflow_missing_id_seen.clear()
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        OverflowMissingIdAgent,
+        session_id="sess-progress-overflow-missing-id",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            },
+            "tool_preview_length": 60,
+        },
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="direct",
+        thread_id="1700000000.000100",
+        adapter_cls=MissingIdOverflowGroupAdapter,
+    )
+    assert isinstance(adapter, MissingIdOverflowGroupAdapter)
+
+    assert result["final_response"] == "done"
+    no_id_content = adapter.visible_without_ids[0]
+    assert adapter.send_attempts.count(no_id_content) == 1
+    visible_text = "\n".join(
+        [*adapter.visible.values(), *adapter.visible_without_ids]
+    )
+    assert visible_text.count("base command") == 1
+    for index in range(1, 7):
+        assert visible_text.count(f"no-id-item-{index}-") == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelled_overflow_send_does_not_retry_attempted_group(
+    monkeypatch, tmp_path
+):
+    """Cancellation mid-split retains only groups that were never attempted."""
+    _cancelled_overflow_initial_sent.clear()
+    _cancelled_overflow_send_started.clear()
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CancelledOverflowGroupAgent,
+        session_id="sess-progress-cancelled-overflow-tail",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            },
+            "tool_preview_length": 60,
+        },
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="direct",
+        thread_id="1700000000.000100",
+        adapter_cls=CancelledOverflowGroupAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert isinstance(adapter, CancelledOverflowGroupAdapter)
+    visible_with_ids = list(adapter.visible.values())
+    visible_text = "\n".join(
+        [visible_with_ids[0], *adapter.visible_without_ids, *visible_with_ids[1:]]
+    )
+    ordered_tokens = ["cancel-base", *(f"cancel-item-{index}-" for index in range(1, 7))]
+    assert [visible_text.count(token) for token in ordered_tokens] == [1] * len(
+        ordered_tokens
+    ), (adapter.send_attempts, adapter.visible, adapter.visible_without_ids)
+    assert [visible_text.index(token) for token in ordered_tokens] == sorted(
+        visible_text.index(token) for token in ordered_tokens
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancellation_progress_drain_finishes_before_streamed_final(
+    monkeypatch,
+    tmp_path,
+):
+    """Pending progress must not appear below the completed final response."""
+    _ordering_draft_sent.clear()
+    _ordering_initial_progress_failed.clear()
+    _ordering_progress_retry_started.clear()
+    _ordering_progress_retry_release.clear()
+    _ordering_final_sent.clear()
+    gateway_run = importlib.import_module("gateway.run")
+    original_cleanup_wait = gateway_run.GatewayRunner._await_adapter_cleanup_with_timeout
+    cleanup_saw_final = []
+
+    async def tracking_cleanup_wait(self, task, timeout):
+        cleanup_saw_final.append(_ordering_final_sent.is_set())
+        return await original_cleanup_wait(self, task, timeout)
+
+    monkeypatch.setattr(
+        gateway_run.GatewayRunner,
+        "_await_adapter_cleanup_with_timeout",
+        tracking_cleanup_wait,
+    )
+    run_task = asyncio.create_task(
+        _run_with_agent(
+            monkeypatch,
+            tmp_path,
+            OrderedFinalProgressAgent,
+            session_id="sess-progress-before-streamed-final",
+            config_data={
+                "display": {
+                    "tool_progress": "all",
+                    "interim_assistant_messages": False,
+                },
+                "streaming": {
+                    "enabled": True,
+                    "edit_interval": 0.01,
+                    "buffer_threshold": 1,
+                },
+            },
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="direct",
+            thread_id="1700000000.000100",
+            adapter_cls=OrderedFinalProgressAdapter,
+        )
+    )
+    retry_started = await asyncio.to_thread(
+        _ordering_progress_retry_started.wait,
+        2,
+    )
+    assert retry_started
+    try:
+        final_overtook_progress = await asyncio.to_thread(
+            _ordering_final_sent.wait,
+            0.2,
+        )
+    finally:
+        _ordering_progress_retry_release.set()
+    adapter, result = await run_task
+
+    assert result["final_response"] == "done"
+    assert isinstance(adapter, OrderedFinalProgressAdapter)
+    assert not final_overtook_progress
+    assert cleanup_saw_final == [False]
+    assert adapter.visible_order == ["draft", "progress", "final"]
+
+
+@pytest.mark.asyncio
+async def test_wedged_cancellation_finalizer_does_not_block_turn(monkeypatch, tmp_path):
+    """A stuck adapter send during cancellation cleanup must be time-bounded."""
+    _initial_send_failed.clear()
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_PROGRESS_FINALIZE_TIMEOUT", 0.05, raising=False)
+
+    started = asyncio.get_running_loop().time()
+    adapter, result = await asyncio.wait_for(
+        _run_with_agent(
+            monkeypatch,
+            tmp_path,
+            FailedInitialProgressSendAgent,
+            session_id="sess-progress-wedged-finalizer",
+            config_data={
+                "display": {
+                    "tool_progress": "all",
+                    "interim_assistant_messages": False,
+                }
+            },
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="direct",
+            thread_id="1700000000.000100",
+            adapter_cls=WedgedCancellationDrainAdapter,
+        ),
+        timeout=1.0,
+    )
+
+    assert result["final_response"] == "done"
+    assert isinstance(adapter, WedgedCancellationDrainAdapter)
+    assert len(adapter.send_attempts) == 2
+    assert asyncio.get_running_loop().time() - started < 0.7
+
+
+@pytest.mark.asyncio
+async def test_pending_no_id_drain_gets_bounded_retry(monkeypatch, tmp_path):
+    """Cancellation finalization retries retained no-ID progress once more."""
+    _initial_send_failed.clear()
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        FailedInitialProgressSendAgent,
+        session_id="sess-progress-no-id-drain-retry",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="direct",
+        thread_id="1700000000.000100",
+        adapter_cls=RetryNoIdDrainAdapter,
+    )
+    assert isinstance(adapter, RetryNoIdDrainAdapter)
+
+    assert result["final_response"] == "done"
+    assert len(adapter.send_attempts) == 3
+    assert adapter.send_attempts[0] == adapter.send_attempts[1]
+    assert adapter.send_attempts[1] == adapter.send_attempts[2]
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["content"].endswith("Running retry me")
+
+
+@pytest.mark.asyncio
+async def test_successful_initial_send_without_id_is_not_replayed(monkeypatch, tmp_path):
+    """A visible initial no-ID bubble is frozen before later progress arrives."""
+    _initial_no_id_delivered.clear()
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        InitialNoIdThenProgressAgent,
+        session_id="sess-progress-initial-missing-id",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="direct",
+        thread_id="1700000000.000100",
+        adapter_cls=SuccessfulInitialNoIdAdapter,
+    )
+    assert isinstance(adapter, SuccessfulInitialNoIdAdapter)
+
+    assert result["final_response"] == "done"
+    assert len(adapter.send_attempts) == 2
+    assert adapter.send_attempts[0].endswith("Running first no-id command")
+    assert "first no-id command" not in adapter.send_attempts[1]
+    assert adapter.send_attempts[1].endswith("Running second command")
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -2089,6 +2089,72 @@ async def test_ambiguous_edit_does_not_fall_back_to_fresh_send(monkeypatch, tmp_
 
 
 @pytest.mark.asyncio
+async def test_raising_visible_edit_retries_exact_payload_before_rollover(monkeypatch):
+    """An untyped edit failure must not replay its possibly-visible tail."""
+    gateway_run = importlib.import_module("gateway.run")
+    clock = [0.0]
+
+    def monotonic():
+        clock[0] += 2.0
+        return clock[0]
+
+    monkeypatch.setattr(gateway_run.time, "monotonic", monotonic)
+    adapter = SmallLimitProgressAdapter(platform=Platform.SLACK)
+    visible = {}
+    first_sent = asyncio.Event()
+    edit_raised = asyncio.Event()
+    exact_retry_succeeded = asyncio.Event()
+    continuation_sent = asyncio.Event()
+    raised_payload = [None]
+    original_send = adapter.send
+
+    async def tracking_send(chat_id, content, reply_to=None, metadata=None):
+        result = await original_send(chat_id, content, reply_to, metadata)
+        if result.message_id:
+            visible[result.message_id] = content
+        if content == "first":
+            first_sent.set()
+        elif content == "third":
+            continuation_sent.set()
+        return result
+
+    async def raising_then_too_long_edit(chat_id, message_id, content):
+        adapter.edits.append(
+            {"chat_id": chat_id, "message_id": message_id, "content": content}
+        )
+        if raised_payload[0] is None:
+            raised_payload[0] = content
+            visible[message_id] = content
+            edit_raised.set()
+            raise RuntimeError("response decode failed after visible edit")
+        if content == raised_payload[0]:
+            visible[message_id] = content
+            exact_retry_succeeded.set()
+            return SendResult(success=True, message_id=message_id)
+        return SendResult(success=False, error="Slack API error: msg_too_long")
+
+    adapter.send = tracking_send
+    adapter.edit_message = raising_then_too_long_edit
+    async with _running_progress_worker(adapter) as (progress_queue, _task):
+        progress_queue.put("first")
+        await asyncio.wait_for(first_sent.wait(), timeout=2)
+        progress_queue.put("second")
+        await asyncio.wait_for(edit_raised.wait(), timeout=2)
+        progress_queue.put("third")
+        await asyncio.wait_for(exact_retry_succeeded.wait(), timeout=2)
+        await asyncio.wait_for(continuation_sent.wait(), timeout=2)
+
+    assert [edit["content"] for edit in adapter.edits[:2]] == [
+        "first\nsecond",
+        "first\nsecond",
+    ]
+    assert [call["content"] for call in adapter.sent] == ["first", "third"]
+    visible_text = "\n".join(visible.values())
+    for line in ("first", "second", "third"):
+        assert visible_text.count(line) == 1
+
+
+@pytest.mark.asyncio
 async def test_content_reset_retries_ambiguous_edit_in_place(monkeypatch):
     """A reset settles an ACK-lost edit before opening a fresh bubble."""
     gateway_run = importlib.import_module("gateway.run")

--- a/tests/gateway/test_send_error_classification.py
+++ b/tests/gateway/test_send_error_classification.py
@@ -23,7 +23,9 @@ class _FakeBadRequest(Exception):
     "text,expected",
     [
         ("Message_too_long", "too_long"),
+        ("Slack API error: msg_too_long", "too_long"),
         ("Bad Request: message is too long", "too_long"),
+        ("relay request took too long awaiting acknowledgement", "unknown"),
         ("Bad Request: can't parse entities: unsupported start tag", "bad_format"),
         ("Bad Request: can't find end of the entity", "bad_format"),
         ("Forbidden: bot was blocked by the user", "forbidden"),

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -123,6 +123,30 @@ class TestSendWithRetryNetworkRetry:
         assert not result.success
         assert len(adapter._send_calls) == 1
 
+    @pytest.mark.asyncio
+    async def test_ambiguous_result_is_never_retried_or_fallback_sent(self):
+        """An ACK-lost non-idempotent send may already be visible."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(
+                success=False,
+                error="relay transport connection lost",
+                ambiguous=True,
+                retryable=True,
+                error_kind="transient",
+            ),
+            SendResult(success=True, message_id="duplicate"),
+        ]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry(
+                "chat1", "hello", max_retries=2, base_delay=0
+            )
+
+        assert result.ambiguous is True
+        mock_sleep.assert_not_called()
+        assert adapter._send_calls == [("chat1", "hello")]
+
 
 # ---------------------------------------------------------------------------
 # _send_with_retry — all retries exhausted → user notification

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -304,6 +304,62 @@ class TestBeforeFinalizeHook:
 
         assert events == ["send", "pause", "edit"]
 
+    @pytest.mark.asyncio
+    async def test_final_delivery_barrier_precedes_post_tool_progressive_send(self):
+        """Post-tool answer deltas stay hidden until progress has settled."""
+        first_sent = asyncio.Event()
+        segment_finalized = asyncio.Event()
+        barrier_started = asyncio.Event()
+        barrier_release = asyncio.Event()
+        final_sent = asyncio.Event()
+        sent_texts = []
+
+        async def send(**kwargs):
+            content = kwargs["content"]
+            sent_texts.append(content)
+            if "Prelude" in content:
+                first_sent.set()
+            if "Final answer" in content:
+                final_sent.set()
+            return SimpleNamespace(
+                success=True,
+                message_id=f"msg-{len(sent_texts)}",
+            )
+
+        async def edit_message(**kwargs):
+            if kwargs.get("finalize"):
+                segment_finalized.set()
+            return SimpleNamespace(success=True, message_id=kwargs["message_id"])
+
+        async def wait_for_progress():
+            barrier_started.set()
+            await barrier_release.wait()
+
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=send)
+        adapter.edit_message = AsyncMock(side_effect=edit_message)
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5),
+            on_before_final_delivery=wait_for_progress,
+        )
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta("Prelude")
+        await asyncio.wait_for(first_sent.wait(), timeout=2)
+        consumer.on_segment_break()
+        await asyncio.wait_for(segment_finalized.wait(), timeout=2)
+        consumer.on_delta("Final answer")
+
+        await asyncio.wait_for(barrier_started.wait(), timeout=2)
+        assert not final_sent.is_set()
+        barrier_release.set()
+        await asyncio.wait_for(final_sent.wait(), timeout=2)
+        consumer.finish()
+        await asyncio.wait_for(task, timeout=2)
+
 
 # ── Segment break (tool boundary) tests ──────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

In Slack, tool progress can appear to freeze partway through a long turn. Once the current progress message is full, later tool updates may be missing, duplicated, or split into one message per update even though the agent is still working.

This happens when Slack rejects an update with `msg_too_long`. The gateway currently treats that as a general editing failure rather than a signal to close the full progress message and continue in a new one.

This PR keeps the completed progress message unchanged and moves only updates that have not yet been shown into a new editable message. It also preserves those pending updates if a continuation send fails, raises an exception, is cancelled, or is interrupted by an assistant-content message. Successful sends without a message ID are treated as delivered but no longer editable, so they are not duplicated.

This is complementary to #69317: that PR bounds Slack adapter payloads before `chat.update`; this patch repairs the gateway progress-buffer state when Slack still returns `msg_too_long`.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: classify Slack's `msg_too_long` response as the platform-neutral `too_long` send-error kind.
- `gateway/run.py`: track confirmed-visible progress, roll only unseen lines into fresh bubbles, preserve failed, raised, or cancelled tails across content resets, bound cancellation cleanup, and freeze successful no-ID deliveries without replaying them.
- `tests/gateway/test_run_progress_topics.py`: cover full-edit rollover, cancellation during a grouped send, content resets with a retained tail, bounded cancellation finalization, transient continuation failure, failed grouped overflow, and successful deliveries without editable IDs.
- `tests/gateway/test_send_error_classification.py`: cover Slack's size-limit error spelling.

## How to Test

1. Run `pytest -q tests/gateway/test_run_progress_topics.py tests/gateway/test_send_error_classification.py`.
2. Run the focused rollover regressions against upstream `main`; seven fail before the production change, while all eight focused cases pass with this patch.
3. In Slack with grouped tool progress enabled, run a turn that produces enough progress to fill an editable bubble and verify later progress continues in a fresh editable bubble without missing or duplicated lines.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing behavior or configuration changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral async state only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused RED on upstream `main` (`7095e23e`): 7 failed, 1 passed.

The cancellation-during-continuation regression added during review also fails before the cancellation-safe state publication.

Affected files through the canonical runner: 56 passed.

The previously timing-sensitive transient-overflow regression passed five consecutive deterministic runs after replacing its fixed sleep with an adapter acknowledgement event.

`ruff check` on the four changed files: passed.

The canonical full-suite run completed but the local dev environment is not globally green: 101 failures across 36 unrelated files plus 11 collection/import failures. Re-running those exact failure-associated files on the immutable upstream base reproduced the same 36 failing files and 11 collection/import failures (100 failures; the one-test variation was in unrelated transcription timing/config coverage).
