### PR TITLE
fix(profiles): clean up Windows gateway before profile delete

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1880,7 +1880,7 @@ def _maybe_unregister_gateway_service(profile_name: str) -> None:
 
 
 def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
-    """Disable and remove systemd/launchd service for a profile."""
+    """Disable and remove the platform gateway service for a profile."""
     import platform as _platform
 
     # Derive service name for this profile
@@ -1918,6 +1918,15 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
                 )
                 plist_path.unlink(missing_ok=True)
                 print("✓ Launchd service removed")
+
+        elif _platform.system() == "Windows":
+            # Reuse the canonical Windows teardown so both Scheduled Task and
+            # Startup-folder persistence are removed before the process is
+            # stopped below.  With HERMES_HOME scoped to profile_dir,
+            # get_task_name() resolves the profile-specific task.
+            from hermes_cli import gateway_windows
+
+            gateway_windows.uninstall()
     except Exception as e:
         print(f"⚠ Service cleanup: {e}")
     finally:
@@ -1928,17 +1937,20 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
 
 
 def _stop_gateway_process(profile_dir: Path) -> None:
-    """Stop a running gateway process via its PID file."""
+    """Stop a running gateway process via its verified runtime record."""
     import time as _time
 
     pid_file = profile_dir / "gateway.pid"
-    if not pid_file.exists():
-        return
 
     try:
-        raw = pid_file.read_text(encoding="utf-8").strip()
-        data = json.loads(raw) if raw.startswith("{") else {"pid": int(raw)}
-        pid = int(data["pid"])
+        # get_running_pid verifies the process against gateway.lock and falls
+        # back to that lock record when gateway.pid is absent.  Task-spawned
+        # Windows gateways can legitimately be in exactly that state.
+        from gateway.status import get_running_pid
+
+        pid = get_running_pid(pid_file, cleanup_stale=False)
+        if pid is None:
+            return
         # Route through terminate_pid so Windows uses the appropriate
         # primitive (taskkill / TerminateProcess) — raw os.kill with
         # _signal.SIGKILL raises AttributeError at import time on Windows,

--- a/tests/hermes_cli/test_profile_delete_gateway_cleanup.py
+++ b/tests/hermes_cli/test_profile_delete_gateway_cleanup.py
@@ -1,0 +1,88 @@
+"""Regression tests for gateway cleanup during profile deletion (#87761)."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import profiles
+from hermes_cli.profiles import create_profile
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    """Isolate profile paths from the user's real Hermes installation."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    return tmp_path
+
+
+@pytest.mark.windows_only
+def test_windows_service_cleanup_uses_profile_scoped_uninstall(
+    profile_env, monkeypatch
+):
+    """Windows removes both task and Startup persistence for the profile."""
+    from hermes_cli import gateway_windows
+
+    profile_dir = create_profile("coder", no_alias=True)
+    default_home = os.environ["HERMES_HOME"]
+    homes_seen = []
+
+    monkeypatch.setattr(
+        gateway_windows,
+        "uninstall",
+        lambda: homes_seen.append(os.environ.get("HERMES_HOME")),
+    )
+
+    profiles._cleanup_gateway_service("coder", profile_dir)
+
+    assert homes_seen == [str(profile_dir)]
+    assert os.environ["HERMES_HOME"] == default_home
+
+
+def test_stop_gateway_uses_lock_fallback_when_pid_file_is_missing(
+    tmp_path, monkeypatch
+):
+    """The authoritative resolver can recover a PID from gateway.lock."""
+    import gateway.status as gateway_status
+
+    pid_file = tmp_path / "gateway.pid"
+    lock_file = tmp_path / "gateway.lock"
+    lock_file.write_text(
+        json.dumps(
+            {
+                "pid": 4321,
+                "kind": "hermes-gateway",
+                "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+                "start_time": 77,
+            }
+        ),
+        encoding="utf-8",
+    )
+    calls = []
+    liveness = iter((True, False))
+
+    monkeypatch.setattr(
+        gateway_status, "is_gateway_runtime_lock_active", lambda _path: True
+    )
+    monkeypatch.setattr(gateway_status, "_pid_exists", lambda _pid: next(liveness))
+    monkeypatch.setattr(gateway_status, "_get_process_start_time", lambda _pid: 77)
+    monkeypatch.setattr(
+        gateway_status,
+        "_read_process_cmdline",
+        lambda _pid: "python -m hermes_cli.main gateway run",
+    )
+    monkeypatch.setattr(
+        gateway_status,
+        "terminate_pid",
+        lambda pid, force=False: calls.append(("terminate", pid, force)),
+    )
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    profiles._stop_gateway_process(tmp_path)
+
+    assert not pid_file.exists()
+    assert calls == [("terminate", 4321, False)]


### PR DESCRIPTION
## Summary

- remove the profile-scoped Windows Scheduled Task and Startup-folder fallback before deleting a profile
- resolve the running gateway through the authoritative runtime-status path, which verifies `gateway.lock` and supports gateways that have no `gateway.pid`
- add focused regressions for profile-scoped Windows cleanup and the lock-only PID path

Fixes #87761.

## Root cause

`delete_profile()` already disables persistence before stopping the gateway, but `_cleanup_gateway_service()` only implemented systemd and launchd. On Windows, the per-profile task or Startup entry therefore survived and could keep the gateway alive while `shutil.rmtree()` tried to remove its locked files.

The subsequent stop path had a second blind spot: `_stop_gateway_process()` returned immediately when `gateway.pid` was absent, even though `gateway.status.get_running_pid()` can validate and recover the PID from the active `gateway.lock` record.

## Implementation

The Windows branch reuses `gateway_windows.uninstall()` while `HERMES_HOME` is temporarily scoped to the profile being removed. This keeps Scheduled Task naming and Startup/script cleanup on the existing Windows lifecycle implementation rather than duplicating private `schtasks` calls.

Gateway shutdown now delegates PID resolution to `get_running_pid(pid_file, cleanup_stale=False)`. Besides covering lock-only task launches, this preserves the existing PID/start-time/command verification instead of trusting an unverified integer from disk.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_profile_delete_gateway_cleanup.py tests/hermes_cli/test_profiles.py tests/gateway/test_status.py -q` — 123 passed, 5 skipped
- `ruff check hermes_cli/profiles.py tests/hermes_cli/test_profile_delete_gateway_cleanup.py`
- `git diff --check`

The Windows service-cleanup regression is marked `windows_only`; the Linux/WSL run skips it and the repository's Windows CI lane executes it.
