### PR TITLE
feat(cli): add session wrap slash commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8180,6 +8180,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._handle_resume_command(cmd_original)
         elif canonical == "sessions":
             self._handle_sessions_command(cmd_original)
+        elif canonical in {"fast-wrap", "full-wrap"}:
+            wrap_seed = "fast wrap" if canonical == "fast-wrap" else "full wrap"
+            self._pending_agent_seed = wrap_seed
+            _cprint(f"  Queued session-wrap mode: {wrap_seed}")
         elif canonical == "model":
             self._handle_model_switch(cmd_original)
         elif canonical == "codex-runtime":

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -120,6 +120,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
+    CommandDef("fast-wrap", "Run the fast session-wrap skill mode for ticket-focused delta closeout", "Session",
+               aliases=("fw", "quick-wrap"), cli_only=True),
+    CommandDef("full-wrap", "Run the full session-wrap skill mode for once-daily hygiene closeout", "Session",
+               aliases=("daily-wrap", "wrap-full"), cli_only=True),
 
     # Configuration
     CommandDef("sessions", "Browse and resume previous sessions", "Session"),

--- a/tests/cli/test_session_wrap_commands.py
+++ b/tests/cli/test_session_wrap_commands.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from cli import HermesCLI
+
+
+def _make_cli() -> HermesCLI:
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pending_resume_sessions = None
+    cli._pending_agent_seed = None
+    return cli
+
+
+def test_fast_wrap_command_queues_fast_wrap_seed():
+    cli = _make_cli()
+
+    assert cli.process_command("/fast-wrap") is True
+
+    assert cli._pending_agent_seed == "fast wrap"
+    assert cli._pending_resume_sessions is None
+
+
+def test_fast_wrap_aliases_queue_fast_wrap_seed():
+    for command in ("/fw", "/quick-wrap"):
+        cli = _make_cli()
+        assert cli.process_command(command) is True
+        assert cli._pending_agent_seed == "fast wrap"
+
+
+def test_full_wrap_command_queues_full_wrap_seed():
+    cli = _make_cli()
+
+    assert cli.process_command("/full-wrap") is True
+
+    assert cli._pending_agent_seed == "full wrap"
+    assert cli._pending_resume_sessions is None
+
+
+def test_full_wrap_aliases_queue_full_wrap_seed():
+    for command in ("/daily-wrap", "/wrap-full"):
+        cli = _make_cli()
+        assert cli.process_command(command) is True
+        assert cli._pending_agent_seed == "full wrap"

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -111,6 +111,21 @@ class TestResolveCommand:
         assert resolve_command("reload_mcp").name == "reload-mcp"
         assert resolve_command("codex_runtime").name == "codex-runtime"
         assert resolve_command("tasks").name == "agents"
+        for alias, canonical in (
+            ("fw", "fast-wrap"),
+            ("quick-wrap", "fast-wrap"),
+            ("daily-wrap", "full-wrap"),
+            ("wrap-full", "full-wrap"),
+        ):
+            cmd = resolve_command(alias)
+            assert cmd is not None
+            assert cmd.name == canonical
+
+    def test_session_wrap_commands_are_cli_only(self):
+        for name in ("fast-wrap", "full-wrap"):
+            cmd = resolve_command(name)
+            assert cmd is not None
+            assert cmd.cli_only is True
 
     def test_topic_is_gateway_command(self):
         topic = resolve_command("topic")
@@ -901,8 +916,14 @@ class TestGhostText:
         assert _suggestion("/fast f") == "ast"
 
     def test_fast_subcommand_suggestion_hidden_when_filtered(self):
-        completer = SlashCommandCompleter(command_filter=lambda cmd: cmd != "/fast")
+        completer = SlashCommandCompleter(
+            command_filter=lambda cmd: cmd not in {"/fast", "/fast-wrap"}
+        )
         assert _suggestion("/fa", completer=completer) is None
+
+    def test_fast_wrap_command_name_suggestion_when_fast_filtered(self):
+        completer = SlashCommandCompleter(command_filter=lambda cmd: cmd != "/fast")
+        assert _suggestion("/fa", completer=completer) == "st-wrap"
 
     def test_no_suggestion_for_non_slash(self):
         assert _suggestion("hello") is None


### PR DESCRIPTION
Implements HERMES-T16.\n\nChanges:\n- Adds CLI-only /fast-wrap with aliases /fw and /quick-wrap.\n- Adds CLI-only /full-wrap with aliases /daily-wrap and /wrap-full.\n- Dispatch queues the existing session-wrap natural-language instructions (fast wrap / full wrap) as the next agent turn instead of duplicating wrap logic in core.\n- Keeps gateway scope explicitly out of this ticket by marking commands cli_only.\n\nVerification:\n- .venv/bin/python -m pytest tests/hermes_cli/test_commands.py tests/cli/test_session_wrap_commands.py -q -o 'addopts=' -> 167 passed\n- .venv/bin/python -m py_compile hermes_cli/commands.py cli.py\n- git diff --check\n