### PR TITLE
fix(gateway): bind clarify resolve to owning session_key

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4406,7 +4406,7 @@ class BasePlatformAdapter(ABC):
             that override this should render inline buttons (one per choice
             plus a final "Other" / free-text option).  Button callbacks
             MUST resolve via
-            ``tools.clarify_gateway.resolve_gateway_clarify(clarify_id, response)``
+            ``tools.clarify_gateway.resolve_gateway_clarify(clarify_id, response, session_key=...)``
             with the chosen string.  Picking the "Other" button calls
             ``mark_awaiting_text(clarify_id)`` so the next message in the
             session is captured as the response.

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1784,7 +1784,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # persist that. Fall back to passing the index; the agent
             # has the prompt in context and can interpret it.
             response_text = str(inner.get("title") or str(idx + 1))
-            resolved = resolve_gateway_clarify(clarify_id, response_text)
+            resolved = resolve_gateway_clarify(clarify_id, response_text, session_key=session_key)
             if not resolved:
                 # Resolver couldn't find a waiter (e.g. agent already
                 # timed out). Fall through to text dispatch.

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -3093,7 +3093,7 @@ class RelayAdapter(BasePlatformAdapter):
                     except ValueError:
                         idx = -1
                     if 0 <= idx < len(choices):
-                        resolve_gateway_clarify(clarify_id, str(choices[idx]))
+                        resolve_gateway_clarify(clarify_id, str(choices[idx]), session_key=session_key)
                         self._send_lifecycle_ack(
                             chat_id,
                             f"✅ {choices[idx]}",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17576,6 +17576,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _clarify_mod.resolve_gateway_clarify(
                         _pending_clarify.clarify_id,
                         "",
+                        session_key=_pending_clarify.session_key,
                     )
 
         # Intercept messages that are responses to a pending /reload-mcp

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7617,7 +7617,7 @@ class DiscordAdapter(BasePlatformAdapter):
         plus a final "✏️ Other (type answer)" button. Picking "Other" flips
         the clarify entry into text-capture mode so the next user message in
         the session becomes the response. Numeric clicks resolve immediately
-        via ``resolve_gateway_clarify(clarify_id, choice_text)``.
+        via ``resolve_gateway_clarify(clarify_id, choice_text, session_key=...)``.
 
         Open-ended mode (``choices`` empty/None): renders the question as
         plain embed text — no buttons. The gateway's text-intercept captures
@@ -7701,6 +7701,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     clarify_id=clarify_id,
                     allowed_user_ids=self._allowed_user_ids,
                     allowed_role_ids=self._allowed_role_ids,
+                    session_key=session_key,
                 )
             else:
                 embed.add_field(
@@ -9635,10 +9636,12 @@ def _define_discord_view_classes() -> None:
             clarify_id: str,
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
+            session_key: str = "",
         ):
             super().__init__(timeout=_read_discord_prompt_timeout())
             self.choices = list(choices)[:24]
             self.clarify_id = clarify_id
+            self.session_key = session_key or ""
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
             self.resolved = False
@@ -9772,7 +9775,9 @@ def _define_discord_view_classes() -> None:
 
             try:
                 from tools.clarify_gateway import resolve_gateway_clarify
-                resolved = resolve_gateway_clarify(self.clarify_id, resolved_text)
+                resolved = resolve_gateway_clarify(
+                    self.clarify_id, resolved_text, session_key=self.session_key
+                )
                 logger.info(
                     "Discord clarify button resolved (id=%s, choice=%r, user=%s, ok=%s)",
                     self.clarify_id, resolved_text,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1204,6 +1204,8 @@ class SlackAdapter(BasePlatformAdapter):
         # Same guard for clarify prompts (interactive multiple-choice
         # buttons); mirrors _approval_resolved.
         self._clarify_resolved: Dict[Any, bool] = {}
+        # clarify_id → session_key for ownership-bound resolve (#87780)
+        self._clarify_session_by_id: Dict[str, str] = {}
         self._CLARIFY_RESOLVED_MAX = 1000
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
@@ -7440,6 +7442,11 @@ class SlackAdapter(BasePlatformAdapter):
                 self._trim_oldest_dict_entries(
                     self._clarify_resolved, self._CLARIFY_RESOLVED_MAX
                 )
+                if clarify_id:
+                    self._clarify_session_by_id[clarify_id] = session_key
+                    self._trim_oldest_dict_entries(
+                        self._clarify_session_by_id, self._CLARIFY_RESOLVED_MAX
+                    )
 
             return SendResult(success=True, message_id=msg_ts, raw_response=result)
         except Exception as e:
@@ -7897,7 +7904,12 @@ class SlackAdapter(BasePlatformAdapter):
         if resolved_text is None:
             resolved_text = f"choice {idx + 1}"
 
-        if _clarify_mod.resolve_gateway_clarify(clarify_id, resolved_text):
+        session_key = self._clarify_session_by_id.pop(clarify_id, "") or (
+            getattr(_clarify_mod._entries.get(clarify_id), "session_key", None) or ""
+        )
+        if _clarify_mod.resolve_gateway_clarify(
+            clarify_id, resolved_text, session_key=session_key
+        ):
             await self._update_clarify_message(
                 channel_id, msg_ts, original_text,
                 f"✅ {user_name}: {resolved_text}",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7493,7 +7493,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._clarify_state.pop(clarify_id, None)
                 try:
                     from tools.clarify_gateway import resolve_gateway_clarify
-                    resolved = resolve_gateway_clarify(clarify_id, resolved_text)
+                    resolved = resolve_gateway_clarify(clarify_id, resolved_text, session_key=session_key)
                 except Exception as exc:
                     logger.error("[%s] resolve_gateway_clarify failed: %s", self.name, exc)
                     resolved = False

--- a/tests/gateway/relay/test_relay_interactive.py
+++ b/tests/gateway/relay/test_relay_interactive.py
@@ -179,7 +179,7 @@ async def test_prompt_response_resolves_clarify_choice_and_other(monkeypatch):
     marked: list[str] = []
     monkeypatch.setattr(
         "tools.clarify_gateway.resolve_gateway_clarify",
-        lambda cid, resp: resolved.append((cid, resp)) or True,
+        lambda cid, resp, session_key=None, **kwargs: resolved.append((cid, resp)) or True,
     )
     monkeypatch.setattr(
         "tools.clarify_gateway.mark_awaiting_text", lambda cid: marked.append(cid)
@@ -278,7 +278,7 @@ async def test_sibling_gateway_ignores_another_instances_prompt_answer(monkeypat
     resolved: list[tuple] = []
     monkeypatch.setattr(
         "tools.clarify_gateway.resolve_gateway_clarify",
-        lambda cid, resp: resolved.append((cid, resp)) or True,
+        lambda cid, resp, session_key=None, **kwargs: resolved.append((cid, resp)) or True,
     )
     monkeypatch.setattr("tools.clarify_gateway.mark_awaiting_text", lambda cid: None)
 
@@ -305,7 +305,7 @@ async def test_repeat_answer_for_resolved_prompt_is_ignored(monkeypatch):
     resolved: list[tuple] = []
     monkeypatch.setattr(
         "tools.clarify_gateway.resolve_gateway_clarify",
-        lambda cid, resp: resolved.append((cid, resp)) or True,
+        lambda cid, resp, session_key=None, **kwargs: resolved.append((cid, resp)) or True,
     )
     event = _event({"prompt_id": prompt_id, "option_id": "c0"})
     assert await adapter._consume_prompt_response(event) is True

--- a/tests/gateway/test_clarify_thread_followup_not_swallowed.py
+++ b/tests/gateway/test_clarify_thread_followup_not_swallowed.py
@@ -147,7 +147,9 @@ async def test_thread_prose_does_not_overwrite_concurrent_button_choice():
         "Pick a UI variant",
         ["buttons", "dropdown"],
     )
-    assert cm.resolve_gateway_clarify("cl-button-race", "buttons") is True
+    assert cm.resolve_gateway_clarify(
+        "cl-button-race", "buttons", session_key=SESSION_KEY
+    ) is True
 
     with pytest.raises(_FellThroughIntercept):
         await _dispatch(runner, _event("one more unrelated thought"))

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1219,7 +1219,7 @@ class TestInteractiveReplyEndToEnd:
         adapter._clarify_state["q1"] = "sess-1"
         monkeypatch.setattr(
             "tools.clarify_gateway.resolve_gateway_clarify",
-            lambda cid, r: True,
+            lambda cid, r, session_key=None, **kwargs: True,
         )
 
         raw = {

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -36,7 +36,7 @@ class TestClarifyPrimitive:
 
         def resolver():
             time.sleep(0.05)
-            cm.resolve_gateway_clarify("id1", "B")
+            cm.resolve_gateway_clarify("id1", "B", session_key="sk1")
 
         threading.Thread(target=resolver).start()
         result = cm.wait_for_response("id1", timeout=10.0)
@@ -48,9 +48,21 @@ class TestClarifyPrimitive:
 
         entry = cm.register("id-race", "sk-race", "Pick one", ["A", "B"])
 
-        assert cm.resolve_gateway_clarify("id-race", "A") is True
-        assert cm.resolve_gateway_clarify("id-race", "") is False
+        assert cm.resolve_gateway_clarify("id-race", "A", session_key="sk-race") is True
+        assert cm.resolve_gateway_clarify("id-race", "", session_key="sk-race") is False
         assert entry.response == "A"
+
+    def test_resolve_requires_matching_session_key(self):
+        """Foreign or missing session_key must not resolve another session's clarify (#87780)."""
+        from tools import clarify_gateway as cm
+
+        entry = cm.register("cid-B", "sB", "Pick", ["A", "B"])
+        assert cm.resolve_gateway_clarify("cid-B", "FORGED") is False
+        assert cm.resolve_gateway_clarify("cid-B", "FORGED", session_key="sA") is False
+        assert entry.response is None
+        assert entry.event.is_set() is False
+        assert cm.resolve_gateway_clarify("cid-B", "OK", session_key="sB") is True
+        assert entry.response == "OK"
 
     def test_open_ended_auto_awaits_text(self):
         """Clarify with no choices is in text-capture mode immediately."""
@@ -121,7 +133,7 @@ class TestClarifyPrimitive:
             fut = pool.submit(waiter)
             time.sleep(0.05)
             # Button wins the race first...
-            assert cm.resolve_gateway_clarify("id-race", "B") is True
+            assert cm.resolve_gateway_clarify("id-race", "B", session_key="sk-race") is True
             # ...then session cleanup runs before the waiter wakes.
             cancelled = cm.clear_session("sk-race")
             assert cancelled == 0
@@ -307,7 +319,7 @@ class TestUnlimitedWait:
         assert t.is_alive()
 
         # Once resolved, the unlimited wait returns the real answer.
-        cm.resolve_gateway_clarify("u1", "B")
+        cm.resolve_gateway_clarify("u1", "B", session_key="sk")
         t.join(timeout=5.0)
         assert not t.is_alive()
         assert result_box["r"] == "B"

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -9,7 +9,7 @@ that:
   * stores a pending clarify request (with a generated ``clarify_id``),
   * blocks the agent thread on an ``Event``,
   * resolves the wait when the gateway's button-callback or text-intercept
-    fires ``resolve_gateway_clarify(clarify_id, response)``,
+    fires ``resolve_gateway_clarify(clarify_id, response, session_key=...)``,
   * supports timeouts so a user who never responds does NOT hang the agent
     thread forever (which would also pin the gateway's running-agent guard).
 
@@ -161,15 +161,44 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
 # Public API — gateway / adapter side
 # =========================================================================
 
-def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
+def resolve_gateway_clarify(
+    clarify_id: str,
+    response: str,
+    *,
+    session_key: Optional[str] = None,
+) -> bool:
     """Unblock the agent thread waiting on ``clarify_id``.
 
-    Returns True if an entry was found and resolved, False otherwise
-    (already resolved, expired, or never existed).
+    Callers **must** pass ``session_key`` matching the entry registered for
+    this clarify. Button callbacks and text intercepts already know the
+    owning session; requiring it closes the ID-only resolution hole where a
+    forged/leaked ``clarify_id`` could answer another session's prompt
+    (see #87780). Omitting ``session_key`` or supplying a mismatch returns
+    False without resolving.
+
+    Returns True if an entry was found, ownership matched, and resolved.
+    Returns False when already resolved, expired, never existed, missing
+    ``session_key``, or session ownership mismatched.
     """
     with _lock:
         entry = _entries.get(clarify_id)
         if entry is None or entry.event.is_set():
+            return False
+        if not session_key:
+            logger.warning(
+                "resolve_gateway_clarify rejected: missing session_key "
+                "(clarify_id=%s)",
+                clarify_id,
+            )
+            return False
+        if entry.session_key != session_key:
+            logger.warning(
+                "resolve_gateway_clarify rejected: session_key mismatch "
+                "(clarify_id=%s expected=%r got=%r)",
+                clarify_id,
+                entry.session_key,
+                session_key,
+            )
             return False
         entry.response = str(response) if response is not None else ""
         entry.event.set()
@@ -446,7 +475,11 @@ def attempt_text_response_for_session(session_key: str, response: str) -> str:
             return TEXT_REJECTED_SELECTION
         return TEXT_REJECTED_PROSE
 
-    if resolve_gateway_clarify(entry.clarify_id, coerced):
+    if resolve_gateway_clarify(
+        entry.clarify_id,
+        coerced,
+        session_key=entry.session_key,
+    ):
         return TEXT_RESOLVED
     # Lost a race with a button/callback resolution — treat as no work left.
     return TEXT_NO_PENDING


### PR DESCRIPTION
## Problem

`resolve_gateway_clarify(clarify_id, response)` accepted any caller who knew a pending `clarify_id`. There was no check that the resolver belonged to the session that registered the clarify.

Text replies were already session-scoped (`attempt_text_response_for_session`). Button/callback resolution was not — a leaked or shoulder-surfed `clarify_id` could answer another session's prompt.

## Root cause

| Path | Behavior on main |
|------|------------------|
| `tools/clarify_gateway.py` `resolve_gateway_clarify` | Lookup by `clarify_id` only |
| `_ClarifyEntry.session_key` | Stored at `register()` but unused on resolve |
| Text intercept | Correctly scoped via `get_pending_for_session(session_key)` |

## Fix

1. Require `session_key=` on `resolve_gateway_clarify`; reject missing or mismatched keys (fail closed).
2. Plumb owning session from adapters that already know it (Telegram/WhatsApp/relay state, Discord view, Slack map, gateway prose-cancel, internal text path).

## Why it matters

Defense-in-depth on the interactive clarify button path. UUID-like IDs make casual guessing hard, but nothing stopped a caller who obtained the ID from resolving a foreign session's wait — while typed answers already could not.

## Test plan

```bash
python -m pytest tests/tools/test_clarify_gateway.py \
  tests/gateway/test_clarify_thread_followup_not_swallowed.py \
  tests/gateway/test_discord_clarify_buttons.py \
  tests/gateway/test_discord_component_auth.py \
  tests/gateway/test_telegram_clarify_buttons.py \
  tests/gateway/test_slack_clarify_buttons.py -q
```

- [x] **31** `test_clarify_gateway` incl. `test_resolve_requires_matching_session_key` @ `91cf32fcb`
- [x] Discord/Telegram/Slack clarify button suites + thread followup — **40** passed
- [ ] Full monorepo suite not run (focused Mini gate)

## Risk / blast radius

- Callers that invoke `resolve_gateway_clarify` without `session_key` now fail closed (return False). In-tree call sites updated.
- Third-party adapters must pass `session_key=` matching `register()`.

## Closest existing work

- none found that binds `resolve_gateway_clarify` to session ownership on current main
- Orthogonal: platform clarify button/expiry PRs; session_search ownership issues

Fixes #87780

### Acceptance retest (2026-08-18)
Rebased onto current `main`. Mini proof @ `affbc17fe`: clarify gateway/discord/relay suites — 56 passed; mock session_key fix.

## Acceptance retest (2026-08-18b)

- Head: `d5b332929`
- WhatsApp interactive-tap mock now accepts session_key= (CI slice 3 TypeError). Mini: whatsapp tap + clarify gateway 40 passed @ d5b332929.

## Mini retest (2026-08-24 acceptance)
- Head `931d9a110a` · pytest tests/gateway/ -k clarify → 51 passed (+1 skip)
- Rebased onto current upstream `main` (force-with-lease, pre-review)
