### PR TITLE
feat(providers): add current Alibaba/Qwen & other models to model list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -566,16 +566,22 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # to https://dashscope-intl.aliyuncs.com/compatible-mode/v1 (OpenAI-compat)
     # or https://dashscope-intl.aliyuncs.com/apps/anthropic (Anthropic-compat).
     "alibaba": [
+        # Qwen 千问系列 (Token Plan 个人版 2026-08)
+        "qwen3.8-max",
         "qwen3.7-max",
         "qwen3.7-plus",
         "qwen3.6-plus",
-        "kimi-k2.5",
+        "qwen3.6-flash",
         "qwen3.5-plus",
         "qwen3-coder-plus",
         "qwen3-coder-next",
-        # Third-party models available on coding-intl
+        # Third-party models on Token Plan / coding-intl
+        "glm-5.2",
         "glm-5",
         "glm-4.7",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash-0731",
+        "kimi-k2.5",
         "MiniMax-M2.5",
     ],
     # Alibaba Coding Plan — same platform as alibaba (DashScope coding-intl),


### PR DESCRIPTION
## Summary
Adds currently-available Alibaba/Tongyi (Qwen), DeepSeek, GLM and Kimi models to the bundled alibaba provider model list in hermes_cli/models.py, so they appear in model selection without manual config edits.

## Changes
- Add qwen3.8-max, qwen3.6-flash (current flagship/fast Qwen)
- Add glm-5.2 (Zhipu)
- Add deepseek-v4-pro, deepseek-v4-flash-0731 (DeepSeek V4)
- Existing entries (qwen3.7-max, qwen3.7-plus, qwen3.6-plus, kimi-k2.5, etc.) are kept.

## Why
Users on the Alibaba/Tongyi provider could not pick these models from the built-in list; keeping the bundled list current avoids per-user config drift.

## Test plan
- python -c 'import ast; ast.parse(open("hermes_cli/models.py").read())' passes
- Local diff scoped to the alibaba list only (+8 / -2 lines)