### PR TITLE
fix(cli): handle Windows profile delete WinError 32 (cleanup scheduled task before kill)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1778,6 +1778,16 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
                 )
                 plist_path.unlink(missing_ok=True)
                 print("✓ Launchd service removed")
+
+        elif _platform.system() == "Windows":
+            # On Windows, the gateway runs as a Scheduled Task. Stop and delete it
+            # before killing the gateway process, otherwise the task's keepalive
+            # trigger may respawn the gateway between the kill and rmtree.
+            try:
+                from hermes_cli.gateway_windows import uninstall as _gw_uninstall
+                _gw_uninstall()
+            except Exception as e:
+                print(f"⚠ Windows gateway service cleanup: {e}")
     except Exception as e:
         print(f"⚠ Service cleanup: {e}")
     finally:
@@ -1788,17 +1798,41 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
 
 
 def _stop_gateway_process(profile_dir: Path) -> None:
-    """Stop a running gateway process via its PID file."""
+    """Stop a running gateway process via its PID file or lock file."""
     import time as _time
 
     pid_file = profile_dir / "gateway.pid"
-    if not pid_file.exists():
+    lock_file = profile_dir / "gateway.lock"
+
+    # Try gateway.pid first, then fall back to gateway.lock (which Task-spawned
+    # gateways on Windows write instead of gateway.pid). The lock file contains
+    # the same JSON record with a "pid" field.
+    pid = None
+    source = None
+
+    if pid_file.exists():
+        try:
+            raw = pid_file.read_text(encoding="utf-8").strip()
+            data = json.loads(raw) if raw.startswith("{") else {"pid": int(raw)}
+            pid = int(data["pid"])
+            source = "gateway.pid"
+        except Exception:
+            pass
+
+    if pid is None and lock_file.exists():
+        try:
+            from gateway.status import _read_gateway_lock_record
+            record = _read_gateway_lock_record(lock_file)
+            if record:
+                pid = int(record["pid"])
+                source = "gateway.lock"
+        except Exception:
+            pass
+
+    if pid is None:
         return
 
     try:
-        raw = pid_file.read_text(encoding="utf-8").strip()
-        data = json.loads(raw) if raw.startswith("{") else {"pid": int(raw)}
-        pid = int(data["pid"])
         # Route through terminate_pid so Windows uses the appropriate
         # primitive (taskkill / TerminateProcess) — raw os.kill with
         # _signal.SIGKILL raises AttributeError at import time on Windows,
@@ -1812,14 +1846,14 @@ def _stop_gateway_process(profile_dir: Path) -> None:
         for _ in range(20):
             _time.sleep(0.5)
             if not _pid_exists(pid):
-                print(f"✓ Gateway stopped (PID {pid})")
+                print(f"✓ Gateway stopped (PID {pid} from {source})")
                 return
         # Force kill
         try:
             _terminate_pid(pid, force=True)
         except (ProcessLookupError, OSError):
             pass
-        print(f"✓ Gateway force-stopped (PID {pid})")
+        print(f"✓ Gateway force-stopped (PID {pid} from {source})")
     except (ProcessLookupError, PermissionError):
         print("✓ Gateway already stopped")
     except Exception as e:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -318,6 +318,68 @@ class TestDeleteProfile:
         pids = profiles._profile_bound_backend_pids("coder", profile_dir)
         assert pids == [101]
 
+    def test_stop_gateway_falls_back_to_lock_when_pid_file_missing(self, profile_env, monkeypatch):
+        """Task-spawned gateways on Windows write gateway.lock instead of
+        gateway.pid; _stop_gateway_process must fall back to the lock record's
+        pid field or the delete never stops the gateway and rmtree hits
+        WinError 32 (issue #87761)."""
+        profile_dir = create_profile("coder", no_alias=True)
+        # Simulate the Windows Task Scheduler scenario: gateway.lock exists with
+        # a valid pid, but gateway.pid does not.
+        lock_pid = 424242
+        (profile_dir / "gateway.lock").write_text(
+            json.dumps({"pid": lock_pid, "kind": "gateway"}), encoding="utf-8"
+        )
+        assert not (profile_dir / "gateway.pid").exists()
+
+        killed = []
+        monkeypatch.setattr(
+            "hermes_cli.profiles.time.sleep", lambda s: None,
+        )
+        monkeypatch.setattr(
+            "gateway.status.terminate_pid",
+            lambda pid, force=False: killed.append((pid, force)),
+        )
+        # _pid_exists returns False immediately → graceful stop path prints
+        # "Gateway stopped" without force-killing.
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+
+        profiles._stop_gateway_process(profile_dir)
+
+        assert killed == [(lock_pid, False)], (
+            f"expected graceful terminate of lock-record pid {lock_pid}, got {killed}"
+        )
+
+    def test_stop_gateway_returns_when_no_pid_or_lock(self, profile_env, monkeypatch):
+        """No identity files → no-op (must not raise)."""
+        profile_dir = create_profile("coder", no_alias=True)
+        profiles._stop_gateway_process(profile_dir)  # should not raise
+
+    def test_cleanup_gateway_service_windows_uses_gateway_windows_uninstall(self, profile_env, monkeypatch):
+        """_cleanup_gateway_service must stop/delete the per-profile Scheduled
+        Task on Windows, otherwise the task keeps the gateway alive (or
+        respawns it) and rmtree fails with WinError 32 (issue #87761)."""
+        profile_dir = get_profile_dir("coder")
+        profile_dir.mkdir(parents=True, exist_ok=True)
+
+        uninstall_called = []
+        fake_module = types.ModuleType("hermes_cli.gateway_windows")
+
+        def _fake_uninstall():
+            uninstall_called.append(True)
+
+        fake_module.uninstall = _fake_uninstall
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway_windows", fake_module)
+        # platform.system() is read directly from the platform module inside
+        # the function; force it to report Windows.
+        monkeypatch.setattr("platform.system", lambda: "Windows")
+
+        profiles._cleanup_gateway_service("coder", profile_dir)
+
+        assert uninstall_called, "expected gateway_windows.uninstall() to be called on Windows"
+        # HERMES_HOME is restored after cleanup
+        assert os.environ.get("HERMES_HOME") == str(profile_env / ".hermes")
+
 
 # ===================================================================
 # TestListProfiles


### PR DESCRIPTION
## Problem
`hermes profile delete` fails with WinError 32 when the profile's gateway runs under Task Scheduler. Three gaps stack up: no Windows branch in `_cleanup_gateway_service` (scheduled task never stopped, gateway respawns), `_stop_gateway_process` returns early when gateway.pid is absent (task-spawned gateways only write gateway.lock), and `_rmtree_with_retry` cannot win against a live gateway holding locks.

## Fix
- `_cleanup_gateway_service`: new Windows branch calling the existing schtasks uninstall machinery (`Hermes_Gateway_<profile>`), before the process kill (prevents keepalive respawn between kill and rmtree)
- `_stop_gateway_process`: fall back to the pid field in gateway.lock via `_read_gateway_lock_record()` when gateway.pid is missing

## Tests
Existing profile tests pass (test_profiles.py).