### PR TITLE
fix(desktop): evict archived/deleted sessions from messaging slice immediately (#87716)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -7,11 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
 import {
+  deleteSession,
   getAllSessionMessages,
   getLatestSessionMessages,
   getSession,
   type SessionInfo,
-  type SessionResumeResponse
+  type SessionResumeResponse,
+  setSessionArchived
 } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
@@ -26,9 +28,11 @@ import {
   $currentProvider,
   $currentReasoningEffort,
   $messages,
+  $messagingSessions,
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
   $selectedStoredSessionId,
+  $sessions,
   $turnStartedAt,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
@@ -40,6 +44,7 @@ import {
   setCurrentProvider,
   setCurrentReasoningEffort,
   setMessages,
+  setMessagingSessions,
   setNewChatWorkspaceTarget,
   setResumeFailedSessionId,
   setSelectedStoredSessionId,
@@ -91,7 +96,7 @@ function deferred<T>() {
 
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
-  'createBackendSessionForSend' | 'selectSidebarItem' | 'startFreshSessionDraft'
+  'archiveSession' | 'createBackendSessionForSend' | 'removeSession' | 'selectSidebarItem' | 'startFreshSessionDraft'
 >
 
 function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
@@ -2548,5 +2553,84 @@ describe('selectSidebarItem', () => {
     expect(navigate).toHaveBeenCalledWith('/skills', undefined)
     expect(noteActiveTreeGroup).toHaveBeenCalledWith(null)
     expect(revealTreePane).toHaveBeenCalledWith('workspace')
+  })
+})
+
+describe('archiveSession / removeSession messaging-slice eviction (#87716)', () => {
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    setMessagingSessions([])
+    vi.restoreAllMocks()
+  })
+
+  it('drops the row from $messagingSessions optimistically when archiving', async () => {
+    const row = storedSession({ id: 'feishu-1', profile: 'default', source: 'feishu' })
+    setSessions([row])
+    setMessagingSessions([row, storedSession({ id: 'feishu-2', profile: 'default', source: 'feishu' })])
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={vi.fn(async () => ({}) as never)} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.archiveSession('feishu-1')
+    })
+
+    expect($messagingSessions.get().map(s => s.id)).toEqual(['feishu-2'])
+    expect(setSessionArchived).toHaveBeenCalledWith('feishu-1', true, 'default')
+  })
+
+  it('drops the row from $messagingSessions optimistically when deleting', async () => {
+    const row = storedSession({ id: 'discord-1', profile: 'default', source: 'discord' })
+    setSessions([row])
+    setMessagingSessions([row, storedSession({ id: 'discord-2', profile: 'default', source: 'discord' })])
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={vi.fn(async () => ({}) as never)} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.removeSession('discord-1')
+    })
+
+    expect($messagingSessions.get().map(s => s.id)).toEqual(['discord-2'])
+    expect(deleteSession).toHaveBeenCalledWith('discord-1', 'default')
+  })
+
+  it('restores the messaging row when the archive RPC fails', async () => {
+    const row = storedSession({ id: 'telegram-1', profile: 'default', source: 'telegram' })
+    setSessions([row])
+    setMessagingSessions([row, storedSession({ id: 'telegram-2', profile: 'default', source: 'telegram' })])
+    vi.mocked(setSessionArchived).mockRejectedValue(new Error('archive boom'))
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={vi.fn(async () => ({}) as never)} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.archiveSession('telegram-1').catch(() => undefined)
+    })
+
+    expect($messagingSessions.get().map(s => s.id).sort()).toEqual(['telegram-1', 'telegram-2'])
+    expect($sessions.get().map(s => s.id)).toEqual(['telegram-1'])
+  })
+
+  it('restores the messaging row when the delete RPC fails', async () => {
+    const row = storedSession({ id: 'slack-1', profile: 'default', source: 'slack' })
+    setSessions([row])
+    setMessagingSessions([row, storedSession({ id: 'slack-2', profile: 'default', source: 'slack' })])
+    vi.mocked(deleteSession).mockRejectedValue(new Error('delete boom'))
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={vi.fn(async () => ({}) as never)} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.removeSession('slack-1').catch(() => undefined)
+    })
+
+    expect($messagingSessions.get().map(s => s.id).sort()).toEqual(['slack-1', 'slack-2'])
+    expect($sessions.get().map(s => s.id)).toEqual(['slack-1'])
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -32,6 +32,7 @@ import {
   $currentProvider,
   $currentReasoningEffort,
   $messages,
+  $messagingSessions,
   $newChatWorkspaceTarget,
   $sessions,
   $yoloActive,
@@ -50,6 +51,7 @@ import {
   setFreshDraftReady,
   setIntroSeed,
   setMessages,
+  setMessagingSessions,
   setNewChatWorkspaceTarget,
   setResumeExhaustedSessionId,
   setResumeFailedSessionId,
@@ -1611,7 +1613,17 @@ export function useSessionActions({
       const removedPinId = removed ? sessionPinId(removed) : storedSessionId
       const removedIds = [storedSessionId, removed?.id, removed?._lineage_root_id]
 
+      // The messaging slice is a separate atom from recents; capture its rows so
+      // a failed delete can roll them back in lockstep with $sessions (#87716).
+      const removedMessagingRows = $messagingSessions
+        .get()
+        .filter(session => sessionMatchesStoredId(session, storedSessionId))
+
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+      // Mirror the optimistic removal on the messaging slice: platform cards
+      // must clear instantly, not on the next refreshMessagingSessions cycle
+      // (which can lag the delete RPC by seconds) (#87716).
+      setMessagingSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
       // Evict from the project tree's optimistic layer too (the backend snapshot
       // still lists it until its next refresh), so grouped + flat views drop the
       // row in lockstep. Pin the tombstone against the projects.tree prune while
@@ -1655,6 +1667,13 @@ export function useSessionActions({
       } catch (err) {
         if (removed) {
           setSessions(prev => [removed, ...prev])
+        }
+
+        if (removedMessagingRows.length) {
+          setMessagingSessions(prev => [
+            ...removedMessagingRows,
+            ...prev.filter(session => !sessionMatchesStoredId(session, storedSessionId))
+          ])
         }
 
         untombstoneSessions(removedIds)
@@ -1713,8 +1732,18 @@ export function useSessionActions({
       const archivedPinId = archived ? sessionPinId(archived) : storedSessionId
       const archivedIds = [storedSessionId, archived?.id, archived?._lineage_root_id]
 
+      // The messaging slice is a separate atom from recents; capture its rows so
+      // a failed archive can roll them back in lockstep with $sessions (#87716).
+      const archivedMessagingRows = $messagingSessions
+        .get()
+        .filter(session => sessionMatchesStoredId(session, storedSessionId))
+
       // Soft-hide: drop from the sidebar immediately, keep the data.
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+      // Mirror the optimistic removal on the messaging slice: platform cards
+      // must clear instantly, not on the next refreshMessagingSessions cycle
+      // (which can lag the archive RPC by seconds) (#87716).
+      setMessagingSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
       tombstoneSessions(archivedIds)
       beginSessionMutation(archivedIds)
       $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
@@ -1742,6 +1771,13 @@ export function useSessionActions({
       } catch (err) {
         if (archived) {
           setSessions(prev => [archived, ...prev.filter(session => !sessionMatchesStoredId(session, storedSessionId))])
+        }
+
+        if (archivedMessagingRows.length) {
+          setMessagingSessions(prev => [
+            ...archivedMessagingRows,
+            ...prev.filter(session => !sessionMatchesStoredId(session, storedSessionId))
+          ])
         }
 
         untombstoneSessions(archivedIds)


### PR DESCRIPTION
## Problem
Archiving/deleting a messaging-platform session leaves the row visible for 2-4s. archiveSession/removeSession only applied optimistic removal to $sessions (recents); the messaging slice ($messagingSessions) was only cleaned on the next refresh via dropTombstoned().

## Fix
Apply the same optimistic filter to the messaging slice in lockstep, with rollback on RPC failure. +88 lines of tests (4 cases: archive/drop, delete/drop, rollback).