### PR TITLE
fix(install): pin cryptography 48.0.1 on Termux to avoid source-build OOM (#87663)

### DIFF
--- a/constraints-termux.txt
+++ b/constraints-termux.txt
@@ -6,6 +6,12 @@
 # These pins keep the tested Android install path stable when upstream packages
 # move faster than Termux-compatible wheels / sdists.
 
+# cryptography>=50 has no pre-built wheel for Android/Termux aarch64 (bionic libc).
+# Building from source requires Rust and exhausts memory on mobile devices.
+# Termux package repository provides cryptography==48.0.1-1 which has a working wheel.
+# Pin to 48.0.1 to avoid source build hang/OOM on Termux. See issue #87663.
+cryptography==48.0.1
+
 ipython<10
 jedi>=0.18.1,<0.20
 parso>=0.8.4,<0.9

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1087,6 +1087,7 @@ install_system_packages() {
             [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
             [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
             log_success "Termux build dependencies installed"
+            log_info "Note: cryptography pinned to 48.0.1 on Termux (via constraints-termux.txt) to avoid source-build OOM — see issue #87663"
             return 0
         fi
 


### PR DESCRIPTION
## Problem
Termux install fails/hangs building cryptography==50.0.0 from source (no Android wheel available), exhausting memory on mobile devices.

## Fix
Add constraints-termux.txt pinning cryptography==48.0.1 (the version with a pre-built wheel in the Termux package repository) + informational log in install.sh. Tests pass (setup_hermes_script, termux_all_extra_compat, packaging_metadata).