### PR TITLE
fix(desktop): group messaging sidebar sections by profile when showing all profiles (#87715)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -26,7 +26,6 @@ import { useContributions } from '@/contrib/react/use-contributions'
 import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { comboTokens } from '@/lib/keybinds/combo'
-import { resolveProfileColor } from '@/lib/profile-color'
 import { sessionMatchesSearch } from '@/lib/session-search'
 import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
@@ -146,6 +145,7 @@ import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarFilterMenu } from './filter-menu'
 import { SidebarLoadMoreRow } from './load-more-row'
 import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
+import { buildProfileGroups } from './profile-groups'
 import { filterSessionsByProfileScope } from './profile-scope'
 import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
@@ -1169,6 +1169,12 @@ export function ChatSidebar({
     }
   }
 
+  // Grouping by profile: one collapsible group per profile, color on the header
+  // (not on every row). Default profile floats to the top, the rest alpha.
+  // Only reachable while the sidebar is showing every profile — scoped to one,
+  // it would draw a single group around the whole list.
+  const profileGrouped = showAllProfiles && grouping === 'profile'
+
   // Each messaging platform is its own self-managed section: split the
   // separately-fetched messaging slice by source, newest platform first, rows
   // within a platform by recency. Per-platform totals (when a "load more" has
@@ -1202,6 +1208,12 @@ export function ChatSidebar({
       bySource.set(sourceId, list)
     }
 
+    // When profileGrouped is true, also group by profile within each platform.
+    // Same helper (and therefore same keying/colors/order) as the recents
+    // profileGroups, so a platform's sub-groups line up with the recents view.
+    const buildProfileGroupsForPlatform = (sessions: SessionInfo[]): SidebarSessionGroup[] =>
+      buildProfileGroups(sessions, profileColors)
+
     return [...bySource.entries()]
       .map(([sourceId, list]) => {
         const ordered = [...list].sort((a, b) => sessionTime(b) - sessionTime(a))
@@ -1209,7 +1221,7 @@ export function ChatSidebar({
         const unpinnedKnown = known == null ? null : Math.max(0, known - (pinnedBySource.get(sourceId) ?? 0))
         const total = Math.max(ordered.length, unpinnedKnown ?? 0)
 
-        return {
+        const section: MessagingSection = {
           // Known exact total → more exist iff total exceeds loaded; otherwise
           // the seed fetch was capped, so assume more until a per-platform load
           // resolves the count.
@@ -1219,44 +1231,23 @@ export function ChatSidebar({
           sourceId,
           total
         }
+
+        // When profileGrouped is true, split sessions into per-profile groups.
+        if (profileGrouped) {
+          section.profileGroups = buildProfileGroupsForPlatform(ordered)
+        }
+
+        return section
       })
       .sort((a, b) => sessionTime(b.sessions[0]) - sessionTime(a.sessions[0]))
-  }, [visibleMessagingSessions, messagingPlatformTotals, messagingTruncated, isPinnedSession, messagingProfile])
-
-  // Grouping by profile: one collapsible group per profile, color on the header
-  // (not on every row). Default profile floats to the top, the rest alpha.
-  // Only reachable while the sidebar is showing every profile — scoped to one,
-  // it would draw a single group around the whole list.
-  const profileGrouped = showAllProfiles && grouping === 'profile'
+  }, [visibleMessagingSessions, messagingPlatformTotals, messagingTruncated, isPinnedSession, messagingProfile, profileGrouped, profileColors])
 
   const profileGroups = useMemo<SidebarSessionGroup[] | undefined>(() => {
     if (!profileGrouped) {
       return undefined
     }
 
-    const groups = new Map<string, SidebarSessionGroup>()
-
-    for (const session of agentSessions) {
-      const key = normalizeProfileKey(session.profile)
-
-      const group = groups.get(key) ?? {
-        color: resolveProfileColor(key, profileColors),
-        id: key,
-        label: key,
-        mode: 'profile',
-        path: null,
-        sessions: []
-      }
-
-      group.sessions.push(session)
-
-      groups.set(key, group)
-    }
-
-    // default (root) first, then the rest alphabetically.
-    return [...groups.values()].sort((a, b) =>
-      a.id === 'default' ? -1 : b.id === 'default' ? 1 : a.label.localeCompare(b.label)
-    )
+    return buildProfileGroups(agentSessions, profileColors)
   }, [profileGrouped, agentSessions, profileColors])
 
   // The flat Sessions list always shows ALL recent sessions; Projects is a
@@ -1811,6 +1802,47 @@ export function ChatSidebar({
                 // still has older threads on disk.
                 const canRevealMore = visible < group.sessions.length || group.hasMore
 
+                // When profileGrouped is true, render profile groups instead of flat sessions.
+                if (profileGrouped && group.profileGroups && group.profileGroups.length > 0) {
+                  return (
+                    <SidebarSessionsSection
+                      activeSessionId={activeSidebarSessionId}
+                      contentClassName={cn('flex max-h-56 flex-col gap-px pb-1.75', GROUP_BODY)}
+                      emptyState={null}
+                      footer={
+                        canRevealMore ? (
+                          <SidebarLoadMoreRow
+                            loading={Boolean(messagingLoadMorePending[group.sourceId])}
+                            onClick={() => revealMoreMessaging(group.sourceId, group.sessions.length, group.hasMore)}
+                            step={Math.min(NON_SESSION_LOAD_STEP, Math.max(0, group.total - shownSessions.length))}
+                          />
+                        ) : null
+                      }
+                      groups={group.profileGroups}
+                      key={group.sourceId}
+                      label={group.label}
+                      labelIcon={
+                        <PlatformAvatar
+                          className="size-4 rounded-[4px] text-[0.5625rem] [&_svg]:size-3"
+                          platformId={group.sourceId}
+                          platformName={group.label}
+                        />
+                      }
+                      onArchiveSession={onArchiveSession}
+                      onDeleteSession={onDeleteSession}
+                      onResumeSession={onResumeSession}
+                      onToggle={() => toggleSidebarMessagingOpen(group.sourceId)}
+                      onTogglePin={pinSession}
+                      onToggleUnread={toggleUnread}
+                      open={messagingOpenIds.includes(group.sourceId)}
+                      pinned={false}
+                      rootClassName="shrink-0 p-0"
+                      sessions={[]}
+                      showProfileTags={false}
+                    />
+                  )
+                }
+
                 return (
                   <SidebarSessionsSection
                     activeSessionId={activeSidebarSessionId}
@@ -1881,4 +1913,7 @@ interface MessagingSection {
   sessions: SessionInfo[]
   total: number
   hasMore: boolean
+  // When profileGrouped is true, sessions are split into per-profile groups.
+  // Each group is a SidebarSessionGroup with mode='profile' and the profile's color.
+  profileGroups?: SidebarSessionGroup[]
 }

--- a/apps/desktop/src/app/chat/sidebar/profile-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/profile-groups.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { buildProfileGroups } from './profile-groups'
+
+/** Build the smallest session row needed by the profile-groups tests. */
+const row = (id: string, profile?: string): SessionInfo =>
+  ({ id, message_count: 1, profile, source: 'signal', started_at: 0, title: id }) as SessionInfo
+
+const NO_COLORS = {}
+
+describe('buildProfileGroups', () => {
+  it('groups sessions by profile key', () => {
+    const groups = buildProfileGroups(
+      [row('default-row', 'default'), row('work-row', 'work'), row('other-row', 'work')],
+      NO_COLORS
+    )
+
+    expect(groups.map(group => [group.id, group.mode, group.sessions.length])).toEqual([
+      ['default', 'profile', 1],
+      ['work', 'profile', 2]
+    ])
+  })
+
+  it('floats the default profile first, then sorts the rest alphabetically', () => {
+    const groups = buildProfileGroups(
+      [row('zeta-row', 'zeta'), row('alpha-row', 'alpha'), row('default-row', 'default')],
+      NO_COLORS
+    )
+
+    expect(groups.map(group => group.id)).toEqual(['default', 'alpha', 'zeta'])
+  })
+
+  it('treats legacy rows without a profile as default', () => {
+    const groups = buildProfileGroups([row('legacy-row'), row('work-row', 'work')], NO_COLORS)
+
+    expect(groups.map(group => group.id)).toEqual(['default', 'work'])
+    expect(groups[0].sessions.map(session => session.id)).toEqual(['legacy-row'])
+  })
+
+  it('carries the profile color from the overrides map', () => {
+    const groups = buildProfileGroups([row('work-row', 'work')], { work: '#aabbcc' })
+
+    expect(groups[0].color).toBe('#aabbcc')
+  })
+
+  it('keeps the default profile colorless', () => {
+    const groups = buildProfileGroups([row('default-row', 'default')], { default: '#aabbcc' })
+
+    expect(groups[0].color).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/profile-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/profile-groups.ts
@@ -1,0 +1,41 @@
+import { resolveProfileColor } from '@/lib/profile-color'
+import { normalizeProfileKey } from '@/store/profile'
+import type { SessionInfo } from '@/types/hermes'
+
+import type { SidebarSessionGroup } from './projects'
+
+/**
+ * Build one collapsible group per profile over `sessions`, each carrying the
+ * profile's color on the header. Default (root) profile floats to the top, the
+ * rest sort alphabetically — the same ordering the recents list uses, so a
+ * messaging platform's profile sub-groups line up with the recents groups.
+ *
+ * Shared by the recents list (profileGrouped view) and the messaging platform
+ * sections (which group by profile only when the whole sidebar is in the
+ * profile-grouped view), so both surfaces attribute rows to the same profile
+ * key and paint them with the same color.
+ */
+export function buildProfileGroups(sessions: SessionInfo[], profileColors: Record<string, string>): SidebarSessionGroup[] {
+  const groups = new Map<string, SidebarSessionGroup>()
+
+  for (const session of sessions) {
+    const key = normalizeProfileKey(session.profile)
+
+    const group = groups.get(key) ?? {
+      color: resolveProfileColor(key, profileColors),
+      id: key,
+      label: key,
+      mode: 'profile',
+      path: null,
+      sessions: []
+    }
+
+    group.sessions.push(session)
+
+    groups.set(key, group)
+  }
+
+  return [...groups.values()].sort((a, b) =>
+    a.id === 'default' ? -1 : b.id === 'default' ? 1 : a.label.localeCompare(b.label)
+  )
+}


### PR DESCRIPTION
## Problem
Messaging platform sections only grouped by profile while the whole sidebar was in profile-grouped view; individual platforms ignored it, so rows from different profiles were mixed within one platform section.

## Fix
Extract buildProfileGroups() (shared helper: same keying/colors/order as recents profile groups, default floats first) and apply it per platform section when showAllProfiles + grouping=profile. 5 vitest tests pass.