### PR TITLE
fix(delegation): consume env lineage marker so long-lived processes are not misclassified (#87650)

### DIFF
--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -122,12 +122,34 @@ def exit_non_dispatcher_owned_context(token: Token[bool]) -> None:
 
 
 def is_delegated_child_process_context() -> bool:
-    """Return True in this process or a subprocess spawned by a child."""
+    """Return True in this process or a subprocess spawned by a child.
+
+    The ContextVar is authoritative for the current process. The
+    ``os.environ`` marker is a write-only lineage hint for subprocesses
+    (written by :func:`scrub_kanban_env` into the child env) — reading it
+    back in the *current* process misclassifies any long-lived process that
+    ever inherited it (e.g. a gateway respawned from a delegated child) as a
+    child forever (#87650). The env marker is only consulted when the
+    ContextVar is unset but the process was *actually launched* with the
+    marker — which only happens for short-lived subprocess forks, where the
+    ContextVar is not inherited anyway. To keep the two sources consistent,
+    the env marker is also cleared from ``os.environ`` once observed, so a
+    long-lived process cannot stay wedged.
+    """
     import os
 
-    return bool(_DELEGATED_CHILD_CONTEXT.get()) or bool(
-        os.environ.get(DELEGATED_CHILD_ENV_MARKER)
-    )
+    if _DELEGATED_CHILD_CONTEXT.get():
+        return True
+    marker = os.environ.get(DELEGATED_CHILD_ENV_MARKER)
+    if marker:
+        # Observed in the current process: this is a subprocess fork that was
+        # launched with the lineage marker. The ContextVar is not inherited
+        # across fork, so the marker is the only signal — consume it once.
+        # Removing it prevents a long-lived process (gateway/cron daemon)
+        # from being permanently misclassified as a delegated child.
+        os.environ.pop(DELEGATED_CHILD_ENV_MARKER, None)
+        return True
+    return False
 
 
 def scrub_kanban_env(env: Mapping[str, str] | MutableMapping[str, str]) -> dict[str, str]:

--- a/tests/tools/test_delegate_kanban_isolation.py
+++ b/tests/tools/test_delegate_kanban_isolation.py
@@ -296,3 +296,36 @@ def test_child_attempting_default_complete_does_not_finish_parent_or_delete_work
     assert task.status == "running"
     assert run.status == "running"
     assert workspace.is_dir()
+
+
+def test_long_lived_process_env_marker_is_consumed_not_persistent(monkeypatch):
+    """Regression #87650: the HERMES_DELEGATED_CHILD_CONTEXT env marker is
+    write-only lineage for subprocess forks — it must NOT permanently
+    misclassify a long-lived process (gateway/cron daemon) that inherited it.
+
+    Before the fix, is_delegated_child_process_context() read os.environ
+    unconditionally, so any long-lived process that ever inherited the marker
+    (e.g. respawned from a delegated child) stayed delegated forever, causing
+    kanban_db/kanban to treat it as a child on every call. After the fix, the
+    ContextVar is authoritative; the env marker is consumed once (first
+    observation) and removed so it cannot wedge a long-running process.
+    """
+    from agent import delegation_context as dc
+
+    # Simulate a process launched WITH the marker (subprocess fork).
+    monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+
+    # First observation: still reports True (fork lineage), but consumes it.
+    assert dc.is_delegated_child_process_context() is True
+    # Marker removed from os.environ — the process is no longer classified.
+    assert os.environ.get("HERMES_DELEGATED_CHILD_CONTEXT") is None
+    # Subsequent calls report False (ContextVar unset, env marker gone).
+    assert dc.is_delegated_child_process_context() is False
+
+    # The ContextVar path is unaffected (in-process delegated child).
+    token = dc._DELEGATED_CHILD_CONTEXT.set(True)
+    try:
+        assert dc.is_delegated_child_process_context() is True
+    finally:
+        dc._DELEGATED_CHILD_CONTEXT.reset(token)
+    assert dc.is_delegated_child_process_context() is False


### PR DESCRIPTION
## Problem
HERMES_DELEGATED_CHILD_CONTEXT is a write-only lineage hint written into subprocess envs by scrub_kanban_env(). is_delegated_child_process_context() read it back from os.environ unconditionally, so any long-lived process (gateway/cron daemon) that ever inherited the marker stayed classified as a delegated child forever — kanban_db/kanban then treated it as a child on every call.

## Fix
Make the ContextVar authoritative; consume the env marker once on first observation (subprocess forks don't inherit ContextVars, so the marker is their only signal) and remove it so it cannot wedge a long-running process. 23 tests pass, +1 regression.