### PR TITLE
fix(desktop): consolidate MEDIA path parsing and streaming

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -406,11 +406,167 @@ describe('renderMediaTags', () => {
     expect(renderMediaTags('MEDIA:/tmp/demo.mp4')).toBe('[Video: demo.mp4](#media:%2Ftmp%2Fdemo.mp4)')
   })
 
+  it('keeps a line-leading inline MEDIA tag separate from trailing prose', () => {
+    expect(renderMediaTags('MEDIA:/tmp/voice.mp3 done')).toBe('[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3) done')
+  })
+
+  it('keeps an extensionless inline MEDIA URL separate from trailing prose', () => {
+    expect(renderMediaTags('MEDIA:https://example.com/download done')).toBe(
+      '[File: download](#media:https%3A%2F%2Fexample.com%2Fdownload) done'
+    )
+  })
+
+  it('renders consecutive inline MEDIA tags at the start of a line independently', () => {
+    expect(renderMediaTags('MEDIA:/tmp/a.png MEDIA:/tmp/b.png')).toBe(
+      '[Image: a.png](#media:%2Ftmp%2Fa.png) [Image: b.png](#media:%2Ftmp%2Fb.png)'
+    )
+  })
+
+  it('leaves ordinary standalone MEDIA prose unchanged', () => {
+    expect(renderMediaTags('before\nMEDIA: the report is ready\nafter')).toBe(
+      'before\nMEDIA: the report is ready\nafter'
+    )
+  })
+
+  it('keeps an unquoted standalone MEDIA path with spaces intact', () => {
+    const path = '/Users/zora/Documents/ZORA/hermes/operations/B17-B Value Extraction and Retirement Receipt.md'
+
+    expect(renderMediaTags(`ready\nMEDIA:${path}`)).toBe(
+      `ready\n[File: B17-B Value Extraction and Retirement Receipt.md](#media:${encodeURIComponent(path)})`
+    )
+  })
+
+  it.each([
+    ['/tmp/foo.txt bar.pdf', 'foo.txt bar.pdf'],
+    ['/Users/me/v1.0 Final/report.md', 'report.md']
+  ])('does not truncate an unquoted path after an extension-like component: %s', (path, label) => {
+    expect(renderMediaTags(`MEDIA:${path}`)).toBe(`[File: ${label}](#media:${encodeURIComponent(path)})`)
+  })
+
+  it.each([
+    ['LF', '\n'],
+    ['CRLF', '\r\n']
+  ])('keeps spaces in consecutive Windows and UNC MEDIA paths with %s line endings', (_label, newline) => {
+    const drivePath = 'C:\\Users\\ADMIN\\My Files\\first report.pdf'
+    const uncPath = '\\\\server\\Shared Files\\second report.pdf'
+
+    expect(renderMediaTags(`MEDIA:${drivePath}${newline}MEDIA:${uncPath}`)).toBe(
+      `[File: first report.pdf](#media:${encodeURIComponent(drivePath)})${newline}` +
+        `[File: second report.pdf](#media:${encodeURIComponent(uncPath)})`
+    )
+  })
+
+  it.each([
+    ['LF', '\n'],
+    ['CRLF', '\r\n']
+  ])('does not consume the following line when a MEDIA path is blank with %s', (_label, newline) => {
+    expect(renderMediaTags(`before${newline}MEDIA:   ${newline}not-a-path`)).toBe(
+      `before${newline}MEDIA:${newline}not-a-path`
+    )
+  })
+
+  it.each(['`', '"', "'"])('keeps spaces in a standalone path quoted with %s', quote => {
+    const path = 'reports/the final report.pdf'
+
+    expect(renderMediaTags(`MEDIA:${quote}${path}${quote}`)).toBe(
+      `[File: the final report.pdf](#media:${encodeURIComponent(path)})`
+    )
+  })
+
   it('renders streamed assistant media once the tag is complete', () => {
     const parts = appendAssistantTextPart(appendAssistantTextPart([], 'ok\nMEDIA:'), '/tmp/voice.mp3')
     const text = chatMessageText({ id: 'a', role: 'assistant', parts })
 
     expect(text).toBe('ok\n[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
+  })
+
+  it('does not reinterpret a legitimate trailing media link when more text streams in', () => {
+    const link = '[File: report.md](#media:%2Ftmp%2Freport.md)'
+    let parts = appendAssistantTextPart([], link, 1)
+
+    parts = appendAssistantTextPart(parts, ' continued', 2)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(`${link} continued`)
+    expect(parts).toHaveLength(1)
+    expect(parts[0]).toMatchObject({ timestamp: 1, type: 'text' })
+  })
+
+  it('treats a closing quote as the end of a streamed standalone MEDIA path', () => {
+    let parts = appendAssistantTextPart([], 'MEDIA:"/tmp/the report.pdf"', 1)
+
+    expect(parts[0]).not.toHaveProperty('provisionalMediaSource')
+    parts = appendAssistantTextPart(parts, ' continued', 2)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(
+      '[File: the report.pdf](#media:%2Ftmp%2Fthe%20report.pdf) continued'
+    )
+  })
+
+  it('treats a quote around the whole streamed MEDIA directive as closed', () => {
+    let parts = appendAssistantTextPart([], '"MEDIA:/tmp/the report.pdf"', 1)
+
+    expect(parts[0]).not.toHaveProperty('provisionalMediaSource')
+    parts = appendAssistantTextPart(parts, ' continued', 2)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(
+      '[File: the report.pdf](#media:%2Ftmp%2Fthe%20report.pdf) continued'
+    )
+  })
+
+  it('does not freeze the B17-B streamed path before later space-separated chunks arrive', () => {
+    const path = '/Users/zora/Documents/ZORA/hermes/operations/B17-B Value Extraction and Retirement Receipt.md'
+    let parts = appendAssistantTextPart([], 'ready\nMEDIA:/Users/zora/Documents/ZORA/hermes/operations/B17-B', 10.125)
+
+    parts = appendAssistantTextPart(parts, ' Value Ex', 10.5)
+    parts = appendAssistantTextPart(parts, 'traction and Retirement Receipt.md\n', 11)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(
+      `ready\n[File: B17-B Value Extraction and Retirement Receipt.md](#media:${encodeURIComponent(path)})\n`
+    )
+    expect(parts).toHaveLength(1)
+    expect(parts[0]).toMatchObject({ timestamp: 10.125, type: 'text' })
+    expect(parts[0].completedAt).toBeUndefined()
+    expect(parts[0]).not.toHaveProperty('provisionalMediaSource')
+  })
+
+  it('does not carry provisional MEDIA state across a reasoning boundary', () => {
+    let parts: ChatMessagePart[] = appendAssistantTextPart([], 'MEDIA:/tmp/partial', 1)
+
+    expect(parts[0]).toHaveProperty('provisionalMediaSource', 'MEDIA:/tmp/partial')
+    parts = appendReasoningPart(parts, 'thinking', 2)
+    parts = appendAssistantTextPart(parts, ' filename.pdf', 3)
+
+    expect(parts.map(part => part.type)).toEqual(['text', 'reasoning', 'text'])
+    expect(parts.map(part => part.timestamp)).toEqual([1, 2, 3])
+    expect(parts.map(part => part.completedAt)).toEqual([2, 3, undefined])
+    expect(parts[0]).not.toHaveProperty('provisionalMediaSource')
+    expect((parts[0] as { text: string }).text).toBe('[File: partial](#media:%2Ftmp%2Fpartial)')
+    expect((parts[2] as { text: string }).text).toBe(' filename.pdf')
+  })
+
+  it('clears provisional MEDIA state when the timeline part completes', () => {
+    const parts = appendAssistantTextPart([], 'MEDIA:/tmp/partial', 1)
+
+    expect(parts[0]).toHaveProperty('provisionalMediaSource')
+    const completed = completeOpenTimelineParts(parts, 2)
+
+    expect(completed[0]).not.toHaveProperty('provisionalMediaSource')
+    expect(completed[0]).toMatchObject({ completedAt: 2, timestamp: 1, type: 'text' })
+  })
+
+  it('clears provisional MEDIA state during final-response reconciliation', () => {
+    const parts = appendAssistantTextPart([], 'MEDIA:/tmp/partial', 1)
+
+    expect(parts[0]).toHaveProperty('provisionalMediaSource')
+    const settled = mergeFinalAssistantText(parts, 'MEDIA:/tmp/partial', 2)
+
+    expect(settled).toHaveLength(1)
+    expect(settled[0]).not.toHaveProperty('provisionalMediaSource')
+    expect(settled[0]).toMatchObject({
+      text: '[File: partial](#media:%2Ftmp%2Fpartial)',
+      timestamp: 1,
+      type: 'text'
+    })
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -14,6 +14,9 @@ export interface TimelinePartMetadata {
   timestamp?: number
   /** Unix seconds when this segment stopped or handed off to the next one. */
   completedAt?: number
+  /** Undecorated source for a trailing MEDIA directive that may receive more
+   * streamed path characters. Live-only and removed when the segment closes. */
+  provisionalMediaSource?: string
 }
 
 export type ChatMessagePart = Exclude<ThreadMessageLike['content'], string>[number] & TimelinePartMetadata
@@ -156,9 +159,10 @@ export function reasoningPart(text: string, timestamp?: number): ChatMessagePart
   return { type: 'reasoning', text, ...(timestamp !== undefined ? { timestamp } : {}) }
 }
 
-const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
+const MEDIA_LINE_RE =
+  /(^|\n)[\t ]*[`"']?MEDIA:[\t ]*(?<line>`[^`\r\n]+`|"[^"\r\n]+"|'[^'\r\n]+'|[^\r\n]*?\S)[`"']?[\t ]*(?=\r?\n|$)/g
 
-const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
+const MEDIA_TAG_RE = /[`"']?MEDIA:[\t ]*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
 
 function unquoteMediaPath(value: string): string {
   const trimmed = value.trim()
@@ -173,15 +177,96 @@ function mediaLink(value: string): string {
   return `[${mediaDisplayLabel(path)}](${mediaMarkdownHref(path)})`
 }
 
-export function renderMediaTags(text: string): string {
-  return text
-    .replace(
-      MEDIA_LINE_RE,
-      (_match, lead: string, value: string, trailer: string) => `${lead}${mediaLink(value)}${trailer}`
-    )
-    .replace(MEDIA_TAG_RE, (_match, value: string) => mediaLink(value))
-    .replace(/[ \t]+\n/g, '\n')
+function isExplicitlyQuotedMediaPath(value: string): boolean {
+  const trimmed = value.trim()
+  const quote = trimmed[0]
+
+  return Boolean(quote && quote === trimmed.at(-1) && ['"', "'", '`'].includes(quote))
+}
+
+function isClosedQuotedMediaDirective(match: string, lead: string): boolean {
+  return isExplicitlyQuotedMediaPath(match.slice(lead.length))
+}
+
+function isPathShapedMediaValue(value: string): boolean {
+  return (
+    /^(?:file:|https?:|data:|\/|~[\\/]|\.{1,2}[\\/]|[a-z]:[\\/]|\\\\)/i.test(value) ||
+    /\.[a-z0-9]{1,16}(?:[?#].*)?$/i.test(value)
+  )
+}
+
+type StandaloneMediaIntent = 'inline' | 'path' | 'prose'
+
+function standaloneMediaIntent(value: string): StandaloneMediaIntent {
+  const trimmed = value.trim()
+
+  if (isExplicitlyQuotedMediaPath(trimmed) || !/\s/.test(trimmed)) {
+    return 'path'
+  }
+
+  if (/\bMEDIA:/.test(trimmed)) {
+    return 'inline'
+  }
+
+  const firstToken = trimmed.match(/^\S+/)?.[0]
+  const suffix = firstToken ? trimmed.slice(firstToken.length).trim() : ''
+
+  if (
+    firstToken &&
+    (/^(?:file:|https?:|data:)/i.test(firstToken) ||
+      (isPathShapedMediaValue(firstToken) &&
+        /\.[a-z0-9]{1,16}(?:[?#].*)?$/i.test(firstToken) &&
+        !isPathShapedMediaValue(suffix)))
+  ) {
+    return 'inline'
+  }
+
+  return isPathShapedMediaValue(trimmed) ? 'path' : 'prose'
+}
+
+function lineLeadingMediaIntent(source: string, offset: number): StandaloneMediaIntent | undefined {
+  const lineStart = source.lastIndexOf('\n', Math.max(0, offset - 1)) + 1
+
+  if (!/^[\t ]*$/.test(source.slice(lineStart, offset))) {
+    return undefined
+  }
+
+  const lineEnd = source.indexOf('\n', offset)
+  const line = source.slice(offset, lineEnd === -1 ? source.length : lineEnd)
+  const marker = line.indexOf('MEDIA:')
+
+  return marker === -1 ? undefined : standaloneMediaIntent(line.slice(marker + 'MEDIA:'.length))
+}
+
+function renderMediaText(text: string): { provisional: boolean; text: string } {
+  let provisional = false
+
+  const rendered = text
+    .replace(MEDIA_LINE_RE, (match, lead: string, value: string, offset: number, source: string) => {
+      if (standaloneMediaIntent(value) !== 'path') {
+        return match
+      }
+
+      provisional ||=
+        !isExplicitlyQuotedMediaPath(value) &&
+        !isClosedQuotedMediaDirective(match, lead) &&
+        offset + match.length === source.length
+
+      return `${lead}${mediaLink(value)}`
+    })
+    .replace(MEDIA_TAG_RE, (match, value: string, offset: number, source: string) => {
+      const lineIntent = lineLeadingMediaIntent(source, offset)
+
+      return lineIntent === 'prose' ? match : mediaLink(value)
+    })
+    .replace(/[ \t]+(?=\r?\n)/g, '')
     .replace(/\n{3,}/g, '\n\n')
+
+  return { provisional, text: rendered }
+}
+
+export function renderMediaTags(text: string): string {
+  return renderMediaText(text).text
 }
 
 export function assistantTextPart(text: string, timestamp?: number): ChatMessagePart {
@@ -266,6 +351,7 @@ export function mergeFinalAssistantText(
   finalText: string,
   fallbackTimestamp?: number
 ): ChatMessagePart[] {
+  parts = clearProvisionalMediaSources(parts)
   const dedupeReference = normalizeWs(finalText)
 
   const streamedText = normalizeWs(
@@ -458,21 +544,65 @@ const STREAM_PART: Record<'reasoning' | 'text', (text: string, timestamp?: numbe
   text: textPart
 }
 
+function clearProvisionalMediaSource(part: ChatMessagePart): ChatMessagePart {
+  if (part.provisionalMediaSource === undefined) {
+    return part
+  }
+
+  const { provisionalMediaSource: _source, ...settled } = part
+
+  return settled as ChatMessagePart
+}
+
+function clearProvisionalMediaSources(parts: ChatMessagePart[]): ChatMessagePart[] {
+  let changed = false
+
+  const settled = parts.map(part => {
+    const next = clearProvisionalMediaSource(part)
+
+    changed ||= next !== part
+
+    return next
+  })
+
+  return changed ? settled : parts
+}
+
+function restoreOpenProvisionalMediaSource(parts: ChatMessagePart[]): ChatMessagePart[] {
+  const tailIndex = parts.length - 1
+  const tail = parts[tailIndex]
+
+  if (tail?.type !== 'text' || tail.completedAt !== undefined || tail.provisionalMediaSource === undefined) {
+    return parts
+  }
+
+  const next = [...parts]
+  const settled = clearProvisionalMediaSource(tail)
+
+  next[tailIndex] = { ...settled, text: tail.provisionalMediaSource } as ChatMessagePart
+
+  return next
+}
+
 function completeOpenStreamParts(parts: ChatMessagePart[], completedAt: number): ChatMessagePart[] {
-  return parts.map(part =>
-    (part.type === 'text' || part.type === 'reasoning') && part.completedAt === undefined
-      ? ({ ...part, completedAt } as ChatMessagePart)
-      : part
-  )
+  return parts.map(part => {
+    const settled = clearProvisionalMediaSource(part)
+
+    return (settled.type === 'text' || settled.type === 'reasoning') && settled.completedAt === undefined
+      ? ({ ...settled, completedAt } as ChatMessagePart)
+      : settled
+  })
 }
 
 /** Seal every still-open visible activity when the assistant turn stops. */
 export function completeOpenTimelineParts(parts: ChatMessagePart[], completedAt: number): ChatMessagePart[] {
-  return parts.map(part =>
-    part.timestamp !== undefined && part.completedAt === undefined
-      ? ({ ...part, completedAt } as ChatMessagePart)
-      : part
-  )
+  return parts.map(part => {
+    const settled = clearProvisionalMediaSource(part)
+
+    return settled.timestamp !== undefined && settled.completedAt === undefined
+      ? ({ ...settled, completedAt } as ChatMessagePart)
+      : settled
+  })
 }
 
 // Coalesce only adjacent deltas of the same channel. Switching between text
@@ -495,12 +625,13 @@ function appendStreamPart(
     return { index: tailIndex, parts: next }
   }
 
-  if (
-    timestamp !== undefined &&
-    (tail?.type === 'text' || tail?.type === 'reasoning') &&
-    tail.completedAt === undefined
-  ) {
-    next[tailIndex] = { ...tail, completedAt: timestamp } as ChatMessagePart
+  if ((tail?.type === 'text' || tail?.type === 'reasoning') && tail.completedAt === undefined) {
+    const settled = clearProvisionalMediaSource(tail)
+
+    next[tailIndex] = {
+      ...settled,
+      ...(timestamp !== undefined ? { completedAt: timestamp } : {})
+    } as ChatMessagePart
   }
 
   next.push(STREAM_PART[type](delta, timestamp))
@@ -521,7 +652,7 @@ export function appendAssistantTextPart(
   delta: string,
   timestamp?: number
 ): ChatMessagePart[] {
-  const { index, parts: next } = appendStreamPart(parts, 'text', delta, timestamp)
+  const { index, parts: next } = appendStreamPart(restoreOpenProvisionalMediaSource(parts), 'text', delta, timestamp)
   const part = next[index]
 
   if (part?.type !== 'text') {
@@ -532,10 +663,16 @@ export function appendAssistantTextPart(
     delta.includes('MEDIA:') || delta.includes('DIA:') || delta.includes('EDIA:') || delta.includes('IA:')
 
   if (mayContainMedia || part.text.includes('MEDIA:')) {
-    const rendered = renderMediaTags(part.text)
+    const rendered = renderMediaText(part.text)
 
-    if (rendered !== part.text) {
-      next[index] = { ...part, text: rendered }
+    if (rendered.text !== part.text || rendered.provisional) {
+      const settled = clearProvisionalMediaSource(part)
+
+      next[index] = {
+        ...settled,
+        text: rendered.text,
+        ...(rendered.provisional ? { provisionalMediaSource: part.text } : {})
+      } as ChatMessagePart
     }
   }
 

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -10,6 +10,7 @@ import {
   isRemoteGateway,
   mediaExternalUrl,
   mediaGatewayStreamUrl,
+  mediaName,
   resolveMediaDisplaySrc,
   resolveMediaPlaybackSrc
 } from './media'
@@ -42,6 +43,13 @@ describe('filePathFromMediaPath', () => {
 
   it('decodes a file:// URL with encoded characters', () => {
     expect(filePathFromMediaPath('file:///tmp/a%20b.png')).toBe('/tmp/a b.png')
+  })
+})
+
+describe('mediaName', () => {
+  it('extracts the basename from Windows drive and UNC paths', () => {
+    expect(mediaName('C:\\Users\\ADMIN\\My Files\\report.pdf')).toBe('report.pdf')
+    expect(mediaName('\\\\server\\Shared Files\\report.pdf')).toBe('report.pdf')
   })
 })
 

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -45,6 +45,10 @@ export function mediaMime(path: string): string {
 }
 
 export function mediaName(path: string): string {
+  if (/^(?:[a-z]:[\\/]|\\\\)/i.test(path)) {
+    return path.split(/[\\/]/).filter(Boolean).pop() || path
+  }
+
   try {
     const url = new URL(path)
 


### PR DESCRIPTION
## Summary

- Parse complete standalone `MEDIA:` paths with spaces across POSIX, Windows drive, UNC, quoted, LF, and CRLF forms while preserving ordinary `MEDIA:` prose and existing inline tags.
- Reconstruct streamed partial paths through transient provenance on the adjacent open text part; never infer source text from rendered `#media:` Markdown.
- Preserve current timeline timestamps, completion state, and text/reasoning boundaries.

## Provenance and consolidation

This materially adapts the broader complete-path parser work from #70801 by Rickard Robin, who is also credited in the commit trailer. #84175 independently identified the B17-B failure and demonstrated a separate multi-chunk streaming defect not handled by the complete-line parser alone.

The earlier `restoreTrailingMediaDirective()` approach from #84175 was rejected after review because rendered Markdown is not reliable provenance. This replacement retains explicit transient source state only on the adjacent open text part.

Both automated-review regressions—ordinary `MEDIA:` prose becoming a path and legitimate trailing `#media:` Markdown being rewritten—were reproduced and closed with RED→GREEN tests.

Related: #70801, #84175. Neither is superseded or closed by this PR.

## Verification

- Focused media/chat/Markdown tests: **113/113**
- Full Desktop UI: **4511/4511**
- Electron/platform: **1233 passed, 2 skipped**
- Typecheck, formatting, lint, diff check, security scan: **pass**
- Desktop build and unsigned macOS app/DMG packaging: **pass**
- Independent focused/adversarial review: **PASS, 117/117**
