### PR TITLE
fix(providers): add missing Qwen Cloud (alibaba) models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -566,16 +566,22 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # to https://dashscope-intl.aliyuncs.com/compatible-mode/v1 (OpenAI-compat)
     # or https://dashscope-intl.aliyuncs.com/apps/anthropic (Anthropic-compat).
     "alibaba": [
+        # Qwen 千问系列 (DashScope / Qwen Cloud)
+        "qwen3.8-max",
         "qwen3.7-max",
         "qwen3.7-plus",
         "qwen3.6-plus",
+        "qwen3.6-flash",
         "kimi-k2.5",
         "qwen3.5-plus",
         "qwen3-coder-plus",
         "qwen3-coder-next",
-        # Third-party models available on coding-intl
+        # Third-party models available on coding-intl / DashScope
+        "glm-5.2",
         "glm-5",
         "glm-4.7",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash-0731",
         "MiniMax-M2.5",
     ],
     # Alibaba Coding Plan — same platform as alibaba (DashScope coding-intl),


### PR DESCRIPTION
## Summary
Adds models that are supported on the Alibaba/DashScope (Qwen Cloud) platform but missing from the bundled `alibaba` provider list in `hermes_cli/models.py`. Scoped to the `alibaba` provider only — no other provider lists touched.

## Added (6 entries to the `alibaba` list)
- `qwen3.8-max` — flagship Qwen3.8
- `qwen3.6-flash` — fast Qwen3.6
- `glm-5.2` — Zhipu GLM (DashScope multi-provider)
- `deepseek-v4-pro`
- `deepseek-v4-flash-0731`
- `kimi-k2.5` was already present; not duplicated

These already exist under the `nous`/vendor-prefixed routes (e.g. `qwen/qwen3.8-max`, `deepseek/deepseek-v4-pro`), but Qwen Cloud / DashScope direct-connection users select bare slugs from the `alibaba` list, where they were absent.

## Test plan
- [x] `python -c "import ast; ast.parse(open('hermes_cli/models.py').read())"` passes
- [x] Diff scoped to the `alibaba` list only (+7 / -1 lines)

🤖 Generated with [Hermes Agent](https://github.com/NousResearch/hermes-agent)