### PR TITLE
fix(desktop): keep streaming response anchored during budget cuts

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -231,6 +231,21 @@ describe('firstVisibleGroupIndex', () => {
 
     expect(firstVisibleGroupIndex(groups, 600, 8)).toBe(0)
   })
+
+  it('keeps the cut stable while the unbudgeted streaming tail grows', () => {
+    const history = [group('old', 50), group('mid', 30), group('recent', 30)]
+    const initial = [...history, group('streaming', 1)]
+    const grown = [...history, group('streaming', 5_000)]
+
+    expect(firstVisibleGroupIndex(initial, 60, 0, 1)).toBe(1)
+    expect(firstVisibleGroupIndex(grown, 60, 0, 1)).toBe(1)
+  })
+
+  it('charges a completed tail to the budget as before', () => {
+    const groups = [group('old', 50), group('recent', 30), group('completed', 5_000)]
+
+    expect(firstVisibleGroupIndex(groups, 60)).toBe(2)
+  })
 })
 
 describe('liveTailStart', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -217,11 +217,20 @@ export function buildGroups(signature: string): MessageGroup[] {
 // Walk turns newest-first, summing their render weights until the budget is met;
 // everything before the first kept turn is hidden. `minVisible` turns are kept
 // regardless of weight. Returns the index of that first visible group.
-export function firstVisibleGroupIndex(groups: readonly MessageGroup[], budget: number, minVisible = 0): number {
+export function firstVisibleGroupIndex(
+  groups: readonly MessageGroup[],
+  budget: number,
+  minVisible = 0,
+  unbudgetedTail = 0
+): number {
   let firstVisible = groups.length
+  const budgetedEnd = Math.max(0, groups.length - unbudgetedTail)
 
   for (let i = groups.length - 1, weight = 0; i >= 0; i--) {
-    weight += groups[i].weight
+    if (i < budgetedEnd) {
+      weight += groups[i].weight
+    }
+
     firstVisible = i
 
     if (weight >= budget) {
@@ -379,6 +388,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     s.thread.messages.map(message => messagePaintWeight(message.content)).join(',')
   )
 
+  const threadRunning = useAuiState(s => s.thread.isRunning)
+
   const { t } = useI18n()
   // Row structure is memoized on the STRUCTURAL signature only, so streaming
   // part-appends can't churn group identity (that would defeat the rows memo
@@ -526,7 +537,13 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   const hiddenCount = firstVisibleGroupIndex(
     weightedGroups,
     renderBudget,
-    renderBudget >= paneBudget ? MIN_VISIBLE_GROUPS : 0
+    renderBudget >= paneBudget ? MIN_VISIBLE_GROUPS : 0,
+    // The active turn has to stay mounted regardless of size. Charging its
+    // growing weight to the history budget made this cut advance mid-stream:
+    // old rows unmounted, scrollHeight shrank, and the browser clamp looked
+    // like a user scroll-up to use-stick-to-bottom. Budget the history around
+    // the live turn instead, so token flushes cannot move the cut boundary.
+    threadRunning ? 1 : 0
   )
 
   // Memoized for IDENTITY, not to save the slice: `rows` below keys off this


### PR DESCRIPTION
## Summary

Fixes #78486.

Hermes Desktop could jump from a live streaming reply to older history when the growing reply crossed the transcript render budget. The budget cut unmounted rows above the viewport, shrinking `scrollHeight`; the browser clamp was then interpreted by `use-stick-to-bottom` as a user scroll-up.

## Fix

- Treat the active streaming turn as mandatory, unbudgeted tail content.
- Continue applying the normal render budget to older history, preserving the long-transcript performance bound.
- Return to the existing behavior as soon as the turn completes.
- Add regressions proving that a live tail growing from 1 to 5,000 weight units cannot advance the history cut, while completed turns are still charged normally.

## Impact

The visible history boundary remains stable throughout a stream, so token growth cannot strand the reader on an older “Show earlier” boundary. No persistence, protocol, or session-state behavior changes.

## Validation

- `npm run test:ui -- src/components/assistant-ui/thread/list.test.ts` — 27 passed
- `npm run typecheck`
- `npx eslint src/components/assistant-ui/thread/list.tsx src/components/assistant-ui/thread/list.test.ts`
- `npx prettier --check src/components/assistant-ui/thread/list.tsx src/components/assistant-ui/thread/list.test.ts`
- `git diff --check`
