### PR TITLE
fix(dashboard-auth): stop login page from recommending dead --insecure bypass

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -393,8 +393,13 @@ _EMPTY_HTML = """\
 <p>This dashboard is bound to a non-loopback host but no authentication
 providers are installed.</p>
 <p>Install <code>plugins/dashboard-auth-nous</code> (default) or another
-auth provider, or restart with <code>--insecure</code> to bypass the
-auth gate (not recommended on untrusted networks).</p>
+auth provider &mdash; run <code>hermes dashboard register</code> for
+OAuth, or set <code>dashboard.basic_auth</code> in config.yaml for a
+username/password provider.</p>
+<p><code>--insecure</code> no longer bypasses this gate (June 2026
+hardening). To keep the dashboard local without configuring a provider,
+bind to <code>127.0.0.1</code> and reach it over an SSH tunnel or
+Tailscale instead.</p>
 </main>
 </body>
 </html>

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -615,6 +615,46 @@ class TestRenderLoginHtmlNext:
         assert "%22injected" in html_out
 
 
+
+# ---------------------------------------------------------------------------
+# Regression: issue #87788 - the zero-providers empty state must not tell
+# operators to restart with the deprecated --insecure bypass, which has
+# been a no-op since the June 2026 hardening (see web_server.py's
+# "--insecure no longer bypasses dashboard authentication" warning).
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyLoginHtmlDoesNotRecommendInsecureBypass:
+    """render_login_html() with zero registered providers renders the
+    "Sign-in unavailable" empty state. It must point operators at a real
+    fix (OAuth registration or the bundled password provider), not the
+    deprecated --insecure flag that no longer bypasses the auth gate."""
+
+    def setup_method(self):
+        clear_providers()
+
+    def teardown_method(self):
+        clear_providers()
+
+    def test_no_providers_omits_insecure_flag(self):
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+
+        html_out = render_login_html()
+        assert "Sign-in unavailable" in html_out
+        assert "restart with" not in html_out
+        assert "to bypass the" not in html_out
+        # --insecure may still be *mentioned* to explain it no longer
+        # works, but must never be framed as the fix.
+        assert "no longer bypasses this gate" in html_out
+
+    def test_no_providers_points_at_working_fix(self):
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+
+        html_out = render_login_html()
+        assert "hermes dashboard register" in html_out
+        assert "dashboard.basic_auth" in html_out
+
+
 # ---------------------------------------------------------------------------
 # Unit-level coverage: /auth/login persists next= into the PKCE cookie
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_login_page_insecure_e2e.py
+++ b/tests/hermes_cli/test_dashboard_login_page_insecure_e2e.py
@@ -1,0 +1,217 @@
+"""E2E + exhaustive regression coverage for issue #87788 / PR #87814.
+
+The zero-providers "Sign-in unavailable" page served at ``GET /login``
+used to tell operators to restart the dashboard with ``--insecure`` to
+bypass the auth gate -- a no-op since the June 2026 hardening
+(``hermes_cli/web_server.py``'s ``--insecure no longer bypasses
+dashboard authentication`` warning). ``tests/hermes_cli/
+test_dashboard_auth_401_reauth.py`` already unit-tests
+``render_login_html()`` directly; this file drives the *real* ASGI app
+through ``TestClient`` so a future change to routing, middleware, or
+the auth-gate wiring can't silently reintroduce the dead advice or
+break the populated-providers branch this fix must not touch.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth import clear_providers, register_provider
+from hermes_cli.dashboard_auth.base import DashboardAuthProvider, Session
+from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+pytestmark = pytest.mark.xdist_group(name="dashboard_auth_app_state")
+
+
+class _StubPasswordProvider(DashboardAuthProvider):
+    """Minimal supports_password=True provider — enough to populate the
+    login page's provider list. Login flow itself is out of scope here;
+    ``test_dashboard_auth_password_login.py`` already covers that."""
+
+    name = "teststub-pw"
+    display_name = "Stub Password"
+    supports_password = True
+
+    def start_login(self, *, redirect_uri: str):
+        raise NotImplementedError
+
+    def complete_login(self, **kwargs):
+        raise NotImplementedError
+
+    def complete_password_login(self, *, username: str, password: str) -> Session:
+        raise NotImplementedError
+
+    def verify_session(self, *, access_token: str):
+        return None
+
+    def refresh_session(self, *, refresh_token: str) -> Session:
+        raise NotImplementedError
+
+    def revoke_session(self, *, refresh_token: str) -> None:
+        return None
+
+
+@pytest.fixture
+def bound_client():
+    """Real ASGI app bound to a non-loopback host, mirroring a Fly deploy
+    where the auth gate always engages."""
+    clear_providers()
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    client = TestClient(web_server.app, base_url="https://fly-app.fly.dev")
+    yield client
+    clear_providers()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+@pytest.fixture
+def loopback_client():
+    """Real ASGI app bound loopback-style, where the auth gate never
+    engages. ``GET /login`` must still render safely with zero providers
+    (an operator can reach it directly even though nothing redirects
+    there on loopback)."""
+    clear_providers()
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "127.0.0.1"
+    web_server.app.state.bound_port = 8420
+    web_server.app.state.auth_required = False
+    client = TestClient(web_server.app, base_url="http://127.0.0.1:8420")
+    yield client
+    clear_providers()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+# ---------------------------------------------------------------------------
+# Zero providers: the exact regression from #87788.
+# ---------------------------------------------------------------------------
+
+
+class TestZeroProvidersEmptyStateE2E:
+    def test_get_login_200_and_no_dead_insecure_advice(self, bound_client):
+        resp = bound_client.get("/login")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Sign-in unavailable" in body
+        assert "restart with" not in body
+        assert "to bypass the" not in body
+
+    def test_get_login_points_at_both_working_remedies(self, bound_client):
+        body = bound_client.get("/login").text
+        assert "hermes dashboard register" in body
+        assert "dashboard.basic_auth" in body
+        assert "127.0.0.1" in body
+
+    def test_get_login_cache_control_no_store(self, bound_client):
+        resp = bound_client.get("/login")
+        cache_control = resp.headers.get("cache-control", "")
+        assert "no-store" in cache_control
+
+    def test_get_login_content_type_html(self, bound_client):
+        resp = bound_client.get("/login")
+        assert "text/html" in resp.headers.get("content-type", "")
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "<script>alert(1)</script>",
+            '"><img src=x onerror=alert(1)>',
+            "javascript:alert(1)",
+            "../../etc/passwd",
+            "%00%0d%0aSet-Cookie:%20evil=1",
+            "hermes-canary-marker-4f2a9c",
+        ],
+    )
+    def test_empty_state_ignores_next_param_injection(self, bound_client, payload):
+        # _EMPTY_HTML is a static string returned before next_path is ever
+        # touched (see render_login_html) — a malicious ``next=`` must not
+        # get reflected into the zero-providers branch at all.
+        resp = bound_client.get("/login", params={"next": payload})
+        assert resp.status_code == 200
+        assert payload not in resp.text
+        assert "Sign-in unavailable" in resp.text
+
+    def test_repeated_requests_are_byte_identical(self, bound_client):
+        # Guards against any future refactor that makes _EMPTY_HTML
+        # mutable / stateful (e.g. accidentally memoizing per-request
+        # data into a module-level string).
+        first = bound_client.get("/login").text
+        for _ in range(25):
+            assert bound_client.get("/login").text == first
+
+    def test_loopback_zero_providers_also_safe(self, loopback_client):
+        resp = loopback_client.get("/login")
+        assert resp.status_code == 200
+        assert "Sign-in unavailable" in resp.text
+        assert "restart with" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: populated-providers branch must be untouched by this fix.
+# ---------------------------------------------------------------------------
+
+
+class TestPopulatedProvidersUnaffected:
+    def test_oauth_provider_renders_form_not_empty_state(self, bound_client):
+        register_provider(StubAuthProvider())
+        body = bound_client.get("/login").text
+        assert "Sign-in unavailable" not in body
+        assert "--insecure" not in body
+
+    def test_password_provider_renders_form_not_empty_state(self, bound_client):
+        register_provider(_StubPasswordProvider())
+        body = bound_client.get("/login").text
+        assert "Sign-in unavailable" not in body
+        assert "--insecure" not in body
+
+    def test_mixed_oauth_and_password_providers(self, bound_client):
+        register_provider(StubAuthProvider())
+        register_provider(_StubPasswordProvider())
+        resp = bound_client.get("/login")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Sign-in unavailable" not in body
+        assert "--insecure" not in body
+
+
+# ---------------------------------------------------------------------------
+# Cross-surface consistency: the HTML fix must mirror the CLI fail-closed
+# hint (web_server.py) so operators aren't given two different stories.
+# ---------------------------------------------------------------------------
+
+
+class TestFixHintWordingConsistency:
+    def test_html_and_cli_hint_share_the_same_two_remedies(self):
+        import inspect
+
+        html_src = inspect.getsource(
+            __import__(
+                "hermes_cli.dashboard_auth.login_page", fromlist=["_EMPTY_HTML"]
+            )
+        )
+        cli_src = inspect.getsource(web_server)
+
+        for phrase in ("hermes dashboard register", "dashboard.basic_auth"):
+            assert phrase in html_src, f"{phrase!r} missing from login_page.py"
+            assert phrase in cli_src, f"{phrase!r} missing from web_server.py"
+
+    def test_neither_surface_recommends_insecure_as_a_fix(self):
+        import inspect
+
+        html_src = inspect.getsource(
+            __import__(
+                "hermes_cli.dashboard_auth.login_page", fromlist=["_EMPTY_HTML"]
+            )
+        )
+        assert "restart with" not in html_src
+        assert "to bypass the" not in html_src


### PR DESCRIPTION
## Summary

- The zero-providers "Sign-in unavailable" empty state served by `GET /login` (`render_login_html()` in `hermes_cli/dashboard_auth/login_page.py`) still told operators to *"restart with `--insecure`"* to reach the dashboard.
- `--insecure` has been a no-op on non-loopback binds since the June 2026 hardening — `web_server.py` already logs `"--insecure no longer bypasses dashboard authentication"` and `main.py`'s interactive setup prompt was updated to match. Only this HTML template was missed, so operators following the on-page instructions get nothing.
- Fixes #87788.

## Root cause

The June 2026 hardening pass (`web_server.py:18419`) removed the `--insecure` auth-gate bypass and updated the fail-closed `SystemExit` fix-hint and the interactive `hermes dashboard` setup prompt accordingly. The static HTML `_EMPTY_HTML` template in `login_page.py` — served directly to the browser when no auth provider is registered — was never touched in that pass, so it kept the pre-hardening advice.

## Fix

Point the empty-state page at the two working fixes, mirroring the wording `web_server.py`'s fail-closed hint already uses:
- `hermes dashboard register` for OAuth (Nous Portal)
- `dashboard.basic_auth` in `config.yaml` for the bundled username/password provider
- loopback bind + SSH tunnel / Tailscale as the no-provider fallback

`--insecure` is still mentioned, but only to explain that it no longer bypasses the gate — never as a recommended fix.

## Test plan

- [x] Added `TestEmptyLoginHtmlDoesNotRecommendInsecureBypass` in `tests/hermes_cli/test_dashboard_auth_401_reauth.py`, asserting the empty-state HTML never frames `--insecure` as a fix and does surface the working OAuth/basic-auth guidance.
- [x] `pytest tests/hermes_cli/test_dashboard_auth_401_reauth.py tests/hermes_cli/test_dashboard_auth_password_login.py tests/hermes_cli/test_dashboard_auth_gate.py` — 53 passed.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔒 Browser hits GET /login] --> B{Any auth provider registered?}
    B -- yes --> C[⚡ Render provider buttons]
    B -- no --> D[🚫 render _EMPTY_HTML]
    D --> E["OLD: 'restart with --insecure' (dead since Jun 2026 hardening)"]
    D --> F["NEW: hermes dashboard register / dashboard.basic_auth / loopback+tunnel"]
    E -.->|removed| G[🗑️ operator hits dead end]
    F -->|fixed| H[🚀 operator reaches a working sign-in path]
```