### PR TITLE
fix(tui-gateway): expose live cache token totals

### DIFF
--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -691,6 +691,8 @@ export interface SessionRuntimeInfo {
 }
 
 export interface UsageStats {
+  cache_read_tokens?: number
+  cache_write_tokens?: number
   calls: number
   context_max?: number
   context_percent?: number

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17426,6 +17426,20 @@ class _BareAgent:
     model = "x"
 
 
+def test_get_usage_includes_cache_totals():
+    agent = types.SimpleNamespace(
+        model="cached-model",
+        session_cache_read_tokens=4_096,
+        session_cache_write_tokens=512,
+        context_compressor=None,
+    )
+
+    usage = server._get_usage(agent)
+
+    assert usage["cache_read_tokens"] == 4_096
+    assert usage["cache_write_tokens"] == 512
+
+
 def test_get_usage_includes_active_subagents(monkeypatch):
     import tools.async_delegation as ad_mod
     monkeypatch.setattr(ad_mod, "active_count", lambda: 4)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5269,6 +5269,8 @@ def _get_usage(agent) -> dict:
         "input": g("session_input_tokens", "session_prompt_tokens"),
         "output": g("session_output_tokens", "session_completion_tokens"),
         "reasoning": g("session_reasoning_tokens"),
+        "cache_read_tokens": g("session_cache_read_tokens"),
+        "cache_write_tokens": g("session_cache_write_tokens"),
         "prompt": g("session_prompt_tokens"),
         "completion": g("session_completion_tokens"),
         "total": g("session_total_tokens"),


### PR DESCRIPTION
## Summary

- expose the agent's existing session cache-read and cache-write counters through the shared TUI gateway usage snapshot
- add the corresponding optional fields to the Desktop `UsageStats` contract
- cover the gateway mapping with a regression test

## Why

The agent already accumulates `session_cache_read_tokens` and `session_cache_write_tokens`, but `_get_usage()` drops both values. Every live consumer of that shared snapshot—including `message.complete`, `session.usage`, `session.info`, and periodic usage ticks—therefore loses cache visibility.

This addresses the cache-token portion of #87769. It deliberately does **not** add cost or duration:

- user-facing provider cost estimates were previously removed as a product-policy decision and should not be reintroduced incidentally
- Desktop already measures turn duration from `message.start` to `message.complete`

## Impact

This is an additive wire-format change. Existing clients can ignore the new keys, while Desktop and other gateway consumers can now calculate cache-hit metrics from canonical session totals.

## Root cause

`_get_usage()` maps the agent's input/output/reasoning counters but omitted the adjacent cache counters, even though both are maintained by the same canonical usage-accounting path.

## Checks

- `scripts/run_tests.sh tests/test_tui_gateway_server.py` — 586 passed
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -k get_usage` — 7 passed
- `npm run typecheck` in `apps/desktop`
- `npx eslint src/types/hermes.ts`
- `git diff --check`

## Related work checked

No PR currently references #87769. Older #43050 concerns persistence/restoration of counters rather than exposing cache totals from the current live TUI gateway snapshot; #67834 is a placeholder for a cost UI and does not implement this data path.
