### PR TITLE
fix(tui): keep mouse tracking off in the dashboard-embedded TUI

### DIFF
--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -1,4 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as EnvModule from '../config/env.js'
+
+// Mutable dashboard-mode flag so tests can flip HERMES_TUI_DASHBOARD per case
+// (env.ts evaluates it once at module load, so a static mock cannot toggle).
+const envState = vi.hoisted(() => ({ dashboard: false }))
+vi.mock('../config/env.js', async importOriginal => {
+  const actual = await importOriginal<EnvModule>()
+
+  return {
+    ...actual,
+    get DASHBOARD_TUI_MODE() {
+      return envState.dashboard
+    }
+  }
+})
 
 import { $uiState, resetUiState } from '../app/uiStore.js'
 import {
@@ -266,6 +282,40 @@ describe('normalizeMouseTracking', () => {
 
   it('falls back to all for unknown strings', () => {
     expect(normalizeMouseTracking({ mouse_tracking: 'rainbows' })).toBe('all')
+  })
+})
+
+describe('applyDisplay dashboard mouse override', () => {
+  beforeEach(() => {
+    resetUiState()
+    envState.dashboard = false
+  })
+  afterEach(() => {
+    envState.dashboard = false
+  })
+
+  it('forces mouse tracking off on the dashboard surface when config is unset', () => {
+    envState.dashboard = true
+    applyDisplay({ config: { display: {} } }, vi.fn())
+    expect($uiState.get().mouseTracking).toBe('off')
+  })
+
+  it('forces mouse tracking off on the dashboard surface even when config requests all', () => {
+    envState.dashboard = true
+    applyDisplay({ config: { display: { mouse_tracking: 'all' } } }, vi.fn())
+    expect($uiState.get().mouseTracking).toBe('off')
+  })
+
+  it('keeps the config-driven default on native terminals', () => {
+    applyDisplay({ config: { display: {} } }, vi.fn())
+    expect($uiState.get().mouseTracking).toBe('all')
+  })
+
+  it('keeps config-driven presets on native terminals', () => {
+    applyDisplay({ config: { display: { mouse_tracking: 'wheel' } } }, vi.fn())
+    expect($uiState.get().mouseTracking).toBe('wheel')
+    applyDisplay({ config: { display: { mouse_tracking: 'off' } } }, vi.fn())
+    expect($uiState.get().mouseTracking).toBe('off')
   })
 })
 

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -1,6 +1,7 @@
 import type { MouseTrackingMode } from '@hermes/ink'
 import { useEffect, useRef } from 'react'
 
+import { DASHBOARD_TUI_MODE } from '../config/env.js'
 import { resolveDetailsMode, resolveSections } from '../domain/details.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { ConfigFullResponse, ConfigMtimeResponse, ReloadMcpResponse } from '../gatewayTypes.js'
@@ -283,7 +284,15 @@ export const applyDisplay = (
     focusView: !!d.focus_view,
     indicatorStyle: normalizeIndicatorStyle(d.tui_status_indicator),
     inlineDiffs: d.inline_diffs !== false,
-    mouseTracking: normalizeMouseTracking(d),
+    // The dashboard embeds this TUI in an xterm.js surface. While ANY mouse
+    // protocol is active, xterm.js 6.x disables its SelectionService entirely,
+    // so plain click-drag can never select text in the browser. The PTY
+    // launcher already sets HERMES_TUI_DISABLE_MOUSE=1 (boot-time default),
+    // but this config fan-out re-enables `all` whenever display.mouse_tracking
+    // is unset (normalizeMouseTracking's default). Force `off` on the
+    // dashboard surface regardless of config; native terminals keep the full
+    // config-driven presets. See #25720 (macOS variant of the same gap).
+    mouseTracking: DASHBOARD_TUI_MODE ? 'off' : normalizeMouseTracking(d),
     pasteCollapseLines: _pasteCollapseLinesFromConfig(cfg),
     pasteCollapseChars: _pasteCollapseCharsFromConfig(cfg),
     sections: resolveSections(d.sections),


### PR DESCRIPTION
## Problem

In the web dashboard `/chat` (embedded xterm.js TUI), click-drag cannot select text at all on Windows/Linux — no highlight appears, so users cannot copy arbitrary ranges from the transcript. On macOS the same root cause was reported in #25720 and only worked around via `macOptionClickForcesSelection`.

## Root cause chain (verified against source + live PTY byte capture)

1. The dashboard PTY launcher sets `HERMES_TUI_DISABLE_MOUSE=1` (`web_server.py::_resolve_chat_argv`) with the explicit intent of keeping mouse tracking off so plain click-drag keeps selecting text in xterm.js.
2. A few seconds after spawn, the TUI's config fan-out (`useConfigSync.applyDisplay`) overwrites the runtime mouse mode with `normalizeMouseTracking(display)`; when `display.mouse_tracking` is unset — the default for every user without the key — that returns `'all'`, and `AlternateScreen` re-emits `?1000h ?1002h ?1003h ?1006h`.
3. While ANY mouse protocol is active, xterm.js 6.x disables its `SelectionService` entirely (`CoreBrowserTerminal.open`), so plain click-drag starts no selection and shows no highlight. Verified live: a ConPTY probe of the real dashboard TUI child shows the enable sequences arriving ~6s after spawn.

## Fix

`applyDisplay` forces `mouseTracking: 'off'` whenever `DASHBOARD_TUI_MODE` is set (the launcher already exports `HERMES_TUI_DASHBOARD=1` for exactly this surface identification). The dashboard surface never enables mouse tracking regardless of config; native terminals keep the full config-driven presets (`off`/`wheel`/`buttons`/`all`), and `/mouse` continues to persist config normally.

## Tests

4 new cases in `useConfigSync.test.ts` (dashboard-forced-off with config unset and with explicit `all`; native default and preset preservation), using a `vi.hoisted` mutable env mock because `env.ts` constants are evaluated at import time.

## Verification

- `npm run --prefix ui-tui check`: build:ink + typecheck clean, full vitest suite green (1636 tests on CI with this change), eslint clean (0 errors).
- End-to-end ConPTY probe of the real TUI child: dashboard env + config without the key → 0 mouse-enable sequences (previously 15); native env → 13 (native behavior preserved).

Related: #25720 (macOS variant of the same gap), #50075 (same mechanism on touch devices).