### PR TITLE
fix(desktop): isolate renderer build typecheck

### DIFF
--- a/apps/desktop/tsconfig.build.json
+++ b/apps/desktop/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "e2e",
+    "electron",
+    "playwright.config.ts",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
+}

--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -60,8 +60,9 @@ let
       patchShebangs .
 
       pushd apps/desktop
-        # typecheck :3
-        npm exec -- tsc -b
+        # Keep the packaged renderer self-contained while the regular desktop
+        # config continues type-checking its test suite and shared fixtures.
+        npm exec -- tsc -b tsconfig.build.json
 
         # build the renderer bundle
         # vite's emptyOutDir wipes dist/ on every run


### PR DESCRIPTION
## What does this PR do?

Fixes the Nix desktop renderer build when its source filter stages only `apps/desktop` and `apps/shared`. The production `tsc -b` invocation no longer type-checks desktop test files that import the intentionally shared gateway/desktop contract fixture, while `npm run typecheck` continues to check those tests.

## Related Issue

Fixes #87692

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/tsconfig.build.json`: add a production-only build config that inherits the regular config but excludes renderer test files.
- `nix/desktop.nix`: run `tsc -b tsconfig.build.json` for the staged renderer package.

## How to Test

1. From `apps/desktop`, run `npm exec -- tsc -b tsconfig.build.json`; it succeeds when the source tree contains only `apps/desktop` and `apps/shared` (with no repo-root `tests/` directory).
2. Run `npm run typecheck` to confirm the regular development configuration still type-checks the test suite and shared fixture import.
3. Run `npm run test:ui -- src/app/session/hooks/use-session-actions.test.tsx`.
4. Run `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

Not applicable.

## Screenshots / Logs

Not applicable; this is a build-configuration fix.

<!-- autocontrib:worker-id=issue-new-525b2267 kind=pr-open -->