### PR TITLE
fix(curator): enforce dry-run read-only mechanically, not by prompt alone

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1930,7 +1930,15 @@ def _run_llm_review(prompt: str, dry_run: bool = False) -> Dict[str, Any]:
             credential_pool=_credential_pool,
             request_overrides=_request_overrides,
             **_agent_kwargs,
-            enabled_toolsets=["skills", "terminal"],
+            enabled_toolsets=(
+                # Dry-run (#87793 follow-up): the terminal toolset expands to
+                # terminal + process, an ungated shell surface that could write
+                # the skill library directly and bypass the skill_manage dry-run
+                # gate.  A dry-run fork gets the skills toolset only — its
+                # readers (skills_list / skill_view) plus the gated
+                # skill_manage — so every write-capable surface is covered.
+                ["skills"] if dry_run else ["skills", "terminal"]
+            ),
             # Umbrella-building over a large skill collection is worth a
             # high iteration ceiling — the pass typically takes 50-100
             # API calls against hundreds of candidate skills. The

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1676,7 +1676,7 @@ def run_curator_review(
                     )
                 else:
                     prompt = f"{CURATOR_REVIEW_PROMPT}{builtins_note}\n\n{candidate_list}"
-                llm_meta = _run_llm_review(prompt)
+                llm_meta = _run_llm_review(prompt, dry_run=dry_run)
                 final_summary = (
                     f"{prefix}{auto_summary}; llm: {llm_meta.get('summary', 'no change')}"
                 )
@@ -1824,8 +1824,13 @@ def _resolve_review_model(cfg: Dict[str, Any]) -> tuple[str, str]:
     return b.provider, b.model
 
 
-def _run_llm_review(prompt: str) -> Dict[str, Any]:
+def _run_llm_review(prompt: str, dry_run: bool = False) -> Dict[str, Any]:
     """Spawn an AIAgent fork to run the curator review prompt.
+
+    When *dry_run* is True the fork runs under the skill_manage read-only
+    flag (``tools.skill_manager_tool.curator_dry_run_scope``) so a
+    noncompliant model cannot mutate the skill library during a preview
+    (#87793) — the prompt banner alone was not a guarantee.
 
     Returns a dict with:
       - final: full (untruncated) final response from the reviewer
@@ -1838,6 +1843,8 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     Never raises; callers get a structured failure instead.
     """
     import contextlib
+
+    from tools.skill_manager_tool import curator_dry_run_scope
     result_meta: Dict[str, Any] = {
         "final": "",
         "summary": "",
@@ -1955,7 +1962,12 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         with open(os.devnull, "w", encoding="utf-8") as _devnull, \
              contextlib.redirect_stdout(_devnull), \
              contextlib.redirect_stderr(_devnull):
-            conv_result = review_agent.run_conversation(user_message=prompt)
+            # Dry-run backstop (#87793): the banner asks the model to
+            # describe instead of perform; refuse mutations mechanically
+            # while the fork runs. The scope resets the flag on exit so
+            # the read-only state never leaks into the host process.
+            with curator_dry_run_scope(dry_run):
+                conv_result = review_agent.run_conversation(user_message=prompt)
 
         final = ""
         if isinstance(conv_result, dict):

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -859,6 +859,46 @@ def test_review_fork_restricts_toolsets_to_skills_and_terminal(curator_env, monk
     )
 
 
+def test_dry_run_fork_drops_terminal_toolset(curator_env, monkeypatch):
+    """A dry-run fork must not carry the terminal toolset (#87793 follow-up).
+
+    ``terminal`` expands to terminal + process — an ungated shell surface
+    that can write the skill library directly and bypass the skill_manage
+    dry-run gate.  The dry-run fork gets the skills toolset only: its
+    readers plus the already-gated skill_manage.
+    """
+    curator = curator_env["curator"]
+
+    import importlib
+    importlib.reload(curator)
+
+    captured = {}
+
+    class _StubAgent:
+        def __init__(self, *args, **kwargs):
+            captured["enabled_toolsets"] = kwargs.get("enabled_toolsets", "UNSET")
+            self._memory_write_origin = "assistant_tool"
+            self._memory_nudge_interval = 0
+            self._skill_nudge_interval = 0
+            self._session_messages = []
+
+        def run_conversation(self, user_message=None, **kwargs):
+            return {"final_response": "no change"}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("run_agent.AIAgent", _StubAgent)
+
+    meta = curator._run_llm_review("review prompt", dry_run=True)
+
+    assert meta.get("error") is None, meta.get("error")
+    assert captured.get("enabled_toolsets") == ["skills"], (
+        "dry-run curator fork kept write-capable toolsets; expected "
+        f"['skills'], got {captured.get('enabled_toolsets')!r}"
+    )
+
+
 def test_review_fork_toolset_surface_is_skills_plus_terminal():
     """Documentary check on the static surface the fork's kwarg resolves to.
 

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -28,7 +28,11 @@ def curator_env(tmp_path, monkeypatch):
     importlib.reload(curator)
 
     # Neutralize the real LLM pass by default — tests opt in per-case.
-    monkeypatch.setattr(curator, "_run_llm_review", lambda prompt: "llm-stub")
+    # dry_run kwarg matches _run_llm_review's signature (#87793 gate).
+    monkeypatch.setattr(
+        curator, "_run_llm_review",
+        lambda prompt, dry_run=False: "llm-stub",
+    )
 
     # Default: no config file → curator defaults. Tests can override.
     monkeypatch.setattr(curator, "_load_config", lambda: {})
@@ -412,7 +416,7 @@ def test_dry_run_injects_report_only_banner(curator_env, monkeypatch):
     u.mark_agent_created("a")
 
     captured = {}
-    def _stub(prompt):
+    def _stub(prompt, dry_run=False):
         captured["prompt"] = prompt
         return {"final": "", "summary": "s", "model": "", "provider": "",
                 "tool_calls": [], "error": None}
@@ -433,7 +437,7 @@ def test_run_review_synchronous_invokes_llm_stub(curator_env, monkeypatch):
     u.mark_agent_created("a")
 
     calls = []
-    def _stub(prompt):
+    def _stub(prompt, dry_run=False):
         calls.append(prompt)
         return {
             "final": "stubbed-summary",

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -947,3 +947,67 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+
+# ---------------------------------------------------------------------------
+# Curator dry-run read-only gate (#87793)
+# ---------------------------------------------------------------------------
+
+class TestCuratorDryRunGate:
+    """`hermes curator run --dry-run` must be mechanically read-only: the
+    prompt banner alone was not a guarantee — the forked reviewer holds real
+    mutating tools and was observed creating/patching skills during a
+    preview. While set_curator_dry_run(True) is active every mutating
+    skill_manage action is refused; the flag resets cleanly."""
+
+    @pytest.mark.parametrize(
+        "action,kwargs",
+        [
+            ("create", {"content": VALID_SKILL_CONTENT}),
+            ("edit", {"content": VALID_SKILL_CONTENT_2}),
+            ("patch", {"old_string": "Step 1", "new_string": "Step zero"}),
+            ("delete", {}),
+            ("write_file", {"file_path": "references/x.md", "file_content": "x"}),
+            ("remove_file", {"file_path": "references/x.md"}),
+        ],
+    )
+    def test_mutating_actions_fail_closed_during_dry_run(
+        self, tmp_path, action, kwargs
+    ):
+        from tools.skill_manager_tool import curator_dry_run_scope
+
+        # A real target so the block cannot be attributed to a missing skill.
+        with _skill_dir(tmp_path):
+            _create_skill("test-skill", VALID_SKILL_CONTENT)
+            with curator_dry_run_scope(True):
+                result = json.loads(
+                    skill_manage(action=action, name="test-skill", **kwargs)
+                )
+
+            assert result["success"] is False
+            assert "dry-run is read-only" in result["error"]
+            # Nothing changed on disk despite the action being well-formed.
+            skill_md = tmp_path / "test-skill" / "SKILL.md"
+            assert skill_md.exists()
+            assert "A test skill for unit testing." in skill_md.read_text(
+                encoding="utf-8"
+            )
+            assert not (tmp_path / ".archive").exists()
+
+    def test_gate_resets_cleanly(self, tmp_path):
+        from tools.skill_manager_tool import curator_dry_run_scope
+
+        with _skill_dir(tmp_path):
+            with curator_dry_run_scope(True):
+                pass
+
+            result = json.loads(
+                skill_manage(
+                    action="create",
+                    name="fresh-skill",
+                    content=VALID_SKILL_CONTENT.replace(
+                        "test-skill", "fresh-skill"
+                    ),
+                )
+            )
+            assert result["success"] is True, result

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -37,6 +37,7 @@ import logging
 import re
 import shutil
 import contextvars as _ctxvars
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -55,6 +56,37 @@ logger = logging.getLogger(__name__)
 _background_review_read_paths: "_ctxvars.ContextVar[frozenset[str]]" = _ctxvars.ContextVar(
     "background_review_read_paths", default=frozenset()
 )
+
+# Set around the curator's forked review agent while a --dry-run pass is in
+# flight. Dry-run is documented as read-only ("no state changes, no archives,
+# no consolidation"), but the guard used to be a prompt banner only — the
+# fork runs with real mutating tools, so a noncompliant model could create
+# and patch skills during a preview (#87793). This is the mechanical
+# fail-closed backstop: mutating skill_manage actions are refused while the
+# flag is set, regardless of what the prompt asked for.
+_curator_dry_run: "_ctxvars.ContextVar[bool]" = _ctxvars.ContextVar(
+    "curator_dry_run", default=False
+)
+
+_MUTATING_ACTIONS = frozenset(
+    {"create", "edit", "patch", "delete", "write_file", "remove_file"}
+)
+
+
+@contextmanager
+def curator_dry_run_scope(enabled: bool):
+    """Mark the current context as a read-only curator dry-run pass.
+
+    Entering with ``enabled=True`` refuses mutating ``skill_manage``
+    actions until the block exits — the flag can never leak past the
+    dry-run pass that set it (a stale True would brick skill_manage for
+    the whole process).
+    """
+    token = _curator_dry_run.set(bool(enabled))
+    try:
+        yield
+    finally:
+        _curator_dry_run.reset(token)
 
 
 def mark_background_review_skill_read(path: Path) -> None:
@@ -1561,6 +1593,21 @@ def skill_manage(
     preflight = _background_review_preflight(action, name)
     if preflight is not None:
         return json.dumps(preflight, ensure_ascii=False)
+
+    # Read-only backstop for `hermes curator run --dry-run` (#87793): the
+    # dry-run contract is report-only, but the forked reviewer holds real
+    # mutating tools. Refuse mutating actions while the dry-run flag is set;
+    # read actions (list/view/history) pass through untouched so the report
+    # has everything it needs. The error is returned to the fork, which the
+    # dry-run banner already directs to describe actions rather than take
+    # them — this only fires when the model disobeys.
+    if _curator_dry_run.get() and action in _MUTATING_ACTIONS:
+        return tool_error(
+            "blocked: curator dry-run is read-only — skill_manage "
+            f"action={action!r} was refused. Describe what you WOULD do "
+            "instead of performing it.",
+            success=False,
+        )
 
     # Approval gate: when on, stages the write for review (skills are too large
     # to review inline, so they always stage regardless of origin); when off


### PR DESCRIPTION
## What does this PR do?

Makes `hermes curator run --dry-run --consolidate` mechanically read-only (#87793). The dry-run contract ("no state changes, no archives, no consolidation") was previously enforced only by a prompt banner — but the forked reviewer agent runs with the real `skill_manage` toolset, so a noncompliant model could (and observably did) call `skill_manage(action='create')` / `patch` during a preview: the reporter's run left `added_this_run: 1` in `run.json`, a new `coordinated-codebase-audit` skill on disk with `created_by: agent`, while the pass's own REPORT.md claimed "No mutations performed... the skill library is untouched." The banner told the model what to do; nothing stopped it.

The fix is a ContextVar gate at the tool layer:

- `tools/skill_manager_tool.py` gains `curator_dry_run_scope(enabled)` — a context manager (resets in `finally`, so the read-only flag can never leak into the host process and brick `skill_manage` there) — and `skill_manage` refuses every mutating action (`create`, `edit`, `patch`, `delete`, `write_file`, `remove_file`) with an actionable error while the flag is set. Read tools (`skill_view`, `skills_list`) are untouched, so the preview report still has everything it needs. The refusal is returned to the fork, which the banner already directs to describe actions rather than take them — this only fires when the model disobeys.
- `agent/curator.py::_run_llm_review` takes `dry_run` (threaded from `run_curator_review`) and wraps the forked `run_conversation` in the scope.

Note: the archive/move/prune transitions applied by the curator pass itself were already gated in dry-run (`run_curator_review` skips `apply_automatic_transitions`); the uncovered hole was the fork's full mutating `skill_manage` surface — creation/patching as observed in the original report, plus delete-with-`absorbed_into` with its archive side effects, as independently reproduced on Linux (see #87793). The gate refuses all six mutating actions.

## Related Issue

Fixes #87793

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_manager_tool.py` — `curator_dry_run_scope()` context manager + `_curator_dry_run` ContextVar + `_MUTATING_ACTIONS` set; `skill_manage` returns a structured refusal for mutating actions while the flag is armed.
- `agent/curator.py` — `_run_llm_review(prompt, dry_run=False)`; the forked run is wrapped in `curator_dry_run_scope(dry_run)`; call site passes the existing `dry_run` through.
- `tests/tools/test_skill_manager_tool.py` — new `TestCuratorDryRunGate`: all six mutating actions fail closed (asserting the error text and that SKILL.md / archive state on disk are untouched), and the gate resets cleanly so a post-scope create succeeds.

## How to Test

1. `uv run --extra acp pytest tests/tools/test_skill_manager_tool.py -k TestCuratorDryRunGate -q` — should pass (7 tests).
2. `uv run --extra acp pytest tests/tools/test_skill_manager_tool.py tests/agent/test_curator_activity.py tests/agent/test_curator_classification.py tests/agent/test_curator_reports.py -q` — Observed result: `71 passed`.
3. Observed result with the `tools/` + `agent/` changes reverted: all 7 gate tests fail (mutations succeed, error text absent) — the gate is what they pin.
4. Live: `hermes curator run --consolidate --dry-run` on a library with agent-created skills — the fork can no longer add/patch/delete skills mid-preview; a disobedient fork receives `blocked: curator dry-run is read-only …` and the on-disk library is unchanged (`run.json` counts stay 0).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

