### PR TITLE
fix(auth): recover rotated Codex tokens by account identity

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -920,21 +920,44 @@ def strip_think_blocks(agent, content: str) -> str:
 
 
 
+def codex_account_identity(access_token: Any) -> Optional[str]:
+    """Return the stable ChatGPT account id carried by a Codex OAuth JWT."""
+    try:
+        from hermes_cli.auth import _decode_jwt_claims
+
+        claims = _decode_jwt_claims(access_token)
+        auth_claims = claims.get("https://api.openai.com/auth")
+        if not isinstance(auth_claims, dict):
+            return None
+        account_id = auth_claims.get("chatgpt_account_id")
+        return account_id.strip() if isinstance(account_id, str) and account_id.strip() else None
+    except Exception:
+        return None
+
+
 def sync_credential_pool_entry_id(agent) -> None:
-    """Rebind ``agent._credential_pool_entry_id`` from the current pool + key.
+    """Rebind stable pool-entry/account identity from the runtime credential.
 
     OAuth refreshes can replace the runtime token before a failed request is
     recovered, so the mutable API-key value alone cannot reliably attribute
-    the failure to its source entry.  This resolves the stable pool-entry ID
-    for the agent's current ``api_key`` and clears it when no pool is bound.
+    the failure to its source entry.  For Codex, ``chatgpt_account_id`` lets
+    the agent retain the binding even when another process already rotated
+    the access token in the shared pool.
     """
     pool = getattr(agent, "_credential_pool", None)
+    account_identity = (
+        codex_account_identity(getattr(agent, "api_key", None))
+        if getattr(agent, "provider", None) == "openai-codex"
+        else None
+    )
+    agent._credential_pool_account_identity = account_identity
     try:
-        agent._credential_pool_entry_id = (
-            pool.entry_id_for_api_key(getattr(agent, "api_key", None))
-            if pool is not None
-            else None
-        )
+        entry_id = None
+        if pool is not None:
+            entry_id = pool.entry_id_for_api_key(getattr(agent, "api_key", None))
+            if entry_id is None and account_identity:
+                entry_id = pool.entry_id_for_account_identity(account_identity)
+        agent._credential_pool_entry_id = entry_id
     except Exception:
         agent._credential_pool_entry_id = None
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -761,6 +761,27 @@ class CredentialPool:
             ]
             return matches[0].id if len(matches) == 1 else None
 
+    def entry_id_for_account_identity(self, account_identity: Any) -> Optional[str]:
+        """Return the unambiguous Codex entry for a stable ChatGPT account id."""
+        if self.provider != "openai-codex":
+            return None
+        expected = str(account_identity or "").strip()
+        if not expected:
+            return None
+        with self._lock:
+            matches = []
+            for entry in self._entries:
+                claims = _decode_jwt_claims(entry.runtime_api_key)
+                auth_claims = claims.get("https://api.openai.com/auth")
+                account_id = (
+                    auth_claims.get("chatgpt_account_id")
+                    if isinstance(auth_claims, dict)
+                    else None
+                )
+                if isinstance(account_id, str) and account_id.strip() == expected:
+                    matches.append(entry)
+            return matches[0].id if len(matches) == 1 else None
+
     def _replace_entry(self, old: PooledCredential, new: PooledCredential) -> None:
         """Swap an entry in-place by id, preserving sort order.
 
@@ -934,37 +955,54 @@ class CredentialPool:
                 return entry
             store_access = tokens.get("access_token", "")
             store_refresh = tokens.get("refresh_token", "")
-            # Adopt auth.json tokens when either side differs.  Codex refresh
-            # tokens are single-use too, so a fresh refresh_token from
-            # another process means our entry's pair is consumed/stale.
-            #
-            # Also adopt when the store has a refresh_token but no
-            # access_token — another process may have rotated the pair
-            # and the store entry's access_token was already consumed;
-            # the important signal is the refresh_token difference.
             entry_access = entry.access_token or ""
             entry_refresh = entry.refresh_token or ""
-            should_adopt = False
-            if store_access and (
-                store_access != entry_access
+
+            # Access/refresh tokens rotate, but the ChatGPT account claim does
+            # not. Never copy singleton tokens onto a pool entry unless both
+            # sides prove they belong to the same account; otherwise a re-login
+            # to account B could silently reroute a long-lived account-A agent.
+            entry_claims = _decode_jwt_claims(entry_access)
+            store_claims = _decode_jwt_claims(store_access)
+            entry_auth = entry_claims.get("https://api.openai.com/auth")
+            store_auth = store_claims.get("https://api.openai.com/auth")
+            entry_account = (
+                entry_auth.get("chatgpt_account_id")
+                if isinstance(entry_auth, dict)
+                else None
+            )
+            store_account = (
+                store_auth.get("chatgpt_account_id")
+                if isinstance(store_auth, dict)
+                else None
+            )
+            tokens_differ = bool(
+                (store_access and store_access != entry_access)
                 or (store_refresh and store_refresh != entry_refresh)
+            )
+            if tokens_differ and not (
+                isinstance(entry_account, str)
+                and entry_account.strip()
+                and isinstance(store_account, str)
+                and store_account.strip() == entry_account.strip()
             ):
-                should_adopt = True
-            elif (
-                store_refresh
-                and store_refresh != entry_refresh
-                and not store_access
-            ):
-                # Store has only a refresh_token (no access_token) —
-                # another process rotated the pair.  Adopt the
-                # refresh_token so we don't replay the consumed one.
-                logger.info(
-                    "Pool entry %s: auth.json has newer refresh_token "
-                    "but no access_token; adopting refresh_token to "
-                    "avoid replaying consumed token",
+                logger.warning(
+                    "Pool entry %s: refusing Codex auth-store token sync because "
+                    "the stable ChatGPT account identity is missing or differs",
                     entry.id,
                 )
-                should_adopt = True
+                return entry
+
+            # Adopt auth.json tokens only after the stable-account gate above.
+            # A changed refresh token means another process consumed the old
+            # single-use grant even if the access token happened to be reissued.
+            should_adopt = bool(
+                store_access
+                and (
+                    store_access != entry_access
+                    or (store_refresh and store_refresh != entry_refresh)
+                )
+            )
 
             if should_adopt:
                 logger.debug(
@@ -1331,9 +1369,11 @@ class CredentialPool:
                 synced = sync_entry(entry)
                 if self.provider == "openai-codex":
                     if synced is not entry:
-                        entry = synced
-                        if not force and not self._entry_needs_refresh(entry):
-                            return entry
+                        # Another process already rotated the same account's
+                        # singleton while this request was in flight. The sync
+                        # path verified account identity; adopt that token and
+                        # do not consume its fresh single-use refresh grant.
+                        return synced
                     return self._refresh_entry_impl(entry, force=force)
                 if (
                     synced.access_token != entry.access_token

--- a/run_agent.py
+++ b/run_agent.py
@@ -5692,18 +5692,10 @@ class AIAgent:
         if self.api_mode != "codex_responses" or self.provider not in {"openai-codex", "xai-oauth"}:
             return False
 
-        # Guard against silent account swap.
-        #
-        # When an agent is using a non-singleton credential — e.g. a manual
-        # pool entry (``hermes auth add xai-oauth``) whose tokens belong to
-        # a different account than the device_code singleton, or an agent
-        # constructed with an explicit ``api_key=`` arg — force-refreshing
-        # the singleton here and adopting its tokens silently re-routes the
-        # rest of the conversation onto the singleton's account.  The
-        # credential pool's reactive recovery (``_recover_with_credential_pool``)
-        # is the right channel for that case; this path is the
-        # singleton-only fallback used when the pool can't recover, and
-        # MUST only fire when the agent really is on singleton tokens.
+        # Guard against silent account swap. A long-lived Codex agent may hold
+        # the previous access token after another process rotates the shared
+        # singleton. Token inequality is therefore not sufficient: permit the
+        # fresh singleton only when both JWTs name the same stable account.
         try:
             if self.provider == "openai-codex":
                 from hermes_cli.auth import resolve_codex_runtime_credentials
@@ -5723,25 +5715,43 @@ class AIAgent:
 
         singleton_key = str(singleton_now.get("api_key") or "").strip()
         active_key = str(self.api_key or "").strip()
+        adopt_same_account_singleton = False
         if singleton_key and active_key and singleton_key != active_key:
-            logger.debug(
-                "%s singleton tokens differ from the active api_key; "
-                "skipping singleton force-refresh to avoid silent account swap. "
-                "Reactive credential rotation should go through the pool.",
-                self.provider,
-            )
-            return False
+            if self.provider == "openai-codex":
+                from agent.agent_runtime_helpers import codex_account_identity
+
+                active_account = (
+                    getattr(self, "_credential_pool_account_identity", None)
+                    or codex_account_identity(active_key)
+                )
+                singleton_account = codex_account_identity(singleton_key)
+                adopt_same_account_singleton = bool(
+                    active_account
+                    and singleton_account
+                    and active_account == singleton_account
+                )
+            if not adopt_same_account_singleton:
+                logger.debug(
+                    "%s singleton tokens differ from the active api_key/account; "
+                    "skipping singleton force-refresh to avoid silent account swap. "
+                    "Reactive credential rotation should go through the pool.",
+                    self.provider,
+                )
+                return False
 
         try:
-            if self.provider == "openai-codex":
+            old_key = str(self.api_key or "").strip()
+            if adopt_same_account_singleton:
+                # Another process already minted a fresh same-account token.
+                # Reuse it instead of consuming another single-use refresh grant.
+                creds = singleton_now
+            elif self.provider == "openai-codex":
                 from hermes_cli.auth import resolve_codex_runtime_credentials
 
-                old_key = str(self.api_key or "").strip()
                 creds = resolve_codex_runtime_credentials(force_refresh=force)
             else:
                 from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
 
-                old_key = str(self.api_key or "").strip()
                 creds = resolve_xai_oauth_runtime_credentials(force_refresh=force)
         except Exception as exc:
             logger.debug("%s credential refresh failed: %s", self.provider, exc)
@@ -5754,10 +5764,7 @@ class AIAgent:
         if not isinstance(base_url, str) or not base_url.strip():
             return False
 
-        # Defect 2 fix: return False when no NEW token was actually minted.
-        # resolve_codex_runtime_credentials returns the same stale token
-        # when the underlying refresh fails (failure is debug-only).
-        # Comparing the access token (api_key) before/after detects this.
+        # Return False when no new token was actually minted/adopted.
         new_key = api_key.strip()
         if old_key and new_key == old_key:
             logger.debug(
@@ -5767,10 +5774,15 @@ class AIAgent:
             )
             return False
 
-        self.api_key = api_key.strip()
+        self.api_key = new_key
         self.base_url = base_url.strip().rstrip("/")
         self._client_kwargs["api_key"] = self.api_key
         self._client_kwargs["base_url"] = self.base_url
+
+        if self.provider == "openai-codex":
+            from agent.agent_runtime_helpers import sync_credential_pool_entry_id
+
+            sync_credential_pool_entry_id(self)
 
         if not self._replace_primary_openai_client(reason=f"{self.provider}_credential_refresh"):
             return False
@@ -6338,6 +6350,10 @@ class AIAgent:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
         self._credential_pool_entry_id = getattr(entry, "id", None)
+        if self.provider == "openai-codex":
+            from agent.agent_runtime_helpers import codex_account_identity
+
+            self._credential_pool_account_identity = codex_account_identity(runtime_key)
         from hermes_cli.route_identity import normalize_route_base_url
 
         route_changed = normalize_route_base_url(self.base_url) != normalize_route_base_url(

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1768,6 +1768,105 @@ def _codex_auth_store(access_token: str, refresh_token: str) -> dict:
     }
 
 
+def _codex_account_token(account_id: str, marker: str) -> str:
+    return _jwt_with_claims(
+        {
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account_id,
+            },
+            "marker": marker,
+        }
+    )
+
+
+def test_sync_codex_entry_adopts_rotated_token_for_same_account(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    old_token = _codex_account_token("acct-same", "old")
+    fresh_token = _codex_account_token("acct-same", "fresh")
+    _write_auth_store(tmp_path, _codex_auth_store(fresh_token, "refresh-new"))
+    entry = PooledCredential(
+        provider="openai-codex",
+        id="codex-singleton",
+        label="Codex",
+        auth_type="oauth",
+        priority=0,
+        source="device_code",
+        access_token=old_token,
+        refresh_token="refresh-old",
+    )
+    pool = CredentialPool("openai-codex", [entry])
+
+    synced = pool._sync_codex_entry_from_auth_store(entry)
+
+    assert synced.access_token == fresh_token
+    assert synced.refresh_token == "refresh-new"
+
+
+def test_sync_codex_entry_refuses_rotated_token_for_different_account(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    old_token = _codex_account_token("acct-original", "old")
+    other_token = _codex_account_token("acct-other", "fresh")
+    _write_auth_store(tmp_path, _codex_auth_store(other_token, "refresh-other"))
+    entry = PooledCredential(
+        provider="openai-codex",
+        id="codex-singleton",
+        label="Codex",
+        auth_type="oauth",
+        priority=0,
+        source="device_code",
+        access_token=old_token,
+        refresh_token="refresh-old",
+    )
+    pool = CredentialPool("openai-codex", [entry])
+
+    synced = pool._sync_codex_entry_from_auth_store(entry)
+
+    assert synced is entry
+    assert synced.access_token == old_token
+    assert synced.refresh_token == "refresh-old"
+
+
+def test_codex_401_recovery_adopts_same_account_store_token_without_re_refresh(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    old_token = _codex_account_token("acct-same", "old")
+    fresh_token = _codex_account_token("acct-same", "fresh")
+    _write_auth_store(tmp_path, _codex_auth_store(fresh_token, "refresh-new"))
+    entry = PooledCredential(
+        provider="openai-codex",
+        id="codex-singleton",
+        label="Codex",
+        auth_type="oauth",
+        priority=0,
+        source="device_code",
+        access_token=old_token,
+        refresh_token="refresh-old",
+    )
+    pool = CredentialPool("openai-codex", [entry])
+    refresh_posts = {"count": 0}
+
+    def _unexpected_refresh(*args, **kwargs):
+        refresh_posts["count"] += 1
+        raise AssertionError("fresh same-account store token must be adopted directly")
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", _unexpected_refresh)
+
+    recovered = pool.try_refresh_matching(
+        api_key_hint=old_token, credential_id="codex-singleton"
+    )
+
+    assert recovered is not None
+    assert recovered.access_token == fresh_token
+    assert refresh_posts["count"] == 0
+
+
 
 
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import sys
 import types
 from types import SimpleNamespace
@@ -55,6 +57,80 @@ def _build_agent(monkeypatch):
     agent._persist_session = lambda messages, history=None: None
     agent._save_trajectory = lambda messages, user_message, completed: None
     return agent
+
+
+def _codex_token(account_id: str, marker: str) -> str:
+    """Build a signature-free JWT-shaped fixture with a stable account claim."""
+    payload = {
+        "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+        "marker": marker,
+    }
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(payload, separators=(",", ":")).encode()
+    ).decode().rstrip("=")
+    return f"header.{encoded}.signature"
+
+
+def test_sync_credential_pool_identity_rebinds_rotated_same_account_token():
+    from agent.agent_runtime_helpers import sync_credential_pool_entry_id
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    old_token = _codex_token("acct-stable", "old")
+    fresh_token = _codex_token("acct-stable", "fresh")
+    pool = CredentialPool(
+        "openai-codex",
+        [
+            PooledCredential(
+                provider="openai-codex",
+                id="codex-singleton",
+                label="Codex",
+                auth_type="oauth",
+                priority=0,
+                source="device_code",
+                access_token=fresh_token,
+                refresh_token="refresh-token",
+            )
+        ],
+    )
+    agent = SimpleNamespace(
+        provider="openai-codex", api_key=old_token, _credential_pool=pool
+    )
+
+    sync_credential_pool_entry_id(agent)
+
+    assert agent._credential_pool_account_identity == "acct-stable"
+    assert agent._credential_pool_entry_id == "codex-singleton"
+
+
+def test_sync_credential_pool_identity_does_not_bind_different_account():
+    from agent.agent_runtime_helpers import sync_credential_pool_entry_id
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    pool = CredentialPool(
+        "openai-codex",
+        [
+            PooledCredential(
+                provider="openai-codex",
+                id="other-account",
+                label="Codex",
+                auth_type="oauth",
+                priority=0,
+                source="device_code",
+                access_token=_codex_token("acct-other", "fresh"),
+                refresh_token="refresh-token",
+            )
+        ],
+    )
+    agent = SimpleNamespace(
+        provider="openai-codex",
+        api_key=_codex_token("acct-original", "old"),
+        _credential_pool=pool,
+    )
+
+    sync_credential_pool_entry_id(agent)
+
+    assert agent._credential_pool_account_identity == "acct-original"
+    assert agent._credential_pool_entry_id is None
 
 
 def _build_copilot_agent(monkeypatch, *, model="gpt-5.4"):
@@ -1147,6 +1223,87 @@ def test_try_refresh_codex_client_credentials_handles_xai_oauth(monkeypatch):
     assert rebuilt["kwargs"]["base_url"] == "https://api.x.ai/v1"
     assert isinstance(agent.client, _RebuiltClient)
     assert agent.api_key == "fresh-xai-token"
+
+
+def test_try_refresh_codex_adopts_new_store_token_for_same_account(monkeypatch):
+    """A long-lived Codex agent may retain an old token after another process
+    rotates the singleton.  The fresh token is safe only for the same account."""
+    agent = _build_agent(monkeypatch)
+    old_token = _codex_token("acct-same", "old")
+    fresh_token = _codex_token("acct-same", "fresh")
+    agent.api_key = old_token
+    agent._credential_pool_account_identity = "acct-same"
+    agent._client_kwargs["api_key"] = old_token
+    force_calls = {"count": 0}
+
+    def _fake_resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        if force_refresh:
+            force_calls["count"] += 1
+        return {
+            "api_key": fresh_token,
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+
+    rebuilt = {"count": 0}
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials", _fake_resolve
+    )
+    monkeypatch.setattr(
+        agent,
+        "_replace_primary_openai_client",
+        lambda **_: rebuilt.__setitem__("count", rebuilt["count"] + 1) or True,
+    )
+
+    assert agent._try_refresh_codex_client_credentials(force=True) is True
+    assert agent.api_key == fresh_token
+    assert agent._client_kwargs["api_key"] == fresh_token
+    assert rebuilt["count"] == 1
+    assert force_calls["count"] == 0, (
+        "adopt the already-fresh same-account singleton without consuming "
+        "another single-use refresh token"
+    )
+
+
+def test_try_refresh_codex_refuses_new_store_token_for_different_account(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    old_token = _codex_token("acct-original", "old")
+    other_token = _codex_token("acct-other", "fresh")
+    agent.api_key = old_token
+    agent._credential_pool_account_identity = "acct-original"
+    agent._client_kwargs["api_key"] = old_token
+    force_calls = {"count": 0}
+
+    def _fake_resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        if force_refresh:
+            force_calls["count"] += 1
+        return {
+            "api_key": other_token,
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials", _fake_resolve
+    )
+
+    assert agent._try_refresh_codex_client_credentials(force=True) is False
+    assert agent.api_key == old_token
+    assert force_calls["count"] == 0
+
+
+def test_codex_pool_swap_updates_stable_account_identity(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent._credential_pool_account_identity = "acct-old"
+    monkeypatch.setattr(agent, "_replace_primary_openai_client", lambda **_: True)
+    entry = SimpleNamespace(
+        id="new-entry",
+        runtime_api_key=_codex_token("acct-new", "rotated"),
+        runtime_base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    agent._swap_credential(entry)
+
+    assert agent._credential_pool_entry_id == "new-entry"
+    assert agent._credential_pool_account_identity == "acct-new"
 
 
 def test_try_refresh_codex_client_credentials_skips_xai_oauth_when_singleton_differs(monkeypatch):


### PR DESCRIPTION
## Summary
- stamp long-lived Codex agents with stable pool-entry and ChatGPT account identity
- adopt a newer shared singleton token only when its account claim matches, without consuming another single-use refresh grant
- refuse different-account token adoption in both pool recovery and singleton fallback paths

## Tests
- `python -m pytest -q tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_credential_pool.py tests/agent/test_credential_pool_routing.py tests/agent/test_credential_pool_oauth_writethrough.py tests/run_agent/test_env_credential_turn_refresh.py` (154 passed)
- `python -m ruff check agent/agent_runtime_helpers.py agent/credential_pool.py run_agent.py tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_credential_pool.py`
- `git diff --check`

Independent exact-diff review: APPROVED (Codex gpt-5.6-sol, medium).