### PR TITLE
fix(gateway): call write_eof() on SSE error paths (connection leak fix)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3981,6 +3981,7 @@ class APIServerAdapter(BasePlatformAdapter):
             raise
         except Exception as exc:
             logger.debug("[api_server] session SSE stream error: %s", exc)
+        await response.write_eof()
         return response
 
     async def _handle_session_model_lock(self, request: "web.Request") -> "web.Response":
@@ -4543,6 +4544,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 }
             await response.write(_sse_frame(finish_chunk))
             await response.write(b"data: [DONE]\n\n")
+            await response.write_eof()
         except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
             # Client disconnected mid-stream.  Interrupt the agent so it
             # stops making LLM API calls at the next loop iteration, then
@@ -4575,6 +4577,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 }
                 await response.write(_sse_frame(error_chunk))
                 await response.write(b"data: [DONE]\n\n")
+                await response.write_eof()
             except Exception:
                 pass
 
@@ -5185,6 +5188,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 pass
             logger.error("Agent crashed mid-stream for %s: %s", response_id, str(agent_error)[:300])
 
+        await response.write_eof()
         return response
 
     @_admit_api_agent_request


### PR DESCRIPTION
## Problem

SSE error paths in the API server do not call `write_eof()` before closing connections. This causes connection pool exhaustion over time as dead connections accumulate.

## Fix

Add `write_eof()` calls on 4 SSE error paths in `gateway/platforms/api_server.py` to properly close connections and prevent pool exhaustion.

## Files Changed

- `gateway/platforms/api_server.py` (4 insertions)

## Testing

- Syntax verified
- No security boundary changes

## Related

This was originally part of PR #78467 which bundled 4 fixes. Per community feedback (alt-glitch, spfcraze, egilewski), this is split out as the second of 3 PRs. See #78467 for full context and community comments.