### PR TITLE
feat(agent): seed rotation pool from N configured env/BWS slots

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2992,6 +2992,31 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
             "CLAUDE_CODE_OAUTH_TOKEN",
             "ANTHROPIC_API_KEY",
         ]
+    else:
+        # Seed from user-configured extra env/BWS slot names too
+        # (credential_pool_sources.<provider> = [ENV_ONE, ENV_TWO, ...]).
+        # This is how a provider pool can hold more keys than its fixed
+        # api_key_env_vars slots allow — e.g. three Google/Gemini keys
+        # stored in Bitwarden as GOOGLE_API_KEY_1/2/3 and listed here, so
+        # each one joins the rotation pool instead of only the canonical
+        # GOOGLE_API_KEY slot. Each configured slot resolves through the
+        # active secret scope (Bitwarden cache included), so a BWS secret
+        # name used here is picked up automatically.
+        _config = _load_config_safe()
+        extra_sources = []
+        if _config is not None:
+            pool_sources = _config.get("credential_pool_sources")
+            if isinstance(pool_sources, dict):
+                configured = pool_sources.get(provider)
+                if isinstance(configured, list):
+                    extra_sources = [
+                        str(item).strip()
+                        for item in configured
+                        if isinstance(item, str) and item.strip()
+                    ]
+        for env_var in extra_sources:
+            if env_var not in env_vars:
+                env_vars.append(env_var)
 
     for env_var in env_vars:
         # Prefer ~/.hermes/.env over os.environ

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5030,6 +5030,7 @@ def _default_value_for_key(dotted_key: str):
 _OPEN_DICT_TOP_LEVEL_KEYS = frozenset({
     "providers",
     "credential_pool_strategies",
+    "credential_pool_sources",
     "mcp_servers",
     "hooks",
     "quick_commands",

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1284,6 +1284,58 @@ def test_least_used_strategy_selects_lowest_count(tmp_path, monkeypatch):
 
 
 
+def test_load_pool_seeds_configured_extra_env_slots(tmp_path, monkeypatch):
+    """credential_pool_sources.<provider> extra env/BWS slots each seed a pool entry."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("GOOGLE_API_KEY", "sk-gemini-1")
+    monkeypatch.setenv("GOOGLE_API_KEY_2", "sk-gemini-2")
+    monkeypatch.setenv("GOOGLE_API_KEY_3", "sk-gemini-3")
+    _write_auth_store(tmp_path, {"version": 1})
+
+    import yaml
+
+    (tmp_path / "hermes" / "config.yaml").write_text(yaml.dump({
+        "credential_pool_sources": {
+            "gemini": ["GOOGLE_API_KEY_2", "GOOGLE_API_KEY_3"],
+        },
+    }))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("gemini")
+    sources = sorted(e.source for e in pool.entries())
+    # GEMINI_API_KEY (second default slot) is unset here, so only
+    # GOOGLE_API_KEY plus the two configured extras should seed.
+    assert sources == sorted([
+        "env:GOOGLE_API_KEY",
+        "env:GOOGLE_API_KEY_2",
+        "env:GOOGLE_API_KEY_3",
+    ])
+
+
+def test_load_pool_skips_unresolvable_configured_extra_slot(tmp_path, monkeypatch):
+    """A configured extra slot with no value (.env/os.environ/BWS) is skipped, not fatal."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("GOOGLE_API_KEY", "sk-gemini-1")
+    # GOOGLE_API_KEY_2 deliberately left unset
+    _write_auth_store(tmp_path, {"version": 1})
+
+    import yaml
+
+    (tmp_path / "hermes" / "config.yaml").write_text(yaml.dump({
+        "credential_pool_sources": {
+            "gemini": ["GOOGLE_API_KEY_2", "GOOGLE_API_KEY_3"],
+        },
+    }))
+    monkeypatch.setenv("GOOGLE_API_KEY_3", "sk-gemini-3")
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("gemini")
+    sources = sorted(e.source for e in pool.entries())
+    assert sources == ["env:GOOGLE_API_KEY", "env:GOOGLE_API_KEY_3"]
+
+
 def test_custom_endpoint_pool_seeds_from_config(tmp_path, monkeypatch):
     """Verify seeding from custom_providers api_key in config.yaml."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))


### PR DESCRIPTION
## Problem

Hermes seeds a provider's rotation pool (`agent/credential_pool.py::_seed_from_env`) only from that provider's fixed `api_key_env_vars` slots. For Google/Gemini that is exactly two slot names (`GOOGLE_API_KEY`, `GEMINI_API_KEY`), so a pool can hold **at most two** credentials auto-seeded from env / secret-scope values. A user with three Google API keys across three accounts (common to spread free-tier quota) cannot get all three into rotation from Bitwarden Secrets Manager or `.env` — the third key never enters the pool, or must be registered manually via `hermes auth add`.

## Change

Add a new open-dict config key `credential_pool_sources.<provider>` (a list of env / secret slot names). `_seed_from_env` now also seeds one `env:<VAR>` entry per configured slot, in addition to the provider's defaults. Each slot resolves through the active secret scope (Bitwarden cache included), so a BWS secret named e.g. `GOOGLE_API_KEY_2` listed here is picked up automatically — no manual `hermes auth add` needed. Unresolvable slots (absent from `.env` / `os.environ` / BWS) are skipped, matching existing default-slot behavior.

```yaml
credential_pool_sources:
  gemini:
    - GOOGLE_API_KEY_2
    - GOOGLE_API_KEY_3
```

with `GOOGLE_API_KEY`, `GOOGLE_API_KEY_2`, `GOOGLE_API_KEY_3` stored in BWS yields a 3-key Gemini rotation pool automatically.

## Notes

- `openrouter` keeps its existing dedicated single-slot `_seed_from_env` branch (it returns before the generic loop); this feature targets the generic api-key providers (`gemini`, `openai-api`, `deepseek`, `xai`, etc.).
- The `anthropic` ordering branch is left unchanged.
- `credential_pool_sources` is registered in `_OPEN_DICT_TOP_LEVEL_KEYS` (same treatment as the existing `credential_pool_strategies`), so `hermes config set credential_pool_sources.gemini.0 GOOGLE_API_KEY_2` validates under the schema.

## Tests

Added two tests in `tests/agent/test_credential_pool.py`:
- `test_load_pool_seeds_configured_extra_env_slots`
- `test_load_pool_skips_unresolvable_configured_extra_slot`

Full file run: `scripts/run_tests.sh tests/agent/test_credential_pool.py` → **61 passed**.
Config schema/validation tests (`tests/hermes_cli/test_config*.py`) → **98 passed**.