### PR TITLE
fix(moa): sanitize prepared aggregator messages

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1812,6 +1812,16 @@ class MoAChatCompletions:
                 "MoA aggregator cache plan failed — sending undecorated "
                 "request (cache misses expected): %s", exc,
             )
+        # MoA calls aggregators through the auxiliary client, bypassing the
+        # normal chat-completions transport conversion.
+        if agg_runtime.get("api_mode") == "chat_completions":
+            transport = get_transport("chat_completions")
+            if transport is None:  # pragma: no cover - built-in transport
+                raise RuntimeError("chat_completions transport unavailable")
+            agg_messages = transport.convert_messages(
+                agg_messages,
+                model=agg_runtime.get("model"),
+            )
         # Record the exact aggregator INPUT (incl. the injected reference
         # context) into the pending trace so a trace captures what the
         # aggregator actually saw, not a reconstruction. Traces are a

--- a/tests/agent/test_moa_slot_api_mode.py
+++ b/tests/agent/test_moa_slot_api_mode.py
@@ -19,6 +19,30 @@ def _response(content="ok"):
     return SimpleNamespace(choices=[choice], usage=None, model="fake")
 
 
+def _capture_prepared_aggregator(monkeypatch, runtime, message):
+    from agent import moa_loop
+
+    captured = {}
+    monkeypatch.setattr(moa_loop, "_slot_runtime", lambda slot: runtime)
+    monkeypatch.setattr(
+        moa_loop,
+        "call_llm",
+        lambda **kwargs: captured.update(kwargs) or _response("acted"),
+    )
+    facade = moa_loop.MoAChatCompletions.__new__(moa_loop.MoAChatCompletions)
+    facade._agent = None
+    facade._pending_trace = None
+    prepared = {
+        "messages": [message],
+        "guidance": None,
+        "aggregator": {"provider": "custom", "model": "strict-model"},
+        "aggregator_temperature": None,
+    }
+
+    facade._call_prepared_aggregator(prepared, {})
+    return captured["messages"][0], prepared["messages"][0]
+
+
 class TestSlotRuntimeApiMode:
     """_slot_runtime should include api_mode when resolve_runtime_provider returns it."""
 
@@ -150,6 +174,42 @@ moa:
         "metadata": {"source": "caller"},
         "reasoning": {"effort": "none"},
     }
+
+
+def test_moa_aggregator_strips_internal_fields_for_chat_completions(monkeypatch):
+    """Persistence metadata must not reach strict chat-completions providers."""
+    wire_message, source_message = _capture_prepared_aggregator(
+        monkeypatch,
+        {
+            "provider": "custom",
+            "model": "strict-model",
+            "api_mode": "chat_completions",
+        },
+        {
+            "role": "user",
+            "content": "hello",
+            "_db_persisted": True,
+        },
+    )
+
+    assert "_db_persisted" not in wire_message
+    assert source_message["_db_persisted"] is True
+
+
+def test_moa_aggregator_defers_sanitization_when_api_mode_is_unresolved(monkeypatch):
+    """Unresolved routes may select a transport that needs replay metadata."""
+    reasoning_items = [{"type": "reasoning", "id": "item-1"}]
+    wire_message, _ = _capture_prepared_aggregator(
+        monkeypatch,
+        {"provider": "openai-codex", "model": "gpt-test"},
+        {
+            "role": "assistant",
+            "content": "working",
+            "codex_reasoning_items": reasoning_items,
+        },
+    )
+
+    assert wire_message["codex_reasoning_items"] == reasoning_items
 
 
 def test_one_shot_aggregate_moa_context_passes_slot_extra_body(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

MoA prepared aggregator requests call the auxiliary client directly, so chat-completions messages skipped the normal transport conversion. Hermes-only metadata such as `_db_persisted` could therefore enter the request payload and be rejected by strict schemas.

Apply the existing `ChatCompletionsTransport.convert_messages()` conversion at the final prepared-aggregator boundary when the slot explicitly resolves to `chat_completions`. Unresolved and non-chat routes remain untouched so provider-specific replay metadata is preserved.

## Related Issue

Related to #30959. This is a focused extraction of the sanitization fix also present in #80837, without its unrelated MoA feature changes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Sanitize prepared MoA aggregator messages through the existing chat-completions transport.
- Keep unresolved routes intact until `call_llm()` selects their transport.
- Add regressions for `_db_persisted` removal, input immutability, and unresolved response replay metadata.

## How to Test

1. Run `python -m pytest tests/agent/test_moa_slot_api_mode.py -q`.
2. Run `python -m pytest tests/agent/test_moa*.py tests/hermes_cli/test_moa*.py -q`.
3. Run `ruff check agent/moa_loop.py tests/agent/test_moa_slot_api_mode.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2/Linux, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The regression test failed before the production change because `_db_persisted` remained in the captured aggregator messages. After the fix:

```text
63 passed, 2 warnings in 3.71s
All checks passed!
No Windows footguns found (2 files scanned).
```

The canonical full-suite runner currently reports 85 failures across 25 unrelated files. Running those exact files from a clean `upstream/main` worktree reproduces the same 85 failures across the same 25 files.
