### PR TITLE
test(system_prompt): pin timezone in legacy workspace-order test

### DIFF
--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -242,6 +242,14 @@ def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
         ),
         patch("agent.file_safety._resolve_active_profile_name", return_value="default"),
         patch("hermes_time.now", return_value=datetime(2026, 1, 2)),
+        # Pin the zone too, not just the clock. ``now`` alone is not enough:
+        # the timestamp line appends a zone suffix derived from
+        # ``hermes_time.get_timezone()``, whose result is cached process-wide
+        # and never reset between tests. conftest scrubs HERMES_TIMEZONE, but a
+        # zone resolved by an earlier test in the same process persists and
+        # would append " (America/New_York)" here, breaking this exact-equality
+        # assert depending on test ordering.
+        patch("hermes_time.get_timezone", return_value=None),
     ):
         prompt = build_system_prompt(agent, system_message="SYSTEM_MESSAGE")
 


### PR DESCRIPTION
## What does this PR do?

Patches `hermes_time.get_timezone` to `None` alongside the existing `hermes_time.now`
patch in `test_coding_prompt_preserves_legacy_workspace_order`, so the rendered
timestamp line is deterministic regardless of the runner's timezone or test ordering.

Follow-up to #87404 (merged as da392043a9), closing the test-robustness gap
@PRATHAMESH75 raised in review of that PR.

## Related Issue

Fixes #87841

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/agent/test_system_prompt.py` — add `patch("hermes_time.get_timezone", return_value=None)`
  to the existing `with` block, plus a comment explaining why pinning `now` alone
  is insufficient.

No production code changes.

## Why `now` alone is not enough

Since da392043a9 the timestamp line appends a zone suffix derived from
`get_timezone()`. `tests/conftest.py` scrubs `HERMES_TIMEZONE`, so a clean run
resolves `None` and the suffix is empty — which is why this passes today. But
`hermes_time` caches the resolved zone in a process-global `_cached_tz` that no
test resets, so a zone resolved by an earlier test in the same process persists
into this one and appends `" (America/New_York)"`, breaking the exact-equality
assert. `delenv` does not clear the cache.

## Verification

Reproduced the latent failure by priming the cache the way an earlier test would
(full plugin in #87841):

```
$ pytest -p poison_tz_plugin tests/agent/test_system_prompt.py::test_coding_prompt_preserves_legacy_workspace_order
E  AssertionError: assert 'IDENTITY\n\n...ica/New_York)' == 'IDENTITY\n\n...uary 02, 2026'
E   - ry 02, 2026
E   + ry 02, 2026 (America/New_York)
1 failed in 0.50s
```

With this change, the same primed-cache run passes:

```
$ pytest -p poison_tz_plugin tests/agent/test_system_prompt.py::test_coding_prompt_preserves_legacy_workspace_order
1 passed in 0.41s

$ pytest tests/agent/test_system_prompt.py tests/agent/test_system_prompt_restore.py \
         tests/run_agent/test_run_agent.py tests/test_timezone.py -q
303 passed in 22.81s
```
