### PR TITLE
fix(agent): trim background_review config to the enabled switch

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -44,9 +44,8 @@ logger = logging.getLogger(__name__)
 # digest. That's the whole policy.
 # ---------------------------------------------------------------------------
 
-# Historical hardcoded value — kept as the default so existing behavior is
-# unchanged when the config key is unset.
-_DEFAULT_REVIEW_MAX_ITERATIONS = 16
+# Historical hardcoded iteration budget for the review fork.
+_REVIEW_MAX_ITERATIONS = 16
 
 
 def _background_review_task_config(
@@ -106,7 +105,7 @@ def is_background_review_enabled(
     refine working (issue #87250).
 
     Prefer :func:`load_background_review_settings` at the spawn call site so
-    the task block is not re-read for prompt / max_iterations on the same turn.
+    the task block is not re-read on the same turn.
     """
     if task_cfg is not None:
         try:
@@ -123,56 +122,6 @@ def is_background_review_enabled(
     enabled, _ = load_background_review_settings()
     return enabled
 
-
-def _resolve_review_max_iterations(
-    task_cfg: Optional[Dict[str, Any]] = None,
-) -> int:
-    """Resolve the review fork's tool-calling iteration budget.
-
-    Default 16 (unchanged historical behavior). Configurable via
-    ``auxiliary.background_review.max_iterations`` so operators can bound the
-    worst-case cost of a review that never concludes "nothing to save".
-    Clamped to [1, 64]; any config-read or parse failure falls back to the
-    default.
-    """
-    try:
-        val = _background_review_task_config(task_cfg).get("max_iterations")
-        if val is None:
-            return _DEFAULT_REVIEW_MAX_ITERATIONS
-        return max(1, min(int(val), 64))
-    except Exception:
-        return _DEFAULT_REVIEW_MAX_ITERATIONS
-
-
-def _load_review_prompt_file(
-    task_cfg: Optional[Dict[str, Any]] = None,
-) -> Optional[str]:
-    """Load ``auxiliary.background_review.prompt_file`` if configured.
-
-    Returns the file contents (stripped) or ``None`` when unset / unreadable.
-    Relative paths resolve against ``HERMES_HOME`` (same pattern as TTS
-    ``persona_prompt_file``).
-    """
-    raw = _background_review_task_config(task_cfg).get("prompt_file")
-    if not isinstance(raw, str) or not raw.strip():
-        return None
-    expanded = os.path.expandvars(raw.strip())
-    path = Path(expanded).expanduser()
-    if not path.is_absolute():
-        try:
-            from hermes_constants import get_hermes_home
-
-            path = get_hermes_home() / path
-        except Exception:
-            path = Path.cwd() / path
-    try:
-        text = path.read_text(encoding="utf-8").strip()
-    except (OSError, UnicodeDecodeError) as exc:
-        logger.warning(
-            "background_review.prompt_file unavailable at %s: %s", path, exc
-        )
-        return None
-    return text or None
 
 
 def _resolve_review_runtime(
@@ -1070,7 +1019,7 @@ def _run_review_in_thread(
                         _fork_kwargs[_pref_attr] = _pref_val
             review_agent = AIAgent(
                 model=_rt.get("model") or agent.model,
-                max_iterations=_resolve_review_max_iterations(task_cfg),
+                max_iterations=_REVIEW_MAX_ITERATIONS,
                 quiet_mode=True,
                 platform=agent.platform,
                 provider=_rt.get("provider") or agent.provider,
@@ -1385,21 +1334,15 @@ def spawn_background_review_thread(
 
     ``task_cfg`` is the already-loaded ``auxiliary.background_review`` block
     from :func:`load_background_review_settings`. When omitted, config is
-    read once here and shared with the worker (prompt file, max_iterations,
-    aux routing) so a single turn does not re-parse the config file.
+    read once here and shared with the worker (aux routing) so a single
+    turn does not re-parse the config file.
     """
     if task_cfg is None:
         task_cfg = _background_review_task_config()
     # Pick the right prompt based on which triggers fired.  Allow per-agent
     # override (the prompts moved to module-level constants but old code paths
     # that set agent._MEMORY_REVIEW_PROMPT etc. directly keep working).
-    # ``auxiliary.background_review.prompt_file`` replaces the built-in text
-    # when set — operators can make the reviewer conservative or redefine
-    # "worth saving" without patching core (issue #87250).
-    prompt_override = _load_review_prompt_file(task_cfg)
-    if prompt_override:
-        prompt = prompt_override
-    elif review_memory and review_skills:
+    if review_memory and review_skills:
         prompt = getattr(agent, "_COMBINED_REVIEW_PROMPT", _COMBINED_REVIEW_PROMPT)
     elif review_memory:
         prompt = getattr(agent, "_MEMORY_REVIEW_PROMPT", _MEMORY_REVIEW_PROMPT)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -787,8 +787,6 @@ prompt_caching:
 #     enabled: true            # false = skip automatic forks (/refine still works)
 #     provider: "auto"         # or pin a cheaper model (see memory.md)
 #     model: ""
-#     max_iterations: 16       # tool-calling budget per fork (clamped 1–64)
-#     prompt_file: ""          # optional custom review prompt (HERMES_HOME-relative)
 
 # =============================================================================
 # Persistent Memory

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1150,16 +1150,6 @@ DEFAULT_CONFIG = {
             "timeout": 120,
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
-            # Tool-calling iteration budget for the review fork. Default 16
-            # matches historical behavior. The review has no hard "nothing to
-            # do" early-out — a session with nothing worth saving can still
-            # burn the full budget. Lower this to bound worst-case cost;
-            # clamped to [1, 64].
-            "max_iterations": 16,
-            # Optional path to a custom review prompt (replaces the built-in
-            # memory/skill/combined prompts). Relative paths resolve under
-            # HERMES_HOME. Empty = use built-in prompts.
-            "prompt_file": "",
         },
         "moa_reference": {
             "provider": "auto",

--- a/run_agent.py
+++ b/run_agent.py
@@ -1833,7 +1833,7 @@ class AIAgent:
         # (``auxiliary.background_review.enabled: false``). Manual ``/refine``
         # still works — same contract as zeroing the nudge intervals (#87250).
         # Load the task block once here and pass it into the spawn path so
-        # prompt_file / max_iterations / aux routing do not re-read config.
+        # aux routing does not re-read config.
         task_cfg = None
         if focus is None:
             from agent.background_review import load_background_review_settings

--- a/tests/agent/test_background_review_usage.py
+++ b/tests/agent/test_background_review_usage.py
@@ -167,15 +167,9 @@ def test_enabled_config_failure_logs_warning(caplog):
     )
 
 
-def test_spawn_reuses_provided_task_cfg_without_rereading(tmp_path):
-    """One config load per spawn — prompt + max_iterations share task_cfg."""
-    prompt_path = tmp_path / "review.md"
-    prompt_path.write_text("Custom review prompt only.\n", encoding="utf-8")
-    task = {
-        "enabled": True,
-        "max_iterations": 3,
-        "prompt_file": str(prompt_path),
-    }
+def test_spawn_reuses_provided_task_cfg_without_rereading():
+    """One config load per spawn — the worker shares task_cfg."""
+    task = {"enabled": True}
     agent = type("A", (), {})()
     with patch(
         "hermes_cli.config.load_config_readonly",
@@ -187,10 +181,8 @@ def test_spawn_reuses_provided_task_cfg_without_rereading(tmp_path):
             review_skills=True,
             task_cfg=task,
         )
-        assert "Custom review prompt only" in prompt
-        assert background_review._resolve_review_max_iterations(task) == 3
+        assert prompt  # built-in skill-review prompt selected
         assert callable(_target)
-
 
 def test_log_review_completion_emits_thread_tag(caplog):
     with caplog.at_level(logging.INFO, logger="agent.background_review"):

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -198,44 +198,6 @@ def test_background_review_runs_at_top_level(monkeypatch):
     assert len(forks) == 1, "top-level review must still spawn the fork"
 
 
-def test_background_review_honors_configured_max_iterations(monkeypatch):
-    """``auxiliary.background_review.max_iterations`` must reach the fork's
-    ``AIAgent(max_iterations=...)`` (#87250)."""
-    from unittest.mock import patch
-
-    forks = []
-
-    class FakeReviewAgent:
-        def __init__(self, **kwargs):
-            forks.append(kwargs)
-
-        def run_conversation(self, **kwargs):
-            pass
-
-        def shutdown_memory_provider(self):
-            pass
-
-        def close(self):
-            pass
-
-    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
-    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
-
-    agent = _bare_agent()
-    agent._delegate_depth = 0
-
-    cfg = {"auxiliary": {"background_review": {"max_iterations": 4}}}
-    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
-        AIAgent._spawn_background_review(
-            agent,
-            messages_snapshot=[{"role": "user", "content": "hello"}],
-            review_memory=True,
-        )
-
-    assert len(forks) == 1
-    assert forks[0]["max_iterations"] == 4
-
-
 def test_background_review_disabled_skips_automatic_spawn(monkeypatch):
     """``auxiliary.background_review.enabled: false`` must skip automatic
     post-turn forks while leaving ``/refine`` (focus set) working (#87250)."""

--- a/tests/run_agent/test_background_review_cost_controls.py
+++ b/tests/run_agent/test_background_review_cost_controls.py
@@ -164,37 +164,6 @@ def test_digest_records_tool_names_in_arc():
 # Cost / configurability controls (issue #87250)
 # ---------------------------------------------------------------------------
 
-def test_max_iterations_unset_falls_back_to_default():
-    with patch("hermes_cli.config.load_config_readonly", return_value={}):
-        assert br._resolve_review_max_iterations() == 16
-
-
-def test_max_iterations_honors_config_override():
-    cfg = {"auxiliary": {"background_review": {"max_iterations": 4}}}
-    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
-        assert br._resolve_review_max_iterations() == 4
-
-
-def test_max_iterations_clamped_to_upper_bound():
-    cfg = {"auxiliary": {"background_review": {"max_iterations": 999}}}
-    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
-        assert br._resolve_review_max_iterations() == 64
-
-
-def test_max_iterations_clamped_to_lower_bound():
-    cfg = {"auxiliary": {"background_review": {"max_iterations": 0}}}
-    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
-        assert br._resolve_review_max_iterations() == 1
-
-
-def test_max_iterations_falls_back_to_default_on_config_error():
-    with patch(
-        "hermes_cli.config.load_config_readonly",
-        side_effect=RuntimeError("boom"),
-    ):
-        assert br._resolve_review_max_iterations() == 16
-
-
 def test_enabled_defaults_true():
     with patch("hermes_cli.config.load_config_readonly", return_value={}):
         assert br.is_background_review_enabled() is True
@@ -204,19 +173,3 @@ def test_enabled_false_disables_automatic_review():
     cfg = {"auxiliary": {"background_review": {"enabled": False}}}
     with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
         assert br.is_background_review_enabled() is False
-
-
-def test_prompt_file_overrides_builtin(tmp_path):
-    prompt_path = tmp_path / "review.md"
-    prompt_path.write_text("Be conservative. Prefer Nothing to save.\n", encoding="utf-8")
-    cfg = {"auxiliary": {"background_review": {"prompt_file": str(prompt_path)}}}
-    agent = _FakeAgent()
-    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
-        _target, prompt = br.spawn_background_review_thread(
-            agent,
-            messages_snapshot=[{"role": "user", "content": "hi"}],
-            review_skills=True,
-        )
-    assert "Be conservative" in prompt
-    assert "ACTIVE" not in prompt  # built-in skill prompt not used
-    assert callable(_target)

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -317,24 +317,19 @@ identical and skill capture near-identical to the main-model review.
 Leave it at `auto` (or set it to your main model) and nothing changes — the
 review keeps running on the main model with the full warm-cache replay.
 
-### Cost controls (`enabled`, `max_iterations`, `prompt_file`)
+### Disabling automatic reviews (`enabled`)
 
 The review fork can burn a meaningful share of total tokens on busy hosts.
-Operators can bound or disable it without zeroing nudge intervals:
+Operators can disable it without zeroing nudge intervals:
 
 ```yaml
 auxiliary:
   background_review:
     enabled: true              # false = skip automatic post-turn forks
-    max_iterations: 16         # tool-calling budget per fork (clamped 1–64)
-    prompt_file: ""            # optional custom prompt (HERMES_HOME-relative)
 ```
 
-| Key | Behaviour |
-|-----|-----------|
-| `enabled: false` | Automatic post-turn forks do not spawn. Manual `/refine` still works. |
-| `max_iterations` | Caps how many tool-calling iterations the fork may run (default `16`). |
-| `prompt_file` | When set to a readable Markdown/text file, replaces the built-in review prompt so you can make the reviewer conservative or redefine "worth saving." |
+With `enabled: false`, automatic post-turn forks do not spawn; manual
+`/refine` still works.
 
 Fork usage is persisted in `session_model_usage` with `task='background_review'`
 and a completion line is written to `agent.log`


### PR DESCRIPTION
## Summary
Trims `auxiliary.background_review` back to the `enabled` switch: removes the `max_iterations` and `prompt_file` knobs added in #87400. The aux model routing (provider/model/base_url/timeout/reasoning_effort) predates #87400 and is unchanged; the usage telemetry (`task='background_review'`) and the enabled gate stay.

Fork iteration budget returns to the historical hardcoded 16.

## Changes
- `agent/background_review.py`: drop `_resolve_review_max_iterations` / `_load_review_prompt_file`; hardcode budget
- `hermes_cli/config_defaults.py`, `cli-config.yaml.example`, `website/docs/.../memory.md`: remove the two keys
- tests: drop/adjust the knob tests (31 background-review tests still pass)

## Validation
| | Result |
|---|---|
| background_review + usage-accounting suites | 41 passed |

## Infographic

![infographic](https://files.catbox.moe/umir1m.png)
