### PR TITLE
fix(session-search): stop cross-chat transcript exfiltration

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3158,8 +3158,12 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
                     detail=next_args.get("detail", "adaptive"),
+                    profile=next_args.get("profile"),
                     db=session_db,
                     current_session_id=agent.session_id,
+                    caller_session_key=getattr(
+                        agent, "_gateway_session_key", None
+                    ),
                 ),
                 next_args,
             )

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2636,12 +2636,12 @@ class APIServerAdapter(BasePlatformAdapter):
         from config.yaml platform_toolsets.api_server (same as all other
         gateway platforms), falling back to the hermes-api-server default.
 
-        ``gateway_session_key`` is a stable per-channel identifier supplied
-        by the client (via ``X-Hermes-Session-Key``).  Unlike ``session_id``
-        which scopes the short-term transcript and rotates on /new, this
-        key is meant to persist across transcripts so long-term memory
-        providers (e.g. Honcho) can scope their per-chat state correctly
-        — matching the semantics of the native gateway's ``session_key``.
+        ``gateway_session_key`` is the effective ownership scope for this API
+        turn. Clients may supply a stable per-channel identifier via
+        ``X-Hermes-Session-Key``; otherwise the request's ``session_id`` is
+        used so agent-facing history tools still fail closed. Unlike
+        ``session_id``, an explicit key persists across transcripts so
+        long-term memory providers can preserve native gateway semantics.
 
         ``route`` is an optional ``model_routes`` entry (per-client model
         routing).  When set — and no session ``/model`` override exists for
@@ -6328,6 +6328,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # run_in_executor threads, so the profile scope must be re-entered
         # inside _run() from this explicit value.
         request_profile = _api_request_profile.get()
+        effective_session_key = gateway_session_key or session_id or ""
 
         def _run():
             from gateway.session_context import clear_session_vars
@@ -6335,7 +6336,7 @@ class APIServerAdapter(BasePlatformAdapter):
             with self._profile_scope(request_profile):
                 tokens = self._bind_api_server_session(
                     chat_id=session_id or "",
-                    session_key=gateway_session_key or session_id or "",
+                    session_key=effective_session_key,
                     session_id=session_id or "",
                 )
                 agent = None
@@ -6347,7 +6348,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_progress_callback=tool_progress_callback,
                         tool_start_callback=tool_start_callback,
                         tool_complete_callback=tool_complete_callback,
-                        gateway_session_key=gateway_session_key,
+                        gateway_session_key=effective_session_key,
                         requested_model=requested_model,
                         requested_provider=requested_provider,
                         model_options=model_options,
@@ -6722,6 +6723,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = session_id or run_id
+        effective_session_key = gateway_session_key or session_id
         # Approval queues gate host-side tool execution and must be isolated
         # per API run.  Client-provided session IDs and memory session keys are
         # conversation/memory scopes, not authorization namespaces: multiple
@@ -6792,7 +6794,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         session_id=session_id,
                         stream_delta_callback=_text_cb,
                         tool_progress_callback=event_cb,
-                        gateway_session_key=gateway_session_key,
+                        gateway_session_key=effective_session_key,
                         requested_model=agent_overrides.get("requested_model"),
                         requested_provider=agent_overrides.get("requested_provider"),
                         model_options=agent_overrides.get("model_options"),

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2233,6 +2233,31 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.debug("SessionDB unavailable for API server: %s", e)
             return None
 
+    def _effective_agent_session_key(
+        self,
+        gateway_session_key: Optional[str],
+        session_id: Optional[str],
+    ) -> str:
+        """Resolve the stable ownership scope for an API agent turn."""
+        if gateway_session_key:
+            return gateway_session_key
+        sid = str(session_id or "").strip()
+        if not sid:
+            return ""
+        try:
+            db = self._ensure_session_db()
+            row = db.get_session(sid) if db is not None else None
+            inherited = str((row or {}).get("session_key") or "").strip()
+            if inherited:
+                return inherited
+        except Exception:
+            logger.debug(
+                "Could not resolve API session ownership scope for %s",
+                sid,
+                exc_info=True,
+            )
+        return sid
+
     async def _ensure_session_db_async(self):
         """Async variant for request handlers: offload the SQLite open/schema
         init off the single aiohttp event-loop thread.
@@ -6328,12 +6353,14 @@ class APIServerAdapter(BasePlatformAdapter):
         # run_in_executor threads, so the profile scope must be re-entered
         # inside _run() from this explicit value.
         request_profile = _api_request_profile.get()
-        effective_session_key = gateway_session_key or session_id or ""
 
         def _run():
             from gateway.session_context import clear_session_vars
 
             with self._profile_scope(request_profile):
+                effective_session_key = self._effective_agent_session_key(
+                    gateway_session_key, session_id
+                )
                 tokens = self._bind_api_server_session(
                     chat_id=session_id or "",
                     session_key=effective_session_key,
@@ -6723,7 +6750,6 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = session_id or run_id
-        effective_session_key = gateway_session_key or session_id
         # Approval queues gate host-side tool execution and must be isolated
         # per API run.  Client-provided session IDs and memory session keys are
         # conversation/memory scopes, not authorization namespaces: multiple
@@ -6789,6 +6815,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                     return
                 with self._profile_scope(request_profile):
+                    effective_session_key = self._effective_agent_session_key(
+                        gateway_session_key, session_id
+                    )
                     agent = self._create_agent(
                         ephemeral_system_prompt=ephemeral_system_prompt,
                         session_id=session_id,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8388,39 +8388,54 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         last_active = session_row.get("last_active") or session_row.get("started_at")
         return float(last_active or 0) > float(last_read)
 
-    def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
-        """Look up a session by exact title. Returns session dict or None."""
+    def get_session_by_title(
+        self, title: str, session_key: str = None
+    ) -> Optional[Dict[str, Any]]:
+        """Look up an exact title, optionally within one gateway scope."""
+        where = "WHERE s.title = ?"
+        params: List[Any] = [title]
+        if session_key:
+            where += " AND s.session_key = ?"
+            params.append(session_key)
         with self._read_ctx() as conn:
             cursor = conn.execute(
                 "SELECT s.*, "
                 "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
                 "FROM sessions s "
                 "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
-                "WHERE s.title = ?",
-                (title,),
+                f"{where}",
+                params,
             )
             row = cursor.fetchone()
         return self._session_row_dict(row) if row else None
 
-    def resolve_session_by_title(self, title: str) -> Optional[str]:
+    def resolve_session_by_title(
+        self, title: str, session_key: str = None
+    ) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
         If the exact title exists, returns that session's ID.
         If not, searches for "title #N" variants and returns the latest one.
         If the exact title exists AND numbered variants exist, returns the
         latest numbered variant (the most recent continuation).
+        Pass ``session_key`` to resolve only within one gateway conversation.
         """
         # First try exact match
-        exact = self.get_session_by_title(title)
+        exact = self.get_session_by_title(title, session_key=session_key)
 
         # Also search for numbered variants: "title #2", "title #3", etc.
         # Escape SQL LIKE wildcards (%, _) in the title to prevent false matches
         escaped = _escape_like(title)
+        numbered_where = "WHERE title LIKE ? ESCAPE '\\'"
+        numbered_params: List[Any] = [f"{escaped} #%"]
+        if session_key:
+            numbered_where += " AND session_key = ?"
+            numbered_params.append(session_key)
         with self._read_ctx() as conn:
             cursor = conn.execute(
                 "SELECT id, title, started_at FROM sessions "
-                "WHERE title LIKE ? ESCAPE '\\' ORDER BY started_at DESC",
-                (f"{escaped} #%",),
+                f"{numbered_where} ORDER BY started_at DESC",
+                numbered_params,
             )
             numbered = cursor.fetchall()
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8481,7 +8481,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return f"{base} #{max_num + 1}"
 
-    def get_compression_tip(self, session_id: str) -> Optional[str]:
+    def get_compression_tip(
+        self, session_id: str, session_key: str = None
+    ) -> Optional[str]:
         """Walk the compression-continuation chain forward and return the tip.
 
         A compression continuation is a child of a session whose
@@ -8504,6 +8506,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         current = session_id
         seen = {current} if current else set()
+        scope_clause = "AND child.session_key = ?" if session_key else ""
         # Bound the walk defensively — compression chains this deep are
         # pathological and shouldn't happen in practice. 100 = plenty.
         for _ in range(100):
@@ -8518,6 +8521,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                       AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
                       AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
                       AND COALESCE(child.source, '') != 'tool'
+                      {scope_clause}
                     ORDER BY
                       CASE
                         WHEN child.end_reason = 'compression' THEN 0
@@ -8529,7 +8533,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                       child.id DESC
                     LIMIT 1
                     """,
-                    (current,),
+                    (current, session_key) if session_key else (current,),
                 )
                 row = cursor.fetchone()
             if row is None:
@@ -8791,6 +8795,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     f"{where_sql} AND {combined}" if where_sql else f"WHERE {combined}"
                 )
             _sel = self._compact_session_cols() if compact_rows else "s.*"
+            chain_scope_sql = "AND child.session_key = ?" if session_key else ""
             query = f"""
                 WITH RECURSIVE chain(root_id, cur_id) AS (
                     SELECT s.id, s.id FROM sessions s {where_sql}
@@ -8803,6 +8808,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                       AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
                       AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
                       AND COALESCE(child.source, '') != 'tool'
+                      {chain_scope_sql}
                 ),
                 chain_max AS (
                     SELECT
@@ -8828,9 +8834,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ORDER BY _effective_last_active DESC, s.started_at DESC, s.id DESC
                 LIMIT ? OFFSET ?
             """
-            # WHERE params apply twice (CTE seed + outer select); the id filter
+            # WHERE params apply twice (CTE seed + outer select); the lineage
+            # scope sits between them in the recursive term, and the id filter
             # only applies to the outer select.
-            params = params + params + id_params + [limit, offset]
+            params = (
+                params
+                + ([session_key] if session_key else [])
+                + params
+                + id_params
+                + [limit, offset]
+            )
         else:
             _sel = self._compact_session_cols() if compact_rows else "s.*"
             query = f"""
@@ -8917,7 +8930,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             for s in sessions:
                 if s.get("end_reason") != "compression":
                     continue
-                tip_id = self.get_compression_tip(s["id"])
+                tip_id = self.get_compression_tip(
+                    s["id"], session_key=session_key
+                )
                 if tip_id != s["id"]:
                     tip_ids_by_root[s["id"]] = tip_id
 

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1345,6 +1345,7 @@ class SessionSearchMixin:
         role_filter: List[str] = None,
         limit: int = 20,
         offset: int = 0,
+        session_key: str = None,
     ) -> Optional[List[Dict[str, Any]]]:
         """Run a search against a substring-capable FTS index.
 
@@ -1381,6 +1382,9 @@ class SessionSearchMixin:
         if exclude_sources is not None:
             tri_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
             tri_params.extend(exclude_sources)
+        if session_key:
+            tri_where.append("s.session_key = ?")
+            tri_params.append(session_key)
         if role_filter:
             tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
             tri_params.extend(role_filter)
@@ -1422,6 +1426,7 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        session_key: str = None,
     ) -> List[Dict[str, Any]]:
         """Instrumented wrapper around :meth:`_search_messages_impl`.
 
@@ -1444,6 +1449,7 @@ class SessionSearchMixin:
                 sort=sort,
                 include_inactive=include_inactive,
                 fields=fields,
+                session_key=session_key,
             )
             return rows
         finally:
@@ -1553,6 +1559,7 @@ class SessionSearchMixin:
         offset: int,
         sort: Optional[str],
         include_inactive: bool,
+        session_key: Optional[str],
     ) -> List[Dict[str, Any]]:
         """Search canonical messages while derived FTS state is stale."""
         predicate, params, snippet_term = self._compile_like_boolean_query(query)
@@ -1570,6 +1577,9 @@ class SessionSearchMixin:
                 f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})"
             )
             params.extend(exclude_sources)
+        if session_key:
+            where.append("s.session_key = ?")
+            params.append(session_key)
         if role_filter:
             where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
             params.extend(role_filter)
@@ -1716,6 +1726,7 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        session_key: str = None,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -1731,6 +1742,10 @@ class SessionSearchMixin:
         ``fields`` selects a result projection; omitting it preserves the
         complete legacy result. Context is only loaded when that projection
         consumes it.
+
+        ``session_key`` scopes every search backend before ranking and LIMIT,
+        so matches from other gateway conversations cannot consume the result
+        window.
 
         ``sort`` controls temporal ordering:
           - ``None`` (default): FTS5 BM25 relevance only. Time-neutral.
@@ -1768,6 +1783,7 @@ class SessionSearchMixin:
                 offset=offset,
                 sort=sort,
                 include_inactive=include_inactive,
+                session_key=session_key,
             )
             return self._finalize_search_matches(
                 matches, result_fields=result_fields
@@ -1812,6 +1828,10 @@ class SessionSearchMixin:
             exclude_placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({exclude_placeholders})")
             params.extend(exclude_sources)
+
+        if session_key:
+            where_clauses.append("s.session_key = ?")
+            params.append(session_key)
 
         if role_filter:
             role_placeholders = ",".join("?" for _ in role_filter)
@@ -1907,6 +1927,9 @@ class SessionSearchMixin:
                 if exclude_sources is not None:
                     cjk_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
                     cjk_params.extend(exclude_sources)
+                if session_key:
+                    cjk_where.append("s.session_key = ?")
+                    cjk_params.append(session_key)
                 if role_filter:
                     cjk_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     cjk_params.extend(role_filter)
@@ -1995,6 +2018,9 @@ class SessionSearchMixin:
                 if exclude_sources is not None:
                     tri_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
                     tri_params.extend(exclude_sources)
+                if session_key:
+                    tri_where.append("s.session_key = ?")
+                    tri_params.append(session_key)
                 if role_filter:
                     tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     tri_params.extend(role_filter)
@@ -2088,6 +2114,9 @@ class SessionSearchMixin:
                 if exclude_sources is not None:
                     like_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
                     like_params.extend(exclude_sources)
+                if session_key:
+                    like_where.append("s.session_key = ?")
+                    like_params.append(session_key)
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
@@ -2150,6 +2179,7 @@ class SessionSearchMixin:
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
                     role_filter=role_filter,
+                    session_key=session_key,
                 )
                 seen_ids = {m["id"] for m in matches}
                 matches.extend(m for m in gap_matches if m["id"] not in seen_ids)
@@ -2190,6 +2220,7 @@ class SessionSearchMixin:
                     role_filter=role_filter,
                     limit=limit,
                     offset=offset,
+                    session_key=session_key,
                 )
                 if cjk_fb:
                     matches = cjk_fb
@@ -2207,6 +2238,7 @@ class SessionSearchMixin:
                     role_filter=role_filter,
                     limit=limit,
                     offset=offset,
+                    session_key=session_key,
                 )
                 if tri_matches:
                     matches = tri_matches
@@ -2222,6 +2254,7 @@ class SessionSearchMixin:
         source_filter: Optional[List[str]] = None,
         exclude_sources: Optional[List[str]] = None,
         role_filter: Optional[List[str]] = None,
+        session_key: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """LIKE-scan the rows the deferred rebuild hasn't indexed yet.
 
@@ -2264,6 +2297,9 @@ class SessionSearchMixin:
         if exclude_sources is not None:
             where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
             params.extend(exclude_sources)
+        if session_key:
+            where.append("s.session_key = ?")
+            params.append(session_key)
         if role_filter:
             where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
             params.extend(role_filter)

--- a/run_agent.py
+++ b/run_agent.py
@@ -663,6 +663,7 @@ class AIAgent:
                 system_prompt=self._cached_system_prompt,
                 user_id=None,
                 parent_session_id=self._parent_session_id,
+                session_key=getattr(self, "_gateway_session_key", None),
                 cwd=_launch_cwd_for_session(source),
                 profile_name=_profile_for_session,
             )

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2488,6 +2488,87 @@ class TestSessionKeyHeader:
             db.close()
 
     @pytest.mark.asyncio
+    async def test_keyless_compression_child_reuses_inherited_session_scope(
+        self, auth_adapter, tmp_path
+    ):
+        from hermes_state import SessionDB
+        from tools.session_search_tool import session_search
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(
+            "parent-session", source="api_server", session_key="parent-session"
+        )
+        db.create_session(
+            "compression-child",
+            source="api_server",
+            session_key="parent-session",
+            parent_session_id="parent-session",
+        )
+        db.append_message(
+            "compression-child", role="user", content="current compressed transcript"
+        )
+        db.create_session(
+            "foreign-session", source="api_server", session_key="foreign-session"
+        )
+        db.append_message(
+            "foreign-session", role="user", content="foreign compressed transcript"
+        )
+        auth_adapter._session_db = db
+        observed = {}
+
+        def _fake_create_agent(**kwargs):
+            observed["scope"] = kwargs.get("gateway_session_key")
+            mock_agent = MagicMock()
+
+            def _run(**_run_kwargs):
+                observed["own_read"] = json.loads(
+                    session_search(
+                        session_id="compression-child",
+                        db=db,
+                        caller_session_key=observed["scope"],
+                    )
+                )
+                observed["foreign_read"] = json.loads(
+                    session_search(
+                        session_id="foreign-session",
+                        db=db,
+                        caller_session_key=observed["scope"],
+                    )
+                )
+                return {"final_response": "ok", "messages": []}
+
+            mock_agent.run_conversation.side_effect = _run
+            mock_agent.session_id = "compression-child"
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        app = _create_app(auth_adapter)
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(
+                    auth_adapter, "_create_agent", side_effect=_fake_create_agent
+                ):
+                    resp = await cli.post(
+                        "/v1/chat/completions",
+                        headers={
+                            "X-Hermes-Session-Id": "compression-child",
+                            "Authorization": "Bearer sk-secret",
+                        },
+                        json={
+                            "model": "hermes-agent",
+                            "messages": [{"role": "user", "content": "continue"}],
+                        },
+                    )
+            assert resp.status == 200
+            assert observed["scope"] == "parent-session"
+            assert observed["own_read"]["success"] is True
+            assert observed["foreign_read"]["success"] is False
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
     async def test_responses_endpoint_accepts_session_key(self, auth_adapter):
         """Responses API honors the same X-Hermes-Session-Key contract."""
         mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2411,6 +2411,83 @@ class TestSessionKeyHeader:
             assert captured_kwargs.get("gateway_session_key") == "agent:main:webui:dm:user-7"
 
     @pytest.mark.asyncio
+    async def test_missing_session_key_scopes_search_to_session_id(
+        self, auth_adapter, tmp_path
+    ):
+        """An authenticated API turn without the optional key is still scoped."""
+        from hermes_state import SessionDB
+        from tools.session_search_tool import session_search
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("session-a", source="api_server", session_key="session-a")
+        db.create_session(
+            "session-a-history", source="api_server", session_key="session-a"
+        )
+        db.append_message(
+            "session-a-history", role="user", content="owned API transcript"
+        )
+        db.create_session(
+            "session-b", source="api_server", session_key="session-b"
+        )
+        db.append_message("session-b", role="user", content="foreign API transcript")
+        auth_adapter._session_db = db
+        observed = {}
+
+        def _fake_create_agent(**kwargs):
+            observed["scope"] = kwargs.get("gateway_session_key")
+            mock_agent = MagicMock()
+
+            def _run(**_run_kwargs):
+                observed["browse"] = json.loads(
+                    session_search(
+                        db=db,
+                        current_session_id="session-a",
+                        caller_session_key=observed["scope"],
+                    )
+                )
+                observed["foreign_read"] = json.loads(
+                    session_search(
+                        session_id="session-b",
+                        db=db,
+                        caller_session_key=observed["scope"],
+                    )
+                )
+                return {"final_response": "ok", "messages": []}
+
+            mock_agent.run_conversation.side_effect = _run
+            mock_agent.session_id = "session-a"
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        app = _create_app(auth_adapter)
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(
+                    auth_adapter, "_create_agent", side_effect=_fake_create_agent
+                ):
+                    resp = await cli.post(
+                        "/v1/chat/completions",
+                        headers={
+                            "X-Hermes-Session-Id": "session-a",
+                            "Authorization": "Bearer sk-secret",
+                        },
+                        json={
+                            "model": "hermes-agent",
+                            "messages": [{"role": "user", "content": "search"}],
+                        },
+                    )
+            assert resp.status == 200
+            assert observed["scope"] == "session-a"
+            assert {
+                row["session_id"] for row in observed["browse"]["results"]
+            } == {"session-a-history"}
+            assert observed["foreign_read"]["success"] is False
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
     async def test_responses_endpoint_accepts_session_key(self, auth_adapter):
         """Responses API honors the same X-Hermes-Session-Key contract."""
         mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -148,12 +148,18 @@ class TestStartRun:
                 assert status["object"] == "hermes.run"
 
     @pytest.mark.asyncio
-    async def test_start_binds_chat_id_for_delegation_wake_target(self, adapter):
-        """/v1/runs must bind the raw session id as the api_server chat_id
-        (like every other agent-entry route does via _run_agent): the async
+    async def test_start_binds_session_id_for_wake_target_and_agent_scope(self, adapter):
+        """/v1/runs must bind the raw session id as chat id and agent scope.
+
+        The chat-id binding provides the delegation wake target, while the
+        agent scope prevents an API run without X-Hermes-Session-Key from
+        receiving trusted local-operator session-search access.
+
+        Like every other agent-entry route does via _run_agent, the async
         delegation dispatch reads HERMES_SESSION_CHAT_ID to pick its wake
-        self-post target, and an empty binding forces background delegations
-        on this route back to synchronous execution."""
+        self-post target; an empty binding forces background delegations on
+        this route back to synchronous execution.
+        """
         app = _create_runs_app(adapter)
         captured = {}
 
@@ -191,6 +197,7 @@ class TestStartRun:
         assert captured.get("origin_session_id") == "runs-raw-sid", (
             "runs route must bind chat_id so delegation dispatch sees a wake target"
         )
+        assert mock_create.call_args.kwargs["gateway_session_key"] == "runs-raw-sid"
 
 
     @pytest.mark.asyncio

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2447,6 +2447,36 @@ class TestAgentRuntimePostHookOwnershipSync:
         assert captured["caller_session_key"] == "telegram:dm:owner"
         assert captured["profile"] == "work"
 
+    def test_api_agent_persists_gateway_scope_on_lazy_session_creation(
+        self, agent, tmp_path
+    ):
+        from hermes_state import SessionDB
+        from tools.session_search_tool import session_search
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        agent._session_db = db
+        agent._session_db_created = False
+        agent._persist_disabled = False
+        agent.platform = "api_server"
+        agent.session_id = "api-created-session"
+        agent._gateway_session_key = "api-conversation-scope"
+
+        try:
+            agent._ensure_db_session()
+
+            row = db.get_session("api-created-session")
+            assert row["session_key"] == "api-conversation-scope"
+            result = json.loads(
+                session_search(
+                    session_id="api-created-session",
+                    db=db,
+                    caller_session_key="api-conversation-scope",
+                )
+            )
+            assert result["success"] is True
+        finally:
+            db.close()
+
 
 class TestPathsOverlap:
     """Unit tests for the _paths_overlap helper."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2416,6 +2416,37 @@ class TestAgentRuntimePostHookOwnershipSync:
             tool_name for tool_name, _ in self._CASES
         }
 
+    def test_session_search_forwards_gateway_scope_and_requested_profile(
+        self, agent, monkeypatch
+    ):
+        captured = {}
+        session_db = object()
+        monkeypatch.setattr(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            lambda *args, **kwargs: (None, None),
+        )
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: False)
+        monkeypatch.setattr(agent, "_get_session_db_for_recall", lambda: session_db)
+        monkeypatch.setattr(
+            "tools.session_search_tool.session_search",
+            lambda **kwargs: captured.update(kwargs) or '{"success":true}',
+        )
+        agent._gateway_session_key = "telegram:dm:owner"
+        agent.session_id = "current-session"
+
+        result = agent._invoke_tool(
+            "session_search",
+            {"query": "needle", "profile": "work"},
+            "task-1",
+            tool_call_id="call-1",
+        )
+
+        assert json.loads(result)["success"] is True
+        assert captured["db"] is session_db
+        assert captured["current_session_id"] == "current-session"
+        assert captured["caller_session_key"] == "telegram:dm:owner"
+        assert captured["profile"] == "work"
+
 
 class TestPathsOverlap:
     """Unit tests for the _paths_overlap helper."""

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -99,7 +99,7 @@ class TestSchema:
             "sort",
             "profile",
         ]
-        assert parameters == [*historical_prefix, "detail"]
+        assert parameters == [*historical_prefix, "detail", "caller_session_key"]
 
 
 class TestFormatTimestamp:
@@ -171,6 +171,149 @@ class TestBrowseShape:
         sids = [r["session_id"] for r in result["results"]]
         assert "s_newest" not in sids
 
+
+class TestGatewayOwnershipScope:
+    @staticmethod
+    def _seed(db):
+        db.create_session(
+            "owned-current", source="telegram", session_key="telegram:dm:owner"
+        )
+        db.create_session(
+            "owned-history", source="telegram", session_key="telegram:dm:owner"
+        )
+        owned_mid = db.append_message(
+            "owned-history", role="user", content="private scope needle owned"
+        )
+        db.create_session(
+            "other-history", source="telegram", session_key="telegram:dm:other"
+        )
+        other_mid = db.append_message(
+            "other-history", role="user", content="private scope needle other"
+        )
+        return owned_mid, other_mid
+
+    def test_browse_only_lists_sessions_in_the_callers_gateway_scope(self, db):
+        self._seed(db)
+
+        result = json.loads(
+            session_search(
+                db=db,
+                current_session_id="owned-current",
+                caller_session_key="telegram:dm:owner",
+            )
+        )
+
+        assert {row["session_id"] for row in result["results"]} == {
+            "owned-history"
+        }
+
+    def test_discovery_only_returns_hits_in_the_callers_gateway_scope(self, db):
+        self._seed(db)
+
+        result = json.loads(
+            session_search(
+                query="private scope needle",
+                detail="full",
+                limit=10,
+                db=db,
+                current_session_id="owned-current",
+                caller_session_key="telegram:dm:owner",
+            )
+        )
+
+        assert {row["session_id"] for row in result["results"]} == {
+            "owned-history"
+        }
+        assert "other" not in json.dumps(result)
+
+    @pytest.mark.parametrize("shape", ["read", "scroll"])
+    def test_direct_lookup_rejects_another_gateway_scope(self, db, shape):
+        _, other_mid = self._seed(db)
+        kwargs = {"session_id": "other-history"}
+        if shape == "scroll":
+            kwargs["around_message_id"] = other_mid
+
+        result = json.loads(
+            session_search(
+                db=db,
+                current_session_id="owned-current",
+                caller_session_key="telegram:dm:owner",
+                **kwargs,
+            )
+        )
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    @pytest.mark.parametrize("shape", ["read", "scroll"])
+    def test_direct_lookup_allows_the_same_gateway_scope(self, db, shape):
+        owned_mid, _ = self._seed(db)
+        kwargs = {"session_id": "owned-history"}
+        if shape == "scroll":
+            kwargs["around_message_id"] = owned_mid
+
+        result = json.loads(
+            session_search(
+                db=db,
+                current_session_id="owned-current",
+                caller_session_key="telegram:dm:owner",
+                **kwargs,
+            )
+        )
+
+        assert result["success"] is True
+        assert result["session_id"] == "owned-history"
+
+    def test_scoped_lookup_fails_closed_for_legacy_row_without_session_key(self, db):
+        db.create_session("legacy", source="telegram")
+        db.append_message("legacy", role="user", content="legacy private text")
+
+        result = json.loads(
+            session_search(
+                db=db,
+                session_id="legacy",
+                caller_session_key="telegram:dm:owner",
+            )
+        )
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_scoped_call_rejects_explicit_and_automatic_cross_profile_lookup(
+        self, db, monkeypatch
+    ):
+        self._seed(db)
+        resolved = []
+        located = []
+        monkeypatch.setattr(
+            "tools.session_search_tool._resolve_profile_db",
+            lambda profile: resolved.append(profile),
+        )
+        monkeypatch.setattr(
+            "tools.session_search_tool._locate_session_db",
+            lambda sid: located.append(sid),
+        )
+
+        explicit = json.loads(
+            session_search(
+                db=db,
+                session_id="foreign",
+                profile="work",
+                caller_session_key="telegram:dm:owner",
+            )
+        )
+        automatic = json.loads(
+            session_search(
+                db=db,
+                session_id="missing",
+                caller_session_key="telegram:dm:owner",
+            )
+        )
+
+        assert explicit["success"] is False
+        assert automatic["success"] is False
+        assert resolved == []
+        assert located == []
 
 # =========================================================================
 # Discovery shape (with query)

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -207,6 +207,37 @@ class TestGatewayOwnershipScope:
             "owned-history"
         }
 
+    def test_browse_does_not_project_to_foreign_compression_child(self, db):
+        db.create_session(
+            "owned-compression-root",
+            source="telegram",
+            session_key="telegram:dm:owner",
+        )
+        db.append_message(
+            "owned-compression-root", role="user", content="owned root preview"
+        )
+        db.end_session("owned-compression-root", "compression")
+        db.create_session(
+            "foreign-compression-child",
+            source="telegram",
+            session_key="telegram:dm:other",
+            parent_session_id="owned-compression-root",
+        )
+        db.append_message(
+            "foreign-compression-child",
+            role="user",
+            content="foreign projected preview",
+        )
+
+        result = json.loads(
+            session_search(db=db, caller_session_key="telegram:dm:owner")
+        )
+
+        assert [row["session_id"] for row in result["results"]] == [
+            "owned-compression-root"
+        ]
+        assert "foreign projected preview" not in json.dumps(result)
+
     def test_discovery_only_returns_hits_in_the_callers_gateway_scope(self, db):
         self._seed(db)
 
@@ -285,6 +316,34 @@ class TestGatewayOwnershipScope:
         assert [row["session_id"] for row in result["results"]] == [
             "owned-title"
         ]
+
+    def test_title_match_does_not_hydrate_foreign_lineage_parent(self, db):
+        db.create_session(
+            "foreign-parent", source="telegram", session_key="telegram:dm:other"
+        )
+        db.set_session_title("foreign-parent", "Foreign Parent Secret")
+        db.create_session(
+            "owned-child",
+            source="telegram",
+            session_key="telegram:dm:owner",
+            parent_session_id="foreign-parent",
+        )
+        db.set_session_title("owned-child", "Owned Child Plan")
+        db.append_message("owned-child", role="user", content="owned child content")
+
+        result = json.loads(
+            session_search(
+                query="Owned Child Plan",
+                detail="full",
+                db=db,
+                caller_session_key="telegram:dm:owner",
+            )
+        )
+
+        assert [row["session_id"] for row in result["results"]] == ["owned-child"]
+        assert result["results"][0]["title"] == "Owned Child Plan"
+        assert "Foreign Parent Secret" not in json.dumps(result)
+        assert "parent_session_id" not in result["results"][0]
 
     @pytest.mark.parametrize("shape", ["read", "scroll"])
     def test_direct_lookup_rejects_another_gateway_scope(self, db, shape):

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -226,6 +226,66 @@ class TestGatewayOwnershipScope:
         }
         assert "other" not in json.dumps(result)
 
+    def test_discovery_scopes_before_ranking_limit(self, db, monkeypatch):
+        monkeypatch.setattr(
+            "tools.session_search_tool._DISCOVER_SCAN_LIMIT", 3
+        )
+        db.create_session(
+            "owned-low-rank", source="telegram", session_key="telegram:dm:owner"
+        )
+        db.append_message(
+            "owned-low-rank",
+            role="user",
+            content="scope starvation needle " + ("unrelated filler " * 200),
+        )
+        for index in range(4):
+            sid = f"foreign-high-rank-{index}"
+            db.create_session(
+                sid, source="telegram", session_key="telegram:dm:other"
+            )
+            db.append_message(
+                sid,
+                role="user",
+                content="scope starvation needle scope starvation needle",
+            )
+
+        result = json.loads(
+            session_search(
+                query="scope starvation needle",
+                detail="full",
+                limit=10,
+                db=db,
+                caller_session_key="telegram:dm:owner",
+            )
+        )
+
+        assert [row["session_id"] for row in result["results"]] == [
+            "owned-low-rank"
+        ]
+
+    def test_title_match_resolves_within_the_callers_gateway_scope(self, db):
+        db.create_session(
+            "owned-title", source="telegram", session_key="telegram:dm:owner"
+        )
+        db.set_session_title("owned-title", "Shared Plan")
+        db.create_session(
+            "foreign-title", source="telegram", session_key="telegram:dm:other"
+        )
+        db.set_session_title("foreign-title", "Shared Plan #2")
+
+        result = json.loads(
+            session_search(
+                query="Shared Plan",
+                detail="full",
+                db=db,
+                caller_session_key="telegram:dm:owner",
+            )
+        )
+
+        assert [row["session_id"] for row in result["results"]] == [
+            "owned-title"
+        ]
+
     @pytest.mark.parametrize("shape", ["read", "scroll"])
     def test_direct_lookup_rejects_another_gateway_scope(self, db, shape):
         _, other_mid = self._seed(db)

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -324,6 +324,32 @@ class TestGatewayOwnershipScope:
         assert result["success"] is True
         assert result["session_id"] == "owned-history"
 
+    def test_scroll_rebind_rejects_child_from_another_gateway_scope(self, db):
+        db.create_session(
+            "owned-parent", source="telegram", session_key="telegram:dm:owner"
+        )
+        db.create_session(
+            "foreign-child",
+            source="telegram",
+            session_key="telegram:dm:other",
+            parent_session_id="owned-parent",
+        )
+        foreign_mid = db.append_message(
+            "foreign-child", role="user", content="foreign child transcript"
+        )
+
+        result = json.loads(
+            session_search(
+                db=db,
+                session_id="owned-parent",
+                around_message_id=foreign_mid,
+                caller_session_key="telegram:dm:owner",
+            )
+        )
+
+        assert result["success"] is False
+        assert "foreign child transcript" not in json.dumps(result)
+
     def test_scoped_lookup_fails_closed_for_legacy_row_without_session_key(self, db):
         db.create_session("legacy", source="telegram")
         db.append_message("legacy", role="user", content="legacy private text")

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -405,6 +405,18 @@ def _session_in_scope(db, session_id: str, caller_session_key: str = None) -> bo
     return bool(row.get("session_key")) and row.get("session_key") == caller_session_key
 
 
+def _scoped_lineage_root(
+    db, session_id: str, caller_session_key: str = None
+) -> str:
+    """Resolve lineage without crossing a gateway ownership boundary."""
+    root = _resolve_lineage(db, session_id)
+    if caller_session_key and not _session_in_scope(
+        db, root, caller_session_key
+    ):
+        return session_id
+    return root
+
+
 def _locate_session_db(session_id: str):
     """Scan every profile's ``state.db`` (read-only) for a session id.
 
@@ -526,10 +538,16 @@ def _list_recent_sessions(
             _resolve_to_parent(db, current_session_id)
             if current_session_id else (None, False)
         )
+        if current_root and caller_session_key and not _session_in_scope(
+            db, current_root, caller_session_key
+        ):
+            current_root = current_session_id
 
         results = []
         for s in sessions:
             sid = s.get("id", "")
+            if not _session_in_scope(db, sid, caller_session_key):
+                continue
             if sid == current_session_id:
                 continue
             # Compression continuation: the root's original turns were
@@ -736,7 +754,9 @@ def _title_match_result(
     if not _session_in_scope(db, session_id, caller_session_key):
         return None
 
-    lineage_root = _resolve_lineage(db, session_id)
+    lineage_root = _scoped_lineage_root(
+        db, session_id, caller_session_key
+    )
     if current_lineage_root and lineage_root == current_lineage_root:
         # Same-lineage title hits are in-context only when the session is
         # still live. /new-reset and compression-ended parents are not.
@@ -802,7 +822,10 @@ def _discover(
 ) -> str:
     """Discovery shape: FTS5 plus adaptive or full result hydration."""
     role_list = role_filter if role_filter else ["user", "assistant"]
-    current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
+    current_lineage_root = (
+        _scoped_lineage_root(db, current_session_id, caller_session_key)
+        if current_session_id else None
+    )
     title_result = _title_match_result(
         db, query, current_lineage_root, caller_session_key
     )
@@ -862,6 +885,10 @@ def _discover(
             break
         raw_sid = r["session_id"]
         resolved_sid, _ = _resolve_to_parent(db, raw_sid)
+        if caller_session_key and not _session_in_scope(
+            db, resolved_sid, caller_session_key
+        ):
+            resolved_sid = raw_sid
         # Skip the current session lineage — UNLESS the hit's transcript has
         # left live context. Three sub-cases:
         #
@@ -909,8 +936,13 @@ def _discover(
             logging.warning("get_anchored_view failed for %s/%s: %s", hit_sid, msg_id, e, exc_info=True)
             continue
 
+        metadata_sid = (
+            lineage_root
+            if _session_in_scope(db, lineage_root, caller_session_key)
+            else hit_sid
+        )
         try:
-            session_meta = db.get_session(lineage_root) or {}
+            session_meta = db.get_session(metadata_sid) or {}
         except Exception:
             session_meta = {}
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -569,6 +569,7 @@ def _scroll(
     around_message_id: int,
     window: int = 5,
     current_session_id: str = None,
+    caller_session_key: str = None,
 ) -> str:
     """Scroll shape: return a window of messages centered on an anchor.
 
@@ -652,7 +653,11 @@ def _scroll(
     rebind_warning = None
     if not messages:
         owning = owning_session_id
-        if owning and owning != session_id:
+        if (
+            owning
+            and owning != session_id
+            and _session_in_scope(db, owning, caller_session_key)
+        ):
             a_root = _resolve_lineage(db, session_id)
             o_root = _resolve_lineage(db, owning)
             if a_root and o_root and a_root == o_root:
@@ -1046,6 +1051,7 @@ def _session_search_impl(
             around_message_id=around_message_id,
             window=window,
             current_session_id=current_session_id,
+            caller_session_key=caller_session_key,
         )
 
     # Read shape: a session_id with no anchor → dump the whole session.

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -717,7 +717,12 @@ def _title_match_result(
         return None
 
     try:
-        session_id = db.resolve_session_by_title(title_query)
+        if caller_session_key:
+            session_id = db.resolve_session_by_title(
+                title_query, session_key=caller_session_key
+            )
+        else:
+            session_id = db.resolve_session_by_title(title_query)
     except Exception:
         logging.debug("resolve_session_by_title failed for %r", title_query, exc_info=True)
         return None
@@ -798,7 +803,7 @@ def _discover(
     )
 
     try:
-        raw_results = db.search_messages(
+        search_kwargs = dict(
             query=query,
             role_filter=role_list,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
@@ -809,6 +814,9 @@ def _discover(
             sort=sort,
             fields=_DISCOVER_SEARCH_FIELDS,
         )
+        if caller_session_key:
+            search_kwargs["session_key"] = caller_session_key
+        raw_results = db.search_messages(**search_kwargs)
     except Exception as e:
         logging.error("FTS5 search failed: %s", e, exc_info=True)
         return tool_error(f"Search failed: {e}", success=False)
@@ -817,13 +825,7 @@ def _discover(
     # high-volume cron corpus can't starve the user's own sessions out of the
     # top `limit` results (#19434). Stable — preserves BM25/recency order
     # within each class.
-    raw_results = _order_for_recall(
-        [
-            row
-            for row in raw_results
-            if _session_in_scope(db, row.get("session_id"), caller_session_key)
-        ]
-    )
+    raw_results = _order_for_recall(raw_results)
 
     if not raw_results and not title_result:
         _empty_payload = {

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -388,6 +388,23 @@ def _session_link(session_id: str, profile: str = None) -> str:
     return f"@session:{name}/{session_id}" if name else f"@session:{session_id}"
 
 
+def _session_in_scope(db, session_id: str, caller_session_key: str = None) -> bool:
+    """Whether *session_id* belongs to the caller's gateway conversation.
+
+    Local CLI/desktop callers have no gateway session key and retain the
+    profile-wide history behavior. Gateway callers are scoped by the exact
+    stable key that already separates DM/group/thread and per-user sessions.
+    Missing or legacy ownership metadata fails closed.
+    """
+    if not caller_session_key:
+        return True
+    try:
+        row = db.get_session(session_id) or {}
+    except Exception:
+        return False
+    return bool(row.get("session_key")) and row.get("session_key") == caller_session_key
+
+
 def _locate_session_db(session_id: str):
     """Scan every profile's ``state.db`` (read-only) for a session id.
 
@@ -482,7 +499,13 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
     return json.dumps(response, ensure_ascii=False)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None) -> str:
+def _list_recent_sessions(
+    db,
+    limit: int,
+    current_session_id: str = None,
+    link_profile: str = None,
+    caller_session_key: str = None,
+) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
         # list_sessions_rich (include_children=False) already applies the
@@ -496,6 +519,7 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_p
             limit=limit + 15,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             order_by_last_active=True,
+            session_key=caller_session_key,
         )  # fetch extra so we can skip current / compression roots
 
         current_root, has_compression_hop = (
@@ -685,6 +709,7 @@ def _title_match_result(
     db,
     query: str,
     current_lineage_root: Optional[str],
+    caller_session_key: str = None,
 ) -> Optional[Dict[str, Any]]:
     """Return a discovery-shaped result when the query matches a session title."""
     title_query = _normalize_title_query(query)
@@ -697,6 +722,8 @@ def _title_match_result(
         logging.debug("resolve_session_by_title failed for %r", title_query, exc_info=True)
         return None
     if not session_id:
+        return None
+    if not _session_in_scope(db, session_id, caller_session_key):
         return None
 
     lineage_root = _resolve_lineage(db, session_id)
@@ -761,11 +788,14 @@ def _discover(
     detail: str,
     current_session_id: str = None,
     link_profile: str = None,
+    caller_session_key: str = None,
 ) -> str:
     """Discovery shape: FTS5 plus adaptive or full result hydration."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
+    title_result = _title_match_result(
+        db, query, current_lineage_root, caller_session_key
+    )
 
     try:
         raw_results = db.search_messages(
@@ -787,7 +817,13 @@ def _discover(
     # high-volume cron corpus can't starve the user's own sessions out of the
     # top `limit` results (#19434). Stable — preserves BM25/recency order
     # within each class.
-    raw_results = _order_for_recall(raw_results)
+    raw_results = _order_for_recall(
+        [
+            row
+            for row in raw_results
+            if _session_in_scope(db, row.get("session_id"), caller_session_key)
+        ]
+    )
 
     if not raw_results and not title_result:
         _empty_payload = {
@@ -949,6 +985,7 @@ def _session_search_impl(
     profile: str = None,
     # Discovery result shaping (appended to preserve positional compatibility)
     detail: str = "adaptive",
+    caller_session_key: str = None,
     *,
     _owned_dbs: Optional[List[Any]] = None,
 ) -> str:
@@ -975,6 +1012,14 @@ def _session_search_impl(
             if emb_profile and (profile is None or not str(profile).strip()):
                 profile = emb_profile
 
+    # A gateway conversation is never authority to traverse another profile.
+    # Local operator surfaces have no caller_session_key and preserve explicit
+    # cross-profile links for desktop/CLI workflows.
+    if caller_session_key and profile is not None and str(profile).strip():
+        return tool_error(
+            "session_id not found in the current conversation", success=False
+        )
+
     # Cross-profile read: swap in the named profile's DB (read-only) for every
     # shape below. The current-session-lineage guards no longer apply across
     # profiles, but they key off ids that won't collide, so they stay inert.
@@ -991,6 +1036,8 @@ def _session_search_impl(
 
     # Scroll shape takes precedence — explicit anchor beats any query.
     if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
+        if not _session_in_scope(db, session_id.strip(), caller_session_key):
+            return tool_error(f"session_id not found: {session_id.strip()}", success=False)
         return _scroll(
             db=db,
             session_id=session_id,
@@ -1002,6 +1049,8 @@ def _session_search_impl(
     # Read shape: a session_id with no anchor → dump the whole session.
     if isinstance(session_id, str) and session_id.strip():
         sid = session_id.strip()
+        if not _session_in_scope(db, sid, caller_session_key):
+            return tool_error(f"session_id not found: {sid}", success=False)
         result = _read_session(db, sid, link_profile=profile)
         if json.loads(result).get("success"):
             return result
@@ -1009,7 +1058,9 @@ def _session_search_impl(
         # Miss in the target profile — the model may have dropped the owning
         # profile from the link. Scan every profile and read it from wherever
         # it lives, tagging the profile it was found in.
-        located, owner = _locate_session_db(sid)
+        located, owner = (None, None)
+        if not caller_session_key:
+            located, owner = _locate_session_db(sid)
         if located is not None:
             try:
                 found = json.loads(_read_session(located, sid, link_profile=owner))
@@ -1030,7 +1081,13 @@ def _session_search_impl(
 
     # Browse shape: no query → recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id, link_profile=profile)
+        return _list_recent_sessions(
+            db,
+            limit,
+            current_session_id,
+            link_profile=profile,
+            caller_session_key=caller_session_key,
+        )
 
     # Parse role_filter
     role_list: Optional[List[str]] = None
@@ -1059,6 +1116,7 @@ def _session_search_impl(
         detail=detail_norm,
         current_session_id=current_session_id,
         link_profile=profile,
+        caller_session_key=caller_session_key,
     )
 
 
@@ -1078,6 +1136,8 @@ def session_search(
     profile: str = None,
     # Discovery result shaping (appended to preserve positional compatibility)
     detail: str = "adaptive",
+    # Internal ownership scope (not model-facing).
+    caller_session_key: str = None,
 ) -> str:
     """Run session search and close databases opened by this invocation."""
     owned_dbs: List[Any] = []
@@ -1106,6 +1166,7 @@ def session_search(
             sort=sort,
             profile=profile,
             detail=detail,
+            caller_session_key=caller_session_key,
             _owned_dbs=owned_dbs,
         )
     finally:
@@ -1315,6 +1376,7 @@ registry.register(
         profile=args.get("profile"),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id"),
+        caller_session_key=kw.get("caller_session_key"),
     ),
     check_fn=check_session_search_requirements,
     emoji="🔍",


### PR DESCRIPTION
## What does this PR do?

Gateway users could ask `session_search` to browse, search, or read transcripts owned by another chat, and scoped requests could also traverse other profiles. This exposed private conversation content across the gateway ownership boundary. The fix forwards the stable gateway session key into the tool, filters every lookup and discovery backend before ranking or limiting results, and keeps unscoped local CLI and Desktop operator workflows unchanged.

### Symptom

A gateway session could discover or read another session's messages from the shared profile database. It could also request another profile explicitly or rely on automatic profile scanning when reading a guessed session ID.

### Impact

Anyone able to invoke the agent-facing tool in a shared gateway profile could retrieve private transcripts belonging to another chat or profile. The affected browse, discovery, read, and scroll shapes returned message content without enforcing the ownership boundary already used by gateway session routing.

### Bug Cause

**Trigger:** `agent/agent_runtime_helpers.py` / `_handle_session_search_tool` invoked `session_search` without the caller's gateway session key.

**Causal chain:**
1. A gateway user invokes a browse, discovery, read, or scroll shape of `session_search`.
2. The runtime passes the shared profile database but omits the stable gateway ownership key, while the tool accepts arbitrary profile targets and may scan profiles automatically.
3. Session queries operate across every row visible to that database or profile lookup and return another owner's transcript.

**Why it is wrong:** Session records already carry the gateway `session_key`, but the tool did not propagate or enforce it. Discovery also ranked and limited global results before ownership filtering, which could hide valid owned matches behind foreign rows and resolve colliding titles from the wrong scope.

**Working sibling / contrast:** Gateway session routing and `/resume` validate the target against the caller's stable session ownership metadata before exposing a conversation.

**Ruled out:** This is not caused by session IDs colliding or by profile filesystem permissions. Disposable databases with distinct session IDs reproduced the leak through the public tool entry solely because ownership metadata was not applied to its queries.

### Fix

- Forward `gateway_session_key` through the agent runtime interception path.
- Fail closed for scoped explicit or automatic cross-profile access.
- Apply the ownership key to browse, discovery, read, scroll, title lookup, and every SessionDB search backend before ranking and `LIMIT`.
- Preserve existing unscoped local CLI and Desktop cross-profile lookup behavior.
- Add regressions for cross-chat access, cross-profile traversal, ranking starvation, title collisions, and runtime argument forwarding.

## Related Issue

Fixes #87779

## Type of Change

- [x] Security fix

## Changes Made

- `agent/agent_runtime_helpers.py` - forwards the gateway ownership scope to `session_search`.
- `tools/session_search_tool.py` - enforces scoped reads and blocks cross-profile traversal for gateway callers.
- `hermes_state.py` and `hermes_state_search.py` - apply session ownership filters before title resolution, ranking, and result limits.
- `tests/tools/test_session_search.py` - covers all tool shapes, cross-profile paths, ranking starvation, and title collisions.
- `tests/run_agent/test_run_agent.py` - verifies runtime scope forwarding.

## How to Test

1. Create disposable sessions with different `session_key` values in one `SessionDB` and confirm a scoped caller can only browse, discover, read, and scroll its own sessions.
2. Confirm scoped explicit and automatic cross-profile lookup fails closed while unscoped local operator lookup remains available.
3. Run the related test suites:

```bash
scripts/run_tests.sh tests/tools/test_session_search.py
scripts/run_tests.sh tests/run_agent/test_run_agent.py -k session_search_forwards_gateway_scope_and_requested_profile
scripts/run_tests.sh tests/test_hermes_state.py
```

Verified results: 63 passed; 1 passed; 237 passed and 2 skipped, respectively. Ruff passed on all six affected production and test files, and `git diff --check hermes/main...HEAD` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on all related suites and all related tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the authorization logic is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; the public schema remains compatible and ownership scope is runtime-internal

## Screenshots / Logs

Not applicable. The security boundary is covered with disposable database behavior tests.
