### PR TITLE
fix(config): tokenise EDITOR value so editor arguments work in config edit

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4730,8 +4730,18 @@ def edit_config():
         print(f"  {config_path}")
         return
     
+    try:
+        from hermes_cli._subprocess_compat import split_command_line
+        editor_argv = split_command_line(editor)
+    except ValueError:
+        # Unbalanced quotes — fall back to the literal string so the launch
+        # still happens (and surfaces the editor's own error) instead of ours.
+        editor_argv = [editor]
+    if not editor_argv:
+        editor_argv = [editor]
+
     print(f"Opening {config_path} in {editor}...")
-    subprocess.run([editor, str(config_path)])
+    subprocess.run([*editor_argv, str(config_path)])
 
 
 def _cron_model_drift_axis_for_config_key(key: str) -> Optional[str]:

--- a/tests/hermes_cli/test_config_edit_editor_args.py
+++ b/tests/hermes_cli/test_config_edit_editor_args.py
@@ -1,0 +1,81 @@
+"""Regression tests for ``hermes config edit`` editor handling.
+
+``edit_config()`` historically passed the whole ``$EDITOR``/``$VISUAL`` string
+as a single argv element, so the extremely common ``EDITOR="code --wait"``
+(or ``vim -f``) spelled a nonexistent executable and crashed with
+``FileNotFoundError`` / WinError 2. The fix tokenizes the editor string with
+``split_command_line`` (Windows-safe, unlike bare ``shlex.split``) and appends
+the config path as the final argument.
+"""
+
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+from hermes_cli import config as config_mod
+from hermes_cli._subprocess_compat import split_command_line
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(config_mod, "is_managed", lambda: False)
+    return home
+
+
+def _run_edit(monkeypatch, editor_value):
+    calls = []
+    def fake_run(argv, *args, **kwargs):
+        calls.append(list(argv))
+        return mock.Mock(returncode=0)
+
+    monkeypatch.setattr(os, "getenv", lambda k, d=None: editor_value if k == "EDITOR" else d)
+    monkeypatch.setattr(config_mod.subprocess, "run", fake_run)
+    config_mod.edit_config()
+    return calls
+
+
+def test_editor_with_arguments(isolated_home, monkeypatch):
+    """EDITOR="code --wait" must arrive as two tokens, not one."""
+    calls = _run_edit(monkeypatch, "code --wait")
+    assert calls, "subprocess.run was never invoked"
+    argv = calls[0]
+    assert argv[:-1] == ["code", "--wait"], f"expected tokenized editor, got {argv}"
+    # The config path is the final argument.
+    assert argv[-1].endswith(os.sep + "config.yaml") or argv[-1].endswith("config.yaml")
+
+
+def test_editor_plain(isolated_home, monkeypatch):
+    """A bare editor name keeps working exactly as before."""
+    calls = _run_edit(monkeypatch, "vim")
+    assert calls[0][:-1] == ["vim"]
+
+
+def test_editor_quoted_path_with_spaces(isolated_home, monkeypatch):
+    """A quoted editor path containing spaces survives tokenization."""
+    editor = '"C:\\Program Files\\My Editor\\editor.exe" -w'
+    calls = _run_edit(monkeypatch, editor)
+    argv = calls[0]
+    assert argv[0] == "C:\\Program Files\\My Editor\\editor.exe", (
+        f"quoted path mangled on {sys.platform}: {argv}"
+    )
+    assert argv[1] == "-w"
+
+
+def test_editor_unbalanced_quotes_falls_back_to_literal(isolated_home, monkeypatch):
+    """A malformed editor string still launches rather than raising."""
+    calls = _run_edit(monkeypatch, 'editor "unclosed')
+    assert calls, "unbalanced quotes should fall back to the literal string"
+
+
+def test_split_command_line_windows_paths_preserved():
+    """The tokenizer must not eat backslashes (why shlex.split is not used)."""
+    tokens = split_command_line('C:\\Editors\\me.exe --flag "C:\\a b.txt"')
+    assert tokens[0] == "C:\\Editors\\me.exe"
+    assert tokens[1] == "--flag"
+    if sys.platform == "win32":
+        assert tokens[2] == "C:\\a b.txt"


### PR DESCRIPTION
## Summary

`hermes config edit` passed the whole `$EDITOR`/`$VISUAL` string to `subprocess.run` as a single argv element, so the common `EDITOR="code --wait"` (or `vim -f`) spelled a nonexistent executable and crashed with `FileNotFoundError` / `WinError 2`.

Tokenise with `split_command_line` (the repo's Windows-safe splitter that preserves backslash paths, unlike bare `shlex.split`), append the config path as thefinal argument, and fall back to the literal string when tokenization fails (unbalanced quotes).

Matches the TUI's `resolveEditor`, which already treats `$EDITOR` as a space-separated command.

## Reproduction (before)

```text
$ EDITOR="code --wait" hermes config edit
Opening .../config.yaml in code --wait...
FileNotFoundError: [WinError 2] The system cannot find the file specified: 'code --wait'
```

## Related issues / PRs

Distinct from #81364 and PRs #81366 / #83732 / #58082 / #59506, which cover the `/prompt` compose shell-fallback path (`cli_commands_mixin.py`), not `config edit`. #71127 only improves the no-editor hint message and does not touch this code path.

## Validation

- New regression tests `tests/hermes_cli/test_config_edit_editor_args.py`: **5 passed** (2 of them fail on the pre-fix code — verified against the untouched upstream tree)
- Existing `tests/hermes_cli/test_config.py`: 77 passed, 1 pre-existing failure (`TestGetHermesHome::test_default_path`, also fails on clean `origin/main` in this environment)
- `scripts/check-windows-footguns.py --all`: no findings across 973 files

## Checklist

- [x] Regression tests added
- [x] No new dependencies
- [x] No secrets added
- [x] Branch pushed to fork only