### PR TITLE
fix(desktop): hermes desktop fails to launch on Linux when a GitHub token is in the environment

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,6 +5,10 @@
   "version": "0.17.0",
   "description": "Native desktop shell for Hermes Agent.",
   "author": "Nous Research",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NousResearch/hermes-agent.git"
+  },
   "type": "module",
   "main": "dist/electron-main.mjs",
   "engines": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,7 +28,7 @@
     "postbuild": "node scripts/assert-dist-built.mjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.mjs",
     "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 node scripts/run-electron-builder.mjs",
-    "pack": "npm run build && npm run builder -- --dir",
+    "pack": "npm run build && npm run builder -- --dir --publish never",
     "dist": "npm run build && npm run builder",
     "dist:mac": "npm run build && npm run builder -- --mac",
     "dist:mac:dmg": "npm run build && npm run builder -- --mac dmg",

--- a/apps/desktop/scripts/local-pack-publish.test.mjs
+++ b/apps/desktop/scripts/local-pack-publish.test.mjs
@@ -1,0 +1,112 @@
+/**
+ * Regression #87758: a local desktop pack must never enter electron-builder's
+ * publish path, and publish resolution must succeed when something else does
+ * enter it.
+ *
+ * These call the real app-builder-lib resolver rather than asserting on the
+ * text of the pack script, so they fail if electron-builder changes the
+ * behavior we depend on — not when someone reformats package.json.
+ */
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, test } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const desktopDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const desktopPkg = require(path.join(desktopDir, 'package.json'))
+
+const { getPublishConfigs } = require('app-builder-lib/out/publish/PublishManager.js')
+const { getRepositoryInfo } = require('app-builder-lib/out/util/repositoryInfo.js')
+
+/**
+ * The slice of PlatformPackager that getPublishConfigs actually reads. The
+ * repositoryInfo getter mirrors what electron-builder does for real: resolve
+ * from THIS package's metadata with projectDir = apps/desktop.
+ */
+function fakePackager(metadata) {
+  const info = {
+    get repositoryInfo() {
+      return getRepositoryInfo(desktopDir, metadata, null)
+    },
+    appInfo: { version: '0.0.0', channel: null, updaterCacheDirName: 'hermes' },
+    config: {},
+    options: {}
+  }
+  return {
+    platformSpecificBuildOptions: {},
+    config: {},
+    info,
+    platform: { name: 'linux' },
+    appInfo: info.appInfo,
+    expandMacro: value => value
+  }
+}
+
+const TOKEN_VARS = ['GH_TOKEN', 'GITHUB_TOKEN', 'GITLAB_TOKEN', 'KEYGEN_TOKEN', 'BITBUCKET_TOKEN']
+let savedEnv
+
+beforeEach(() => {
+  savedEnv = {}
+  for (const key of TOKEN_VARS) {
+    savedEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  for (const key of TOKEN_VARS) {
+    if (savedEnv[key] === undefined) delete process.env[key]
+    else process.env[key] = savedEnv[key]
+  }
+})
+
+describe('local desktop pack stays out of the publish path', () => {
+  test('the pack script pins an explicit publish policy', () => {
+    // electron-builder 26 infers `onTagOrDraft` from CI when --publish is
+    // absent, and `hermes desktop` runs the pack with CI=1 (_npm_lifecycle_env).
+    // v27 drops the implicit behavior, so being explicit is also forward-safe.
+    const pack = desktopPkg.scripts.pack
+    assert.match(pack, /--dir\b/)
+    assert.match(pack, /--publish\s+never\b/)
+  })
+
+  test('publish resolution succeeds with a GitHub token present', async () => {
+    // The #87758 failure mode: CI=1 makes isPublish true, a GITHUB_TOKEN in the
+    // environment auto-selects the github provider, and the provider needs a
+    // repository it cannot find — apps/desktop has no .git/config of its own
+    // and app-builder-lib does not walk up to the workspace root.
+    process.env.GITHUB_TOKEN = 'x'
+
+    const configs = await getPublishConfigs(
+      fakePackager(desktopPkg),
+      null,
+      null,
+      /* errorIfCannot */ true
+    )
+
+    assert.ok(Array.isArray(configs) && configs.length > 0)
+    assert.equal(configs[0].provider, 'github')
+    assert.equal(configs[0].owner, 'NousResearch')
+    assert.equal(configs[0].repo, 'hermes-agent')
+  })
+
+  test('a package without the repository field is what breaks resolution', async () => {
+    // Guards the fix itself: proves the assertion above passes because of the
+    // repository field, not because the throw is unreachable.
+    process.env.GITHUB_TOKEN = 'x'
+    const { repository, ...withoutRepository } = desktopPkg
+    assert.ok(repository, 'apps/desktop/package.json must declare a repository')
+
+    await assert.rejects(
+      () => getPublishConfigs(fakePackager(withoutRepository), null, null, true),
+      /Cannot detect repository by \.git\/config/
+    )
+  })
+
+  test('resolution is quiet when no publish token is configured', async () => {
+    const configs = await getPublishConfigs(fakePackager(desktopPkg), null, null, true)
+    assert.deepEqual(configs, [])
+  })
+})


### PR DESCRIPTION
`hermes desktop` fails to launch on Linux after updating: the desktop rebuild dies in electron-builder before the app window (or the gateway dialog) ever appears.

```
• Implicit publishing triggered by CI detection.
⨯ Cannot detect repository by .git/config. Please specify "repository" in the package.json
✗ Desktop GUI build failed
```

Two independent conditions have to line up, which is why this only hit some people. `_npm_lifecycle_env()` sets `CI=1` (added in #87440 to scrub `ESBUILD_BINARY_PATH`), and electron-builder 26 reads an ambient CI as an implicit request to publish when `--publish` is absent. That alone is harmless. But if the user also has a `GITHUB_TOKEN` in their environment — a secrets manager populating the shell is enough — electron-builder auto-selects the github publish provider, which needs to resolve `owner`/`repo`. It reads the `repository` field, falling back to `<projectDir>/.git/config`. `projectDir` is `apps/desktop`, which has no `.git` of its own, and app-builder-lib does not walk up to the workspace root. Resolution returns null and throws.

Verified against the installed app-builder-lib 26.15.3:

| environment | `isPublish` | result |
|---|---|---|
| no CI, no token (pre-#87440) | false | ok |
| CI=1, no token | true | ok |
| **CI=1 + GITHUB_TOKEN** | true | **throws** |
| CI=1 + token, `--publish never` | false | ok |
| CI=1 + token, `repository` declared | true | ok → `github` |

It surfaces on Linux specifically. The throw happens in `onAfterPack`, and that handler early-returns for darwin unless the target is dmg/zip and for Windows unless it's an nsis-family target — a plain `dir` build skips it. Linux has no equivalent guard, so a `--dir` pack runs the publish resolution for real.

The fix is both halves, because they cover different callers. `--publish never` on the `pack` script keeps the local unpacked build out of the publish path entirely, and matches what electron-builder asks for — the implicit-CI behavior is removed in v27. Declaring `repository` fixes resolution for the paths `--publish never` doesn't cover: `dist:*` and `scripts/test-desktop.mjs` still resolve publish config on any machine with a token, and `scripts/install.sh` invokes `npm run pack` directly without going through `_npm_lifecycle_env()` at all.

Scrubbing `CI` from the build env was the other candidate and I did not take it: it only fixes callers that go through `hermes_cli/main.py`, leaving the installer's direct `npm run pack` broken, and `CI=1` is load-bearing there — it's what keeps `unicode-animations`' postinstall from animating to `/dev/tty`.

The tests call the real app-builder-lib resolver instead of asserting on the text of `package.json`, so they track electron-builder's actual behavior rather than our formatting. Three of the four fail on unpatched `main` and pass with the fix.

## Testing

- `npx vitest run --project electron` — 1239 passed. One unrelated pre-existing failure (`connection-registry.test.ts > backendScopeKey`, `shared.backendScopeKey is not a function`), confirmed failing identically on untouched `main`.
- `scripts/run_tests.sh tests/hermes_cli/test_gui_command.py` — 23 passed, 8 skipped.
- Reverted each half and confirmed the new tests go red, so they can actually detect the regression.
- A full Linux pack can't run from macOS (node-pty has no linux-arm64 prebuild), so the Linux `onAfterPack` path was exercised by calling `getAppUpdatePublishConfiguration` directly with the real library: throws before, resolves to `NousResearch/hermes-agent` after.

Supersedes #87667, #87778, #87784, #87800.
Closes #87758.

Credit to @airo7 and @frankmendes1979 for the `repository` diagnosis, and @webtecnica and @fangliquanflq for identifying the #87440 CI regression.