### PR TITLE
fix(gateway): end api_server sessions on /v1/runs complete (ghost-session leak)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6774,6 +6774,21 @@ class APIServerAdapter(BasePlatformAdapter):
         async def _run_and_close():
             try:
                 self._set_run_status(run_id, "running")
+                # Reopen a session that a previous run closed. strategy="issue"
+                # (Paperclip's resolveSessionKey) deliberately reuses one
+                # session_id across runs on the same issue, and neither
+                # _insert_session_row's ON CONFLICT nor append_message clears or
+                # checks ended_at -- so without this a reused session would stay
+                # marked ended while still accreting messages, i.e. prune bait.
+                # MUST stay paired with the end_session() in the finally below.
+                try:
+                    _db = self._ensure_session_db()
+                    if _db is not None:
+                        _row = _db.get_session(session_id) or {}
+                        if _row.get("ended_at") is not None:
+                            _db.reopen_session(session_id)
+                except Exception:
+                    logger.debug("[api_server] session reopen failed", exc_info=True)
                 if run_id in self._stopping_run_ids:
                     _put_event_if_active({
                         "event": "run.cancelled",
@@ -7029,6 +7044,33 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
                 self._stopping_run_ids.discard(run_id)
+                # Close the persisted session row -- the ghost-session leak.
+                #
+                # Despite the name, _run_and_close() closed no session: it never
+                # called agent.close() and never called SessionDB.end_session(),
+                # so every /v1/runs session kept ended_at NULL forever. Because
+                # prune_sessions() only ever reaps rows with ended_at set, those
+                # sessions were permanently unreclaimable and state.db grew
+                # without bound. cron/scheduler.py already closes in its own
+                # finally, and webhook.py's _end_webhook_session fixed this
+                # exact bug on the sibling path -- see its docstring, which
+                # names "the ghost-session leak" and "state.db bloat".
+                #
+                # The guard runs AFTER the pops so a run never sees itself.
+                # end_session() is first-reason-wins and no-ops on an
+                # already-ended row, so this cannot clobber a
+                # 'compression'/'agent_close' reason.
+                try:
+                    _still_active = any(
+                        (self._run_statuses.get(_other) or {}).get("session_id") == session_id
+                        for _other in self._active_run_tasks
+                    )
+                    if not _still_active:
+                        _db = self._ensure_session_db()
+                        if _db is not None:
+                            _db.end_session(session_id, "api_run_complete")
+                except Exception:
+                    logger.debug("[api_server] failed to end session", exc_info=True)
 
         self._activate_admitted_request()
         task = asyncio.create_task(_run_and_close())

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -123,6 +123,76 @@ def auth_adapter():
 
 class TestStartRun:
     @pytest.mark.asyncio
+    async def test_completed_run_ends_persisted_session(self, adapter):
+        app = _create_runs_app(adapter)
+        session_db = MagicMock()
+        session_db.get_session.return_value = {"id": "runs-session", "ended_at": None}
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_ensure_session_db", return_value=session_db),
+                patch.object(adapter, "_create_agent") as mock_create,
+            ):
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "runs-session"},
+                )
+                run_id = (await resp.json())["run_id"]
+                for _ in range(40):
+                    if run_id not in adapter._active_run_tasks:
+                        break
+                    await asyncio.sleep(0.05)
+
+        session_db.end_session.assert_called_once_with(
+            "runs-session", "api_run_complete"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reused_ended_session_is_reopened_before_run(self, adapter):
+        app = _create_runs_app(adapter)
+        session_db = MagicMock()
+        session_db.get_session.return_value = {
+            "id": "runs-session",
+            "ended_at": "2026-08-01T00:00:00Z",
+        }
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_ensure_session_db", return_value=session_db),
+                patch.object(adapter, "_create_agent") as mock_create,
+            ):
+                mock_agent = MagicMock()
+
+                def _run(**_kwargs):
+                    session_db.reopen_session.assert_called_once_with("runs-session")
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "runs-session"},
+                )
+                run_id = (await resp.json())["run_id"]
+                for _ in range(40):
+                    if run_id not in adapter._active_run_tasks:
+                        break
+                    await asyncio.sleep(0.05)
+
+        session_db.reopen_session.assert_called_once_with("runs-session")
+
+    @pytest.mark.asyncio
     async def test_start_returns_202(self, adapter):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:


### PR DESCRIPTION
## Why

`_run_and_close()` never called `SessionDB.end_session()`, so every `/v1/runs` session kept `ended_at` NULL forever. `prune_sessions()` only reaps ended rows, so api_server sessions accumulated unbounded and drove `state.db` bloat.

The identical bug was already fixed on the webhook path (`webhook.py::_end_webhook_session` / "the ghost-session leak").

## What

Paired changes (must ship together):

- **finally:** `end_session(session_id, "api_run_complete")` when no other in-flight run still shares the `session_id`
- **run start:** `reopen_session` if a previous run already closed it (issue-scoped session reuse leaves `ended_at` set; `ON CONFLICT` never clears it)

## Notes

- `/v1/chat/completions` and `/v1/responses` appear by inspection to share the same shape; not claimed fixed here.
- Replaces the conflicting earlier PR #79467 (same fix, rebased onto current `main`).

## Tests

`pytest tests/gateway/test_api_server_runs.py::TestStartRun::test_completed_run_ends_persisted_session tests/gateway/test_api_server_runs.py::TestStartRun::test_reused_ended_session_is_reopened_before_run tests/gateway/test_api_server_runs.py::TestStartRun::test_start_returns_202` — 3 passed.