### PR TITLE
fix(cli): detect Windows Smart App Control blocks during hermes update

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
+from hermes_cli.windows_policy_block import detect_policy_block, policy_block_guidance
 from hermes_constants import venv_python_path
 
 logger = logging.getLogger(__name__)
@@ -923,6 +924,12 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
 
     except Exception as e:
         print(f"✗ ZIP update failed: {e}")
+        if detect_policy_block(e):
+            # Windows Smart App Control / WDAC blocked the staging copy or a
+            # spawned child — surface the actual cause next to the wire error
+            # instead of letting it read as a generic, unexplained failure
+            # (#87789). Guidance only: no policy is touched here.
+            print(policy_block_guidance("the update"))
         # The two-phase replace either commits every entry or rolls them all
         # back, so a failure here does not leave a mixed-version tree — don't
         # scare the user toward a reinstall they don't need.

--- a/hermes_cli/windows_policy_block.py
+++ b/hermes_cli/windows_policy_block.py
@@ -1,0 +1,106 @@
+"""Detect Windows application-control policy blocks (Smart App Control / WDAC).
+
+When Smart App Control or a WDAC/Application-Control policy blocks a spawn or
+file-copy Hermes needs for install/update/launch, Windows fails the underlying
+syscall instead of raising anything Hermes-specific. The only signal is a raw
+``OSError``/``CalledProcessError`` whose message looks like:
+
+    An Application Control policy has blocked this file. (os error 4551)
+
+or a Win32 error code of 1260 (``ERROR_ACCESS_DISABLED_BY_POLICY``), the
+documented code for the same class of block under Group Policy / WDAC. Field
+reports (issue #87789) also show the code 4551, which isn't in the standard
+Win32 system-error table but is what ``FormatMessage``/``std::io::Error``
+surface for this exact block on affected machines — so both codes, plus the
+stable text signatures Windows prints for either, are treated as equivalent.
+
+Detection is guidance-only (see #87789): it never changes policy or retries
+with elevated rights, it only recognizes the block and attaches an actionable
+message next to the original error. The raw error is always preserved.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Win32 error 1260 — ERROR_ACCESS_DISABLED_BY_POLICY. Documented code for
+# Group Policy / WDAC application-control blocks.
+WINERROR_ACCESS_DISABLED_BY_POLICY = 1260
+
+# Observed in the wild (issue #87789 support logs) for Smart App Control
+# blocking a spawn/copy. Not in the standard Win32 system-error table, but
+# reproducible enough across reports to treat as a second known code.
+WINERROR_SMART_APP_CONTROL_BLOCK = 4551
+
+_KNOWN_WINERRORS = frozenset(
+    {WINERROR_ACCESS_DISABLED_BY_POLICY, WINERROR_SMART_APP_CONTROL_BLOCK}
+)
+
+# Text Windows/antivirus stacks are known to emit for this block class.
+# Matched case-insensitively against the exception's string form (and, for
+# subprocess failures, its captured stdout/stderr) since the winerror
+# attribute is not always populated — e.g. when the block surfaces inside a
+# child process's own stderr rather than as a Python-level OSError.
+_TEXT_SIGNATURES = (
+    "application control policy has blocked this file",
+    "blocked by group policy",
+    "this program is blocked by group policy",
+    "smart app control",
+)
+
+_OS_ERROR_SUFFIX_RE = re.compile(r"\(os error (\d+)\)")
+
+
+def _winerror_code(exc: BaseException) -> int | None:
+    """Best-effort Win32 error code for *exc*, walking the exception chain."""
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        code = getattr(current, "winerror", None)
+        if isinstance(code, int):
+            return code
+        text = str(current)
+        match = _OS_ERROR_SUFFIX_RE.search(text)
+        if match:
+            return int(match.group(1))
+        current = current.__cause__ or current.__context__
+    return None
+
+
+def _matching_text(*texts: str | None) -> str | None:
+    for text in texts:
+        if not text:
+            continue
+        lowered = text.lower()
+        for signature in _TEXT_SIGNATURES:
+            if signature in lowered:
+                return text
+    return None
+
+
+def detect_policy_block(exc: BaseException, *extra_text: str | None) -> bool:
+    """Whether *exc* (optionally plus *extra_text*, e.g. captured stderr) looks
+    like a Windows application-control policy block rather than an ordinary
+    I/O failure.
+    """
+    code = _winerror_code(exc)
+    if code in _KNOWN_WINERRORS:
+        return True
+    return _matching_text(str(exc), *extra_text) is not None
+
+
+def policy_block_guidance(context: str) -> str:
+    """Actionable guidance block for a confirmed policy-block failure.
+
+    *context* names the operation that was blocked (e.g. ``"update"``,
+    ``"launch"``) so the message reads naturally next to the raw error.
+    """
+    return (
+        "  This looks like Windows Smart App Control or an application-control\n"
+        f"  policy blocking Hermes' Python during {context} — not a corrupted\n"
+        "  install. A Windows update can silently re-enable Smart App Control.\n"
+        "  See https://aka.ms/smartappcontrol to check its state, or ask your\n"
+        "  IT administrator for an exemption if it's managed by policy.\n"
+        "  This message is guidance only — Hermes has not changed any policy."
+    )

--- a/tests/hermes_cli/test_update_windows_policy_block.py
+++ b/tests/hermes_cli/test_update_windows_policy_block.py
@@ -1,0 +1,299 @@
+"""Windows Smart App Control / WDAC policy-block detection (issue #87789).
+
+Smart App Control / Application-Control policies block Hermes' spawned
+processes and file copies with a raw ``OSError`` — winerror 1260
+(``ERROR_ACCESS_DISABLED_BY_POLICY``) or the field-observed 4551 — that
+``hermes update``'s ZIP path previously surfaced verbatim as an opaque
+"ZIP update failed: ..." with no indication of the actual cause. These tests
+pin the detector's classification (including an exhaustive fuzz pass to rule
+out false positives) and the wiring that attaches guidance to the real
+failure path.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import random
+import textwrap
+
+import pytest
+
+from hermes_cli import update_cmd
+from hermes_cli.windows_policy_block import (
+    WINERROR_ACCESS_DISABLED_BY_POLICY,
+    WINERROR_SMART_APP_CONTROL_BLOCK,
+    detect_policy_block,
+    policy_block_guidance,
+)
+
+
+# ---------------------------------------------------------------------------
+# Positive detection: known winerror codes
+# ---------------------------------------------------------------------------
+
+
+def _os_error_with_winerror(code: int, message: str = "blocked") -> OSError:
+    exc = OSError(message)
+    exc.winerror = code
+    return exc
+
+
+@pytest.mark.parametrize(
+    "code", [WINERROR_ACCESS_DISABLED_BY_POLICY, WINERROR_SMART_APP_CONTROL_BLOCK]
+)
+def test_detects_known_winerror_codes(code):
+    assert detect_policy_block(_os_error_with_winerror(code)) is True
+
+
+def test_detects_winerror_via_os_error_suffix_when_attribute_absent():
+    """Rust/subprocess-relayed errors carry the code only in text, e.g. the
+    ``(os error 4551)`` suffix ``std::io::Error``'s ``Display`` produces —
+    ``winerror`` is a Windows-only ``OSError`` attribute Python does not
+    always populate for text relayed from a child process."""
+    exc = OSError(
+        "An Application Control policy has blocked this file. (os error 4551)"
+    )
+    del exc.winerror  # CPython sets this to 0 by default on non-Windows too
+    assert detect_policy_block(exc) is True
+
+
+def test_detects_1260_suffix_variant():
+    exc = Exception("spawning hermes.exe: Access is disabled by policy. (os error 1260)")
+    assert detect_policy_block(exc) is True
+
+
+# ---------------------------------------------------------------------------
+# Positive detection: text signatures (case-insensitive, embedded anywhere)
+# ---------------------------------------------------------------------------
+
+_TEXT_SIGNATURE_CASES = [
+    "An Application Control policy has blocked this file.",
+    "APPLICATION CONTROL POLICY HAS BLOCKED THIS FILE",
+    "This program is blocked by group policy. Contact your administrator.",
+    "spawn EPERM: blocked by group policy",
+    "Windows Smart App Control prevented this action.",
+    "smart app control is on",
+]
+
+
+@pytest.mark.parametrize("text", _TEXT_SIGNATURE_CASES)
+def test_detects_known_text_signatures(text):
+    assert detect_policy_block(Exception(text)) is True
+
+
+def test_detects_signature_in_extra_text_not_just_exception_message():
+    """Subprocess failures often carry the real signal in captured
+    stdout/stderr, not the Python-level exception message."""
+    exc = Exception("update.ps1 exited with code 1")
+    stderr = "ERROR: Smart App Control blocked venv\\Scripts\\python.exe"
+    assert detect_policy_block(exc) is False
+    assert detect_policy_block(exc, stderr) is True
+
+
+def test_detects_through_exception_chain_cause():
+    original = _os_error_with_winerror(WINERROR_SMART_APP_CONTROL_BLOCK)
+    try:
+        try:
+            raise original
+        except OSError as inner:
+            raise RuntimeError("ZIP update failed") from inner
+    except RuntimeError as chained:
+        assert detect_policy_block(chained) is True
+
+
+def test_detects_through_implicit_exception_context():
+    original = _os_error_with_winerror(WINERROR_ACCESS_DISABLED_BY_POLICY)
+    try:
+        try:
+            raise original
+        except OSError:
+            raise RuntimeError("wrapped without explicit chaining")
+    except RuntimeError as chained:
+        assert detect_policy_block(chained) is True
+
+
+# ---------------------------------------------------------------------------
+# Negative detection: must not false-positive on ordinary failures
+# ---------------------------------------------------------------------------
+
+_ORDINARY_FAILURES = [
+    OSError(2, "No such file or directory"),
+    OSError(5, "Access is denied"),
+    OSError(28, "No space left on device"),
+    OSError(13, "Permission denied"),
+    FileNotFoundError("agent/tools.py"),
+    RuntimeError("not enough free disk space to stage the update safely"),
+    ConnectionError("could not reach github.com"),
+    ValueError("branch name contains invalid characters"),
+    Exception(""),
+]
+
+
+@pytest.mark.parametrize("exc", _ORDINARY_FAILURES)
+def test_does_not_flag_ordinary_failures(exc):
+    assert detect_policy_block(exc) is False
+
+
+def test_does_not_flag_unrelated_winerror_codes():
+    for code in (2, 3, 5, 13, 32, 183, 1223):  # includes ERROR_CANCELLED etc.
+        assert detect_policy_block(_os_error_with_winerror(code)) is False
+
+
+def test_does_not_flag_unrelated_os_error_suffix_numbers():
+    for code in (2, 5, 13, 28, 32, 183):
+        exc = OSError(f"some unrelated failure (os error {code})")
+        assert detect_policy_block(exc) is False
+
+
+# ---------------------------------------------------------------------------
+# Exhaustive fuzz pass — the "no false positives across a wide surface" check
+# ---------------------------------------------------------------------------
+
+_UNRELATED_WORDS = [
+    "timeout",
+    "disk",
+    "network",
+    "permission",
+    "denied",
+    "not found",
+    "corrupt",
+    "invalid",
+    "argument",
+    "retry",
+    "exit",
+    "code",
+    "failed",
+    "python",
+    "venv",
+    "pip",
+    "uv",
+    "git",
+    "zip",
+    "hash",
+    "mismatch",
+    "encoding",
+    "utf-8",
+    "socket",
+    "closed",
+]
+
+
+def test_fuzz_random_os_errors_never_false_positive():
+    """Exhaustion check: a large randomized sweep of OSErrors with codes
+    outside the two known ones, and messages built from unrelated words,
+    must never be classified as a policy block. Deterministic seed keeps the
+    sweep reproducible across CI runs."""
+    rng = random.Random(87789)
+    known = {WINERROR_ACCESS_DISABLED_BY_POLICY, WINERROR_SMART_APP_CONTROL_BLOCK}
+    false_positives = []
+    for _ in range(5000):
+        code = rng.randint(0, 20000)
+        if code in known:
+            continue
+        word_count = rng.randint(1, 6)
+        message = " ".join(rng.choice(_UNRELATED_WORDS) for _ in range(word_count))
+        message = f"{message} (os error {code})"
+        exc = _os_error_with_winerror(code, message)
+        if detect_policy_block(exc):
+            false_positives.append((code, message))
+    assert not false_positives, f"false positives: {false_positives[:10]}"
+
+
+def test_fuzz_signature_variants_always_detected():
+    """Complement of the false-positive sweep: known signatures must survive
+    arbitrary surrounding noise and casing."""
+    rng = random.Random(4551)
+    signatures = [
+        "Application Control policy has blocked this file",
+        "blocked by group policy",
+        "Smart App Control",
+    ]
+    misses = []
+    for _ in range(2000):
+        sig = rng.choice(signatures)
+        if rng.random() < 0.5:
+            sig = sig.upper()
+        elif rng.random() < 0.5:
+            sig = sig.lower()
+        prefix = " ".join(rng.choice(_UNRELATED_WORDS) for _ in range(rng.randint(0, 4)))
+        suffix = " ".join(rng.choice(_UNRELATED_WORDS) for _ in range(rng.randint(0, 4)))
+        message = f"{prefix} {sig} {suffix}".strip()
+        if not detect_policy_block(Exception(message)):
+            misses.append(message)
+    assert not misses, f"missed signature variants: {misses[:10]}"
+
+
+# ---------------------------------------------------------------------------
+# Guidance text
+# ---------------------------------------------------------------------------
+
+
+def test_guidance_names_the_operation_and_stays_guidance_only():
+    text = policy_block_guidance("the update")
+    assert "the update" in text
+    assert "Smart App Control" in text
+    assert "aka.ms/smartappcontrol" in text
+    assert "guidance only" in text.lower()
+
+
+@pytest.mark.parametrize("context", ["the update", "launch", "install"])
+def test_guidance_never_raises_for_any_context(context):
+    assert isinstance(policy_block_guidance(context), str)
+    assert policy_block_guidance(context)  # never empty
+
+
+# ---------------------------------------------------------------------------
+# Wiring contract: _update_via_zip must actually call the detector
+# ---------------------------------------------------------------------------
+
+
+def test_update_via_zip_wires_policy_block_detection_into_its_failure_path():
+    """AST pin: the ZIP-update failure handler must call detect_policy_block
+    (and print guidance when it fires) rather than only ever printing the
+    raw wire error, or a refactor could silently drop the #87789 fix."""
+    src = textwrap.dedent(inspect.getsource(update_cmd._update_via_zip))
+    tree = ast.parse(src)
+
+    def _calls(node, name):
+        return any(
+            isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == name
+            for n in ast.walk(node)
+        )
+
+    wired = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        for handler in node.handlers:
+            if _calls(handler, "detect_policy_block") and _calls(
+                handler, "policy_block_guidance"
+            ):
+                wired = True
+    assert wired, (
+        "_update_via_zip's exception handler no longer calls "
+        "detect_policy_block/policy_block_guidance — the raw ZIP-update "
+        "failure would go back to being unclassified (#87789)"
+    )
+
+
+def test_zip_update_failure_prints_guidance_when_policy_blocked(capsys):
+    """Behavioral confirmation of the classify-and-print step in isolation,
+    mirroring exactly what the except block in _update_via_zip does."""
+    exc = _os_error_with_winerror(WINERROR_SMART_APP_CONTROL_BLOCK, "blocked copy")
+    print(f"✗ ZIP update failed: {exc}")
+    if detect_policy_block(exc):
+        print(policy_block_guidance("the update"))
+    out = capsys.readouterr().out
+    assert "ZIP update failed" in out
+    assert "Smart App Control" in out
+
+
+def test_zip_update_failure_stays_silent_on_guidance_for_ordinary_errors(capsys):
+    exc = OSError(28, "No space left on device")
+    print(f"✗ ZIP update failed: {exc}")
+    if detect_policy_block(exc):
+        print(policy_block_guidance("the update"))
+    out = capsys.readouterr().out
+    assert "ZIP update failed" in out
+    assert "Smart App Control" not in out

--- a/tests/hermes_cli/test_update_windows_policy_block.py
+++ b/tests/hermes_cli/test_update_windows_policy_block.py
@@ -49,12 +49,16 @@ def test_detects_known_winerror_codes(code):
 def test_detects_winerror_via_os_error_suffix_when_attribute_absent():
     """Rust/subprocess-relayed errors carry the code only in text, e.g. the
     ``(os error 4551)`` suffix ``std::io::Error``'s ``Display`` produces —
-    ``winerror`` is a Windows-only ``OSError`` attribute Python does not
-    always populate for text relayed from a child process."""
+    ``winerror`` is a Windows-only ``OSError`` attribute. On Windows CPython
+    sets it to 0 by default when unset; on other platforms the attribute is
+    never populated at all, so deletion must tolerate both."""
     exc = OSError(
         "An Application Control policy has blocked this file. (os error 4551)"
     )
-    del exc.winerror  # CPython sets this to 0 by default on non-Windows too
+    try:
+        del exc.winerror
+    except AttributeError:
+        pass  # not populated on non-Windows platforms
     assert detect_policy_block(exc) is True
 
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -164,8 +164,26 @@ The same pattern works on Arch (the installer uses pacman with the same sudo-det
 | `hermes: command not found` | Reload your shell (`source ~/.bashrc`) or check PATH |
 | `API key not set` | Run `hermes model` to configure your provider, or `hermes config set OPENROUTER_API_KEY your_key` |
 | Missing config after update | Run `hermes config check` then `hermes config migrate` |
+| Windows: install/update fails with `os error 4551` / `os error 1260`, or the desktop app won't launch after an update | Windows Smart App Control or an application-control (WDAC) policy is blocking Hermes' Python. See [Windows Smart App Control blocks](#windows-smart-app-control-blocks) below. |
 
 For more diagnostics, run `hermes doctor` — it will tell you exactly what's missing and how to fix it.
+
+### Windows Smart App Control blocks
+
+Windows Smart App Control (and, on managed machines, Application Control/WDAC policies) can block the embedded Python runtime Hermes uses to install, update, and launch. When this happens you'll typically see one of:
+
+- `hermes update` failing with `os error 4551` or `os error 1260` (`ERROR_ACCESS_DISABLED_BY_POLICY`) in the error text
+- the Desktop app failing to launch after an update, with no other explanation
+- a fresh install failing during venv setup
+
+This is not a corrupted install — it's Windows refusing to run (or copy) an unsigned/untrusted binary. A Windows feature update can silently turn Smart App Control back on even if you (or your IT admin) previously allowed Hermes.
+
+To resolve it:
+
+1. Check whether Smart App Control is on: Settings → Privacy & security → Windows Security → App & browser control → Smart App Control, or run `Get-MpComputerStatus | Select SmartAppControlState` in PowerShell.
+2. See [Microsoft's Smart App Control documentation](https://aka.ms/smartappcontrol) for how to allow a specific app or turn it off.
+3. On a managed machine, ask your IT administrator for an exemption for Hermes if Smart App Control/WDAC is enforced by policy.
+4. Re-run `hermes update` (or reinstall) once the block is cleared — a blocked update leaves your existing install in place, so nothing needs to be recovered first.
 
 ## Install method auto-detection
 


### PR DESCRIPTION
## Summary

Windows Smart App Control / WDAC application-control policies block Hermes' embedded Python during install/update/launch with a raw `os error 4551` (or the documented `1260` / `ERROR_ACCESS_DISABLED_BY_POLICY`). Hermes never recognized this class of failure, so `hermes update` on the Windows ZIP-fallback path (used whenever git file I/O is already broken on that machine) surfaced it as an opaque `✗ ZIP update failed: ...` with zero indication of the actual cause — sending users into multi-hour support threads until someone manually spotted `4551` in a raw installer log.

This adds a small, dependency-free detector (`hermes_cli/windows_policy_block.py`) that recognizes the known winerror codes and text signatures Windows/`std::io::Error` emit for this exact block class — including through wrapped/chained exceptions — and wires it into `_update_via_zip`'s existing failure handler to print actionable guidance **next to** the raw error. It never replaces the wire error and never touches policy; it's detection + guidance only, per the issue's own "honest diagnosis" constraint.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
flowchart TD
    A[⚡ hermes update --ZIP path] --> B{shutil.copytree / os.rename}
    B -->|Smart App Control blocks Python| C[🔒 OSError winerror 1260 / 4551]
    B -->|ordinary I/O failure| D[Generic OSError]
    C --> E[🧠 detect_policy_block]
    D --> E
    E -->|match: known code or text signature| F[🚀 Guidance printed next to raw error]
    E -->|no match| G[Raw error only, unchanged]
    F -.->|never mutates policy| H[(Windows Policy)]
```

### Root cause

`_update_via_zip` (`hermes_cli/update_cmd.py`) stages the update tree with `shutil.copytree`/`copy2` before swapping it in with atomic renames. When Smart App Control blocks that copy, Python raises a plain `OSError` (`winerror=1260`, or `4551` per this issue's field reports) that the existing `except Exception as e: print(f"✗ ZIP update failed: {e}")` handler printed verbatim — technically correct, but unclassified, which reads as "something is broken" rather than "Windows is blocking this on purpose, here's what to do." Three other issues (#55004, #63796, #70544, #56554, #50210, #72310) each cover one Smart App Control code path individually; none added detection/guidance — this is the cross-cutting piece for the `hermes update` surface specifically.

### Scope note (why this PR doesn't touch the other two named surfaces)

The issue names three surfaces: the bootstrap installer (Rust/Tauri), `hermes update` (Python), and Desktop boot-failure (Electron). This PR covers **`hermes update`** only, deliberately:

- **Bootstrap installer** (`apps/bootstrap-installer/src-tauri`) is Rust, and this environment has no `cargo`/`rustc` available to compile or test changes there. Shipping unverified Rust would violate the same "don't guess" principle this issue is about. The equivalent fix (classify `std::io::Error` for the same winerror/text signatures around the `Command::new(...).spawn()` call in `bootstrap.rs`/`update.rs`) is a natural follow-up once it can be built and tested.
- **Desktop boot-failure** (`apps/desktop/electron/main.ts`, the `hermesProcess.once('error', ...)` handler): investigated and intentionally skipped. Node's `child_process.spawn()` on Windows goes through libuv's `uv_spawn`, which translates `GetLastError()` via a fixed switch table; codes outside that table (1260 and 4551 are not documented Win32 codes) fall through to `UV_UNKNOWN`, and libuv does not preserve the original code or `FormatMessage` text in the error it hands back to Node. A `spawn` failure at that layer surfaces as a generic `spawn ... UNKNOWN` with no signal to classify against — reliable detection there would need a native probe, which is out of scope for a guidance-only fix.

Filing the Rust and Electron pieces as explicit follow-ups (rather than guessing) keeps this PR's fix root-caused and verifiable end to end.

### Docs

Added a "Windows Smart App Control blocks" troubleshooting section to `website/docs/getting-started/installation.md` explaining the symptom, why it happens (a Windows feature update can silently re-enable Smart App Control), and how to check/allow/exempt Hermes.

## Test plan

- [x] `pytest tests/hermes_cli/test_update_windows_policy_block.py -q` — 33 new tests: known winerror codes (1260, 4551), `(os error N)` text-suffix parsing, text-signature matching (case-insensitive, embedded, via subprocess stderr), detection through both explicit (`raise ... from`) and implicit exception chaining, an exhaustive **5,000-sample randomized fuzz sweep** asserting zero false positives across unrelated `OSError`s/codes, a **2,000-sample fuzz sweep** asserting every known signature variant (arbitrary casing/surrounding noise) is still caught, guidance-text assertions, and an AST wiring-contract test pinning that `_update_via_zip`'s exception handler actually calls the detector (so a refactor can't silently drop it).
- [x] `pytest tests/hermes_cli/test_update_zip_two_phase.py -q` — 19 existing ZIP two-phase tests still pass (no regression to the staging/commit/rollback machinery this hooks into).
- [x] `pytest tests/hermes_cli/test_cmd_update.py -q` — full existing update-command suite still passes.
- [x] `python -c "import ast; ast.parse(...)"` syntax check on both modified/new Python files.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits
- [x] Searched existing PRs/issues (#63810 covers a different code path — the embedded-Python `_ssl` DLL-load import error in the dashboard backend entrypoint, not the ZIP-update copy/spawn path this PR fixes) to avoid duplication
- [x] PR contains only changes related to this fix
- [x] Tests added, all passing

Fixes #87789