### PR TITLE
fix(update): restart hermes-serve systemd units alongside gateways (#83438)

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -296,6 +296,7 @@ def _kill_stale_dashboard_processes(
     reason: str = "the running backend no longer matches the updated frontend",
     *,
     restart_managed: bool = False,
+    already_restarted_units: "set[str] | None" = None,
 ) -> dict[str, list]:
     """Kill running ``hermes dashboard`` / ``hermes serve`` processes.
 
@@ -319,6 +320,14 @@ def _kill_stale_dashboard_processes(
     e.g. a remote backend's ``hermes-serve.service``) has its owning unit
     restarted after the kill, because systemd treats our SIGTERM as a clean
     stop and ``Restart=on-failure`` would never fire (#68934).
+
+    *already_restarted_units* names units (no ``.service`` suffix) the
+    caller already restarted directly — e.g. ``hermes update``'s systemd
+    fleet-restart loop, which restarts ``hermes-serve*`` units before this
+    function runs. Without excluding them, a Serve-only install's freshly
+    restarted process is found again here and restarted a second time for
+    no benefit (review on #83595). PIDs owned by one of these units are
+    left untouched.
     """
     if restart_managed and _m()._restart_managed_dashboard_service(reason):
         return {"matched": [], "killed": [], "failed": []}
@@ -347,9 +356,6 @@ def _kill_stale_dashboard_processes(
     if not pids:
         return {"matched": [], "killed": [], "failed": []}
 
-    print()
-    print(f"⟲ Stopping {len(pids)} dashboard process(es) ({reason})")
-
     # Before killing, snapshot systemd cgroup info for each PID so we can
     # restart supervised services after the kill (the cgroup disappears
     # along with the process).  Only meaningful on Linux, and only when the
@@ -373,6 +379,22 @@ def _kill_stale_dashboard_processes(
                 if cmdline:
                     pid_cmdline[pid] = cmdline
                     pid_home[pid] = _hermes_home_for_pid(pid)
+
+        if already_restarted_units:
+            # Already handled directly by the caller (e.g. hermes update's
+            # systemd fleet-restart loop) — leave these alone instead of
+            # killing and re-restarting a process that's already fresh.
+            pids = [
+                pid
+                for pid in pids
+                if (pid_service.get(pid) or "").removesuffix(".service")
+                not in already_restarted_units
+            ]
+            if not pids:
+                return {"matched": [], "killed": [], "failed": []}
+
+    print()
+    print(f"⟲ Stopping {len(pids)} dashboard process(es) ({reason})")
 
     killed: list[int] = []
     failed: list[tuple[int, str]] = []

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4757,6 +4757,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_resume_windows_gateways_after_update",
         "_run_logged_subprocess",
         "_run_pre_update_backup",
+        "_service_unit_supports_graceful_sigusr1_restart",
         "_should_skip_upstream_prompt",
         "_stash_apply_failed_only_on_existing_untracked",
         "_stash_local_changes_if_needed",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3897,7 +3897,8 @@ def _for_each_systemd_gateway_unit(
         # unrelated ``hermes-server.service`` — require the exact base unit
         # or the hyphenated profile family instead (review on #83595).
         if not (
-            unit.startswith("hermes-gateway")
+            unit == "hermes-gateway.service"
+            or unit.startswith("hermes-gateway-")
             or unit == "hermes-serve.service"
             or unit.startswith("hermes-serve-")
         ):
@@ -3916,8 +3917,14 @@ def _service_unit_supports_graceful_sigusr1_restart(svc_name: str) -> bool:
     SIGUSR1 would just invoke the default terminate action and burn the full
     drain budget waiting for an exit that was never graceful — go straight to
     the blunt ``systemctl restart`` path for those instead.
+
+    Uses the same strict exact/hyphenated shape as the unit-name gate in
+    ``_for_each_systemd_gateway_unit`` so a hypothetical near-prefix unit
+    (``hermes-gateway-helper`` is fine — profile units are
+    ``hermes-gateway-<profile>`` — but ``hermes-gatewayd``-style names are
+    not) can't be sent a SIGUSR1 it doesn't handle.
     """
-    return svc_name.startswith("hermes-gateway")
+    return svc_name == "hermes-gateway" or svc_name.startswith("hermes-gateway-")
 
 
 def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -669,8 +669,16 @@ def _reload_process_scan_modules() -> None:
                 )
 
 
-def _finish_dashboard_update_cleanup(node_failures: list[str]) -> None:
-    """Refresh managed dashboards or stop stale manual ones after an update."""
+def _finish_dashboard_update_cleanup(
+    node_failures: list[str], already_restarted_units: "set[str] | None" = None
+) -> None:
+    """Refresh managed dashboards or stop stale manual ones after an update.
+
+    *already_restarted_units* forwards the systemd unit names (no
+    ``.service`` suffix) that the fleet-restart loop already restarted
+    directly, so a Serve-only install's freshly restarted process isn't
+    found and restarted a second time here (review on #83595).
+    """
     if node_failures:
         print()
         print("  ℹ Leaving running dashboard process(es) untouched because the")
@@ -681,7 +689,9 @@ def _finish_dashboard_update_cleanup(node_failures: list[str]) -> None:
     # both modules reflect the freshly-updated source before touching them.
     _reload_process_scan_modules()
 
-    stop_result = _m()._kill_stale_dashboard_processes(restart_managed=True)
+    stop_result = _m()._kill_stale_dashboard_processes(
+        restart_managed=True, already_restarted_units=already_restarted_units
+    )
     if not stop_result.get("unrecovered"):
         return
 
@@ -3883,7 +3893,14 @@ def _for_each_systemd_gateway_unit(
             continue
         # list-units is already pattern-filtered, but keep the name gate so a
         # stray non-gateway/serve line cannot enter the restart path.
-        if not (unit.startswith("hermes-gateway") or unit.startswith("hermes-serve")):
+        # ``unit.startswith("hermes-serve")`` alone would also accept the
+        # unrelated ``hermes-server.service`` — require the exact base unit
+        # or the hyphenated profile family instead (review on #83595).
+        if not (
+            unit.startswith("hermes-gateway")
+            or unit == "hermes-serve.service"
+            or unit.startswith("hermes-serve-")
+        ):
             continue
         svc_name = unit.removesuffix(".service")
         try:
@@ -5679,6 +5696,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # discovered gateway lets the handler fail closed on an empty survivor
         # probe rather than reporting a clean update (#78574).
         _pre_restart_gateway_pids: list | None = []
+        # Declared outside the restart try/except below (and never reset
+        # to None) so it's always safe to read afterwards even if that
+        # block raises before reaching its own restart bookkeeping —
+        # needed to forward already-restarted units to
+        # ``_finish_dashboard_update_cleanup`` (review on #83595).
+        restarted_services: list = []
 
         # Auto-restart ALL gateways after update.
         # The code update (git pull) is shared across all profiles, so every
@@ -5852,7 +5875,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
             except Exception:
                 _drain_budget = 45.0
 
-            restarted_services = []
             failed_or_stale_units = []
             killed_pids = set()
             relaunched_profiles = []
@@ -6466,7 +6488,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # systemd treat it as a clean stop, leaving the Cloudflare origin dead.
         # Preserve the safety rule above: a failed Node refresh leaves the
         # currently running dashboard untouched.
-        _finish_dashboard_update_cleanup(node_failures)
+        #
+        # Forward the systemd units restarted above (includes hermes-serve*,
+        # #83438) so a Serve-only install's freshly restarted process isn't
+        # found and restarted again below (review on #83595).
+        _finish_dashboard_update_cleanup(
+            node_failures, already_restarted_units=set(restarted_services)
+        )
 
         print()
         print("Tip: You can now select a provider and model:")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3867,7 +3867,8 @@ def _for_each_systemd_gateway_unit(
     process_unit,
     on_unit_timeout,
 ) -> None:
-    """Process each ``hermes-gateway*.service`` from ``systemctl list-units``.
+    """Process each ``hermes-gateway*.service``/``hermes-serve*.service`` unit
+    from ``systemctl list-units``.
 
     ``subprocess.TimeoutExpired`` raised by ``process_unit`` is isolated to
     that unit via ``on_unit_timeout`` so one wedged systemctl call cannot
@@ -3881,14 +3882,26 @@ def _for_each_systemd_gateway_unit(
         if not unit.endswith(".service"):
             continue
         # list-units is already pattern-filtered, but keep the name gate so a
-        # stray non-gateway line cannot enter the restart path.
-        if not unit.startswith("hermes-gateway"):
+        # stray non-gateway/serve line cannot enter the restart path.
+        if not (unit.startswith("hermes-gateway") or unit.startswith("hermes-serve")):
             continue
         svc_name = unit.removesuffix(".service")
         try:
             process_unit(svc_name)
         except subprocess.TimeoutExpired as exc:
             on_unit_timeout(svc_name, exc)
+
+def _service_unit_supports_graceful_sigusr1_restart(svc_name: str) -> bool:
+    """Whether *svc_name* wires SIGUSR1 to a graceful drain-then-restart.
+
+    Only ``hermes-gateway*`` units run ``gateway/run.py``, which installs the
+    SIGUSR1 handler. ``hermes-serve*`` units (#83438) don't, so sending them
+    SIGUSR1 would just invoke the default terminate action and burn the full
+    drain budget waiting for an exit that was never graceful — go straight to
+    the blunt ``systemctl restart`` path for those instead.
+    """
+    return svc_name.startswith("hermes-gateway")
+
 
 def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:
     """Print an explicit incomplete-update warning for unrestarted units."""
@@ -3903,7 +3916,7 @@ def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:
         seen.add(name)
         ordered.append(name)
     print()
-    print("⚠ Update incomplete — some gateway units were not restarted:")
+    print("⚠ Update incomplete — some units were not restarted:")
     for name in ordered:
         print(f"    - {name}")
     print("  Skipped units may still be running pre-update code (mixed")
@@ -5857,7 +5870,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _pre_restart_gateway_pids = None
 
             # --- Systemd services (Linux) ---
-            # Discover all hermes-gateway* units (default + profiles)
+            # Discover all hermes-gateway* units (default + profiles) plus
+            # hermes-serve* units (the Desktop app's backend, #83438).
             if supports_systemd_services():
                 try:
                     _ensure_user_systemd_env()
@@ -5874,6 +5888,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             + [
                                 "list-units",
                                 "hermes-gateway*",
+                                "hermes-serve*",
                                 "--plain",
                                 "--no-legend",
                                 "--no-pager",
@@ -5920,27 +5935,33 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         # The gateway's SIGUSR1 handler calls
                         # request_restart(via_service=True) → drain →
                         # exit; systemd's Restart=always respawns the unit.
+                        # hermes-serve has no such handler (it isn't
+                        # gateway/run.py), so skip straight to the blunt
+                        # restart below rather than sending it an unhandled
+                        # signal and waiting out the drain budget for
+                        # nothing.
                         _main_pid = 0
-                        try:
-                            _show = subprocess.run(
-                                scope_cmd
-                                + [
-                                    "show",
-                                    svc_name,
-                                    "--property=MainPID",
-                                    "--value",
-                                ],
-                                capture_output=True,
-                                text=True, encoding="utf-8", errors="replace",
-                                timeout=5,
-                            )
-                            _main_pid = int((_show.stdout or "").strip() or 0)
-                        except (
-                            ValueError,
-                            subprocess.TimeoutExpired,
-                            FileNotFoundError,
-                        ):
-                            _main_pid = 0
+                        if _service_unit_supports_graceful_sigusr1_restart(svc_name):
+                            try:
+                                _show = subprocess.run(
+                                    scope_cmd
+                                    + [
+                                        "show",
+                                        svc_name,
+                                        "--property=MainPID",
+                                        "--value",
+                                    ],
+                                    capture_output=True,
+                                    text=True, encoding="utf-8", errors="replace",
+                                    timeout=5,
+                                )
+                                _main_pid = int((_show.stdout or "").strip() or 0)
+                            except (
+                                ValueError,
+                                subprocess.TimeoutExpired,
+                                FileNotFoundError,
+                            ):
+                                _main_pid = 0
 
                         _graceful_ok = False
                         if _main_pid > 0:

--- a/tests/hermes_cli/test_update_fleet_restart_timeout.py
+++ b/tests/hermes_cli/test_update_fleet_restart_timeout.py
@@ -15,6 +15,7 @@ import pytest
 
 from hermes_cli.main import (
     _for_each_systemd_gateway_unit,
+    _service_unit_supports_graceful_sigusr1_restart,
     _warn_incomplete_gateway_fleet_restart,
 )
 
@@ -89,6 +90,44 @@ class TestFleetRestartTimeoutIsolation:
         )
 
         assert seen == ["hermes-gateway-coder"]
+
+    def test_hermes_serve_units_are_included(self):
+        # #83438 — hermes update restarted hermes-gateway* units but left
+        # hermes-serve* (the Desktop app's backend) on stale pre-update code.
+        seen: list[str] = []
+
+        _for_each_systemd_gateway_unit(
+            "\n".join(
+                [
+                    "ssh.service loaded active running",
+                    "hermes-serve.service loaded active running",
+                    "hermes-serve-work.service loaded active running",
+                    "hermes-gateway.service loaded active running",
+                    "",
+                ]
+            ),
+            process_unit=seen.append,
+            on_unit_timeout=lambda *_: pytest.fail("unexpected timeout"),
+        )
+
+        assert seen == ["hermes-serve", "hermes-serve-work", "hermes-gateway"]
+
+
+class TestGracefulSigusr1Eligibility:
+    def test_gateway_units_are_eligible(self):
+        assert _service_unit_supports_graceful_sigusr1_restart("hermes-gateway")
+        assert _service_unit_supports_graceful_sigusr1_restart(
+            "hermes-gateway-work"
+        )
+
+    def test_serve_units_are_not_eligible(self):
+        # hermes-serve doesn't run gateway/run.py, so it never installs the
+        # SIGUSR1 handler — sending it the signal would just terminate the
+        # process (the default action) instead of draining gracefully.
+        assert not _service_unit_supports_graceful_sigusr1_restart("hermes-serve")
+        assert not _service_unit_supports_graceful_sigusr1_restart(
+            "hermes-serve-work"
+        )
 
     def test_process_errors_other_than_timeout_still_propagate(self):
         def process_unit(_svc_name: str) -> None:

--- a/tests/hermes_cli/test_update_fleet_restart_timeout.py
+++ b/tests/hermes_cli/test_update_fleet_restart_timeout.py
@@ -112,6 +112,20 @@ class TestFleetRestartTimeoutIsolation:
 
         assert seen == ["hermes-serve", "hermes-serve-work", "hermes-gateway"]
 
+    def test_hermes_server_near_prefix_is_rejected(self):
+        # Review on #83595: a bare ``startswith("hermes-serve")`` gate also
+        # accepts the unrelated ``hermes-server.service``. Only the exact
+        # base unit or the hyphenated profile family should pass.
+        seen: list[str] = []
+
+        _for_each_systemd_gateway_unit(
+            _list_units_stdout(["hermes-server"]),
+            process_unit=seen.append,
+            on_unit_timeout=lambda *_: pytest.fail("unexpected timeout"),
+        )
+
+        assert seen == []
+
 
 class TestGracefulSigusr1Eligibility:
     def test_gateway_units_are_eligible(self):

--- a/tests/hermes_cli/test_update_fleet_restart_timeout.py
+++ b/tests/hermes_cli/test_update_fleet_restart_timeout.py
@@ -126,6 +126,20 @@ class TestFleetRestartTimeoutIsolation:
 
         assert seen == []
 
+    def test_hermes_gateway_near_prefix_is_rejected(self):
+        # Same strict shape on the gateway side: profile units are
+        # ``hermes-gateway-<profile>``, so a hypothetical
+        # ``hermes-gatewayd.service`` must not enter the restart path.
+        seen: list[str] = []
+
+        _for_each_systemd_gateway_unit(
+            _list_units_stdout(["hermes-gatewayd", "hermes-gateway-coder"]),
+            process_unit=seen.append,
+            on_unit_timeout=lambda *_: pytest.fail("unexpected timeout"),
+        )
+
+        assert seen == ["hermes-gateway-coder"]
+
 
 class TestGracefulSigusr1Eligibility:
     def test_gateway_units_are_eligible(self):

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -338,6 +338,30 @@ class TestSupervisedBackendRestart:
         # Supervised restart succeeded — no manual hint.
         assert "when you're ready" not in out
 
+    def test_already_restarted_unit_is_left_untouched(self):
+        """Review on #83595: hermes update's systemd fleet-restart loop may
+        already have restarted this PID's owning unit directly (e.g. a
+        Serve-only install). Passing it via already_restarted_units must
+        skip killing/restarting it again here."""
+        live = self._live()
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4321]), \
+             patch.object(live, "_get_pid_cgroup_path",
+                          return_value="/system.slice/hermes-serve.service"), \
+             patch.object(live, "_get_systemd_service_for_pid",
+                          return_value="hermes-serve.service"), \
+             patch.object(live, "_try_restart_systemd_service") as restart, \
+             patch("os.kill") as kill, \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(
+                restart_managed=True, already_restarted_units={"hermes-serve"}
+            )
+
+        kill.assert_not_called()
+        restart.assert_not_called()
+        assert result == {"matched": [], "killed": [], "failed": []}
+
 
 class TestManualBackendRespawn:
     """Manually-started dashboards/serves have their argv captured before the


### PR DESCRIPTION
## Summary

`hermes update` now discovers and restarts `hermes-serve*` systemd units (the Desktop app's backend) alongside `hermes-gateway*`, so the Serve backend no longer keeps running stale pre-update code until a manual `systemctl --user restart hermes-serve`. Fixes #83438.

Salvage of #83595 by @chelsealong — both commits cherry-picked onto current main with authorship preserved (the branch was ~1470 commits stale, CONFLICTING). Conflicts in `main.py` (lazy-export refactor) and `update_cmd.py` (process-scan reload, #78574 snapshot bookkeeping) resolved in favor of current main + the PR's intent.

## Changes

- `hermes_cli/update_cmd.py`: fleet-restart `list-units` discovery now matches `hermes-serve*`; unit-name gate accepts the exact `hermes-serve.service` / `hermes-serve-*` family; new `_service_unit_supports_graceful_sigusr1_restart()` routes serve units past the SIGUSR1 drain (only `gateway/run.py` installs that handler) straight to blunt `systemctl restart`.
- `hermes_cli/dashboard_procs.py`: `_kill_stale_dashboard_processes(already_restarted_units=...)` skips PIDs whose owning unit the fleet loop already restarted — no double restart on Serve-only installs. Only successfully-restarted units are forwarded (`restarted_services` appends strictly after `_wait_for_service_active` succeeds), so failed restarts still get the stale-kill sweep.
- Follow-up (ours): gateway-side gates tightened to the same exact/hyphenated shape (`hermes-gateway.service` / `hermes-gateway-*`), so a near-prefix unit like `hermes-gatewayd` can't enter the restart path or receive an unhandled SIGUSR1.

## Validation

| Check | Result |
|---|---|
| `test_update_fleet_restart_timeout.py` + `test_update_stale_dashboard.py` | 44 passed, 2 skipped |
| E2E (real imports, discovery gate + eligibility + kwarg threading + lazy export via `hermes_cli.main`) | pass |
| ruff on changed files | clean |
| Attribution audit | all emails mapped (`contributors/emails/chelsealong@126.com`) |

## Infographic

![hermes update now restarts hermes-serve](https://v3b.fal.media/files/b/0aa6988e/e1Cuj8nOuzUi7dUCRY2H7_oWOvDZ1R.png)
