### PR TITLE
feat(discord): scope approval mentions to thread participants

### DIFF
--- a/contributors/emails/pwn@example.com
+++ b/contributors/emails/pwn@example.com
@@ -1,0 +1,2 @@
+cruzanstx
+# PR #87862

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2117,6 +2117,12 @@ DEFAULT_CONFIG = {
         # override: DISCORD_APPROVAL_MENTIONS. Default false avoids surprise
         # pings.
         "approval_mentions": False,
+        # Who gets mentioned when approval_mentions is on. "all" pings every
+        # numeric allowlist entry; "participants" only pings allowlisted users
+        # who have taken part in the thread the approval fires in, falling
+        # back to "all" when none can be identified. Env override:
+        # DISCORD_APPROVAL_MENTIONS_SCOPE.
+        "approval_mentions_scope": "all",
         # Discord voice-channel inactivity timeout, in seconds. Set to 0 to
         # keep the bot in VC until an explicit `/voice leave` / disconnect.
         "voice_channel_inactivity_timeout_seconds": 300,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7447,6 +7447,73 @@ class DiscordAdapter(BasePlatformAdapter):
             return None
         return " ".join(f"<@{uid}>" for uid in user_ids)
 
+    async def _approval_mention_content_scoped(self, channel) -> Optional[str]:
+        """Return approval mentions honouring ``DISCORD_APPROVAL_MENTIONS_SCOPE``.
+
+        ``all`` (default) mentions every numeric allowlist entry — the original
+        behaviour. ``participants`` narrows the ping to allowlisted users who
+        have taken part in the target thread, so approvers working in other
+        threads are not pulled into every prompt. When no allowlisted
+        participant can be identified (or the target is not a thread) it falls
+        back to mentioning all approvers so a prompt is never left silent.
+        """
+        content = self._approval_mention_content()
+        if not content:
+            return None
+        scope = os.getenv("DISCORD_APPROVAL_MENTIONS_SCOPE", "all").strip().lower()
+        if scope != "participants":
+            return content
+        participant_ids = await self._thread_participant_approver_ids(channel)
+        if not participant_ids:
+            return content
+        return " ".join(f"<@{uid}>" for uid in sorted(participant_ids))
+
+    async def _thread_participant_approver_ids(self, channel) -> set:
+        """Collect numeric allowlist IDs that have participated in ``channel``.
+
+        Participation means having authored a message in the thread, including
+        the parent-channel message the thread was spawned from. Thread
+        *membership* is deliberately not used: without the privileged members
+        intent the gateway only syncs the bot's own membership, and Discord
+        auto-joins anyone mentioned in a thread — so one all-approver ping
+        would permanently widen the scope again. Returns an empty set for
+        non-threads or when lookups fail (callers fall back to all approvers).
+        """
+        approver_ids = {str(uid) for uid in self._allowed_user_ids if str(uid).isdigit()}
+        if not approver_ids:
+            return set()
+        if not (DISCORD_AVAILABLE and isinstance(channel, discord.Thread)):
+            return set()
+        found: set = set()
+        try:
+            async for msg in channel.history(limit=100):
+                author = getattr(msg, "author", None)
+                if author is None or getattr(author, "bot", False):
+                    continue
+                uid = str(getattr(author, "id", ""))
+                if uid in approver_ids:
+                    found.add(uid)
+                    if found == approver_ids:
+                        return found
+        except Exception as e:
+            logger.debug("Approval mention scope: thread history scan failed: %s", e)
+        # A just-created auto-thread may hold no human messages yet — the
+        # requester's message lives in the parent channel as the thread's
+        # starter. Public threads share their id with that origin message.
+        if found != approver_ids:
+            starter = getattr(channel, "starter_message", None)
+            if starter is None and getattr(channel, "parent", None) is not None:
+                try:
+                    starter = await channel.parent.fetch_message(channel.id)
+                except Exception:
+                    starter = None
+            author = getattr(starter, "author", None)
+            if author is not None and not getattr(author, "bot", False):
+                uid = str(getattr(author, "id", ""))
+                if uid in approver_ids:
+                    found.add(uid)
+        return found
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -7491,7 +7558,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             if smart_denied:
                 prompt_prefix += "**Smart DENY:** owner override applies to this one operation only.\n\n"
-            mention_content = self._approval_mention_content()
+            mention_content = await self._approval_mention_content_scoped(channel)
             if mention_content:
                 prompt_prefix = f"{mention_content}\n{prompt_prefix}"
             prompt_tail = f"\n```\n**Reason:** {reason_display}"
@@ -10393,6 +10460,12 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     )
     if approval_mentions_cfg is not None and not os.getenv("DISCORD_APPROVAL_MENTIONS"):
         os.environ["DISCORD_APPROVAL_MENTIONS"] = str(approval_mentions_cfg).lower()
+    approval_scope_cfg = (
+        discord_cfg["approval_mentions_scope"] if "approval_mentions_scope" in discord_cfg
+        else platform_extra_cfg.get("approval_mentions_scope")
+    )
+    if approval_scope_cfg is not None and not os.getenv("DISCORD_APPROVAL_MENTIONS_SCOPE"):
+        os.environ["DISCORD_APPROVAL_MENTIONS_SCOPE"] = str(approval_scope_cfg).strip().lower()
     frc = discord_cfg.get("free_response_channels")
     if frc is not None:
         if isinstance(frc, list):

--- a/tests/gateway/test_discord_approval_mentions.py
+++ b/tests/gateway/test_discord_approval_mentions.py
@@ -28,6 +28,52 @@ class _FakeClient:
         return self.channel
 
 
+def _msg(uid, bot=False):
+    return SimpleNamespace(author=SimpleNamespace(id=uid, bot=bot))
+
+
+def _make_thread(messages, starter_msg=None, parent_chan=None):
+    """Build a minimal object that passes ``isinstance(x, discord.Thread)``.
+
+    Subclassing without calling ``discord.Thread.__init__`` sidesteps the
+    gateway-state plumbing; class attributes shadow the ``starter_message`` /
+    ``parent`` properties.
+    """
+    import discord
+
+    class _FakeThread(discord.Thread):
+        starter_message = starter_msg
+        parent = parent_chan
+
+        def __init__(self):
+            self._msgs = list(messages)
+            self.sent_kwargs = None
+
+        def history(self, *, limit=None, oldest_first=False):
+            msgs = self._msgs
+
+            async def _gen():
+                for m in msgs:
+                    yield m
+
+            return _gen()
+
+        async def send(self, **kwargs):
+            self.sent_kwargs = kwargs
+            return SimpleNamespace(id=12345)
+
+    return _FakeThread()
+
+
+def _make_adapter(channel):
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = _FakeClient(channel)
+    adapter._allowed_user_ids = {"222", "111"}
+    adapter._allowed_role_ids = set()
+    adapter.config = SimpleNamespace(extra=None)
+    return adapter
+
+
 @pytest.mark.asyncio
 async def test_exec_approval_mentions_allowed_users_when_enabled(monkeypatch):
     monkeypatch.setenv("DISCORD_APPROVAL_MENTIONS", "true")
@@ -51,6 +97,92 @@ async def test_exec_approval_mentions_allowed_users_when_enabled(monkeypatch):
     assert "make check" in channel.sent_kwargs["content"]
     assert "allowed_mentions" in channel.sent_kwargs
     assert channel.sent_kwargs["embed"].title.endswith("Command Approval Required")
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_participants_scope_mentions_thread_participants(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPROVAL_MENTIONS", "true")
+    monkeypatch.setenv("DISCORD_APPROVAL_MENTIONS_SCOPE", "participants")
+    thread = _make_thread([_msg(999, bot=True), _msg(111), _msg(333)])
+    adapter = _make_adapter(thread)
+
+    result = await adapter.send_exec_approval(
+        chat_id="99",
+        command="make check",
+        session_key="session-1",
+        description="dangerous command",
+    )
+
+    assert result.success is True
+    # Only the approver active in this thread is pinged; 333 is not an
+    # approver, 999 is a bot, and 222 is working elsewhere.
+    assert thread.sent_kwargs["content"].startswith("<@111>\n")
+    assert "<@222>" not in thread.sent_kwargs["content"]
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_participants_scope_falls_back_to_all(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPROVAL_MENTIONS", "true")
+    monkeypatch.setenv("DISCORD_APPROVAL_MENTIONS_SCOPE", "participants")
+    thread = _make_thread([_msg(999, bot=True)])
+    adapter = _make_adapter(thread)
+
+    result = await adapter.send_exec_approval(
+        chat_id="99",
+        command="make check",
+        session_key="session-1",
+        description="dangerous command",
+    )
+
+    assert result.success is True
+    assert thread.sent_kwargs["content"].startswith("<@111> <@222>\n")
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_participants_scope_uses_starter_message_author(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPROVAL_MENTIONS", "true")
+    monkeypatch.setenv("DISCORD_APPROVAL_MENTIONS_SCOPE", "participants")
+    # Fresh auto-thread: no human messages inside yet, requester authored the
+    # parent-channel message the thread hangs off.
+    thread = _make_thread([_msg(999, bot=True)], starter_msg=_msg(222))
+    adapter = _make_adapter(thread)
+
+    result = await adapter.send_exec_approval(
+        chat_id="99",
+        command="make check",
+        session_key="session-1",
+        description="dangerous command",
+    )
+
+    assert result.success is True
+    assert thread.sent_kwargs["content"].startswith("<@222>\n")
+    assert "<@111>" not in thread.sent_kwargs["content"]
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_participants_scope_non_thread_mentions_all(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPROVAL_MENTIONS", "true")
+    monkeypatch.setenv("DISCORD_APPROVAL_MENTIONS_SCOPE", "participants")
+    channel = _FakeChannel()
+    adapter = _make_adapter(channel)
+
+    result = await adapter.send_exec_approval(
+        chat_id="99",
+        command="make check",
+        session_key="session-1",
+        description="dangerous command",
+    )
+
+    assert result.success is True
+    assert channel.sent_kwargs["content"].startswith("<@111> <@222>\n")
+
+
+def test_yaml_config_bridges_approval_mentions_scope(monkeypatch):
+    monkeypatch.delenv("DISCORD_APPROVAL_MENTIONS_SCOPE", raising=False)
+
+    _apply_yaml_config({}, {"approval_mentions_scope": "Participants"})
+
+    assert os.environ["DISCORD_APPROVAL_MENTIONS_SCOPE"] == "participants"
 
 
 def test_yaml_config_seeds_websocket_health_with_primary_precedence(monkeypatch):


### PR DESCRIPTION
Closes #87861

## What

Adds `discord.approval_mentions_scope` (`"all"` | `"participants"`, default `"all"`, env `DISCORD_APPROVAL_MENTIONS_SCOPE`) controlling who gets mentioned by exec-approval prompts when `approval_mentions` is enabled.

| Scope | Behavior |
|---|---|
| `all` (default) | Current behavior — every numeric allowlist entry is mentioned |
| `participants` | Only allowlisted users who took part in the target thread; falls back to `all` when none are found or the target isn't a thread |

## Why

With two or more approvers on `DISCORD_ALLOWED_USERS` working in separate threads, every approval prompt pings all of them — each operator gets interrupted for sessions they aren't part of, and (because Discord auto-joins mentioned users) gets subscribed to the other's thread. Details in #87861.

## How

- `_approval_mention_content_scoped()` wraps the existing `_approval_mention_content()`; scope `participants` narrows to `_thread_participant_approver_ids()`.
- Participation = authored a message in the thread (history scan, limit 100, bots skipped) or authored the thread's starter message (covers a fresh auto-thread whose only human message is the parent-channel origin message).
- Thread *membership* is deliberately not used: without the privileged members intent the gateway only syncs the bot's own membership, and mention auto-join means one all-approver ping would permanently widen membership-based scoping.
- Empty result → falls back to all approvers, so a prompt is never left silent. Non-Discord platforms untouched.
- Config → env bridged in `_apply_yaml_config` next to the existing `approval_mentions` bridge; default seeded in `config_defaults.py`.

## Tests

`tests/gateway/test_discord_approval_mentions.py` — 5 new cases: participant-only mention, fallback when no participants, starter-message author, non-thread fallback, yaml→env bridge. Existing 2 cases unchanged and green.

Backward compatible: absent config key ⇒ `all` ⇒ byte-identical prompts to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
