### PR TITLE
fix(gateway): honor API_SERVER_ENABLED=false as an off switch (#87856)

### DIFF
--- a/gateway/config_env.py
+++ b/gateway/config_env.py
@@ -19,6 +19,7 @@ from gateway.config import (
     HomeChannel,
     Platform,
     PlatformConfig,
+    _coerce_bool,
     _getenv_str,
     _has_usable_api_server_key,
 )
@@ -290,7 +291,18 @@ def _sms_api_key(config: GatewayConfig, sms_config: PlatformConfig) -> None:
 
 
 def _api_server(config: GatewayConfig) -> None:
-    """Require a usable key: an unauthenticated adapter refuses to start and the reconnect watcher would spin."""
+    """Require a usable key: an unauthenticated adapter refuses to start and the reconnect watcher would spin.
+
+    ``API_SERVER_ENABLED`` is the documented on/off toggle, but this gated solely on a usable key — and a fresh
+    install auto-generates a usable ``API_SERVER_KEY`` on first boot, so an explicit ``API_SERVER_ENABLED=false``
+    was dead and the listener started anyway (#87856). Read it as a tri-state: an explicit false is a fail-safe
+    off switch that wins over the key-based force-enable (and over ``enabled: true`` in config.yaml); an unset or
+    unrecognized value keeps the historical key-based behavior."""
+    enabled_raw = getenv("API_SERVER_ENABLED")
+    if enabled_raw.strip() and _coerce_bool(enabled_raw, default=True) is False:
+        if Platform.API_SERVER in config.platforms:
+            config.platforms[Platform.API_SERVER].enabled = False
+        return
     key = getenv("API_SERVER_KEY")
     if not _has_usable_api_server_key(key):
         return

--- a/tests/gateway/test_teams_dotenv_isolation.py
+++ b/tests/gateway/test_teams_dotenv_isolation.py
@@ -250,3 +250,75 @@ class TestLoadGatewayConfigApiServerExplicitDisable:
         assert api_cfg is not None
         assert api_cfg.enabled is False
         assert api_cfg.extra.get("key") == "test-key-0123456789abcdef"
+
+    def test_api_server_enabled_env_false_disables_despite_usable_key(
+        self, tmp_path, monkeypatch
+    ):
+        """API_SERVER_ENABLED=false must win over the key-based force-enable.
+
+        Regression for #87856: a fresh install auto-generates a usable
+        API_SERVER_KEY, so the enable branch always fired and the documented
+        ``API_SERVER_ENABLED`` off switch was dead — the listener started
+        regardless.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("API_SERVER_ENABLED", "false")
+        monkeypatch.setenv("API_SERVER_KEY", "test-key-0123456789abcdef")
+        monkeypatch.chdir(tmp_path)
+
+        from gateway.config import Platform, load_gateway_config
+
+        config = load_gateway_config()
+        api_cfg = config.platforms.get(Platform.API_SERVER)
+        # The platform may still be materialized (key/extras recorded) but must
+        # not be enabled.
+        assert api_cfg is None or api_cfg.enabled is False
+
+    def test_api_server_enabled_env_false_overrides_config_yaml_true(
+        self, tmp_path, monkeypatch
+    ):
+        """An explicit deployment off switch beats a config.yaml ``enabled: true``.
+
+        The env var is the outer, deployment-level override; a fail-safe
+        ``false`` there must take a listener down even when config.yaml turned
+        it on.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  api_server:\n"
+            "    enabled: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("API_SERVER_ENABLED", "false")
+        monkeypatch.setenv("API_SERVER_KEY", "test-key-0123456789abcdef")
+        monkeypatch.chdir(tmp_path)
+
+        from gateway.config import Platform, load_gateway_config
+
+        config = load_gateway_config()
+        api_cfg = config.platforms.get(Platform.API_SERVER)
+        assert api_cfg is not None
+        assert api_cfg.enabled is False
+
+    def test_api_server_unset_env_still_enables_with_usable_key(
+        self, tmp_path, monkeypatch
+    ):
+        """Unset ``API_SERVER_ENABLED`` keeps the historical key-based enable."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("API_SERVER_ENABLED", raising=False)
+        monkeypatch.setenv("API_SERVER_KEY", "test-key-0123456789abcdef")
+        monkeypatch.chdir(tmp_path)
+
+        from gateway.config import Platform, load_gateway_config
+
+        config = load_gateway_config()
+        api_cfg = config.platforms.get(Platform.API_SERVER)
+        assert api_cfg is not None
+        assert api_cfg.enabled is True


### PR DESCRIPTION
Fixes #87856.

## Problem

`load_gateway_config()`'s API-server enable branch (`gateway/config.py`) gated **solely** on `_has_usable_api_server_key(api_server_key)` and never read `API_SERVER_ENABLED` at all. Inside the branch, `enabled` is force-set to `True` unless the *config.yaml* `_enabled_explicit` marker says otherwise — the env var never fed into that decision.

Since a fresh install auto-generates a usable `API_SERVER_KEY` on first boot (`[stage2] Generated API_SERVER_KEY for the loopback gateway api_server`), `_has_usable_api_server_key` is true by default going forward, so the documented `API_SERVER_ENABLED=false` toggle was effectively dead and the OpenAI-compatible listener started regardless.

Impact (from the issue): combined with an explicit `API_SERVER_HOST=0.0.0.0` and `terminal.backend: local`, the endpoint — which dispatches agent work "as the host user with full terminal/file access" per the gateway's own warning — is reachable from every other container on the same Docker network, and the config knob a user reaches for to prevent that did nothing.

## Fix

Read `API_SERVER_ENABLED` as a **tri-state** (unset / on / off) via the profile-scope-aware `_getenv` and the existing `_coerce_bool` helper:

- An explicit **`false`** is honored as a fail-safe off switch: it wins over the key-based force-enable **and** over a config.yaml `enabled: true`. A user who sets `API_SERVER_ENABLED=false` gets no listener even though a usable key is present.
- **Unset** or an unrecognized value keeps the historical key-based behavior (no regression for existing deployments).
- An explicit env **`true`** still does **not** override a config.yaml `enabled: false` — that path is unchanged, so the multiplex secondary-profile guard (which pins `platforms.api_server.enabled: false` to share the default listener) keeps working.

The asymmetry is deliberate and documented in the code: an explicit *disable* is authoritative (fail-safe), while *enabling* still requires a usable key and a not-explicitly-disabled config.

## Tests

`tests/gateway/test_teams_dotenv_isolation.py`:
- `test_api_server_enabled_env_false_disables_despite_usable_key` — the #87856 repro (usable key + `API_SERVER_ENABLED=false`, no config.yaml → not enabled).
- `test_api_server_enabled_env_false_overrides_config_yaml_true` — env off switch beats config.yaml `enabled: true`.
- `test_api_server_unset_env_still_enables_with_usable_key` — regression guard for the historical key-based enable.

The pre-existing `test_load_gateway_config_honors_explicit_api_server_disable` (env `true` must not override config.yaml `false`) still passes unchanged. Preflight green (windows-footguns, ruff, affected tests).
