### PR TITLE
feat(computer_use): let capture ask the aux vision model a question

### DIFF
--- a/tests/tools/test_computer_use_capture_routing.py
+++ b/tests/tools/test_computer_use_capture_routing.py
@@ -307,3 +307,183 @@ class TestBugReproductionAnchor:
         # main provider in #24015.
         assert "data:image" not in resp
         assert "image_url" not in resp
+
+
+# ---------------------------------------------------------------------------
+# capture(question=...) — issue #87818
+# ---------------------------------------------------------------------------
+
+class TestCaptureQuestion:
+    """A caller-supplied ``question`` directs the aux-vision analysis.
+
+    Before #87818 there was nothing to direct it with: ``question`` was not a
+    declared parameter, so a hand-crafted one rode into ``args`` on the back of
+    a permissive schema and was then dropped on the floor, and the aux model
+    always got the same hardcoded "describe what is visible" prompt no matter
+    what the caller wanted to know.
+
+    The narrow-but-load-bearing part of this contract is that a question
+    replaces the *instruction* only. The AX/SOM index below it is what lets the
+    aux model's answer name element numbers that the main model can click by
+    index, so replacing the whole prompt with the question would trade this bug
+    for a worse one.
+    """
+
+    @staticmethod
+    def _prompt_for(cap, **kwargs) -> str:
+        """Run the routed path and return the prompt handed to the aux model."""
+        from tools.computer_use import tool as cu_tool
+
+        fake_vat = MagicMock(return_value="<coro>")
+
+        with patch.object(cu_tool, "_should_route_through_aux_vision",
+                          return_value=True), \
+             patch("model_tools._run_async",
+                   side_effect=lambda _coro: _stub_aux_analysis("ok")), \
+             patch("tools.vision_tools.vision_analyze_tool",
+                   new_callable=lambda: fake_vat):
+            cu_tool._capture_response(cap, **kwargs)
+
+        return fake_vat.call_args[0][1]
+
+    def test_question_reaches_the_aux_vision_prompt(self, tmp_cache_dir):
+        prompt = self._prompt_for(
+            _make_capture(mode="som"),
+            question="Is the Sign in button enabled?",
+        )
+
+        assert "Is the Sign in button enabled?" in prompt
+        # The general-description instruction is what the question replaces.
+        assert "Describe what is visible" not in prompt
+
+    def test_ax_som_index_survives_a_directed_question(self, tmp_cache_dir):
+        """The regression guard for the obvious wrong fix.
+
+        Swapping the whole prompt for the caller's question would read as
+        working — the question reaches the model, the answer comes back — while
+        silently costing ``mode='som'`` the element index its click-by-index
+        contract is built on. Assert the index is still there.
+        """
+        prompt = self._prompt_for(
+            _make_capture(mode="som"),
+            question="What error is in the dialog?",
+        )
+
+        assert "AX/SOM index for cross-reference:" in prompt
+        # …and the actual index content, not just the header.
+        assert "Sign in" in prompt
+        assert "username" in prompt
+
+    def test_directed_question_keeps_the_do_not_invent_clause(
+        self, tmp_cache_dir,
+    ):
+        """A yes/no question invites confabulation more readily than an open
+        describe does, so the anti-invention clause is needed more on this
+        branch, not less."""
+        prompt = self._prompt_for(
+            _make_capture(mode="som"),
+            question="Is there an unsaved-changes indicator?",
+        )
+
+        assert "Do not invent details that are not actually visible." in prompt
+
+    def test_no_question_falls_back_to_the_general_description(
+        self, tmp_cache_dir,
+    ):
+        prompt = self._prompt_for(_make_capture(mode="som"))
+
+        assert "Describe what is visible in this desktop application" in prompt
+        assert "Answer this question" not in prompt
+        # Unchanged from before #87818 on this branch.
+        assert "AX/SOM index for cross-reference:" in prompt
+        assert "Do not invent details that are not actually visible." in prompt
+
+    def test_blank_question_falls_back_rather_than_asking_nothing(
+        self, tmp_cache_dir,
+    ):
+        """``question=""`` must not produce an instruction to answer an empty
+        question — it is indistinguishable from not passing one at all."""
+        prompt = self._prompt_for(_make_capture(mode="som"), question="")
+
+        assert "Describe what is visible in this desktop application" in prompt
+        assert "Answer this question" not in prompt
+
+
+class TestCaptureQuestionPlumbing:
+    """``question`` must be reachable from a real tool call, not just from a
+    direct ``_capture_response`` call in a test."""
+
+    def test_declared_in_the_schema(self):
+        """Threading the value through without declaring it leaves the feature
+        unreachable for any well-behaved client, and stripped outright by a
+        strict-schema one. Both halves are the fix."""
+        from tools.computer_use.schema import COMPUTER_USE_SCHEMA
+
+        prop = COMPUTER_USE_SCHEMA["parameters"]["properties"]["question"]
+        assert prop["type"] == "string"
+        assert "capture" in prop["description"]
+
+    def test_dispatch_threads_question_from_tool_args(self):
+        from tools.computer_use import tool as cu_tool
+
+        backend = MagicMock()
+        backend.capture.return_value = _make_capture(mode="som")
+
+        with patch.object(cu_tool, "_capture_response",
+                          return_value="{}") as fake_resp:
+            cu_tool._dispatch(
+                backend,
+                "capture",
+                {"mode": "som", "question": "Is the Save button enabled?"},
+            )
+
+        _args, kwargs = fake_resp.call_args
+        assert kwargs["question"] == "Is the Save button enabled?"
+
+    def test_dispatch_passes_none_when_no_question_given(self):
+        from tools.computer_use import tool as cu_tool
+
+        backend = MagicMock()
+        backend.capture.return_value = _make_capture(mode="som")
+
+        with patch.object(cu_tool, "_capture_response",
+                          return_value="{}") as fake_resp:
+            cu_tool._dispatch(backend, "capture", {"mode": "som"})
+
+        _args, kwargs = fake_resp.call_args
+        assert kwargs["question"] is None
+
+
+class TestCoerceQuestion:
+    """``_coerce_question`` is the same shape as ``_coerce_max_elements``: a
+    malformed tool-call argument degrades to the default behaviour instead of
+    reaching the prompt."""
+
+    @pytest.mark.parametrize("value", [None, 42, 3.5, True, [], {}, object()])
+    def test_non_strings_are_dropped(self, value):
+        from tools.computer_use import tool as cu_tool
+
+        assert cu_tool._coerce_question(value) is None
+
+    @pytest.mark.parametrize("value", ["", "   ", "\n\t "])
+    def test_blank_strings_are_dropped(self, value):
+        from tools.computer_use import tool as cu_tool
+
+        assert cu_tool._coerce_question(value) is None
+
+    def test_surrounding_whitespace_is_stripped(self):
+        from tools.computer_use import tool as cu_tool
+
+        assert cu_tool._coerce_question("  what is on screen?  ") == (
+            "what is on screen?"
+        )
+
+    def test_overlong_question_is_capped(self):
+        """An unbounded question is interpolated ahead of the AX/SOM index and
+        can crowd out the index it is meant to accompany."""
+        from tools.computer_use import tool as cu_tool
+
+        coerced = cu_tool._coerce_question("q" * 5000)
+
+        assert coerced is not None
+        assert len(coerced) == cu_tool._MAX_QUESTION_CHARS

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -132,6 +132,22 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                 "minimum": 1,
                 "maximum": 1000,
             },
+            "question": {
+                "type": "string",
+                "description": (
+                    "Optional question to direct `action='capture'` at "
+                    "something specific (\"is the Save button enabled?\", "
+                    "\"what error is in the dialog?\") instead of taking a "
+                    "general description. Only takes effect when the "
+                    "screenshot is routed through the auxiliary vision "
+                    "model, which happens when the main model cannot "
+                    "consume images itself; a multimodal main model sees "
+                    "the screenshot directly and needs no relay of what it "
+                    "was already asking. The AX/SOM element index is still "
+                    "returned either way, so click-by-index keeps working. "
+                    "Truncated past 2000 characters."
+                ),
+            },
             # ── click / drag / scroll targeting ────────────────────
             "element": {
                 "type": "integer",

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -708,7 +708,11 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
                 "window_id": args.get("window_id"),
             })
         cap = backend.capture(**capture_kwargs)
-        return _capture_response(cap, max_elements=_coerce_max_elements(args.get("max_elements")))
+        return _capture_response(
+            cap,
+            max_elements=_coerce_max_elements(args.get("max_elements")),
+            question=_coerce_question(args.get("question")),
+        )
 
     if action == "wait":
         seconds = float(args.get("seconds", 1.0))
@@ -1087,6 +1091,10 @@ _DEFAULT_MAX_ELEMENTS = 100
 # call passing a very large integer would silently disable the safeguard and
 # reintroduce the original unbounded behavior.
 _MAX_ALLOWED_MAX_ELEMENTS = 1000
+# Cap on the caller-supplied capture `question`. It is interpolated into the
+# auxiliary vision prompt ahead of the AX/SOM index, so an unbounded one can
+# crowd out the index that click-by-index depends on.
+_MAX_QUESTION_CHARS = 2000
 _MIN_PROVIDER_IMAGE_DIMENSION = 8
 
 
@@ -1166,7 +1174,30 @@ def _coerce_max_elements(value: Any) -> int:
     return n
 
 
-def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEMENTS) -> Any:
+def _coerce_question(value: Any) -> Optional[str]:
+    """Validate the caller-supplied capture ``question``.
+
+    Returns ``None`` for anything that is not usable as an instruction —
+    missing, non-string, or whitespace-only — so the aux-vision prompt falls
+    back to the general description rather than embedding an empty or
+    ``None``-stringified line. Length is capped for the same reason
+    ``max_elements`` is: the question is interpolated into the auxiliary
+    model's prompt, and an unbounded one lets a single tool-call argument
+    crowd out the AX/SOM index it is meant to accompany.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    return text[:_MAX_QUESTION_CHARS]
+
+
+def _capture_response(
+    cap: CaptureResult,
+    max_elements: int = _DEFAULT_MAX_ELEMENTS,
+    question: Optional[str] = None,
+) -> Any:
     total_elements = len(cap.elements)
     visible_elements = cap.elements[:max_elements]
     truncated_elements = max(0, total_elements - len(visible_elements))
@@ -1253,6 +1284,7 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
                 truncated_elements=truncated_elements,
                 elements_file=elements_file,
                 screenshot_path=screenshot_path,
+                question=question,
             )
             if routed is not None:
                 return routed
@@ -1460,6 +1492,7 @@ def _route_capture_through_aux_vision(
     truncated_elements: int = 0,
     elements_file: Optional[str] = None,
     screenshot_path: Optional[str] = None,
+    question: Optional[str] = None,
 ) -> Optional[str]:
     """Pre-analyse the captured PNG via ``vision_analyze`` and return a text result.
 
@@ -1510,13 +1543,35 @@ def _route_capture_through_aux_vision(
         raw, scale_note = _shrink_capture_for_vision(raw, ext)
         temp_image_path.write_bytes(raw)
 
+        # A caller-supplied question replaces the general-description
+        # instruction, but only that. The AX/SOM index below it is what lets
+        # the aux model's answer name element numbers the main model can then
+        # click by index, so it is appended in both branches — swapping the
+        # whole prompt for the question would silently cost `som` mode its
+        # click-by-index contract. The do-not-invent clause is likewise kept
+        # in both: a directed question invites a confabulated yes/no more
+        # readily than an open describe does, not less.
+        if question:
+            instruction = (
+                "Answer this question about the desktop application "
+                f"screenshot:\n{question}\n\n"
+                "Answer directly and specifically, citing the on-screen text "
+                "or control you are reading it from. If the screenshot does "
+                "not show enough to answer, say so plainly instead of "
+                "guessing. Do not invent details that are not actually "
+                "visible."
+            )
+        else:
+            instruction = (
+                "Describe what is visible in this desktop application screenshot in "
+                "concise but specific terms. Mention the app name and window "
+                "title if visible, the overall layout, any labelled buttons, "
+                "menus or text fields, and any prominent text content the user "
+                "would need to know about. Do not invent details that are not "
+                "actually visible."
+            )
         prompt = (
-            "Describe what is visible in this desktop application screenshot in "
-            "concise but specific terms. Mention the app name and window "
-            "title if visible, the overall layout, any labelled buttons, "
-            "menus or text fields, and any prominent text content the user "
-            "would need to know about. Do not invent details that are not "
-            "actually visible.\n\n"
+            f"{instruction}\n\n"
             f"AX/SOM index for cross-reference:\n{summary}"
         )
         if scale_note:


### PR DESCRIPTION
## What does this PR do?

`computer_use(action='capture')` had exactly one thing to say to the auxiliary vision model: a hardcoded "describe what is visible" prompt. When the main model cannot consume images itself (the whole reason the aux-vision route exists, per #24015), that generic paragraph is the *only* view of the screen the agent ever gets. Ask "is the Save button enabled?" and you get prose about the window, and the caller has to infer an answer from text that was never aimed at the question.

#87818 reported this as a dropped parameter. It is worth being precise, because it changes the fix: `question` is not dropped, it was **never declared**. `COMPUTER_USE_SCHEMA['parameters']['properties']` has 47 entries and `question` is not among them (`query` is browser-state only, `prompt_text` is for page dialogs), and `grep -c question tools/computer_use/tool.py` on `main` returns 0. The reason the reporter's hand-crafted key appears to reach `args` at all is that the schema does not set `additionalProperties: false`, so the extra key rides along and is then ignored. No model would ever emit it on its own, because nothing advertises it.

So threading `args.get("question")` through on its own would not fix this: the feature would stay unreachable for any well-behaved client and be stripped outright by a strict-schema one. Both halves are here.

### The part that needed care

A caller-supplied question replaces the general-description **instruction** only. It does not replace the prompt. The prompt on `main` is two things joined together:

```python
prompt = (
    "Describe what is visible in this desktop application screenshot ..."
    f"AX/SOM index for cross-reference:\n{summary}"
)
```

That trailing block is the AX/SOM element index, and it is the reason `mode='som'` exists: it is what lets the aux model's answer refer to element numbers that the main model can then click by index. Swapping the whole prompt for the caller's question is the obvious fix and it reads as working (the question reaches the model, an answer comes back) while silently costing every directed capture its click-by-index contract. `test_ax_som_index_survives_a_directed_question` is there specifically to fail if someone later makes that trade.

The "do not invent details that are not actually visible" clause is likewise kept on both branches. A directed yes/no question invites a confabulated answer more readily than an open describe does, not less.

## Related Issue

Fixes #87818

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

Filed as a bug; typing it as a feature because the parameter never existed, so nothing regressed. No existing behaviour changes when `question` is absent.

## Changes Made

- `tools/computer_use/schema.py` — declare `question` (string, capture-scoped) next to `max_elements`. The description states plainly that it only takes effect on the aux-vision route, that a multimodal main model sees the screenshot directly and needs no relay of what it was already asking, and that the element index is returned either way.
- `tools/computer_use/tool.py`
  - `_MAX_QUESTION_CHARS = 2000` and `_coerce_question()`, mirroring `_MAX_ALLOWED_MAX_ELEMENTS` / `_coerce_max_elements()`. Non-string, missing and whitespace-only inputs degrade to `None` so a malformed tool-call argument falls back to the general description instead of instructing the model to answer nothing. The cap exists because the question is interpolated *ahead of* the AX/SOM index, so an unbounded one crowds out the index it is meant to accompany.
  - `_dispatch` capture branch passes `question=_coerce_question(args.get("question"))`.
  - `_capture_response(cap, max_elements=..., question=None)` forwards it.
  - `_route_capture_through_aux_vision(..., question=None)` selects the instruction; the AX/SOM index and the `scale_note` append are unchanged and shared by both branches.
- `tests/tools/test_computer_use_capture_routing.py` — 16 tests appended to the existing #24015 routing harness (same file, same stubs, no new fixtures).

## How to Test

1. `pytest tests/tools/test_computer_use_capture_routing.py -q` — 27 passed.
2. Mutation check, so the new tests are not decoration. Revert `tools/computer_use/tool.py` and `tools/computer_use/schema.py`, keep the tests, and re-run: **19 of the 20 new test cases fail**, `TypeError: unexpected keyword argument 'question'` / `KeyError: 'question'` / `AttributeError: _coerce_question`.
3. The one that passes both ways is `test_no_question_falls_back_to_the_general_description`, and it is meant to. It pins the unchanged default path, so it is a guard against this PR having quietly altered behaviour for callers who pass nothing, not a proof of the bug. Calling it out rather than letting it be counted as coverage it is not.
4. End to end, with a non-vision main model and `auxiliary.vision` configured:
   ```
   computer_use(action="capture", mode="som", question="Is the Save button enabled?")
   ```
   Before: a paragraph describing the window. After: an answer to the question, with the `elements` array and SOM indices still present so the follow-up `click(element=N)` still works.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

On the unchecked box, since I would rather say what I actually ran than check it and be wrong. I ran `tests/tools/test_computer_use*.py` and `tests/computer_use/` (164 passed, 4 skipped) rather than the full suite. Five failures in that set are pre-existing and environment-dependent, not from this change: `test_cua_driver_cmd_env_override_is_resolved_dynamically`, `test_cli_fallback_reads_screenshot_from_file`, `test_linux_default_capture_skips_gnome_shell_helper`, and the two `test_cua_wsl_manifest_path.py` cases. Verified by stashing the whole diff and re-running: identical 5 failures on a clean tree. They are Linux/WSL-shaped and fail on a Windows box regardless. CI is the real gate for the rest.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on `_coerce_question`, and a comment at the prompt fork explaining why the index block is not part of the swap)
- [x] N/A — no config keys added
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — `scripts/check-windows-footguns.py --all` clean over 973 files. The change is pure string handling with no path, encoding or subprocess surface.
- [x] I've updated tool descriptions/schemas — this is half the fix

## Notes for the reviewer

**Two things I want a maintainer opinion on rather than to have decided quietly.**

**1. `capture_after` does not get a question, and that is deliberate.** `_maybe_follow_capture` calls `_capture_response(cap)` with no tuning arguments at all, so `max_elements` is *already* silently ignored on that path today. `question` follows the existing precedent rather than establishing a new asymmetry. Making capture-tuning arguments apply to `capture_after` is a real improvement, but it touches seven call sites and would need to fix `max_elements` in the same breath, so it belongs in its own PR. Happy to write it if wanted.

**2. `ruff format` is not clean on these files, and matching it would be the anomaly.** `tools/computer_use/tool.py` and `schema.py` are manually wrapped at roughly 79 columns; `ruff format` wants 88 and would rejoin those lines. On a clean tree the three files I touch already produce 535 diff lines under `ruff format --diff`, and after my change 570, so the ~35 added lines are my new code being wrapped in exactly the same house style as the code above and below it. The one hunk inside my own change that `ruff` objects to sits directly beside a pre-existing `_run_async(...)` call it objects to identically. `ruff check` passes clean on both files. I matched local idiom rather than reformatting; say the word if the project would rather I ran the formatter.

**3.** Credit to @alloevil for the report, and a correction of mine on the issue thread: I initially told them their cited signature for `_route_capture_through_aux_vision` was not what is on `main`. It was, exactly. I had read a stale checkout, and I have said so on the issue.
