### PR TITLE
feat(agent): add configurable execution modes

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1871,6 +1871,14 @@ def init_agent(
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
+    # Resolve once per AIAgent so config edits cannot mutate the cached prompt
+    # for a conversation that is already in progress.
+    from agent.prompt_builder import normalize_execution_mode
+
+    agent._execution_mode = normalize_execution_mode(
+        _agent_section.get("execution_mode", "rigorous")
+    )
+
     # Intent-ack continuation config: "auto" (default — codex_responses only,
     # the historical gate), true (all api_modes), false (never), or a list of
     # model-name substrings.  Resolved against the active api_mode/model in the

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -354,6 +354,38 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "without acting are not acceptable."
 )
 
+EXECUTION_MODES = ("fast", "balanced", "rigorous")
+
+
+def normalize_execution_mode(value: object) -> str:
+    """Return a supported execution mode, preserving legacy rigor by default."""
+    mode = str(value or "rigorous").strip().lower()
+    return mode if mode in EXECUTION_MODES else "rigorous"
+
+
+def build_tool_use_enforcement_guidance(execution_mode: str) -> str:
+    """Build deterministic tool-action guidance for one conversation mode."""
+    mode = normalize_execution_mode(execution_mode)
+    if mode == "fast":
+        return (
+            "# Tool-use discipline\n"
+            "Answer direct conversational questions directly. Use tools only when the answer "
+            "depends on live/current facts, calculations, hashes or encodings, system or file "
+            "state, Git state, current versions, a requested side effect, or materially necessary "
+            "verification. If you state that you will take an action, make the corresponding tool "
+            "call in the same response; never promise work you do not perform. Stop when the "
+            "user's actual request is satisfied."
+        )
+    if mode == "balanced":
+        return (
+            "# Tool-use discipline\n"
+            "Use tools when they are materially useful for correctness or to perform a requested "
+            "action. If you state that you will take an action, make the corresponding tool call "
+            "in the same response; never promise work you do not perform. Verify side effects and "
+            "consequential claims, and stop once the request is satisfied."
+        )
+    return TOOL_USE_ENFORCEMENT_GUIDANCE
+
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
 TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm", "qwen", "deepseek")
@@ -388,6 +420,28 @@ TASK_COMPLETION_GUIDANCE = (
     "for results you couldn't actually produce. Reporting a blocker honestly "
     "is always better than inventing a result."
 )
+
+
+def build_task_completion_guidance(execution_mode: str) -> str:
+    """Build completion/retry guidance without weakening real-action grounding."""
+    mode = normalize_execution_mode(execution_mode)
+    if mode == "fast":
+        return (
+            "# Finishing the job\n"
+            "When the user requests an action, perform it and report the real result; do not stop "
+            "at a promise, stub, or plan. For routine low-risk work, try at most one materially "
+            "different strategy after a failure, then report the blocker. Never fabricate output "
+            "or claim a side effect occurred without verification. Stop when the request is satisfied."
+        )
+    if mode == "balanced":
+        return (
+            "# Finishing the job\n"
+            "When the user requests an action, complete it and report the real result rather than "
+            "a promise, stub, or plan. Retry a failure when another attempt has a reasonable chance "
+            "of succeeding. Never fabricate output, and verify side effects and consequential claims. "
+            "Stop when the request is satisfied."
+        )
+    return TASK_COMPLETION_GUIDANCE
 
 # Universal parallel-tool-call guidance — applied to ALL models.
 #
@@ -438,7 +492,7 @@ PARALLEL_TOOL_CALL_GUIDANCE = (
 # without tool calls, suggests workarounds instead of using existing tools,
 # replies with plans/suggestions instead of executing). The body is
 # family-agnostic; the OPENAI_ prefix reflects origin, not exclusivity.
-OPENAI_MODEL_EXECUTION_GUIDANCE = (
+RIGOROUS_MODEL_EXECUTION_GUIDANCE = (
     "# Execution discipline\n"
     "<tool_persistence>\n"
     "- Use tools whenever they improve correctness, completeness, or grounding.\n"
@@ -497,6 +551,46 @@ OPENAI_MODEL_EXECUTION_GUIDANCE = (
     "- If you must proceed with incomplete information, label assumptions explicitly.\n"
     "</missing_context>"
 )
+
+FAST_MODEL_EXECUTION_GUIDANCE = (
+    "# Execution discipline\n"
+    "Give direct answers to direct conversational questions. A simple request should normally "
+    "need zero to three tool calls. Do not use tools unless the answer depends on current/live "
+    "facts; arithmetic or calculations; hashes, checksums, or encodings; current date, time, or "
+    "timezone; system state; file contents or filesystem facts; Git history, branches, or diffs; "
+    "current versions; a requested side effect; or materially necessary verification.\n"
+    "For routine low-risk work, retry a failed or incomplete result at most once using a "
+    "materially different strategy, then report the blocker. Use proportional verification: "
+    "verify real side effects and high-risk claims without repeatedly rechecking settled facts. "
+    "Stop when the user's actual request is satisfied. Never fabricate tool output or claim an "
+    "action occurred without confirming it. Preserve approval, secret-handling, injection-defense, "
+    "and destructive/external/financial/credential/deployment/production safeguards."
+)
+
+BALANCED_MODEL_EXECUTION_GUIDANCE = (
+    "# Execution discipline\n"
+    "Use tools when materially useful. Retry incomplete results when another attempt has a "
+    "reasonable chance of succeeding. Require tools for arithmetic and calculations; hashes, "
+    "checksums, and encodings; current date, time, and timezone; live system or filesystem state; "
+    "file contents; Git history, branches, and diffs; current news, weather, versions, and other "
+    "time-sensitive facts; and requested side effects. Verify side effects and consequential "
+    "claims, but avoid exhaustive investigation after the request is satisfied. Never fabricate "
+    "tool output or claim an action occurred without confirming it. Preserve approval, secret-"
+    "handling, injection-defense, and high-risk-action safeguards."
+)
+
+
+def build_model_execution_guidance(execution_mode: str) -> str:
+    """Return the byte-stable model execution block for *execution_mode*."""
+    return {
+        "fast": FAST_MODEL_EXECUTION_GUIDANCE,
+        "balanced": BALANCED_MODEL_EXECUTION_GUIDANCE,
+        "rigorous": RIGOROUS_MODEL_EXECUTION_GUIDANCE,
+    }[normalize_execution_mode(execution_mode)]
+
+
+# Backward-compatible export for callers/tests that import the historical name.
+OPENAI_MODEL_EXECUTION_GUIDANCE = RIGOROUS_MODEL_EXECUTION_GUIDANCE
 
 # Gemini/Gemma-specific operational guidance, adapted from OpenCode's gemini.txt.
 # Injected alongside TOOL_USE_ENFORCEMENT_GUIDANCE when the model is Gemini or Gemma.
@@ -1744,6 +1838,7 @@ def build_skills_system_prompt(
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
     skills_dir_override: "Path | None" = None,
+    execution_mode: str = "rigorous",
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -1765,6 +1860,7 @@ def build_skills_system_prompt(
     visible and loadable via ``skill_view`` / ``skills_list``; only the
     descriptions are dropped, and a footer note explains the demotion.
     """
+    execution_mode = normalize_execution_mode(execution_mode)
     # Home resolution is EXPLICIT when a caller passes skills_dir_override
     # (the agent knows its own profile home from its session_db path). This
     # avoids the ContextVar-on-a-thread trap: build threads that didn't bind
@@ -1790,6 +1886,7 @@ def build_skills_system_prompt(
             available_tools,
             available_toolsets,
             compact_categories,
+            execution_mode,
         )
     finally:
         if _home_token is not None:
@@ -1802,6 +1899,7 @@ def _build_skills_system_prompt_inner(
     available_tools: "set[str] | None",
     available_toolsets: "set[str] | None",
     compact_categories: "frozenset[str] | None",
+    execution_mode: str,
 ) -> str:
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
@@ -1815,6 +1913,7 @@ def _build_skills_system_prompt_inner(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        execution_mode,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -2023,19 +2122,44 @@ def _build_skills_system_prompt_inner(
                 else:
                     index_lines.append(f"    - {name}")
 
-        result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
+        if execution_mode == "fast":
+            skills_heading = "## Skills"
+            skill_policy = (
+                "Before replying, scan the skills below. Load a skill with skill_view(name) only "
+                "when it is clearly relevant and likely to materially improve correctness. Do not "
+                "load a skill merely because it is tangentially or partially relevant. "
+            )
+        elif execution_mode == "balanced":
+            skills_heading = "## Skills"
+            skill_policy = (
+                "Before replying, scan the skills below. If a skill is relevant and materially "
+                "useful to the task, load it with skill_view(name) and follow its instructions. "
+            )
+        else:
+            skills_heading = "## Skills (mandatory)"
+            skill_policy = (
+                "Before replying, scan the skills below. If a skill matches or is even partially relevant "
+                "to your task, you MUST load it with skill_view(name) and follow its instructions. "
+                "Err on the side of loading — it is always better to have context you don't need "
+                "than to miss critical steps, pitfalls, or established workflows. "
+            )
+        skill_value = (
             "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
-            "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
+            "and proven workflows that can outperform general-purpose approaches. "
+        )
+        if execution_mode == "rigorous":
+            skill_value += (
+                "Load the skill even if you think you could handle the task with basic tools like "
+                "web_search or terminal. Skills also encode the user's preferred approach, "
+                "conventions, and quality standards for tasks like code review, planning, and "
+                "testing — load them even for tasks you already know how to do, because the skill "
+                "defines how it should be done here.\n"
+            )
+        result = (
+            skills_heading + "\n"
+            + skill_policy
+            + skill_value
+            + "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
             "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
             "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
@@ -2049,7 +2173,11 @@ def _build_skills_system_prompt_inner(
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
             "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            + (
+                "Only proceed without loading a skill if genuinely none are relevant to the task."
+                if execution_mode == "rigorous"
+                else "Proceed without loading a skill when none meet the relevance standard above."
+            )
             + hidden_note
         )
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -37,16 +37,16 @@ from agent.prompt_builder import (
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
     MEMORY_GUIDANCE,
-    OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
     PLATFORM_HINTS,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
     STEER_CHANNEL_NOTE,
-    TASK_COMPLETION_GUIDANCE,
     TELEGRAM_RICH_MESSAGES_HINT,
-    TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    build_model_execution_guidance,
+    build_task_completion_guidance,
+    build_tool_use_enforcement_guidance,
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
@@ -369,6 +369,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         if isinstance(_cc_len, int) and _cc_len > 0:
             _ctx_len = _cc_len
 
+    # Frozen during AIAgent initialization. Never re-read config here: the
+    # selected prompt mode must remain byte-stable for this conversation.
+    execution_mode = getattr(agent, "_execution_mode", "rigorous")
+
     # ── Stable tier ────────────────────────────────────────────────
     stable_parts: List[str] = []
 
@@ -399,7 +403,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # config.yaml ``agent.task_completion_guidance`` (default True) so
     # users who want a leaner prompt can turn it off.
     if getattr(agent, "_task_completion_guidance", True) and agent.valid_tool_names:
-        stable_parts.append(TASK_COMPLETION_GUIDANCE)
+        stable_parts.append(build_task_completion_guidance(execution_mode))
 
     # Universal parallel-tool-call guidance.  Tells the model to batch
     # independent tool calls into one assistant turn rather than emitting one
@@ -471,7 +475,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             model_lower = (agent.model or "").lower()
             _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
         if _inject:
-            stable_parts.append(TOOL_USE_ENFORCEMENT_GUIDANCE)
+            stable_parts.append(build_tool_use_enforcement_guidance(execution_mode))
             _model_lower = (agent.model or "").lower()
             # Google model operational guidance (conciseness, absolute
             # paths, parallel tool calls, verify-before-edit, etc.)
@@ -483,7 +487,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             # without tool calls, suggests workarounds instead of using
             # existing tools, replies with plans instead of executing).
             if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
-                stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
+                stable_parts.append(build_model_execution_guidance(execution_mode))
 
     has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
     if has_skills_tools:
@@ -512,6 +516,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
             skills_dir_override=_agent_skills_dir(agent),
+            execution_mode=execution_mode,
         )
     else:
         skills_prompt = ""

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -932,6 +932,12 @@ skills:
 # Agent Behavior
 # =============================================================================
 agent:
+  # Prompt execution posture: fast | balanced | rigorous (default: rigorous).
+  # "fast" answers simple questions directly and uses tools/skills selectively;
+  # "balanced" uses them when materially useful; "rigorous" preserves the
+  # historical exhaustive execution and verification behavior.
+  # execution_mode: rigorous
+
   # Maximum tool-calling iterations per conversation (default: 500)
   # Higher = more room for complex tasks, but costs more tokens
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1994,6 +1994,9 @@ class ConfigIssue:
     hint: str
 
 
+_EXECUTION_MODES = frozenset({"fast", "balanced", "rigorous"})
+
+
 def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:
     """Validate config.yaml structure and return a list of detected issues.
 
@@ -2022,6 +2025,16 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 "error",
                 f"voice.submit_mode must be 'direct' or 'draft', got {submit_mode!r}",
                 "Set voice.submit_mode to direct (submit immediately) or draft (edit before sending)",
+            ))
+
+    agent_cfg = config.get("agent")
+    if isinstance(agent_cfg, dict) and "execution_mode" in agent_cfg:
+        execution_mode = agent_cfg.get("execution_mode")
+        if not isinstance(execution_mode, str) or execution_mode.strip().lower() not in _EXECUTION_MODES:
+            issues.append(ConfigIssue(
+                "error",
+                "agent.execution_mode must be one of: fast, balanced, rigorous",
+                "Set it with: hermes config set agent.execution_mode fast",
             ))
 
     # ── custom_providers must be a list, not a dict ──────────────────────
@@ -5219,6 +5232,15 @@ def set_config_value(key: str, value: str, force: bool = False):
     if is_managed():
         managed_error("set configuration values")
         return
+    if key.strip().lower() == "agent.execution_mode":
+        normalized_mode = str(value).strip().lower()
+        if normalized_mode not in _EXECUTION_MODES:
+            print(
+                "✗ agent.execution_mode must be one of: fast, balanced, rigorous",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        value = normalized_mode
     # Managed scope guard (D2): a key pinned by the managed layer cannot be set by
     # the user — the next load would override it anyway. Hard-reject and name the
     # source. Distinct from is_managed() above (the package-manager write-lock).

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -124,6 +124,10 @@ DEFAULT_CONFIG = {
         # provider hiccups on a single provider.
         "api_max_retries": 3,
         "service_tier": "",
+        # Prompt execution posture. Missing values preserve the historical
+        # exhaustive behavior through the normal defaults deep-merge.
+        # Values: "fast", "balanced", or "rigorous".
+        "execution_mode": "rigorous",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.
         # Values: "auto" (default — applies to gpt/codex models), true/false

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -238,6 +238,7 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("agent", "gateway_timeout"),
         ("agent", "session_stall_timeout"),
         ("agent", "tool_use_enforcement"),
+        ("agent", "execution_mode"),
         ("terminal", "backend"),
         ("terminal", "docker_image"),
         ("terminal", "persistent_shell"),

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -28,6 +28,9 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
+    build_model_execution_guidance,
+    build_task_completion_guidance,
+    build_tool_use_enforcement_guidance,
     PARALLEL_TOOL_CALL_GUIDANCE,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     MEMORY_GUIDANCE,
@@ -54,6 +57,30 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_execution_guidance_is_mode_specific_and_grounded(self):
+        fast = build_model_execution_guidance("fast")
+        balanced = build_model_execution_guidance("balanced")
+        rigorous = build_model_execution_guidance("rigorous")
+
+        assert "zero to three tool calls" in fast
+        assert "arithmetic" in fast and "Git history" in fast
+        assert "reasonable chance" in balanced
+        assert "Keep calling tools until" in rigorous
+        assert rigorous == OPENAI_MODEL_EXECUTION_GUIDANCE
+        assert len({fast, balanced, rigorous}) == 3
+
+    def test_tool_use_guidance_still_requires_stated_actions(self):
+        for mode in ("fast", "balanced", "rigorous"):
+            guidance = build_tool_use_enforcement_guidance(mode)
+            assert "action" in guidance.lower()
+            assert "tool" in guidance.lower()
+
+    def test_fast_completion_guidance_bounds_retry_and_preserves_grounding(self):
+        guidance = build_task_completion_guidance("fast")
+        assert "at most one" in guidance
+        assert "Never fabricate" in guidance
+        assert "verification" in guidance
 
 
 # =========================================================================
@@ -293,6 +320,24 @@ class TestBuildSkillsSystemPrompt:
         result = build_skills_system_prompt()
         # "search" should appear only once per category
         assert result.count("- search") == 1
+
+    def test_skill_loading_policy_and_cache_are_mode_specific(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "tools" / "search"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: search\ndescription: Search stuff\n---\n"
+        )
+
+        fast = build_skills_system_prompt(execution_mode="fast")
+        balanced = build_skills_system_prompt(execution_mode="balanced")
+        rigorous = build_skills_system_prompt(execution_mode="rigorous")
+
+        assert "clearly relevant" in fast
+        assert "tangentially or partially relevant" in fast
+        assert "relevant and materially useful" in balanced
+        assert "even partially relevant" in rigorous
+        assert len({fast, balanced, rigorous}) == 3
 
 
     def test_compact_categories_demote_nested_and_miss_cache_separately(
@@ -988,5 +1033,3 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -194,6 +194,23 @@ def test_build_system_prompt_records_stable_prefix():
     assert prompt[len(agent._cached_system_prompt_static):].startswith("\n\ncontext")
 
 
+def test_execution_mode_selects_stable_prompt_guidance():
+    common = dict(
+        valid_tool_names=["read_file"],
+        model="gpt-5",
+        _tool_use_enforcement=True,
+        _parallel_tool_call_guidance=False,
+    )
+    fast = _stable_prompt(_make_agent(_execution_mode="fast", **common))
+    balanced = _stable_prompt(_make_agent(_execution_mode="balanced", **common))
+    rigorous = _stable_prompt(_make_agent(_execution_mode="rigorous", **common))
+
+    assert "zero to three tool calls" in fast
+    assert "reasonable chance" in balanced
+    assert "Keep calling tools until" in rigorous
+    assert len({fast, balanced, rigorous}) == 3
+
+
 def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
     """The cache split must not reorder the stored coding prompt."""
     import agent.system_prompt as system_prompt

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -39,6 +39,21 @@ class TestGetHermesHome:
             assert home == Path.home() / ".hermes"
 
 
+class TestExecutionModeConfig:
+    def test_existing_config_defaults_to_rigorous_without_materializing_key(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("agent:\n  max_turns: 50\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            loaded = load_config()
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert DEFAULT_CONFIG["agent"]["execution_mode"] == "rigorous"
+        assert loaded["agent"]["execution_mode"] == "rigorous"
+        assert "execution_mode" not in raw.get("agent", {})
+
+
 class TestEnsureHermesHome:
 
     def test_creates_default_soul_md_if_missing(self, tmp_path):

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -111,6 +111,20 @@ class TestVoiceSubmitModeValidation:
         )
 
 
+class TestExecutionModeValidation:
+    def test_accepts_supported_modes(self):
+        for mode in ("fast", "balanced", "rigorous"):
+            issues = validate_config_structure({"agent": {"execution_mode": mode}})
+            assert not any("execution_mode" in issue.message for issue in issues)
+
+    def test_rejects_unknown_mode(self):
+        issues = validate_config_structure({"agent": {"execution_mode": "turbo"}})
+        assert any(
+            issue.severity == "error" and "fast, balanced, rigorous" in issue.message
+            for issue in issues
+        )
+
+
 class TestUnknownTopLevelKeys:
     """Arbitrary top-level keys must NOT warn — they are bridged to os.environ.
 
@@ -140,4 +154,3 @@ class TestUnknownTopLevelKeys:
         ]
         assert any("base_url" in i.message for i in misplaced)
         assert any("api_key" in i.message for i in misplaced)
-

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -391,6 +391,16 @@ class TestStringTypedConfigValues:
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
         assert saved["custom"]["enabled"] is False
 
+    def test_execution_mode_is_validated_and_normalized(self, _isolated_hermes_home):
+        set_config_value("agent.execution_mode", "FAST")
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["agent"]["execution_mode"] == "fast"
+
+        with pytest.raises(SystemExit):
+            set_config_value("agent.execution_mode", "turbo")
+
 
 # ---------------------------------------------------------------------------
 # Secret redaction in display output (issue #50245)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1014,7 +1014,12 @@ class TestBuildSystemPrompt:
 class TestToolUseEnforcementConfig:
     """Tests for the agent.tool_use_enforcement config option."""
 
-    def _make_agent(self, model="openai/gpt-4.1", tool_use_enforcement="auto"):
+    def _make_agent(
+        self,
+        model="openai/gpt-4.1",
+        tool_use_enforcement="auto",
+        execution_mode="rigorous",
+    ):
         """Create an agent with tools and a specific enforcement config."""
         with (
             patch(
@@ -1025,10 +1030,21 @@ class TestToolUseEnforcementConfig:
             patch("run_agent.OpenAI"),
             patch(
                 "hermes_cli.config.load_config",
-                return_value={"agent": {"tool_use_enforcement": tool_use_enforcement}},
-            ), patch(
+                return_value={
+                    "agent": {
+                        "tool_use_enforcement": tool_use_enforcement,
+                        "execution_mode": execution_mode,
+                    }
+                },
+            ),
+            patch(
                 "hermes_cli.config.load_config_readonly",
-                return_value={"agent": {"tool_use_enforcement": tool_use_enforcement}},
+                return_value={
+                    "agent": {
+                        "tool_use_enforcement": tool_use_enforcement,
+                        "execution_mode": execution_mode,
+                    }
+                },
             ),
         ):
             a = AIAgent(
@@ -1047,6 +1063,11 @@ class TestToolUseEnforcementConfig:
         agent = self._make_agent(model="openai/gpt-4.1", tool_use_enforcement="auto")
         prompt = agent._build_system_prompt()
         assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+
+    def test_execution_mode_is_frozen_on_agent_and_selects_fast_guidance(self):
+        agent = self._make_agent(execution_mode="fast")
+        assert agent._execution_mode == "fast"
+        assert "zero to three tool calls" in agent._build_system_prompt()
 
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1015,6 +1015,31 @@ When the iteration budget is fully exhausted, the CLI shows a notification to th
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 
+### Execution mode
+
+`agent.execution_mode` controls how aggressively the system prompt asks the agent to use tools, retry, verify, and load skills. The default is `rigorous`, preserving the behavior of existing installations.
+
+| Mode | Behavior |
+|------|----------|
+| `fast` | Direct answers for simple questions, selective skill loading, bounded retries, and proportional verification. Grounding and side-effect checks remain mandatory. |
+| `balanced` | Uses tools and skills when materially useful, retries when likely to help, and verifies side effects and consequential claims. |
+| `rigorous` | Preserves exhaustive execution, persistence, verification, and mandatory skill loading for builds, migrations, incident response, and high-risk work. |
+
+For faster everyday interactions:
+
+```bash
+hermes config set agent.execution_mode fast
+```
+
+Or edit `config.yaml`:
+
+```yaml
+agent:
+  execution_mode: fast
+```
+
+The selected mode is fixed when a conversation starts. Changing it affects new conversations, not the cached prompt of an existing conversation.
+
 ## Verify-on-Stop (coding verification)
 
 When enabled, Hermes refuses to accept a final answer on a turn where the agent edited code in a workspace but produced no fresh verification evidence (a passing test run, build, lint, etc.) — it injects a synthetic follow-up asking the agent to verify or explain why it can't. Doc/markdown/skill-only edits never trigger it, and the loop is bounded so it can never trap the agent.


### PR DESCRIPTION
## What does this PR do?

Adds `agent.execution_mode: fast | balanced | rigorous` so users can choose proportional prompt execution behavior without changing existing installations. The default is `rigorous`, which preserves the current execution-persistence and mandatory-skill-loading posture.

The selected mode is resolved once during `AIAgent` initialization and included in the skills prompt cache key, keeping prompt construction deterministic and byte-stable for the lifetime of a conversation.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added mode-specific builders for model execution, tool-use, task-completion, and skill-loading guidance.
- Preserved mandatory grounding for calculations, hashes/encodings, current facts, system/filesystem/Git state, and real side effects in every mode.
- Added the default, config validation, CLI enum validation/normalization, config dump visibility, migration/default-merge coverage, and the example configuration.
- Documented `hermes config set agent.execution_mode fast` and the equivalent YAML.
- Added behavioral tests for all three prompt modes, cache separation, legacy default behavior, CLI configuration, and frozen per-agent mode selection.

## How to Test

1. Run:
   `scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_config.py tests/run_agent/test_run_agent.py -k 'not TestAnthropicInterruptHandler'`
2. Confirm 519 tests pass (one unrelated Anthropic optional-dependency test is intentionally excluded).
3. Run `hermes config set agent.execution_mode fast`, then `hermes config get agent.execution_mode`; confirm it prints `fast`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs/issues for this execution-mode configuration and found no matching implementation.
- [x] My PR contains only changes related to this feature.
- [x] I've added focused behavioral tests for the change.
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Updated user documentation and `cli-config.yaml.example`.
- [x] Considered cross-platform impact; the implementation is config and prompt construction only.
- [x] Tool descriptions/schemas: N/A — no model tool was added or changed.
