### PR TITLE
fix(auxiliary): stop sending response_format on the Anthropic wire

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2056,18 +2056,27 @@ class _AnthropicCompletionsAdapter:
         # form is the documented Anthropic SDK passthrough for non-standard
         # request body keys; merge on top of whatever build_anthropic_kwargs
         # already produced (e.g. fast-mode ``speed``) so call-time settings
-        # survive. Two exclusions:
+        # survive. Three exclusions:
         #   - ``reasoning``: the OpenAI-shaped config dict is TRANSLATED into
         #     the native ``thinking`` field above (build_anthropic_kwargs);
         #     forwarding the raw field alongside would double-specify
         #     reasoning and 400 on strict gateways.
+        #   - ``response_format``: a Chat Completions field with no Messages
+        #     API equivalent. The native surface rejects the whole request
+        #     with 400 "response_format: Extra inputs are not permitted", so
+        #     forwarding it doesn't degrade structured output — it removes
+        #     the response entirely. Callers that ask for JSON this way
+        #     already parse defensively (see title_generator's
+        #     _extract_title_text) precisely because not every provider
+        #     honors the field.
         #   - ``_``-prefixed keys: private Hermes plumbing (_reasoning_config
         #     et al.), never wire fields.
         caller_extra_body = kwargs.get("extra_body")
         if caller_extra_body and isinstance(caller_extra_body, dict):
             passthrough = {
                 k: v for k, v in caller_extra_body.items()
-                if k != "reasoning" and not str(k).startswith("_")
+                if k not in ("reasoning", "response_format")
+                and not str(k).startswith("_")
             }
             if passthrough:
                 existing = anthropic_kwargs.get("extra_body") or {}

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2386,6 +2386,29 @@ class TestAuxiliaryTaskExtraBody:
             "thinking": {"type": "disabled"}, "metadata": {"user_id": "u1"},
         }
 
+    def test_anthropic_aux_drops_response_format(self):
+        """response_format is Chat Completions only; Messages rejects the request.
+
+        Forwarding it does not degrade structured output, it 400s the whole
+        call with "response_format: Extra inputs are not permitted" — which
+        took out title generation on every run against a native Anthropic
+        provider. Callers asking for JSON this way already parse defensively.
+        """
+        api_kwargs = self._run_anthropic_adapter(
+            call_extra_body={
+                "response_format": {"type": "json_schema", "json_schema": {"name": "t"}},
+                "metadata": {"user_id": "u1"},
+            },
+        )
+        assert api_kwargs.get("extra_body") == {"metadata": {"user_id": "u1"}}
+
+    def test_anthropic_aux_response_format_only_leaves_no_extra_body(self):
+        """Stripping the sole key must not leave an empty extra_body behind."""
+        api_kwargs = self._run_anthropic_adapter(
+            call_extra_body={"response_format": {"type": "json_object"}},
+        )
+        assert not api_kwargs.get("extra_body")
+
 
 
 


### PR DESCRIPTION
## Summary

- omit the OpenAI-only `response_format` field from native Anthropic Messages requests
- preserve the existing defensive title parsing fallback
- add focused coverage that the field is not sent on the Anthropic wire

## Why

Native Anthropic rejects `response_format`, so auxiliary title generation failed with HTTP 400 and fell back to generic titles. This was found during the Cua Driver integration test pass but is independent of computer use, so it is split from #87646.

## Validation

Exact tested SHA: `d0a2be341`

- `scripts/run_tests.sh tests/agent/test_auxiliary_client.py -q`: 183 passed
- Ruff on changed Python files: passed
- `git diff --check`: passed