### PR TITLE
fix(desktop): dedupe duplicate toolCallId parts at the runtime boundary (#87857)

### DIFF
--- a/apps/desktop/src/app/chat/runtime-repository.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.ts
@@ -3,6 +3,7 @@ import type { ExportedMessageRepository, ThreadMessage } from '@assistant-ui/rea
 import { useMemo, useRef } from 'react'
 
 import type { ChatMessage } from '@/lib/chat-messages'
+import { withUniqueToolCallIdsWithinMessage } from '@/lib/chat-messages'
 import { coalesceToolOnlyAssistants, createToolMergeCache, toRuntimeMessage } from '@/lib/chat-runtime'
 
 // The exact fallback status ExportedMessageRepository.fromBranchableArray uses.
@@ -56,10 +57,17 @@ export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMe
         parentId = branchParentByGroup.get(message.branchGroupId) ?? null
       }
 
+      // Guard against two `tool-call` parts of one message sharing a
+      // `toolCallId`: assistant-ui's `useResources` throws on the duplicate key
+      // and crash-loops the renderer (#87857). Same class of defensive dedup as
+      // the repeated-`message.id` skip above, one level down at the parts. Keeps
+      // identity when clean, so the cache below is unaffected in the common case.
+      const deduped = withUniqueToolCallIdsWithinMessage(message)
+
       const cachedMessage = cacheRef.current.get(message)
 
       const runtimeMessage =
-        cachedMessage ?? fromThreadMessageLike(toRuntimeMessage(message), message.id, FALLBACK_STATUS)
+        cachedMessage ?? fromThreadMessageLike(toRuntimeMessage(deduped), message.id, FALLBACK_STATUS)
 
       if (!cachedMessage) {
         cacheRef.current.set(message, runtimeMessage)

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -15,8 +15,44 @@ import {
   renderMediaTags,
   sealOpenToolParts,
   toChatMessages,
-  upsertToolPart
+  upsertToolPart,
+  withUniqueToolCallIdsWithinMessage
 } from './chat-messages'
+
+const toolCallPart = (toolCallId: string): ChatMessagePart =>
+  ({ type: 'tool-call' as const, toolCallId, toolName: 'read_file', args: {} as never, argsText: '{}' }) as ChatMessagePart
+
+const assistantWith = (parts: ChatMessagePart[]): ChatMessage =>
+  ({ id: 'm1', role: 'assistant', parts, timestamp: 0 }) as unknown as ChatMessage
+
+describe('withUniqueToolCallIdsWithinMessage', () => {
+  it('renames a duplicate toolCallId within one message (#87857)', () => {
+    const message = assistantWith([toolCallPart('call_x'), toolCallPart('call_x')])
+
+    const result = withUniqueToolCallIdsWithinMessage(message)
+
+    const ids = result.parts
+      .filter((part): part is Extract<ChatMessagePart, { type: 'tool-call' }> => part.type === 'tool-call')
+      .map(part => part.toolCallId)
+
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids[0]).toBe('call_x')
+    expect(ids[1]).not.toBe('call_x')
+  })
+
+  it('returns the same reference when there is no duplicate', () => {
+    const message = assistantWith([toolCallPart('call_a'), toolCallPart('call_b')])
+
+    expect(withUniqueToolCallIdsWithinMessage(message)).toBe(message)
+  })
+
+  it('does not touch parts without a toolCallId', () => {
+    const textPart = { type: 'text' as const, text: 'hi' } as ChatMessagePart
+    const message = assistantWith([textPart, toolCallPart('call_a')])
+
+    expect(withUniqueToolCallIdsWithinMessage(message)).toBe(message)
+  })
+})
 
 describe('toChatMessages', () => {
   it('rebuilds the full command from a gateway tool row carrying args', () => {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -1046,6 +1046,56 @@ function withUniqueToolCallIds(messages: ChatMessage[]): ChatMessage[] {
   })
 }
 
+/**
+ * Ensure no two `tool-call` parts of a SINGLE message share a `toolCallId`.
+ *
+ * assistant-ui's `useResources` derives one resource key per content part
+ * (`toolCallId-<id>`) and throws `Duplicate key <key> in useResources` on a
+ * collision, which the desktop error boundary turns into a renderer crash loop
+ * that blanks the window (#87857). Two paths can produce a message whose parts
+ * carry the same id: the streaming reducer appends the same tool-call part
+ * twice under a specific optimistic-update ordering, and coalescing tool-only
+ * assistant turns can fold two parts with the same id into one message. Neither
+ * passes through {@link withUniqueToolCallIds} — that runs only on the static
+ * `toChatMessages` output, not the live runtime boundary — so the dedup is
+ * applied again at the point ChatMessages are converted for the runtime.
+ *
+ * The scope is deliberately per-message (a fresh seen-set each call): the
+ * assistant-ui key space is per-message, so a `toolCallId` shared across
+ * different messages is not a collision and must not be renamed. Only the
+ * later duplicate within one message is renamed, mirroring the list-level
+ * helper. Returns the same reference when nothing changes, so the runtime
+ * repository's identity cache is preserved for the common no-duplicate case.
+ */
+export function withUniqueToolCallIdsWithinMessage(message: ChatMessage): ChatMessage {
+  let seen: null | Set<string> = null
+  let changed = false
+
+  const parts = message.parts.map((part, index) => {
+    if (part.type !== 'tool-call' || !part.toolCallId) {
+      return part
+    }
+
+    if (seen === null) {
+      seen = new Set<string>()
+    }
+
+    if (!seen.has(part.toolCallId)) {
+      seen.add(part.toolCallId)
+
+      return part
+    }
+
+    changed = true
+    const uniqueId = `${part.toolCallId}-dup-${index}`
+    seen.add(uniqueId)
+
+    return { ...part, toolCallId: uniqueId } as ChatMessagePart
+  })
+
+  return changed ? { ...message, parts } : message
+}
+
 export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
   const result: ChatMessage[] = []
   let pendingToolParts: ChatMessagePart[] = []


### PR DESCRIPTION
Fixes #87857.

## Problem

When two `tool-call` parts of a **single** assistant message carry the same `toolCallId`, assistant-ui's `useResources` derives two identical resource keys (`toolCallId-<id>`) and throws `Duplicate key toolCallId-<id> in useResources`. `error-boundary:contrib:workspace` catches it, re-renders, re-throws, and the renderer enters a crash loop — the window content area goes blank (observed 613s CPU / 711 MB RSS, the error logged 48×).

As the issue verifies against `state.db`, the database holds a **single** occurrence of the id; the duplication is introduced at render time. The desktop already has `withUniqueToolCallIds`, but it runs **only** at the end of `toChatMessages` (the static conversion). The streaming runtime path (`use-message-stream`, which can append the same tool-call part twice under a specific optimistic-update ordering) and tool-only-assistant coalescing both reach the assistant-ui runtime **without** passing through that helper.

## Fix

Dedup at the single boundary where `ChatMessage[]` becomes the assistant-ui message repository — `useRuntimeMessageRepository` (`apps/desktop/src/app/chat/runtime-repository.ts`), shared by the static and streaming paths and by session tiles. This is exactly one level down from the existing defensive guard in the same loop that skips a repeated `message.id` (which otherwise crashes `MessageRepository` the same way).

`withUniqueToolCallIdsWithinMessage(message)`:
- Scope is **per-message** (fresh seen-set each call): assistant-ui's key space is per-message, so a `toolCallId` legitimately shared across *different* messages (a tool-call and its later result) is not a collision and is left alone — only a duplicate *within one message* is renamed.
- Renames the later duplicate (`<id>-dup-<index>`), matching the list-level helper's rename-don't-drop behavior, so the row stays renderable.
- Returns the **same reference** when nothing changes, so the repository's `WeakMap` identity cache is preserved for the overwhelmingly common no-duplicate case (no extra re-normalization of the settled transcript during streaming).

## Tests

`apps/desktop/src/lib/chat-messages.test.ts` — three unit tests: duplicate within one message is renamed to a unique id, a clean message returns the same reference, and non-`tool-call` parts are untouched.

Verified locally: `vitest run src/lib/chat-messages.test.ts` (69 passed), `eslint` clean on the touched files, and `tsc -p tsconfig.json` shows no new errors (the 9 pre-existing errors are the unrelated missing optional `frimousse`/`bippy` dev deps, present on `main`).
