### PR TITLE
fix(desktop): keep sleep/wake reconnect on the primary backend (salvage of #74552)

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -2,7 +2,9 @@ import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
-import { $currentCwd, $gatewayState } from '@/store/session'
+import { closeSecondaryGateways, isActivePrimary } from '@/store/gateway'
+import { $activeGatewayProfile, ensureGatewayProfile } from '@/store/profile'
+import { $connection, $currentCwd, $gatewayState } from '@/store/session'
 
 import { takeGatewaySurvivor } from './gateway-hmr-survivor'
 import { useGatewayBoot } from './use-gateway-boot'
@@ -76,18 +78,30 @@ class FakeWebSocket {
   }
 }
 
-function fakeDesktop() {
-  const conn = {
-    authMode: 'token' as const,
-    baseUrl: 'https://vps.example.com',
-    profile: 'default',
-    token: 't',
-    wsUrl: 'wss://vps.example.com/api/ws?token=t'
-  }
+const primaryConn = {
+  authMode: 'token' as const,
+  baseUrl: 'https://vps.example.com',
+  profile: 'default',
+  token: 't',
+  wsUrl: 'wss://vps.example.com/api/ws?token=t'
+}
 
+const coderConn = {
+  authMode: 'token' as const,
+  baseUrl: 'https://coder.example.com',
+  profile: 'coder',
+  token: 'c',
+  wsUrl: 'wss://coder.example.com/api/ws?token=c'
+}
+
+function fakeDesktop() {
   return {
-    getConnection: vi.fn(async () => conn),
-    getGatewayWsUrl: vi.fn(async () => conn.wsUrl),
+    getConnection: vi.fn(async (profile?: null | string) => {
+      const key = (profile ?? '').trim()
+
+      return !key || key === 'default' ? primaryConn : coderConn
+    }),
+    getGatewayWsUrl: vi.fn(async (conn?: { wsUrl?: string }) => conn?.wsUrl ?? primaryConn.wsUrl),
     getBootProgress: vi.fn(async () => ({
       error: null,
       fakeMode: false,
@@ -143,6 +157,9 @@ beforeEach(() => {
     }
   }
 
+  closeSecondaryGateways()
+  $activeGatewayProfile.set('default')
+  $connection.set(null)
   vi.useFakeTimers()
   FakeWebSocket.mode = 'open'
   FakeWebSocket.instances = []
@@ -177,6 +194,9 @@ afterEach(() => {
     }
   }
 
+  closeSecondaryGateways()
+  $activeGatewayProfile.set('default')
+  $connection.set(null)
   vi.useRealTimers()
   ;(globalThis as { WebSocket: unknown }).WebSocket = originalWebSocket
   delete (window as { hermesDesktop?: unknown }).hermesDesktop
@@ -382,5 +402,46 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect(cwdAtConnect).toBe('C:\\Hermes')
     expect($currentCwd.get()).toBe('C:\\Hermes')
+  })
+
+  it('FIX: primary sleep/wake reconnect dials the window backend, not the active secondary profile', async () => {
+    const desktop = fakeDesktop()
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect(FakeWebSocket.instances[0].url).toBe(primaryConn.wsUrl)
+
+    // Profile swap opens a secondary WS; briefly use real timers so that
+    // handshake isn't wedged behind the suite's fake clock.
+    vi.useRealTimers()
+    await ensureGatewayProfile('coder')
+    vi.useFakeTimers()
+
+    expect(isActivePrimary()).toBe(false)
+    expect($activeGatewayProfile.get()).toBe('coder')
+    expect($connection.get()?.profile).toBe('coder')
+    expect($connection.get()?.baseUrl).toBe(coderConn.baseUrl)
+
+    const callsBeforeDrop = desktop.getConnection.mock.calls.length
+    const socketsBeforeDrop = FakeWebSocket.instances.length
+    const primarySocket = FakeWebSocket.instances[0]
+
+    act(() => primarySocket.drop())
+    await flushAsync()
+    await advanceBackoff()
+
+    const reconnectCalls = desktop.getConnection.mock.calls.slice(callsBeforeDrop)
+    expect(reconnectCalls.some(args => (args[0] ?? '').trim() === 'coder')).toBe(false)
+    expect(reconnectCalls.some(args => args.length === 0 || args[0] == null || args[0] === '')).toBe(true)
+
+    const primaryReconnectSockets = FakeWebSocket.instances
+      .slice(socketsBeforeDrop)
+      .filter(socket => socket.url === primaryConn.wsUrl)
+    expect(primaryReconnectSockets.length).toBeGreaterThan(0)
+    expect($connection.get()?.profile).toBe('coder')
+    expect($connection.get()?.baseUrl).toBe(coderConn.baseUrl)
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -19,6 +19,7 @@ import {
   configureGatewayRegistry,
   disposeSecondariesForConnection,
   ensureGatewayForProfile,
+  isActivePrimary,
   pruneSecondaryGateways,
   reconnectSecondaryGateways,
   reportPrimaryGatewayState,
@@ -168,13 +169,23 @@ export function useGatewayBoot({
         // "Starting Hermes…". The probe is a no-op for a healthy or local backend.
         await desktop.revalidateConnection?.().catch(() => undefined)
 
-        const conn = await desktop.getConnection($activeGatewayProfile.get())
+        // Primary sleep/wake reconnect must dial the WINDOW-owned primary backend
+        // (same as boot/softSwitch). Passing $activeGatewayProfile would retarget
+        // this primary socket at a secondary profile's backend after a live swap.
+        // Secondaries reconnect via reconnectSecondaryGateways().
+        const conn = await desktop.getConnection()
 
         if (cancelled) {
           return
         }
 
-        publish(conn)
+        // Only publish the primary descriptor when the primary is active.
+        // Otherwise a background-profile view would inherit the primary's
+        // mode/baseUrl and break image.attach / fs / media routing (#46651).
+        if (isActivePrimary()) {
+          publish(conn)
+        }
+
         // Re-mint the WS URL before reconnecting. OAuth tickets are single-use
         // with a short TTL, so the ticket baked into the cached conn.wsUrl is
         // dead on every reconnect after the initial boot — reusing it surfaces


### PR DESCRIPTION
## Summary

Salvages #74552 by @fangliquanflq: stops Desktop sleep/wake (and any primary WebSocket drop) from rewiring the window-owned primary chat socket to the currently active secondary profile's backend.

Fixes #74551.

## Changes

- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`
  - `attemptReconnect` now dials the window-owned primary backend with no-arg `desktop.getConnection()` (matching boot and softSwitch at the other two call sites), instead of `desktop.getConnection($activeGatewayProfile.get())` which retargeted the primary socket at a secondary profile's backend after a live swap.
  - `publish(conn)` is gated on `isActivePrimary()`, so a background-profile view no longer inherits the primary descriptor (mode/baseUrl) and breaks image.attach / fs / media routing (#46651).
  - Secondary profiles keep reconnecting via the existing `reconnectSecondaryGateways()` registry path — `reconnectNow()` (wired to power-resume, `online`, and `visibilitychange`) already calls it before nudging the primary loop, so all wake signals funnel through the fixed path; no sibling site carries the wrong-profile lookup.
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx`
  - Regression test: activate secondary profile `coder` with its own backend, drop the primary socket, assert the reconnect never queries `coder`'s descriptor, redials the primary `wsUrl`, and leaves the active secondary's `$connection` untouched.
  - Multi-profile-aware `fakeDesktop()` (per-profile connection descriptors) plus store resets in `beforeEach`/`afterEach`.

Cherry-picked onto current main with one test-file conflict (main's #71873 project-dir seeding test landed in the same region); resolved by keeping both tests. The fix required no adaptation to #87600's `ensureGatewayAgent`/mutex work — the reconnect loop's seam is unchanged and the new test passes against the post-#87600 store shape.

## Validation

| Check | Result |
| --- | --- |
| `npx vitest run src/app/gateway/hooks/use-gateway-boot.test.tsx` | 8/8 passed (7 existing + 1 new regression) |
| `npm run check:lint` (apps/desktop: tsc ×3 + eslint) | 0 errors (112 pre-existing warnings, none new) |
| `python3 scripts/audit_pr_attribution.py --fix` | all contributor emails mapped |

## Credit

Authored by @fangliquanflq — cherry-picked from #74552 with authorship preserved (`fangliquanflq <fangliquan@qq.com>`).

## Infographic

![Sleep-wake reconnect](https://v3b.fal.media/files/b/0aa698d3/fBGqsI1kIA_nJmZGXeenJ_f4vAYNjO.png)
