### PR TITLE
fix(cron): keep relative reminders timezone-safe

### DIFF
--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -19,3 +19,15 @@ def test_cronjob_schema_action_description_flags_create_requirements():
     assert "REQUIRED" in action_desc
 
 
+def test_cronjob_schema_keeps_relative_requests_relative():
+    """The model contract must not ask the LLM to perform clock arithmetic."""
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    schedule_desc = CRONJOB_SCHEMA["parameters"]["properties"]["schedule"][
+        "description"
+    ]
+
+    assert "one-shot" in schedule_desc
+    assert "normalize the delay to '2m'" in schedule_desc
+    assert "do not calculate" in schedule_desc.lower()
+    assert "explicit 'every 30m'" in schedule_desc

--- a/tests/cron/test_relative_schedule.py
+++ b/tests/cron/test_relative_schedule.py
@@ -1,0 +1,36 @@
+"""End-to-end coverage for model-authored relative cron schedules."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+
+def test_cronjob_relative_duration_uses_configured_clock(monkeypatch):
+    """The public tool path must preserve a relative delay across timezones."""
+    from tools.cronjob_tools import cronjob
+
+    configured_now = datetime(
+        2026,
+        8,
+        16,
+        11,
+        51,
+        0,
+        tzinfo=timezone(timedelta(hours=-4)),
+    )
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: configured_now)
+
+    result = json.loads(
+        cronjob(
+            action="create",
+            prompt="Send this reminder: take a bath",
+            schedule="2m",
+        )
+    )
+
+    next_run_at = datetime.fromisoformat(result["next_run_at"])
+    assert result["success"] is True
+    assert result["schedule"] == "once in 2m"
+    assert next_run_at == configured_now + timedelta(minutes=2)
+    assert next_run_at.utcoffset() == configured_now.utcoffset()

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1593,7 +1593,16 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
             },
             "schedule": {
                 "type": "string",
-                "description": "REQUIRED for action=create. For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30m' (every 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). You MUST include this field when action=create."
+                "description": (
+                    "REQUIRED for action=create. For a relative request such as "
+                    "'in two minutes', normalize the delay to '2m'; do not calculate "
+                    "an absolute wall-clock time. '30m' means one-shot in 30 minutes; "
+                    "only an explicit 'every 30m' recurs. Other "
+                    "formats: '0 9 * * *' (daily at 9am) or "
+                    "'2026-06-01T09:00:00' (absolute one-shot in the configured "
+                    "Hermes timezone when no offset is supplied). You MUST include "
+                    "this field when action=create."
+                ),
             },
             "name": {
                 "type": "string",


### PR DESCRIPTION
## Summary

- correct the cron tool contract: bare durations such as `30m` are one-shot; only explicit `every 30m` schedules recur
- tell the model to normalize natural-language delays (for example, “in two minutes” → `2m`) instead of calculating an absolute wall-clock timestamp
- add model-contract and end-to-end regression coverage for a UTC host with an Eastern configured clock

## Root cause

The scheduler already treats `2m` as a one-shot relative to `hermes_time.now()`. The model-facing schema contradicted that behavior by describing `30m` as “every 30 minutes.”

That incorrect contract encouraged models to avoid the relative form and manufacture an ISO timestamp using the host clock. When the host runs in UTC but the user is in Eastern Time, “remind me in two minutes” can therefore be stored hours late.

## Fix

Keep natural-language interpretation with the model, but make the tool boundary unambiguous:

- normalize relative intent to the existing compact duration format
- never perform wall-clock arithmetic for a relative request
- reserve recurrence for the explicit `every …` form

No scheduler parser, channel integration, configuration, dependency, or public tool surface is added.

## How to test

The end-to-end test pins Hermes to `2026-08-16 11:51:00-04:00` while the hermetic test runner uses a UTC host timezone. Creating a real `cronjob(schedule="2m")` must persist `11:53:00-04:00`, exactly two minutes later with the configured offset preserved.

## Validation

- `scripts/run_tests.sh tests/cron/ -q` — 718 passed, 0 failed, 1 expected Linux skip for the Windows-only lane
- focused schema + end-to-end tests — 3 passed
- `ruff check .` — passed
- `ruff format --check` on the new test files — passed
- `scripts/check-windows-footguns.py --diff HEAD^` — passed
- `git diff --check` — passed

Tested locally on Linux. Native Windows behavior remains covered by the repository's OS-specific CI lane once GitHub Actions is authorized for the forked PR.
