### PR TITLE
fix(update): restore a Desktop build wiped by a previous update run

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2255,6 +2255,16 @@ def _repair_node_deps_on_current_checkout(print_completion) -> None:
     # _update_node_dependencies call site; it staleness-checks internally,
     # so this is a no-op when nothing changed.
     _m()._build_web_ui(_m().PROJECT_ROOT / "web")
+    # Restore a wiped Desktop build (#83846): a prior run's ZIP fallback can
+    # delete apps/desktop/release/ and every later update lands here — the
+    # version check passes, so without this call the app is never rebuilt
+    # and the failure is self-concealing. Cheap for everyone else: the
+    # in-process stamp check short-circuits when the app exists and is
+    # current, and users who never built Desktop return immediately.
+    _rebuild_desktop_after_update(
+        _m().PROJECT_ROOT / "apps" / "desktop",
+        had_desktop_app_before_update=False,
+    )
     print_completion("✓ Already up to date!")
 
 
@@ -4237,14 +4247,37 @@ def _desktop_app_present(desktop_dir: Path) -> bool:
     )
 
 
+def _desktop_build_stamp_recorded() -> bool:
+    """True when a Desktop build was ever recorded for this HERMES_HOME.
+
+    The stamp lives OUTSIDE the checkout (``$HERMES_HOME/desktop-build-
+    stamp.json``), so it survives events that delete the built app itself —
+    most notably the ZIP fallback replacing ``apps/`` wholesale (#83846).
+    It is the only durable "this user had Desktop" signal once the release
+    tree is gone.
+    """
+    try:
+        return _m()._desktop_stamp_path().is_file()
+    except Exception:
+        return False
+
+
 def _rebuild_desktop_after_update(
     desktop_dir: Path, *, had_desktop_app_before_update: bool
 ) -> None:
     """Rebuild an installed Desktop app when its source or artifact changed."""
     # The release tree is ignored by git and can disappear during an update.
     # Its pre-update presence is enough to restore it; do not make people who
-    # have never used Desktop pay for an Electron build.
-    has_desktop_app = had_desktop_app_before_update or _desktop_app_present(desktop_dir)
+    # have never used Desktop pay for an Electron build. The build stamp
+    # covers the third case (#83846): a PREVIOUS run wiped the app, so both
+    # in-run signals are False for every later update, and the user was
+    # stranded on "Already up to date!" with no app until a manual
+    # `hermes desktop --force-build`.
+    has_desktop_app = (
+        had_desktop_app_before_update
+        or _desktop_app_present(desktop_dir)
+        or _desktop_build_stamp_recorded()
+    )
     if not (
         (desktop_dir / "package.json").exists()
         and _m()._resolve_node_runtime_npm()

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -884,6 +884,76 @@ class TestNodeRuntimeNpmResolution:
             env=ANY,
         )
 
+    def test_desktop_wiped_in_prior_run_rebuilds_via_stamp(self, tmp_path):
+        """#83846: both in-run signals are False after a PRIOR run wiped the
+        app; the HERMES_HOME build stamp must still trigger the rebuild."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        desktop_dir = PROJECT_ROOT / "apps" / "desktop"
+        build_ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        stamp = tmp_path / "desktop-build-stamp.json"
+        stamp.write_text('{"contentHash": "abc", "sourceMode": false}\n')
+
+        with (
+            patch.object(hm, "_desktop_packaged_executable", return_value=None),
+            patch.object(hm, "_desktop_dist_exists", return_value=False),
+            patch.object(hm, "_desktop_stamp_path", return_value=stamp),
+            patch.object(hm, "_resolve_node_runtime_npm", return_value="npm.cmd"),
+            patch.object(hm, "_desktop_build_needed", return_value=True),
+            patch.object(
+                hm, "_run_logged_subprocess", return_value=build_ok
+            ) as desktop_build,
+        ):
+            update_cmd._rebuild_desktop_after_update(
+                desktop_dir,
+                had_desktop_app_before_update=False,
+            )
+
+        desktop_build.assert_called_once()
+
+    def test_no_stamp_no_app_skips_desktop_build(self, tmp_path):
+        """Users who never built Desktop must not pay for an Electron build."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        desktop_dir = PROJECT_ROOT / "apps" / "desktop"
+        missing_stamp = tmp_path / "desktop-build-stamp.json"  # never written
+
+        with (
+            patch.object(hm, "_desktop_packaged_executable", return_value=None),
+            patch.object(hm, "_desktop_dist_exists", return_value=False),
+            patch.object(hm, "_desktop_stamp_path", return_value=missing_stamp),
+            patch.object(hm, "_resolve_node_runtime_npm", return_value="npm.cmd"),
+            patch.object(hm, "_run_logged_subprocess") as desktop_build,
+        ):
+            update_cmd._rebuild_desktop_after_update(
+                desktop_dir,
+                had_desktop_app_before_update=False,
+            )
+
+        desktop_build.assert_not_called()
+
+    def test_already_up_to_date_path_restores_wiped_desktop(self, monkeypatch):
+        """#83846: the commit_count==0 short-circuit must also check Desktop —
+        every post-wipe update lands there and used to skip the rebuild."""
+        from hermes_cli import update_cmd
+
+        calls = []
+        monkeypatch.setattr(update_cmd, "_update_node_dependencies", lambda: [])
+        monkeypatch.setattr(
+            update_cmd,
+            "_rebuild_desktop_after_update",
+            lambda desktop_dir, *, had_desktop_app_before_update: calls.append(
+                (desktop_dir, had_desktop_app_before_update)
+            ),
+        )
+        update_cmd._repair_node_deps_on_current_checkout(lambda _msg: None)
+
+        assert len(calls) == 1
+        assert calls[0][0] == PROJECT_ROOT / "apps" / "desktop"
+        assert calls[0][1] is False
+
     def test_git_failure_zip_fallback_rebuilds_missing_desktop(self, tmp_path, monkeypatch):
         """The Windows ZIP fallback restores Desktop after replacing ``apps/``."""
         import zipfile


### PR DESCRIPTION
## Summary

A Desktop build deleted by a previous update run is now rebuilt by the next `hermes update`, instead of being stranded forever behind "Already up to date!".

Fixes the two residual gaps of #83846 (partially addressed by 4aa9f738ce, which only covers loss during the *current* run).

## Root cause

After a ZIP-fallback run wipes `apps/desktop/release/` (#83846, #87304):
1. `_rebuild_desktop_after_update` gates on `had_desktop_app_before_update or _desktop_app_present(...)` — both False on every LATER update, so the rebuild is silently skipped.
2. Post-wipe updates land on the `commit_count == 0` "Already up to date!" short-circuit, which never called the desktop rebuild at all — the failure is self-concealing (shortcuts point at a deleted Hermes.exe while updates report success).

Only a manual `hermes desktop --force-build` recovered.

## Changes

- `_desktop_build_stamp_recorded()`: `$HERMES_HOME/desktop-build-stamp.json` lives outside the checkout and survives the wipe — it is the durable "this user had Desktop" signal, and now satisfies the rebuild gate.
- The "Already up to date!" path (`_repair_node_deps_on_current_checkout`) now calls `_rebuild_desktop_after_update`. Cheap for everyone else: the in-process content-hash stamp check short-circuits when the app exists and is current; users who never built Desktop return immediately (no stamp, no app, no npm spawn).

## Validation

| Check | Result |
|---|---|
| New: prior-run wipe + stamp present → rebuild fires | pass |
| New: no stamp, no app → no Electron build imposed | pass |
| New: up-to-date path calls the rebuild with the right args | pass |
| Full `tests/hermes_cli/test_cmd_update.py` | 38 passed |
