### PR TITLE
fix(desktop): prefer native-arch app when multiple macOS builds coexist

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6593,6 +6593,22 @@ def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
     existing = [p for p in candidates if p.exists()]
     if not existing:
         return None
+    if sys.platform == "darwin" and len(existing) > 1:
+        # Multiple unpacked trees can coexist (e.g. a stale mac/ left behind by
+        # a cross-arch experiment next to the real mac-arm64/). Picking purely
+        # by mtime can then hand a wrong-architecture Hermes.app to the
+        # launcher, which macOS rejects with a silent no-window hang (#75612).
+        # On an arm64 host BOTH trees are "runnable" (x86_64 via Rosetta), so
+        # a mere runnability filter is a no-op — prefer the host's NATIVE arch
+        # first, then merely-runnable, then mtime when nothing parses.
+        native = _darwin_native_cpu_types()
+        preferred = [p for p in existing if _macho_cpu_types(p) & native]
+        if preferred:
+            existing = preferred
+        else:
+            runnable = [p for p in existing if _macho_matches_host_arch(p)]
+            if runnable:
+                existing = runnable
     if sys.platform == "win32" and len(existing) > 1:
         # Multiple unpacked trees can coexist (e.g. a stale win-arm64-unpacked
         # left behind by a cross-arch experiment next to the real win-unpacked).
@@ -6605,6 +6621,145 @@ def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
         if matching:
             existing = matching
     return max(existing, key=lambda p: p.stat().st_mtime)
+
+
+# ─── macOS arch guard (#75612) ─────────────────────────────────────────────
+#
+# Mach-O CPU type constants (see <mach/machine.h>).
+_MACHO_CPU_TYPE_X86_64 = 0x01000007
+_MACHO_CPU_TYPE_ARM64 = 0x0100000C
+
+# Mach-O magic constants (see <mach-o/loader.h> / <mach-o/fat.h>).
+_MH_MAGIC_64 = 0xFEEDFACF
+_MH_CIGAM_64 = 0xCFFAEDFE
+_FAT_MAGIC = 0xCAFEBABE
+_FAT_CIGAM = 0xBEBAFECA
+
+
+def _darwin_native_machine() -> str:
+    """The macOS host's NATIVE machine architecture, normalized lower.
+
+    ``platform.machine()`` reports the *process* architecture, which lies
+    under Rosetta: the desktop update chain can run an x86_64 Python (e.g.
+    from an x64-bundled runtime) on an Apple Silicon host, where
+    ``platform.machine()`` returns ``x86_64`` even though the OS is arm64.
+    An arch guard keyed to that lie would prefer the wrong-architecture
+    ``mac/`` build over the working ``mac-arm64/`` one (#75612).
+
+    The Rosetta-proof probe is ``sysctl.proc_translated``: it is ``1`` only
+    when the *current process* is x86_64 code translated onto an arm64 host,
+    so a translated process unambiguously means the native host is arm64.
+    Falls back to ``platform.machine()`` / ``hw.machine`` when not translated.
+    """
+    import platform
+    import subprocess
+
+    def _sysctl(name: str) -> Optional[str]:
+        try:
+            out = subprocess.check_output(
+                ["/usr/sbin/sysctl", "-n", name], stderr=subprocess.DEVNULL
+            )
+            return out.decode().strip() or None
+        except (OSError, subprocess.CalledProcessError):
+            return None
+
+    if _sysctl("sysctl.proc_translated") == "1":
+        return "arm64"
+    machine = platform.machine().lower()
+    if machine in ("arm64", "x86_64"):
+        return machine
+    return (_sysctl("hw.machine") or machine).lower()
+
+
+def _darwin_host_cpu_types() -> frozenset[int]:
+    """Return the set of Mach-O CPU types this macOS host can execute.
+
+    An arm64 host runs both arm64 and (under Rosetta) x86_64 binaries; an
+    x86_64 host runs only x86_64. Host detection uses the OS-native machine
+    (see ``_darwin_native_machine``), not the process architecture.
+    """
+    if _darwin_native_machine() == "arm64":
+        return frozenset({_MACHO_CPU_TYPE_ARM64, _MACHO_CPU_TYPE_X86_64})
+    return frozenset({_MACHO_CPU_TYPE_X86_64})
+
+
+def _darwin_native_cpu_types() -> frozenset[int]:
+    """Return only the host's NATIVE Mach-O CPU type — the preferred build.
+
+    Unlike ``_darwin_host_cpu_types`` (everything the host *can* run, which
+    on arm64 includes x86_64 via Rosetta), this is the single architecture
+    the launcher should prefer when several unpacked trees coexist. On an
+    arm64 host a stale x86_64 ``mac/`` tree is runnable but wrong; preferring
+    the native slice keeps the mtime race from reselecting it (#75612).
+    """
+    if _darwin_native_machine() == "arm64":
+        return frozenset({_MACHO_CPU_TYPE_ARM64})
+    return frozenset({_MACHO_CPU_TYPE_X86_64})
+
+
+def _macho_cpu_types(path: Path) -> frozenset[int]:
+    """Return the CPU types encoded in a Mach-O or fat/Universal binary.
+
+    Reads only the file header (and the fat header + arch records for
+    Universal binaries), never the whole file. Returns an empty set when
+    the file is not a recognized Mach-O layout or cannot be read.
+    """
+    import struct
+
+    try:
+        with path.open("rb") as fh:
+            magic_bytes = fh.read(4)
+            if len(magic_bytes) < 4:
+                return frozenset()
+            magic = struct.unpack(">I", magic_bytes)[0]
+
+            if magic in (_FAT_MAGIC, _FAT_CIGAM):
+                # Fat/Universal: 4-byte nfat_arch follows the magic.
+                nfat_bytes = fh.read(4)
+                if len(nfat_bytes) < 4:
+                    return frozenset()
+                nfat = struct.unpack(">I", nfat_bytes)[0]
+                cpu_types: set[int] = set()
+                for _ in range(nfat):
+                    # Each fat_arch record is 20 bytes: cputype(4), cpusubtype(4),
+                    # offset(4), size(4), align(4).
+                    record = fh.read(20)
+                    if len(record) < 20:
+                        break
+                    cpu_types.add(struct.unpack(">I", record[:4])[0])
+                return frozenset(cpu_types)
+
+            if magic in (_MH_MAGIC_64, _MH_CIGAM_64):
+                # 64-bit Mach-O: cputype is at offset 4. Every real macOS
+                # desktop binary (Intel or Apple Silicon) is little-endian on
+                # disk, so the header data fields are always read "<I". The
+                # magic constant only tells us this IS a 64-bit Mach-O; it
+                # does NOT select the data-field endianness — reading CIGAM as
+                # big-endian yields a garbage cputype (0x0c000001 instead of
+                # CPU_TYPE_ARM64 0x0100000c) and misclassifies the real arch.
+                cpu_bytes = fh.read(4)
+                if len(cpu_bytes) < 4:
+                    return frozenset()
+                return frozenset({struct.unpack("<I", cpu_bytes)[0]})
+
+            # 32-bit Mach-O and unknown formats are not launchable desktop
+            # targets on any supported macOS version.
+            return frozenset()
+    except OSError:
+        return frozenset()
+
+
+def _macho_matches_host_arch(path: Path) -> bool:
+    """Return ``True`` when ``path`` is a Mach-O executable this host can run.
+
+    Fat/Universal binaries match when *any* slice is executable. Non-Mach-O
+    files (read failures, wrong magic) conservatively return ``False`` so the
+    caller falls back to mtime ordering rather than trusting a broken parse.
+    """
+    cpu_types = _macho_cpu_types(path)
+    if not cpu_types:
+        return False
+    return bool(cpu_types & _darwin_host_cpu_types())
 
 
 # ─── Desktop exe integrity gate (#69179) ────────────────────────────────────

--- a/tests/hermes_cli/test_desktop_darwin_arch_guard.py
+++ b/tests/hermes_cli/test_desktop_darwin_arch_guard.py
@@ -1,0 +1,200 @@
+"""Behavior tests for the macOS desktop arch guard (#75612).
+
+The desktop self-update chain (Desktop → ``hermes update`` →
+``hermes desktop --build-only`` → relaunch) can rebuild the Electron app for
+the wrong architecture when the build runs under an x86_64 Python on an Apple
+Silicon host (``stage-native-deps.mjs`` defaults ``arch = process.arch``).
+That leaves a stale x86_64 ``release/mac/`` tree beside the working
+``release/mac-arm64/`` one. ``_desktop_packaged_executable`` used to pick the
+candidate purely by mtime, so the freshly-built wrong-arch tree always won and
+the launcher hung with no window.
+
+These tests exercise the behavior contract only: synthetic Mach-O files go in,
+selection verdicts come out. The host-arch probes (``sysctl`` subprocess,
+``platform.machine``) are mocked so the suite runs on any CI host.
+"""
+
+from __future__ import annotations
+
+import struct
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import main as cli_main
+
+CPU_X86_64 = 0x01000007
+CPU_ARM64 = 0x0100000C
+
+MH_CIGAM_64 = 0xCFFAEDFE
+FAT_MAGIC = 0xCAFEBABE
+
+
+def make_thin_macho(path: Path, cputype: int) -> Path:
+    """Write a minimal little-endian 64-bit thin Mach-O header.
+
+    Layout: magic (4) + cputype (4) + padding. Every real macOS desktop
+    binary is little-endian on disk, so the header fields are written "<I".
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(struct.pack("<II", MH_CIGAM_64, cputype) + b"\x00" * 56)
+    return path
+
+
+def make_fat_macho(path: Path, *cputypes: int) -> Path:
+    """Write a minimal fat/Universal header listing ``cputypes`` slices."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = struct.pack(">II", FAT_MAGIC, len(cputypes))
+    records = b"".join(struct.pack(">IIIII", ct, 0, 0, 0, 0) for ct in cputypes)
+    path.write_bytes(header + records)
+    return path
+
+
+def _fake_sysctl(values: dict[str, str]):
+    """Return a ``subprocess.check_output`` fake keyed by sysctl name."""
+
+    def _check_output(cmd, *args, **kwargs):
+        # cmd is ["/usr/sbin/sysctl", "-n", <name>]
+        name = cmd[-1]
+        if name in values:
+            return (values[name] + "\n").encode()
+        raise subprocess.CalledProcessError(1, cmd)
+
+    return _check_output
+
+
+# ─── _darwin_native_machine ─────────────────────────────────────────────────
+
+
+def test_native_machine_translated_process_means_arm64_host():
+    """The #75612 regression: x86_64 Python under Rosetta reports
+    ``platform.machine() == "x86_64"`` on an arm64 host. The
+    ``sysctl.proc_translated == 1`` probe must override that lie.
+    """
+    with patch("subprocess.check_output", _fake_sysctl({"sysctl.proc_translated": "1"})), \
+         patch("platform.machine", return_value="x86_64"):
+        assert cli_main._darwin_native_machine() == "arm64"
+
+
+def test_native_machine_native_arm64_process():
+    with patch("subprocess.check_output", _fake_sysctl({"sysctl.proc_translated": "0"})), \
+         patch("platform.machine", return_value="arm64"):
+        assert cli_main._darwin_native_machine() == "arm64"
+
+
+def test_native_machine_native_x86_64_process():
+    with patch("subprocess.check_output", _fake_sysctl({"sysctl.proc_translated": "0"})), \
+         patch("platform.machine", return_value="x86_64"):
+        assert cli_main._darwin_native_machine() == "x86_64"
+
+
+def test_native_machine_falls_back_to_hw_machine_on_exotic_arch():
+    """Unknown ``platform.machine()`` values fall through to ``hw.machine``."""
+    with patch(
+        "subprocess.check_output",
+        _fake_sysctl({"sysctl.proc_translated": "0", "hw.machine": "arm64"}),
+    ), patch("platform.machine", return_value="riscv64"):
+        assert cli_main._darwin_native_machine() == "arm64"
+
+
+# ─── _darwin_host_cpu_types / _darwin_native_cpu_types ──────────────────────
+
+
+def test_host_cpu_types_arm64_host_runs_both():
+    with patch.object(cli_main, "_darwin_native_machine", return_value="arm64"):
+        assert cli_main._darwin_host_cpu_types() == frozenset({CPU_ARM64, CPU_X86_64})
+
+
+def test_host_cpu_types_x86_64_host_runs_only_x64():
+    with patch.object(cli_main, "_darwin_native_machine", return_value="x86_64"):
+        assert cli_main._darwin_host_cpu_types() == frozenset({CPU_X86_64})
+
+
+def test_native_cpu_types_is_single_arch():
+    with patch.object(cli_main, "_darwin_native_machine", return_value="arm64"):
+        assert cli_main._darwin_native_cpu_types() == frozenset({CPU_ARM64})
+    with patch.object(cli_main, "_darwin_native_machine", return_value="x86_64"):
+        assert cli_main._darwin_native_cpu_types() == frozenset({CPU_X86_64})
+
+
+# ─── _macho_cpu_types ───────────────────────────────────────────────────────
+
+
+def test_macho_cpu_types_thin_arm64(tmp_path):
+    exe = make_thin_macho(tmp_path / "Hermes", CPU_ARM64)
+    assert cli_main._macho_cpu_types(exe) == frozenset({CPU_ARM64})
+
+
+def test_macho_cpu_types_thin_x86_64(tmp_path):
+    exe = make_thin_macho(tmp_path / "Hermes", CPU_X86_64)
+    assert cli_main._macho_cpu_types(exe) == frozenset({CPU_X86_64})
+
+
+def test_macho_cpu_types_fat_universal(tmp_path):
+    exe = make_fat_macho(tmp_path / "Hermes", CPU_ARM64, CPU_X86_64)
+    assert cli_main._macho_cpu_types(exe) == frozenset({CPU_ARM64, CPU_X86_64})
+
+
+def test_macho_cpu_types_unreadable_returns_empty(tmp_path):
+    assert cli_main._macho_cpu_types(tmp_path / "missing") == frozenset()
+
+
+def test_macho_cpu_types_non_macho_returns_empty(tmp_path):
+    junk = tmp_path / "junk"
+    junk.write_bytes(b"not a mach-o binary at all")
+    assert cli_main._macho_cpu_types(junk) == frozenset()
+
+
+# ─── _desktop_packaged_executable (darwin selection) ────────────────────────
+
+
+def _make_app(release: Path, tree: str, cputype: int, *, mtime: float) -> Path:
+    exe = release / tree / "Hermes.app" / "Contents" / "MacOS" / "Hermes"
+    make_thin_macho(exe, cputype)
+    import os
+
+    os.utime(exe, (mtime, mtime))
+    return exe
+
+
+@pytest.mark.macos_only
+def test_selection_prefers_native_over_newer_wrong_arch(tmp_path, monkeypatch):
+    """The core #75612 scenario: a stale x86_64 ``mac/`` tree with a NEWER
+    mtime than the working ``mac-arm64/`` tree must not win the selection.
+    """
+    monkeypatch.setattr(sys, "platform", "darwin")
+    release = tmp_path / "release"
+    arm_exe = _make_app(release, "mac-arm64", CPU_ARM64, mtime=1_000_000)
+    _make_app(release, "mac", CPU_X86_64, mtime=9_999_999)  # newer, wrong arch
+
+    with patch.object(cli_main, "_darwin_native_machine", return_value="arm64"):
+        picked = cli_main._desktop_packaged_executable(tmp_path)
+    assert picked == arm_exe
+
+
+@pytest.mark.macos_only
+def test_selection_single_candidate_untouched(tmp_path, monkeypatch):
+    """A lone candidate is returned regardless of arch (no regression)."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    release = tmp_path / "release"
+    x64_exe = _make_app(release, "mac", CPU_X86_64, mtime=1_000_000)
+
+    with patch.object(cli_main, "_darwin_native_machine", return_value="arm64"):
+        picked = cli_main._desktop_packaged_executable(tmp_path)
+    assert picked == x64_exe
+
+
+@pytest.mark.macos_only
+def test_selection_falls_back_to_runnable_when_no_native(tmp_path, monkeypatch):
+    """On an x86_64 host with only an x86_64 tree, that tree is picked."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    release = tmp_path / "release"
+    x64_exe = _make_app(release, "mac", CPU_X86_64, mtime=1_000_000)
+    _make_app(release, "mac-arm64", CPU_ARM64, mtime=9_999_999)  # unrunnable here
+
+    with patch.object(cli_main, "_darwin_native_machine", return_value="x86_64"):
+        picked = cli_main._desktop_packaged_executable(tmp_path)
+    assert picked == x64_exe


### PR DESCRIPTION
## Problem

On Apple Silicon, the desktop self-update chain (Desktop → `hermes update` → `hermes desktop --build-only` → relaunch) can rebuild the Electron app for the **wrong architecture**. `stage-native-deps.mjs` defaults `arch = process.arch`, and the build runs under Hermes's bundled **x86_64** node — so it stages `darwin-x64` node-pty and packages a `release/mac/` (x64) app even on an M-series Mac.

That leaves two unpacked trees side by side:

```
release/mac/Hermes.app          ← x86_64, freshly rebuilt (newer mtime)
release/mac-arm64/Hermes.app    ← arm64, the working one (older mtime)
```

`_desktop_packaged_executable` picked the candidate **purely by mtime**, so the freshly-built wrong-arch tree always won. The x64 app's `electron-main` imports node-pty before creating any window; the x64 `.node` can't load into the arm64 main process, so the app dies during init — **no renderer, no window, no crash report**. Just a silent headless process in the Dock.

Reproduced on an M1 / macOS 26.6: main + GPU + network helpers alive, zero renderers, zero windows.

## Root cause

The Windows launcher already has an arch guard (#69179): when several `win-*-unpacked` trees coexist, it prefers the one whose PE machine matches the host. **macOS had no equivalent** — the darwin branch was mtime-only.

## Fix

Mirror the Windows guard for darwin. When multiple `mac*/` trees coexist, prefer the one whose Mach-O CPU type matches the host's **native** arch, then merely-runnable, then mtime:

- **`_darwin_native_machine()`** — Rosetta-proof host-arch detection. `platform.machine()` reports the *process* arch, which lies under an emulated x64 Python (returns `x86_64` on an arm64 host) — exactly the update-chain shape. The probe is `sysctl.proc_translated`: it's `1` only when the current process is x86_64 translated onto an arm64 host, so a translated process unambiguously means the native host is arm64. This is the darwin analog of the Windows `IsWow64Process2` probe in `_windows_native_machine`.
- **`_macho_cpu_types()`** — parse thin and fat/Universal Mach-O headers (cputype at offset 4, little-endian; fat arch table for Universal).
- **Selection** — native-arch first, then runnable, then mtime.

**Why native-first and not just runnable:** on an arm64 host *both* trees are runnable (x86_64 via Rosetta), so a mere runnability filter is a no-op and the mtime race persists. Preferring the native slice is what actually closes it.

## Test plan

- New `tests/hermes_cli/test_desktop_darwin_arch_guard.py` (15 tests): synthetic thin/fat Mach-O files, mocked `sysctl`/`platform.machine` host probes, and end-to-end selection cases (native-over-newer-wrong-arch, single candidate, x86_64-host fallback). All pass.
- Existing `test_desktop_exe_integrity.py` still passes (1 passed, 4 skipped as `windows_only` on this host).
- Verified live on the affected M1: after the fix, `_desktop_packaged_executable` returns the arm64 app even with a newer-mtime x64 tree present.

## Note

This stops the launcher from *selecting* the wrong-arch build. The build itself still stages x64 native deps under an x64 node (the deeper root cause in `stage-native-deps.mjs` defaulting to `process.arch`); happy to follow up on that separately — but with this guard, a wrong-arch rebuild is harmless instead of a silent no-window hang.