### PR TITLE
fix(gateway): honor whatsapp.group_allow_from for no-user-id routed group turns

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -480,15 +480,75 @@ class GatewayAuthorizationMixin:
             # triggered group messages (_apply_telegram_group_observe_attribution),
             # so the env-var-only check above misses config.yaml-configured
             # allowlists.  Read the live adapter's config.extra as a fallback.
+            #
+            # Under multiplex_profiles the routed source can carry a secondary
+            # profile name while the transport adapter is registered under the
+            # default profile, so _adapter_for_source fails closed and returns
+            # None (correct for reply egress). For this READ-ONLY consultation
+            # of the documented config allowlist, fall back to the gateway's
+            # own platform config — the same values that gated intake — so a
+            # config.yaml allowlist isn't silently erased by profile routing
+            # (#87830).
             try:
                 adapter = self._adapter_for_source(source)
-                if adapter is not None:
-                    extra = getattr(getattr(adapter, "config", None), "extra", None) or {}
+                extra = (
+                    getattr(getattr(adapter, "config", None), "extra", None)
+                    if adapter is not None
+                    else None
+                )
+                if not isinstance(extra, dict) or not extra:
+                    config = getattr(self, "config", None)
+                    platform_cfg = (
+                        config.platforms.get(source.platform)
+                        if config is not None and hasattr(config, "platforms")
+                        else None
+                    )
+                    extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+                if isinstance(extra, dict):
                     adapter_group_allowed = extra.get("group_allowed_chats")
                     if adapter_group_allowed:
                         allowed = _coerce_allow_set(adapter_group_allowed)
                         if "*" in allowed or source.chat_id in allowed:
                             return True
+                    # WhatsApp's chat allowlist key is group_allow_from —
+                    # entries are GROUP JIDs matched against chat_id at
+                    # intake (_is_group_allowed), not sender user IDs. A
+                    # mention-triggered group message arrives with
+                    # user_id=None (shared-transcript observe path), so
+                    # honoring the documented whatsapp.group_allow_from
+                    # config here mirrors intake semantics. Gate on the
+                    # effective group_policy actually being "allowlist":
+                    # under "open"/"disabled" the list carries no
+                    # operator-configured restriction signal (#87830).
+                    if source.platform in {Platform.WHATSAPP, Platform.WHATSAPP_CLOUD}:
+                        wa_policy = (
+                            self._adapter_group_policy(
+                                source.platform,
+                                profile=getattr(source, "profile", None),
+                            )
+                            or str(extra.get("group_policy") or "").strip().lower()
+                        )
+                        wa_allow = extra.get("group_allow_from") or extra.get("groupAllowFrom")
+                        if wa_policy == "allowlist" and wa_allow:
+                            allowed = _coerce_allow_set(wa_allow)
+                            if "*" in allowed or source.chat_id in allowed:
+                                return True
+                            # Resolve phone↔LID/JID aliases like intake does
+                            # so either configured form matches.
+                            try:
+                                from gateway.whatsapp_identity import (
+                                    expand_whatsapp_aliases,
+                                    normalize_whatsapp_identifier,
+                                )
+
+                                candidate_aliases = expand_whatsapp_aliases(source.chat_id)
+                                for entry in allowed:
+                                    if normalize_whatsapp_identifier(entry) in candidate_aliases:
+                                        return True
+                                    if expand_whatsapp_aliases(entry) & candidate_aliases:
+                                        return True
+                            except Exception:
+                                pass
             except Exception:
                 pass
 

--- a/tests/gateway/test_whatsapp_group_allow_from_authz.py
+++ b/tests/gateway/test_whatsapp_group_allow_from_authz.py
@@ -1,0 +1,104 @@
+"""Regression tests for #87830: whatsapp.group_allow_from must authorize
+routed/observed group turns that arrive with user_id=None.
+
+The shared-transcript observe path strips sender identity from triggered
+WhatsApp group messages, so the chat-scoped authorization in
+GatewayAuthorizationMixin._is_user_authorized is the only gate. Before the
+fix, only the WHATSAPP_GROUP_ALLOWED_USERS process env var authorized these
+turns; the documented config surface (whatsapp.group_allow_from) was never
+consulted — and under multiplex_profiles the adapter lookup fails closed for
+routed profiles, so the adapter-extra fallback silently never fired.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.run import GatewayRunner
+from gateway.session import Platform, SessionSource
+
+GROUP_JID = "120363028379211573@g.us"
+
+
+def _bare_runner(platform_extra=None):
+    runner = object.__new__(GatewayRunner)
+    if platform_extra is not None:
+        runner.config = SimpleNamespace(
+            platforms={Platform.WHATSAPP: SimpleNamespace(extra=dict(platform_extra))}
+        )
+    return runner
+
+
+def _observed_group_source(profile=None, chat_id=GROUP_JID):
+    return SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id=chat_id,
+        chat_type="group",
+        user_id=None,
+        user_name=None,
+        profile=profile,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in (
+        "WHATSAPP_GROUP_ALLOWED_USERS",
+        "WHATSAPP_ALLOWED_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_config_group_allow_from_authorizes_no_user_id_turn():
+    runner = _bare_runner(
+        {"group_policy": "allowlist", "group_allow_from": [GROUP_JID]}
+    )
+    assert runner._is_user_authorized(_observed_group_source()) is True
+
+
+def test_config_group_allow_from_authorizes_routed_profile_source():
+    """Multiplex: the routed source carries a secondary profile; the adapter
+    registry fails closed for it, but the gateway's own platform config (the
+    same values that gated intake) must still authorize the chat."""
+    runner = _bare_runner(
+        {"group_policy": "allowlist", "group_allow_from": [GROUP_JID]}
+    )
+    src = _observed_group_source(profile="research")
+    assert runner._is_user_authorized(src) is True
+
+
+def test_unlisted_group_is_still_denied():
+    runner = _bare_runner(
+        {"group_policy": "allowlist", "group_allow_from": [GROUP_JID]}
+    )
+    src = _observed_group_source(chat_id="999999999999999999@g.us")
+    assert runner._is_user_authorized(src) is False
+
+
+def test_open_group_policy_does_not_authorize_via_stale_allowlist():
+    """Under group_policy: open the allow_from list carries no restriction
+    signal — authorizing from it would be a fail-open."""
+    runner = _bare_runner({"group_policy": "open", "group_allow_from": [GROUP_JID]})
+    assert runner._is_user_authorized(_observed_group_source()) is False
+
+
+def test_no_config_no_env_denies():
+    runner = _bare_runner()
+    assert runner._is_user_authorized(_observed_group_source()) is False
+
+
+def test_wildcard_entry_authorizes_any_group():
+    runner = _bare_runner({"group_policy": "allowlist", "group_allow_from": ["*"]})
+    src = _observed_group_source(chat_id="111222333444555666@g.us")
+    assert runner._is_user_authorized(src) is True
+
+
+def test_env_var_path_still_works(monkeypatch):
+    """The pre-existing env path must keep working unchanged."""
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "")
+    runner = _bare_runner()
+    # env-based group user allowlists are consulted later (user_id path);
+    # a no-user-id turn with no chat-scoped grant stays denied.
+    assert runner._is_user_authorized(_observed_group_source()) is False


### PR DESCRIPTION
## Summary
`whatsapp.group_allow_from` in config.yaml now authorizes mention-triggered group turns — previously only the `WHATSAPP_GROUP_ALLOWED_USERS` process env var did, and under `gateway.multiplex_profiles` the documented config surface was silently dropped.

Root cause: triggered WhatsApp group messages carry `user_id=None` (shared-transcript observe path strips sender identity), so authorization falls to the chat-scoped path in `_is_user_authorized`. That path only knew Telegram/QQ chat keys, and its adapter-extra fallback resolved the adapter by the routed profile — under multiplex, the WhatsApp adapter is registered on the default profile, so the lookup failed closed and the fallback never fired. Result: invisible drop (`Ignoring message with no user_id from whatsapp`, DEBUG only) unless the same allowlist was duplicated as a root `.env` var.

Fixes #87830 (reported by @NehoraiHadad).

## Changes
- `gateway/authz_mixin.py`: chat-scoped fallback now falls back to the gateway's own platform config (the same values that gated intake) when the routed-profile adapter lookup yields nothing; for WhatsApp/WhatsApp Cloud, honors `group_allow_from` as the chat allowlist — gated on the effective `group_policy` actually being `allowlist` (open/disabled carry no restriction signal, so no fail-open), with phone/LID/JID alias expansion matching intake semantics.
- `tests/gateway/test_whatsapp_group_allow_from_authz.py`: 7 regression tests — config allowlist authorizes no-user-id turns, routed-profile (multiplex) sources, wildcard; denies unlisted groups, `group_policy: open` with a stale list, and the no-config case. Sabotage-verified: 3 tests fail on unfixed `origin/main`.

## Validation
| | Before | After |
|---|---|---|
| `group_allow_from` in config, mention in listed group (multiplex) | silent drop | authorized |
| Same, `group_policy: open` | drop | still denied (no fail-open) |
| Unlisted group | drop | still denied |
| Targeted suites (whatsapp/telegram/auth_fallback/multiplex authz) | — | 36 passed |

## Infographic

![WhatsApp group allowlist fix](https://v3b.fal.media/files/b/0aa69982/umtoUQxAEARCp5B1EGyak_0o9GB4Zx.png)
