### PR TITLE
fix(config): harden config backup permissions

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -91,7 +91,7 @@ def _backup_corrupt_config(config_path: Path) -> Optional[Path]:
                 continue
         if backup_path.exists():
             return None
-        shutil.copy2(config_path, backup_path)
+        copy_config_backup(config_path, backup_path)
         return backup_path
     except Exception:
         return None
@@ -837,6 +837,33 @@ def _secure_file(path):
             os.chmod(path, 0o600)
     except (OSError, NotImplementedError):
         pass
+
+
+def copy_config_backup(source: Path, destination: Path) -> Path:
+    """Copy a config backup without briefly exposing secrets on POSIX hosts."""
+    if os.name == "nt" or is_managed() or _is_container():
+        shutil.copy2(source, destination)
+        return destination
+
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(destination.parent),
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        # Keep using mkstemp's already-open descriptor: closing and reopening
+        # the name would create a symlink-swap window before secret bytes land.
+        with os.fdopen(fd, "wb") as tmp_file:
+            with source.open("rb") as source_file:
+                shutil.copyfileobj(source_file, tmp_file)
+        # Backup names are generated files, not managed config symlinks. Replace
+        # the directory entry itself so a pre-created symlink cannot redirect
+        # secret-bearing backup contents to another path.
+        os.replace(tmp_path, destination)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+    return destination
 
 
 def _ensure_default_soul_md(home: Path) -> None:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2853,7 +2853,7 @@ def run_setup_wizard(args):
       hermes setup telemetry — just local shared metrics
       hermes setup agent     — just agent settings
     """
-    from hermes_cli.config import is_managed, managed_error
+    from hermes_cli.config import copy_config_backup, is_managed, managed_error
     if is_managed():
         managed_error("run setup wizard")
         return
@@ -2878,8 +2878,7 @@ def run_setup_wizard(args):
             f".yaml.bak.{_dt.now().strftime('%Y%m%d_%H%M%S')}"
         )
         try:
-            import shutil
-            shutil.copy2(config_path, _backup_path)
+            copy_config_backup(config_path, _backup_path)
         except Exception:
             _backup_path = None
     else:

--- a/hermes_cli/xai_retirement.py
+++ b/hermes_cli/xai_retirement.py
@@ -139,7 +139,6 @@ def format_issue(issue: RetirementIssue) -> str:
 import datetime as _dt
 import io
 from pathlib import Path
-import shutil
 
 
 @dataclass(frozen=True)
@@ -236,12 +235,14 @@ def apply_migration(
         )
 
     backup_path: Optional[Path] = None
+    from hermes_cli.config import copy_config_backup
+
     if backup:
         ts = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
         backup_path = config_path.with_name(
             f"{config_path.name}.bak-pre-migrate-xai-{ts}"
         )
-        shutil.copy2(config_path, backup_path)
+        copy_config_backup(config_path, backup_path)
 
     from hermes_cli.config import require_readable_config_before_write
     from utils import atomic_write_text

--- a/scripts/docker_config_migrate.py
+++ b/scripts/docker_config_migrate.py
@@ -10,6 +10,7 @@ from typing import Iterable
 
 from hermes_cli.config import (
     check_config_version,
+    copy_config_backup,
     get_config_path,
     get_env_path,
     migrate_config,
@@ -39,7 +40,7 @@ def _backup_existing(paths: Iterable[Path]) -> dict[Path, Path]:
         if not path.is_file():
             continue
         dest = _backup_path(path, stamp)
-        shutil.copy2(path, dest)
+        copy_config_backup(path, dest)
         backups[path] = dest
     return backups
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -65,6 +65,92 @@ class TestEnsureHermesHome:
 
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are not enforced on Windows")
+class TestCopyConfigBackup:
+    def test_secure_temp_is_hidden_until_atomic_replace(self, tmp_path):
+        from hermes_cli import config as cfg_mod
+
+        source = tmp_path / "config.yaml"
+        destination = tmp_path / "config.yaml.bak"
+        source.write_text("secret: placeholder\n", encoding="utf-8")
+        source.chmod(0o644)
+        real_copyfileobj = cfg_mod.shutil.copyfileobj
+
+        def inspect_copy(src, temp_file):
+            assert not destination.exists()
+            assert os.fstat(temp_file.fileno()).st_mode & 0o777 == 0o600
+            return real_copyfileobj(src, temp_file)
+
+        old_umask = os.umask(0)
+        try:
+            with patch.object(cfg_mod, "is_managed", return_value=False), patch.object(
+                cfg_mod, "_is_container", return_value=False
+            ), patch.object(cfg_mod.shutil, "copyfileobj", side_effect=inspect_copy):
+                cfg_mod.copy_config_backup(source, destination)
+        finally:
+            os.umask(old_umask)
+
+        assert destination.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")
+        assert destination.stat().st_mode & 0o777 == 0o600
+
+    def test_replaces_destination_symlink_without_following_it(self, tmp_path):
+        from hermes_cli import config as cfg_mod
+
+        source = tmp_path / "config.yaml"
+        destination = tmp_path / "config.yaml.bak"
+        victim = tmp_path / "unrelated.yaml"
+        source.write_text("model: test/backup\n", encoding="utf-8")
+        victim.write_text("keep: unchanged\n", encoding="utf-8")
+        destination.symlink_to(victim)
+
+        with patch.object(cfg_mod, "is_managed", return_value=False), patch.object(
+            cfg_mod, "_is_container", return_value=False
+        ):
+            cfg_mod.copy_config_backup(source, destination)
+
+        assert not destination.is_symlink()
+        assert destination.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")
+        assert destination.stat().st_mode & 0o777 == 0o600
+        assert victim.read_text(encoding="utf-8") == "keep: unchanged\n"
+
+    @pytest.mark.parametrize("managed,container", [(True, False), (False, True)])
+    def test_preserves_shared_mode_when_hardening_is_disabled(
+        self, tmp_path, managed, container
+    ):
+        from hermes_cli import config as cfg_mod
+
+        source = tmp_path / "config.yaml"
+        destination = tmp_path / "config.yaml.bak"
+        source.write_text("model: test/shared\n", encoding="utf-8")
+        source.chmod(0o640)
+
+        with patch.object(cfg_mod, "is_managed", return_value=managed), patch.object(
+            cfg_mod, "_is_container", return_value=container
+        ):
+            cfg_mod.copy_config_backup(source, destination)
+
+        assert destination.stat().st_mode & 0o777 == 0o640
+
+    def test_removes_partial_temp_on_copy_error(self, tmp_path):
+        from hermes_cli import config as cfg_mod
+
+        source = tmp_path / "config.yaml"
+        destination = tmp_path / "config.yaml.bak"
+        source.write_text("model: test/original\n", encoding="utf-8")
+        destination.write_text("model: test/existing-backup\n", encoding="utf-8")
+
+        with patch.object(cfg_mod, "is_managed", return_value=False), patch.object(
+            cfg_mod, "_is_container", return_value=False
+        ), patch.object(
+            cfg_mod.shutil, "copyfileobj", side_effect=OSError("disk full")
+        ):
+            with pytest.raises(OSError, match="disk full"):
+                cfg_mod.copy_config_backup(source, destination)
+
+        assert destination.read_text(encoding="utf-8") == "model: test/existing-backup\n"
+        assert not list(tmp_path.glob(f".{destination.name}.*.tmp"))
+
+
 class TestLoadConfigDefaults:
     def test_returns_defaults_when_no_file(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
@@ -112,7 +198,9 @@ class TestLoadConfigParseFailure:
         from hermes_cli import config as cfg_mod
         cfg_mod._CONFIG_PARSE_WARNED.clear()
 
-        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}), patch.object(
+            cfg_mod, "_is_container", return_value=False
+        ):
             broken = "\tmodel: test/custom\nbroken indent:\n"
             (tmp_path / "config.yaml").write_text(broken)
 
@@ -123,6 +211,7 @@ class TestLoadConfigParseFailure:
             assert len(baks) == 1, f"expected one backup, got {baks}"
             # Backup preserves the original broken content verbatim
             assert baks[0].read_text() == broken
+            assert baks[0].stat().st_mode & 0o777 == 0o600
             # Original config.yaml is left untouched (not reset to clean state)
             assert (tmp_path / "config.yaml").read_text() == broken
             # User is told where the backup landed

--- a/tests/hermes_cli/test_migrate_xai.py
+++ b/tests/hermes_cli/test_migrate_xai.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -151,10 +152,12 @@ class TestBackup:
     def test_backup_is_written_by_default(self, trap_config: Path):
         issues = find_retired_xai_refs(_parse(trap_config))
         original = trap_config.read_text(encoding="utf-8")
-        result = apply_migration(trap_config, issues)
+        with patch("hermes_cli.config._is_container", return_value=False):
+            result = apply_migration(trap_config, issues)
         assert result.backup_path is not None
         assert result.backup_path.exists()
         assert result.backup_path.read_text(encoding="utf-8") == original
+        assert result.backup_path.stat().st_mode & 0o777 == 0o600
 
 
     def test_no_backup_when_disabled(self, trap_config: Path):

--- a/tests/hermes_cli/test_setup_reconfigure.py
+++ b/tests/hermes_cli/test_setup_reconfigure.py
@@ -12,6 +12,8 @@ On a fresh install, all three are no-ops — fall through to first-time setup.
 
 from argparse import Namespace
 from contextlib import ExitStack
+import stat
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -157,6 +159,32 @@ class TestQuickFlag:
         m["agent"].assert_not_called()
         m["gateway"].assert_not_called()
         m["tools"].assert_not_called()
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="POSIX mode bits are not enforced on Windows",
+    )
+    @pytest.mark.parametrize("source_mode", [0o600, 0o644])
+    def test_existing_config_backup_is_owner_only(self, existing_install, source_mode):
+        config_path = existing_install / "config.yaml"
+        config_path.write_text("model: test/original\n", encoding="utf-8")
+        config_path.chmod(source_mode)
+        args = _make_setup_args(quick=True)
+
+        with ExitStack() as stack:
+            _enter_existing_install_patches(
+                stack,
+                quick="hermes_cli.setup._run_quick_setup",
+            )
+            stack.enter_context(
+                patch("hermes_cli.config._is_container", return_value=False)
+            )
+            from hermes_cli.setup import run_setup_wizard
+            run_setup_wizard(args)
+
+        backups = list(existing_install.glob("config.yaml.bak.*"))
+        assert len(backups) == 1
+        assert stat.S_IMODE(backups[0].stat().st_mode) == 0o600
 
 
 class TestFreshInstall:


### PR DESCRIPTION
## Summary
- create normal POSIX config backups through an owner-only temporary file and atomic replace
- route setup, corrupt-config recovery, xAI retirement, and Docker migration backup paths through the shared helper
- preserve existing Windows, managed/NixOS, and container `copy2` behavior

## Security
- prevents a legacy `0644` source mode from being inherited by backup files
- keeps partial copies hidden and owner-only, replaces pre-existing destination symlinks instead of following them, and cleans up on copy failures
- copies through the open `mkstemp` descriptor to avoid a temp-path reopen race

## Verification
- `scripts/run_tests.sh` focused backup regressions: 8 passed
- `scripts/run_tests.sh tests/tools/test_docker_config_migrate.py`: 8 passed
- Ruff on all changed Python files: passed
- `python -m compileall` on all changed Python files: passed
- `git diff --check`: passed

No new dependencies or configuration.