### PR TITLE
fix(desktop): isolate pooled profile cwd

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -7,6 +7,7 @@ import {
   appendUniquePathEntries,
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
+  buildPooledProfileBackendEnv,
   hermesManagedNodePathEntries,
   normalizeHermesHomeRoot,
   pathEnvKey,
@@ -145,6 +146,38 @@ test('buildDesktopBackendEnv forces PYTHONUTF8 unless the user set it explicitly
   })
 
   assert.equal(optedOut.PYTHONUTF8, '0')
+})
+
+test('pooled profile backend drops inherited terminal cwd before profile config resolves it', () => {
+  const env = buildPooledProfileBackendEnv({
+    hermesHome: '/Users/test/.hermes',
+    currentEnv: { PATH: '/usr/bin', TERMINAL_CWD: '/source/profile-workspace', KEEP_ME: 'parent' },
+    backendEnv: {
+      HERMES_HOME: '/backend-specific-home',
+      PYTHONPATH: '/repo',
+      TERMINAL_CWD: '/stale/backend-workspace',
+      KEEP_BACKEND: 'backend'
+    }
+  })
+
+  assert.equal(env.HERMES_HOME, '/backend-specific-home')
+  assert.equal(env.KEEP_ME, 'parent')
+  assert.equal(env.KEEP_BACKEND, 'backend')
+  assert.equal(env.PYTHONPATH, '/repo')
+  assert.equal(env.TERMINAL_CWD, undefined)
+})
+
+test('pooled profile backend removes case-insensitive terminal cwd on Windows', () => {
+  const env = buildPooledProfileBackendEnv({
+    hermesHome: 'C:\\Hermes',
+    currentEnv: { Terminal_Cwd: 'C:\\source', Path: 'C:\\Windows' },
+    backendEnv: { terminal_cwd: 'C:\\backend' },
+    platform: 'win32'
+  })
+
+  assert.equal(env.Terminal_Cwd, undefined)
+  assert.equal(env.terminal_cwd, undefined)
+  assert.equal(env.HERMES_HOME, 'C:\\Hermes')
 })
 
 test('normalizeHermesHomeRoot maps profile homes back to the global Hermes root', () => {

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -149,10 +149,34 @@ function buildDesktopBackendEnv({
   }
 }
 
+// A pooled backend is started for a different profile but inherits Electron's
+// process environment. TERMINAL_CWD is profile-scoped configuration, so carrying
+// it over would make an unset/placeholder target profile execute in the source
+// profile's workspace. Remove it from both inherited and runtime-provided env
+// mappings and let the target profile resolve its own config after --profile.
+function buildPooledProfileBackendEnv({
+  hermesHome,
+  currentEnv = process.env,
+  backendEnv = {},
+  platform = process.platform
+}: any = {}): Record<string, string | undefined> {
+  const isTerminalCwd = (key: string) =>
+    platform === 'win32' ? key.toUpperCase() === 'TERMINAL_CWD' : key === 'TERMINAL_CWD'
+  const withoutTerminalCwd = (env: Record<string, string | undefined> = {}) =>
+    Object.fromEntries(Object.entries(env).filter(([key]) => !isTerminalCwd(key)))
+
+  return {
+    ...withoutTerminalCwd(currentEnv),
+    HERMES_HOME: hermesHome,
+    ...withoutTerminalCwd(backendEnv)
+  }
+}
+
 export {
   appendUniquePathEntries,
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
+  buildPooledProfileBackendEnv,
   delimiterForPlatform,
   hermesManagedNodePathEntries,
   normalizeHermesHomeRoot,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -34,7 +34,12 @@ import { classifyActiveRuntime } from './active-runtime-state'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
-import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
+import {
+  buildDesktopBackendEnv,
+  buildPooledProfileBackendEnv,
+  hermesManagedNodePathEntries,
+  normalizeHermesHomeRoot
+} from './backend-env'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
 import { backendCommandMatches, createBackendOwnership, createBackendShutdownCoordinator } from './backend-ownership'
 import {
@@ -9565,13 +9570,11 @@ async function spawnPoolBackend(profile, entry) {
     hiddenWindowsChildOptions({
       cwd: hermesCwd,
       env: {
-        ...process.env,
-        HERMES_HOME,
-        ...backend.env,
-        // Pin the gateway's tool/terminal cwd to the same directory we chose for
-        // the child process. Inherited TERMINAL_CWD (or a stale config bridge)
-        // can still point at the install dir even when spawn cwd is home.
-        TERMINAL_CWD: hermesCwd,
+        ...buildPooledProfileBackendEnv({
+          hermesHome: HERMES_HOME,
+          currentEnv: process.env,
+          backendEnv: backend.env
+        }),
         HERMES_DASHBOARD_SESSION_TOKEN: token,
         // Marks this dashboard backend as desktop-spawned so it runs the cron
         // scheduler tick loop (the gateway isn't running under the app).


### PR DESCRIPTION
## Summary
- remove source-profile `TERMINAL_CWD` from pooled backend child environments
- preserve target profile config resolution after `--profile`
- cover POSIX and case-insensitive Windows environment keys

## Verification
- `npx vitest run apps/desktop/electron/backend-env.test.ts`
- `npx prettier --check apps/desktop/electron/backend-env.ts apps/desktop/electron/backend-env.test.ts apps/desktop/electron/main.ts`
- `git diff --check`

`npm run typecheck --workspace apps/desktop` and targeted ESLint are blocked in this scratch workspace by unresolved existing Desktop dev dependencies (`vitest`, `electron`, `globals`, and testing-library packages).

Closes #87584