### PR TITLE
fix(memory): support Russian holographic recall

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -402,10 +402,15 @@ class HolographicMemoryProvider(MemoryProvider):
             re.compile(r'\bI\s+(?:prefer|like|love|use|want|need)\s+(.+)', re.IGNORECASE),
             re.compile(r'\bmy\s+(?:favorite|preferred|default)\s+\w+\s+is\s+(.+)', re.IGNORECASE),
             re.compile(r'\bI\s+(?:always|never|usually)\s+(.+)', re.IGNORECASE),
+            re.compile(r'\bЯ\s+(?:предпочитаю|люблю|использую|хочу|не\s+хочу)\s+(.+)', re.IGNORECASE),
+            re.compile(r'\bМне\s+(?:нравится|нужно|важно)\s+(.+)', re.IGNORECASE),
+            re.compile(r'\bЯ\s+(?:всегда|никогда|обычно)\s+(.+)', re.IGNORECASE),
         ]
         _DECISION_PATTERNS = [
             re.compile(r'\bwe\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+)', re.IGNORECASE),
             re.compile(r'\bthe\s+project\s+(?:uses|needs|requires)\s+(.+)', re.IGNORECASE),
+            re.compile(r'\bМы\s+(?:решили|договорились|выбрали)\s+(.+)', re.IGNORECASE),
+            re.compile(r'\bПроект\s+(?:использует|требует|нуждается\s+в)\s+(.+)', re.IGNORECASE),
         ]
 
         extracted = 0

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -127,19 +127,56 @@ class FactRetriever:
         category: str | None = None,
         limit: int = 10,
     ) -> list[dict]:
-        """Compositional entity query using HRR algebra.
+        """Return facts linked to an entity, with HRR algebra as fallback.
 
-        Unbinds entity from memory bank to extract associated content.
-        This is NOT keyword search — it uses algebraic structure to find facts
-        where the entity plays a structural role.
+        Exact entity and alias matches use the relational links created during
+        fact ingestion. Unknown entities fall back to algebraic retrieval by
+        unbinding the entity from fact or category-bank vectors.
 
         Falls back to FTS5 search if numpy unavailable.
         """
-        if not hrr._HAS_NUMPY:
-            # Fallback to keyword search on entity name
-            return self.search(entity, category=category, limit=limit)
-
         conn = self.store._conn
+
+        # SQLite's built-in NOCASE collation is ASCII-only. Resolve names and
+        # aliases in Python so Cyrillic and other Unicode scripts get proper
+        # case-insensitive exact matching instead of noisy HRR ranking.
+        entity_key = entity.strip().casefold()
+        entity_ids = []
+        for row in conn.execute("SELECT entity_id, name, aliases FROM entities"):
+            names = [row["name"], *(row["aliases"] or "").split(",")]
+            if any(name.strip().casefold() == entity_key for name in names if name.strip()):
+                entity_ids.append(row["entity_id"])
+
+        if entity_ids:
+            placeholders = ",".join("?" * len(entity_ids))
+            category_clause = ""
+            params: list = list(entity_ids)
+            if category is not None:
+                category_clause = "AND f.category = ?"
+                params.append(category)
+            params.append(limit)
+            rows = conn.execute(
+                f"""
+                SELECT DISTINCT f.fact_id, f.content, f.category, f.tags,
+                       f.trust_score, f.retrieval_count, f.helpful_count,
+                       f.created_at, f.updated_at
+                FROM facts f
+                JOIN fact_entities fe ON fe.fact_id = f.fact_id
+                WHERE fe.entity_id IN ({placeholders})
+                  {category_clause}
+                ORDER BY f.trust_score DESC, f.updated_at DESC
+                LIMIT ?
+                """,
+                params,
+            ).fetchall()
+            results = [dict(row) for row in rows]
+            for fact in results:
+                fact["score"] = fact["trust_score"]
+            return results
+
+        if not hrr._HAS_NUMPY:
+            # Fallback to keyword search on an unknown entity name.
+            return self.search(entity, category=category, limit=limit)
 
         # Encode entity as role-bound vector
         role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -81,8 +81,10 @@ _UNHELPFUL_DELTA = -0.10
 _TRUST_MIN       =  0.0
 _TRUST_MAX       =  1.0
 
-# Entity extraction patterns
-_RE_CAPITALIZED  = re.compile(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b')
+# Entity extraction patterns. Python's built-in ``re`` has no Unicode
+# category escapes such as ``\p{Lu}``, so title-casing is checked with
+# ``str.isupper`` below after tokenising Unicode letter words here.
+_RE_WORD         = re.compile(r"[^\W\d_]+(?:[-'’][^\W\d_]+)*", re.UNICODE)
 _RE_DOUBLE_QUOTE = re.compile(r'"([^"]+)"')
 _RE_SINGLE_QUOTE = re.compile(r"'([^']+)'")
 _RE_AKA          = re.compile(
@@ -464,8 +466,29 @@ class MemoryStore:
                 seen.add(stripped.lower())
                 candidates.append(stripped)
 
-        for m in _RE_CAPITALIZED.finditer(text):
-            _add(m.group(1))
+        capitalized_run: list[re.Match[str]] = []
+
+        def _flush_capitalized_run() -> None:
+            if len(capitalized_run) >= 2:
+                start = capitalized_run[0].start()
+                end = capitalized_run[-1].end()
+                _add(text[start:end])
+            capitalized_run.clear()
+
+        for match in _RE_WORD.finditer(text):
+            word = match.group(0)
+            first_letter = next((char for char in word if char.isalpha()), "")
+            separated_by_space = (
+                not capitalized_run
+                or text[capitalized_run[-1].end():match.start()].isspace()
+            )
+            if first_letter.isupper() and separated_by_space:
+                capitalized_run.append(match)
+            else:
+                _flush_capitalized_run()
+                if first_letter.isupper():
+                    capitalized_run.append(match)
+        _flush_capitalized_run()
 
         for m in _RE_DOUBLE_QUOTE.finditer(text):
             _add(m.group(1))

--- a/tests/plugins/memory/test_holographic_auto_extract.py
+++ b/tests/plugins/memory/test_holographic_auto_extract.py
@@ -122,6 +122,25 @@ def test_real_user_messages_still_extracted_alongside_summary(tmp_path):
     provider.shutdown()
 
 
+@pytest.mark.parametrize(
+    "message,category",
+    [
+        ("Я предпочитаю использовать короткие ответы без лишних повторов", "user_pref"),
+        ("Мне нужно подтверждение перед изменением конфигурации", "user_pref"),
+        ("Мы решили использовать PostgreSQL для постоянного хранения", "project"),
+        ("Проект использует Kubernetes для запуска приложений", "project"),
+    ],
+)
+def test_russian_user_preferences_and_decisions_are_extracted(tmp_path, message, category):
+    provider = _make_provider(tmp_path, auto_extract=True)
+    provider.on_session_end([_user(message)])
+
+    assert provider._store is not None
+    facts = provider._store.list_facts(category=category, limit=100)
+    assert [fact["content"] for fact in facts] == [message]
+    provider.shutdown()
+
+
 # ---------------------------------------------------------------------------
 # is_compaction_summary_message — public helper contract
 # ---------------------------------------------------------------------------

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -95,6 +95,23 @@ def test_prefetch_recovers_prose_query(retriever_with_facts):
     assert "deployment rollback" in results[0]["content"].lower()
 
 
+def test_probe_exact_unicode_entity_returns_only_linked_facts(tmp_path):
+    store = MemoryStore(str(tmp_path / "unicode_probe.db"), hrr_dim=64)
+    try:
+        linked = "Иван Петров предпочитает поэтапные изменения инфраструктуры."
+        store.add_fact(linked, category="user_pref")
+        store.add_fact(
+            "Unrelated deployment fact about Kubernetes networking.",
+            category="project",
+        )
+
+        results = FactRetriever(store=store, hrr_dim=64).probe("иван петров")
+
+        assert [fact["content"] for fact in results] == [linked]
+    finally:
+        store.close()
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -154,6 +154,25 @@ class TestCloseSemantics:
         assert [f["content"] for f in facts] == ["first lifetime"]
 
 
+class TestUnicodeEntityExtraction:
+    def test_cyrillic_multiword_name_is_extracted_and_linked(self, db_path):
+        with MemoryStore(db_path) as store:
+            fact_id = store.add_fact(
+                "Иван Петров предпочитает поэтапные изменения инфраструктуры"
+            )
+            entities = store._conn.execute(
+                """
+                SELECT e.name
+                FROM entities e
+                JOIN fact_entities fe ON fe.entity_id = e.entity_id
+                WHERE fe.fact_id = ?
+                """,
+                (fact_id,),
+            ).fetchall()
+
+        assert [row["name"] for row in entities] == ["Иван Петров"]
+
+
 class TestConcurrency:
     def test_concurrent_multi_instance_writers(self, db_path):
         """Many instances writing from many threads must never hit


### PR DESCRIPTION
## Summary
- recognize explicit Russian preference and project-decision phrases during Holographic session-end extraction
- extract and link capitalized multi-word entities across Unicode scripts without adding dependencies
- make exact Unicode entity probes return only relationally linked facts, retaining HRR as the unknown-entity fallback
- preserve existing English, quoted-term, compaction-summary, and shared-SQLite behavior

## Tests
- `scripts/run_tests.sh tests/plugins/memory/test_holographic_*.py tests/plugins/test_holographic_vector_storage.py -q`
- 57 passed