### PR TITLE
fix(update): wait for keypress after slash update

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -3609,7 +3609,10 @@ class CLICommandsMixin:
         # skip terminal cleanup on POSIX (execvp replaces the process mid-TUI)
         # and only exit the worker thread on Windows (subprocess.run +
         # sys.exit inside a non-main thread does not exit the process).
-        self._pending_relaunch = ["update"]
+        # The internal flag keeps the update process open at completion so a
+        # terminal window launched for Hermes is not dismissed before the user
+        # can read the result. Direct `hermes update` calls remain unchanged.
+        self._pending_relaunch = ["update", "--wait-for-keypress"]
         return True
 
     def _handle_voice_command(self, command: str):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2815,7 +2815,9 @@ def _launch_tui(
                 pass
 
     # Exit code 42 = TUI requested an update. Relaunch as `hermes update` so
-    # the user sees update output directly and gets the new version.
+    # the user sees update output directly and gets the new version. The
+    # internal pause flag keeps a dedicated terminal window open afterward so
+    # the result remains readable until the user dismisses it.
     # preserve_inherited=False ensures --tui and other flags are NOT carried
     # into the update subcommand.
     if code == 42:
@@ -2824,7 +2826,7 @@ def _launch_tui(
         print()
         print("⚕ Launching update...")
         print()
-        relaunch(["update"], preserve_inherited=False)
+        relaunch(["update", "--wait-for-keypress"], preserve_inherited=False)
 
     sys.exit(code)
 
@@ -9793,7 +9795,57 @@ def _size_delta_label(saved_mb: float) -> str:
     return f"grew by {-saved_mb:.1f} MB"
 
 
-def cmd_update(args):
+def _read_single_key(stream) -> None:
+    """Read exactly one key from an interactive terminal without Enter."""
+    if sys.platform == "win32":
+        import msvcrt
+
+        msvcrt.getwch()
+        return
+
+    import termios
+    import tty
+
+    fd = stream.fileno()
+    previous = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        stream.read(1)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, previous)
+
+
+def _wait_for_update_keypress(*, stdin=None, stdout=None) -> None:
+    """Keep an interactive /update window open until the user dismisses it."""
+    stdin = sys.stdin if stdin is None else stdin
+    stdout = sys.stdout if stdout is None else stdout
+    try:
+        if not stdin.isatty():
+            return
+    except (AttributeError, OSError):
+        return
+
+    try:
+        stdout.write("\nUpdate process finished. Press any key to close this window...")
+        stdout.flush()
+    except (OSError, ValueError):
+        return
+
+    try:
+        _read_single_key(stdin)
+    except (EOFError, OSError, KeyboardInterrupt):
+        # If the terminal disappears while waiting, preserve the updater's
+        # original result rather than replacing it with a dismissal error.
+        pass
+    finally:
+        try:
+            stdout.write("\n")
+            stdout.flush()
+        except (OSError, ValueError):
+            pass
+
+
+def _cmd_update_without_keypress_wait(args):
     """Update Hermes Agent to the latest version.
 
     Thin wrapper around ``_cmd_update_impl``: installs hangup protection,
@@ -9866,6 +9918,19 @@ def cmd_update(args):
     finally:
         _update_lock.release()
         _finalize_update_output(_update_io_state)
+
+
+def cmd_update(args):
+    """Run the updater and optionally pause before a /update window closes."""
+    try:
+        return _cmd_update_without_keypress_wait(args)
+    finally:
+        if getattr(args, "wait_for_keypress", False):
+            try:
+                _wait_for_update_keypress()
+            except BaseException:
+                # This optional pause must never replace the updater's result.
+                pass
 
 
 def _coalesce_session_name_args(argv: list) -> list:

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -6,6 +6,7 @@ Handler injected to avoid importing ``main``.
 
 from __future__ import annotations
 
+import argparse
 from typing import Callable
 
 
@@ -72,5 +73,11 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         action="store_true",
         default=False,
         help="Windows: mutate the venv even while other processes are running from its interpreter (desktop backend, gateway, terminals). Those processes keep native .pyd files locked, so the dependency sync will likely fail partway and strand the install half-updated. Use only if you know the detected holders are false positives.",
+    )
+    update_parser.add_argument(
+        "--wait-for-keypress",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
     )
     update_parser.set_defaults(func=cmd_update)

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -2,17 +2,17 @@
 
 Verifies that ``HermesCLI._handle_update_command`` correctly:
 - Refuses to run under a managed install (Homebrew, Docker, etc.)
-- Sets ``_pending_relaunch`` and returns ``True`` on confirmation
+- Relaunches the updater with a post-run keypress pause on confirmation
 - Cancels cleanly on a "no"-shaped answer or unrecognized input
 - Cancels cleanly when ``_prompt_text_input_modal`` returns None (timeout /
   modal dismissed)
 
 Also verifies that ``hermes_cli.main._launch_tui`` correctly handles exit
-code 42 (the TUI's signal to trigger an update) by calling
-``relaunch(["update"], preserve_inherited=False)`` from the Python wrapper
-side.  The companion Vitest (``ui-tui/src/__tests__/createSlashHandler.test.ts``)
-covers the TypeScript slash-handler that *emits* code 42; this file covers
-the Python wrapper branch that *acts on* it.
+code 42 (the TUI's signal to trigger an update) by relaunching the updater
+with the same pause behavior. The companion Vitest
+(``ui-tui/src/__tests__/createSlashHandler.test.ts``) covers the TypeScript
+slash-handler that *emits* code 42; this file covers the Python wrapper branch
+that *acts on* it.
 """
 
 from __future__ import annotations
@@ -95,13 +95,13 @@ def test_managed_install_refuses_and_does_not_set_pending_relaunch(capsys):
 @pytest.mark.parametrize("answer", ["y", "Y", "yes", "YES", "1", "ok"])
 def test_affirmative_answer_sets_pending_relaunch_and_returns_true(answer, capsys):
     """Recognised affirmative answers ("y", "yes", "1", "ok") set
-    ``_pending_relaunch = ["update"]`` and return ``True`` so the caller
-    (process_command) can trigger the main-thread app-exit path."""
+    the paused update relaunch and return ``True`` so the caller can trigger
+    the main-thread app-exit path."""
     self_ = _make_self(modal_response=answer)
     with patch("hermes_cli.config.is_managed", return_value=False):
         result = _call(self_)
 
-    assert self_._pending_relaunch == ["update"]
+    assert self_._pending_relaunch == ["update", "--wait-for-keypress"]
     assert result is True
     assert "Launching update" in capsys.readouterr().out
 
@@ -148,3 +148,32 @@ def test_unrecognized_or_cancel_input_cancels(answer, capsys):
 
     assert self_._pending_relaunch is None
     assert not result
+
+
+def test_tui_update_relaunch_requests_keypress_pause(tmp_path, monkeypatch):
+    """Exit code 42 carries the pause flag into the updater process."""
+    from hermes_cli import config
+    from hermes_cli import main
+    from hermes_cli import relaunch as relaunch_module
+    from tools.environments import local
+
+    requested = []
+
+    def capture(args, **kwargs):
+        requested.append((args, kwargs))
+        raise RuntimeError("relaunch captured")
+
+    monkeypatch.setattr(main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(main, "_make_tui_argv", lambda *_args: (["node", "tui"], tmp_path))
+    monkeypatch.setattr(main, "_resolve_tui_heap_mb", lambda: 512)
+    monkeypatch.setattr(main.subprocess, "call", lambda *_args, **_kwargs: 42)
+    monkeypatch.setattr(local, "build_subprocess_env", lambda **_kwargs: {})
+    monkeypatch.setattr(config, "apply_terminal_config_to_env", lambda **_kwargs: None)
+    monkeypatch.setattr(relaunch_module, "relaunch", capture)
+
+    with pytest.raises(RuntimeError, match="relaunch captured"):
+        main._launch_tui()
+
+    assert requested == [
+        (["update", "--wait-for-keypress"], {"preserve_inherited": False})
+    ]

--- a/tests/hermes_cli/test_update_keypress_wait.py
+++ b/tests/hermes_cli/test_update_keypress_wait.py
@@ -1,0 +1,191 @@
+"""Regression tests for /update's post-run keypress pause."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import main
+from hermes_cli.subcommands.update import build_update_parser
+
+
+class _TtyInput(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+class _NonTtyInput(io.StringIO):
+    def isatty(self) -> bool:
+        return False
+
+
+class _BrokenOutput:
+    def write(self, _text):
+        raise OSError("terminal closed")
+
+    def flush(self):
+        raise OSError("terminal closed")
+
+
+def _parse_update(*argv: str):
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_update_parser(subparsers, cmd_update=lambda _args: None)
+    return parser.parse_args(["update", *argv])
+
+
+def test_update_parser_accepts_internal_wait_for_keypress_flag():
+    args = _parse_update("--wait-for-keypress")
+
+    assert args.wait_for_keypress is True
+
+
+def test_wait_for_update_keypress_reads_one_key_and_prints_prompt(monkeypatch):
+    stdin = _TtyInput()
+    stdout = io.StringIO()
+    reads = []
+    monkeypatch.setattr(main, "_read_single_key", lambda stream: reads.append(stream))
+
+    main._wait_for_update_keypress(stdin=stdin, stdout=stdout)
+
+    assert reads == [stdin]
+    assert "Press any key to close this window" in stdout.getvalue()
+
+
+def test_wait_for_update_keypress_skips_noninteractive_stdin(monkeypatch):
+    stdin = _NonTtyInput()
+    stdout = io.StringIO()
+    monkeypatch.setattr(
+        main,
+        "_read_single_key",
+        lambda _stream: pytest.fail("non-interactive input must not be read"),
+    )
+
+    main._wait_for_update_keypress(stdin=stdin, stdout=stdout)
+
+    assert stdout.getvalue() == ""
+
+
+def test_wait_for_update_keypress_preserves_result_when_output_is_closed(monkeypatch):
+    monkeypatch.setattr(
+        main,
+        "_read_single_key",
+        lambda _stream: pytest.fail("a closed terminal cannot be dismissed"),
+    )
+
+    main._wait_for_update_keypress(stdin=_TtyInput(), stdout=_BrokenOutput())
+
+
+def test_read_single_key_restores_posix_terminal_after_read_failure(monkeypatch):
+    calls = []
+    previous = object()
+
+    def fail_read(_size):
+        raise RuntimeError("read failed")
+
+    stream = SimpleNamespace(fileno=lambda: 23, read=fail_read)
+    termios = SimpleNamespace(
+        TCSADRAIN=99,
+        tcgetattr=lambda fd: calls.append(("get", fd)) or previous,
+        tcsetattr=lambda fd, when, state: calls.append(("restore", fd, when, state)),
+    )
+    tty = SimpleNamespace(setraw=lambda fd: calls.append(("raw", fd)))
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setitem(sys.modules, "termios", termios)
+    monkeypatch.setitem(sys.modules, "tty", tty)
+
+    with pytest.raises(RuntimeError, match="read failed"):
+        main._read_single_key(stream)
+
+    assert calls == [("get", 23), ("raw", 23), ("restore", 23, 99, previous)]
+
+
+def test_read_single_key_uses_msvcrt_getwch_on_windows(monkeypatch):
+    calls = []
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setitem(
+        sys.modules,
+        "msvcrt",
+        SimpleNamespace(getwch=lambda: calls.append("getwch")),
+    )
+    stream = SimpleNamespace(fileno=lambda: pytest.fail("Windows must not use fileno"))
+
+    main._read_single_key(stream)
+
+    assert calls == ["getwch"]
+
+
+def test_cmd_update_waits_after_update_completion(monkeypatch):
+    calls = []
+    monkeypatch.setattr(main, "_cmd_update_without_keypress_wait", lambda args: calls.append(("update", args)))
+    monkeypatch.setattr(main, "_wait_for_update_keypress", lambda: calls.append(("wait", None)))
+    args = SimpleNamespace(wait_for_keypress=True)
+
+    main.cmd_update(args)
+
+    assert calls == [("update", args), ("wait", None)]
+
+
+@pytest.mark.parametrize(
+    "pause_error",
+    [ValueError("no fileno"), RuntimeError("pause failed"), SystemExit(9)],
+)
+def test_cmd_update_preserves_successful_result_when_pause_fails(monkeypatch, pause_error):
+    expected = object()
+    monkeypatch.setattr(main, "_cmd_update_without_keypress_wait", lambda _args: expected)
+
+    def fail_pause():
+        raise pause_error
+
+    monkeypatch.setattr(main, "_wait_for_update_keypress", fail_pause)
+
+    result = main.cmd_update(SimpleNamespace(wait_for_keypress=True))
+
+    assert result is expected
+
+
+def test_cmd_update_waits_after_update_failure(monkeypatch):
+    calls = []
+
+    def fail(_args):
+        calls.append(("update", None))
+        raise SystemExit(7)
+
+    monkeypatch.setattr(main, "_cmd_update_without_keypress_wait", fail)
+    monkeypatch.setattr(main, "_wait_for_update_keypress", lambda: calls.append(("wait", None)))
+
+    with pytest.raises(SystemExit, match="7"):
+        main.cmd_update(SimpleNamespace(wait_for_keypress=True))
+
+    assert calls == [("update", None), ("wait", None)]
+
+
+@pytest.mark.parametrize("pause_error", [ValueError("no fileno"), SystemExit(9)])
+def test_cmd_update_preserves_original_system_exit_when_pause_fails(monkeypatch, pause_error):
+    def fail_update(_args):
+        raise SystemExit(7)
+
+    def fail_pause():
+        raise pause_error
+
+    monkeypatch.setattr(main, "_cmd_update_without_keypress_wait", fail_update)
+    monkeypatch.setattr(main, "_wait_for_update_keypress", fail_pause)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main.cmd_update(SimpleNamespace(wait_for_keypress=True))
+
+    assert exc_info.value.code == 7
+
+
+def test_direct_cmd_update_does_not_wait(monkeypatch):
+    calls = []
+    monkeypatch.setattr(main, "_cmd_update_without_keypress_wait", lambda _args: calls.append("update"))
+    monkeypatch.setattr(main, "_wait_for_update_keypress", lambda: calls.append("wait"))
+
+    main.cmd_update(SimpleNamespace(wait_for_keypress=False))
+
+    assert calls == ["update"]


### PR DESCRIPTION
## Summary

- keep the update process launched by `/update` open after it finishes
- wait for one keypress so users can read success or failure output before the terminal window closes
- preserve direct `hermes update` and non-interactive behavior
- make the pause best-effort so terminal I/O failures never mask the updater's original exit status

## Implementation

Both the classic CLI and Ink TUI slash-command paths relaunch the updater with a hidden `--wait-for-keypress` flag. The updater pauses only when stdin is interactive, reads one key without requiring Enter, restores POSIX terminal state, and uses `msvcrt.getwch()` on Windows.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_update_*.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_cmd_update_docker.py tests/cli/test_update_command.py`
  - 348 passed, 0 failed, 3 Windows-only skipped on WSL
- `uvx ruff check hermes_cli/main.py hermes_cli/cli_commands_mixin.py hermes_cli/subcommands/update.py tests/cli/test_update_command.py tests/hermes_cli/test_update_keypress_wait.py`
- `git diff --check`
- manually verified the single-key pause in a real POSIX PTY under WSL2
- added mocked coverage for Windows `msvcrt.getwch()` and POSIX raw-mode restoration

## Platforms tested

- WSL2 / Ubuntu 22.04
- Windows behavior covered with platform-mocked unit tests; native Windows CI remains authoritative

## Duplicate search

Searched open/closed issues and pull requests for `keypress update`, `Press any key`, and `update window close`; no matching implementation was found.
