### PR TITLE
fix(cli): map kitty/xterm modified cursor-key sequences to plain arrows

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -81,6 +81,7 @@ try:
         install_cmd_backspace_alias,
         install_ctrl_enter_alias,
         install_ignored_terminal_sequences,
+        install_modified_cursor_key_aliases,
         install_modify_other_keys_aliases,
         install_shift_enter_alias,
     )
@@ -88,8 +89,9 @@ try:
     install_ctrl_enter_alias()
     install_cmd_backspace_alias()
     install_modify_other_keys_aliases()
+    install_modified_cursor_key_aliases()
     install_ignored_terminal_sequences()
-    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_modify_other_keys_aliases, install_ignored_terminal_sequences
+    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_modify_other_keys_aliases, install_modified_cursor_key_aliases, install_ignored_terminal_sequences
 except Exception:
     pass
 import threading

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -389,6 +389,55 @@ def install_modify_other_keys_aliases() -> int:
     return changed
 
 
+def install_modified_cursor_key_aliases() -> int:
+    """Map kitty/xterm *modified cursor-key* sequences to plain arrows.
+
+    When the numpad is used for the arrow keys (or numpad Enter etc.), kitty
+    reports the arrow cluster in the ``CSI 1;<mod> <final>`` cursor-key form
+    *with* the keypad flag riding in the modifier suffix — e.g.
+    ``\\x1b[1;129A`` (Up), ``\\x1b[1;129B`` (Down), ``\\x1b[1;129C`` (Right),
+    ``\\x1b[1;129D`` (Left), where 129 = 0x80 keypad flag | 0x01. Stock
+    prompt_toolkit only maps the *bare* ``\\x1b[A/B/C/D`` forms, so any
+    modified/flagged variant falls through to literal character insertion —
+    the ``[1;129A[1;129C[1;129D[1;129B`` leak.
+
+    Modifier suffixes kitty emits for cursor keys follow the same bitmask
+    scheme as the CSI-u functional keys: base-2 bits for Shift/Alt/Ctrl/Super/
+    Hyper/Meta and combinations (1..16) plus the 0x80-keypad-flag OR range
+    (129..144). Home/End tickle the same path (``\\x1b[1;129H`` / ``\\x1b[1;129F``).
+    We register every variant of the final bytes ``A B C D H F`` and remap them
+    to the matching prompt_toolkit arrow / navigation key. ``setdefault`` so a
+    user or downstream mapping wins; plain sequences already present are left
+    untouched.
+
+    Returns the number of sequences whose mapping was newly installed.
+    """
+    try:
+        from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+        from prompt_toolkit.keys import Keys
+    except Exception:
+        return 0
+
+    targets = {
+        "A": Keys.Up,
+        "B": Keys.Down,
+        "C": Keys.Right,
+        "D": Keys.Left,
+        "H": Keys.Home,
+        "F": Keys.End,
+    }
+    changed = 0
+    for final, key_val in targets.items():
+        for m in list(range(1, 17)) + list(range(129, 145)):
+            seq = f"\x1b[1;{m}{final}"
+            if seq not in ANSI_SEQUENCES:
+                ANSI_SEQUENCES[seq] = key_val
+                changed += 1
+    if changed:
+        _clear_vt100_prefix_cache()
+    return changed
+
+
 def install_ignored_terminal_sequences() -> int:
     """Map terminal-emitted noise sequences to ``Keys.Ignore`` so they
     are consumed by the VT100 parser before they reach key bindings or

--- a/tests/cli/test_modified_cursor_keys.py
+++ b/tests/cli/test_modified_cursor_keys.py
@@ -1,0 +1,51 @@
+"""Regression tests for kitty/xterm modified cursor-key sequences.
+
+Kitty reports the arrow cluster in the ``CSI 1;<mod> <final>`` cursor-key form
+with the keypad flag riding in the modifier suffix — e.g. ``\\x1b[1;129A`` (Up),
+``\\x1b[1;129B`` (Down), ``\\x1b[1;129C`` (Right), ``\\x1b[1;129D`` (Left),
+129 = 0x80 keypad flag | 0x01. Without mappings these leak into the prompt as
+literal text like ``[1;129A[1;129C[1;129D[1;129B``.
+"""
+
+from prompt_toolkit.input.vt100_parser import Vt100Parser
+from prompt_toolkit.keys import Keys
+
+from hermes_cli.pt_input_extras import install_modified_cursor_key_aliases
+
+
+def _parse_keys(data: str):
+    events = []
+    parser = Vt100Parser(events.append)
+    parser.feed_and_flush(data)
+    return [(event.key, event.data) for event in events]
+
+
+def test_kitty_keypad_flagged_arrows_parse_as_navigation_keys():
+    install_modified_cursor_key_aliases()
+
+    assert _parse_keys("\x1b[1;129A") == [(Keys.Up, "\x1b[1;129A")]
+    assert _parse_keys("\x1b[1;129B") == [(Keys.Down, "\x1b[1;129B")]
+    assert _parse_keys("\x1b[1;129C") == [(Keys.Right, "\x1b[1;129C")]
+    assert _parse_keys("\x1b[1;129D") == [(Keys.Left, "\x1b[1;129D")]
+    assert _parse_keys("\x1b[1;129H") == [(Keys.Home, "\x1b[1;129H")]
+    assert _parse_keys("\x1b[1;129F") == [(Keys.End, "\x1b[1;129F")]
+
+
+def test_keypad_flagged_arrows_do_not_leak_as_literal_text():
+    install_modified_cursor_key_aliases()
+
+    # The exact reported leak must NOT print the raw escape bytes to the
+    # prompt; each sequence is consumed as a single navigation key.
+    result = _parse_keys("\x1b[1;129A\x1b[1;129C\x1b[1;129D\x1b[1;129B")
+    assert result == [
+        (Keys.Up, "\x1b[1;129A"),
+        (Keys.Right, "\x1b[1;129C"),
+        (Keys.Left, "\x1b[1;129D"),
+        (Keys.Down, "\x1b[1;129B"),
+    ]
+
+
+def test_install_is_idempotent_and_default_safe():
+    install_modified_cursor_key_aliases()
+    # Second call adds nothing new since sequences are already present.
+    assert install_modified_cursor_key_aliases() == 0


### PR DESCRIPTION
## Problem

When running Hermes inside the kitty terminal with the numpad arrow cluster
(or numpad Enter), kitty reports the keys in its `CSI 1;<mod> <final>`
cursor-key form **with the keypad flag riding in the modifier suffix** —
e.g. `ESC[1;129A` (Up), `ESC[1;129B` (Down), `ESC[1;129C` (Right),
`ESC[1;129D` (Left), where 129 = 0x80 keypad flag | 0x01.

Stock prompt_toolkit only maps the *bare* `ESC[A/B/C/D` forms, so these
flagged variants fall through to literal character insertion and leak onto
the prompt as `[1;129A[1;129C[1;129D[1;129B` garbage.

## Fix

Add `install_modified_cursor_key_aliases()` to
`hermes_cli/pt_input_extras.py` which registers every variant of the
cursor-key finals `A B C D H F` across kitty's base-2 modifier range
(1..16) and keypad-flagged range (129..144), remapping them to the matching
prompt_toolkit navigation `Keys`. Wired at CLI startup alongside the
existing kitty/xterm alias installers in `cli.py`.

## Test

Adds `tests/cli/test_modified_cursor_keys.py` covering:
- flagged arrows/Home/End decode to the correct navigation key
- the exact reported `[1;129A[1;129C[1;129D[1;129B` sequence is consumed
  as four navigation keys (no literal-text leak)
- install is idempotent / `setdefault`-safe

All 177 tests in the modified-cursor-key, terminal-shortcut, and
modifyOtherKeys suites pass.