### PR TITLE
feat(discord): configurable presence/activity (discord.activity config + app-attached Rich Presence)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1174,6 +1174,9 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#   activity: ""                     # Presence text on the bot profile, e.g. "Hermes Agent"
+#   activity_type: playing           # playing | watching | listening | custom (default: playing)
+#   activity_large_image: ""         # Rich Presence asset key from your app's dev-portal Art Assets
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1384,6 +1384,31 @@ class DiscordAdapter(BasePlatformAdapter):
             async def on_ready():
                 logger.info("[%s] Connected as %s", adapter_self.name, adapter_self._client.user)
 
+                # Set presence/activity ("Playing <X>") when configured.
+                # Sources (first wins): DISCORD_ACTIVITY / DISCORD_ACTIVITY_TYPE
+                # env vars, else config.yaml's discord.activity /
+                # discord.activity_type keys — bridged to those same env vars by
+                # _apply_yaml_config below, so this read is env-only.
+                # change_presence lives in on_ready so the presence re-applies
+                # after every reconnect/RESUME, not just first boot — without a
+                # presence the bot shows as visually offline (#64932).
+                _act = (os.getenv("DISCORD_ACTIVITY", "") or "").strip()
+                if _act:
+                    try:
+                        _atype = (os.getenv("DISCORD_ACTIVITY_TYPE", "") or "playing").strip().lower()
+                        if _atype == "watching":
+                            _activity = discord.Activity(type=discord.ActivityType.watching, name=_act)
+                        elif _atype == "listening":
+                            _activity = discord.Activity(type=discord.ActivityType.listening, name=_act)
+                        elif _atype == "custom":
+                            _activity = discord.CustomActivity(name=_act)
+                        else:
+                            _activity = discord.Game(name=_act)
+                        await adapter_self._client.change_presence(activity=_activity)
+                        logger.info("[%s] Presence set: %s '%s'", adapter_self.name, _atype, _act)
+                    except Exception:
+                        logger.debug("[%s] Failed to set Discord presence", adapter_self.name, exc_info=True)
+
                 # Resolve any usernames in the allowed list to numeric IDs
                 await adapter_self._resolve_allowed_usernames()
                 adapter_self._ready_event.set()
@@ -10339,6 +10364,10 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     """
     if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
         os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
+    if "activity" in discord_cfg and not os.getenv("DISCORD_ACTIVITY"):
+        os.environ["DISCORD_ACTIVITY"] = str(discord_cfg["activity"])
+    if "activity_type" in discord_cfg and not os.getenv("DISCORD_ACTIVITY_TYPE"):
+        os.environ["DISCORD_ACTIVITY_TYPE"] = str(discord_cfg["activity_type"])
     if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):
         os.environ["DISCORD_THREAD_REQUIRE_MENTION"] = str(discord_cfg["thread_require_mention"]).lower()
     if "bots_require_inline_mention" in discord_cfg and not os.getenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION"):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1392,20 +1392,52 @@ class DiscordAdapter(BasePlatformAdapter):
                 # change_presence lives in on_ready so the presence re-applies
                 # after every reconnect/RESUME, not just first boot — without a
                 # presence the bot shows as visually offline (#64932).
+                #
+                # The activity is attached to the bot's own application_id
+                # (fetched once here) so Discord renders it as a real app
+                # presence (game icon + elapsed time) rather than bare text.
+                # Optional Rich-Presence keys in config.yaml's discord: block
+                # (or DISCORD_ACTIVITY_* env): activity_details, activity_state,
+                # activity_large_image / activity_large_text,
+                # activity_small_image / activity_small_text (asset keys from
+                # the app's Rich Presence Assets page in the dev portal).
                 _act = (os.getenv("DISCORD_ACTIVITY", "") or "").strip()
                 if _act:
                     try:
                         _atype = (os.getenv("DISCORD_ACTIVITY_TYPE", "") or "playing").strip().lower()
-                        if _atype == "watching":
-                            _activity = discord.Activity(type=discord.ActivityType.watching, name=_act)
-                        elif _atype == "listening":
-                            _activity = discord.Activity(type=discord.ActivityType.listening, name=_act)
-                        elif _atype == "custom":
+                        _app_id = None
+                        try:
+                            _app_id = (await adapter_self._client.application_info()).id
+                        except Exception:
+                            logger.debug("[%s] application_info() failed; presence without app id", adapter_self.name)
+                        _rp_kwargs: dict = {}
+                        for _k in ("details", "state", "large_image", "large_text", "small_image", "small_text"):
+                            _v = (os.getenv(f"DISCORD_ACTIVITY_{_k.upper()}", "") or "").strip()
+                            if _v:
+                                _rp_kwargs[_k] = _v
+                        if _atype == "custom":
                             _activity = discord.CustomActivity(name=_act)
                         else:
-                            _activity = discord.Game(name=_act)
+                            _type_map = {
+                                "watching": discord.ActivityType.watching,
+                                "listening": discord.ActivityType.listening,
+                            }
+                            _activity = discord.Activity(
+                                type=_type_map.get(_atype, discord.ActivityType.playing),
+                                name=_act,
+                                application_id=_app_id,
+                                details=_rp_kwargs.get("details"),
+                                state=_rp_kwargs.get("state"),
+                                timestamps={"start": int(dt.datetime.now(dt.timezone.utc).timestamp() * 1000)},
+                                assets={k: v for k, v in {
+                                    "large_image": _rp_kwargs.get("large_image"),
+                                    "large_text": _rp_kwargs.get("large_text"),
+                                    "small_image": _rp_kwargs.get("small_image"),
+                                    "small_text": _rp_kwargs.get("small_text"),
+                                }.items() if v},
+                            )
                         await adapter_self._client.change_presence(activity=_activity)
-                        logger.info("[%s] Presence set: %s '%s'", adapter_self.name, _atype, _act)
+                        logger.info("[%s] Presence set: %s '%s' (app_id=%s)", adapter_self.name, _atype, _act, _app_id)
                     except Exception:
                         logger.debug("[%s] Failed to set Discord presence", adapter_self.name, exc_info=True)
 
@@ -10368,6 +10400,13 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         os.environ["DISCORD_ACTIVITY"] = str(discord_cfg["activity"])
     if "activity_type" in discord_cfg and not os.getenv("DISCORD_ACTIVITY_TYPE"):
         os.environ["DISCORD_ACTIVITY_TYPE"] = str(discord_cfg["activity_type"])
+    # Optional Rich Presence fields (asset keys come from the owning app's
+    # Rich Presence → Art Assets page in the Discord dev portal).
+    for _rp_key in ("details", "state", "large_image", "large_text", "small_image", "small_text"):
+        _cfg_key = f"activity_{_rp_key}"
+        _env_key = f"DISCORD_ACTIVITY_{_rp_key.upper()}"
+        if _cfg_key in discord_cfg and not os.getenv(_env_key):
+            os.environ[_env_key] = str(discord_cfg[_cfg_key])
     if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):
         os.environ["DISCORD_THREAD_REQUIRE_MENTION"] = str(discord_cfg["thread_require_mention"]).lower()
     if "bots_require_inline_mention" in discord_cfg and not os.getenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION"):

--- a/plugins/platforms/discord/plugin.yaml
+++ b/plugins/platforms/discord/plugin.yaml
@@ -32,3 +32,11 @@ optional_env:
     description: "Display name for the Discord home channel"
     prompt: "Home channel display name"
     password: false
+  - name: DISCORD_ACTIVITY
+    description: "Presence activity text shown on the bot profile (e.g. \"Hermes Agent\"). Without a presence the bot shows as offline. Can also be set via the discord.activity config key; env wins."
+    prompt: "Bot presence activity text (optional)"
+    password: false
+  - name: DISCORD_ACTIVITY_TYPE
+    description: "Presence type: playing (default), watching, listening, or custom. Config equivalent: discord.activity_type."
+    prompt: "Activity type (playing/watching/listening/custom)"
+    password: false

--- a/tests/platforms/test_discord_activity.py
+++ b/tests/platforms/test_discord_activity.py
@@ -45,3 +45,17 @@ def test_adapter_source_has_presence_call_and_bridge():
     assert "change_presence" in src
     assert 'os.getenv("DISCORD_ACTIVITY"' in src
     assert '"activity" in discord_cfg' in src
+
+
+def test_rich_presence_keys_bridge():
+    discord_adapter._apply_yaml_config({}, {"activity": "X", "activity_large_image": "hermes-logo"})
+    assert os.environ.get("DISCORD_ACTIVITY_LARGE_IMAGE") == "hermes-logo"
+
+
+def test_activity_uses_base_activity_with_app_id_not_game():
+    """discord.Game can't carry application_id/assets; the adapter must build
+    the base Activity so the presence attaches to the bot's own app."""
+    src = open(os.path.join(os.path.dirname(discord_adapter.__file__), "adapter.py")).read()
+    assert "application_info()" in src
+    assert "application_id=_app_id" in src
+    assert "discord.Game(" not in src.split("on_ready")[1].split("_resolve_allowed_usernames")[0]

--- a/tests/platforms/test_discord_activity.py
+++ b/tests/platforms/test_discord_activity.py
@@ -1,0 +1,47 @@
+"""Discord presence/activity config (#64932-adjacent): config.yaml's
+``discord.activity`` / ``discord.activity_type`` keys must reach the adapter
+via the ``_apply_yaml_config`` YAML→env bridge (first-writer-wins, matching
+every other DISCORD_* key), and on_ready must call change_presence from the
+resulting env so the bot doesn't render as visually offline."""
+import os
+import pytest
+
+pytest.importorskip("discord", reason="discord.py not installed in test env")
+
+from plugins.platforms.discord import adapter as discord_adapter  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for k in ("DISCORD_ACTIVITY", "DISCORD_ACTIVITY_TYPE"):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+def test_config_keys_bridge_to_env():
+    discord_adapter._apply_yaml_config({}, {"activity": "Hermes Agent", "activity_type": "watching"})
+    assert os.environ["DISCORD_ACTIVITY"] == "Hermes Agent"
+    assert os.environ["DISCORD_ACTIVITY_TYPE"] == "watching"
+
+
+def test_env_wins_over_config(monkeypatch):
+    monkeypatch.setenv("DISCORD_ACTIVITY", "from-env")
+    discord_adapter._apply_yaml_config({}, {"activity": "from-config"})
+    assert os.environ["DISCORD_ACTIVITY"] == "from-env"
+
+
+def test_type_defaults_to_playing_at_read_site():
+    # The on_ready read uses `os.getenv("DISCORD_ACTIVITY_TYPE", "") or "playing"`.
+    assert (os.getenv("DISCORD_ACTIVITY_TYPE", "") or "playing") == "playing"
+
+
+def test_no_config_no_env_sets_nothing():
+    discord_adapter._apply_yaml_config({}, {})
+    assert "DISCORD_ACTIVITY" not in os.environ
+
+
+def test_adapter_source_has_presence_call_and_bridge():
+    src = open(os.path.join(os.path.dirname(discord_adapter.__file__), "adapter.py")).read()
+    assert "change_presence" in src
+    assert 'os.getenv("DISCORD_ACTIVITY"' in src
+    assert '"activity" in discord_cfg' in src

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -314,6 +314,12 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_ALLOW_MENTION_USERS` | No | `true` | When `true` (default), the bot can ping individual users by ID. |
 | `DISCORD_ALLOW_MENTION_REPLIED_USER` | No | `true` | When `true` (default), replying to a message pings the original author. |
 | `DISCORD_PROXY` | No | — | Proxy URL for Discord connections (HTTP, WebSocket, REST). Overrides `HTTPS_PROXY`/`ALL_PROXY`. Supports `http://`, `https://`, and `socks5://` schemes. |
+| `DISCORD_ACTIVITY` | No | — | Presence/activity text shown on the bot profile (e.g. `"Hermes Agent"`). Attached to the bot's own application with a start timestamp, so it renders as a real app presence (icon + elapsed time) instead of bare text. Without any presence the bot shows as visually offline. |
+| `DISCORD_ACTIVITY_TYPE` | No | `"playing"` | Presence type: `playing`, `watching`, `listening`, or `custom`. |
+| `DISCORD_ACTIVITY_DETAILS` | No | — | Rich Presence details line (second row of text). |
+| `DISCORD_ACTIVITY_STATE` | No | — | Rich Presence state line (third row of text). |
+| `DISCORD_ACTIVITY_LARGE_IMAGE` / `DISCORD_ACTIVITY_LARGE_TEXT` | No | — | Large image asset key + hover text. Asset keys come from the owning application's **Rich Presence → Art Assets** page in the Discord Developer Portal. |
+| `DISCORD_ACTIVITY_SMALL_IMAGE` / `DISCORD_ACTIVITY_SMALL_TEXT` | No | — | Small (corner) image asset key + hover text. Same asset registration as above. |
 | `DISCORD_ALLOW_ANY_ATTACHMENT` | No | `false` | When `true`, the bot accepts attachments of any file type (not just the built-in PDF/text/zip/office allowlist). Unknown types are cached to disk and surfaced to the agent as a local path with `application/octet-stream` MIME so it can inspect them with `terminal` / `read_file` / `ffprobe` / etc. |
 | `DISCORD_MAX_ATTACHMENT_BYTES` | No | `33554432` | Maximum bytes per attachment the gateway will download and cache. Default 32 MiB. Set to `0` for no cap (attachments are held in memory while being written, so unlimited carries a real memory cost). |
 | `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` | No | `0.6` | Grace window the adapter waits before flushing a queued text chunk. Useful for smoothing streamed output. |


### PR DESCRIPTION
## What does this PR do?

Adds configurable Discord presence/activity for gateway bots. Today a Hermes Discord bot has **no presence at all** — it renders as visually offline even while connected and responding (#64932), and there is no supported way to set one.

This PR adds:
- `discord.activity` / `discord.activity_type` config keys (and `DISCORD_ACTIVITY` / `DISCORD_ACTIVITY_TYPE` env vars — env wins, matching every other `DISCORD_*` key via the platform's existing `_apply_yaml_config` YAML→env bridge).
- The presence is attached to the **bot's own application_id** (fetched via `application_info()` in `on_ready`) with a start timestamp, so Discord renders it as a real app presence (icon + elapsed time) rather than bare text. (`discord.Game` can't carry `application_id`/assets, so the base `discord.Activity` is used.)
- Optional Rich Presence keys — `discord.activity_details` / `activity_state` / `activity_large_image` / `activity_large_text` / `activity_small_image` / `activity_small_text` (env equivalents `DISCORD_ACTIVITY_*`) — so operators can brand their bot's presence. Asset values are asset keys from the owning application's **Rich Presence → Art Assets** page in the dev portal.
- `change_presence` runs in `on_ready`, so the presence re-applies after every reconnect/RESUME, not just first boot.

**Note / future thought:** this implementation attaches the presence to each operator's own application ID (the only thing a self-hosted bot can do). It might be nice for Hermes to eventually offer an *official* Hermes Agent Discord application/bot ID — with official branding and pre-registered Rich Presence assets — that operators could optionally point at, so a stock Hermes bot gets a polished, official-looking presence out of the box. Not required for this PR (the config here works with any app), just a direction worth considering.

## Related Issue

Refs #64932 (bot stays visually offline while connected — this gives operators the presence knob; the issue's default-offline rendering is the same underlying absence of a presence).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/discord/adapter.py` — presence set in `on_ready` (app-attached `discord.Activity`, `CustomActivity` for type=custom); `_apply_yaml_config` bridges `discord.activity*` keys → `DISCORD_ACTIVITY_*` env (first-writer-wins, env precedence preserved)
- `plugins/platforms/discord/plugin.yaml` — `DISCORD_ACTIVITY` / `DISCORD_ACTIVITY_TYPE` in `optional_env`
- `cli-config.yaml.example` — commented example keys
- `website/docs/user-guide/messaging/discord.md` — Configuration Reference rows for all `DISCORD_ACTIVITY_*` vars
- `tests/platforms/test_discord_activity.py` — 7 tests (bridge behavior, env precedence, defaults, no-op when unset, app-id/assets source guard)

## How to Test

1. Set `discord.activity: "Hermes Agent"` in `~/.hermes/config.yaml` (or `DISCORD_ACTIVITY` env), leave the type default.
2. Start/restart the gateway (`hermes gateway`).
3. Log shows `[Discord] Presence set: playing 'Hermes Agent' (app_id=...)`; the bot's Discord profile shows "Playing Hermes Agent" with the app icon + elapsed timer.
4. `pytest tests/platforms/test_discord_activity.py -q` → 7 passed.

Live-verified on macOS (Hermes 2026.8.13, discord.py 2.7.1): presence with `app_id` confirmed in the gateway boot log after a restart with env vars disabled (config-only path).

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`feat(discord):`)
- [x] I searched for existing PRs — no duplicate (nearest: #64932 is an issue; no open PR implements presence config)
- [x] PR contains only changes related to this feature
- [x] `pytest tests/ -q` passes for the new + adjacent tests
- [x] Tests added (7)
- [x] Tested on macOS 26 (arm64)

### Documentation & Housekeeping
- [x] Updated `website/docs/user-guide/messaging/discord.md` configuration reference
- [x] Updated `cli-config.yaml.example` with the new config keys
- [x] Cross-platform: pure discord.py API, no platform-specific calls — N/A concerns
