### PR TITLE
fix(buzz): default unfetched channel metadata to group, never auto-DM

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1089,12 +1089,17 @@ class BuzzAdapter(BasePlatformAdapter):
 
         Known real community channels (real name or non-empty description in
         ``channels list``) must never turn into DMs just because a message
-        p-tags us.  A conversation with no metadata at all is trusted only
-        when the user did not explicitly configure it as a watched channel.
+        p-tags us.  A conversation with no metadata at all is assumed to be a
+        group channel: with ``BUZZ_CHANNELS`` unset (watch-all mode) every
+        channel legitimately has no configured entry, so keying off
+        ``channel_id not in self.channels`` there would tag each un-fetched
+        group as a DM candidate and latch its replies to the home/DM channel
+        (#87899).  Relay-materialized DMs are still caught once their
+        ``channels list`` metadata loads (name "DM", empty description).
         """
         meta = self._channel_meta.get(channel_id)
         if meta is None:
-            return channel_id not in self.channels
+            return False
         name = str(meta.get("name") or "").strip()
         description = str(meta.get("description") or "").strip()
         return name == "DM" and not description

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -380,6 +380,42 @@ class TestDmClassification:
         assert CHANNEL not in a._channel_state
         assert a._may_reclassify_as_dm(CHANNEL) is False
 
+    @pytest.mark.asyncio
+    async def test_unfetched_metadata_group_never_reclassifies_as_dm(self, adapter):
+        """#87899: with BUZZ_CHANNELS unset (watch-all mode), a group whose
+        metadata has not been fetched must default to group — a p-tagged,
+        un-mentioned message can no longer latch it to the DM/home channel."""
+        adapter._channel_meta.pop(CHANNEL)  # metadata not yet loaded
+        assert adapter.channels == []       # watch-all: no explicit BUZZ_CHANNELS
+        assert adapter._may_reclassify_as_dm(CHANNEL) is False
+        await self._poll_with(
+            adapter, CHANNEL,
+            _tagged_event("e1", CHANNEL, content="plain reply without mention", p=SELF_PUBKEY),
+        )
+        assert adapter._channel_state[CHANNEL]["chat_type"] == "group"
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_dm_latch_waits_for_loaded_metadata(self, adapter):
+        """Without metadata the DM latch never fires; once the relay's
+        channels-list metadata loads with the DM shape (name "DM", empty
+        description) the same message shape latches as before."""
+        adapter._channel_meta.pop(DM_CHANNEL)  # metadata not yet loaded
+        await self._poll_with(
+            adapter, DM_CHANNEL,
+            _tagged_event("e1", DM_CHANNEL, content="here's a test message", p=SELF_PUBKEY),
+        )
+        assert adapter._channel_state[DM_CHANNEL]["chat_type"] == "group"
+        adapter._channel_meta[DM_CHANNEL] = {
+            "channel_id": DM_CHANNEL, "name": "DM", "description": "",
+        }
+        await self._poll_with(
+            adapter, DM_CHANNEL,
+            _tagged_event("e2", DM_CHANNEL, content="still no mention",
+                          created_at=1001, p=SELF_PUBKEY),
+        )
+        assert adapter._channel_state[DM_CHANNEL]["chat_type"] == "dm"
+
 
 # ── Sending ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Stops the Buzz adapter from latching group conversations as DMs when their channel metadata has not been fetched yet. In `_may_reclassify_as_dm`, the `meta is None` branch previously returned `channel_id not in self.channels`. With `BUZZ_CHANNELS` unset — the documented watch-all default — `self.channels` is empty, so *every* channel without loaded metadata was treated as a DM candidate. The first p-tagged, un-mentioned group message (e.g. a plain reply, or a relay that auto-p-tags mentions) then permanently latched the conversation as `chat_type="dm"`, silently rerouting all of its replies to `BUZZ_HOME_CHANNEL`/DM until gateway restart.

The fix makes missing metadata default to **group**: absent `channels list` metadata must never auto-DM a conversation. Relay-materialized DMs (the #68871 case this guard was built for) are unaffected — they are still latched via their metadata shape (name `"DM"`, empty description) once it loads, and the p-tag discriminator itself is unchanged.

## Related Issue

Fixes #87899

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/buzz/adapter.py` — `_may_reclassify_as_dm`: the `meta is None` branch now returns `False` (assume group) instead of `channel_id not in self.channels`; docstring updated to document the watch-all failure mode and the metadata-based DM path.
- `tests/gateway/test_buzz_adapter.py` — two regression tests: an un-fetched-metadata group is never reclassified in watch-all mode (stays `group`, message dropped by the group gate), and the DM latch still fires once the DM-shaped metadata loads (group before load, `dm` after).

## How to Test

1. `python -m pytest tests/gateway/test_buzz_adapter.py -q`
2. Observed result: 25 passed (23 pre-existing + 2 new), including both new #87899 regressions.
3. `python -m pytest tests/gateway/test_buzz_websocket.py -q` — Observed result: 4 passed (no collateral impact).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

New regression tests capturing both sides of the fix:

```
test_unfetched_metadata_group_never_reclassifies_as_dm  # group stays group in watch-all mode
test_dm_latch_waits_for_loaded_metadata                 # DM still latches once metadata loads
25 passed, 1 warning in 3.56s
```