### PR TITLE
fix(cron): give the Windows fire fence the same bounded-poll budget as POSIX

### DIFF
--- a/cron/cross_process_lock.py
+++ b/cron/cross_process_lock.py
@@ -1,0 +1,64 @@
+# Windows cross-process lock helper shared by the cron locks.
+#
+# msvcrt.locking(LK_LOCK) retries internally for only ~10 seconds (10 tries
+# x 1s) before raising OSError(EDEADLK). The POSIX branches poll with a
+# 30-second budget (#60703 discipline: bounded wait, then fail closed but
+# ALIVE). This helper gives the msvcrt backend the same bounded-polling
+# semantics so both platforms wait for the same window before giving up.
+
+import time
+
+try:
+    import fcntl  # POSIX
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+try:
+    import msvcrt  # Windows
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None
+
+
+def lock_exclusive_bounded(fd, timeout_seconds: float, *, poll_interval: float = 0.1) -> bool:
+    """Acquire an exclusive lock on ``fd`` within ``timeout_seconds``.
+
+    POSIX: fcntl.flock(LOCK_EX | LOCK_NB) polled until the deadline.
+    Windows: msvcrt.locking(LK_NBLCK) polled until the deadline
+    (LK_LOCK alone retries only ~10s internally, which is shorter than
+    the callers' budget and makes Windows fail closed early).
+
+    Returns True when the lock is held by the caller.
+    """
+    if fcntl is not None:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return True
+            except (OSError, IOError):
+                if time.monotonic() >= deadline:
+                    return False
+                time.sleep(poll_interval)
+    if msvcrt is not None:
+        fileno = fd.fileno() if hasattr(fd, "fileno") else fd
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            try:
+                msvcrt.locking(fileno, msvcrt.LK_NBLCK, 1)
+                return True
+            except (OSError, IOError):
+                if time.monotonic() >= deadline:
+                    return False
+                time.sleep(poll_interval)
+    return False  # no backend: caller decides (fail closed)
+
+
+def unlock_quietly(fd) -> None:
+    """Best-effort release matching :func:`lock_exclusive_bounded`."""
+    try:
+        fileno = fd.fileno() if hasattr(fd, "fileno") else fd
+        if fcntl is not None:
+            fcntl.flock(fileno, fcntl.LOCK_UN)
+        elif msvcrt is not None:
+            msvcrt.locking(fileno, msvcrt.LK_UNLCK, 1)
+    except (OSError, IOError):
+        pass

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -24,13 +24,15 @@ import uuid
 # in which case _jobs_lock() degrades to in-process locking only (the old
 # behaviour) rather than failing.
 try:
-    import fcntl
-except ImportError:  # pragma: no cover - non-Unix
+    import fcntl  # POSIX
+except ImportError:  # pragma: no cover - Windows
     fcntl = None
 try:
-    import msvcrt
-except ImportError:  # pragma: no cover - non-Windows
+    import msvcrt  # Windows
+except ImportError:  # pragma: no cover - POSIX
     msvcrt = None
+
+from cron.cross_process_lock import lock_exclusive_bounded, unlock_quietly
 from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -350,7 +352,24 @@ def _jobs_lock():
                                 break
                             time.sleep(0.1)
                 elif msvcrt is not None:
-                    getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+                    # Bounded polling (not LK_LOCK, whose ~10s internal retry
+                    # is shorter than the POSIX budget above — see the fire
+                    # fence note in _fire_job_lock). Degrade identically to
+                    # the POSIX timeout path: log, close, proceed in-process.
+                    if not lock_exclusive_bounded(lock_fd, _JOBS_LOCK_TIMEOUT_SECONDS):
+                        logger.error(
+                            "Timed out after %.0fs waiting for the cron "
+                            "jobs lock (%s) — another process is holding "
+                            "it. Proceeding with in-process locking only "
+                            "so the scheduler stays alive (#60703).",
+                            _JOBS_LOCK_TIMEOUT_SECONDS,
+                            _jobs_lock_file(),
+                        )
+                        try:
+                            lock_fd.close()
+                        except OSError:
+                            pass
+                        lock_fd = None
             except (OSError, IOError) as e:
                 # Never let a locking failure take down cron writes — fall back to
                 # in-process-only protection (still held via _jobs_file_lock).
@@ -360,15 +379,8 @@ def _jobs_lock():
                 yield
             finally:
                 if lock_fd is not None:
-                    try:
-                        if fcntl is not None:
-                            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-                        elif msvcrt is not None:
-                            getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1)
-                    except (OSError, IOError):
-                        pass
-                    finally:
-                        lock_fd.close()
+                    unlock_quietly(lock_fd)
+                    lock_fd.close()
         finally:
             _jobs_lock_state.depth = 0
             _jobs_lock_state.load_stamp = None
@@ -396,28 +408,24 @@ def _fire_job_lock(job_id: str):
         try:
             lock_fd = open(lock_path, "a+", encoding="utf-8")
             lock_fd.seek(0)
-            if fcntl is not None:
-                deadline = time.monotonic() + _JOBS_LOCK_TIMEOUT_SECONDS
-                while True:
-                    try:
-                        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                        acquired = True
-                        break
-                    except (OSError, IOError):
-                        if time.monotonic() >= deadline:
-                            logger.error(
-                                "Timed out waiting for fire fence %s; failing closed",
-                                lock_path,
-                            )
-                            break
-                        time.sleep(0.1)
-            elif msvcrt is not None:
-                getattr(msvcrt, "locking")(
-                    lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1
+            # Same bounded-polling discipline on every backend: POSIX fcntl
+            # polls LOCK_NB against the deadline (#60703); the msvcrt branch
+            # used LK_LOCK, whose internal retry gives up after only ~10s —
+            # shorter than the POSIX budget, so Windows failed closed EARLY.
+            # A second gateway holding the fence for a legitimate long
+            # delivery (>10s, <30s) then saw mark_job_run return False,
+            # which run_one_job interprets as "fire claim ownership lost"
+            # and discards the successful completion. Poll LK_NBLCK against
+            # the same _JOBS_LOCK_TIMEOUT_SECONDS budget instead.
+            acquired = lock_exclusive_bounded(
+                lock_fd, _JOBS_LOCK_TIMEOUT_SECONDS
+            )
+            if not acquired:
+                logger.error(
+                    "Timed out after %.0fs waiting for fire fence %s; failing closed",
+                    _JOBS_LOCK_TIMEOUT_SECONDS,
+                    lock_path,
                 )
-                acquired = True
-            else:  # pragma: no cover - supported platforms provide one backend
-                logger.error("No cross-process lock backend for cron fire fence")
         except (OSError, IOError) as exc:
             logger.error("Cron fire fence unavailable for %s: %s", job_id, exc)
 
@@ -425,17 +433,9 @@ def _fire_job_lock(job_id: str):
             yield acquired
         finally:
             if lock_fd is not None:
-                try:
-                    if acquired and fcntl is not None:
-                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
-                    elif acquired and msvcrt is not None:
-                        getattr(msvcrt, "locking")(
-                            lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1
-                        )
-                except (OSError, IOError):
-                    pass
-                finally:
-                    lock_fd.close()
+                if acquired:
+                    unlock_quietly(lock_fd)
+                lock_fd.close()
 
 
 @contextlib.contextmanager

--- a/tests/cron/test_fire_fence_windows_budget.py
+++ b/tests/cron/test_fire_fence_windows_budget.py
@@ -1,0 +1,123 @@
+"""Regression tests for the Windows fire-fence bounded-polling fix.
+
+Historical behaviour: ``_fire_job_lock``/``_jobs_lock`` used
+``msvcrt.locking(LK_LOCK)`` on Windows, which retries internally for only
+~10 seconds before raising ``OSError(EDEADLK)``. The POSIX branches poll
+``LOCK_NB`` against a 30-second budget (#60703). Windows therefore failed
+closed EARLY: a second gateway legitimately holding the per-job fire fence
+for 10-30 seconds (long delivery) made ``mark_job_run`` return False, which
+``run_one_job`` interprets as "fire claim ownership lost" — the successful
+completion was silently discarded.
+
+The fix routes both branches through
+``cron.cross_process_lock.lock_exclusive_bounded`` so every backend waits
+the same ``_JOBS_LOCK_TIMEOUT_SECONDS`` budget.
+
+These tests exercise the real store against a temp HERMES_HOME (E2E over
+mocks, per project discipline). The cross-process contention tests are
+Windows-only (msvcrt); POSIX is covered by the equivalent fcntl polling
+already tested in test_ticker_stall_60703.py.
+"""
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+msvcrt = pytest.importorskip("msvcrt", reason="Windows-only lock backend")
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _hold_raw_lock(lock_path_str, ready, hold):
+    """Child process: hold a raw msvcrt lock on ``lock_path_str`` for ``hold`` s."""
+    fd = open(lock_path_str, "a+")
+    fd.seek(0)
+    msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+    ready.set()
+    time.sleep(hold)
+    msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+    fd.close()
+
+
+def _hold_fire_fence(store_str, job_id, ready, hold):
+    """Child process: hold the per-job fire fence via the real public API."""
+    sys.path.insert(0, str(_REPO_ROOT))
+    from cron.jobs import use_cron_store, _fire_job_lock
+    with use_cron_store(Path(store_str)):
+        with _fire_job_lock(job_id):
+            ready.set()
+            time.sleep(hold)
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so jobs.json doesn't touch the real store."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def test_lock_exclusive_bounded_polls_past_msvcrt_internal_limit(temp_home):
+    """Direct probe: a lock held for >10s (<30s budget) by another PROCESS
+    must still be acquired once released — not fail at msvcrt's ~10s
+    internal LK_LOCK retry ceiling."""
+    import multiprocessing as mp
+    from cron.cross_process_lock import lock_exclusive_bounded, unlock_quietly
+
+    lock_path = temp_home / "probe.lock"
+    lock_path.touch()
+
+    ctx = mp.get_context("spawn")
+    ready = ctx.Event()
+    proc = ctx.Process(target=_hold_raw_lock, args=(str(lock_path), ready, 12))
+    proc.start()
+    try:
+        assert ready.wait(10), "holder never acquired the lock"
+
+        fd = open(lock_path, "a+")
+        fd.seek(0)
+        t0 = time.monotonic()
+        acquired = lock_exclusive_bounded(fd, 30.0)
+        waited = time.monotonic() - t0
+        assert acquired is True, (
+            "fence acquisition failed before the 30s budget elapsed — "
+            "the msvcrt ~10s internal retry ceiling is leaking through"
+        )
+        assert waited >= 10.0, f"acquired after only {waited:.1f}s; contention not exercised"
+        unlock_quietly(fd)
+        fd.close()
+    finally:
+        proc.terminate()
+        proc.join(timeout=10)
+
+
+def test_mark_job_run_survives_cross_process_fence_contention(temp_home):
+    """End-to-end: while another PROCESS holds the job's fire fence for 12s
+    (a legitimate long delivery window), mark_job_run must block past the
+    old ~10s failure point and record the successful completion."""
+    import multiprocessing as mp
+    from cron.jobs import use_cron_store, save_jobs, mark_job_run
+
+    with use_cron_store(temp_home):
+        save_jobs([{
+            "id": "fence-e2e",
+            "name": "e2e",
+            "schedule": {"kind": "once", "at": "2030-01-01T00:00:00"},
+        }])
+
+    ctx = mp.get_context("spawn")
+    ready = ctx.Event()
+    proc = ctx.Process(target=_hold_fire_fence, args=(str(temp_home), "fence-e2e", ready, 12))
+    proc.start()
+    try:
+        assert ready.wait(10), "holder never acquired the fence"
+
+        with use_cron_store(temp_home):
+            ok = mark_job_run("fence-e2e", True, None)
+        assert ok is True, (
+            "mark_job_run failed closed under cross-process contention "
+            "before the 30s budget elapsed (old msvcrt LK_LOCK ~10s ceiling)"
+        )
+    finally:
+        proc.terminate()
+        proc.join(timeout=10)


### PR DESCRIPTION
## What & Why

The cron fire fence (`_fire_job_lock`) and the global jobs-store lock (`_jobs_lock`) poll `fcntl.flock(LOCK_NB)` against a 30-second budget on POSIX (#60703 discipline), but the Windows branch called `msvcrt.locking(LK_LOCK)` directly. `LK_LOCK` retries internally for only ~10 seconds (10 tries x 1s) before raising `OSError(EDEADLK)` — so Windows failed closed **early** while the POSIX path would have kept waiting.

### Impact

When another gateway process legitimately holds the per-job fire fence for 10–30s (a long delivery write inside `fire_claim_fence`, which deliberately holds the fence across network delivery):

1. `mark_job_run` fails to acquire the fence after ~10s and returns `False`
2. `run_one_job` interprets `False` as *"fire claim ownership lost"* and **discards the successful completion** — `last_run_at`/`next_run_at` are never written, output bookkeeping is abandoned, and recurring jobs can re-fire for the same slot
3. The same asymmetry shortens the global `jobs.json` lock window on Windows (a blocked acquirer degrades the store to in-process-only locking earlier than designed)

Measured on Windows 11 with a spawned holder process: acquisition failed at **9.1s** under contention; after the fix the same scenario (15s hold) waits for the holder and records the completion normally.

## How to test

New regression tests reproduce the contention with real spawned processes against a temp store: `tests/cron/test_fire_fence_windows_budget.py` (Windows-only via `pytest.importorskip("msvcrt")`; the POSIX fcntl polling side is already covered by `tests/cron/test_ticker_stall_60703.py`).

Manual repro (Windows):

- Process A: `use_cron_store(tmp)` then hold `_fire_job_lock("j")` for 15 seconds
- Process B (same store): seed a job via `save_jobs`, then call `mark_job_run("j", True, None)`
- Before: returns `False` after ~9s. After: returns `True` after ~15s.

## The change

- New shared helper `cron/cross_process_lock.py`: `lock_exclusive_bounded(fd, timeout)` / `unlock_quietly(fd)` — non-blocking acquire polled against a deadline on **both** backends, so the budget is the authority, not the backend's internal retry limit
- `_fire_job_lock`: both branches route through the helper; identical timeout log ("Timed out after %.0fs waiting for fire fence ...; failing closed")
- `_jobs_lock`: the msvcrt branch now degrades exactly like the POSIX timeout path (log, close fd, proceed in-process-only) instead of raising out of the acquisition

Fail-closed semantics on true timeout are preserved — the fix only widens the waiting window to the designed 30s budget.

## Platforms tested

- Windows 11 (Python 3.11) — full repro before/after, plus the new regression tests
- POSIX behaviour unchanged (same fcntl LOCK_NB polling, now factored into the shared helper)

## Tests

- `tests/cron/test_fire_fence_windows_budget.py` — 2 new regressions (spawned cross-process holders): pass
- Full `tests/cron/` after the change: 689 passed, 21 skipped (9 pre-existing failures on this Windows host excluded as environment noise — POSIX permission bits, tilde expansion, desktop ticker — verified failing on the untouched base commit too)
- Focused lock suites (`test_claim_job_for_fire`, `test_ticker_stall_60703`, `test_script_claim_heartbeat`, `test_shutdown_interrupt`): 55 passed, 9 skipped
