### PR TITLE
fix(desktop): disable electron-builder implicit publish for pack

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,7 +28,7 @@
     "postbuild": "node scripts/assert-dist-built.mjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.mjs",
     "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 node scripts/run-electron-builder.mjs",
-    "pack": "npm run build && npm run builder -- --dir",
+    "pack": "npm run build && npm run builder -- --dir --publish never",
     "dist": "npm run build && npm run builder",
     "dist:mac": "npm run build && npm run builder -- --mac",
     "dist:mac:dmg": "npm run build && npm run builder -- --mac dmg",


### PR DESCRIPTION
## Summary

`hermes update` / `hermes desktop` runs the desktop `pack` script under `CI=1` from `_npm_lifecycle_env()`. electron-builder then enables implicit publishing and aborts when `apps/desktop` has no `repository` metadata — even though the unpackaged app was already written. Pass `--publish never` on the local `--dir` pack path so directory builds stay local-only.

## Testing

- Confirmed `apps/desktop` `pack` script is `… --dir --publish never`
- `dist:*` release scripts unchanged (still publish-capable)

Closes #87824