### PR TITLE
fix(agent): log unavailable fallback skips at warning level

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2483,7 +2483,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         unavailable = set()
         agent._unavailable_fallback_keys = unavailable
     if fb_key in unavailable:
-        logger.debug("Fallback skip: %s previously marked unavailable", fb_key)
+        logger.warning("Fallback skip: %s previously marked unavailable", fb_key)
         return agent._try_activate_fallback(reason)
     fb_provider = (fb.get("provider") or "").strip().lower()
     fb_model = (fb.get("model") or "").strip()


### PR DESCRIPTION
## Summary

When the fallback chain skips an entry previously marked unavailable, that path used `logger.debug`, so default logs showed no reason for the skip. Other skip paths already log at warning. Promote this one so multi-hop failover decisions are reconstructible from agent logs.

## Testing

- Diff review of `try_activate_fallback` skip branch in `agent/chat_completion_helpers.py`
- Other skip paths remain at warning

Closes #87815