### PR TITLE
fix(desktop): keep parent session live across delegated children

### DIFF
--- a/apps/desktop/src/app/agents/index.test.tsx
+++ b/apps/desktop/src/app/agents/index.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $subagentsBySession, type SubagentProgress } from '@/store/subagents'
+
+import { AgentsView } from './index'
+
+Element.prototype.animate = function animate() {
+  return {
+    cancel() {},
+    finished: Promise.resolve(this)
+  } as unknown as Animation
+}
+
+const running = (extra: Partial<SubagentProgress> = {}): SubagentProgress => ({
+  filesRead: [],
+  filesWritten: [],
+  goal: 'resume the interrupted Phase 7 repair',
+  id: 'sa-routed',
+  parentId: null,
+  startedAt: 1,
+  status: 'running',
+  stream: [],
+  taskCount: 1,
+  taskIndex: 0,
+  updatedAt: 1,
+  ...extra
+})
+
+describe('AgentsView route display', () => {
+  afterEach(() => {
+    cleanup()
+    $subagentsBySession.set({})
+  })
+
+  it('shows the delegation route on the far right of a subagent row', () => {
+    $subagentsBySession.set({
+      '20260812_130336_16394e': [running({ route: 'implement' })]
+    })
+
+    render(<AgentsView onClose={() => undefined} />)
+
+    const row = screen.getByRole('button', { name: /resume the interrupted Phase 7 repair/i })
+    const route = screen.getByTestId('subagent-route')
+
+    expect(route.textContent).toBe('implement')
+    expect(row.lastElementChild).toBe(route)
+  })
+})

--- a/apps/desktop/src/app/agents/index.tsx
+++ b/apps/desktop/src/app/agents/index.tsx
@@ -347,6 +347,14 @@ function SubagentRow({ node, depth = 0, nowMs }: { node: SubagentNode; depth?: n
           ) : null}
         </span>
         {running ? <ActivityTimerText className="mt-1 shrink-0 text-[0.6rem]" seconds={durationSeconds} /> : null}
+        {node.route ? (
+          <span
+            className="mt-1 shrink-0 font-mono text-[0.6rem] text-muted-foreground/70"
+            data-testid="subagent-route"
+          >
+            {node.route}
+          </span>
+        ) : null}
       </button>
 
       {visibleRows.length > 0 ? (

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -78,7 +78,12 @@ import {
   setYoloActive
 } from '@/store/session'
 import { dropSessionState, unbindTileRuntime } from '@/store/session-states'
-import { pruneDelegateFallbackSubagents, pruneFinishedSessionSubagents, upsertSubagent } from '@/store/subagents'
+import {
+  hydrateActiveSubagents,
+  pruneDelegateFallbackSubagents,
+  pruneFinishedSessionSubagents,
+  upsertSubagent
+} from '@/store/subagents'
 import { reportMcpToolResult } from '@/store/suggestion-providers/repair'
 import { invalidateSkillSuggestionIndex } from '@/store/suggestion-providers/skill'
 import { requestScrollToBottom } from '@/store/thread-scroll'
@@ -425,6 +430,26 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       }
 
       if (event.type === 'gateway.ready') {
+        // Relayed subagent events are transient. A renderer that connects after
+        // a delegation started (or reconnects during one) otherwise starts with
+        // an empty subagent store, making the parent look idle and hiding the
+        // parked-work notice above its composer until the next child event.
+        const gateway = $gateway.get()
+
+        void gateway
+          ?.request<{ active?: unknown }>('delegation.status')
+          .then(result => {
+            // A connection edit may replace the global gateway while the old
+            // request is in flight; never hydrate stale topology into the new
+            // backend's renderer state.
+            if ($gateway.get() !== gateway || !Array.isArray(result?.active)) {
+              return
+            }
+
+            hydrateActiveSubagents(result.active.filter(item => item && typeof item === 'object'))
+          })
+          .catch(() => undefined)
+
         // Seed the active skin into the desktop theme registry without applying,
         // so a fresh connect never overrides the user's persisted desktop theme.
         ingestBackendSkin((payload as { skin?: HermesSkin } | undefined)?.skin, { apply: false })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -7,7 +7,9 @@ import { isTargetSessionBusy } from '@/app/session/hooks/use-prompt-actions/util
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { modelOptionsQueryKey } from '@/lib/model-options'
+import { $gateway } from '@/store/gateway'
 import { setCurrentModel, setCurrentProvider } from '@/store/session'
+import { $subagentsBySession } from '@/store/subagents'
 import type { RpcEvent } from '@/types/hermes'
 
 import { PRE_TURN_LIVE_SETTLE_GRACE_MS } from './utils'
@@ -75,12 +77,16 @@ beforeEach(() => {
   queryClient = new QueryClient()
   setCurrentModel('')
   setCurrentProvider('')
+  $gateway.set(null)
+  $subagentsBySession.set({})
 })
 
 afterEach(() => {
   cleanup()
   setCurrentModel('')
   setCurrentProvider('')
+  $gateway.set(null)
+  $subagentsBySession.set({})
   vi.useRealTimers()
   vi.restoreAllMocks()
 })
@@ -116,6 +122,37 @@ describe('session.info config refetch gating', () => {
     })
 
     expect(refreshHermesConfig).not.toHaveBeenCalled()
+  })
+})
+
+describe('gateway.ready delegation hydration', () => {
+  it('rehydrates active children into their parent runtime session', async () => {
+    const request = vi.fn().mockResolvedValue({
+      active: [
+        {
+          child_session_id: 'child-session-1',
+          goal: 'inspect live state',
+          owner_session_id: 'parent-runtime-1',
+          parent_session_id: 'stored-parent-1',
+          status: 'running',
+          subagent_id: 'sa-reconnected',
+          task_index: 0
+        }
+      ]
+    })
+    $gateway.set({ request } as never)
+    await mountStream()
+
+    act(() => handleEvent!({ type: 'gateway.ready' }))
+
+    await waitFor(() => expect(request).toHaveBeenCalledWith('delegation.status'))
+    await waitFor(() =>
+      expect($subagentsBySession.get()['stored-parent-1']?.[0]).toMatchObject({
+        id: 'sa-reconnected',
+        sessionId: 'child-session-1',
+        status: 'running'
+      })
+    )
   })
 })
 

--- a/apps/desktop/src/store/session-dot-state.test.ts
+++ b/apps/desktop/src/store/session-dot-state.test.ts
@@ -9,6 +9,9 @@ import { clearAllSessionStates, publishSessionState } from './session-states'
 import { $unreadWriteGuard } from './session-unread-remote'
 import { $subagentsBySession, type SubagentProgress } from './subagents'
 
+const storedRow = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
+  ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
+
 describe('showsRunningArc', () => {
   it('keeps the arc when an authoritative turn goes quiet', () => {
     expect(showsRunningArc('working')).toBe(true)
@@ -84,10 +87,49 @@ describe('$delegatingSessionIds', () => {
 
     expect($delegatingSessionIds.get()).toContain('runtime-fresh')
   })
-})
 
-const storedRow = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
-  ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
+  it('claims a stored parent id when hydration keyed the child there', () => {
+    $subagentsBySession.set({ '20260812_130336_16394e': [subagent('running')] })
+
+    expect($delegatingSessionIds.get()).toContain('20260812_130336_16394e')
+    expect($sessionDotStateById.get()['20260812_130336_16394e']).toBe('working')
+  })
+
+  it('does not let a child heartbeat flip the parent row between working and unread', () => {
+    setSessions([
+      storedRow('20260812_130336_16394e', { source: 'desktop' }),
+      storedRow('20260816_081051_6efbd7', {
+        parent_session_id: '20260812_130336_16394e',
+        source: 'subagent'
+      })
+    ])
+    $subagentsBySession.set({ '20260812_130336_16394e': [subagent('running')] })
+
+    publishSessionState('child-runtime', {
+      ...createClientSessionState('20260816_081051_6efbd7'),
+      busy: true
+    })
+    expect($sessionDotStateById.get()['20260812_130336_16394e']).toBe('working')
+
+    publishSessionState('child-runtime', {
+      ...createClientSessionState('20260816_081051_6efbd7'),
+      busy: false
+    })
+    expect($sessionDotStateById.get()['20260812_130336_16394e']).toBe('working')
+    expect($sessionDotStateById.get()['20260816_081051_6efbd7'] ?? 'idle').not.toBe('working')
+    expect($sessionDotStateById.get()['20260816_081051_6efbd7'] ?? 'idle').not.toBe('unread')
+  })
+
+  it('does not mint unread when the parent turn ends while children are still running', () => {
+    publishSessionState('runtime-1', { ...createClientSessionState('stored-1'), busy: true })
+    $subagentsBySession.set({ 'runtime-1': [subagent('running')] })
+
+    publishSessionState('runtime-1', { ...createClientSessionState('stored-1'), busy: false })
+
+    expect($sessionDotStateById.get()['stored-1']).toBe('working')
+    expect($unreadFinishedSessionIds.get()).not.toContain('stored-1')
+  })
+})
 
 describe('persisted unread (backend watermark)', () => {
   beforeEach(() => {

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -158,11 +158,11 @@ export const $sessionDotStateById = computed(
     claim(persistedUnread, 'unread')
 
     claim(background, 'background')
-    // Async delegation: the parent turn has ended but its subagents are still
-    // running, so the session's work continues in child sessions. Same visual
-    // claim as background processes — and it yields to `working` below the
-    // moment the parent turn itself is live (synchronous orchestrator children).
-    claim(delegating, 'background')
+    // Async delegation is still the parent's work: the parent turn may have
+    // ended, but parked children mean the conversation is not done. Claim the
+    // same live working state as a direct turn so the sidebar keeps the filled
+    // accent + running arc. `background` stays reserved for terminal jobs.
+    claim(delegating, 'working')
     claim(working, 'working')
 
     // Stalled REFINES working rather than rivalling it — the turn is still

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -48,7 +48,43 @@ import {
   setSessions
 } from './session'
 import { ackStoredSessionId, markSessionUnreadFinished } from './session-unread'
+import { $subagentsBySession, activeSubagentCount } from './subagents'
 import { isSecondaryWindow } from './windows'
+
+const CHILD_STATUS_SOURCES = new Set(['subagent', 'tool'])
+
+function isDelegatedChildSession(storedId: string | null | undefined): boolean {
+  if (!storedId) {
+    return false
+  }
+
+  return $sessions.get().some(
+    session => sessionMatchesStoredId(session, storedId) && CHILD_STATUS_SOURCES.has(session.source ?? '')
+  )
+}
+
+function hasLiveDelegatedChildren(storedId: string | null | undefined): boolean {
+  if (!storedId) {
+    return false
+  }
+
+  const sessions = $sessions.get()
+  const states = $sessionStates.get()
+
+  for (const [runtimeId, items] of Object.entries($subagentsBySession.get())) {
+    if (activeSubagentCount(items) === 0) {
+      continue
+    }
+
+    const ownerId = states[runtimeId]?.storedSessionId ?? runtimeId
+
+    if (lineageAliases(ownerId, sessions).includes(storedId)) {
+      return true
+    }
+  }
+
+  return false
+}
 
 // ---------------------------------------------------------------------------
 // Reactive per-runtime session state (view mirror of the wiring cache).
@@ -231,9 +267,14 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
   } else if (!next.busy && wasWorking) {
     markSettled(storedId)
 
-    // FOCUSED, not selected: a session finishing in the tile the user is
-    // watching is already seen, and a tile is never the primary selection.
-    if (storedId !== $focusedStoredSessionId.get()) {
+    // Child/subagent heartbeats must not mint sidebar unread on the parent
+    // conversation. Their own rows are excluded from recents; treating a
+    // child settle as unread is what made parent dots ping-pong.
+    if (
+      !isDelegatedChildSession(storedId) &&
+      !hasLiveDelegatedChildren(storedId) &&
+      storedId !== $focusedStoredSessionId.get()
+    ) {
       // Re-light only genuinely new completions: if the user already viewed
       // this session (or its family) at or after this settle moment, a
       // re-assert of the same completion must not re-arm the dot. `-1` for
@@ -400,7 +441,7 @@ const storedIds = (
   const ids = new Set<string>()
 
   for (const [runtimeId, state] of Object.entries(states)) {
-    if (!pred(state)) {
+    if (!pred(state) || isDelegatedChildSession(state.storedSessionId ?? runtimeId)) {
       continue
     }
 

--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -7,6 +7,7 @@ import {
   buildSubagentTree,
   clearSessionSubagents,
   failedSubagentCount,
+  hydrateActiveSubagents,
   pruneDelegateFallbackSubagents,
   pruneFinishedSessionSubagents,
   upsertSubagent
@@ -131,6 +132,72 @@ describe('subagent store', () => {
 
     expect($subagentsBySession.get().s1).toBeUndefined()
     expect($subagentsBySession.get().s2).toHaveLength(1)
+  })
+
+  it('hydrates running children into their parent sessions after a gateway reconnect', () => {
+    hydrateActiveSubagents([
+      {
+        child_session_id: 'child-1',
+        goal: 'inspect the live status flow',
+        owner_session_id: 'parent-runtime-1',
+        status: 'running',
+        subagent_id: 'sa-reconnected',
+        task_index: 0
+      }
+    ])
+
+    const item = listFor('parent-runtime-1')[0]
+    expect(item).toMatchObject({
+      goal: 'inspect the live status flow',
+      id: 'sa-reconnected',
+      sessionId: 'child-1',
+      status: 'running'
+    })
+    expect(activeSubagentCount(listFor('parent-runtime-1'))).toBe(1)
+  })
+
+  it('preserves the delegation route alias on a hydrated child', () => {
+    hydrateActiveSubagents([
+      {
+        child_session_id: 'child-route-1',
+        goal: 'inspect the live status flow',
+        owner_session_id: 'parent-runtime-1',
+        parent_session_id: 'stored-parent-1',
+        route: 'implement',
+        status: 'running',
+        subagent_id: 'sa-routed',
+        task_index: 0
+      }
+    ])
+
+    expect(listFor('stored-parent-1')[0]).toMatchObject({
+      id: 'sa-routed',
+      route: 'implement',
+      status: 'running'
+    })
+  })
+
+  it('hydrates a child under its stored parent id so sidebar rows light up', () => {
+    hydrateActiveSubagents([
+      {
+        child_session_id: '20260816_081051_6efbd7',
+        goal: 'resume the interrupted Phase 7 repair',
+        owner_session_id: '10b21015',
+        parent_session_id: '20260812_130336_16394e',
+        status: 'running',
+        subagent_id: 'sa-live-child',
+        task_index: 0
+      }
+    ])
+
+    expect(listFor('10b21015')).toHaveLength(0)
+    expect(listFor('20260812_130336_16394e')[0]).toMatchObject({
+      goal: 'resume the interrupted Phase 7 repair',
+      id: 'sa-live-child',
+      sessionId: '20260816_081051_6efbd7',
+      status: 'running'
+    })
+    expect(activeSubagentCount(listFor('20260812_130336_16394e'))).toBe(1)
   })
 
   // Regression test for #64015: still-RUNNING background subagents must survive

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -18,6 +18,8 @@ export interface SubagentProgress {
   goal: string
   /** The child's own stored session id — lets UIs open its session window. */
   sessionId?: string
+  /** Operator-owned delegation route alias, when the child was spawned on one. */
+  route?: string
   model?: string
   status: SubagentStatus
   taskCount: number
@@ -189,6 +191,7 @@ function toProgress(payload: SubagentPayload, prev: SubagentProgress | undefined
     parentId: str(payload.parent_id) || prev?.parentId || null,
     goal: str(payload.goal) || prev?.goal || 'Subagent',
     sessionId: str(payload.child_session_id) || prev?.sessionId,
+    route: str(payload.route) || prev?.route,
     model: str(payload.model) || prev?.model,
     status,
     taskCount: num(payload.task_count) ?? prev?.taskCount ?? 1,
@@ -285,6 +288,22 @@ export function upsertSubagent(sid: string, payload: SubagentPayload, createIfMi
   const nextList = idx >= 0 ? list.map(item => (item.id === id ? next : item)) : [...list, next]
 
   $subagentsBySession.set({ ...map, [sid]: nextList })
+}
+
+/** Rebuild live children that were already running before this renderer
+ * attached or reconnected. Prefer the durable stored parent id so sidebar
+ * rows (keyed on stored session ids) light up even when the commissioning
+ * UI sid has rotated. */
+export function hydrateActiveSubagents(snapshots: readonly SubagentPayload[]) {
+  for (const snapshot of snapshots) {
+    const parentSessionId = str(snapshot.parent_session_id) || str(snapshot.owner_session_id)
+
+    if (!parentSessionId) {
+      continue
+    }
+
+    upsertSubagent(parentSessionId, snapshot, true, 'subagent.start')
+  }
 }
 
 export function buildSubagentTree(items: readonly SubagentProgress[]): SubagentNode[] {

--- a/tests/tools/test_subagent_steer.py
+++ b/tests/tools/test_subagent_steer.py
@@ -38,6 +38,8 @@ def _with_registered(
     owner_session_id: str | None = None,
     owner_transport=None,
     owner_session_record=None,
+    parent_session_id: str | None = None,
+    route: str | None = None,
 ) -> None:
     _register_subagent(
         {
@@ -50,6 +52,8 @@ def _with_registered(
             "owner_session_id": owner_session_id,
             "owner_transport": owner_transport,
             "owner_session_record": owner_session_record,
+            "parent_session_id": parent_session_id,
+            "route": route,
         }
     )
 
@@ -154,6 +158,37 @@ def test_status_snapshot_never_leaks_owner_or_lifecycle_metadata():
         assert all(value is not owner_session_record for value in snapshot.values())
     finally:
         _unregister_subagent("sid-private-metadata", agent=agent)
+
+
+def test_owner_scoped_status_snapshot_maps_child_to_its_parent_runtime():
+    from tools.delegate_tool import list_active_subagents
+
+    agent = _StubAgent()
+    agent.session_id = "child-session-1"
+    owner_transport = object()
+    _with_registered(
+        "sid-reconnect-hydration",
+        agent,
+        owner_session_id="parent-runtime-1",
+        owner_transport=owner_transport,
+        parent_session_id="20260812_130336_16394e",
+        route="implement",
+    )
+    try:
+        snapshot = next(
+            item
+            for item in list_active_subagents(
+                owner_transport=owner_transport,
+                include_owner_session=True,
+            )
+            if item["subagent_id"] == "sid-reconnect-hydration"
+        )
+        assert snapshot["owner_session_id"] == "parent-runtime-1"
+        assert snapshot["child_session_id"] == "child-session-1"
+        assert snapshot["parent_session_id"] == "20260812_130336_16394e"
+        assert snapshot["route"] == "implement"
+    finally:
+        _unregister_subagent("sid-reconnect-hydration", agent=agent)
 
 
 class TestMissedSteerRetention:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -300,28 +300,61 @@ def _capture_gateway_steer_authority(
         return None, None
 
 
-def list_active_subagents() -> List[Dict[str, Any]]:
+def list_active_subagents(
+    *,
+    owner_transport: Any = None,
+    include_owner_session: bool = False,
+) -> List[Dict[str, Any]]:
     """Snapshot of the currently running subagent tree.
 
     Each record: {subagent_id, parent_id, depth, goal, model, started_at,
-    tool_count, status}.  Safe to call from any thread — returns a copy.
+    tool_count, status}.  Passing ``owner_transport`` scopes the snapshot to
+    the caller's UI transport.  Only that scoped form may include the parent
+    runtime session id needed to rehydrate a reconnecting UI.
+
+    Safe to call from any thread — returns copies.
     """
     with _active_subagents_lock:
-        return [
-            {
-                k: v
-                for k, v in r.items()
-                if k
-                not in {
-                    "agent",
-                    "owner_session_id",
-                    "owner_transport",
-                    "owner_session_record",
-                    "accepting_steer",
-                }
+        records = list(_active_subagents.values())
+
+    snapshots: List[Dict[str, Any]] = []
+    for record in records:
+        if owner_transport is not None and record.get("owner_transport") is not owner_transport:
+            continue
+
+        snapshot = {
+            k: v
+            for k, v in record.items()
+            if k
+            not in {
+                "agent",
+                "owner_session_id",
+                "owner_transport",
+                "owner_session_record",
+                "accepting_steer",
             }
-            for r in _active_subagents.values()
-        ]
+        }
+
+        if include_owner_session and owner_transport is not None:
+            owner_session_id = record.get("owner_session_id")
+            if isinstance(owner_session_id, str) and owner_session_id:
+                snapshot["owner_session_id"] = owner_session_id
+
+            child_session_id = getattr(record.get("agent"), "session_id", None)
+            if isinstance(child_session_id, str) and child_session_id:
+                snapshot["child_session_id"] = child_session_id
+
+            parent_session_id = record.get("parent_session_id")
+            if isinstance(parent_session_id, str) and parent_session_id:
+                snapshot["parent_session_id"] = parent_session_id
+
+            route = record.get("route")
+            if isinstance(route, str) and route:
+                snapshot["route"] = route
+
+        snapshots.append(snapshot)
+
+    return snapshots
 
 
 def _is_descendant_of(child_agent: Any, parent_agent: Any, max_hops: int = 8) -> bool:
@@ -1235,6 +1268,7 @@ def _build_child_progress_callback(
     model: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     session_ref: Optional[Dict[str, Any]] = None,
+    route: Optional[str] = None,
 ) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
@@ -1280,6 +1314,8 @@ def _build_child_progress_callback(
             kw["depth"] = depth
         if model is not None:
             kw["model"] = model
+        if route:
+            kw["route"] = str(route)
         if toolsets is not None:
             kw["toolsets"] = list(toolsets)
         # The child's own session id — filled into the shared ref once the
@@ -1486,6 +1522,7 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    route: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1619,6 +1656,7 @@ def _build_child_agent(
         model=effective_model_for_cb,
         toolsets=child_toolsets,
         session_ref=child_session_ref,
+        route=route,
     )
 
     # Each subagent gets its own iteration budget capped at max_iterations
@@ -2320,6 +2358,7 @@ def _run_single_child(
     owner_session_id: Optional[str] = None,
     owner_transport: Any = None,
     owner_session_record: Any = None,
+    route: Optional[str] = None,
     **_kwargs,
 ) -> Dict[str, Any]:
     """
@@ -2481,6 +2520,7 @@ def _run_single_child(
                     if isinstance(getattr(child, "model", None), str)
                     else None
                 ),
+                "task_index": task_index,
                 "started_at": time.time(),
                 "status": "running",
                 "tool_count": 0,
@@ -2490,6 +2530,8 @@ def _run_single_child(
                 "owner_session_id": owner_session_id,
                 "owner_transport": owner_transport,
                 "owner_session_record": owner_session_record,
+                "parent_session_id": getattr(parent_agent, "session_id", None),
+                "route": route,
             }
         )
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3182,10 +3182,19 @@ def _(rid, params: dict) -> dict:
         _get_max_spawn_depth,
     )
 
+    # A reconnecting desktop has no replay buffer for relayed ``subagent.*``
+    # events. Return only children owned by THIS transport, including their
+    # parent runtime ids, so it can rebuild its in-memory status projection
+    # without exposing another client's session topology.
+    transport = current_transport() or _stdio_transport
+
     return _ok(
         rid,
         {
-            "active": list_active_subagents(),
+            "active": list_active_subagents(
+                owner_transport=transport,
+                include_owner_session=True,
+            ),
             "paused": is_spawn_paused(),
             "max_spawn_depth": _get_max_spawn_depth(),
             "max_concurrent_children": _get_max_concurrent_children(),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5994,6 +5994,8 @@ def _on_tool_progress(
             payload["depth"] = int(_kwargs["depth"])
         if _kwargs.get("model"):
             payload["model"] = str(_kwargs["model"])
+        if _kwargs.get("route"):
+            payload["route"] = str(_kwargs["route"])
         if _kwargs.get("tool_count") is not None:
             payload["tool_count"] = int(_kwargs["tool_count"])
         if _kwargs.get("toolsets"):


### PR DESCRIPTION
## Bug Description

After a parent parks delegated children, the desktop sidebar treats the parent as `background` (or idle) instead of still working. Reconnecting mid-delegation starts with an empty subagent store, so the parent looks idle until the next child event. Child/subagent settle events also mint unread on the parent, causing the sidebar dot to ping-pong between working and unread.

## Root Cause

- Async delegation claimed `background` rather than live `working`.
- Child settle transitions were treated like parent completions and could re-arm unread.
- Relayed `subagent.*` events are transient; `gateway.ready` never rehydrated the live child tree.
- `list_active_subagents()` was unscoped and stripped the parent/child session ids a reconnecting UI needs.

## Fix

- Keep the parent sidebar in `working` while parked children run; reserve `background` for terminal jobs.
- Ignore delegated child sessions when building stored-id working sets and when minting unread on settle.
- Scope `list_active_subagents` to the caller's transport and optionally include owner/parent/child/route fields for reconnect hydration.
- On `gateway.ready`, call `delegation.status` and `hydrateActiveSubagents`.
- Carry an optional `route` on snapshots and show it in AgentsView. This PR does **not** introduce `selected_aliases` (that lives in #85567).

## How to Verify

1. Start a parent turn that parks delegated children, then leave the parent composer.
2. Confirm the parent sidebar row stays `working` (filled accent + running arc), not `background`.
3. Let a child heartbeat/settle; the parent must not flip to unread while children are still running.
4. Reload/reconnect the desktop mid-delegation; Agents should rehydrate the live children via `delegation.status`.

## Test Plan

- [x] `scripts/run_tests.sh tests/tools/test_subagent_steer.py` (31 passed)
- [x] vitest: `session-dot-state`, `subagents`, `session-info-side-effects`, `agents/index.test.tsx` (48 passed)
- [x] `git diff --check` clean

## Risk Assessment

Medium — changes parent sidebar status, unread minting, and the `delegation.status` snapshot shape. The extra owner/session fields are only returned for the caller's own transport.
