### PR TITLE
fix(providers): omit Cloudflare generic reasoning and honor output caps

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -92,6 +92,22 @@ class CLIAgentSetupMixin:
         resolved_acp_command = runtime.get("command")
         resolved_acp_args = list(runtime.get("args") or [])
         resolved_credential_pool = runtime.get("credential_pool")
+        # Match gateway/API-server precedence for custom-provider output caps:
+        # an explicit global model.max_tokens wins, otherwise the resolved
+        # provider's max_output_tokens bounds CLI generations too. Clear a
+        # previously runtime-derived cap before applying a newly resolved route.
+        if getattr(self, "_max_tokens_from_runtime", False):
+            self.max_tokens = None
+            self._max_tokens_from_runtime = False
+        runtime_max_tokens = runtime.get("max_output_tokens")
+        if (
+            self.max_tokens is None
+            and isinstance(runtime_max_tokens, int)
+            and not isinstance(runtime_max_tokens, bool)
+            and runtime_max_tokens > 0
+        ):
+            self.max_tokens = runtime_max_tokens
+            self._max_tokens_from_runtime = True
         # A callable api_key is a bearer-token provider (Azure Foundry
         # Entra ID — ``azure_identity_adapter.build_token_provider``).
         # The OpenAI SDK accepts ``Callable[[], str]`` for ``api_key`` and

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1362,7 +1362,7 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "key_cmd",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "max_output_tokens", "max_tokens", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
         "ssl_ca_cert", "ssl_verify",
@@ -1481,6 +1481,11 @@ def _normalize_custom_provider_entry(
     if isinstance(context_length, int) and context_length > 0:
         normalized["context_length"] = context_length
 
+    for output_cap_key in ("max_output_tokens", "max_tokens"):
+        output_cap = entry.get(output_cap_key)
+        if isinstance(output_cap, int) and not isinstance(output_cap, bool) and output_cap > 0:
+            normalized[output_cap_key] = output_cap
+
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
@@ -1534,6 +1539,8 @@ def _custom_provider_entry_to_provider_config(
         "key_env",
         "models",
         "context_length",
+        "max_output_tokens",
+        "max_tokens",
         "rate_limit_delay",
         "discover_models",
         "extra_body",

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -13,6 +13,7 @@ Volcengine ARK, vLLM, llama.cpp). Key quirks:
 """
 
 from typing import Any
+from urllib.parse import urlparse
 
 from providers import register_provider
 from providers.base import ProviderProfile
@@ -30,6 +31,21 @@ class CustomProfile(ProviderProfile):
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
+
+        # Cloudflare's account-scoped REST API and legacy /compat surface use
+        # OpenAI-compatible request envelopes, but reject the generic
+        # reasoning_effort / think controls emitted for Ollama, GLM, and ARK.
+        # Omit both and let the selected upstream model apply its own default.
+        parsed_base_url = urlparse(str(ctx.get("base_url") or ""))
+        cloudflare_path = parsed_base_url.path.rstrip("/")
+        if (
+            parsed_base_url.hostname == "api.cloudflare.com"
+            and cloudflare_path.endswith("/ai/v1")
+        ) or (
+            parsed_base_url.hostname == "gateway.ai.cloudflare.com"
+            and cloudflare_path.endswith("/compat")
+        ):
+            return extra_body, top_level
 
         # Ollama context window
         if ollama_num_ctx:

--- a/tests/hermes_cli/test_cli_custom_provider_vision.py
+++ b/tests/hermes_cli/test_cli_custom_provider_vision.py
@@ -32,6 +32,7 @@ class _RuntimeCLI(CLIAgentSetupMixin):
         self._explicit_base_url = None
         self._credential_pool = None
         self.service_tier = None
+        self.max_tokens = None
 
     def _normalize_model_for_provider(self, _provider: str) -> bool:
         return False
@@ -47,6 +48,7 @@ providers:
   qwen-token-plan:
     base_url: https://qwen-token-plan.example/v1
     api_key: test-key
+    max_output_tokens: 4096
     models:
       qwen3.8-max-preview:
         supports_vision: true
@@ -96,6 +98,12 @@ def test_real_cli_args_keep_transport_and_capability_identities_separate():
     cli.agent = sentinel_agent
     assert cli._ensure_runtime_credentials() is True
     assert cli.agent is sentinel_agent
+
+
+def test_named_custom_provider_output_cap_reaches_cli_agent_config():
+    cli, _route = _resolve_cli_route()
+
+    assert cli.max_tokens == 4096
 
 
 def test_named_identity_reaches_agent_and_vision_tool_native_gates():

--- a/tests/hermes_cli/test_custom_provider_normalize_no_mutate.py
+++ b/tests/hermes_cli/test_custom_provider_normalize_no_mutate.py
@@ -60,3 +60,15 @@ def test_normalized_models_mapping_is_not_shared_with_input():
     assert "injected" not in entry["models"], (
         "normalized models mapping must not alias the caller's dict"
     )
+
+
+def test_normalizer_preserves_provider_output_cap():
+    entry = {
+        "base_url": "https://x.example/v1",
+        "max_output_tokens": 4096,
+    }
+
+    out = _normalize_custom_provider_entry(entry, provider_key="p")
+
+    assert out is not None
+    assert out["max_output_tokens"] == 4096

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -96,6 +96,32 @@ class TestCustomReasoningWireShape:
         )
         assert eb.get("think") is not True
 
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.cloudflare.com/client/v4/accounts/account/ai/v1",
+            "https://gateway.ai.cloudflare.com/v1/account/gateway/compat",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "reasoning_config",
+        [
+            {"enabled": False, "effort": "none"},
+            {"enabled": True, "effort": "high"},
+        ],
+    )
+    def test_cloudflare_compat_surfaces_omit_generic_reasoning_controls(
+        self, custom_profile, base_url, reasoning_config
+    ):
+        """Cloudflare's OpenAI-compatible surfaces reject generic controls."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config=reasoning_config,
+            model="openai/gpt-5.6-luna",
+            base_url=base_url,
+        )
+        assert eb == {}
+        assert tl == {}
+
 
 class TestCustomReasoningWithNumCtx:
     """Ollama num_ctx and reasoning are independent and compose."""


### PR DESCRIPTION
## Bug Description

Custom Cloudflare OpenAI-compatible surfaces (`api.cloudflare.com/.../ai/v1` and `gateway.ai.cloudflare.com/.../compat`) reject the generic `reasoning_effort` / `think` controls that the custom provider emits for Ollama, GLM, and ARK. Separately, a custom provider's `max_output_tokens` / `max_tokens` was dropped during normalize, so the CLI never applied that output cap.

## Root Cause

- `CustomProfile.build_api_kwargs_extras` always emitted generic reasoning extras for OpenAI-compatible URLs.
- `_normalize_custom_provider_entry` / `_custom_provider_entry_to_provider_config` did not preserve output-cap keys, and the CLI setup mixin never copied a resolved provider `max_output_tokens` into `self.max_tokens`.

## Fix

- Detect Cloudflare `ai/v1` and gateway `compat` URLs and omit generic reasoning controls.
- Preserve `max_output_tokens` / `max_tokens` through normalize and apply them as the CLI runtime cap when no explicit global `model.max_tokens` is set.

## How to Verify

1. Point a custom provider at a Cloudflare `.../ai/v1` or `.../compat` URL and confirm the request body has no `reasoning_effort` / `think`.
2. Set `max_output_tokens: 4096` on a named custom provider and confirm the CLI agent receives `max_tokens == 4096`.

## Test Plan

- [x] `scripts/run_tests.sh tests/plugins/model_providers/test_custom_profile.py tests/hermes_cli/test_custom_provider_normalize_no_mutate.py tests/hermes_cli/test_cli_custom_provider_vision.py` (23 passed)
- [x] `git diff --check` clean

## Risk Assessment

Low — Cloudflare-only omit path, plus additive preservation of already-configured output caps.
