### PR TITLE
fix(auxiliary): omit disabled reasoning field for Gemini endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8560,6 +8560,18 @@ def _build_call_kwargs(
                 sticky_key = None
             if sticky_key:
                 merged_extra["session_id"] = sticky_key
+    # Gemini's OpenAI-compatible endpoint rejects the ``reasoning`` field
+    # outright (400 "Unknown name reasoning: Cannot find field"), so a
+    # reasoning-disabled config — ``{"enabled": False}``, e.g. from
+    # ``auxiliary.<task>.reasoning_effort: none`` — must be omitted rather
+    # than serialized. Omission is equivalent for Gemini: it never reasons
+    # unless explicitly asked. Providers that need an explicit disabled
+    # field are untouched (#87910).
+    if merged_extra.get("reasoning") == {"enabled": False}:
+        if str(provider or "").strip().lower() in {
+            "gemini", "google", "google-gemini", "google-ai-studio",
+        }:
+            merged_extra.pop("reasoning", None)
     if merged_extra:
         kwargs["extra_body"] = merged_extra
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -465,6 +465,66 @@ class TestBuildCallKwargsMaxTokens:
         assert "max_tokens" not in kw3
 
 
+class TestGeminiDisabledReasoningOmitted:
+    """#87910: Gemini's OpenAI-compatible endpoint rejects the ``reasoning``
+    field outright (400 "Unknown name reasoning: Cannot find field"). A
+    reasoning-disabled config — ``{"enabled": False}``, e.g. from
+    ``auxiliary.compression.reasoning_effort: none`` — must therefore be
+    OMITTED for Gemini (omission is equivalent: Gemini never reasons unless
+    explicitly asked), while providers that accept an explicit disabled
+    field keep it."""
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["gemini", "google", "google-gemini", "google-ai-studio"],
+    )
+    def test_disabled_reasoning_omitted_for_gemini(self, provider):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model="gemini-3.6-flash",
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"enabled": False}},
+        )
+        extra = kwargs.get("extra_body") or {}
+        assert "reasoning" not in extra
+
+    def test_disabled_reasoning_via_reasoning_config_also_omitted(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="gemini",
+            model="gemini-3.6-flash",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_config={"enabled": False},
+        )
+        extra = kwargs.get("extra_body") or {}
+        assert "reasoning" not in extra
+
+    def test_enabled_reasoning_kept_for_gemini(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="gemini",
+            model="gemini-3.6-flash",
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"enabled": True, "effort": "high"}},
+        )
+        assert kwargs["extra_body"]["reasoning"] == {"enabled": True, "effort": "high"}
+
+    def test_disabled_reasoning_kept_for_other_providers(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="openai",
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"enabled": False}},
+        )
+        assert kwargs["extra_body"]["reasoning"] == {"enabled": False}
+
+
 
 
 class TestNousTagsScoping:


### PR DESCRIPTION
## What does this PR do?

Stops auxiliary LLM calls (context compression, titles, etc.) from sending the `reasoning` field to Gemini's OpenAI-compatible endpoint when reasoning is disabled. When a task is configured with `reasoning_effort: none`, `_get_task_extra_body()` serializes it as `extra_body.reasoning = {"enabled": false}` and the chat-completions wire passes it through verbatim. Gemini rejects the field outright (`400 Unknown name "reasoning": Cannot find field`) before generation, so context compression could never produce an LLM summary and silently fell back to deterministic pruning.

The fix is provider-aware and placed in `_build_call_kwargs` — the single chokepoint every auxiliary call path (sync, async, retry, fallback) goes through: for `gemini`/`google`/`google-gemini`/`google-ai-studio` providers, the disabled-form reasoning dict (`{"enabled": false}`) is omitted entirely. Omission is lossless for Gemini — it never generates reasoning unless explicitly asked. Explicitly enabled reasoning and all other providers are untouched, preserving providers that require an explicit disabled field.

## Related Issue

Fixes #87910

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` — `_build_call_kwargs`: after merging task/extra_body/reasoning_config into `merged_extra`, drop the disabled-form `reasoning` entry when the provider normalizes to Gemini, with a comment documenting the Gemini 400 and the lossless-omission rationale.
- `tests/agent/test_auxiliary_client.py` — new `TestGeminiDisabledReasoningOmitted`: disabled reasoning omitted across all four Gemini provider spellings (also via the `reasoning_config` path), explicitly enabled reasoning kept, and other providers keep the disabled field.

## How to Test

1. `python -m pytest tests/agent/test_auxiliary_client.py -q`
2. Observed result: 188 passed (181 pre-existing + 7 new), including all four Gemini-alias omission cases.
3. `python -m pytest tests/agent/test_context_compressor.py -q` — Observed result: 136 passed (compression path unaffected for other providers).
4. Manual repro from the issue (auxiliary.compression with provider gemini + reasoning_effort none triggering /compress) no longer sends the `reasoning` field, so the 400 disappears and the Gemini summary is produced.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

New regression tests:

```
TestGeminiDisabledReasoningOmitted
  test_disabled_reasoning_omitted_for_gemini[gemini] PASSED
  test_disabled_reasoning_omitted_for_gemini[google] PASSED
  test_disabled_reasoning_omitted_for_gemini[google-gemini] PASSED
  test_disabled_reasoning_omitted_for_gemini[google-ai-studio] PASSED
  test_disabled_reasoning_via_reasoning_config_also_omitted PASSED
  test_enabled_reasoning_kept_for_gemini PASSED
  test_disabled_reasoning_kept_for_other_providers PASSED
188 passed in 8.29s
```