### PR TITLE
fix(cli): stop doctor's journal-mode probe from cancelling live SQLite locks

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -118,6 +118,23 @@ def _hermes_database_paths(hermes_home: Path) -> list[tuple[str, Path]]:
 _SQLITE_HEADER_MAGIC = b"SQLite format 3\x00"
 
 
+def _unreadable_reason(db_path: Path) -> str:
+    """Explain why a database file could not be read, without opening it.
+
+    ``read_header_bytes_preopen`` collapses every ``OSError`` into ``None``,
+    but doctor's job is to say *which* problem it hit. ``stat()`` and
+    ``access()`` answer that from directory metadata alone — neither takes a
+    file descriptor, so neither can cancel the file's POSIX advisory locks.
+    """
+    try:
+        db_path.stat()
+    except OSError as exc:
+        return str(exc)
+    if not os.access(db_path, os.R_OK):
+        return f"permission denied: {db_path}"
+    return "file could not be read"
+
+
 def _read_journal_mode(db_path: Path) -> tuple[str | None, str | None]:
     """Return (journal mode, error) from the file header without opening the database.
 
@@ -142,7 +159,7 @@ def _read_journal_mode(db_path: Path) -> tuple[str | None, str | None]:
     if header is None:
         if has_live_connection(db_path):
             return None, "database is open in this process"
-        return None, "file could not be read"
+        return None, _unreadable_reason(db_path)
     if len(header) == 0:
         return None, "file is empty"
     if len(header) < 20 or not header.startswith(_SQLITE_HEADER_MAGIC):

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -124,12 +124,25 @@ def _read_journal_mode(db_path: Path) -> tuple[str | None, str | None]:
     Header byte 18 is 2 for WAL and 1 for a rollback journal. Opening the
     database through the SQLite engine — even read-only — creates -wal/-shm
     sidecar files, which a diagnostic must not do.
+
+    The byte read is routed through ``read_header_bytes_preopen`` rather than
+    a bare ``open()``: closing *any* descriptor for a database file cancels
+    this process's POSIX advisory locks on it, so a raw read would drop the
+    locks a live connection is holding (see ``hermes_cli.sqlite_safe_read``).
+    ``run_doctor`` is also called in-process by the dashboard console, which
+    holds live ``SessionDB`` connections. The helper refuses in that case and
+    the mode is reported as unreadable instead.
     """
-    try:
-        with open(db_path, "rb") as fh:
-            header = fh.read(20)
-    except OSError as exc:
-        return None, str(exc)
+    from hermes_cli.sqlite_safe_read import (
+        has_live_connection,
+        read_header_bytes_preopen,
+    )
+
+    header = read_header_bytes_preopen(db_path, length=20)
+    if header is None:
+        if has_live_connection(db_path):
+            return None, "database is open in this process"
+        return None, "file could not be read"
     if len(header) == 0:
         return None, "file is empty"
     if len(header) < 20 or not header.startswith(_SQLITE_HEADER_MAGIC):

--- a/tests/hermes_cli/test_doctor_journal_modes.py
+++ b/tests/hermes_cli/test_doctor_journal_modes.py
@@ -14,6 +14,12 @@ import sqlite3
 import pytest
 
 import hermes_cli.doctor as doctor
+from hermes_cli.sqlite_safe_read import (
+    connect_tracked,
+    has_live_connection,
+    track_connection,
+    untrack_connection,
+)
 
 VULNERABLE = (3, 50, 4)
 FIXED_VERSIONS = [(3, 51, 3), (3, 52, 0), (3, 50, 7), (3, 44, 6)]
@@ -36,6 +42,16 @@ def _sidecars(directory):
     return sorted(
         p.name for p in directory.iterdir() if p.name.endswith(("-wal", "-shm"))
     )
+
+
+@pytest.fixture
+def clean_registry():
+    """Keep the module-level connection registry from leaking across tests."""
+    yield
+    import hermes_cli.sqlite_safe_read as mod
+
+    with mod._live_lock:
+        mod._live_connections.clear()
 
 
 class TestReadJournalMode:
@@ -139,6 +155,113 @@ class TestReadJournalMode:
         assert wal_db.read_bytes() == wal_bytes
         assert rollback_db.read_bytes() == rollback_bytes
         assert _sidecars(tmp_path) == []
+
+
+class TestLiveConnectionSafety:
+    """The probe must not raw-open a database this process has connections to.
+
+    close() on any descriptor cancels every POSIX advisory lock the process
+    holds on that file, so a byte-probe run while a connection is live drops
+    that connection's locks — including the EXCLUSIVE lock a VACUUM holds
+    mid-rewrite. run_doctor is reachable in-process (the dashboard console
+    imports and calls it directly while holding live SessionDB connections),
+    so the probe must defer to the registry rather than open the file.
+    """
+
+    def test_probe_is_refused_while_a_tracked_connection_is_live(
+        self, tmp_path, clean_registry
+    ):
+        db = tmp_path / "state.db"
+        _make_db(db, journal_mode="WAL")
+
+        track_connection(db)
+        try:
+            assert has_live_connection(db)
+
+            mode, error = doctor._read_journal_mode(db)
+
+            assert mode is None
+            assert error == "database is open in this process"
+        finally:
+            untrack_connection(db)
+
+    def test_probe_is_refused_for_a_real_tracked_connection(
+        self, tmp_path, clean_registry
+    ):
+        """The same, through connect_tracked — the path SessionDB actually takes."""
+        db = tmp_path / "state.db"
+        _make_db(db, journal_mode="WAL")
+
+        conn = connect_tracked(db)
+        try:
+            assert has_live_connection(db)
+
+            mode, error = doctor._read_journal_mode(db)
+
+            assert mode is None
+            assert error == "database is open in this process"
+        finally:
+            conn.close()
+
+    def test_probe_resumes_once_the_connection_closes(self, tmp_path, clean_registry):
+        db = tmp_path / "state.db"
+        _make_db(db, journal_mode="WAL")
+
+        conn = connect_tracked(db)
+        assert doctor._read_journal_mode(db)[0] is None
+        conn.close()
+
+        assert not has_live_connection(db)
+        assert doctor._read_journal_mode(db) == ("wal", None)
+
+    def test_refusal_creates_no_new_sidecars(self, tmp_path, clean_registry):
+        db = tmp_path / "state.db"
+        _make_db(db, journal_mode="WAL")
+
+        conn = connect_tracked(db)
+        try:
+            before = _sidecars(tmp_path)
+
+            doctor._read_journal_mode(db)
+
+            assert _sidecars(tmp_path) == before
+        finally:
+            conn.close()
+
+    def test_report_degrades_instead_of_probing_a_live_database(
+        self, tmp_path, capsys, clean_registry
+    ):
+        db = tmp_path / "state.db"
+        _make_db(db, journal_mode="WAL")
+
+        conn = connect_tracked(db)
+        try:
+            doctor._report_database_journal_modes(tmp_path, VULNERABLE)
+        finally:
+            conn.close()
+
+        out = capsys.readouterr().out
+        assert "state.db: journal mode could not be read" in out
+        assert "database is open in this process" in out
+        assert "cannot rule out WAL exposure" in out
+
+    def test_an_untracked_lock_holder_does_not_block_the_probe(self, tmp_path):
+        """Only this process's *registered* connections gate the read.
+
+        A plain sqlite3.connect elsewhere is not in the registry, and a lock
+        held by another process is irrelevant — neither can be cancelled by a
+        close() we never perform. Guards against over-correcting into refusing
+        every read.
+        """
+        db = tmp_path / "state.db"
+        _make_db(db)
+        holder = sqlite3.connect(db, isolation_level=None)
+        try:
+            holder.execute("BEGIN EXCLUSIVE")
+
+            assert doctor._read_journal_mode(db) == ("rollback", None)
+        finally:
+            holder.close()
 
 
 class TestReportDatabaseJournalModes:

--- a/tests/hermes_cli/test_doctor_journal_modes.py
+++ b/tests/hermes_cli/test_doctor_journal_modes.py
@@ -46,12 +46,24 @@ def _sidecars(directory):
 
 @pytest.fixture
 def clean_registry():
-    """Keep the module-level connection registry from leaking across tests."""
-    yield
+    """Isolate a test from the module-level connection registry.
+
+    Clears on both sides, not just teardown: a test that leaks a tracked
+    connection (an earlier failure, or a test that does not take this
+    fixture) would otherwise leave the registry dirty and make the *next*
+    test's refusal assertion pass for the wrong reason.
+    """
     import hermes_cli.sqlite_safe_read as mod
 
-    with mod._live_lock:
-        mod._live_connections.clear()
+    def _clear():
+        with mod._live_lock:
+            mod._live_connections.clear()
+
+    _clear()
+    try:
+        yield
+    finally:
+        _clear()
 
 
 class TestReadJournalMode:

--- a/tests/hermes_cli/test_doctor_journal_modes.py
+++ b/tests/hermes_cli/test_doctor_journal_modes.py
@@ -264,6 +264,49 @@ class TestLiveConnectionSafety:
             holder.close()
 
 
+class TestUnreadableReason:
+    def test_missing_file_keeps_the_os_error_text(self, tmp_path):
+        reason = doctor._unreadable_reason(tmp_path / "gone.db")
+
+        assert "No such file or directory" in reason
+
+    @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
+    @pytest.mark.skipif(
+        # os.geteuid is POSIX-only, and a skipif condition is evaluated at
+        # collection time — calling it unguarded would raise AttributeError
+        # and take the whole module down on Windows.
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root ignores file permissions",
+    )
+    def test_unreadable_file_is_reported_as_permission_denied(self, tmp_path):
+        db = tmp_path / "state.db"
+        _make_db(db)
+        os.chmod(db, 0o000)
+        try:
+            mode, error = doctor._read_journal_mode(db)
+        finally:
+            os.chmod(db, 0o644)
+
+        assert mode is None
+        assert "permission denied" in error.lower()
+
+    def test_reason_does_not_open_the_file(self, tmp_path, monkeypatch):
+        """_unreadable_reason must answer from metadata only.
+
+        It runs on database paths, so taking a descriptor would reintroduce
+        the very close() this module's guard exists to prevent.
+        """
+        db = tmp_path / "state.db"
+        _make_db(db)
+
+        def _fail(*args, **kwargs):
+            raise AssertionError("_unreadable_reason must not open the file")
+
+        monkeypatch.setattr("builtins.open", _fail)
+
+        assert doctor._unreadable_reason(db) == "file could not be read"
+
+
 class TestReportDatabaseJournalModes:
     def test_vulnerable_runtime_wal_db_is_exposed(self, tmp_path, capsys):
         _make_db(tmp_path / "state.db", journal_mode="WAL")


### PR DESCRIPTION
## What does this PR do?

`hermes_cli/doctor.py::_read_journal_mode` reads header byte 18 of every Hermes database with a bare `open(db_path, "rb")`. **The read is harmless; the `close()` is not.** Per [SQLite's own corruption documentation](https://sqlite.org/howtocorrupt.html#_posix_advisory_locks_canceled_by_a_separate_thread_doing_close_), `close()` on *any* descriptor for a file cancels **every POSIX advisory lock the process holds on it** — so the close at the end of that `with` block drops the locks a live connection is holding, including the EXCLUSIVE lock a `VACUUM` holds while it rewrites the whole file. Another process is then free to write into a file its writer still believes it owns: the documented route to `database disk image is malformed`.

This PR routes the read through the repo's own sanctioned helper, `read_header_bytes_preopen`, which performs the registry check and the `open`/`read`/`close` together under the connection-lifecycle lock and refuses once any connection to the path is live.

**Scope, stated honestly:** in a standalone `hermes doctor` CLI process nothing is live and the current code is harmless. The bug is the **in-process dashboard console** path (see below). I am not claiming `hermes doctor` corrupts databases from a terminal.

**The invariant is the repo's own, not my preference.** `hermes_cli/sqlite_safe_read.py` exists solely to prevent this and states it as a numbered rule in its module docstring:

> **Rule 1.** Never `open()` a database file that may have live connections in this process.
> **Rule 2.** Byte-level probes … route those through `read_header_bytes_preopen`, which refuses once a connection has been registered for the path.

and `read_header_bytes_preopen` is documented as *"the ONLY sanctioned byte-level read of a database file"*.

**This is a regression against that audit, by ancestry:**

| | |
|---|---|
| audit that converted the other byte-probes | `95fb4778561` — *"fix(state): close the tracking leak and finish the audit of raw DB reads"*, **2026-07-25** |
| `_read_journal_mode` introduced | `65832970868` — *"feat(doctor): report per-database journal mode…"*, **2026-08-06** |
| `git merge-base --is-ancestor 95fb4778561 65832970868` | **YES** |

The sweep landed 12 days before the new probe, so the pattern was reintroduced after the tree had already ruled it out. The three sites the sweep converted are still converted: `hermes_state.py:2750`, `hermes_cli/backup.py:436`, `hermes_cli/kanban_db.py:1861`. `_read_journal_mode` was the only survivor — I grepped every `SQLite format 3` header probe in the tree to confirm there is no second one.

### Why it is reachable

`run_doctor` is not only a CLI entrypoint. Every leg verified against `main`:

1. `doctor.py:174` — `_read_journal_mode(path)` runs over **every** Hermes database.
2. `console_engine.py:570` registers the `doctor` console command; `console_engine.py:1297-1299` does `from hermes_cli.doctor import run_doctor` and calls it **directly, in-process**.
3. `hermes_cli/web_server.py:16152-16154` builds that `HermesConsoleEngine` in the dashboard process, dispatched on the console thread pool (`:15923`).
4. That same process holds **live tracked connections**: `SessionDB(..., read_only=False)` at `web_server.py:11673`, `read_only=True` at `:11689`, plus `:344`, `:11686`, `:11709`. `SessionDB` connects via `_connect_tracked_db` → `connect_tracked`, so these are registered in the very registry the helper consults.

So typing `doctor` in the dashboard console raw-`open()`/`close()`s `state.db`, `projects.db`, `response_store.db`, `cron/executions.db` and every board's `kanban.db` on a worker thread while those connections are live and the server is serving other requests.

**The contrast that settles intent:** the HTTP route `/api/ops/doctor` (`web_server.py:13591`) deliberately **spawns a subprocess** via `_spawn_hermes_action`. That path already avoids running doctor in the connection-holding process; the console path does not.

### The docstring's stated property is preserved

The function's docstring promises no SQLite engine open and therefore no `-wal`/`-shm` sidecars. `read_header_bytes_preopen` is itself a plain byte read, so that holds — **this is deliberately not fixed by opening a read-only SQLite connection**, which would create exactly the sidecars the original author guarded against. A test asserts no new sidecars appear.

## Related Issue

No filed issue — found by auditing `main` against `sqlite_safe_read.py`'s stated rules.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/doctor.py` — `_read_journal_mode` acquires the header via `read_header_bytes_preopen(db_path, length=20)` instead of `open(db_path, "rb")`. Only the acquisition changes; the empty / not-a-database / unrecognized-format-version branches are untouched.
- `hermes_cli/doctor.py` — new `_unreadable_reason` helper. The pre-open reader collapses every `OSError` into `None`, which would have flattened `[Errno 2] No such file or directory` and `[Errno 13] Permission denied` into one opaque string; doctor prints that string verbatim and on a vulnerable SQLite it is the user's only clue why WAL exposure could not be ruled out. `stat()` and `os.access(..., R_OK)` recover it from metadata alone — **neither takes a file descriptor**, so neither can cancel the advisory locks this PR is about.
- `tests/hermes_cli/test_doctor_journal_modes.py` — 9 cases across `TestLiveConnectionSafety` and `TestUnreadableReason`.

Split into 4 atomic commits (two fixes, two test commits); each is independently green.

**On `has_live_connection`:** it is consulted **only after** `read_header_bytes_preopen` has already returned `None`, purely to choose an error string — never to gate I/O. This is deliberately *not* the check-then-read pattern `offline_file_access` warns about, because the helper itself remains the guard and performs its check atomically under the lock.

## How to Test

Regression direction, verified both ways:

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_doctor_journal_modes.py -q
```

- **Before** the `doctor.py` change (tests kept, production hunk reverted to `main`): **6 failed, 30 passed**. The core case fails with `AssertionError: assert 'wal' is None` — the old probe read the header straight out of a live database.
- **After**: **36 passed**.
- Adjacent suites, all green together: `tests/hermes_cli/test_doctor_journal_modes.py`, `test_doctor.py`, `test_doctor_dedicated_provider_skip.py`, `test_doctor_live.py`, and the owner module's `tests/test_sqlite_lock_safe_inspection.py` — **122 passed**.

Three of the nine new cases hold in *both* directions by design and are guards rather than probes:

- an untracked `sqlite3.connect` holding `BEGIN EXCLUSIVE` must **not** block the read — only connections this process registered can be cancelled by a `close()` we make. Without this, a later "refuse whenever the file looks busy" change would silently turn every doctor row into `could not be read`.
- the refusal creates no new `-wal`/`-shm` sidecars.
- `test_reason_does_not_open_the_file` patches `builtins.open` to raise and asserts `_unreadable_reason` still answers, so a future edit that reaches for `open()` to get a better message fails loudly instead of reintroducing the bug on the error path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the doctor suites and the `sqlite_safe_read` owner suite (122 passed), not the full tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), CPython 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the `_read_journal_mode` docstring now records why the read is routed through the helper
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — see the note below
- [x] N/A — no tool descriptions or schemas changed

**Cross-platform note.** The advisory-lock behaviour is POSIX; on Windows the raw read is not a lock hazard, so this is a no-op there rather than a regression. My new root check is written as `hasattr(os, "geteuid") and os.geteuid() == 0` rather than the bare `os.geteuid()` the surrounding tests use, because `skipif` conditions are evaluated at collection time and `os.geteuid` is POSIX-only. I deliberately left the pre-existing bare occurrences alone — **#81926** and **#84073** are already open against exactly those lines, and I did not want to duplicate either; this change only avoids adding a third instance.

## Related / Positioning

`hermes_cli/doctor.py` is a crowded file: I enumerated **43 distinct open PRs** touching it in the last 7 days (24 updated on 2026-08-16, 19 on 08-10..08-15) and fetched and grepped each one's diff for `_read_journal_mode`, `open(db_path`, `read_header_bytes_preopen`, `_SQLITE_HEADER_MAGIC` and `_report_database_journal_modes`. **All 43 are clear of this fix site.** The nearest is #86678, whose closest hunk is an import at line 18 — this change adds no module-level import, so there is no overlap. This PR is confined to `_read_journal_mode` (`doctor.py:119-155`) and is disjoint from all of them.

**Pre-empting one specific reading: this is not a duplicate of my own #76003, which also touches `hermes_cli/doctor.py`.**

- #76003's two `doctor.py` hunks are `@@ -703` and `@@ -1499`; this fix site is `:119-155`. Disjoint by ~580 lines, different functions.
- `gh pr diff 76003 | grep -c _read_journal_mode` → **0**. It never mentions the symbol.
- `_read_journal_mode` **does not exist on #76003's branch at all** — that branch's merge-base predates `65832970868`, which introduced the function. A textual conflict is not merely unlikely, it is impossible.
- Different bug, different failure mode: #76003 bounds a *SQLite probe* with a deadline (it hangs); this removes a *raw file-header read* that cancels POSIX locks (it corrupts).

They are independently reviewable and can land in either order.
