### PR TITLE
fix(desktop): report the conversation category even when it is empty

### DIFF
--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -20,6 +20,17 @@ _SUBAGENT_TOOL_NAMES = frozenset({"delegate_task"})
 # configured" - true for MCP, memory and skills, and false for the
 # conversation. Every session has one, so hiding the row at zero makes an empty
 # transcript indistinguishable from a breakdown that never measured it (#87903).
+#
+# The membership rule, stated so a later addition argues from the same
+# principle rather than from "this one felt important": a category belongs
+# here when zero is a MEASUREMENT of something every session has, not the
+# ABSENCE of something optional. "conversation" qualifies because a session
+# cannot not have a transcript, so zero means "nothing said yet" and is worth
+# showing. "mcp", "memory", "skills" and "subagent_definitions" do not: zero
+# there means the user configured none, which is what dropping the row already
+# communicates, and a permanent 0-token row would be noise on most hosts.
+# "system_prompt" and "tool_definitions" are always present too but are never
+# zero in practice, so adding them would buy nothing.
 _ALWAYS_REPORTED = frozenset({"conversation"})
 
 _CATEGORY_COLORS = {

--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -16,6 +16,12 @@ _SKILLS_BLOCK_RE = re.compile(r"<available_skills>.*?</available_skills>", re.DO
 
 _SUBAGENT_TOOL_NAMES = frozenset({"delegate_task"})
 
+# A category at zero tokens is dropped from the payload, which reads as "not
+# configured" - true for MCP, memory and skills, and false for the
+# conversation. Every session has one, so hiding the row at zero makes an empty
+# transcript indistinguishable from a breakdown that never measured it (#87903).
+_ALWAYS_REPORTED = frozenset({"conversation"})
+
 _CATEGORY_COLORS = {
     "system_prompt": "var(--context-usage-system)",
     "tool_definitions": "var(--context-usage-tools)",
@@ -146,7 +152,7 @@ def compute_session_context_breakdown(
                 "tokens": tokens,
             }
             for category_id, label, tokens in categories
-            if tokens > 0
+            if tokens > 0 or category_id in _ALWAYS_REPORTED
         ],
         "context_max": context_max,
         "context_percent": context_percent,

--- a/apps/desktop/src/app/shell/context-usage-panel.test.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.test.tsx
@@ -85,6 +85,43 @@ describe('useContextBreakdown', () => {
     expect(requestGateway).toHaveBeenLastCalledWith('session.context_breakdown', { session_id: 'runtime-2' })
   })
 
+  it('flags the numbers it keeps across a turn as pre-turn rather than current', async () => {
+    // The estimate is deliberately not refreshed mid-turn, and the gateway
+    // snapshots session history at turn start, so a refetch could not see the
+    // in-flight turn either. The panel has to say so (#87903).
+    const requestGateway = vi.fn().mockResolvedValue(breakdown)
+
+    const { rerender, result } = renderHook(
+      ({ busy }) => useContextBreakdown({ busy, enabled: true, requestGateway, sessionId: 'runtime-1' }),
+      { initialProps: { busy: false } }
+    )
+
+    await waitFor(() => expect(result.current.breakdown).toEqual(breakdown))
+    expect(result.current.stale).toBe(false)
+
+    rerender({ busy: true })
+
+    expect(result.current.breakdown).toEqual(breakdown)
+    expect(result.current.stale).toBe(true)
+
+    rerender({ busy: false })
+
+    await waitFor(() => expect(result.current.stale).toBe(false))
+  })
+
+  it('does not call numbers it never had pre-turn', async () => {
+    // Busy from the start means nothing was ever fetched, and `stale` on an
+    // empty panel would label the loading state as out of date.
+    const requestGateway = vi.fn().mockResolvedValue(breakdown)
+
+    const { result } = renderHook(() =>
+      useContextBreakdown({ busy: true, enabled: true, requestGateway, sessionId: 'runtime-1' })
+    )
+
+    expect(result.current.breakdown).toBeNull()
+    expect(result.current.stale).toBe(false)
+  })
+
   it('reports the measured occupancy the backend sends, not just the estimate', async () => {
     // `context_used` on the payload is already the measured figure once a turn
     // has run — the estimate is the backend's own fallback, not a second value
@@ -106,6 +143,35 @@ describe('ContextUsagePanel', () => {
 
     expect(screen.getByText('47% Full')).toBeTruthy()
     expect(screen.getByText('Conversation')).toBeTruthy()
+  })
+
+  it('says the estimate is pre-turn while a turn is running', () => {
+    render(<ContextUsagePanel breakdown={breakdown} loading={false} stale usage={usage} />)
+
+    expect(screen.getByText('Estimated before this turn')).toBeTruthy()
+  })
+
+  it('does not label the estimate pre-turn when it is current', () => {
+    render(<ContextUsagePanel breakdown={breakdown} loading={false} usage={usage} />)
+
+    expect(screen.queryByText('Estimated before this turn')).toBeNull()
+  })
+
+  it('renders a conversation category the backend reports as empty', () => {
+    // A fresh session sends `conversation` at zero rather than omitting it, so
+    // the row must survive the panel's own rendering (#87903).
+    const fresh: ContextBreakdown = {
+      ...breakdown,
+      categories: [
+        { color: 'blue', id: 'system_prompt', label: 'System prompt', tokens: 4_200 },
+        { color: 'teal', id: 'conversation', label: 'Conversation', tokens: 0 }
+      ]
+    }
+
+    render(<ContextUsagePanel breakdown={fresh} loading={false} usage={usage} />)
+
+    expect(screen.getByText('Conversation')).toBeTruthy()
+    expect(screen.queryByText('No context data yet')).toBeNull()
   })
 
   it('says so when there is no breakdown rather than painting an empty bar', () => {

--- a/apps/desktop/src/app/shell/context-usage-panel.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.tsx
@@ -8,6 +8,7 @@ import type { ContextBreakdown, ContextUsageCategory, UsageStats } from '@/types
 interface ContextUsagePanelProps {
   breakdown: ContextBreakdown | null
   loading: boolean
+  stale?: boolean
   usage: UsageStats
 }
 
@@ -16,7 +17,7 @@ interface ContextUsagePanelProps {
  *  popover opens with its numbers already in hand. `usage` is the gauge's
  *  merged figure — measured occupancy when the backend has it, the estimate
  *  otherwise — so the header and the bar can never disagree. */
-export function ContextUsagePanel({ breakdown, loading, usage }: ContextUsagePanelProps) {
+export function ContextUsagePanel({ breakdown, loading, stale = false, usage }: ContextUsagePanelProps) {
   const { t } = useI18n()
   const copy = t.shell.statusbar.contextUsagePanel
   const contextMax = usage.context_max ?? 0
@@ -62,6 +63,10 @@ export function ContextUsagePanel({ breakdown, loading, usage }: ContextUsagePan
         ))}
       </ul>
 
+      {stale && categories.length > 0 && (
+        <p className="text-[0.6875rem] text-muted-foreground">{copy.staleDuringTurn}</p>
+      )}
+
       {loading && !categories.length && <p className="text-[0.6875rem] text-muted-foreground">{copy.loading}</p>}
 
       {!loading && !categories.length && <p className="text-[0.6875rem] text-muted-foreground">{copy.empty}</p>}
@@ -84,16 +89,21 @@ function ContextUsageBar({
       )}
       data-slot="context-usage-bar"
     >
-      {categories.map(category => (
-        <span
-          className="h-full min-w-px"
-          key={category.id}
-          style={{
-            background: category.color,
-            width: `${(category.tokens / segmentTotal) * 100}%`
-          }}
-        />
-      ))}
+      {/* `min-w-px` guarantees a sliver for a category too small to round to a
+          visible width, so a zero-token category has to be dropped here rather
+          than painted: the list below still names it (#87903). */}
+      {categories
+        .filter(category => category.tokens > 0)
+        .map(category => (
+          <span
+            className="h-full min-w-px"
+            key={category.id}
+            style={{
+              background: category.color,
+              width: `${(category.tokens / segmentTotal) * 100}%`
+            }}
+          />
+        ))}
     </div>
   )
 }

--- a/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
@@ -56,8 +56,17 @@ export function useContextBreakdown({ busy, enabled, requestGateway, sessionId }
     }
   }, [busy, enabled, requestGateway, sessionId])
 
+  const forSession = fetched && fetched.sessionId === sessionId ? fetched.breakdown : null
+
   return {
-    breakdown: fetched && fetched.sessionId === sessionId ? fetched.breakdown : null,
-    loading
+    breakdown: forSession,
+    loading,
+    // The numbers on hand predate a running turn: the estimate is deliberately
+    // not refreshed mid-turn, and the gateway snapshots `session["history"]` at
+    // turn start and only writes the turn back once the agent returns, so a
+    // refetch could not see the in-flight turn either. Surfaced so the panel
+    // can say the figures are pre-turn instead of implying they are current
+    // (#87903).
+    stale: busy && forSession !== null
   }
 }

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -237,7 +237,11 @@ export function useStatusbarItems({
   // toggled off, so this covers the rest.
   const contextItemHidden = useStore($statusbarHiddenIds).includes('context-usage')
 
-  const { breakdown: contextBreakdown, loading: contextBreakdownLoading } = useContextBreakdown({
+  const {
+    breakdown: contextBreakdown,
+    loading: contextBreakdownLoading,
+    stale: contextBreakdownStale
+  } = useContextBreakdown({
     busy,
     enabled: !contextItemHidden,
     requestGateway,
@@ -550,7 +554,12 @@ export function useStatusbarItems({
         menuAlign: 'end',
         menuClassName: 'w-auto border-(--ui-stroke-secondary) p-0',
         menuContent: (
-          <ContextUsagePanel breakdown={contextBreakdown} loading={contextBreakdownLoading} usage={gaugeUsage} />
+          <ContextUsagePanel
+            breakdown={contextBreakdown}
+            loading={contextBreakdownLoading}
+            stale={contextBreakdownStale}
+            usage={gaugeUsage}
+          />
         ),
         toggleLabel: copy.toggleContextUsage,
         variant: 'menu'
@@ -591,6 +600,7 @@ export function useStatusbarItems({
       contextBar,
       contextBreakdown,
       contextBreakdownLoading,
+      contextBreakdownStale,
       contextUsage,
       copy,
       gaugeUsage,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2841,6 +2841,7 @@ export const en: Translations = {
         empty: 'No context data yet',
         loading: 'Loading breakdown…',
         percentFull: percent => `${percent}% Full`,
+        staleDuringTurn: 'Estimated before this turn',
         title: 'Context Usage',
         tokenSummary: (used, max) => `${used} / ${max} Tokens`
       },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2495,6 +2495,7 @@ export const ja = defineLocale({
         empty: 'コンテキストデータはまだありません',
         loading: '内訳を読み込み中…',
         percentFull: percent => `${percent}% 使用中`,
+        staleDuringTurn: 'このターン開始前の推定値',
         title: 'コンテキスト使用状況',
         tokenSummary: (used, max) => `${used} / ${max} Tokens`
       },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2416,6 +2416,7 @@ export interface Translations {
         empty: string
         loading: string
         percentFull: (percent: number) => string
+        staleDuringTurn: string
         title: string
         tokenSummary: (used: string, max: string) => string
       }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2410,6 +2410,7 @@ export const zhHant = defineLocale({
         empty: '尚無上下文資料',
         loading: '正在載入明細…',
         percentFull: percent => `已用 ${percent}%`,
+        staleDuringTurn: '本輪開始前的估算',
         title: '上下文使用量',
         tokenSummary: (used, max) => `${used} / ${max} Tokens`
       },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3009,6 +3009,7 @@ export const zh: Translations = {
         empty: '暂无上下文数据',
         loading: '正在加载明细…',
         percentFull: percent => `已用 ${percent}%`,
+        staleDuringTurn: '本轮开始前的估算',
         title: '上下文用量',
         tokenSummary: (used, max) => `${used} / ${max} Tokens`
       },

--- a/tests/agent/test_context_breakdown.py
+++ b/tests/agent/test_context_breakdown.py
@@ -50,6 +50,64 @@ def test_breakdown_includes_major_categories():
     assert data["estimated_total"] > 0
 
 
+def test_conversation_is_reported_at_zero_on_an_empty_transcript():
+    """An empty conversation must read as zero, not as a missing category.
+
+    Dropping the row makes "nothing said yet" indistinguishable from "the
+    breakdown never measured the conversation", which is what #87903 reports
+    on a fresh session.
+    """
+    agent, parts = _make_agent()
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        data = compute_session_context_breakdown(agent, [])
+
+    conversation = [item for item in data["categories"] if item["id"] == "conversation"]
+    assert len(conversation) == 1
+    assert conversation[0]["tokens"] == 0
+    assert conversation[0]["label"] == "Conversation"
+
+
+def test_conversation_is_reported_at_zero_when_history_is_none():
+    """``messages=None`` is the same empty conversation, not a missing one."""
+    agent, parts = _make_agent()
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        data = compute_session_context_breakdown(agent, None)
+
+    assert [item["id"] for item in data["categories"]].count("conversation") == 1
+
+
+def test_structurally_absent_categories_are_still_dropped():
+    """Only the conversation is exempt: an unconfigured category stays hidden.
+
+    Otherwise the panel grows permanent zero rows for every feature the
+    operator has not turned on.
+    """
+    agent, parts = _make_agent(
+        stable="base guidance",  # no <available_skills> block
+        context="",  # no rules
+        tools=[{"type": "function", "function": {"name": "terminal"}}],
+    )
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        data = compute_session_context_breakdown(agent, [])
+
+    ids = {item["id"] for item in data["categories"]}
+    assert "conversation" in ids
+    assert {"skills", "mcp", "subagent_definitions", "rules", "memory"} & ids == set()
+
+
+def test_zero_conversation_does_not_inflate_the_estimated_total():
+    agent, parts = _make_agent()
+    history = [{"role": "user", "content": "hello there"}]
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        empty = compute_session_context_breakdown(agent, [])
+        spoken = compute_session_context_breakdown(agent, history)
+
+    assert empty["estimated_total"] < spoken["estimated_total"]
+
 
 # ── /context renderers (pure functions over the payload) ────────────────────
 


### PR DESCRIPTION
## What does this PR do?

The context-usage breakdown drops every category measuring zero tokens before
it leaves the backend. That is right for MCP, memory and skills: zero there
genuinely means "not configured", and a row of zeroes would be noise. It is
wrong for the conversation, because every session has one. An empty transcript
therefore became indistinguishable from a breakdown that never measured the
transcript at all, and opening the popover on a fresh session showed System
prompt and Tools and then simply no Conversation row.

The fix keeps the drop and exempts `conversation` from it, so the row is always
present and reads `0` until the first turn lands. The category list is the
panel's own inventory of what it measured, and a category it always measures
should always appear.

Two consequences worth calling out:

- The stacked bar now filters zero-token segments itself. `min-w-px` on each
  segment guarantees a visible sliver to anything the bar paints, precisely so
  that a tiny category is not invisible, which means a genuinely-zero category
  would draw a stripe representing nothing. The bar drops it; the list below
  still names it. Those are the correct opposite defaults for the two surfaces.
- The panel implied its figures were current while a turn was running. They are
  not, so it now says so.

### A correction to the issue's diagnosis

The issue reads the `busy` guard in `useContextBreakdown` as the cause, on the
theory that the hook refuses to fetch during the first turn and so has nothing
to show. That guard is real, but removing it would not have fixed anything, and
I want to be explicit about why rather than quietly shipping a different patch
than the one that was asked for.

An in-flight turn is not reachable from the data the estimate is computed over.
The gateway snapshots `session["history"]` when the turn starts
(`server.py:10527`) and writes the turn back only once the agent returns
(`server.py:10868`); the prompt itself is passed as an argument and never
appears in `history` in between. So a mid-turn refetch would recompute the
identical pre-turn number at the cost of an extra round trip. The empty
Conversation row is not a fetch-timing problem, it is the zero-token filter.

That is also why the second half of this PR is a label rather than a refetch.
The hook returns `stale` when it is holding pre-turn numbers across a running
turn, and the panel renders "Estimated before this turn". Saying the figures
are pre-turn is honest and cheap; making them current is not possible from this
side of the gateway.

### Deliberately out of scope

While tracing this I found a separate bug in the same neighbourhood:
`use-statusbar-items.tsx:250` overrides live streamed gauge usage with the
retained pre-turn breakdown for the whole duration of a turn, which contradicts
the comment directly above it. That belongs to #70871, not here, and widening
this PR to cover it would make the diff harder to review for no gain. I will
report it there.

## Related Issue

Fixes #87903

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_breakdown.py`: added `_ALWAYS_REPORTED = frozenset({"conversation"})`
  and changed the payload comprehension's filter from `if tokens > 0` to
  `if tokens > 0 or category_id in _ALWAYS_REPORTED`. Structurally-absent
  categories are still dropped, and `estimated_total` is unaffected because a
  zero-token category adds zero.
- `apps/desktop/src/app/shell/hooks/use-context-breakdown.ts`: returns
  `stale: busy && forSession !== null`, with the reasoning above recorded where
  the next reader will look for it.
- `apps/desktop/src/app/shell/context-usage-panel.tsx`: new optional `stale`
  prop rendering `copy.staleDuringTurn` beneath the category list; the stacked
  bar filters `tokens > 0`.
- `apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx`: threads `stale`
  from the hook into the panel.
- `apps/desktop/src/i18n/en.ts`, `apps/desktop/src/i18n/types.ts`: added
  `staleDuringTurn`. Non-`en` locales are partial overrides deep-merged onto
  `en` via `defineLocale`, so no other catalog needs touching and no locale
  regresses to a missing key.
- `tests/agent/test_context_breakdown.py`: 4 new tests.
- `apps/desktop/src/app/shell/context-usage-panel.test.tsx`: 5 new tests.

## How to Test

1. Start a fresh session and open the context-usage popover in Desktop before
   sending anything. Before this change the list shows System prompt and Tools
   with no Conversation row; after it, Conversation is listed at `0`.
2. Send a message and watch the popover while the turn is running. The note
   "Estimated before this turn" appears under the list, and disappears once the
   turn ends and the estimate refetches.
3. Backend regression, and proof the tests bite:

   ```
   pytest tests/agent/test_context_breakdown.py -q          # 8 passed
   ```

   Revert just the filter change (`if tokens > 0 or category_id in
   _ALWAYS_REPORTED` back to `if tokens > 0`) and rerun: 3 failed, 5 passed.
   The three that fail are
   `test_conversation_is_reported_at_zero_on_an_empty_transcript`,
   `test_conversation_is_reported_at_zero_when_history_is_none` and
   `test_structurally_absent_categories_are_still_dropped`.
   `test_zero_conversation_does_not_inflate_the_estimated_total` passes either
   way by design: it is a guardrail against a future fix that reports the row by
   adding a phantom token, not a proof of this one.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected suites
      rather than the whole tree; see "Notes on verification" for exactly what
      ran and for the one pre-existing failure I confirmed against a clean
      `upstream/main`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro 26200

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Notes on verification

- `pytest tests/agent/test_context_breakdown.py -q`: 8 passed.
- `pytest tests/gateway/test_status_command.py tests/gateway/test_usage_command.py
  tests/agent/test_context_breakdown.py -q`: 23 passed, 1 failed. The failure is
  `test_profile_command_reports_source_stamped_profile`, which asserts an
  absolute Windows home path but gets a `~`-abbreviated one. I confirmed it
  fails identically on a clean `upstream/main` checkout with this branch
  stashed, and nothing here touches profile or home-path rendering, so it is
  pre-existing and environment-specific rather than a regression from this
  change.
- `ruff check`: all checks passed. `ruff format --diff` produces the same hunk
  count on the touched files as it does at `upstream/main`, so this adds no new
  formatting drift.
- `scripts/check-windows-footguns.py --all`: no footguns, 973 files scanned.
- The five new Desktop tests could not be run locally: this worktree has no
  installed `node_modules` and no npm cache to install from offline. They are
  written against the existing patterns in
  `context-usage-panel.test.tsx` (`renderHook` driving `busy` false to true to
  false for the hook cases, and direct render assertions for the panel cases),
  but CI is their first real execution. Flagging it rather than implying a green
  run I did not have. Happy to iterate if they need adjusting.

## Cross-check against nearby open PRs

Two open PRs touch these files, and neither overlaps in intent:

- **#71757** adds `context_used_is_estimate` and provenance labelling. It does
  not touch the zero-token filter.
- **#71420** reworks the bar's denominator and adds scale toggles. It does not
  touch which categories are painted.

Both are based on an older revision of `context-usage-panel.tsx` and will
conflict textually with each other regardless of this PR. Happy to rebase in
whatever order maintainers prefer.
