### PR TITLE
fix(agent): scope custom request overrides to runtime route

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -19,6 +19,7 @@ preserved.
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import re
@@ -429,16 +430,60 @@ def _custom_provider_model_matches(agent_model: str, entry: Dict[str, Any]) -> b
 def _custom_provider_extra_body_for_agent(
     *,
     provider: str,
+    requested_provider: str = "",
     model: str,
     base_url: str,
     custom_providers: List[Dict[str, Any]],
 ) -> Optional[Dict[str, Any]]:
-    provider_norm = (provider or "").strip().lower()
-    if provider_norm == "custom":
-        provider_key_filter = ""
-    elif provider_norm.startswith("custom:"):
-        provider_key_filter = provider_norm.split(":", 1)[1].strip()
-    else:
+    try:
+        from hermes_cli.models import CANONICAL_PROVIDERS
+
+        native_provider_ids = {
+            str(entry.slug or "").strip().lower()
+            for entry in CANONICAL_PROVIDERS
+            if str(entry.slug or "").strip().lower() != "custom"
+        }
+        native_catalog_available = True
+    except Exception:
+        # Without the native catalog, bare provider IDs are ambiguous.  Fail
+        # closed and require the explicit ``custom:`` identity instead of
+        # risking a custom-name collision with a native route.
+        native_provider_ids = set()
+        native_catalog_available = False
+    native_provider_ids.update({"openai", "github", "github-copilot"})
+
+    configured_keys = {
+        value
+        for entry in custom_providers or []
+        if isinstance(entry, dict)
+        for value in (
+            str(entry.get("provider_key", "") or "").strip().lower(),
+            str(entry.get("name", "") or "").strip().lower(),
+        )
+        if value
+    }
+    provider_key_filter = ""
+    is_custom_route = False
+    for raw_identity in (requested_provider, provider):
+        identity = str(raw_identity or "").strip().lower()
+        if identity == "custom":
+            is_custom_route = True
+            continue
+        if identity.startswith("custom:"):
+            is_custom_route = True
+            provider_key_filter = identity.split(":", 1)[1].strip()
+            break
+        # Live model switches may carry the configured provider key as the
+        # provider identity rather than the canonical ``custom`` label.
+        if (
+            native_catalog_available
+            and identity in configured_keys
+            and identity not in native_provider_ids
+        ):
+            is_custom_route = True
+            provider_key_filter = identity
+            break
+    if not is_custom_route:
         return None
 
     target_url = _normalized_custom_base_url(base_url)
@@ -471,23 +516,84 @@ def _custom_provider_extra_body_for_agent(
     return fallback
 
 
+def _remove_provider_owned_values(
+    current: Dict[str, Any], owned: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Remove unchanged provider-owned leaves from a nested mapping."""
+    result = copy.deepcopy(current)
+    for key, owned_value in owned.items():
+        if key not in result:
+            continue
+        current_value = result[key]
+        if current_value == owned_value:
+            result.pop(key)
+        elif isinstance(current_value, dict) and isinstance(owned_value, dict):
+            nested = _remove_provider_owned_values(current_value, owned_value)
+            if nested:
+                result[key] = nested
+            else:
+                result.pop(key)
+    return result
+
+
+def _merge_provider_defaults_with_caller(
+    defaults: Dict[str, Any], caller: Dict[str, Any]
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Deep-merge mappings and return effective values plus owned leaves."""
+    merged = copy.deepcopy(defaults)
+    owned = copy.deepcopy(defaults)
+    for key, caller_value in caller.items():
+        default_value = defaults.get(key)
+        if isinstance(default_value, dict) and isinstance(caller_value, dict):
+            merged_value, owned_value = _merge_provider_defaults_with_caller(
+                default_value, caller_value
+            )
+            merged[key] = merged_value
+            if owned_value:
+                owned[key] = owned_value
+            else:
+                owned.pop(key, None)
+        else:
+            merged[key] = copy.deepcopy(caller_value)
+            owned.pop(key, None)
+    return merged, owned
+
+
 def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, Any]]) -> None:
-    extra_body = _custom_provider_extra_body_for_agent(
+    destination_defaults = _custom_provider_extra_body_for_agent(
         provider=agent.provider,
+        requested_provider=getattr(agent, "requested_provider", ""),
         model=agent.model,
         base_url=agent.base_url,
         custom_providers=custom_providers,
-    )
-    if not extra_body:
-        return
+    ) or {}
 
-    overrides = dict(getattr(agent, "request_overrides", {}) or {})
-    merged_extra_body = dict(extra_body)
+    overrides = copy.deepcopy(getattr(agent, "request_overrides", {}) or {})
     existing_extra_body = overrides.get("extra_body")
-    if isinstance(existing_extra_body, dict):
-        merged_extra_body.update(existing_extra_body)
-    overrides["extra_body"] = merged_extra_body
+    caller_extra_body = (
+        copy.deepcopy(existing_extra_body)
+        if isinstance(existing_extra_body, dict)
+        else {}
+    )
+
+    # Remove only unchanged values that Hermes previously injected.  A value
+    # changed after injection is treated as caller/runtime-owned and preserved.
+    previous_owned = copy.deepcopy(
+        getattr(agent, "_custom_provider_extra_body", {}) or {}
+    )
+    caller_extra_body = _remove_provider_owned_values(
+        caller_extra_body, previous_owned
+    )
+
+    merged_extra_body, destination_owned = _merge_provider_defaults_with_caller(
+        destination_defaults, caller_extra_body
+    )
+    if merged_extra_body:
+        overrides["extra_body"] = merged_extra_body
+    else:
+        overrides.pop("extra_body", None)
     agent.request_overrides = overrides
+    agent._custom_provider_extra_body = destination_owned
 
 
 def init_agent(
@@ -2540,7 +2646,6 @@ def init_agent(
                 # connections, clients); in that case fall back to the built-in
                 # compressor with an ACCURATE message rather than silently
                 # mislabelling it "not found".
-                import copy
                 try:
                     _selected_engine = copy.deepcopy(_candidate)
                 except Exception as _copy_err:
@@ -2910,6 +3015,12 @@ def init_agent(
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        "request_overrides": copy.deepcopy(
+            getattr(agent, "request_overrides", {}) or {}
+        ),
+        "custom_provider_extra_body": copy.deepcopy(
+            getattr(agent, "_custom_provider_extra_body", {}) or {}
+        ),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         # Context engine state that _try_activate_fallback() overwrites.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1349,6 +1349,17 @@ def try_recover_primary_transport(
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
+        if "request_overrides" in rt:
+            agent.request_overrides = copy.deepcopy(rt["request_overrides"])
+            agent._custom_provider_extra_body = copy.deepcopy(
+                rt.get("custom_provider_extra_body", {})
+            )
+        else:
+            from agent.agent_init import _merge_custom_provider_extra_body
+
+            _merge_custom_provider_extra_body(
+                agent, getattr(agent, "_custom_providers", None) or []
+            )
 
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -1580,6 +1591,19 @@ def restore_primary_runtime(agent) -> bool:
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
         agent._client_kwargs = dict(rt["client_kwargs"])
+        if "request_overrides" in rt:
+            agent.request_overrides = copy.deepcopy(rt["request_overrides"])
+            agent._custom_provider_extra_body = copy.deepcopy(
+                rt.get("custom_provider_extra_body", {})
+            )
+        else:
+            # Compatibility for bare/older runtime snapshots: reconcile the
+            # live state against the restored route rather than crashing.
+            from agent.agent_init import _merge_custom_provider_extra_body
+
+            _merge_custom_provider_extra_body(
+                agent, getattr(agent, "_custom_providers", None) or []
+            )
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the
         # native-vs-proxy split (older sessions saved before this PR).
@@ -2657,6 +2681,21 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # _client_kwargs is a dict — snapshot a shallow copy so mutating the
     # live dict doesn't poison the rollback target.
     _snapshot["_client_kwargs"] = dict(getattr(agent, "_client_kwargs", {}) or {})
+    _snapshot["request_overrides"] = (
+        copy.deepcopy(agent.request_overrides)
+        if hasattr(agent, "request_overrides")
+        else _MISSING
+    )
+    _snapshot["_custom_provider_extra_body"] = (
+        copy.deepcopy(agent._custom_provider_extra_body)
+        if hasattr(agent, "_custom_provider_extra_body")
+        else _MISSING
+    )
+    _snapshot["_custom_providers"] = (
+        copy.deepcopy(agent._custom_providers)
+        if hasattr(agent, "_custom_providers")
+        else _MISSING
+    )
     # Snapshot the credential pool reference so a failed client rebuild can
     # restore the original pool (issue #52727: pool reload is part of this
     # switch and must be reversible on rollback).
@@ -2668,10 +2707,26 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     def _restore_snapshot() -> None:
         for _name, _value in _snapshot.items():
             if _value is _MISSING:
-                # Attribute did not exist before the swap — don't fabricate it.
+                # Remove anything the failed transaction created when the
+                # attribute did not exist before the swap.
+                try:
+                    delattr(agent, _name)
+                except AttributeError:
+                    pass
                 continue
             try:
-                setattr(agent, _name, _value)
+                setattr(
+                    agent,
+                    _name,
+                    copy.deepcopy(_value)
+                    if _name in {
+                        "_client_kwargs",
+                        "request_overrides",
+                        "_custom_provider_extra_body",
+                        "_custom_providers",
+                    }
+                    else _value,
+                )
             except Exception:  # noqa: BLE001
                 pass
 
@@ -2715,6 +2770,31 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent._transport_cache.clear()
         if api_key:
             agent.api_key = api_key
+
+        # Provider-scoped extra_body defaults must follow the destination
+        # route. Refresh live config once; if that read fails, the cached
+        # catalog still lets us remove proven source-owned values safely.
+        try:
+            from hermes_cli.config import (
+                get_compatible_custom_providers,
+                load_config_readonly,
+            )
+
+            _sm_custom_providers = get_compatible_custom_providers(
+                load_config_readonly()
+            )
+        except Exception:
+            logger.debug(
+                "custom-provider override catalog refresh skipped on switch_model",
+                exc_info=True,
+            )
+            _sm_custom_providers = copy.deepcopy(
+                getattr(agent, "_custom_providers", None) or []
+            )
+        agent._custom_providers = _sm_custom_providers
+        from agent.agent_init import _merge_custom_provider_extra_body
+
+        _merge_custom_provider_extra_body(agent, _sm_custom_providers)
 
         # ── Reload credential pool for the new provider (issue #52727) ──
         # Without this, ``recover_with_credential_pool`` sees a
@@ -2847,16 +2927,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         raise
 
     # ── LM Studio: preload before probing context length ──
-    _sm_custom_providers = None
     try:
         from hermes_cli.config import (
-            get_compatible_custom_providers,
             get_custom_provider_context_length,
-            load_config,
         )
 
-        _sm_cfg = load_config()
-        _sm_custom_providers = get_compatible_custom_providers(_sm_cfg)
         _destination_context_intent = get_custom_provider_context_length(
             model=agent.model,
             base_url=agent.base_url,
@@ -2967,6 +3042,12 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        "request_overrides": copy.deepcopy(
+            getattr(agent, "request_overrides", {}) or {}
+        ),
+        "custom_provider_extra_body": copy.deepcopy(
+            getattr(agent, "_custom_provider_extra_body", {}) or {}
+        ),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         "reasoning_config": dict(agent.reasoning_config) if getattr(agent, "reasoning_config", None) else None,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2656,6 +2656,15 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             agent._transport_cache.clear()
         agent._fallback_activated = True
 
+        # Provider-scoped custom extra_body defaults belong to the route that
+        # produced them. Remove only unchanged source-owned values and apply
+        # the fallback destination's defaults before building its request.
+        from agent.agent_init import _merge_custom_provider_extra_body
+
+        _merge_custom_provider_extra_body(
+            agent, getattr(agent, "_custom_providers", None) or []
+        )
+
         # Rebind the credential pool to the fallback provider when the provider
         # changes.  Keeping the primary pool attached would make downstream
         # recovery (rate_limit / billing / auth) mutate the wrong credential

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -1,4 +1,6 @@
+import sys
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from agent.agent_init import _merge_custom_provider_extra_body
 
@@ -38,6 +40,7 @@ def test_custom_provider_extra_body_preserves_caller_override():
         "reasoning_effort": "low",
         "caller_only": True,
     }
+    assert agent._custom_provider_extra_body == {"enable_thinking": True}
 
 
 
@@ -71,3 +74,216 @@ def test_named_custom_provider_extra_body_matches_provider_key():
     )
 
     assert agent.request_overrides == {"extra_body": {"enable_thinking": False}}
+
+
+def test_custom_to_native_removes_only_provider_owned_extra_body():
+    providers = [
+        {
+            "provider_key": "ollama-local",
+            "base_url": "http://localhost:11434/v1",
+            "model": "qwen3.5",
+            "extra_body": {"think": False, "num_ctx": 65536},
+        }
+    ]
+    agent = SimpleNamespace(
+        provider="custom:ollama-local",
+        requested_provider="custom:ollama-local",
+        model="qwen3.5",
+        base_url="http://localhost:11434/v1",
+        request_overrides={
+            "service_tier": "priority",
+            "extra_body": {"caller_only": True},
+        },
+    )
+
+    _merge_custom_provider_extra_body(agent, providers)
+    assert agent._custom_provider_extra_body == {"think": False, "num_ctx": 65536}
+
+    agent.provider = "openai-codex"
+    agent.requested_provider = "openai-codex"
+    agent.model = "gpt-5.6"
+    agent.base_url = "https://chatgpt.com/backend-api/codex/responses"
+    _merge_custom_provider_extra_body(agent, providers)
+
+    assert agent.request_overrides == {
+        "service_tier": "priority",
+        "extra_body": {"caller_only": True},
+    }
+    assert agent._custom_provider_extra_body == {}
+
+
+def test_custom_a_to_b_replaces_defaults_and_preserves_caller_collision():
+    providers = [
+        {
+            "provider_key": "a",
+            "base_url": "https://a.test/v1",
+            "model": "model-a",
+            "extra_body": {"think": False, "shared": "a"},
+        },
+        {
+            "provider_key": "b",
+            "base_url": "https://b.test/v1",
+            "model": "model-b",
+            "extra_body": {"enable_thinking": True, "shared": "b"},
+        },
+    ]
+    agent = SimpleNamespace(
+        provider="custom",
+        requested_provider="custom:a",
+        model="model-a",
+        base_url="https://a.test/v1",
+        request_overrides={"extra_body": {"shared": "caller", "caller_only": 1}},
+    )
+
+    _merge_custom_provider_extra_body(agent, providers)
+    assert agent.request_overrides["extra_body"] == {
+        "think": False,
+        "shared": "caller",
+        "caller_only": 1,
+    }
+    assert agent._custom_provider_extra_body == {"think": False}
+
+    # Live switches may carry the configured provider key as a bare identity.
+    agent.provider = "b"
+    agent.requested_provider = "b"
+    agent.model = "model-b"
+    agent.base_url = "https://b.test/v1"
+    _merge_custom_provider_extra_body(agent, providers)
+
+    assert agent.request_overrides["extra_body"] == {
+        "enable_thinking": True,
+        "shared": "caller",
+        "caller_only": 1,
+    }
+    assert agent._custom_provider_extra_body == {"enable_thinking": True}
+
+
+def test_equal_value_caller_collision_is_never_provider_owned():
+    providers = [
+        {
+            "provider_key": "local",
+            "base_url": "http://localhost:11434/v1",
+            "extra_body": {"think": False},
+        }
+    ]
+    agent = SimpleNamespace(
+        provider="custom:local",
+        requested_provider="custom:local",
+        model="qwen",
+        base_url="http://localhost:11434/v1",
+        request_overrides={"extra_body": {"think": False}},
+    )
+
+    _merge_custom_provider_extra_body(agent, providers)
+    assert agent._custom_provider_extra_body == {}
+
+    agent.provider = "openai-codex"
+    agent.requested_provider = "openai-codex"
+    agent.base_url = "https://chatgpt.com/backend-api/codex/responses"
+    _merge_custom_provider_extra_body(agent, providers)
+
+    assert agent.request_overrides == {"extra_body": {"think": False}}
+
+
+def test_changed_provider_owned_value_becomes_caller_owned():
+    providers = [
+        {
+            "provider_key": "local",
+            "base_url": "http://localhost:11434/v1",
+            "extra_body": {"num_ctx": 65536},
+        }
+    ]
+    agent = SimpleNamespace(
+        provider="custom:local",
+        requested_provider="custom:local",
+        model="qwen",
+        base_url="http://localhost:11434/v1",
+        request_overrides={},
+    )
+
+    _merge_custom_provider_extra_body(agent, providers)
+    assert agent._custom_provider_extra_body == {"num_ctx": 65536}
+    agent.request_overrides["extra_body"]["num_ctx"] = 32768
+
+    agent.provider = "openai-codex"
+    agent.requested_provider = "openai-codex"
+    agent.base_url = "https://chatgpt.com/backend-api/codex/responses"
+    _merge_custom_provider_extra_body(agent, providers)
+
+    assert agent.request_overrides == {"extra_body": {"num_ctx": 32768}}
+    assert agent._custom_provider_extra_body == {}
+
+
+def test_native_provider_identity_wins_over_colliding_custom_name():
+    providers = [
+        {
+            "provider_key": "openrouter",
+            "name": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "extra_body": {"think": True},
+        }
+    ]
+    agent = SimpleNamespace(
+        provider="openrouter",
+        requested_provider="openrouter",
+        model="some-model",
+        base_url="https://openrouter.ai/api/v1",
+        request_overrides={},
+    )
+
+    _merge_custom_provider_extra_body(agent, providers)
+
+    assert agent.request_overrides == {}
+    assert agent._custom_provider_extra_body == {}
+
+
+def test_catalog_import_failure_cannot_turn_native_name_into_custom_route():
+    providers = [
+        {
+            "provider_key": "openrouter",
+            "name": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "extra_body": {"think": True},
+        }
+    ]
+    agent = SimpleNamespace(
+        provider="openrouter",
+        requested_provider="openrouter",
+        model="some-model",
+        base_url="https://openrouter.ai/api/v1",
+        request_overrides={},
+    )
+
+    with patch.dict(sys.modules, {"hermes_cli.models": None}):
+        _merge_custom_provider_extra_body(agent, providers)
+
+    assert agent.request_overrides == {}
+    assert agent._custom_provider_extra_body == {}
+
+
+def test_nested_provider_fields_are_removed_without_losing_caller_fields():
+    agent = SimpleNamespace(
+        provider="openai-codex",
+        requested_provider="openai-codex",
+        model="gpt-5.5",
+        base_url="https://chatgpt.com/backend-api/codex",
+        request_overrides={
+            "extra_body": {
+                "options": {
+                    "mode": "a",
+                    "num_ctx": 65536,
+                    "caller_flag": True,
+                }
+            }
+        },
+        _custom_provider_extra_body={
+            "options": {"mode": "a", "num_ctx": 65536}
+        },
+    )
+
+    _merge_custom_provider_extra_body(agent, [])
+
+    assert agent.request_overrides == {
+        "extra_body": {"options": {"caller_flag": True}}
+    }
+    assert agent._custom_provider_extra_body == {}

--- a/tests/run_agent/test_fallback_request_overrides.py
+++ b/tests/run_agent/test_fallback_request_overrides.py
@@ -1,0 +1,302 @@
+"""Regression tests for provider-scoped overrides across fallback routes."""
+
+import copy
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _client(base_url, api_key="fallback-key"):
+    client = MagicMock()
+    client.base_url = base_url
+    client.api_key = api_key
+    return client
+
+
+def _make_agent(*, source_provider, source_model, source_url, overrides, owned, providers, chain):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="source-key",
+            base_url=source_url,
+            provider=source_provider,
+            model=source_model,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=chain,
+        )
+    agent.client = MagicMock(name="source-client")
+    agent.provider = source_provider
+    agent.requested_provider = source_provider
+    agent.model = source_model
+    agent.base_url = source_url
+    agent.api_mode = "chat_completions"
+    agent._client_kwargs = {"api_key": "source-key", "base_url": source_url}
+    agent.request_overrides = copy.deepcopy(overrides)
+    agent._custom_provider_extra_body = copy.deepcopy(owned)
+    agent._custom_providers = copy.deepcopy(providers)
+    agent._primary_runtime.update(
+        {
+            "model": source_model,
+            "provider": source_provider,
+            "requested_provider": source_provider,
+            "base_url": source_url,
+            "api_mode": "chat_completions",
+            "api_key": "source-key",
+            "client_kwargs": dict(agent._client_kwargs),
+            "request_overrides": copy.deepcopy(overrides),
+            "custom_provider_extra_body": copy.deepcopy(owned),
+        }
+    )
+    agent._fallback_chain = copy.deepcopy(chain)
+    agent._fallback_index = 0
+    agent._fallback_activated = False
+    agent._unavailable_fallback_keys = set()
+    agent._rate_limited_until = 0
+    return agent
+
+
+def _activate(agent, clients):
+    with (
+        patch(
+            "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+            return_value=None,
+        ),
+        patch("agent.auxiliary_client.resolve_provider_client", side_effect=clients),
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch(
+            "hermes_cli.model_normalize.normalize_model_for_provider",
+            side_effect=lambda model, _provider: model,
+        ),
+    ):
+        return agent._try_activate_fallback()
+
+
+def test_custom_primary_to_native_fallback_removes_only_provider_owned_fields():
+    providers = [
+        {
+            "provider_key": "ollama-local",
+            "name": "ollama-local",
+            "base_url": "http://localhost:11434/v1",
+            "model": "qwen",
+            "extra_body": {"think": False, "num_ctx": 65536},
+        }
+    ]
+    chain = [{"provider": "openai-codex", "model": "gpt-5.6"}]
+    agent = _make_agent(
+        source_provider="custom:ollama-local",
+        source_model="qwen",
+        source_url="http://localhost:11434/v1",
+        overrides={
+            "service_tier": "priority",
+            "extra_body": {"think": False, "num_ctx": 65536, "caller_only": True},
+        },
+        owned={"think": False, "num_ctx": 65536},
+        providers=providers,
+        chain=chain,
+    )
+
+    assert _activate(
+        agent,
+        [(_client("https://chatgpt.com/backend-api/codex/responses"), "gpt-5.6")],
+    ) is True
+
+    assert agent.request_overrides == {
+        "service_tier": "priority",
+        "extra_body": {"caller_only": True},
+    }
+    assert agent._custom_provider_extra_body == {}
+
+
+def test_native_primary_to_custom_fallback_applies_destination_defaults():
+    providers = [
+        {
+            "provider_key": "b",
+            "name": "b",
+            "base_url": "https://b.test/v1",
+            "model": "model-b",
+            "extra_body": {"enable_thinking": True},
+        }
+    ]
+    chain = [
+        {
+            "provider": "custom:b",
+            "model": "model-b",
+            "base_url": "https://b.test/v1",
+        }
+    ]
+    agent = _make_agent(
+        source_provider="openrouter",
+        source_model="openai/gpt-5",
+        source_url="https://openrouter.ai/api/v1",
+        overrides={"extra_body": {"caller_only": 1}},
+        owned={},
+        providers=providers,
+        chain=chain,
+    )
+
+    assert _activate(agent, [(_client("https://b.test/v1"), "model-b")]) is True
+
+    assert agent.request_overrides == {
+        "extra_body": {"enable_thinking": True, "caller_only": 1}
+    }
+    assert agent._custom_provider_extra_body == {"enable_thinking": True}
+
+
+def test_fallback_chain_rebases_custom_a_to_b_to_native():
+    providers = [
+        {
+            "provider_key": "a",
+            "name": "a",
+            "base_url": "https://a.test/v1",
+            "model": "model-a",
+            "extra_body": {"mode_a": True},
+        },
+        {
+            "provider_key": "b",
+            "name": "b",
+            "base_url": "https://b.test/v1",
+            "model": "model-b",
+            "extra_body": {"mode_b": True},
+        },
+    ]
+    chain = [
+        {"provider": "custom:b", "model": "model-b", "base_url": "https://b.test/v1"},
+        {"provider": "openai-codex", "model": "gpt-5.6"},
+    ]
+    agent = _make_agent(
+        source_provider="custom:a",
+        source_model="model-a",
+        source_url="https://a.test/v1",
+        overrides={"extra_body": {"mode_a": True, "caller_only": 1}},
+        owned={"mode_a": True},
+        providers=providers,
+        chain=chain,
+    )
+
+    assert _activate(agent, [(_client("https://b.test/v1"), "model-b")]) is True
+    assert agent.request_overrides == {
+        "extra_body": {"mode_b": True, "caller_only": 1}
+    }
+    assert _activate(
+        agent,
+        [(_client("https://chatgpt.com/backend-api/codex/responses"), "gpt-5.6")],
+    ) is True
+    assert agent.request_overrides == {"extra_body": {"caller_only": 1}}
+    assert agent._custom_provider_extra_body == {}
+
+
+def test_primary_restore_recovers_exact_override_state():
+    providers = [
+        {
+            "provider_key": "a",
+            "name": "a",
+            "base_url": "https://a.test/v1",
+            "model": "model-a",
+            "extra_body": {"mode_a": True},
+        }
+    ]
+    primary_overrides = {
+        "service_tier": "priority",
+        "extra_body": {"mode_a": True, "caller_only": 1},
+    }
+    agent = _make_agent(
+        source_provider="custom:a",
+        source_model="model-a",
+        source_url="https://a.test/v1",
+        overrides=primary_overrides,
+        owned={"mode_a": True},
+        providers=providers,
+        chain=[{"provider": "openai-codex", "model": "gpt-5.6"}],
+    )
+
+    assert _activate(
+        agent,
+        [(_client("https://chatgpt.com/backend-api/codex/responses"), "gpt-5.6")],
+    ) is True
+    agent._rate_limited_until = 0
+    with (
+        patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+        patch("agent.credential_pool.load_pool", return_value=None),
+    ):
+        assert agent._restore_primary_runtime() is True
+
+    assert agent.request_overrides == primary_overrides
+    assert agent._custom_provider_extra_body == {"mode_a": True}
+
+
+def test_legacy_primary_snapshot_without_override_keys_rebases_safely():
+    providers = [
+        {
+            "provider_key": "a",
+            "name": "a",
+            "base_url": "https://a.test/v1",
+            "model": "model-a",
+            "extra_body": {"mode_a": True},
+        }
+    ]
+    agent = _make_agent(
+        source_provider="custom:a",
+        source_model="model-a",
+        source_url="https://a.test/v1",
+        overrides={"extra_body": {"mode_a": True, "caller": 1}},
+        owned={"mode_a": True},
+        providers=providers,
+        chain=[],
+    )
+    agent._primary_runtime.pop("request_overrides")
+    agent._primary_runtime.pop("custom_provider_extra_body")
+    agent._fallback_activated = True
+    agent.request_overrides = {"extra_body": {"mode_b": True, "caller": 1}}
+    agent._custom_provider_extra_body = {"mode_b": True}
+
+    with (
+        patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+        patch("agent.credential_pool.load_pool", return_value=None),
+    ):
+        assert agent._restore_primary_runtime() is True
+
+    assert agent.request_overrides == {
+        "extra_body": {"mode_a": True, "caller": 1}
+    }
+    assert agent._custom_provider_extra_body == {"mode_a": True}
+
+
+def test_transient_primary_recovery_restores_override_snapshot():
+    providers = [
+        {
+            "provider_key": "a",
+            "name": "a",
+            "base_url": "https://a.test/v1",
+            "model": "model-a",
+            "extra_body": {"mode_a": True},
+        }
+    ]
+    primary = {"extra_body": {"mode_a": True, "caller": 1}}
+    agent = _make_agent(
+        source_provider="custom:a",
+        source_model="model-a",
+        source_url="https://a.test/v1",
+        overrides=primary,
+        owned={"mode_a": True},
+        providers=providers,
+        chain=[],
+    )
+    agent.request_overrides = {"extra_body": {"stale": True}}
+    agent._custom_provider_extra_body = {"stale": True}
+    error = type("ConnectError", (Exception,), {})("temporary")
+
+    with (
+        patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+        patch("agent.agent_runtime_helpers.time.sleep", return_value=None),
+    ):
+        assert agent._try_recover_primary_transport(
+            error, retry_count=3, max_retries=3
+        ) is True
+
+    assert agent.request_overrides == primary
+    assert agent._custom_provider_extra_body == {"mode_a": True}

--- a/tests/run_agent/test_switch_model_request_overrides.py
+++ b/tests/run_agent/test_switch_model_request_overrides.py
@@ -1,0 +1,240 @@
+"""Regression tests for provider-scoped overrides during live model switches."""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+OLLAMA_URL = "http://localhost:11434/v1"
+CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
+
+
+def _make_agent(*, provider, requested_provider, model, base_url, overrides, owned, providers):
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = provider
+    agent.requested_provider = requested_provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.api_key = "source-key"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock(name="source-client")
+    agent._client_kwargs = {"api_key": "source-key", "base_url": base_url}
+    agent.request_overrides = overrides
+    agent._custom_provider_extra_body = owned
+    agent._custom_providers = providers
+    agent.context_compressor = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = None
+    agent._anthropic_client = None
+    agent._is_anthropic_oauth = False
+    agent._cached_system_prompt = "cached"
+    agent._primary_runtime = {}
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._config_context_length = None
+    agent._credential_pool = None
+    agent._credential_pool_entry_id = None
+    agent._transport_cache = {}
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent.reasoning_config = None
+    agent._consecutive_stale_streams = 0
+    agent._create_openai_client = MagicMock(return_value=MagicMock(name="destination-client"))
+    agent._apply_client_headers_for_base_url = MagicMock()
+    agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
+    agent._ensure_lmstudio_runtime_loaded = MagicMock(return_value=None)
+    agent._lmstudio_load_was_unverified = MagicMock(return_value=False)
+    agent._effective_lmstudio_context_length = MagicMock(return_value=None)
+    return agent
+
+
+def _switch(agent, providers, *, model, provider, base_url):
+    cfg = {"custom_providers": providers, "agent": {}}
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value=cfg),
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+    ):
+        agent.switch_model(
+            new_model=model,
+            new_provider=provider,
+            api_key="destination-key",
+            base_url=base_url,
+            api_mode="codex_responses" if provider == "openai-codex" else "chat_completions",
+        )
+
+
+def test_ollama_to_codex_drops_provider_fields_but_preserves_caller_overrides():
+    providers = [
+        {
+            "provider_key": "ollama-local",
+            "base_url": OLLAMA_URL,
+            "model": "qwen3.5",
+            "extra_body": {"think": False, "num_ctx": 65536},
+        }
+    ]
+    agent = _make_agent(
+        provider="custom:ollama-local",
+        requested_provider="custom:ollama-local",
+        model="qwen3.5",
+        base_url=OLLAMA_URL,
+        overrides={
+            "service_tier": "priority",
+            "extra_body": {"think": False, "num_ctx": 65536, "caller_only": True},
+        },
+        owned={"think": False, "num_ctx": 65536},
+        providers=providers,
+    )
+
+    _switch(agent, providers, model="gpt-5.6", provider="openai-codex", base_url=CODEX_URL)
+
+    assert agent.provider == "openai-codex"
+    assert agent.request_overrides == {
+        "service_tier": "priority",
+        "extra_body": {"caller_only": True},
+    }
+    assert agent._custom_provider_extra_body == {}
+
+
+def test_switch_between_named_custom_providers_replaces_provider_defaults():
+    providers = [
+        {
+            "provider_key": "a",
+            "name": "a",
+            "base_url": "https://a.test/v1",
+            "model": "model-a",
+            "extra_body": {"think": False},
+        },
+        {
+            "provider_key": "b",
+            "name": "b",
+            "base_url": "https://b.test/v1",
+            "model": "model-b",
+            "extra_body": {"enable_thinking": True},
+        },
+    ]
+    agent = _make_agent(
+        provider="custom:a",
+        requested_provider="custom:a",
+        model="model-a",
+        base_url="https://a.test/v1",
+        overrides={"extra_body": {"think": False, "caller_only": 1}},
+        owned={"think": False},
+        providers=providers,
+    )
+
+    _switch(agent, providers, model="model-b", provider="b", base_url="https://b.test/v1")
+
+    assert agent.request_overrides == {
+        "extra_body": {"enable_thinking": True, "caller_only": 1}
+    }
+    assert agent._custom_provider_extra_body == {"enable_thinking": True}
+
+
+def test_same_custom_endpoint_model_switch_refreshes_model_defaults():
+    providers = [
+        {
+            "provider_key": "local",
+            "name": "local",
+            "base_url": "https://shared.test/v1",
+            "model": "model-a",
+            "extra_body": {"mode_a": True},
+        },
+        {
+            "provider_key": "local",
+            "name": "local",
+            "base_url": "https://shared.test/v1",
+            "model": "model-b",
+            "extra_body": {"mode_b": True},
+        },
+    ]
+    agent = _make_agent(
+        provider="custom:local",
+        requested_provider="custom:local",
+        model="model-a",
+        base_url="https://shared.test/v1",
+        overrides={"extra_body": {"mode_a": True}},
+        owned={"mode_a": True},
+        providers=providers,
+    )
+
+    _switch(
+        agent,
+        providers,
+        model="model-b",
+        provider="custom:local",
+        base_url="https://shared.test/v1",
+    )
+
+    assert agent.request_overrides == {"extra_body": {"mode_b": True}}
+    assert agent._custom_provider_extra_body == {"mode_b": True}
+
+
+def test_primary_runtime_override_snapshot_is_independent():
+    providers = [
+        {
+            "provider_key": "ollama-local",
+            "base_url": OLLAMA_URL,
+            "model": "qwen3.5",
+            "extra_body": {"num_ctx": 65536},
+        }
+    ]
+    agent = _make_agent(
+        provider="custom:ollama-local",
+        requested_provider="custom:ollama-local",
+        model="qwen3.5",
+        base_url=OLLAMA_URL,
+        overrides={"extra_body": {"num_ctx": 65536}},
+        owned={"num_ctx": 65536},
+        providers=providers,
+    )
+
+    _switch(agent, providers, model="gpt-5.6", provider="openai-codex", base_url=CODEX_URL)
+
+    assert agent._primary_runtime["request_overrides"] == agent.request_overrides
+    assert agent._primary_runtime["custom_provider_extra_body"] == {}
+    agent.request_overrides.setdefault("extra_body", {})["later"] = True
+    agent._custom_provider_extra_body["later"] = True
+    assert "later" not in agent._primary_runtime["request_overrides"].get("extra_body", {})
+    assert "later" not in agent._primary_runtime["custom_provider_extra_body"]
+
+
+def test_config_refresh_failure_still_removes_source_owned_fields():
+    providers = [
+        {
+            "provider_key": "ollama-local",
+            "base_url": OLLAMA_URL,
+            "model": "qwen3.5",
+            "extra_body": {"think": False, "num_ctx": 65536},
+        }
+    ]
+    agent = _make_agent(
+        provider="custom:ollama-local",
+        requested_provider="custom:ollama-local",
+        model="qwen3.5",
+        base_url=OLLAMA_URL,
+        overrides={"extra_body": {"think": False, "num_ctx": 65536, "caller": 1}},
+        owned={"think": False, "num_ctx": 65536},
+        providers=providers,
+    )
+    cfg = {"custom_providers": providers, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config_readonly", side_effect=OSError("unreadable")),
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+    ):
+        agent.switch_model(
+            new_model="gpt-5.6",
+            new_provider="openai-codex",
+            api_key="destination-key",
+            base_url=CODEX_URL,
+            api_mode="codex_responses",
+        )
+
+    assert agent.request_overrides == {"extra_body": {"caller": 1}}
+    assert agent._custom_provider_extra_body == {}

--- a/tests/run_agent/test_switch_model_rollback.py
+++ b/tests/run_agent/test_switch_model_rollback.py
@@ -34,6 +34,12 @@ def _make_agent_openrouter():
         "api_key": "or-key-original",
         "base_url": "https://openrouter.ai/api/v1",
     }
+    agent.request_overrides = {
+        "service_tier": "priority",
+        "extra_body": {"source_owned": True, "caller_only": 1},
+    }
+    agent._custom_provider_extra_body = {"source_owned": True}
+    agent._custom_providers = []
     agent.context_compressor = None
     agent._anthropic_api_key = ""
     agent._anthropic_base_url = None
@@ -83,6 +89,11 @@ def test_openai_client_rebuild_failure_rolls_back_to_original_state():
 
     original_client = agent.client
     original_kwargs = dict(agent._client_kwargs)
+    original_overrides = {
+        "service_tier": "priority",
+        "extra_body": {"source_owned": True, "caller_only": 1},
+    }
+    original_owned = {"source_owned": True}
 
     # _create_openai_client raises mid-swap (simulates bad key / network error)
     def boom(*_a, **_kw):
@@ -108,6 +119,8 @@ def test_openai_client_rebuild_failure_rolls_back_to_original_state():
     assert agent.api_key == "or-key-original"
     assert agent.client is original_client
     assert agent._client_kwargs == original_kwargs
+    assert agent.request_overrides == original_overrides
+    assert agent._custom_provider_extra_body == original_owned
 
 
 def test_anthropic_client_rebuild_failure_rolls_back_to_original_state():
@@ -202,3 +215,32 @@ def test_successful_switch_still_works_after_rollback_refactor():
     assert agent.provider == "openrouter"
     assert agent.api_key == "or-key-new"
     assert agent.client is new_client
+
+
+def test_failure_does_not_fabricate_missing_override_metadata():
+    """Bare/legacy agents return to the exact missing-attribute shape."""
+    agent = _make_agent_openrouter()
+    for name in (
+        "request_overrides",
+        "_custom_provider_extra_body",
+        "_custom_providers",
+    ):
+        delattr(agent, name)
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("client build failed")
+
+    agent._create_openai_client = boom
+    with patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None):
+        with pytest.raises(RuntimeError, match="client build failed"):
+            agent.switch_model(
+                new_model="gpt-5.5",
+                new_provider="openai-codex",
+                api_key="new-key",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_mode="codex_responses",
+            )
+
+    assert not hasattr(agent, "request_overrides")
+    assert not hasattr(agent, "_custom_provider_extra_body")
+    assert not hasattr(agent, "_custom_providers")


### PR DESCRIPTION
## Summary

- Track custom-provider `extra_body` defaults with explicit, recursive provenance instead of leaving them in a long-lived unscoped `request_overrides` dict.
- Rebase only Hermes-owned provider defaults on live model switches, fallback-to-fallback transitions, primary restore, and transient primary recovery while preserving caller/session overrides.
- Make switch rollback restore both effective overrides and ownership metadata exactly, including the attribute-existence shape of legacy/bare agents.

## Problem

Custom-provider defaults are currently merged into `agent.request_overrides` during initialization. They survive route changes, so fields such as Ollama's `think` or `num_ctx` can reach an unrelated provider (for example `openai-codex`) and fail with `Unsupported parameter`.

Clearing all request overrides is not safe because it also deletes legitimate caller/session settings such as `service_tier` and caller-owned `extra_body` fields.

## Approach

`agent._custom_provider_extra_body` records only the nested leaves Hermes actually injected. On each provider transition the shared rebase helper:

1. removes a previously owned leaf only when its current value is still the injected value;
2. preserves changed/caller-owned leaves;
3. recursively applies the destination provider's defaults with caller precedence;
4. removes an empty `extra_body` container;
5. deep-copies effective state and provenance for snapshots/rollback.

Bare named custom-provider IDs remain supported, but cannot override a colliding native-provider identity. If the native provider catalog cannot be imported, bare identities fail closed and explicit `custom:<id>` remains available.

## Covered transitions

- custom provider -> native provider
- custom provider A -> custom provider B
- model A -> model B on the same custom endpoint
- primary -> fallback
- fallback -> fallback
- fallback -> primary restore
- transient primary transport recovery
- failed live switch rollback
- config-read failure using the cached provider catalog
- legacy runtime snapshots without the new metadata

## Related open PRs

This is a consolidated class-level fix informed by:

- #64633 — resets request overrides too broadly and can remove caller/session overrides;
- #75139 — covers fallback activation only;
- #86180 — keeps distinct named custom providers reachable and refreshes switch defaults, but does not cover provenance-safe caller preservation, rollback, fallback chains, or restore paths.

## Verification

- `30 passed` in the focused override/switch/fallback/rollback matrix.
- `66 passed` in nearby switch, fallback, credential, context, and restore suites.
- Regression test demonstrated to fail when the switch rebase helper is sabotaged to a no-op, then pass after restoration.
- Broad `tests/agent tests/run_agent` run completed with the same 14 failures in the same 10 files reproduced on the base commit; these are existing environment/dependency failures (primarily the optional Anthropic SDK is not installed), not new failures from this change.
- `git diff --check` and Python compilation passed.
- Two independent read-only reviews on exact HEAD `8890511ca761073b0e71f8d84838246c40ac504b`: spec review `PASS`; adversarial review `APPROVED`.
