### PR TITLE
docs(computer-use): note driver contract auto-repair at update and runtime

### DIFF
--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -63,9 +63,11 @@ on macOS/Linux, `install.ps1` on Windows. Use `hermes computer-use
 status` to verify the install.
 
 Already have cua-driver? Hermes reuses it when it supports the 0.20 runtime
-contract. During setup and toolset enablement, Hermes checks the local version
-and manifest. It repairs an old or incomplete standard installation through
-the upstream installer. A binary selected with `HERMES_CUA_DRIVER_CMD` stays
+contract. During setup, toolset enablement, `hermes update`, and the first
+`computer_use` call of a session, Hermes checks the local version and
+manifest. It repairs an old or incomplete standard installation through
+the upstream installer (at most once per session at runtime). A binary
+selected with `HERMES_CUA_DRIVER_CMD` stays
 under your control, so Hermes reports the incompatibility and leaves it
 unchanged.
 


### PR DESCRIPTION
## Summary
Docs follow-up to #87923: the Computer Use page now says the driver runtime-contract repair also runs during `hermes update` and once per session at the first `computer_use` call — previously it only mentioned setup and toolset enablement.

## Changes
- `website/docs/user-guide/features/computer-use.md`: one paragraph updated (repair trigger points + once-per-session runtime note).

## Validation
Docs-only; paragraph matches merged behavior in #87923 (`_maybe_repair_runtime_contract`, `install_cua_driver` upgrade-path repair).

## Infographic

![Docs coverage of driver auto-repair triggers](https://v3b.fal.media/files/b/0aa69bf0/E7RP5M0mv_0Rmfm1qFM9H_a71EvjHK.png)
