### PR TITLE
fix(desktop): stop electron-builder publish-detection crash and broken launcher icon

### DIFF
--- a/apps/desktop/scripts/run-electron-builder.mjs
+++ b/apps/desktop/scripts/run-electron-builder.mjs
@@ -37,7 +37,16 @@ function electronBuilderCli() {
 }
 
 const dist = electronDistDir()
-const args = []
+// Local `hermes desktop` builds only ever package (--dir or dist), never
+// publish a GitHub release — no CI workflow drives this script. But the npm
+// lifecycle env sets CI=1 (so esbuild's postinstall doesn't try interactive
+// animations), and electron-builder treats CI=1 as a signal to implicitly
+// resolve a publish target. That resolution reads <projectDir>/.git/config
+// directly — projectDir here is apps/desktop, which has no .git of its own
+// (only the repo root does) and no "repository" field in its package.json —
+// so it fails with "Cannot detect repository by .git/config". Pin publish to
+// "never" so electron-builder skips that lookup entirely.
+const args = ["--publish", "never"]
 if (dist && fs.existsSync(distBinary(dist))) {
   args.push(`-c.electronDist=${dist}`)
 } else {

--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -67,11 +67,50 @@ def resolve_exec_command() -> str:
     from hermes_cli.relaunch import resolve_hermes_bin
 
     bin_path = resolve_hermes_bin()
-    if bin_path:
+    if bin_path and not _needs_venv_reexec(bin_path):
         argv = [str(Path(bin_path).resolve()), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        # sys.executable is already documented as absolute — do not
+        # Path(...).resolve() it. A venv's python is commonly a *symlink*
+        # to the base interpreter (as it is here); resolving it dereferences
+        # that symlink and launches the base interpreter directly, which
+        # has no association with the venv's pyvenv.cfg and so can't see
+        # its site-packages — reintroducing the exact missing-dependency
+        # crash this fallback exists to avoid.
+        argv = [sys.executable, "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
+
+
+def _needs_venv_reexec(bin_path: str) -> bool:
+    """True when *bin_path* can't be launched standalone outside this venv.
+
+    The installed ``~/.local/bin/hermes`` launcher does
+    ``exec venv/bin/python /path/to/hermes "$@"``. Python always sets
+    ``sys.argv[0]`` to the *script* it was told to run, never the
+    interpreter that ran it, so ``resolve_hermes_bin()``'s argv0 fast-path
+    ends up returning that raw script — it's absolute and executable, so
+    it looks like a valid launcher. But its own shebang
+    (``#!/usr/bin/env python3``) resolves to whichever bare ``python3`` is
+    first on ``PATH``, not this venv. A desktop launcher runs with no shell
+    customizations, so that bare interpreter is missing Hermes's
+    dependencies and the app crashes on startup instead of launching
+    (#found via a broken "Hermes" taskbar icon).
+
+    Only python scripts outside the currently-running venv are suspect —
+    a console-script shim installed inside the venv, or a self-contained
+    binary (e.g. a nix store launcher) outside one, both work standalone.
+    """
+    if sys.prefix == sys.base_prefix:
+        return False  # not running inside a venv; argv0 needs no rewrite
+    resolved = os.path.realpath(bin_path)
+    if resolved.startswith(os.path.realpath(sys.prefix) + os.sep):
+        return False  # lives inside this venv already (e.g. a console script)
+    try:
+        with open(bin_path, "r", encoding="utf-8", errors="replace") as fh:
+            first_line = fh.readline()
+    except OSError:
+        return False
+    return first_line.startswith("#!") and "python" in first_line and sys.executable not in first_line
 
 
 def _quote_exec_arg(arg: str) -> str:


### PR DESCRIPTION
## What

Two related fixes uncovered while debugging a fresh reinstall on Linux where `hermes desktop` intermittently failed to build, and the installed launcher icon crashed on click even though the CLI (`hermes desktop`) worked fine.

### 1. `apps/desktop/scripts/run-electron-builder.mjs` — pin `--publish never`

`hermes desktop` sets `CI=1` for the npm lifecycle env (so esbuild's postinstall doesn't try interactive animations — see `_npm_lifecycle_env`). electron-builder treats `CI=1` as a signal to implicitly resolve a GitHub publish target. That resolution reads `<projectDir>/.git/config` directly, but `projectDir` for this packager is `apps/desktop`, which has no `.git` of its own (only the repo root does) and no `"repository"` field in its `package.json`. Result:

```
⨯ Cannot detect repository by .git/config. Please specify "repository" in the package.json
```

This build never actually publishes a release — no CI workflow drives this script, it's purely local packaging for `hermes desktop`. Pinning `--publish never` skips the whole resolution path.

### 2. `hermes_cli/linux_desktop_entry.py` — fix the generated `.desktop` `Exec=` line

`resolve_hermes_bin()` picks `sys.argv[0]` when it looks like a real executable. Under the installed `~/.local/bin/hermes` wrapper (which does `exec venv/bin/python /path/to/hermes "$@"`), Python sets `argv[0]` to that raw checkout script, not the wrapper — CPython always reports the script being run, not the binary that ran it. That script is absolute and executable, so `resolve_hermes_bin()` happily returns it — but its own shebang (`#!/usr/bin/env python3`) resolves to whatever `python3` is first on `PATH`, not the venv. A desktop launcher runs with no shell customizations, so that bare interpreter is missing Hermes's dependencies and the app crashes on startup instead of launching:

```
ModuleNotFoundError: No module named 'pathspec'
```

Added `_needs_venv_reexec()` to detect this specific situation (running inside a venv, resolved bin path outside it, python shebang that isn't the running interpreter) and fall back to invoking the currently-running interpreter as `python -m hermes_cli.main desktop` instead.

That fallback itself had a second, independent bug: it built the command with `Path(sys.executable).resolve()`. In this install, `venv/bin/python` is a *symlink* to the base interpreter — resolving it dereferences the symlink and launches the base interpreter directly, bypassing the venv's `pyvenv.cfg` and losing its site-packages entirely, reintroducing the same crash. `sys.executable` is already documented as absolute, so the fix just drops the `.resolve()` call.

## Verification

- `CI=1 npm run builder -- --dir` (in `apps/desktop`) completes cleanly with no "Implicit publishing triggered by CI detection" message at all.
- Full `hermes desktop --force-build` rebuilds and launches the packaged app successfully.
- The generated `Exec=` command (`<venv>/bin/python -m hermes_cli.main desktop`) runs clean start-to-finish under `env -i` (no `PATH`, no shell rc files) — the same conditions a desktop launcher invokes under — reaching `→ Launching packaged Hermes Desktop: .../linux-unpacked/Hermes` with no import errors.
- Re-ran `hermes desktop` a second time and confirmed the regenerated `.desktop` file stays correct (doesn't regress back to the broken form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)