### PR TITLE
feat(acp): support an explicit per-session toolset policy via namespaced session metadata

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -72,7 +72,12 @@ from acp_adapter.events import (
 )
 from acp_adapter.permissions import make_approval_callback
 from acp_adapter.provenance import session_provenance_meta
-from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
+from acp_adapter.session import (
+    SessionManager,
+    SessionState,
+    _expand_acp_enabled_toolsets,
+    _normalize_acp_toolsets,
+)
 from acp_adapter.tools import build_tool_complete, build_tool_start
 from agent.context_compressor import (
     COMPRESSED_SUMMARY_METADATA_KEY,
@@ -221,6 +226,15 @@ _TEXT_RESOURCE_MIME_TYPES = {
     "application/toml",
     "application/sql",
 }
+
+_PATROCLO_SESSION_TOOLSETS_META = "dev.patroclo/session-toolsets"
+
+
+def _session_toolsets_from_kwargs(kwargs: dict[str, Any]) -> list[str] | None:
+    """Read Patroclo's namespaced ACP metadata after the SDK merges it into kwargs."""
+    if _PATROCLO_SESSION_TOOLSETS_META not in kwargs:
+        return None
+    return _normalize_acp_toolsets(kwargs[_PATROCLO_SESSION_TOOLSETS_META])
 
 
 def _resource_display_name(uri: str, name: str | None = None, title: str | None = None) -> str:
@@ -1009,7 +1023,7 @@ class HermesACPAgent(acp.Agent):
             from agent.memory_manager import inject_memory_provider_tools
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
+                getattr(state.agent, "enabled_toolsets", None),
                 mcp_server_names=[server.name for server in mcp_servers],
             )
             state.agent.enabled_toolsets = enabled_toolsets
@@ -1438,7 +1452,8 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> NewSessionResponse:
-        state = self.session_manager.create_session(cwd=cwd)
+        toolsets = _session_toolsets_from_kwargs(kwargs)
+        state = self.session_manager.create_session(cwd=cwd, enabled_toolsets=toolsets)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
@@ -1460,7 +1475,10 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> LoadSessionResponse | None:
-        state = self.session_manager.update_cwd(session_id, cwd)
+        toolsets = _session_toolsets_from_kwargs(kwargs)
+        state = self.session_manager.update_cwd(
+            session_id, cwd, enabled_toolsets=toolsets
+        )
         if state is None:
             logger.warning("load_session: session %s not found", session_id)
             return None
@@ -2181,6 +2199,7 @@ class HermesACPAgent(acp.Agent):
             cwd=state.cwd,
             model=new_model,
             requested_provider=target_provider,
+            enabled_toolsets=state.enabled_toolsets,
         )
         self.session_manager.save_session(state.session_id)
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
@@ -2194,7 +2213,7 @@ class HermesACPAgent(acp.Agent):
             from agent.memory_manager import inject_memory_provider_tools
 
             toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
+                getattr(state.agent, "enabled_toolsets", None)
             )
             tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
             tool_view = SimpleNamespace(
@@ -2433,6 +2452,7 @@ class HermesACPAgent(acp.Agent):
                 requested_provider=requested_provider,
                 base_url=current_base_url,
                 api_mode=current_api_mode,
+                enabled_toolsets=state.enabled_toolsets,
             )
             self.session_manager.save_session(session_id)
             logger.info(

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -126,13 +126,36 @@ def _register_task_cwd(task_id: str, cwd: str) -> None:
         logger.debug("Failed to register ACP task cwd override", exc_info=True)
 
 
+def _normalize_acp_toolsets(toolsets: Any) -> List[str] | None:
+    """Validate an explicit per-session toolset policy; None means configured defaults."""
+    if toolsets is None:
+        return None
+    if not isinstance(toolsets, list) or len(toolsets) > 32:
+        raise ValueError("ACP toolsets must be a list of at most 32 names")
+    normalized: List[str] = []
+    for name in toolsets:
+        if not isinstance(name, str) or re.fullmatch(r"[A-Za-z0-9_.-]{1,64}", name) is None:
+            raise ValueError("invalid ACP toolset name")
+        if name not in normalized:
+            normalized.append(name)
+    return normalized
+
+
 def _expand_acp_enabled_toolsets(
     toolsets: List[str] | None = None,
     mcp_server_names: List[str] | None = None,
 ) -> List[str]:
     """Return ACP toolsets plus explicit MCP server toolsets for this session."""
     expanded: List[str] = []
-    for name in list(toolsets or ["hermes-acp"]):
+    # Internal call sites may hand us whatever lives on the agent object
+    # (including non-list sentinels from mocked agents in tests); only an
+    # actual list is a real per-session policy — anything else falls back
+    # to the configured default.
+    if isinstance(toolsets, list):
+        source = _normalize_acp_toolsets(toolsets)
+    else:
+        source = ["hermes-acp"]
+    for name in source:
         if name and name not in expanded:
             expanded.append(name)
 
@@ -170,6 +193,7 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    enabled_toolsets: List[str] | None = None
 
 
 class SessionManager:
@@ -196,19 +220,27 @@ class SessionManager:
 
     # ---- public API ---------------------------------------------------------
 
-    def create_session(self, cwd: str = ".") -> SessionState:
+    def create_session(
+        self,
+        cwd: str = ".",
+        enabled_toolsets: List[str] | None = None,
+    ) -> SessionState:
         """Create a new session with a unique ID and a fresh AIAgent."""
         import threading
 
         cwd = _translate_acp_cwd(cwd)
+        enabled_toolsets = _normalize_acp_toolsets(enabled_toolsets)
         session_id = str(uuid.uuid4())
-        agent = self._make_agent(session_id=session_id, cwd=cwd)
+        agent = self._make_agent(
+            session_id=session_id, cwd=cwd, enabled_toolsets=enabled_toolsets
+        )
         state = SessionState(
             session_id=session_id,
             agent=agent,
             cwd=cwd,
             model=getattr(agent, "model", "") or "",
             cancel_event=threading.Event(),
+            enabled_toolsets=enabled_toolsets,
         )
         with self._lock:
             self._sessions[session_id] = state
@@ -217,7 +249,9 @@ class SessionManager:
         logger.info("Created ACP session %s (cwd=%s)", session_id, cwd)
         return state
 
-    def get_session(self, session_id: str) -> Optional[SessionState]:
+    def get_session(
+        self, session_id: str, enabled_toolsets: List[str] | None = None
+    ) -> Optional[SessionState]:
         """Return the session for *session_id*, or ``None``.
 
         If the session is not in memory but exists in the database (e.g. after
@@ -226,9 +260,9 @@ class SessionManager:
         with self._lock:
             state = self._sessions.get(session_id)
         if state is not None:
-            return state
+            return self._apply_toolset_policy(state, enabled_toolsets)
         # Attempt to restore from database.
-        return self._restore(session_id)
+        return self._restore(session_id, enabled_toolsets=enabled_toolsets)
 
     def remove_session(self, session_id: str) -> bool:
         """Remove a session from memory and database. Returns True if it existed."""
@@ -253,6 +287,7 @@ class SessionManager:
             session_id=new_id,
             cwd=cwd,
             model=original.model or None,
+            enabled_toolsets=original.enabled_toolsets,
         )
         state = SessionState(
             session_id=new_id,
@@ -261,6 +296,7 @@ class SessionManager:
             model=getattr(agent, "model", original.model) or original.model,
             history=copy.deepcopy(original.history),
             cancel_event=threading.Event(),
+            enabled_toolsets=copy.deepcopy(original.enabled_toolsets),
         )
         with self._lock:
             self._sessions[new_id] = state
@@ -343,10 +379,13 @@ class SessionManager:
         results.sort(key=lambda item: _updated_at_sort_key(item.get("updated_at")), reverse=True)
         return results
 
-    def update_cwd(self, session_id: str, cwd: str) -> Optional[SessionState]:
+    def update_cwd(
+        self, session_id: str, cwd: str,
+        enabled_toolsets: List[str] | None = None,
+    ) -> Optional[SessionState]:
         """Update the working directory for a session and its tool overrides."""
         cwd = _translate_acp_cwd(cwd)
-        state = self.get_session(session_id)  # checks DB too
+        state = self.get_session(session_id, enabled_toolsets=enabled_toolsets)
         if state is None:
             return None
         state.cwd = cwd
@@ -422,6 +461,8 @@ class SessionManager:
         # Ensure model is a plain string (not a MagicMock or other proxy).
         model_str = str(state.model) if state.model else None
         session_meta = {"cwd": state.cwd}
+        if state.enabled_toolsets is not None:
+            session_meta["enabled_toolsets"] = list(state.enabled_toolsets)
         provider = getattr(state.agent, "provider", None)
         base_url = getattr(state.agent, "base_url", None)
         api_mode = getattr(state.agent, "api_mode", None)
@@ -441,7 +482,7 @@ class SessionManager:
                     session_id=state.session_id,
                     source="acp",
                     model=model_str,
-                    model_config={"cwd": state.cwd},
+                    model_config=session_meta,
                 )
             else:
                 # Update model_config (contains cwd) if changed.
@@ -495,7 +536,10 @@ class SessionManager:
         except Exception:
             logger.warning("Failed to persist ACP session %s", state.session_id, exc_info=True)
 
-    def _restore(self, session_id: str) -> Optional[SessionState]:
+    def _restore(
+        self, session_id: str,
+        enabled_toolsets: List[str] | None = None,
+    ) -> Optional[SessionState]:
         """Load a session from the database into memory, recreating the AIAgent."""
         import threading
 
@@ -521,6 +565,7 @@ class SessionManager:
         requested_provider = row.get("billing_provider")
         restored_base_url = row.get("billing_base_url")
         restored_api_mode = None
+        persisted_toolsets = None
         mc = row.get("model_config")
         if mc:
             try:
@@ -530,8 +575,12 @@ class SessionManager:
                     requested_provider = meta.get("provider") or requested_provider
                     restored_base_url = meta.get("base_url") or restored_base_url
                     restored_api_mode = meta.get("api_mode") or restored_api_mode
+                    persisted_toolsets = _normalize_acp_toolsets(meta.get("enabled_toolsets"))
             except (json.JSONDecodeError, TypeError):
                 pass
+            except ValueError:
+                logger.warning("Ignoring invalid persisted ACP toolset policy for %s", session_id)
+        effective_toolsets = _normalize_acp_toolsets(enabled_toolsets) if enabled_toolsets is not None else persisted_toolsets
 
         model = row.get("model") or None
 
@@ -556,6 +605,7 @@ class SessionManager:
                 requested_provider=requested_provider,
                 base_url=restored_base_url,
                 api_mode=restored_api_mode,
+                enabled_toolsets=effective_toolsets,
             )
         except Exception:
             logger.warning("Failed to recreate agent for ACP session %s", session_id, exc_info=True)
@@ -568,6 +618,7 @@ class SessionManager:
             model=model or getattr(agent, "model", "") or "",
             history=history,
             cancel_event=threading.Event(),
+            enabled_toolsets=effective_toolsets,
         )
         with self._lock:
             self._sessions[session_id] = state
@@ -588,6 +639,37 @@ class SessionManager:
 
     # ---- internal -----------------------------------------------------------
 
+    def _apply_toolset_policy(
+        self, state: SessionState, enabled_toolsets: List[str] | None
+    ) -> SessionState:
+        """Apply an explicit policy without letting an omitted field elevate a restricted session."""
+        if enabled_toolsets is None:
+            return state
+        normalized = _normalize_acp_toolsets(enabled_toolsets)
+        if state.enabled_toolsets == normalized:
+            return state
+        previous = state.agent
+        provider = getattr(previous, "provider", None)
+        base_url = getattr(previous, "base_url", None)
+        api_mode = getattr(previous, "api_mode", None)
+        state.agent = self._make_agent(
+            session_id=state.session_id,
+            cwd=state.cwd,
+            model=state.model or None,
+            requested_provider=provider if isinstance(provider, str) else None,
+            base_url=base_url if isinstance(base_url, str) else None,
+            api_mode=api_mode if isinstance(api_mode, str) else None,
+            enabled_toolsets=normalized,
+        )
+        state.enabled_toolsets = normalized
+        self._persist(state)
+        logger.info(
+            "Session %s: applied explicit ACP toolset policy (%d toolsets)",
+            state.session_id,
+            len(normalized),
+        )
+        return state
+
     def _make_agent(
         self,
         *,
@@ -597,6 +679,7 @@ class SessionManager:
         requested_provider: str | None = None,
         base_url: str | None = None,
         api_mode: str | None = None,
+        enabled_toolsets: List[str] | None = None,
     ):
         if self._agent_factory is not None:
             return self._agent_factory()
@@ -621,11 +704,12 @@ class SessionManager:
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
 
+        normalized_toolsets = _normalize_acp_toolsets(enabled_toolsets)
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
-                mcp_server_names=configured_mcp_servers,
+                normalized_toolsets,
+                mcp_server_names=configured_mcp_servers if normalized_toolsets is None else [],
             ),
             "quiet_mode": True,
             "session_id": session_id,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -58,6 +58,38 @@ def agent(mock_manager):
 
 
 @pytest.mark.asyncio
+async def test_new_session_honors_explicit_empty_patroclo_toolsets(agent):
+    resp = await agent.new_session(
+        cwd="/tmp",
+        **{"dev.patroclo/session-toolsets": []},
+    )
+    state = agent.session_manager.get_session(resp.session_id)
+    assert state.enabled_toolsets == []
+
+
+@pytest.mark.asyncio
+async def test_load_session_applies_and_persists_restricted_toolsets(agent):
+    resp = await agent.new_session(cwd="/tmp")
+    await agent.load_session(
+        cwd="/tmp",
+        session_id=resp.session_id,
+        **{"dev.patroclo/session-toolsets": []},
+    )
+    state = agent.session_manager.get_session(resp.session_id)
+    assert state.enabled_toolsets == []
+    # Omitting the extension later must not silently elevate the room session.
+    await agent.load_session(cwd="/tmp", session_id=resp.session_id)
+    assert agent.session_manager.get_session(resp.session_id).enabled_toolsets == []
+
+
+def test_explicit_empty_toolsets_do_not_expand_to_hermes_defaults():
+    from acp_adapter.session import _expand_acp_enabled_toolsets
+
+    assert _expand_acp_enabled_toolsets([]) == []
+    assert _expand_acp_enabled_toolsets(None) == ["hermes-acp"]
+
+
+@pytest.mark.asyncio
 async def test_new_session_exposes_edit_approvals_as_modes_not_config_options(agent):
     resp = await agent.new_session(cwd="/tmp")
 


### PR DESCRIPTION
## What

Lets an ACP client pin a session's toolsets explicitly at `session/new` / `session/load` via a namespaced `_meta` extension key (`dev.patroclo/session-toolsets`), instead of always receiving the configured defaults. An explicit empty list creates a session with **no built-in tools at all** — the client can then mount exactly the MCP servers it wants that session to have.

- `_normalize_acp_toolsets()` validates the list (bounded length, `[A-Za-z0-9_.-]{1,64}` names, deduped).
- The policy persists with the session and survives restore, `session/load`, model switches, and agent rebuilds.
- **Omitting the key on a later `session/load` does not silently re-elevate a restricted session** — omission means "no opinion", never "reset to defaults".
- Under an explicit policy, configured MCP servers are not auto-mounted; session-injected `mcpServers` still are.

## Why

Embedded clients (kiosks, wall panels, room assistants) open agent sessions that are reachable from surfaces the operator doesn't fully trust — a prompt-injected room session with `terminal`/`write_file` is a house-level security problem. Server-side enforcement matters because the client can't strip tools itself: it only sees tool calls after the fact. We've run this patch in production on a home-automation deployment for a month (and carry it as a local patch today — upstreaming so others get the same control and we stop re-porting it).

## Tests

`tests/acp/test_server.py`: explicit-empty honored on `session/new`; applied + persisted on `session/load` with omission-must-not-elevate; `_expand_acp_enabled_toolsets([]) == []` vs `None` → defaults. Full `tests/acp/test_server.py` suite passes (33/33).

## Naming

`dev.patroclo/session-toolsets` follows ACP's namespaced-extension convention from our deployment. Happy to rename to whatever you'd prefer (e.g. a first-class `toolsets` param or a `dev.nousresearch/*` key) — say the word and I'll update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)