### PR TITLE
fix(sessions): reclaim deleted-session data during vacuum

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -12689,6 +12689,43 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # table only exists (and is only queryable) when the loadable tokenizer
     # is present — so we probe each before touching it (see optimize_fts).
     _FTS_TABLES = ("messages_fts", "messages_fts_trigram", "messages_fts_cjk")
+    _ORPHAN_MESSAGE_GC_BATCH_SIZE = 10_000
+
+    def prune_orphaned_messages(
+        self, *, batch_size: Optional[int] = _ORPHAN_MESSAGE_GC_BATCH_SIZE
+    ) -> int:
+        """Delete one bounded batch of messages whose session no longer exists.
+
+        Current session deletion paths remove canonical messages before their
+        session row, but older Hermes versions did not. Those historical rows
+        keep both ``messages`` and its FTS5 indexes alive indefinitely. Deleting
+        from the canonical table deliberately lets the existing FTS triggers
+        remove the corresponding search entries.
+
+        ``batch_size`` bounds the write transaction so callers can use this on
+        large upgraded databases without one monolithic delete. Pass ``None``
+        to remove every orphan in one transaction. Returns the rows deleted.
+        """
+        if batch_size is not None:
+            batch_size = int(batch_size)
+            if batch_size <= 0:
+                return 0
+
+        def _do(conn):
+            limit_sql = " LIMIT ?" if batch_size is not None else ""
+            params = (batch_size,) if batch_size is not None else ()
+            cursor = conn.execute(
+                "DELETE FROM messages WHERE id IN ("
+                "SELECT m.id FROM messages m "
+                "WHERE NOT EXISTS ("
+                "SELECT 1 FROM sessions s WHERE s.id = m.session_id"
+                ") ORDER BY m.id"
+                f"{limit_sql})",
+                params,
+            )
+            return max(cursor.rowcount, 0)
+
+        return self._execute_write(_do) or 0
 
     def logical_size_bytes(self) -> Optional[int]:
         """Database size in bytes as SQLite itself accounts for it.
@@ -12732,13 +12769,30 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         active. Safe to call at startup before the gateway/CLI starts
         serving traffic.
 
-        FTS5 segments are merged first via :meth:`optimize_fts` so the
-        subsequent VACUUM reclaims the pages freed by the merge. This is a
-        layout-only optimization — search results are unchanged.
+        Historical orphan messages are garbage-collected in bounded
+        transactions first. FTS5 segments are then merged via
+        :meth:`optimize_fts` so the subsequent VACUUM reclaims the pages freed
+        by both steps. Search results for live sessions are unchanged.
 
         Returns the number of FTS indexes that were optimized (0 if the
         merge step failed or no FTS tables exist).
         """
+        # Use bounded transactions even though VACUUM itself is an offline,
+        # foreground operation. A legacy database can contain millions of
+        # orphan rows; one giant DELETE would create a correspondingly giant
+        # WAL transaction before VACUUM gets a chance to reclaim anything.
+        orphan_messages = 0
+        while True:
+            deleted = self.prune_orphaned_messages()
+            orphan_messages += deleted
+            if deleted < self._ORPHAN_MESSAGE_GC_BATCH_SIZE:
+                break
+        if orphan_messages:
+            logger.info(
+                "Garbage-collected %d orphaned message rows before VACUUM",
+                orphan_messages,
+            )
+
         # Merge FTS5 segments before VACUUM so the freed pages are returned
         # to the OS in the same pass. optimize_fts() manages its own lock.
         optimized = 0

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2593,6 +2593,53 @@ class TestStateMeta:
 
 
 class TestVacuum:
+    @staticmethod
+    def _orphan_session_messages(db, session_ids):
+        db._conn.commit()
+        db._conn.execute("PRAGMA foreign_keys = OFF")
+        try:
+            placeholders = ",".join("?" * len(session_ids))
+            db._conn.execute(
+                f"DELETE FROM sessions WHERE id IN ({placeholders})", session_ids
+            )
+            db._conn.commit()
+        finally:
+            db._conn.execute("PRAGMA foreign_keys = ON")
+
+    def test_orphan_message_gc_is_bounded_and_updates_fts(self, db):
+        for sid, content in (
+            ("dead-a", "ORPHANALPHA"),
+            ("dead-b", "ORPHANBRAVO"),
+            ("live", "SURVIVORCHARLIE"),
+        ):
+            db.create_session(session_id=sid, source="cli")
+            db.append_message(session_id=sid, role="user", content=content)
+        self._orphan_session_messages(db, ["dead-a", "dead-b"])
+
+        assert db.prune_orphaned_messages(batch_size=1) == 1
+        assert db._conn.execute(
+            "SELECT COUNT(*) FROM messages m "
+            "WHERE NOT EXISTS (SELECT 1 FROM sessions s WHERE s.id = m.session_id)"
+        ).fetchone()[0] == 1
+
+        assert db.prune_orphaned_messages(batch_size=1) == 1
+        assert db.prune_orphaned_messages(batch_size=1) == 0
+        assert db.search_messages("ORPHANALPHA") == []
+        assert db.search_messages("ORPHANBRAVO") == []
+        assert len(db.search_messages("SURVIVORCHARLIE")) == 1
+
+    def test_vacuum_garbage_collects_historical_orphan_messages(self, db):
+        db.create_session(session_id="dead", source="cli")
+        db.append_message(
+            session_id="dead", role="user", content="VACUUMORPHANNEEDLE"
+        )
+        self._orphan_session_messages(db, ["dead"])
+
+        db.vacuum()
+
+        assert db._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 0
+        assert db.search_messages("VACUUMORPHANNEEDLE") == []
+
     def test_vacuum_runs_without_error(self, db):
         """VACUUM must succeed on a fresh DB (no rows to reclaim)."""
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
## What does this PR do?

Deleted sessions can leave historical canonical messages and matching FTS rows behind in databases upgraded from older Hermes versions. Because existing vacuum maintenance only merged FTS segments and rewrote pages, those live orphan rows survived every maintenance pass and allowed `state.db` to retain unbounded deleted-session data. This change garbage-collects orphan messages through the canonical table in bounded batches before FTS optimization and VACUUM, so existing delete triggers clean all available search indexes while live session data remains intact.

### Symptom

After session deletion or pruning on affected upgraded databases, `messages` can still contain rows whose `session_id` no longer exists. Those rows remain searchable through FTS and continue occupying database pages even after `hermes sessions vacuum`.

### Impact

Operators can retain most of their historical message and FTS storage after deleting sessions. The reported deployment had 36,785 orphan messages across 1,383 deleted session IDs, accounting for 94% of its message rows in a 572 MB `state.db`.

### Bug Cause

**Trigger:** `hermes_state.py` / `SessionDB.vacuum()`

**Causal chain:**
1. Older session-deletion paths removed session rows without deleting their canonical messages.
2. Since no canonical `DELETE FROM messages` occurred, the existing FTS delete triggers never removed the corresponding index entries.
3. FTS optimization and VACUUM preserved those still-live orphan rows, so deleted-session data and index entries remained on disk.

**Why it is wrong:** Vacuum maintenance optimized storage layout but did not remove historical rows that no longer had an owning session.

**Working sibling / contrast:** Current `delete_session`, bulk delete, empty-session cleanup, and prune paths delete canonical messages transactionally before deleting sessions, so future deletion through those paths already fires the FTS triggers.

**Ruled out:** FTS segment fragmentation alone was not the cause because the canonical orphan messages still existed; optimizing or vacuuming cannot reclaim live rows.

### Fix

Add `prune_orphaned_messages()` to delete canonical orphan rows in deterministic batches of 10,000, then run it to completion before the existing FTS optimization and VACUUM steps. Canonical deletion reuses existing FTS triggers instead of modifying shadow tables directly. Tests cover bounded batches, live-message preservation, FTS cleanup, and vacuum integration.

## Related Issue

Closes #87928

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` - add bounded orphan-message garbage collection and invoke it before FTS optimization and VACUUM.
- `tests/test_hermes_state.py` - verify batch bounds, survivor preservation, FTS deletion, and vacuum cleanup.

## How to Test

1. Create live and legacy-orphan message rows in an isolated `SessionDB`.
2. Run `prune_orphaned_messages()` or `vacuum()` and verify orphan canonical and FTS rows disappear while live rows and search hits remain.
3. Run the related test suite:

```bash
scripts/run_tests.sh tests/test_hermes_state.py
scripts/run_tests.sh tests/test_wal_checkpoint.py
```

Local results: 239 passed and 2 skipped for `tests/test_hermes_state.py`; 8 WAL checkpoint tests passed. A real SQLite/FTS probe also verified batches of 10,000 plus 1 over 10,001 orphan rows with clean integrity checks.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A because this changes internal database maintenance behavior without changing the user interface.
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed.
- [x] I've considered cross-platform impact; the implementation uses portable SQLite SQL and existing `SessionDB` locking and write paths.
- [x] Tool description/schema updates are N/A because no model tool changed.

## Screenshots / Logs

N/A - verified through automated tests and an isolated real SQLite/FTS database probe.
