### PR TITLE
feat(memory): let users control background review saves

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -69,6 +69,13 @@ def _background_review_task_config(
     return task if isinstance(task, dict) else {}
 
 
+def _memory_review_config(task_cfg: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return the nested memory-save policy from a background-review block."""
+    task = _background_review_task_config(task_cfg)
+    memory_cfg = task.get("memory", {})
+    return memory_cfg if isinstance(memory_cfg, dict) else {}
+
+
 def load_background_review_settings() -> tuple[bool, Dict[str, Any]]:
     """Single config read for the automatic-review gate + task block.
 
@@ -872,6 +879,10 @@ def _run_review_in_thread(
     # Local import to avoid a hard circular dep at module load.
     from run_agent import AIAgent
     from tools.terminal_tool import set_approval_callback as _set_approval_callback
+    from tools.write_approval import (
+        reset_background_memory_policy,
+        set_background_memory_policy,
+    )
 
     # Install a non-interactive approval callback on this worker
     # thread so any dangerous-command guard the review agent trips
@@ -892,6 +903,9 @@ def _run_review_in_thread(
     review_agent = None
     review_messages: List[Dict] = []
     review_usage: Dict[str, Any] = {}
+    memory_policy_token = set_background_memory_policy(
+        _memory_review_config(task_cfg)
+    )
 
     def _unregister_review_agent(agent_ref) -> None:
         """Idempotent: clears the review fork from both tracking slots.
@@ -1279,6 +1293,7 @@ def _run_review_in_thread(
             _log_review_completion(review_usage, "error")
         agent._emit_auxiliary_failure("background review", e)
     finally:
+        reset_background_memory_policy(memory_policy_token)
         # Safety-net cleanup for the exception path.  Normal completion already
         # shut down inside the thread-scoped silence above.  Re-enter the
         # thread-scoped silence here so teardown output (Honcho flush, Hindsight
@@ -1342,10 +1357,24 @@ def spawn_background_review_thread(
     # Pick the right prompt based on which triggers fired.  Allow per-agent
     # override (the prompts moved to module-level constants but old code paths
     # that set agent._MEMORY_REVIEW_PROMPT etc. directly keep working).
-    if review_memory and review_skills:
+    memory_cfg = _memory_review_config(task_cfg)
+    configured_memory_prompt = memory_cfg.get("review_prompt")
+    if not isinstance(configured_memory_prompt, str):
+        configured_memory_prompt = ""
+    configured_memory_prompt = configured_memory_prompt.strip()
+    if review_memory and review_skills and configured_memory_prompt:
+        prompt = (
+            f"{configured_memory_prompt}\n\n"
+            "After applying the memory instructions above, independently "
+            "review skills using these instructions:\n\n"
+            f"{getattr(agent, '_SKILL_REVIEW_PROMPT', _SKILL_REVIEW_PROMPT)}"
+        )
+    elif review_memory and review_skills:
         prompt = getattr(agent, "_COMBINED_REVIEW_PROMPT", _COMBINED_REVIEW_PROMPT)
     elif review_memory:
-        prompt = getattr(agent, "_MEMORY_REVIEW_PROMPT", _MEMORY_REVIEW_PROMPT)
+        prompt = configured_memory_prompt or getattr(
+            agent, "_MEMORY_REVIEW_PROMPT", _MEMORY_REVIEW_PROMPT
+        )
     else:
         prompt = getattr(agent, "_SKILL_REVIEW_PROMPT", _SKILL_REVIEW_PROMPT)
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1150,6 +1150,15 @@ DEFAULT_CONFIG = {
             "timeout": 120,
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "memory": {
+                # Empty keeps the built-in memory-review prompt.
+                "review_prompt": "",
+                # Case-insensitive literal substrings rejected from proposed
+                # background-review add/replace content. Removals remain allowed.
+                "deny_patterns": [],
+                # Stage background-review memory writes for /memory approval.
+                "require_confirmation": False,
+            },
         },
         "moa_reference": {
             "provider": "auto",

--- a/tests/run_agent/test_background_review_cost_controls.py
+++ b/tests/run_agent/test_background_review_cost_controls.py
@@ -173,3 +173,48 @@ def test_enabled_false_disables_automatic_review():
     cfg = {"auxiliary": {"background_review": {"enabled": False}}}
     with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
         assert br.is_background_review_enabled() is False
+
+
+def test_memory_review_prompt_can_be_overridden_without_affecting_defaults():
+    agent = _FakeAgent()
+    task_cfg = {"memory": {"review_prompt": "Save only durable device facts."}}
+
+    _target, prompt = br.spawn_background_review_thread(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+        task_cfg=task_cfg,
+    )
+
+    assert prompt == "Save only durable device facts."
+    assert callable(_target)
+
+
+def test_custom_memory_prompt_keeps_skill_instructions_in_combined_review():
+    agent = _FakeAgent()
+    task_cfg = {"memory": {"review_prompt": "Save only durable device facts."}}
+
+    _target, prompt = br.spawn_background_review_thread(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+        review_skills=True,
+        task_cfg=task_cfg,
+    )
+
+    assert "Save only durable device facts." in prompt
+    assert "update the skill library" in prompt
+
+
+def test_unset_memory_policy_preserves_builtin_combined_prompt():
+    agent = _FakeAgent()
+
+    _target, prompt = br.spawn_background_review_thread(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+        review_skills=True,
+        task_cfg={},
+    )
+
+    assert prompt == br._COMBINED_REVIEW_PROMPT

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -257,6 +257,114 @@ def test_memory_invalid_params_rejected_before_staging(hermes_home):
     assert wa.pending_count("memory") == 0
 
 
+def _bind_background_memory_policy(wa, policy):
+    from tools.skill_provenance import set_current_write_origin
+
+    return (
+        set_current_write_origin("background_review"),
+        wa.set_background_memory_policy(policy),
+    )
+
+
+def _reset_background_memory_policy(wa, tokens):
+    from tools.skill_provenance import reset_current_write_origin
+
+    origin_token, policy_token = tokens
+    wa.reset_background_memory_policy(policy_token)
+    reset_current_write_origin(origin_token)
+
+
+def test_background_memory_deny_patterns_block_add_case_insensitively(hermes_home):
+    from tools.memory_tool import MemoryStore, memory_tool
+    from tools import write_approval as wa
+
+    tokens = _bind_background_memory_policy(wa, {"deny_patterns": ["deploy secret"]})
+    try:
+        store = MemoryStore(); store.load_from_disk()
+        result = json.loads(memory_tool("add", "memory", "Remember DEPLOY SECRET steps", store=store))
+    finally:
+        _reset_background_memory_policy(wa, tokens)
+
+    assert result["success"] is False
+    assert "deny_patterns" in result["error"]
+    assert store.memory_entries == []
+    assert wa.pending_count("memory") == 0
+
+
+def test_background_memory_deny_patterns_allow_removing_matching_entry(hermes_home):
+    from tools.memory_tool import MemoryStore, memory_tool
+    from tools import write_approval as wa
+
+    store = MemoryStore(); store.load_from_disk()
+    store.add("memory", "obsolete deploy secret steps")
+    tokens = _bind_background_memory_policy(wa, {"deny_patterns": ["deploy secret"]})
+    try:
+        result = json.loads(
+            memory_tool("remove", "memory", old_text="deploy secret", store=store)
+        )
+    finally:
+        _reset_background_memory_policy(wa, tokens)
+
+    assert result["success"] is True
+    assert store.memory_entries == []
+
+
+def test_background_memory_deny_patterns_reject_batch_atomically(hermes_home):
+    from tools.memory_tool import MemoryStore, memory_tool
+    from tools import write_approval as wa
+
+    store = MemoryStore(); store.load_from_disk()
+    operations = [
+        {"action": "add", "content": "durable device fact"},
+        {"action": "add", "content": "one-off deployment detail"},
+    ]
+    tokens = _bind_background_memory_policy(wa, {"deny_patterns": ["deployment"]})
+    try:
+        result = json.loads(memory_tool(target="memory", operations=operations, store=store))
+    finally:
+        _reset_background_memory_policy(wa, tokens)
+
+    assert result["success"] is False
+    assert store.memory_entries == []
+
+
+def test_background_memory_confirmation_stages_without_global_gate(hermes_home):
+    from tools.memory_tool import MemoryStore, memory_tool
+    from tools import write_approval as wa
+
+    store = MemoryStore(); store.load_from_disk()
+    tokens = _bind_background_memory_policy(wa, {"require_confirmation": True})
+    try:
+        result = json.loads(memory_tool("add", "memory", "durable device fact", store=store))
+    finally:
+        _reset_background_memory_policy(wa, tokens)
+
+    assert result["success"] is True
+    assert result["staged"] is True
+    assert store.memory_entries == []
+    pending = wa.list_pending("memory")
+    assert len(pending) == 1
+    assert pending[0]["origin"] == "background_review"
+
+
+def test_background_memory_policy_does_not_gate_foreground_writes(hermes_home):
+    from tools.memory_tool import MemoryStore, memory_tool
+    from tools import write_approval as wa
+
+    policy_token = wa.set_background_memory_policy(
+        {"deny_patterns": ["device"], "require_confirmation": True}
+    )
+    try:
+        store = MemoryStore(); store.load_from_disk()
+        result = json.loads(memory_tool("add", "memory", "durable device fact", store=store))
+    finally:
+        wa.reset_background_memory_policy(policy_token)
+
+    assert result["success"] is True
+    assert result.get("staged") is None
+    assert store.memory_entries == ["durable device fact"]
+
+
 class TestSkillGist:
     """skill_gist builds a heuristic one-line summary for a pending skill write.
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -946,7 +946,21 @@ def _apply_write_gate(action: str, target: str, content: Optional[str],
         summary = f"remove from {label}"
         detail = old_text or ""
 
-    decision = wa.evaluate_gate(wa.MEMORY, inline_summary=summary, inline_detail=detail)
+    denied_pattern = wa.denied_background_memory_pattern(action, content)
+    if denied_pattern:
+        return tool_error(
+            "Background memory write rejected by "
+            "auxiliary.background_review.memory.deny_patterns "
+            f"(matched literal: {denied_pattern!r}).",
+            success=False,
+        )
+
+    decision = wa.evaluate_gate(
+        wa.MEMORY,
+        inline_summary=summary,
+        inline_detail=detail,
+        force_approval=wa.background_memory_confirmation_required(),
+    )
 
     if decision.allow:
         return None
@@ -1000,7 +1014,28 @@ def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]]) -> Op
             detail_lines.append(f"- {act}: {_op_content}")
     detail = "\n".join(detail_lines)
 
-    decision = wa.evaluate_gate(wa.MEMORY, inline_summary=summary, inline_detail=detail)
+    for op in operations:
+        op = op or {}
+        op_content = op.get("content")
+        if op_content is None:
+            op_content = op.get("new_text")
+        denied_pattern = wa.denied_background_memory_pattern(
+            op.get("action", ""), op_content
+        )
+        if denied_pattern:
+            return tool_error(
+                "Background memory batch rejected by "
+                "auxiliary.background_review.memory.deny_patterns "
+                f"(matched literal: {denied_pattern!r}). No operations were applied.",
+                success=False,
+            )
+
+    decision = wa.evaluate_gate(
+        wa.MEMORY,
+        inline_summary=summary,
+        inline_detail=detail,
+        force_approval=wa.background_memory_confirmation_required(),
+    )
 
     if decision.allow:
         return None

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -42,6 +42,7 @@ web dashboard.
 
 from __future__ import annotations
 
+import contextvars
 import json
 import logging
 import os
@@ -65,6 +66,49 @@ _SUBSYSTEMS = (MEMORY, SKILLS)
 # "block all writes" state — to disable a subsystem entirely use its own
 # enable flag (e.g. ``memory.memory_enabled: false``).
 CONFIG_KEY = "write_approval"
+
+_background_memory_policy: contextvars.ContextVar[Dict[str, Any]] = (
+    contextvars.ContextVar("background_memory_policy", default={})
+)
+
+
+def set_background_memory_policy(policy: Dict[str, Any]) -> contextvars.Token:
+    """Bind one review fork's memory-save policy to its execution context."""
+    return _background_memory_policy.set(policy if isinstance(policy, dict) else {})
+
+
+def reset_background_memory_policy(token: contextvars.Token) -> None:
+    """Restore the previous background memory policy."""
+    _background_memory_policy.reset(token)
+
+
+def denied_background_memory_pattern(action: str, content: Any) -> Optional[str]:
+    """Return the configured literal that rejects a background memory write.
+
+    Only new content is filtered: removals remain possible so a review can
+    delete an existing entry that contains a denied topic.
+    """
+    if not is_background() or action not in {"add", "replace"}:
+        return None
+    if not isinstance(content, str):
+        return None
+    patterns = _background_memory_policy.get().get("deny_patterns", [])
+    if not isinstance(patterns, list):
+        return None
+    folded = content.casefold()
+    for raw in patterns:
+        if isinstance(raw, str) and raw.strip() and raw.strip().casefold() in folded:
+            return raw.strip()
+    return None
+
+
+def background_memory_confirmation_required() -> bool:
+    """Return whether this background fork must stage memory writes."""
+    if not is_background():
+        return False
+    return _normalize_enabled(
+        _background_memory_policy.get().get("require_confirmation", False)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -251,7 +295,7 @@ class GateDecision:
 
 
 def evaluate_gate(subsystem: str, *, inline_summary: str = "",
-                  inline_detail: str = "") -> GateDecision:
+                  inline_detail: str = "", force_approval: bool = False) -> GateDecision:
     """Decide what to do with a pending write for ``subsystem``.
 
     Args:
@@ -271,7 +315,7 @@ def evaluate_gate(subsystem: str, *, inline_summary: str = "",
     delays a write for approval, never silently refuses it. ``blocked`` is
     still produced when the user *actively denies* an inline prompt.
     """
-    if not write_approval_enabled(subsystem):
+    if not force_approval and not write_approval_enabled(subsystem):
         return GateDecision(allow=True)
 
     background = is_background()
@@ -280,10 +324,15 @@ def evaluate_gate(subsystem: str, *, inline_summary: str = "",
     # background skill write happens in a daemon thread with no user present.
     if subsystem == SKILLS or background:
         where = "/skills pending" if subsystem == SKILLS else "/memory pending"
+        gate_name = (
+            "auxiliary.background_review.memory.require_confirmation"
+            if force_approval and subsystem == MEMORY
+            else f"{subsystem}.write_approval"
+        )
         return GateDecision(
             stage=True,
             message=(
-                f"Staged for approval ({subsystem}.write_approval is on). "
+                f"Staged for approval ({gate_name} is on). "
                 f"Not yet saved — review with {where}."
             ),
         )

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -331,6 +331,31 @@ auxiliary:
 With `enabled: false`, automatic post-turn forks do not spawn; manual
 `/refine` still works.
 
+### Controlling what the review saves
+
+Memory-save policy can be scoped to the background review without changing
+foreground memory writes:
+
+```yaml
+auxiliary:
+  background_review:
+    memory:
+      review_prompt: |-
+        Save only durable user preferences, device facts, and environment facts.
+        Skip one-off task details and completed-work logs.
+      deny_patterns: ["one-off deployment", "temporary credential"]
+      require_confirmation: false
+```
+
+`review_prompt` replaces only the memory portion of the review; combined
+memory-and-skill reviews keep the built-in skill instructions. `deny_patterns`
+are case-insensitive literal substrings enforced on proposed memory additions
+and replacements (including batches), so the model cannot bypass them by
+ignoring the prompt. Removals remain allowed. With `require_confirmation: true`,
+background-review memory writes are staged instead of saved immediately; review
+them with `/memory pending`, `/memory approve <id>`, or `/memory reject <id>`.
+All three settings default to the previous behavior when omitted.
+
 Fork usage is persisted in `session_model_usage` with `task='background_review'`
 and a completion line is written to `agent.log`
 (`Background review complete: thread=bg-review calls=… in=… out=… result=…`).


### PR DESCRIPTION
## What does this PR do?

This adds a memory-specific policy under `auxiliary.background_review.memory` so users can control what automatic background reviews save without changing foreground memory writes or skill review behavior. Users can provide a review prompt, reject configured literal patterns, and require approval before background-review memory writes are persisted. Unset settings preserve the existing prompt and save behavior.

## Related Issue

Closes #87927

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/background_review.py` - load the nested memory policy, apply it only inside each review context, and preserve built-in skill instructions for combined reviews.
- `tools/memory_tool.py` and `tools/write_approval.py` - reject configured case-insensitive literal patterns for background add/replace operations and reuse the pending-memory approval flow when confirmation is required.
- `hermes_cli/config_defaults.py` - add backward-compatible defaults for `review_prompt`, `deny_patterns`, and `require_confirmation`.
- `tests/run_agent/test_background_review_cost_controls.py` and `tests/tools/test_write_approval.py` - cover prompt selection, default compatibility, filtering, atomic batches, confirmation staging, and foreground isolation.
- `website/docs/user-guide/features/memory.md` - document the new configuration and approval workflow.

## How to Test

1. Configure `auxiliary.background_review.memory.review_prompt` and verify a memory-only review uses it while a combined memory-and-skill review retains the built-in skill instructions.
2. Configure `deny_patterns` and verify matching background additions and replacements are rejected atomically while removals and foreground writes remain allowed.
3. Configure `require_confirmation: true` and verify background-review memory writes appear under `/memory pending` instead of being saved immediately.
4. Run the focused automated tests (113 passed locally on Windows 11):

```bash
scripts/run_tests.sh tests/run_agent/test_background_review_cost_controls.py tests/tools/test_write_approval.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all 113 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because the canonical defaults and memory guide document these nested settings
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because this does not change contribution workflows or architecture
- [x] I've considered cross-platform impact; the policy uses platform-independent configuration and context-local state
- [x] Tool descriptions and schemas are N/A because no model tool schema changed

## Screenshots / Logs

N/A - the behavior is configuration-driven and covered by focused automated tests.
