### PR TITLE
fix(install): serialize Rust builds to stop Termux cryptography source-build OOM (#87663)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,13 @@ dependencies = [
   # A pin here is not sufficient on its own. alibabacloud-tea-openapi caps
   # cryptography<49, so [tool.uv] also holds an override. Read that comment
   # before you move this version.
+  #
+  # No cryptography release publishes an Android wheel (checked across the
+  # whole 46-50 series), so Termux always source-builds this from the sdist
+  # regardless of which version is pinned here — do NOT "fix" a Termux OOM by
+  # downgrading this pin, which only reintroduces the CVEs above without
+  # avoiding the build. The actual OOM cause and fix (serialized Rust build)
+  # live in scripts/install.sh / setup-hermes.sh, see #87663.
   "cryptography==50.0.0",  # CVE-2026-69247, GHSA-m2h6-j472-rp4c, GHSA-jwv3-5hgf-82ww, CVE-2026-39892, CVE-2026-34073, GHSA-537c-gmf6-5ccf
   # Windows has no IANA tzdata shipped with the OS, so Python's ``zoneinfo``
   # (PEP 615) raises ``ZoneInfoNotFoundError`` for every non-UTC timezone

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1505,6 +1505,22 @@ install_deps() {
             log_info "Using ANDROID_API_LEVEL=$ANDROID_API_LEVEL for Android wheel builds"
         fi
 
+        # cryptography (and pydantic-core, another maturin/Rust-backed direct
+        # dependency) ships no Android wheel on PyPI at any version, so pip
+        # always source-builds them on Termux. Cargo defaults to one rustc
+        # process per CPU core; on an 8-core phone sharing a few GB of RAM
+        # with the rest of Android, that many concurrent rustc processes
+        # exhausts RAM+swap. The OOM killer then reaps rustc without cargo
+        # surfacing a build error, so pip is left waiting on a dead child
+        # forever instead of failing loudly (#87663). Serializing the build
+        # keeps peak memory bounded at the cost of a slower (but finite)
+        # build; respect a caller-provided value instead of clobbering it.
+        if [ -z "${CARGO_BUILD_JOBS:-}" ]; then
+            export CARGO_BUILD_JOBS=1
+            log_info "Serializing Rust extension builds (CARGO_BUILD_JOBS=1) to avoid Termux OOM while compiling cryptography/pydantic-core from source"
+            log_info "This can take several minutes on a phone — it is not stuck."
+        fi
+
         "$PIP_PYTHON" -m pip install --upgrade pip setuptools wheel >/dev/null
 
         # On Android, psutil's setup.py rejects sys.platform == 'android' before

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -193,6 +193,15 @@ echo -e "${CYAN}→${NC} Installing dependencies..."
 if is_termux; then
     export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk 2>/dev/null || printf '%s' "${ANDROID_API_LEVEL:-}")"
     echo -e "${CYAN}→${NC} Termux detected — installing the tested Android bundle"
+    # cryptography/pydantic-core have no Android wheel on PyPI, so pip always
+    # source-builds them here. Cargo's default one-rustc-per-core parallelism
+    # exhausts RAM+swap on a phone and gets silently OOM-killed, leaving pip
+    # hung on a dead child instead of failing loudly (#87663). Serialize the
+    # build; respect a caller-provided value instead of clobbering it.
+    if [ -z "${CARGO_BUILD_JOBS:-}" ]; then
+        export CARGO_BUILD_JOBS=1
+        echo -e "${CYAN}→${NC} Serializing Rust extension builds (CARGO_BUILD_JOBS=1) to avoid Termux OOM — this can take several minutes"
+    fi
     "$SETUP_PYTHON" -m pip install --upgrade pip setuptools wheel
     if [ -f "constraints-termux.txt" ]; then
         "$SETUP_PYTHON" -m pip install -e ".[termux]" -c constraints-termux.txt || {

--- a/tests/test_termux_cargo_build_jobs.py
+++ b/tests/test_termux_cargo_build_jobs.py
@@ -1,0 +1,57 @@
+"""Regression coverage for the Termux cryptography source-build OOM fix.
+
+cryptography (and pydantic-core) ship no Android wheel on PyPI, so both
+Termux install paths always source-build them from the sdist. Cargo's default
+one-rustc-per-core parallelism exhausts RAM+swap on a phone, and the OOM
+killer reaps rustc silently instead of cargo surfacing a build error, so pip
+is left hanging on a dead child forever (#87663). The fix serializes the Rust
+build via CARGO_BUILD_JOBS=1 instead of downgrading the CVE-fixed
+cryptography pin.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+SETUP_HERMES_SH = REPO_ROOT / "setup-hermes.sh"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def test_install_sh_serializes_rust_builds_on_termux() -> None:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    assert 'if [ -z "${CARGO_BUILD_JOBS:-}" ]; then' in text
+    assert "export CARGO_BUILD_JOBS=1" in text
+    assert "#87663" in text
+    # The guard must run before the pip install call it protects.
+    guard_pos = text.index("export CARGO_BUILD_JOBS=1")
+    pip_install_pos = text.index("pip install -e '.[termux-all]' -c constraints-termux.txt")
+    assert guard_pos < pip_install_pos
+
+
+def test_setup_hermes_sh_serializes_rust_builds_on_termux() -> None:
+    text = SETUP_HERMES_SH.read_text(encoding="utf-8")
+    assert 'if [ -z "${CARGO_BUILD_JOBS:-}" ]; then' in text
+    assert "export CARGO_BUILD_JOBS=1" in text
+    guard_pos = text.index("export CARGO_BUILD_JOBS=1")
+    pip_install_pos = text.index('pip install -e ".[termux]" -c constraints-termux.txt')
+    assert guard_pos < pip_install_pos
+
+
+def test_cargo_build_jobs_guard_respects_caller_override() -> None:
+    """The guard must not clobber a value the caller/environment already set."""
+    for path in (INSTALL_SH, SETUP_HERMES_SH):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        guard_idx = next(
+            i for i, line in enumerate(lines) if 'if [ -z "${CARGO_BUILD_JOBS:-}" ]; then' in line
+        )
+        # Guarded assignment on the very next line, not an unconditional export.
+        assert lines[guard_idx + 1].strip() == "export CARGO_BUILD_JOBS=1"
+
+
+def test_cryptography_pin_not_downgraded_for_termux() -> None:
+    """Guard against 'fixing' the Termux OOM by reintroducing the CVEs the
+    cryptography==50.0.0 pin exists to close (no Android wheel exists at any
+    version, so downgrading would not even avoid the source build)."""
+    text = PYPROJECT.read_text(encoding="utf-8")
+    assert '"cryptography==50.0.0"' in text
+    assert '"cryptography==48.0.1"' not in text


### PR DESCRIPTION
## Summary

- `cryptography` (and `pydantic-core`, another maturin/Rust-backed direct dependency) publishes **no Android wheel on PyPI at any version** — verified against the whole 46-50 series. On Termux, pip therefore always falls back to a source build via the Rust/maturin backend, regardless of which version is pinned.
- Cargo defaults to one `rustc` process **per CPU core**. On a phone sharing a few GB of RAM with the rest of Android, that many concurrent `rustc` processes exhausts RAM+swap. Android's low-memory killer then reaps `rustc` silently — `cargo` never gets to surface a build error, so `pip` is left hanging on a dead child indefinitely (confirmed via `htop`/`ps aux` in the issue: 99.6% swap used, no compiler process alive, no error).
- Fix: export `CARGO_BUILD_JOBS=1` (honoring any caller-provided override) right before the Termux pip install step, in **both** Termux install paths (`scripts/install.sh` and the legacy `setup-hermes.sh` bootstrap). This serializes the Rust build, keeping peak memory bounded, at the cost of a slower but finite build. A log line makes clear the long wait is expected, not a hang.
- The `cryptography==50.0.0` pin (fixing CVE-2026-69247, GHSA-m2h6-j472-rp4c, GHSA-jwv3-5hgf-82ww, CVE-2026-39892, CVE-2026-34073, GHSA-537c-gmf6-5ccf) is left intact and documented against future "fixes" that downgrade it — since no version ships an Android wheel, downgrading would not even avoid the source build, and would reopen the CVEs the pin exists to close.

## Why not downgrade the pin (#87802)?

`constraints-termux.txt` cannot lower a version below an already-pinned exact `==` requirement from `[project.dependencies]` — pip would report a resolution conflict (`cryptography==50.0.0` vs `cryptography==48.0.1`), not silently downgrade. Even if it could, no `cryptography` release publishes an Android wheel, so the source build — and its OOM — would still happen. That approach also reintroduces three fixed CVEs. This PR fixes the actual root cause (unbounded build parallelism on a memory-constrained device) instead of trading a hang for a broken/insecure install.

 
## Test plan

- [x] `bash -n scripts/install.sh` / `bash -n setup-hermes.sh` — syntax OK
- [x] `pytest tests/test_termux_cargo_build_jobs.py tests/test_packaging_metadata.py` — new regression tests pass (guard present before the pip install call, guard respects a caller-provided `CARGO_BUILD_JOBS`, `cryptography==50.0.0` pin not downgraded)
- [ ] Full `curl .../install.sh | bash` on a real Termux device (CI can't run this; the reporter of #87663 can re-verify)

Fixes #87663

## Infographic :

<img width="1376" height="768" alt="termux_rust_oom_fix_infographic" src="https://github.com/user-attachments/assets/aa5e2ea0-e36a-4d36-bb27-b1f19d003f72" />

