### PR TITLE
feat(desktop): add per-block word-wrap toggle to code blocks

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.wrap.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.wrap.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { clearArtifactRegistry } from '@/store/artifacts'
+import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
+
+import { MarkdownTextContent } from './markdown-text'
+
+function fenced(language: string, body: string): string {
+  return `\`\`\`${language}\n${body}\n\`\`\`\n`
+}
+
+// A fenced code block renders a hover-revealed word-wrap switch next to the
+// copy button; toggling it flags the card so styles.css reflows long lines
+// instead of scrolling horizontally.
+describe('MarkdownTextContent word-wrap toggle', () => {
+  beforeEach(() => {
+    $activeSessionId.set('session-wrap')
+    $selectedStoredSessionId.set(null)
+    window.localStorage.clear()
+    clearArtifactRegistry()
+  })
+
+  afterEach(() => {
+    cleanup()
+    $activeSessionId.set(null)
+    $selectedStoredSessionId.set(null)
+    clearArtifactRegistry()
+    window.localStorage.clear()
+  })
+
+  it('toggles word wrap on a code block', () => {
+    const { container } = render(<MarkdownTextContent isRunning={false} text={fenced('js', 'const x = 1')} />)
+
+    const card = () => container.querySelector('[data-slot="code-card"]')
+
+    expect(card()).not.toBeNull()
+    expect(card()?.hasAttribute('data-wrap')).toBe(false)
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Toggle word wrap' }))
+
+    expect(card()?.hasAttribute('data-wrap')).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
-import { type ComponentProps, type FC, lazy, Suspense, useMemo } from 'react'
+import { type ComponentProps, type FC, lazy, Suspense, useId, useMemo, useState } from 'react'
 import type ShikiHighlighter from 'react-shiki'
 
 import { CodeCard, CodeCardBody } from '@/components/chat/code-card'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { CopyButton } from '@/components/ui/copy-button'
+import { Switch } from '@/components/ui/switch'
 import { useI18n } from '@/i18n'
 import { isLikelyProseCodeBlock } from '@/lib/markdown-code'
 
@@ -123,6 +124,35 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   )
 }
 
+/** Hover-revealed word-wrap switch shown in a code card's header, to the left
+ *  of the copy button. It is the only per-block control; wrapping is applied
+ *  via the card's `data-wrap` attribute in styles.css. */
+function WordWrapToggle({
+  checked,
+  onCheckedChange
+}: {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+}) {
+  const { t } = useI18n()
+  const id = useId()
+
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md px-1 py-0.5 text-[0.7rem] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground">
+      <Switch
+        aria-label={t.assistant.tool.toggleWordWrap}
+        checked={checked}
+        id={id}
+        onCheckedChange={onCheckedChange}
+        size="xs"
+      />
+      <label className="cursor-pointer select-none" htmlFor={id}>
+        {t.assistant.tool.wordWrap}
+      </label>
+    </span>
+  )
+}
+
 export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
   components: { Pre },
   language,
@@ -131,6 +161,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
 }) => {
   const { t } = useI18n()
   const trimmed = (code ?? '').replace(/^\n+/, '').trimEnd()
+  const [wrap, setWrap] = useState(false)
 
   // Streaming may hand us empty/incomplete fences — render nothing rather
   // than a transient empty card.
@@ -145,15 +176,18 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
   const plain = defer || exceedsHighlightBudget(trimmed)
 
   return (
-    <CodeCard data-streaming={defer ? 'true' : undefined}>
-      <CopyButton
-        appearance="inline"
-        className="absolute right-1.5 top-1.5 z-10 h-5 gap-0 rounded-md px-1 opacity-0 transition-opacity group-hover/code:opacity-100 focus-visible:opacity-100"
-        iconClassName="size-2.5"
-        label={t.assistant.tool.copyCode}
-        showLabel={false}
-        text={trimmed}
-      />
+    <CodeCard data-streaming={defer ? 'true' : undefined} data-wrap={wrap || undefined}>
+      <div className="absolute right-1.5 top-1.5 z-10 flex items-center gap-0.5 opacity-0 transition-opacity group-hover/code:opacity-100 focus-within:opacity-100">
+        <WordWrapToggle checked={wrap} onCheckedChange={setWrap} />
+        <CopyButton
+          appearance="inline"
+          className="h-5 gap-0 rounded-md px-1"
+          iconClassName="size-2.5"
+          label={t.assistant.tool.copyCode}
+          showLabel={false}
+          text={trimmed}
+        />
+      </div>
       <CodeCardBody className="[&_pre]:px-3 [&_pre]:py-2.5">
         <ExpandableBlock>
           <Pre className="aui-shiki m-0 overflow-hidden bg-transparent p-0">

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2529,6 +2529,8 @@ export const ar = defineLocale({
     },
     tool: {
       copyCode: 'نسخ الكود',
+      wordWrap: 'التفاف الأسطر',
+      toggleWordWrap: 'تبديل التفاف الأسطر',
       renderingImage: 'جار عرض الصورة...',
       copyOutput: 'نسخ الإخراج',
       copyCommand: 'نسخ الأمر',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3206,6 +3206,8 @@ export const en: Translations = {
     },
     tool: {
       copyCode: 'Copy code',
+      wordWrap: 'Word wrap',
+      toggleWordWrap: 'Toggle word wrap',
       renderingImage: 'Rendering image',
       copyOutput: 'Copy output',
       copyCommand: 'Copy command',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2833,6 +2833,8 @@ export const ja = defineLocale({
     },
     tool: {
       copyCode: 'コードをコピー',
+      wordWrap: '折り返し',
+      toggleWordWrap: '折り返しを切り替え',
       renderingImage: '画像をレンダリング中',
       copyOutput: '出力をコピー',
       copyCommand: 'コマンドをコピー',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2770,6 +2770,8 @@ export interface Translations {
     }
     tool: {
       copyCode: string
+      wordWrap: string
+      toggleWordWrap: string
       renderingImage: string
       copyOutput: string
       copyCommand: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2741,6 +2741,8 @@ export const zhHant = defineLocale({
     },
     tool: {
       copyCode: '複製程式碼',
+      wordWrap: '自動換行',
+      toggleWordWrap: '切換自動換行',
       renderingImage: '正在渲染圖片',
       copyOutput: '複製輸出',
       copyCommand: '複製指令',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3367,6 +3367,8 @@ export const zh: Translations = {
     },
     tool: {
       copyCode: '复制代码',
+      wordWrap: '自动换行',
+      toggleWordWrap: '切换自动换行',
       renderingImage: '正在渲染图片',
       copyOutput: '复制输出',
       copyCommand: '复制命令',

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1871,6 +1871,18 @@ body.guest-pointer-lock :is(webview, iframe) {
   padding: 0 !important;
 }
 
+/* Word-wrap mode: when a code card's wrap toggle is on, reflow long lines
+   instead of scrolling horizontally. Mirrors the prose-fence treatment
+   (`white-space: pre-wrap` + `overflow-wrap: anywhere`) but is per-block and
+   user-controlled. `!important` overrides the `pre` UA default, Tailwind's
+   `whitespace-pre` on the plain path, and Streamdown's `white-space: inherit`
+   chrome-strip on the nested `code`. */
+[data-slot='code-card'][data-wrap] pre,
+[data-slot='code-card'][data-wrap] pre code {
+  white-space: pre-wrap !important;
+  overflow-wrap: anywhere !important;
+}
+
 [data-slot='aui_assistant-message-content'] .aui-md .aui-md-table {
   border-spacing: 0;
 }


### PR DESCRIPTION
## What does this PR do?

Adds a hover-revealed **word-wrap toggle** to fenced code blocks in the desktop chat. Each code block gets a small `Switch` in its header — immediately to the left of the copy button — labeled "Word wrap". Toggling it on reflows long lines to wrap at the block's width instead of scrolling horizontally; toggling it off restores the current horizontal-scroll behavior.

The wrap mechanics already exist: prose-detected fences are rendered with `white-space: pre-wrap` + `overflow-wrap: anywhere` (`isLikelyProseCodeBlock` in `markdown-code.ts`). This change extends that treatment with explicit per-block, user-controlled opt-in rather than the automatic prose heuristic, so a real code block (bash / JSON / log output) can also be wrapped when the user wants to read it in place.

## Related Issue

No existing issue. The closest neighbors are unrelated surfaces: #87677 (wrap-lines toggle for the review diff pane) and #70451 (markdown preview horizontal scroll).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/components/chat/shiki-highlighter.tsx` — add `WordWrapToggle` (reuses the existing `Switch` component) to the code-card header, left of the copy button; flag the card with `data-wrap` when on.
- `apps/desktop/src/styles.css` — `[data-slot='code-card'][data-wrap]` rule reflows the plain and Shiki code paths (`white-space: pre-wrap; overflow-wrap: anywhere`).
- `apps/desktop/src/i18n/types.ts`, `en.ts`, `zh.ts` — add `tool.wordWrap` / `tool.toggleWordWrap` strings.
- `apps/desktop/src/components/assistant-ui/markdown-text.wrap.test.tsx` — test that toggling the switch flags the card.

## How to Test

1. Open a session and produce an assistant message containing a fenced code block with long lines (e.g. a long `bash` snippet).
2. Hover the code block; a "Word wrap" switch appears to the left of the copy button.
3. Toggle it on: long lines wrap at the block width (no horizontal scrollbar).
4. Toggle it off: behavior returns to horizontal scroll.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (Linux)

### Validation performed

- `npm run typecheck` (renderer + electron + e2e) — passes
- `npx eslint` on changed files — clean
- `npx vitest run --project ui` (full UI suite) — 482 files / 4490 tests pass
- Focused tests for the new toggle and the existing code-card / artifact / overflow tests pass

### Documentation & Housekeeping

- [x] N/A — no docs, architecture, config-key, or tool-schema changes
