### PR TITLE
fix(gateway): scan every served profile's /loop wakeups, not just the launch profile's

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21212,95 +21212,132 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
           idle boundary)
         - no routing metadata on the loop → skip with a one-time warning
           (CLI/TUI loops carry no route and are driven by their own surfaces)
+
+        **Multi-profile:** this is a single gateway-wide asyncio task, so
+        ``get_hermes_home()`` would otherwise stay pinned to whichever
+        profile's context was ambient when the task was created — every
+        loop set from any other profile's chat would never fire, silently
+        (same class of bug ``_kanban_notifier_watcher`` avoids by
+        discovering boards on disk rather than trusting ambient state).
+        Each tick re-resolves the served profile set and scans every
+        profile's loops under its own ``_profile_runtime_scope``.
         """
         await asyncio.sleep(5)  # let platforms finish connecting
         warned_no_route: set = set()
         while self._running:
             try:
-                from hermes_cli.loops import (
-                    LoopManager,
-                    goal_blocks_loop_tick,
-                    list_active_loops,
+                from hermes_cli.profiles import profiles_to_serve
+
+                profile_homes = profiles_to_serve(
+                    multiplex=bool(getattr(self.config, "multiplex_profiles", False)),
+                    profile_allowlist=getattr(self.config, "multiplex_profile_allowlist", None),
                 )
-
-                now = time.time()
-                for sid, state in list_active_loops():
-                    if state.awaiting_response or now < state.next_due_at:
-                        continue
-                    route = state.route or {}
-                    platform_name = route.get("platform", "")
-                    chat_id = route.get("chat_id", "")
-                    if not platform_name or not chat_id:
-                        # CLI / TUI-owned loop — their own schedulers drive it.
-                        continue
-                    adapter = None
-                    for p, a in self.adapters.items():
-                        if p.value == platform_name:
-                            adapter = a
-                            break
-                    if adapter is None:
-                        if sid not in warned_no_route:
-                            warned_no_route.add(sid)
-                            logger.debug(
-                                "loop wakeup: no adapter for platform %r (session %s)",
-                                platform_name, sid,
-                            )
-                        continue
-
-                    # Build the source + session key to check business.
-                    evt_stub = {
-                        "session_key": "",
-                        "platform": platform_name,
-                        "chat_id": chat_id,
-                        "chat_type": route.get("chat_type", ""),
-                        "thread_id": route.get("thread_id", ""),
-                        "user_id": route.get("user_id", ""),
-                        "user_name": route.get("user_name", ""),
-                    }
-                    source = self._build_process_event_source(evt_stub)
-                    if source is None:
-                        continue
-                    try:
-                        session_key = self._session_key_for_source(source)
-                    except Exception:
-                        session_key = None
-                    if session_key and session_key in self._running_agents:
-                        continue  # busy — stays due, next scan retries
-                    if goal_blocks_loop_tick(sid):
-                        continue
-
-                    mgr = LoopManager(session_id=sid)
-                    if not mgr.is_due(now):
-                        continue
-                    wakeup = mgr.fire_tick()
-                    if not wakeup:
-                        continue
-                    try:
-                        synth_event = MessageEvent(
-                            text=wakeup,
-                            message_type=MessageType.TEXT,
-                            source=source,
-                            internal=True,
-                        )
-                        logger.info(
-                            "loop wakeup #%s — injecting for %s chat=%s thread=%s",
-                            mgr.state.ticks_fired if mgr.state else "?",
-                            platform_name, source.chat_id, source.thread_id,
-                        )
-                        await adapter.handle_message(synth_event)
-                        # Slash-command loops dispatch through the command
-                        # path and never hit the post-turn completion hook —
-                        # complete the tick immediately (caps + scheduling).
-                        if wakeup.lstrip().startswith("/"):
-                            mgr.complete_tick("")
-                    except Exception as exc:
-                        logger.warning("loop wakeup injection failed for %s: %s", sid, exc)
-                        try:
-                            mgr.abandon_tick()
-                        except Exception:
-                            pass
             except Exception as exc:
-                logger.debug("loop wakeup watcher error: %s", exc)
+                logger.debug("loop wakeup watcher: could not resolve served profiles: %s", exc)
+                profile_homes = []
+
+            for _profile_name, profile_home in profile_homes:
+                try:
+                    with _profile_runtime_scope(profile_home):
+                        from hermes_cli.loops import (
+                            LoopManager,
+                            goal_blocks_loop_tick,
+                            list_active_loops,
+                        )
+
+                        now = time.time()
+                        for sid, state in list_active_loops():
+                            if state.awaiting_response or now < state.next_due_at:
+                                continue
+                            route = state.route or {}
+                            platform_name = route.get("platform", "")
+                            chat_id = route.get("chat_id", "")
+                            if not platform_name or not chat_id:
+                                # CLI / TUI-owned loop — their own schedulers drive it.
+                                continue
+                            try:
+                                platform_enum = Platform(platform_name)
+                            except (ValueError, KeyError):
+                                platform_enum = None
+                            # Profile-aware, fail-closed resolution
+                            # (gateway/authz_mixin.py) — a bare
+                            # self.adapters lookup only ever sees the
+                            # default profile's adapters, so a secondary
+                            # profile's loop would either find no adapter
+                            # or, worse, fire through the WRONG (default
+                            # profile's) bot for a platform both profiles
+                            # happen to have connected.
+                            adapter = (
+                                self._authorization_adapter(platform_enum, _profile_name)
+                                if platform_enum is not None
+                                else None
+                            )
+                            if adapter is None:
+                                if sid not in warned_no_route:
+                                    warned_no_route.add(sid)
+                                    logger.debug(
+                                        "loop wakeup: no adapter for platform %r (session %s)",
+                                        platform_name, sid,
+                                    )
+                                continue
+
+                            # Build the source + session key to check business.
+                            evt_stub = {
+                                "session_key": "",
+                                "platform": platform_name,
+                                "chat_id": chat_id,
+                                "chat_type": route.get("chat_type", ""),
+                                "thread_id": route.get("thread_id", ""),
+                                "user_id": route.get("user_id", ""),
+                                "user_name": route.get("user_name", ""),
+                            }
+                            source = self._build_process_event_source(evt_stub)
+                            if source is None:
+                                continue
+                            try:
+                                session_key = self._session_key_for_source(source)
+                            except Exception:
+                                session_key = None
+                            if session_key and session_key in self._running_agents:
+                                continue  # busy — stays due, next scan retries
+                            if goal_blocks_loop_tick(sid):
+                                continue
+
+                            mgr = LoopManager(session_id=sid)
+                            if not mgr.is_due(now):
+                                continue
+                            wakeup = mgr.fire_tick()
+                            if not wakeup:
+                                continue
+                            try:
+                                synth_event = MessageEvent(
+                                    text=wakeup,
+                                    message_type=MessageType.TEXT,
+                                    source=source,
+                                    internal=True,
+                                )
+                                logger.info(
+                                    "loop wakeup #%s — injecting for %s chat=%s thread=%s",
+                                    mgr.state.ticks_fired if mgr.state else "?",
+                                    platform_name, source.chat_id, source.thread_id,
+                                )
+                                await adapter.handle_message(synth_event)
+                                # Slash-command loops dispatch through the command
+                                # path and never hit the post-turn completion hook —
+                                # complete the tick immediately (caps + scheduling).
+                                if wakeup.lstrip().startswith("/"):
+                                    mgr.complete_tick("")
+                            except Exception as exc:
+                                logger.warning("loop wakeup injection failed for %s: %s", sid, exc)
+                                try:
+                                    mgr.abandon_tick()
+                                except Exception:
+                                    pass
+                except Exception as exc:
+                    logger.debug(
+                        "loop wakeup watcher error (profile %s): %s", _profile_name, exc
+                    )
+
             await asyncio.sleep(interval)
 
     @staticmethod

--- a/tests/gateway/test_loop_command.py
+++ b/tests/gateway/test_loop_command.py
@@ -248,3 +248,158 @@ async def test_post_turn_session_resolution_failure_is_logged(loop_env, caplog):
         )
 
     assert "post-turn session resolution failed: store unavailable" in caplog.text
+
+
+def _install_scoped_loop_db(home) -> None:
+    """Pre-populate loops._DB_CACHE with an explicitly-pathed SessionDB for
+    `home`.
+
+    tests/conftest.py's autouse _hermetic_environment fixture re-points
+    hermes_state.DEFAULT_DB_PATH to ONE fixed file for the whole test (a
+    hygiene guard against a bare SessionDB() ever touching a developer's
+    real ~/.hermes). _get_session_db() calls SessionDB() with no explicit
+    db_path, so — left alone — every simulated profile home in a
+    multi-profile test would collapse onto that same pinned file instead of
+    getting its own. Installing an explicitly-pathed instance under the
+    cache key _get_session_db() will look up (str(get_hermes_home()) while
+    `home` is the active override) bypasses that shortcut and restores the
+    real per-home separation this test needs to exercise.
+    """
+    from hermes_state import SessionDB
+
+    key = str(home)
+    if key not in loops._DB_CACHE:
+        loops._DB_CACHE[key] = SessionDB(db_path=home / "state.db")
+
+
+def _seed_due_loop(home, session_id: str, chat_id: str) -> None:
+    """Persist a due, routed loop directly to `home`'s own state.db."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    _install_scoped_loop_db(home)
+    token = set_hermes_home_override(str(home))
+    try:
+        state = loops.LoopState(
+            prompt="poll CI",
+            interval_seconds=300,
+            next_due_at=time.time() - 1,
+            route={
+                "platform": "discord",
+                "chat_id": chat_id,
+                "chat_type": "dm",
+                "thread_id": "",
+                "user_id": "",
+                "user_name": "",
+            },
+        )
+        loops.save_loop(session_id, state)
+    finally:
+        reset_hermes_home_override(token)
+
+
+async def _run_one_wakeup_tick(monkeypatch, runner):
+    """Drive _loop_wakeup_watcher for exactly one tick (mirrors the same
+    technique tests/gateway/test_kanban_notifier.py uses for its watcher)."""
+    import asyncio
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await GatewayRunner._loop_wakeup_watcher(runner, interval=1)
+
+
+@pytest.mark.asyncio
+async def test_loop_wakeup_watcher_fires_secondary_profile_loops(tmp_path, monkeypatch):
+    """Regression: _loop_wakeup_watcher is a single gateway-wide asyncio
+    task. get_hermes_home() would otherwise stay pinned to whichever
+    profile's context was ambient when the task was created, and adapter
+    resolution only ever consulted the default profile's self.adapters —
+    so a loop set from a secondary profile's chat would never fire, and
+    even if it were scanned, would risk firing through the WRONG (default
+    profile's) bot. Seeds one due loop per profile, in that profile's own
+    state.db, each routed to a different chat, and asserts each fires
+    through its OWN profile's adapter."""
+    home_default = tmp_path / "default_home"
+    home_work = tmp_path / "work_home"
+    home_default.mkdir()
+    home_work.mkdir()
+    _seed_due_loop(home_default, "sid-default", "chat-default")
+    _seed_due_loop(home_work, "sid-work", "chat-work")
+
+    adapter_default = AsyncMock()
+    adapter_work = AsyncMock()
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {Platform.DISCORD: adapter_default}
+    runner._profile_adapters = {"work": {Platform.DISCORD: adapter_work}}
+    runner._running_agents = {}
+    runner._cached_session_sources = {}
+    runner._session_sources_max = 512
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex, profile_allowlist=None: [("default", home_default), ("work", home_work)],
+    )
+    monkeypatch.setattr(GatewayRunner, "_active_profile_name", lambda self: "default")
+
+    await _run_one_wakeup_tick(monkeypatch, runner)
+
+    assert adapter_default.handle_message.await_count == 1, "default profile's due loop never fired"
+    assert adapter_work.handle_message.await_count == 1, "secondary profile's due loop never fired"
+    assert adapter_default.handle_message.call_args.args[0].source.chat_id == "chat-default"
+    assert adapter_work.handle_message.call_args.args[0].source.chat_id == "chat-work"
+
+    # Each profile's own loop must be marked fired — not left due forever
+    # (which would also produce a false "it fired" from a retried scan).
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    for name, home in (("sid-default", home_default), ("sid-work", home_work)):
+        token = set_hermes_home_override(str(home))
+        try:
+            reloaded = loops.load_loop(name)
+            assert reloaded.ticks_fired == 1
+        finally:
+            reset_hermes_home_override(token)
+
+
+@pytest.mark.asyncio
+async def test_loop_wakeup_watcher_single_profile_unchanged(tmp_path, monkeypatch, loop_env):
+    """Non-multiplex gateways (the overwhelming majority) must see
+    byte-for-byte the same single-profile behavior as before this fix, and
+    the fix must resolve the served-profile set with THIS gateway's own
+    multiplex_profiles flag — not unconditionally multiplex=True (which
+    would sweep in every profile directory found on disk, including ones
+    this gateway was never configured to serve)."""
+    _seed_due_loop(loop_env, "sid-solo", "chat-solo")
+
+    adapter = AsyncMock()
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner.config = GatewayConfig(multiplex_profiles=False)
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {}
+    runner._running_agents = {}
+    runner._cached_session_sources = {}
+    runner._session_sources_max = 512
+
+    seen_multiplex_flags = []
+
+    def fake_profiles_to_serve(multiplex, profile_allowlist=None):
+        seen_multiplex_flags.append(multiplex)
+        return [("default", loop_env)]
+
+    monkeypatch.setattr("hermes_cli.profiles.profiles_to_serve", fake_profiles_to_serve)
+
+    await _run_one_wakeup_tick(monkeypatch, runner)
+
+    assert seen_multiplex_flags == [False]
+    assert adapter.handle_message.await_count == 1
+    assert adapter.handle_message.call_args.args[0].source.chat_id == "chat-solo"


### PR DESCRIPTION
## Summary

\`_loop_wakeup_watcher\` (\`gateway/run.py\`) is a single gateway-wide \`asyncio\` task, spawned once from \`GatewayRunner.start()\` outside any profile scope. \`asyncio.create_task\` freezes the ambient context at creation time, so for the task's entire lifetime \`get_hermes_home()\` stayed pinned to whichever profile was ambient when \`start()\` ran (the launch/default profile) — a \`/loop\` set from any other multiplexed profile's chat would never fire, silently, forever.

This is the same class of bug independently found and fixed in this repo before: the Nous-token cache, A2A adapter, MoA runtime cache, and heartbeat poller all had the identical "process-global cache/task, no profile key" shape.

Even a correctly-scanned secondary-profile loop still risked firing through the **wrong bot**: adapter resolution only ever consulted \`self.adapters\`, which per \`gateway/run.py\`'s own comment is *"the default/active profile's map"* — secondary-profile adapters live in \`self._profile_adapters\` and were never consulted by this watcher.

## Fix

- Each tick now resolves the served profile set via \`hermes_cli.profiles.profiles_to_serve(multiplex=<this gateway's own multiplex_profiles config>, ...)\` and scans every profile's loops under its own \`_profile_runtime_scope\` — mirroring the multi-profile pattern already established at ~15 other call sites in this file. A non-multiplex gateway still resolves to exactly one profile (the launch profile), unchanged from before.
- Adapter resolution now goes through \`gateway/authz_mixin.py::_authorization_adapter(platform, profile)\`, the existing fail-closed helper that correctly consults \`_profile_adapters\` for a secondary profile instead of silently falling back to the default profile's adapter.

## Testing

- Two new tests in \`tests/gateway/test_loop_command.py\`:
  - \`test_loop_wakeup_watcher_fires_secondary_profile_loops\` — seeds a due loop in each of two profiles' own \`state.db\` (routed to different chats) and asserts each fires through its OWN profile's adapter, not the default profile's.
  - \`test_loop_wakeup_watcher_single_profile_unchanged\` — confirms a non-multiplex gateway resolves the served set with \`multiplex=False\` (not unconditionally \`True\`, which would sweep in every profile directory found on disk regardless of whether this gateway is configured to serve it) and keeps firing its single loop exactly as before.
- **Mutation-verified**: reverting the production fix makes both new tests fail with the exact pre-fix symptom — the multi-profile test's default-profile adapter is never called at all (0 instead of 1, since the old code has no profile resolution and runs against whatever context happens to be ambient); the single-profile test's \`profiles_to_serve\` is never called at all.
- Full \`tests/gateway/test_loop_command.py\`: 12 passed. Multiplex-focused suites (\`test_multiplex_adapter_registry.py\`, \`test_multiplex_profile_authz.py\`, \`test_multiplex_http_routing.py\`, \`test_multiplex_api_server_routing.py\`, \`test_64674_multiplex_primary_token_scope.py\`, \`test_gateway_platform_event_hook.py\`) and every test exercising \`_authorization_adapter\` (\`test_kanban_notifier.py\`, \`test_kanban_notifier_zero_sub_gate.py\`, \`test_kanban_notify.py\`): 106 passed total.
- \`ruff check\` clean; \`python3 -c "import gateway.run"\` clean.

## Competing PRs — significant textual overlap, no semantic conflict

\#87115 (\`fix(gateway): bind loop wakeups to their originating session\`, open) rewrites the *same* lines this PR touches inside \`_loop_wakeup_watcher\` — the \`session_key in self._running_agents\` check and the \`MessageEvent(...)\` construction — but for an entirely different, orthogonal concern: verifying a due loop's session hasn't been superseded by a \`/new\` reset before firing, and attaching strict-session metadata to the synthetic event. Read its diff directly to confirm: it adds session-boundary/reset verification *within* the per-\`sid\` body; this PR wraps that whole body in a per-served-profile scan and fixes adapter resolution. The two changes are complementary (a merge would want both), but whichever lands second will need a manual rebase over the other's reshaped function body — flagging for visibility, not as a reason to withhold either fix.