### PR TITLE
fix(desktop): skip electron-winstaller install script on Linux

### DIFF
--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -1258,6 +1258,9 @@ def _install_desktop_workspace_deps(npm: str, env: dict) -> None:
     nixos_env = with_hermes_node_path(_nixos_build_env())
     install_result = _run_npm_install_deterministic(npm, PROJECT_ROOT, capture_output=False, env=nixos_env)
     if install_result.returncode == 0:
+        # ignore-scripts retry can skip electron's postinstall; refill dist if staged package is empty.
+        if _electron_pkg_staged_missing_dist(PROJECT_ROOT):
+            _try_redownload_electron_dist(PROJECT_ROOT, env)
         return
     if not _electron_pkg_staged_missing_dist(PROJECT_ROOT):
         print(f"✗ Desktop dependency install failed\n  Run manually:  cd {PROJECT_ROOT} && npm ci")

--- a/hermes_cli/main_web_build.py
+++ b/hermes_cli/main_web_build.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Callable
 from hermes_cli.main_tui_launch import (
     _npm_lifecycle_env, _termux_workspace_install_context, _workspace_root)
+from hermes_cli.npm_winstaller import _is_electron_winstaller_unix_failure
 
 # Log-record parity with the origin module.
 logger = logging.getLogger("hermes_cli.main")
@@ -338,7 +339,18 @@ def _run_npm_install_deterministic(
             ci_result = _run(["ci"])
             if ci_result.returncode == 0:
                 return ci_result
-        return _run(["install", "--no-save"])
+            if "--ignore-scripts" not in extra_args and _is_electron_winstaller_unix_failure(ci_result):
+                ci_retry = _run(["ci", "--ignore-scripts"])
+                if ci_retry.returncode == 0:
+                    return ci_retry
+        install_result = _run(["install", "--no-save"])
+        if (
+            install_result.returncode != 0
+            and "--ignore-scripts" not in extra_args
+            and _is_electron_winstaller_unix_failure(install_result)
+        ):
+            return _run(["install", "--no-save", "--ignore-scripts"])
+        return install_result
 
     result = _attempt(npm)
     if result.returncode == 0:

--- a/hermes_cli/npm_winstaller.py
+++ b/hermes_cli/npm_winstaller.py
@@ -1,0 +1,15 @@
+"""Detect electron-winstaller Unix install-script failures."""
+import sys
+import subprocess
+
+def _is_electron_winstaller_unix_failure(result):
+    if sys.platform == "win32":
+        return False
+    text = (result.stderr or "") + (result.stdout or "")
+    if "select-7z-arch.js" in text:
+        return True
+    if "7z-x64.exe" in text:
+        return True
+    if "electron-winstaller" in text and "ENOENT" in text:
+        return True
+    return False

--- a/hermes_cli/npm_winstaller.py
+++ b/hermes_cli/npm_winstaller.py
@@ -1,9 +1,12 @@
 """Detect electron-winstaller Unix install-script failures."""
-import sys
-import subprocess
 
-def _is_electron_winstaller_unix_failure(result):
+import sys
+
+
+def _is_electron_winstaller_unix_failure(result) -> bool:
     if sys.platform == "win32":
+        return False
+    if getattr(result, "returncode", 1) == 0:
         return False
     text = (result.stderr or "") + (result.stdout or "")
     if "select-7z-arch.js" in text:

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "unicode-animations": false,
     "esbuild@0.28.1": true,
     "node-pty@1.1.0": true,
-    "electron-winstaller@5.4.0": true,
+    "electron-winstaller@5.4.0": false,
     "electron@40.10.2": true,
     "fsevents@2.3.2": true,
     "fsevents@2.3.3": true,

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -424,16 +424,25 @@ class TestBuildRecoversFromMissingToolchain:
 class TestElectronWinstallerUnixFailure:
     def _result(self, stderr="", returncode=1):
         import subprocess
+
         return subprocess.CompletedProcess([], returncode, stdout="", stderr=stderr)
+
     def test_select_7z_arch_is_a_unix_failure(self):
         err = "select-7z-arch.js failed"
         assert _is_electron_winstaller_unix_failure(self._result(err)) is True
+
     def test_missing_7z_binary_is_a_unix_failure(self):
         err = "ENOENT copyfile vendor/7z-x64.exe"
         assert _is_electron_winstaller_unix_failure(self._result(err)) is True
+
     def test_network_error_is_not_this_failure(self):
         err = "ECONNRESET"
         assert _is_electron_winstaller_unix_failure(self._result(err)) is False
+
+    def test_success_returncode_is_not_this_failure(self):
+        err = "select-7z-arch.js failed"
+        assert _is_electron_winstaller_unix_failure(self._result(err, returncode=0)) is False
+
     def test_windows_never_matches(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.npm_winstaller.sys.platform", "win32")
         err = "select-7z-arch.js failed"

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -20,6 +20,7 @@ import pytest
 
 from hermes_cli.main_web_build import _build_web_ui, _run_npm_install_deterministic
 from hermes_cli.main_web_build import _web_ui_build_needed, _compute_web_ui_content_hash, _missing_web_build_tool, _web_ui_stamp_path, _write_web_ui_build_stamp
+from hermes_cli.npm_winstaller import _is_electron_winstaller_unix_failure
 from hermes_cli.update_cmd import _web_build_toolchain_ready, _web_toolchain_roots
 
 
@@ -419,3 +420,21 @@ class TestBuildRecoversFromMissingToolchain:
         assert mock_install.call_count == 1
         assert mock_build.call_count == 1
 
+
+class TestElectronWinstallerUnixFailure:
+    def _result(self, stderr="", returncode=1):
+        import subprocess
+        return subprocess.CompletedProcess([], returncode, stdout="", stderr=stderr)
+    def test_select_7z_arch_is_a_unix_failure(self):
+        err = "select-7z-arch.js failed"
+        assert _is_electron_winstaller_unix_failure(self._result(err)) is True
+    def test_missing_7z_binary_is_a_unix_failure(self):
+        err = "ENOENT copyfile vendor/7z-x64.exe"
+        assert _is_electron_winstaller_unix_failure(self._result(err)) is True
+    def test_network_error_is_not_this_failure(self):
+        err = "ECONNRESET"
+        assert _is_electron_winstaller_unix_failure(self._result(err)) is False
+    def test_windows_never_matches(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.npm_winstaller.sys.platform", "win32")
+        err = "select-7z-arch.js failed"
+        assert _is_electron_winstaller_unix_failure(self._result(err)) is False


### PR DESCRIPTION
## Summary

Linux desktop install fails when electron-winstaller runs its Windows 7z copy script.

## Fix

Disable that install script and retry without lifecycle scripts on the Unix ENOENT. Redownload Electron if its dist is missing afterwards.

## Test plan

- Unit tests for the Unix-failure helper
- hermes desktop on Linux gets past workspace dependency install

Fixes #82960
