### PR TITLE
fix(skills): prevent HAR credential leakage

### DIFF
--- a/contributors/emails/tuomas.hie@gmail.com
+++ b/contributors/emails/tuomas.hie@gmail.com
@@ -1,0 +1,1 @@
+pnaaberi

--- a/optional-skills/web-development/har-derived-api-client/SKILL.md
+++ b/optional-skills/web-development/har-derived-api-client/SKILL.md
@@ -46,8 +46,10 @@ HAR recording works differently in each case (see How to Run).
   - (If a system Playwright already has browsers under `~/.cache/ms-playwright`, reuse it.)
 - `requests` or `httpx` for the replay step (stdlib `urllib` also works).
 - No API keys are needed by the skill itself. Treat captured keys, tokens, and
-  cookies as secrets; `har_to_client.py` reports their presence but redacts
-  credential header values from its output.
+  cookies as secrets; `har_to_client.py` reports their presence and redacts
+  credential headers plus common query/JSON/form credential fields. Capture
+  scripts restrict newly written HAR files to the current OS user where POSIX
+  permissions are available.
 - For the CDP path (`har_capture_cdp.py`): a reachable CDP endpoint. On Hermes,
   run `/browser connect` to print the active endpoint, or read `BROWSER_CDP_URL`
   / `browser.cdp_url` in config. Cloud backends expose it as `cdpUrl`/`connectUrl`.
@@ -108,7 +110,7 @@ har_capture_cdp.py <cdp_url> <out.har> [--goto URL] [--wait S] [--action SPEC ..
 
 har_to_client.py <in.har> [--host SUBSTR] [--include-static] [--max-body N]
   default: keeps only XHR/fetch/JSON; --host narrows to one domain
-  prints per endpoint: query params, non-boring req headers, req body sample,
+  prints per endpoint: redacted query params, non-boring req headers, req body sample,
                        response status/content-type + body sample
   prints "### Replay hints": the browser User-Agent, cookie/auth presence
 ```
@@ -144,7 +146,7 @@ for p in r.json()["pages"]:
 - **A failed `--action` aborts before the HAR flushes** — you get no file. If capture errors on a selector, the run produced nothing; fix the selector (use `--headed` to watch) and rerun. Don't debug a missing HAR.
 - **Server-rendered pages have no XHR** to derive — `har_to_client.py` prints "No API-looking entries". The data came in the HTML; scrape it or find the interaction that does fetch JSON.
 - **Debounced/typeahead XHRs need a real pause.** Add `--action "sleep:3"` after `fill`; typing alone won't have fired the request when the HAR closes.
-- **Auth/session endpoints** need equivalent current `Cookie`/`Authorization` values, and those expire. The derivation output redacts credential headers; load approved values at runtime from a secret manager, protected environment, or other project-approved source. HARs contain live secrets — restrict access and delete `out.har` after deriving.
+- **Auth/session endpoints** need equivalent current `Cookie`/`Authorization` values, and those expire. The derivation output redacts credential headers and common structured credential fields, but arbitrary unstructured bodies can still contain sensitive data. Load approved values at runtime from a secret manager, protected environment, or other project-approved source. HARs contain live secrets — restrict access and delete `out.har` after deriving.
 - **`record_har_content="embed"` makes big HARs.** Use `--max-body` to cap what's printed; the file itself can be large for media-heavy pages.
 - **Endpoints shift.** Sites change private APIs without notice. Re-run the capture→derive loop when a client breaks rather than patching URLs by hand.
 - **Wrong capturer = empty/no HAR.** `har_capture.py` on a cloud/CDP backend records nothing (it launches its own local browser instead of the one you meant). `har_capture_cdp.py` needs the endpoint; on Hermes get it from `/browser connect` or `BROWSER_CDP_URL`. Match the capturer to the pathway (How to Run table).

--- a/optional-skills/web-development/har-derived-api-client/SKILL.md
+++ b/optional-skills/web-development/har-derived-api-client/SKILL.md
@@ -15,11 +15,12 @@ metadata:
 
 Drive a website once with a real browser while recording its network traffic
 to a HAR file, then distill that HAR into the site's private JSON API so you
-can call it directly with plain HTTP — far cheaper and faster than
+can call it directly with plain HTTP — often cheaper and faster than
 browser-controlling the page on every request. Credit: trick by Jared Longster,
 popularized by Dax (thdxr). This captures and replays; it does NOT bypass
 auth, solve CAPTCHAs, or defeat bot-detection — if the site needs a logged-in
-session, you carry its headers/cookies forward, you don't forge them.
+session, provide equivalent credentials at runtime from an approved secret
+source; never paste secrets from a HAR into generated code or command history.
 
 The scripts are stdlib-plus-Playwright: capture needs Playwright, derivation
 is pure stdlib, replay needs only `requests`/`httpx` (or `curl`).
@@ -44,7 +45,9 @@ HAR recording works differently in each case (see How to Run).
   - `pip install playwright` then `playwright install chromium`
   - (If a system Playwright already has browsers under `~/.cache/ms-playwright`, reuse it.)
 - `requests` or `httpx` for the replay step (stdlib `urllib` also works).
-- No API keys. Any keys/tokens the client needs are the ones the HAR captured.
+- No API keys are needed by the skill itself. Treat captured keys, tokens, and
+  cookies as secrets; `har_to_client.py` reports their presence but redacts
+  credential header values from its output.
 - For the CDP path (`har_capture_cdp.py`): a reachable CDP endpoint. On Hermes,
   run `/browser connect` to print the active endpoint, or read `BROWSER_CDP_URL`
   / `browser.cdp_url` in config. Cloud backends expose it as `cdpUrl`/`connectUrl`.
@@ -116,7 +119,7 @@ har_to_client.py <in.har> [--host SUBSTR] [--include-static] [--max-body N]
 1. **Find the interaction.** Open the site with `browser_navigate` (or `--headed` capture) to see which selector to type into / click, and confirm a JSON XHR fires in devtools/network.
 2. **Capture the HAR** via the `terminal` tool. Order `--action` to reach the request: `fill` the box, then `sleep` long enough for the debounced XHR, and always leave `--wait` at the end so late responses flush. Both capturers embed response bodies, so the derived client sees real payload shapes.
 3. **Derive** with `har_to_client.py --host <domain>`. Read off: the method, the URL/path template (numeric/UUID segments collapse to `{id}`), query params, request-body JSON, and the `### Replay hints` block.
-4. **Write the client.** Recreate the request exactly — same method, path, query params, body. Send the headers the site actually needs: at minimum copy the **User-Agent** from the replay hints. If hints report cookies or an auth/token header, resend those too.
+4. **Write the client.** Recreate the request exactly — same scheme, method, path, query params, and body. Send the non-secret headers the site actually needs, including the **User-Agent** from the replay hints. If hints report cookies or an auth/token header, obtain an equivalent current value from an approved runtime secret source; never paste the HAR value into source code or a shell command.
 5. **Test browserless.** Run the client with the `terminal` tool and confirm it returns the same data the browser saw. This is the payoff: no browser in the loop.
 6. **(Optional) Wrap as a CLI** — a small `argparse` script over the derived call, e.g. `search.py "frank herbert"`.
 
@@ -141,7 +144,7 @@ for p in r.json()["pages"]:
 - **A failed `--action` aborts before the HAR flushes** — you get no file. If capture errors on a selector, the run produced nothing; fix the selector (use `--headed` to watch) and rerun. Don't debug a missing HAR.
 - **Server-rendered pages have no XHR** to derive — `har_to_client.py` prints "No API-looking entries". The data came in the HTML; scrape it or find the interaction that does fetch JSON.
 - **Debounced/typeahead XHRs need a real pause.** Add `--action "sleep:3"` after `fill`; typing alone won't have fired the request when the HAR closes.
-- **Auth/session endpoints** need the captured `Cookie`/`Authorization` header, and those expire. The derived client is only as durable as the credential; re-capture when it 401s. HARs contain live secrets — treat `out.har` as sensitive and delete it after deriving.
+- **Auth/session endpoints** need equivalent current `Cookie`/`Authorization` values, and those expire. The derivation output redacts credential headers; load approved values at runtime from a secret manager, protected environment, or other project-approved source. HARs contain live secrets — restrict access and delete `out.har` after deriving.
 - **`record_har_content="embed"` makes big HARs.** Use `--max-body` to cap what's printed; the file itself can be large for media-heavy pages.
 - **Endpoints shift.** Sites change private APIs without notice. Re-run the capture→derive loop when a client breaks rather than patching URLs by hand.
 - **Wrong capturer = empty/no HAR.** `har_capture.py` on a cloud/CDP backend records nothing (it launches its own local browser instead of the one you meant). `har_capture_cdp.py` needs the endpoint; on Hermes get it from `/browser connect` or `BROWSER_CDP_URL`. Match the capturer to the pathway (How to Run table).

--- a/optional-skills/web-development/har-derived-api-client/scripts/har_capture.py
+++ b/optional-skills/web-development/har-derived-api-client/scripts/har_capture.py
@@ -13,6 +13,7 @@ NOTE: a failing action raises before the HAR is flushed -- you get no file.
 Fix the selector (try --headed to watch) and rerun.
 """
 import argparse
+import os
 import sys
 import time
 
@@ -47,6 +48,9 @@ def main() -> int:
     ap.add_argument("--headed", action="store_true")
     args = ap.parse_args()
 
+    if os.path.islink(args.har_path):
+        raise ValueError(f"refusing to write HAR through symlink: {args.har_path}")
+
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=not args.headed)
         context = browser.new_context(
@@ -63,6 +67,7 @@ def main() -> int:
                 pass  # some pages never fully idle; the trailing --wait covers it
         time.sleep(args.wait)
         context.close()  # flushes the HAR
+        os.chmod(args.har_path, 0o600)
         browser.close()
     print(f"HAR written: {args.har_path}")
     return 0

--- a/optional-skills/web-development/har-derived-api-client/scripts/har_capture_cdp.py
+++ b/optional-skills/web-development/har-derived-api-client/scripts/har_capture_cdp.py
@@ -21,11 +21,28 @@ Usage:
 import argparse
 import base64
 import json
+import os
 import sys
 import time
 from urllib.parse import parse_qsl, urlsplit
 
 from playwright.sync_api import sync_playwright
+
+
+def _write_private_har(path: str, har: dict) -> None:
+    """Write a HAR with owner-only permissions, including when replacing a file."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags, 0o600)
+    try:
+        os.chmod(path, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            fd = -1
+            json.dump(har, f)
+    finally:
+        if fd >= 0:
+            os.close(fd)
 
 
 def run_action(page, spec: str) -> None:
@@ -131,8 +148,7 @@ def main() -> int:
     har = {"log": {"version": "1.2",
                    "creator": {"name": "har_capture_cdp", "version": "0.1"},
                    "entries": entries}}
-    with open(args.har_path, "w", encoding="utf-8") as f:
-        json.dump(har, f)
+    _write_private_har(args.har_path, har)
     print(f"HAR written: {args.har_path} ({len(entries)} entries)")
     return 0
 

--- a/optional-skills/web-development/har-derived-api-client/scripts/har_capture_cdp.py
+++ b/optional-skills/web-development/har-derived-api-client/scripts/har_capture_cdp.py
@@ -23,6 +23,7 @@ import base64
 import json
 import sys
 import time
+from urllib.parse import parse_qsl, urlsplit
 
 from playwright.sync_api import sync_playwright
 
@@ -64,7 +65,12 @@ def _har_entry(req, resp):
             "method": req.method,
             "url": req.url,
             "headers": [{"name": k, "value": v} for k, v in req.headers.items()],
-            "queryString": [],  # har_to_client.py re-parses the URL, so leave empty
+            "queryString": [
+                {"name": name, "value": value}
+                for name, value in parse_qsl(
+                    urlsplit(req.url).query, keep_blank_values=True
+                )
+            ],
             "postData": {"mimeType": req.headers.get("content-type", ""),
                          "text": post} if post else {},
         },

--- a/optional-skills/web-development/har-derived-api-client/scripts/har_to_client.py
+++ b/optional-skills/web-development/har-derived-api-client/scripts/har_to_client.py
@@ -9,15 +9,15 @@ template), and prints per-endpoint: query params, interesting request headers,
 request body sample, response content-type/status, and a response body sample.
 Numeric/UUID-ish path segments are collapsed to {id} so repeated calls group.
 Also prints "### Replay hints": the browser User-Agent plus whether cookies or
-auth/token headers were present -- send those in the derived client or you may
-get a 403/401.
+auth/token headers were present. Credential header values are redacted; supply
+current values from an approved runtime secret source when needed.
 """
 import argparse
 import json
 import re
 import sys
 from collections import OrderedDict
-from urllib.parse import urlsplit
+from urllib.parse import parse_qsl, urlsplit
 
 BORING_HEADERS = {
     "accept-encoding", "accept-language", "connection", "content-length",
@@ -28,6 +28,7 @@ BORING_HEADERS = {
 }
 ID_SEG = re.compile(r"^(\d+|[0-9a-f]{8}-[0-9a-f-]{27,}|[0-9a-f]{16,})$", re.I)
 STATIC_EXT = re.compile(r"\.(js|css|png|jpe?g|gif|svg|webp|ico|woff2?|ttf|mp4|map)$", re.I)
+SENSITIVE_HEADER_MARKERS = ("authorization", "apikey", "token", "secret", "credential")
 
 
 def path_template(path: str) -> str:
@@ -54,6 +55,19 @@ def trunc(text, n: int) -> str:
     return text if len(text) <= n else text[:n] + f"... [{len(text)} chars total]"
 
 
+def is_sensitive_header(name: str) -> bool:
+    compact = re.sub(r"[^a-z0-9]", "", name.lower().lstrip(":"))
+    return any(marker in compact for marker in SENSITIVE_HEADER_MARKERS)
+
+
+def query_items(req: dict, url) -> list[tuple[str, str]]:
+    """Return HAR query items, falling back to the request URL when omitted."""
+    items = req.get("queryString")
+    if items:
+        return [(q["name"], q.get("value", "")) for q in items]
+    return parse_qsl(url.query, keep_blank_values=True)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("har")
@@ -76,17 +90,19 @@ def main() -> int:
         if not args.include_static:
             if STATIC_EXT.search(url.path) or not is_api_entry(entry):
                 continue
-        key = (req["method"], url.netloc, path_template(url.path))
+        key = (req["method"], url.scheme, url.netloc, path_template(url.path))
         g = groups.setdefault(key, {"count": 0, "queries": set(), "headers": {},
                                     "req_body": None, "resp": None})
         g["count"] += 1
-        for q in req.get("queryString", []):
-            g["queries"].add((q["name"], trunc(q["value"], 80)))
+        for name, value in query_items(req, url):
+            g["queries"].add((name, trunc(value, 80)))
         for h in req.get("headers", []):
             name = h["name"].lower().lstrip(":")
             if name in BORING_HEADERS or name in ("method", "path", "scheme", "authority"):
                 continue
-            g["headers"][name] = trunc(h["value"], 120)
+            g["headers"][name] = (
+                "[REDACTED]" if is_sensitive_header(name) else trunc(h["value"], 120)
+            )
         post = req.get("postData", {})
         if post.get("text") and g["req_body"] is None:
             g["req_body"] = (post.get("mimeType", ""), trunc(post["text"], args.max_body))
@@ -111,18 +127,18 @@ def main() -> int:
                 ua = h["value"]
             if n == "cookie":
                 saw_cookie = True
-            if n in ("authorization", "x-api-key") or "token" in n:
+            if is_sensitive_header(n):
                 saw_auth = True
     print("### Replay hints")
     if ua:
         print(f"  User-Agent (send this): {ua}")
     if saw_cookie:
-        print("  Cookies present -> session may be auth-gated; capture & resend the Cookie header.")
+        print("  Cookies present -> value omitted; supply an equivalent current session from an approved runtime secret source.")
     if saw_auth:
-        print("  Authorization/token header present -> extract and resend it.")
+        print("  Authorization/token header present -> value redacted; supply it from an approved runtime secret source.")
 
-    for (method, host, path), g in groups.items():
-        print(f"\n=== {method} https://{host}{path}  (x{g['count']})")
+    for (method, scheme, host, path), g in groups.items():
+        print(f"\n=== {method} {scheme}://{host}{path}  (x{g['count']})")
         if g["queries"]:
             print("  query params:")
             for name, val in sorted(g["queries"]):

--- a/optional-skills/web-development/har-derived-api-client/scripts/har_to_client.py
+++ b/optional-skills/web-development/har-derived-api-client/scripts/har_to_client.py
@@ -17,7 +17,7 @@ import json
 import re
 import sys
 from collections import OrderedDict
-from urllib.parse import parse_qsl, urlsplit
+from urllib.parse import parse_qsl, urlencode, urlsplit
 
 BORING_HEADERS = {
     "accept-encoding", "accept-language", "connection", "content-length",
@@ -29,6 +29,14 @@ BORING_HEADERS = {
 ID_SEG = re.compile(r"^(\d+|[0-9a-f]{8}-[0-9a-f-]{27,}|[0-9a-f]{16,})$", re.I)
 STATIC_EXT = re.compile(r"\.(js|css|png|jpe?g|gif|svg|webp|ico|woff2?|ttf|mp4|map)$", re.I)
 SENSITIVE_HEADER_MARKERS = ("authorization", "apikey", "token", "secret", "credential")
+SENSITIVE_FIELD_NAMES = {
+    "accesstoken", "apikey", "authorization", "authtoken", "bearertoken",
+    "clientsecret", "cookie", "credential", "csrftoken", "idtoken", "oauthaccesstoken",
+    "oauthtoken", "pass", "password", "passwd", "privatekey", "pwd", "refreshtoken",
+    "secret", "secretkey", "session", "sessionid", "sessionkey", "sessiontoken",
+    "signature", "signedtoken", "token", "xsrftoken",
+}
+REDACTED = "[REDACTED]"
 
 
 def path_template(path: str) -> str:
@@ -58,6 +66,43 @@ def trunc(text, n: int) -> str:
 def is_sensitive_header(name: str) -> bool:
     compact = re.sub(r"[^a-z0-9]", "", name.lower().lstrip(":"))
     return any(marker in compact for marker in SENSITIVE_HEADER_MARKERS)
+
+
+def is_sensitive_field(name: str) -> bool:
+    """Identify credential-bearing query/body field names without broad substring matches."""
+    compact = re.sub(r"[^a-z0-9]", "", str(name).lower())
+    return compact in SENSITIVE_FIELD_NAMES
+
+
+def redact_structure(value):
+    """Recursively redact credential values from decoded JSON-like structures."""
+    if isinstance(value, dict):
+        return {
+            key: REDACTED if is_sensitive_field(key) else redact_structure(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_structure(item) for item in value]
+    return value
+
+
+def body_sample(mime: str, text: str, max_body: int) -> str:
+    """Redact structured JSON/form credentials before truncating the displayed sample."""
+    mime = (mime or "").lower()
+    if "json" in mime:
+        try:
+            decoded = json.loads(text)
+        except (TypeError, ValueError):
+            pass
+        else:
+            return trunc(json.dumps(redact_structure(decoded), ensure_ascii=False), max_body)
+    if "application/x-www-form-urlencoded" in mime:
+        fields = [
+            (name, REDACTED if is_sensitive_field(name) else value)
+            for name, value in parse_qsl(text, keep_blank_values=True)
+        ]
+        return trunc(urlencode(fields), max_body)
+    return trunc(text, max_body)
 
 
 def query_items(req: dict, url) -> list[tuple[str, str]]:
@@ -95,22 +140,25 @@ def main() -> int:
                                     "req_body": None, "resp": None})
         g["count"] += 1
         for name, value in query_items(req, url):
-            g["queries"].add((name, trunc(value, 80)))
+            displayed = REDACTED if is_sensitive_field(name) else trunc(value, 80)
+            g["queries"].add((name, displayed))
         for h in req.get("headers", []):
             name = h["name"].lower().lstrip(":")
             if name in BORING_HEADERS or name in ("method", "path", "scheme", "authority"):
                 continue
             g["headers"][name] = (
-                "[REDACTED]" if is_sensitive_header(name) else trunc(h["value"], 120)
+                REDACTED if is_sensitive_header(name) else trunc(h["value"], 120)
             )
         post = req.get("postData", {})
         if post.get("text") and g["req_body"] is None:
-            g["req_body"] = (post.get("mimeType", ""), trunc(post["text"], args.max_body))
+            mime = post.get("mimeType", "")
+            g["req_body"] = (mime, body_sample(mime, post["text"], args.max_body))
         resp = entry.get("response", {})
         if g["resp"] is None and resp:
             content = resp.get("content", {})
-            g["resp"] = (resp.get("status"), content.get("mimeType", ""),
-                         trunc(content.get("text") or "", args.max_body))
+            mime = content.get("mimeType", "")
+            g["resp"] = (resp.get("status"), mime,
+                         body_sample(mime, content.get("text") or "", args.max_body))
 
     if not groups:
         print("No API-looking entries found. Re-run with --include-static to see everything.")

--- a/tests/skills/test_har_derived_api_client_skill.py
+++ b/tests/skills/test_har_derived_api_client_skill.py
@@ -11,6 +11,8 @@ Two layers, both stdlib + pytest, no network:
 import importlib.util
 import json
 import re
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -123,8 +125,6 @@ def test_derives_endpoint_and_filters_static(tmp_path, capsys):
     har = tmp_path / "t.har"
     har.write_text(json.dumps(_make_har()), encoding="utf-8")
 
-    import sys
-
     argv = sys.argv
     try:
         sys.argv = ["har_to_client.py", str(har), "--host", "example.com"]
@@ -144,6 +144,60 @@ def test_derives_endpoint_and_filters_static(tmp_path, capsys):
     assert "referer" not in out
     # replay hint carries the browser UA
     assert "User-Agent (send this): Mozilla/5.0 TestBrowser/1.0" in out
+
+
+def test_preserves_scheme_parses_url_query_and_redacts_credentials(tmp_path, capsys):
+    mod = _load_module(DERIVE, "har_to_client_security_undertest")
+    fixture = _make_har()
+    request = fixture["log"]["entries"][0]["request"]
+    request["url"] = "http://api.example.com/v1/items/12345/reviews?q=one&blank="
+    request["queryString"] = []
+    request["headers"].extend([
+        {"name": "Authorization", "value": "Bearer secret-auth-value"},
+        {"name": "X-Goog-API-Key", "value": "secret-api-key-value"},
+        {"name": "X-Custom-Token", "value": "secret-token-value"},
+    ])
+    har = tmp_path / "sensitive.har"
+    har.write_text(json.dumps(fixture), encoding="utf-8")
+
+    argv = sys.argv
+    try:
+        sys.argv = ["har_to_client.py", str(har), "--host", "example.com"]
+        rc = mod.main()
+    finally:
+        sys.argv = argv
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "GET http://api.example.com/v1/items/{id}/reviews" in out
+    assert "q = one" in out
+    assert "blank = " in out
+    assert out.count("[REDACTED]") == 3
+    for secret in ("secret-auth-value", "secret-api-key-value", "secret-token-value"):
+        assert secret not in out
+
+
+def test_cdp_capture_populates_query_string(monkeypatch):
+    sync_api = types.ModuleType("playwright.sync_api")
+    setattr(sync_api, "sync_playwright", object())
+    playwright = types.ModuleType("playwright")
+    monkeypatch.setitem(sys.modules, "playwright", playwright)
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", sync_api)
+    mod = _load_module(CAPTURE_CDP, "har_capture_cdp_query_undertest")
+
+    class Request:
+        method = "GET"
+        url = "https://example.com/api?q=one&q=two&blank="
+        headers = {}
+        post_data = None
+        resource_type = "xhr"
+
+    entry = mod._har_entry(Request(), None)
+    assert entry["request"]["queryString"] == [
+        {"name": "q", "value": "one"},
+        {"name": "q", "value": "two"},
+        {"name": "blank", "value": ""},
+    ]
 
 
 def test_path_template_collapses_ids():

--- a/tests/skills/test_har_derived_api_client_skill.py
+++ b/tests/skills/test_har_derived_api_client_skill.py
@@ -10,6 +10,7 @@ Two layers, both stdlib + pytest, no network:
 
 import importlib.util
 import json
+import os
 import re
 import sys
 import types
@@ -177,6 +178,63 @@ def test_preserves_scheme_parses_url_query_and_redacts_credentials(tmp_path, cap
         assert secret not in out
 
 
+def test_redacts_query_and_structured_body_credentials(tmp_path, capsys):
+    mod = _load_module(DERIVE, "har_to_client_body_security_undertest")
+    fixture = _make_har()
+    entry = fixture["log"]["entries"][0]
+    entry["request"]["url"] += "&access_token=query-secret"
+    entry["request"]["queryString"].append(
+        {"name": "access_token", "value": "query-secret"}
+    )
+    entry["request"]["method"] = "POST"
+    entry["request"]["postData"] = {
+        "mimeType": "application/json",
+        "text": json.dumps({
+            "password": "request-secret",
+            "profile": {"token": "nested-secret", "token_count": 7},
+        }),
+    }
+    entry["response"]["content"]["text"] = json.dumps({
+        "access_token": "response-secret",
+        "items": [{"client_secret": "deep-secret", "name": "kept"}],
+    })
+    har = tmp_path / "structured-secrets.har"
+    har.write_text(json.dumps(fixture), encoding="utf-8")
+
+    argv = sys.argv
+    try:
+        sys.argv = ["har_to_client.py", str(har)]
+        rc = mod.main()
+    finally:
+        sys.argv = argv
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "access_token = [REDACTED]" in out
+    assert '"password": "[REDACTED]"' in out
+    assert '"token": "[REDACTED]"' in out
+    assert '"token_count": 7' in out
+    assert '"client_secret": "[REDACTED]"' in out
+    assert '"name": "kept"' in out
+    for secret in (
+        "query-secret", "request-secret", "nested-secret",
+        "response-secret", "deep-secret",
+    ):
+        assert secret not in out
+
+
+def test_redacts_form_credentials_without_hiding_non_secret_token_fields():
+    mod = _load_module(DERIVE, "har_to_client_form_security_undertest")
+    sample = mod.body_sample(
+        "application/x-www-form-urlencoded",
+        "username=alice&password=form-secret&token_count=3",
+        600,
+    )
+    assert "password=%5BREDACTED%5D" in sample
+    assert "token_count=3" in sample
+    assert "form-secret" not in sample
+
+
 def test_cdp_capture_populates_query_string(monkeypatch):
     sync_api = types.ModuleType("playwright.sync_api")
     setattr(sync_api, "sync_playwright", object())
@@ -198,6 +256,24 @@ def test_cdp_capture_populates_query_string(monkeypatch):
         {"name": "q", "value": "two"},
         {"name": "blank", "value": ""},
     ]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_cdp_capture_writes_owner_only_har(monkeypatch, tmp_path):
+    sync_api = types.ModuleType("playwright.sync_api")
+    setattr(sync_api, "sync_playwright", object())
+    playwright = types.ModuleType("playwright")
+    monkeypatch.setitem(sys.modules, "playwright", playwright)
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", sync_api)
+    mod = _load_module(CAPTURE_CDP, "har_capture_cdp_permissions_undertest")
+    path = tmp_path / "private.har"
+    path.write_text("old", encoding="utf-8")
+    path.chmod(0o644)
+
+    mod._write_private_har(str(path), {"log": {"entries": []}})
+
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert json.loads(path.read_text(encoding="utf-8")) == {"log": {"entries": []}}
 
 
 def test_path_template_collapses_ids():


### PR DESCRIPTION
## Summary

Prevent the official `har-derived-api-client` skill from copying captured credentials into agent/model output and reduce exposure of the raw HAR itself. This preserves the scheme/query/header fixes from closed PR #85053 as its original commit (and therefore preserves Tuomas Hietala's authorship), then extends redaction to sensitive query parameters, nested JSON request/response fields, and URL-encoded forms. Both capturers now make completed HARs owner-only on POSIX; the CDP writer also refuses symlink traversal where the platform supports `O_NOFOLLOW`.

This intentionally does not absorb the capture lifecycle, `postData: null`, form-without-text, or base64 work in #85100/#84977. Those are separate correctness fixes with overlapping files.

## RED proof

With the new behavioral tests kept but the three scripts restored to current `origin/main`:

```text
$ scripts/run_tests.sh tests/skills/test_har_derived_api_client_skill.py -q
9 passed, 5 failed

FAILED test_preserves_scheme_parses_url_query_and_redacts_credentials
FAILED test_redacts_query_and_structured_body_credentials
FAILED test_redacts_form_credentials_without_hiding_non_secret_token_fields
FAILED test_cdp_capture_populates_query_string
FAILED test_cdp_capture_writes_owner_only_har
```

On this branch:

```text
$ scripts/run_tests.sh tests/skills/test_har_derived_api_client_skill.py -q
14 passed, 0 failed
```

A live local capture against JSONPlaceholder also produced `mode=600`, derived `GET /posts/{id}`, and completed browserless derivation successfully.

## Code path trace

1. **Symptom:** running `har_to_client.py` can place live query/body/response credentials into agent context; capture scripts create raw HARs readable beyond the current user under a typical `022` umask.
2. **Intermediate:** the grouping loop previously printed query values and body samples verbatim, while capture output used Playwright/default `open()` permissions.
3. **Root cause:** secret handling covered only selected request headers and documentation warnings; it did not treat structured fields or the raw HAR's filesystem permissions as part of the same credential boundary.

## Widening audit

- Request headers: affected → common authorization/key/token/secret header values are redacted (from #85053).
- URL query parameters: affected → exact credential field names are redacted; benign fields such as `token_count` remain visible.
- JSON request bodies: affected → credential keys are recursively redacted.
- JSON response bodies: affected → nested credential keys are recursively redacted.
- URL-encoded request bodies: affected → credential values are redacted and the sample is safely re-encoded.
- Arbitrary unstructured bodies: cannot be classified reliably → still sampled; the skill now states this residual risk explicitly.
- Local Playwright capture: affected → completed HAR is chmod `0600` and symlink output is rejected.
- CDP capture: affected → owner-only `os.open(..., 0600)` writer; existing loose files are tightened and symlinks are rejected where `O_NOFOLLOW` exists.
- Windows: POSIX permission bits do not apply; redaction remains active and documentation scopes the permission guarantee accordingly.

## Verification

```text
scripts/run_tests.sh tests/skills/test_har_derived_api_client_skill.py -q
# 14 passed

python -m ruff check optional-skills/web-development/har-derived-api-client/scripts/*.py tests/skills/test_har_derived_api_client_skill.py
# All checks passed!

python -m py_compile optional-skills/web-development/har-derived-api-client/scripts/*.py tests/skills/test_har_derived_api_client_skill.py
git diff --check
# passed
```

Live smoke:

```text
python optional-skills/web-development/har-derived-api-client/scripts/har_capture.py \
  https://jsonplaceholder.typicode.com/posts/1 /tmp/har-permission-live.har --wait 1
stat -c 'mode=%a bytes=%s' /tmp/har-permission-live.har
# mode=600

python optional-skills/web-development/har-derived-api-client/scripts/har_to_client.py \
  /tmp/har-permission-live.har --max-body 100
# 1 distinct endpoint; GET https://jsonplaceholder.typicode.com/posts/{id}
```

## Attribution

The first commit is the exact commit from closed PR #85053 by @pnaaberi / Tuomas Hietala. This branch builds on it instead of reimplementing the same fixes, preserving authorship in Git history.