### PR TITLE
fix(cron): let scripts tell a scheduled fire from a manual run

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3288,6 +3288,24 @@ def _run_job_script(
             }
         env = build_subprocess_env()
         env.update(env_overlay)
+        # Tell the script it is running as a REAL scheduled fire, not by hand.
+        #
+        # Watchdog scripts commonly fire once and then delete their own state
+        # file to disarm ("alert the operator, then stay quiet until the
+        # condition clears"). That makes them NOT idempotent: running one
+        # manually to check on it consumes the pending alert -- the message
+        # goes to the operator's terminal, the state file is gone, and the
+        # next scheduled run has nothing left to report. The person the alert
+        # was for never hears about it.
+        #
+        # Nothing in the environment distinguished the two callers, so a
+        # script could not defend itself. Scripts gate their destructive state
+        # transitions on this: set = real run, mutate state; absent = manual
+        # run, report findings and change nothing.
+        #
+        # Internal runner->subprocess signal (like HERMES_HOME above), not
+        # user-facing configuration -- there is nothing here for a user to set.
+        env["HERMES_CRON_RUN"] = "1"
         # Use the job's workdir as the subprocess cwd when configured,
         # otherwise default to the scripts-dir parent (back-compat).
         # NEVER mutate the Python process cwd — that would leak into

--- a/tests/cron/test_cron_run_marker.py
+++ b/tests/cron/test_cron_run_marker.py
@@ -1,0 +1,137 @@
+"""A cron script must be able to tell a real fire from a manual run.
+
+Watchdog scripts commonly fire once and then delete their own state file to
+disarm. That makes them NOT idempotent: running one by hand to check on it
+consumes the pending alert -- output goes to the operator's terminal, the
+state file is gone, and the next scheduled run has nothing left to report.
+
+Nothing in the subprocess environment distinguished the two callers, so a
+script had no way to defend itself. ``_run_job_script`` now exports
+``HERMES_CRON_RUN=1``; absent means "invoked by hand, don't mutate state".
+
+The scripts here are real files executed by the real runner -- the contract
+under test is what a script actually observes in its environment.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.scheduler import _run_job_script  # noqa: E402
+
+
+@pytest.fixture
+def scripts_dir(tmp_path, monkeypatch):
+    """Real HERMES_HOME layout: the runner only executes files under scripts/."""
+    home = tmp_path / ".hermes"
+    (home / "scripts").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home / "scripts"
+
+
+def _script(where: Path, name: str, body: str) -> Path:
+    p = where / name
+    p.write_text(body)
+    p.chmod(0o755)
+    return p
+
+
+class TestCronRunMarker:
+    def test_scheduled_run_sets_the_marker(self, scripts_dir):
+        s = _script(
+            scripts_dir,
+            "probe.py",
+            "import os\nprint(os.environ.get('HERMES_CRON_RUN', 'ABSENT'))\n",
+        )
+        ok, out = _run_job_script(str(s))
+        assert ok, out
+        assert out.strip() == "1"
+
+    def test_marker_reaches_shell_scripts_too(self, scripts_dir):
+        s = _script(scripts_dir, "probe.sh", 'echo "${HERMES_CRON_RUN:-ABSENT}"\n')
+        ok, out = _run_job_script(str(s))
+        assert ok, out
+        assert out.strip() == "1"
+
+    def test_manual_invocation_does_not_see_the_marker(self, tmp_path, monkeypatch):
+        """The whole point: running the script directly must look different.
+
+        This is the case that silently ate an alert -- a human running the
+        same file gets no marker, so a guarded script leaves its state alone.
+        """
+        monkeypatch.delenv("HERMES_CRON_RUN", raising=False)
+        s = _script(
+            tmp_path,
+            "probe.py",
+            "import os\nprint(os.environ.get('HERMES_CRON_RUN', 'ABSENT'))\n",
+        )
+        import subprocess
+
+        r = subprocess.run(
+            [sys.executable, str(s)], capture_output=True, text=True, timeout=60
+        )
+        assert r.stdout.strip() == "ABSENT"
+
+    def test_one_shot_watchdog_keeps_its_alert_on_a_manual_run(self, tmp_path):
+        """End-to-end on the real failure shape: fire-once-then-disarm.
+
+        Same script, both callers. Under cron it announces and disarms; run by
+        hand it must announce nothing and leave the state file intact so the
+        next scheduled run can still deliver.
+        """
+        state = tmp_path / "pending.flag"
+        state.write_text("armed")
+        watchdog = _script(
+            tmp_path,
+            "watchdog.sh",
+            'STATE="$1"\n'
+            'if [ -f "$STATE" ]; then\n'
+            '  if [ "${HERMES_CRON_RUN:-}" != "1" ]; then\n'
+            '    echo "[dry-run] would announce" >&2\n'
+            "    exit 0\n"
+            "  fi\n"
+            '  rm -f "$STATE"\n'
+            '  echo "ALERT"\n'
+            "fi\n",
+        )
+        import subprocess
+
+        # Manual: no marker -> must not consume the alert.
+        env = dict(os.environ)
+        env.pop("HERMES_CRON_RUN", None)
+        r = subprocess.run(
+            ["bash", str(watchdog), str(state)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+        )
+        assert "ALERT" not in r.stdout
+        assert state.exists(), "manual run disarmed the watchdog -- alert lost"
+
+        # Scheduled: marker present -> announces and disarms exactly once.
+        env["HERMES_CRON_RUN"] = "1"
+        r = subprocess.run(
+            ["bash", str(watchdog), str(state)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+        )
+        assert "ALERT" in r.stdout
+        assert not state.exists()
+
+    def test_marker_does_not_clobber_existing_env(self, scripts_dir):
+        """HERMES_HOME and friends must still arrive intact."""
+        s = _script(
+            scripts_dir,
+            "probe.py",
+            "import os\nprint('HOME_OK' if os.environ.get('HERMES_HOME') else 'HOME_MISSING')\n",
+        )
+        ok, out = _run_job_script(str(s))
+        assert ok, out
+        assert "HOME_OK" in out


### PR DESCRIPTION
## The bug

Watchdog scripts commonly fire once and then delete their own state file to disarm — *"alert, then stay quiet until the condition clears"*. That makes them **not idempotent**, and nothing in the subprocess environment distinguished a real scheduled fire from a human running the same file to check on it.

So running one by hand **consumes the pending alert**: the output goes to the operator's terminal, the state file is gone, and the next scheduled run has nothing left to report. The person the alert was for never hears about it.

Observed on a recovery watchdog: its "service is back" notice was run manually to verify the script worked. The notice printed to a terminal, the marker was deleted, and the user waiting on the notification was never told — and no later cron run could tell them either, because the watchdog had disarmed itself.

The mirror case is just as bad: a watchdog that *writes* a state file to dedup its alert gets that file armed by a manual run, silently muting the next real alert.

## The fix

`_run_job_script` exports `HERMES_CRON_RUN=1`. Scripts gate their destructive state transitions on it:

- **set** → real scheduled fire, mutate state
- **absent** → manual run, report findings and change nothing

One export at the single choke point every script job already routes through, so it covers `.sh` and `.py` alike with no per-script changes. Scripts that ignore the variable behave exactly as before.

## Why an env var and not config.yaml

This is an **internal runner→subprocess signal**, sitting on the same env dict as `HERMES_HOME` a few lines above — not user-facing configuration. There is nothing here for a user to set, so no `config.yaml` surface is added. Per AGENTS.md: *"Bridge to an internal env var if the mechanism needs one."*

Also considered and rejected as heavier for no gain: passing a CLI flag (breaks every existing script's argv contract), or a sentinel file (adds cleanup and a failure mode of its own).

## Testing

`tests/cron/test_cron_run_marker.py` — real scripts executed through the real runner against a temp `HERMES_HOME`, asserting what a script actually observes in its environment:

- both interpreters (`.py` and `.sh`) see the marker under cron
- a direct invocation does **not** see it
- an end-to-end fire-once-then-disarm watchdog keeps its alert on a manual run, and still announces exactly once under cron
- pre-existing env (`HERMES_HOME`) still arrives intact

Both marker tests fail without the export (`AssertionError: assert 'ABSENT' == '1'`). Full `tests/cron` suite green: **721 passed, 1 skipped**.


## Platforms tested

Linux (aarch64, Python 3.11). The change is pure `env` dict manipulation with no
platform-specific syscalls; the runner's existing Windows/macOS interpreter
selection (`_windows_cron_python_invocation`) is untouched and the marker rides
the same `env` that already carries `HERMES_HOME` on every platform.