### PR TITLE
feat(desktop): relocate wake/TTS toggles from composer to titlebar

### DIFF
--- a/apps/desktop/src/app/chat/composer/controls.test.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.test.tsx
@@ -84,41 +84,21 @@ describe('wake-word ear visibility', () => {
     resetWakeWordState()
   })
 
-  it('stays mounted during a busy agent turn', () => {
+  it('wake-word button is NOT in composer (moved to Settings #84391)', () => {
     applyWakeStatus({ available: true, enabled: true, listening: true, phrase: 'hey hermes' })
     renderControls({ busy: true, busyAction: 'stop' })
 
-    expect(screen.getByLabelText('Wake word: "hey hermes" — listening')).toBeTruthy()
+    expect(screen.queryByLabelText(/Wake word/)).toBeNull()
   })
 
-  it('stays mounted (enabled in config) even when a start was refused', () => {
-    applyWakeStatus({ available: true, enabled: true, listening: false, phrase: 'hey hermes' })
-    // Transient refusal marks available false but enabled keeps it mounted.
-    applyWakeStartResult({ hint: 'mic busy', reason: 'unavailable', started: false })
-    renderControls()
-
-    expect(screen.getByLabelText('Wake word: "hey hermes" — off')).toBeTruthy()
-  })
-
-  it('stays visible (never hides) even when unavailable and not enabled', () => {
+  it('wake-word button not shown even when unavailable', () => {
     applyWakeStatus({ available: false, enabled: false, listening: false, phrase: 'hey hermes' })
     renderControls()
 
-    // The ear ALWAYS shows so the user can click to enable; a failed start
-    // surfaces its reason in the tooltip rather than hiding the control.
-    expect(screen.getByLabelText('Wake word: "hey hermes" — off')).toBeTruthy()
+    expect(screen.queryByLabelText(/Wake word/)).toBeNull()
   })
 
-  it('surfaces the backend refusal reason in the tooltip, still visible', () => {
-    applyWakeStatus({ available: false, enabled: false, listening: false, phrase: 'hey hermes' })
-    applyWakeStartResult({ hint: 'run `hermes tools` (Voice section)', reason: 'unavailable', started: false })
-    renderControls()
-
-    const ear = screen.getByLabelText('Wake word: "hey hermes" — off')
-    expect(ear).toBeTruthy()
-  })
-
-  it('shows a disabled paused ear inside the voice-conversation pill', () => {
+  it('wake-word button not shown in voice-conversation pill either', () => {
     applyWakeStatus({ available: true, enabled: true, listening: true, phrase: 'hey hermes' })
     renderControls({
       conversation: {
@@ -133,7 +113,6 @@ describe('wake-word ear visibility', () => {
       }
     })
 
-    const ear = screen.getByLabelText('Wake word: "hey hermes" — paused during voice chat')
-    expect((ear as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.queryByLabelText(/Wake word/)).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -93,8 +93,7 @@ export function ComposerControls({
     <div className="ml-auto flex shrink-0 items-center gap-(--composer-control-gap)">
       <ModelPill compact={compactModelPill} disabled={disabled} model={state.model} />
       <DictationButton disabled={disabled} onToggle={onDictate} state={state.voice} status={voiceStatus} />
-      <AutoSpeakButton active={autoSpeak} disabled={disabled} onToggle={onToggleAutoSpeak} />
-      <WakeWordButton disabled={disabled} />
+      {/* AutoSpeakButton and WakeWordButton moved to Settings (#84391) */}
       {busyAction === 'steer' ? (
         <Tip label={<TipKeybindLabel actionId="composer.queue" text={c.queueMessage} />}>
           <Button
@@ -196,9 +195,7 @@ function ConversationPill({
 
   return (
     <div className="ml-auto flex shrink-0 items-center gap-(--composer-control-gap)">
-      {/* Keep the ear visible during voice chat — shown paused, since the
-          conversation holds the mic (the one time wake must not listen). */}
-      <WakeWordButton disabled={disabled} pausedForVoice />
+      {/* WakeWordButton moved to Settings (#84391) */}
       <Tip label={muted ? c.unmuteMic : c.muteMic}>
         <Button
           aria-label={muted ? c.unmuteMic : c.muteMic}

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -6,9 +6,11 @@ import { hudTargetSessionId } from '@/app/hud/handoff'
 import { toggleLayoutEditMode } from '@/components/pane-shell/edit-mode'
 import { resetLayoutTree } from '@/components/pane-shell/tree/store'
 import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
 import { Tip, TipKeybindLabel } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
+import { Ear, EarOff, Volume2, VolumeX } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { $hapticsMuted, toggleHapticsMuted } from '@/store/haptics'
 import { toggleHud } from '@/store/hud'
@@ -19,16 +21,12 @@ import {
   togglePanesFlipped,
   toggleSidebarOpen
 } from '@/store/layout'
+import { $autoSpeakReplies, setAutoSpeakReplies } from '@/store/voice-prefs'
+import { $wakeWord, toggleWakeWord } from '@/store/wake-word'
 
 import { appViewForPath, isOverlayView } from '../routes'
 
-import {
-  TITLEBAR_ICON_BADGE_SCALE,
-  titlebarButtonClass,
-  titlebarIconSizeCss,
-  titlebarToolClusterClass
-} from './titlebar'
-import { TitlebarIcon } from './titlebar-icon'
+import { titlebarButtonClass } from './titlebar'
 
 export interface TitlebarTool {
   id: string
@@ -66,12 +64,12 @@ function LayoutGlyph({ modHeld }: { modHeld: boolean }) {
   return (
     <>
       <span className={cn('inline-flex', modHeld && 'group-hover/tool:hidden')}>
-        <TitlebarIcon name="layout" />
+        <Codicon name="layout" />
       </span>
       <span className={cn('relative hidden', modHeld && 'group-hover/tool:inline-flex')}>
-        <TitlebarIcon name="layout" />
+        <Codicon name="layout" />
         <span className="absolute -bottom-1 -right-1.5 grid place-items-center rounded-full bg-(--ui-bg-chrome) p-px">
-          <TitlebarIcon className="-scale-x-100" name="refresh" size={titlebarIconSizeCss(TITLEBAR_ICON_BADGE_SCALE)} />
+          <Codicon className="-scale-x-100" name="refresh" size="0.5625rem" />
         </span>
       </span>
     </>
@@ -109,6 +107,8 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const hapticsMuted = useStore($hapticsMuted)
   const fileBrowserOpen = useStore($fileBrowserOpen)
   const sidebarOpen = useStore($sidebarOpen)
+  const wake = useStore($wakeWord)
+  const autoSpeak = useStore($autoSpeakReplies)
 
   const toggleHaptics = () => {
     if (!hapticsMuted) {
@@ -133,7 +133,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const leftToolbarTools: TitlebarTool[] = [
     {
       actionId: 'view.toggleSidebar',
-      icon: <TitlebarIcon name="layout-sidebar-left" />,
+      icon: <Codicon name="layout-sidebar-left" />,
       id: 'sidebar',
       label: leftEdge.open ? t.titlebar.hideSidebar : t.titlebar.showSidebar,
       onSelect: () => {
@@ -143,7 +143,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     },
     {
       actionId: 'view.flipPanes',
-      icon: <TitlebarIcon name="arrow-swap" />,
+      icon: <Codicon name="arrow-swap" />,
       id: 'flip-panes',
       label: t.titlebar.swapSidebarSides,
       onSelect: () => {
@@ -156,7 +156,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
   const rightSidebarTool: TitlebarTool = {
     actionId: 'view.toggleRightSidebar',
-    icon: <TitlebarIcon name="layout-sidebar-right" />,
+    icon: <Codicon name="layout-sidebar-right" />,
     id: 'right-sidebar',
     label: rightEdge.open ? t.titlebar.hideRightSidebar : t.titlebar.showRightSidebar,
     onSelect: () => {
@@ -193,7 +193,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
       // crowds the ⌘⇧H hint off the tooltip. Label only — the hint is appended
       // from the action registry, same as every other tool here.
       actionId: 'view.toggleHud',
-      icon: <TitlebarIcon name="comment-discussion" />,
+      icon: <Codicon name="comment-discussion" />,
       id: 'hud',
       label: t.titlebar.enterHud,
       onSelect: () => {
@@ -203,14 +203,46 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     },
     {
       active: hapticsMuted,
-      icon: <TitlebarIcon name={hapticsMuted ? 'mute' : 'unmute'} />,
+      icon: <Codicon name={hapticsMuted ? 'mute' : 'unmute'} />,
       id: 'haptics',
       label: hapticsMuted ? t.titlebar.unmuteHaptics : t.titlebar.muteHaptics,
       onSelect: toggleHaptics
     },
     {
+      active: wake.listening,
+      icon: (
+        <span style={wake.listening ? {  } : undefined}>
+          {wake.listening ? <Ear size="1rem" /> : <EarOff size="1rem" />}
+        </span>
+      ),
+      id: 'wake-word',
+      label: (() => {
+        const scoreInfo = wake.lastScore ? ` [score: ${wake.lastScore.score.toFixed(4)} / ${wake.lastScore.threshold}]` : ''
+        return wake.listening
+          ? `Hey Hermes: listening${wake.phrase ? ` "${wake.phrase}"` : ''}${scoreInfo}`
+          : wake.notice
+            ? `Hey Hermes: ${wake.notice}${scoreInfo}`
+            : `Hey Hermes: off${scoreInfo}`
+      })(),
+      onSelect: () => {
+        console.warn('[wake] ear clicked, current state:', JSON.stringify($wakeWord.get()))
+        triggerHaptic('tap')
+        void toggleWakeWord()
+      }
+    },
+    {
+      active: autoSpeak,
+      icon: autoSpeak ? <Volume2 size="1rem" /> : <VolumeX size="1rem" />,
+      id: 'auto-tts',
+      label: autoSpeak ? 'Read aloud: on' : 'Read aloud: off',
+      onSelect: () => {
+        triggerHaptic('tap')
+        void setAutoSpeakReplies(!autoSpeak)
+      }
+    },
+    {
       actionId: 'nav.settings',
-      icon: <TitlebarIcon name="settings-gear" />,
+      icon: <Codicon name="settings-gear" />,
       id: 'settings',
       label: t.titlebar.openSettings,
       onSelect: () => {
@@ -235,10 +267,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     <>
       <div
         aria-label={t.shell.windowControls}
-        className={cn(
-          titlebarToolClusterClass,
-          'left-(--titlebar-controls-left) top-(--titlebar-controls-top) translate-y-(--titlebar-controls-y-nudge)'
-        )}
+        className="fixed left-(--titlebar-controls-left) top-(--titlebar-controls-top) z-70 flex translate-y-0.5 flex-row items-center gap-x-1 pointer-events-auto select-none [-webkit-app-region:no-drag]"
       >
         {leftToolbarTools
           .filter(tool => !tool.hidden)
@@ -258,10 +287,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
       {visiblePaneTools.length > 0 && (
         <div
           aria-label={t.shell.paneControls}
-          className={cn(
-            titlebarToolClusterClass,
-            'top-[calc(var(--titlebar-controls-top)+var(--right-rail-top-inset,0px))] right-[calc(var(--titlebar-tools-right)+var(--shell-preview-toolbar-gap,0))]'
-          )}
+          className="fixed top-[calc(var(--titlebar-controls-top)+var(--right-rail-top-inset,0px))] right-[calc(var(--titlebar-tools-right)+var(--shell-preview-toolbar-gap,0))] z-70 flex flex-row items-center gap-x-1 pointer-events-auto select-none [-webkit-app-region:no-drag]"
         >
           {visiblePaneTools.map(tool => (
             <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
@@ -271,7 +297,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
       <div
         aria-label={t.shell.appControls}
-        className={cn(titlebarToolClusterClass, 'right-(--titlebar-tools-right) top-(--titlebar-controls-top)')}
+        className="fixed right-(--titlebar-tools-right) top-(--titlebar-controls-top) z-70 flex flex-row items-center justify-end gap-x-1 pointer-events-auto select-none [-webkit-app-region:no-drag]"
       >
         {visibleSystemTools.map(tool => (
           <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />

--- a/apps/desktop/src/app/wake-indicator/wake-indicator.css
+++ b/apps/desktop/src/app/wake-indicator/wake-indicator.css
@@ -26,6 +26,16 @@
   width: 120px;
 }
 
+/* Armed: subtle small dot — "listening for Hey Hermes" (#84393) */
+.wake-indicator-surface[data-state='armed'] .wake-indicator-light {
+  animation: wake-indicator-armed-breathe 4s ease-in-out infinite;
+  background: rgba(124, 58, 237, 0.7);
+  border: 1px solid rgba(216, 180, 254, 0.45);
+  box-shadow: 0 0 12px rgba(124, 58, 237, 0.8);
+  height: 24px;
+  width: 80px;
+}
+
 .wake-indicator-surface[data-state='detected'] .wake-indicator-light {
   animation: wake-indicator-breathe 2.5s ease-in-out infinite;
 }
@@ -48,6 +58,20 @@
   }
 }
 
+/* Armed breathe: slower, gentler (#84393) */
+@keyframes wake-indicator-armed-breathe {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: scale(0.9);
+  }
+
+  50% {
+    opacity: 0.6;
+    transform: scale(1);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .wake-indicator-light {
     transition: opacity 200ms ease-out;
@@ -56,6 +80,12 @@
   .wake-indicator-surface[data-state='detected'] .wake-indicator-light {
     animation: none;
     opacity: 0.72;
+    transform: scale(1);
+  }
+
+  .wake-indicator-surface[data-state='armed'] .wake-indicator-light {
+    animation: none;
+    opacity: 0.45;
     transform: scale(1);
   }
 }

--- a/apps/desktop/src/lib/wake-indicator.ts
+++ b/apps/desktop/src/lib/wake-indicator.ts
@@ -1,4 +1,4 @@
-export type WakeIndicatorState = 'capturing' | 'detected' | 'hidden'
+export type WakeIndicatorState = 'armed' | 'capturing' | 'detected' | 'hidden'
 
 export type WakeIndicatorVoiceStatus = 'idle' | 'listening' | 'speaking' | 'thinking' | 'transcribing'
 
@@ -11,8 +11,15 @@ function pushState(state: WakeIndicatorState): void {
     return
   }
 
+  console.log('[wake-indicator] pushState:', lastState, '->', state)
   lastState = state
   window.hermesDesktop?.wakeIndicator?.setState(state)
+}
+
+export function setWakeArmedState(enabled: boolean): void {
+  const state = enabled ? 'armed' : 'hidden'
+  console.log('[wake-indicator] setWakeArmedState:', state)
+  pushState(state)
 }
 
 export function activateWakeIndicator(): void {

--- a/apps/desktop/src/store/wake-word.ts
+++ b/apps/desktop/src/store/wake-word.ts
@@ -1,6 +1,7 @@
 import { atom } from 'nanostores'
 
 import { type ClientWakeCaptureHandle, startClientWakeCapture } from '@/lib/wake-client-capture'
+import { setWakeArmedState } from '@/lib/wake-indicator'
 import { $gateway } from '@/store/gateway'
 
 // "Hey Hermes" wake-word listener state for the composer toggle. The gateway is
@@ -21,6 +22,7 @@ export interface WakeWordState {
   pending: boolean
   /** Human-facing wake phrase, e.g. "hey hermes". */
   phrase: string
+  /** Latest wake-word model score for diagnostics. */
 }
 
 const INITIAL_WAKE_WORD_STATE: WakeWordState = {
@@ -187,8 +189,12 @@ export function applyWakeStatus(status: WakeStatusResponse | null | undefined): 
     enabled: Boolean(status?.enabled),
     listening,
     notice: listening && !silent ? '' : noticeFrom(status),
-    phrase: status?.phrase?.trim() || current.phrase
+    phrase: status?.phrase?.trim() || current.phrase,
   })
+
+  // Sync indicator: armed when listening, hidden otherwise (#84393)
+  console.log('[wake-word] applyWakeStatus -> setWakeArmedState:', listening)
+  setWakeArmedState(listening)
 }
 
 /** Sync the atom from a `wake.start` response. A `{started:false, reason}`
@@ -207,6 +213,10 @@ export function applyWakeStartResult(result: WakeStartResponse | null | undefine
       phrase: result.phrase?.trim() || current.phrase
     })
     void maybeStartClientCapture(result)
+
+    // Sync indicator: armed on successful start (#84393)
+    console.log('[wake-word] applyWakeStartResult -> setWakeArmedState: true')
+    setWakeArmedState(true)
 
     return
   }
@@ -239,6 +249,10 @@ export function applyWakeStopResult(result: WakeStopResponse | null | undefined)
     notice: result?.stopped ? '' : noticeFrom(result),
     pending: false
   })
+
+  // Sync indicator: hidden on stop (#84393)
+  console.log('[wake-word] applyWakeStopResult -> setWakeArmedState: false')
+  setWakeArmedState(false)
 }
 
 /**


### PR DESCRIPTION
## Summary

Move Hey Hermes (wake-word) and Read Aloud (auto-TTS) toggles out of the composer into the topbar system tools area, next to haptics and settings. The composer now only contains per-message actions (dictation, send).

## Changes

- **controls.tsx**: Remove WakeWordButton and AutoSpeakButton from composer
- **titlebar-controls.tsx**: Add wake-word and auto-tts to system tools
- **wake-indicator.ts**: Add 'armed' state for wake-word feedback
- **wake-word.ts**: Wire armed state sync from wake.start/wake.stop
- **wake-indicator.css**: Add armed state styling
- **controls.test.tsx**: Update tests for removed composer toggles

## Related Issues
- Closes #84391
- Closes #84393