### PR TITLE
fix(tui): never send skill slashes through the slash worker

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -594,6 +594,23 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     return cmd_key if cmd_key in get_skill_commands() else None
 
 
+def resolve_skill_slash(command: str, *, rescan_if_missing: bool = True) -> Optional[str]:
+    """Resolve a typed slash token to a skill key, optionally rescanning once.
+
+    ``get_skill_commands()`` is a process-wide cache. A long-lived ``hermes
+    serve`` can miss a skill that a freshly spawned slash_worker would see, or
+    an import/scan blip can leave the map empty. One rescan is cheap compared
+    to parking the expanded skill body on the worker's unread ``_pending_input``
+    queue (Desktop then renders ``⚡ Loading skill`` and never starts a turn).
+    """
+    token = (command or "").strip().lstrip("/").split(None, 1)[0] if command else ""
+    key = resolve_skill_command_key(token)
+    if key is not None or not rescan_if_missing:
+        return key
+    scan_skill_commands()
+    return resolve_skill_command_key(token)
+
+
 def build_skill_invocation_message(
     cmd_key: str,
     user_instruction: str = "",

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1203,6 +1203,51 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
     expect(renderedText).not.toContain('/goal: no output')
   })
 
+  it('falls through to command.dispatch when slash.exec only printed Loading skill', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'slash.exec') {
+        return { output: '⚡ Loading skill: ratchet-panel' } as never
+      }
+
+      if (method === 'command.dispatch') {
+        return {
+          type: 'skill',
+          name: 'ratchet-panel',
+          message: '[IMPORTANT: invoked ratchet-panel]\n\nDo the panel.',
+          display: '/ratchet-panel'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/ratchet-panel')
+
+    expect(calls.map(c => c.method)).toEqual(['slash.exec', 'command.dispatch', 'prompt.submit'])
+    expect(calls[1]?.params).toEqual({
+      session_id: RUNTIME_SESSION_ID,
+      name: 'ratchet-panel',
+      arg: ''
+    })
+    expect(calls[2]?.params).toMatchObject({
+      session_id: RUNTIME_SESSION_ID,
+      text: '[IMPORTANT: invoked ratchet-panel]\n\nDo the panel.'
+    })
+  })
+
   it('queues the /goal kickoff instead of dropping it when the session is busy (#63352)', async () => {
     // The backend sets the goal the moment slash.exec runs — dropping the
     // returned kickoff message because busyRef was true left a goal the agent

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -383,9 +383,16 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             applyGoalStatusText(sessionId, output.output)
           }
 
-          renderSlashOutput(output?.warning ? `warning: ${output.warning}\n${body}` : body)
+          // Worker-swallowed skill: process_command printed "⚡ Loading skill"
+          // and parked the body on unread _pending_input. Treat that as a miss
+          // and fall through to command.dispatch so the turn still starts.
+          if (/loading skill/i.test(body)) {
+            slashExecError = new Error(body)
+          } else {
+            renderSlashOutput(output?.warning ? `warning: ${output.warning}\n${body}` : body)
 
-          return
+            return
+          }
         } catch (error) {
           // Fall back to command.dispatch for skill/send/alias directives, but
           // keep the worker error: a slash.exec worker timeout/crash is the real

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -763,26 +763,106 @@ def test_cli_exec_blocked(server, argv):
 # ── slash.exec skill command interception ────────────────────────────
 
 
-def test_slash_exec_rejects_skill_commands(server):
-    """slash.exec must reject skill commands so the TUI falls through to command.dispatch."""
-    # Register a mock session
+def test_slash_exec_dispatches_skill_commands(server):
+    """slash.exec must return the skill payload, never spawn the worker."""
     sid = "test-session"
     server._sessions[sid] = {"session_key": sid, "agent": None}
+    spawned = {"n": 0}
 
-    # Mock scan_skill_commands to return a known skill
-    fake_skills = {"/hermes-agent-dev": {"name": "hermes-agent-dev", "description": "Dev workflow"}}
+    class _BoomWorker:
+        def __init__(self, *args, **kwargs):
+            spawned["n"] += 1
 
+        def run(self, cmd):
+            raise AssertionError(f"worker must not run skill slash {cmd!r}")
+
+    server._SlashWorker = _BoomWorker
+    fake_skills = {"/ratchet-panel": {"name": "ratchet-panel", "description": "vet"}}
+
+    def fake_dispatch(rid, params):
+        assert params["name"] == "ratchet-panel"
+        assert params["arg"] == "PLAN.md"
+        return server._ok(
+            rid,
+            {
+                "type": "skill",
+                "name": "ratchet-panel",
+                "message": "SKILL_BODY",
+                "display": "/ratchet-panel PLAN.md",
+            },
+        )
+
+    server._methods["command.dispatch"] = fake_dispatch
     with patch("agent.skill_commands.get_skill_commands", return_value=fake_skills):
-        resp = server.handle_request({
-            "id": "r1",
-            "method": "slash.exec",
-            "params": {"command": "hermes-agent-dev", "session_id": sid},
-        })
+        resp = server.handle_request(
+            {
+                "id": "r1",
+                "method": "slash.exec",
+                "params": {
+                    "command": "ratchet-panel PLAN.md",
+                    "session_id": sid,
+                },
+            }
+        )
 
-    # Should return an error so the TUI's .catch() fires command.dispatch
-    assert "error" in resp
+    assert "error" not in resp
+    assert resp["result"]["type"] == "skill"
+    assert resp["result"]["message"] == "SKILL_BODY"
+    assert spawned["n"] == 0
+
+
+def test_slash_exec_resolves_underscored_skill_name(server):
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid, "agent": None}
+    seen = {}
+
+    def fake_dispatch(rid, params):
+        seen.update(params)
+        return server._ok(rid, {"type": "skill", "name": "ratchet-panel", "message": "BODY"})
+
+    server._methods["command.dispatch"] = fake_dispatch
+    with patch(
+        "agent.skill_commands.get_skill_commands",
+        return_value={"/ratchet-panel": {"name": "ratchet-panel"}},
+    ):
+        resp = server.handle_request(
+            {
+                "id": "r2",
+                "method": "slash.exec",
+                "params": {"command": "ratchet_panel", "session_id": sid},
+            }
+        )
+
+    assert "error" not in resp
+    assert seen["name"] == "ratchet-panel"
+
+
+def test_slash_exec_skill_resolver_failure_is_4018_not_worker(server):
+    """Import/scan failure must 4018 so clients fall through — never the worker."""
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid, "agent": None}
+    spawned = {"n": 0}
+
+    class _BoomWorker:
+        def __init__(self, *args, **kwargs):
+            spawned["n"] += 1
+
+    server._SlashWorker = _BoomWorker
+    with patch(
+        "agent.skill_commands.resolve_skill_slash",
+        side_effect=RuntimeError("scan exploded"),
+    ):
+        resp = server.handle_request(
+            {
+                "id": "r3",
+                "method": "slash.exec",
+                "params": {"command": "ratchet-panel", "session_id": sid},
+            }
+        )
+
     assert resp["error"]["code"] == 4018
     assert "skill command" in resp["error"]["message"]
+    assert spawned["n"] == 0
 
 
 def test_command_dispatch_queue_sends_message(server):

--- a/tests/tui_gateway/test_slash_worker_ansi.py
+++ b/tests/tui_gateway/test_slash_worker_ansi.py
@@ -21,3 +21,26 @@ def test_run_strips_ansi_from_output():
 
     assert "\x1b[" not in out
     assert out == "colored plain"
+
+
+def test_run_refuses_skill_slash_instead_of_pending_input(monkeypatch):
+    from tui_gateway import slash_worker
+
+    monkeypatch.setattr(
+        "agent.skill_commands.resolve_skill_slash",
+        lambda token, **kwargs: "/ratchet-panel",
+    )
+
+    class _CLI:
+        console = None
+
+        def process_command(self, cmd: str) -> None:
+            raise AssertionError(f"must not process_command skill {cmd!r}")
+
+    try:
+        slash_worker._run(_CLI(), "ratchet-panel")
+    except RuntimeError as exc:
+        assert "skill command" in str(exc)
+        assert "ratchet-panel" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError for skill slash")

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1176,16 +1176,30 @@ def _(rid, params: dict) -> dict:
     except Exception:
         pass
 
+    # Skills must never reach the slash worker. The worker's process_command
+    # loads the skill into HermesCLI._pending_input — a queue nobody reads in
+    # that child — and returns "⚡ Loading skill: …". Desktop treats that as
+    # successful exec output, so the agent turn never starts. Prefer returning
+    # the same structured {type: skill, …} payload command.dispatch already
+    # builds (current Desktop/TUI submit it). On resolver failure, 4018 so
+    # older clients still fall through to command.dispatch.
     try:
-        from agent.skill_commands import get_skill_commands
+        from agent.skill_commands import resolve_skill_slash
 
-        _cmd_key = f"/{_cmd_base}"
-        if _cmd_key in get_skill_commands():
-            return _err(
-                rid, 4018, f"skill command: use command.dispatch for {_cmd_key}"
+        _cmd_key = resolve_skill_slash(_cmd_base)
+        if _cmd_key is not None:
+            return _methods["command.dispatch"](
+                rid,
+                {
+                    "name": _cmd_key.lstrip("/"),
+                    "arg": _cmd_arg,
+                    "session_id": params.get("session_id", ""),
+                },
             )
     except Exception:
-        pass
+        return _err(
+            rid, 4018, f"skill command: use command.dispatch for /{_cmd_base}"
+        )
 
     plugin_handler = None
     resolve_plugin_command_result = None

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -97,6 +97,17 @@ def _run(cli: HermesCLI, command: str) -> str:
     if not cmd.startswith("/"):
         cmd = f"/{cmd}"
 
+    # Belt: slash.exec should have bounced skills already. If one still lands
+    # here, refuse instead of parking the body on unread _pending_input.
+    try:
+        from agent.skill_commands import resolve_skill_slash
+
+        skill_key = resolve_skill_slash(cmd[1:].split(None, 1)[0])
+    except Exception:
+        skill_key = None
+    if skill_key:
+        raise RuntimeError(f"skill command: use command.dispatch for {skill_key}")
+
     buf = io.StringIO()
 
     # Rich Console captures its file handle at construction time, so


### PR DESCRIPTION
## Bug Description

Desktop `/ratchet-panel` (and any other skill slash) typed as the **first message of a new chat** never starts an agent turn. The session id appears in the UI, a `slash_worker` subprocess is spawned, and the chat stays empty. `state.db` never gets a row. Reproduced 2026-08-16 on remote Desktop (`20260816_174506_d27fef`, `20260816_173659_8e56aa`).

Related stale approach: #53070 (routes skills through dispatch; last updated 2026-07-15, does not cover the worker-swallow / empty-session path).

## Root Cause

`slash.exec` is supposed to 4018 skill commands so the client falls through to `command.dispatch`. Two holes:

1. Skill detection is an exact `f\"/{base}\" in get_skill_commands()` wrapped in `except Exception: pass`. A cache miss or scan blip falls through to the worker.
2. The worker's `process_command` loads the skill into `HermesCLI._pending_input` — a queue **nobody reads** in that child — and returns `⚡ Loading skill: …`. Desktop treats that as successful exec output and **does not** call `command.dispatch`.

## Fix

- `resolve_skill_slash()`: hyphen/underscore + one rescan if the cache misses.
- `slash.exec` returns the existing `command.dispatch` `{type: skill, message, display}` payload. Current Desktop/TUI already submit that. Resolver **exception** still 4018 (legacy fallback) and **never** spawns a worker.
- Worker belt: refuse leftover skill slashes instead of parking the body.
- Desktop: if `slash.exec` only printed `Loading skill`, fall through to `command.dispatch`.

## How to Verify

1. New Desktop chat (empty). Type `/ratchet-panel` or any installed skill slash.
2. Expect a user bubble with the invocation and an agent turn — not a one-line `⚡ Loading skill` and silence.
3. `state.db` should have a session row after the turn starts.

## Test Plan

- [x] `tests/tui_gateway/test_protocol.py` — dispatch payload, underscore alias, resolver failure is 4018 and does not spawn worker
- [x] `tests/tui_gateway/test_slash_worker_ansi.py` — worker refuses skill slashes
- [x] Desktop vitest: slash.exec `Loading skill` output falls through to `command.dispatch` + `prompt.submit`
- [x] `pytest tests/tui_gateway/test_protocol.py::test_slash_exec_* tests/tui_gateway/test_slash_worker_ansi.py -q` — 5 passed
- [ ] Desktop vitest not run in this worktree (no workspace node_modules); CI will run it

## Risk Assessment

Low — skill slashes already had a dedicated path; this closes the fall-through. Unknown `/commands` still go to the worker. Plugin slashes unchanged.