### PR TITLE
fix(vision): keep tools available for named custom providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6473,10 +6473,21 @@ def resolve_provider_client(
         # entries that coincidentally match a canonical provider (e.g. ``nous``)
         # still defer to the built-in per `_get_named_custom_provider`'s guard.
         custom_entry = None
-        if original_provider and original_provider != provider:
-            custom_entry = _get_named_custom_provider(original_provider)
-        if custom_entry is None:
-            custom_entry = _get_named_custom_provider(provider)
+        try:
+            if original_provider and original_provider != provider:
+                custom_entry = _get_named_custom_provider(original_provider)
+            if custom_entry is None:
+                custom_entry = _get_named_custom_provider(provider)
+        except Exception:
+            # Profile-backed config lookup can fail independently of the live
+            # turn in a long-lived multi-profile process. The context-local
+            # runtime fallback below can still resolve the exact same requested
+            # provider safely.
+            logger.warning(
+                "resolve_provider_client: named custom provider lookup failed",
+                exc_info=True,
+            )
+            custom_entry = None
         if custom_entry:
             custom_base = (custom_entry.get("base_url") or "").strip()
             custom_key = (custom_entry.get("api_key") or "").strip()
@@ -6579,9 +6590,55 @@ def resolve_provider_client(
             logger.warning(
                 "resolve_provider_client: named custom provider %r has no base_url",
                 provider)
-            return None, None
     except ImportError:
         pass
+
+    # A live turn has already resolved its main custom endpoint. Reuse that
+    # answer when (and only when) the explicit named request is the same
+    # identity. This keeps profile/context lookup failures from stripping
+    # auxiliary capabilities without ever borrowing another session/provider's
+    # endpoint.
+    runtime_requested = str(
+        (main_runtime or {}).get("requested_provider") or ""
+    ).strip().lower()
+    runtime_provider = str(
+        (main_runtime or {}).get("provider") or ""
+    ).strip().lower()
+    runtime_base_url = str(
+        (main_runtime or {}).get("base_url") or ""
+    ).strip()
+
+    def _custom_identity(value: str) -> str:
+        value = (value or "").strip().lower()
+        return value.removeprefix("custom:")
+
+    requested_identity = _custom_identity(original_provider or provider)
+    if (
+        runtime_base_url
+        and runtime_requested
+        and (runtime_provider == "custom" or runtime_provider.startswith("custom:"))
+        and _custom_identity(runtime_requested) == requested_identity
+    ):
+        runtime_api_key = (main_runtime or {}).get("api_key")
+        if not isinstance(runtime_api_key, str):
+            runtime_api_key = None
+        logger.debug(
+            "resolve_provider_client: reusing matching live runtime for named "
+            "custom provider %r",
+            original_provider or provider,
+        )
+        return resolve_provider_client(
+            "custom",
+            model=model or (main_runtime or {}).get("model"),
+            async_mode=async_mode,
+            raw_codex=raw_codex,
+            explicit_base_url=runtime_base_url,
+            explicit_api_key=runtime_api_key,
+            api_mode=api_mode or (main_runtime or {}).get("api_mode") or None,
+            main_runtime=main_runtime,
+            is_vision=is_vision,
+            task=task,
+        )
 
     # ── Azure Foundry (delegates to runtime resolver for auth_mode-aware routing) ─
     #

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -122,6 +122,65 @@ class TestResolveProviderClientNamedCustom:
         assert client is not None
         # no-key-required should be used
 
+    def test_named_custom_recovers_matching_live_runtime(self, tmp_path):
+        """A matching context-local runtime remains authoritative when the
+        profile-backed named-provider lookup is unavailable for this call."""
+        _write_config(tmp_path, {
+            "auxiliary": {
+                "vision": {
+                    "provider": "ai2.example.com:8081",
+                    "model": "/models/Qwen3.8-27B-IQ4_NL.gguf",
+                },
+            },
+        })
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        runtime = {
+            "provider": "custom",
+            "requested_provider": "ai2.example.com:8081",
+            "base_url": "http://ai2.example.com:8081/v1",
+            "api_key": "runtime-key",
+            "model": "/models/Qwen3.8-27B-IQ4_NL.gguf",
+        }
+        with patch(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            side_effect=RuntimeError("profile context unavailable"),
+        ):
+            provider, client, model = resolve_vision_provider_client(
+                main_runtime=runtime,
+            )
+
+        assert provider == "ai2.example.com:8081"
+        assert client is not None
+        assert model == runtime["model"]
+        assert "ai2.example.com:8081" in str(client.base_url)
+        assert client.api_key == "runtime-key"
+
+    def test_named_custom_rejects_unrelated_live_runtime(self, tmp_path):
+        """Runtime recovery must never borrow another provider's endpoint."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        runtime = {
+            "provider": "custom",
+            "requested_provider": "other-provider",
+            "base_url": "https://other.example.com/v1",
+            "api_key": "other-key",
+            "model": "other-model",
+        }
+        with patch(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            return_value=None,
+        ):
+            client, model = resolve_provider_client(
+                "ai2.example.com:8081",
+                model="vision-model",
+                main_runtime=runtime,
+                is_vision=True,
+            )
+
+        assert client is None
+        assert model is None
+
 
 
 class TestResolveProviderClientModelNormalization:

--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -238,6 +238,25 @@ auxiliary:
         from tools.vision_tools import check_vision_requirements
         assert check_vision_requirements() is True
 
+    def test_check_vision_logs_resolver_exception(self, isolated_home, caplog):
+        """Capability probe failures must explain why tools were stripped."""
+        from unittest.mock import patch
+
+        _fresh_modules()
+        from tools.vision_tools import check_vision_requirements
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                side_effect=RuntimeError("profile context unavailable"),
+            ),
+            caplog.at_level("WARNING", logger="tools.vision_tools"),
+        ):
+            assert check_vision_requirements() is False
+
+        assert "Vision capability probe failed" in caplog.text
+        assert "profile context unavailable" in caplog.text
+
 
 
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1635,6 +1635,11 @@ def check_vision_requirements() -> bool:
     try:
         from agent.auxiliary_client import aux_probe_mode, resolve_vision_provider_client
     except ImportError:
+        logger.warning(
+            "Vision capability probe could not import the auxiliary resolver; "
+            "vision tools will be unavailable this turn",
+            exc_info=True,
+        )
         return False
     try:
         # Probe mode answers "is a vision client resolvable?" without paying
@@ -1649,6 +1654,11 @@ def check_vision_requirements() -> bool:
             _provider, client, _model = resolve_vision_provider_client(provider="auto")
             return client is not None
     except Exception:
+        logger.warning(
+            "Vision capability probe failed; vision tools will be unavailable "
+            "this turn",
+            exc_info=True,
+        )
         return False
 
 


### PR DESCRIPTION
## What does this PR do?

Restores vision tools when `auxiliary.vision.provider` names the same custom provider already resolved for the live turn, but profile-backed lookup cannot recover that provider's endpoint. Without this fix, the capability gate silently removes vision tools for affected multi-profile desktop and gateway sessions even though the configured endpoint is usable.

### Symptom

A named custom vision provider without a duplicated `auxiliary.vision.base_url` can make `check_vision_requirements()` return false and strip vision tools for the entire turn. Repeating the same endpoint under the auxiliary vision config works around the failure.

### Impact

Users with this named-provider configuration cannot invoke vision tools from affected sessions. The failure is silent at the tool surface, so the model receives no vision tool schema even though the endpoint works for direct image analysis and other auxiliary tasks.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py` / `resolve_provider_client()` / explicit named custom provider lookup returns no usable endpoint.

**Causal chain:**
1. `auxiliary.vision.provider` selects a named custom provider whose endpoint has already been resolved into the context-local main runtime.
2. The explicit named-provider branch relies only on profile-backed lookup and returns no client when that lookup has no usable endpoint.
3. `check_vision_requirements()` receives no client, suppresses resolver failures, and the registry removes vision tools from the turn.

**Why it is wrong:** The resolver discards an already resolved, session-local endpoint for the exact requested provider identity, while the capability probe hides the reason for removal.

**Working sibling / contrast:** Auto resolution can recover a live runtime endpoint, and duplicating `base_url` in the auxiliary vision block also makes the explicit path resolve.

**Ruled out:** This is not a general endpoint or model failure; the reported endpoint works for the main chat, title generation, and direct image analysis, and the duplicated `base_url` workaround restores end-to-end vision behavior.

### Fix

Reuse the live main runtime only when it has a usable endpoint, resolves as a custom provider, and its normalized requested-provider identity exactly matches the explicit auxiliary provider. Unrelated or built-in runtimes remain rejected. Capability-probe import and resolver exceptions are now warning-logged with tracebacks instead of being silently converted to unavailable tools.

## Related Issue

Closes #87950

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - recover the exact matching named custom provider from the context-local live runtime while preserving provider isolation.
- `tools/vision_tools.py` - log capability-probe failures before vision tools are removed.
- `tests/agent/test_auxiliary_named_custom_providers.py` - cover matching-runtime recovery and rejection of unrelated runtimes.
- `tests/agent/test_vision_routing_31179.py` - cover diagnostic logging when the vision resolver raises.

## How to Test

1. Configure `auxiliary.vision.provider` with a named custom provider already resolved by the live turn, without duplicating its endpoint in `auxiliary.vision.base_url`.
2. Verify that the vision capability probe resolves the matching runtime and keeps vision tools available.
3. Verify that a mismatched provider runtime is rejected and resolver exceptions emit warning logs.
4. Automated: the related post-commit selection passed 38 tests. Four unrelated base/environment failures were reproduced before the production edits and excluded from the green selection.

```bash
scripts/run_tests.sh tests/agent/test_auxiliary_named_custom_providers.py tests/agent/test_vision_routing_31179.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - provider resolution is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no schema changed

## Screenshots / Logs

N/A - behavior is covered by resolver and capability-gate tests.
