### PR TITLE
fix(anthropic): anchor azure.com host matching in bearer-auth/1M-beta predicates

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -619,7 +619,9 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     normalized = normalized.rstrip("/").lower()
     return (
         normalized.startswith(("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"))
-        or "azure.com" in normalized
+        # Hostname match (not substring) so e.g. a proxy path containing the
+        # literal text "azure.com" doesn't trigger Bearer auth (#74312 class).
+        or base_url_host_matches(normalized, "azure.com")
         # Palantir Foundry LLM proxy (<org>.palantirfoundry.com/api/v2/llm/proxy/anthropic)
         # rejects x-api-key with 401 and requires Authorization: Bearer.
         # Hostname match (not substring) so e.g. evil.com/palantirfoundry
@@ -633,7 +635,8 @@ def _base_url_needs_context_1m_beta(base_url: str | None) -> bool:
     normalized = _normalize_base_url_text(base_url).lower()
     if not normalized:
         return False
-    return "azure.com" in normalized
+    # Hostname match (not substring) — see _requires_bearer_auth (#74312 class).
+    return base_url_host_matches(normalized, "azure.com")
 
 
 def _is_minimax_anthropic_endpoint(base_url: str | None) -> bool:

--- a/tests/hermes_cli/test_base_url_host_identity.py
+++ b/tests/hermes_cli/test_base_url_host_identity.py
@@ -154,3 +154,22 @@ def test_figma_remote_mcp_host_anchored():
     # Name fallback still host-checks the URL when one is present.
     assert _is_figma_remote_mcp(server_name="figma", server_url="https://phish.example/figma") is False
     assert _is_figma_remote_mcp(server_name="figma") is True
+
+
+def test_anthropic_adapter_azure_predicates_host_anchored():
+    """agent/anthropic_adapter.py's Azure detection missed the #74312 sweep:
+    _requires_bearer_auth and _base_url_needs_context_1m_beta both used a raw
+    'azure.com' in normalized substring check, unlike the host-anchored
+    palantirfoundry.com check two lines below in the same function."""
+    from agent.anthropic_adapter import (
+        _requires_bearer_auth,
+        _base_url_needs_context_1m_beta,
+    )
+
+    assert _requires_bearer_auth("https://myres.openai.azure.com/anthropic") is True
+    assert _requires_bearer_auth("https://proxy.corp/azure.com-compat/anthropic") is False
+    assert _requires_bearer_auth("https://azure.com.evil.net/anthropic") is False
+
+    assert _base_url_needs_context_1m_beta("https://myres.openai.azure.com/anthropic") is True
+    assert _base_url_needs_context_1m_beta("https://proxy.corp/azure.com-compat/anthropic") is False
+    assert _base_url_needs_context_1m_beta("https://azure.com.evil.net/anthropic") is False


### PR DESCRIPTION
## Summary

`agent/anthropic_adapter.py::_requires_bearer_auth()` and `_base_url_needs_context_1m_beta()` both used a raw `"azure.com" in normalized` substring check on the base URL, missed by today's hostname-anchoring sweep (#74312, commits `bc5805c35f`/`4b7b2b0049`) which claimed to complete the class sweep across the repo ("never-patch-predicates: one owner, every site") but never touched this file.

## Bug

The same function already has the correct, host-anchored pattern two lines below for Palantir Foundry:

```python
or base_url_host_matches(normalized, "palantirfoundry.com")
```

with a comment explicitly documenting why: *"Hostname match (not substring) so e.g. evil.com/palantirfoundry paths don't trigger Bearer auth."* The `"azure.com" in normalized` check right above it does not have this protection.

`_normalize_base_url_text()` returns the full URL string including path and query, not just the host. A custom/proxied `base_url` containing the literal text `azure.com` anywhere — e.g. `https://proxy.corp/azure.com-compat/anthropic` — would be misclassified as an Azure endpoint: it would incorrectly switch to `Authorization: Bearer` auth (breaking a working `x-api-key` credential) and add the `context-1m-2025-08-07` beta header the actual (non-Azure) provider doesn't support.

## Fix

Both predicates now use `base_url_host_matches()`, the same helper already imported in this file and used for the sibling Palantir check and dozens of other sites — matching the established fix pattern from the #74312 sweep exactly.

## Tests

Added `test_anthropic_adapter_azure_predicates_host_anchored` to `tests/hermes_cli/test_base_url_host_identity.py` — the shared file the #74312 sweep itself extends for this exact bug class (see its `"Widened class coverage (follow-up to #85737)"` section). Covers the real Azure host, a lookalike path, and a lookalike subdomain for both predicates.

Mutation-verified: reverting the fix makes the new test fail with `AssertionError: assert True is False` on the lookalike-path case.

```
uv run --frozen --extra dev python -m pytest tests/hermes_cli/test_base_url_host_identity.py tests/agent/test_anthropic_adapter.py tests/agent/test_nous_portal_anthropic_wire.py tests/agent/test_minimax_auxiliary_url.py -q
```
14/14 new-file tests pass; 2 pre-existing failures in `test_nous_portal_anthropic_wire.py` are environment-only (`ImportError: The 'anthropic' package is required...`, reproduced identically with the fix reverted) and unrelated to this change.

`ruff check` clean on both changed files.

## Competing PR check

Searched for open PRs touching `anthropic_adapter.py` Azure/Bearer-auth logic and the `_requires_bearer_auth`/`_base_url_needs_context_1m_beta` predicates specifically — none found targeting this substring check.

## Checklist

- [x] Read the Contributing Guide
- [x] Conventional Commit message
- [x] Searched for existing PRs — no duplicate found
- [x] Contains only changes related to this fix
- [x] Ran relevant tests, they pass (except pre-existing, unrelated env failures)
- [x] Added regression tests
- [x] Considered cross-platform impact — N/A (pure string/URL logic)