### PR TITLE
fix(cron): media-send failure logs an empty reason when the cause is a timeout

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2188,7 +2188,13 @@ def _send_media_via_adapter(
                     job.get("id", "?"), media_path, getattr(result, "error", "unknown"),
                 )
         except Exception as e:
-            logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
+            # Argument-less exceptions (notably TimeoutError, the most likely
+            # failure on this path) have an empty str(), which would render this
+            # warning with no reason at all. Fall back to the class name.
+            logger.warning(
+                "Job '%s': failed to send media %s: %s",
+                job.get("id", "?"), media_path, str(e) or type(e).__name__,
+            )
 
 
 def _confirm_adapter_delivery(send_result) -> bool:


### PR DESCRIPTION
### Problem

When a cron job's media delivery fails on a timeout, the log records no cause at all:

```
WARNING cron.scheduler: Job 'abc123': failed to send media /path/to/file.mp3:
```

Note the trailing colon with nothing after it. The operator cannot tell whether this was a timeout, an auth failure, a size rejection, or a network error — and no traceback is emitted on this path either.

### Root cause

`cron/scheduler.py` bounds the send with `future.result(timeout=30)` and re-raises `TimeoutError` into the generic handler, which formats the exception with `%s`:

```python
try:
    result = future.result(timeout=30)
except TimeoutError:
    future.cancel()
    raise                                   # -> outer handler
...
except Exception as e:
    logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
```

`TimeoutError` is raised with no arguments, and **`str(TimeoutError())` is the empty string**. So the single most likely failure on this path is precisely the one that erases itself from the log.

```pycon
>>> import concurrent.futures
>>> repr(str(concurrent.futures.TimeoutError()))
"''"
>>> "failed to send media %s: %s" % ("/path/file.mp3", concurrent.futures.TimeoutError())
'failed to send media /path/file.mp3: '
```

### Fix

Fall back to the exception class name when `str(e)` is empty, so an argument-less exception still identifies itself. Messages that do exist are unchanged.

### Related

Same defect class as #63357 (`computer_use: empty TimeoutError surfaces as blank "capture failed: "`), which is still open — this is the `cron/scheduler.py` instance of the same pattern.

### Scope

Logging only. No behaviour change, no new configuration.

### How it was found

A ~7.4 MB audio attachment built correctly and then failed to deliver in production. The log line was empty by construction, so identifying the cause required reading the source rather than the journal.
