### PR TITLE
fix(agent): anchor ZAI vision-error base_url check to real hosts

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4315,6 +4315,26 @@ def _is_unsupported_temperature_error(exc: Exception) -> bool:
     return _is_unsupported_parameter_error(exc, "temperature")
 
 
+def _is_zai_vision_param_error(err_str: str, base_url) -> bool:
+    """Detect ZAI's undocumented error code 1210 for a multimodal ``max_tokens`` call.
+
+    ZAI vision models (glm-4v-flash etc.) return error code 1210 ("API
+    调用参数有误") when ``max_tokens`` is passed on multimodal calls. The
+    error message does NOT contain "max_tokens" so the generic
+    unsupported-parameter retry never fires — this is the only signal.
+
+    Hostname match (not substring) on the client's own ``base_url``: a
+    proxied endpoint whose path merely contains the text "bigmodel" must
+    not misfire on an unrelated provider's error text (same class as
+    #74312 / the ZAI/Kimi host-anchoring fix already applied to
+    ``_to_openai_base_url()``).
+    """
+    if "1210" not in (err_str or ""):
+        return False
+    url = str(base_url or "")
+    return base_url_host_matches(url, "open.bigmodel.cn") or base_url_host_matches(url, "api.z.ai")
+
+
 def _is_model_not_found_error(exc: Exception) -> bool:
     """Detect "the requested model doesn't exist" errors (404 / invalid model).
 
@@ -9489,15 +9509,7 @@ def _call_llm_impl(
                 kwargs = retry_kwargs
 
         err_str = str(first_err)
-        # ZAI vision models (glm-4v-flash etc.) return error code 1210
-        # ("API 调用参数有误") when max_tokens is passed on multimodal
-        # calls.  The error message does NOT contain "max_tokens" so the
-        # generic retry below never fires.  Detect the ZAI-specific error
-        # and strip max_tokens before retrying.
-        _is_zai_param_error = (
-            "1210" in err_str
-            and "bigmodel" in str(getattr(client, "base_url", ""))
-        )
+        _is_zai_param_error = _is_zai_vision_param_error(err_str, getattr(client, "base_url", ""))
         if max_tokens is not None and (
             "max_tokens" in err_str
             or "unsupported_parameter" in err_str
@@ -10201,15 +10213,7 @@ async def _async_call_llm_impl(
                 kwargs = retry_kwargs
 
         err_str = str(first_err)
-        # ZAI vision models (glm-4v-flash etc.) return error code 1210
-        # ("API 调用参数有误") when max_tokens is passed on multimodal
-        # calls.  The error message does NOT contain "max_tokens" so the
-        # generic retry below never fires.  Detect the ZAI-specific error
-        # and strip max_tokens before retrying.
-        _is_zai_param_error = (
-            "1210" in err_str
-            and "bigmodel" in str(getattr(client, "base_url", ""))
-        )
+        _is_zai_param_error = _is_zai_vision_param_error(err_str, getattr(client, "base_url", ""))
         if max_tokens is not None and (
             "max_tokens" in err_str
             or "unsupported_parameter" in err_str

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -26,6 +26,7 @@ from agent.auxiliary_client import (
     _is_rate_limit_error,
     _is_model_not_found_error,
     _is_model_incompatible_error,
+    _is_zai_vision_param_error,
     _refresh_nous_recommended_model,
     _normalize_aux_provider,
     _try_payment_fallback,
@@ -1384,6 +1385,32 @@ class TestIsModelNotFoundError:
         assert _is_model_not_found_error(exc) is False
 
 
+class TestIsZaiVisionParamError:
+    """_is_zai_vision_param_error must host-anchor the client base_url, not
+    substring-match "bigmodel" — regression for the sibling gap left behind
+    by the #74312 host-anchoring sweep, which fixed _to_openai_base_url()'s
+    ZAI/Kimi rewrite but missed this identical classifier."""
+
+    def test_real_bigmodel_host_matches(self):
+        assert _is_zai_vision_param_error("Error 1210: API 调用参数有误", "https://open.bigmodel.cn/api/paas/v4") is True
+
+    def test_real_zai_host_matches(self):
+        assert _is_zai_vision_param_error("Error 1210: API 调用参数有误", "https://api.z.ai/api/paas/v4") is True
+
+    def test_proxied_path_containing_bigmodel_does_not_match(self):
+        """A proxy whose path merely contains "bigmodel" is not ZAI — the
+        exact false-positive class the substring check had."""
+        assert _is_zai_vision_param_error("Error 1210: something else entirely", "https://proxy.corp/bigmodel-fallback/v1") is False
+
+    def test_lookalike_subdomain_does_not_match(self):
+        assert _is_zai_vision_param_error("Error 1210", "https://open.bigmodel.cn.evil.net/v1") is False
+
+    def test_non_1210_error_does_not_match_even_on_real_host(self):
+        assert _is_zai_vision_param_error("Error 400: bad request", "https://open.bigmodel.cn/api/paas/v4") is False
+
+    def test_missing_base_url_does_not_crash(self):
+        assert _is_zai_vision_param_error("Error 1210", None) is False
+        assert _is_zai_vision_param_error("Error 1210", "") is False
 
 
 class TestIsModelIncompatibleError:


### PR DESCRIPTION
## Summary

`_call_llm_impl`/`_async_call_llm_impl` (`agent/auxiliary_client.py`, sync and async twins) both classify ZAI's undocumented error code 1210 (a multimodal `max_tokens` rejection with no `max_tokens` in the message text) with a raw substring check:

```python
_is_zai_param_error = (
    "1210" in err_str
    and "bigmodel" in str(getattr(client, "base_url", ""))
)
```

## Bug

`"bigmodel" in base_url` matches anywhere in the URL, including the path. A proxied/self-hosted endpoint whose path merely contains the text `bigmodel` — e.g. `https://proxy.corp/bigmodel-fallback/v1` — would be misclassified as ZAI, stripping `max_tokens`/`max_completion_tokens` from an unrelated provider's retry on an unrelated 1210-containing error.

This is the sibling gap left behind by the #74312 host-anchoring sweep (`bc5805c35f`/`4b7b2b0049`), which explicitly fixed the ZAI/Kimi proxy-rewrite logic in this same file (`_to_openai_base_url()`, now using `base_url_host_matches(url, "open.bigmodel.cn")` / `base_url_host_matches(url, "api.z.ai")`) but never touched this identical, verbatim-duplicated classifier a few hundred lines away in both the sync and async retry paths.

## Fix

Extracted the duplicated inline check into a single named, testable helper — `_is_zai_vision_param_error(err_str, base_url)` — using the same `base_url_host_matches()` pattern already established in this file for the real ZAI hosts (`open.bigmodel.cn`, `api.z.ai`). This matches the file's existing convention of small `_is_*_error` classifier functions (`_is_payment_error`, `_is_model_not_found_error`, `_is_unsupported_temperature_error`, etc.) and removes the duplication that let one site get fixed while the other didn't.

Both the sync and async call sites now call the shared helper.

## Tests

Added `TestIsZaiVisionParamError` to `tests/agent/test_auxiliary_client.py` (real `open.bigmodel.cn`/`api.z.ai` hosts match; proxied path containing "bigmodel" does not; lookalike subdomain does not; non-1210 errors don't match even on a real ZAI host; `None`/empty `base_url` doesn't crash).

Mutation-verified: temporarily reverted the helper body to the old substring check — 3 of 6 assertions flip to failing (the real `api.z.ai` host, the proxied-path false-positive, and the lookalike-subdomain false-positive), confirming the tests actually exercise the fixed behavior.

```
uv run --frozen --extra dev python -m pytest tests/agent/test_auxiliary_client.py -q
```
187/187 pass. `ruff check` clean on both changed files.

## Competing PR check

**PR #78321** ("peel stacked unsupported auxiliary params") is an open, broader refactor that also touches this exact classifier region (a new consolidated retry helper around the same lines in both the sync and async paths). Its diff still carries the same unfixed `"bigmodel" in (client_base_url or "").lower()` substring check forward, so this PR's fix is not redundant with it — but the two will likely conflict textually if #78321 lands first, since both restructure the same ~10 lines. Flagging for the maintainer's awareness; happy to rebase onto whichever lands first.

No other open PR found targeting this specific ZAI host-matching predicate.

## Checklist

- [x] Read the Contributing Guide
- [x] Conventional Commit message
- [x] Searched for existing PRs — found #78321 (broader, overlapping region, does not fix this bug — disclosed above)
- [x] Contains only changes related to this fix
- [x] Ran relevant tests, they pass
- [x] Added regression tests
- [x] Considered cross-platform impact — N/A (pure string/URL logic)