### PR TITLE
feat(cron): make the media-send timeout configurable via HERMES_CRON_MEDIA_SEND_TIMEOUT

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2178,7 +2178,12 @@ def _send_media_via_adapter(
                 )
                 return
             try:
-                result = future.result(timeout=30)
+                # Large attachments (long TTS audio, concatenated recordings,
+                # big exports) can legitimately exceed a fixed 30s upload
+                # window. Configurable, matching the other cron timeouts.
+                result = future.result(
+                    timeout=int(os.getenv("HERMES_CRON_MEDIA_SEND_TIMEOUT", "300"))
+                )
             except TimeoutError:
                 future.cancel()
                 raise


### PR DESCRIPTION
### Problem

`cron/scheduler.py` bounds media delivery with a hardcoded `future.result(timeout=30)`. Any job producing a large attachment — long TTS audio, a concatenated recording, a sizeable export — fails once the upload exceeds 30 seconds, and there is no way to raise the limit short of patching the file.

Observed in production: a ~7.4 MB MP3 was generated correctly and then failed to deliver, while 3.0–3.3 MB files on the same path had always succeeded. Nothing was wrong with the file, the credentials, or the transport — the upload simply took longer than 30 s.

### Why an environment variable, and why this name

The same module already reads three sibling timeouts from the environment:

- `HERMES_CRON_SCRIPT_TIMEOUT`
- `HERMES_CRON_TIMEOUT`
- `HERMES_CRON_SESSION_DB_TIMEOUT`

Media send is the odd one out. This follows the established convention rather than introducing a new mechanism, and `os` is already imported.

### Default

Raised from 30 s to 300 s. Set `HERMES_CRON_MEDIA_SEND_TIMEOUT=30` to restore the previous behaviour exactly.

### Docs

The three sibling `HERMES_CRON_*` variables are not currently documented in `website/docs/user-guide/configuration.md` or `cli-config.yaml.example`, so this PR matches that convention rather than expanding scope. Happy to add documentation for all four in this PR if you'd prefer.

### Related

- #87965 — companion fix. Without it, exceeding this timeout logs `failed to send media <path>:` with no reason at all, because `str(TimeoutError())` is empty. The two PRs touch nearby lines in the same file and are independent; whichever lands second is a trivial rebase.
- #67655 and #69984 address media upload timeouts in the Telegram adapter (`plugins/platforms/telegram/adapter.py`). This is the separate `cron/scheduler.py` delivery path and does not overlap them.
