### PR TITLE
fix(gateway): don't feed a bare media filename to the model as message text

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2858,6 +2858,32 @@ def _event_media_is_audio(event, index: int) -> bool:
     return getattr(event, "message_type", None) in {MessageType.VOICE, MessageType.AUDIO}
 
 
+def _is_bare_media_filename(text: str) -> bool:
+    """Return True when message text is only a transport filename.
+
+    Matrix ``m.audio``/``m.file`` events populate ``content.body`` with the
+    uploaded filename when the sender adds no caption, and the adapter only
+    blanks that for ``m.image``. The filename then survives into ``event.text``
+    and is appended after the transcript, where the model reads it as the
+    user's message rather than as transport noise.
+
+    Deliberately conservative -- a single token, no whitespace, no path
+    separators, and a known media suffix -- so a genuine caption is never
+    discarded.
+    """
+    candidate = str(text or "").strip()
+    if not candidate or any(ch.isspace() for ch in candidate):
+        return False
+    if os.path.basename(candidate) != candidate:
+        return False
+    suffix = os.path.splitext(candidate)[1].lower()
+    return suffix in {
+        ".ogg", ".oga", ".opus", ".m4a", ".mp3", ".wav", ".flac", ".aac", ".amr",
+        ".mp4", ".webm", ".mov", ".mkv",
+        ".jpg", ".jpeg", ".png", ".gif", ".webp", ".heic",
+    }
+
+
 def _event_media_is_stt_input(event, index: int) -> bool:
     """True when an audio attachment should enter the automatic STT pipeline."""
     message_type = getattr(event, "message_type", None)
@@ -24074,6 +24100,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _placeholder = "(The user sent a message with no text content)"
             if user_text and user_text.strip() == _placeholder:
                 return prefix, []
+            if user_text and _is_bare_media_filename(user_text):
+                return prefix, []
             if user_text:
                 return f"{prefix}\n\n{user_text}", []
             return prefix, []
@@ -24088,6 +24116,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             unavailable_note = "[voice message could not be transcribed]"
             _placeholder = "(The user sent a message with no text content)"
             if user_text and user_text.strip() == _placeholder:
+                return unavailable_note, []
+            if user_text and _is_bare_media_filename(user_text):
                 return unavailable_note, []
             if user_text:
                 return f"{unavailable_note}\n\n{user_text}", []
@@ -24169,6 +24199,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # when we successfully transcribed the audio — it's redundant.
             _placeholder = "(The user sent a message with no text content)"
             if user_text and user_text.strip() == _placeholder:
+                return prefix, successful_transcripts
+            if user_text and _is_bare_media_filename(user_text):
                 return prefix, successful_transcripts
             if user_text:
                 return f"{prefix}\n\n{user_text}", successful_transcripts


### PR DESCRIPTION
### Problem

Matrix `m.audio` / `m.file` events populate `content.body` with the uploaded **filename** when the sender adds no caption. The adapter blanks that only for `m.image`, so for audio and generic files the filename survives into `event.text` and is appended after the transcript — where the model reads it as the user's message rather than as transport noise.

In practice a voice note transcribed as *"remind me to call the dentist"* reaches the model followed by a bare token like `voice-20260725-114233.ogg`, and the model frequently answers the filename instead of the request.

### "Why not just extend the image blanking to audio/files?"

That was my first instinct too, and I think it's the weaker fix:

- The blanking lives in the adapter, so extending it fixes one platform. The enrichment path in `gateway/run.py` is shared, so the same class of noise arriving from any other transport that puts a filename in the body is handled once, here.
- Blanking is lossy at the wrong layer — it discards the value before anything can decide whether it's a caption. The guard here runs at the point where the text is about to be concatenated onto a transcript, which is exactly where "is this content or is this noise?" can be answered.
- There is already precedent at these call sites: they strip the `(The user sent a message with no text content)` placeholder for the same reason. This adds one more well-understood species of noise to the same check.

Happy to rework it as adapter-side blanking if you'd rather — the behaviour is the same for Matrix, and the diff would be smaller.

### Fix

```python
def _is_bare_media_filename(text: str) -> bool:
    candidate = str(text or "").strip()
    if not candidate or any(ch.isspace() for ch in candidate):
        return False
    if os.path.basename(candidate) != candidate:
        return False
    return os.path.splitext(candidate)[1].lower() in _MEDIA_SUFFIXES
```

Requires **all** of: a single token, no whitespace, no path separators, and a known media suffix. A genuine caption essentially always contains a space, so it is never discarded. The worst case for a false positive is a one-word caption that is exactly a media filename.

Applied at all three media-enrichment return sites — STT not run, transcription module unavailable, and successful transcription — since the filename is appended identically in each.

### Diff shape

32 additions, 0 deletions, one file. No existing behaviour is modified; the guard only adds an early return that was previously unreachable.

### History

Before v2026.7.1 the voice transcript was *framed*, which disambiguated the trailing filename. v2026.7.1 replaced the framing with a bare quoted string; the filename was always present but is now indistinguishable from content. Still reproducible on current `main`.

### Testing

Voice notes and file uploads with and without captions: captions preserved, bare filenames dropped, transcripts unaffected.
