### PR TITLE
fix(tools): surface plugin-registered STT providers in the capabilities picker

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -3146,6 +3146,57 @@ def _plugin_tts_providers() -> list[dict]:
     return rows
 
 
+def _plugin_stt_providers() -> list[dict]:
+    """Build picker-row dicts from plugin-registered STT providers.
+
+    Mirrors ``_plugin_tts_providers()`` for the transcription side.
+    Built-in STT rows stay hardcoded in ``TOOL_CATEGORIES["stt"]``;
+    this function only injects PLUGIN-registered providers (e.g. Bifrost).
+
+    Defensive: plugins whose name collides with a built-in STT provider
+    are filtered out — the registry already rejects them at registration
+    time, but filtering here keeps the picker invariant.
+    """
+    try:
+        from agent.transcription_registry import _BUILTIN_NAMES, list_providers
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        providers = list_providers()
+    except Exception:
+        return []
+
+    rows: list[dict] = []
+    for provider in providers:
+        name = getattr(provider, "name", None)
+        if not name:
+            continue
+        # Defensive: reject built-in shadowing at the picker layer too.
+        if name.lower().strip() in _BUILTIN_NAMES:
+            continue
+        try:
+            schema = provider.get_setup_schema()
+        except Exception:
+            continue
+        if not isinstance(schema, dict):
+            continue
+        row = {
+            "name": schema.get("name", provider.display_name),
+            "badge": schema.get("badge", ""),
+            "tag": schema.get("tag", ""),
+            "env_vars": schema.get("env_vars", []),
+            # Selecting this row writes ``stt.provider: <name>`` — the
+            # same write-path used by hardcoded rows. The plugin
+            # dispatcher picks it up automatically from there.
+            "stt_provider": name,
+            "stt_plugin_name": name,
+        }
+        if schema.get("post_setup"):
+            row["post_setup"] = schema["post_setup"]
+        rows.append(row)
+    return rows
+
+
 def _visible_providers(
     cat: dict,
     config: dict,
@@ -3228,6 +3279,12 @@ def _visible_providers(
     # is filtered out by ``_plugin_tts_providers`` defensively.
     if cat.get("name") == "Text-to-Speech":
         visible.extend(_plugin_tts_providers())
+
+    # Inject plugin-registered STT backends (mirror of TTS). Plugin rows
+    # render BELOW the hardcoded built-in rows. Built-in shadowing
+    # is filtered out by ``_plugin_stt_providers`` defensively.
+    if cat.get("name") == "Speech-to-Text":
+        visible.extend(_plugin_stt_providers())
 
     return visible
 


### PR DESCRIPTION
Closes #87934 (backend part).

## Problem

The capabilities picker injected plugin-registered providers into the visible list for TTS (#68017), image-gen, video-gen, web, and browser — but not for Speech-to-Text. Plugin STT backends were fully functional at runtime (the transcription dispatcher routed to them via `stt.provider`) yet invisible in the desktop and CLI picker: no row, no way to select them, no active-provider highlight.

## Fix

Add `_plugin_stt_providers()` mirroring `_plugin_tts_providers()`:
- Pulls providers from `agent.transcription_registry.list_providers()`
- Filters built-in name collisions (`_BUILTIN_NAMES`)
- Builds picker rows from each provider's `get_setup_schema()`
- Injects into `_visible_providers()` when category is `"Speech-to-Text"`

## Scope

Backend-only. The desktop frontend (`constants.ts` hardcoded enums, `SECTIONS` field lists) still needs work to render plugin STT config fields in the native Voice settings form — tracked in #87935. This PR fixes the Capabilities picker, which is the primary selection surface.