### PR TITLE
fix(desktop): handle data-training tier confirm_required in Settings and chat picker

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -6,7 +6,7 @@ import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { isBusySessionModelSwitch } from '@/lib/gateway-rpc'
 import { manualPickRemoved, modelOptionsQueryKey } from '@/lib/model-options'
-import { notifyError } from '@/store/notifications'
+import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
@@ -235,18 +235,54 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         const persistsAsDefault = touchesPrimary && !isSessionOnlyPreset
         const scope = persistsAsDefault ? '--global' : '--session'
 
-        const result = await requestGateway<{ deferred?: boolean }>('config.set', {
+        const result = await requestGateway<{
+          confirm_required?: boolean
+          confirm_message?: string
+          deferred?: boolean
+          value?: string
+        }>('config.set', {
           session_id: liveSessionId,
           key: 'model',
           value: `${selection.model} --provider ${selection.provider} ${scope}`
         })
+
+        // The backend refuses to persist a model that trips a selection guard
+        // (expensive model, or a data-training tier like Meta's
+        // *-contributor) unless the user explicitly acknowledges it. It
+        // answers confirm_required + confirm_message WITHOUT applying the
+        // switch. Without this handling the picker silently closed and the
+        // model never changed (the Settings page had the same bug). Ask the
+        // user, then retry with the acknowledgment flag.
+        let applied = result
+        if (result?.confirm_required && result.confirm_message) {
+          const acknowledged = await confirmModelSwitchWarning(result.confirm_message)
+          if (!acknowledged) {
+            throw new Error(copy.modelSwitchDeclined)
+          }
+          applied = await requestGateway<{
+            confirm_required?: boolean
+            confirm_message?: string
+            deferred?: boolean
+            value?: string
+          }>('config.set', {
+            session_id: liveSessionId,
+            key: 'model',
+            value: `${selection.model} --provider ${selection.provider} ${scope}`,
+            confirm_expensive_model: true
+          })
+          if (applied?.confirm_required) {
+            // Should not happen (we sent the flag), but never leave the user
+            // with a silently-unapplied pick.
+            throw new Error(applied.confirm_message || copy.modelSwitchFailed)
+          }
+        }
 
         // A pick made DURING a turn is queued by the gateway and applied at the
         // next turn start (`deferred`). Re-fetching now would answer with the
         // model still running and repaint the old name over the user's choice —
         // the switch publishes session.info when it lands, and that is what
         // re-syncs every surface.
-        if (!result?.deferred) {
+        if (!applied?.deferred) {
           void queryClient.invalidateQueries({ queryKey: modelOptionsQueryKey(liveGatewayProfile, liveSessionId) })
         }
 
@@ -289,4 +325,38 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
   )
 
   return { applySavedMainModel, refreshCurrentModel, selectModel }
+}
+
+/**
+ * Present a selection-guard warning (expensive model / data-training tier) as
+ * a confirm notification instead of an error. Resolves true when the user
+ * explicitly accepts; false when they dismiss.
+ */
+function confirmModelSwitchWarning(message: string): Promise<boolean> {
+  const id = `model-switch-confirm-${Date.now()}`
+
+  return new Promise(resolve => {
+    let settled = false
+    const finish = (value: boolean) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      resolve(value)
+    }
+
+    notify({
+      id,
+      kind: 'warning',
+      title: 'Model Selection Warning',
+      message,
+      durationMs: 0,
+      placement: 'default',
+      action: {
+        label: 'Confirm',
+        onClick: () => finish(true)
+      },
+      onDismiss: () => finish(false)
+    })
+  })
 }

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1403,7 +1403,11 @@ export const ar = defineLocale({
       message: count => `سيتم تخطي ${count} من المهام المجدولة حتى تراجع إعدادات النموذج الخاصة بها.`,
       detailMore: (names, remaining) => `${names} و${remaining} أخرى`,
       review: 'مراجعة المهام المجدولة',
-      saveFailed: 'لم يحفظ Hermes تغيير النموذج هذا.'
+      saveFailed: 'لم يحفظ Hermes تغيير النموذج هذا.',
+      confirmTitle: 'تحذير اختيار النموذج',
+      confirmDetail: 'أكد فقط إذا كنت تقبل هذا التنازل.',
+      confirmAction: 'تأكيد',
+      declined: 'تم إلغاء تغيير النموذج - رفضت تحذير مستوى التدريب على البيانات.'
     },
     search: 'بحث',
     loading: 'جار التحميل...',
@@ -2619,6 +2623,9 @@ export const ar = defineLocale({
     cwdStagedTitle: 'تم تجهيز مجلد العمل',
     cwdStagedMessage: 'سيطبق مجلد العمل على الرسالة التالية.',
     modelSwitchFailed: 'فشل تبديل النموذج',
+    modelSwitchDeclined: 'تم إلغاء تغيير النموذج - رفضت تحذير مستوى التدريب على البيانات.',
+    modelSwitchConfirmTitle: 'تحذير اختيار النموذج',
+    modelSwitchConfirmAction: 'تأكيد',
     sessionExported: 'تم تصدير الجلسة',
     sessionExportFailed: 'فشل تصدير الجلسة',
     imageSaved: 'تم حفظ الصورة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1770,7 +1770,11 @@ export const en: Translations = {
         `${count} scheduled ${count === 1 ? 'job' : 'jobs'} will be skipped until you review their model settings.`,
       detailMore: (names, remaining) => `${names} and ${remaining} more`,
       review: 'Review scheduled jobs',
-      saveFailed: 'Hermes did not save that model change.'
+      saveFailed: 'Hermes did not save that model change.',
+      confirmTitle: 'Model Selection Warning',
+      confirmDetail: 'Confirm only if you accept this trade-off.',
+      confirmAction: 'Confirm',
+      declined: 'Model change cancelled — you declined the data-training tier warning.'
     },
     search: 'Search cron jobs...',
     loading: 'Loading cron jobs...',
@@ -3154,6 +3158,9 @@ export const en: Translations = {
     cwdStagedTitle: 'Working directory staged',
     cwdStagedMessage: 'Restart the desktop backend to apply cwd changes to this active session.',
     modelSwitchFailed: 'Model switch failed',
+    modelSwitchDeclined: 'Model switch cancelled — you declined the data-training tier warning.',
+    modelSwitchConfirmTitle: 'Model Selection Warning',
+    modelSwitchConfirmAction: 'Confirm',
     sessionExported: 'Session exported',
     sessionExportFailed: 'Could not export session',
     imageSaved: 'Image saved',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1537,7 +1537,11 @@ export const ja = defineLocale({
       message: count => `モデル設定を確認するまで、${count} 件のスケジュール済みジョブがスキップされます。`,
       detailMore: (names, remaining) => `${names}、ほか ${remaining} 件`,
       review: 'スケジュール済みジョブを確認',
-      saveFailed: 'Hermes はモデルの変更を保存しませんでした。'
+      saveFailed: 'Hermes はモデルの変更を保存しませんでした。',
+      confirmTitle: 'モデル選択の警告',
+      confirmDetail: 'このトレードオフを受け入れる場合のみ確認してください。',
+      confirmAction: '確認',
+      declined: 'モデル変更はキャンセルされました - データ学習ティアの警告を拒否しました。'
     },
     search: 'Cron ジョブを検索...',
     loading: 'Cron ジョブを読み込み中...',
@@ -2859,6 +2863,9 @@ export const ja = defineLocale({
     cwdStagedMessage:
       'このアクティブなセッションへの cwd の変更を適用するにはデスクトップバックエンドを再起動してください。',
     modelSwitchFailed: 'モデルの切り替えに失敗しました',
+    modelSwitchDeclined: 'モデル変更はキャンセルされました - データ学習ティアの警告を拒否しました。',
+    modelSwitchConfirmTitle: 'モデル選択の警告',
+    modelSwitchConfirmAction: '確認',
     sessionExported: 'セッションをエクスポートしました',
     sessionExportFailed: 'セッションをエクスポートできませんでした',
     imageSaved: '画像を保存しました',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1500,6 +1500,10 @@ export interface Translations {
       detailMore: (names: string, remaining: number) => string
       review: string
       saveFailed: string
+      confirmTitle: string
+      confirmDetail: string
+      confirmAction: string
+      declined: string
     }
     search: string
     loading: string
@@ -2690,6 +2694,9 @@ export interface Translations {
     cwdStagedTitle: string
     cwdStagedMessage: string
     modelSwitchFailed: string
+    modelSwitchDeclined: string
+    modelSwitchConfirmTitle: string
+    modelSwitchConfirmAction: string
     sessionExported: string
     sessionExportFailed: string
     imageSaved: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1480,7 +1480,11 @@ export const zhHant = defineLocale({
       message: count => `在您檢查模型設定之前，${count} 個排程工作將被略過。`,
       detailMore: (names, remaining) => `${names}，以及另外 ${remaining} 個`,
       review: '檢查排程工作',
-      saveFailed: 'Hermes 未儲存該模型變更。'
+      saveFailed: 'Hermes 未儲存該模型變更。',
+      confirmTitle: '模型選擇警告',
+      confirmDetail: '僅在接受此權衡時確認。',
+      confirmAction: '確認',
+      declined: '模型變更已取消——您拒絕了資料訓練層級警告。'
     },
     search: '搜尋排程工作…',
     loading: '正在載入排程工作…',
@@ -2739,6 +2743,9 @@ export const zhHant = defineLocale({
     cwdStagedTitle: '工作目錄已暫存',
     cwdStagedMessage: '重新啟動桌面後端後，工作目錄變更才會套用至此作用中工作階段。',
     modelSwitchFailed: '模型切換失敗',
+    modelSwitchDeclined: '模型切換已取消——您拒絕了資料訓練層級警告。',
+    modelSwitchConfirmTitle: '模型選擇警告',
+    modelSwitchConfirmAction: '確認',
     sessionExported: '工作階段已匯出',
     sessionExportFailed: '無法匯出工作階段',
     imageSaved: '圖片已儲存',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1957,7 +1957,11 @@ export const zh: Translations = {
       message: count => `在您检查模型设置之前，${count} 个定时任务将被跳过。`,
       detailMore: (names, remaining) => `${names}，以及另外 ${remaining} 个`,
       review: '检查定时任务',
-      saveFailed: 'Hermes 未保存该模型更改。'
+      saveFailed: 'Hermes 未保存该模型更改。',
+      confirmTitle: '模型选择警告',
+      confirmDetail: '仅在接受此权衡时确认。',
+      confirmAction: '确认',
+      declined: '模型更改已取消——您拒绝了数据训练层级警告。'
     },
     search: '搜索定时任务…',
     loading: '正在加载定时任务…',
@@ -3305,6 +3309,9 @@ export const zh: Translations = {
     cwdStagedTitle: '工作目录已暂存',
     cwdStagedMessage: '重启桌面后端后，工作目录更改才会应用到当前活跃会话。',
     modelSwitchFailed: '模型切换失败',
+    modelSwitchDeclined: '模型切换已取消——您拒绝了数据训练层级警告。',
+    modelSwitchConfirmTitle: '模型选择警告',
+    modelSwitchConfirmAction: '确认',
     sessionExported: '会话已导出',
     sessionExportFailed: '无法导出会话',
     imageSaved: '图片已保存',

--- a/apps/desktop/src/store/cron-model-impact.test.ts
+++ b/apps/desktop/src/store/cron-model-impact.test.ts
@@ -122,7 +122,49 @@ describe('setMainModelAssignment', () => {
     expect($notifications.get()).toEqual([])
   })
 
-  it('rejects non-persisted confirmation outcomes without changing impact state', async () => {
+  it('surfaces a confirm prompt for guard-blocked assignments and retries with acknowledgment when accepted', async () => {
+    setModelAssignment.mockResolvedValueOnce(response(positive()))
+    await setMainModelAssignment({ provider: 'nous', model: 'one' })
+
+    // First attempt trips the guard: backend answers ok:false + confirm_required
+    // + confirm_message and does NOT persist. The desktop must not treat this
+    // as a plain error — it must ask the user and retry with
+    // confirm_expensive_model: true (mirrors the CLI's [y/N] prompt).
+    const guardResponse = {
+      ok: false,
+      scope: 'main',
+      provider: 'openrouter',
+      model: 'openai/gpt-5.5-pro',
+      confirm_required: true,
+      confirm_message: 'Confirm this expensive model.'
+    } satisfies ModelAssignmentResponse
+
+    setModelAssignment.mockResolvedValueOnce(guardResponse)
+    const pending = setMainModelAssignment({ provider: 'openrouter', model: 'openai/gpt-5.5-pro' })
+
+    // The confirm prompt is a notification with an action; while it is open
+    // the assignment must still be pending (not resolved/rejected yet).
+    await vi.waitFor(() => {
+      const n = $notifications.get().find(n => n.id.startsWith('model-warning-confirm-'))
+      expect(n?.message).toBe('Confirm this expensive model.')
+    })
+    const confirmNotification = $notifications.get().find(n => n.id.startsWith('model-warning-confirm-'))
+
+    // Accepting re-sends with the acknowledgment flag and persists.
+    setModelAssignment.mockResolvedValueOnce(response(positive()))
+    confirmNotification?.action?.onClick()
+    await pending
+    expect(setModelAssignment).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        provider: 'openrouter',
+        model: 'openai/gpt-5.5-pro',
+        scope: 'main',
+        confirm_expensive_model: true
+      })
+    )
+  })
+
+  it('rejects (declines) guard-blocked assignments with a neutral message when the user dismisses', async () => {
     setModelAssignment.mockResolvedValueOnce(response(positive()))
     await setMainModelAssignment({ provider: 'nous', model: 'one' })
 
@@ -135,14 +177,20 @@ describe('setMainModelAssignment', () => {
       confirm_message: 'Confirm this expensive model.'
     } satisfies ModelAssignmentResponse)
 
-    await expect(setMainModelAssignment({ provider: 'openrouter', model: 'openai/gpt-5.5-pro' })).rejects.toThrow(
-      'Confirm this expensive model.'
+    const pending = setMainModelAssignment({ provider: 'openrouter', model: 'openai/gpt-5.5-pro' })
+    await vi.waitFor(() => {
+      expect($notifications.get().some(n => n.id.startsWith('model-warning-confirm-'))).toBe(true)
+    })
+    const confirmNotification = $notifications.get().find(n => n.id.startsWith('model-warning-confirm-'))
+    confirmNotification?.onDismiss?.()
+
+    await expect(pending).rejects.toThrow()
+    expect(setModelAssignment).not.toHaveBeenCalledWith(
+      expect.objectContaining({ confirm_expensive_model: true })
     )
-    expect($notifications.get()).toHaveLength(1)
-    const action = $notifications.get()[0].action
-    const reviewCount = $cronReviewRequest.get()
-    action?.onClick()
-    expect($cronReviewRequest.get()).toBe(reviewCount + 1)
+    // The cron impact notification from the first call is still there;
+    // no new error notification with the giant warning text should exist.
+    expect($notifications.get().filter(n => n.kind === 'error').length).toBe(0)
   })
 
   it('publishes only the latest same-profile assignment when responses reverse', async () => {

--- a/apps/desktop/src/store/cron-model-impact.ts
+++ b/apps/desktop/src/store/cron-model-impact.ts
@@ -145,13 +145,39 @@ function publishImpact(impact: CronModelImpact, profile: string, connection: str
 }
 
 export async function setMainModelAssignment(
-  request: Omit<ModelAssignmentRequest, 'scope'>
+  request: Omit<ModelAssignmentRequest, 'scope'>,
+  options?: { confirmMessage?: string; skipConfirmPrompt?: boolean }
 ): Promise<ModelAssignmentResponse> {
   const { connection, generation } = beginCronModelImpactAssignment()
   const profile = profileIdentity()
   const result = await setModelAssignment({ ...request, scope: 'main' })
 
   if (result.ok !== true) {
+    // The backend demands an explicit acknowledgment before persisting a
+    // model that trips a selection guard (expensive model, or a data-training
+    // tier like Meta's *-contributor). It answers ok:false + confirm_required
+    // + confirm_message and does NOT save. Without handling this, the desktop
+    // app surfaced the guard text as a red error and could never persist the
+    // selection at all (CLI worked because it prompts [y/N]).
+    if (result.confirm_required && result.confirm_message) {
+      const acknowledged =
+        options?.confirmMessage === result.confirm_message ||
+        (options?.skipConfirmPrompt
+          ? false
+          : await confirmModelWarning(result.confirm_message))
+      if (acknowledged) {
+        return setMainModelAssignment({ ...request, confirm_expensive_model: true }, { confirmMessage: result.confirm_message })
+      }
+      // User declined the guard prompt — the assignment was intentionally
+      // not saved. A neutral message beats re-showing the full warning as
+      // an error (they already read it and said no).
+      throw new Error(
+        options?.skipConfirmPrompt
+          ? result.confirm_message || translateNow('cron.modelImpact.declined')
+          : translateNow('cron.modelImpact.declined')
+      )
+    }
+
     throw new Error(result.confirm_message?.trim() || translateNow('cron.modelImpact.saveFailed'))
   }
 
@@ -185,3 +211,44 @@ export function invalidateCronModelImpactScope(options: { clearNotification?: bo
 // Scope changes originating outside this module (profile/backend switches)
 // clear any warning that belongs to the old runtime.
 onCronModelImpactScopeInvalidated(() => dismissNotification(CRON_MODEL_IMPACT_NOTIFICATION_ID))
+
+/**
+ * Present a selection-guard warning (expensive model / data-training tier)
+ * as a confirm dialog instead of an error. Resolves true when the user
+ * explicitly accepts the trade-off; false when they decline.
+ *
+ * The desktop app has no generic blocking confirm API, so this uses a
+ * non-dismissible action notification: the only way out is Confirm (true) or
+ * Dismiss (false). The message is single-shot and not re-surfaced after the
+ * user acts.
+ */
+function confirmModelWarning(message: string): Promise<boolean> {
+  const id = `model-warning-confirm-${Date.now()}`
+
+  return new Promise(resolve => {
+    let settled = false
+    const finish = (value: boolean) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      dismissNotification(id)
+      resolve(value)
+    }
+
+    notify({
+      id,
+      kind: 'warning',
+      title: translateNow('cron.modelImpact.confirmTitle') || 'Model Selection Warning',
+      message,
+      detail: translateNow('cron.modelImpact.confirmDetail') || 'Confirm only if you accept this trade-off.',
+      durationMs: 0,
+      placement: 'default',
+      action: {
+        label: translateNow('cron.modelImpact.confirmAction') || 'Confirm',
+        onClick: () => finish(true)
+      },
+      onDismiss: () => finish(false)
+    })
+  })
+}

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -318,10 +318,17 @@ async function completeWithModelConfirm(
     // config provider (e.g. anthropic from a prior failed setup) cannot make
     // setup.runtime_check validate the wrong backend after a fresh OAuth login.
     try {
-      const res = await setMainModelAssignment({
-        provider: defaults.providerSlug,
-        model: defaults.defaultModel
-      })
+      const res = await setMainModelAssignment(
+        {
+          provider: defaults.providerSlug,
+          model: defaults.defaultModel
+        },
+        // Onboarding is a headless automated flow — there is no user at the
+        // keyboard to answer a guard confirmation prompt. If the backend
+        // demands one (expensive model / data-training tier), fail with the
+        // message instead of dangling a prompt nobody can click.
+        { skipConfirmPrompt: true }
+      )
 
       notifyGatewayTools(res.gateway_tools)
     } catch (error) {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1297,6 +1297,11 @@ export interface ModelAssignmentRequest {
   /** OpenAI-compatible endpoint URL. Only honored for custom/local providers
    *  on the main slot — wires a self-hosted endpoint into runtime resolution. */
   base_url?: string
+  /** Explicitly acknowledge an expensive-model / data-policy warning so the
+   *  backend persists the assignment. The backend returns
+   *  ``{ok:false, confirm_required:true, confirm_message}`` on the first
+   *  attempt; the UI surfaces that message, then retries with this flag. */
+  confirm_expensive_model?: boolean
   model: string
   provider: string
   scope: 'main' | 'auxiliary'


### PR DESCRIPTION
## What does this PR do?

Fixes desktop inability to select any model whose selection guard fires (`confirm_required`). The backend (`POST /api/model/set` and `config.set` via tui_gateway) correctly returns `ok: false` + `confirm_required: true` + `confirm_message` for data-training tiers (e.g. `muse-spark-1.2-contributor`) and expensive models until the user explicitly acknowledges. Desktop never handled that shape.

**Settings path (`/api/model/set`):** `setMainModelAssignment` treated `confirm_required` as a plain error and rendered the giant `!!! CONTRIBUTOR TIER [...] Source: https://dev.meta.ai/docs/pricing-rate-limits/` warning as a red error text. Raw i18n keys (`cron.modelImpact.confirmTitle` etc.) also leaked because `translateNow` returns the key on miss and the code used `|| fallback` (non-empty key is truthy). Now it shows a proper warning notification with a Confirm action and retries with `confirm_expensive_model: true`; decline is a neutral message. Onboarding (headless automated flow) gets `skipConfirmPrompt: true` so it fails with the message instead of dangling a prompt nobody can click.

**Chat picker path (`config.set`):** `selectModel` in `use-model-controls.ts` (the model pill next to the composer input) optimistically painted the new model/provider, closed the picker, but never inspected `confirm_required` from the gateway. The switch was never persisted, so the picker appeared to close without changing the model. Now it inspects `confirm_required`, prompts, and retries with `confirm_expensive_model: true` with correct `deferred`/rollback handling.

Adds the four missing i18n keys (`confirmTitle`/`confirmDetail`/`confirmAction`/`declined`) and `modelSwitchDeclined`/`modelSwitchConfirm*` to `en` + locales and `types.ts`.

This is a follow-up to #86710, which fixed the non-interactive CLI startup guard (`security.allow_data_training_tiers_noninteractive`) for kanban/cron but left both desktop surfaces broken.

## Related Issue

Follow-up to #86653 / #86710 (same `data_policy` guard, remaining desktop surfaces).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/types/hermes.ts` — add `confirm_expensive_model?: boolean` to `ModelAssignmentRequest`
- `apps/desktop/src/store/cron-model-impact.ts` — handle `confirm_required` in `setMainModelAssignment` (confirm notification + retry with ack; `skipConfirmPrompt` for onboarding; correct i18n keys, no `|| fallback` on non-empty key)
- `apps/desktop/src/store/onboarding.ts` — pass `skipConfirmPrompt: true` for headless flow
- `apps/desktop/src/app/session/hooks/use-model-controls.ts` — handle `confirm_required` in chat picker `selectModel` (prompt + retry with `confirm_expensive_model: true`, correct `deferred` on retry)
- `apps/desktop/src/i18n/en.ts`, `ar.ts`, `ja.ts`, `zh.ts`, `zh-hant.ts`, `types.ts` — add `cron.modelImpact.confirmTitle`/`confirmDetail`/`confirmAction`/`declined` and `desktop.modelSwitchDeclined` etc.
- `apps/desktop/src/store/cron-model-impact.test.ts` — replace stale rejection test with accept/dismiss coverage for the confirm prompt

## How to Test

1. Set `model.provider: command-code` (or any provider) and open Settings -> Model and the chat model pill picker; select `meta/muse-spark-1.2-contributor` (or any model that trips the guard).
2. Before: Settings showed raw `cron.modelImpact.*` keys in red; chat picker closed without changing. After: a warning notification with Confirm appears in both places; Confirm persists the model (verify in `config.yaml` and next new chat).
3. Dismiss/decline keeps the old model with a neutral message, no giant warning re-rendered as error.
4. `npm ci && npx vitest run src/store/cron-model-impact.test.ts src/app/session/hooks/use-model-controls.test.tsx src/store/onboarding.test.ts` — 29 tests pass; full `src/store` 876 pass; `tsc --noEmit -p tsconfig.json` clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(desktop): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (`gh search prs --repo NousResearch/hermes-agent --state all "confirm_required|contributor tier|muse-spark"` — only #86710)
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` equivalent (`npx vitest run ...` for desktop; `tsc --noEmit` clean) and all tests pass
- [x] I've added tests for my changes (updated `cron-model-impact.test.ts` with accept/dismiss)
- [x] I've tested on my platform: Windows 11, `hermes desktop` packaged (`release/win-unpacked`, asar `updates-BFtK1Mal.js` verified via `asar extractAll` contains the fix), provider `command-code` (`https://api.commandcode.ai/provider/v1`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (no config key added)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (desktop renderer only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before: raw `cron.modelImpact.confirmTitle` + full `!!! CONTRIBUTOR TIER [...]` in Details + `cron.modelImpact.confirmAction`. After: localized title/detail/action from the new i18n keys.

