### PR TITLE
fix(desktop): make Show earlier and timeline jumps reach older turns

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -22,6 +22,7 @@ import { useI18n } from '@/i18n'
 import { messagePaintWeight } from '@/lib/render-weight'
 import { cn } from '@/lib/utils'
 import {
+  onRevealMessageRequest,
   onScrollToBottomRequest,
   onThreadEditClose,
   onThreadEditOpen,
@@ -32,6 +33,7 @@ import { isSecondaryWindow } from '@/store/windows'
 
 import { MessageRenderBoundary } from '../message-render-boundary'
 
+import { renderBudgetToRevealGroup, shouldClampTranscriptBudget } from './transcript-budget'
 import { resolveShowEarlierAction, useTranscriptWindow } from './transcript-window'
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
@@ -433,9 +435,11 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     setBudgetSessionKey(sessionKey)
     setHadGroups(hasGroups)
     setRenderBudget(FIRST_PAINT_BUDGET)
-  } else if (renderBudget > paneBudget) {
+  } else if (shouldClampTranscriptBudget(paneLifecycle === 'hot-hidden', renderBudget, paneBudget)) {
     // Apply the hidden budget during render so React never first commits the
-    // stale full transcript after this pane moves to the background.
+    // stale full transcript after this pane moves to the background. Guarded
+    // on hot-hidden: a visible pane's Show-earlier / timeline-reveal growth
+    // must survive the next render.
     setRenderBudget(paneBudget)
   } else if (hadGroups !== hasGroups) {
     setHadGroups(hasGroups)
@@ -566,6 +570,31 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
   // Floating jump button (outside this subtree) → return to the bottom.
   useEffect(() => onScrollToBottomRequest(() => void scrollToBottom()), [scrollToBottom])
+
+  // Timeline rail lists every user prompt in the assistant-ui store, but only
+  // the current DOM page is mounted. A click on an older dash must raise the
+  // budget (or pull another store page) before scrollToPrompt can find a node.
+  const revealHandlerRef = useRef<(id: string) => void>(() => {})
+
+  revealHandlerRef.current = (id: string) => {
+    if (paneLifecycle !== 'visible') {
+      return
+    }
+
+    const needed = renderBudgetToRevealGroup(groups, id)
+
+    if (needed != null) {
+      if (needed > renderBudget) {
+        setRenderBudget(needed)
+      }
+    } else if (olderAvailable) {
+      expandWindow()
+    }
+
+    stopScroll()
+  }
+
+  useEffect(() => onRevealMessageRequest(id => revealHandlerRef.current(id)), [])
 
   // Waking from display: hidden (HUD mode hides the main window; OS hide does
   // the same to any window): rAF and ResizeObserver may have been frozen, so

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-data.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-data.test.ts
@@ -37,6 +37,20 @@ describe('deriveTimelineEntries', () => {
       ]).map(e => e.id)
     ).toEqual(['u3'])
   })
+
+  it('drops context-compaction handoffs that are not human prompts', () => {
+    expect(
+      deriveTimelineEntries([
+        { id: 'u1', role: 'user', text: 'first prompt' },
+        {
+          id: 'c1',
+          role: 'user',
+          text: '[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted'
+        },
+        { id: 'u2', role: 'user', text: 'after compaction' }
+      ]).map(e => e.id)
+    ).toEqual(['u1', 'u2'])
+  })
 })
 
 describe('sameTimelineEntries', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-data.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-data.ts
@@ -13,6 +13,7 @@ export interface TimelineEntry {
 
 // Injected as user messages for alternation; not human prompts (thread.tsx).
 const PROCESS_NOTIFICATION_RE = /^\[IMPORTANT: Background process [\s\S]*\]$/
+const COMPACTION_HANDOFF_RE = /^\[CONTEXT (?:COMPACTION|SUMMARY)/
 
 const PREVIEW_MAX = 120
 
@@ -36,7 +37,7 @@ export function deriveTimelineEntries(messages: readonly TimelineSourceMessage[]
 
     const text = message.text.trim()
 
-    if (!text || PROCESS_NOTIFICATION_RE.test(text)) {
+    if (!text || PROCESS_NOTIFICATION_RE.test(text) || COMPACTION_HANDOFF_RE.test(text)) {
       continue
     }
 

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -4,6 +4,7 @@ import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'reac
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
+import { requestRevealMessage } from '@/store/thread-scroll'
 
 import {
   activeTimelineIndex,
@@ -110,18 +111,43 @@ function jumpScroll(viewport: HTMLElement, top: number, duration = 170): void {
 export const ownViewport = (root: HTMLElement | null): HTMLElement | null =>
   (root?.closest('[data-session-anchor]') ?? document).querySelector<HTMLElement>(VIEWPORT)
 
-function scrollToPrompt(root: HTMLElement | null, id: string) {
+function scrollToPrompt(root: HTMLElement | null, id: string): boolean {
   const viewport = ownViewport(root)
   const node = viewport?.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(id)}"]`)
 
   if (!viewport || !node) {
-    return
+    return false
   }
 
   const top = viewport.scrollTop + (node.getBoundingClientRect().top - viewport.getBoundingClientRect().top) - 8
 
   triggerHaptic('selection')
   jumpScroll(viewport, Math.max(0, top))
+
+  return true
+}
+
+const REVEAL_WAIT_FRAMES = 45
+
+function jumpToPrompt(root: HTMLElement | null, id: string): void {
+  if (scrollToPrompt(root, id)) {
+    return
+  }
+
+  requestRevealMessage(id)
+
+  let frames = 0
+
+  const wait = () => {
+    if (scrollToPrompt(root, id) || ++frames > REVEAL_WAIT_FRAMES) {
+      return
+    }
+
+    requestRevealMessage(id)
+    requestAnimationFrame(wait)
+  }
+
+  requestAnimationFrame(wait)
 }
 
 /**
@@ -212,7 +238,7 @@ const ActiveThreadTimeline: FC = () => {
   const [open, setOpen] = useState(false)
   const closeTimerRef = useRef<number | undefined>(undefined)
   const rootRef = useRef<HTMLDivElement | null>(null)
-  const jump = useCallback((id: string) => scrollToPrompt(rootRef.current, id), [])
+  const jump = useCallback((id: string) => jumpToPrompt(rootRef.current, id), [])
 
   // Hover sync lives on the DOM, not in React state — the tick and its popover
   // row are siblings in different subtrees, so a shared index-keyed paint() lights

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-budget.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-budget.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderBudgetToRevealGroup, shouldClampTranscriptBudget } from './transcript-budget'
+
+describe('shouldClampTranscriptBudget', () => {
+  it('never snaps a visible pane back after Show earlier / timeline reveal', () => {
+    expect(shouldClampTranscriptBudget(false, 1200, 600)).toBe(false)
+    expect(shouldClampTranscriptBudget(false, 40, 600)).toBe(false)
+  })
+
+  it('snaps only a hot-hidden pane that outgrew the retention budget', () => {
+    expect(shouldClampTranscriptBudget(true, 1200, 40)).toBe(true)
+    expect(shouldClampTranscriptBudget(true, 40, 40)).toBe(false)
+  })
+})
+
+describe('renderBudgetToRevealGroup', () => {
+  it('sums newest-first weight through the target group', () => {
+    const groups = [
+      { id: 'u1', weight: 10 },
+      { id: 'u2', weight: 20 },
+      { id: 'u3', weight: 5 }
+    ]
+
+    expect(renderBudgetToRevealGroup(groups, 'u3')).toBe(5)
+    expect(renderBudgetToRevealGroup(groups, 'u2')).toBe(25)
+    expect(renderBudgetToRevealGroup(groups, 'u1')).toBe(35)
+  })
+
+  it('returns null when the prompt is not in the materialized groups', () => {
+    expect(renderBudgetToRevealGroup([{ id: 'u1', weight: 10 }], 'missing')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-budget.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-budget.ts
@@ -1,0 +1,29 @@
+/**
+ * DOM-page budget helpers for the transcript list.
+ *
+ * Kept out of `list.tsx` so the clamp / reveal contracts can be unit-tested
+ * without mounting the React thread.
+ */
+
+export function shouldClampTranscriptBudget(hidden: boolean, renderBudget: number, paneBudget: number): boolean {
+  return hidden && renderBudget > paneBudget
+}
+
+export function renderBudgetToRevealGroup(
+  groups: readonly { id: string; weight: number }[],
+  messageId: string
+): number | null {
+  const index = groups.findIndex(group => group.id === messageId)
+
+  if (index < 0) {
+    return null
+  }
+
+  let weight = 0
+
+  for (let i = groups.length - 1; i >= index; i--) {
+    weight += groups[i].weight
+  }
+
+  return weight
+}

--- a/apps/desktop/src/store/thread-scroll.ts
+++ b/apps/desktop/src/store/thread-scroll.ts
@@ -41,6 +41,21 @@ export const onScrollToBottomRequest = (handler: () => void) => {
 
 export const requestScrollToBottom = () => handlers.forEach(handler => handler())
 
+// Timeline rail → transcript list. The rail lists prompts the DOM page has
+// not mounted yet; the list raises its render budget (or store window) so
+// the subsequent scroll can find `[data-message-id]`.
+const revealHandlers = new Set<(id: string) => void>()
+
+export const onRevealMessageRequest = (handler: (id: string) => void) => {
+  revealHandlers.add(handler)
+
+  return () => void revealHandlers.delete(handler)
+}
+
+export const requestRevealMessage = (id: string) => {
+  revealHandlers.forEach(handler => handler(id))
+}
+
 // Inline edit grows a sticky human bubble. Fire on pointerdown so the viewport
 // escapes stick-to-bottom before focus/layout; close clears the edit flag when
 // the inline composer unmounts.


### PR DESCRIPTION
## Summary

Long Desktop sessions page the transcript (DOM budget + store window). Two history controls then silently no-op:

1. **Show earlier messages** — each click raises `renderBudget` *above* `paneBudget`. A render-phase cap (`renderBudget > paneBudget → setRenderBudget(paneBudget)`) immediately undid that growth. The button rendered and did nothing. Regression from `62eefff697` (bound long-running app resource use). The cap was meant only for **hot-hidden** panes keeping a live tail.

2. **Right-edge timeline / first-prompt jump** — the rail lists every user prompt in the assistant-ui store, but `scrollToPrompt` looks up `[data-message-id]` in the mounted DOM and returns if the node is missing. Clicking an older prompt (including the first one) did nothing.

Also: compaction handoffs (`[CONTEXT COMPACTION — REFERENCE ONLY]`) showed up as rail rows with no transcript node — more dead clicks.

## Changes

- Gate the budget cap with `shouldClampTranscriptBudget(hidden, …)` so a visible pane keeps Show-earlier / reveal growth.
- Timeline miss → `requestRevealMessage` → list raises the DOM budget (or `expandWindow`) and retries the jump for a few frames.
- Filter compaction / context-summary handoffs from `deriveTimelineEntries`.

## Related

- #87182 — timeline click does nothing behind Show earlier (this PR).
- #87686 — concurrent clamp-only fix (same Show-earlier root cause; this PR includes that gate plus the rail).
- #52834 — older rail-reveal PR against pre-windowing `list.tsx`; this is the current-tree version.
- #80141 — sticky user bubble covering the Show-earlier button (separate).

## Test plan

- [x] Unit: `shouldClampTranscriptBudget` / `renderBudgetToRevealGroup` / compaction rail filter (node strip-types assertions + new vitest files).
- [ ] Open a long compacted session in Desktop.
- [ ] Click **Show earlier messages** — older turns prepend; view stays anchored.
- [ ] Open the right-edge rail and click the **first prompt** — transcript reveals and scrolls there.
- [ ] Compaction rows no longer appear in the rail.