### PR TITLE
fix(tools): scope resolved names to active turn

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -258,9 +258,34 @@ TOOL_TO_TOOLSET_MAP: Dict[str, str] = registry.get_tool_to_toolset_map()
 
 TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
 
-# Resolved tool names from the last get_tool_definitions() call.
-# Used by code_execution_tool to know which tools are available in this session.
+# Resolved tool names for the active execution context. get_tool_definitions()
+# populates this before a turn can dispatch execute_code, so concurrent gateway
+# turns cannot overwrite each other's sandbox allowlist.
+_resolved_tool_names: ContextVar[Tuple[str, ...]] = ContextVar(
+    "resolved_tool_names", default=()
+)
+
+# Deprecated compatibility mirror for integrations that imported this private
+# name. Never use it to authorize a tool call: it remains process-global.
 _last_resolved_tool_names: List[str] = []
+
+
+def _get_resolved_tool_names() -> List[str]:
+    """Return the active execution context's resolved tool names."""
+    return list(_resolved_tool_names.get())
+
+
+def _set_current_resolved_tool_names(tool_names: List[str]) -> None:
+    """Set tool names only for the active execution context."""
+    _resolved_tool_names.set(tuple(tool_names))
+
+
+def _set_resolved_tool_names(tool_names: List[str]) -> None:
+    """Record tool names in the current execution context and legacy mirror."""
+    names = tuple(tool_names)
+    _set_current_resolved_tool_names(list(names))
+    global _last_resolved_tool_names
+    _last_resolved_tool_names = list(names)
 
 
 # =============================================================================
@@ -378,16 +403,18 @@ def get_tool_definitions(
         with _tool_defs_cache_lock:
             cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
         if cached is not None:
-            # Update _last_resolved_tool_names so downstream callers see
-            # consistent state even on a cache hit.
-            global _last_resolved_tool_names
-            _last_resolved_tool_names = [t["function"]["name"] for t in cached]
+            if not skip_tool_search_assembly:
+                _set_resolved_tool_names(
+                    [t["function"]["name"] for t in cached]
+                )
             # Return a shallow copy of the list but share the dict references —
             # schemas are treated as read-only by all known callers.
             return list(cached)
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
                                        skip_tool_search_assembly=skip_tool_search_assembly)
+    if not skip_tool_search_assembly:
+        _set_resolved_tool_names([t["function"]["name"] for t in result])
     if quiet_mode and cache_key is not None:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -598,9 +625,6 @@ def _compute_tool_definitions(
             print(f"🛠️  Final tool selection ({len(filtered_tools)} tools): {', '.join(tool_names)}")
         else:
             print("🛠️  No tools selected (all filtered out or unavailable)")
-
-    global _last_resolved_tool_names
-    _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
 
     # Sanitize schemas for broad backend compatibility. llama.cpp's
     # json-schema-to-grammar converter (used by its OAI server to build
@@ -1214,10 +1238,8 @@ def handle_function_call(
         function_args: Arguments for the function.
         task_id: Unique identifier for terminal/browser session isolation.
         user_task: The user's original task (for browser_snapshot context).
-        enabled_tools: Tool names enabled for this session.  When provided,
-                       execute_code uses this list to determine which sandbox
-                       tools to generate.  Falls back to the process-global
-                       ``_last_resolved_tool_names`` for backward compat.
+        enabled_tools: Tool names enabled for this session. When omitted,
+                       execute_code uses the active turn's resolved tool names.
         enabled_toolsets: The session's enabled toolsets.  Used to scope the
                        Tool Search bridge catalog so ``tool_search`` /
                        ``tool_describe`` / ``tool_call`` only see and invoke
@@ -1491,9 +1513,14 @@ def handle_function_call(
             reset_current_observability_context = None
         try:
             if function_name == "execute_code":
-                # Prefer the caller-provided list so subagents can't overwrite
-                # the parent's tool set via the process-global.
-                sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
+                # Prefer the caller-provided list. The fallback is scoped to
+                # this turn, so concurrent resolution cannot change the
+                # execute_code sandbox allowlist.
+                sandbox_enabled = (
+                    enabled_tools
+                    if enabled_tools is not None
+                    else list(_resolved_tool_names.get())
+                )
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
                     return registry.dispatch(
                         function_name, next_args,

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -1,6 +1,8 @@
 """Tests for model_tools.py — function call dispatch, agent-loop interception, legacy toolsets."""
 
 import json
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 from unittest.mock import ANY, call, patch
 
 
@@ -219,6 +221,56 @@ class TestHandleFunctionCall:
         [post_call] = [call for call in hook_calls if call[0] == "post_tool_call"]
         assert post_call[1]["status"] == "blocked"
         assert post_call[1]["error_type"] == "edit_approval_denied"
+
+
+
+class TestResolvedToolNamesIsolation:
+    def test_concurrent_tool_resolution_does_not_change_execute_code_fallback(
+        self, monkeypatch
+    ):
+        """A turn's execute_code fallback must retain its own resolved names."""
+        import model_tools
+
+        model_tools._tool_defs_cache.clear()
+        alpha_resolved = Event()
+        beta_resolved = Event()
+        dispatched_enabled_tools = []
+
+        def definition(name):
+            return {"type": "function", "function": {"name": name}}
+
+        def compute(enabled_toolsets, *_args, **_kwargs):
+            resolved_names = [enabled_toolsets[0]]
+            # Mirror the existing compute boundary: resolution currently
+            # persists the names only in mutable module state.
+            model_tools._last_resolved_tool_names = resolved_names
+            return [definition(resolved_names[0])]
+
+        def dispatch(_name, _args, **kwargs):
+            dispatched_enabled_tools.append(kwargs.get("enabled_tools"))
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr(model_tools, "_compute_tool_definitions", compute)
+        monkeypatch.setattr(model_tools.registry, "dispatch", dispatch)
+
+        def alpha_turn():
+            model_tools.get_tool_definitions(["alpha"], quiet_mode=True)
+            alpha_resolved.set()
+            assert beta_resolved.wait(timeout=2)
+            return model_tools.handle_function_call("execute_code", {})
+
+        def beta_turn():
+            assert alpha_resolved.wait(timeout=2)
+            model_tools.get_tool_definitions(["beta"], quiet_mode=True)
+            beta_resolved.set()
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            alpha = pool.submit(alpha_turn)
+            beta = pool.submit(beta_turn)
+            assert json.loads(alpha.result(timeout=2)) == {"ok": True}
+            beta.result(timeout=2)
+
+        assert dispatched_enabled_tools == [["alpha"]]
 
 
 # =========================================================================

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -15,6 +15,7 @@ import threading
 import time
 import types
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -464,17 +465,15 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["api_mode"], "anthropic_messages")
 
 class TestToolNamePreservation(unittest.TestCase):
-    """Verify _last_resolved_tool_names is restored after subagent runs."""
+    """Verify delegation preserves the caller's turn-local tool names."""
 
-    def test_global_tool_names_restored_after_delegation(self):
-        """The process-global _last_resolved_tool_names must be restored
-        after a subagent completes so the parent's execute_code sandbox
-        generates correct imports."""
+    def test_turn_local_tool_names_preserved_after_delegation(self):
+        """Delegation must not alter the parent's execute_code fallback."""
         import model_tools
 
         parent = _make_mock_parent(depth=0)
         original_tools = ["terminal", "read_file", "web_search", "execute_code", "delegate_task"]
-        model_tools._last_resolved_tool_names = list(original_tools)
+        model_tools._set_resolved_tool_names(original_tools)
 
         with patch("run_agent.AIAgent") as MockAgent:
             mock_child = MagicMock()
@@ -485,17 +484,16 @@ class TestToolNamePreservation(unittest.TestCase):
 
             delegate_task(goal="Test tool preservation", parent_agent=parent)
 
-        self.assertEqual(model_tools._last_resolved_tool_names, original_tools)
+        self.assertEqual(model_tools._get_resolved_tool_names(), original_tools)
 
 
     def test_saved_tool_names_set_on_child_before_run(self):
-        """_run_single_child must set _delegate_saved_tool_names on the child
-        from model_tools._last_resolved_tool_names before run_conversation."""
+        """The child receives the caller's names before run_conversation."""
         import model_tools
 
         parent = _make_mock_parent(depth=0)
         expected_tools = ["read_file", "web_search", "execute_code"]
-        model_tools._last_resolved_tool_names = list(expected_tools)
+        model_tools._set_resolved_tool_names(expected_tools)
 
         captured = {}
 
@@ -512,6 +510,39 @@ class TestToolNamePreservation(unittest.TestCase):
             delegate_task(goal="capture test", parent_agent=parent)
 
         self.assertEqual(captured["saved"], expected_tools)
+
+    def test_concurrent_child_construction_uses_each_turns_context(self):
+        """Concurrent parents must not snapshot the legacy global mirror."""
+        import model_tools
+        import tools.delegate_tool as delegate_tool
+
+        alpha_ready = threading.Event()
+        beta_resolved = threading.Event()
+
+        def build_child(**_kwargs):
+            return MagicMock()
+
+        def alpha_turn():
+            model_tools._set_resolved_tool_names(["alpha"])
+            alpha_ready.set()
+            self.assertTrue(beta_resolved.wait(timeout=2))
+            return delegate_tool._build_child_preserving_parent_tools()
+
+        def beta_turn():
+            self.assertTrue(alpha_ready.wait(timeout=2))
+            model_tools._set_resolved_tool_names(["beta"])
+            beta_resolved.set()
+            return delegate_tool._build_child_preserving_parent_tools()
+
+        with patch.object(delegate_tool, "_build_child_agent", side_effect=build_child):
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                alpha = pool.submit(alpha_turn)
+                beta = pool.submit(beta_turn)
+                alpha_child = alpha.result(timeout=2)
+                beta_child = beta.result(timeout=2)
+
+        self.assertEqual(getattr(alpha_child, "_delegate_saved_tool_names"), ["alpha"])
+        self.assertEqual(getattr(beta_child, "_delegate_saved_tool_names"), ["beta"])
 
 
 class TestDelegateObservability(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2318,13 +2318,15 @@ def _run_single_child(
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, "tool_progress_callback", None)
 
-    # Restore parent tool names using the value saved before child construction
-    # mutated the global. This is the correct parent toolset, not the child's.
+    # A child runs in a fresh thread, so seed that thread's ContextVar from the
+    # parent names captured during construction. Never infer authorization from
+    # the deprecated process-global compatibility mirror.
     import model_tools
 
     _saved_tool_names = getattr(
-        child, "_delegate_saved_tool_names", list(model_tools._last_resolved_tool_names)
+        child, "_delegate_saved_tool_names", model_tools._get_resolved_tool_names()
     )
+    model_tools._set_current_resolved_tool_names(_saved_tool_names)
 
     child_pool = getattr(child, "_credential_pool", None)
     leased_cred_id = None
@@ -3145,14 +3147,6 @@ def _run_single_child(
             except Exception as exc:
                 logger.debug("Failed to release credential lease: %s", exc)
 
-        # Restore the parent's tool names so the process-global is correct
-        # for any subsequent execute_code calls or other consumers.
-        import model_tools
-
-        saved_tool_names = getattr(child, "_delegate_saved_tool_names", None)
-        if isinstance(saved_tool_names, list):
-            model_tools._last_resolved_tool_names = list(saved_tool_names)
-
         # Remove child from active tracking
 
         # Unregister child from interrupt propagation
@@ -3204,11 +3198,11 @@ def _build_child_preserving_parent_tools(**kwargs):
     import model_tools
 
     with _CHILD_CONSTRUCTION_LOCK:
-        parent_tool_names = list(model_tools._last_resolved_tool_names)
+        parent_tool_names = model_tools._get_resolved_tool_names()
         try:
             child = _build_child_agent(**kwargs)
         finally:
-            model_tools._last_resolved_tool_names = parent_tool_names
+            model_tools._set_current_resolved_tool_names(parent_tool_names)
     child._delegate_saved_tool_names = parent_tool_names
     return child
 


### PR DESCRIPTION
## Summary
- keep resolved tool-name fallback in a `ContextVar` scoped to the executing turn instead of authorizing from a mutable process-global list
- seed delegated worker threads from the caller's scoped tool names without restoring shared authorization state in a finalizer
- add deterministic concurrent-resolution coverage for direct `execute_code` dispatch and delegated-child construction

## Test plan
- [x] `scripts/run_tests.sh tests/test_model_tools.py -q`
- [x] `scripts/run_tests.sh tests/tools/test_delegate.py -q`
- [x] `uv run python -m compileall -q model_tools.py tools/delegate_tool.py tests/test_model_tools.py tests/tools/test_delegate.py`
- [x] `git diff origin/main...HEAD --check`

This prevents concurrent turns with distinct toolsets from overwriting each other's `execute_code` sandbox allowlist.