### PR TITLE
fix(gateway): scope /reasoning and /fast to the routed multiplex profile

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3472,12 +3472,26 @@ class GatewaySlashCommandsMixin:
         preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
         return t("gateway.background.started", preview=preview, task_id=task_id)
 
-    def _save_gateway_config_key(self, key_path: str, value) -> bool:
+    def _command_profile_home_for_source(self, source):
+        """Routed multiplex profile home for this slash command, if any.
+
+        Same capture as ``_handle_model_command``: the primary adapter
+        dispatches under the process/default scope, so callers must resolve
+        the source's profile before reading or writing config.yaml (#87939).
+        """
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return None
+        resolve = getattr(self, "_resolve_profile_home_for_source", None)
+        if resolve is None:
+            return None
+        return resolve(source)
+
+    def _save_gateway_config_key(self, key_path: str, value, profile_home=None) -> bool:
         """Save a dot-separated key to config.yaml (shared by /reasoning, /fast
         and their interactive pickers)."""
-        from gateway.run import _hermes_home
+        from gateway.run import _gateway_config_home
         from hermes_cli.config import read_user_config_raw
-        config_path = _hermes_home / "config.yaml"
+        config_path = (profile_home or _gateway_config_home()) / "config.yaml"
         try:
             # Write-back round-trip: raw read is correct (merged defaults must
             # not be persisted back to the user's file).
@@ -3490,6 +3504,15 @@ class GatewaySlashCommandsMixin:
                 current = current[k]
             current[keys[-1]] = value
             atomic_config_write(config_path, user_config)
+            # save_config() pops this; atomic_config_write does not.
+            # Same-size edits (none→high) can keep a stale read_raw_config
+            # hit for the next /reasoning status in this process (#87939).
+            try:
+                from hermes_cli.config import _RAW_CONFIG_CACHE
+
+                _RAW_CONFIG_CACHE.pop(str(config_path), None)
+            except Exception:
+                pass
             return True
         except Exception as e:
             logger.error("Failed to save config key %s: %s", key_path, e)
@@ -3501,6 +3524,7 @@ class GatewaySlashCommandsMixin:
         platform_key: str,
         value: str,
         persist_global: bool = False,
+        profile_home=None,
     ) -> str:
         """Apply a /reasoning argument (typed or picked) and return the reply.
 
@@ -3516,13 +3540,17 @@ class GatewaySlashCommandsMixin:
         if value in {"show", "on"}:
             self._show_reasoning = True
             self._save_gateway_config_key(
-                f"display.platforms.{platform_key}.show_reasoning", True
+                f"display.platforms.{platform_key}.show_reasoning",
+                True,
+                profile_home=profile_home,
             )
             return t("gateway.reasoning.display_set_on", platform=platform_key)
         if value in {"hide", "off"}:
             self._show_reasoning = False
             self._save_gateway_config_key(
-                f"display.platforms.{platform_key}.show_reasoning", False
+                f"display.platforms.{platform_key}.show_reasoning",
+                False,
+                profile_home=profile_home,
             )
             return t("gateway.reasoning.display_set_off", platform=platform_key)
 
@@ -3530,7 +3558,13 @@ class GatewaySlashCommandsMixin:
             if persist_global:
                 return t("gateway.reasoning.reset_global_unsupported")
             self._set_session_reasoning_override(session_key, None)
-            self._reasoning_config = self._load_reasoning_config()
+            if profile_home is not None:
+                from gateway.run import _profile_runtime_scope
+
+                with _profile_runtime_scope(profile_home):
+                    self._reasoning_config = self._load_reasoning_config()
+            else:
+                self._reasoning_config = self._load_reasoning_config()
             self._evict_cached_agent(session_key)
             return t("gateway.reasoning.reset_done")
 
@@ -3540,7 +3574,9 @@ class GatewaySlashCommandsMixin:
 
         self._reasoning_config = parsed
         if persist_global:
-            if self._save_gateway_config_key("agent.reasoning_effort", value):
+            if self._save_gateway_config_key(
+                "agent.reasoning_effort", value, profile_home=profile_home
+            ):
                 self._set_session_reasoning_override(session_key, None)
                 self._evict_cached_agent(session_key)
                 return t("gateway.reasoning.set_global", effort=value)
@@ -3629,7 +3665,7 @@ class GatewaySlashCommandsMixin:
             /reasoning show|on               Show model reasoning in responses
             /reasoning hide|off              Hide model reasoning from responses
         """
-        from gateway.run import _platform_config_key
+        from gateway.run import _platform_config_key, _profile_runtime_scope
 
         raw_args = event.get_command_args().strip()
         args, persist_global = self._parse_reasoning_command_args(raw_args)
@@ -3638,17 +3674,27 @@ class GatewaySlashCommandsMixin:
         # reads — same fix as /model (#30479).
         _reasoning_source = await asyncio.to_thread(self._normalize_source_for_session_key, event.source)
         session_key = self._session_key_for_source(_reasoning_source)
-        self._show_reasoning = self._load_show_reasoning()
+        _command_profile_home = self._command_profile_home_for_source(_reasoning_source)
         # Use the session's effective model (session /model override wins over
         # config default) so per-model reasoning_overrides display correctly.
         _session_model = str(
             ((getattr(self, "_session_model_overrides", {}) or {}).get(session_key) or {}).get("model") or ""
         )
-        self._reasoning_config = self._resolve_session_reasoning_config(
-            source=event.source,
-            session_key=session_key,
-            model=_session_model,
-        )
+        if _command_profile_home is not None:
+            with _profile_runtime_scope(_command_profile_home):
+                self._show_reasoning = self._load_show_reasoning()
+                self._reasoning_config = self._resolve_session_reasoning_config(
+                    source=event.source,
+                    session_key=session_key,
+                    model=_session_model,
+                )
+        else:
+            self._show_reasoning = self._load_show_reasoning()
+            self._reasoning_config = self._resolve_session_reasoning_config(
+                source=event.source,
+                session_key=session_key,
+                model=_session_model,
+            )
 
         if not raw_args:
             # Show current state
@@ -3680,7 +3726,10 @@ class GatewaySlashCommandsMixin:
 
             async def _on_reasoning_choice(_chat_id: str, value: str) -> str:
                 return self._apply_reasoning_selection(
-                    session_key, _picker_platform_key, value
+                    session_key,
+                    _picker_platform_key,
+                    value,
+                    profile_home=_command_profile_home,
                 )
 
             picker_sent = await self._try_send_choice_picker(
@@ -3708,7 +3757,11 @@ class GatewaySlashCommandsMixin:
         # Typed argument path — same applier the picker uses.
         platform_key = _platform_config_key(event.source.platform)
         return self._apply_reasoning_selection(
-            session_key, platform_key, args, persist_global=persist_global
+            session_key,
+            platform_key,
+            args,
+            persist_global=persist_global,
+            profile_home=_command_profile_home,
         )
 
     async def _handle_memory_command(self, event: MessageEvent) -> str:
@@ -3819,7 +3872,11 @@ class GatewaySlashCommandsMixin:
         Session-scoped by default; ``--global`` persists agent.service_tier
         to config.yaml (parity with /model and /reasoning).
         """
-        from gateway.run import _load_gateway_config, _resolve_gateway_model
+        from gateway.run import (
+            _load_gateway_config,
+            _profile_runtime_scope,
+            _resolve_gateway_model,
+        )
         from hermes_cli.models import model_supports_fast_mode
 
         raw_args = event.get_command_args().strip().lower()
@@ -3827,11 +3884,22 @@ class GatewaySlashCommandsMixin:
         # normalizes unicode dashes.
         args, persist_global = self._parse_reasoning_command_args(raw_args)
         session_key = self._session_key_for_source(event.source)
-        self._service_tier = self._resolve_session_service_tier(
-            session_key=session_key
-        )
-
-        user_config = _load_gateway_config()
+        _command_profile_home = self._command_profile_home_for_source(event.source)
+        # Resolve tier + model under the same home as --global writes.
+        # Loading service_tier before the scope (then clearing the session
+        # override on persist) made a follow-up /fast report the default
+        # profile (#87939 dual-step).
+        if _command_profile_home is not None:
+            with _profile_runtime_scope(_command_profile_home):
+                self._service_tier = self._resolve_session_service_tier(
+                    session_key=session_key
+                )
+                user_config = _load_gateway_config()
+        else:
+            self._service_tier = self._resolve_session_service_tier(
+                session_key=session_key
+            )
+            user_config = _load_gateway_config()
         model = _resolve_gateway_model(user_config)
         if not model_supports_fast_mode(model):
             return t("gateway.fast.not_supported")
@@ -3850,7 +3918,11 @@ class GatewaySlashCommandsMixin:
                 return t("gateway.fast.unknown_arg", arg=value)
             self._service_tier = tier
             if persist:
-                if self._save_gateway_config_key("agent.service_tier", saved_value):
+                if self._save_gateway_config_key(
+                    "agent.service_tier",
+                    saved_value,
+                    profile_home=_command_profile_home,
+                ):
                     # Global write supersedes any session override.
                     self._set_session_service_tier_override(
                         session_key, None, clear=True

--- a/tests/gateway/test_reasoning_multiplex_profile.py
+++ b/tests/gateway/test_reasoning_multiplex_profile.py
@@ -1,0 +1,162 @@
+"""Routed multiplex /reasoning and /fast must use the routed profile config.
+
+Regression for #87939: slash-command dispatch stays in the process/default
+profile scope, so status reads and --global writes hit the default
+config.yaml instead of the profile that actually runs the turn.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/reasoning", platform=Platform.TELEGRAM, user_id="123", chat_id="routed-chat"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(profile_home):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner.config = SimpleNamespace(multiplex_profiles=True)
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._session_reasoning_overrides = {}
+    runner._session_model_overrides = {}
+    runner._show_reasoning = False
+    runner._service_tier = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner._resolve_profile_home_for_source = lambda _source: profile_home
+    return runner
+
+
+def _write_homes(tmp_path):
+    default_home = tmp_path / "default"
+    routed_home = tmp_path / "profiles" / "beta"
+    default_home.mkdir()
+    routed_home.mkdir(parents=True)
+    (default_home / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: medium\n  service_tier: normal\n",
+        encoding="utf-8",
+    )
+    (routed_home / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: none\n  service_tier: normal\n",
+        encoding="utf-8",
+    )
+    return default_home, routed_home
+
+
+def _read_yaml(path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_reasoning_status_reads_routed_profile_config(tmp_path, monkeypatch):
+    default_home, routed_home = _write_homes(tmp_path)
+    monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+    default_before = (default_home / "config.yaml").read_bytes()
+
+    runner = _make_runner(routed_home)
+    result = await runner._handle_reasoning_command(_make_event("/reasoning"))
+
+    assert result is not None
+    assert "`none" in result
+    assert "**Effort:**" in result
+    assert (default_home / "config.yaml").read_bytes() == default_before
+
+
+@pytest.mark.asyncio
+async def test_reasoning_global_write_updates_only_routed_profile(tmp_path, monkeypatch):
+    default_home, routed_home = _write_homes(tmp_path)
+    monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+    default_before = (default_home / "config.yaml").read_bytes()
+
+    runner = _make_runner(routed_home)
+    result = await runner._handle_reasoning_command(_make_event("/reasoning high --global"))
+
+    assert result is not None
+    assert _read_yaml(routed_home / "config.yaml")["agent"]["reasoning_effort"] == "high"
+    assert (default_home / "config.yaml").read_bytes() == default_before
+
+
+@pytest.mark.asyncio
+async def test_reasoning_picker_callback_writes_routed_profile(tmp_path, monkeypatch):
+    default_home, routed_home = _write_homes(tmp_path)
+    monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+    default_before = (default_home / "config.yaml").read_bytes()
+
+    captured = {}
+
+    async def _capture_picker(*_args, on_choice_selected=None, **_kwargs):
+        captured["on_choice"] = on_choice_selected
+        return True
+
+    runner = _make_runner(routed_home)
+    runner._try_send_choice_picker = _capture_picker
+
+    result = await runner._handle_reasoning_command(_make_event("/reasoning"))
+    assert result is None
+    assert captured["on_choice"] is not None
+
+    await captured["on_choice"]("routed-chat", "show")
+
+    routed = _read_yaml(routed_home / "config.yaml")
+    assert routed["display"]["platforms"]["telegram"]["show_reasoning"] is True
+    assert (default_home / "config.yaml").read_bytes() == default_before
+
+
+@pytest.mark.asyncio
+async def test_fast_global_write_updates_only_routed_profile(tmp_path, monkeypatch):
+    default_home, routed_home = _write_homes(tmp_path)
+    monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+    default_before = (default_home / "config.yaml").read_bytes()
+    monkeypatch.setattr(
+        "hermes_cli.models.model_supports_fast_mode",
+        lambda _model: True,
+    )
+
+    runner = _make_runner(routed_home)
+    result = await runner._handle_fast_command(_make_event("/fast on --global"))
+
+    assert result is not None
+    assert _read_yaml(routed_home / "config.yaml")["agent"]["service_tier"] == "fast"
+    assert (default_home / "config.yaml").read_bytes() == default_before
+
+    follow = await runner._handle_fast_command(_make_event("/fast"))
+    assert follow is not None
+    assert "fast" in follow.lower() or "priority" in follow.lower()
+
+
+@pytest.mark.asyncio
+async def test_reasoning_global_then_status_stays_on_routed_profile(tmp_path, monkeypatch):
+    default_home, routed_home = _write_homes(tmp_path)
+    monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+    default_before = (default_home / "config.yaml").read_bytes()
+
+    runner = _make_runner(routed_home)
+    await runner._handle_reasoning_command(_make_event("/reasoning high --global"))
+    result = await runner._handle_reasoning_command(_make_event("/reasoning"))
+
+    assert result is not None
+    assert "`high`" in result
+    assert (default_home / "config.yaml").read_bytes() == default_before


### PR DESCRIPTION
## What does this PR do?

Gateway `/reasoning` (status, `--global`, and picker `show`/`hide`) and `/fast --global` in a multiplexed route now read and write the **routed** profile's `config.yaml`, not the process/default profile.

Slash dispatch on the primary adapter still runs under the default-profile process scope; the agent turn later re-enters the source's profile. `/model` already captured that home. `/reasoning` and the shared `_save_gateway_config_key` helper did not — status showed the default `agent.reasoning_effort`, and `--global` mutated the default file. Dashboard and the next agent turn already used the named profile, so users saw a split.

Same pattern as `/model`: resolve `_command_profile_home` from `event.source`, load under `_profile_runtime_scope`, and pass that home into the save helper. Picker callbacks close over the captured home because they run after the handler returns. After a write, the raw-config cache for that path is dropped so a follow-up `/reasoning` or `/fast` sees the new value.

Residual: `/memory`, `/skills`, and `/verbose` still use the process home (not this contract). Slash `Display` still reads global `display.show_reasoning` while picker `show`/`hide` writes `display.platforms.<p>.show_reasoning`. No live Telegram multiplex e2e here.

## Related Issue

Fixes #87939

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/slash_commands.py`: `_command_profile_home_for_source`; `_save_gateway_config_key` writes `(profile_home or _gateway_config_home()) / config.yaml` and drops `_RAW_CONFIG_CACHE` for that path; `_handle_reasoning_command` / `_handle_fast_command` capture the home, scope loads, and pass it to apply/save; picker closures keep the home.
- `tests/gateway/test_reasoning_multiplex_profile.py`: default=`medium` vs routed=`none` — status, `--global` write, picker `show`, `/fast --global`, and dual-step status after write; default file bytes unchanged.

## How to Test

1. Multiplex gateway: default `agent.reasoning_effort: medium`, routed profile `none`. From the routed Telegram/Discord chat: `/new` then `/reasoning`. Effort should be `none`.
2. `/reasoning high --global` — only the routed `config.yaml` changes. Default file unchanged.
3. `/fast on --global` then `/fast` — status is FAST from the routed file.
4. Unit (worktree / this branch):

```
./scripts/run_tests.sh tests/gateway/test_reasoning_multiplex_profile.py \
  tests/gateway/test_reasoning_command.py tests/gateway/test_fast_command.py \
  tests/gateway/test_choice_picker.py tests/gateway/test_model_command_profile_config.py -q
```

21 passed (5 multiplex + 8 reasoning + 3 fast + 4 picker + 1 model-profile).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux WSL2 (class repro + targeted tests); no live Telegram multiplex e2e

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A