### PR TITLE
fix(desktop): prefer live context usage during turns

### DIFF
--- a/apps/desktop/src/app/shell/context-usage-panel.test.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.test.tsx
@@ -66,6 +66,24 @@ describe('useContextBreakdown', () => {
     expect(requestGateway).not.toHaveBeenCalled()
   })
 
+  it('drops a pre-turn estimate while live usage is streaming', async () => {
+    const requestGateway = vi.fn().mockResolvedValue(breakdown)
+
+    const { rerender, result } = renderHook(
+      ({ busy }) => useContextBreakdown({ busy, enabled: true, requestGateway, sessionId: 'runtime-1' }),
+      { initialProps: { busy: false } }
+    )
+
+    await waitFor(() => expect(result.current.breakdown).toEqual(breakdown))
+
+    rerender({ busy: true })
+
+    // The status bar must fall back to the live `session.usage` frame rather
+    // than overwrite it with the snapshot fetched before this turn started.
+    expect(result.current.breakdown).toBeNull()
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+  })
+
   it('refetches on a session switch and never reports the previous session numbers', async () => {
     const requestGateway = vi.fn().mockResolvedValue(breakdown)
 

--- a/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
@@ -31,7 +31,13 @@ export function useContextBreakdown({ busy, enabled, requestGateway, sessionId }
   useEffect(() => {
     // Mid-turn the transcript changes on every delta and the gateway already
     // streams measured usage, so an estimate would be both stale and wasteful.
+    // Drop the previous turn's estimate as well: otherwise the status bar
+    // prefers it over each live `session.usage` frame until this turn ends.
     if (!enabled || !sessionId || busy) {
+      if (busy) {
+        setFetched(current => (current ? null : current))
+      }
+
       return
     }
 
@@ -57,7 +63,10 @@ export function useContextBreakdown({ busy, enabled, requestGateway, sessionId }
   }, [busy, enabled, requestGateway, sessionId])
 
   return {
-    breakdown: fetched && fetched.sessionId === sessionId ? fetched.breakdown : null,
+    // Hide a prior breakdown immediately when a turn begins. Effects run
+    // after paint, so relying solely on the clear above can flash stale
+    // occupancy over the first streamed usage frame.
+    breakdown: !busy && fetched && fetched.sessionId === sessionId ? fetched.breakdown : null,
     loading
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop context-usage gauge being pinned to a pre-turn estimate while a response streams. The gateway already emits live `session.usage` measurements; this change removes the stale estimate for the active turn so those measurements drive the bar, then refetches the normal per-session breakdown once the turn settles.

## Related Issue

Refs #70871

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/shell/hooks/use-context-breakdown.ts`: clear and immediately hide an older context-breakdown snapshot while a turn is busy, allowing live `session.usage` to win.
- `apps/desktop/src/app/shell/context-usage-panel.test.tsx`: cover the idle-estimate-to-streaming transition.

## How to Test

1. Open or resume a Desktop session with the context-usage status item visible.
2. Submit a turn after the gauge has fetched its idle breakdown.
3. Confirm that incoming `session.usage` updates change the gauge during the turn rather than leaving it at the pre-turn value.
4. Run `npm run --workspace apps/desktop test:ui -- src/app/shell/context-usage-panel.test.tsx` (8 tests pass).
5. Run `npm run --workspace apps/desktop typecheck`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (the supplied full-suite command stopped at collection under the system interpreter because FastAPI is unavailable; the Desktop covering test above passes)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — this is a state-selection fix covered by the regression test.

<!-- autocontrib:worker-id=issue-new-b40a4d1c kind=pr-open -->