### PR TITLE
fix(desktop): guard the whole build-critical dep set, before clean

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,7 +27,7 @@
     "profile:main": "tsc --build tsconfig.electron.json && wait-on http://127.0.0.1:5174 && node scripts/bundle-electron-main.mjs --dev && cross-env XCURSOR_SIZE=24 HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron --inspect=9229 .",
     "profile:main:cpu": "tsc --build tsconfig.electron.json && wait-on http://127.0.0.1:5174 && node scripts/bundle-electron-main.mjs --dev && cross-env XCURSOR_SIZE=24 NODE_OPTIONS=--cpu-prof HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron .",
     "start": "npm run build && electron .",
-    "prebuild": "npm run clean",
+    "prebuild": "node scripts/assert-root-install.mjs && npm run clean",
     "build": "node scripts/assert-root-install.mjs && node scripts/write-build-stamp.mjs && vite build && node scripts/bundle-electron-main.mjs && node scripts/stage-native-deps.mjs",
     "postbuild": "node scripts/assert-dist-built.mjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.mjs",

--- a/apps/desktop/scripts/assert-root-install.mjs
+++ b/apps/desktop/scripts/assert-root-install.mjs
@@ -1,35 +1,118 @@
-import { accessSync, readFileSync } from "fs"
+// Build-time guard: refuse to start a build the installed tree cannot finish.
+//
+// The desktop workspace's dependencies are hoisted to the repo-root
+// `node_modules`, so a root install that only covers *part* of the workspace
+// graph leaves this app importable-looking but unbuildable. The guard exists to
+// turn that into one actionable line ("run npm ci from the repo root") instead
+// of a failure deep inside vite.
+//
+// It runs from `prebuild`, ahead of `npm run clean`, so a tree that cannot
+// build is rejected before the build starts deleting its own outputs. `build`
+// re-runs it for anyone invoking the build steps directly; the check is pure
+// filesystem lookups, so paying for it twice costs nothing.
+
+import { existsSync, readFileSync } from "fs"
 import { createRequire } from "module"
-import { resolve, join } from "path"
+import { resolve, join, dirname } from "path"
+import { isMain } from "./utils.mjs"
 
-const app = resolve(import.meta.dirname, "..")
-const root = resolve(app, "..", "..")
+// Packages the build *consumes*, as opposed to merely declares. Each one is
+// load-bearing for a distinct build step, and each one has been observed
+// missing from a partial root install:
+//
+//   vite            — bundles the renderer (`vite build`).
+//   katex           — `src/styles.css` imports `katex/dist/katex.min.css`, so
+//                     the CSS transform fails before a single chunk is emitted.
+//   electron        — the runtime electron-builder packages; without it `pack`
+//                     cannot produce an unpacked app at all.
+//   electron-builder — the packager `npm run builder` shells out to.
+//
+// Checking only `vite` (the original guard) passes a tree missing any of the
+// others, which is how an incomplete install reached `vite build` and died on
+// an unresolved `katex/dist/katex.min.css` with no hint that the install — not
+// the source — was at fault (#86443).
+const BUILD_CRITICAL_PACKAGES = ["vite", "katex", "electron", "electron-builder"]
 
-try {
-  accessSync(join(root, "node_modules", "vite", "package.json"))
-} catch {
-  console.error(`Run from repo root: cd ${root} && npm ci`)
-  process.exit(1)
+// Resolve the way Node's own lookup does — walk `node_modules` upward — rather
+// than through `require.resolve`. A package whose `exports` map does not expose
+// `./package.json` is not resolvable by path even when correctly installed, and
+// that must not read as "missing".
+function packageIsInstalled(name, fromDir) {
+  let dir = fromDir
+  for (;;) {
+    if (existsSync(join(dir, "node_modules", name, "package.json"))) return true
+    const parent = dirname(dir)
+    if (parent === dir) return false
+    dir = parent
+  }
 }
 
-// `vite.config.ts` aliases react/react-dom to whatever this workspace resolves,
-// and React refuses to run when the two come from different installed copies
-// ("Minified React error #527" — it throws before the first paint, so the app
-// window stays blank). npm stays silent about the split because the hoisted
-// react still satisfies react-dom's caret peer range. Fail the build loudly
-// instead of shipping a white screen.
-const requireFromApp = createRequire(join(app, "package.json"))
-const installedVersion = (pkg) =>
-  JSON.parse(readFileSync(requireFromApp.resolve(`${pkg}/package.json`), "utf8")).version
+// Pure check — returns { ok: true } or { ok: false, error: "..." }.
+// Kept side-effect-free so it can be unit tested without spawning a process.
+export function checkRootInstall(appDir, rootDir) {
+  const missing = BUILD_CRITICAL_PACKAGES.filter(pkg => !packageIsInstalled(pkg, appDir))
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      error:
+        `the desktop build needs ${missing.join(", ")}, which the current install ` +
+        `does not provide. A partial root install leaves the workspace looking ` +
+        `present while the build cannot complete. Reinstall from the repo root: ` +
+        `cd ${rootDir} && npm ci`
+    }
+  }
 
-const react = installedVersion("react")
-const reactDom = installedVersion("react-dom")
+  // `vite.config.ts` aliases react/react-dom to whatever this workspace resolves,
+  // and React refuses to run when the two come from different installed copies
+  // ("Minified React error #527" — it throws before the first paint, so the app
+  // window stays blank). npm stays silent about the split because the hoisted
+  // react still satisfies react-dom's caret peer range. Fail the build loudly
+  // instead of shipping a white screen.
+  const requireFromApp = createRequire(join(appDir, "package.json"))
+  const installedVersion = pkg =>
+    JSON.parse(readFileSync(requireFromApp.resolve(`${pkg}/package.json`), "utf8")).version
 
-if (react !== reactDom) {
-  console.error(
-    `react@${react} / react-dom@${reactDom} version mismatch — React would fail ` +
-      `with error #527 and render a blank window. Pin both to the same version ` +
-      `in ${join(app, "package.json")}, then reinstall: cd ${root} && npm ci`
-  )
-  process.exit(1)
+  let react
+  let reactDom
+  try {
+    react = installedVersion("react")
+    reactDom = installedVersion("react-dom")
+  } catch (err) {
+    // Both are in BUILD_CRITICAL_PACKAGES' spirit but not its list: they are
+    // checked by version, and an unreadable package.json is a broken install
+    // rather than an absent one. Report it as such instead of throwing.
+    return {
+      ok: false,
+      error: `could not read the installed react/react-dom versions (${err.message}). Reinstall from the repo root: cd ${rootDir} && npm ci`
+    }
+  }
+
+  if (react !== reactDom) {
+    return {
+      ok: false,
+      error:
+        `react@${react} / react-dom@${reactDom} version mismatch — React would fail ` +
+        `with error #527 and render a blank window. Pin both to the same version ` +
+        `in ${join(appDir, "package.json")}, then reinstall: cd ${rootDir} && npm ci`
+    }
+  }
+
+  return { ok: true }
 }
+
+function main() {
+  const app = resolve(import.meta.dirname, "..")
+  const root = resolve(app, "..", "..")
+  const result = checkRootInstall(app, root)
+
+  if (!result.ok) {
+    console.error(`✗ assert-root-install: ${result.error}`)
+    process.exit(1)
+  }
+}
+
+if (isMain(import.meta.url)) {
+  main()
+}
+
+export default { checkRootInstall }

--- a/apps/desktop/scripts/assert-root-install.test.mjs
+++ b/apps/desktop/scripts/assert-root-install.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'vitest'
+
+import { checkRootInstall } from '../scripts/assert-root-install.mjs'
+
+const BUILD_CRITICAL = ['vite', 'katex', 'electron', 'electron-builder']
+
+// Build a throwaway repo shaped like this one: an app workspace whose
+// dependencies are hoisted to the repo root, which is what the guard walks.
+function makeTree({ rootPackages = BUILD_CRITICAL, react = '19.2.7', reactDom = '19.2.7' } = {}) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-assert-root-'))
+  const appDir = path.join(tempRoot, 'apps', 'desktop')
+  fs.mkdirSync(appDir, { recursive: true })
+  fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify({ name: 'desktop' }), 'utf8')
+
+  const writePackage = (name, version) => {
+    const dir = path.join(tempRoot, 'node_modules', name)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name, version }), 'utf8')
+  }
+  for (const name of rootPackages) writePackage(name, '1.0.0')
+  if (react !== null) writePackage('react', react)
+  if (reactDom !== null) writePackage('react-dom', reactDom)
+
+  return { tempRoot, appDir }
+}
+
+test('checkRootInstall passes on a complete root install', () => {
+  const { tempRoot, appDir } = makeTree()
+  try {
+    assert.deepEqual(checkRootInstall(appDir, tempRoot), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// The regression this guard was widened for: the updater's partial `npm install`
+// left katex out while vite was present, so the old vite-only check passed and
+// the build died on an unresolved `katex/dist/katex.min.css` (#86443).
+test('checkRootInstall fails when katex is missing but vite is present', () => {
+  const { tempRoot, appDir } = makeTree({
+    rootPackages: BUILD_CRITICAL.filter(name => name !== 'katex')
+  })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /katex/)
+    assert.match(result.error, /npm ci/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkRootInstall fails when electron is missing', () => {
+  const { tempRoot, appDir } = makeTree({
+    rootPackages: BUILD_CRITICAL.filter(name => name !== 'electron')
+  })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /electron/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkRootInstall reports every missing package at once', () => {
+  const { tempRoot, appDir } = makeTree({ rootPackages: ['vite'] })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    for (const name of ['katex', 'electron', 'electron-builder']) {
+      assert.match(result.error, new RegExp(name))
+    }
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// The original guard's only check — kept, so widening coverage cannot silently
+// drop the case it already handled.
+test('checkRootInstall still fails when vite is missing', () => {
+  const { tempRoot, appDir } = makeTree({
+    rootPackages: BUILD_CRITICAL.filter(name => name !== 'vite')
+  })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /vite/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkRootInstall fails on a react/react-dom version split', () => {
+  const { tempRoot, appDir } = makeTree({ react: '19.2.7', reactDom: '19.1.0' })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /#527/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// A package installed into the app's own node_modules rather than hoisted to the
+// root is still installed. The guard walks upward like Node does, so it must not
+// insist on the hoisted location.
+test('checkRootInstall accepts a package nested in the app workspace', () => {
+  const { tempRoot, appDir } = makeTree({
+    rootPackages: BUILD_CRITICAL.filter(name => name !== 'katex')
+  })
+  const nested = path.join(appDir, 'node_modules', 'katex')
+  fs.mkdirSync(nested, { recursive: true })
+  fs.writeFileSync(path.join(nested, 'package.json'), JSON.stringify({ name: 'katex' }), 'utf8')
+  try {
+    assert.deepEqual(checkRootInstall(appDir, tempRoot), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## What does this PR do?

`apps/desktop/scripts/assert-root-install.mjs` exists to turn an incomplete root install into one actionable line instead of a failure deep inside the build. It only ever checked one package:

```js
accessSync(join(root, "node_modules", "vite", "package.json"))
```

The desktop workspace's dependencies are hoisted to the repo-root `node_modules`, so an install that covers *part* of the workspace graph leaves `vite` present and the guard satisfied while the build still cannot finish. This PR checks the packages the build actually consumes, and reports every missing one at once.

### Why these four

| package | what fails without it |
|---|---|
| `vite` | bundles the renderer (`vite build`) — the original check |
| `katex` | `apps/desktop/src/styles.css:4` is `@import 'katex/dist/katex.min.css'`, so the CSS transform fails before a single chunk is emitted |
| `electron` | the runtime `electron-builder` packages; `pack` cannot produce an unpacked app without it |
| `electron-builder` | the packager `npm run builder` shells out to |

### Ordering

The guard now runs from `prebuild`, ahead of `npm run clean`, so a tree that cannot build is rejected before the build starts deleting its own outputs. **I want to be precise about how much this buys**, because the issue attributes more to it: on current `main`, `clean` is three `tsc --build --clean` invocations, which remove `build/electron-types` and the tsbuildinfo files — **not** `release/`. So this ordering is not by itself what saves a packaged app. It is the narrow correctness point that a build known to be doomed should not destroy anything first.

`build` keeps its own call for anyone invoking the build steps directly, and the check is pure filesystem lookups, so paying for it twice costs nothing.

### Resolution strategy

Resolution walks `node_modules` upward the way Node's own lookup does, rather than going through `require.resolve`. A package whose `exports` map does not expose `./package.json` is not resolvable by path even when correctly installed, and that must not read as "missing". Walking upward also keeps a dependency that landed in `apps/desktop/node_modules` instead of the hoisted root passing, which is a legitimate npm layout.

## Related Issue

Refs #86443

**Deliberately `Refs` and not `Fixes`.** #86443 is a P0 with five suggested fixes, and this PR is one of them (#2, "install/verify the desktop workspace's dependencies", approached from the verify side). It does not close the issue. See the triage note below for what I found already landed and what is still open, which I will also post on the issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/scripts/assert-root-install.mjs`
  - Extracted the check as a pure `checkRootInstall(appDir, rootDir)` returning `{ok, error}`, matching the `assert-dist-built.mjs` idiom, so it is unit testable without spawning a process.
  - Widened coverage from `vite` to the four build-critical packages, naming every missing one in a single error.
  - `node_modules` upward walk instead of a fixed root path / `require.resolve`.
  - Kept the react/react-dom parity check unchanged, with an added guard so an unreadable `package.json` is reported as a broken install rather than thrown.
- `apps/desktop/package.json`: `prebuild` is now `node scripts/assert-root-install.mjs && npm run clean`.
- `apps/desktop/scripts/assert-root-install.test.mjs`: 7 tests, colocated per the existing `scripts/*.test.mjs` convention (`assert-dist-built.test.mjs`, `before-pack.test.mjs`, `stage-native-deps.test.mjs`). Picked up by the `electron` vitest project, whose include glob is already `scripts/**.test.{ts,mjs}`.

## How to Test

```
cd apps/desktop && npm run test:desktop:platforms
```

Proof the tests are load-bearing — same tests, guard reverted to its original `["vite"]` coverage:

```
  PASS  passes on a complete root install
  FAIL  fails when katex is missing but vite is present
  FAIL  fails when electron is missing
  FAIL  reports every missing package at once
  PASS  still fails when vite is missing
  PASS  fails on a react/react-dom version split
  PASS  accepts a package nested in the app workspace
  4/7 passed
```

The three failures are the new coverage. The four that pass either way are deliberate guardrails on behaviour this change must not disturb: the original vite-only case, the react split, the nested-install layout, and the clean-install happy path.

Manually, the reported shape:

1. From a complete checkout, `rm -rf node_modules/katex`.
2. `cd apps/desktop && npm run build`.
3. Before: the build proceeds and fails in the vite CSS transform with `Can't resolve 'katex/dist/katex.min.css'`. After: it stops at `✗ assert-root-install: the desktop build needs katex ... cd <root> && npm ci`, before `clean` runs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — no Python changed; see "Notes on verification"
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro 26200
- [x] I've considered cross-platform impact — `scripts/check-windows-footguns.py --all`: no footguns, 973 files scanned. The check is `path.join` + `existsSync` only, with no separator or case assumptions.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Triage note on #86443, for whoever owns it

I worked through all five of the issue's suggested fixes against current `main` before writing this. Most of the report has already been addressed, which is worth recording so nobody re-treads it — the reporter is on `31e571acf` and a lot has moved since:

| # | suggestion | status on current `main` |
|---|---|---|
| 1 | don't clean until the build can succeed | **partly, this PR.** The preflight now precedes `clean`. Full stage-and-swap packaging is not done; #78431 does it for macOS. |
| 2 | install the desktop workspace's deps | **this PR, verify side.** `hermes desktop --build-only` already runs a full `_run_npm_install_deterministic(PROJECT_ROOT)` before building (`main.py:7799`), so the install itself is covered; what was missing is that it can partially fail and continue (`_electron_pkg_staged_missing_dist` branch) into a build with no guard. |
| 3 | surface the subprocess result | **already landed.** `_rebuild_desktop_after_update` captures via `_run_logged_subprocess`, retries once, prints the failing tail and points at `logs/update.log`. |
| 4 | post-update verification | **already landed.** `--build-only` exits 1 when it produced no launchable app (`main.py:7930`). |
| 5 | make `has_desktop_app` sticky | **already landed / in flight.** `_rebuild_desktop_after_update` gates on `had_desktop_app_before_update or _desktop_app_present(...)`; open PR #87879 closes the remaining "Already up to date!" short-circuit. |

So the residual P0 surface after this PR is suggestion 1's real form: **`npm run pack` packs in place, so a pack that fails midway leaves `release/win-unpacked` broken with no rollback.** That is the mechanism that actually loses the app, and it is a bigger change than this one — #78431 is the existing precedent for staging it away from the live release on macOS. I have not taken it on here and am not claiming it.

Also worth flagging: one message this touches is now slightly overstated for the failing case. `_rebuild_desktop_after_update` prints "Desktop build failed (non-fatal; run `hermes desktop` to retry)" — but if the pack already replaced `release/`, the app is not merely un-updated, it is gone, and "non-fatal" reads wrong to the person whose shortcut just stopped working. I left it alone because changing it belongs with the rollback work, not here.

## Notes on verification

- The vitest suite could not be run on this machine: a workspace install needs npm outside `<11.10.0 || >=11.17.0`, and this box has npm 11.16.0, which `engine-strict` rejects. This is the same engine trap the reporter hit from the other side.
- Instead the module was exercised directly under Node 24.18.0 with an identical driver (same 7 scenarios, same assertions, `node:assert/strict`): **7/7 passed**, and 4/7 against the reverted guard as shown above. The committed `.test.mjs` is the same assertions in vitest form, so CI is the first place it runs as vitest — please treat a red `check:test:desktop:platforms` as mine to fix and I will turn it around.
- `scripts/check-windows-footguns.py --all`: no footguns, 973 files scanned.
- No Python changed, so `ruff` and the pytest suites are untouched by this diff.
