### PR TITLE
fix(sessions): trace export describes the session, not the exporting shell

### DIFF
--- a/agent/trace_upload.py
+++ b/agent/trace_upload.py
@@ -132,6 +132,24 @@ def _tool_calls_to_blocks(tool_calls: Any, redact: bool) -> List[Dict[str, Any]]
     return blocks
 
 
+def _probe_git_branch(cwd: str) -> str:
+    """Branch checked out in *cwd* right now, or "" if that can't be read."""
+    if not cwd:
+        return ""
+    try:
+        import subprocess
+
+        r = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=3, cwd=cwd,
+        )
+        if r.returncode == 0:
+            return r.stdout.strip()
+    except Exception:
+        logger.debug("git branch probe failed for %s", cwd, exc_info=True)
+    return ""
+
+
 def build_trace_jsonl(
     messages: List[Dict[str, Any]],
     *,
@@ -139,6 +157,7 @@ def build_trace_jsonl(
     model: str = "",
     cwd: str = "",
     redact: bool = True,
+    git_branch: Optional[str] = None,
 ) -> str:
     """Render Hermes conversation messages as Claude Code JSONL text.
 
@@ -152,22 +171,22 @@ def build_trace_jsonl(
     Tool results are emitted as user turns carrying a ``tool_result``
     block keyed by ``tool_call_id`` — the same way Claude Code records
     them. Turns are linked via ``uuid`` / ``parentUuid``.
+
+    ``cwd`` is the workspace the session ran in, and belongs to the
+    session, not to whoever is exporting it — callers with a session row
+    should pass ``meta["cwd"]``.
+
+    ``git_branch`` is used verbatim when given (``""`` included, meaning
+    "known to be unavailable"). Left as ``None`` it is probed from ``cwd``
+    with git, which is a subprocess per call and reports the branch that
+    is checked out *now* rather than the one the session ran on — so a
+    caller holding the recorded ``sessions.git_branch`` should pass it.
     """
     lines: List[str] = []
     parent: Optional[str] = None
     base_ts = _now_iso()
-    git_branch = ""
-    try:
-        import subprocess
-        if cwd:
-            r = subprocess.run(
-                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=3, cwd=cwd,
-            )
-            if r.returncode == 0:
-                git_branch = r.stdout.strip()
-    except Exception:
-        git_branch = ""
+    if git_branch is None:
+        git_branch = _probe_git_branch(cwd)
 
     def _common(turn_uuid: str) -> Dict[str, Any]:
         return {
@@ -382,13 +401,18 @@ def upload_session_trace(
         return "No transcript to upload for this session yet."
 
     resolved_model = model or meta.get("model") or ""
+    # The trace describes where the *session* ran. Falling through to the
+    # uploader's own cwd would stamp the operator's shell directory onto
+    # someone else's transcript.
+    resolved_cwd = cwd or meta.get("cwd") or ""
     try:
         jsonl = build_trace_jsonl(
             messages,
             session_id=session_id,
             model=resolved_model,
-            cwd=cwd,
+            cwd=resolved_cwd,
             redact=redact,
+            git_branch=meta.get("git_branch") or "",
         )
     except TraceRedactionError:
         return _REDACTION_BLOCKED_MESSAGE

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -560,7 +560,6 @@ def cmd_sessions(args, sessions_parser=None):
                 db.close()
                 status = upload_session_trace(
                     resolved,
-                    cwd="",
                     redact=redact_trace,
                     private=not getattr(args, "public", False),
                 )
@@ -598,8 +597,11 @@ def cmd_sessions(args, sessions_parser=None):
                     messages,
                     session_id=sid,
                     model=meta.get("model") or "",
-                    cwd="",
+                    cwd=meta.get("cwd") or "",
                     redact=redact_trace,
+                    # Passed explicitly (even when empty) so a bulk export
+                    # never fans out one git subprocess per session.
+                    git_branch=meta.get("git_branch") or "",
                 )
 
             try:

--- a/tests/agent/test_trace_upload.py
+++ b/tests/agent/test_trace_upload.py
@@ -177,3 +177,72 @@ def test_upload_happy_path_mocked(monkeypatch):
 
 
 
+
+
+# ---------------------------------------------------------------------------
+# cwd / gitBranch provenance
+# ---------------------------------------------------------------------------
+
+def test_git_branch_is_used_verbatim_when_supplied():
+    jsonl = build_trace_jsonl(
+        _sample_messages(), session_id="s1", cwd="/w/p", git_branch="release/2.1"
+    )
+    assert {json.loads(x)["gitBranch"] for x in jsonl.strip().split("\n")} == {"release/2.1"}
+
+
+def test_an_explicit_empty_branch_suppresses_the_probe():
+    """"" means "known unavailable" — distinct from None's "go find out"."""
+    with patch.object(trace_upload, "_probe_git_branch",
+                      side_effect=AssertionError("probed despite an explicit branch")):
+        jsonl = build_trace_jsonl(
+            _sample_messages(), session_id="s1", cwd="/w/p", git_branch=""
+        )
+    assert {json.loads(x)["gitBranch"] for x in jsonl.strip().split("\n")} == {""}
+
+
+def test_branch_is_probed_from_cwd_when_not_supplied():
+    """Back-compat: callers holding only a cwd keep the old behavior."""
+    with patch.object(trace_upload, "_probe_git_branch", return_value="main") as probe:
+        jsonl = build_trace_jsonl(_sample_messages(), session_id="s1", cwd="/w/p")
+    probe.assert_called_once_with("/w/p")
+    assert {json.loads(x)["gitBranch"] for x in jsonl.strip().split("\n")} == {"main"}
+
+
+def test_probe_returns_empty_without_a_cwd():
+    assert trace_upload._probe_git_branch("") == ""
+
+
+def test_upload_takes_cwd_and_branch_from_the_session_row():
+    """The uploader's own directory must never label someone else's session."""
+    meta = {"model": "claude-x", "cwd": "/w/recorded", "git_branch": "feature/z"}
+    captured = {}
+
+    def _capture(messages, **kwargs):
+        captured.update(kwargs)
+        return ""
+
+    with patch.object(trace_upload, "load_session_messages",
+                      return_value=(_sample_messages(), meta)), \
+         patch.object(trace_upload, "_resolve_hf_token", return_value="tok"), \
+         patch.object(trace_upload, "build_trace_jsonl", side_effect=_capture):
+        upload_session_trace("20260817_abc")
+
+    assert captured["cwd"] == "/w/recorded"
+    assert captured["git_branch"] == "feature/z"
+
+
+def test_an_explicit_cwd_still_wins_over_the_session_row():
+    meta = {"model": "m", "cwd": "/w/recorded", "git_branch": "b"}
+    captured = {}
+
+    def _capture(messages, **kwargs):
+        captured.update(kwargs)
+        return ""
+
+    with patch.object(trace_upload, "load_session_messages",
+                      return_value=(_sample_messages(), meta)), \
+         patch.object(trace_upload, "_resolve_hf_token", return_value="tok"), \
+         patch.object(trace_upload, "build_trace_jsonl", side_effect=_capture):
+        upload_session_trace("20260817_abc", cwd="/w/override")
+
+    assert captured["cwd"] == "/w/override"

--- a/tests/hermes_cli/test_sessions_export_trace_cwd.py
+++ b/tests/hermes_cli/test_sessions_export_trace_cwd.py
@@ -1,0 +1,121 @@
+"""``sessions export --format trace`` must describe the session, not the shell.
+
+The trace format is Claude Code JSONL for the HF Agent Trace Viewer, and every
+record carries ``cwd`` and ``gitBranch``. Those describe the workspace the
+session ran in — which the session row already records — so reading them off
+the exporting process mislabels the transcript.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+
+SESSION_CWD = "/w/some-project"
+SESSION_BRANCH = "feature/trace-cwd"
+
+
+@pytest.fixture()
+def exported_session(tmp_path):
+    """A real session row with a recorded cwd + branch, and its export path."""
+    from hermes_state import SessionDB
+
+    sid = "20260817_090000_tracec"
+    db = SessionDB()
+    try:
+        db.create_session(sid, source="cli", cwd=SESSION_CWD)
+        db.append_message(sid, "user", "where am I")
+        db.append_message(sid, "assistant", "in the project")
+        db.update_session_cwd(
+            sid,
+            SESSION_CWD,
+            git_branch=SESSION_BRANCH,
+            git_repo_root=SESSION_CWD,
+        )
+    finally:
+        db.close()
+    return sid, tmp_path / "trace.jsonl"
+
+
+def _export(monkeypatch, sid, out, extra=()):
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setattr(
+        sys, "argv",
+        ["hermes", "sessions", "export", str(out),
+         "--format", "trace", "--session-id", sid, *extra],
+    )
+    main_mod.main()
+    assert out.exists(), "trace export wrote no file"
+    return [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_trace_records_carry_the_session_cwd(monkeypatch, exported_session):
+    sid, out = exported_session
+    records = _export(monkeypatch, sid, out)
+
+    assert records, "no trace records emitted"
+    stamped = {r["cwd"] for r in records}
+    assert stamped == {SESSION_CWD}, (
+        f"trace stamped {stamped} instead of the session's cwd {SESSION_CWD!r} — "
+        "the viewer attributes the transcript to the wrong project"
+    )
+    assert os.getcwd() not in stamped, (
+        "the exporting process's directory leaked into another session's trace"
+    )
+
+
+def test_trace_records_carry_the_recorded_branch(monkeypatch, exported_session):
+    sid, out = exported_session
+    records = _export(monkeypatch, sid, out)
+
+    assert {r["gitBranch"] for r in records} == {SESSION_BRANCH}, (
+        "gitBranch was not taken from the session row; it is recorded at "
+        "session start precisely because the checkout's branch moves on"
+    )
+
+
+def test_bulk_export_does_not_probe_git_per_session(monkeypatch, exported_session):
+    """The recorded branch is authoritative, so no subprocess should run.
+
+    Probing would be both slower (one `git rev-parse` per exported session)
+    and wrong (it reports the branch checked out now, not the one the session
+    ran on).
+    """
+    from agent import trace_upload
+
+    def _forbidden(cwd):
+        raise AssertionError(f"git branch probe ran for {cwd!r} during export")
+
+    monkeypatch.setattr(trace_upload, "_probe_git_branch", _forbidden)
+
+    sid, out = exported_session
+    records = _export(monkeypatch, sid, out)
+    assert records
+
+
+def test_a_session_without_a_recorded_branch_exports_an_empty_one(
+    monkeypatch, tmp_path
+):
+    """No branch on the row is reported as unknown, not guessed from the shell."""
+    from agent import trace_upload
+    from hermes_state import SessionDB
+
+    sid = "20260817_090100_nobranch"
+    db = SessionDB()
+    try:
+        db.create_session(sid, source="cli", cwd=SESSION_CWD)
+        db.append_message(sid, "user", "hi")
+    finally:
+        db.close()
+
+    monkeypatch.setattr(
+        trace_upload, "_probe_git_branch",
+        lambda cwd: (_ for _ in ()).throw(AssertionError("probed anyway")),
+    )
+    records = _export(monkeypatch, sid, tmp_path / "t.jsonl")
+
+    assert {r["gitBranch"] for r in records} == {""}
+    assert {r["cwd"] for r in records} == {SESSION_CWD}


### PR DESCRIPTION
## The bug

`sessions export --format trace` emits Claude Code JSONL for the HF Agent Trace Viewer, and every record carries `cwd` and `gitBranch`. Both call sites in `sessions_cmd.py` pass `cwd=""` — even though the session row is already loaded and `meta["model"]` is read from it one line above. `build_trace_jsonl` then falls back to `os.getcwd()`, so the viewer attributes the transcript to whatever directory the export happened to run from.

Exporting a session recorded against `/tmp/proj` from a different checkout:

```json
{"cwd": "/Users/…/hermes-agent", "gitBranch": "", "sessionId": "20260817_120000_abcdef", …}
```

Neither field describes the session. On a server or a cron-driven export they describe nothing at all.

## Why `gitBranch` was empty too

The branch probe is guarded by `if cwd:`. With `cwd=""` hardcoded it never ran, so **every** trace ever exported carries `gitBranch: ""`.

That makes the obvious one-line fix wrong: passing the cwd through would *start* the probe running — one `git rev-parse` subprocess per session on a bulk export, reporting whichever branch is checked out **now** rather than the one the session ran on.

The session row already records the right answer. `update_session_cwd`'s own docstring says why `sessions.git_branch` exists:

> the main checkout's *current* branch is transient and would misattribute past sessions

So both call sites pass the recorded branch and the probe stays off.

## The change

- `build_trace_jsonl` gains `git_branch`, tri-state so **no existing caller changes behavior**: a string is used verbatim (`""` meaning "known unavailable"), `None` keeps the probe.
- The probe moves into `_probe_git_branch` so it can be asserted against.
- `upload_session_trace` defaults `cwd`/`git_branch` from `meta`, exactly the way it already defaults `model`. An explicit argument still wins.
- Both `sessions_cmd.py` call sites pass the session's own values.

## Verification

Four end-to-end tests drive the real `hermes sessions export` against a real `SessionDB` — no mocked export path. Reverting the fix fails the two that pin provenance, on the assertion rather than on an import error:

```
AssertionError: trace stamped {'/Users/…/wt-trace'} instead of the
session's cwd '/w/some-project' — the viewer attributes the
transcript to the wrong project
```

The remaining cases cover the tri-state contract (verbatim / explicit-empty / probe), that a bulk export fans out no git subprocesses, and that a session with no recorded branch reports an empty one rather than guessing from the shell.

`tests/agent/test_trace_upload.py` gains six unit tests for the same contract at the function boundary.