### PR TITLE
fix(update): propagate desktop rebuild failure into hermes update's exit status

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -838,11 +838,14 @@ def _print_update_completion(message: str) -> None:
         print(f"=== hermes-update completed {action_id} ===")
 
 
-def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
+def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> bool:
     """Update Hermes Agent by downloading a ZIP archive.
 
     Used on Windows when git file I/O is broken (antivirus, NTFS filter
     drivers causing 'Invalid argument' errors on file creation).
+
+    Returns ``False`` when the desktop rebuild ran and failed (#86443);
+    ``True`` otherwise.
     """
     active_tool_dependencies = _m()._capture_active_tool_dependencies()
 
@@ -1091,7 +1094,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
 
     node_failures = _update_node_dependencies()
     _m()._build_web_ui(_m().PROJECT_ROOT / "web")
-    _rebuild_desktop_after_update(
+    desktop_build_ok = _rebuild_desktop_after_update(
         _m().PROJECT_ROOT / "apps" / "desktop",
         had_desktop_app_before_update=had_desktop_app_before_update,
     )
@@ -1217,6 +1220,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
     # Don't stop a working dashboard when the Node refresh failed — see the
     # git-update path for rationale (#30271).
     _finish_dashboard_update_cleanup(node_failures)
+    return desktop_build_ok
 
 def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
     status = subprocess.run(
@@ -4331,8 +4335,14 @@ def _desktop_app_present(desktop_dir: Path) -> bool:
 
 def _rebuild_desktop_after_update(
     desktop_dir: Path, *, had_desktop_app_before_update: bool
-) -> None:
-    """Rebuild an installed Desktop app when its source or artifact changed."""
+) -> bool:
+    """Rebuild an installed Desktop app when its source or artifact changed.
+
+    Returns ``False`` only when a rebuild was attempted and the build itself
+    failed — callers propagate this into ``hermes update``'s exit status so
+    a broken desktop rebuild is no longer reported as a successful update
+    (#86443). ``True`` covers both "nothing to rebuild" and "rebuilt fine".
+    """
     # The release tree is ignored by git and can disappear during an update.
     # Its pre-update presence is enough to restore it; do not make people who
     # have never used Desktop pay for an Electron build.
@@ -4342,7 +4352,7 @@ def _rebuild_desktop_after_update(
         and _m()._resolve_node_runtime_npm()
         and has_desktop_app
     ):
-        return
+        return True
 
     print("→ Checking if desktop app needs rebuilding...")
     # Consult the content-hash stamp IN-PROCESS first. The spawned
@@ -4361,7 +4371,7 @@ def _rebuild_desktop_after_update(
         skip_desktop_build = False
     if skip_desktop_build:
         print("  ✓ Desktop app up to date")
-        return
+        return True
 
     desktop_build_cmd = [sys.executable, "-m", "hermes_cli.main", "desktop", "--build-only"]
     # Capture the (very loud) Electron/vite build output into update.log
@@ -4386,15 +4396,17 @@ def _rebuild_desktop_after_update(
             desktop_build_cmd, cwd=_m().PROJECT_ROOT, env=build_env
         )
     if build_result.returncode != 0:
-        print("  ⚠ Desktop build failed (non-fatal; run `hermes desktop` to retry)")
+        print("  ⚠ Desktop build failed — this update will report as failed")
+        print("    (run `hermes desktop` to retry the desktop rebuild)")
         tail = "\n".join((build_result.stdout or "").strip().splitlines()[-15:])
         if tail:
             print(tail)
         from hermes_constants import display_hermes_home as _dhh
 
         print(f"  Full build log: {_dhh()}/logs/update.log")
-    else:
-        print("  ✓ Desktop app up to date")
+        return False
+    print("  ✓ Desktop app up to date")
+    return True
 
 
 def _cmd_update_impl(args, gateway_mode: bool):
@@ -4608,12 +4620,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
     if use_zip_update:
         # ZIP-based update for Windows when git is broken
         try:
-            _update_via_zip(
+            desktop_build_ok = _update_via_zip(
                 args,
                 had_desktop_app_before_update=had_desktop_app_before_update,
             )
         finally:
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+        if gateway_mode:
+            _exit_code_path = get_hermes_home() / ".update_exit_code"
+            try:
+                _exit_code_path.write_text(
+                    "0" if desktop_build_ok else "1", encoding="utf-8"
+                )
+            except OSError:
+                pass
         return
 
     # Fetch and pull
@@ -5196,7 +5216,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         node_failures = _update_node_dependencies()
         _m()._build_web_ui(_m().PROJECT_ROOT / "web")
 
-        _rebuild_desktop_after_update(
+        desktop_build_ok = _rebuild_desktop_after_update(
             desktop_dir,
             had_desktop_app_before_update=had_desktop_app_before_update,
         )
@@ -5687,11 +5707,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
         #
         # Writing the marker here — after git pull + pip install succeed but
         # before we attempt the restart — ensures the new gateway sees it
-        # regardless of how we die.
+        # regardless of how we die. Gated on desktop_build_ok (#86443): a
+        # desktop rebuild failure here must not be reported as "0" — the
+        # gateway's own /update watcher (gateway/run.py) polls this exact
+        # file to tell the chat platform whether the update succeeded.
         if gateway_mode:
             _exit_code_path = get_hermes_home() / ".update_exit_code"
             try:
-                _exit_code_path.write_text("0", encoding="utf-8")
+                _exit_code_path.write_text(
+                    "0" if desktop_build_ok else "1", encoding="utf-8"
+                )
             except OSError:
                 pass
 
@@ -6518,10 +6543,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print(f"⚠ Git update failed: {e}")
             print("→ Falling back to ZIP download...")
             print()
-            _update_via_zip(
+            desktop_build_ok = _update_via_zip(
                 args,
                 had_desktop_app_before_update=had_desktop_app_before_update,
             )
+            if gateway_mode:
+                _exit_code_path = get_hermes_home() / ".update_exit_code"
+                try:
+                    _exit_code_path.write_text(
+                        "0" if desktop_build_ok else "1", encoding="utf-8"
+                    )
+                except OSError:
+                    pass
         else:
             print(f"✗ Update failed: {e}")
             sys.exit(1)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1200,13 +1200,20 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
         )
 
     print()
-    if node_failures:
-        print(
-            "⚠ Update partially complete — Node.js dependencies for "
-            f"{', '.join(node_failures)} did not refresh."
-        )
-        print("  Code and Python deps are updated, but the dashboard/TUI may")
-        print("  be in a mixed state until the Node deps are rebuilt.")
+    if node_failures or not desktop_build_ok:
+        parts = []
+        if node_failures:
+            parts.append(
+                f"Node.js dependencies for {', '.join(node_failures)} did not refresh"
+            )
+        if not desktop_build_ok:
+            parts.append("the desktop app was not rebuilt and is still on the previous build")
+        print("⚠ Update partially complete — " + "; ".join(parts) + ".")
+        if node_failures:
+            print("  Code and Python deps are updated, but the dashboard/TUI may")
+            print("  be in a mixed state until the Node deps are rebuilt.")
+        if not desktop_build_ok:
+            print("  Run `hermes desktop` to retry the desktop rebuild.")
     else:
         _print_update_completion("✓ Update complete!")
     try:
@@ -5594,13 +5601,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
             logger.debug("Cron jobs auto-restore check failed: %s", exc)
 
         print()
-        if node_failures:
-            print(
-                "⚠ Update partially complete — Node.js dependencies for "
-                f"{', '.join(node_failures)} did not refresh."
-            )
-            print("  Code and Python deps are updated, but the dashboard/TUI may")
-            print("  be in a mixed state until the Node deps are rebuilt.")
+        if node_failures or not desktop_build_ok:
+            parts = []
+            if node_failures:
+                parts.append(
+                    f"Node.js dependencies for {', '.join(node_failures)} did not refresh"
+                )
+            if not desktop_build_ok:
+                parts.append("the desktop app was not rebuilt and is still on the previous build")
+            print("⚠ Update partially complete — " + "; ".join(parts) + ".")
+            if node_failures:
+                print("  Code and Python deps are updated, but the dashboard/TUI may")
+                print("  be in a mixed state until the Node deps are rebuilt.")
+            if not desktop_build_ok:
+                print("  Run `hermes desktop` to retry the desktop rebuild.")
         else:
             _print_update_completion("✓ Update complete!")
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -884,6 +884,50 @@ class TestNodeRuntimeNpmResolution:
             env=ANY,
         )
 
+    def test_rebuild_desktop_after_update_returns_true_on_success(self):
+        """A successful rebuild must report ok=True."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        desktop_dir = PROJECT_ROOT / "apps" / "desktop"
+        build_ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        with (
+            patch.object(update_cmd, "_desktop_app_present", return_value=True),
+            patch.object(hm, "_resolve_node_runtime_npm", return_value="npm.cmd"),
+            patch.object(hm, "_desktop_build_needed", return_value=True),
+            patch.object(hm, "_run_logged_subprocess", return_value=build_ok),
+        ):
+            ok = update_cmd._rebuild_desktop_after_update(
+                desktop_dir, had_desktop_app_before_update=True
+            )
+
+        assert ok is True
+
+    def test_rebuild_desktop_after_update_returns_false_on_build_failure(self):
+        """A failed desktop rebuild (#86443) must report ok=False so ``hermes update``'s
+        exit status — and the ``.update_exit_code`` marker gateway watchers poll — stops
+        claiming success while the packaged app is broken or missing."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        desktop_dir = PROJECT_ROOT / "apps" / "desktop"
+        build_failed = subprocess.CompletedProcess(
+            [], 1, stdout="npm ERR! missing dep", stderr=""
+        )
+
+        with (
+            patch.object(update_cmd, "_desktop_app_present", return_value=True),
+            patch.object(hm, "_resolve_node_runtime_npm", return_value="npm.cmd"),
+            patch.object(hm, "_desktop_build_needed", return_value=True),
+            patch.object(hm, "_run_logged_subprocess", return_value=build_failed),
+        ):
+            ok = update_cmd._rebuild_desktop_after_update(
+                desktop_dir, had_desktop_app_before_update=True
+            )
+
+        assert ok is False
+
     def test_git_failure_zip_fallback_rebuilds_missing_desktop(self, tmp_path, monkeypatch):
         """The Windows ZIP fallback restores Desktop after replacing ``apps/``."""
         import zipfile


### PR DESCRIPTION

Fixes #86443

## Root cause

`_rebuild_desktop_after_update()` in `hermes_cli/update_cmd.py` only ever
printed `⚠ Desktop build failed (non-fatal; run \`hermes desktop\` to
retry)` when the packaged Desktop rebuild failed. It never affected
`hermes update`'s exit status.

The gateway's `/update` slash-command watcher (`gateway/run.py`,
`gateway/slash_commands.py`) polls `$HERMES_HOME/.update_exit_code` to
tell the chat platform (Telegram/Slack/etc.) whether an update actually
succeeded. That file was written unconditionally as `"0"` right after
`git pull` + `pip install` succeeded — completely independent of whether
the desktop rebuild that ran moments earlier had failed. Two other call
paths (`use_zip_update` direct, and the zip-fallback taken when `git pull`
itself fails on Windows) never wrote the marker at all in gateway mode.

Net effect: a desktop rebuild that fails (missing native deps after an
`npm prune`, a corrupted Electron cache, etc.) is reported to the user as
a **successful** update, exit code 0 — exactly the "exits 0, desktop
rebuild fails" symptom in #86443.

## Fix

- `_rebuild_desktop_after_update()` now returns `bool`: `True` when
  nothing needed rebuilding or the rebuild succeeded, `False` only when a
  rebuild was attempted and the build itself failed.
- `_update_via_zip()` propagates that result.
- All three call sites in `_cmd_update_impl` now write `"0"`/`"1"` to
  `.update_exit_code` based on that result, instead of writing `"0"`
  unconditionally (or nothing at all, for the two paths that previously
  skipped the marker entirely).

## Scope note (avoiding duplicate work)

This PR is intentionally scoped to the **exit-code propagation** half of
#86443. The other half — the packaged Desktop app itself being wiped by
`before-pack.mjs`'s destructive clean when a subsequent build fails, with
no rollback — is architecturally the same class of fix already proposed
in open PR #53040 (targeting #44225 / #46939), which reworks
`before-pack.mjs` to rename instead of delete and auto-restores from
backup in `main.py`. Reimplementing that mechanism here would just
duplicate #53040's approach, so this PR does not touch
`before-pack.mjs` / the packaged-artifact rollback path at all — only the
exit-code/marker-file gap, which no open PR currently covers.

## Test plan

- [x] `pytest tests/hermes_cli/test_cmd_update.py -k "rebuild_desktop or desktop_that_disappears or git_failure_zip_fallback"` — 4 passed (2 new tests added: returns `True` on success, returns `False` on build failure)
- [x] `python -m py_compile hermes_cli/update_cmd.py`
- [x] Full `tests/hermes_cli/test_cmd_update.py` + related update suites: 71 passed, 6 pre-existing failures unrelated to this change (local npm/node version mismatch + missing `fcntl` on Windows — none of the failing tests reach the changed code paths)

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A["hermes update (gateway mode)"] --> B["git pull + pip install OK"]
    B --> C["_rebuild_desktop_after_update()"]
    C -->|"npm build fails"| D["⚠ printed warning only"]
    C -->|"build OK / nothing to do"| E["desktop_build_ok = True"]
    D --> F["desktop_build_ok = False"]
    F --> G{".update_exit_code write"}
    E --> G
    G -->|"BEFORE this PR"| H["always writes '0'"]
    G -->|"AFTER this PR"| I["writes '0' or '1' from desktop_build_ok"]
    H --> J["gateway /update watcher"]
    I --> J
    J --> K["chat platform: reports success/failure"]

    style D fill:#ff007f,color:#fff
    style H fill:#ff007f,color:#fff
    style I fill:#00f0ff,color:#0a0a16
```

## Infographic :
<img width="1376" height="768" alt="update_exit_comic" src="https://github.com/user-attachments/assets/64081fc0-0a9f-4690-9623-778468be9799" />


