### PR TITLE
fix(agent): reject copied pruning markers in effectful calls

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -35,6 +35,7 @@ from typing import Any, Dict, List, Optional
 from agent.message_metadata import stamp_message_timestamp
 from agent.tool_result_classification import (
     FILE_MUTATING_TOOL_NAMES as _FILE_MUTATING_TOOLS,
+    tool_may_have_side_effect,
 )
 from tools.threat_patterns import scan_for_threats
 
@@ -88,6 +89,52 @@ _DESTRUCTIVE_PATTERNS = re.compile(
 )
 # Output redirects that overwrite files (> but not >>)
 _REDIRECT_OVERWRITE = re.compile(r'[^>]>[^>]|^>[^>]')
+
+_CONTEXT_PRUNED_ARG_MARKER = (
+    "...[context-pruned middle; reread the durable source before reuse]..."
+)
+_LEGACY_PRUNED_ARG_TAILS = ("...[truncated]", "…[truncated]")
+
+
+def _context_pruned_argument_paths(tool_name: str, args: Any) -> list[str]:
+    """Return model-visible argument paths that contain compressor sentinels.
+
+    Historical context pruning deliberately rewrites old tool-call string
+    values.  Those placeholders are safe in replayed history but must never be
+    copied into a fresh effect-capable call: doing so turns a compact preview
+    into durable content.  Unknown/plugin/MCP tools are effect-capable by
+    default; known read-only tools remain free to search for or quote markers.
+    """
+    if not tool_may_have_side_effect(tool_name):
+        return []
+
+    found: list[str] = []
+
+    def _walk(value: Any, path: str) -> None:
+        if isinstance(value, str):
+            stripped = value.rstrip()
+            if (
+                _CONTEXT_PRUNED_ARG_MARKER in value
+                or stripped.endswith(_LEGACY_PRUNED_ARG_TAILS)
+            ):
+                found.append(path)
+            return
+        if isinstance(value, dict):
+            for key, child in value.items():
+                key_text = str(key)
+                child_path = (
+                    f"{path}.{key_text}"
+                    if key_text.isidentifier()
+                    else f"{path}[{key_text!r}]"
+                )
+                _walk(child, child_path)
+            return
+        if isinstance(value, (list, tuple)):
+            for index, child in enumerate(value):
+                _walk(child, f"{path}[{index}]")
+
+    _walk(args, "$")
+    return found
 
 
 def _is_destructive_command(cmd: str) -> bool:
@@ -715,6 +762,7 @@ __all__ = [
     "_PATH_SCOPED_WRITERS",
     "_DESTRUCTIVE_PATTERNS",
     "_REDIRECT_OVERWRITE",
+    "_context_pruned_argument_paths",
     "_is_destructive_command",
     "_plan_tool_batch_segments",
     "_should_parallelize_tool_batch",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -38,6 +38,7 @@ from agent.tool_dispatch_helpers import (
     _is_multimodal_tool_result,
     _multimodal_text_summary,
     _append_subdir_hint_to_multimodal,
+    _context_pruned_argument_paths,
     _plan_tool_batch_segments,
     make_tool_result_message,
 )
@@ -110,6 +111,13 @@ _START_ORDER_GATE_TIMEOUT_S = 120.0
 # answering an approval prompt, which self-terminates at approvals.timeout —
 # so a holder that overstays it is wedged and must not starve the batch.
 _AUTHORIZATION_GATE_LOCK_TIMEOUT_S = 360.0
+_PRUNED_TOOL_ARGUMENTS_ERROR = "suspected_pruned_tool_arguments"
+_PRUNED_TOOL_ARGUMENTS_MESSAGE = (
+    "Tool was not executed because effect-capable arguments contain a Hermes "
+    "context-pruning marker. Recover the exact content from its durable source "
+    "or ask the user, then issue a complete new call; do not retry these "
+    "arguments."
+)
 
 
 def _authorization_gate_lock_timeout() -> float:
@@ -156,6 +164,20 @@ def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
         },
         ensure_ascii=False,
     )
+
+
+def _pruned_tool_arguments_block(
+    function_name: str,
+    function_args: dict[str, Any],
+) -> dict[str, Any] | None:
+    paths = _context_pruned_argument_paths(function_name, function_args)
+    if not paths:
+        return None
+    return {
+        "error": _PRUNED_TOOL_ARGUMENTS_ERROR,
+        "message": _PRUNED_TOOL_ARGUMENTS_MESSAGE,
+        "argument_paths": paths,
+    }
 
 
 def _resolve_concurrent_tool_timeout() -> float | None:
@@ -596,6 +618,15 @@ def _run_agent_tool_execution_middleware(
 
         block_message = scope_block
         block_error_type = "tool_scope_block"
+        block_payload: dict[str, Any] | None = None
+        if block_message is None:
+            block_payload = _pruned_tool_arguments_block(
+                function_name,
+                final_args,
+            )
+            if block_payload is not None:
+                block_error_type = _PRUNED_TOOL_ARGUMENTS_ERROR
+                block_message = _PRUNED_TOOL_ARGUMENTS_MESSAGE
         if block_message is None:
             block_error_type = "plugin_block"
 
@@ -628,6 +659,15 @@ def _run_agent_tool_execution_middleware(
                 else authorization_gate.run(_resolve_pre_tool_block)
             )
 
+        if block_message is None:
+            block_payload = _pruned_tool_arguments_block(
+                function_name,
+                final_args,
+            )
+            if block_payload is not None:
+                block_error_type = _PRUNED_TOOL_ARGUMENTS_ERROR
+                block_message = _PRUNED_TOOL_ARGUMENTS_MESSAGE
+
         guardrail_decision = None
         if block_message is None:
             guardrail_decision = agent._tool_guardrails.before_call(
@@ -640,7 +680,10 @@ def _run_agent_tool_execution_middleware(
             _advance_start_order()
             state["blocked"] = True
             if block_message is not None:
-                result = json.dumps({"error": block_message}, ensure_ascii=False)
+                result = json.dumps(
+                    block_payload or {"error": block_message},
+                    ensure_ascii=False,
+                )
                 error_type = block_error_type
                 error_message = block_message
             else:

--- a/tests/agent/test_tool_dispatch_helpers.py
+++ b/tests/agent/test_tool_dispatch_helpers.py
@@ -11,6 +11,7 @@ from a known-untrusted source.
 import pytest
 
 from agent.tool_dispatch_helpers import (
+    _context_pruned_argument_paths,
     _extract_file_mutation_targets,
     _is_untrusted_tool,
     _maybe_wrap_untrusted,
@@ -46,6 +47,45 @@ class TestUntrustedToolClassification:
     def test_empty_name_is_not_untrusted(self):
         assert not _is_untrusted_tool("")
         assert not _is_untrusted_tool(None)
+
+
+class TestContextPrunedArgumentPaths:
+    def test_finds_legacy_marker_tail_in_nested_effectful_arguments(self):
+        paths = _context_pruned_argument_paths(
+            "mcp_send",
+            {"query": {"text": "Bonjour, nous po...[truncated]"}},
+        )
+
+        assert paths == ["$.query.text"]
+
+    def test_finds_current_middle_marker_in_effectful_arguments(self):
+        paths = _context_pruned_argument_paths(
+            "write_file",
+            {
+                "content": (
+                    "head\n...[context-pruned middle; reread the durable source "
+                    "before reuse]...\ntail"
+                )
+            },
+        )
+
+        assert paths == ["$.content"]
+
+    def test_allows_marker_in_middle_and_long_complete_content(self):
+        assert _context_pruned_argument_paths(
+            "mcp_send",
+            {"text": "literal ...[truncated] quote followed by complete content"},
+        ) == []
+        assert _context_pruned_argument_paths(
+            "mcp_send",
+            {"text": "complete " * 200},
+        ) == []
+
+    def test_known_read_only_tool_can_search_for_marker(self):
+        assert _context_pruned_argument_paths(
+            "web_search",
+            {"query": "Hermes ...[truncated]"},
+        ) == []
 
 
 # =========================================================================

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -344,6 +344,93 @@ def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
     assert agent._tool_guardrails.before_call("web_search", args).action == "allow"
 
 
+def test_sequential_effectful_call_rejects_legacy_pruned_sms_before_plugins_or_dispatch():
+    agent = _make_agent("mcp__messaging__send")
+    args = {
+        "method": "POST",
+        "endpoint": "/messages",
+        "query": {
+            "text": (
+                "Here is the complete customer reply with the requested "
+                "schedule, pricing details, reservation instructions, and "
+                "contact information. The final scheduling detail is "
+                "tomorrow between seven and eight, and we can st...[truncated]"
+            )
+        },
+    }
+    tc = _mock_tool_call(
+        "mcp__messaging__send",
+        json.dumps(args, ensure_ascii=False),
+        "c-pruned-sms",
+    )
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with (
+        patch("hermes_cli.plugins._dispatch_pre_tool_call_hooks") as plugin,
+        patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as dispatch,
+    ):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    plugin.assert_not_called()
+    dispatch.assert_not_called()
+    content = messages[0]["content"]
+    assert '"error": "suspected_pruned_tool_arguments"' in content
+    assert "Recover the exact content from its durable source" in content
+    assert '"argument_paths": ["$.query.text"]' in content
+
+
+def test_sequential_effectful_call_allows_complete_long_sms():
+    agent = _make_agent("mcp__messaging__send")
+    text = (
+        "Here is the complete customer reply. "
+        + "All requested details are included. " * 40
+        + "Please reply with your preferred time."
+    )
+    args = {
+        "method": "POST",
+        "endpoint": "/messages",
+        "query": {"text": text},
+    }
+    tc = _mock_tool_call(
+        "mcp__messaging__send",
+        json.dumps(args, ensure_ascii=False),
+        "c-complete-sms",
+    )
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch(
+        "run_agent.handle_function_call",
+        return_value=json.dumps({"result": "Message Processed Successfully"}),
+    ) as dispatch:
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    dispatch.assert_called_once()
+    assert '"result": "Message Processed Successfully"' in messages[0]["content"]
+
+
+def test_concurrent_effectful_call_rejects_current_middle_marker():
+    agent = _make_agent("mcp_write")
+    args = {
+        "body": (
+            "head\n...[context-pruned middle; reread the durable source before "
+            "reuse]...\ntail"
+        )
+    }
+    tc = _mock_tool_call("mcp_write", json.dumps(args), "c-pruned-middle")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as dispatch:
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+
+    dispatch.assert_not_called()
+    content = messages[0]["content"]
+    assert '"error": "suspected_pruned_tool_arguments"' in content
+    assert '"argument_paths": ["$.body"]' in content
+
+
 def test_default_run_conversation_warns_without_guardrail_halt():
     agent = _make_agent("web_search", max_iterations=10)
     same_args = {"query": "same"}


### PR DESCRIPTION
## What does this PR do?

Rejects fresh effect-capable tool calls whose final arguments contain a context-pruning marker. This prevents a compacted historical preview such as `...[truncated]` from being copied into an SMS, email, file write, or other durable side effect.

The check runs in the shared execution middleware before plugin hooks and again after plugins may modify arguments. Known read-only tools remain able to search for or quote the marker. Unknown, plugin, and MCP tools fail closed because they may have side effects.

This complements #83449: preserving more of pruned arguments reduces the chance of copying an incomplete value, while this runtime boundary protects existing persisted sessions containing the legacy marker and rejects the newer middle-pruning marker if a model copies it into a fresh write.

## Related Issue

Related to #83435. Complements #83449.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add recursive detection of current and legacy pruning markers in effect-capable tool arguments.
- Block malformed calls before plugins and re-check plugin-modified arguments before dispatch.
- Return a structured `suspected_pruned_tool_arguments` result with the affected JSON paths and recovery instructions.
- Cover sequential and concurrent execution, nested MCP arguments, read-only tools, and complete long messages.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_tool_dispatch_helpers.py tests/run_agent/test_tool_call_guardrail_runtime.py -q`.
2. Confirm an effectful `mcp__messaging__send` call ending in `...[truncated]` returns `suspected_pruned_tool_arguments` without invoking plugin hooks or the tool.
3. Confirm the same tool accepts a complete long message and known read-only tools may search for the marker.

Focused result: 36 tests passed. Broader agent/relay/runtime regression selection: 276 tests passed. Ruff and `git diff --check` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (x86_64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior and recovery are documented in code and the structured error
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure Python argument inspection, no platform-specific paths or commands
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no public tool schema changed

## Screenshots / Logs

Not applicable; regression tests assert the blocked result and prove the external tool is not called.
