### PR TITLE
fix(aux): drop OpenAI-only extra_body keys before native Anthropic calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1170,6 +1170,24 @@ def _nous_extra_body() -> dict:
 # ``_nous_extra_body()`` or import ``nous_portal_tags`` directly.
 NOUS_EXTRA_BODY = _nous_extra_body()
 
+# extra_body keys that are OpenAI-shaped ONLY and must never be forwarded to a
+# native Anthropic Messages call. Anthropic rejects unknown top-level body keys
+# outright ("Extra inputs are not permitted", HTTP 400), so a caller that asks
+# for OpenAI structured output (``response_format``) would silently break the
+# whole auxiliary task on an Anthropic aux slot rather than degrade gracefully.
+#   - ``reasoning``: translated into the native ``thinking`` field upstream;
+#     forwarding it too would double-specify reasoning.
+#   - ``response_format`` / ``json_schema`` / ``json_mode``: OpenAI structured
+#     output. Callers already have prose/JSON-scan fallbacks (see
+#     agent/title_generator.py::_extract_title_text), so dropping the hint is
+#     strictly better than a 400.
+_OPENAI_ONLY_EXTRA_BODY_KEYS = frozenset({
+    "reasoning",
+    "response_format",
+    "json_schema",
+    "json_mode",
+})
+
 # Set at resolve time — True if the auxiliary client points to Nous Portal
 auxiliary_is_nous: bool = False
 
@@ -2067,7 +2085,8 @@ class _AnthropicCompletionsAdapter:
         if caller_extra_body and isinstance(caller_extra_body, dict):
             passthrough = {
                 k: v for k, v in caller_extra_body.items()
-                if k != "reasoning" and not str(k).startswith("_")
+                if k not in _OPENAI_ONLY_EXTRA_BODY_KEYS
+                and not str(k).startswith("_")
             }
             if passthrough:
                 existing = anthropic_kwargs.get("extra_body") or {}

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2386,6 +2386,31 @@ class TestAuxiliaryTaskExtraBody:
             "thinking": {"type": "disabled"}, "metadata": {"user_id": "u1"},
         }
 
+    def test_anthropic_aux_drops_openai_only_response_format(self):
+        """response_format must NOT reach a native Anthropic Messages call.
+
+        Anthropic rejects unknown top-level body keys with HTTP 400
+        ``response_format: Extra inputs are not permitted``, which killed
+        session titling outright on an Anthropic aux slot. Callers already
+        fall back to prose parsing, so the key must be dropped, not forwarded.
+        """
+        api_kwargs = self._run_anthropic_adapter(
+            call_extra_body={
+                "response_format": {"type": "json_schema", "json_schema": {}},
+                "metadata": {"user_id": "u1"},
+            },
+        )
+        forwarded = api_kwargs.get("extra_body") or {}
+        assert "response_format" not in forwarded
+        assert forwarded == {"metadata": {"user_id": "u1"}}
+
+    def test_anthropic_aux_drops_only_openai_key_leaves_no_empty_extra_body(self):
+        """When the ONLY extra_body key is OpenAI-shaped, nothing is forwarded."""
+        api_kwargs = self._run_anthropic_adapter(
+            call_extra_body={"response_format": {"type": "json_object"}},
+        )
+        assert not api_kwargs.get("extra_body")
+
 
 
 


### PR DESCRIPTION
## Symptom

On an Anthropic auxiliary slot, **session titling fails outright** with:

```
400 response_format: Extra inputs are not permitted
```

Observed live on a production instance (two occurrences in `errors.log` within
11 minutes; every session in that window went untitled).

## Root cause

`agent/title_generator.py:404` sends an OpenAI structured-output hint:

```python
extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
```

`_AnthropicCompletionsAdapter` in `agent/auxiliary_client.py` builds its
passthrough **by exclusion**:

```python
passthrough = {
    k: v for k, v in caller_extra_body.items()
    if k != "reasoning" and not str(k).startswith("_")
}
```

So every caller key except `reasoning` is forwarded verbatim into the native
Messages call. Anthropic rejects unknown top-level body keys, and the whole
auxiliary task dies rather than degrading.

Because the rule is a deny-one/allow-the-rest, this is a **bug class, not a
single site**: any OpenAI-only field a caller adds later is a latent 400 at the
same provider boundary.

## Fix

Replace the single-key exclusion with an explicit deny set of OpenAI-shaped
keys — `reasoning`, `response_format`, `json_schema`, `json_mode` — documented
inline with the reason each is listed.

Dropping the hint is the correct degrade, not a silent loss: callers already
have fallbacks (`_extract_title_text` scans prose/JSON when the provider
doesn't honour `response_format`), so a dropped hint yields a slightly less
constrained title, while forwarding it yields no title at all.

`reasoning` keeps its existing behaviour — it is translated into the native
`thinking` field upstream, so forwarding it too would double-specify.

## Tests

Two regression tests in `tests/agent/test_auxiliary_client.py`:

- `test_anthropic_aux_drops_openai_only_response_format` — `response_format` is
  dropped while a legitimate key (`metadata`) still passes through.
- `test_anthropic_aux_drops_only_openai_key_leaves_no_empty_extra_body` — when
  the only key is OpenAI-shaped, no empty `extra_body` is forwarded.

Both were **proved RED** by reverting the one-line filter back to
`if k != "reasoning"` (test fails on the assertion), then **GREEN** with the fix
restored.

Full file suite on this branch: **182 passed, 1 failed**. The one failure is
`TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events`,
which **fails identically on pristine `main`** — verified by cloning upstream
`main` separately and running that test three times on each tree (3/3 FAIL on
both). It is pre-existing and unrelated to this change.
