### PR TITLE
feat(sessions): restore Hermes's own export with `sessions import --from hermes`

### DIFF
--- a/hermes_cli/foreign_sessions.py
+++ b/hermes_cli/foreign_sessions.py
@@ -30,6 +30,12 @@ role-alternation invariant Hermes enforces everywhere else:
   never fabricate ``tool_calls`` structures);
 * consecutive same-role turns are merged rather than stubbed;
 * system/developer payloads are never imported.
+
+``--from hermes`` is the odd one out: it reads Hermes's *own*
+``sessions export --format jsonl`` backups, which need no conversion at
+all. ``SessionDB.import_sessions`` already restores that payload — it was
+simply unreachable from the CLI, leaving `sessions export` a one-way
+door with the dashboard's HTTP endpoint as the only way back in.
 """
 
 from __future__ import annotations
@@ -387,6 +393,152 @@ def import_foreign_session(source: str, path, db=None) -> str:
                 pass
 
 
+# ── Hermes's own export ──────────────────────────────────────────────────
+
+
+def read_hermes_export(path: Path) -> List[Dict[str, Any]]:
+    """Load session objects from a ``sessions export --format jsonl`` file.
+
+    The exporter writes one session object per line. A hand-assembled file
+    holding a JSON array, or a single object, is accepted too — the shape
+    that matters is that each entry carries an ``id`` and ``messages``.
+    """
+    text = path.read_text(encoding="utf-8", errors="replace").strip()
+    if not text:
+        return []
+
+    # A whole-file array or object (what the dashboard's import endpoint
+    # takes) rather than JSONL.
+    if text[0] == "[" or (text[0] == "{" and "\n" not in text.strip()):
+        try:
+            blob = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            blob = None
+        if isinstance(blob, list):
+            return [s for s in blob if isinstance(s, dict)]
+        if isinstance(blob, dict):
+            return [blob]
+
+    sessions: List[Dict[str, Any]] = []
+    for line_no, line in enumerate(text.splitlines(), 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ValueError(f"{path}:{line_no}: not valid JSON ({exc})") from exc
+        if isinstance(obj, dict):
+            sessions.append(obj)
+    return sessions
+
+
+def looks_like_hermes_export(path: Path) -> bool:
+    """True when *path*'s first record has the shape of a Hermes export.
+
+    Hermes exports have no filename convention — the user names the output
+    — so the source is sniffed from content rather than guessed from the
+    path the way the Claude/Codex stores are.
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                head = line[0]
+                if head == "[":
+                    line = line.lstrip("[").strip().rstrip(",")
+                elif head != "{":
+                    return False
+                try:
+                    obj = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    return False
+                return (
+                    isinstance(obj, dict)
+                    and isinstance(obj.get("id"), str)
+                    and isinstance(obj.get("messages"), list)
+                )
+    except OSError:
+        return False
+    return False
+
+
+def import_hermes_export(path, db=None) -> Dict[str, Any]:
+    """Restore sessions from a Hermes export via ``SessionDB.import_sessions``.
+
+    Returns that method's report unchanged:
+    ``{ok, imported, skipped, detached, imported_ids, errors}``.
+    Sessions whose id already exists are skipped, never overwritten.
+    """
+    path = Path(path).expanduser()
+    if not path.is_file():
+        raise ValueError(f"Export file not found: {path}")
+
+    sessions = read_hermes_export(path)
+    if not sessions:
+        raise ValueError(f"No session records found in {path}")
+    missing = [
+        s.get("id") or "<no id>"
+        for s in sessions
+        if not isinstance(s.get("messages"), list)
+    ]
+    if missing:
+        raise ValueError(
+            f"{path} is not a Hermes session export "
+            f"(no 'messages' on {len(missing)} record(s), e.g. {missing[0]!r}). "
+            "For a Claude Code or Codex CLI transcript pass --from claude|codex."
+        )
+
+    owns_db = db is None
+    if owns_db:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+    try:
+        return db.import_sessions(sessions)
+    finally:
+        if owns_db:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+
+def _report_hermes_import(result: Dict[str, Any]) -> Optional[str]:
+    """Print the import report. Returns the single imported id, if exactly one."""
+    imported_ids = result.get("imported_ids") or []
+    imported = result.get("imported", 0)
+    skipped = result.get("skipped", 0)
+    detached = result.get("detached", 0)
+    errors = result.get("errors") or []
+
+    if not result.get("ok", False):
+        print("Error: import rejected; nothing was written.")
+        for err in errors[:10]:
+            print(f"  - {err}")
+        if len(errors) > 10:
+            print(f"  ... {len(errors) - 10} more")
+        return None
+
+    print(f"✓ Imported {imported} session(s) from the Hermes export")
+    if skipped:
+        print(f"  {skipped} already present (kept as-is, never overwritten)")
+    if detached:
+        print(f"  {detached} detached from a parent session not in this file")
+    for err in errors[:10]:
+        print(f"  ! {err}")
+
+    if imported == 1 and imported_ids:
+        sid = imported_ids[0]
+        print(f"  Continue it with:  hermes --resume {sid}")
+        return sid
+    if imported_ids:
+        print("  List them with:    hermes sessions list")
+    return None
+
+
 # ── Picker / CLI helpers ─────────────────────────────────────────────────
 
 
@@ -463,15 +615,33 @@ def run_sessions_import(args, db=None) -> Optional[str]:
                 source = "claude"
             if "/.codex/" in p or Path(p).name.startswith("rollout-"):
                 source = "codex"
+            # Content wins over the path: a Hermes export is named by the
+            # user, so it can easily sit at a path that looks foreign.
+            if looks_like_hermes_export(Path(path).expanduser()):
+                source = "hermes"
         if not source:
-            print("Cannot infer source from path; pass --from claude|codex.")
+            print("Cannot infer source from path; pass --from claude|codex|hermes.")
             return None
         chosen_path = Path(path)
+    elif source == "hermes":
+        # There is no well-known location to scan: the export path is
+        # wherever the user pointed `sessions export`.
+        print("--from hermes needs the export file: "
+              "hermes sessions import --from hermes <file.jsonl>")
+        return None
     else:
         picked = pick_foreign_session(source)
         if picked is None:
             return None
         source, chosen_path = picked.source, picked.path
+
+    if source == "hermes":
+        try:
+            result = import_hermes_export(chosen_path, db=db)
+        except ValueError as e:
+            print(f"Error: {e}")
+            return None
+        return _report_hermes_import(result)
 
     try:
         session_id = import_foreign_session(source, chosen_path, db=db)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13266,24 +13266,33 @@ def main():
 
     sessions_import = sessions_subparsers.add_parser(
         "import",
-        help="Import a Claude Code or Codex CLI session into Hermes",
+        help="Import a Claude Code, Codex CLI, or exported Hermes session",
         description=(
             "Pull a conversation started in Claude Code (~/.claude/projects) "
             "or Codex CLI (~/.codex/sessions) into the Hermes session store "
             "so it can be resumed with 'hermes --resume <id>'. The foreign "
-            "files are only read, never modified."
+            "files are only read, never modified.\n\n"
+            "'--from hermes <file>' restores Hermes's own backups — the "
+            "output of 'hermes sessions export --format jsonl'. Sessions "
+            "whose id is already present are skipped, never overwritten."
         ),
     )
     sessions_import.add_argument(
         "--from",
         dest="from_source",
-        choices=["claude", "codex"],
-        help="Which tool to import from (default: pick across both)",
+        choices=["claude", "codex", "hermes"],
+        help=(
+            "Which tool to import from (default: sniff the file, or pick "
+            "across Claude Code and Codex CLI)"
+        ),
     )
     sessions_import.add_argument(
         "path",
         nargs="?",
-        help="Path to a specific session JSONL file (skips the picker)",
+        help=(
+            "Path to a specific session JSONL file (skips the picker; "
+            "required for --from hermes)"
+        ),
     )
 
 

--- a/tests/hermes_cli/test_sessions_import_hermes_export.py
+++ b/tests/hermes_cli/test_sessions_import_hermes_export.py
@@ -1,0 +1,260 @@
+"""``sessions import --from hermes`` — restoring Hermes's own export.
+
+``sessions export --format jsonl`` is documented as a backup ("Suitable for
+writing to a JSONL file for backup/analysis") and ``SessionDB.import_sessions``
+already restores exactly that payload — but the only caller was the dashboard's
+HTTP endpoint, so from a terminal the export was a one-way door.
+
+These tests drive the real CLI and two real ``SessionDB`` stores; the restore
+path is never mocked.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.foreign_sessions import (
+    import_hermes_export,
+    looks_like_hermes_export,
+    read_hermes_export,
+)
+from hermes_state import SessionDB
+
+SID = "20260817_140000_native"
+
+
+def _store(tmp_path, name):
+    return SessionDB(db_path=tmp_path / name / "state.db")
+
+
+def _seed(db, sid=SID, title="Merkle notes"):
+    db.create_session(sid, source="cli", cwd="/w/proj")
+    db.append_message(sid, "user", "what is a Merkle tree")
+    db.append_message(sid, "assistant", "A hash tree where each leaf is a data hash.")
+    db.set_session_title(sid, title)  # titles are unique per store
+    db.update_session_cwd(sid, "/w/proj", git_branch="main", git_repo_root="/w/proj")
+    return sid
+
+
+def _export_file(db, tmp_path, sid=SID, name="backup.jsonl"):
+    path = tmp_path / name
+    path.write_text(json.dumps(db.export_session(sid)) + "\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def exported(tmp_path):
+    """A populated source store and the backup file taken from it."""
+    src = _store(tmp_path, "src")
+    try:
+        _seed(src)
+        yield _export_file(src, tmp_path)
+    finally:
+        src.close()
+
+
+class TestRestore:
+    def test_a_backup_restores_into_an_empty_store(self, tmp_path, exported):
+        """The disaster-recovery case: nothing here yet, bring it back."""
+        dst = _store(tmp_path, "dst")
+        try:
+            result = import_hermes_export(exported, db=dst)
+
+            assert result["ok"] and result["imported"] == 1
+            row = dst.get_session(SID) or {}
+            assert row.get("id") == SID, "the session id was not preserved"
+            assert row.get("title") == "Merkle notes"
+            assert row.get("cwd") == "/w/proj"
+            assert row.get("git_branch") == "main"
+            assert [
+                (m["role"], m["content"])
+                for m in dst.get_messages_as_conversation(SID)
+            ] == [
+                ("user", "what is a Merkle tree"),
+                ("assistant", "A hash tree where each leaf is a data hash."),
+            ]
+        finally:
+            dst.close()
+
+    def test_reimport_skips_and_never_overwrites(self, tmp_path, exported):
+        """A second run must not clobber a session that moved on since export."""
+        dst = _store(tmp_path, "dst")
+        try:
+            import_hermes_export(exported, db=dst)
+            dst.append_message(SID, "user", "a turn added after the backup")
+
+            result = import_hermes_export(exported, db=dst)
+
+            assert result["ok"]
+            assert result["imported"] == 0 and result["skipped"] == 1
+            assert len(dst.get_messages_as_conversation(SID)) == 3, (
+                "re-importing overwrote history recorded after the backup"
+            )
+        finally:
+            dst.close()
+
+    def test_several_sessions_in_one_file(self, tmp_path):
+        src = _store(tmp_path, "src")
+        dst = _store(tmp_path, "dst")
+        try:
+            ids = [
+                _seed(src, f"20260817_1500{i:02d}_multi", title=f"note {i}")
+                for i in range(3)
+            ]
+            path = tmp_path / "all.jsonl"
+            path.write_text(
+                "".join(json.dumps(src.export_session(i)) + "\n" for i in ids),
+                encoding="utf-8",
+            )
+
+            result = import_hermes_export(path, db=dst)
+
+            assert result["imported"] == 3
+            assert sorted(result["imported_ids"]) == sorted(ids)
+        finally:
+            src.close()
+            dst.close()
+
+
+class TestFileShapes:
+    def test_jsonl_one_object_per_line(self, tmp_path, exported):
+        assert len(read_hermes_export(exported)) == 1
+
+    def test_a_whole_file_array_is_accepted(self, tmp_path, exported):
+        """The shape the dashboard's import endpoint takes."""
+        arr = tmp_path / "arr.json"
+        arr.write_text(json.dumps(read_hermes_export(exported)), encoding="utf-8")
+        assert len(read_hermes_export(arr)) == 1
+
+    def test_a_single_object_is_accepted(self, tmp_path, exported):
+        one = tmp_path / "one.json"
+        one.write_text(json.dumps(read_hermes_export(exported)[0]), encoding="utf-8")
+        assert len(read_hermes_export(one)) == 1
+
+    def test_an_empty_file_is_empty_not_an_error(self, tmp_path):
+        p = tmp_path / "empty.jsonl"
+        p.write_text("   \n\n", encoding="utf-8")
+        assert read_hermes_export(p) == []
+
+    def test_a_malformed_line_names_itself(self, tmp_path, exported):
+        broken = tmp_path / "broken.jsonl"
+        broken.write_text(
+            exported.read_text(encoding="utf-8") + "{not json\n", encoding="utf-8"
+        )
+        with pytest.raises(ValueError, match=r":2:"):
+            read_hermes_export(broken)
+
+
+class TestSourceDetection:
+    def test_a_hermes_export_is_recognised(self, exported):
+        assert looks_like_hermes_export(exported)
+
+    def test_a_claude_transcript_is_not(self, tmp_path):
+        """Claude Code lines have `type`/`message`, never a top-level `messages`."""
+        p = tmp_path / "session.jsonl"
+        p.write_text(
+            json.dumps({
+                "type": "user", "sessionId": "abc",
+                "message": {"role": "user", "content": "hi"},
+            }) + "\n",
+            encoding="utf-8",
+        )
+        assert not looks_like_hermes_export(p)
+
+    def test_a_missing_file_is_not(self, tmp_path):
+        assert not looks_like_hermes_export(tmp_path / "nope.jsonl")
+
+    def test_binary_garbage_is_not(self, tmp_path):
+        p = tmp_path / "x.jsonl"
+        p.write_bytes(b"\x00\x01\x02not json at all\n")
+        assert not looks_like_hermes_export(p)
+
+
+class TestRejection:
+    def test_a_foreign_transcript_names_the_right_flag(self, tmp_path):
+        """Wrong --from must not half-import; it must say what to use."""
+        p = tmp_path / "claude.jsonl"
+        p.write_text(
+            json.dumps({"type": "user", "message": {"role": "user", "content": "hi"}})
+            + "\n",
+            encoding="utf-8",
+        )
+        dst = _store(tmp_path, "dst")
+        try:
+            with pytest.raises(ValueError, match=r"--from claude\|codex"):
+                import_hermes_export(p, db=dst)
+        finally:
+            dst.close()
+
+    def test_a_missing_file_is_reported(self, tmp_path):
+        with pytest.raises(ValueError, match="not found"):
+            import_hermes_export(tmp_path / "nope.jsonl")
+
+    def test_an_empty_export_is_reported(self, tmp_path):
+        p = tmp_path / "empty.jsonl"
+        p.write_text("\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="No session records"):
+            import_hermes_export(p)
+
+
+class TestCli:
+    """The surface a user actually types."""
+
+    def _run(self, monkeypatch, argv):
+        import hermes_cli.main as main_mod
+
+        monkeypatch.setattr(sys, "argv", ["hermes", "sessions", "import", *argv])
+        main_mod.main()
+
+    def test_end_to_end_restore(self, monkeypatch, tmp_path, capsys):
+        db = SessionDB()
+        try:
+            _seed(db)
+            backup = _export_file(db, tmp_path)
+            db.delete_session(SID)
+            assert db.get_session(SID) is None, "precondition: session is gone"
+        finally:
+            db.close()
+
+        self._run(monkeypatch, ["--from", "hermes", str(backup)])
+
+        out = capsys.readouterr().out
+        assert "Imported 1 session" in out, out
+        assert f"hermes --resume {SID}" in out
+        db = SessionDB()
+        try:
+            assert (db.get_session(SID) or {}).get("title") == "Merkle notes"
+        finally:
+            db.close()
+
+    def test_content_beats_a_misleading_path(self, monkeypatch, tmp_path, capsys):
+        """A user-named export can easily land on a claude-looking path."""
+        db = SessionDB()
+        try:
+            _seed(db)
+            backup = _export_file(db, tmp_path, name="claude-notes.jsonl")
+            db.delete_session(SID)
+        finally:
+            db.close()
+
+        self._run(monkeypatch, [str(backup)])
+
+        assert "Imported 1 session" in capsys.readouterr().out
+
+    def test_from_hermes_without_a_path_says_so(self, monkeypatch, capsys):
+        """There is no store to scan, so the picker must not be offered."""
+        self._run(monkeypatch, ["--from", "hermes"])
+        out = capsys.readouterr().out
+        assert "needs the export file" in out, out
+
+    def test_a_bad_file_writes_nothing(self, monkeypatch, tmp_path, capsys):
+        p = tmp_path / "junk.jsonl"
+        p.write_text(json.dumps({"type": "user"}) + "\n", encoding="utf-8")
+        before = len(SessionDB().search_sessions(limit=1000))
+
+        self._run(monkeypatch, ["--from", "hermes", str(p)])
+
+        assert "Error:" in capsys.readouterr().out
+        assert len(SessionDB().search_sessions(limit=1000)) == before


### PR DESCRIPTION
## The gap

`sessions export --format jsonl` is a backup format by its own documentation:

> Suitable for writing to a JSONL file for backup/analysis
> — `export_all`, `hermes_state_portability.py`

And `SessionDB.import_sessions` already restores exactly that payload — ID-collision skipping, parent detachment for partial imports, deliberate reset of live runtime state, an explicitly reasoned activity-field contract, and its own regression suite.

Nothing connected the two. `import_sessions`'s only caller is the dashboard's HTTP endpoint, whose docstring reads:

> Import one or more sessions exported from the dashboard **or CLI**

So the CLI export is already an intended input to it — reachable only by starting the web server. From a terminal, `sessions export` was a one-way door.

## What people do instead

The nearest workaround is a detour through the foreign-import path: `--format trace` emits Claude Code JSONL, and `--from claude` can read that back. It "works", and loses the session id, the title, the model and the recorded cwd, because the foreign converter deliberately flattens everything to plain user/assistant text.

## The change

`--from hermes <file>` wires the existing primitive to the existing subcommand.

```console
$ hermes sessions export backup.jsonl --format jsonl --session-id 20260817_140000_native
Exported 1 session to backup.jsonl

# …on another machine, or after losing the store
$ hermes sessions import --from hermes backup.jsonl
✓ Imported 1 session(s) from the Hermes export
  Continue it with:  hermes --resume 20260817_140000_native
```

The restored row keeps its id, title, cwd, git branch and full transcript. Re-running skips what is already present:

```console
$ hermes sessions import --from hermes backup.jsonl
✓ Imported 0 session(s) from the Hermes export
  1 already present (kept as-is, never overwritten)
```

**Source detection is by content, not path.** Claude Code and Codex have fixed stores to pattern-match; a Hermes export is named by whoever ran the export and lands wherever they pointed it. Sniffing the first record means `backup.jsonl` sitting in a directory full of claude notes still resolves correctly.

**A wrong `--from` fails whole.** A foreign transcript passed to `--from hermes` is rejected before anything is written, naming the flag that would have worked:

```console
Error: …/4e53229c.jsonl is not a Hermes session export (no 'messages' on 201
record(s), e.g. '<no id>'). For a Claude Code or Codex CLI transcript pass
--from claude|codex.
```

## Scope

No change to `import_sessions` itself, to the dashboard endpoint, or to the Claude/Codex paths — the 9 existing `test_foreign_sessions.py` tests pass untouched.

`--from hermes` requires a path and never offers the picker: unlike the foreign sources there is no well-known location to scan.

## Tests

19 tests driving the real CLI and two real `SessionDB` stores — restore into an empty store, re-import against a session that gained a turn after the backup, multi-session files, the JSONL / array / single-object shapes, content-vs-path detection, and each rejection path asserting nothing was written.