### PR TITLE
fix(update): handle launchd-managed dashboards during update

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -363,14 +363,31 @@ def _kill_stale_dashboard_processes(
     # stay a stop, not a restart.
     pid_cgroup: dict[int, str | None] = {}
     pid_service: dict[int, str | None] = {}
+    pid_launchd: dict[int, str | None] = {}
+    pid_launchd_errors: dict[int, str] = {}
     pid_cmdline: dict[int, list[str]] = {}
     pid_home: dict[int, str | None] = {}
     if restart_managed and sys.platform != "win32":
         for pid in pids:
-            cg_path = _m()._get_pid_cgroup_path(pid)
-            pid_cgroup[pid] = cg_path
-            pid_service[pid] = _m()._get_systemd_service_for_pid(pid)
-            if not pid_service[pid]:
+            if sys.platform == "darwin":
+                launchd_target, launchd_error = _m()._get_launchd_job_for_pid(pid)
+                pid_launchd[pid] = launchd_target
+                if launchd_error:
+                    pid_launchd_errors[pid] = launchd_error
+                manually_started = not launchd_target and not launchd_error
+                if not launchd_target and not launchd_error:
+                    # Keep the existing systemd fallback for POSIX
+                    # environments that do not use launchd.
+                    cg_path = _m()._get_pid_cgroup_path(pid)
+                    pid_cgroup[pid] = cg_path
+                    pid_service[pid] = _m()._get_systemd_service_for_pid(pid)
+                    manually_started = not pid_service[pid]
+            else:
+                cg_path = _m()._get_pid_cgroup_path(pid)
+                pid_cgroup[pid] = cg_path
+                pid_service[pid] = _m()._get_systemd_service_for_pid(pid)
+                manually_started = not pid_service[pid]
+            if manually_started:
                 # Manually-started process: preserve its exact argv so we
                 # can respawn it after the update (#40449, #68934).
                 # Snapshot HERMES_HOME before the kill so per-profile caps
@@ -393,11 +410,44 @@ def _kill_stale_dashboard_processes(
             if not pids:
                 return {"matched": [], "killed": [], "failed": []}
 
-    print()
-    print(f"⟲ Stopping {len(pids)} dashboard process(es) ({reason})")
-
+    matched_pids = list(pids)
     killed: list[int] = []
     failed: list[tuple[int, str]] = []
+    unrecovered: list[int] = []
+    launchd_restarted: list[tuple[int, str]] = []
+    launchd_lookup_failures: dict[int, str] = {}
+    launchd_kickstart_failures: dict[int, str] = {}
+
+    if restart_managed and sys.platform == "darwin":
+        manual_pids: list[int] = []
+        for pid in pids:
+            launchd_target = pid_launchd.get(pid)
+            launchd_error = pid_launchd_errors.get(pid)
+            if launchd_error:
+                error = f"launchd ownership lookup failed: {launchd_error}"
+                failed.append((pid, error))
+                launchd_lookup_failures[pid] = error
+            elif launchd_target:
+                restarted, error = _m()._kickstart_launchd_job(launchd_target)
+                if restarted:
+                    launchd_restarted.append((pid, launchd_target))
+                else:
+                    detail = error or "launchctl kickstart returned non-zero"
+                    # kickstart may have killed or restarted the job before
+                    # returning failure, so the PID's post-state is unknown.
+                    failure = (
+                        f"launchd kickstart failed for {launchd_target}; "
+                        f"post-state is indeterminate: {detail}"
+                    )
+                    failed.append((pid, failure))
+                    launchd_kickstart_failures[pid] = failure
+            else:
+                manual_pids.append(pid)
+        pids = manual_pids
+
+    if pids:
+        print()
+        print(f"⟲ Stopping {len(pids)} dashboard process(es) ({reason})")
 
     if sys.platform == "win32":
         for pid in pids:
@@ -460,7 +510,20 @@ def _kill_stale_dashboard_processes(
     for pid in killed:
         print(f"    ✓ stopped PID {pid}")
     for pid, err_msg in failed:
-        print(f"    ✗ failed to stop PID {pid}: {err_msg}")
+        if pid in launchd_lookup_failures:
+            print(f"    ⚠ left PID {pid} untouched: {err_msg}")
+        elif pid in launchd_kickstart_failures:
+            print(f"    ⚠ state of PID {pid} is indeterminate: {err_msg}")
+        else:
+            print(f"    ✗ failed to stop PID {pid}: {err_msg}")
+    for _pid, target in launchd_restarted:
+        print(f"    ✓ restarted launchd job {target}")
+    if launchd_lookup_failures:
+        print("  Resolve launchd ownership lookup failure before restarting")
+        print("  these dashboard processes; they were left untouched.")
+    if launchd_kickstart_failures:
+        print("  A failed launchd kickstart leaves the dashboard post-state")
+        print("  indeterminate; do not retry with raw kill or detached respawn.")
 
     # Restart what we just killed (update path only).  Two categories:
     #  - systemd-supervised PIDs: restart the owning unit.  Without this, a
@@ -471,7 +534,6 @@ def _kill_stale_dashboard_processes(
     #    Filtered so Desktop ``serve|dashboard --port 0`` backends are not
     #    resurrected and duplicates collapse to one per profile (#78821).
     restarted_services: list[str] = []
-    unrecovered: list[int] = []
     if killed and restart_managed:
         failed_restarts: list[tuple[str, str]] = []
         seen_services: set[str] = set()
@@ -514,7 +576,7 @@ def _kill_stale_dashboard_processes(
         print("    hermes dashboard --port <port>")
 
     return {
-        "matched": list(pids),
+        "matched": matched_pids,
         "killed": list(killed),
         "failed": list(failed),
         "unrecovered": list(unrecovered),
@@ -979,4 +1041,3 @@ def _reap_orphaned_desktop_local_serves(
             pass
 
     return {"matched": matched, "killed": killed, "failed": failed}
-

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -321,6 +321,15 @@ def _kill_stale_dashboard_processes(
     restarted after the kill, because systemd treats our SIGTERM as a clean
     stop and ``Restart=on-failure`` would never fire (#68934).
 
+    macOS: a PID owned directly by a launchd job is restarted with
+    ``launchctl kickstart -k`` and never signalled, so KeepAlive cannot race
+    our SIGTERM.  Anything launchd does not claim is treated as manual — but
+    only while we can prove it: if such a PID has already vanished when we go
+    to signal it, the ownership snapshot is stale (a replaced KeepAlive job
+    looks exactly like a manual backend that exited), so it fails closed
+    without a detached respawn rather than duplicating the job launchd just
+    restarted (review on #87989).
+
     *already_restarted_units* names units (no ``.service`` suffix) the
     caller already restarted directly — e.g. ``hermes update``'s systemd
     fleet-restart loop, which restarts ``hermes-serve*`` units before this
@@ -417,6 +426,7 @@ def _kill_stale_dashboard_processes(
     launchd_restarted: list[tuple[int, str]] = []
     launchd_lookup_failures: dict[int, str] = {}
     launchd_kickstart_failures: dict[int, str] = {}
+    launchd_turnover_failures: dict[int, str] = {}
 
     if restart_managed and sys.platform == "darwin":
         manual_pids: list[int] = []
@@ -474,8 +484,25 @@ def _kill_stale_dashboard_processes(
             try:
                 os.kill(pid, _signal.SIGTERM)
             except ProcessLookupError:
-                # Already gone — count as killed.
-                killed.append(pid)
+                if restart_managed and sys.platform == "darwin":
+                    # The PID vanished before we signalled it, so the launchd
+                    # ownership snapshot taken by the scan above is stale: a
+                    # KeepAlive job replaced between the two snapshots is
+                    # absent from both bootstrap domains and indistinguishable
+                    # from a manual backend that exited on its own.  Counting
+                    # it killed would publish a detached respawn next to the
+                    # process launchd just restarted (duplicate listener /
+                    # EADDRINUSE), so fail closed instead (review on #87989).
+                    failure = (
+                        "candidate vanished before the stop signal; launchd "
+                        "ownership could not be revalidated, so no detached "
+                        "respawn was published"
+                    )
+                    failed.append((pid, failure))
+                    launchd_turnover_failures[pid] = failure
+                else:
+                    # Already gone — count as killed.
+                    killed.append(pid)
             except (PermissionError, OSError) as e:
                 failed.append((pid, str(e)))
 
@@ -510,7 +537,7 @@ def _kill_stale_dashboard_processes(
     for pid in killed:
         print(f"    ✓ stopped PID {pid}")
     for pid, err_msg in failed:
-        if pid in launchd_lookup_failures:
+        if pid in launchd_lookup_failures or pid in launchd_turnover_failures:
             print(f"    ⚠ left PID {pid} untouched: {err_msg}")
         elif pid in launchd_kickstart_failures:
             print(f"    ⚠ state of PID {pid} is indeterminate: {err_msg}")
@@ -524,6 +551,10 @@ def _kill_stale_dashboard_processes(
     if launchd_kickstart_failures:
         print("  A failed launchd kickstart leaves the dashboard post-state")
         print("  indeterminate; do not retry with raw kill or detached respawn.")
+    if launchd_turnover_failures:
+        print("  A dashboard PID that vanished before the stop signal may have")
+        print("  been replaced by its launchd job; check the job's current PID")
+        print("  before starting another dashboard by hand.")
 
     # Restart what we just killed (update path only).  Two categories:
     #  - systemd-supervised PIDs: restart the owning unit.  Without this, a

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8162,6 +8162,96 @@ def _get_systemd_service_for_pid(pid: int) -> str | None:
     return None
 
 
+def _query_launchd_domain(domain: str) -> tuple[dict[int, str], str | None]:
+    """Return direct service PIDs for a launchd bootstrap domain."""
+    from hermes_cli._subprocess_compat import bounded_probe_run
+
+    command = ["launchctl", "print", domain]
+    result = bounded_probe_run(command, timeout=5)
+    if result is None:
+        return {}, f"launchctl print {domain} failed or timed out"
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        kind, _, uid = domain.partition("/")
+        if f"Could not find domain for user {kind}: {uid}" in stderr:
+            return {}, None
+        return {}, stderr or f"launchctl print {domain} failed"
+
+    services: dict[int, str] = {}
+    in_services = False
+    closed_services = False
+    service_line = re.compile(
+        r"^\s*(\d+)\s+(?:-|[-+]?\d+|\([^)]*\))\s+(\S+)\s*$"
+    )
+    for line in (result.stdout or "").splitlines():
+        stripped = line.strip()
+        if stripped == "services = {":
+            in_services = True
+            continue
+        if in_services and stripped == "}":
+            closed_services = True
+            break
+        if not in_services:
+            continue
+        match = service_line.match(line)
+        if not match:
+            return {}, f"ambiguous launchctl output for {domain}"
+        service_pid = int(match.group(1))
+        if service_pid == 0:
+            continue
+        label = match.group(2)
+        previous = services.get(service_pid)
+        if previous is not None and previous != label:
+            return {}, f"ambiguous launchd PID {service_pid} in {domain}"
+        services[service_pid] = label
+
+    if not closed_services:
+        return {}, f"ambiguous launchctl output for {domain}"
+    return services, None
+
+
+def _get_launchd_job_for_pid(pid: int) -> tuple[str | None, str | None]:
+    """Return ``(qualified_target, error)`` for a direct launchd-managed PID."""
+    try:
+        uid = os.getuid()
+    except AttributeError:
+        return None, "current user ID is unavailable"
+
+    matches: list[str] = []
+    for kind in ("user", "gui"):
+        domain = f"{kind}/{uid}"
+        services, error = _query_launchd_domain(domain)
+        if error:
+            return None, error
+        label = services.get(pid)
+        if label:
+            matches.append(f"{domain}/{label}")
+
+    if len(matches) > 1:
+        return None, f"ambiguous launchd ownership for PID {pid}"
+    return (matches[0] if matches else None), None
+
+
+def _kickstart_launchd_job(target: str) -> tuple[bool, str]:
+    """Force-restart a launchd job and return success plus an error message."""
+    command = ["launchctl", "kickstart", "-k", target]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return False, str(exc)
+    if result.returncode == 0:
+        return True, ""
+    return False, (result.stderr or result.stdout or "").strip()
+
+
 def _extract_scope_from_cgroup(cgroup_entry: str) -> str | None:
     """Extract the systemd scope (``user`` or ``system``) from a cgroup path.
 

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -363,6 +363,297 @@ class TestSupervisedBackendRestart:
         assert result == {"matched": [], "killed": [], "failed": []}
 
 
+class TestLaunchdBackendRestart:
+    """Darwin launchd jobs must be kickstarted, never detached-respawned."""
+
+    def _live(self):
+        return sys.modules["hermes_cli.main"]
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Darwin launchd path")
+    def test_gui_job_is_kickstarted_without_signal_or_respawn(self):
+        live = self._live()
+        launchctl_calls: list[list[str]] = []
+
+        def fake_run(args, *a, **kw):
+            launchctl_calls.append(list(args))
+            if args == ["launchctl", "print", "user/502"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout="user/502 = {\n services = {\n }\n}\n",
+                    stderr="",
+                )
+            if args == ["launchctl", "print", "gui/502"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "gui/502 = {\n"
+                        " services = {\n"
+                        " 4321      -  com.hermes.dashboard\n"
+                        " }\n"
+                        "}\n"
+                    ),
+                    stderr="",
+                )
+            if args == [
+                "launchctl", "kickstart", "-k", "gui/502/com.hermes.dashboard"
+            ]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        with patch("sys.platform", "darwin"), \
+             patch.object(live.os, "getuid", return_value=502), \
+             patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4321]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_dashboard_cmdline_for_pid") as cmdline, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli._subprocess_compat.bounded_probe_run", side_effect=fake_run), \
+             patch("os.kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert [
+            "launchctl", "kickstart", "-k", "gui/502/com.hermes.dashboard"
+        ] in launchctl_calls
+        kill.assert_not_called()
+        cmdline.assert_not_called()
+        respawn.assert_not_called()
+        assert result["matched"] == [4321]
+        assert result["killed"] == []
+        assert result["unrecovered"] == []
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Darwin launchd path")
+    def test_user_job_keeps_user_bootstrap_target(self):
+        live = self._live()
+        launchctl_calls: list[list[str]] = []
+
+        def fake_run(args, *a, **kw):
+            launchctl_calls.append(list(args))
+            if args == ["launchctl", "print", "user/502"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "user/502 = {\n"
+                        " services = {\n"
+                        " 4322      -  com.hermes.dashboard.user\n"
+                        " }\n"
+                        "}\n"
+                    ),
+                    stderr="",
+                )
+            if args == ["launchctl", "print", "gui/502"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout="gui/502 = {\n services = {\n }\n}\n",
+                    stderr="",
+                )
+            if args == [
+                "launchctl", "kickstart", "-k", "user/502/com.hermes.dashboard.user"
+            ]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        with patch("sys.platform", "darwin"), \
+             patch.object(live.os, "getuid", return_value=502), \
+             patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4322]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_dashboard_cmdline_for_pid") as cmdline, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli._subprocess_compat.bounded_probe_run", side_effect=fake_run), \
+             patch("os.kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert [
+            "launchctl", "kickstart", "-k", "user/502/com.hermes.dashboard.user"
+        ] in launchctl_calls
+        kill.assert_not_called()
+        cmdline.assert_not_called()
+        respawn.assert_not_called()
+        assert result["matched"] == [4322]
+        assert result["killed"] == []
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Darwin launchd path")
+    @pytest.mark.parametrize("lookup_failure", ["command", "ambiguous", "malformed"])
+    def test_unsafe_launchd_lookup_fails_closed(self, lookup_failure, capsys):
+        live = self._live()
+        argv = ["hermes", "dashboard", "--port", "8302"]
+
+        def fake_run(args, *a, **kw):
+            if args == ["launchctl", "print", "user/502"]:
+                if lookup_failure == "command":
+                    return MagicMock(returncode=1, stdout="", stderr="launchctl unavailable")
+                if lookup_failure == "malformed":
+                    return MagicMock(
+                        returncode=0,
+                        stdout=(
+                            "user/502 = {\n"
+                            " services = {\n"
+                            " unexpected launchd record\n"
+                            " }\n"
+                            "}\n"
+                        ),
+                        stderr="",
+                    )
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "user/502 = {\n"
+                        " services = {\n"
+                        " 4323      -  com.hermes.dashboard.one\n"
+                        " }\n"
+                        "}\n"
+                    ),
+                    stderr="",
+                )
+            if args == ["launchctl", "print", "gui/502"]:
+                gui_stdout = (
+                    "gui/502 = {\n"
+                    " services = {\n"
+                    " 4323      -  com.hermes.dashboard.two\n"
+                    " }\n"
+                    "}\n"
+                ) if lookup_failure == "ambiguous" else (
+                    "gui/502 = {\n services = {\n }\n}\n"
+                )
+                return MagicMock(
+                    returncode=0,
+                    stdout=gui_stdout,
+                    stderr="",
+                )
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        with patch("sys.platform", "darwin"), \
+             patch.object(live.os, "getuid", return_value=502), \
+             patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4323]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_dashboard_cmdline_for_pid", return_value=argv) as cmdline, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli._subprocess_compat.bounded_probe_run", side_effect=fake_run), \
+             patch("os.kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        kill.assert_not_called()
+        cmdline.assert_not_called()
+        respawn.assert_not_called()
+        assert result["killed"] == []
+        assert result["failed"]
+        assert result["failed"][0][0] == 4323
+        assert "left PID 4323 untouched" in capsys.readouterr().out
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Darwin launchd path")
+    @pytest.mark.parametrize("kickstart_failure", ["nonzero", "timeout"])
+    def test_failed_launchd_kickstart_is_indeterminate_without_kill_or_respawn(
+        self, kickstart_failure, capsys
+    ):
+        live = self._live()
+        target = "gui/502/com.hermes.dashboard.failed"
+
+        def fake_run(args, *a, **kw):
+            assert args == ["launchctl", "kickstart", "-k", target]
+            if kickstart_failure == "nonzero":
+                return subprocess.CompletedProcess(
+                    args, 1, stdout="", stderr="kickstart denied"
+                )
+            raise subprocess.TimeoutExpired(args, 15)
+
+        with patch("sys.platform", "darwin"), \
+             patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4325]), \
+             patch.object(live, "_get_launchd_job_for_pid", return_value=(target, None)), \
+             patch.object(live, "_dashboard_cmdline_for_pid") as cmdline, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(live.subprocess, "run", side_effect=fake_run), \
+             patch("os.kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        kill.assert_not_called()
+        cmdline.assert_not_called()
+        respawn.assert_not_called()
+        assert result["matched"] == [4325]
+        assert result["killed"] == []
+        assert result["unrecovered"] == []
+        assert result["failed"][0][0] == 4325
+        assert "post-state is indeterminate" in result["failed"][0][1]
+        out = capsys.readouterr().out
+        assert "indeterminate" in out
+        assert "left PID 4325 untouched" not in out
+        assert "they were left untouched" not in out
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Darwin launchd path")
+    def test_launchd_lookup_uses_deadlock_safe_bounded_probe(self):
+        live = self._live()
+        empty_domains = {
+            "user/502": "user/502 = {\n services = {\n }\n}\n",
+            "gui/502": "gui/502 = {\n services = {\n }\n}\n",
+        }
+
+        def fake_run(args, *a, **kw):
+            assert args[:3] == ["launchctl", "print", args[2]]
+            return MagicMock(
+                returncode=0,
+                stdout=empty_domains[args[2]],
+                stderr="",
+            )
+
+        with patch("sys.platform", "darwin"), \
+             patch.object(live.os, "getuid", return_value=502), \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli._subprocess_compat.bounded_probe_run") as probe:
+            probe.side_effect = lambda argv, **kw: subprocess.CompletedProcess(
+                argv, 0, stdout=empty_domains[argv[-1]], stderr=""
+            )
+            assert live._get_launchd_job_for_pid(9999) == (None, None)
+
+        assert probe.call_count == 2
+        assert all(call.kwargs["timeout"] for call in probe.call_args_list)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Darwin launchd path")
+    def test_manual_darwin_dashboard_keeps_manual_respawn(self):
+        live = self._live()
+        argv = ["hermes", "dashboard", "--port", "8303"]
+
+        def fake_run(args, *a, **kw):
+            if args in (
+                ["launchctl", "print", "user/502"],
+                ["launchctl", "print", "gui/502"],
+            ):
+                domain = args[-1]
+                return MagicMock(
+                    returncode=0,
+                    stdout=f"{domain} = {{\n services = {{\n }}\n}}\n",
+                    stderr="",
+                )
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                raise ProcessLookupError
+
+        with patch("sys.platform", "darwin"), \
+             patch.object(live.os, "getuid", return_value=502), \
+             patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4324]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_dashboard_cmdline_for_pid", return_value=argv), \
+             patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=None), \
+             patch.object(live, "_respawn_dashboard_processes", return_value=[]) as respawn, \
+             patch("hermes_cli._subprocess_compat.bounded_probe_run", side_effect=fake_run), \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        respawn.assert_called_once_with([argv])
+        assert result["killed"] == [4324]
+
+
 class TestManualBackendRespawn:
     """Manually-started dashboards/serves have their argv captured before the
     kill and are respawned detached after the update (#40449)."""

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -653,6 +653,137 @@ class TestLaunchdBackendRestart:
         respawn.assert_called_once_with([argv])
         assert result["killed"] == [4324]
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Darwin launchd path")
+    def test_pid_turnover_before_signal_fails_closed(self, capsys):
+        """KeepAlive churn between the scan and the ownership lookup must not
+        publish a detached respawn.
+
+        The stale-process scan and ``_get_launchd_job_for_pid`` are separate
+        snapshots.  When launchd replaces the job in between, the scanned PID
+        is absent from both bootstrap domains and looks manually started;
+        ``SIGTERM`` then raises ``ProcessLookupError``.  Counting that as a
+        clean kill and respawning the captured argv detaches a second
+        dashboard alongside the one launchd just restarted — the duplicate
+        listener / ``EADDRINUSE`` incident.  Fail closed instead.
+        """
+        live = self._live()
+        argv = ["hermes", "dashboard", "--port", "9119"]
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        with patch("sys.platform", "darwin"), \
+             patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4321]), \
+             patch.object(live, "_get_launchd_job_for_pid", return_value=(None, None)), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_dashboard_cmdline_for_pid", return_value=argv), \
+             patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=None), \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        respawn.assert_not_called()
+        assert result["matched"] == [4321]
+        assert result["killed"] == []
+        # Not "unrecovered" either: telling the operator to relaunch by hand
+        # would recreate the duplicate launchd is already supervising.
+        assert result["unrecovered"] == []
+        assert result["failed"][0][0] == 4321
+        assert "vanished" in result["failed"][0][1]
+        out = capsys.readouterr().out
+        assert "left PID 4321 untouched" in out
+        assert "when you're ready" not in out
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Darwin launchd path")
+    def test_loaded_launchd_job_without_current_pid_fails_closed(self, capsys):
+        """A loaded job between KeepAlive restarts reports PID 0.
+
+        ``launchctl print`` lists a loaded-but-not-running job with ``0`` in
+        the PID column, so the stale scanned PID matches no label and the
+        real lookup returns "manually started".  The PID-0 entry must never
+        be claimed as the owner of an unrelated PID, and the vanished
+        candidate must still fail closed rather than respawn.
+        """
+        live = self._live()
+        argv = ["hermes", "dashboard", "--port", "9119"]
+
+        def fake_run(args, *a, **kw):
+            if args == ["launchctl", "print", "gui/502"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "gui/502 = {\n"
+                        " services = {\n"
+                        "        0      - \tcom.hermes.dashboard\n"
+                        " }\n"
+                        "}\n"
+                    ),
+                    stderr="",
+                )
+            if args == ["launchctl", "print", "user/502"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout="user/502 = {\n services = {\n }\n}\n",
+                    stderr="",
+                )
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        with patch("sys.platform", "darwin"), \
+             patch.object(live.os, "getuid", return_value=502), \
+             patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4321]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_dashboard_cmdline_for_pid", return_value=argv), \
+             patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=None), \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli._subprocess_compat.bounded_probe_run", side_effect=fake_run), \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        respawn.assert_not_called()
+        assert result["killed"] == []
+        assert result["unrecovered"] == []
+        assert result["failed"][0][0] == 4321
+        assert "vanished" in result["failed"][0][1]
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX kill semantics")
+    def test_non_darwin_vanished_manual_pid_still_respawns(self):
+        """The fail-closed guard is launchd-specific.
+
+        Off macOS there is no KeepAlive replacement to collide with, so a
+        manual backend that exits between the scan and ``SIGTERM`` keeps the
+        #40449 respawn.
+        """
+        live = self._live()
+        argv = ["hermes", "dashboard", "--port", "8300"]
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        with patch("sys.platform", "linux"), \
+             patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[6002]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_dashboard_cmdline_for_pid", return_value=argv), \
+             patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=None), \
+             patch.object(live, "_respawn_dashboard_processes", return_value=[]) as respawn, \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        respawn.assert_called_once_with([argv])
+        assert result["killed"] == [6002]
+
 
 class TestManualBackendRespawn:
     """Manually-started dashboards/serves have their argv captured before the


### PR DESCRIPTION
## What does this PR do?

On macOS, `hermes update` kill-and-respawns launchd-supervised dashboard processes as if they had been started by hand. The respawned copy is detached (`start_new_session=True`), wins the race for the dashboard port, and the launchd-managed job then crash-loops on `EADDRINUSE`.

The cause is that managed-process detection is Linux-only. `_get_systemd_service_for_pid` reads `/proc/<pid>/cgroup`; macOS has no `/proc`, so it returns `None` for every pid, and `_kill_stale_dashboard_processes(restart_managed=True)` classifies every launchd job as manually started.

This adds the macOS equivalent: resolve a pid to its launchd service and treat that the same way a systemd unit is treated — let the service manager restart it instead of spawning a detached duplicate.

Observed impact before the fix: a single detached copy won the port and the launchd job logged 2,449 failed spawns, all `[Errno 48] EADDRINUSE`, while an external watchdog reported the service as repeatedly "revived" when it had never actually been down.

## Related Issue

No existing issue — this was diagnosed locally. Happy to open one if you'd prefer it tracked separately.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — add `_get_launchd_service_for_pid`, resolving a pid to its launchd label by parsing `launchctl print` for both the `gui/<uid>` and `user/<uid>` domains. Only a **direct** pid match is treated as actionable: an indirect match (a child process inside a supervised job) is ambiguous, because kickstarting that job would not restart the process in question, so it deliberately returns no service.
- `hermes_cli/dashboard_procs.py` — consult launchd alongside systemd when classifying dashboard processes, and restart managed jobs via `launchctl kickstart -k` using the domain the job was actually found in. Fails closed on ambiguous ownership or an unclear restart result, so the failure mode is "leave it to the service manager" rather than "spawn a detached duplicate".
- `tests/hermes_cli/test_update_stale_dashboard.py` — coverage for both domains, direct vs indirect pid matches, kickstart success and failure paths, and the existing manual-process behaviour.

Behaviour on Linux/systemd, Windows, and for genuinely hand-started macOS processes is unchanged.

## How to Test

1. With a launchd-managed dashboard running, note the listening pid and confirm it matches the job: `launchctl list <your.dashboard.label>`.
2. Run `hermes update`.
3. Before this change, the port is held by a detached process that is no longer the launchd job's pid, and the job crash-loops on `EADDRINUSE`. After it, the listening pid is still the launchd job's pid and no second dashboard process exists.

Automated: `pytest tests/hermes_cli/test_update_stale_dashboard.py -q` → **43 passed, 2 skipped**.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the dashboard-update test suite and it passes (`tests/hermes_cli/test_update_stale_dashboard.py`: 43 passed, 2 skipped). I have not run the full `pytest tests/ -q` suite.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Apple silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing surface changes
- [x] I've updated `cli-config.yaml.example` — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact: the new path is macOS-only and gated behind a platform check; systemd and Windows behaviour is untouched and still covered by the existing tests
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Symptom before the fix, from the launchd job's own log:

```
[Errno 48] EADDRINUSE  (x2449 spawns)
```

The listening socket was held by a detached process whose pid did not match the one reported by `launchctl list`.
