### PR TITLE
feat(gateway): context meter + compaction alerts

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1455,6 +1455,9 @@ def init_agent(
     compression_abort_on_summary_failure = str(
         _compression_cfg.get("abort_on_summary_failure", False)
     ).lower() in {"true", "1", "yes"}
+    # Fraction of the compaction threshold at which to surface a
+    # pre-compaction heads-up (before auto-compaction fires). Default 0.85.
+    compression_warn_at = float(_compression_cfg.get("warn_at", 0.85))
     # In-place compaction: when True, compress_context() rewrites the message
     # list + rebuilds the system prompt WITHOUT rotating the session id (no
     # parent_session_id chain, no `name #N` renumber). See #38763 and
@@ -1702,6 +1705,7 @@ def init_agent(
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
             max_tokens=agent.max_tokens,
+            warn_at=compression_warn_at,
         )
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
     if callable(_bind_session_state):
@@ -1711,6 +1715,11 @@ def init_agent(
             pass
     agent.compression_enabled = compression_enabled
     agent.compression_in_place = compression_in_place
+    # Once-shot guard for the pre-compaction warning (4tp-2). Set True after the
+    # heads-up fires; re-armed when usage drops back below the warn band or a
+    # compaction resets the budget. Lives on the agent (not the compressor) so
+    # plugin context engines without a warn band don't need to carry it.
+    agent._precompaction_warned = False
 
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).

--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -28,6 +28,19 @@ _CATEGORY_COLORS = {
 }
 
 
+def _safe_int(value: Any) -> int:
+    """Coerce *value* to a non-negative int, tolerating Mocks/None/garbage.
+
+    ``getattr`` on a live compressor returns real ints, but tests pass a
+    ``MagicMock`` whose unset attributes are child mocks — ``int(mock)`` raises.
+    """
+    try:
+        ivalue = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return ivalue if ivalue > 0 else 0
+
+
 def _chars_to_tokens(text: str) -> int:
     if not text:
         return 0
@@ -128,12 +141,23 @@ def compute_session_context_breakdown(
     estimated_total = sum(tokens for _, _, tokens in categories)
 
     comp = getattr(agent, "context_compressor", None)
-    context_max = int(getattr(comp, "context_length", 0) or 0) if comp else 0
-    measured_used = int(getattr(comp, "last_prompt_tokens", 0) or 0) if comp else 0
+    context_max = _safe_int(getattr(comp, "context_length", 0)) if comp else 0
+    measured_used = _safe_int(getattr(comp, "last_prompt_tokens", 0)) if comp else 0
     context_used = measured_used if measured_used > 0 else estimated_total
     context_percent = (
         max(0, min(100, round(context_used / context_max * 100)))
         if context_max
+        else 0
+    )
+
+    # Compaction-relative usage: auto-compaction fires at threshold_tokens
+    # (~50% of the effective window), NOT at 100% of the window. This is the
+    # actionable meter — 100% here means "compaction fires now" — and it is the
+    # scale the reply-footer floor and pre-compaction warning are measured on.
+    compaction_threshold = _safe_int(getattr(comp, "threshold_tokens", 0)) if comp else 0
+    compaction_percent = (
+        max(0, round(context_used / compaction_threshold * 100))
+        if compaction_threshold
         else 0
     )
 
@@ -148,6 +172,8 @@ def compute_session_context_breakdown(
             for category_id, label, tokens in categories
             if tokens > 0
         ],
+        "compaction_percent": compaction_percent,
+        "compaction_threshold": compaction_threshold,
         "context_max": context_max,
         "context_percent": context_percent,
         "context_used": context_used,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -966,6 +966,7 @@ class ContextCompressor(ContextEngine):
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
         max_tokens: int | None = None,
+        warn_at: float = 0.85,
     ):
         self.model = model
         self.base_url = base_url
@@ -1004,6 +1005,13 @@ class ContextCompressor(ContextEngine):
         self.threshold_tokens = self._compute_threshold_tokens(
             self.context_length, threshold_percent, self.max_tokens,
         )
+        # Fraction of the compaction threshold at which we surface a
+        # pre-compaction heads-up (before auto-compaction actually fires).
+        # ``warn_threshold_tokens`` is a property so it tracks any later
+        # change to ``threshold_tokens`` (feasibility auto-lower, update_model)
+        # without a manual re-sync.  Clamp to (0, 1]: a value <=0 or >1 would
+        # disable the warning or make it fire only at/after compaction.
+        self.warn_at = max(0.01, min(float(warn_at), 1.0))
         self.compression_count = 0
 
         # Derive token budgets: ratio is relative to the threshold, not total context
@@ -1132,6 +1140,31 @@ class ContextCompressor(ContextEngine):
 
         self.last_rough_tokens_when_real_prompt_fit = max(baseline, rough_tokens)
         return True
+
+    @property
+    def warn_threshold_tokens(self) -> int:
+        """Token count at which to emit the pre-compaction heads-up.
+
+        Derived (not stored) so it always reflects the current
+        ``threshold_tokens`` — which can change after construction via the
+        feasibility auto-lower path and ``update_model``.
+        """
+        return int(self.threshold_tokens * self.warn_at)
+
+    def should_warn(self, prompt_tokens: int = None) -> bool:
+        """True when usage has entered the pre-compaction warning band.
+
+        The band is ``[warn_threshold_tokens, threshold_tokens)`` — usage is
+        approaching compaction but has not yet crossed it, so a heads-up can
+        still be acted on (e.g. ``/handoff``) before the middle of the session
+        gets summarized away.  At/above ``threshold_tokens`` this returns False
+        (``should_compress`` owns that band); a non-positive count (unknown /
+        the post-compaction ``-1`` sentinel) also returns False.
+        """
+        tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
+        if tokens <= 0:
+            return False
+        return self.warn_threshold_tokens <= tokens < self.threshold_tokens
 
     def should_compress(self, prompt_tokens: int = None) -> bool:
         """Check if context exceeds the compression threshold.

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -897,20 +897,11 @@ def compress_context(
         except Exception as _me_err:
             logger.debug("memory manager on_session_switch (compression): %s", _me_err)
 
-        # Warn on repeated compressions (quality degrades with each pass).
-        # Route through _emit_status (like the other compression warnings above)
-        # so the warning reaches the TUI / Telegram / Discord via status_callback,
-        # not just CLI stdout. _emit_status still _vprints for the CLI, and
-        # storing it on _compression_warning lets replay_compression_warning
-        # re-deliver it once a late-bound gateway status_callback is wired (#36908).
+        # Repeated-compression escalation is folded into the delivered
+        # post-compaction caveat below (4tp-2), which reaches Telegram/Discord
+        # instead of being dropped by the gateway noise filter like the old
+        # "Session compressed N times" status was.
         _cc = agent.context_compressor.compression_count
-        if _cc >= 2:
-            _cc_msg = (
-                f"{agent.log_prefix}⚠️  Session compressed {_cc} times — "
-                f"accuracy may degrade. Consider /new to start fresh."
-            )
-            agent._compression_warning = _cc_msg
-            agent._emit_status(_cc_msg)
 
         # Emit session:compress event so hooks (e.g. MemPalace sync) can ingest
         # the completed old session before its details are lost. In in-place mode
@@ -946,6 +937,40 @@ def compress_context(
         agent.context_compressor.last_prompt_tokens = -1
         agent.context_compressor.last_completion_tokens = 0
         agent.context_compressor.awaiting_real_usage_after_compression = True
+
+        # ── Delivered compaction notice + post-compaction caveat (4tp-2) ─────────
+        # The transient "Compacting context…" start line is filtered out of chat
+        # gateways by the noise regex (gateway/run.py). Once the summary lands,
+        # emit an explicit, delivered notice — worded so it passes that filter — so
+        # Sven actually sees on Telegram that context was dropped, plus a caveat on
+        # what may have been lost and how to recover. Escalates when the session has
+        # been compacted repeatedly (the silent-double-compaction failure mode).
+        def _fmt_k(n: Optional[int]) -> str:
+            if not n or n <= 0:
+                return ""
+            return f"{n / 1000:.0f}K" if n >= 1000 else str(int(n))
+
+        _pre_k, _post_k = _fmt_k(approx_tokens), _fmt_k(_compressed_est)
+        _size = f", ~{_pre_k}→{_post_k} tokens" if (_pre_k and _post_k) else ""
+        _caveat = (
+            f"🗜️ Compacted — summarized the earlier middle of this session "
+            f"({_pre_msg_count}→{len(compressed)} messages{_size}).\n"
+            "⚠️ I may have dropped fine detail from the middle (exact code, side "
+            "decisions). If I seem to forget something, paste it back — or run "
+            "/handoff before /new."
+        )
+        if _cc >= 2:
+            _caveat += (
+                f" This session has been compacted {_cc}× now; accuracy may be "
+                "degrading — consider /new for a fresh start."
+            )
+        # _emit_warning (status_key "warn"), not _emit_status ("lifecycle"): the
+        # caveat gets its own gateway bubble so transient lifecycle progress lines
+        # can't overwrite it — it stays visible ("delivered, non-transient").
+        agent._emit_warning(_caveat)
+        # Re-arm the pre-compaction heads-up: usage just dropped well below the
+        # warn band, so the next approach to the threshold should warn again.
+        agent._precompaction_warned = False
 
         # Clear the file-read dedup cache.  After compression the original
         # read content is summarised away — if the model re-reads the same

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2100,6 +2100,11 @@ def run_conversation(
                     }
                     agent.context_compressor.update_from_response(usage_dict)
 
+                    # Pre-compaction heads-up: warn once as real usage nears the
+                    # compaction threshold, before it fires (4tp-2). Uses the
+                    # provider-reported prompt_tokens — the authoritative signal.
+                    agent._maybe_warn_precompaction(prompt_tokens)
+
                     # Cache discovered context length after successful call.
                     # Only persist limits confirmed by the provider (parsed
                     # from the error message), not guessed probe tiers.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -410,7 +410,13 @@ compression:
   # Trigger compression at this % of model's context limit (default: 0.50 = 50%)
   # Lower values = more aggressive compression, higher values = compress later
   threshold: 0.50
-  
+
+  # Surface a pre-compaction heads-up once usage reaches this fraction of the
+  # compaction threshold, before compaction fires (default: 0.85 = 85%).
+  # e.g. with threshold 0.50, the warning fires around 42.5% of the window.
+  # Gives you a chance to /handoff before the middle of the session is dropped.
+  warn_at: 0.85
+
   # Fraction of the threshold to preserve as recent tail (default: 0.20 = 20%)
   # e.g. 20% of 50% threshold = 10% of total context kept as recent messages.
   # Summary output is separately capped at 12K tokens (Gemini output limit).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8997,6 +8997,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _evt_cmd = event.get_command()
             _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
 
+            # /context is read-only session info (like /status) — always answer
+            # it mid-run and pre-gate so users can see context pressure even
+            # while a turn is in flight.
+            if _cmd_def_inner and _cmd_def_inner.name == "context":
+                return await self._handle_context_command(event)
+
             # Slash command access control on the running-agent fast-path.
             # Mirrors the cold-path gate further below so non-admin users
             # can't bypass gating just because an agent happens to be busy.
@@ -9495,6 +9501,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "status":
             return await self._handle_status_command(event)
+
+        if canonical == "context":
+            return await self._handle_context_command(event)
 
         if canonical == "agents":
             return await self._handle_agents_command(event)
@@ -11376,19 +11385,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     else:
                         response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
 
-            # Runtime-metadata footer — only on the FINAL message of the turn.
-            # Off by default (display.runtime_footer.enabled=false).  When
-            # streaming already delivered the body, we can't mutate the sent
-            # text, so we fire a separate trailing send below.
+            # Runtime-metadata / context-meter footer — only on the FINAL
+            # message of the turn. The manual footer is off by default
+            # (display.runtime_footer.enabled=false), but the meter footer
+            # surfaces on its own once context pressure crosses the floor
+            # (display.context_meter.footer_floor). When streaming already
+            # delivered the body, we can't mutate the sent text, so we fire a
+            # separate trailing send below.
             _footer_line = ""
             try:
-                from gateway.runtime_footer import build_footer_line as _bfl
-                _footer_line = _bfl(
+                from gateway.runtime_footer import build_meter_footer as _bmf
+                _footer_line = _bmf(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
+                    threshold_tokens=agent_result.get("threshold_tokens") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                 )
             except Exception as _footer_err:
@@ -18340,12 +18353,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _input_toks = 0
             _output_toks = 0
             _context_length = 0
+            _threshold_toks = 0
             _agent = agent_holder[0]
             if _agent and hasattr(_agent, "context_compressor"):
                 _last_prompt_toks = getattr(_agent.context_compressor, "last_prompt_tokens", 0)
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
                 _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
+                _threshold_toks = getattr(_agent.context_compressor, "threshold_tokens", 0) or 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
             # Sync session_id immediately after run_conversation(). Compression
@@ -18475,6 +18490,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
                     "context_length": _context_length,
+                    "threshold_tokens": _threshold_toks,
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -18575,6 +18591,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
                 "context_length": _context_length,
+                "threshold_tokens": _threshold_toks,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
                 "response_transformed": result.get("response_transformed", False),

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -10,10 +10,17 @@ Config (``~/.hermes/config.yaml``)::
       runtime_footer:
         enabled: true                       # off by default
         fields: [model, context_pct, cwd]   # order shown; drop any to hide
+      context_meter:
+        footer_floor: 0.70                  # always-on meter kicks in here
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
 and any gateway platform.
+
+Even with the manual footer off, an always-on meter footer surfaces once
+context pressure crosses ``context_meter.footer_floor`` — the fraction of the
+way to auto-compaction (default 70%) — so a silent compaction never sneaks up.
+See ``build_meter_footer``.
 
 The footer is appended to the final response text in ``gateway/run.py`` right
 before returning the response to the adapter send path — so it only lands on
@@ -29,7 +36,59 @@ import os
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+# Fields for the always-on footer that appears once context pressure crosses
+# the floor even when the manual footer is off. Headlines the compaction meter.
+_METER_FIELDS: tuple[str, ...] = ("model", "compaction", "cwd")
 _SEP = " · "
+
+# Fraction of the way to auto-compaction at which the reply footer starts
+# showing on its own (even with the manual footer off). Tunable via
+# ``display.context_meter.footer_floor``. 0.70 = surface at 70% of the way to
+# the ~50%-of-window compaction point (i.e. ~35% of the raw window).
+_DEFAULT_FOOTER_FLOOR = 0.70
+
+
+def compaction_percent(context_tokens: int, threshold_tokens: Optional[int]) -> Optional[int]:
+    """Return usage as a % of the compaction threshold, or None if unknown.
+
+    100 means auto-compaction fires now. Can exceed 100 (compaction is checked
+    after a send, so usage briefly overshoots the trigger).
+    """
+    if threshold_tokens and threshold_tokens > 0 and context_tokens >= 0:
+        return max(0, round((context_tokens / threshold_tokens) * 100))
+    return None
+
+
+def _compaction_marker(pct: int) -> str:
+    """Render the compaction-pressure field: an emoji tier plus the percentage."""
+    if pct >= 100:
+        emoji = "🔴"
+    elif pct >= 85:
+        emoji = "🟠"
+    else:
+        emoji = "🟡"
+    return f"{emoji} {pct}% to compaction"
+
+
+def resolve_meter_config(user_config: dict[str, Any] | None) -> dict[str, Any]:
+    """Resolve the always-on context-meter footer config.
+
+    ``display.context_meter.footer_floor`` — fraction (0-1) of the way to
+    auto-compaction at which the footer surfaces on its own. Values outside
+    (0, 1] fall back to the default so a stray 0/negative can't either spam
+    every reply or silence the meter entirely.
+    """
+    floor = _DEFAULT_FOOTER_FLOOR
+    cfg = (user_config or {}).get("display") or {}
+    meter = cfg.get("context_meter")
+    if isinstance(meter, dict) and "footer_floor" in meter:
+        try:
+            candidate = float(meter["footer_floor"])
+            if 0.0 < candidate <= 1.0:
+                floor = candidate
+        except (TypeError, ValueError):
+            pass
+    return {"footer_floor": floor}
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -95,6 +154,7 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    threshold_tokens: Optional[int] = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
@@ -111,6 +171,10 @@ def format_runtime_footer(
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
                 parts.append(f"{pct}%")
+        elif field == "compaction":
+            pct = compaction_percent(context_tokens, threshold_tokens)
+            if pct is not None:
+                parts.append(_compaction_marker(pct))
         elif field == "cwd":
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
@@ -130,13 +194,9 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    threshold_tokens: Optional[int] = None,
 ) -> str:
-    """Top-level entry point used by gateway/run.py.
-
-    Returns the footer text (empty string when disabled or no data).  Callers
-    append this to the final response themselves, preserving a single blank
-    line of separation.
-    """
+    """Manual runtime footer (``/footer on``). Empty when disabled or no data."""
     cfg = resolve_footer_config(user_config, platform_key)
     if not cfg.get("enabled"):
         return ""
@@ -146,4 +206,61 @@ def build_footer_line(
         context_length=context_length,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        threshold_tokens=threshold_tokens,
     )
+
+
+def build_meter_footer(
+    *,
+    user_config: dict[str, Any] | None,
+    platform_key: str | None,
+    model: Optional[str],
+    context_tokens: int,
+    context_length: Optional[int],
+    threshold_tokens: Optional[int] = None,
+    cwd: Optional[str] = None,
+) -> str:
+    """Top-level footer entry point used by gateway/run.py.
+
+    Two ways a footer lands on a reply:
+      1. The user turned it on with ``/footer on`` → the configured manual
+         footer, unchanged. If context pressure is also past the floor, the
+         compaction marker is appended so the warning rides along.
+      2. The footer is off but context pressure has crossed
+         ``display.context_meter.footer_floor`` (default 70% of the way to
+         auto-compaction) → an always-on meter footer surfaces on its own so a
+         silent compaction never sneaks up.
+
+    Returns "" when neither applies. The caller appends this to the final
+    reply, preserving one blank line of separation.
+    """
+    manual = build_footer_line(
+        user_config=user_config,
+        platform_key=platform_key,
+        model=model,
+        context_tokens=context_tokens,
+        context_length=context_length,
+        cwd=cwd,
+        threshold_tokens=threshold_tokens,
+    )
+
+    pct = compaction_percent(context_tokens, threshold_tokens)
+    floor_pct = resolve_meter_config(user_config)["footer_floor"] * 100
+    past_floor = pct is not None and pct >= floor_pct
+
+    if manual:
+        # Manual footer already shows the compaction field → don't double it.
+        if past_floor and "to compaction" not in manual:
+            return f"{manual}{_SEP}{_compaction_marker(pct)}"
+        return manual
+
+    if past_floor:
+        return format_runtime_footer(
+            model=model,
+            context_tokens=context_tokens,
+            context_length=context_length,
+            cwd=cwd,
+            fields=_METER_FIELDS,
+            threshold_tokens=threshold_tokens,
+        )
+    return ""

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -643,6 +643,119 @@ class GatewaySlashCommandsMixin:
 
         return "\n".join(lines)
 
+    async def _handle_context_command(self, event: MessageEvent) -> str:
+        """Handle /context — live context-window usage + per-category breakdown.
+
+        Headlines usage as a % of the auto-compaction point (compaction fires
+        at ~50% of the window, not 100%), the actionable number for seeing a
+        silent compaction coming. Falls back to the cached agent between turns.
+        """
+        from gateway.run import _AGENT_PENDING_SENTINEL
+
+        source = event.source
+        session_entry = self.session_store.get_or_create_session(source)
+        session_key = session_entry.session_key
+
+        # Prefer the live running agent; fall back to the cached one from the
+        # last turn (mirrors /status). The breakdown needs a real agent to read
+        # the system-prompt tiers, tools, and memory blocks.
+        agent = self._running_agents.get(session_key)
+        if agent is None or agent is _AGENT_PENDING_SENTINEL:
+            agent = None
+            cache_lock = getattr(self, "_agent_cache_lock", None)
+            cache = getattr(self, "_agent_cache", None)
+            if cache_lock is not None and cache is not None:
+                try:
+                    with cache_lock:
+                        cached = cache.get(session_key)
+                    if cached:
+                        agent = cached[0]
+                except Exception:
+                    agent = None
+
+        if agent is None or agent is _AGENT_PENDING_SENTINEL:
+            return t("gateway.context.no_agent")
+
+        # Transcript for the conversation category. Prefer the live agent's
+        # message buffer, fall back to the persisted transcript. The headline %
+        # uses measured tokens regardless, so an empty history only zeroes the
+        # conversation line — never the top-line number.
+        history: list = []
+        try:
+            live_msgs = getattr(agent, "_session_messages", None)
+            if isinstance(live_msgs, list) and live_msgs:
+                history = live_msgs
+            else:
+                history = self.session_store.load_transcript(session_entry.session_id) or []
+        except Exception:
+            history = []
+
+        try:
+            from agent.context_breakdown import compute_session_context_breakdown
+
+            data = compute_session_context_breakdown(agent, history)
+        except Exception as exc:
+            logger.debug("context breakdown failed: %s", exc)
+            return t("gateway.context.unavailable")
+
+        model = data.get("model") or ""
+        used = int(data.get("context_used") or 0)
+        context_max = int(data.get("context_max") or 0)
+        threshold = int(data.get("compaction_threshold") or 0)
+        comp_pct = int(data.get("compaction_percent") or 0)
+        window_pct = int(data.get("context_percent") or 0)
+
+        lines = [
+            t("gateway.context.header", model=model)
+            if model
+            else t("gateway.context.header_no_model"),
+            "",
+        ]
+
+        if threshold > 0:
+            # Full gauge: green while healthy, escalating as compaction nears.
+            emoji = "🔴" if comp_pct >= 100 else ("🟠" if comp_pct >= 85 else "🟢")
+            lines.append(t("gateway.context.headline", emoji=emoji, pct=comp_pct))
+            lines.append(
+                t("gateway.context.toward", used=f"{used:,}", threshold=f"{threshold:,}")
+            )
+            if context_max > 0:
+                comp_at = max(1, round(threshold / context_max * 100))
+                lines.append(
+                    t(
+                        "gateway.context.window",
+                        window_pct=window_pct,
+                        max=f"{context_max:,}",
+                        comp_at=comp_at,
+                    )
+                )
+        elif context_max > 0:
+            lines.append(
+                t(
+                    "gateway.context.no_threshold",
+                    used=f"{used:,}",
+                    window_pct=window_pct,
+                    max=f"{context_max:,}",
+                )
+            )
+
+        categories = data.get("categories") or []
+        if categories:
+            lines.append("")
+            lines.append(t("gateway.context.breakdown_header"))
+            for cat in sorted(
+                categories, key=lambda c: c.get("tokens", 0), reverse=True
+            ):
+                lines.append(
+                    t(
+                        "gateway.context.category_line",
+                        label=cat.get("label", ""),
+                        tokens=f"{int(cat.get('tokens', 0)):,}",
+                    )
+                )
+
+        return "\n".join(lines)
+
     @staticmethod
     def _redact_matrix_session_key(session_key: str) -> str:
         """Return a stable Matrix session-key fingerprint for shared room status."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -118,6 +118,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("subgoal", "Add or manage extra criteria on the active goal", "Session",
                args_hint="[text | remove N | clear]"),
     CommandDef("status", "Show session, model, token, and context info", "Session"),
+    CommandDef("context", "Show context-window usage and per-category breakdown", "Info",
+               aliases=("ctx",), gateway_only=True),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -305,6 +305,18 @@ gateway:
     queued:                "**Queued follow-ups:** {count}"
     platforms:             "**Connected Platforms:** {platforms}"
 
+  context:
+    header:                "🧭 **Context** — `{model}`"
+    header_no_model:       "🧭 **Context**"
+    headline:              "{emoji} **{pct}% to auto-compaction**"
+    toward:                "{used} / {threshold} tok toward compaction"
+    window:                "_{window_pct}% of {max} window · compaction at ~{comp_at}%_"
+    breakdown_header:      "**Breakdown:**"
+    category_line:         "• {label} — {tokens}"
+    no_threshold:          "**Context:** {used} tokens used ({window_pct}% of {max} window)"
+    no_agent:              "🧭 No active agent in this session yet — send a message first, then /context shows the live breakdown."
+    unavailable:           "🧭 Context data isn't available for this session yet."
+
   stop:
     stopped_pending:       "⚡ Stopped. The agent hadn't started yet — you can continue this session."
     stopped:               "⚡ Stopped. You can continue this session."

--- a/run_agent.py
+++ b/run_agent.py
@@ -919,6 +919,45 @@ class AIAgent:
             except Exception:
                 logger.debug("status_callback error in _emit_warning", exc_info=True)
 
+    def _maybe_warn_precompaction(self, prompt_tokens: int) -> None:
+        """Emit a one-shot heads-up as usage approaches the compaction point.
+
+        Fires once when real usage enters the pre-compaction band
+        (``warn_threshold_tokens <= tokens < threshold_tokens``), before
+        auto-compaction actually summarizes the middle of the session — so the
+        user can ``/handoff`` first if they're mid-something delicate.  The
+        one-shot re-arms when usage drops back under the band (compaction
+        resets ``_precompaction_warned`` directly).  (4tp-2)
+
+        Never raises: a warning must never break the turn loop.
+        """
+        try:
+            if not getattr(self, "compression_enabled", False):
+                return
+            comp = getattr(self, "context_compressor", None)
+            should_warn = getattr(comp, "should_warn", None)
+            if comp is None or not callable(should_warn):
+                return  # plugin context engine without a warn band
+            if not should_warn(prompt_tokens):
+                # Below the band → re-arm so a later approach warns again.
+                if prompt_tokens < getattr(comp, "warn_threshold_tokens", 0):
+                    self._precompaction_warned = False
+                return
+            if getattr(self, "_precompaction_warned", False):
+                return
+            self._precompaction_warned = True
+            threshold = getattr(comp, "threshold_tokens", 0) or 0
+            pct = int(prompt_tokens / threshold * 100) if threshold else 0
+            # _emit_warning (status_key "warn") keeps the heads-up in its own
+            # gateway bubble, separate from transient lifecycle progress lines.
+            self._emit_warning(
+                f"⚠️ Approaching compaction (~{pct}% of the compaction budget). "
+                "The next big turn may summarize-and-drop the middle of this "
+                "session. If you're mid-something delicate, /handoff first."
+            )
+        except Exception:
+            logger.debug("precompaction warning failed", exc_info=True)
+
     def _emit_notice(self, notice) -> None:
         """Fire a structured ``AgentNotice`` to the active driver (TUI / CLI).
 

--- a/tests/agent/test_compression_count_warning_36908.py
+++ b/tests/agent/test_compression_count_warning_36908.py
@@ -1,12 +1,18 @@
-"""Regression for #36908: the repeated-compression warning must reach the
-TUI / gateway, not just CLI stdout.
+"""Regression for #36908 + 4tp-2: the repeated-compression escalation must
+reach the TUI / gateway, not just CLI stdout.
 
-When a session is compressed >= 2 times, ``compress_context`` warns that
-accuracy may degrade. That warning used to go through ``_vprint`` (stdout
-only), so the Ink TUI / Telegram / Discord never saw it — unlike the two
-other compression warnings in the same module, which route through
-``_emit_status`` (and store ``_compression_warning`` for late-bound
-gateway replay). This pins the warning onto the gateway-aware channel.
+Originally (#36908) the "compressed N times — accuracy may degrade" warning
+went through ``_vprint`` (stdout only), so the Ink TUI / Telegram / Discord
+never saw it. It was moved onto ``_emit_status`` — but the gateway noise
+filter (gateway/run.py) then re-suppressed that exact phrasing on chat
+surfaces, so on Telegram the repeated-compaction signal was silently dropped
+again (Sven's "quality craters after a double compaction with no marker").
+
+4tp-2 folds the escalation into the delivered post-compaction caveat, which is
+worded to pass the gateway noise filter. This pins that:
+  * every successful compaction emits a delivered notice via ``_emit_status``;
+  * from the 2nd compaction on, that notice carries the degradation escalation;
+  * the escalation is absent on the 1st compaction.
 """
 
 from __future__ import annotations
@@ -49,39 +55,52 @@ def _build_agent_with_db(db: SessionDB, session_id: str, compression_count: int)
     return agent
 
 
-def test_repeated_compression_warning_routed_through_emit_status(tmp_path: Path) -> None:
+def test_repeated_compression_escalation_reaches_emit_status(tmp_path: Path) -> None:
     db = SessionDB(db_path=tmp_path / "state.db")
     sid = "PARENT_36908"
     db.create_session(sid, source="cli")
 
-    # compression_count == 2 → the "compressed N times" warning should fire.
+    # compression_count == 2 → the delivered caveat carries the escalation.
     agent = _build_agent_with_db(db, sid, compression_count=2)
 
     emitted: list[str] = []
-    agent._emit_status = lambda message: emitted.append(message)
+    agent._emit_warning = lambda message: emitted.append(message)
 
     messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
     agent._compress_context(messages, "sys", approx_tokens=120_000)
 
-    # The warning reached the gateway-aware channel...
-    assert any("compressed 2 times" in m.lower() for m in emitted), (
-        f"repeated-compression warning not emitted via _emit_status: {emitted}"
-    )
-    # ...and was stored for late-bound gateway status_callback replay.
-    assert "compressed 2 times" in (getattr(agent, "_compression_warning", "") or "").lower()
+    # A delivered compaction caveat reached the gateway-aware channel...
+    caveats = [m for m in emitted if "compacted" in m.lower()]
+    assert caveats, f"no delivered compaction caveat via _emit_status: {emitted}"
+    # ...and it escalates on repeated compaction (worded to pass the gateway
+    # noise filter — NOT the old "compressed N times" phrasing it dropped).
+    joined = " ".join(caveats).lower()
+    assert "2×" in joined
+    assert "degrad" in joined
+
+    # Sanity: the escalation is worded so the Telegram noise filter lets it
+    # through, unlike the old "Session compressed N times" status.
+    from gateway.run import _prepare_gateway_status_message
+    from gateway.config import Platform
+
+    assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", caveats[0]) is not None
 
 
-def test_no_warning_below_threshold(tmp_path: Path) -> None:
+def test_first_compaction_caveat_has_no_repeat_escalation(tmp_path: Path) -> None:
     db = SessionDB(db_path=tmp_path / "state.db")
     sid = "PARENT_36908_ONCE"
     db.create_session(sid, source="cli")
 
-    # compression_count == 1 → no repeated-compression warning.
+    # compression_count == 1 → the caveat fires but without the repeat escalation.
     agent = _build_agent_with_db(db, sid, compression_count=1)
     emitted: list[str] = []
-    agent._emit_status = lambda message: emitted.append(message)
+    agent._emit_warning = lambda message: emitted.append(message)
 
     messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
     agent._compress_context(messages, "sys", approx_tokens=120_000)
 
-    assert not any("compressed" in m.lower() and "times" in m.lower() for m in emitted)
+    caveats = [m for m in emitted if "compacted" in m.lower()]
+    assert caveats, f"no delivered compaction caveat via _emit_status: {emitted}"
+    joined = " ".join(caveats).lower()
+    assert "×" not in joined
+    assert "degrad" not in joined

--- a/tests/agent/test_context_breakdown.py
+++ b/tests/agent/test_context_breakdown.py
@@ -13,6 +13,7 @@ def _make_agent(
     tools: list | None = None,
     context_length: int = 200_000,
     last_prompt_tokens: int = 0,
+    threshold_tokens: int = 100_000,
 ):
     agent = MagicMock()
     agent.model = "openai/gpt-5.4"
@@ -27,6 +28,7 @@ def _make_agent(
     agent.context_compressor = MagicMock(
         context_length=context_length,
         last_prompt_tokens=last_prompt_tokens,
+        threshold_tokens=threshold_tokens,
     )
     return agent, {"stable": stable, "context": context, "volatile": volatile}
 
@@ -58,3 +60,26 @@ def test_breakdown_uses_measured_context_when_available():
 
     assert data["context_used"] == 42_000
     assert data["context_percent"] == 21
+
+
+def test_breakdown_reports_compaction_relative_percent():
+    # 70k used against a 100k compaction threshold → 70% of the way to compaction,
+    # even though that's only 35% of a 200k window.
+    agent, parts = _make_agent(last_prompt_tokens=70_000, threshold_tokens=100_000)
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        data = compute_session_context_breakdown(agent, [])
+
+    assert data["compaction_threshold"] == 100_000
+    assert data["compaction_percent"] == 70
+    assert data["context_percent"] == 35
+
+
+def test_breakdown_compaction_percent_zero_without_threshold():
+    agent, parts = _make_agent(last_prompt_tokens=42_000, threshold_tokens=0)
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        data = compute_session_context_breakdown(agent, [])
+
+    assert data["compaction_threshold"] == 0
+    assert data["compaction_percent"] == 0

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -46,6 +46,50 @@ class TestShouldCompress:
 
 
 
+class TestShouldWarn:
+    # Fixture: context 100_000, threshold_percent 0.85 → threshold_tokens 85_000,
+    # warn_at default 0.85 → warn_threshold_tokens 72_250.
+    def test_below_warn_band(self, compressor):
+        assert compressor.should_warn(70_000) is False
+
+    def test_at_warn_threshold(self, compressor):
+        assert compressor.warn_threshold_tokens == 72_250
+        assert compressor.should_warn(72_250) is True
+
+    def test_inside_warn_band(self, compressor):
+        assert compressor.should_warn(80_000) is True
+
+    def test_at_or_above_compaction_threshold_does_not_warn(self, compressor):
+        # should_compress owns this band.
+        assert compressor.should_warn(85_000) is False
+        assert compressor.should_warn(90_000) is False
+
+    def test_non_positive_tokens_never_warn(self, compressor):
+        assert compressor.should_warn(0) is False
+        assert compressor.should_warn(-1) is False  # post-compaction sentinel
+
+    def test_uses_last_prompt_tokens_when_unspecified(self, compressor):
+        compressor.last_prompt_tokens = 75_000
+        assert compressor.should_warn() is True
+        compressor.last_prompt_tokens = 60_000
+        assert compressor.should_warn() is False
+
+    def test_warn_threshold_tracks_threshold_changes(self, compressor):
+        # The property is derived, so lowering threshold_tokens (e.g. aux
+        # feasibility auto-lower) moves the warn band with it.
+        compressor.threshold_tokens = 50_000
+        assert compressor.warn_threshold_tokens == 42_500
+        assert compressor.should_warn(45_000) is True
+        assert compressor.should_warn(40_000) is False
+
+    def test_warn_at_is_clamped(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            hi = ContextCompressor(model="m", threshold_percent=0.85, warn_at=1.5, quiet_mode=True)
+            assert hi.warn_at == 1.0  # never warn only at/after compaction
+            lo = ContextCompressor(model="m", threshold_percent=0.85, warn_at=0.0, quiet_mode=True)
+            assert lo.warn_at == 0.01
+
+
 class TestUpdateFromResponse:
     def test_updates_fields(self, compressor):
         compressor.awaiting_real_usage_after_compression = True

--- a/tests/agent/test_precompaction_warning_4tp2.py
+++ b/tests/agent/test_precompaction_warning_4tp2.py
@@ -1,0 +1,100 @@
+"""4tp-2: pre-compaction heads-up fires once as usage nears the threshold.
+
+``AIAgent._maybe_warn_precompaction`` should:
+  * emit exactly one heads-up while usage is in the warn band
+    (``warn_threshold_tokens <= tokens < threshold_tokens``);
+  * stay quiet at/above the compaction threshold (that's ``should_compress``);
+  * re-arm once usage drops back below the band, so a later approach warns
+    again;
+  * produce copy that passes the gateway noise filter (so it reaches Telegram,
+    unlike the transient "Compacting context…" line).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor
+from run_agent import AIAgent
+
+
+class _FakeAgent:
+    """Minimal duck type carrying only what the helper touches."""
+
+    def __init__(self, compressor):
+        self.compression_enabled = True
+        self.context_compressor = compressor
+        self._precompaction_warned = False
+        self.emitted: list[str] = []
+
+    def _emit_warning(self, message: str) -> None:
+        self.emitted.append(message)
+
+    # Bind the real, unbound method under test.
+    warn = AIAgent._maybe_warn_precompaction
+
+
+def _compressor():
+    # context 100_000 · threshold 85_000 · warn band starts at 72_250.
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        return ContextCompressor(model="m", threshold_percent=0.85, quiet_mode=True)
+
+
+def test_warns_once_in_band_then_stays_quiet():
+    agent = _FakeAgent(_compressor())
+    agent.warn(75_000)
+    agent.warn(78_000)  # still in band, but already warned
+    assert len(agent.emitted) == 1
+    assert "approaching compaction" in agent.emitted[0].lower()
+
+
+def test_no_warning_below_band():
+    agent = _FakeAgent(_compressor())
+    agent.warn(60_000)
+    assert agent.emitted == []
+
+
+def test_no_warning_at_or_above_threshold():
+    agent = _FakeAgent(_compressor())
+    agent.warn(90_000)  # compaction territory — should_compress owns this
+    assert agent.emitted == []
+
+
+def test_rearms_after_dropping_below_band():
+    agent = _FakeAgent(_compressor())
+    agent.warn(75_000)          # warns
+    agent.warn(50_000)          # drops below band → re-arm
+    assert agent._precompaction_warned is False
+    agent.warn(75_000)          # approaches again → warns again
+    assert len(agent.emitted) == 2
+
+
+def test_disabled_compression_never_warns():
+    agent = _FakeAgent(_compressor())
+    agent.compression_enabled = False
+    agent.warn(75_000)
+    assert agent.emitted == []
+
+
+def test_plugin_engine_without_warn_band_is_safe():
+    class _NoWarn:
+        warn_threshold_tokens = 0
+        threshold_tokens = 85_000
+        # no should_warn method
+
+    agent = _FakeAgent(_NoWarn())
+    agent.warn(75_000)  # must not raise
+    assert agent.emitted == []
+
+
+def test_warning_copy_passes_gateway_noise_filter():
+    from gateway.run import _prepare_gateway_status_message
+    from gateway.config import Platform
+
+    agent = _FakeAgent(_compressor())
+    agent.warn(75_000)
+    assert agent.emitted
+    assert (
+        _prepare_gateway_status_message(Platform.TELEGRAM, "warn", agent.emitted[0])
+        is not None
+    )

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -8,11 +8,15 @@ import os
 import pytest
 
 from gateway.runtime_footer import (
+    _compaction_marker,
     _home_relative_cwd,
     _model_short,
     build_footer_line,
+    build_meter_footer,
+    compaction_percent,
     format_runtime_footer,
     resolve_footer_config,
+    resolve_meter_config,
 )
 
 
@@ -260,3 +264,173 @@ def test_build_footer_no_data_returns_empty_even_when_enabled():
     # With no TERMINAL_CWD env either
     if not os.environ.get("TERMINAL_CWD"):
         assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# compaction_percent + _compaction_marker — the context-meter primitives
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "tokens,threshold,expected",
+    [
+        (3500, 5000, 70),     # 70% of the way to compaction
+        (5000, 5000, 100),    # compaction fires now
+        (6000, 5000, 120),    # overshoot allowed (checked after send)
+        (0, 5000, 0),
+    ],
+)
+def test_compaction_percent_basic(tokens, threshold, expected):
+    assert compaction_percent(tokens, threshold) == expected
+
+
+@pytest.mark.parametrize("threshold", [None, 0, -10])
+def test_compaction_percent_none_when_threshold_unknown(threshold):
+    assert compaction_percent(50_000, threshold) is None
+
+
+def test_compaction_percent_none_for_negative_tokens():
+    assert compaction_percent(-5, 5000) is None
+
+
+@pytest.mark.parametrize(
+    "pct,emoji",
+    [(70, "🟡"), (84, "🟡"), (85, "🟠"), (99, "🟠"), (100, "🔴"), (130, "🔴")],
+)
+def test_compaction_marker_emoji_tiers(pct, emoji):
+    marker = _compaction_marker(pct)
+    assert marker.startswith(emoji)
+    assert f"{pct}% to compaction" in marker
+
+
+# ---------------------------------------------------------------------------
+# format_runtime_footer — compaction field
+# ---------------------------------------------------------------------------
+
+def test_format_footer_compaction_field():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=3500,
+        context_length=100_000,
+        cwd="",
+        fields=("model", "compaction"),
+        threshold_tokens=5000,
+    )
+    assert out == "gpt-5.4 · 🟡 70% to compaction"
+
+
+def test_format_footer_compaction_field_dropped_without_threshold():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=3500,
+        context_length=100_000,
+        cwd="",
+        fields=("model", "compaction"),
+        threshold_tokens=None,
+    )
+    assert out == "gpt-5.4"
+
+
+# ---------------------------------------------------------------------------
+# resolve_meter_config
+# ---------------------------------------------------------------------------
+
+def test_resolve_meter_default_floor():
+    assert resolve_meter_config({})["footer_floor"] == 0.70
+    assert resolve_meter_config(None)["footer_floor"] == 0.70
+
+
+def test_resolve_meter_custom_floor():
+    user = {"display": {"context_meter": {"footer_floor": 0.5}}}
+    assert resolve_meter_config(user)["footer_floor"] == 0.5
+
+
+@pytest.mark.parametrize("bad", [0, -0.2, 1.5, "high", None])
+def test_resolve_meter_out_of_range_falls_back(bad):
+    user = {"display": {"context_meter": {"footer_floor": bad}}}
+    assert resolve_meter_config(user)["footer_floor"] == 0.70
+
+
+# ---------------------------------------------------------------------------
+# build_meter_footer — manual toggle + always-on-past-floor behavior
+# ---------------------------------------------------------------------------
+
+def _meter(**kw):
+    base = dict(
+        user_config={},
+        platform_key="telegram",
+        model="openai/gpt-5.4",
+        context_length=200_000,
+        cwd="",
+    )
+    base.update(kw)
+    return build_meter_footer(**base)
+
+
+def test_meter_footer_silent_below_floor(monkeypatch):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    # 60% to compaction, floor is 70% → nothing
+    out = _meter(context_tokens=3000, threshold_tokens=5000)
+    assert out == ""
+
+
+def test_meter_footer_surfaces_past_floor(monkeypatch):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    # 80% to compaction, manual footer OFF → always-on meter footer appears
+    out = _meter(context_tokens=4000, threshold_tokens=5000)
+    assert out == "gpt-5.4 · 🟡 80% to compaction"
+
+
+def test_meter_footer_escalates_emoji_past_compaction(monkeypatch):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    out = _meter(context_tokens=5200, threshold_tokens=5000)
+    assert "🔴 104% to compaction" in out
+
+
+def test_meter_footer_manual_on_below_floor_shows_window_pct(monkeypatch):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    # Manual footer on, below floor → configured footer (window %), no marker
+    out = _meter(
+        user_config={"display": {"runtime_footer": {"enabled": True}}},
+        context_tokens=40_000,      # 20% of 200k window
+        threshold_tokens=100_000,   # 40% to compaction → below 70 floor
+    )
+    assert out == "gpt-5.4 · 20%"
+    assert "to compaction" not in out
+
+
+def test_meter_footer_manual_on_past_floor_appends_marker(monkeypatch):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    # Manual footer on AND past floor → window footer + compaction marker
+    out = _meter(
+        user_config={"display": {"runtime_footer": {"enabled": True}}},
+        context_tokens=80_000,      # 40% of 200k window
+        threshold_tokens=100_000,   # 80% to compaction → past floor
+    )
+    assert out == "gpt-5.4 · 40% · 🟡 80% to compaction"
+
+
+def test_meter_footer_manual_with_compaction_field_not_doubled(monkeypatch):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    # Manual footer already includes the compaction field → don't append twice
+    out = _meter(
+        user_config={
+            "display": {
+                "runtime_footer": {"enabled": True, "fields": ["model", "compaction"]}
+            }
+        },
+        context_tokens=80_000,
+        threshold_tokens=100_000,
+    )
+    assert out == "gpt-5.4 · 🟡 80% to compaction"
+    assert out.count("to compaction") == 1
+
+
+def test_meter_footer_custom_floor_respected(monkeypatch):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    # Lower the floor to 50% → a 60% reading now surfaces
+    out = _meter(
+        user_config={"display": {"context_meter": {"footer_floor": 0.5}}},
+        context_tokens=3000,
+        threshold_tokens=5000,
+    )
+    assert out == "gpt-5.4 · 🟡 60% to compaction"


### PR DESCRIPTION
## What does this PR do?

Adds visibility into context usage and compaction, so a long conversation stops silently degrading without the user knowing why.

Two parts:

**Context meter** — a `/context` command (alias `/ctx`) reporting usage as a percentage toward auto-compaction, with a per-category breakdown, plus an always-on compaction-pressure footer once usage passes a configurable floor (`display.context_meter.footer_floor`).

**Compaction alerts** — a warning *before* compaction fires (`compression.warn_at`, default `0.85`), an explicit notice when it happens, and a post-compaction quality caveat that escalates on repeat compaction. These are routed through the warning channel specifically because the gateway noise filter was silently dropping them.

## Related Issue

No existing issue — this implements the accepted 4tp design for context/compaction visibility (`4tp-1`, `4tp-2`).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/context_breakdown.py` — per-category context accounting behind the meter
- `agent/context_compressor.py`, `agent/conversation_compression.py`, `agent/conversation_loop.py` — pre-compaction warning, compaction notice, and the escalating post-compaction quality caveat
- `agent/agent_init.py`, `run_agent.py` — wiring
- `gateway/` — `/context` (`/ctx`) command and the compaction-pressure footer; alerts routed via the warning channel so the noise filter does not drop them
- `locales/en.yaml` — user-facing strings
- `cli-config.yaml.example` — new config keys `display.context_meter.footer_floor` and `compression.warn_at`
- Tests: context breakdown, compressor behaviour, pre-compaction warning, and the gateway runtime footer

## How to Test

1. Start a conversation and run `/context` (or `/ctx`) — expect usage as a percentage toward auto-compaction plus the per-category breakdown.
2. Drive the conversation past `display.context_meter.footer_floor` — expect the compaction-pressure footer to appear.
3. Continue past `compression.warn_at` (default `0.85`) — expect a warning *before* compaction, then an explicit notice when it fires, and a quality caveat afterwards that escalates if compaction repeats.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (single commit)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run against current `main`**, see the note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Apple silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` for the new config keys
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A, no platform-specific code
- [x] I've updated tool descriptions/schemas — N/A

## Note on the branch base — please read before reviewing

**This branch is based on a `main` from 2026-07-06 and is ~8,679 commits behind current `main`.** The diff shown here is a single focused commit, but it has not been rebased onto or tested against today's `main`, and it will very likely conflict.

I'm opening it now to check whether the feature is wanted at all before investing in the rebase. If you're interested, say so and I'll rebase onto current `main`, re-run the suite, and push a clean update. If the functionality has since landed in another form, close this and I'll drop the branch — no hard feelings.
