### PR TITLE
fix(cli): purge plugin config state on uninstall (supersedes #80162)

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1151,13 +1151,16 @@ def _plugin_removal_identities(target: Path) -> set:
 def _remove_plugin_config_state(identities: set) -> None:
     """Drop *identities* from ``plugins.enabled`` / ``disabled`` / ``entries``.
 
-    One load/save pair so a removal cannot half-apply. Managed-config
-    refusals are handled by ``save_config``, which reports the canonical
-    managed error and returns without writing.
+    One load/save pair so a removal cannot half-apply. Managed installs
+    cannot persist user config, so they retain the previous silent uninstall
+    behavior instead of attempting a managed write.
     """
     if not identities:
         return
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import is_managed, load_config, save_config
+
+    if is_managed():
+        return
 
     config = load_config()
     plugins_cfg = config.get("plugins")

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1096,6 +1096,95 @@ def _remove_plugin_core(target: Path) -> None:
     shutil.rmtree(staging)
 
 
+def _plugin_removal_identities(target: Path) -> set:
+    """Return the ``plugins.*`` config keys demonstrably owned by *target*.
+
+    Uninstall has to strip the removed plugin out of ``plugins.enabled`` /
+    ``plugins.disabled`` / ``plugins.entries``, and ``plugins.entries.<key>``
+    can hold the privileged ``allow_tool_override`` grant — a record left
+    behind here is re-applied to whatever is installed at that key next.
+
+    Ownership is established by the directory being deleted, not by the name
+    the user typed: the discovered entry whose directory *is* *target* supplies
+    the canonical key and manifest name. A bare directory leaf is not an
+    identity on its own, because path-derived keys mean a namespaced
+    ``image_gen/openai`` shares its leaf with a separate flat ``openai``. A
+    leaf or manifest alias is collected only when ``_resolve_plugin_key`` maps
+    it back to this same plugin and it is not another installed plugin's
+    canonical key or manifest name.
+
+    MUST be called before the tree is deleted; discovery scans the plugins
+    directory. Returns an empty set when discovery cannot establish ownership,
+    which leaves config untouched.
+    """
+    try:
+        target_dir = target.resolve()
+        entries = _discover_all_plugins()
+        # Entry-point plugins carry a "pkg.mod:register" string in the
+        # dir_path slot; only real Path entries can identify *target*.
+        owned = [
+            entry
+            for entry in entries
+            if isinstance(entry[4], Path) and entry[4].resolve() == target_dir
+        ]
+        if len(owned) != 1:
+            return set()
+        manifest_name, canonical = owned[0][0], owned[0][5]
+        identities = {canonical}
+        foreign_identities = {
+            identity
+            for entry in entries
+            if entry[5] != canonical
+            for identity in (entry[5], entry[0])
+        }
+        for alias in (manifest_name, target.name):
+            if not alias or alias in identities or alias in foreign_identities:
+                continue
+            if _resolve_plugin_key(alias) == canonical:
+                identities.add(alias)
+        return identities
+    except Exception:
+        logger.debug("Plugin discovery failed; leaving config untouched", exc_info=True)
+        return set()
+
+
+def _remove_plugin_config_state(identities: set) -> None:
+    """Drop *identities* from ``plugins.enabled`` / ``disabled`` / ``entries``.
+
+    One load/save pair so a removal cannot half-apply. Managed-config
+    refusals are handled by ``save_config``, which reports the canonical
+    managed error and returns without writing.
+    """
+    if not identities:
+        return
+    from hermes_cli.config import load_config, save_config
+
+    config = load_config()
+    plugins_cfg = config.get("plugins")
+    if not isinstance(plugins_cfg, dict):
+        return
+
+    changed = False
+    for list_key in ("enabled", "disabled"):
+        current = plugins_cfg.get(list_key)
+        if not isinstance(current, list):
+            continue
+        kept = [item for item in current if item not in identities]
+        if len(kept) != len(current):
+            plugins_cfg[list_key] = kept
+            changed = True
+
+    entries = plugins_cfg.get("entries")
+    if isinstance(entries, dict):
+        for identity in identities:
+            if identity in entries:
+                del entries[identity]
+                changed = True
+
+    if changed:
+        save_config(config)
+
+
 def cmd_remove(name: str) -> None:
     """Remove an installed plugin by name."""
     from rich.console import Console
@@ -1109,7 +1198,11 @@ def cmd_remove(name: str) -> None:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
+    # Strip config state before the tree goes away: identity resolution needs
+    # the plugin on disk, and a failed config write must leave the plugin
+    # installed rather than strand a deleted plugin in plugins.enabled.
     try:
+        _remove_plugin_config_state(_plugin_removal_identities(target))
         _remove_plugin_core(target)
     except (OSError, PluginOperationError) as exc:
         console.print(f"[red]Error:[/red] Could not remove plugin '{name}': {exc}")
@@ -2849,7 +2942,7 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
 
 
 def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
-    """Delete a plugin tree under ``~/.hermes/plugins/`` only."""
+    """Delete a plugin tree under ``~/.hermes/plugins/`` and its config state."""
     plugins_dir = _plugins_dir()
     for n, _ver, _d, src, _path, _key in _discover_all_plugins():
         if n == name and src == "bundled":
@@ -2862,7 +2955,10 @@ def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
             "error": f"Plugin '{name}' was not found under {plugins_dir}.",
         }
 
+    # Same ordering as the CLI path: resolve identities and clean config while
+    # the plugin is still on disk.
     try:
+        _remove_plugin_config_state(_plugin_removal_identities(target))
         _remove_plugin_core(target)
     except (OSError, PluginOperationError) as exc:
         return {"ok": False, "error": f"Could not remove plugin '{name}': {exc}"}

--- a/tests/hermes_cli/test_plugins_cmd_remove.py
+++ b/tests/hermes_cli/test_plugins_cmd_remove.py
@@ -366,7 +366,7 @@ class TestEntryPointPlugins:
 class TestManagedMode:
     """Managed mode keeps main's behaviour: the tree goes, config is not written."""
 
-    def test_managed_install_still_removes_the_tree(self, plugin_env):
+    def test_managed_install_still_removes_the_tree(self, plugin_env, capsys):
         home = plugin_env
         plugin_dir = _install(home, "solo", "solo")
         _write_plugins_config(
@@ -382,7 +382,8 @@ class TestManagedMode:
 
         cmd_remove("solo")
 
-        # save_config prints the canonical managed error and returns without
-        # writing, so the removal proceeds exactly as it does on main today.
+        # Managed installs cannot persist user config. Preserve main's silent
+        # uninstall behavior instead of emitting a managed-write warning.
         assert not plugin_dir.exists()
         assert (home / "config.yaml").read_text(encoding="utf-8") == before
+        assert capsys.readouterr().err == ""

--- a/tests/hermes_cli/test_plugins_cmd_remove.py
+++ b/tests/hermes_cli/test_plugins_cmd_remove.py
@@ -1,0 +1,388 @@
+"""Regression tests for plugin-removal config cleanup.
+
+``cmd_remove`` / ``dashboard_remove_user_plugin`` delete the plugin tree, so
+they must also drop the plugin out of ``plugins.enabled`` /
+``plugins.disabled`` / ``plugins.entries`` — a stale ``plugins.entries.<key>``
+record keeps a privileged ``allow_tool_override`` grant alive for whatever is
+installed at that key next.
+
+Cleanup has to be scoped to identities the removed plugin demonstrably owns.
+User plugins may be nested and their keys are path-derived, so a namespaced
+``image_gen/openai`` shares its directory leaf with a separate flat ``openai``
+plugin. These tests drive real ``config.yaml`` I/O under a temporary
+``HERMES_HOME`` rather than patching the helpers under test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli.plugins_cmd import cmd_remove, dashboard_remove_user_plugin
+
+
+@pytest.fixture
+def plugin_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME, the bundled plugin tree, and entry-point plugins."""
+    home = tmp_path / "home"
+    (home / "plugins").mkdir(parents=True)
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    # Discovery is deliberately real, but it must not see the repo's own
+    # bundled plugins or whatever happens to be pip-installed in this
+    # environment; either could collide with the fixture keys below.
+    monkeypatch.setattr("hermes_cli.plugins.get_bundled_plugins_dir", lambda: bundled)
+    monkeypatch.setattr(
+        "hermes_cli.plugins_cmd._discover_entrypoint_plugins", lambda: []
+    )
+    return home
+
+
+def _install(home: Path, rel_path: str, manifest_name: str) -> Path:
+    """Create a user plugin at ``plugins/<rel_path>`` with *manifest_name*."""
+    plugin_dir = home / "plugins" / rel_path
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": manifest_name, "version": "1.0.0"}),
+        encoding="utf-8",
+    )
+    return plugin_dir
+
+
+def _write_plugins_config(home: Path, plugins_block: dict) -> None:
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": plugins_block}), encoding="utf-8"
+    )
+
+
+def _read_plugins_config(home: Path) -> dict:
+    raw = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8")) or {}
+    return raw.get("plugins") or {}
+
+
+def _grant(*keys: str) -> dict:
+    return {key: {"allow_tool_override": True} for key in keys}
+
+
+class TestAliasCollision:
+    """A removal must not strip another installed plugin's shared aliases."""
+
+    def test_removing_namespaced_plugin_spares_flat_plugin_sharing_the_leaf(
+        self, plugin_env
+    ):
+        home = plugin_env
+        namespaced = _install(home, "image_gen/openai", "openai")
+        flat = _install(home, "openai", "openai")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["image_gen/openai", "openai"],
+                "disabled": [],
+                "entries": _grant("image_gen/openai", "openai"),
+            },
+        )
+
+        cmd_remove("image_gen/openai")
+
+        plugins_cfg = _read_plugins_config(home)
+        assert "openai" in plugins_cfg["enabled"]
+        assert plugins_cfg["entries"]["openai"]["allow_tool_override"] is True
+        assert flat.is_dir()
+        assert "image_gen/openai" not in plugins_cfg["enabled"]
+        assert "image_gen/openai" not in plugins_cfg["entries"]
+        assert not namespaced.exists()
+
+    def test_removing_flat_plugin_spares_namespaced_plugin_sharing_the_leaf(
+        self, plugin_env
+    ):
+        home = plugin_env
+        namespaced = _install(home, "image_gen/openai", "openai")
+        flat = _install(home, "openai", "openai")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["image_gen/openai", "openai"],
+                "disabled": [],
+                "entries": _grant("image_gen/openai", "openai"),
+            },
+        )
+
+        cmd_remove("openai")
+
+        plugins_cfg = _read_plugins_config(home)
+        assert "image_gen/openai" in plugins_cfg["enabled"]
+        assert plugins_cfg["entries"]["image_gen/openai"]["allow_tool_override"] is True
+        assert namespaced.is_dir()
+        assert "openai" not in plugins_cfg["enabled"]
+        assert "openai" not in plugins_cfg["entries"]
+        assert not flat.exists()
+
+    def test_removing_plugin_spares_shared_manifest_alias(self, plugin_env):
+        home = plugin_env
+        target = _install(home, "alpha/relay", "shared_alias")
+        _install(home, "other/dir", "shared_alias")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["alpha/relay", "other/dir", "shared_alias", "relay"],
+                "disabled": [],
+                "entries": _grant("alpha/relay", "other/dir", "shared_alias", "relay"),
+            },
+        )
+
+        cmd_remove("alpha/relay")
+
+        plugins_cfg = _read_plugins_config(home)
+        assert plugins_cfg["enabled"] == ["other/dir", "shared_alias"]
+        assert set(plugins_cfg["entries"]) == {"other/dir", "shared_alias"}
+        assert not target.exists()
+
+
+class TestOwnedStateIsCleaned:
+    """The removed plugin's own identities are stripped from all three keys."""
+
+    def test_flat_plugin_cleared_from_enabled_disabled_and_entries(self, plugin_env):
+        home = plugin_env
+        _install(home, "solo", "solo")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["solo", "bystander"],
+                "disabled": ["solo"],
+                "entries": _grant("solo", "bystander"),
+            },
+        )
+
+        cmd_remove("solo")
+
+        plugins_cfg = _read_plugins_config(home)
+        assert plugins_cfg["enabled"] == ["bystander"]
+        assert plugins_cfg["disabled"] == []
+        assert "solo" not in plugins_cfg["entries"]
+        assert plugins_cfg["entries"]["bystander"]["allow_tool_override"] is True
+
+    def test_distinct_manifest_name_and_leaf_are_cleaned(self, plugin_env):
+        home = plugin_env
+        _install(home, "tools/relay_dir", "nemo_relay")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["tools/relay_dir", "nemo_relay"],
+                "disabled": ["relay_dir"],
+                "entries": _grant("tools/relay_dir", "nemo_relay", "relay_dir"),
+            },
+        )
+
+        cmd_remove("tools/relay_dir")
+
+        plugins_cfg = _read_plugins_config(home)
+        assert plugins_cfg["enabled"] == []
+        assert plugins_cfg["disabled"] == []
+        assert plugins_cfg["entries"] == {}
+
+    def test_uninstalling_a_never_enabled_plugin_leaves_config_untouched(
+        self, plugin_env
+    ):
+        home = plugin_env
+        _install(home, "solo", "solo")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["bystander"],
+                "disabled": [],
+                "entries": _grant("bystander"),
+            },
+        )
+        before = (home / "config.yaml").read_text(encoding="utf-8")
+
+        cmd_remove("solo")
+
+        assert (home / "config.yaml").read_text(encoding="utf-8") == before
+
+
+class TestRemovalOrdering:
+    """Config state is cleaned before the tree is deleted."""
+
+    def test_cli_config_write_failure_leaves_the_plugin_installed(
+        self, plugin_env, monkeypatch
+    ):
+        home = plugin_env
+        plugin_dir = _install(home, "solo", "solo")
+        _write_plugins_config(
+            home, {"enabled": ["solo"], "disabled": [], "entries": _grant("solo")}
+        )
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("config volume is read-only")
+
+        monkeypatch.setattr("hermes_cli.config.save_config", _boom)
+
+        with pytest.raises(SystemExit) as excinfo:
+            cmd_remove("solo")
+
+        assert excinfo.value.code == 1
+        # The tree survives, so the operator can retry rather than being left
+        # with a deleted plugin still listed in plugins.enabled.
+        assert plugin_dir.is_dir()
+
+    def test_dashboard_config_write_failure_leaves_the_plugin_installed(
+        self, plugin_env, monkeypatch
+    ):
+        home = plugin_env
+        plugin_dir = _install(home, "solo", "solo")
+        _write_plugins_config(
+            home, {"enabled": ["solo"], "disabled": [], "entries": _grant("solo")}
+        )
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("config volume is read-only")
+
+        monkeypatch.setattr("hermes_cli.config.save_config", _boom)
+
+        result = dashboard_remove_user_plugin("solo")
+
+        assert result["ok"] is False
+        assert plugin_dir.is_dir()
+
+
+class TestInstallMetadata:
+    """Installer-managed plugins lose their metadata record with their config."""
+
+    def test_metadata_record_and_tree_are_removed_together(self, plugin_env):
+        home = plugin_env
+        plugin_dir = _install(home, "solo", "solo")
+        metadata_path = home / "plugins" / ".install-metadata.json"
+        metadata_path.write_text(
+            json.dumps({
+                "solo": {
+                    "source": "https://example.invalid/solo.git",
+                    "revision": "a" * 40,
+                },
+                "bystander": {
+                    "source": "https://example.invalid/other.git",
+                    "revision": "b" * 40,
+                },
+            }),
+            encoding="utf-8",
+        )
+        _write_plugins_config(
+            home, {"enabled": ["solo"], "disabled": [], "entries": _grant("solo")}
+        )
+
+        cmd_remove("solo")
+
+        assert not plugin_dir.exists()
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        assert "solo" not in metadata
+        assert "bystander" in metadata
+        plugins_cfg = _read_plugins_config(home)
+        assert plugins_cfg["enabled"] == []
+        assert "solo" not in plugins_cfg["entries"]
+
+
+class TestDashboardRemoval:
+    """The dashboard entry point cleans the same state as the CLI."""
+
+    def test_dashboard_removal_clears_config_state(self, plugin_env):
+        home = plugin_env
+        plugin_dir = _install(home, "solo", "solo")
+        _write_plugins_config(
+            home, {"enabled": ["solo"], "disabled": [], "entries": _grant("solo")}
+        )
+
+        result = dashboard_remove_user_plugin("solo")
+
+        assert result["ok"] is True
+        plugins_cfg = _read_plugins_config(home)
+        assert plugins_cfg["enabled"] == []
+        assert "solo" not in plugins_cfg["entries"]
+        assert not plugin_dir.exists()
+
+    def test_dashboard_removal_spares_flat_plugin_sharing_the_leaf(self, plugin_env):
+        home = plugin_env
+        _install(home, "image_gen/openai", "openai")
+        flat = _install(home, "openai", "openai")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["image_gen/openai", "openai"],
+                "disabled": [],
+                "entries": _grant("image_gen/openai", "openai"),
+            },
+        )
+
+        result = dashboard_remove_user_plugin("image_gen/openai")
+
+        assert result["ok"] is True
+        plugins_cfg = _read_plugins_config(home)
+        assert "openai" in plugins_cfg["enabled"]
+        assert plugins_cfg["entries"]["openai"]["allow_tool_override"] is True
+        assert flat.is_dir()
+
+
+class TestEntryPointPlugins:
+    """An entry-point plugin must not take part in directory matching.
+
+    ``_discover_all_plugins`` stores the entry-point value ("pkg.mod:register")
+    where directory-backed plugins store a ``Path``. A raise there would
+    abandon the whole identity set and silently skip cleanup.
+    """
+
+    @pytest.mark.parametrize(
+        "ep_value",
+        [
+            "pkg.mod:register",
+            # Stands in for any value Path() rejects outright; Windows reaches
+            # the same branch with the ordinary colon-bearing value above.
+            "pkg.mod:register\x00bad",
+        ],
+    )
+    def test_entry_point_plugin_does_not_block_cleanup(
+        self, plugin_env, monkeypatch, ep_value
+    ):
+        home = plugin_env
+        _install(home, "solo", "solo")
+        _write_plugins_config(
+            home, {"enabled": ["solo"], "disabled": [], "entries": _grant("solo")}
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins_cmd._discover_entrypoint_plugins",
+            lambda: [("ep_plugin", "1.0.0", "", ep_value)],
+        )
+
+        cmd_remove("solo")
+
+        plugins_cfg = _read_plugins_config(home)
+        assert plugins_cfg["enabled"] == []
+        assert "solo" not in plugins_cfg["entries"]
+
+
+class TestManagedMode:
+    """Managed mode keeps main's behaviour: the tree goes, config is not written."""
+
+    def test_managed_install_still_removes_the_tree(self, plugin_env):
+        home = plugin_env
+        plugin_dir = _install(home, "solo", "solo")
+        _write_plugins_config(
+            home, {"enabled": ["solo"], "disabled": [], "entries": _grant("solo")}
+        )
+        before = (home / "config.yaml").read_text(encoding="utf-8")
+        # A managed install is laid out by the activation script, which creates
+        # these before anything reads config; ensure_hermes_home() verifies them
+        # rather than creating them under managed mode.
+        for subdir in ("cron", "sessions", "logs", "memories"):
+            (home / subdir).mkdir()
+        (home / ".managed").write_text("", encoding="utf-8")
+
+        cmd_remove("solo")
+
+        # save_config prints the canonical managed error and returns without
+        # writing, so the removal proceeds exactly as it does on main today.
+        assert not plugin_dir.exists()
+        assert (home / "config.yaml").read_text(encoding="utf-8") == before


### PR DESCRIPTION
## What does this PR do?

`hermes plugins uninstall <name>` deletes the plugin tree and install metadata but leaves every config trace behind. After uninstall, `plugins.enabled` / `plugins.disabled` can still list the plugin, so `hermes plugins list` reports a deleted plugin as enabled. Worse, `plugins.entries.<key>` survives — including `allow_tool_override: true` — so installing anything later at the same canonical key silently re-acquires the prior built-in-tool-override grant with no new consent prompt.

This PR resolves every config identity the runtime can associate with the plugin being removed (canonical path key, leaf alias, and `manifest.name`) before the tree is deleted, then removes those identities from `plugins.enabled`, `plugins.disabled`, and `plugins.entries`. Both removal surfaces — the CLI `plugins uninstall` command and the dashboard's `dashboard_remove_user_plugin` — share the same cleanup helpers, so the two paths cannot drift. A shared leaf name belonging to a different installed plugin is spared; a config write failure leaves the plugin installed.

Supersedes #80162 (same fix, re-derived on main after `_remove_plugin_core` restructured the removal path).

## Related Issue

Fixes #54336

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins_cmd.py`: add `_plugin_removal_identities` and `_remove_plugin_config_state`; call them from `cmd_remove` and `dashboard_remove_user_plugin`
- `tests/hermes_cli/test_plugins_cmd_remove.py`: isolated regression tests for identity resolution, both removal surfaces, shared-leaf safety, and failure ordering

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_plugins_cmd_remove.py -v`
2. Manual: enable a plugin, uninstall it, then run `hermes plugins list` — the plugin must not appear; inspect `~/.hermes/config.yaml` and confirm `plugins.enabled`, `plugins.disabled`, and `plugins.entries` no longer contain it.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commit message
- [x] Searched existing PRs
- [x] Only changes related to this fix
- [x] Targeted pytest file passes
- [x] Tests added
- [x] Tested on macOS 15.2

### Documentation & Housekeeping
- [x] N/A — no docs/config-key/architecture/tool-behavior changes
- [x] Cross-platform considered (pure config/path logic, no OS branches)
