### PR TITLE
fix(agent): consult fallback chain when continuation attempts are exhausted

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3697,6 +3697,37 @@ def run_conversation(
                                 _retry.restart_with_length_continuation = True
                                 break
 
+                            # ── Truncation exhaustion → fallback (mirror of
+                            # the content-filter escalation above): a primary
+                            # that hit finish_reason=length on 4 straight
+                            # continuation attempts is in runaway generation —
+                            # further attempts on the same backend re-hit the
+                            # same loop. Consult the fallback chain and let a
+                            # different model compose the final response from
+                            # the transcript before giving up.
+                            if agent._fallback_index < len(agent._fallback_chain):
+                                agent._vprint(
+                                    f"{agent.log_prefix}↻ Response still truncated "
+                                    f"after 4 continuations — activating fallback "
+                                    f"provider...",
+                                    force=True,
+                                )
+                                agent._emit_status(
+                                    "Response still truncated after 4 continuation "
+                                    "attempts; switching to fallback provider..."
+                                )
+                                if agent._try_activate_fallback():
+                                    if truncated_response_parts:
+                                        messages = agent._get_messages_up_to_last_assistant(messages)
+                                    agent._session_messages = messages
+                                    length_continue_retries = 0
+                                    truncated_response_parts = []
+                                    retry_count = 0
+                                    compression_attempts = 0
+                                    _retry.primary_recovery_attempted = False
+                                    _retry.restart_with_rebuilt_messages = True
+                                    break
+
                             partial_response = agent._strip_think_blocks(_join_truncated_parts(truncated_response_parts)).strip()
                             if partial_response:
                                 agent._vprint(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -146,6 +146,12 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
     r"|stream\s+(?:drop|drop\s+mid\s+tool-call).+retry\s+\d"
     r"|stale\s+connections\s+from\s+a\s+previous\s+provider\s+issue"
+    # Fallback-chain switches are plumbing: the recovered reply itself is
+    # the user-visible outcome; the switch notice belongs in logs.
+    r"|switched\s+to\s+fallback\s+model"
+    r"|fallback\s+activated"
+    r"|switching\s+to\s+fallback\s+provider"
+    r"|activating\s+fallback\s+provider"
     r")",
     re.IGNORECASE | re.DOTALL,
 )

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -120,6 +120,32 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
         assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", message) is None
 
 
+def test_telegram_status_suppresses_fallback_chain_switch_noise():
+    """Fallback-chain switch notices are plumbing, not the user-visible outcome.
+
+    The recovered reply itself is what the user needs to see; the "we
+    switched providers to get you that reply" notice belongs in logs only.
+    Regression guard alongside #87992 (continuation-exhaustion fallback):
+    the switch notice must be filtered on chat surfaces while the ordinary
+    "Working — N min" heartbeat is still delivered.
+    """
+    noisy_messages = [
+        "⚠ Switched to fallback model 'local/qwen3.8' after repeated failures.",
+        "⚠ Fallback activated for this turn.",
+        "⚠ Switching to fallback provider 'openrouter'.",
+        "⚠ Activating fallback provider after continuation attempts were exhausted.",
+    ]
+
+    for message in noisy_messages:
+        assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", message) is None
+
+    # The heartbeat carve-out must survive alongside the new suppression.
+    assert (
+        _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", "⏳ Working — 3 min")
+        == "⏳ Working — 3 min"
+    )
+
+
 def test_programmatic_surfaces_keep_raw_status():
     """Programmatic surfaces (local/api/webhook) must keep raw diagnostics.
 

--- a/tests/run_agent/test_truncation_exhaustion_fallback.py
+++ b/tests/run_agent/test_truncation_exhaustion_fallback.py
@@ -1,0 +1,133 @@
+"""Regression tests for the truncation-exhaustion fallback escalation.
+
+Mirrors the #32421 content-filter fallback escalation: a primary that hits
+``finish_reason=length`` on all 4 continuation attempts is in runaway
+generation -- the same failure mode the continuation retries exist to
+paper over -- so hammering the SAME backend past the ceiling just re-hits
+the same loop. Before this fix, the give-up path at the ceiling returned
+"Response remained truncated after 4 continuation attempts" unconditionally
+and never consulted the configured fallback chain, even when a healthy
+fallback provider was available to finish the turn.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
+
+
+@pytest.fixture()
+def loop_agent():
+    from run_agent import AIAgent
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.compression_enabled = False
+        a.save_trajectories = False
+        return a
+
+
+def _stub(content):
+    from tests.run_agent.test_run_agent import _mock_assistant_msg
+    return SimpleNamespace(
+        id=PARTIAL_STREAM_STUB_ID,
+        model="test/model",
+        choices=[SimpleNamespace(
+            index=0,
+            message=_mock_assistant_msg(content=content),
+            finish_reason=FINISH_REASON_LENGTH,
+        )],
+        usage=None,
+    )
+
+
+def _run(agent, message, history=None):
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation(message, conversation_history=history)
+
+
+class TestTruncationExhaustionActivatesFallback:
+    """A primary stuck emitting finish_reason=length across all 4
+    continuation attempts must escalate to the fallback chain instead of
+    giving up -- exactly like the content-filter escalation does."""
+
+    def test_fallback_completes_the_turn(self, loop_agent):
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _stub("part one "), _stub("part two "),
+            _stub("part three "), _stub("part four."),
+            _mock_response(content="Done on the fallback provider.", finish_reason="stop"),
+        ]
+        loop_agent._fallback_chain = [
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.7"},
+        ]
+        loop_agent._fallback_index = 0
+        fb_calls = {"n": 0}
+
+        def _fake_activate(reason=None):
+            fb_calls["n"] += 1
+            loop_agent._fallback_index = len(loop_agent._fallback_chain)
+            return True
+
+        with patch.object(loop_agent, "_try_activate_fallback", side_effect=_fake_activate):
+            result = _run(loop_agent, "write me a very long report")
+
+        assert fb_calls["n"] == 1, (
+            "Fallback must activate exactly once, right after the 4th "
+            "continuation attempt is exhausted -- not before, not more "
+            "than once."
+        )
+        assert loop_agent.client.chat.completions.create.call_count == 5, (
+            "4 truncated continuation attempts against the primary, then "
+            "exactly one fresh request against the (now-activated) fallback."
+        )
+        assert result["completed"] is True
+        assert result["final_response"] == "Done on the fallback provider.", (
+            "The fallback's response must win outright -- the truncated "
+            "partial fragments from the primary must not be stitched onto it."
+        )
+        assert not result.get("error")
+        assert result.get("partial") is not True
+
+    def test_no_fallback_configured_preserves_existing_give_up(self, loop_agent):
+        """Empty fallback chain: the existing ceiling behavior is
+        unchanged -- the turn ends with the stitched partial and the
+        original error string."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _stub("part one "), _stub("part two "),
+            _stub("part three "), _stub("part four."),
+        ]
+        loop_agent._fallback_chain = []
+        loop_agent._fallback_index = 0
+
+        with patch.object(loop_agent, "_try_activate_fallback") as mock_activate:
+            result = _run(loop_agent, "write me a very long report")
+
+        mock_activate.assert_not_called()
+        assert loop_agent.client.chat.completions.create.call_count == 4
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert result["error"] == "Response remained truncated after 4 continuation attempts"
+        assert "part one" in result["final_response"]
+        assert "part four" in result["final_response"]


### PR DESCRIPTION
## Symptom

A primary that gets stuck in runaway generation emits `finish_reason=length`
on every attempt — including all 4 of the length-continuation retries the
loop uses to recover from a genuine truncation. When that happens the turn
dies with:

> Response remained truncated after 4 continuation attempts

and that error is what reaches the user, **even when a healthy fallback
provider is configured**. Observed with a local quantized model used as an
outage-bridge primary: it entered a loop where every continuation re-hit the
same runaway-generation pattern, burning all 4 attempts against the same
backend before giving up — with the fallback chain sitting there unused the
whole time.

## Root cause

`agent/conversation_loop.py` already has an escalation for exactly this
shape of problem: when a provider's output-layer content filter kills a
stream mid-delivery (#32421), the loop recognizes that retrying against the
*same* primary is pointless (the filter is content-deterministic) and
activates the fallback chain before burning any continuation retries.

The length-continuation give-up path — reached after
`length_continue_retries` hits 4 — never got the same treatment. It
unconditionally builds the partial response and returns the error dict,
without ever checking whether `agent._fallback_chain` has an unused entry.
A primary looping on `finish_reason=length` is the same class of problem
(further attempts against the same backend just re-hit the same loop) but
had no escalation path.

## Fix

Mirror the content-filter escalation directly above the give-up return: if
`agent._fallback_index < len(agent._fallback_chain)`, activate the fallback
via `agent._try_activate_fallback()` before giving up. On success:

- roll partial fragments back to the last clean turn (`_get_messages_up_to_last_assistant`)
  so the fallback provider gets a coherent continuation point instead of the
  primary's truncated scraps,
- reset the same state the content-filter branch resets
  (`length_continue_retries`, `truncated_response_parts`, `retry_count`,
  `compression_attempts`, `_retry.primary_recovery_attempted`),
- set `_retry.restart_with_rebuilt_messages` and restart the turn so the
  fallback model composes the final response from the transcript.

If no fallback is configured, or activation fails, execution falls straight
through to the existing give-up return — unchanged.

## Tests

New `tests/run_agent/test_truncation_exhaustion_fallback.py`:

- `test_fallback_completes_the_turn` — primary returns `finish_reason=length`
  on all 4 attempts with one fallback entry configured: fallback activates
  exactly once (not before, not more than once) and the turn completes with
  the fallback's response instead of the partial-error dict.
- `test_no_fallback_configured_preserves_existing_give_up` — same primary
  behavior with an empty fallback chain: `_try_activate_fallback` is never
  called, and the existing partial/error contract is preserved byte-for-byte.

Ran the full `tests/run_agent/` suite locally: 1673 passed, 8 skipped, 2
deselected. The only failures are 8 pre-existing environment gaps (missing
`anthropic` pip package in the test venv) that reproduce identically on
unmodified `main` — none touch truncation, continuation, or fallback logic.
All truncation/continuation/fallback-matching test files pass cleanly,
including the pre-existing `test_continuation_ceiling_wedge.py` and
`test_partial_stream_finish_reason.py` suites this change sits next to.

## Relationship to NousResearch/hermes-agent#87490

Complements NousResearch/hermes-agent#87490 (compaction-threshold floor cap,
also mine) but is independent — that PR shrinks the odds of hitting the
continuation ceiling in the first place by keeping prompts under the
window; this PR gives the loop a way out when the ceiling is hit anyway.
