### PR TITLE
fix(approval): protected-instruction gate hangs in `hermes chat -q` sessions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7848,6 +7848,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         """Install tool callbacks that need the live prompt UI."""
         if getattr(self, "_tool_callbacks_installed", False):
             return
+        if getattr(self, "_modal_prompts_disabled", False):
+            # Headless one-shot session (`hermes chat -q`, kanban workers):
+            # there is no prompt_toolkit Application to render a modal into,
+            # so installing these callbacks only manufactures a fake human
+            # channel that always times out. See
+            # _disable_modal_prompt_callbacks().
+            return
         set_sudo_password_callback(self._sudo_password_callback)
         set_approval_callback(self._approval_callback)
         set_secret_capture_callback(self._secret_capture_callback)
@@ -7858,6 +7865,37 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except ImportError:
             pass
         self._tool_callbacks_installed = True
+
+    def _disable_modal_prompt_callbacks(self) -> None:
+        """Unregister the prompt_toolkit-backed modal callbacks.
+
+        The approval and sudo callbacks render into the live prompt_toolkit
+        layout (``_approval_state`` → ``approval_widget``) and then block on a
+        response queue that only a key binding can fill. In a session that
+        never builds an Application — ``hermes chat -q`` one-shot runs, which
+        is how every kanban worker is spawned — that queue can never be
+        answered, so the prompt silently burned the whole approval timeout and
+        returned ``"timeout"``. Callers then reported "approval prompt timed
+        out without a user response", which reads as a human ignoring a prompt
+        when in fact no prompt was ever rendered anywhere (#t_9691f08d).
+
+        Clearing the callbacks makes headless sessions take the honest
+        no-human-channel branch immediately: gates fail closed with "no
+        interactive user or gateway is present", with no bogus wait.
+        """
+        try:
+            set_approval_callback(None)
+            set_sudo_password_callback(None)
+        except Exception:
+            logger.debug("Failed to clear modal prompt callbacks", exc_info=True)
+        try:
+            from tools.computer_use_tool import set_approval_callback as _set_cu_cb
+
+            _set_cu_cb(None)
+        except Exception:
+            pass
+        self._tool_callbacks_installed = False
+        self._modal_prompts_disabled = True
 
     def _ensure_tirith_security(self) -> None:
         """Check tirith availability once before tools can run terminal commands."""
@@ -19857,6 +19895,15 @@ def main(
         # agent must wait the full MCP cold-start bound before its first
         # (and only) tool snapshot. See #51316.
         cli._single_query_mode = True
+        # One-shot mode never builds a prompt_toolkit Application, so the
+        # modal approval / sudo callbacks installed at construction have no
+        # surface to render into and no key binding that can answer them.
+        # Leaving them registered makes every approval gate burn its full
+        # timeout and then report "the prompt timed out without a user
+        # response" — indistinguishable from a human ignoring a prompt, when
+        # no prompt was ever shown. Clear them so gates take the honest
+        # "no interactive user or gateway is present" branch immediately.
+        cli._disable_modal_prompt_callbacks()
         if not cli._claim_active_session("cli", stderr=bool(quiet)):
             sys.exit(1)
         try:

--- a/tests/cli/test_chat_q_exit_clear.py
+++ b/tests/cli/test_chat_q_exit_clear.py
@@ -77,6 +77,11 @@ def test_single_query_main_skips_clear_on_exit_summary(monkeypatch):
                 platform="cli",
             )
 
+        def _disable_modal_prompt_callbacks(self):
+            # One-shot mode clears the prompt_toolkit modal callbacks; see
+            # cli._disable_modal_prompt_callbacks.
+            calls.append("disable-modal-callbacks")
+
         def _claim_active_session(self, surface, *, stderr=False):
             calls.append(("claim", surface, stderr))
             return True
@@ -104,6 +109,7 @@ def test_single_query_main_skips_clear_on_exit_summary(monkeypatch):
     cli_mod.main(query="hello", quiet=False, toolsets="terminal")
 
     assert calls == [
+        "disable-modal-callbacks",
         ("claim", "cli", False),
         "query-label",
         "advisories",

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -99,6 +99,11 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
                 platform="cli",
             )
 
+        def _disable_modal_prompt_callbacks(self):
+            # One-shot mode clears the prompt_toolkit modal callbacks; see
+            # cli._disable_modal_prompt_callbacks.
+            calls.append("disable-modal-callbacks")
+
         def _claim_active_session(self, surface, *, stderr=False):
             calls.append(("claim", surface, stderr))
             return True
@@ -124,6 +129,7 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
     cli_mod.main(query="hello", quiet=False, toolsets="terminal")
 
     assert calls == [
+        "disable-modal-callbacks",
         ("claim", "cli", False),
         "query-label",
         "advisories",
@@ -162,6 +168,11 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
                 tool_gen_callback=object(),
                 run_conversation=run_conversation,
             )
+
+        def _disable_modal_prompt_callbacks(self):
+            # One-shot mode clears the prompt_toolkit modal callbacks; see
+            # cli._disable_modal_prompt_callbacks.
+            calls.append("disable-modal-callbacks")
 
         def _claim_active_session(self, surface, *, stderr=False):
             calls.append(("claim", surface, stderr))

--- a/tests/tools/test_protected_instruction_cli_channel.py
+++ b/tests/tools/test_protected_instruction_cli_channel.py
@@ -1,0 +1,178 @@
+"""Protected-instruction approval must be answerable on an interactive CLI
+session, and must NOT pretend a human channel exists in a headless one-shot
+(`hermes chat -q`) session.
+
+Defect (kanban t_9691f08d): every write to a protected agent-instruction file
+from a kanban worker failed with
+
+    BLOCKED: ... approval prompt timed out without a user response.
+    Silence is not consent.
+
+which reads as "a human ignored the prompt". In fact those workers are spawned
+as ``hermes chat -q``, which never builds a prompt_toolkit Application — but
+``HermesCLI.__init__`` had already registered ``_approval_callback`` as the
+thread-local CLI approval callback. ``_request_protected_instruction_approval``
+therefore saw a callback, believed a human channel existed, pushed a modal into
+a layout that is never rendered, and blocked on a response queue no key binding
+could ever fill until the approval timeout expired.
+
+Two invariants are locked here:
+
+1. Interactive CLI: a registered approval callback that answers ``once`` lets
+   the write through, and ``deny`` blocks it. The channel works.
+2. Headless one-shot: the modal callbacks are cleared, so the gate fails closed
+   *immediately* with the honest "no interactive user or gateway is present"
+   message instead of manufacturing a timeout.
+"""
+
+import json
+import threading
+import time
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _gate_on(monkeypatch):
+    import tools.file_tools as ft
+    monkeypatch.setattr(ft, "_protected_instruction_config", lambda: (True, []))
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_callbacks():
+    from tools.terminal_tool import set_approval_callback
+    set_approval_callback(None)
+    yield
+    set_approval_callback(None)
+
+
+def _write(path, content="content"):
+    from tools.file_tools import write_file_tool
+    return json.loads(write_file_tool(str(path), content))
+
+
+class TestInteractiveCliChannelDelivers:
+    """An interactive CLI session can actually answer the prompt."""
+
+    def test_interactive_approval_allows_write(self, tmp_path):
+        from tools.terminal_tool import set_approval_callback
+
+        seen = []
+
+        def cb(command, description, **kwargs):
+            seen.append((command, description, kwargs))
+            return "once"
+
+        set_approval_callback(cb)
+        target = tmp_path / "SOUL.md"
+        res = _write(target, "approved by a live human")
+
+        assert not res.get("error"), res
+        assert target.read_text(encoding="utf-8") == "approved by a live human"
+        assert len(seen) == 1, "the human channel was never used"
+        assert "SOUL.md" in seen[0][0]
+        # One-operation only: no session/permanent scope is offered.
+        assert seen[0][2].get("allow_permanent") is False
+
+    def test_interactive_denial_blocks_write(self, tmp_path):
+        from tools.terminal_tool import set_approval_callback
+        set_approval_callback(lambda c, d, **k: "deny")
+
+        target = tmp_path / "SOUL.md"
+        res = _write(target)
+        assert res.get("error") and "BLOCKED" in res["error"]
+        assert "denied by the user" in res["error"]
+        assert not target.exists()
+
+    def test_real_cli_approval_modal_round_trip(self, tmp_path):
+        """End-to-end through the actual HermesCLI modal, not a stub callback.
+
+        Drives ``HermesCLI._approval_callback`` — the same function the CLI
+        registers — from a worker thread, waits for the modal state the TUI
+        renders, then answers it exactly as the Enter key binding does. This is
+        the path that was unreachable for headless workers.
+        """
+        from unittest.mock import MagicMock
+        from types import SimpleNamespace
+
+        from cli import HermesCLI
+        from tools.terminal_tool import set_approval_callback
+
+        cli = HermesCLI.__new__(HermesCLI)
+        cli._approval_state = None
+        cli._approval_deadline = 0
+        cli._approval_lock = threading.Lock()
+        cli._invalidate = MagicMock()
+        cli._app = SimpleNamespace(invalidate=MagicMock())
+        cli._paint_now = MagicMock()
+        cli._persist_prompt_summary = MagicMock()
+
+        answered = threading.Event()
+
+        def _answer_when_prompted():
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                state = cli._approval_state
+                if state is not None:
+                    # The modal really was raised with a decidable choice set.
+                    assert "once" in state["choices"]
+                    assert "always" not in state["choices"]
+                    state["response_queue"].put("once")
+                    answered.set()
+                    return
+                time.sleep(0.01)
+
+        threading.Thread(target=_answer_when_prompted, daemon=True).start()
+        set_approval_callback(cli._approval_callback)
+
+        target = tmp_path / "AGENTS.md"
+        res = _write(target, "written after a real modal approval")
+
+        assert answered.is_set(), "the approval modal never rendered"
+        assert not res.get("error"), res
+        assert target.read_text(encoding="utf-8") == "written after a real modal approval"
+
+
+class TestHeadlessOneShotFailsClosedHonestly:
+    """`hermes chat -q` must not claim a human channel it does not have."""
+
+    def test_no_callback_reports_no_human_not_timeout(self, tmp_path):
+        target = tmp_path / "SOUL.md"
+        res = _write(target)
+        assert res.get("error") and "BLOCKED" in res["error"]
+        assert "no interactive user or gateway is present" in res["error"]
+        assert "timed out" not in res["error"], (
+            "headless run reported a timeout, implying a human ignored a "
+            "prompt that was never rendered"
+        )
+        assert not target.exists()
+
+    def test_disable_modal_prompt_callbacks_clears_and_latches(self):
+        from unittest.mock import MagicMock
+
+        from cli import HermesCLI
+        from tools.terminal_tool import (
+            _get_approval_callback,
+            _get_sudo_password_callback,
+            set_approval_callback,
+        )
+
+        cli = HermesCLI.__new__(HermesCLI)
+        cli._approval_callback = MagicMock(return_value="once")
+        cli._sudo_password_callback = MagicMock()
+        cli._secret_capture_callback = MagicMock()
+        cli._computer_use_approval_callback = MagicMock()
+
+        set_approval_callback(cli._approval_callback)
+        assert _get_approval_callback() is not None
+
+        cli._disable_modal_prompt_callbacks()
+
+        assert _get_approval_callback() is None
+        assert _get_sudo_password_callback() is None
+
+        # Latched: a later _install_tool_callbacks() must not silently
+        # re-register the unreachable modal channel.
+        cli._install_tool_callbacks()
+        assert _get_approval_callback() is None


### PR DESCRIPTION
## Problem

Any write to a protected agent-instruction file (`SOUL.md`, `AGENTS.md`, `.cursorrules`, project-local `.hermes/*`) from a non-interactive session fails with:

```
BLOCKED: write to protected agent-instruction file(s) (SOUL.md) approval prompt
timed out without a user response. Silence is not consent.
```

That message states a human ignored a prompt. **No prompt was ever rendered anywhere.** The gate is a correct human gate that had no working delivery path, so on this surface it behaved as an unconditional wall — with a 60s stall and a misleading diagnosis on every attempt.

## Root cause

`HermesCLI.__init__` registers `_approval_callback` as the thread-local CLI approval callback before it is known whether the run will build a prompt_toolkit `Application`. One-shot `hermes chat -q` runs never build one (this is how the kanban dispatcher spawns every worker).

`tools/file_tools.py::_request_protected_instruction_approval` probes `_get_approval_callback()` to decide whether a human is reachable. It saw a live callback, took the "interactive CLI human is here" branch, set `_approval_state` for a layout that is never rendered, and blocked on a response queue only a prompt_toolkit key binding can fill — until `approvals.timeout` expired and returned `"timeout"`.

The callback's presence is not evidence of a human. It's evidence a `HermesCLI` was constructed.

Same trap applies to every consumer of `prompt_dangerous_approval` on this surface, not just the protected-instruction gate.

## Fix

Single-query mode clears the modal approval/sudo callbacks up front (`_disable_modal_prompt_callbacks`) and latches the decision so a later `_install_tool_callbacks()` cannot silently re-register the unreachable channel. Headless runs now take the honest no-human-channel branch immediately.

**Policy is unchanged**: still fail-closed, no allowlist, no persistent consent, no `--yolo` bypass, and an interactive CLI user can still approve.

Measured on the reported case:

| | elapsed | message |
|---|---|---|
| before | 60.0s | `approval prompt timed out without a user response` |
| after | 0.00s | `requires approval but no interactive user or gateway is present` |

## Tests

New `tests/tools/test_protected_instruction_cli_channel.py`:

- interactive approve (`once`) allows the write; `deny` blocks it
- an **end-to-end round trip through the real `HermesCLI._approval_callback` modal** — a worker thread waits for `_approval_state` and answers it exactly as the Enter key binding does — proving the interactive path genuinely delivers, not just that a stub callback was invoked
- headless runs report "no interactive user or gateway is present" and never "timed out"
- `_disable_modal_prompt_callbacks` clears both callbacks and latches against re-install

Three existing `FakeCLI` stubs in `tests/cli/` gained the new method.

Full `tests/cli` (1028), `tests/tools/test_approval.py`, `test_file_write_safety.py`, `test_write_approval.py`, `tests/acp/` pass. One pre-existing failure in `tests/cli/test_resume_quiet_stderr.py` reproduces on unmodified `main` (verified in a clean `--shared` clone) and is unrelated.