### PR TITLE
fix(prompt-builder): honor terminal.docker_network in the backend-probe container

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1235,6 +1235,12 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "modal_mode": config.get("modal_mode", "auto"),
                 "docker_volumes": config.get("docker_volumes", []),
                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                # Sibling container_config sites (terminal/file/code_execution)
+                # carry this too — without it the probe container silently
+                # falls back to bridge networking while the session container
+                # honors the no-network lockdown (#87995, same asymmetry class
+                # as #46358).
+                "docker_network": config.get("docker_network", True),
                 "docker_forward_env": config.get("docker_forward_env", []),
                 "docker_env": config.get("docker_env", {}),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),

--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -29,8 +29,9 @@ def test_sibling_container_config_sites_carry_docker_network():
 
     import tools.code_execution_tool as code_execution_tool
     import tools.file_tools as file_tools
+    import agent.prompt_builder as prompt_builder
 
-    for module in (terminal_tool, file_tools, code_execution_tool):
+    for module in (terminal_tool, file_tools, code_execution_tool, prompt_builder):
         tree = ast.parse(inspect.getsource(module))
         sites = 0
         for node in ast.walk(tree):


### PR DESCRIPTION
## What does this PR do?

Makes the `prompt-backend-probe` container honor `terminal.docker_network`. The `container_config` dict in `agent/prompt_builder.py` forwarded every docker knob (cpu/memory/disk/persistent/volumes/mount/env/run-as-user/extra-args/shm/persist/orphan-reaper) **except** `docker_network`, which then defaulted to `True` downstream. With `terminal.backend: docker` + `terminal.docker_network: false`, the session container was correctly created with `--network=none` while the probe container silently fell back to **bridge networking — still mounting the project directory read-write**, so a profile explicitly configured for no network got a container with project files and unrestricted outbound network (#87995). This is the same probe/exec asymmetry class the sibling-site guard test was written for (#46358); the guard's module list just didn't include `agent.prompt_builder`.

The fix adds the missing `docker_network` key (same `config.get("docker_network", True)` form as the terminal/file/code_execution sites) and extends `test_sibling_container_config_sites_carry_docker_network` to iterate `agent.prompt_builder` as well, so a future container_config site there cannot silently regress the no-network lockdown.

## Related Issue

Fixes #87995

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py` — `container_config` gains `docker_network: config.get("docker_network", True)` with a comment referencing the asymmetry class; behavior for default (`true`) configs is unchanged.
- `tests/tools/test_docker_network_config.py` — the sibling-site guard now also walks `agent.prompt_builder`'s AST for container_config dicts.

## How to Test

1. `python -m pytest tests/tools/test_docker_network_config.py -q`
2. Observed result: 5 passed, including the extended guard.
3. Guard fail-closed check (A/B): reverting only the `agent/prompt_builder.py` hunk makes `test_sibling_container_config_sites_carry_docker_network` FAIL with "builds a container_config with docker_run_as_host_user but without docker_network"; with the hunk it passes — the guard genuinely catches this class.
4. Manual repro from the issue (profile with `docker_network: false`, fresh containers, any prompt build): the probe container now comes up with `net=none` like the session container instead of `net=bridge`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/tools/test_docker_network_config.py -q          # with fix
5 passed in 0.98s
$ git stash -- agent/prompt_builder.py && pytest ... -q        # guard A/B
1 failed  ("agent.prompt_builder builds a container_config with
           docker_run_as_host_user but without docker_network")
```