### PR TITLE
fix(kanban): stop the block-loop breaker from feeding cards back into dispatch

### DIFF
--- a/contributors/emails/daniel@danielgreen.net
+++ b/contributors/emails/daniel@danielgreen.net
@@ -1,0 +1,1 @@
+PolyphonyRequiem

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -119,16 +119,20 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 #
 # ``needs_input`` and ``capability`` are "truly blocked": they go to ``blocked``
 # for a human, and the unblock-loop breaker (see ``block_task`` /
-# ``BLOCK_RECURRENCE_LIMIT``) escalates them to ``triage`` if a cron keeps
-# unblocking them only to have the worker re-block for the same reason.
+# ``BLOCK_RECURRENCE_LIMIT``) marks them loop-escalated (a
+# ``block_loop_detected`` event plus a raised ``block_recurrences``) if a cron
+# keeps unblocking them only to have the worker re-block.
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
 VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 
 # After a task has been blocked, unblocked, and re-blocked this many times for
-# the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
-# unblocker (usually a cron) and routes the task to ``triage`` instead of back
-# to ``blocked`` — breaking the infinite unblock↔re-block loop and forcing a
-# human-in-the-loop decision. Mirrors the dispatcher's ``DEFAULT_FAILURE_LIMIT``
+# a truly-blocked reason, the unblock-loop breaker stops trusting the
+# unblocker (usually a cron) and records a ``block_loop_detected`` event; the
+# task stays in ``blocked`` — breaking the infinite unblock↔re-block loop and
+# forcing a human-in-the-loop decision. It deliberately does NOT route to
+# ``triage``: ``triage`` is swept unconditionally by the gateway
+# auto-decomposer, which would re-dispatch the card and restart the loop.
+# Mirrors the dispatcher's ``DEFAULT_FAILURE_LIMIT``
 # spirit (default 2) but counts a different signal: manual unblock recurrences,
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
@@ -1417,9 +1421,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- the SAME kind can be recognised as a loop.
     block_kind           TEXT,
     -- Unblock-loop counter. Incremented each time a task is re-blocked for the
-    -- same truly-blocked reason after having been unblocked. When it reaches
-    -- BLOCK_RECURRENCE_LIMIT the task is routed to ``triage`` instead of
-    -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
+    -- reason after having been unblocked. When it reaches
+    -- BLOCK_RECURRENCE_LIMIT the task is flagged loop-escalated (it stays in
+    -- ``blocked``) so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
     block_recurrences    INTEGER NOT NULL DEFAULT 0
@@ -6186,16 +6190,18 @@ def block_task(
       "Type 1"). Lands in ``blocked`` for a human. BUT: each time such a task
       is re-blocked for the SAME kind after having been unblocked, the
       unblock-loop counter (``block_recurrences``) increments. When it reaches
-      :data:`BLOCK_RECURRENCE_LIMIT`, the task is routed to ``triage`` instead
-      of ``blocked`` — breaking the cron-unblock ↔ worker-re-block loop and
-      forcing a human-in-the-loop triage decision.
+      :data:`BLOCK_RECURRENCE_LIMIT`, a ``block_loop_detected`` event is
+      recorded and the task stays in ``blocked`` — breaking the cron-unblock ↔
+      worker-re-block loop and forcing a human-in-the-loop decision. It is NOT
+      routed to ``triage``, which the auto-decomposer sweeps back into
+      dispatch.
 
     * ``transient`` — treated like a generic block for routing, but a worker
       can use it to signal "this might clear on its own"; it still participates
       in the loop breaker so a forever-flaky task eventually escalates.
 
-    Returns True on any successful transition (to ``blocked``, ``todo``, or
-    ``triage``), False when the task wasn't in a blockable state.
+    Returns True on any successful transition (to ``blocked`` or ``todo``),
+    False when the task wasn't in a blockable state.
     """
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(
@@ -6272,22 +6278,35 @@ def block_task(
             )
             return True
 
-        # Truly-blocked kinds. Increment the unblock-loop counter when this is a
-        # re-block for the SAME reason after a prior unblock. block_task only
-        # fires from running/ready (i.e. AFTER an unblock returned the task to
-        # the work pool), so a stored block_kind that matches the incoming kind
-        # means: blocked → unblocked → about-to-re-block for the same cause.
-        # An un-typed (None) block compares as "same" to a prior un-typed block.
-        same_cause = prev_kind == kind
-        recurrences = prev_recurrences + 1 if same_cause else 1
+        # Truly-blocked kinds. Increment the unblock-loop counter: block_task
+        # only fires from running/ready (i.e. AFTER an unblock returned the
+        # task to the work pool), so reaching here means
+        # blocked → unblocked → about-to-re-block.
+        # Count CONSECUTIVE blocks regardless of kind. Counting only same-kind
+        # recurrences (``prev + 1 if same_cause else 1``) inverted the
+        # incentive: a worker that honestly reported the same wall every time
+        # escalated, while one whose reported ``kind`` varied (``capability``
+        # then ``transient`` then ``needs_input``) reset the counter to 1 and
+        # escaped the breaker indefinitely. The kind is still recorded on the
+        # task and in the event payload for display/triage; it just no longer
+        # gates the counter. A "decay by one on changed kind" variant was
+        # considered and rejected: at the default BLOCK_RECURRENCE_LIMIT of 2
+        # it is arithmetically identical to the old reset (increment then
+        # decrement nets zero), so it would preserve the escape hatch.
+        recurrences = prev_recurrences + 1
 
         if recurrences >= BLOCK_RECURRENCE_LIMIT:
-            # Loop detected — stop letting the unblocker spin this task. Route
-            # to triage for a human-in-the-loop decision instead of blocked.
+            # Loop detected — stop letting the unblocker spin this task. It
+            # stays in ``blocked`` (NOT ``triage``): ``triage`` is swept
+            # unconditionally by the gateway auto-decomposer, which would feed
+            # the escalated card straight back into dispatch and re-arm the
+            # very loop this breaker exists to stop. The ``block_loop_detected``
+            # event and the elevated ``block_recurrences`` value are what mark
+            # the card as loop-escalated rather than ordinarily blocked.
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status        = 'triage',
+                   SET status        = 'blocked',
                        claim_lock    = NULL,
                        claim_expires = NULL,
                        worker_pid    = NULL,

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -8,8 +8,13 @@ forever. The fix gives ``block_task`` a typed ``kind`` and a persistent
 * ``dependency`` blocks route to ``todo`` (parent-gated, auto-resumed) and
   never enter the human ``blocked`` bucket a cron would keep unblocking.
 * ``needs_input`` / ``capability`` / un-typed blocks land in ``blocked``;
-  each same-cause re-block after an unblock increments ``block_recurrences``,
-  and at ``BLOCK_RECURRENCE_LIMIT`` the task routes to ``triage`` for a human.
+  each re-block after an unblock increments ``block_recurrences``, and at
+  ``BLOCK_RECURRENCE_LIMIT`` the task is flagged loop-escalated (a
+  ``block_loop_detected`` event) while STAYING in ``blocked`` — it must not
+  land in ``triage``, which the gateway auto-decomposer sweeps back into
+  dispatch.
+* A re-block with a DIFFERENT ``kind`` decays the counter but never resets it,
+  so a worker cannot escape the breaker by varying its reported kind.
 * ``unblock_task`` deliberately does NOT reset ``block_recurrences`` (the
   amnesia that let the loop run unbounded).
 * A successful ``complete_task`` resets the loop memory.
@@ -61,6 +66,63 @@ def _make_running_again(conn, tid):
 
 
 
+
+
+def test_loop_escalation_lands_in_blocked_not_triage(kanban_home: Path) -> None:
+    """N>=limit same-kind blocks => blocked + block_loop_detected, NOT triage.
+
+    ``triage`` is swept unconditionally by the gateway auto-decomposer
+    (``_auto_decompose_tick``), so escalating there fed the card straight back
+    into dispatch and re-armed the loop. Escalation must be a terminal resting
+    state for a human, and the card must not appear in ``list_triage_ids()``.
+    """
+    from hermes_cli import kanban_decompose
+
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        for i in range(kb.BLOCK_RECURRENCE_LIMIT):
+            kb.block_task(conn, tid, reason="wall", kind="capability")
+            if i < kb.BLOCK_RECURRENCE_LIMIT - 1:
+                kb.unblock_task(conn, tid)
+                _make_running_again(conn, tid)
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_recurrences >= kb.BLOCK_RECURRENCE_LIMIT
+        assert [e for e in kb.list_events(conn, tid)
+                if e.kind == "block_loop_detected"]
+
+    assert tid not in kanban_decompose.list_triage_ids()
+
+
+def test_alternating_block_kinds_still_escalate(kanban_home: Path) -> None:
+    """Varying the reported ``kind`` must not reset the recurrence counter.
+
+    The old rule was ``recurrences = prev + 1 if same_cause else 1``, which
+    rewarded a worker for reporting a different kind each time: the counter
+    reset to 1 forever and the breaker never fired. A changed kind may decay
+    the counter, never zero it.
+    """
+    kinds = ["capability", "transient", "needs_input", "capability",
+             "transient", "needs_input"]
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        escalated = False
+        for kind in kinds:
+            kb.block_task(conn, tid, reason="wall", kind=kind)
+            task = kb.get_task(conn, tid)
+            assert task.block_recurrences >= 1
+            if [e for e in kb.list_events(conn, tid)
+                    if e.kind == "block_loop_detected"]:
+                escalated = True
+                break
+            kb.unblock_task(conn, tid)
+            _make_running_again(conn, tid)
+
+        assert escalated, (
+            "alternating block kinds escaped the loop breaker: "
+            f"recurrences={kb.get_task(conn, tid).block_recurrences}"
+        )
 
 
 def test_block_loop_detected_event_emitted(kanban_home: Path) -> None:


### PR DESCRIPTION
## The loop

`block_task`'s unblock-loop breaker is supposed to be the terminal backstop: after `BLOCK_RECURRENCE_LIMIT` re-blocks, stop trusting the unblocker and park the card for a human. On a live board it did the opposite — it *amplified* the loop. Two defects, both in `hermes_cli/kanban_db.py`.

### 1. The escalation destination is a dispatch source

The `recurrences >= BLOCK_RECURRENCE_LIMIT` branch set `status='triage'`. But `triage` is swept **unconditionally** by the gateway auto-decomposer (`gateway/kanban_watchers.py` `_auto_decompose_tick` → `kanban_decompose.list_triage_ids()`), which re-specifies the card or fans it out into fresh children and puts the work straight back into dispatch.

So the breaker's escalation *was itself a re-dispatch*. The worker hits the same wall, blocks again, escalates again — with a new generation of child cards each pass.

Measured on one live board:

- **31 `block_loop_detected` events across 14 distinct tasks**
- **31 `specified`/`decomposed` passes on those same 14 tasks** — a 1:1 correspondence between "loop detected" and "card re-dispatched"

Concrete instance on that board — `t_a52d5af6`, a review card whose only remaining action was a human PR merge (a genuine `needs_input` wall no worker can clear):

```
14:43  block_loop_detected  {"reason": "Gate C ... PASS ... HUMAN MERGE REQUIRED", "recurrences": 2}
14:43  specified            {"changed_fields": ["title", "body"]}
14:43  promoted             {"status": "review"}
14:43  claimed / spawned    → worker runs again, hits the same wall
14:45  block_loop_detected  {"reason": "HUMAN MERGE REQUIRED — Daniel, merge PR #504 ..."}
14:46  decomposed           {"child_ids": [5 new cards]}
```

The escalation fired twice and produced five new cards for work that was already complete. The card is now sitting in `todo` with `block_recurrences=3`, dispatchable, still waiting on the same unmerged PR.

**Fix:** escalation leaves the task in `blocked`. `blocked` is not swept. The `block_loop_detected` event and the elevated `block_recurrences` are what mark the card as *loop-escalated* rather than ordinarily blocked, so the notifier ping and dashboard surfacing are unchanged — only the resting place moves.

### 2. The counter rewarded dishonest workers

```python
same_cause = prev_kind == kind
recurrences = prev_recurrences + 1 if same_cause else 1
```

Keying the counter on the reported block `kind` inverts the incentive. A worker that honestly reports the same wall every time (`capability`, `capability`, …) escalates. A worker whose reported kind varies — `capability`, then `transient`, then `needs_input` — resets the counter to 1 on every pass and **never** trips the breaker, no matter how many times it spins.

**Fix:** count consecutive blocks regardless of kind. The kind is still stored on the task and in the event payload for display and triage; it just no longer gates the counter.

A "decay by one on changed kind" variant was considered and rejected: at the default `BLOCK_RECURRENCE_LIMIT` of 2, increment-then-decrement nets zero, so it is arithmetically the same escape hatch.

## Tests

Two new cases in `tests/hermes_cli/test_kanban_block_kinds.py`:

- `test_loop_escalation_lands_in_blocked_not_triage` — N≥limit blocks land in `blocked`, carry `block_loop_detected`, and the id is **absent from `list_triage_ids()`**.
- `test_alternating_block_kinds_still_escalate` — cycling `capability` → `transient` → `needs_input` still escalates; the counter never resets.

Both fail on `main` and pass here. `pytest tests/hermes_cli/ tests/gateway/test_kanban_notifier.py -k kanban` gives an **identical failure set** before and after this change (16 pre-existing failures on `origin/main`, unrelated to the kanban block path — plugin-hook and write-guard tests).

## Relationship to the open PRs in this area

Four open PRs touch this code. This one is deliberately at a different layer — it removes the condition the others work around — so they should be read together rather than in isolation.

- **#81353** (`keep block-loop triage out of the auto-decomposer`) and **#78895** (`gate auto-decomposer past block_loop_detected cards`) both keep `triage` as the escalation destination and add machinery to stop the decomposer picking those cards up — a skip predicate in #78895, an audited operator recovery path in #81353. Those guards become unnecessary for *this* vector once escalation stops entering `triage` at all, but #81353's `recover_escalated_triage_task` is independently useful for cards that reach triage by other routes, and neither conflicts textually with this diff.
- **#77280** (`dependency_wait respawn cooldown + fix recurrence counter`) copies the `same_cause`/reset pattern into the `dependency` path. If both land, that new `dep_recurrences` line carries the same reset escape hatch this PR removes from the truly-blocked path, and should be updated to match.
- **#74364** (`let human unblocks reset the block-recurrence breaker`) changes reset-on-unblock, which this PR does not touch. They compose, but #74364's tests assert `status == "triage"` on escalation and will need updating for the new destination.

Happy to rebase onto whichever of these a maintainer wants to land first.
