### PR TITLE
fix(desktop): pin Kanban board slug so header matches cards

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -29,7 +29,10 @@ type Socket = (path: string, onMessage: (data: unknown) => void) => () => void
 
 let rest: null | Rest = null
 
-/** Selected board slug ('' = the server's current board). Persisted. */
+/** Selected board slug. Empty only on first paint (follow server current).
+ *  After the user picks a board, always store the explicit slug — never '' —
+ *  or cards fetch live `/board` while the header still shows a stale
+ *  `boards.current` (drivers call `boards switch` every tick). */
 export const $boardSlug = atom<string>('')
 
 /** Whether the "how this board works" intro was dismissed. Persisted. */

--- a/apps/desktop/src/plugins/kanban/board-switcher.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.tsx
@@ -214,7 +214,7 @@ export function BoardSwitcher() {
           {boards.boards.map(meta => (
             <DropdownMenuItem
               key={meta.slug}
-              onSelect={() => $boardSlug.set(meta.slug === boards.current ? '' : meta.slug)}
+              onSelect={() => $boardSlug.set(meta.slug)} // never '' — empty follows server current
             >
               {meta.name || meta.slug}
               {typeof meta.total === 'number' && (


### PR DESCRIPTION
## Bug Description

Desktop Kanban can show board A's name in the switcher while rendering board B's cards.

Selecting the **currently-current** board stored `$boardSlug = ''` (\"follow server current\"). The header then used a 30s-cached `boards.current`; card fetches with no `?board=` hit live `/board`. A driver calling `hermes kanban boards switch` every tick flips the live current, so the two diverge.

Reproduced with two implement boards on one tenant: header `Ratchet Implement · Apple H…`, cards were Food Scoring (`DONE 55`, T11a, IR-B1 food scoring).

## Root Cause

```tsx
onSelect={() => $boardSlug.set(meta.slug === boards.current ? '' : meta.slug)}
```

Empty slug is documented as first-paint follow-current. Reusing it after a click made `withBoard()` omit `?board=`, which is the opposite of this plugin's contract (\"desktop selection never flips / never follows the server pointer\").

## Fix

Always persist the clicked slug. Empty remains first paint only.

## How to Verify

1. Two Kanban boards; a process that `boards switch`es between them (or switch in CLI).
2. In Desktop, click the board that is server-current, wait for another switch.
3. **Before:** header stays on the first board's name; cards become the other board's.
4. **After:** header and cards stay on the board you clicked.

## Test Plan

- [ ] Existing tests still pass
- [x] Manual verification of the fix (local two-board tenant; click-current then CLI switch)
- [ ] No new unit test — one-line event handler; a snapshot would be a change-detector

## Risk Assessment

Low — selection still never writes server current (`?board=` is passed whenever slug is set). First load with empty slug is unchanged.