### PR TITLE
fix(cli): don't warn on plugin toolsets; skip kanban TERMINAL_CWD deprecation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4939,8 +4939,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Validate each toolset — MCP server names are resolved via
             # live registry aliases (registered during discover_mcp_tools),
             # but discovery hasn't run yet at this point, so exclude them.
+            # Same for plugin toolset names declared in known_plugin_toolsets:
+            # plugins register their toolsets during load, which happens
+            # after this validation, so a declared plugin toolset must not
+            # be reported as unknown.
             mcp_names = set((CLI_CONFIG.get("mcp_servers") or {}).keys())
-            invalid = [t for t in toolsets if not validate_toolset(t) and t not in mcp_names]
+            known_plugin = (CLI_CONFIG.get("known_plugin_toolsets") or {}).get("cli") or []
+            excluded = mcp_names | set(known_plugin)
+            invalid = [t for t in toolsets if not validate_toolset(t) and t not in excluded]
             if invalid:
                 self._console_print(f"[bold red]Warning: Unknown toolsets: {', '.join(invalid)}[/]")
         

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2205,7 +2205,11 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
             f"  \033[33m⚠\033[0m MESSAGING_CWD={messaging_cwd} found in .env — "
             f"this is deprecated."
         )
-    if terminal_cwd_env and not config_has_explicit_cwd:
+    # Kanban workers deliberately pin TERMINAL_CWD to the task workspace so
+    # file tools anchor there (kanban_db worker spawn); that is a runtime
+    # bridge, not a stale .env entry — don't warn about it.
+    _is_kanban_worker = os.environ.get("HERMES_SESSION_SOURCE") == "kanban"
+    if terminal_cwd_env and not config_has_explicit_cwd and not _is_kanban_worker:
         # TERMINAL_CWD in env but not from config bridge — likely from .env
         lines.append(
             f"  \033[33m⚠\033[0m TERMINAL_CWD={terminal_cwd_env} found in .env — "


### PR DESCRIPTION
## Summary

Two startup false-positives that spam every kanban worker log (and any CLI run that enables a plugin toolset):

1. **`cli.py` — 'Unknown toolsets: omh' for plugin toolsets.** `HermesCLI` validates toolset names at startup, but plugin toolsets are registered during plugin load, which happens *after* this validation — the same timing problem as MCP server names, which were already excluded (see existing `mcp_names` exclusion). This PR excludes names declared in `known_plugin_toolsets.<platform>` the same way.

2. **`hermes_cli/config.py` — spurious TERMINAL_CWD deprecation warning in kanban workers.** `warn_deprecated_cwd_env_vars()` warned that `TERMINAL_CWD` was a stale .env entry. Kanban workers *deliberately* pin `TERMINAL_CWD` to the task workspace (kanban_db.py worker spawn) so file tools and context-file loading anchor on the workspace. Workers are marked with `HERMES_SESSION_SOURCE=kanban`; the warning now skips that case only.

## Motivation

A kanban worker task (`t_fc43cdca`) crashed twice at startup in July because its required skill was missing — but the *only* content in the worker log was these warning lines, which made the real error hard to spot. Clean worker logs make kanban diagnostics readable.

## Verification

- `python -m py_compile cli.py hermes_cli/config.py` — clean.
- With default profile: `invalid = []` for `platform_toolsets.cli` (omh no longer flagged).
- Fresh kanban worker dispatch (run 9, smoke task) produced a log with **neither** warning.
- Normal CLI behavior unchanged (non-worker TERMINAL_CWD warnings still fire).