### PR TITLE
fix(cron): stamp Desktop session as origin so watches can mirror

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2360,6 +2360,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
 
+        if str(platform_name).lower() in {"desktop", "tui", "cli"}:
+            # No gateway adapter. origin.chat_id is the creating session_id.
+            if mirror_enabled and mirror_text:
+                _maybe_mirror_cron_delivery(
+                    job, platform_name, str(chat_id), mirror_text,
+                    thread_id=None, user_id=None, enabled=True,
+                )
+            logger.info(
+                "Job '%s': mirrored to %s session %s (no adapter)",
+                job["id"], platform_name, chat_id,
+            )
+            continue
+
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = _resolve_origin(job) or {}
         origin_thread = origin.get("thread_id")

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -111,6 +111,10 @@ def _find_session_id(
     same-chat candidates exist and none matches the user, return None instead
     of guessing and contaminating another participant's session.
     """
+    # Local surfaces stamp origin.chat_id = HERMES_SESSION_ID.
+    if str(platform or "").lower() in {"desktop", "tui", "cli"} and chat_id:
+        return str(chat_id)
+
     # Primary: state.db
     try:
         from hermes_state import SessionDB

--- a/tests/cron/test_desktop_cron_origin.py
+++ b/tests/cron/test_desktop_cron_origin.py
@@ -1,0 +1,70 @@
+"""Desktop/TUI/CLI cron origin: stamp session_id so attach_to_session can mirror.
+
+Desktop does not set HERMES_SESSION_PLATFORM / CHAT_ID. Without a fallback,
+deliver=origin from a Desktop chat writes only a cron_* session the operator
+never opens. Capture HERMES_SESSION_SOURCE + HERMES_SESSION_ID as origin so
+mirror_to_session can append to that transcript. No gateway adapter is used.
+"""
+
+from unittest.mock import patch
+
+from gateway.mirror import _find_session_id
+from tools.cronjob_tools import _origin_from_env
+
+
+def _session_env(env: dict):
+    return patch(
+        "gateway.session_context.get_session_env",
+        side_effect=lambda name, default="": env.get(name, default),
+    )
+
+
+class TestDesktopOriginCapture:
+    def test_desktop_session_id_becomes_origin(self):
+        env = {
+            "HERMES_SESSION_SOURCE": "desktop",
+            "HERMES_SESSION_ID": "20260816_180049_da67a1",
+        }
+        with _session_env(env):
+            origin = _origin_from_env()
+        assert origin is not None
+        assert origin["platform"] == "desktop"
+        assert origin["chat_id"] == "20260816_180049_da67a1"
+        assert origin["thread_id"] is None
+
+    def test_tui_same_shape(self):
+        env = {
+            "HERMES_SESSION_SOURCE": "tui",
+            "HERMES_SESSION_ID": "20260816_120000_abc123",
+        }
+        with _session_env(env):
+            origin = _origin_from_env()
+        assert origin is not None
+        assert origin["platform"] == "tui"
+        assert origin["chat_id"] == "20260816_120000_abc123"
+
+    def test_messaging_platform_still_wins(self):
+        env = {
+            "HERMES_SESSION_PLATFORM": "telegram",
+            "HERMES_SESSION_CHAT_ID": "-1004301769804",
+            "HERMES_SESSION_SOURCE": "desktop",
+            "HERMES_SESSION_ID": "should-not-win",
+        }
+        with _session_env(env):
+            origin = _origin_from_env()
+        assert origin is not None
+        assert origin["platform"] == "telegram"
+        assert origin["chat_id"] == "-1004301769804"
+
+    def test_source_without_session_id_is_none(self):
+        env = {"HERMES_SESSION_SOURCE": "desktop"}
+        with _session_env(env):
+            assert _origin_from_env() is None
+
+
+class TestDesktopMirrorLookup:
+    def test_find_session_id_returns_chat_id_for_desktop(self):
+        assert (
+            _find_session_id("desktop", "20260816_180049_da67a1")
+            == "20260816_180049_da67a1"
+        )

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -353,6 +353,19 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             # gateway.mirror.mirror_to_session. Harmless for DMs/shared sessions.
             "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
         }
+    # Desktop / TUI / CLI have no messaging platform+chat_id. Stamp the live
+    # session_id so deliver=origin + attach_to_session can mirror back into
+    # that transcript (otherwise output dies in an invisible cron_* session).
+    session_id = get_session_env("HERMES_SESSION_ID") or None
+    source = (get_session_env("HERMES_SESSION_SOURCE") or "").strip().lower()
+    if session_id and source in {"desktop", "tui", "cli"}:
+        return {
+            "platform": source,
+            "chat_id": session_id,
+            "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
+            "thread_id": None,
+            "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
+        }
     return None
 
 


### PR DESCRIPTION
## Bug Description

A cron job created from Hermes Desktop with `deliver=origin` + `attach_to_session=true` never re-enters the creating chat. COMPLETE/STUCK board watches landed only in `cron_<jobid>_*` sessions the operator does not open.

## Root Cause

`_origin_from_env` requires `HERMES_SESSION_PLATFORM` + `HERMES_SESSION_CHAT_ID`. Desktop/TUI/CLI bind `HERMES_SESSION_SOURCE` and `HERMES_SESSION_ID` and leave the messaging platform empty (`NON_MESSAGING_SESSION_SURFACES`). Origin is `None`, so origin delivery is local-only (#51568 class).

## Fix

- Stamp origin as `{platform: desktop|tui|cli, chat_id: session_id}` when those env vars are set and no messaging platform exists.
- Messaging platform+chat_id still wins (Telegram create unchanged).
- `_find_session_id` treats that chat_id as the session id.
- `_deliver_result` skips the gateway adapter for those surfaces and mirrors only.

## How to Verify

1. From Desktop, create a cron job with `deliver=origin` + `attach_to_session=true`.
2. Fire it. Creating session transcript should gain a `[Cron delivery: …]` user turn.
3. Telegram-created jobs still use platform+chat_id origin.

## Test Plan

- [x] `tests/cron/test_desktop_cron_origin.py` (5) + Slack origin tests (4) — 9 passed
- [ ] Manual Desktop fire after merge

## Risk Assessment

Low — messaging origins unchanged. Local surfaces never had an adapter path; we skip `Platform("desktop")` instead of erroring.