### PR TITLE
fix(gateway): mark lifecycle exited on drain-timeout planned stops

### DIFF
--- a/gateway/lifecycle_ledger.py
+++ b/gateway/lifecycle_ledger.py
@@ -20,11 +20,16 @@ This module closes that gap with a tiny state machine persisted to
   telemetry snapshot — is appended to ``gateway-exit-diag.log`` as a
   ``gateway.previous_unclean_exit`` record and logged at WARNING.  The
   sentinel is then rewritten as ``phase=running`` for the new life.
-* On every clean exit path, :func:`mark_exited` rewrites the sentinel as
-  ``phase=exited`` with the exit code and a reason string.  Wired into
-  ``_exit_after_graceful_shutdown`` (the single funnel for all graceful
-  exits, #53107) and the two watchdog ``os._exit`` sites in
-  :mod:`gateway.shutdown_watchdog`.
+* On every clean / planned exit path, :func:`mark_exited` (or
+  :func:`mark_exited_for_pid` for an external stopper) rewrites the
+  sentinel as ``phase=exited`` with the exit code and a reason string.
+  Wired into ``GatewayRunner.stop()`` as soon as a planned drain begins
+  (so a Windows/systemd force-kill mid-drain cannot leave a false
+  ``gateway.previous_unclean_exit``), refined after drain success /
+  drain-timeout, ``_exit_after_graceful_shutdown`` (the final funnel for
+  graceful exits, #53107), the two watchdog ``os._exit`` sites in
+  :mod:`gateway.shutdown_watchdog`, and Windows ``gateway stop`` before
+  it force-terminates a PID that was asked to drain but did not exit.
 
 :func:`sample_memory` provides the cheap (<1ms, pure /proc reads) memory
 snapshot that :func:`gateway.shutdown_watchdog.write_loop_heartbeat`
@@ -277,6 +282,53 @@ def record_startup(home: Optional[Path] = None) -> Optional[Dict[str, Any]]:
     return evidence
 
 
+def mark_exited_for_pid(
+    pid: int,
+    exit_code: Optional[int] = None,
+    reason: str = "planned_force_stop",
+    home: Optional[Path] = None,
+) -> bool:
+    """Mark a planned exit for another process's lifecycle sentinel.
+
+    Used by Windows ``hermes gateway stop`` when the CLI force-kills a
+    gateway that was asked to drain (planned-stop marker written) but did
+    not exit within the stop drain budget.  Without this, the next boot
+    sees ``phase=running`` for a dead PID and falsely reports
+    ``gateway.previous_unclean_exit``.
+
+    Only rewrites when the sentinel's ``pid`` matches ``pid``.  Returns
+    True when the sentinel was rewritten.  Never raises.
+    """
+    try:
+        pid_int = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if pid_int <= 0:
+        return False
+    try:
+        sentinel = _read_json(get_lifecycle_sentinel_path(home))
+        if sentinel is None or sentinel.get("pid") != pid_int:
+            return False
+        _write_sentinel(
+            {
+                "phase": "exited",
+                "pid": pid_int,
+                "exit_code": exit_code,
+                "exit_reason": reason,
+                "exited_at": datetime.now(timezone.utc).isoformat(),
+            },
+            home,
+        )
+        return True
+    except Exception:
+        logger.debug(
+            "Failed to mark lifecycle sentinel exited for pid=%s",
+            pid,
+            exc_info=True,
+        )
+        return False
+
+
 def mark_exited(
     exit_code: Optional[int] = None,
     reason: str = "graceful_shutdown",
@@ -292,22 +344,7 @@ def mark_exited(
     likewise left alone: we must not overwrite evidence we cannot prove is
     ours with a ``clean exit`` claim.
     """
-    try:
-        sentinel = _read_json(get_lifecycle_sentinel_path(home))
-        if sentinel is not None and sentinel.get("pid") != os.getpid():
-            return
-        _write_sentinel(
-            {
-                "phase": "exited",
-                "pid": os.getpid(),
-                "exit_code": exit_code,
-                "exit_reason": reason,
-                "exited_at": datetime.now(timezone.utc).isoformat(),
-            },
-            home,
-        )
-    except Exception:
-        logger.debug("Failed to mark lifecycle sentinel exited", exc_info=True)
+    mark_exited_for_pid(os.getpid(), exit_code=exit_code, reason=reason, home=home)
 
 
 def read_prior_exit_label(profile_home: Path) -> str:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14208,6 +14208,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._clear_plugin_message_injector()
             self._draining = True
 
+            # Persist planned-exit intent BEFORE the drain wait. Windows
+            # ``gateway stop`` caps its wait (~30s) then force-kills, and
+            # systemd TimeoutStopSec can SIGKILL mid-drain — both happen
+            # before ``_exit_after_graceful_shutdown`` can run. Marking
+            # here prevents the next boot from falsely reporting
+            # ``gateway.previous_unclean_exit`` for a planned stop.
+            try:
+                from gateway.lifecycle_ledger import mark_exited as _lifecycle_mark_exited
+                _lifecycle_mark_exited(0, reason="planned_shutdown")
+            except Exception as _e:
+                logger.debug("lifecycle mark_exited(planned_shutdown) failed: %s", _e)
+
             stop_watchdog = getattr(self, "_stop_systemd_watchdog", None)
             if callable(stop_watchdog):
                 await stop_watchdog()
@@ -14288,6 +14300,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _api_at_start,
                 self._active_api_run_count(),
             )
+
+            # Refine the lifecycle reason now that drain outcome is known.
+            # Still best-effort and ownership-guarded; the early
+            # planned_shutdown mark above already covers force-kill during
+            # the drain itself.
+            try:
+                from gateway.lifecycle_ledger import mark_exited as _lifecycle_mark_exited
+                _lifecycle_mark_exited(
+                    0,
+                    reason=(
+                        "drain_timeout_shutdown"
+                        if timed_out
+                        else "graceful_shutdown"
+                    ),
+                )
+            except Exception as _e:
+                logger.debug("lifecycle mark_exited after drain failed: %s", _e)
 
             if not timed_out:
                 # Drain completed gracefully — all running sessions finished.

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1645,6 +1645,22 @@ def stop() -> None:
     # process sweep here: Windows direct-spawn starts are profile-scoped, and a
     # stop command must be bounded even if the scanner or shutdown path is wedged.
     stop_pids.extend(pid for pid in _collect_gateway_stop_pids() if pid not in stop_pids)
+    # If the planned drain did not finish in time, mark those PIDs as a
+    # planned force-stop in the lifecycle sentinel BEFORE TerminateProcess.
+    # Otherwise the next boot sees phase=running + dead PID and falsely
+    # reports gateway.previous_unclean_exit (drain-timeout lifecycle bug).
+    if not drained and stop_pids:
+        try:
+            from gateway.lifecycle_ledger import mark_exited_for_pid
+
+            for force_pid in stop_pids:
+                mark_exited_for_pid(
+                    force_pid,
+                    exit_code=1,
+                    reason="windows_stop_drain_timeout",
+                )
+        except Exception:
+            pass
     killed = _force_terminate_known_gateway_pids(stop_pids)
     if killed:
         stopped_any = True

--- a/tests/gateway/test_cron_active_work_drain.py
+++ b/tests/gateway/test_cron_active_work_drain.py
@@ -18,6 +18,7 @@ this relies on (get_running_job_ids, mark_running_jobs_interrupted).
 """
 
 import asyncio
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -115,4 +116,55 @@ class TestKillToolSubprocessesMarksCronInterrupted:
 
         assert marked_calls, "mark_running_jobs_interrupted was never called during shutdown"
         assert any(result == ["job-1"] for _reason, result in marked_calls)
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_marks_lifecycle_exited(tmp_path, monkeypatch):
+    """Planned stop that times out draining must still mark lifecycle exited.
+
+    Regression for the false ``gateway.previous_unclean_exit`` after a
+    planned stop with in-flight cron work: mark_exited used to run only in
+    ``_exit_after_graceful_shutdown``, so a force-kill during post-drain
+    teardown left ``phase=running`` for a dead PID.
+    """
+    import cron.scheduler as sched
+    import tools.process_registry as _pr
+    import tools.terminal_tool as _tt
+    import tools.browser_tool as _bt
+    from gateway.lifecycle_ledger import (
+        detect_unclean_exit,
+        get_lifecycle_sentinel_path,
+        record_startup,
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    record_startup(home=tmp_path)
+    sentinel_before = json.loads(
+        get_lifecycle_sentinel_path(tmp_path).read_text(encoding="utf-8")
+    )
+    assert sentinel_before["phase"] == "running"
+
+    runner, adapter = make_restart_runner()
+    runner._restart_drain_timeout = 0.01
+    runner._cron_drain_timeout = 0.01
+    adapter.disconnect = _make_async_noop()
+    sched._running_job_ids.add("job-drain-timeout")
+
+    monkeypatch.setattr(_pr.process_registry, "kill_all", lambda task_id=None: 0)
+    monkeypatch.setattr(_tt, "cleanup_all_environments", lambda: None)
+    monkeypatch.setattr(_bt, "cleanup_all_browsers", lambda: None)
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"), \
+         patch("cron.scheduler.mark_job_run"):
+        await runner.stop()
+
+    sentinel = json.loads(
+        get_lifecycle_sentinel_path(tmp_path).read_text(encoding="utf-8")
+    )
+    assert sentinel["phase"] == "exited"
+    assert sentinel["exit_reason"] == "drain_timeout_shutdown"
+    # Simulate the process dying without reaching _exit_after_graceful_shutdown:
+    # the next boot must NOT report previous_unclean_exit.
+    assert detect_unclean_exit(home=tmp_path) is None
+
 

--- a/tests/gateway/test_lifecycle_ledger.py
+++ b/tests/gateway/test_lifecycle_ledger.py
@@ -204,6 +204,49 @@ def test_mark_exited_leaves_pid_none_sentinel_alone(tmp_path: Path) -> None:
     assert sentinel["pid"] is None
 
 
+def test_mark_exited_for_pid_rewrites_matching_sentinel(tmp_path: Path) -> None:
+    """External stoppers (Windows drain-timeout force-kill) must be able to
+    mark another PID's sentinel so the next boot does not false-positive
+    previous_unclean_exit."""
+    from gateway.lifecycle_ledger import mark_exited_for_pid
+
+    _write_sentinel(tmp_path, {
+        "phase": "running",
+        "pid": _DEAD_PID,
+        "start_time": 1000.0,
+        "started_at": "2026-08-16T19:37:00+00:00",
+    })
+    assert mark_exited_for_pid(
+        _DEAD_PID,
+        exit_code=1,
+        reason="windows_stop_drain_timeout",
+        home=tmp_path,
+    ) is True
+    sentinel = _read_sentinel(tmp_path)
+    assert sentinel["phase"] == "exited"
+    assert sentinel["pid"] == _DEAD_PID
+    assert sentinel["exit_reason"] == "windows_stop_drain_timeout"
+    assert detect_unclean_exit(home=tmp_path) is None
+
+
+def test_mark_exited_for_pid_ignores_mismatched_owner(tmp_path: Path) -> None:
+    from gateway.lifecycle_ledger import mark_exited_for_pid
+
+    _write_sentinel(tmp_path, {
+        "phase": "running",
+        "pid": _DEAD_PID,
+        "start_time": 1000.0,
+    })
+    assert mark_exited_for_pid(
+        _DEAD_PID + 1,
+        reason="windows_stop_drain_timeout",
+        home=tmp_path,
+    ) is False
+    sentinel = _read_sentinel(tmp_path)
+    assert sentinel["phase"] == "running"
+    assert sentinel["pid"] == _DEAD_PID
+
+
 # ---------------------------------------------------------------------------
 # read_prior_exit_label (container-boot annotation)
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -364,6 +364,71 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_windows_stop_marks_lifecycle_before_force_kill(monkeypatch, tmp_path):
+    """When drain times out, mark lifecycle exited before TerminateProcess.
+
+    Prevents the next boot from reporting previous_unclean_exit for a
+    planned Windows stop that force-killed mid-drain.
+    """
+    import json
+
+    from gateway.lifecycle_ledger import (
+        detect_unclean_exit,
+        get_lifecycle_sentinel_path,
+        record_startup,
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    record_startup(home=tmp_path)
+    # Pretend the running gateway is a different (dead) PID that owns the
+    # sentinel — the Windows stopper must rewrite *that* PID's record.
+    gateway_pid = 424242
+    path = get_lifecycle_sentinel_path(tmp_path)
+    sentinel = json.loads(path.read_text(encoding="utf-8"))
+    sentinel["pid"] = gateway_pid
+    path.write_text(json.dumps(sentinel), encoding="utf-8")
+
+    force_calls: list[tuple[int, bool]] = []
+    lifecycle_before_kill: list[dict] = []
+
+    def _fake_drain(pid, drain_timeout):
+        assert pid == gateway_pid
+        return False  # timed out
+
+    def _fake_terminate(pids):
+        lifecycle_before_kill.append(
+            json.loads(path.read_text(encoding="utf-8"))
+        )
+        for pid in pids:
+            force_calls.append((pid, True))
+        return len(pids)
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: False)
+    monkeypatch.setattr(
+        "gateway.status.get_running_pid", lambda: gateway_pid
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_collect_gateway_stop_pids", lambda primary=None: [gateway_pid]
+    )
+    monkeypatch.setattr(gateway_windows, "_drain_gateway_pid", _fake_drain)
+    monkeypatch.setattr(
+        gateway_windows, "_force_terminate_known_gateway_pids", _fake_terminate
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_windows_stop_drain_timeout", lambda: 1.0
+    )
+
+    gateway_windows.stop()
+
+    assert force_calls == [(gateway_pid, True)]
+    assert lifecycle_before_kill, "lifecycle must be marked before force-kill"
+    assert lifecycle_before_kill[0]["phase"] == "exited"
+    assert lifecycle_before_kill[0]["pid"] == gateway_pid
+    assert lifecycle_before_kill[0]["exit_reason"] == "windows_stop_drain_timeout"
+    assert detect_unclean_exit(home=tmp_path) is None
+
+
 
 
 


### PR DESCRIPTION
## Summary
- Confirmed defect: `mark_exited` only ran in `_exit_after_graceful_shutdown`, so a planned stop that timed out draining in-flight cron work (then got Windows/systemd force-killed mid-teardown) left `phase=running` and the next boot falsely reported `gateway.previous_unclean_exit`.
- Mark the lifecycle sentinel at planned-stop start (`planned_shutdown`) and again after drain (`drain_timeout_shutdown` / `graceful_shutdown`).
- Add `mark_exited_for_pid` and call it from Windows `gateway stop` before force-kill when the drain wait times out.
- Regression coverage for ledger ownership, stop drain-timeout marking, and Windows pre-kill marking.

## Test plan
- [x] `uv run pytest tests/gateway/test_lifecycle_ledger.py tests/gateway/test_cron_active_work_drain.py tests/hermes_cli/test_gateway_windows.py::test_windows_stop_marks_lifecycle_before_force_kill tests/gateway/test_gateway_shutdown.py -q` → 24 passed, 1 skipped
- [ ] CI green on this PR

Kanban: t_ea02e894 (parent t_19e51c65 incident classification).


Made with [Cursor](https://cursor.com)