### PR TITLE
feat(kanban): expose task max runtime in JSON

### DIFF
--- a/contributors/emails/lorenzo@bemind.me
+++ b/contributors/emails/lorenzo@bemind.me
@@ -1,0 +1,2 @@
+whirmill
+# PR #88011

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -75,6 +75,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "completed_at": t.completed_at,
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
+        "max_runtime_seconds": t.max_runtime_seconds,
         "max_retries": t.max_retries,
         "model_override": t.model_override,
         "provider_override": t.provider_override,

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -19,6 +19,7 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home
@@ -55,6 +56,32 @@ def test_kanban_list_json_includes_session_id(kanban_home):
         and row.get("session_id") == "acp-x"
         for row in payload
     )
+
+
+def test_kanban_json_includes_max_runtime_for_set_and_unset_tasks(kanban_home):
+    limited = json.loads(kc.run_slash(
+        "create 'limited task' --max-runtime 4377 "
+        "--idempotency-key runtime-observability --json"
+    ))
+    reused = json.loads(kc.run_slash(
+        "create 'ignored replacement' --max-runtime 9999 "
+        "--idempotency-key runtime-observability --json"
+    ))
+    uncapped = json.loads(kc.run_slash("create 'uncapped task' --json"))
+
+    assert reused["id"] == limited["id"]
+
+    rows = {
+        row["id"]: row
+        for row in json.loads(kc.run_slash("list --json"))
+    }
+    assert rows[limited["id"]]["max_runtime_seconds"] == 4377
+    assert rows[uncapped["id"]]["max_runtime_seconds"] is None
+
+    limited_show = json.loads(kc.run_slash(f"show {limited['id']} --json"))
+    uncapped_show = json.loads(kc.run_slash(f"show {uncapped['id']} --json"))
+    assert limited_show["task"]["max_runtime_seconds"] == 4377
+    assert uncapped_show["task"]["max_runtime_seconds"] is None
 
 
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -111,6 +111,40 @@ def test_list_filters_tasks(monkeypatch, worker_env):
     assert tenant_ids == [c]
 
 
+def test_show_and_list_include_max_runtime_for_set_and_unset_tasks(
+    monkeypatch, worker_env,
+):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        limited = kb.create_task(
+            conn,
+            title="limited",
+            assignee="runtime-reader",
+            max_runtime_seconds=4377,
+        )
+        uncapped = kb.create_task(
+            conn,
+            title="uncapped",
+            assignee="runtime-reader",
+        )
+    finally:
+        conn.close()
+
+    limited_show = json.loads(kt._handle_show({"task_id": limited}))
+    uncapped_show = json.loads(kt._handle_show({"task_id": uncapped}))
+    assert limited_show["task"]["max_runtime_seconds"] == 4377
+    assert uncapped_show["task"]["max_runtime_seconds"] is None
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    listing = json.loads(kt._handle_list({"assignee": "runtime-reader"}))
+    tasks = {task["id"]: task for task in listing["tasks"]}
+    assert tasks[limited]["max_runtime_seconds"] == 4377
+    assert tasks[uncapped]["max_runtime_seconds"] is None
+
+
 def test_complete_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_complete({

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -501,6 +501,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "started_at": task.started_at,
         "completed_at": task.completed_at,
         "current_run_id": task.current_run_id,
+        "max_runtime_seconds": task.max_runtime_seconds,
         "model_override": task.model_override,
         "provider_override": task.provider_override,
         "parents": parents,
@@ -547,6 +548,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "completed_at": t.completed_at,
                     "result": t.result,
                     "current_run_id": t.current_run_id,
+                    "max_runtime_seconds": t.max_runtime_seconds,
                     "model_override": t.model_override,
                     "provider_override": t.provider_override,
                 }

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -630,6 +630,11 @@ Multi-profile, multi-project collaboration board. Each install can host many boa
 | `decompose <id>` / `decompose --all` | Fan a triage-column task out into a graph of child tasks routed to specialist profiles by description. Falls back to specify-style single-task promotion when the LLM decides the task doesn't benefit from fan-out. Same flags as `specify`. Configure the decomposer model under `auxiliary.kanban_decomposer` in `config.yaml`; `kanban.orchestrator_profile` only controls who owns the root/orchestration task after fan-out. Also runs automatically every dispatcher tick when `kanban.auto_decompose: true` (the default). See [Auto vs Manual orchestration](/user-guide/features/kanban#auto-vs-manual-orchestration). |
 | `gc` | Remove scratch workspaces for archived tasks. |
 
+The task objects emitted by `create --json` and `list --json`, and the `task`
+object emitted by `show --json`, include `max_runtime_seconds`. The value is an
+integer number of seconds when a per-task cap is configured, or JSON `null`
+when the task has no cap.
+
 Examples:
 
 ```bash

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -256,6 +256,12 @@ hermes kanban create "nightly ops review" \
     --json
 ```
 
+Machine-readable task objects expose the persisted timeout as
+`max_runtime_seconds`: an integer number of seconds when configured, or JSON
+`null` when unset. This field is present in CLI `create --json` / `list --json`,
+the `task` object from CLI `show --json`, `kanban_list` task summaries, and the
+`task` object returned by `kanban_show`.
+
 ### Bulk CLI verbs
 
 All the lifecycle verbs accept multiple ids so you can clean up a batch


### PR DESCRIPTION
## Summary

- expose persisted task `max_runtime_seconds` in `hermes kanban list/show --json`
- expose the same integer-or-null field in the official `kanban_list` / `kanban_show` tool serializers
- document the additive JSON contract in the CLI reference and Kanban guide

## Motivation

Hermes already accepts `--max-runtime` when creating a task, but supported read surfaces omitted the persisted value. An external fail-closed client therefore could not verify that an idempotently reused task retained the required timeout before releasing a gated graph.

This patch is intentionally additive: it does not change persistence, task creation, dispatch, migrations, dashboard behavior, or existing JSON keys.

## Contract

- configured timeout: `"max_runtime_seconds": 4377`
- unset timeout: `"max_runtime_seconds": null`
- idempotently reused tasks report the persisted value

## Verification

- `tests/hermes_cli/test_kanban_cli.py`: 5 passed
- `tests/tools/test_kanban_tools.py`: 33 passed
- `tests/hermes_cli/test_kanban_core_functionality.py`: 23 passed, 1 skipped
- `tests/hermes_cli/test_config.py`: 78 passed
- `tests/hermes_cli/test_kanban_db.py`: 29 passed, 1 OS-specific skip under a temporary test-only Git signing shim
- Ruff passed for all four changed Python/test files; targeted `ty` passed
- disposable candidate CLI smoke verified integer/null values through create/list/show
- disposable downstream integration verified both a positive gated apply and fail-closed rejection of an idempotently reused task with the wrong timeout

No live Hermes checkout or service was updated while preparing this PR.
