### PR TITLE
fix(agent): wait for background review exit before live turns

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -875,6 +875,10 @@ def init_agent(
     # the end of the prior turn had finished).
     agent._background_review_agent = None
     agent._background_review_lock = threading.Lock()
+    agent._background_review_done = threading.Event()
+    agent._background_review_done.set()
+    agent._background_review_registered = threading.Event()
+    agent._background_review_registered.set()
 
     # Store OpenRouter provider preferences
     agent.providers_allowed = providers_allowed

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -889,6 +889,13 @@ def _run_review_in_thread(
     except Exception:
         pass
 
+    # Capture this fork's generation-specific lifecycle events. A later live
+    # turn can finish and spawn a new review before this daemon completes its
+    # teardown; setting the parent's then-current events would incorrectly mark
+    # that newer review as done.
+    _review_done = getattr(agent, "_background_review_done", None)
+    _review_registered = getattr(agent, "_background_review_registered", None)
+
     review_agent = None
     review_messages: List[Dict] = []
     review_usage: Dict[str, Any] = {}
@@ -905,8 +912,16 @@ def _run_review_in_thread(
                 with _br_lock:
                     if agent._background_review_agent is agent_ref:
                         agent._background_review_agent = None
+                        if _review_done is not None:
+                            _review_done.set()
+                        if _review_registered is not None:
+                            _review_registered.set()
             elif agent._background_review_agent is agent_ref:
                 agent._background_review_agent = None
+                if _review_done is not None:
+                    _review_done.set()
+                if _review_registered is not None:
+                    _review_registered.set()
         if hasattr(agent, "_active_children"):
             try:
                 _ac_lock = getattr(agent, "_active_children_lock", None)
@@ -1128,8 +1143,12 @@ def _run_review_in_thread(
                 if _br_lock is not None:
                     with _br_lock:
                         agent._background_review_agent = review_agent
+                        if _review_registered is not None:
+                            _review_registered.set()
                 else:
                     agent._background_review_agent = review_agent
+                    if _review_registered is not None:
+                        _review_registered.set()
             if hasattr(agent, "_active_children"):
                 _ac_lock = getattr(agent, "_active_children_lock", None)
                 if _ac_lock is not None:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -170,6 +170,11 @@ _HANDOFF_SKIP_FINAL_RESPONSE = (
 # to treat it as cancellation metadata rather than assistant prose.
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
+# A cancelled review normally unwinds as soon as its request-local socket is
+# aborted (well under a second). Keep the barrier bounded so a broken review
+# cannot replace the old 30-minute live-turn stall with an unbounded prologue.
+_BACKGROUND_REVIEW_CANCEL_WAIT_SECONDS = 10.0
+
 
 def _should_rearm_compression_budget(
     compression_attempts: int,
@@ -1672,28 +1677,102 @@ def run_conversation(
 
     # If a background memory/skill review spawned at the end of a PRIOR turn
     # (agent/background_review.py) is still running its own run_conversation()
-    # when THIS turn starts, cancel it now rather than letting both make
-    # outbound API calls concurrently against the same session_id/credentials.
-    # That concurrency can produce doubled prompt-token accounting on this
-    # turn's own calls and, because the review fork is a fully separate
-    # AIAgent with no route back to THIS agent's interrupt() by default, a
-    # lockup that survives a normal /stop and needs a hard Ctrl+C.
-    # ``review_agent.interrupt()`` is fire-and-forget here — it just flags
-    # cancellation and aborts the review's in-flight socket; it does not
-    # block waiting for the review's daemon thread to exit, so it can't add
-    # latency to this turn. Only ever set on the real owning agent (the
-    # review fork's own copy of this attribute stays None — reviews don't
-    # spawn nested reviews), so this is a no-op on every other run_conversation
-    # caller (subagents, the review fork itself, etc).
-    _pending_review = getattr(agent, "_background_review_agent", None)
-    if _pending_review is not None:
-        try:
-            _pending_review.interrupt("superseded by a new live turn")
-        except Exception:
-            logger.debug(
-                "Failed to cancel in-flight background review for a new turn",
-                exc_info=True,
+    # when THIS turn starts, cancel it and wait for its turn to unwind before
+    # entering live-turn setup. ``interrupt()`` is only a cancellation request:
+    # proceeding immediately used to leave a race window where the review and
+    # live turn shared one session/Relay runtime. In production that repeatedly
+    # froze the live turn after its tool batch until the 30-minute gateway idle
+    # timeout. The review unregisters itself as soon as run_conversation exits;
+    # _background_review_done is the barrier for that exact boundary.
+    _review_lock = getattr(agent, "_background_review_lock", None)
+    if _review_lock is not None:
+        with _review_lock:
+            _pending_review = getattr(agent, "_background_review_agent", None)
+            _review_done = getattr(agent, "_background_review_done", None)
+            _review_registered = getattr(
+                agent, "_background_review_registered", None
             )
+    else:
+        _pending_review = getattr(agent, "_background_review_agent", None)
+        _review_done = getattr(agent, "_background_review_done", None)
+        _review_registered = getattr(agent, "_background_review_registered", None)
+
+    _review_in_flight = _pending_review is not None or (
+        _review_done is not None and not _review_done.is_set()
+    )
+    if _review_in_flight:
+        _review_deadline = (
+            time.monotonic() + _BACKGROUND_REVIEW_CANCEL_WAIT_SECONDS
+        )
+
+        # The thread clears the lifecycle event before start, then registers
+        # its concrete AIAgent after setup. Wait for either registration or
+        # completion so the setup window cannot escape cancellation.
+        if _pending_review is None and _review_registered is not None:
+            _review_registered.wait(
+                timeout=max(0.0, _review_deadline - time.monotonic())
+            )
+            if _review_lock is not None:
+                with _review_lock:
+                    _pending_review = getattr(
+                        agent, "_background_review_agent", None
+                    )
+            else:
+                _pending_review = getattr(agent, "_background_review_agent", None)
+
+        if _pending_review is not None:
+            try:
+                _pending_review.interrupt("superseded by a new live turn")
+            except Exception:
+                logger.debug(
+                    "Failed to cancel in-flight background review for a new turn",
+                    exc_info=True,
+                )
+
+        if _review_done is not None:
+            _review_stopped = _review_done.wait(
+                timeout=max(0.0, _review_deadline - time.monotonic())
+            )
+        else:
+            # Compatibility for lightweight/test agents created without
+            # agent_init: observe the existing identity-guarded pointer.
+            while time.monotonic() < _review_deadline:
+                if _review_lock is not None:
+                    with _review_lock:
+                        _review_stopped = (
+                            getattr(agent, "_background_review_agent", None)
+                            is not _pending_review
+                        )
+                else:
+                    _review_stopped = (
+                        getattr(agent, "_background_review_agent", None)
+                        is not _pending_review
+                    )
+                if _review_stopped:
+                    break
+                time.sleep(0.01)
+            else:
+                _review_stopped = False
+
+        if not _review_stopped:
+            _review_error = (
+                "The previous background review did not stop within "
+                f"{_BACKGROUND_REVIEW_CANCEL_WAIT_SECONDS:g} seconds; "
+                "refusing to start a concurrent live turn against the same session."
+            )
+            logger.error(_review_error)
+            return {
+                "final_response": (
+                    "⚠️ A background self-improvement review did not stop promptly, "
+                    "so I cancelled this attempt instead of risking another long "
+                    "stall. Please resend your message."
+                ),
+                "messages": list(conversation_history or []),
+                "api_calls": 0,
+                "completed": False,
+                "failed": True,
+                "error": _review_error,
+            }
 
     # Adopt any ~/.hermes/.env credential/base-url edits made since the last
     # turn — a Settings save updates .env but not this worker's client, which

--- a/run_agent.py
+++ b/run_agent.py
@@ -1850,12 +1850,48 @@ class AIAgent:
             focus=focus,
             task_cfg=task_cfg,
         )
+        # Publish the review lifecycle before the daemon starts. The fork does
+        # non-trivial setup before it can register its AIAgent pointer; without
+        # these events, a new live turn can slip through that setup window and
+        # race the review before there is anything available to interrupt.
+        _review_done = threading.Event()
+        _review_registered = threading.Event()
+        _review_lock = getattr(self, "_background_review_lock", None)
+        if _review_lock is not None:
+            with _review_lock:
+                self._background_review_done = _review_done
+                self._background_review_registered = _review_registered
+        else:
+            self._background_review_done = _review_done
+            self._background_review_registered = _review_registered
+
+        def _review_target() -> None:
+            try:
+                target()
+            finally:
+                # Setup failures can happen before the fork registers itself.
+                # Wake both wait sites so a live turn never blocks on a review
+                # thread that has already exited.
+                if _review_registered is not None:
+                    _review_registered.set()
+                if _review_done is not None:
+                    _review_done.set()
+
         # Carry the active profile into the review thread so MEMORY.md / skill
         # review writes land in the right profile (#54937).
         t = threading.Thread(
-            target=propagate_context_to_thread(target), daemon=True, name="bg-review"
+            target=propagate_context_to_thread(_review_target),
+            daemon=True,
+            name="bg-review",
         )
-        t.start()
+        try:
+            t.start()
+        except Exception:
+            if _review_registered is not None:
+                _review_registered.set()
+            if _review_done is not None:
+                _review_done.set()
+            raise
 
     def _build_memory_write_metadata(
         self,

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import threading
+import time
+
+import pytest
+
 import run_agent as run_agent_module
 from run_agent import AIAgent
 
@@ -32,6 +37,10 @@ def _bare_agent() -> AIAgent:
     import threading as _threading
     agent._background_review_agent = None
     agent._background_review_lock = _threading.Lock()
+    agent._background_review_done = _threading.Event()
+    agent._background_review_done.set()
+    agent._background_review_registered = _threading.Event()
+    agent._background_review_registered.set()
     agent._active_children = []
     agent._active_children_lock = _threading.Lock()
     return agent
@@ -296,6 +305,12 @@ def test_background_review_registers_on_active_children_for_interrupt(monkeypatc
             # the parent must already point at this fork.
             seen["active_children_during_run"] = list(agent._active_children)
             seen["background_review_agent_during_run"] = agent._background_review_agent
+            seen["background_review_done_during_run"] = (
+                agent._background_review_done.is_set()
+            )
+            seen["background_review_registered_during_run"] = (
+                agent._background_review_registered.is_set()
+            )
 
         def shutdown_memory_provider(self):
             pass
@@ -317,11 +332,15 @@ def test_background_review_registers_on_active_children_for_interrupt(monkeypatc
     fork = seen["background_review_agent_during_run"]
     assert fork is not None
     assert seen["active_children_during_run"] == [fork]
+    assert seen["background_review_done_during_run"] is False
+    assert seen["background_review_registered_during_run"] is True
 
     # After the review completes, both tracking slots must be cleared —
     # otherwise a later interrupt() would try to cancel an already-closed
     # agent, or the next turn would wait on a review that no longer exists.
     assert agent._background_review_agent is None
+    assert agent._background_review_done.is_set()
+    assert agent._background_review_registered.is_set()
     assert agent._active_children == []
 
 
@@ -353,6 +372,128 @@ def test_new_live_turn_cancels_still_running_background_review(monkeypatch):
     _pending_review.interrupt("superseded by a new live turn")
 
     assert calls == ["superseded by a new live turn"]
+
+
+def test_new_live_turn_waits_until_background_review_has_exited(monkeypatch):
+    """The live turn must not enter setup while the cancelled review is alive.
+
+    ``interrupt()`` only requests cancellation; the review worker unregisters
+    itself asynchronously after ``run_conversation()`` unwinds.  Entering the
+    next turn between those two events recreates the same-session overlap that
+    the cancellation guard exists to prevent.
+    """
+    import agent.conversation_loop as conversation_loop_module
+
+    review_exited = threading.Event()
+    agent = _bare_agent()
+
+    class FakeReviewAgent:
+        def interrupt(self, message=None):
+            assert message == "superseded by a new live turn"
+
+            def finish_exit():
+                time.sleep(0.15)
+                with agent._background_review_lock:
+                    agent._background_review_agent = None
+                    agent._background_review_done.set()
+                review_exited.set()
+
+            threading.Thread(target=finish_exit, daemon=True).start()
+
+    agent._background_review_done.clear()
+    agent._background_review_agent = FakeReviewAgent()
+
+    class StopAfterPrologue(Exception):
+        pass
+
+    def fake_build_turn_context(*args, **kwargs):
+        assert review_exited.is_set(), (
+            "live turn entered setup before the interrupted background review exited"
+        )
+        raise StopAfterPrologue
+
+    monkeypatch.setattr(
+        conversation_loop_module,
+        "build_turn_context",
+        fake_build_turn_context,
+    )
+
+    with pytest.raises(StopAfterPrologue):
+        conversation_loop_module.run_conversation(agent, "next live message")
+
+
+def test_new_live_turn_fails_closed_when_background_review_will_not_exit(
+    monkeypatch,
+):
+    """A wedged review must not be allowed to overlap the live turn."""
+    import agent.conversation_loop as conversation_loop_module
+
+    class WedgedReviewAgent:
+        def interrupt(self, message=None):
+            assert message == "superseded by a new live turn"
+
+    agent = _bare_agent()
+    agent._background_review_done.clear()
+    agent._background_review_agent = WedgedReviewAgent()
+    monkeypatch.setattr(
+        conversation_loop_module,
+        "_BACKGROUND_REVIEW_CANCEL_WAIT_SECONDS",
+        0.01,
+    )
+    build_calls = []
+    monkeypatch.setattr(
+        conversation_loop_module,
+        "build_turn_context",
+        lambda *args, **kwargs: build_calls.append(True),
+    )
+
+    result = conversation_loop_module.run_conversation(agent, "next live message")
+
+    assert result["failed"] is True
+    assert "refusing to start a concurrent live turn" in result["error"]
+    assert build_calls == []
+
+
+def test_new_live_turn_catches_background_review_setup_window(monkeypatch):
+    """A review is in flight before its forked AIAgent pointer is published."""
+    import agent.conversation_loop as conversation_loop_module
+
+    agent = _bare_agent()
+    agent._background_review_done.clear()
+    agent._background_review_registered.clear()
+    review_exited = threading.Event()
+
+    class RegisteringReviewAgent:
+        def interrupt(self, message=None):
+            assert message == "superseded by a new live turn"
+            with agent._background_review_lock:
+                agent._background_review_agent = None
+                agent._background_review_done.set()
+            review_exited.set()
+
+    def finish_setup():
+        time.sleep(0.05)
+        with agent._background_review_lock:
+            agent._background_review_agent = RegisteringReviewAgent()
+            agent._background_review_registered.set()
+
+    threading.Thread(target=finish_setup, daemon=True).start()
+
+    class StopAfterPrologue(Exception):
+        pass
+
+    def fake_build_turn_context(*args, **kwargs):
+        assert review_exited.is_set()
+        raise StopAfterPrologue
+
+    monkeypatch.setattr(
+        conversation_loop_module,
+        "build_turn_context",
+        fake_build_turn_context,
+    )
+
+    with pytest.raises(StopAfterPrologue):
+        conversation_loop_module.run_conversation(agent, "next live message")
 
 
 


### PR DESCRIPTION
## Summary
- publish generation-specific lifecycle events before each background review thread starts
- interrupt and wait for the prior review to exit before beginning a live turn
- fail closed after a bounded 10-second wait instead of allowing same-session concurrency

## Root cause
The existing foreground guard called interrupt() but immediately proceeded. A background review sharing the parent session could still be unwinding while the next live turn entered setup. In the Telegram gateway this repeatedly left the foreground turn stuck after tool completion until the 30-minute idle timeout.

## Tests
- Added a deterministic regression test that was red before the barrier: the live turn entered setup before review teardown completed.
- Added coverage for the pre-registration setup window and bounded fail-closed behavior.
- 106 affected tests pass across seven suites; Ruff and git diff checks pass.

## Live evidence
Two gateway incidents showed the same pattern: a new live turn began while a background review was active, its tool results persisted successfully, and no subsequent model call occurred before the 1800-second idle timeout.