### PR TITLE
feat(kanban): add `unarchive` so archiving stops being a one-way door

### DIFF
--- a/contributors/emails/daniel@danielgreen.net
+++ b/contributors/emails/daniel@danielgreen.net
@@ -1,0 +1,1 @@
+PolyphonyRequiem

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -743,6 +743,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Permanently delete already-archived task ids from the board",
     )
 
+    p_unarchive = sub.add_parser(
+        "unarchive", help="Restore one or more archived tasks to the board",
+    )
+    p_unarchive.add_argument("task_ids", nargs="+",
+                             help="Archived task ids to restore (to 'todo')")
+
     # --- tail ---
     p_tail = sub.add_parser("tail", help="Follow a task's event stream")
     p_tail.add_argument("task_id")
@@ -1135,6 +1141,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "reopen-review":  _cmd_reopen_review,
             "promote":  _cmd_promote,
             "archive":  _cmd_archive,
+            "unarchive": _cmd_unarchive,
             "tail":     _cmd_tail,
             "dispatch": _cmd_dispatch,
             "daemon":   _cmd_daemon,
@@ -1200,6 +1207,7 @@ _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
     "unblock",
     "promote",
     "archive",
+    "unarchive",
     "dispatch",
     "daemon",
     "repair",
@@ -2595,6 +2603,27 @@ def _cmd_archive(args: argparse.Namespace) -> int:
                 print(f"cannot archive {tid}", file=sys.stderr)
             else:
                 print(f"Archived {tid}")
+    return 0 if not failed else 1
+
+
+def _cmd_unarchive(args: argparse.Namespace) -> int:
+    """Restore archived tasks. Refuses (non-zero) on a non-archived id."""
+    ids = list(args.task_ids or [])
+    if not ids:
+        print("at least one task_id is required", file=sys.stderr)
+        return 1
+    failed: list[str] = []
+    with kb.connect_closing() as conn:
+        for tid in ids:
+            if not kb.unarchive_task(conn, tid):
+                failed.append(tid)
+                print(
+                    f"cannot unarchive {tid} (must be an archived task)",
+                    file=sys.stderr,
+                )
+            else:
+                status = kb.get_task(conn, tid).status
+                print(f"Unarchived {tid} -> {status}")
     return 0 if not failed else 1
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7455,6 +7455,45 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     return True
 
 
+def unarchive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Restore an archived task to the board.
+
+    The inverse of :func:`archive_task`, which is a pure status change —
+    nothing is deleted, so the restore is expressible. Comments, events and
+    runs are untouched.
+
+    The card is restored to ``todo``, never to its pre-archive status and
+    never to ``running``: ``todo`` is the only safe landing state because
+    dependency recomputation then decides whether it may promote to
+    ``ready``. A card whose parents are still incomplete stays in ``todo``.
+    No claim is re-created; the dispatcher owns claiming.
+
+    Returns False (without writing) when the task does not exist or is not
+    archived — an explicit refusal rather than a silent no-op.
+    """
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if not row or row["status"] != "archived":
+            return False
+        conn.execute(
+            "UPDATE tasks SET status = 'todo', "
+            "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+            "WHERE id = ?",
+            (task_id,),
+        )
+        _append_event(
+            conn, task_id, "unarchived", {"restored_status": "todo"},
+        )
+    # A restored card is no longer a satisfied ('archived') parent, so its
+    # children's readiness — and its own — must be recomputed. This is what
+    # promotes it to 'ready' if and only if its parents are genuinely done.
+    recompute_ready(conn)
+    return True
+
+
 def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """Permanently remove an already-archived task and its related rows.
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -70,6 +70,32 @@ def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     assert "Cannot operate on a closed database" not in output
 
 
+def test_run_slash_unarchive_restores_archived_task(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="swept by mistake", assignee="alice")
+        kb.add_comment(conn, tid, "user", "still here")
+        assert kb.archive_task(conn, tid) is True
+
+    out = kc.run_slash(f"unarchive {tid}")
+    assert f"Unarchived {tid}" in out
+
+    with kb.connect_closing() as conn:
+        # No parents -> promoted out of 'todo' by recompute_ready.
+        assert kb.get_task(conn, tid).status == "ready"
+        assert [c.body for c in kb.list_comments(conn, tid)] == ["still here"]
+        assert "unarchived" in [e.kind for e in kb.list_events(conn, tid)]
+
+
+def test_run_slash_unarchive_refuses_non_archived_task(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="live card", assignee="alice")
+
+    out = kc.run_slash(f"unarchive {tid}")
+    assert "cannot unarchive" in out.lower()
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, tid).status == "ready"
+
+
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):
     kb.create_board("alpha")
     kb.create_board("beta")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -473,6 +473,58 @@ def test_delete_archived_task_removes_related_rows(kanban_home):
         assert conn.execute("SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (tid,)).fetchone()[0] == 0
 
 
+def test_unarchive_task_restores_to_todo_and_preserves_history(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="restore me", assignee="worker")
+        kb.add_comment(conn, tid, "user", "keep this comment")
+        kb.claim_task(conn, tid)
+        kb.complete_task(conn, tid, result="done")
+        comments_before = len(kb.list_comments(conn, tid))
+        runs_before = len(kb.list_runs(conn, tid))
+
+        assert kb.archive_task(conn, tid) is True
+        assert kb.get_task(conn, tid).status == "archived"
+
+        assert kb.unarchive_task(conn, tid) is True
+        task = kb.get_task(conn, tid)
+        # No parents -> recompute_ready promotes todo -> ready.
+        assert task.status == "ready"
+        assert task.claim_lock is None
+        assert task.worker_pid is None
+
+        # History survives intact.
+        assert len(kb.list_comments(conn, tid)) == comments_before
+        assert len(kb.list_runs(conn, tid)) == runs_before
+        kinds = [e.kind for e in kb.list_events(conn, tid)]
+        assert "archived" in kinds
+        assert "unarchived" in kinds
+        payload = [
+            e.payload for e in kb.list_events(conn, tid) if e.kind == "unarchived"
+        ][-1]
+        assert payload["restored_status"] == "todo"
+
+
+def test_unarchive_task_with_incomplete_parent_stays_in_todo(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = kb.create_task(conn, title="child", parents=[parent], assignee="worker")
+        assert kb.archive_task(conn, child) is True
+
+        assert kb.unarchive_task(conn, child) is True
+        # Parent is not done -> must land in todo and stay there.
+        assert kb.get_task(conn, child).status == "todo"
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "todo"
+
+
+def test_unarchive_task_refuses_non_archived_task(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="live one", assignee="worker")
+        assert kb.unarchive_task(conn, tid) is False
+        assert kb.get_task(conn, tid).status == "ready"
+        assert kb.unarchive_task(conn, "t_does_not_exist") is False
+
+
 def test_delete_task_removes_task_and_cascades(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="to-delete", assignee="alice")


### PR DESCRIPTION
## Symptom

`hermes kanban archive` is a one-way door. There is no `unarchive` anywhere in the codebase — no DB function in `hermes_cli/kanban_db.py`, no CLI subcommand in `hermes_cli/kanban.py`, no dashboard action. (The `unarchive` hits that do exist belong to the *session* store and are unrelated.)

Restoring an archived card today means hand-written SQL against `kanban.db`, with the status to restore inferred from the event log.

This matters because archive is used as a **bulk** triage tool. On the board this was found on, 75 cards are archived — 44 of them from a single triage sweep in one day. A bulk sweep is precisely the operation that mis-fires, and precisely the case where hand-written SQL is the least appealing recovery path.

## Why the inverse is expressible

`archive_task` is a pure status change: it sets `status='archived'`, clears the claim, closes any in-flight run as `reclaimed`, and appends an event. Nothing is deleted. So the restore is a status change too — no reconstruction required.

## The fix

**`kanban_db.unarchive_task(conn, task_id)`**

- Restores the card to **`todo`**, not to its pre-archive status and never to `running`. `todo` is the only safe landing state: `recompute_ready` then promotes it to `ready` **iff** its parents are genuinely done. A card with an incomplete parent lands in `todo` and stays there.
- Appends an `unarchived` event with `{"restored_status": "todo"}` so the restore is auditable in `task_events`.
- Does **not** re-create a claim — the dispatcher owns claiming.
- Returns `False` without writing on a non-archived or unknown id: an explicit refusal, not a silent no-op.

**`hermes kanban unarchive <id>...`** — accepts one or more ids, prints the resulting status per card, exits non-zero if any id was refused.

## Explicitly out of scope

`delete_archived_task` (reached via `hermes kanban archive --rm`) is untouched. It hard-deletes comments, events, runs and notify-subs and is genuinely irreversible; it must stay a deliberate human action.

## Tests

`tests/hermes_cli/test_kanban_db.py`
- `test_unarchive_task_restores_to_todo_and_preserves_history` — archive→unarchive round trip; comments, runs and events survive intact; `archived` and `unarchived` both present in the event log; claim fields cleared.
- `test_unarchive_task_with_incomplete_parent_stays_in_todo` — restored child with an unfinished parent stays `todo` across an explicit `recompute_ready`.
- `test_unarchive_task_refuses_non_archived_task` — `False` on a live card and on an unknown id.

`tests/hermes_cli/test_kanban_cli.py`
- `test_run_slash_unarchive_restores_archived_task` — end-to-end through the same `run_slash` entry the CLI and gateway share.
- `test_run_slash_unarchive_refuses_non_archived_task`.

All targeted suites pass (`tests/hermes_cli/test_kanban_db.py`, `tests/hermes_cli/test_kanban_cli.py`: 38 passed). The 15 failures in the wider `-k kanban` selection reproduce identically on a clean `origin/main` and are unrelated (test-isolation-wrapper dependent). `ruff check` clean on all four files.
