### PR TITLE
fix(desktop): resolve the macOS release dir on x64 hosts

### DIFF
--- a/apps/desktop/scripts/test-desktop.mjs
+++ b/apps/desktop/scripts/test-desktop.mjs
@@ -19,7 +19,15 @@ const PLATFORM = process.platform
 // launch via install.ps1 / install.sh, per the Phase 1 thin-installer flow).
 const APP = (() => {
   if (PLATFORM === 'darwin') {
-    const appPath = path.join(RELEASE_ROOT, `mac-${ARCH}`, 'Hermes.app')
+    // electron-builder omits the arch suffix for its default arch, and that
+    // default is x64 -- so an Intel pack lands in `release/mac` while arm64
+    // gets `release/mac-arm64`. `release/mac-x64` is never produced, which
+    // left every Intel host failing here with "app not found". Probe the
+    // suffixed path first, then the bare one, mirroring the mac-arm64 -> mac
+    // fallback scripts/install.sh and scripts/desktop-update/posix.sh use.
+    const appPath =
+      [`mac-${ARCH}`, 'mac'].map(dir => path.join(RELEASE_ROOT, dir, 'Hermes.app')).find(exists) ??
+      path.join(RELEASE_ROOT, `mac-${ARCH}`, 'Hermes.app')
     return {
       appPath,
       binary: path.join(appPath, 'Contents', 'MacOS', 'Hermes'),

--- a/contributors/emails/magerb@gmail.com
+++ b/contributors/emails/magerb@gmail.com
@@ -1,0 +1,1 @@
+IntrepidBytes


### PR DESCRIPTION
## Problem

`apps/desktop/scripts/test-desktop.mjs` builds its darwin app path as:

```js
const appPath = path.join(RELEASE_ROOT, `mac-${ARCH}`, 'Hermes.app')
```

But electron-builder omits the arch suffix for its *default* arch, and that default is x64:

```js
// builder-util/out/arch.js
function getArchSuffix(arch, defaultArch) {
  return arch === defaultArchFromString(defaultArch) ? "" : `-${Arch[arch]}`
}
function defaultArchFromString(name) { return name ? archFromString(name) : Arch.x64 }
```

`mac.defaultArch` isn't set in `apps/desktop/package.json`, so an arm64 pack lands in `release/mac-arm64` while an x64 pack lands in bare `release/mac`. **`release/mac-x64` is never produced.**

The result is that every `npm run test:desktop*` mode fails on an x64 macOS host with "app not found", pointing at a directory the packer cannot emit. arm64 hosts match on the first path, which is why this went unnoticed.

## Fix

Probe the suffixed path first, then the bare one.

This mirrors the `mac-arm64` → `mac` fallback that `scripts/install.sh` and `scripts/desktop-update/posix.sh` **already use for exactly this reason** — so all three call sites now resolve the packed app identically. This is a consistency fix; those two sites already handle the x64 layout and this one was the odd one out.

No behavior change on arm64: `mac-arm64` still matches first.

## Verification

On an x64 macOS host, a clean `hermes desktop --build-only --force-build` produced `release/mac/Hermes.app`:

```
host arch      : x64
OLD (upstream) : …/release/mac-x64/Hermes.app -> NOT FOUND
NEW (fixed)    : …/release/mac/Hermes.app     -> FOUND
```

Built artifact confirmed `Mach-O 64-bit executable x86_64`, with `node-pty` resolving its `darwin-x64` prebuild and `codesign --verify --deep --strict` passing.