### PR TITLE
docs: add ClawMetry to Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ scripts/run_tests.sh
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🔌 [ClawMetry](https://github.com/vivekchand/clawmetry) — Zero-config observability dashboard for Hermes agents: live sessions, token costs, tool calls, and transcripts, alongside 20+ other agent runtimes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ scripts/run_tests.sh
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
-- 🔌 [ClawMetry](https://github.com/vivekchand/clawmetry) — Zero-config observability dashboard for Hermes agents: live sessions, token costs, tool calls, and transcripts, alongside 20+ other agent runtimes.
+- 🔌 [ClawMetry](https://github.com/vivekchand/clawmetry) ([website](https://clawmetry.com)) — Zero-config observability dashboard for Hermes agents: live sessions, token costs, tool calls, and transcripts, alongside 20+ other agent runtimes.
 
 ---
 


### PR DESCRIPTION
Adds ClawMetry to the Community section, matching the existing entry format. It is a zero-config local dashboard that reads Hermes session logs and shows live sessions, token costs, tool calls, and transcripts. I searched open and merged PRs and issues for clawmetry first and found no existing entry.

Website: https://clawmetry.com
