### PR TITLE
fix(skills): never join metadata and bundle across sources

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -123,33 +123,31 @@ def _format_extra_metadata_lines(extra: Dict[str, Any]) -> list[str]:
 
 
 def _resolve_source_meta_and_bundle(identifier: str, sources):
-    """Resolve metadata and bundle for a specific identifier."""
-    meta = None
-    bundle = None
-    matched_source = None
+    """Resolve metadata and bundle for a specific identifier.
 
+    Both MUST come from the same source: the first source whose ``inspect``
+    resolves the identifier anchors the lookup, and only that source's
+    ``fetch`` is consulted for the payload. The previous loop let metadata
+    from one source be joined to a bundle another source served under the
+    bare skill name, so a fully-qualified skills.sh identifier could render
+    a third party's SKILL.md behind the legitimate repo URL while the
+    provenance check passed (#88020). A failed fetch now yields
+    ``bundle=None`` — callers already fail closed on that (install refuses
+    instead of installing mismatched content).
+    """
     for src in sources:
-        if meta is None:
-            try:
-                meta = src.inspect(identifier)
-                if meta:
-                    matched_source = src
-            except Exception:
-                meta = None
+        try:
+            meta = src.inspect(identifier)
+        except Exception:
+            meta = None
+        if not meta:
+            continue
         try:
             bundle = src.fetch(identifier)
         except Exception:
             bundle = None
-        if bundle:
-            matched_source = src
-            if meta is None:
-                try:
-                    meta = src.inspect(identifier)
-                except Exception:
-                    meta = None
-            break
-
-    return meta, bundle, matched_source
+        return meta, bundle, src
+    return None, None, None
 
 
 def _derive_category_from_install_path(install_path: str) -> str:

--- a/tests/hermes_cli/test_skills_source_join.py
+++ b/tests/hermes_cli/test_skills_source_join.py
@@ -1,0 +1,94 @@
+"""Same-source joins in _resolve_source_meta_and_bundle (#88020).
+
+Metadata and the SKILL.md payload must come from the SAME source. The old
+loop let a fully-qualified skills.sh identifier keep its correct repo
+metadata while the bundle was fetched from a later source that indexed the
+bare skill name — serving a third party's SKILL.md behind a legitimate
+repo URL.
+"""
+
+from hermes_cli.skills_hub import _resolve_source_meta_and_bundle
+
+
+class _Meta:
+    def __init__(self, name, identifier):
+        self.name = name
+        self.description = f"{name} from {identifier}"
+        self.source = "test"
+        self.identifier = identifier
+        self.tags = []
+
+
+class _Bundle:
+    def __init__(self, author):
+        self.files = {"SKILL.md": f"---\nauthor: {author}\n---\ncontent"}
+        self.metadata = {"author": author}
+
+
+class _Source:
+    """Fake source: inspect/fetch hit only when the identifier is listed."""
+
+    def __init__(self, name, inspect_ids=(), fetch_ids=(), author="nobody"):
+        self.name = name
+        self._inspect_ids = set(inspect_ids)
+        self._fetch_ids = set(fetch_ids)
+        self._author = author
+
+    def inspect(self, identifier):
+        if identifier in self._inspect_ids:
+            return _Meta(identifier.rsplit("/", 1)[-1], identifier)
+        return None
+
+    def fetch(self, identifier):
+        if identifier in self._fetch_ids:
+            return _Bundle(self._author)
+        return None
+
+
+QUALIFIED = "skills-sh/mvanhorn/last30days-skill/last30days"
+
+
+def test_bundle_never_joined_across_sources():
+    """Anchoring source fails to fetch -> bundle is None, not the later
+    source's bare-name payload (the #88020 third-party substitution)."""
+    skills_sh = _Source(
+        "skills_sh",
+        inspect_ids={QUALIFIED},
+        fetch_ids=set(),  # fetch fails for the qualified id
+        author="mvanhorn",
+    )
+    clawhub = _Source(
+        "clawhub",
+        inspect_ids=set(),
+        fetch_ids={QUALIFIED},  # would serve a bare-name match
+        author="AIsa",
+    )
+    meta, bundle, matched = _resolve_source_meta_and_bundle(
+        QUALIFIED, [skills_sh, clawhub]
+    )
+    assert meta is not None and meta.identifier == QUALIFIED
+    assert matched is skills_sh
+    assert bundle is None, (
+        "bundle was joined across sources — metadata from "
+        f"{skills_sh.name} with payload from {clawhub.name}"
+    )
+
+
+def test_same_source_meta_and_bundle():
+    src = _Source(
+        "skills_sh",
+        inspect_ids={QUALIFIED},
+        fetch_ids={QUALIFIED},
+        author="mvanhorn",
+    )
+    other = _Source("clawhub", fetch_ids={QUALIFIED}, author="AIsa")
+    meta, bundle, matched = _resolve_source_meta_and_bundle(QUALIFIED, [src, other])
+    assert meta is not None and bundle is not None
+    assert matched is src
+    assert bundle.metadata["author"] == "mvanhorn"
+
+
+def test_no_source_matches():
+    src = _Source("skills_sh")
+    meta, bundle, matched = _resolve_source_meta_and_bundle(QUALIFIED, [src])
+    assert meta is None and bundle is None and matched is None


### PR DESCRIPTION
## What does this PR do?

Stops the skills resolver from joining metadata and payload across different sources. `_resolve_source_meta_and_bundle` iterated the source router with two independent hit conditions: the first source whose `inspect()` resolved the identifier supplied the **metadata**, while the first source whose `fetch()` returned anything supplied the **SKILL.md bundle**. A fully-qualified upstream identifier could therefore keep its correct repo metadata (so the provenance check passes) while a later source that indexes the bare skill name served its own SKILL.md — a third party's content (different author, different homepage, its own `primaryEnv` API-key requirement) behind the legitimate repo URL (#88020).

The fix anchors the lookup: the first source whose `inspect()` resolves the identifier is the only source whose `fetch()` is consulted. A failed fetch yields `bundle=None`, and every caller already fails closed on that — the install path refuses with "Could not fetch" instead of installing mismatched content.

## Related Issue

Fixes #88020

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/skills_hub.py` — `_resolve_source_meta_and_bundle` rewritten: anchor on the first successful `inspect`, fetch the bundle from that source only, return `bundle=None` on fetch failure; return signature unchanged. Docstring documents the cross-source join hazard.
- `tests/hermes_cli/test_skills_source_join.py` — new: the cross-source substitution regression (anchoring source fails to fetch → bundle must be None, never the later source's bare-name payload), the same-source happy path, and the no-match path.

## How to Test

1. `python -m pytest tests/hermes_cli/test_skills_source_join.py -q`
2. Observed result: 3 passed. A/B guard: reverting only the resolver hunk makes `test_bundle_never_joined_across_sources` FAIL (the old loop serves the later source's payload), with the fix it passes.
3. `python -m pytest tests/hermes_cli/test_skills_skip_confirm.py -q` — Observed result: 5 passed (existing resolver consumers unaffected).
4. Manual repro from the issue (`hermes skills inspect <fully-qualified id>` where the anchoring source cannot fetch): the header keeps the correct repo metadata and the preview is absent rather than showing a third party's SKILL.md; install refuses instead of installing mismatched content.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/hermes_cli/test_skills_source_join.py -q        # with fix
3 passed in 0.55s
$ git stash -- <resolver file> && pytest ... -q                # A/B guard
1 failed  (bundle was joined across sources)
```
