### PR TITLE
fix(agent): keep cloud hint reads off tool completion path

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -58,6 +58,17 @@ _EXCLUDED_DIR_NAMES = frozenset({
     "vendor", "third_party",
 })
 
+# Cloud-sync filesystem boundaries are not safe to probe synchronously from the
+# live tool-completion path. A context file can exist in directory metadata but
+# block indefinitely in ``read_text()`` while FileProvider hydrates it. This is
+# intentionally relative to ``working_dir``: a user who opens a workspace
+# inside a synced root still gets its project hints, while a broad home-folder
+# workspace does not opportunistically traverse into cloud storage.
+_REMOTE_SYNC_DIR_NAMES = frozenset({
+    "Mobile Documents",
+    "com~apple~CloudDocs",
+})
+
 
 def _is_ancestor_or_same(a: Path, b: Path) -> bool:
     """Check if *a* is the same as or an ancestor of *b* (parent directory check)."""
@@ -170,7 +181,11 @@ class SubdirectoryHintTracker:
             p = Path(raw_path).expanduser()
             if not p.is_absolute():
                 p = self.working_dir / p
+            if self._crosses_remote_sync_boundary(p):
+                return
             p = p.resolve()
+            if self._crosses_remote_sync_boundary(p):
+                return
             # Use parent if it's a file path (has extension or doesn't exist as dir)
             if p.suffix or (p.exists() and p.is_file()):
                 p = p.parent
@@ -214,6 +229,8 @@ class SubdirectoryHintTracker:
         (e.g. ~/.codex/AGENTS.md, ~/.claude/CLAUDE.md), which causes
         cross-agent context contamination and instruction mixup.
         """
+        if self._crosses_remote_sync_boundary(path):
+            return False
         try:
             if not path.is_dir():
                 return False
@@ -236,6 +253,14 @@ class SubdirectoryHintTracker:
         if self._is_excluded(path):
             return False
         return True
+
+    def _crosses_remote_sync_boundary(self, path: Path) -> bool:
+        """Return True when *path* leaves this workspace through cloud storage."""
+        try:
+            rel_parts = path.relative_to(self.working_dir).parts
+        except ValueError:
+            rel_parts = path.parts
+        return any(part in _REMOTE_SYNC_DIR_NAMES for part in rel_parts)
 
     def _is_excluded(self, path: Path) -> bool:
         """True when the path sits inside a directory that holds copies, not context.

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -1,5 +1,7 @@
 """Tests for progressive subdirectory hint discovery."""
 
+import time
+
 import pytest
 from pathlib import Path
 from unittest.mock import patch
@@ -242,6 +244,66 @@ class TestContentDeduplication:
 
 class TestExcludedDirectories:
     """Backups, vendored deps, and caches hold copies — never context."""
+
+    def test_icloud_hint_file_cannot_block_tool_completion(self, tmp_path):
+        """Cloud-synced context discovery must stay off the live tool path."""
+        cloud_root = (
+            tmp_path
+            / "Library"
+            / "Mobile Documents"
+            / "com~apple~CloudDocs"
+        )
+        finances = cloud_root / "Finances"
+        receipts = finances / "2026" / "Receipts"
+        receipts.mkdir(parents=True)
+        hint_path = finances / "CLAUDE.md"
+        hint_path.write_text("Cloud-synced instructions")
+
+        original_read_text = Path.read_text
+        cloud_reads = []
+
+        def slow_cloud_read(path, *args, **kwargs):
+            if path == hint_path:
+                cloud_reads.append(path)
+                time.sleep(0.25)
+            return original_read_text(path, *args, **kwargs)
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        started = time.monotonic()
+        with patch.object(Path, "read_text", slow_cloud_read):
+            result = tracker.check_tool_call(
+                "search_files",
+                {"path": str(receipts)},
+            )
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 0.1, (
+            "subdirectory hint discovery blocked tool completion on an iCloud read"
+        )
+        assert cloud_reads == []
+        assert result is None
+
+    def test_workspace_opened_inside_icloud_still_loads_child_hints(self, tmp_path):
+        """An explicitly selected cloud workspace keeps normal hint behavior."""
+        project = (
+            tmp_path
+            / "Library"
+            / "Mobile Documents"
+            / "com~apple~CloudDocs"
+            / "project"
+        )
+        package = project / "package"
+        package.mkdir(parents=True)
+        (package / "AGENTS.md").write_text("Package instructions")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        result = tracker.check_tool_call(
+            "read_file",
+            {"path": str(package / "module.py")},
+        )
+
+        assert result is not None
+        assert "Package instructions" in result
 
     @pytest.mark.parametrize(
         "excluded",


### PR DESCRIPTION
## Summary
- skip opportunistic subdirectory hint discovery when a broad workspace crosses into macOS iCloud Drive
- reject those paths before resolve/is_dir/read_text can synchronously invoke FileProvider
- preserve normal hint discovery when the user explicitly opens a workspace inside the synced root

## Root cause
A live Telegram turn stalled after a parallel tool batch. A SIGUSR2 faulthandler dump captured the foreground worker blocked in pathlib.Path.read_text, called by SubdirectoryHintTracker._load_hints_for_directory while post-processing an iCloud Finances search path. The file was iCloud Drive/Finances/CLAUDE.md. Tool activity had already been marked completed, so the gateway misleadingly reported the last completed search_files call until its inactivity watchdog fired.

## Regression
The new test simulates a 250ms cloud hydration pause. Before the fix it fails because hint discovery blocks tool completion for 261ms; after the fix it returns without reading the cloud file. A counter-test verifies that a workspace deliberately rooted inside iCloud still loads child hints.

## Verification
30 relevant subdirectory-hint and tool-executor tests pass. Ruff and git diff checks pass.