### PR TITLE
fix(logs): survive log rotation in 'hermes logs -f' follow mode

### DIFF
--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -19,6 +19,7 @@ Usage examples::
     hermes logs --since 30m -f     # follow, starting 30 min ago
 """
 
+import os
 import re
 import sys
 import time
@@ -338,6 +339,30 @@ def _read_last_n_lines(path: Path, n: int) -> list:
         return all_lines[-n:]
 
 
+def _same_file(f, path: Path) -> bool:
+    """True when the open handle ``f`` still refers to the file at ``path``.
+
+    Hermes logs rotate via ``RotatingFileHandler`` (default 5MB, 3 backups):
+    the live file is renamed to ``agent.log.1`` and a fresh file is created
+    at the original path.  A follower holding the old fd would silently go
+    quiet forever.  Compare device+inode (falling back to a size-shrink
+    check on platforms where inodes are unreliable, e.g. Windows).
+    """
+    try:
+        fd_stat = os.fstat(f.fileno())
+        path_stat = os.stat(path)
+    except OSError:
+        # Rotation window: the new file may not exist yet. Treat as rotated
+        # so the caller retries the reopen.
+        return False
+    if (fd_stat.st_dev, fd_stat.st_ino) != (path_stat.st_dev, path_stat.st_ino):
+        return False
+    # Same inode but the file shrank under us (truncate-in-place rotation).
+    if path_stat.st_size < f.tell():
+        return False
+    return True
+
+
 def _follow_log(
     path: Path,
     *,
@@ -346,20 +371,46 @@ def _follow_log(
     since: Optional[datetime] = None,
     component_prefixes: Optional[Sequence[str]] = None,
 ) -> None:
-    """Poll a log file for new content and print matching lines."""
-    with open(path, "r", encoding="utf-8", errors="replace") as f:
-        # Seek to end
+    """Poll a log file for new content and print matching lines.
+
+    Survives log rotation: when the path is replaced (rename+recreate) or
+    truncated, the follower reopens the new file from the beginning so no
+    post-rotation lines are missed.
+    """
+    f = open(path, "r", encoding="utf-8", errors="replace")
+    try:
+        # Seek to end for the initial attach only; reopens after rotation
+        # start at offset 0 so the new file's first lines are shown.
         f.seek(0, 2)
+        idle_polls = 0
         while True:
             line = f.readline()
             if line:
+                idle_polls = 0
                 if _matches_filters(line, min_level=min_level,
                                     session_filter=session_filter, since=since,
                                     component_prefixes=component_prefixes):
                     print(line, end="")
                     sys.stdout.flush()
             else:
+                # Only stat when idle — rotation can't outrun an active read
+                # of the same file, and this keeps the hot path syscall-free.
+                idle_polls += 1
+                if idle_polls >= 2 and not _same_file(f, path):
+                    try:
+                        new_f = open(path, "r", encoding="utf-8",
+                                     errors="replace")
+                    except OSError:
+                        # Mid-rotation gap — retry on the next poll.
+                        time.sleep(0.3)
+                        continue
+                    f.close()
+                    f = new_f
+                    idle_polls = 0
+                    continue
                 time.sleep(0.3)
+    finally:
+        f.close()
 
 
 def list_logs() -> None:

--- a/tests/hermes_cli/test_logs.py
+++ b/tests/hermes_cli/test_logs.py
@@ -149,3 +149,104 @@ class TestLogFiles:
         assert "errors" in LOG_FILES
         assert "gateway" in LOG_FILES
         assert "gui" in LOG_FILES
+
+
+class TestSameFile:
+    """Rotation detection for `hermes logs -f` (_same_file)."""
+
+    def test_same_file_true(self, tmp_path):
+        from hermes_cli.logs import _same_file
+
+        p = tmp_path / "agent.log"
+        p.write_text("hello\n")
+        with open(p, "r") as f:
+            assert _same_file(f, p) is True
+
+    def test_rename_recreate_detected(self, tmp_path):
+        from hermes_cli.logs import _same_file
+
+        p = tmp_path / "agent.log"
+        p.write_text("old\n")
+        with open(p, "r") as f:
+            # RotatingFileHandler-style rollover: rename + recreate.
+            p.rename(tmp_path / "agent.log.1")
+            p.write_text("new\n")
+            assert _same_file(f, p) is False
+
+    def test_missing_path_detected(self, tmp_path):
+        from hermes_cli.logs import _same_file
+
+        p = tmp_path / "agent.log"
+        p.write_text("old\n")
+        with open(p, "r") as f:
+            p.unlink()
+            assert _same_file(f, p) is False
+
+    def test_truncate_in_place_detected(self, tmp_path):
+        from hermes_cli.logs import _same_file
+
+        p = tmp_path / "agent.log"
+        p.write_text("some longer content here\n")
+        with open(p, "r") as f:
+            f.seek(0, 2)  # follower sits at EOF
+            p.write_text("")  # truncated under us
+            assert _same_file(f, p) is False
+
+
+class TestFollowLogRotation:
+    def test_follow_survives_rotation(self, tmp_path, monkeypatch):
+        """_follow_log keeps emitting lines written after a rename+recreate
+        rotation (the pre-fix follower held the old fd and went silent)."""
+        import threading
+        import time as _time
+
+        import hermes_cli.logs as logs_mod
+
+        p = tmp_path / "agent.log"
+        p.write_text("before\n")
+
+        captured = []
+        stop = threading.Event()
+
+        real_sleep = _time.sleep
+
+        def fake_print(line, end=""):
+            captured.append(line)
+
+        def fast_sleep(_secs):
+            real_sleep(0.02)
+            if stop.is_set():
+                raise KeyboardInterrupt
+
+        monkeypatch.setattr("builtins.print", fake_print)
+        monkeypatch.setattr(logs_mod.time, "sleep", fast_sleep)
+
+        t = threading.Thread(
+            target=lambda: _swallow_kbi(logs_mod._follow_log, p), daemon=True
+        )
+        t.start()
+        try:
+            real_sleep(0.15)
+            # Rotate: rename live file away, create a fresh one at the path.
+            p.rename(tmp_path / "agent.log.1")
+            with open(p, "w") as f:
+                f.write("after-rotation\n")
+            deadline = _time.time() + 5.0
+            while _time.time() < deadline:
+                if any("after-rotation" in ln for ln in captured):
+                    break
+                real_sleep(0.05)
+        finally:
+            stop.set()
+            t.join(timeout=5.0)
+
+        assert any("after-rotation" in ln for ln in captured), (
+            f"follower missed post-rotation lines; captured={captured!r}"
+        )
+
+
+def _swallow_kbi(fn, *args):
+    try:
+        fn(*args)
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
## Summary

`hermes logs -f` now survives log rotation — the follower detects rename/recreate and truncate-in-place, reopens the new file, and keeps streaming instead of going silent forever.

Port from [openclaw/openclaw#124369](https://github.com/openclaw/openclaw/pull/124369) ("keep Logs tails bound to their source file"), adapted from their Control UI byte-cursor model to our CLI follower.

## Root cause

`_follow_log()` opened one fd and polled it forever. Hermes logs use `RotatingFileHandler` (default 5MB, 3 backups): rollover renames `agent.log` → `agent.log.1` and recreates `agent.log`. Any active `hermes logs -f` was left holding the renamed backup's fd — no error, just permanent silence.

## Changes

- `hermes_cli/logs.py`: `_same_file()` (device+inode compare, plus size-shrink check for truncate-in-place) and a reopen path in `_follow_log()`. Stat only runs on idle polls, so the hot read path is unchanged; reopens start at offset 0 so post-rotation lines aren't skipped; mid-rotation gaps (path briefly missing) retry on the next poll.
- `tests/hermes_cli/test_logs.py`: 4 `_same_file` unit tests + a threaded regression that performs a real rename+recreate rotation under a live follower.

## Validation

| | Before | After |
|---|---|---|
| rotation under `hermes logs -f` | silent forever | streams new file |
| test suite | — | 19/19 pass |
| sabotage run (`_same_file` → always True) | — | regression test fails as expected |

## Architectural notes

OpenClaw's fix carries a file path alongside a byte cursor through their gateway RPC and rereads in the UI; hermes's follower is a local CLI loop, so the equivalent invariant ("a cursor belongs to one exact file") is enforced with fstat/stat identity checks at the poll site.

## Infographic

![rotation-safe follow](https://v3b.fal.media/files/b/0aa6a1c3/pwTzKZH-5eVBP6PtXu2TS_p53LjBWZ.png)
