### PR TITLE
fix(desktop): stop natural-language actions from losing tool names

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -85,6 +85,35 @@ class TestClassification:
         for name in BRIDGE_TOOL_NAMES:
             assert not is_deferrable_tool_name(name)
 
+    def test_gui_surface_tools_stay_visible_without_global_core_exposure(self):
+        """A GUI session must not gain the generic bridge only because it has
+        finite first-party renderer capabilities that classic CLI lacks."""
+        from tools.registry import discover_builtin_tools
+        from tools.tool_search import (
+            ToolSearchConfig,
+            assemble_tool_defs,
+            classify_tools,
+        )
+        from toolsets import _HERMES_CORE_TOOLS, resolve_toolset
+
+        discover_builtin_tools()
+        gui_names = set(resolve_toolset("desktop_ui")) | set(resolve_toolset("project"))
+        gui_defs = [_td(name, f"First-party GUI capability {name}") for name in gui_names]
+
+        visible, deferrable = classify_tools(gui_defs)
+
+        assert {td["function"]["name"] for td in visible} == gui_names
+        assert deferrable == []
+        assert gui_names.isdisjoint(_HERMES_CORE_TOOLS)
+
+        assembled = assemble_tool_defs(
+            gui_defs,
+            context_length=200_000,
+            config=ToolSearchConfig.from_raw({"enabled": "on"}),
+        )
+        assert not assembled.activated
+        assert {td["function"]["name"] for td in assembled.tool_defs} == gui_names
+
     def test_unknown_tool_not_deferrable(self):
         """Defensive: a tool name we cannot resolve to a registry entry must
         not be claimed as deferrable. This protects against the OpenClaw

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -188,6 +188,16 @@ def load_config() -> ToolSearchConfig:
 # ---------------------------------------------------------------------------
 
 
+# Finite, first-party tools that only exist on a GUI session.  They stay out of
+# _HERMES_CORE_TOOLS so non-GUI clients never pay for their schemas, but once a
+# GUI session enables them they must remain direct model tools.  Treating them
+# as an unbounded plugin catalog makes Desktop/TUI gain the generic ``tool_call``
+# bridge solely because the renderer is present, and small local models may then
+# select that bridge without its required ``name`` instead of using an ordinary
+# core tool.
+_DIRECT_SURFACE_TOOLSETS = frozenset({"desktop_ui", "project"})
+
+
 def _core_tool_names() -> frozenset[str]:
     """Return the set of tool names that must NEVER be deferred.
 
@@ -201,13 +211,33 @@ def _core_tool_names() -> frozenset[str]:
         return frozenset()
 
 
+def _direct_surface_tool_names() -> frozenset[str]:
+    """Return the statically declared tools for direct GUI surfaces.
+
+    Read the built-in declarations rather than trusting a registry entry's
+    toolset so a plugin cannot opt an arbitrary schema out of deferral merely
+    by reusing the ``desktop_ui`` or ``project`` toolset name.
+    """
+    try:
+        from toolsets import TOOLSETS
+
+        return frozenset(
+            name
+            for toolset in _DIRECT_SURFACE_TOOLSETS
+            for name in TOOLSETS.get(toolset, {}).get("tools", ())
+        )
+    except Exception:
+        return frozenset()
+
+
 def is_deferrable_tool_name(name: str) -> bool:
     """Return True if a tool with this name is *eligible* for deferral.
 
     A tool is deferrable iff it is registered with an MCP toolset prefix
-    OR it is not in ``_HERMES_CORE_TOOLS``. Core tools are never deferred
-    even when their toolset is technically plugin-provided (this protects
-    against accidental shadowing).
+    OR it is neither in ``_HERMES_CORE_TOOLS`` nor a finite first-party GUI
+    surface toolset. Core and direct surface tools are never deferred even
+    when their toolset is technically plugin-provided (this protects against
+    accidental shadowing).
     """
     if name in BRIDGE_TOOL_NAMES:
         return False
@@ -221,6 +251,8 @@ def is_deferrable_tool_name(name: str) -> bool:
             return False
         if entry.toolset.startswith("mcp-"):
             return True
+        if name in _direct_surface_tool_names():
+            return False
         # Non-MCP, non-core → plugin tool, eligible.
         return True
     except Exception:


### PR DESCRIPTION
## What does this PR do?

Desktop and TUI sessions could replace their finite first-party GUI tool schemas with the generic tool-search bridge. Small local models could then emit `tool_call` without its required `name`, so natural-language actions that worked in the classic CLI did not execute in Desktop. This change keeps session-gated GUI tools directly visible while preserving deferred discovery for genuine MCP and plugin catalogs.

### Symptom

With the same model and configuration, a natural-language tool request executes in the classic CLI but Desktop can return a generic `tool_call` with no `name` and perform no action.

### Impact

Affected Desktop and TUI users can receive a plausible response without the requested tool action being executed. The observed report uses `ollama-local/qwen3:8b-q4_K_M`; the broader model blast radius is unknown.

### Bug Cause

**Trigger:** `tools/tool_search.py:204` / `is_deferrable_tool_name()` classified every registered non-core tool as deferrable.

**Causal chain:**
1. A Desktop or TUI session enables the finite first-party `desktop_ui` and `project` toolsets.
2. Their presence activates tool search and replaces those direct schemas with `tool_search`, `tool_describe`, and generic `tool_call` bridge schemas.
3. A local model selects the newly introduced generic bridge without its required `name`, and the requested action is rejected instead of executed.

**Why it is wrong:** GUI surface tools are bounded first-party session capabilities, not an unbounded plugin or MCP catalog. Their schemas are already gated by session source, so deferring them changes Desktop's provider request without reducing global core-tool exposure.

**Working sibling / contrast:** The classic CLI does not enable `desktop_ui` or `project`, so the same coding toolset does not activate the generic bridge solely because of the client surface.

**Ruled out:** Typed skill expansion already follows `slash.exec` -> `command.dispatch` and submits the expanded skill payload; related Desktop slash-command tests pass unchanged. The failure is in tool assembly rather than skill message construction.

### Fix

Declare the built-in GUI surface toolsets as direct-only during tool-search classification, deriving names from the static `TOOLSETS` declarations so plugins cannot opt arbitrary tools out of deferral by reusing a toolset label. Add a regression that proves GUI schemas stay direct and outside the global core list while no generic bridge is activated.

## Related Issue

Closes #88006

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tool_search.py` - keep statically declared `desktop_ui` and `project` tools directly visible to GUI sessions.
- `tests/tools/test_tool_search.py` - cover GUI visibility, non-core isolation, and bridge non-activation.

## How to Test

1. Run the tool-search regression suite and confirm the GUI surface classification test passes.
2. Run the related Desktop slash and skill-dispatch tests and confirm existing typed skill expansion remains green.
3. Verify the assembled Desktop tool list contains direct GUI schemas without adding generic bridge tools solely for those schemas.

```bash
scripts/run_tests.sh tests/tools/test_tool_search.py
cd apps/desktop && npx vitest run src/lib/desktop-slash-commands.test.ts
```

Related local validation completed with 94 Python tests and 60 Desktop tests passing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example`: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow contract changed
- [x] Cross-platform impact considered: the classification is platform-independent and session-gated
- [x] Tool descriptions/schemas: N/A - schemas are unchanged; only direct versus deferred exposure changes

## Screenshots / Logs

N/A - the regression is deterministic tool-definition assembly covered by automated tests.
