### PR TITLE
fix(tools): route openai-api through native vision and fail closed on vision refusals

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -172,6 +172,11 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "anthropic": "anthropic",
     "openai": "openai",
     "openai-codex": "openai",
+    # api-key access to the same api.openai.com catalog that "openai-codex"
+    # reaches by subscription. Without this alias every capability lookup on
+    # an api-key OpenAI setup missed, so vision routing read supports_vision
+    # as unknown and demoted the turn to the auxiliary text path.
+    "openai-api": "openai",
     "zai": "zai",
     "kimi": "kimi-for-coding",
     "kimi-coding": "kimi-for-coding",

--- a/tests/tools/test_vision_openai_api_provider.py
+++ b/tests/tools/test_vision_openai_api_provider.py
@@ -1,0 +1,183 @@
+"""``openai-api`` must reach native vision, same as every other OpenAI id.
+
+Regression for a weekly image-curation job that ran with
+``provider: openai-api`` (api-key access to api.openai.com) on a
+vision-capable model. Both capability gates missed the id — it was absent
+from ``PROVIDER_TO_MODELS_DEV`` and from the media-in-tool-results allowlist
+— so every ``vision_analyze`` call was demoted to the auxiliary text model
+instead of attaching the pixels to the main model. Crop reads were the
+visible casualty: they only exist to be looked at.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from unittest.mock import patch
+
+import pytest
+
+from agent.image_routing import decide_image_input_mode, _lookup_supports_vision
+from agent.models_dev import PROVIDER_TO_MODELS_DEV, get_model_capabilities
+from tools.vision_tools import (
+    _handle_vision_analyze,
+    _should_use_native_vision_fast_path,
+    _supports_media_in_tool_results,
+)
+
+
+_MODEL = "gpt-5.6-luna"
+
+# Minimal valid 1x1 PNG bytes.
+_TINY_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+)
+
+# Shape mirrors a real models.dev entry: vision is read off modalities.input.
+_FAKE_CATALOG = {
+    "openai": {
+        "models": {
+            _MODEL: {
+                "tool_call": True,
+                "reasoning": True,
+                "modalities": {"input": ["text", "image"]},
+                "limit": {"context": 1050000, "output": 128000},
+                "family": "gpt-luna",
+            }
+        }
+    }
+}
+
+
+# ─── models.dev provider alias ───────────────────────────────────────────────
+
+
+class TestModelsDevAlias:
+    def test_openai_api_maps_to_openai(self):
+        assert PROVIDER_TO_MODELS_DEV.get("openai-api") == "openai"
+        assert PROVIDER_TO_MODELS_DEV.get("openai-codex") == "openai"
+
+    def test_capability_lookup_resolves(self):
+        """Regression: this returned None, so vision routing saw "unknown"."""
+        with patch("agent.models_dev.fetch_models_dev", return_value=_FAKE_CATALOG):
+            caps = get_model_capabilities("openai-api", _MODEL)
+        assert caps is not None
+        assert caps.supports_vision is True
+
+    def test_capability_lookup_matches_the_openai_id(self):
+        with patch("agent.models_dev.fetch_models_dev", return_value=_FAKE_CATALOG):
+            via_alias = get_model_capabilities("openai-api", _MODEL)
+            via_canonical = get_model_capabilities("openai", _MODEL)
+        assert via_alias == via_canonical
+
+    def test_unmapped_provider_still_returns_none(self):
+        """The alias is a targeted addition, not a blanket fallthrough."""
+        with patch("agent.models_dev.fetch_models_dev", return_value=_FAKE_CATALOG):
+            assert get_model_capabilities("not-a-provider", _MODEL) is None
+
+
+# ─── media-in-tool-results allowlist ─────────────────────────────────────────
+
+
+class TestSupportsMediaInToolResults:
+    def test_openai_api_yes(self):
+        assert _supports_media_in_tool_results("openai-api", _MODEL) is True
+
+    def test_case_and_whitespace_tolerant(self):
+        assert _supports_media_in_tool_results("  OpenAI-API  ", _MODEL) is True
+
+    def test_unknown_provider_still_no(self):
+        assert _supports_media_in_tool_results("some-local-relay", _MODEL) is False
+
+
+# ─── the routing decision ────────────────────────────────────────────────────
+
+
+class TestImageInputMode:
+    def test_openai_api_routes_native(self):
+        with patch("agent.models_dev.fetch_models_dev", return_value=_FAKE_CATALOG):
+            assert _lookup_supports_vision("openai-api", _MODEL, {}) is True
+            assert decide_image_input_mode("openai-api", _MODEL, {}) == "native"
+
+    def test_explicit_aux_vision_config_does_not_preempt_native(self):
+        """The cron's config sets auxiliary.vision; it is a fallback, not a veto."""
+        cfg = {"auxiliary": {"vision": {"provider": "openai-api", "model": "gpt-4o-mini"}}}
+        with patch("agent.models_dev.fetch_models_dev", return_value=_FAKE_CATALOG):
+            assert decide_image_input_mode("openai-api", _MODEL, cfg) == "native"
+
+
+# ─── the gate the cron actually hit ──────────────────────────────────────────
+
+
+class TestNativeFastPathGate:
+    def test_fast_path_selected_under_openai_api(self):
+        with (
+            patch("agent.auxiliary_client._read_main_provider", return_value="openai-api"),
+            patch("agent.auxiliary_client._read_main_model", return_value=_MODEL),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("agent.models_dev.fetch_models_dev", return_value=_FAKE_CATALOG),
+        ):
+            assert _should_use_native_vision_fast_path() is True
+
+
+class TestRegionReadReachesNativeInput:
+    """The reproduced failure: a region crop under ``openai-api``.
+
+    Acceptance is that the crop arrives as image input for the main model and
+    the auxiliary vision model is never called at all.
+    """
+
+    @pytest.mark.asyncio
+    async def test_region_crop_returns_multimodal_envelope(self, tmp_path):
+        pytest.importorskip("PIL", reason="region cropping requires Pillow")
+        from PIL import Image
+
+        img = tmp_path / "candidate.png"
+        Image.new("RGB", (200, 120), (40, 40, 90)).save(img, format="PNG")
+
+        async def _boom(*args, **kwargs):
+            raise AssertionError("auxiliary vision model must not be called")
+
+        with (
+            patch("agent.auxiliary_client._read_main_provider", return_value="openai-api"),
+            patch("agent.auxiliary_client._read_main_model", return_value=_MODEL),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("agent.models_dev.fetch_models_dev", return_value=_FAKE_CATALOG),
+            patch("tools.vision_tools.async_call_llm", new=_boom),
+        ):
+            result = await _handle_vision_analyze({
+                "image_url": str(img),
+                "question": "Full-size read: banding, artifacting, smearing.",
+                "region": [20, 20, 140, 100],
+            })
+
+        assert isinstance(result, dict), result
+        assert result.get("_multimodal") is True
+        parts = result["content"]
+        assert [p["type"] for p in parts] == ["text", "image_url"]
+        assert parts[1]["image_url"]["url"].startswith("data:image/")
+        # The crop offset has to survive, or reported coordinates are wrong.
+        assert "offset (20, 20)" in parts[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_whole_image_also_reaches_native_input(self, tmp_path):
+        img = tmp_path / "candidate.png"
+        img.write_bytes(_TINY_PNG)
+
+        async def _boom(*args, **kwargs):
+            raise AssertionError("auxiliary vision model must not be called")
+
+        with (
+            patch("agent.auxiliary_client._read_main_provider", return_value="openai-api"),
+            patch("agent.auxiliary_client._read_main_model", return_value=_MODEL),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("agent.models_dev.fetch_models_dev", return_value=_FAKE_CATALOG),
+            patch("tools.vision_tools.async_call_llm", new=_boom),
+        ):
+            result = await _handle_vision_analyze({
+                "image_url": str(img),
+                "question": "Thumbnail read: does the composition stay legible?",
+            })
+
+        assert isinstance(result, dict), result
+        assert result.get("_multimodal") is True

--- a/tests/tools/test_vision_refusal_fail_closed.py
+++ b/tests/tools/test_vision_refusal_fail_closed.py
@@ -1,0 +1,161 @@
+"""The auxiliary vision path must fail closed on a non-analysis response.
+
+A vision model that declines returns prose on the HTTP success path, so
+nothing downstream could tell "I'm unable to describe the image" apart from a
+real description — ``vision_analyze`` reported ``success: true`` either way.
+Gates that require an actual visual read then pass on a picture nothing ever
+looked at.
+
+The refusal detector is deliberately conservative: a false positive blocks a
+legitimate read, so the negative cases below matter as much as the positive
+ones. In particular, "I can't see any banding in this crop" is a real finding
+about the pixels, not a refusal to look at them.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools.vision_tools import _is_vision_refusal, vision_analyze_tool
+
+
+# The exact text the OpenAI auxiliary model returned on every cropped read.
+_OBSERVED_REFUSAL = (
+    "I'm unable to describe or analyze the specific content of the image. "
+    "However, I can help you understand how to describe texture and edges in "
+    "general.\n\nWhen discussing texture, consider the following aspects:\n\n"
+    "1. **Surface Quality**: Is it smooth, rough, glossy, or matte?"
+)
+
+
+# ─── _is_vision_refusal ──────────────────────────────────────────────────────
+
+
+class TestIsVisionRefusalPositive:
+    def test_observed_production_refusal(self):
+        assert _is_vision_refusal(_OBSERVED_REFUSAL) is True
+
+    @pytest.mark.parametrize("text", [
+        "I'm unable to analyze this image.",
+        "I am not able to describe the image.",
+        "I cannot process the image you provided.",
+        "Sorry, but I can't describe the image.",
+        "Unfortunately, I am unable to view the picture.",
+        "I don't have the ability to see images.",
+        "I can't interpret the cropped region of the image.",
+        "No image was provided.",
+        "There is no image attached to analyze.",
+        "I don't see an image in your message.",
+    ])
+    def test_refusal_forms(self, text):
+        assert _is_vision_refusal(text) is True
+
+    def test_leading_whitespace_and_case(self):
+        assert _is_vision_refusal("\n\n  I'M UNABLE TO ANALYZE THE IMAGE.  ") is True
+
+
+class TestIsVisionRefusalNegative:
+    @pytest.mark.parametrize("text", [
+        # The whole point of a render-defect read: reporting absences.
+        "I can't see any banding in this crop; the gradient is clean.",
+        "I cannot make out fine grain within the image at this scale.",
+        "There is no visible smearing in the image.",
+        # Ordinary descriptions.
+        "The image features a series of pyramidal shapes casting long shadows.",
+        "A cropped dark mass sits low-left against a pale blue field.",
+        # Describing an inability that belongs to the subject, not the model.
+        "The figure appears unable to see past the doorway.",
+        "The composition is unable to resolve into a single focal point.",
+        # Hedged but substantive.
+        "It is hard to describe the edge quality precisely, but the fibers "
+        "read as torn rather than cut, with visible rag texture.",
+    ])
+    def test_not_a_refusal(self, text):
+        assert _is_vision_refusal(text) is False
+
+    def test_late_disclaimer_after_real_analysis_is_not_a_refusal(self):
+        analysis = (
+            "The crop shows a scorched-paper ground with three warm inclusions "
+            "clustered low-right. Edge quality is soft but intact; no banding, "
+            "no compression artifacting, no smearing along the torn seam. The "
+            "rag fiber stays legible at full size. " + ("Grain is even. " * 20)
+            + "I can't describe the image beyond this without a wider view."
+        )
+        assert _is_vision_refusal(analysis) is False
+
+    @pytest.mark.parametrize("value", ["", "   ", None, 42, [], {}])
+    def test_non_text_inputs(self, value):
+        assert _is_vision_refusal(value) is False
+
+
+# ─── vision_analyze_tool integration ─────────────────────────────────────────
+
+
+def _response(content):
+    mock_response = MagicMock()
+    mock_choice = MagicMock()
+    mock_choice.message.content = content
+    mock_response.choices = [mock_choice]
+    return mock_response
+
+
+async def _run(tmp_path, content, **kwargs):
+    img = tmp_path / "test.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+    with (
+        patch(
+            "tools.vision_tools._image_to_base64_data_url",
+            return_value="data:image/png;base64,abc",
+        ),
+        patch(
+            "tools.vision_tools.async_call_llm",
+            new_callable=AsyncMock,
+            return_value=_response(content),
+        ),
+    ):
+        return json.loads(
+            await vision_analyze_tool(str(img), "describe this", "test/model", **kwargs)
+        )
+
+
+class TestAuxPathFailsClosed:
+    @pytest.mark.asyncio
+    async def test_refusal_is_an_explicit_failure(self, tmp_path):
+        result = await _run(tmp_path, _OBSERVED_REFUSAL)
+        assert result["success"] is False
+        assert result["refusal"] is True
+        assert "not analyzed" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_refusal_keeps_the_model_text_for_diagnosis(self, tmp_path):
+        result = await _run(tmp_path, _OBSERVED_REFUSAL)
+        assert "unable to describe" in result["analysis"]
+
+    @pytest.mark.asyncio
+    async def test_empty_response_is_an_explicit_failure(self, tmp_path):
+        """Previously reported success with a canned "problem" string."""
+        result = await _run(tmp_path, "")
+        assert result["success"] is False
+        assert result["refusal"] is True
+        assert "empty response" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_real_analysis_still_succeeds(self, tmp_path):
+        result = await _run(
+            tmp_path,
+            "Rough rag fiber, torn seam, no banding or smearing at full size.",
+        )
+        assert result["success"] is True
+        assert "refusal" not in result
+        assert "rag fiber" in result["analysis"]
+
+    @pytest.mark.asyncio
+    async def test_negative_finding_still_succeeds(self, tmp_path):
+        """A clean technical read reports absences — it must not be swallowed."""
+        result = await _run(
+            tmp_path, "I can't see any banding or artifacting in this crop."
+        )
+        assert result["success"] is True

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -35,6 +35,7 @@ import json
 from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
+import re
 import uuid
 from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
@@ -793,6 +794,72 @@ def _build_scale_note(
     return " ".join(parts)
 
 
+# How far into the response a refusal has to appear to count as one. A model
+# that declines leads with the disclaimer; a genuine analysis that mentions
+# not being able to make something out does so partway through, after it has
+# already described what it *can* see.
+_REFUSAL_SCAN_CHARS = 400
+
+# First-person inability → an analysis verb → an image noun, with bounded,
+# sentence-local gaps so the three parts have to belong to one clause.
+_VISION_REFUSAL_RE = re.compile(
+    r"(?:i(?:'m| am)? (?:unable|not able) to"
+    r"|i (?:can'?t|cannot|can not|don'?t|do not)"
+    r"|(?:sorry|unfortunately)[,.]? (?:but )?i (?:can'?t|cannot|am unable to))"
+    r"[^.]{0,60}?"
+    r"(?:describe|analyz|analys|interpret|process|view|see|make out"
+    r"|provide (?:a )?(?:description|analysis)"
+    r"|have the ability to (?:see|view|analyz|analys))"
+    r"[^.]{0,80}?"
+    r"(?:image|picture|photo|crop|visual content|the content)",
+    re.IGNORECASE,
+)
+
+# "I can't see any banding in this crop" is a real observation about the
+# pixels, not a refusal to look at them. The giveaway is that the image noun
+# is a *location* ("in the image") rather than the thing being declined
+# ("of the image"), so drop matches whose span reads that way.
+_REFUSAL_FALSE_POSITIVE_RE = re.compile(
+    r"\b(?:in|within|on|across|near|inside)\s+(?:the|this|that)\s+"
+    r"(?:image|picture|photo|crop)",
+    re.IGNORECASE,
+)
+
+# Blunter forms that never carry an analysis: nothing arrived to look at.
+_NO_IMAGE_RE = re.compile(
+    r"(?:no image (?:was )?(?:provided|attached|received|included)"
+    r"|there (?:is|was) no image"
+    r"|i (?:don'?t|do not) see (?:an|any) image)",
+    re.IGNORECASE,
+)
+
+
+def _is_vision_refusal(analysis: str) -> bool:
+    """Whether the auxiliary vision model declined instead of analyzing.
+
+    A refusal is prose, not an API error, so it arrives on the success path
+    and reads as a normal result to everything downstream. Gates that require
+    an actual visual read (render-defect checks, alt-text grounding) cannot
+    tell it apart from a real description, so it has to be caught here and
+    turned into an explicit failure.
+
+    Deliberately conservative — a false positive blocks a legitimate read, so
+    the match requires a first-person inability, an analysis verb, and an
+    image noun inside one clause near the start of the response.
+    """
+    if not isinstance(analysis, str):
+        return False
+    head = analysis.strip()[:_REFUSAL_SCAN_CHARS]
+    if not head:
+        return False
+    if _NO_IMAGE_RE.search(head):
+        return True
+    match = _VISION_REFUSAL_RE.search(head)
+    if match is None:
+        return False
+    return _REFUSAL_FALSE_POSITIVE_RE.search(match.group(0)) is None
+
+
 def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
                               max_base64_bytes: int = _RESIZE_TARGET_BYTES,
                               max_dimension: Optional[int] = None,
@@ -1541,21 +1608,59 @@ async def vision_analyze_tool(
             analysis = extract_content_or_reasoning(response)
 
         analysis_length = len(analysis)
-        
+
         logger.info("Image analysis completed (%s characters)", analysis_length)
-        
-        # Prepare successful response
-        analysis = analysis or "There was a problem with the request and the image could not be analyzed."
+
         scale_note = _build_scale_note(
             _scale_info or None, _crop_offset or None,
         )
+
+        # Fail closed on a non-analysis response. An empty completion or a
+        # prose refusal both come back on the success path, and reporting
+        # either as success=True hands callers a green result for an image
+        # nothing ever looked at.
+        if not analysis:
+            refusal_reason = "the vision model returned an empty response"
+        elif _is_vision_refusal(analysis):
+            refusal_reason = "the vision model declined to analyze the image"
+        else:
+            refusal_reason = ""
+
+        if refusal_reason:
+            logger.warning(
+                "Vision analysis failed closed: %s (model=%s)",
+                refusal_reason, model or "auto",
+            )
+            error_msg = (
+                f"Image was not analyzed: {refusal_reason}. This is a tooling "
+                f"failure, not a description of the image — do not treat it as "
+                f"a visual read."
+            )
+            result = {
+                "success": False,
+                "error": error_msg,
+                "refusal": True,
+                "analysis": (
+                    f"[{scale_note}] {analysis}" if scale_note and analysis
+                    else (analysis or error_msg)
+                ),
+            }
+            if scale_note:
+                result["scale_note"] = scale_note
+            debug_call_data["error"] = error_msg
+            debug_call_data["analysis_length"] = analysis_length
+            _debug.log_call("vision_analyze_tool", debug_call_data)
+            _debug.save()
+            return json.dumps(result, indent=2, ensure_ascii=False)
+
+        # Prepare successful response
         result = {
             "success": True,
             "analysis": f"[{scale_note}] {analysis}" if scale_note else analysis,
         }
         if scale_note:
             result["scale_note"] = scale_note
-        
+
         debug_call_data["success"] = True
         debug_call_data["analysis_length"] = analysis_length
         

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1005,8 +1005,12 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     if p in {"anthropic", "claude", "anthropic-direct"}:
         return True
 
-    # OpenAI Chat Completions and Responses
-    if p in {"openai", "openai-chat", "openai-codex", "azure-openai"}:
+    # OpenAI Chat Completions and Responses. ``openai-api`` is the api-key
+    # provider for the same api.openai.com endpoints that ``openai-codex``
+    # reaches by subscription — same overlay transport (``codex_responses``),
+    # same catalog. Omitting it here silently demoted every vision call on an
+    # api-key OpenAI setup to the auxiliary-LLM text path.
+    if p in {"openai", "openai-api", "openai-chat", "openai-codex", "azure-openai"}:
         return True
 
     # Gemini — gate on model name; older Gemini variants did not support


### PR DESCRIPTION
## What & why

A weekly image-curation cron running provider `openai-api` on a vision-capable model had **every** `vision_analyze` call silently demoted to the auxiliary text model. Native-resolution crop reads (`region=[x1,y1,x2,y2]`) were the visible casualty — they exist only to be looked at, and the auxiliary model answered them with "I'm unable to analyze the specific content of the image" reported as `success: true`.

Two independent defects, both on the same incident path:

### 1. `openai-api` was missing from both vision capability gates

`openai-api` is API-key access to the same `api.openai.com` catalog that `openai-codex` reaches by subscription, and both declare the same `codex_responses` overlay transport. But the id was absent from both gates:

- `PROVIDER_TO_MODELS_DEV` had no entry, so `get_model_capabilities()` returned `None`, `_lookup_supports_vision()` returned unknown, and `decide_image_input_mode()` fell through to `"text"`.
- `_supports_media_in_tool_results()` allowlisted `openai`, `openai-chat`, `openai-codex` and `azure-openai` but not `openai-api`, so the `or` arm could not rescue it either.

Both gates failing meant `_should_use_native_vision_fast_path()` was always `False` for this provider. models.dev already knows the model is vision-capable; nothing was asking it under a key it recognizes.

### 2. A vision-model refusal was reported as success

A vision model that declines returns prose on the HTTP success path, so `vision_analyze` returned `success: true` wrapped around a refusal. Nothing downstream could tell that apart from a real description — an automated render-defect or alt-text-grounding check would pass on an image nothing ever looked at. The empty-completion case was the same false green in a different costume: `success: true` around a canned "there was a problem" string.

Now a refusal or empty completion returns `success: false, refusal: true` with an error saying the image was not analyzed. The model's own text is preserved in `analysis` so the failure is diagnosable rather than opaque.

`_is_vision_refusal` is deliberately conservative — a false positive blocks a legitimate read. It requires a first-person inability, an analysis verb and an image noun inside one clause near the start of the response, and drops matches whose image noun is a location rather than the object being declined. *"I can't see any banding in this crop"* is a real finding about the pixels and still passes.

These are kept in one PR because they are the same incident: fix (1) alone still leaves refusals reported as success, and the refusal path stays reachable for genuinely text-only main models after (1) lands.

## How to test

Reproduction on the affected runtime (provider `openai-api`, vision-capable model), before the change:

```python
decide_image_input_mode("openai-api", "<vision-capable-model>", cfg)  # -> "text"
get_model_capabilities("openai-api", "<vision-capable-model>")        # -> None
get_model_capabilities("openai",     "<vision-capable-model>")        # -> supports_vision=True
_supports_media_in_tool_results("openai-api", ...)                    # -> False
_should_use_native_vision_fast_path(...)                              # -> False
```

After: capability lookup resolves (`supports_vision=True`), mode is `"native"`, the fast path is selected, and the `region` call that had been refused returns the crop as image input with its offset note intact — verified with the auxiliary client patched to raise, proving it is no longer reached.

Automated coverage (44 new tests, both files confirmed red without the source change):

```
scripts/run_tests.sh tests/tools/test_vision_openai_api_provider.py tests/tools/test_vision_refusal_fail_closed.py -q
# 44 passed
```

Blast radius, same runner, branch vs. its merge-base:

```
scripts/run_tests.sh tests/tools/ tests/agent/ -q
```

Identical results on both — 19 files / 67 tests failing, byte-identical `FAILED` line sets, all pre-existing local-environment failures (absent API keys, Daytona/Modal/fal, voice deps). No new failures introduced.

## Platforms tested

- macOS 15 (Darwin 24.6.0), Python 3.13 — full test runs above
- Linux (Debian VPS) — live reproduction and post-fix verification against the real config that produced the incident
