### PR TITLE
fix(cron): clear inherited delegate_task lineage at scheduled-job start

### DIFF
--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -121,6 +121,33 @@ def exit_non_dispatcher_owned_context(token: Token[bool]) -> None:
     _NON_DISPATCHER_OWNED_CONTEXT.reset(token)
 
 
+def reset_delegated_child_lineage() -> Token[bool]:
+    """Clear inherited delegate_task lineage for a scope that is NOT a child.
+
+    Scheduled cron jobs are never delegate_task children, but a job's asyncio
+    task can inherit ``_DELEGATED_CHILD_CONTEXT`` (and, defensively, a leaked
+    ``HERMES_DELEGATED_CHILD_CONTEXT`` os.environ marker) when a
+    delegation-enabled session has a child active at task-spawn time.  Left
+    set, every terminal subprocess the job spawns gets its env scrubbed and
+    marked (``scrub_kanban_env``), so ``hermes kanban`` invocations die at DB
+    init with the child mutation guard — a false alarm for the job.
+
+    Token-based for callers whose scope is a long ``try``/``finally`` rather
+    than a ``with`` block.  Pair with :func:`restore_delegated_child_lineage`.
+    """
+    import os
+
+    # Never legitimate in this process's own environ: the marker is only set
+    # in *copied* envs handed to child subprocesses.  Popping is corrective.
+    os.environ.pop(DELEGATED_CHILD_ENV_MARKER, None)
+    return _DELEGATED_CHILD_CONTEXT.set(False)
+
+
+def restore_delegated_child_lineage(token: Token[bool]) -> None:
+    """Restore the flag saved by :func:`reset_delegated_child_lineage`."""
+    _DELEGATED_CHILD_CONTEXT.reset(token)
+
+
 def is_delegated_child_process_context() -> bool:
     """Return True in this process or a subprocess spawned by a child."""
     import os

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -58,6 +58,8 @@ from agent.interrupt_compat import request_hard_interrupt
 from agent.delegation_context import (
     enter_non_dispatcher_owned_context,
     exit_non_dispatcher_owned_context,
+    reset_delegated_child_lineage,
+    restore_delegated_child_lineage,
 )
 
 logger = logging.getLogger(__name__)
@@ -4695,6 +4697,7 @@ def run_job(
     _cron_session_var = _VAR_MAP["HERMES_CRON_SESSION"]
     _cron_session_token = None
     _non_dispatcher_token = None
+    _delegated_lineage_token = None
     try:
         if not _cwd_lock_acquired:
             # Fail closed (#79768): running without the lock would let a
@@ -4737,6 +4740,13 @@ def run_job(
         # concurrent cron jobs on the parallel pool.  contextvars.copy_context()
         # at the run_conversation hop carries this into the agent thread.
         _non_dispatcher_token = enter_non_dispatcher_owned_context()
+        # Scheduled jobs are never delegate_task children, but the job's
+        # asyncio task can inherit delegated-child lineage from a session
+        # that had a child active at spawn time.  Clear it so the job's
+        # terminal subprocesses don't get the child env scrub/marker (which
+        # makes `hermes kanban` die at DB init with the mutation guard —
+        # the intermittent "Watchdog tooling broken" false alarm).
+        _delegated_lineage_token = reset_delegated_child_lineage()
         if _job_workdir:
             os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
@@ -5561,6 +5571,8 @@ def run_job(
             _cron_session_var.reset(_cron_session_token)
         if _non_dispatcher_token is not None:
             exit_non_dispatcher_owned_context(_non_dispatcher_token)
+        if _delegated_lineage_token is not None:
+            restore_delegated_child_lineage(_delegated_lineage_token)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
         if _session_db:

--- a/tests/cron/test_cron_kanban_env_isolation.py
+++ b/tests/cron/test_cron_kanban_env_isolation.py
@@ -375,6 +375,97 @@ class TestRunJobKanbanIsolation:
 
 
 # ---------------------------------------------------------------------------
+# Delegated-child lineage must not leak INTO cron jobs
+# ---------------------------------------------------------------------------
+
+class TestRunJobDelegatedLineageReset:
+    """A scheduled job's asyncio task can inherit ``_DELEGATED_CHILD_CONTEXT``
+    from a session that had a delegate_task child active at spawn time. Left
+    set, ``is_delegated_child_process_context()`` is True for the whole job,
+    every terminal subprocess env gets scrubbed + marked, and ``hermes kanban``
+    dies at DB init with the child mutation guard — the intermittent
+    \"Watchdog tooling broken: ... delegate_task child contexts cannot mutate\"
+    false alarm (observed live 2026-07-30 → 2026-08-16)."""
+
+    def test_reset_helper_clears_contextvar_and_env_marker(self, monkeypatch):
+        import agent.delegation_context as dc
+
+        monkeypatch.setenv(dc.DELEGATED_CHILD_ENV_MARKER, "1")
+        token = dc._DELEGATED_CHILD_CONTEXT.set(True)
+        try:
+            assert dc.is_delegated_child_process_context() is True
+            reset_token = dc.reset_delegated_child_lineage()
+            try:
+                assert dc.is_delegated_child_process_context() is False
+                assert dc.DELEGATED_CHILD_ENV_MARKER not in os.environ
+            finally:
+                dc.restore_delegated_child_lineage(reset_token)
+            # ContextVar restored for the (real-child) outer scope.
+            assert dc.is_delegated_child_context() is True
+        finally:
+            dc._DELEGATED_CHILD_CONTEXT.reset(token)
+
+    def test_run_job_clears_inherited_delegated_lineage(self, monkeypatch):
+        import cron.scheduler as sched
+        import agent.delegation_context as dc
+
+        observed: dict = {}
+
+        class LineageProbeAgent:
+            def __init__(self, **kwargs):
+                observed["child_ctx_during_init"] = (
+                    dc.is_delegated_child_process_context()
+                )
+
+            def run_conversation(self, *_a, **_kw):
+                observed["child_ctx_during_run"] = (
+                    dc.is_delegated_child_process_context()
+                )
+                # This is what tools/environments/local.py consults before
+                # scrubbing + marking every terminal subprocess env.
+                observed["subprocess_env"] = dc.delegated_child_subprocess_env(None)
+                return {"final_response": "done", "messages": []}
+
+            def get_activity_summary(self):
+                return {"seconds_since_activity": 0.0}
+
+        TestRunJobKanbanIsolation._install_stubs(
+            monkeypatch, observed, agent_cls=LineageProbeAgent
+        )
+
+        # Simulate the leak: lineage inherited at job start.
+        token = dc._DELEGATED_CHILD_CONTEXT.set(True)
+        try:
+            success, *_ = sched.run_job(
+                TestRunJobKanbanIsolation._job("delegated-lineage-leak")
+            )
+        finally:
+            dc._DELEGATED_CHILD_CONTEXT.reset(token)
+
+        assert success is True
+        assert observed["child_ctx_during_init"] is False
+        assert observed["child_ctx_during_run"] is False
+        # env=None passthrough preserved — no scrub, no marker injection.
+        assert observed["subprocess_env"] is None
+
+    def test_run_job_clears_leaked_env_marker(self, monkeypatch):
+        import cron.scheduler as sched
+        import agent.delegation_context as dc
+
+        observed: dict = {}
+        TestRunJobKanbanIsolation._install_stubs(monkeypatch, observed)
+
+        monkeypatch.setenv(dc.DELEGATED_CHILD_ENV_MARKER, "1")
+        success, *_ = sched.run_job(
+            TestRunJobKanbanIsolation._job("delegated-lineage-envleak")
+        )
+
+        assert success is True
+        assert observed["kanban_env_during_init"] == {}
+        assert dc.DELEGATED_CHILD_ENV_MARKER not in os.environ
+
+
+# ---------------------------------------------------------------------------
 # Drift guard
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Symptom

A scheduled cron job whose agent runs `hermes kanban` (or any subprocess touching the Kanban DB) intermittently fails with:

```
kanban: could not initialize database: delegate_task child contexts cannot mutate Kanban tasks or boards
```

even though the job is not a delegate_task child and the board is healthy. Observed roughly weekly on a 30-min kanban watchdog cron (2026-07-30 → 2026-08-16) whenever a delegation-enabled session had a child active concurrently.

## Root cause

`_DELEGATED_CHILD_CONTEXT` is a ContextVar; a scheduled job's asyncio task can inherit it (contextvar snapshot at task spawn) from a session with an active `delegate_task` child. Defensively, a leaked `HERMES_DELEGATED_CHILD_CONTEXT` os.environ marker has the same effect via `is_delegated_child_process_context()`. Either way, every terminal subprocess env the job spawns is scrubbed + marked by `scrub_kanban_env()`, and `hermes_cli/kanban_db.py` raises the child mutation guard at DB init — killing even read-only `kanban list`.

## Fix

`run_job()` now resets delegated-child lineage (ContextVar → False, pop the env marker) right after `enter_non_dispatcher_owned_context()`, token-restored in the existing `finally` block — mirroring the established non-dispatcher isolation pattern. Scheduled jobs are by construction never delegate_task children, so this is always correct at that point.

## Tests

`tests/cron/test_cron_kanban_env_isolation.py` gains `TestRunJobDelegatedLineageReset`: helper semantics (clear + token restore), run_job wiring with inherited ContextVar lineage (asserts `delegated_child_subprocess_env(None)` passthrough is preserved), and the leaked env-marker case. RED-proven against the pre-fix scheduler (2 of 3 fail without the run_job change); full `tests/cron/` suite: 518 passed, 1 skipped.