### PR TITLE
fix(tools): exempt Go-template YAML from the write syntax gate

### DIFF
--- a/tests/tools/test_write_file_syntax_gate.py
+++ b/tests/tools/test_write_file_syntax_gate.py
@@ -74,3 +74,38 @@ class TestFailClosedSyntaxGate:
         res = ops.write_file(str(target), content)
         assert res.error is None, res.error
         assert target.read_text() == content
+
+    def test_helm_template_yaml_is_written_not_refused(self, ops, tmp_path: Path):
+        """Go-template YAML (Helm chart templates, Argo/flux patches) is NOT
+        plain YAML — {{ .Values.x }} / {{- if }} directives make PyYAML's
+        parser fail with flow-node/block-end errors at the delimiter.  The
+        file only becomes YAML after ``helm template`` renders it, so the
+        syntax gate must skip it (mirrors the CloudFormation/Ansible tag
+        exemption above: a consumer convention, not a syntax error).  This
+        exact content was refused by the gate before the exemption."""
+        target = tmp_path / "postgres-cluster.yaml"
+        content = (
+            "{{- if .Values.postgresql.enabled }}\n"
+            "apiVersion: postgresql.cnpg.io/v1\n"
+            "kind: Cluster\n"
+            "metadata:\n"
+            "  name: {{ include \"9chat.pg.name\" . }}\n"
+            "spec:\n"
+            "  instances: {{ .Values.postgresql.instances }}\n"
+            "  {{- with .Values.postgresql.storage.storageClass }}\n"
+            "  storageClass: {{ . }}\n"
+            "  {{- end }}\n"
+            "{{- end }}\n"
+        )
+        res = ops.write_file(str(target), content)
+        assert res.error is None, res.error
+        assert target.read_text() == content
+
+    def test_broken_plain_yaml_is_still_refused(self, ops, tmp_path: Path):
+        """The Go-template exemption must not weaken the gate for plain YAML:
+        real syntax errors (tab-mangled block map) are still hard-refused."""
+        target = tmp_path / "values.yaml"
+        res = ops.write_file(str(target), "a: 1\n\tb: tab-indented\n")
+        assert res.error is not None
+        assert "yaml" in res.error.lower()
+        assert not target.exists(), "broken YAML must NOT be written to disk"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -714,7 +714,18 @@ def _lint_yaml_inproc(content: str) -> tuple[bool, str]:
     here refuses a legitimate write outright.  ``yaml.parse`` still
     catches real scanner/parser failures (unclosed quotes, bad
     indentation, tab-mangled block maps).
+
+    Go-template content (Helm charts, Argo/flux patches) is likewise
+    skipped: ``{{ .Values.x }}`` / ``{{- if ... }}`` directives are not
+    YAML syntax at all, and PyYAML's parser trips on them (flow-node /
+    block-end errors at the delimiter).  These files are only valid YAML
+    after the template engine renders them — validated with
+    ``helm template`` / ``helm lint``, never by a raw YAML parser.  The
+    check is a conservative substring scan for ``{{`` + ``}}``; template
+    code is never plain YAML, so this cannot mask a real YAML error.
     """
+    if "{{" in content and "}}" in content:
+        return True, "__SKIP__"
     try:
         import yaml as _yaml
     except ImportError:


### PR DESCRIPTION
## Problem

`write_file`/`patch` refuse every Helm chart template with:

```
Refusing to write '.../postgres-cluster.yaml': candidate content fails .yaml syntax validation
(YAMLError: while parsing a flow node ... expected the node content, but found '-')
```

Helm templates (`{{ .Values.x }}`, `{{- if }}`) are **not plain YAML** — they only become YAML after the template engine renders them. PyYAML's parser fails on the delimiters, so the fail-closed pre-write gate (`_FAIL_CLOSED_INPROC_EXTS`) hard-refused every legitimate Helm template write, forcing agents into sed/terminal workarounds.

## Fix

`_lint_yaml_inproc` skips content containing `{{` + `}}` (returns `__SKIP__`), mirroring the existing CloudFormation `!Sub`/`!Ref` / Ansible `!vault` exemption in the same function — a consumer convention, not a syntax error. Chart validity is checked with `helm lint` / `helm template`, never a raw YAML parser.

Conservative substring scan: template content is never plain YAML, so this cannot mask a real syntax error — broken plain YAML is still hard-refused.

## Tests

- `test_helm_template_yaml_is_written_not_refused` — real Helm template content that was refused before
- `test_broken_plain_yaml_is_still_refused` — gate strength unchanged for plain YAML
- Existing 4 gate tests + 66 `test_file_operations.py` tests pass

```bash
python -m pytest tests/tools/test_write_file_syntax_gate.py tests/tools/test_file_operations.py -q
# 6 passed / 66 passed, 2 skipped
```
