### PR TITLE
fix(gateway): reap orphaned MCP watchdog children on manual restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1848,6 +1848,17 @@ def stop_profile_gateway() -> bool:
     except Exception:
         pass
 
+    # Snapshot descendants (e.g. MCP stdio watchdog + server pairs) BEFORE
+    # signalling the gateway: once it exits they are reparented and can no
+    # longer be discovered by a parent walk. Mirrors the reap done by the
+    # gateway/run.py `--replace` path — this manual stop/restart fallback
+    # was missing it, leaving orphaned MCP watchdogs behind (#87906).
+    try:
+        from gateway.status import _snapshot_gateway_children
+        _old_gateway_children = _snapshot_gateway_children(pid)
+    except Exception:
+        _old_gateway_children = []
+
     try:
         os.kill(pid, signal.SIGTERM)
     except ProcessLookupError:
@@ -1868,6 +1879,12 @@ def stop_profile_gateway() -> bool:
 
     if get_running_pid() is None:
         remove_pid_file()
+
+    try:
+        from gateway.status import reap_gateway_children
+        reap_gateway_children(_old_gateway_children, parent_pid=pid)
+    except Exception:
+        logger.debug("Child reap for stopped gateway PID %d failed", pid, exc_info=True)
 
     # Also reap any orphans from prior restarts whose PIDs were overwritten
     # in the pid file before they exited (#75936).  Exclude the PID we just

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -560,6 +560,47 @@ class TestStopProfileGateway:
         assert len(reap_extra_excludes) == 1
         assert killed_pid in reap_extra_excludes[0]
 
+    def test_stop_profile_gateway_reaps_orphaned_children(self, monkeypatch):
+        """MCP watchdog/server children of the stopped gateway must be reaped.
+
+        Regression guard for #87906: without a pre-kill children snapshot,
+        `gateway restart`'s manual stop path had no way to find the old
+        gateway's descendants after it exited (they are reparented once the
+        parent is gone), so duplicate MCP watchdog processes kept running.
+        """
+        pid = 4242
+        fake_children = ["watchdog-proc", "mcp-server-proc"]
+        events = []
+
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: pid)
+        monkeypatch.setattr(gateway.os, "kill", lambda p, sig: events.append(("kill", p)))
+        monkeypatch.setattr("gateway.status._pid_exists", lambda p: False)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+        monkeypatch.setattr(gateway, "_reap_unsupervised_gateway_orphans", lambda extra_exclude=None: False)
+        monkeypatch.setattr(
+            "gateway.status._snapshot_gateway_children",
+            lambda target_pid: events.append(("snapshot", target_pid)) or fake_children,
+        )
+
+        def fake_reap(children, *, parent_pid):
+            events.append(("reap", tuple(children), parent_pid))
+            return len(children)
+
+        monkeypatch.setattr("gateway.status.reap_gateway_children", fake_reap)
+
+        assert gateway.stop_profile_gateway() is True
+
+        # Children must be snapshotted BEFORE the kill signal — after the
+        # parent exits they are reparented and undiscoverable.
+        assert events[0] == ("snapshot", pid)
+        assert ("kill", pid) in events
+        assert ("reap", tuple(fake_children), pid) in events
+        snapshot_index = events.index(("snapshot", pid))
+        kill_index = events.index(("kill", pid))
+        reap_index = events.index(("reap", tuple(fake_children), pid))
+        assert snapshot_index < kill_index < reap_index
+
 
 class TestReapUnsupervisedGatewayOrphansMacOS:
     """Tests that the orphan reaper excludes launchd-managed PIDs on macOS.


### PR DESCRIPTION
Fixes #87906

## Bug

`hermes gateway restart` on hosts without a registered systemd/launchd
service falls back to `stop_profile_gateway()` (`hermes_cli/gateway.py`)
followed by `run_gateway()`. That stop path only sent `SIGTERM` to the
recorded gateway PID and waited for it to exit — it never looked at the
old gateway's children.

`gateway/run.py`'s `start_gateway(..., replace=True)` codepath already
has to deal with exactly this: on POSIX, once a parent process exits its
children are reparented (to init) and can no longer be discovered by a
parent walk, so any snapshot has to happen *before* the kill signal. That
path snapshots descendants via `_snapshot_gateway_children()` first, then
reaps survivors via `reap_gateway_children()` once the old PID is
confirmed dead. `stop_profile_gateway()` was missing both steps.

Concretely: a Hermes gateway with an `mcp_servers` entry (stdio
transport, e.g. `arr-mcp`) spawns a watchdog (`mcp_stdio_watchdog.py`) +
MCP server pair as children. `gateway restart` killed the parent gateway
PID but left that pair running as orphans; the new gateway then spawned
its own pair, and the two MCP server instances competed on stdio,
producing intermittent "unreachable" errors — exactly the repro in
#87906.

## Fix

`stop_profile_gateway()` now mirrors the `--replace` pattern:
snapshot the gateway's live children before sending `SIGTERM`, then
reap any that are still alive (SIGTERM, bounded wait, SIGKILL for
survivors) once the PID is confirmed gone. Both helpers
(`_snapshot_gateway_children` / `reap_gateway_children`) already existed
in `gateway/status.py`; this just wires the manual-restart path into
the same reap used by the service-replace path.

## Test

Added `test_stop_profile_gateway_reaps_orphaned_children` in
`tests/hermes_cli/test_gateway.py`, asserting the snapshot happens
before the kill signal and the reap happens after, using the previously
snapshotted children.

Confirmed it fails without the fix (`git stash push -- hermes_cli/gateway.py`, ran, restored):

```
FAILED tests/hermes_cli/test_gateway.py::TestStopProfileGateway::test_stop_profile_gateway_reaps_orphaned_children
AssertionError: assert ('kill', 4242) == ('snapshot', 4242)
```

With the fix:

```
$ python -m pytest tests/hermes_cli/test_gateway.py -q
sss..............................                                        [100%]
30 passed, 3 skipped in 7.67s
```

Also ran the existing `--replace` child-reap regression suite to confirm
no interaction:

```
$ python -m pytest tests/gateway/test_replace_child_reap.py -q
.....                                                                    [100%]
5 passed in 1.04s
```

`ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway.py` — all checks passed.

## AI disclosure

This PR was authored by an autonomous coding agent (Claude, via an
OSS-contribution pipeline) with no human edits to the diff.
