### PR TITLE
fix(skills): rescan skill commands cache when active profile changes

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
+_skill_commands_home: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -206,6 +207,22 @@ def _resolve_skill_commands_platform() -> Optional[str]:
     except Exception:
         resolved_platform = os.getenv("HERMES_PLATFORM")
     return resolved_platform or None
+
+
+def _resolve_skill_commands_home() -> str:
+    """Return the effective Hermes home the skill scan should be scoped to.
+
+    A gateway session can switch between profiles that each carry their own
+    ``skills.external_dirs`` (via ``set_hermes_home_override``), but the
+    module-level scan only tracked ``_resolve_skill_commands_platform()``.
+    Switching profiles without a platform change left the previous profile's
+    skill list cached, so ``get_skill_commands()`` reported a cache miss for
+    skills that only exist under the new profile (#88023).
+    """
+    from hermes_constants import get_hermes_home
+
+    return str(get_hermes_home())
+
 
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:
     """Load a skill by name/path and return (loaded_payload, skill_dir, display_name)."""
@@ -405,8 +422,9 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
-    global _skill_commands, _skill_commands_platform
+    global _skill_commands, _skill_commands_platform, _skill_commands_home
     _skill_commands_platform = _resolve_skill_commands_platform()
+    _skill_commands_home = _resolve_skill_commands_home()
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
@@ -500,11 +518,14 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
 
     Rescans when the active platform scope changes (e.g. a gateway
     process serving Telegram and Discord concurrently) so each platform
-    sees its own ``skills.platform_disabled`` view (#14536).
+    sees its own ``skills.platform_disabled`` view (#14536), and when the
+    active profile's Hermes home changes (e.g. Desktop switching profiles
+    mid-session) so each profile sees its own ``skills.external_dirs`` (#88023).
     """
     if (
         not _skill_commands
         or _skill_commands_platform != _resolve_skill_commands_platform()
+        or _skill_commands_home != _resolve_skill_commands_home()
     ):
         scan_skill_commands()
     return _skill_commands

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -200,6 +200,61 @@ class TestScanSkillCommands:
             assert "/telegram-only" in discord_commands
             assert "/discord-only" not in discord_commands
 
+    def test_get_skill_commands_rescans_when_profile_home_changes(self, tmp_path):
+        """Switching profiles must rescan even when the platform is unchanged
+        (#88023): a Desktop session that switches profiles mid-session keeps
+        the same platform scope, so only ``HERMES_HOME`` moves. Each profile
+        declares its own ``skills.external_dirs``, and the previous profile's
+        skill list must not leak into the new one.
+        """
+        import agent.skill_commands as sc_mod
+        from agent.skill_commands import get_skill_commands
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        empty_local_dir = tmp_path / "no-local-skills"
+        empty_local_dir.mkdir()
+
+        profile_a = tmp_path / "profile_a"
+        profile_b = tmp_path / "profile_b"
+        external_a = tmp_path / "external_a"
+        external_b = tmp_path / "external_b"
+        profile_a.mkdir()
+        profile_b.mkdir()
+        _make_skill(external_a, "a-only")
+        _make_skill(external_b, "b-only")
+        (profile_a / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_a}\n"
+        )
+        (profile_b / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_b}\n"
+        )
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", empty_local_dir),
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_home", None),
+        ):
+            token = set_hermes_home_override(profile_a)
+            try:
+                profile_a_commands = dict(get_skill_commands())
+            finally:
+                reset_hermes_home_override(token)
+
+            assert "/a-only" in profile_a_commands
+            assert "/b-only" not in profile_a_commands
+
+            # Switching profiles without touching the cache directly must
+            # rescan — not keep serving profile_a's stale view.
+            token = set_hermes_home_override(profile_b)
+            try:
+                profile_b_commands = dict(get_skill_commands())
+            finally:
+                reset_hermes_home_override(token)
+
+            assert "/b-only" in profile_b_commands
+            assert "/a-only" not in profile_b_commands
+
     def test_get_skill_commands_rescans_when_leaving_platform_scope(self, tmp_path, monkeypatch):
         """Returning to no-platform-scope (CLI / cron / RL) after a gateway
         session must rescan so the unfiltered view is repopulated (#14536).

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -785,6 +785,59 @@ def test_slash_exec_rejects_skill_commands(server):
     assert "skill command" in resp["error"]["message"]
 
 
+def test_slash_exec_scopes_skill_lookup_to_session_profile(server, tmp_path):
+    """slash.exec must resolve get_skill_commands() against the session's own
+    profile_home rather than the gateway process's ambient HERMES_HOME
+    (#88023). A Desktop session that switches profiles mid-session shares
+    the same gateway process, so a skill declared only under the new
+    profile's skills.external_dirs must still be recognized here — else the
+    command falls through to the slash-worker dead path instead of routing
+    to command.dispatch.
+    """
+    import agent.skill_commands as sc_mod
+
+    empty_local_dir = tmp_path / "no-local-skills"
+    empty_local_dir.mkdir()
+
+    profile_b = tmp_path / "profile_b"
+    external_b = tmp_path / "external_b"
+    profile_b.mkdir()
+    skill_dir = external_b / "b-only"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: b-only\ndescription: Only in profile b.\n---\n\n# b-only\n\nDo the thing.\n"
+    )
+    (profile_b / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {external_b}\n"
+    )
+
+    sid = "test-session-profile-b"
+    server._sessions[sid] = {
+        "session_key": sid,
+        "agent": None,
+        "profile_home": str(profile_b),
+    }
+
+    with (
+        patch("tools.skills_tool.SKILLS_DIR", empty_local_dir),
+        patch.object(sc_mod, "_skill_commands", {}),
+        patch.object(sc_mod, "_skill_commands_platform", None),
+        patch.object(sc_mod, "_skill_commands_home", None),
+    ):
+        resp = server.handle_request({
+            "id": "r1",
+            "method": "slash.exec",
+            "params": {"command": "b-only", "session_id": sid},
+        })
+
+    # The gateway's own HERMES_HOME (the test-isolation tempdir, no
+    # skills.external_dirs) has no "b-only" skill — the only way this
+    # resolves is by scoping the lookup to the session's profile_home.
+    assert "error" in resp
+    assert resp["error"]["code"] == 4018
+    assert "skill command" in resp["error"]["message"]
+
+
 def test_command_dispatch_queue_sends_message(server):
     """command.dispatch /queue returns {type: 'send', message: ...} for the TUI."""
     sid = "test-session"

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1178,12 +1178,26 @@ def _(rid, params: dict) -> dict:
 
     try:
         from agent.skill_commands import get_skill_commands
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
-        _cmd_key = f"/{_cmd_base}"
-        if _cmd_key in get_skill_commands():
-            return _err(
-                rid, 4018, f"skill command: use command.dispatch for {_cmd_key}"
-            )
+        # Re-bind HERMES_HOME to the session's profile so get_skill_commands()
+        # sees that profile's skills.external_dirs rather than whatever the
+        # process-level env happens to carry (#88023): dispatch() runs this
+        # handler on the pool with a copied context, and nothing upstream of
+        # here binds the override for slash.exec.
+        _profile_home = session.get("profile_home")
+        _home_token = (
+            set_hermes_home_override(_profile_home) if _profile_home else None
+        )
+        try:
+            _cmd_key = f"/{_cmd_base}"
+            if _cmd_key in get_skill_commands():
+                return _err(
+                    rid, 4018, f"skill command: use command.dispatch for {_cmd_key}"
+                )
+        finally:
+            if _home_token is not None:
+                reset_hermes_home_override(_home_token)
     except Exception:
         pass
 


### PR DESCRIPTION
## What does this PR do?

`get_skill_commands()` (`agent/skill_commands.py`) caches the scanned skill
slash-command map in a process-global dict, and only rescans when the
*platform* scope changes (`_resolve_skill_commands_platform()`, added for
#14536). It never checked whether the active **profile** changed.

Hermes Desktop can run multiple profiles in one process, each with its own
`HERMES_HOME` (via `set_hermes_home_override`) and its own
`skills.external_dirs`. Switching profiles mid-session changes `HERMES_HOME`
but not the platform, so `get_skill_commands()` kept serving the previous
profile's skill list.

That cache-primitive fix alone isn't enough for `slash.exec`
(`tui_gateway/methods_tools.py`), the caller named in #88023 as the one that
falls through to the slash_worker "dead path" (the worker parks the
expanded skill body in a queue nobody reads and Desktop shows `⚡ Loading
skill` with no agent turn). `slash.exec` is a `_LONG_HANDLER` — `dispatch()`
schedules it on the pool with a copied context (`server.py`'s `dispatch()`),
and neither stdio (`entry.py`) nor WS (`ws.py`) binds
`_HERMES_HOME_OVERRIDE` around that call. So even with the cache keyed on
the active home, `get_skill_commands()` at that call site always resolved
against the process-level `HERMES_HOME` — never the requesting session's
profile — and a profile-B-only skill was still invisible there.

This PR now also binds the session's own `profile_home` around the
`get_skill_commands()` check inside `slash.exec`, mirroring the same
bind/reset-in-`finally` pattern used at every other per-turn `HERMES_HOME`
scoping site in this codebase (e.g. `server.py`'s prompt-turn and
system-prompt-rebuild paths). That closes the gap: the cache now varies with
the profile, and `slash.exec` now feeds it the right profile to vary by.

## Related Issue

Fixes #88023

#88023 is a follow-up to #87961 (currently open), asking to confirm
multi-profile switching as an *additional* trigger for the same
`Loading skill` dead-end, and to cover it with a test. This PR fixes the
root cause of that specific trigger end-to-end — both the cache never
invalidating on a profile switch, and `slash.exec` never scoping its lookup
to the session's profile in the first place — independently of #87961's
worker/resolver fallback fix (different region of `agent/skill_commands.py`,
no overlap: #87961 adds `resolve_skill_slash()` after line 594, this PR only
touches the scan/cache functions above it, plus `methods_tools.py`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_commands.py`: track the Hermes home the last scan was scoped
  to (`_skill_commands_home`), via a new `_resolve_skill_commands_home()`
  helper. `get_skill_commands()` now rescans when either the platform *or*
  the active home changed, not just the platform.
- `tui_gateway/methods_tools.py`: `slash.exec`'s skill-command check now
  binds `set_hermes_home_override(session["profile_home"])` around the
  `get_skill_commands()` call (reset in a `finally`), so the lookup actually
  observes the requesting session's profile instead of the gateway
  process's ambient `HERMES_HOME`.
- `tests/agent/test_skill_commands.py`: added
  `test_get_skill_commands_rescans_when_profile_home_changes`, which sets up
  two profile homes with distinct `skills.external_dirs`, switches between
  them via `set_hermes_home_override`, and asserts each profile only sees
  its own skill.
- `tests/tui_gateway/test_protocol.py`: added
  `test_slash_exec_scopes_skill_lookup_to_session_profile`, an end-to-end
  reproduction that registers a session with `profile_home` pointing at a
  profile whose `skills.external_dirs` declares a skill absent from the
  gateway's own `HERMES_HOME`, calls `slash.exec` for that skill, and
  asserts it's recognized (4018 "use command.dispatch") instead of falling
  through to the slash worker.

## How to Test

1. Configure two profiles with different `skills.external_dirs` (or just
   different local `~/.hermes/skills/` contents).
2. In a long-lived `hermes serve` / Desktop session, invoke a skill slash
   command under profile A, then switch to profile B and invoke a skill
   that only exists under profile B.
3. Before this fix: `slash.exec`'s `get_skill_commands()` check resolves
   against the process's ambient `HERMES_HOME`, never the session's
   profile, so profile B's skill is treated as unknown and the command
   falls through to the slash_worker dead path.
4. After this fix: `slash.exec` binds the session's `profile_home` before
   checking, `get_skill_commands()` rescans for that home, and profile B's
   skill is recognized and routed to `command.dispatch`.

Test output:

```
$ scripts/run_tests.sh tests/agent/test_skill_commands.py tests/tui_gateway/test_protocol.py -q
=== Summary: 2 files, 80 tests passed, 0 failed (100% complete) ===
```

Confirmed both new tests fail without their respective source change:

- `git checkout HEAD~2 -- agent/skill_commands.py` (pre-cache-fix), rerun
  `test_get_skill_commands_rescans_when_profile_home_changes`:
  `AttributeError: <module 'agent.skill_commands'> does not have the
  attribute '_skill_commands_home'`.
- `git checkout HEAD~1 -- tui_gateway/methods_tools.py` (cache fix present,
  call-site fix reverted), rerun
  `test_slash_exec_scopes_skill_lookup_to_session_profile`: the skill is not
  recognized and the handler falls through to the slash worker instead of
  returning the 4018 error —
  `AssertionError: assert 'error' in {'result': {'output': '\n⚡ Loading
  skill: b-only'}}`, i.e. the exact dead path from #88023.

`ruff check agent/skill_commands.py tui_gateway/methods_tools.py
tests/agent/test_skill_commands.py tests/tui_gateway/test_protocol.py` —
all checks passed.

Also ran the full `tests/tui_gateway/` + `tests/test_tui_gateway_server.py`
suites (1060 tests) to check for regressions from the `slash.exec` change:
all pass.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (see
      Related Issue note re: #87961 — complementary, not overlapping)
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass (relevant suites; a
      handful of unrelated `tests/gateway/test_matrix.py` /
      `tests/agent/test_*` failures in my sandbox are pre-existing, caused
      by optional extras — `aiohttp`, `anthropic`, matrix/e2ee deps — not
      installed in this minimal venv, not by this change)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — not tested on Windows/macOS Desktop
      directly; verified via the unit-level and end-to-end repro above

## AI assistance disclosure

This PR was prepared with AI assistance (Claude).
