### PR TITLE
fix(disk-cleanup): never auto-delete persistent trees; scope cache cleanup to owned ephemeral roots

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -151,7 +151,33 @@ _EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
     # User-authored project trees — never sweep empty directories
     # inside these (#75403).
     "patches", "projects", "skins", "themes", "contributors",
+    # Runtime / persistent state trees that must never be auto-cleaned:
+    # the isolated Chrome profile, vendored dependencies, benchmark
+    # fixtures, and user plans are all durable user data.  Missing from
+    # the blacklist, quick()'s empty-dir sweep recursed into them and
+    # rmdir'd runtime state (e.g. browser-profile/Default/blob_storage).
+    "browser-profile", "vendor", "benchmarks", "plans",
 })
+
+# The union of every top-level tree under HERMES_HOME that is durable user
+# data and must never be auto-categorised, auto-tracked, or deleted.  Shared
+# by guess_category() (auto-tracking) and quick() (deletion + empty-dir
+# sweep) so the two never drift.
+#
+# NOTE: ``cron`` / ``cronjobs`` are intentionally NOT here: they have a
+# dedicated rule in guess_category() (only the disposable ``output/``
+# subtree is tracked as cron-output), and the empty-dir sweep protects the
+# whole tree via _EMPTY_DIR_PROTECTED_TOP_LEVEL.  Moving them here would
+# make guess_category() return None for cron/output/* and break cron-output
+# cleanup.
+_PROTECTED_TOP_LEVEL = frozenset(
+    _EMPTY_DIR_PROTECTED_TOP_LEVEL
+    - {"cron", "cronjobs"}
+    | {
+        "config.yaml", ".env", "USER.md", "MEMORY.md", "SOUL.md",
+        "auth.json",
+    }
+)
 
 _EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({
     ".git", "node_modules", "venv", ".venv",
@@ -323,34 +349,24 @@ def quick() -> Dict[str, Any]:
 
         age = (now - datetime.fromisoformat(item["timestamp"])).days
 
-        # ---- stale-state migration (fixes #37721) ----
-        # Old tracked.json entries may carry a "cron-output" category for
-        # paths that are NOT under cron/output/ (e.g. cron/jobs.json).
-        # guess_category() was fixed in #34840, but existing entries are
-        # never re-validated.  Re-classify here so stale entries for cron
-        # control-plane state are not deleted.
-        if cat == "cron-output":
-            re_cat = guess_category(p)
-            if re_cat != "cron-output":
+        # ---- stale-state migration (fixes #37721, #75403) ----
+        # Old tracked.json entries may carry a category for paths that are
+        # no longer auto-manageable: cron control-plane state (cron-output
+        # for cron/jobs.json, #37721), or files that now live under a
+        # protected project/persistent tree (test, #75403).  guess_category()
+        # was tightened in those fixes, but existing entries are never
+        # re-validated.  Re-run today's classification before ANY deletion:
+        # if the path is now protected — or outside HERMES_HOME entirely —
+        # skip and drop the stale entry so it never blocks again.
+        if cat in ("test", "temp", "cron-output"):
+            if is_safe_path(p):
+                re_cat = guess_category(p)
+            else:
+                re_cat = None
+            if re_cat != cat:
                 _log(
-                    f"SKIP stale cron-output entry: {p} "
-                    f"(re-classified as {re_cat!r})"
-                )
-                # Drop the stale entry — it was misclassified.
-                continue
-
-        # ---- stale-state migration for 'test' category (fixes #75403) ----
-        # Old tracked.json entries may carry a "test" category for paths
-        # that are now under protected project directories (patches/,
-        # projects/, etc.).  guess_category() was tightened in the fix for
-        # #75403, but existing entries are never re-validated.  Re-classify
-        # here so stale entries for protected paths are not deleted.
-        if cat == "test":
-            re_cat = guess_category(p)
-            if re_cat != "test":
-                _log(
-                    f"SKIP stale test entry: {p} "
-                    f"(re-classified as {re_cat!r} — under protected tree)"
+                    f"SKIP stale {cat} entry: {p} "
+                    f"(re-classified as {re_cat!r} — no longer auto-manageable)"
                 )
                 continue
 
@@ -572,21 +588,14 @@ def guess_category(path: Path) -> Optional[str]:
     if not is_safe_path(path):
         return None
 
-    # Skip the state dir itself, logs, memory files, sessions, config.
+    # Skip the state dir itself, logs, memory files, sessions, config, and
+    # every durable user-data tree (shared _PROTECTED_TOP_LEVEL so
+    # auto-tracking can never drift from the empty-dir sweep's guard list).
     hermes_home = get_hermes_home()
     try:
         rel = path.resolve().relative_to(hermes_home)
         top = rel.parts[0] if rel.parts else ""
-        if top in {
-            "disk-cleanup", "logs", "memories", "sessions", "config.yaml",
-            "skills", "plugins", ".env", "USER.md", "MEMORY.md", "SOUL.md",
-            "auth.json", "hermes-agent",
-            # User-authored and project trees — never auto-delete files
-            # inside these just because they happen to be named test_* or
-            # tmp_* (#75403, also #32164, #37721).
-            "patches", "projects", "skins", "themes", "contributors",
-            "profiles", "backups", "optional-skills",
-        }:
+        if top in _PROTECTED_TOP_LEVEL:
             return None
         if top == "cron" or top == "cronjobs":
             # Only files under the disposable ``output/`` subtree are

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -184,6 +184,20 @@ _EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({
     "site-packages", "__pycache__",
 })
 
+# Auto-cleanup is opt-in for cache paths.  Cache contains durable binaries,
+# indexes, and downloaded state, so only tool-owned ephemeral subtrees may be
+# classified as temp.  Keep this path-component based for platform stability.
+_MANAGED_EPHEMERAL_CACHE_ROOTS = frozenset({
+    ("cache", "vision", "temp_vision_images"),
+    ("cache", "video", "temp_video_files"),
+})
+
+
+def _is_managed_ephemeral_path(rel: Path) -> bool:
+    """Return whether a HERMES_HOME-relative path is plugin-owned temporary data."""
+    parts = rel.parts
+    return any(parts[:len(root)] == root for root in _MANAGED_EPHEMERAL_CACHE_ROOTS)
+
 
 # Paths under $HERMES_HOME that must NEVER be deleted by quick(),
 # regardless of what the stored category says.  This is a defense-in-depth
@@ -298,12 +312,12 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
         cat = item["category"]
         size = item["size"]
 
-        # Re-validate stale "cron-output" entries (fixes #37721).
-        if cat == "cron-output":
-            re_cat = guess_category(p)
-            if re_cat != "cron-output":
-                # Stale entry — would be skipped by quick(); omit from
-                # dry-run output too.
+        # Re-validate every auto-delete category so dry-run and quick() share
+        # the same ownership boundary.  Legacy tracking may point at a path
+        # that is now protected or outside HERMES_HOME.
+        if cat in ("test", "temp", "cron-output"):
+            re_cat = guess_category(p) if is_safe_path(p) else None
+            if re_cat != cat:
                 continue
 
         if cat == "test":
@@ -595,6 +609,8 @@ def guess_category(path: Path) -> Optional[str]:
     try:
         rel = path.resolve().relative_to(hermes_home)
         top = rel.parts[0] if rel.parts else ""
+        if _is_managed_ephemeral_path(rel):
+            return "temp"
         if top in _PROTECTED_TOP_LEVEL:
             return None
         if top == "cron" or top == "cronjobs":

--- a/tests/plugins/test_disk_cleanup_protected_trees.py
+++ b/tests/plugins/test_disk_cleanup_protected_trees.py
@@ -67,6 +67,33 @@ class TestGuessCategoryProtectedTrees:
         assert dg.guess_category(p) is None
 
 
+class TestCacheOwnership:
+    """Only explicitly plugin-owned cache roots are auto-managed."""
+
+    def test_vision_temporary_root_is_categorised_as_temp(self, _isolate_env):
+        dg = _load_lib()
+        p = _isolate_env / "cache" / "vision" / "temp_vision_images" / "capture.png"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+
+        assert dg.guess_category(p) == "temp"
+    def test_video_temporary_root_is_categorised_as_temp(self, _isolate_env):
+        dg = _load_lib()
+        p = _isolate_env / "cache" / "video" / "temp_video_files" / "render.mp4"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+
+        assert dg.guess_category(p) == "temp"
+
+    def test_unmanaged_cache_path_is_not_categorised(self, _isolate_env):
+        dg = _load_lib()
+        p = _isolate_env / "cache" / "tool" / "rtk-bin" / "rtk"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+
+        assert dg.guess_category(p) is None
+
+
 class TestQuickEmptyDirSweepProtectedTrees:
     """Empty-dir sweep must not rmdir inside persistent subtrees."""
 
@@ -121,6 +148,36 @@ class TestQuickRevalidatesTrackedEntries:
         summary = dg.quick()
         assert summary["deleted"] == 0
         assert p.exists(), "path outside HERMES_HOME must never be deleted"
+
+    def test_stale_temp_entry_in_unmanaged_cache_is_not_deleted(self, _isolate_env):
+        dg = _load_lib()
+        p = _isolate_env / "cache" / "tool" / "rtk-bin" / "rtk"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+        self._seed_tracked(_isolate_env, {
+            "path": str(p), "category": "temp",
+            "timestamp": _old_ts(8), "size": 1,
+        })
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert p.exists(), "unmanaged cache file must survive stale temp tracking"
+
+    def test_dry_run_omits_stale_temp_entry_in_unmanaged_cache(self, _isolate_env):
+        dg = _load_lib()
+        p = _isolate_env / "cache" / "tool" / "rtk-bin" / "rtk"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+        self._seed_tracked(_isolate_env, {
+            "path": str(p), "category": "temp",
+            "timestamp": _old_ts(8), "size": 1,
+        })
+
+        auto, prompt = dg.dry_run()
+
+        assert auto == []
+        assert prompt == []
 
     def test_legitimate_test_file_still_deleted(self, _isolate_env):
         """The fix must not break the feature: real test files are still cleaned."""

--- a/tests/plugins/test_disk_cleanup_protected_trees.py
+++ b/tests/plugins/test_disk_cleanup_protected_trees.py
@@ -1,0 +1,133 @@
+"""Regression tests: disk-cleanup must never auto-delete persistent trees.
+
+Covers the 2026-08-13 incident class: HERMES_HOME persistent subtrees
+(``browser-profile``, ``vendor``, ``benchmarks``, ``plans``) are not in the
+protected-top-level lists, so (a) ``guess_category`` mis-classifies files
+named ``test_*``/``tmp_*`` inside them as ``test`` (deleted at session end),
+(b) ``quick``'s empty-dir sweep recurses into them and rmdirs runtime state,
+and (c) a stale ``tracked.json`` entry pointing into such a tree (or outside
+HERMES_HOME entirely) is deleted without re-validation.
+
+Same harness style as ``test_disk_cleanup_plugin.py``: import the real plugin
+library from the repo path, isolate ``HERMES_HOME`` under ``tmp_path``.
+"""
+import importlib
+import json
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    yield hermes_home
+
+
+def _load_lib():
+    repo_root = Path(__file__).resolve().parents[2]
+    lib_path = repo_root / "plugins" / "disk-cleanup" / "disk_cleanup.py"
+    spec = importlib.util.spec_from_file_location(
+        "disk_cleanup_under_test", lib_path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _old_ts(days: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+class TestGuessCategoryProtectedTrees:
+    """Files inside persistent subtrees must never be auto-categorised."""
+
+    @pytest.mark.parametrize("subtree", [
+        "browser-profile", "vendor", "benchmarks", "plans",
+    ])
+    def test_test_named_file_in_persistent_subtree_not_categorised(self, _isolate_env, subtree):
+        dg = _load_lib()
+        p = _isolate_env / subtree / "Default" / "blob_storage" / "test_cache"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+        assert dg.guess_category(p) is None
+
+    @pytest.mark.parametrize("subtree", [
+        "browser-profile", "vendor", "benchmarks", "plans",
+    ])
+    def test_tmp_named_file_in_persistent_subtree_not_categorised(self, _isolate_env, subtree):
+        dg = _load_lib()
+        p = _isolate_env / subtree / "tmp_state.log"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+        assert dg.guess_category(p) is None
+
+
+class TestQuickEmptyDirSweepProtectedTrees:
+    """Empty-dir sweep must not rmdir inside persistent subtrees."""
+
+    @pytest.mark.parametrize("subtree,leaf", [
+        ("browser-profile", "Default/blob_storage"),
+        ("vendor", "some_pkg/empty_dir"),
+        ("benchmarks", "suite/empty_dir"),
+        ("plans", "draft/empty_dir"),
+    ])
+    def test_empty_dir_under_persistent_subtree_survives_quick(self, _isolate_env, subtree, leaf):
+        dg = _load_lib()
+        empty = _isolate_env / subtree / leaf
+        empty.mkdir(parents=True)
+        # A normal file must exist for quick() to consider the tree at all.
+        dg.track(str(_isolate_env / "test_legit.py"), "test", silent=True)
+        _ = dg.quick()
+        assert empty.is_dir(), f"{subtree}/{leaf} must survive quick()"
+
+
+class TestQuickRevalidatesTrackedEntries:
+    """quick() must re-validate every candidate before deleting (fail-closed)."""
+
+    def _seed_tracked(self, hermes_home, entry):
+        tf = hermes_home / "disk-cleanup" / "tracked.json"
+        tf.parent.mkdir(parents=True, exist_ok=True)
+        tf.write_text(json.dumps([entry]))
+
+    def test_stale_entry_in_protected_tree_not_deleted(self, _isolate_env):
+        dg = _load_lib()
+        p = _isolate_env / "browser-profile" / "Default" / "Service Worker" / "test_sw"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+        self._seed_tracked(_isolate_env, {
+            "path": str(p), "category": "test",
+            "timestamp": _old_ts(1), "size": 1,
+        })
+        summary = dg.quick()
+        assert summary["deleted"] == 0
+        assert p.exists(), "persistent-tree file must survive even with stale entry"
+
+    def test_entry_outside_hermes_home_not_deleted(self, _isolate_env, tmp_path):
+        dg = _load_lib()
+        # A sibling dir outside HERMES_HOME (same tmp_path, but not under .hermes)
+        outside = tmp_path / "outside" 
+        outside.mkdir()
+        p = outside / "test_escape.py"
+        p.write_text("x")
+        self._seed_tracked(_isolate_env, {
+            "path": str(p), "category": "test",
+            "timestamp": _old_ts(1), "size": 1,
+        })
+        summary = dg.quick()
+        assert summary["deleted"] == 0
+        assert p.exists(), "path outside HERMES_HOME must never be deleted"
+
+    def test_legitimate_test_file_still_deleted(self, _isolate_env):
+        """The fix must not break the feature: real test files are still cleaned."""
+        dg = _load_lib()
+        p = _isolate_env / "test_real.py"
+        p.write_text("x")
+        assert dg.track(str(p), "test", silent=True) is True
+        summary = dg.quick()
+        assert summary["deleted"] == 1
+        assert not p.exists()


### PR DESCRIPTION
## Summary

Fixes the root-cause class reported in #83378: `disk-cleanup`'s `guess_category()` mis-classifies files whose names happen to match `test_*`/`tmp_*`/`*.test.*` inside durable user-data trees, and `quick()`'s empty-dir sweep recurses into those same trees and `rmdir`s runtime state.

Rather than guarding a few specific directories, this change makes the ownership boundary explicit and shared by every path that touches cleanup:

- **Protected top-level trees** (`browser-profile`, `vendor`, `benchmarks`, `plans`, plus config/memory/secret files) are never auto-categorised, auto-tracked, or empty-dir-scanned. One shared `_PROTECTED_TOP_LEVEL` set feeds `guess_category()` and the empty-dir sweep, so the two cannot drift.
- **Cache cleanup is opt-in, not wholesale.** `cache/**` is treated as durable state except two explicitly plugin-owned ephemeral roots: `cache/vision/temp_vision_images/` and `cache/video/temp_video_files/` (`_MANAGED_EPHEMERAL_CACHE_ROOTS`). This replaces the previous blanket `if top == "cache": return "temp"`.
- **Stale `tracked.json` entries are re-validated before ANY deletion.** `quick()` and `dry_run()` now share one re-classification pass for `test`/`temp`/`cron-output` entries, fail-closed on paths outside `HERMES_HOME` or under a now-protected tree, so preview always matches what `quick()` actually does.

## Why this approach

- Full-cache protection is too coarse (users legitimately keep tool binaries and indexes there).
- A per-directory blacklist is structural risk: the next new persistent tree silently regresses to the incident class.
- A managed-root whitelist is fail-closed: "who creates a tree, who may clean it" is decided in one place.

Note: #83385 already covers `node/`/`lsp/` dependency subtrees; this PR addresses the broader persistent-tree boundary (incl. the empty-dir sweep) that #83385 does not.

## Tests

- New `tests/plugins/test_disk_cleanup_protected_trees.py` (20 tests): protected-subtree `test_*`/`tmp_*` classification, cache ownership boundary, empty-dir sweep survival, stale-entry re-validation.
- Existing `tests/plugins/test_disk_cleanup_plugin.py` (27 tests) still green.
- `ruff check` and `git diff --check` clean.

```
scripts/run_tests.sh tests/plugins/test_disk_cleanup_plugin.py tests/plugins/test_disk_cleanup_protected_trees.py -q
# 47 tests passed
```

Fixes #83378
Refs #32164 #37721 #75403