### PR TITLE
fix(update): fall back to ZIP download when git fetch hits a trampoline

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4654,6 +4654,31 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print(
                     "✗ Authentication failed — check your git credentials or SSH key."
                 )
+            elif "fork bomb" in stderr.lower():
+                # A Git-for-Windows trampoline launcher (the small bin\git.exe /
+                # cmd\git.exe shim, ~46KB) that fails to re-exec the real
+                # git-core binary refuses every git call with this guard
+                # instead of running it (#87876) — it's a broken PATH entry,
+                # not a network or filesystem problem. Every OTHER git
+                # failure in this update flow already falls back to the ZIP
+                # download path on Windows (via the CalledProcessError
+                # handler below, which never shells out to git); give the
+                # fetch step, which reports its error instead of raising,
+                # the same fallback rather than a bare exit.
+                print("✗ The 'git' on PATH is a broken launcher (trampoline):")
+                print(f"  {stderr.splitlines()[0]}" if stderr else "")
+                if _m()._is_windows():
+                    print("→ Falling back to ZIP download...")
+                    print()
+                    _update_via_zip(
+                        args,
+                        had_desktop_app_before_update=had_desktop_app_before_update,
+                    )
+                    return
+                print(
+                    "  Fix PATH so it resolves the real git binary (e.g. "
+                    "the git-core dir under your Git install), then retry."
+                )
             else:
                 print("✗ Failed to fetch updates from origin.")
                 if stderr:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -974,6 +974,88 @@ class TestNodeRuntimeNpmResolution:
         assert desktop_builds == [True]
 
 
+class TestFetchForkBombFallback:
+    """A Git-for-Windows trampoline launcher that fails to re-exec git-core
+    refuses every git call with a "BUG (fork bomb)" guard instead of running
+    it (#87876). Unlike other git failures in this update flow — which raise
+    and are already caught by the CalledProcessError handler that falls back
+    to the ZIP download path on Windows — the initial ``git fetch`` reports
+    its failure via returncode, so it needs its own fallback."""
+
+    def _patch_common(self, hm, update_cmd, monkeypatch, project_root, *, windows):
+        monkeypatch.setattr(hm, "PROJECT_ROOT", project_root)
+        monkeypatch.setattr(hm, "_is_windows", lambda: windows)
+        monkeypatch.setattr(hm, "_run_pre_update_backup", lambda _args: None)
+        monkeypatch.setattr(hm, "_pause_windows_gateways_for_update", lambda: None)
+        monkeypatch.setattr(hm, "_get_origin_url", lambda *_args: "")
+        monkeypatch.setattr(update_cmd, "_discard_lockfile_churn", lambda *_args: None)
+        monkeypatch.setattr(update_cmd, "_normalize_managed_eol", lambda *_args: None)
+
+    @staticmethod
+    def _fake_run(command, **_kwargs):
+        joined = " ".join(str(c) for c in command)
+        if "fetch" in joined and "origin" in joined:
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                stdout="",
+                stderr="BUG (fork bomb): tried to spawn itself, check your PATH\n",
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    def test_falls_back_to_zip_on_windows(self, tmp_path, monkeypatch, capsys):
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        project_root = tmp_path / "hermes-agent"
+        (project_root / ".git").mkdir(parents=True)
+        self._patch_common(hm, update_cmd, monkeypatch, project_root, windows=True)
+
+        zip_calls = []
+        monkeypatch.setattr(
+            update_cmd, "_update_via_zip", lambda *a, **kw: zip_calls.append(kw)
+        )
+
+        with (
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("subprocess.run", side_effect=self._fake_run),
+        ):
+            update_cmd._cmd_update_impl(
+                SimpleNamespace(yes=True, force=True, force_venv=True, branch=None),
+                gateway_mode=False,
+            )
+
+        assert len(zip_calls) == 1
+        out = capsys.readouterr().out
+        assert "broken launcher" in out.lower()
+        assert "Falling back to ZIP download" in out
+
+    def test_non_windows_exits_with_trampoline_message(self, tmp_path, monkeypatch, capsys):
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        project_root = tmp_path / "hermes-agent"
+        (project_root / ".git").mkdir(parents=True)
+        self._patch_common(hm, update_cmd, monkeypatch, project_root, windows=False)
+
+        with (
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("subprocess.run", side_effect=self._fake_run),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                update_cmd._cmd_update_impl(
+                    SimpleNamespace(yes=True, force=True, force_venv=True, branch=None),
+                    gateway_mode=False,
+                )
+
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        # Distinct from the generic "Failed to fetch updates from origin"
+        # message — the trampoline case gets actionable guidance instead.
+        assert "broken launcher" in out.lower()
+        assert "Failed to fetch updates from origin" not in out
+
+
 class TestUpdateNodeDependencies:
     """Unit tests for _update_node_dependencies — issue #43564.
 


### PR DESCRIPTION
## What does this PR do?

Fixes the `git fetch` step in `hermes update` so it falls back to the ZIP
download path on Windows when the `git` resolved from `PATH` is a broken
Git-for-Windows trampoline launcher, instead of always exiting with a
generic, unhelpful error.

## Related Issue

Fixes #87876

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/update_cmd.py`: in `_cmd_update_impl`'s fetch-failure
  handling, detect the Git-for-Windows trampoline's distinctive `"BUG
  (fork bomb)"` stderr (issue #87876's root cause #1 — the small
  `bin\git.exe`/`cmd\git.exe` shim fails to re-exec the real `git-core`
  binary and refuses every git call instead of running it). This is a
  broken PATH entry, not a network/auth/filesystem problem, so it needs
  its own branch rather than falling into the generic
  "Failed to fetch updates from origin" exit.
  - On Windows, fall back to the ZIP download path — the same recovery
    every *other* git failure in this update flow already gets via the
    `CalledProcessError` handler further down (which never shells out to
    git). The initial fetch was the one exception: it reports its
    failure through a returncode rather than raising, so it never reached
    that handler.
  - On non-Windows (or if ZIP recovery isn't applicable), print an
    actionable message pointing at the broken PATH entry instead of the
    generic failure text.
- `tests/hermes_cli/test_cmd_update.py`: new `TestFetchForkBombFallback`
  with two tests exercising `_cmd_update_impl` end-to-end (mocking
  `subprocess.run` to simulate the trampoline's fetch failure):
  - `test_falls_back_to_zip_on_windows` — confirms `_update_via_zip` is
    invoked and the update does not hard-exit.
  - `test_non_windows_exits_with_trampoline_message` — confirms the exit
    still happens off-Windows, but with the specific trampoline message
    rather than the generic "Failed to fetch updates from origin" text.

Out of scope for this PR: the issue also describes venv-recreation
atomicity and self-lock-during-replace failure modes. Both are already
substantially covered by prior work in this codebase (the venv-holder
detection/quarantine in `_detect_venv_python_processes`,
`_abort_dependency_sync_if_self_locked`, and `_venv_core_imports_healthy`
repair path, covered by `tests/hermes_cli/test_update_self_lock.py` and
`tests/hermes_cli/test_update_venv_health.py`), so this PR is scoped to
the one root cause (broken git trampoline) that had no handling at all.

## How to Test

1. `source .venv/bin/activate && python -m pytest tests/hermes_cli/test_cmd_update.py -k ForkBomb -v`

```
tests/hermes_cli/test_cmd_update.py::TestFetchForkBombFallback::test_falls_back_to_zip_on_windows PASSED [ 50%]
tests/hermes_cli/test_cmd_update.py::TestFetchForkBombFallback::test_non_windows_exits_with_trampoline_message PASSED [100%]

2 passed, 35 deselected in 0.67s
```

2. Confirmed both new tests **fail** against the pre-fix code (`git checkout HEAD -- hermes_cli/update_cmd.py` with the tests kept):

```
FAILED ...test_falls_back_to_zip_on_windows - SystemExit: 1
FAILED ...test_non_windows_exits_with_trampoline_message - AssertionError: assert 'broken launcher' in '...Failed to fetch updates from origin...'
```

3. Full file regression check: `python -m pytest tests/hermes_cli/test_cmd_update.py -q` → `37 passed`
4. Related update-flow suites unaffected: `python -m pytest tests/hermes_cli/test_update_self_lock.py tests/hermes_cli/test_update_venv_health.py tests/hermes_cli/test_update_zip_two_phase.py tests/hermes_cli/test_update_zip_symlink_reject.py -q` → `45 passed`
5. `ruff check hermes_cli/update_cmd.py tests/hermes_cli/test_cmd_update.py` → all checks passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` (scoped to the affected files above; full run not feasible in this environment) and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform: <!-- prepared in a Linux sandbox; the Windows-specific branch is exercised via `_is_windows()` patching per this repo's own testing convention (see AGENTS.md "Don't fake the host OS" — pure functions that take platform as data are fine to test this way) -->

### Documentation & Housekeeping

- [x] N/A — no config/schema/doc changes needed for this fix

## AI-assistance disclosure

This PR was prepared with the assistance of an AI coding agent (Claude),
which located the gap, wrote the fix and the tests, and verified the test
failure/pass behavior described above. A human reviewed the change before
it was pushed.
