### PR TITLE
feat(state): support the context-manager protocol on SessionDB

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4341,6 +4341,42 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         except Exception as exc:
             logger.warning("WAL checkpoint (PASSIVE) failed: %s", exc)
 
+    def __enter__(self) -> "SessionDB":
+        """Enter a scope that closes this handle on the way out.
+
+        Ownership of a SessionDB has to be released explicitly: once the
+        background token writer starts, the instance pins ITSELF via
+        ``atexit.register(self._drain_token_queue_at_exit)`` and via the
+        writer thread's bound-method target, and only ``close()``
+        unregisters the former.  Dropping the last reference therefore does
+        NOT release the db/-wal/-shm descriptors the way plain refcounting
+        would suggest, and ``__del__`` never runs for exactly the instances
+        that leak.  That is why call sites owning a handle are expected to
+        close it (see the ownership comments in ``run_agent.py`` and
+        ``tui_gateway/methods_session.py``).
+
+        This makes the correct usage the easy one, so an owning scope can be
+        exception-safe by construction rather than by remembering a
+        ``try/finally``:
+
+            with SessionDB(path) as db:
+                db.append_message(...)
+
+        Purely additive: it changes nothing for callers that already call
+        ``close()`` directly, and ``close()`` stays idempotent, so a scope
+        that closes early still exits cleanly.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        """Close the handle, then let any exception propagate.
+
+        Returns False (never suppressing), so ``with`` here only manages the
+        descriptor lifetime and never swallows a caller's error.
+        """
+        self.close()
+        return False
+
     def close(self):
         """Close the database connection.
 

--- a/tests/test_session_db_context_manager.py
+++ b/tests/test_session_db_context_manager.py
@@ -1,0 +1,99 @@
+"""``SessionDB`` must support ``with``, so an owning scope releases its fds.
+
+A SessionDB handle cannot be released by dropping the last reference. Once its
+background token writer starts, the instance pins ITSELF two ways: the writer
+thread's target is a bound method, and ``queue_token_counts`` registers
+``atexit.register(self._drain_token_queue_at_exit)``, which only ``close()``
+unregisters. A dropped-but-pinned handle keeps its ``state.db``/``-wal``/
+``-shm`` descriptors for the life of the process, and ``__del__`` never runs
+for it -- so the safety net is dead code for exactly the instances that leak.
+
+That is why owning call sites are expected to close explicitly; the ownership
+comments in ``run_agent.py`` and ``tui_gateway/methods_session.py`` say so in
+those words. This module pins the ergonomic half of that contract: an owner can
+scope a handle with ``with`` and be exception-safe by construction, instead of
+hand-writing a ``try/finally`` at each of the ~59 instantiation sites (#88033).
+
+Following ``test_session_db_read_conn_pool.py``, these assert on the
+``sqlite_safe_read`` tracking registry rather than on raw descriptor counts:
+SQLite's unix VFS parks a closed descriptor on a per-inode reuse list while any
+connection still holds POSIX locks on that inode, so descriptor counts lag the
+real connection count and make such assertions flaky.
+"""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _live_count(path) -> int:
+    """Live-connection count the tracking registry holds for *path*."""
+    import hermes_cli.sqlite_safe_read as mod
+
+    with mod._live_lock:
+        return mod._live_connections.get(mod._key(path), 0)
+
+
+def test_with_block_closes_the_handle(tmp_path):
+    """The whole point: leaving the scope releases the connection."""
+    path = tmp_path / "state.db"
+
+    with SessionDB(db_path=path) as db:
+        db.create_session(session_id="s1", source="cli", model="m")
+        db.append_message("s1", role="user", content="hello")
+        assert db._conn is not None
+        assert _live_count(path) > 0
+
+    assert db._conn is None
+    assert _live_count(path) == 0
+
+
+def test_enter_returns_the_same_handle(tmp_path):
+    """``with SessionDB(...) as db`` must bind the instance, not a wrapper.
+
+    Returning anything else would silently break every attribute access in the
+    body, so this is cheap insurance on the one line that is easy to get wrong.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    with db as entered:
+        assert entered is db
+
+    assert db._conn is None
+
+
+def test_exception_inside_the_block_still_closes_and_propagates(tmp_path):
+    """Exception safety is the reason to prefer ``with`` over a bare close().
+
+    The handle must be released on the failure path (the path that leaked
+    hardest, since it is the one callers forget), and ``__exit__`` must NOT
+    suppress: swallowing a caller's error to release a descriptor would trade
+    one bug for a worse one.
+    """
+    path = tmp_path / "state.db"
+    db = SessionDB(db_path=path)
+
+    with pytest.raises(ValueError, match="boom"):
+        with db:
+            db.create_session(session_id="s1", source="cli", model="m")
+            raise ValueError("boom")
+
+    assert db._conn is None
+    assert _live_count(path) == 0
+
+
+def test_closing_inside_the_block_leaves_the_exit_clean(tmp_path):
+    """``close()`` is documented idempotent; the scope must not fight a caller.
+
+    A call site converted to ``with`` may still hold an explicit ``close()``
+    (or hit one on an internal error path). The second close from ``__exit__``
+    must be a no-op rather than an error.
+    """
+    path = tmp_path / "state.db"
+
+    with SessionDB(db_path=path) as db:
+        db.create_session(session_id="s1", source="cli", model="m")
+        db.close()
+        assert db._conn is None
+
+    assert _live_count(path) == 0


### PR DESCRIPTION
## What does this PR do?

Adds `__enter__`/`__exit__` to `SessionDB` so an owning scope can release its descriptors with `with`, which is suggested fix #1 in #88033.

The reason this is worth having is narrower and more specific than "context managers are nice". A `SessionDB` handle **cannot** be released by dropping the last reference. Once its background token writer starts, the instance pins ITSELF two ways:

- the writer thread's target is a bound method (`target=self._token_writer_loop`), and
- `queue_token_counts` registers `atexit.register(self._drain_token_queue_at_exit)`, which only `close()` unregisters.

So a dropped-but-pinned handle keeps its `state.db`/`-wal`/`-shm` descriptors for the life of the process, and `__del__` never runs for it. The existing `__del__` safety net is therefore dead code for exactly the instances that leak, which is why owning call sites are expected to close explicitly. The codebase already says this in those words:

> A pinned handle keeps its db/-wal/-shm fds and its writer thread for the life of the process.
> `tui_gateway/methods_session.py`

> once that writer has started the instance pins ITSELF via `atexit.register(_drain_token_queue_at_exit)` which only `close()` unregisters, so it survives for the life of the process.
> `run_agent.py`

This PR does not change that contract. It makes the correct usage the easy one, so an owner can be exception-safe by construction instead of hand-writing a `try/finally` at each of the ~59 instantiation sites:

```python
with SessionDB(path) as db:
    db.append_message(...)
```

Purely additive. `__enter__` returns `self`; `__exit__` closes and returns `False` so a caller's exception always propagates; `close()` is already documented idempotent, so a scope that closes early still exits cleanly. Nothing changes for callers that already call `close()` directly.

## What this deliberately does NOT do

Being explicit, because #88033 is broader than this change and the area is busy:

- **It does not convert the ~59 call sites.** That work is already underway across a number of open PRs (closing handles in `react_to_message`, `session_search`, cron skip paths, TUI profile teardown, and so on), and sweeping them here would collide with all of it.
- **It does not remove the self-pin.** Making the atexit hook and the writer thread hold weak references would let orphaned handles be collected, but that reverses a deliberate, documented design in the most critical file in the repo, and the maintainers' established remedy is clearly "close at ownership boundaries". That is a call for whoever owns this area, not something to slip into a PR that was asked for as an additive helper.
- **It does not touch the read-connection pool.** `_read_pool`/`_read_conns` bounding is its own mechanism with its own open work.
- **It does not address the `state.db` busy-timeout point** raised at the end of #88033, which the issue itself offers to split out.

## A correction to the issue's analysis, for whoever picks up the rest

I checked each claim against `main` (`3c108589f`) before writing anything, and two parts of #88033 do not hold. I have posted the same detail on the issue.

**Root cause 2 (`/dev/null` handles) does not reproduce on any of its three sites.**

- `hermes_cli/oneshot.py:237` already closes in a `finally` (`devnull.close()`).
- `tools/mcp_tool.py:182` is guarded by `if _mcp_stderr_log_fh is not None: return` under a lock, so it opens at most once per process. The issue's own suggested remedy ("opening once and guarding re-entry") is already what the code does.
- `agent/thread_scoped_output.py:136` caches into `_sinks`, a module-level `dict[str, TextIO]` keyed by `"stdout"`/`"stderr"` under `_install_lock`, and reuses the sink unless it is closed. It is not per-thread, so it cannot account for a count in the hundreds.

So the measured 393 `/dev/null` handles have some other origin, and that is still worth chasing, just not at these three lines.

**Root cause 1's "no finalizer" is not accurate either**, though its conclusion survives for a different reason: `SessionDB.__del__` exists (and delegates to `close()`). The real problem is that it can never fire for a pinned instance, per the mechanism above. Relatedly, the case made for `weakref.finalize` over `__del__` ("it still runs for objects in reference cycles") has not been true since PEP 442 landed in Python 3.4; objects with `__del__` in cycles are finalized on this tree's Python 3.11.

The `SessionDB` half of the measurement (300 `state.db` + 296 `-wal` = 596 of 1023 handles) is real and is the dominant term.

## Related Issue

Refs #88033 (partial, deliberately: see "What this does not do" above, so this is not written as `Fixes` and should not auto-close the issue).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

Typed as a feature rather than a fix on purpose: it adds a capability that makes the leak easy to avoid, but on its own it does not close a leaking descriptor anywhere. Calling it a bug fix would overstate it.

## Changes Made

- `hermes_state.py` — added `SessionDB.__enter__` (returns `self`) and `SessionDB.__exit__` (closes, returns `False`), placed immediately above `close()`. The docstring records why refcount-drop is not a release path here, so the next reader does not have to rediscover the self-pin.
- `tests/test_session_db_context_manager.py` — new, 4 regressions.

## How to Test

1. `pytest tests/test_session_db_context_manager.py -q` — 4 passed.
2. Confirm the tests are load-bearing rather than tautological:
   - Remove `__enter__`/`__exit__` from `SessionDB`: **4 failed** (the protocol genuinely does not exist without them).
   - Keep them but make `__exit__` `return True`: **1 failed**, `test_exception_inside_the_block_still_closes_and_propagates` with `Failed: DID NOT RAISE ValueError`, pinning non-suppression specifically.
3. Surrounding suites, with the change applied: `pytest tests/test_session_db_read_conn_pool.py tests/test_session_db_read_path_split.py tests/test_hermes_state.py tests/agent/test_async_token_accounting.py -q` — **272 passed, 1 failed**.

   The one failure is `TestFTS5Search::test_search_projection_skips_context_enrichment_queries`, and it is **pre-existing and unrelated**: I reproduced it on a pristine checkout of `3c108589f` with this branch's changes stashed, and it fails identically there. It is an FTS5 search-projection assertion that this diff cannot reach.

The tests assert on the `hermes_cli.sqlite_safe_read` tracking registry rather than on raw descriptor counts, matching the reasoning already documented in `test_session_db_read_conn_pool.py`: SQLite's unix VFS parks a closed descriptor on a per-inode reuse list while any connection still holds POSIX locks on that inode, so raw counts lag the real connection count and make such assertions flaky.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (10.0.26200), Python 3.11

On the full-suite box: I ran the targeted and surrounding suites listed above rather than the entire `tests/` tree, so I am leaving that box unchecked rather than checking it inaccurately. CI runs the full sharded suite on this PR.

On duplicate checking specifically, since this area has a lot of concurrent work: I enumerated the open PR titles via the API rather than relying on search, and read the two nearest candidates (#79457 "bound session database file descriptors" and #78287 "bound SQLite file descriptor usage") to confirm they pool *read connections inside one instance* and neither adds the instance-lifecycle protocol this PR adds. #88033 itself has no linked PRs and no claim comments.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new methods carry docstrings explaining the ownership contract; no user-facing docs describe `SessionDB` construction, so nothing else needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, additive protocol only
- [x] I've considered cross-platform impact (Windows, macOS) — the change is pure Python protocol methods with no platform-specific behavior, and the tests avoid descriptor-count assertions precisely because those are platform-sensitive. Developed and run on Windows 11.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool behavior changes
