### PR TITLE
fix(x_search): prefer an explicit API key over subscription OAuth

### DIFF
--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -312,3 +312,84 @@ def test_x_search_not_degraded_when_no_filters_active(monkeypatch):
     assert result["degraded"] is False
     assert result["degraded_reason"] is None
 
+
+def _xcred(prefix: str) -> str:
+    """Synthesize a distinct fake credential value (never a bare literal)."""
+    return prefix + "-key-" + "x1"
+
+
+def test_x_search_prefers_explicit_api_key_over_oauth(monkeypatch):
+    """#88040: with a paid XAI_API_KEY configured alongside subscription
+    OAuth, x_search must use the API key — the OAuth path authorizes but
+    answers /v1/responses in a degraded Grok explanatory mode with no
+    citations. Same prefer-API-key shape as the TTS fix (#87045/#87081)."""
+    from tools.registry import invalidate_check_fn_cache
+    from tools.x_search_tool import x_search_tool
+
+    paid_key = _xcred("paid")
+    oauth_token = _xcred("oauth")
+
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_value",
+        lambda name, default=None: {
+            "XAI_API_KEY": paid_key,
+            "XAI_BASE_URL": None,
+        }.get(name, default),
+    )
+
+    def _fake_resolve():
+        return {
+            "provider": "xai-oauth",
+            "api_key": oauth_token,
+            "base_url": "https://api.x.ai/v1",
+        }
+
+    monkeypatch.setattr(
+        "tools.x_search_tool.resolve_xai_http_credentials", _fake_resolve
+    )
+    invalidate_check_fn_cache()
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["headers"] = headers
+        return _FakeResponse({"output_text": "Real posts with citations."})
+
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(x_search_tool(query="from:elon latest"))
+
+    assert result["success"] is True
+    assert result["credential_source"] == "xai"
+    assert captured["headers"]["Authorization"] == "Bearer " + paid_key
+
+
+def test_x_search_bearer_helper_falls_back_to_oauth_without_api_key(monkeypatch):
+    """No explicit XAI_API_KEY: the OAuth-first resolver path is unchanged."""
+    from tools.x_search_tool import _resolve_xai_bearer
+
+    oauth_token = _xcred("oauth")
+
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_value",
+        lambda name, default=None: default,
+    )
+
+    def _fake_resolve():
+        return {
+            "provider": "xai-oauth",
+            "api_key": oauth_token,
+            "base_url": "https://api.x.ai/v1",
+        }
+
+    monkeypatch.setattr(
+        "tools.x_search_tool.resolve_xai_http_credentials", _fake_resolve
+    )
+
+    api_key, base_url, source = _resolve_xai_bearer()
+    assert (api_key, base_url, source) == (
+        oauth_token,
+        "https://api.x.ai/v1",
+        "xai-oauth",
+    )
+

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -52,7 +52,6 @@ import requests
 
 from tools.registry import registry, tool_error
 from tools.xai_http import hermes_xai_user_agent, resolve_xai_http_credentials
-
 logger = logging.getLogger(__name__)
 
 DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
@@ -128,7 +127,22 @@ def _resolve_xai_bearer() -> Tuple[str, str, str]:
     gate makes that case unreachable in normal operation, but the runtime
     check exists so a credential that expires between registration and
     invocation produces a clean tool error instead of a 401.
+
+    x_search is API-index access: when a subscription OAuth credential is
+    configured alongside a paid ``XAI_API_KEY``, the OAuth path authorizes
+    but answers ``/v1/responses`` in a degraded Grok explanatory mode with
+    no citations, while the API key returns real posts (#88040). Prefer the
+    explicit API key — same shape as the TTS fix for #87045 (#87081) —
+    keeping OAuth as the fallback when no API key is configured.
     """
+    from hermes_cli.config import get_env_value
+
+    explicit_key = str(get_env_value("XAI_API_KEY") or "").strip()
+    if explicit_key:
+        base_url = str(
+            get_env_value("XAI_BASE_URL") or DEFAULT_XAI_BASE_URL
+        ).strip().rstrip("/")
+        return explicit_key, base_url, "xai"
     creds = resolve_xai_http_credentials()
     api_key = str(creds.get("api_key") or "").strip()
     if not api_key:


### PR DESCRIPTION
## What does this PR do?

Stops `x_search` from silently degrading when a paid `XAI_API_KEY` is configured alongside xAI SuperGrok OAuth. `_resolve_xai_bearer()` preferred the OAuth credential unconditionally; the OAuth path authorizes `/v1/responses` but answers in a degraded Grok explanatory mode with no citations (`degraded: true`, `credential_source: "xai-oauth"`, zero real posts), while the API-key path returns real posts with inline citations. Removing the OAuth credential made the same queries work — the credential choice, not the query, was the difference (#88040).

This applies the issue's option 2: the same prefer-API-key logic PR #87081 introduced for TTS (#87045), extended to x_search's single credential chokepoint. An explicit `XAI_API_KEY` (plus optional `XAI_BASE_URL`) wins when set; OAuth remains the fallback when no API key is configured. The shared `resolve_xai_http_credentials()` resolver and every other xAI call site (images, video, transcription, TTS) are unchanged.

## Related Issue

Fixes #88040

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/x_search_tool.py` — `_resolve_xai_bearer()` checks `XAI_API_KEY` via `get_env_value` first and returns `(key, XAI_BASE_URL or default, "xai")` when set; otherwise falls through to the OAuth-first resolver unchanged. Docstring documents the degraded-mode rationale and the #87081 lineage.
- `tests/tools/test_x_search_tool.py` — two regression tests: both credentials present → the paid API key is used and `credential_source` is `xai`; no API key → the OAuth fallback path is byte-identical to before.

## How to Test

1. `python -m pytest tests/tools/test_x_search_tool.py -q`
2. Observed result: 10 passed (8 pre-existing + 2 new). A/B guard: with only the `tools/x_search_tool.py` hunk stashed, `test_x_search_prefers_explicit_api_key_over_oauth` FAILS (the OAuth bearer is sent); with the hunk it passes.
3. `python -m pytest tests/tools/test_xai_http_credentials.py -q` — Observed result: 2 passed (the shared resolver's own contract is untouched).
4. Manual repro from the issue: with both credentials configured, `x_search` now reports `credential_source: "xai"` and returns posts with citations; with only OAuth configured, behavior is unchanged (`xai-oauth`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/tools/test_x_search_tool.py -q           # with fix
10 passed in 0.86s
$ git stash -- tools/x_search_tool.py && pytest ... -q  # A/B guard
1 failed  (OAuth bearer sent despite paid API key)
```
