### PR TITLE
fix(terminal): avoid FileProvider reads in lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -109,6 +109,23 @@ _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
 _MAX_REFERENCED_SCRIPT_DEPTH = 8
 _CONTROL_CHARS = frozenset(";&|()")
 
+
+def _is_apple_file_provider_path(path: Path) -> bool:
+    """Return True for paths inside macOS's cloud-backed document root.
+
+    ``O_NONBLOCK`` does not make regular-file reads non-blocking.  Opening an
+    evicted FileProvider placeholder below ``~/Library/Mobile Documents`` can
+    therefore wait indefinitely for hydration.  The lifecycle guard runs
+    before a terminal command's timeout starts, so it must identify this
+    boundary from path metadata and fail closed without opening the file.
+    """
+    parts = path.parts
+    return any(
+        parts[index - 1] == "Library" and part == "Mobile Documents"
+        for index, part in enumerate(parts)
+        if index
+    )
+
 # Executables whose arguments are DATA, not commands: search patterns, SQL
 # statements, log filters. None of these can execute their argument text, so
 # a lifecycle-shaped string inside their arguments (a grep pattern hunting
@@ -532,6 +549,11 @@ def _contains_unsafe_gateway_action(
             return True
 
     for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
+        # Do not touch a FileProvider path even to discover whether the file is
+        # hydrated.  The lexical check covers direct cloud paths; the resolved
+        # check below covers local launchers that are symlinks into iCloud.
+        if _is_apple_file_provider_path(script_path):
+            return True
         try:
             resolved = script_path.resolve(strict=False)
         except (OSError, ValueError):
@@ -539,6 +561,8 @@ def _contains_unsafe_gateway_action(
             # from a binary's decoded contents tokenized as a path — a
             # guarded path must never crash the guard (#76762).
             resolved = script_path
+        if _is_apple_file_provider_path(resolved):
+            return True
         if resolved in visited:
             continue
         visited.add(resolved)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -761,6 +761,48 @@ class TestLifecycleGuardModule:
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily ops", str(script))
 
+    def test_cloud_backed_symlink_fails_closed_without_opening_target(
+        self, tmp_path, monkeypatch
+    ):
+        """A FileProvider placeholder must not block terminal preflight.
+
+        ``O_NONBLOCK`` has no effect on regular files.  On macOS, opening an
+        iCloud placeholder can therefore wait indefinitely for hydration,
+        before the terminal command's own timeout has even started.  Detect
+        the resolved FileProvider path from local metadata and fail closed
+        without opening it.
+        """
+        import cron.lifecycle_guard as lifecycle_guard
+
+        cloud_dir = (
+            tmp_path
+            / "Library"
+            / "Mobile Documents"
+            / "com~apple~CloudDocs"
+            / "scripts"
+        )
+        cloud_dir.mkdir(parents=True)
+        target = cloud_dir / "helper"
+        target.write_text("#!/bin/sh\necho safe\n", encoding="utf-8")
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        launcher = bin_dir / "helper"
+        launcher.symlink_to(target)
+
+        real_open = lifecycle_guard.os.open
+
+        def reject_cloud_open(path, flags, *args, **kwargs):
+            if str(path) == str(launcher):
+                pytest.fail("lifecycle guard opened a cloud-backed symlink")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(lifecycle_guard.os, "open", reject_cloud_open)
+
+        assert lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(
+            str(launcher)
+        ) is True
+
     # -- Whole-class regression tests (tilllt's T1-T4 on PR #79454) --------
 
     def test_tilde_nul_candidate_does_not_crash_terminal_walk(self):


### PR DESCRIPTION
## Summary
- detect macOS FileProvider paths before referenced-script reads
- fail closed for direct iCloud scripts and local symlinks into iCloud
- prevent terminal preflight from hanging before the command timeout starts

## Regression evidence
- reproduced with a local executable symlink into `Library/Mobile Documents/com~apple~CloudDocs` and asserted the guard never calls `os.open`
- regression failed before the fix and passes after it
- `tests/hermes_cli/test_gateway_restart_loop.py`: 128 passed
- Ruff passed for changed files

## Production evidence
A live macOS gateway stack during a stalled terminal call was blocked at `terminal_tool -> cron.lifecycle_guard._read_referenced_script -> os.open`. The referenced executable was a local symlink whose target lived under iCloud FileProvider storage; no terminal child had started, so the configured terminal timeout could not apply.