### PR TITLE
feat: raise Codex OAuth context to 900K for gpt-5.6 family and gpt-5.4 (subscription 1M rollout)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2348,12 +2348,17 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
 }
 
 # Codex OAuth advertises 272K via /backend-api/codex/models for these
-# families, but the backend actually ACCEPTS more (verified live Aug 16 2026
-# against chatgpt.com/backend-api/codex/responses: ~371K input tokens
-# completed OK for gpt-5.6-sol/terra/luna and gpt-5.4; ~382K+ rejected with
-# ``context_length_exceeded``; gpt-5.5 rejected 360K, so its 272K
-# advertisement is real and it is NOT listed). 350K keeps ~22K margin under
-# the observed ~372K enforcement.
+# families, but the backend actually ACCEPTS far more. OpenAI enabled the
+# large-context window for ChatGPT-subscription Codex accounts on
+# Aug 16 2026 (announced by @thsottiaux; previously API-key-only).
+# Verified live against chatgpt.com/backend-api/codex/responses the same
+# day: 911,276 input tokens completed OK on gpt-5.6-sol; ~925K+ rejected
+# with ``context_length_exceeded`` (the 1.05M window minus reserved output
+# headroom). gpt-5.6-terra, gpt-5.6-luna, and gpt-5.4 all completed 900,026
+# tokens OK. gpt-5.5 and gpt-5.4-mini still rejected >272K, so their
+# advertisement is real enforcement and they are NOT listed. 900K keeps
+# ≥11K margin under the observed ceiling and matches the compaction point
+# Codex's own client config documents for the 1M window.
 #
 # Applied ONLY when the resolved value (live probe or fallback table) is
 # exactly the known-stale 272,000 advertisement — if OpenAI moves the
@@ -2362,13 +2367,13 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
 # this table is inert. ``gpt-5.6`` is a FAMILY PREFIX (sol/terra/luna and
 # dated snapshots; ``-pro`` slugs are not routable on Codex OAuth — the
 # backend 400s them — so over-matching there is moot). ``gpt-5.4`` is EXACT:
-# gpt-5.4-mini was probed and genuinely enforces 272K (rejected 360K), so
+# gpt-5.4-mini was probed and genuinely enforces 272K (rejected 500K), so
 # prefix-matching the 5.4 family would over-report for mini.
 _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES: Dict[str, int] = {
-    "gpt-5.6": 350_000,   # sol / terra / luna — all three verified live
+    "gpt-5.6": 900_000,   # sol / terra / luna — all three verified live at 900K
 }
 _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {
-    "gpt-5.4": 350_000,   # verified live; gpt-5.4-mini rejected 360K — excluded
+    "gpt-5.4": 900_000,   # verified live at 900K; gpt-5.4-mini rejected 500K — excluded
 }
 
 # The advertised value the verified-above table is allowed to override.

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -520,9 +520,11 @@ class TestCodexOAuthContextLength:
             "gpt-5.4",
         ],
     )
-    def test_stale_272k_advertisement_bumped_to_live_verified_350k(self, slug):
-        """Codex advertises 272K for these slugs but the backend accepts ~372K
-        (verified live Aug 2026); the resolver lifts exactly-272K to 350K."""
+    def test_stale_272k_advertisement_bumped_to_live_verified_900k(self, slug):
+        """Codex advertises 272K for these slugs but the backend accepts ~911K
+        (verified live Aug 2026, after OpenAI enabled the large-context window
+        for ChatGPT-subscription accounts); the resolver lifts exactly-272K
+        to 900K."""
         from agent.model_metadata import get_model_context_length
 
         fake_response = MagicMock()
@@ -539,7 +541,7 @@ class TestCodexOAuthContextLength:
                 api_key="fake-token",
                 provider="openai-codex",
             )
-        assert ctx == 350_000
+        assert ctx == 900_000
 
     def test_non_272k_advertisement_is_trusted_verbatim(self):
         """Any advertised value other than the known-stale 272,000 — higher or
@@ -567,7 +569,7 @@ class TestCodexOAuthContextLength:
 
     @pytest.mark.parametrize("slug", ["gpt-5.5", "gpt-5.4-mini"])
     def test_slugs_that_enforce_272k_keep_advertised_value(self, slug):
-        """gpt-5.5 and gpt-5.4-mini both rejected 360K in the live probe —
+        """gpt-5.5 and gpt-5.4-mini both rejected large inputs in the live probe (360K and 500K respectively) —
         their 272K advertisement is real enforcement, so no bump applies
         (gpt-5.4 is an exact-match entry precisely to exclude -mini)."""
         from agent.model_metadata import get_model_context_length
@@ -605,7 +607,7 @@ class TestCodexOAuthContextLength:
                 api_key="expired-token",
                 provider="openai-codex",
             )
-        assert ctx == 350_000
+        assert ctx == 900_000
 
 
 


### PR DESCRIPTION
## Summary
Raises the Codex OAuth context override for the gpt-5.6 family (sol/terra/luna) and gpt-5.4 from 350K (#87981, merged earlier today) to **900K**. OpenAI enabled the large-context window for ChatGPT-subscription Codex accounts this afternoon (announced by @thsottiaux — previously API-key-only), and live re-probing confirms the backend now accepts ~911K input tokens on these slugs.

## Live probe evidence (chatgpt.com/backend-api/codex/responses, Aug 16 2026, post-rollout)

| Slug | 500K | 900K | 911K | ~925K+ | Resolved ctx |
|---|---|---|---|---|---|
| gpt-5.6-sol | ✅ | ✅ | ✅ 911,276 OK | ❌ context_length_exceeded | **900K** |
| gpt-5.6-terra | ✅ | ✅ 900,026 OK | — | — | **900K** |
| gpt-5.6-luna | ✅ | ✅ 900,026 OK | — | — | **900K** |
| gpt-5.4 | ✅ | ✅ 900,026 OK | — | — | **900K** |
| gpt-5.5 | ❌ rejected | — | — | — | 272K (still enforced) |
| gpt-5.4-mini | ❌ rejected | — | — | — | 272K (still enforced) |

The ~925K ceiling is the 1.05M window minus reserved output headroom. The Codex `/models` catalog **still advertises 272,000** for every slug above, so the stale-advertisement override mechanism from #87981 is exactly the right lever — this PR only changes its value. 900K keeps ≥11K margin under the verified ceiling and matches the compaction point Codex's own client config documents for the 1M window.

## Changes
- `agent/model_metadata.py`: `_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_*` tables 350K → 900K; evidence comments updated. No mechanism changes: override still fires only when the resolved value is exactly the stale 272,000 advertisement, and any live catalog change (higher or lower) is trusted verbatim — verified E2E that an advertised 1.05M passes through untouched.
- `tests/agent/test_model_metadata.py`: expected values 350K → 900K, test name/docstrings updated.

## Validation
| | Result |
|---|---|
| tests/agent/test_model_metadata.py | 91/91 passed |
| Sibling ctx tests (9 files) | 179/179 passed |
| E2E real-import chain (fallback + live-272K bump + 1.05M trusted verbatim) | all pass |
| Compaction coherence | 85% autoraise × 900K → trigger ~765K, inside window |

## Infographic

![Codex subs 900K context infographic](https://v3b.fal.media/files/b/0aa6a37e/l_dl6qZJRzuvq9w3bZDJJ_xtxbj4s5.png)
