### PR TITLE
fix(telegram): rebind TypeHandler on lazy re-import

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -416,6 +416,7 @@ def check_telegram_requirements() -> bool:
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
     global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global TypeHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -435,6 +436,7 @@ def check_telegram_requirements() -> bool:
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
             MessageHandler as _MH,
+            TypeHandler as _TH,
             ContextTypes as _CT, filters as _filters,
         )
         from telegram.constants import ParseMode as _PM, ChatType as _CtT
@@ -451,6 +453,7 @@ def check_telegram_requirements() -> bool:
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
     TelegramMessageHandler = _MH
+    TypeHandler = _TH
     ContextTypes = _CT
     filters = _filters
     ParseMode = _PM


### PR DESCRIPTION
## Problem

`plugins/platforms/telegram/adapter.py` has a cold-load import guard (module-level `try: from telegram.ext import ... except ImportError:`). When `python-telegram-bot` isn't importable at plugin-load time, every PTB name is bound to the `Any` fallback.

`check_telegram_requirements()` later re-imports and rebinds most of those globals — but it **omitted `TypeHandler`**. So `TypeHandler` stayed `Any`, and `_register_handlers()` called `TypeHandler(Update, ...)` → `typing.Any.__new__` → `TypeError("Any cannot be instantiated")` on Telegram connect.

Symptom in `gateway.log`:

```
Platform 'Telegram' dependencies missing — attempting install...
Connecting to telegram...
[Telegram] Failed to connect to Telegram: Any cannot be instantiated
```

## Fix

Add `TypeHandler` to the `global` block, the `from telegram.ext import (...)` tuple, and the rebind block in `check_telegram_requirements()` — 3 lines.

## Verification

- Simulated the fallback → re-import path and confirmed `TypeHandler` is rebound to `telegram.ext.TypeHandler` (not `Any`).
- Real Telegram connect succeeds on a fresh gateway start (`✓ telegram connected`).