### PR TITLE
fix(state): stop abandoned sessions from exhausting file descriptors

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -29,6 +29,7 @@ import sqlite3
 import sys
 import threading
 import time
+import weakref
 from collections import deque
 from contextlib import contextmanager
 from pathlib import Path
@@ -3173,6 +3174,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     _IMPORT_MAX_TOTAL_MESSAGES = 50_000
     _IMPORT_MAX_SESSION_BYTES = 5 * 1024 * 1024
     _IMPORT_MAX_TOTAL_BYTES = 25 * 1024 * 1024
+    # Demand-started accounting workers retire after an idle window so their
+    # bound targets do not keep abandoned SessionDB instances (and SQLite
+    # descriptors) alive forever. A later enqueue starts a fresh worker.
+    _TOKEN_WRITER_IDLE_SECONDS = 30.0
 
     @staticmethod
     def _store_system_prompt(conn, system_prompt: Optional[str]) -> Optional[str]:
@@ -3311,6 +3316,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self._token_writer_thread: Optional[threading.Thread] = None
         self._token_writer_stop = False
         self._token_writer_busy = False
+        self._token_atexit_hook: Optional[Callable[[], None]] = None
         initialization_complete = False
         try:
             if read_only:
@@ -4352,12 +4358,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         #45383). Read-only connections never request a checkpoint.
         """
         self._stop_token_writer()
-        # The atexit hook holds a strong reference to this instance (bound
-        # method); without unregistering, every closed SessionDB stays
-        # reachable until interpreter exit. Bound methods compare equal by
-        # (instance, function), so this removes exactly our registration;
-        # no-op when the writer never started.
-        atexit.unregister(self._drain_token_queue_at_exit)
+        hook, self._token_atexit_hook = self._token_atexit_hook, None
+        if hook is not None:
+            atexit.unregister(hook)
         # Drain the read-only connection pool.  Setting the closed flag
         # under the lock first means a reader still in flight closes its own
         # connection on release instead of re-populating a pool that has
@@ -4390,20 +4393,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 conn, self._conn = self._conn, None
                 self._close_connection_quietly(conn)
 
+    def __enter__(self) -> "SessionDB":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb) -> None:
+        self.close()
+
     def __del__(self) -> None:
         """Safety net: close the connection if the caller forgot.
 
-        ``atexit.register`` in ``__init__`` pins this instance alive until
-        interpreter exit, which prevents GC from collecting orphaned
-        ``SessionDB`` instances on exception paths.  When callers forget
-        ``.close()``, the sqlite FDs leak until the process exits (EMFILE).
-
-        A ``__del__`` finalizer is the last-resort guard: it fires when the
-        GC collects the object, which *can* happen once ``atexit`` is
-        unregistered (via ``close()``) **or** when the atexit-held
-        reference is the only remaining root and the interpreter is
-        shutting down.  During normal interpreter teardown the order of
-        module cleanup is undefined, so we guard every attribute access.
+        The async accounting worker retires when idle and its atexit hook
+        holds only a weak reference, so neither can pin an otherwise orphaned
+        instance. During interpreter teardown the order of module cleanup is
+        undefined, so every attribute access remains guarded.
 
         Delegates to ``close()`` so the read pool, token writer, and atexit
         hook are all cleaned up — not just the writer connection.
@@ -7221,7 +7223,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     )
                     self._token_writer_thread = thread
                     thread.start()
-                    atexit.register(self._drain_token_queue_at_exit)
+                    if self._token_atexit_hook is None:
+                        self_ref = weakref.ref(self)
+
+                        def _drain_at_exit() -> None:
+                            db = self_ref()
+                            if db is not None:
+                                db._drain_token_queue_at_exit()
+
+                        self._token_atexit_hook = _drain_at_exit
+                        atexit.register(_drain_at_exit)
                 self._token_queue_cond.notify_all()
         if writer_stopped:
             # Writer permanently stopped (close() ran; a stop-flagged but
@@ -7287,9 +7298,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def _token_writer_loop(self) -> None:
         while True:
             with self._token_queue_cond:
+                idle_deadline = time.monotonic() + self._TOKEN_WRITER_IDLE_SECONDS
                 while not self._token_queue and not self._token_writer_stop:
-                    self._token_queue_cond.wait()
+                    remaining = idle_deadline - time.monotonic()
+                    if remaining <= 0:
+                        # Publish retirement under the same lock used by
+                        # queue_token_counts() to decide whether to spawn. An
+                        # enqueue cannot strand a delta behind an exiting worker.
+                        self._token_writer_thread = None
+                        return
+                    self._token_queue_cond.wait(remaining)
                 if not self._token_queue:
+                    self._token_writer_thread = None
                     return  # stop requested and fully drained
                 # busy is set BEFORE the queue is cleared: the lock-free
                 # fast path in flush_token_counts() reads queue-then-busy,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4393,12 +4393,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 conn, self._conn = self._conn, None
                 self._close_connection_quietly(conn)
 
-    def __enter__(self) -> "SessionDB":
-        return self
-
-    def __exit__(self, _exc_type, _exc, _tb) -> None:
-        self.close()
-
     def __del__(self) -> None:
         """Safety net: close the connection if the caller forgot.
 

--- a/tests/agent/test_async_token_accounting.py
+++ b/tests/agent/test_async_token_accounting.py
@@ -338,12 +338,54 @@ class TestRouteSwitchBarrier:
 
 class TestDurability:
 
+    def test_idle_writer_restarts_for_later_delta(self, tmp_path, monkeypatch):
+        db = SessionDB(db_path=tmp_path / "writer-restart.db")
+        monkeypatch.setattr(SessionDB, "_TOKEN_WRITER_IDLE_SECONDS", 0.01)
+        try:
+            db.create_session("s-restart", "test")
+            db.queue_token_counts("s-restart", input_tokens=1, api_call_count=1)
+            assert db.flush_token_counts()
+
+            deadline = time.monotonic() + 2.0
+            while db._token_writer_thread is not None and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert db._token_writer_thread is None
+
+            db.queue_token_counts("s-restart", input_tokens=2, api_call_count=1)
+            assert db.flush_token_counts()
+            totals = _totals(db, "s-restart")
+            assert totals["input_tokens"] == 3
+            assert totals["api_call_count"] == 2
+        finally:
+            db.close()
+
+    def test_abandoned_db_releases_writer_and_connection(self, tmp_path, monkeypatch):
+        """An async-accounting writer must not pin an abandoned SessionDB."""
+        import gc
+        import time
+        import weakref
+
+        from hermes_cli.sqlite_safe_read import has_live_connection
+
+        db_path = tmp_path / "abandoned.db"
+        monkeypatch.setattr(SessionDB, "_TOKEN_WRITER_IDLE_SECONDS", 0.01, raising=False)
+        db = SessionDB(db_path=db_path)
+        db.create_session("s-abandoned", "test")
+        db.queue_token_counts("s-abandoned", input_tokens=1, api_call_count=1)
+        assert db.flush_token_counts()
+
+        ref = weakref.ref(db)
+        del db
+        deadline = time.monotonic() + 2.0
+        while ref() is not None and time.monotonic() < deadline:
+            gc.collect()
+            time.sleep(0.01)
+
+        assert ref() is None
+        assert has_live_connection(db_path) is False
 
     def test_close_unregisters_atexit_hook(self, tmp_path):
-        """close() must unregister the atexit drain hook: it holds a strong
-        reference (bound method) that would otherwise pin every closed
-        SessionDB — and its sqlite connection object — until interpreter
-        exit in multi-open/close processes."""
+        """close() unregisters the now-weak atexit drain hook immediately."""
         import gc
         import weakref
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -104,6 +104,17 @@ def _no_fts_rebuild_throttle(monkeypatch):
 
 
 class TestConnectionLifecycle:
+    def test_context_manager_closes_connection(self, tmp_path):
+        from hermes_cli.sqlite_safe_read import has_live_connection
+
+        db_path = tmp_path / "context-managed.db"
+        with SessionDB(db_path=db_path) as managed:
+            managed.create_session("s-context", source="test")
+            assert has_live_connection(db_path) is True
+
+        assert managed._conn is None
+        assert has_live_connection(db_path) is False
+
     def test_failed_writable_open_does_not_leak_tracked_connection(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -104,17 +104,6 @@ def _no_fts_rebuild_throttle(monkeypatch):
 
 
 class TestConnectionLifecycle:
-    def test_context_manager_closes_connection(self, tmp_path):
-        from hermes_cli.sqlite_safe_read import has_live_connection
-
-        db_path = tmp_path / "context-managed.db"
-        with SessionDB(db_path=db_path) as managed:
-            managed.create_session("s-context", source="test")
-            assert has_live_connection(db_path) is True
-
-        assert managed._conn is None
-        assert has_live_connection(db_path) is False
-
     def test_failed_writable_open_does_not_leak_tracked_connection(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## What does this PR do?

Long-running Hermes processes can retain abandoned `SessionDB` instances after asynchronous token accounting starts, leaving their SQLite descriptors open until the process reaches its file-descriptor limit. This change lets idle accounting workers retire and makes the process-exit drain hook weak, so an otherwise unreachable database can be finalized while later token deltas still restart the writer safely.

### Symptom

A long-running `hermes serve` process accumulates `state.db` and WAL descriptors until ordinary session, cron, and file operations fail with `EMFILE`, while the service may still appear active.

### Impact

Operators must restart the process to recover. Once the descriptor table is exhausted, session storage, cron database access, and unrelated file reads can all fail.

### Bug Cause

**Trigger:** `hermes_state.py:7217` / `SessionDB.queue_token_counts()` after the asynchronous accounting writer starts

**Causal chain:**
1. An ephemeral or exception-path `SessionDB` queues token-accounting work and its owner later drops the database without calling `close()`.
2. The writer thread targets the bound `_token_writer_loop` method and waits indefinitely, while the registered bound process-exit callback also retains the instance.
3. `SessionDB.__del__()` cannot run, so the SQLite connection and its `state.db` and WAL descriptors remain open for the life of the process.

**Why it is wrong:** Both asynchronous lifecycle helpers strongly retain the resource owner after normal application code no longer needs it. The existing finalizer is therefore unreachable on the exact path it is intended to guard.

**Working sibling / contrast:** Explicitly closed databases already stop the writer, unregister the process-exit hook, and close their connection. A retired writer can also restart when a later token delta arrives, preserving live-instance accounting behavior.

**Ruled out:** The three reported `/dev/null` sites are not the same unbounded leak on current `main`: the one-shot path closes its handle in `finally`, the MCP path owns one guarded process-lifetime handle, and thread-scoped output reuses cached sinks.

### Fix

- Retire a demand-started token-accounting worker after an idle window, publishing retirement under the same condition lock used by enqueuers so no delta can be stranded.
- Register one weak process-exit callback per `SessionDB`, and unregister that exact callback during `close()`.
- Cover writer restart and abandoned-database reclamation with lifecycle tests.

## Related Issue

Refs #88033. This PR covers the abandoned SessionDB `state.db`/`-wal` descriptor leak only. The measured `/dev/null` leak from that issue is still unresolved.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` - retire idle token-accounting workers, use a weak process-exit drain hook, and preserve safe writer restart and explicit close behavior.
- `tests/agent/test_async_token_accounting.py` - verify restart after idle retirement and reclamation of an abandoned database and tracked connection.

## How to Test

1. In a Windows 11 real-environment probe, create 40 `SessionDB` instances, enqueue and flush token accounting, drop all owner references, wait for writer retirement, and collect garbage. Confirm all 40 instances and tracked SQLite connections are released.
2. Run the related suites (252 passed, 2 skipped):

```bash
scripts/run_tests.sh tests/agent/test_async_token_accounting.py tests/test_hermes_state.py
```

3. Run static checks:

```bash
uv run ruff check hermes_state.py tests/agent/test_async_token_accounting.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the repository test entry on the related suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A, this is an internal lifecycle correction covered by code comments and tests
- [x] I've updated `cli-config.yaml.example` if I added or changed config keys - N/A, no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no workflow changes
- [x] I've considered cross-platform impact per the compatibility guide - the lifecycle logic uses Python threading, weak references, and SQLite cleanup without platform-specific branches
- [x] I've updated tool descriptions or schemas if I changed tool behavior - N/A, no tool schema changes
