### PR TITLE
fix(gateway): ignore invalid managed Node directories

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3261,19 +3261,20 @@ def _append_node_dir_for_service(
 
     PATH lookup remains the fallback rung for installs with no managed Node.
     """
-    from hermes_constants import iter_hermes_node_dirs
+    from hermes_constants import (
+        hermes_managed_node_tree_present,
+        iter_hermes_node_dirs,
+    )
 
-    managed_node_present = False
-    for directory in iter_hermes_node_dirs(hermes_root):
+    managed_node_present = hermes_managed_node_tree_present(hermes_root)
+    for directory in iter_hermes_node_dirs(hermes_root) if managed_node_present else ():
         entry = str(directory)
         try:
             present = directory.is_dir()
         except OSError:
             present = False
-        if present:
-            managed_node_present = True
-            if entry not in path_entries:
-                path_entries.append(entry)
+        if present and entry not in path_entries:
+            path_entries.append(entry)
 
     # Ambient PATH lookup is a fallback, not an additional rung. Once the
     # target Hermes home provides managed Node, consulting the invoker's PATH

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -845,6 +845,37 @@ class TestDetectVenvDir:
 class TestSystemUnitHermesHome:
     """HERMES_HOME in system units must reference the target user, not root."""
 
+    def test_empty_managed_node_dir_uses_only_ambient_fallback(
+        self, monkeypatch, tmp_path
+    ):
+        managed_bin = tmp_path / ".hermes" / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        monkeypatch.setattr(
+            gateway_cli.shutil, "which", lambda name: "/opt/external-node/bin/node"
+        )
+        entries: list[str] = []
+
+        gateway_cli._append_node_dir_for_service(entries, tmp_path / ".hermes")
+
+        assert entries == ["/opt/external-node/bin"]
+
+    def test_non_executable_managed_node_uses_only_ambient_fallback(
+        self, monkeypatch, tmp_path
+    ):
+        managed_bin = tmp_path / ".hermes" / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        node = managed_bin / "node"
+        node.write_text("#!/bin/sh\n")
+        node.chmod(0o644)
+        monkeypatch.setattr(
+            gateway_cli.shutil, "which", lambda name: "/opt/external-node/bin/node"
+        )
+        entries: list[str] = []
+
+        gateway_cli._append_node_dir_for_service(entries, tmp_path / ".hermes")
+
+        assert entries == ["/opt/external-node/bin"]
+
     def test_managed_node_makes_system_unit_independent_of_callers_path(
         self, monkeypatch, tmp_path
     ):
@@ -855,6 +886,9 @@ class TestSystemUnitHermesHome:
         root_hermes = root_home / ".hermes"
         managed_bin = target_hermes / "node" / "bin"
         managed_bin.mkdir(parents=True)
+        node = managed_bin / "node"
+        node.write_text("#!/bin/sh\n")
+        node.chmod(0o755)
         root_hermes.mkdir(parents=True)
 
         monkeypatch.setattr(Path, "home", staticmethod(lambda: root_home))
@@ -883,6 +917,10 @@ class TestSystemUnitHermesHome:
         """External Node installs still work when the managed tree is absent."""
         monkeypatch.setattr(
             "hermes_constants.iter_hermes_node_dirs", lambda root=None: []
+        )
+        monkeypatch.setattr(
+            "hermes_constants.hermes_managed_node_tree_present",
+            lambda root=None: False,
         )
         monkeypatch.setattr(
             gateway_cli.shutil, "which", lambda name: "/opt/external-node/bin/node"


### PR DESCRIPTION
## Summary

- follow up on merged #87118 by validating the managed Node tree before making it authoritative
- omit empty or non-executable managed Node directories from generated service PATH entries
- preserve ambient Node fallback when the managed installation is incomplete

## Why

#87118 made Hermes-managed Node suppress caller-specific PATH fallback, fixing non-deterministic systemd units. Its automated review correctly identified a remaining edge case: directory existence alone does not prove that the managed runtime is usable. An interrupted installation can leave `$HERMES_HOME/node/bin` behind without an executable Node/npm/npx shim.

This follow-up reuses the existing `hermes_managed_node_tree_present()` predicate. Only a validated managed tree is added and made authoritative; otherwise the broken directory is skipped and ambient Node remains the fallback.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -q` — 83 passed, 1 platform skip
- `python -m ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `git diff --check`

New regressions cover both an empty managed directory and a non-executable managed Node shim; neither may shadow a working ambient Node.
