### PR TITLE
fix(desktop): map SSH profile aliases in cron/REST profile filters

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -43,7 +43,8 @@ import {
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,
-  tokenPreview
+  tokenPreview,
+  translateSelfProfileQuery
 } from './connection-config'
 
 // --- connectionScopeKey / normAuthMode ---
@@ -370,6 +371,56 @@ test('pathWithGlobalRemoteProfile skips local and per-profile remote override pa
     }),
     '/api/model/info'
   )
+})
+
+test('pathWithGlobalRemoteProfile translates a desktop SSH alias in an explicit profile query', () => {
+  assert.equal(
+    pathWithGlobalRemoteProfile('/api/cron/jobs?profile=mara', 'mara', {
+      globalRemote: false,
+      profileRemoteOverride: true,
+      backendProfile: 'default'
+    }),
+    '/api/cron/jobs?profile=default'
+  )
+})
+
+test('pathWithGlobalRemoteProfile preserves cross-profile selectors when translating an SSH alias', () => {
+  const opts = {
+    globalRemote: false,
+    profileRemoteOverride: true,
+    backendProfile: 'default'
+  }
+
+  assert.equal(pathWithGlobalRemoteProfile('/api/cron/jobs?profile=all', 'mara', opts), '/api/cron/jobs?profile=all')
+  assert.equal(pathWithGlobalRemoteProfile('/api/cron/jobs?profile=worker', 'mara', opts), '/api/cron/jobs?profile=worker')
+})
+
+// --- translateSelfProfileQuery (registry SSH-scoped hermes:api contract) ---
+
+test('translateSelfProfileQuery rewrites the self-profile filter into the backend namespace', () => {
+  assert.equal(
+    translateSelfProfileQuery('/api/cron/jobs?profile=mara', 'mara', 'default'),
+    '/api/cron/jobs?profile=default'
+  )
+  assert.equal(
+    translateSelfProfileQuery('/api/cron/blueprints/instantiate?profile=mara', 'mara', 'default'),
+    '/api/cron/blueprints/instantiate?profile=default'
+  )
+})
+
+test('translateSelfProfileQuery leaves cross-profile and unfiltered paths untouched', () => {
+  assert.equal(translateSelfProfileQuery('/api/cron/jobs?profile=all', 'mara', 'default'), '/api/cron/jobs?profile=all')
+  assert.equal(
+    translateSelfProfileQuery('/api/cron/jobs?profile=worker', 'mara', 'default'),
+    '/api/cron/jobs?profile=worker'
+  )
+  assert.equal(translateSelfProfileQuery('/api/cron/jobs', 'mara', 'default'), '/api/cron/jobs')
+})
+
+test('translateSelfProfileQuery no-ops when alias and backend profile agree or are missing', () => {
+  assert.equal(translateSelfProfileQuery('/api/cron/jobs?profile=mara', 'mara', 'mara'), '/api/cron/jobs?profile=mara')
+  assert.equal(translateSelfProfileQuery('/api/cron/jobs?profile=mara', 'mara', ''), '/api/cron/jobs?profile=mara')
+  assert.equal(translateSelfProfileQuery('/api/cron/jobs?profile=mara', '', 'default'), '/api/cron/jobs?profile=mara')
 })
 
 test('pathWithGlobalRemoteProfile skips empty profile/path safely', () => {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -388,6 +388,9 @@ function profileRemoteOverride(config, profile) {
 }
 
 export interface ProfileRouteOptions {
+  /** Profile name on a separately-scoped backend when it differs from the
+   * desktop's local routing label (managed SSH `remoteProfile`). */
+  backendProfile?: null | string
   globalRemote?: boolean
   primaryProfile?: null | string
   profileRemoteOverride?: boolean
@@ -442,15 +445,66 @@ function resolveProfileBackendRoute(profile, opts: ProfileRouteOptions = {}): Pr
 }
 
 /**
- * Add renderer-side `request.profile` to a REST path when the route says the
- * serving backend is not already scoped to that profile.
+ * Reconcile the renderer's desktop-facing profile label with the backend's
+ * profile namespace, then add `request.profile` when a shared backend needs it.
+ *
+ * A managed SSH override can deliberately map local `mara` to remote `default`.
+ * Endpoint-level filters (cron list / blueprint instantiate) arrive as an
+ * explicit `?profile=mara`; translate only that self-scope. Cross-profile
+ * selectors such as `all` or another concrete profile retain their meaning.
  */
 function pathWithGlobalRemoteProfile(path, profile, opts: ProfileRouteOptions = {}) {
+  const translated = translateSelfProfileQuery(path, profile, opts.backendProfile)
+
+  if (translated !== path) {
+    return translated
+  }
+
   if (!resolveProfileBackendRoute(profile, opts).scopePath) {
     return path
   }
 
   return pathWithProfileScope(path, profile)
+}
+
+/**
+ * Translate an explicit self-profile query from a Desktop routing alias to the
+ * backend's own profile namespace (a managed SSH `remoteProfile` can map local
+ * `mara` to remote `default`). Only a `?profile=` equal to the alias itself is
+ * rewritten; cross-profile selectors (`all`, another concrete profile) and
+ * unfiltered paths pass through untouched. Used by the v1 profile route above
+ * and by the registry SSH branch of the `hermes:api` handler — both routes
+ * reach a backend whose namespace is the remote profile, not the alias.
+ */
+function translateSelfProfileQuery(path, profile, backendProfile) {
+  const scopedProfile = connectionScopeKey(profile)
+  const backend = connectionScopeKey(backendProfile)
+
+  if (!scopedProfile || !backend || backend === scopedProfile) {
+    return path
+  }
+
+  const rawPath = String(path || '')
+
+  if (!rawPath) {
+    return path
+  }
+
+  let parsed
+
+  try {
+    parsed = new URL(rawPath, 'http://hermes.local')
+  } catch {
+    return path
+  }
+
+  if (connectionScopeKey(parsed.searchParams.get('profile')) !== scopedProfile) {
+    return path
+  }
+
+  parsed.searchParams.set('profile', backend)
+
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`
 }
 
 /**
@@ -650,5 +704,6 @@ export {
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,
-  tokenPreview
+  tokenPreview,
+  translateSelfProfileQuery
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -82,7 +82,8 @@ import {
   resolveProfileBackendRoute,
   resolveTestWsUrl,
   savedProfileSsh,
-  tokenPreview
+  tokenPreview,
+  translateSelfProfileQuery
 } from './connection-config'
 import {
   backendScopeKey,
@@ -7078,10 +7079,11 @@ async function saveGatewayFile(payload: any = {}) {
   const fallbackName = path.basename(filePath) || suggested || 'download'
   const ctx = { suggested, fallbackName }
 
-  const requestPath = pathWithGlobalRemoteProfile(`/api/fs/download?path=${encodeURIComponent(filePath)}`, profile, {
-    globalRemote: globalRemoteActive(),
-    profileRemoteOverride: profileHasRemoteOverride(profile)
-  })
+  const requestPath = pathWithGlobalRemoteProfile(
+    `/api/fs/download?path=${encodeURIComponent(filePath)}`,
+    profile,
+    profileRouteOptions(profile)
+  )
 
   const url = `${connection.baseUrl}${requestPath}`
 
@@ -7109,10 +7111,7 @@ async function saveGatewayFileViaDataUrl(connection, profile, filePath, ctx: any
   const requestPath = pathWithGlobalRemoteProfile(
     `/api/fs/read-data-url?path=${encodeURIComponent(filePath)}`,
     profile,
-    {
-      globalRemote: globalRemoteActive(),
-      profileRemoteOverride: profileHasRemoteOverride(profile)
-    }
+    profileRouteOptions(profile)
   )
 
   const url = `${connection.baseUrl}${requestPath}`
@@ -9238,10 +9237,16 @@ function primaryProfileKey() {
 
 // Options describing the current connection setup for `resolveProfileBackendRoute`.
 function profileRouteOptions(profile) {
+  const config = readDesktopConnectionConfig()
+  const sshOverride = profileSshOverride(config, profile)
+
   return {
+    // A desktop profile can be only a client-side routing alias. Keep backend
+    // endpoint filters in the SSH target's namespace (e.g. mara → default).
+    backendProfile: sshOverride?.remoteProfile,
     globalRemote: globalRemoteActive(),
     primaryProfile: primaryProfileKey(),
-    profileRemoteOverride: Boolean(profileHasRemoteOverride(profile))
+    profileRemoteOverride: Boolean(profileRemoteOverride(config, profile) || sshOverride)
   }
 }
 
@@ -9443,6 +9448,10 @@ async function connectRegistryBackend(source, profile, key, poolEntry) {
       ...connection,
       profile: profileKey,
       connectionId: source.id,
+      // The remote process runs as this profile; the desktop-side profile key
+      // is only the routing label. hermes:api uses it to translate explicit
+      // self-profile query filters into the backend's namespace.
+      remoteProfile: sshConfig.remoteProfile || '',
       logs: hermesLog.slice(-80),
       ...getWindowState()
     }
@@ -12771,7 +12780,13 @@ ipcMain.handle('hermes:api', async (_event, request) => {
   if (registryConnectionId) {
     const connection: any = await ensureRegistryBackend(registryConnectionId, request?.profile)
 
-    const requestPath = connection.sharedRemote ? pathWithProfileScope(request.path, request?.profile) : request.path
+    // A shared remote host serves every profile via ?profile=; an SSH-scoped
+    // backend instead runs AS one remote profile, so an explicit self-profile
+    // filter must be translated from the desktop routing label into that
+    // backend namespace (same contract as the v1 profileRouteOptions path).
+    const requestPath = connection.sharedRemote
+      ? pathWithProfileScope(request.path, request?.profile)
+      : translateSelfProfileQuery(request.path, request?.profile, connection.remoteProfile)
 
     return fetchJsonForBackend(connection, requestPath, {
       method: request?.method,

--- a/contributors/emails/hello@jpanganiban.com
+++ b/contributors/emails/hello@jpanganiban.com
@@ -1,0 +1,1 @@
+thejpanganiban


### PR DESCRIPTION
# fix(desktop): map SSH profile aliases in cron/REST profile filters

Salvage of #82536 (author: @thejpanganiban, cherry-picked to preserve attribution), rebased onto current main and extended to cover the registry-routed SSH path that landed after the original PR was opened.

Fixes #82530

## Problem

Hermes Desktop can map a local profile label to a differently named profile on a managed SSH gateway (local `mara` → remote `default`). `request.profile` correctly selects the per-profile SSH backend, but endpoint-level self-profile filters ride the path untranslated:

```text
/api/cron/jobs?profile=mara   →   remote backend has no "mara" profile → cron view fails
```

Every cron surface that names the active profile in the query is affected — the cron list and blueprint instantiation carry an explicit `?profile=` today, and the fix is at the Electron REST routing boundary so any future endpoint-level self-profile filter is covered too.

## What changed

- **`electron/connection-config.ts`** — new pure helper `translateSelfProfileQuery(path, profile, backendProfile)`: rewrites an explicit `?profile=` **only when it equals the desktop alias itself**, into the backend's profile namespace. Cross-profile selectors (`all`, another concrete profile) and unfiltered paths pass through byte-identical. `pathWithGlobalRemoteProfile` now runs this translation before its existing scope-path logic.
- **`electron/main.ts`**
  - `profileRouteOptions()` now surfaces the managed SSH override's `remoteProfile` as `backendProfile`, and counts an SSH override as a per-profile remote route (v1 path).
  - The **registry SSH branch** of the `hermes:api` handler (added by the #87882/#88000-era connection routing) gets the same translation: the SSH registry descriptor now carries `remoteProfile`, and non-`sharedRemote` requests are passed through `translateSelfProfileQuery` instead of going out untouched. Shared remote/cloud registry hosts keep the existing `pathWithProfileScope` contract (they genuinely serve every profile via `?profile=`).
  - The two `/api/fs/*` call sites that hand-rolled route options now use `profileRouteOptions()` so the whole class shares one resolver.

## Why this is not redundant with recent merges

- #88000 (merged) added **connection routing** — it makes the request reach the right host, but forwards `request.path` untouched on SSH-scoped backends, so the desktop alias still leaks into `?profile=`.
- #87936 (open) is a backend-side cron run-history read fix — different layer, no path translation.
- #87977's `plugin-profile-routes` computes `targetProfile` for the plugin runtime only; the core `hermes:api` REST path had no equivalent.

## Verification

- Regression tests fail with the translation sabotaged to a no-op (2 failed) and pass with the change.
- `npx vitest run --project electron electron/connection-config.test.ts` — 88 passed.
- `npx vitest run --project electron` — 101 files, 1269 tests passed.
- `tsc -p . --noEmit` and `tsc -p tsconfig.electron.json --noEmit` — clean.
- `npm run lint` — 0 errors.
- `scripts/audit_pr_attribution.py` — all contributor emails mapped (adds `contributors/emails/hello@jpanganiban.com`).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa6a44f/GPp1Phf7qz1AudeyW6pIY_1m6awyeG.png)
