### PR TITLE
fix(skills): treat a package-root external dir as its own skill name

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -655,9 +655,18 @@ def normalize_skill_lookup_name(identifier: str) -> str:
     # an arbitrary absolute path that skill_view() refuses to load.
     for root in trusted_roots:
         try:
-            return str(identifier_path.relative_to(root))
+            relative = identifier_path.relative_to(root)
         except ValueError:
             continue
+        # A skills.external_dirs entry may BE the skill package (a one-skill
+        # repo configured as its own dir) rather than a parent of many
+        # skills — relative_to(root) then yields ".", which is not a valid
+        # skill_view() name and made /<skill> slash dispatch fail with
+        # "not a skill command" (#88064). The package directory name is the
+        # identifier discovery registered the skill under.
+        if str(relative) == ".":
+            return identifier_path.name
+        return str(relative)
 
     try:
         return str(identifier_path.resolve().relative_to(primary_root.resolve()))

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -285,6 +285,34 @@ class TestNormalizeSkillLookupName:
         monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
         assert normalize_skill_lookup_name(str(link)) == "my-skill"
 
+    def test_external_dir_that_is_the_skill_package_yields_its_name(
+        self, tmp_path, monkeypatch
+    ):
+        """#88064: skills.external_dirs may point at the skill package itself
+        (a one-skill repo configured as its own dir). relative_to(root) then
+        yields "." — not a skill_view()-safe name — and /<skill> slash
+        dispatch failed with "not a skill command". The package directory
+        name is the identifier."""
+        from agent.skill_utils import get_external_skills_dirs, normalize_skill_lookup_name
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        package = tmp_path / "my-skills" / "wayfinder"
+        package.mkdir(parents=True)
+
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+        monkeypatch.setattr(
+            "agent.skill_utils.get_external_skills_dirs", lambda: [package]
+        )
+        # Sanity: the module-level accessor the resolver consults is patched.
+        import agent.skill_utils as _su
+
+        assert _su.get_external_skills_dirs() == [package]
+
+        assert normalize_skill_lookup_name(str(package)) == "wayfinder"
+        # Parent-dir layouts keep producing the nested relative path.
+        assert normalize_skill_lookup_name(str(package)) != "."
+
 
 
 # ── parse_frontmatter: UTF-8 BOM tolerance ─────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Fixes `/<skill>` slash invocation for the layout where a `skills.external_dirs` entry **is the skill package itself** (a one-skill repo configured as its own directory, containing `SKILL.md`) rather than a parent of many skills. `normalize_skill_lookup_name()` assumed every external dir is a parent root, so `relative_to(root)` produced `"."` — not a `skill_view()`-safe name. `_load_skill_payload()` then returned `None` and slash dispatch fell through with the misleading `not a quick/plugin/bundle/skill command: wayfinder`, even though discovery had registered the skill and the `/` picker advertised it (#88064).

When the relative path is `"."`, the normalizer now returns the package directory name — the identifier discovery registered the skill under. Parent-dir layouts and `~/.hermes/skills/<name>` are unchanged.

## Related Issue

Fixes #88064

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_utils.py` — `normalize_skill_lookup_name()`: the trusted-root loop keeps a `relative_to` that yields `"."` from falling through as a bare dot; it returns `identifier_path.name` instead, with a comment documenting the one-skill-package layout.
- `tests/agent/test_skill_utils.py` — `TestNormalizeSkillLookupName` gains the package-root regression: external dir == skill package normalizes to the package name, never `"."`.

## How to Test

1. `python -m pytest tests/agent/test_skill_utils.py -q`
2. Observed result: 24 passed. A/B guard: with only the `agent/skill_utils.py` hunk stashed, the new test FAILS (the normalizer returns `"."`), with the hunk it passes.
3. `python -m pytest tests/agent/test_skill_commands.py -q` — Observed result: 25 passed (the dispatch-side payload loader consumers are unaffected).
4. Manual repro from the issue: with `skills.external_dirs: [/path/to/my-skills/wayfinder]`, `/wayfinder` now resolves through `skill_view("wayfinder")` instead of erroring; a parent-dir entry keeps its nested relative form.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/agent/test_skill_utils.py -q                  # with fix
24 passed in 0.47s
$ git stash -- agent/skill_utils.py && pytest ... -q         # A/B guard
1 failed  (normalize returned "." for the package-root layout)
```
