### PR TITLE
fix(desktop): preserve pre-tool assistant text

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -919,6 +919,57 @@ def strip_think_blocks(agent, content: str) -> str:
     return content
 
 
+def public_codex_commentary(
+    message: Dict[str, Any], *, show_commentary: bool = True
+) -> str:
+    """Return safe, user-visible Codex commentary for transcript display.
+
+    Canonical assistant ``content`` and the raw replay sidecar remain unchanged.
+    Only explicit ``phase=commentary`` output-text parts cross this display
+    boundary; analysis is never projected.
+    """
+    if not show_commentary or message.get("role") != "assistant" or message.get("content"):
+        return ""
+
+    items = message.get("codex_message_items")
+    if isinstance(items, str):
+        try:
+            items = json.loads(items)
+        except (json.JSONDecodeError, TypeError):
+            return ""
+    if not isinstance(items, list):
+        return ""
+
+    from agent.redact import redact_sensitive_text
+
+    commentary: List[str] = []
+    for item in items:
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        phase = item.get("phase")
+        if not isinstance(phase, str) or phase.strip().lower() != "commentary":
+            continue
+        parts = item.get("content")
+        if not isinstance(parts, list):
+            continue
+        text = "".join(
+            part.get("text", "")
+            for part in parts
+            if isinstance(part, dict)
+            and part.get("type") == "output_text"
+            and isinstance(part.get("text"), str)
+        ).strip()
+        if text:
+            text = redact_sensitive_text(
+                strip_think_blocks(None, text),
+                force=True,
+                redact_url_credentials=True,
+            ).strip()
+        if text:
+            commentary.append(text)
+    return "\n\n".join(commentary)
+
+
 
 def sync_credential_pool_entry_id(agent) -> None:
     """Rebind ``agent._credential_pool_entry_id`` from the current pool + key.

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -65,6 +65,15 @@ const complete = (text: string) =>
 const completePreviewed = (text: string) =>
   act(() => handleEvent!({ payload: { text, response_previewed: true }, session_id: SID, type: 'message.complete' }))
 
+const toolStart = () =>
+  act(() =>
+    handleEvent!({
+      payload: { args: {}, name: 'terminal', tool_id: 'tc-1' },
+      session_id: SID,
+      type: 'tool.start'
+    })
+  )
+
 function getState(): ClientSessionState {
   return sessionStates.get(SID) ?? createClientSessionState()
 }
@@ -109,6 +118,23 @@ describe('useMessageStream interim text sealing', () => {
     const texts = assistantMessages()
     expect(texts).toContain('awaaaaa clean!! tsc zero errors')
     expect(texts).toContain('All checks passed.')
+  })
+
+  it('preserves distinct commentary that seals after a tool has already started', async () => {
+    await mountStream()
+    await start()
+
+    // Codex can announce the tool before its completed commentary item reaches
+    // message.interim. That orders the live parts as tool → commentary. The
+    // commentary is sealed public text, not a trailing draft for completion to
+    // replace.
+    await toolStart()
+    await interim('Start this task now.')
+    await complete('Maintenance finished.')
+
+    const texts = assistantMessages()
+    expect(texts).toContain('Start this task now.')
+    expect(texts).toContain('Maintenance finished.')
   })
 
   it('marks sealed interim bubbles interim and leaves the final reply unmarked', async () => {

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -19,6 +19,22 @@ import {
 } from './chat-messages'
 
 describe('toChatMessages', () => {
+  it('hydrates public Codex commentary before its stored tool call', () => {
+    const messages = toChatMessages([
+      {
+        role: 'assistant',
+        content: '',
+        display_content: "I'll inspect the repo first.",
+        timestamp: 1,
+        tool_calls: [{ id: 'tc', function: { name: 'terminal', arguments: '{}' } }]
+      }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].parts.map(part => part.type)).toEqual(['text', 'tool-call'])
+    expect(chatMessageText(messages[0])).toBe("I'll inspect the repo first.")
+  })
+
   it('rebuilds the full command from a gateway tool row carrying args', () => {
     // Gateway watch-window hydration projects tool rows as
     // {role:'tool', name, context, args?}. `context` is an 80-char preview;
@@ -1132,18 +1148,50 @@ describe('mergeFinalAssistantText', () => {
     expect(result[0]).toMatchObject({ text: 'final answer', timestamp: 12.5, type: 'text' })
   })
 
-  it('removes all text parts and appends the final text', () => {
+  it('preserves provider-neutral pre-tool text and appends the final text', () => {
     const parts = [
-      { type: 'text' as const, text: 'streamed delta 1' },
-      { type: 'text' as const, text: 'streamed delta 2' },
+      { type: 'text' as const, text: 'Start this task now.' },
       { type: 'tool-call' as const, toolCallId: 'tc1', toolName: 'terminal', args: {} as never, argsText: '{}' }
     ]
 
-    const result = mergeFinalAssistantText(parts, 'final answer')
+    const result = mergeFinalAssistantText(parts, 'Maintenance finished.')
 
-    expect(result.filter(p => p.type === 'text')).toHaveLength(1)
-    expect(result.filter(p => p.type === 'text')[0]).toMatchObject({ text: 'final answer' })
-    expect(result.some(p => p.type === 'tool-call')).toBe(true)
+    expect(result.filter(p => p.type === 'text')).toHaveLength(2)
+    expect(result.map(p => p.type)).toEqual(['text', 'tool-call', 'text'])
+    expect(result.filter(p => p.type === 'text').map(p => p.text)).toEqual([
+      'Start this task now.',
+      'Maintenance finished.'
+    ])
+  })
+
+  it('preserves narration between multiple tools but replaces trailing text', () => {
+    const parts = [
+      { type: 'text' as const, text: 'First task.' },
+      { type: 'tool-call' as const, toolCallId: 'tc1', toolName: 'terminal', args: {} as never, argsText: '{}' },
+      { type: 'text' as const, text: 'Second task.' },
+      { type: 'tool-call' as const, toolCallId: 'tc2', toolName: 'read_file', args: {} as never, argsText: '{}' },
+      { type: 'text' as const, text: 'unfinished draft' }
+    ]
+
+    const result = mergeFinalAssistantText(parts, 'Finished.')
+
+    expect(result.filter(p => p.type === 'text').map(p => p.text)).toEqual([
+      'First task.',
+      'Second task.',
+      'Finished.'
+    ])
+  })
+
+  it('keeps pre-tool narration when completion has no final text', () => {
+    const parts = [
+      { type: 'text' as const, text: 'Start now.' },
+      { type: 'tool-call' as const, toolCallId: 'tc1', toolName: 'terminal', args: {} as never, argsText: '{}' },
+      { type: 'text' as const, text: 'unfinished draft' }
+    ]
+
+    const result = mergeFinalAssistantText(parts, '')
+
+    expect(result.filter(p => p.type === 'text').map(p => p.text)).toEqual(['Start now.'])
   })
 
   it('drops reasoning that the final text fully covers (reasoning ⊆ final)', () => {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -253,13 +253,14 @@ const normalizeWs = (value: string) => value.replace(/\s+/g, ' ').trim()
 /**
  * Merge the final assistant text into a message's parts.
  *
- * - Removes all existing `text` parts (they were streamed deltas, now superseded
- *   by the authoritative final response).
+ * - Preserves text before the last tool boundary: it was already presented as
+ *   actionable pre-tool narration and must not disappear at completion.
+ * - Replaces only trailing text after the last tool call with the authoritative
+ *   final response. With no tool call, all streamed text remains replaceable.
  * - Keeps `reasoning` parts, but drops one that the final text fully covers
  *   (reasoning ⊆ final) — the final restates it. A short final ("Done.") must
  *   NOT swallow a longer reasoning block that merely starts with it (#61447).
  * - Keeps all other part types (tool-call, image, etc.).
- * - Appends the final text as a new text part.
  */
 export function mergeFinalAssistantText(
   parts: ChatMessagePart[],
@@ -281,15 +282,16 @@ export function mergeFinalAssistantText(
     return parts
   }
 
-  const previousText = parts.findLast(part => part.type === 'text')
+  const lastToolIndex = parts.findLastIndex(part => part.type === 'tool-call')
+  const previousText = parts.findLast(
+    (part, index) => part.type === 'text' && (lastToolIndex < 0 || index > lastToolIndex)
+  )
 
-  const kept = parts.filter(part => {
+  const kept = parts.filter((part, index) => {
     if (part.type === 'text') {
-      // Sealed text parts were already finalized into their own bubbles —
-      // this filter only runs on the LAST streaming bubble, so there are no
-      // sealed parts here. All text parts are streamed deltas that get
-      // replaced by the authoritative final text.
-      return false
+      // Text before a tool boundary was already a complete, actionable segment.
+      // Only the open trailing segment is superseded by message.complete.
+      return lastToolIndex >= 0 && index < lastToolIndex
     }
 
     if (part.type !== 'reasoning' || !dedupeReference) {
@@ -1120,7 +1122,7 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       return
     }
 
-    const content = message.content || message.text || message.context || message.name
+    const content = message.display_content || message.content || message.text || message.context || message.name
 
     const rawDisplayContent = transcriptContent(
       message.display_kind,

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -565,6 +565,8 @@ export interface SessionMessage {
   codex_reasoning_items?: unknown
   content: unknown
   context?: unknown
+  /** Public transcript-only text projected by the backend; never model history. */
+  display_content?: unknown
   name?: string
   reasoning?: null | string
   reasoning_content?: null | string

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1375,6 +1375,17 @@ class APIServerAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.API_SERVER)
         extra = config.extra or {}
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            display = (load_config_readonly() or {}).get("display", {})
+            self._show_commentary = bool(
+                display.get("show_commentary", True)
+                if isinstance(display, dict)
+                else True
+            )
+        except Exception:
+            self._show_commentary = True
         self._host: str = extra.get("host", os.getenv("API_SERVER_HOST", DEFAULT_HOST))
         raw_port = extra.get("port")
         if raw_port is None:
@@ -3322,13 +3333,29 @@ class APIServerAdapter(BasePlatformAdapter):
         return payload
 
     @staticmethod
-    def _message_response(message: Dict[str, Any]) -> Dict[str, Any]:
+    def _message_response(
+        message: Dict[str, Any],
+        *,
+        show_commentary: bool = True,
+    ) -> Dict[str, Any]:
         safe_keys = (
             "id", "session_id", "role", "content", "tool_call_id", "tool_calls",
             "tool_name", "timestamp", "token_count", "finish_reason", "reasoning",
             "reasoning_content",
         )
-        return {key: message.get(key) for key in safe_keys if key in message}
+        payload = {key: message.get(key) for key in safe_keys if key in message}
+
+        # Keep replay state private; expose only the shared, privacy-filtered
+        # public transcript projection.
+        from agent.agent_runtime_helpers import public_codex_commentary
+
+        commentary = public_codex_commentary(
+            message, show_commentary=show_commentary
+        )
+        if commentary:
+            payload["display_content"] = commentary
+
+        return payload
 
     async def _read_json_body(self, request: "web.Request") -> tuple[Dict[str, Any], Optional["web.Response"]]:
         try:
@@ -3628,7 +3655,10 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response({
             "object": "list",
             "session_id": resolved_id,
-            "data": [self._message_response(m) for m in messages],
+            "data": [
+                self._message_response(m, show_commentary=self._show_commentary)
+                for m in messages
+            ],
             "pagination": {
                 "limit": limit,
                 "offset": offset,
@@ -6106,9 +6136,8 @@ class APIServerAdapter(BasePlatformAdapter):
             return len(prior)
         return 0
 
-    @classmethod
     def _turn_transcript_messages(
-        cls,
+        self,
         conversation_history: List[Dict[str, Any]],
         user_message: Any,
         result: Dict[str, Any],
@@ -6131,7 +6160,7 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_messages = result.get("messages") if isinstance(result, dict) else None
         if not isinstance(agent_messages, list) or not agent_messages:
             return []
-        start = cls._response_messages_turn_start_index(
+        start = self._response_messages_turn_start_index(
             conversation_history, user_message, result
         )
         turn = agent_messages[start:]
@@ -6141,7 +6170,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 continue
             if msg.get("role") not in {"assistant", "tool"}:
                 continue
-            out.append(cls._message_response(msg))
+            out.append(
+                self._message_response(msg, show_commentary=self._show_commentary)
+            )
         return out
 
     @staticmethod

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -613,6 +613,13 @@ async def get_session_messages(
             detail="order must be one of: oldest, latest",
         )
 
+    from hermes_cli.config import load_config_readonly
+
+    display = (load_config_readonly() or {}).get("display", {})
+    show_commentary = bool(
+        display.get("show_commentary", True) if isinstance(display, dict) else True
+    )
+
     def _read():
         db = _open_session_db_for_profile(profile, read_only=True)
         try:
@@ -642,9 +649,22 @@ async def get_session_messages(
     if result is None:
         raise HTTPException(status_code=404, detail="Session not found")
     sid, _limit, messages = result
+    from agent.agent_runtime_helpers import public_codex_commentary
+
+    projected_messages = []
+    for message in messages:
+        projected = dict(message)
+        commentary = public_codex_commentary(
+            projected, show_commentary=show_commentary
+        )
+        if commentary:
+            projected["display_content"] = commentary
+        # The opaque provider replay carrier never crosses the Desktop API.
+        projected.pop("codex_message_items", None)
+        projected_messages.append(projected)
     return {
         "session_id": sid,
-        "messages": messages,
+        "messages": projected_messages,
         "pagination": {
             "limit": _limit,
             "offset": offset,

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -1,4 +1,5 @@
 """Tests for hermes-api-server toolset and API server tool availability."""
+import json
 from unittest.mock import patch, MagicMock
 
 
@@ -50,6 +51,68 @@ class TestApiServerPlatformConfig:
 
 
 class TestApiServerAdapterToolset:
+    def test_message_response_projects_public_codex_commentary_for_display(self):
+        """Codex commentary stays out of canonical content but survives hydration."""
+        from gateway.platforms.api_server import APIServerAdapter
+
+        payload = APIServerAdapter._message_response({
+            "id": 7,
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "tc-1", "function": {"name": "terminal", "arguments": "{}"}}],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "I'll inspect the repo first."}],
+                },
+                {
+                    "type": "message",
+                    "phase": "analysis",
+                    "content": [{"type": "output_text", "text": "private scratchpad"}],
+                },
+            ],
+        })
+
+        assert payload["content"] == ""
+        assert payload["display_content"] == "I'll inspect the repo first."
+        assert "private scratchpad" not in payload["display_content"]
+        assert "codex_message_items" not in payload
+
+    def test_message_response_honors_commentary_visibility(self):
+        from gateway.platforms.api_server import APIServerAdapter
+
+        payload = APIServerAdapter._message_response({
+            "role": "assistant",
+            "content": "",
+            "codex_message_items": [{
+                "type": "message",
+                "phase": "commentary",
+                "content": [{"type": "output_text", "text": "Public while enabled."}],
+            }],
+        }, show_commentary=False)
+
+        assert "display_content" not in payload
+        assert "codex_message_items" not in payload
+
+    def test_message_response_forces_secret_redaction_at_projection_boundary(self):
+        from gateway.platforms.api_server import APIServerAdapter
+
+        secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+        with patch("agent.redact._REDACT_ENABLED", False):
+            payload = APIServerAdapter._message_response({
+                "role": "assistant",
+                "content": "",
+                "codex_message_items": json.dumps([{
+                    "type": "message",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": f"Token: {secret}"}],
+                }]),
+            })
+
+        assert secret not in payload["display_content"]
+        assert "codex_message_items" not in payload
+
     @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
     def test_create_agent_reads_config_toolsets(self):
         """API server resolves toolsets from config like all other platforms."""

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1892,6 +1892,93 @@ class TestWebServerEndpoints:
         assert payload["limit"] == 3
         assert len(payload["sessions"]) == 3
 
+    def test_get_session_messages_projects_public_codex_commentary_for_desktop(self):
+        """Desktop's real HTTP hydration path preserves public pre-tool text."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="codex-commentary-display", source="desktop")
+            db.append_message(
+                session_id="codex-commentary-display",
+                role="assistant",
+                content="",
+                tool_calls=[
+                    {
+                        "id": "tc-1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+                codex_message_items=[
+                    {
+                        "type": "message",
+                        "phase": "commentary",
+                        "content": [
+                            {"type": "output_text", "text": "Start this task now."}
+                        ],
+                    },
+                    {
+                        "type": "message",
+                        "phase": "analysis",
+                        "content": [
+                            {"type": "output_text", "text": "private scratchpad"}
+                        ],
+                    },
+                ],
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get(
+            "/api/sessions/codex-commentary-display/messages?limit=20&order=latest"
+        )
+
+        assert resp.status_code == 200
+        message = resp.json()["messages"][0]
+        assert message["content"] == ""
+        assert message["display_content"] == "Start this task now."
+        assert "private scratchpad" not in message["display_content"]
+        assert "codex_message_items" not in message
+
+    def test_get_session_messages_hides_codex_commentary_when_disabled(self, monkeypatch):
+        from hermes_state import SessionDB
+        import hermes_cli.config as config
+
+        monkeypatch.setattr(
+            config,
+            "load_config_readonly",
+            lambda: {"display": {"show_commentary": False}},
+        )
+        db = SessionDB()
+        try:
+            db.create_session(session_id="codex-commentary-hidden", source="desktop")
+            db.append_message(
+                session_id="codex-commentary-hidden",
+                role="assistant",
+                content="",
+                codex_message_items=[
+                    {
+                        "type": "message",
+                        "phase": "commentary",
+                        "content": [
+                            {"type": "output_text", "text": "Must remain hidden."}
+                        ],
+                    }
+                ],
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get(
+            "/api/sessions/codex-commentary-hidden/messages?limit=20&order=latest"
+        )
+
+        assert resp.status_code == 200
+        message = resp.json()["messages"][0]
+        assert "display_content" not in message
+        assert "codex_message_items" not in message
+
     def test_get_session_messages_rejects_negative_limit(self):
         """limit=-1 previously bypassed the documented 500-row clamp because
         min(-1, 500) == -1, which SQLite treats as 'no limit'."""


### PR DESCRIPTION
## Summary

Fixes disappearing assistant text in Desktop tool-using turns through two paths:

- preserve provider-neutral text that appears before a tool boundary so `message.complete` or an authoritative transcript refresh cannot remove it;
- project explicit OpenAI Codex `phase=commentary` sidecar text into a client-only `display_content` field so session hydration restores text that was visible live, without mutating canonical assistant content or replay state.

## Root cause

For ordinary providers, Desktop completion reconciliation could replace streamed text. For Codex Responses, user-visible commentary is persisted in `codex_message_items` while canonical `content` stays empty, and the transcript endpoints omitted that sidecar entirely — so the live stream and the reload disagreed, and a re-read of the authoritative transcript could wipe text the user had already seen.

Two fixes were required because Desktop hydrates through **two** backend surfaces:

1. `gateway/platforms/api_server.py` (`/api/sessions/{id}/messages`) — the API-server transcript surface.
2. `hermes_cli/web_routers/sessions.py` (`/api/sessions/{id}/messages`) — the **real** dashboard/Desktop hydration endpoint, which was the actual live-path gap.

Both now route through one shared privacy-filtered projector in `agent/agent_runtime_helpers.py`.

## Safety and privacy

- projects only `type=message`, `phase=commentary`, `type=output_text` parts;
- never exposes raw `codex_message_items` to the client (removed from the payload);
- never promotes `phase=analysis`;
- honors `display.show_commentary=false` on both endpoints;
- forces secret and URL-credential redaction at the API egress boundary;
- leaves canonical assistant content, role ordering, tool pairing, prompt caching, and Codex continuation replay unchanged.

## Tests

Endpoint-level (real HTTP surfaces, not just the helper):

- `test_get_session_messages_projects_public_codex_commentary_for_desktop` — Desktop dashboard route emits `display_content`, filters analysis, strips the raw sidecar; was RED before the fix.
- `test_get_session_messages_hides_codex_commentary_when_disabled` — `show_commentary=false` hides it on the dashboard route.
- existing API-server privacy tests (`test_api_server_toolset.py`).

Focused results:

- backend: `132 passed` (web-server + API-server session/run suites);
- Desktop: `86 passed` (chat-messages + interim-sealing), plus a new ordering regression test (`tool.start → message.interim → message.complete`);
- Desktop TypeScript typecheck: passed;
- production build + `assert-dist-built`: passed;
- independent security/correctness review (2x): passed.

## Live verification status

Local packaged-app verification has confirmed hydration durability across session switches (the interim/Thought entry now survives). Live automated verification of the fully corrected endpoint path is in progress and will be added as a comment when complete. The full Windows gateway suite is not used as a completion claim; the focused surfaces changed here completed cleanly.
