### PR TITLE
fix(desktop): self-heal dropped SSH/HTTP remote connections + status bar reconnect (#82679, #80430)

### DIFF
--- a/apps/desktop/electron/backend-start-failure.test.ts
+++ b/apps/desktop/electron/backend-start-failure.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
+import { isRetryableRemoteBootFailure, shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
 
 test('latches a LOCAL backend failure so the install-retry loop is broken', () => {
   assert.equal(shouldLatchBackendStartFailure({ attemptedRemote: false }), true)
@@ -48,5 +48,32 @@ test('the two latches never fire for the same failure', () => {
       const reauth = shouldLatchRemoteReauthFailure({ attemptedRemote, isReauth })
       assert.ok(!(start && reauth), `both latched for remote=${attemptedRemote} reauth=${isReauth}`)
     }
+  }
+})
+
+test('FIX #82679: a transient remote failure is retryable so a dropped SSH/HTTP connection self-heals', () => {
+  // The dropped-registered-connection class: "Could not verify the existing
+  // SSH backend", ERR_CONNECTION_RESET on an HTTP remote, mint timeouts. All
+  // surface as non-reauth remote boot failures and must enter the bounded
+  // renderer retry loop instead of parking on "Desktop boot failed".
+  assert.equal(isRetryableRemoteBootFailure({ attemptedRemote: true, isReauth: false }), true)
+})
+
+test('a CONFIRMED reauth rejection is never auto-retried (missing capability, not transient failure)', () => {
+  assert.equal(isRetryableRemoteBootFailure({ attemptedRemote: true, isReauth: true }), false)
+})
+
+test('local failures are never auto-retried by the remote self-heal loop', () => {
+  assert.equal(isRetryableRemoteBootFailure({ attemptedRemote: false, isReauth: false }), false)
+  assert.equal(isRetryableRemoteBootFailure({ attemptedRemote: false, isReauth: true }), false)
+})
+
+test('retryable and reauth-latch are mutually exclusive for remote failures', () => {
+  // Every remote failure either self-heals (transient) or latches for sign-in
+  // (confirmed reauth) — never both, never neither.
+  for (const isReauth of [true, false]) {
+    const retry = isRetryableRemoteBootFailure({ attemptedRemote: true, isReauth })
+    const latch = shouldLatchRemoteReauthFailure({ attemptedRemote: true, isReauth })
+    assert.equal(retry !== latch, true, `remote failure with reauth=${isReauth} must pick exactly one path`)
   }
 })

--- a/apps/desktop/electron/backend-start-failure.ts
+++ b/apps/desktop/electron/backend-start-failure.ts
@@ -70,3 +70,32 @@ export interface RemoteReauthFailureContext {
 export function shouldLatchRemoteReauthFailure(context: RemoteReauthFailureContext): boolean {
   return context.attemptedRemote && context.isReauth
 }
+
+export interface RemoteBootRetryContext {
+  /** True when the boot that just failed was dialing a REMOTE (or cloud/SSH) backend. */
+  attemptedRemote: boolean
+  /**
+   * True when the failure was a CONFIRMED auth rejection (401/403), which can
+   * never self-heal without the user signing in again.
+   */
+  isReauth: boolean
+}
+
+/**
+ * Whether a failed primary-backend boot is a TRANSIENT remote failure the
+ * renderer may retry automatically (bounded, with backoff).
+ *
+ * This closes the self-heal gap of issue #82679: a dropped SSH/HTTP remote
+ * connection surfaces at the next boot as a transient transport failure
+ * ("Could not verify the existing SSH backend", ERR_CONNECTION_RESET, mint
+ * timeouts). Those never latch (see shouldLatchBackendStartFailure), but
+ * nothing ever RE-ATTEMPTED the boot either — the renderer's reconnect loop
+ * only arms after a completed boot, so the app sat on "Desktop boot failed"
+ * until the user manually re-entered the same connection details (which just
+ * forced a fresh bootstrap). A missing capability differs from a transient
+ * failure: confirmed reauth rejections and local failures stay out of the
+ * retry path; everything else remote is connectivity and should retry.
+ */
+export function isRetryableRemoteBootFailure(context: RemoteBootRetryContext): boolean {
+  return context.attemptedRemote && !context.isReauth
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -45,7 +45,7 @@ import {
   verifyHermesCli
 } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
-import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
+import { isRetryableRemoteBootFailure, shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
 import {
   detectRemoteDisplay,
   isWindowsBinaryPathInWsl,
@@ -1245,6 +1245,7 @@ let bootProgressState = {
   message: 'Waiting to start Hermes backend',
   phase: 'idle',
   progress: 0,
+  retryable: false,
   running: false,
   timestamp: Date.now()
 }
@@ -1811,6 +1812,12 @@ function updateBootProgress(update, options: { allowDecrease?: boolean } = {}) {
     error: update.error === undefined ? bootProgressState.error : update.error,
     fakeMode: BOOT_FAKE_MODE || Boolean(update.fakeMode),
     progress: nextProgress,
+    // `retryable` rides with `error`: it survives updates that preserve the
+    // error and resets alongside a new/cleared error unless explicitly set.
+    retryable:
+      update.retryable === undefined
+        ? update.error === undefined && Boolean(bootProgressState.retryable)
+        : Boolean(update.retryable),
     timestamp: Date.now()
   }
 
@@ -8644,6 +8651,20 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
       } catch {
         void 0
       }
+    } else {
+      // The cached master was reused but the lifecycle probe against it
+      // failed ("Could not verify the existing SSH backend"). Keeping the
+      // stale entry means every subsequent boot re-attempts through the same
+      // wedged master/tunnel and fails identically until the user re-enters
+      // the connection details (whose changed fingerprint forces a teardown).
+      // Tear it down now so the next attempt — automatic retry included —
+      // bootstraps a fresh master, which is exactly what manual re-entry
+      // did (#82679).
+      try {
+        await teardownSshConnection(profile)
+      } catch {
+        void 0
+      }
     }
 
     const err = new Error(error.message) as any
@@ -10183,6 +10204,12 @@ async function startHermes() {
         error: message,
         message: `Desktop boot failed: ${message}`,
         phase: 'backend.error',
+        // Renderer contract for the self-heal loop (#82679): a transient
+        // REMOTE failure (dropped SSH/HTTP registered connection, mint
+        // timeout) is retryable — the renderer re-attempts the boot with
+        // bounded backoff. Local failures and confirmed reauth rejections
+        // are not: those end in the recovery overlay / sign-in affordance.
+        retryable: isRetryableRemoteBootFailure({ attemptedRemote, isReauth: isReauthRequiredError(error) }),
         running: false
       },
       { allowDecrease: true }

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
 import { closeSecondaryGateways, isActivePrimary } from '@/store/gateway'
+import { reconnectGateway } from '@/store/gateway-reconnect'
 import { $activeGatewayProfile, $profiles, ensureGatewayProfile } from '@/store/profile'
 import { $connection, $currentCwd, $gatewayState } from '@/store/session'
 
@@ -121,6 +122,7 @@ function fakeDesktop() {
       }
     }),
     onPowerResume: vi.fn(() => () => undefined),
+    revalidateConnection: vi.fn(async () => ({ ok: true, rebuilt: false })),
     onWindowStateChanged: vi.fn(() => () => undefined),
     touchBackend: vi.fn(async () => undefined),
     profile: { get: vi.fn(async () => ({ profile: 'default' })) }
@@ -389,6 +391,31 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect($gatewayState.get()).toBe('open')
     expect($desktopBoot.get().error).toBeNull()
+  })
+
+  it('manual reconnect revalidates, re-resolves, re-mints, and re-dials the dropped socket', async () => {
+    const desktop = fakeDesktop()
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($gatewayState.get()).toBe('open')
+    act(() => FakeWebSocket.instances[0].drop())
+    FakeWebSocket.mode = 'open'
+
+    await act(async () => {
+      const reconnect = reconnectGateway()
+      await vi.advanceTimersByTimeAsync(0)
+      await reconnect
+    })
+
+    expect(desktop.revalidateConnection).toHaveBeenCalledOnce()
+    expect(desktop.getConnection).toHaveBeenLastCalledWith('default')
+    expect(desktop.getGatewayWsUrl).toHaveBeenCalledTimes(2)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    expect($gatewayState.get()).toBe('open')
   })
 
   it('FIX: a failed session-list fetch during boot is non-fatal — the app still boots', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -104,12 +104,13 @@ function fakeDesktop() {
     }),
     getGatewayWsUrl: vi.fn(async (conn?: { wsUrl?: string }) => conn?.wsUrl ?? primaryConn.wsUrl),
     getBootProgress: vi.fn(async () => ({
-      error: null,
+      error: null as null | string,
       fakeMode: false,
       message: '',
       phase: 'init',
       progress: 0,
-      running: true,
+      retryable: false as boolean,
+      running: true as boolean,
       timestamp: Date.now()
     })),
     onBootProgress: vi.fn(() => () => undefined),
@@ -412,7 +413,11 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     })
 
     expect(desktop.revalidateConnection).toHaveBeenCalledOnce()
-    expect(desktop.getConnection).toHaveBeenLastCalledWith('default')
+    // The manual reconnect dials the WINDOW-owned primary backend (no profile
+    // arg) — same contract as the sleep/wake reconnect: passing the active
+    // profile would retarget the primary socket after a live profile swap.
+    const lastCall = desktop.getConnection.mock.calls.at(-1) ?? []
+    expect(lastCall.length === 0 || lastCall[0] == null || lastCall[0] === '').toBe(true)
     expect(desktop.getGatewayWsUrl).toHaveBeenCalledTimes(2)
     expect(FakeWebSocket.instances).toHaveLength(2)
     expect($gatewayState.get()).toBe('open')
@@ -524,5 +529,110 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(primaryReconnectSockets.length).toBeGreaterThan(0)
     expect($connection.get()?.profile).toBe('coder')
     expect($connection.get()?.baseUrl).toBe(coderConn.baseUrl)
+  })
+
+  it('FIX #82679: a transient remote boot failure self-heals — the next attempt rebuilds the dropped connection', async () => {
+    // The reported class: the app relaunches (or wakes) against a registered
+    // SSH/HTTP remote whose transport dropped. startHermes() rejects with a
+    // transient transport error ("Could not verify the existing SSH backend"),
+    // main tags the boot progress `retryable`, and — before the fix — the app
+    // parked on "Desktop boot failed" until the user re-entered the exact same
+    // connection details. Now the renderer retries the boot with backoff and
+    // the second attempt (fresh bootstrap, same details) succeeds.
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Could not verify the existing SSH backend.'))
+      .mockImplementation(async () => primaryConn)
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: 'Could not verify the existing SSH backend.',
+      fakeMode: false,
+      message: 'Desktop boot failed: Could not verify the existing SSH backend.',
+      phase: 'backend.error',
+      progress: 24,
+      retryable: true,
+      running: false,
+      timestamp: Date.now()
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    // First attempt failed but the failure is retryable: no terminal error,
+    // the overlay shows the retry status instead of the dead-end failure.
+    expect($desktopBoot.get().error).toBeNull()
+    expect($gatewayState.get()).not.toBe('open')
+
+    // Walk past the first backoff delay (2s base, 15s cap, full jitter).
+    await advanceBackoff()
+
+    // Second boot attempt rebuilt the connection — no manual re-entry.
+    expect(desktop.getConnection.mock.calls.length).toBeGreaterThan(1)
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().error).toBeNull()
+  })
+
+  it('FIX #82679: boot retries are BOUNDED — a persistently dead remote ends in the recovery overlay, not a spinner', async () => {
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi.fn(async () => {
+      throw new Error('Could not verify the existing SSH backend.')
+    })
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: 'Could not verify the existing SSH backend.',
+      fakeMode: false,
+      message: 'Desktop boot failed: Could not verify the existing SSH backend.',
+      phase: 'backend.error',
+      progress: 24,
+      retryable: true,
+      running: false,
+      timestamp: Date.now()
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    // Exhaust the bounded retry budget (5 attempts, ≤15s jittered delay each).
+    for (let i = 0; i < 7; i += 1) {
+      await advanceBackoff()
+    }
+
+    // 1 initial + 5 bounded retries; the loop then STOPS retrying and the
+    // terminal boot error surfaces the real recovery affordance.
+    expect(desktop.getConnection).toHaveBeenCalledTimes(6)
+    expect($desktopBoot.get().error).toBeTruthy()
+
+    // No further attempts after the budget is spent — bounded, not infinite.
+    await advanceBackoff()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(6)
+  })
+
+  it('FIX #82679: a NON-retryable boot failure (local / confirmed reauth) fails immediately without auto-retry', async () => {
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi.fn(async () => {
+      throw new Error('401: gateway session expired')
+    })
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: '401: gateway session expired',
+      fakeMode: false,
+      message: 'Desktop boot failed: 401: gateway session expired',
+      phase: 'backend.error',
+      progress: 24,
+      retryable: false,
+      running: false,
+      timestamp: Date.now()
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBeTruthy()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+
+    // Still no retry later: a missing capability is not a transient failure.
+    await advanceBackoff()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -27,6 +27,7 @@ import {
   setPrimaryGateway,
   touchSecondaryGateways
 } from '@/store/gateway'
+import { registerGatewayReconnect } from '@/store/gateway-reconnect'
 import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from '@/store/gateway-switch'
 import { notify, notifyError } from '@/store/notifications'
 import {
@@ -259,7 +260,7 @@ export function useGatewayBoot({
       }, delay)
     }
 
-    const reconnectNow = () => {
+    const reconnectNow = async () => {
       if (cancelled || !bootCompleted || $gatewaySwitching.get()) {
         return
       }
@@ -271,7 +272,7 @@ export function useGatewayBoot({
       reconnectSecondaryGateways()
 
       if (!gatewayOpen()) {
-        void attemptReconnect()
+        await attemptReconnect()
       }
     }
 
@@ -486,8 +487,9 @@ export function useGatewayBoot({
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the
     // window regaining focus/visibility. Each nudges an immediate reconnect.
-    const offPowerResume = desktop.onPowerResume?.(() => reconnectNow())
+    const offPowerResume = desktop.onPowerResume?.(() => void reconnectNow())
     const offConnectionApplied = desktop.onConnectionApplied?.(() => void softSwitch())
+    const offGatewayReconnect = registerGatewayReconnect(reconnectNow)
 
     // Registry lifecycle: a removed connection's secondaries must close NOW
     // (remote/cloud have no local process whose death would drop the socket —
@@ -501,11 +503,11 @@ export function useGatewayBoot({
       disposeSecondariesForConnection(payload.connectionId, { redial: payload.reason === 'updated' })
     })
 
-    const onOnline = () => reconnectNow()
+    const onOnline = () => void reconnectNow()
 
     const onVisible = () => {
       if (document.visibilityState === 'visible') {
-        reconnectNow()
+        void reconnectNow()
       }
     }
 
@@ -708,6 +710,7 @@ export function useGatewayBoot({
       offPowerResume?.()
       offConnectionApplied?.()
       offConnectionsChanged?.()
+      offGatewayReconnect()
       offState()
       offEvent()
       offExit()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -11,6 +11,7 @@ import {
   applyDesktopBootProgress,
   completeDesktopBoot,
   failDesktopBoot,
+  resumeDesktopBootForRetry,
   setDesktopBootStep
 } from '@/store/boot'
 import {
@@ -69,6 +70,20 @@ import { stashGatewaySurvivor, survivorIsStale, takeGatewaySurvivor } from './ga
 // 1→15s ladder took ~45s to reach six failures — this threshold keeps that
 // original ~45s calibration.
 const RECONNECT_ESCALATE_AFTER_MS = 45_000
+
+// Bounded self-heal for a failed REMOTE boot (#82679): when the primary boot
+// fails on a transient remote fault (dropped SSH/HTTP registered connection,
+// mint timeout — main tags those `retryable` on the boot progress), the
+// renderer re-attempts the whole boot with the same full-jitter backoff the
+// post-boot reconnect loop uses, up to this many attempts. Retries are
+// bounded and end in the real recovery affordance (the boot-failure overlay
+// with Retry / Settings), never an infinite spinner. Local failures and
+// confirmed reauth rejections never enter this loop — a missing capability
+// differs from a transient failure.
+const BOOT_RETRY_MAX_ATTEMPTS = 5
+// Base delay for boot retries. Deliberately slower than the socket reconnect
+// loop's 300ms: each attempt may rebuild an SSH master + remote dashboard.
+const BOOT_RETRY_BASE_DELAY_MS = 2_000
 
 interface GatewayBootOptions {
   beforeConnectionSwitch: () => void
@@ -148,6 +163,30 @@ export function useGatewayBoot({
     // dead-end CONNECTING screen. Reset on a clean open or a manual/
     // wake-driven reconnect.
     let escalated = false
+    // Bounded automatic boot retry for transient REMOTE failures (#82679).
+    let bootRetryAttempt = 0
+    let bootRetryTimer: ReturnType<typeof setTimeout> | null = null
+
+    const clearBootRetryTimer = () => {
+      if (bootRetryTimer !== null) {
+        clearTimeout(bootRetryTimer)
+        bootRetryTimer = null
+      }
+    }
+
+    // Whether the failed boot is a TRANSIENT remote fault main marked as
+    // retryable (dropped SSH/HTTP registered connection, mint timeout).
+    // Local failures and confirmed reauth rejections come back false and go
+    // straight to the recovery overlay.
+    const bootFailureIsRetryable = async (): Promise<boolean> => {
+      try {
+        const snapshot = await desktop.getBootProgress()
+
+        return snapshot?.retryable === true
+      } catch {
+        return false
+      }
+    }
 
     // Wrap the live getter in a call so TS control-flow analysis doesn't narrow
     // `connectionState` to a constant across the early-return guards (the state
@@ -322,6 +361,8 @@ export function useGatewayBoot({
 
       $gatewaySwitching.set(true)
       clearReconnectTimer()
+      clearBootRetryTimer()
+      bootRetryAttempt = 0
       reconnectAttempt = 0
       reconnectFailingSince = null
       escalated = false
@@ -650,9 +691,32 @@ export function useGatewayBoot({
 
         completeDesktopBoot()
         bootCompleted = true
+        bootRetryAttempt = 0
       } catch (err) {
         if (!cancelled) {
           const message = err instanceof Error ? err.message : String(err)
+
+          // Transient remote failure (dropped SSH/HTTP registered connection,
+          // mint timeout): self-heal with bounded, jittered retries instead of
+          // parking on "Desktop boot failed" until the user re-enters the same
+          // connection details (#82679). Main already cleared the failed cached
+          // descriptor, so the next getConnection() rebuilds the connection —
+          // exactly what manual re-entry forced. Exhausted retries, local
+          // failures, and confirmed reauth rejections end in the real recovery
+          // affordance (the boot-failure overlay), never an infinite spinner.
+          if (bootRetryAttempt < BOOT_RETRY_MAX_ATTEMPTS && (await bootFailureIsRetryable()) && !cancelled) {
+            const delay = reconnectBackoffDelayMs(bootRetryAttempt, { baseDelayMs: BOOT_RETRY_BASE_DELAY_MS })
+            bootRetryAttempt += 1
+            resumeDesktopBootForRetry(translateNow('boot.steps.retryingRemoteBackend'))
+            clearBootRetryTimer()
+            bootRetryTimer = setTimeout(() => {
+              bootRetryTimer = null
+              void boot()
+            }, delay)
+
+            return
+          }
+
           failDesktopBoot(message)
           notifyError(err, translateNow('boot.errors.desktopBootFailed'))
           setSessionsLoading(false)
@@ -701,6 +765,7 @@ export function useGatewayBoot({
       cancelled = true
       $gatewaySwitching.set(false)
       clearReconnectTimer()
+      clearBootRetryTimer()
       clearInterval(keepaliveTimer)
       offWorking()
       offAttention()

--- a/apps/desktop/src/app/shell/gateway-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/gateway-menu-panel.test.tsx
@@ -1,0 +1,101 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  notifyError: vi.fn(),
+  reconnectGateway: vi.fn<() => Promise<void>>()
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tip: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/hermes', () => ({
+  getLogs: vi.fn().mockResolvedValue({ lines: [] })
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      commandCenter: { restartGateway: 'Restart gateway' },
+      shell: {
+        gatewayMenu: {
+          checkingInference: 'Checking inference',
+          connected: 'Connected',
+          connecting: 'Connecting',
+          disconnected: 'Disconnected',
+          inferenceNotReady: 'Inference not ready',
+          inferenceReady: 'Inference ready',
+          messagingPlatforms: 'Messaging platforms',
+          offline: 'Offline',
+          openSystem: 'Open system panel',
+          recentActivity: 'Recent activity',
+          reconnectGateway: 'Reconnect gateway',
+          viewAllLogs: 'View all logs'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/gateway-reconnect', () => ({
+  reconnectGateway: mocks.reconnectGateway
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notifyError: mocks.notifyError
+}))
+
+vi.mock('@/store/system-actions', () => ({
+  runGatewayRestart: vi.fn()
+}))
+
+import { GatewayMenuPanel } from './gateway-menu-panel'
+
+const renderPanel = (gatewayState: string) =>
+  render(
+    <GatewayMenuPanel
+      gatewayState={gatewayState}
+      inferenceStatus={null}
+      onClose={vi.fn()}
+      onOpenSystem={vi.fn()}
+      statusSnapshot={null}
+    />
+  )
+
+describe('GatewayMenuPanel reconnect action', () => {
+  beforeEach(() => {
+    mocks.reconnectGateway.mockReset().mockResolvedValue(undefined)
+    mocks.notifyError.mockReset()
+  })
+
+  afterEach(() => cleanup())
+
+  it('shows reconnect only while disconnected and disables it in flight', async () => {
+    let finish: (() => void) | undefined
+    mocks.reconnectGateway.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          finish = resolve
+        })
+    )
+
+    renderPanel('closed')
+
+    const reconnect = screen.getByRole('button', { name: 'Reconnect gateway' })
+    fireEvent.click(reconnect)
+    fireEvent.click(reconnect)
+
+    expect(mocks.reconnectGateway).toHaveBeenCalledOnce()
+    expect((reconnect as HTMLButtonElement).disabled).toBe(true)
+
+    await act(async () => finish?.())
+  })
+
+  it('hides reconnect while the socket is open', async () => {
+    renderPanel('open')
+    await act(async () => undefined)
+
+    expect(screen.queryByRole('button', { name: 'Reconnect gateway' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/shell/gateway-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/gateway-menu-panel.tsx
@@ -9,6 +9,8 @@ import { useI18n } from '@/i18n'
 import { LayoutDashboard, RefreshCw } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { cn } from '@/lib/utils'
+import { reconnectGateway } from '@/store/gateway-reconnect'
+import { notifyError } from '@/store/notifications'
 import { runGatewayRestart } from '@/store/system-actions'
 import type { StatusResponse } from '@/types/hermes'
 
@@ -96,6 +98,7 @@ export function GatewayMenuPanel({
 }: GatewayMenuPanelProps) {
   const { t } = useI18n()
   const copy = t.shell.gatewayMenu
+  const [reconnecting, setReconnecting] = useState(false)
 
   // Both jumps open the system panel, which owns the full view — so dismiss the
   // little status popover on the way out.
@@ -109,6 +112,17 @@ export function GatewayMenuPanel({
   const restart = () => {
     onClose()
     void runGatewayRestart()
+  }
+
+  const reconnect = () => {
+    if (reconnecting) {
+      return
+    }
+
+    setReconnecting(true)
+    void reconnectGateway()
+      .catch(err => notifyError(err, copy.reconnectGateway))
+      .finally(() => setReconnecting(false))
   }
 
   const gatewayOpen = gatewayState === 'open'
@@ -157,6 +171,20 @@ export function GatewayMenuPanel({
           </span>
         </div>
         <div className="flex shrink-0 items-center gap-0.5">
+          {!gatewayOpen && (
+            <Tip label={copy.reconnectGateway}>
+              <Button
+                aria-label={copy.reconnectGateway}
+                className="text-muted-foreground hover:text-foreground"
+                disabled={reconnecting}
+                onClick={reconnect}
+                size="icon-xs"
+                variant="ghost"
+              >
+                <RefreshCw className={cn(reconnecting && 'animate-spin')} />
+              </Button>
+            </Tip>
+          )}
           <Tip label={t.commandCenter.restartGateway}>
             <Button
               aria-label={t.commandCenter.restartGateway}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -914,6 +914,13 @@ export interface DesktopBootProgress {
   message: string
   phase: string
   progress: number
+  /**
+   * True when the boot failure carried by `error` was a TRANSIENT remote
+   * failure (dropped SSH/HTTP registered connection, mint timeout) that the
+   * renderer may retry automatically. Absent/false on success updates,
+   * local failures, and confirmed reauth rejections.
+   */
+  retryable?: boolean
   running: boolean
   timestamp: number
 }

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2121,6 +2121,7 @@ export const ar = defineLocale({
       inferenceNotReady: 'الاستدلال غير جاهز',
       checkingInference: 'جار فحص الاستدلال',
       disconnected: 'منقطع',
+      reconnectGateway: 'إعادة الاتصال بالبوابة',
       openSystem: 'فتح النظام',
       connection: label => `الاتصال: ${label}`,
       recentActivity: 'النشاط الأخير',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -61,6 +61,7 @@ export const ar = defineLocale({
       connectingGateway: 'جار الاتصال ببوابة سطح المكتب',
       loadingSettings: 'جار تحميل إعدادات Hermes',
       loadingSessions: 'جار تحميل الجلسات الأخيرة',
+      retryingRemoteBackend: 'جارٍ إعادة الاتصال بخادم Hermes البعيد…',
       startingDesktopConnection: 'جار بدء اتصال سطح المكتب',
       startingHermesDesktop: 'جار تشغيل Hermes Desktop...'
     },

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -68,6 +68,7 @@ export const en: Translations = {
       connectingGateway: 'Connecting live desktop gateway',
       loadingSettings: 'Loading Hermes settings',
       loadingSessions: 'Loading recent sessions',
+      retryingRemoteBackend: 'Reconnecting to the remote Hermes backend…',
       startingDesktopConnection: 'Starting desktop connection',
       startingHermesDesktop: 'Starting Hermes Desktop…'
     },

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2642,6 +2642,7 @@ export const en: Translations = {
       inferenceNotReady: 'Inference not ready',
       checkingInference: 'Checking inference',
       disconnected: 'Disconnected',
+      reconnectGateway: 'Reconnect gateway',
       openSystem: 'Open system panel',
       connection: label => `Connection: ${label}`,
       recentActivity: 'Recent activity',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2367,6 +2367,7 @@ export const ja = defineLocale({
       inferenceNotReady: '推論準備未完了',
       checkingInference: '推論を確認中',
       disconnected: '切断済み',
+      reconnectGateway: 'ゲートウェイに再接続',
       openSystem: 'システムパネルを開く',
       connection: label => `接続: ${label}`,
       recentActivity: '最近のアクティビティ',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -68,6 +68,7 @@ export const ja = defineLocale({
       connectingGateway: 'ライブデスクトップゲートウェイに接続中',
       loadingSettings: 'Hermes の設定を読み込み中',
       loadingSessions: '最近のセッションを読み込み中',
+      retryingRemoteBackend: 'リモート Hermes バックエンドに再接続中…',
       startingDesktopConnection: 'デスクトップ接続を開始中',
       startingHermesDesktop: 'Hermes Desktop を起動中…'
     },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2224,6 +2224,7 @@ export interface Translations {
       inferenceNotReady: string
       checkingInference: string
       disconnected: string
+      reconnectGateway: string
       openSystem: string
       connection: (label: string) => string
       recentActivity: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -114,6 +114,7 @@ export interface Translations {
       connectingGateway: string
       loadingSettings: string
       loadingSessions: string
+      retryingRemoteBackend: string
       startingDesktopConnection: string
       startingHermesDesktop: string
     }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -68,6 +68,7 @@ export const zhHant = defineLocale({
       connectingGateway: '正在連線桌面閘道',
       loadingSettings: '正在載入 Hermes 設定',
       loadingSessions: '正在載入最近工作階段',
+      retryingRemoteBackend: '正在重新連線遠端 Hermes 後端…',
       startingDesktopConnection: '正在啟動桌面連線',
       startingHermesDesktop: '正在啟動 Hermes Desktop…'
     },

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2284,6 +2284,7 @@ export const zhHant = defineLocale({
       inferenceNotReady: '推論未就緒',
       checkingInference: '正在檢查推論',
       disconnected: '已中斷連線',
+      reconnectGateway: '重新連線閘道',
       openSystem: '開啟系統面板',
       connection: label => `連線：${label}`,
       recentActivity: '最近活動',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2813,6 +2813,7 @@ export const zh: Translations = {
       inferenceNotReady: '推理未就绪',
       checkingInference: '正在检查推理',
       disconnected: '已断开',
+      reconnectGateway: '重连网关',
       openSystem: '打开系统面板',
       connection: label => `连接：${label}`,
       recentActivity: '最近活动',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -68,6 +68,7 @@ export const zh: Translations = {
       connectingGateway: '正在连接桌面网关',
       loadingSettings: '正在加载 Hermes 设置',
       loadingSessions: '正在加载最近会话',
+      retryingRemoteBackend: '正在重新连接远程 Hermes 后端…',
       startingDesktopConnection: '正在启动桌面连接',
       startingHermesDesktop: '正在启动 Hermes 桌面版…'
     },

--- a/apps/desktop/src/store/boot.ts
+++ b/apps/desktop/src/store/boot.ts
@@ -66,6 +66,27 @@ export function setDesktopBootStep(step: {
   })
 }
 
+/**
+ * Re-arm the boot overlay for an automatic bounded retry of a failed REMOTE
+ * boot (#82679). Unlike setDesktopBootStep — whose null `error` intentionally
+ * cannot clear a latched failure — this explicitly lifts the error so the
+ * overlay shows the retry status instead of the terminal failure surface
+ * while the retry is in flight. failDesktopBoot() re-latches when the
+ * bounded retries are exhausted.
+ */
+export function resumeDesktopBootForRetry(message: string) {
+  const current = $desktopBoot.get()
+  $desktopBoot.set({
+    ...current,
+    error: null,
+    message,
+    phase: 'renderer.boot.retry',
+    running: true,
+    timestamp: Date.now(),
+    visible: true
+  })
+}
+
 export function completeDesktopBoot(message = translateNow('boot.ready')) {
   const current = $desktopBoot.get()
   $desktopBoot.set({

--- a/apps/desktop/src/store/gateway-reconnect.test.ts
+++ b/apps/desktop/src/store/gateway-reconnect.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { reconnectGateway, registerGatewayReconnect } from './gateway-reconnect'
+
+const disposers: Array<() => void> = []
+
+afterEach(() => {
+  while (disposers.length > 0) {
+    disposers.pop()?.()
+  }
+})
+
+describe('gateway reconnect controller', () => {
+  it('coalesces repeated requests onto one active reconnect', async () => {
+    let finish: (() => void) | undefined
+
+    const handler = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>(resolve => {
+            finish = resolve
+          })
+      )
+      .mockResolvedValueOnce(undefined)
+
+    disposers.push(registerGatewayReconnect(handler))
+
+    const first = reconnectGateway()
+    const second = reconnectGateway()
+
+    expect(second).toBe(first)
+    await Promise.resolve()
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    finish?.()
+    await first
+
+    await reconnectGateway()
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
+  it('only lets the current registration remove itself', async () => {
+    const stale = vi.fn()
+    const current = vi.fn()
+    const disposeStale = registerGatewayReconnect(stale)
+    disposers.push(registerGatewayReconnect(current))
+
+    disposeStale()
+    await reconnectGateway()
+
+    expect(stale).not.toHaveBeenCalled()
+    expect(current).toHaveBeenCalledOnce()
+  })
+
+  it('rejects when the gateway boot owner is not mounted', async () => {
+    await expect(reconnectGateway()).rejects.toThrow('Gateway reconnect is unavailable')
+  })
+})

--- a/apps/desktop/src/store/gateway-reconnect.ts
+++ b/apps/desktop/src/store/gateway-reconnect.ts
@@ -1,0 +1,34 @@
+type GatewayReconnectHandler = () => Promise<void> | void
+
+let activeHandler: GatewayReconnectHandler | null = null
+let inFlight: Promise<void> | null = null
+
+export function registerGatewayReconnect(handler: GatewayReconnectHandler): () => void {
+  activeHandler = handler
+
+  return () => {
+    if (activeHandler === handler) {
+      activeHandler = null
+    }
+  }
+}
+
+export function reconnectGateway(): Promise<void> {
+  if (inFlight) {
+    return inFlight
+  }
+
+  const handler = activeHandler
+
+  if (!handler) {
+    return Promise.reject(new Error('Gateway reconnect is unavailable'))
+  }
+
+  inFlight = Promise.resolve()
+    .then(handler)
+    .finally(() => {
+      inFlight = null
+    })
+
+  return inFlight
+}


### PR DESCRIPTION
## Summary

Hermes Desktop now **self-heals a dropped SSH/HTTP registered remote connection** — automatic bounded-backoff boot retries with a manual status-bar Reconnect action — instead of parking on "Desktop boot failed" until the user deletes and re-enters the exact same connection details.

Salvages open contributor PR #80694 by @fangliquanflq (status-bar reconnect, cherry-picked with authorship preserved) and builds the self-heal class fix for the primary/registered-connection path on top.

Fixes #82679
Fixes #80430

## Root cause

The remote-connection lifecycle already handled the *post-boot* drop (renderer reconnect loop with full-jitter backoff + `revalidateConnection` cache invalidation), and secondaries already had their own backoff loop in `store/gateway.ts`. The uncovered class was the **failed boot of a registered primary remote**:

1. A dropped SSH/HTTP transport surfaces at the next boot as a transient transport error (`"Could not verify the existing SSH backend"`, `ERR_CONNECTION_RESET`, mint timeout). `shouldLatchBackendStartFailure` correctly does **not** latch it — but nothing ever **re-attempted** the boot: the renderer's reconnect machinery only arms after `bootCompleted`. The app sat on the terminal failure overlay; manual re-entry "fixed" it only because it forced the fresh bootstrap an automatic retry would have performed.
2. On the SSH leg, a reused cached master whose lifecycle probe failed was **kept** in `sshConnections`, so every subsequent attempt re-failed through the same wedged master/tunnel until re-entered details changed the config fingerprint and forced a teardown.

## Changes

**Commit 1 — salvaged from #80694 (author @fangliquanflq):**
- `store/gateway-reconnect.ts` — single-flight renderer reconnect action, registered by `use-gateway-boot`'s existing profile-aware reconnect path
- `app/shell/gateway-menu-panel.tsx` — Reconnect button in the gateway status menu whenever the socket is not open (re-applied here; the PR's pill-plugin file moved on main)
- Localized copy for en/ar/ja/zh/zh-hant + behavior tests

**Commit 2 — self-heal class fix:**
- `electron/backend-start-failure.ts` — new `isRetryableRemoteBootFailure()`: remote + non-reauth ⇒ transient/retryable; local failures and confirmed 401/403 are not (*a missing capability differs from a transient failure*)
- `electron/main.ts` — boot-failure broadcast now carries `retryable` (rides with `error` through `updateBootProgress`); failed SSH reuse probe tears down the stale cached master so the next attempt bootstraps fresh
- `use-gateway-boot.ts` — bounded self-heal loop: up to **5** boot re-attempts with the same full-jitter backoff shape as the socket reconnect loop (2s base, 15s cap); exhausted retries end in the real boot-failure recovery overlay — never an infinite spinner; reset on success/soft-switch, timer cleared on unmount
- `store/boot.ts` — `resumeDesktopBootForRetry()` re-arms the overlay with retry status while an automatic retry is in flight

## Validation

| Check | Result |
| --- | --- |
| `vitest` electron/backend-start-failure.test.ts (predicate matrix, retryable vs reauth-latch exclusivity) | ✅ pass |
| `vitest` use-gateway-boot.test.tsx (13 tests: transient SSH failure self-heals on retry; retries bounded at 6 total dials then recovery overlay, no further attempts; non-retryable fails immediately) | ✅ pass |
| `vitest` gateway-reconnect.test.ts + gateway-menu-panel.test.tsx (salvaged) | ✅ pass |
| Sabotage verification (disable retry budget / predicate) | ✅ 4 tests fail as expected, restored green |
| `tsc -p tsconfig.json` / `tsconfig.electron.json` / `tsconfig.e2e.json` | ✅ clean |
| `eslint` on all touched files | ✅ clean |
| `scripts/audit_pr_attribution.py --fix` | ✅ all contributor emails mapped |

One salvaged test assertion was updated to current main's contract (primary reconnect dials the window-owned backend with no profile arg — post-#46651 semantics).

## #58875 (React stack overflow on remote gateway connect)

Investigated separately and **out of scope for this PR**: per @DavidMetcalfe's analysis on the issue, it is a renderer-side `@assistant-ui/react` infinite render loop inside `AssistantMessage` *after* a successful connection — a different layer from the connection lifecycle touched here. The reporter reinstalled and can no longer reproduce, and no repro currently exists to write a failing test against, so claiming a fix would be dishonest. Referenced here for the cluster record only; it remains open.

## Infographic

![Desktop remote reconnect self-heal](https://v3b.fal.media/files/b/0aa6a494/5E6u7SrIGULZu64MVfGkn_TOI6yNgR.png)

---

Credit to @fangliquanflq for the status-bar reconnect groundwork (#80694), preserved as an authored commit on this branch.
