### PR TITLE
fix(security): redact OAuth JSON fields

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -269,8 +269,15 @@ def _should_redact_assignment(key: str, value: str, *, check_keyword: bool) -> b
 
 
 # JSON field patterns: "apiKey": "value", "token": "value", etc.
-_JSON_KEY_NAMES = r"(?:api_?[Kk]ey|token|secret|password|access_token|refresh_token|auth_token|bearer|secret_value|raw_secret|secret_input|key_material)"
-_JSON_FIELD_RE = re.compile(rf'("{_JSON_KEY_NAMES}")\s*:\s*"([^"]+)"', re.IGNORECASE)
+_JSON_KEY_NAMES = (
+    r"(?:api_?[Kk]ey|token|secret|password|access_token|refresh_token|id_token|"
+    r"auth_token|authorization|client_?secret|private_?key|bearer|secret_value|"
+    r"raw_secret|secret_input|key_material)"
+)
+_JSON_FIELD_RE = re.compile(
+    rf'("{_JSON_KEY_NAMES}")\s*:\s*"([^"]+)"',
+    re.IGNORECASE,
+)
 
 # Authorization / Proxy-Authorization, any scheme or bare credential; header
 # name and scheme word preserved. The credential class excludes quotes: pulling


### PR DESCRIPTION
## Summary

- redact OAuth and key-bearing JSON fields that the central text redactor previously missed
- cover snake_case and camelCase forms of client secrets and private keys
- preserve unrelated JSON fields unchanged

## Root cause

`_SENSITIVE_BODY_KEYS` already classifies `id_token`, `authorization`, `client_secret`, and `private_key` as sensitive, but the separate `_JSON_KEY_NAMES` regex did not include them. As a result, serialized JSON containing opaque values under those keys passed through `redact_sensitive_text()` unchanged.

## Impact

Tool output, logs, or transcripts containing serialized OAuth responses or request metadata can now mask these credential values through the existing central redaction path.

## Validation

- reproduced all six snake_case/camelCase samples leaking on current `main`
- focused smoke: all synthetic values are absent after redaction
- focused smoke: unrelated `{"model": "gpt-5"}` JSON remains unchanged
- `python -m py_compile agent/redact.py`
- `git diff --check`
