### PR TITLE
fix(skills): remove dangling subagent-driven-development related_skills references

### DIFF
--- a/skills/software-development/plan/SKILL.md
+++ b/skills/software-development/plan/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [planning, plan-mode, implementation, workflow, design, documentation]
-    related_skills: [subagent-driven-development, test-driven-development, requesting-code-review]
+    related_skills: [test-driven-development, requesting-code-review]
 ---
 
 # Plan Mode

--- a/skills/software-development/requesting-code-review/SKILL.md
+++ b/skills/software-development/requesting-code-review/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [code-review, security, verification, quality, pre-commit, auto-fix]
-    related_skills: [subagent-driven-development, plan, test-driven-development, github-code-review]
+    related_skills: [plan, test-driven-development, github-code-review]
 ---
 
 # Pre-Commit Code Verification

--- a/skills/software-development/spike/SKILL.md
+++ b/skills/software-development/spike/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [spike, prototype, experiment, feasibility, throwaway, exploration, research, planning, mvp, proof-of-concept]
-    related_skills: [sketch, subagent-driven-development, plan]
+    related_skills: [sketch, plan]
 ---
 
 # Spike

--- a/skills/software-development/systematic-debugging/SKILL.md
+++ b/skills/software-development/systematic-debugging/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [debugging, troubleshooting, problem-solving, root-cause, investigation]
-    related_skills: [test-driven-development, plan, subagent-driven-development]
+    related_skills: [test-driven-development, plan]
 ---
 
 # Systematic Debugging

--- a/skills/software-development/test-driven-development/SKILL.md
+++ b/skills/software-development/test-driven-development/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [testing, tdd, development, quality, red-green-refactor]
-    related_skills: [systematic-debugging, plan, subagent-driven-development]
+    related_skills: [systematic-debugging, plan]
 ---
 
 # Test-Driven Development (TDD)


### PR DESCRIPTION
## Summary
- `subagent-driven-development` does not exist anywhere in `skills/` at `main` (checked against the full skills tree, 653 paths), so a `related_skills` entry pointing at it can never resolve in the catalog.
- Removes that dangling entry from the five skills that carry it: `test-driven-development`, `systematic-debugging`, `plan`, `spike`, `requesting-code-review` — one line per file, nothing else touched.
- Complements #37415, which fixes the tree's other stale references (`concept-diagrams`, `stable-diffusion`, …) but does not touch these five files. Note: the `research-paper-writing` line that #37415 rewrites currently *keeps* a `subagent-driven-development` entry — deliberately left to that PR to absorb, so the two stay conflict-free.

## Verification
- Tree-wide `related_skills` reference scan over `skills/**/SKILL.md`: before this diff, 8 dangling references (these five, plus the three #37415 already covers); after, only #37415's three remain — no new danglers introduced.
- YAML frontmatter parses on all five files after the edit (`yaml.safe_load`), lists otherwise unchanged.
- Metadata-only diff; my local runtime venv lacks the dev extras for `scripts/run_tests.sh`, so deferring `tests/tools/test_skills_tool.py` / `tests/agent/test_skill_utils.py` to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
