### PR TITLE
fix(discord): treat voice/stage built-in text chat as free-response

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -8136,9 +8136,16 @@ class DiscordAdapter(BasePlatformAdapter):
             require_mention = self._discord_require_mention()
             # Voice-linked text channels act as free-response while voice is active.
             # Only the exact bound channel gets the exemption, not sibling threads.
+            # Also exempt the voice/stage channel's own built-in text chat: Discord
+            # rejects thread creation from messages posted there (400/50024 "Cannot
+            # execute action on this channel type"), which is a different channel id
+            # from whatever text channel `/voice join` was invoked in, so it isn't
+            # caught by the voice_linked_ids membership check alone.
             voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
             current_channel_id = str(message.channel.id)
-            is_voice_linked_channel = current_channel_id in voice_linked_ids
+            is_voice_linked_channel = current_channel_id in voice_linked_ids or isinstance(
+                message.channel, (discord.VoiceChannel, discord.StageChannel)
+            )
             is_free_channel = (
                 "*" in free_channels
                 or bool(channel_keys & free_channels)

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -198,6 +198,8 @@ def _ensure_discord_mock() -> None:
     discord_mod.DMChannel = type("DMChannel", (), {})
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.VoiceChannel = type("VoiceChannel", (), {})
+    discord_mod.StageChannel = type("StageChannel", (), {})
     discord_mod.Interaction = object
     discord_mod.Message = type("Message", (), {})
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -22,6 +22,8 @@ def _ensure_discord_mock():
     discord_mod.DMChannel = type("DMChannel", (), {})
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.VoiceChannel = type("VoiceChannel", (), {})
+    discord_mod.StageChannel = type("StageChannel", (), {})
     discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
     discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
     discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
@@ -96,11 +98,30 @@ class FakeThread:
         return _iter()
 
 
+class FakeVoiceChannel:
+    """A Discord voice channel's own built-in text chat (distinct channel id
+    from whatever text channel `/voice join` was invoked in)."""
+
+    def __init__(self, channel_id: int = 1, name: str = "General", guild_name: str = "Hermes Server"):
+        self.id = channel_id
+        self.name = name
+        self.guild = SimpleNamespace(name=guild_name)
+        self.topic = None
+
+    def history(self, *, limit, before, after=None, oldest_first=None):
+        async def _iter():
+            return
+            yield
+        return _iter()
+
+
 @pytest.fixture
 def adapter(monkeypatch):
     monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
     monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
     monkeypatch.setattr(discord_platform.discord, "ForumChannel", FakeForumChannel, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "VoiceChannel", FakeVoiceChannel, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "StageChannel", type("StageChannel", (), {}), raising=False)
 
     # Clear DISCORD_* env vars the test file exercises so tests don't leak
     # process-env state from the contributor's shell into per-test behaviour.
@@ -273,6 +294,41 @@ async def test_discord_voice_linked_channel_skips_mention_requirement_and_auto_t
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "follow-up from voice text chat"
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_discord_voice_channel_native_chat_skips_auto_thread(adapter, monkeypatch):
+    """Typing in a voice channel's own built-in text chat must not attempt
+    auto-thread creation.
+
+    Discord rejects thread creation for messages posted in a voice/stage
+    channel (400/50024 "Cannot execute action on this channel type"). That
+    channel has its own id, distinct from whatever text channel `/voice
+    join` was invoked in — so the ``_voice_text_channels`` membership check
+    alone doesn't catch it; the exemption must also key off the channel's
+    actual type.
+    """
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+
+    # /voice join was invoked in a different, bound text channel (456);
+    # the user is typing directly in the voice channel's own chat (789).
+    adapter._voice_text_channels[111] = 456
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(
+        channel=FakeVoiceChannel(channel_id=789),
+        content="typed in the voice channel's own chat",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "typed in the voice channel's own chat"
     assert event.source.chat_type == "group"
 
 


### PR DESCRIPTION
## What does this PR do?

Treat Discord's built-in text chat inside **voice/stage channels** as
free-response input instead of routing it through the normal command parsing.
A message typed into a voice-channel text chat was being parsed as a slash
command / structured message, when it should just be a free-form turn.

## Related Issue

N/A (no issue exists).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/discord/adapter.py` — detect voice/stage built-in text
  chat and mark the message as free-response
- `tests/gateway/test_discord_free_response.py` — new regression tests
- `tests/gateway/conftest.py` — test fixture support

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_discord_free_response.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — focused test file passes locally; full suite runs in CI
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [ ] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

N/A