### PR TITLE
feat(kanban) kanban_attach accepts content_file local path

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1134,3 +1134,118 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# kanban_attach — content_file (local path) + content_base64 (legacy)
+# ---------------------------------------------------------------------------
+
+
+def test_attach_content_file_happy_path(worker_env, tmp_path):
+    """content_file reads a local file server-side and stores it byte-identical,
+    without the worker hand-assembling a base64 string."""
+    from pathlib import Path
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    payload = b"content-file-payload-bytes"
+    src = tmp_path / "report.csv"
+    src.write_bytes(payload)
+
+    out = kt._handle_attach(
+        {"filename": "report.csv", "content_file": str(src), "content_type": "text/csv"}
+    )
+    d = json.loads(out)
+    assert d.get("ok") is True, out
+    assert d["size"] == len(payload)
+
+    conn = kb.connect()
+    try:
+        atts = kb.list_attachments(conn, worker_env)
+        assert [a.filename for a in atts] == ["report.csv"]
+        assert atts[0].content_type == "text/csv"
+        assert Path(atts[0].stored_path).read_bytes() == payload
+    finally:
+        conn.close()
+
+
+def test_attach_content_file_missing_returns_error(worker_env, tmp_path):
+    from tools import kanban_tools as kt
+
+    missing = tmp_path / "does-not-exist.bin"
+    out = kt._handle_attach({"filename": "x.bin", "content_file": str(missing)})
+    d = json.loads(out)
+    assert "error" in d
+    assert "not an existing file" in d["error"]
+
+
+def test_attach_content_file_unreadable_returns_error(worker_env, tmp_path, monkeypatch):
+    from tools import kanban_tools as kt
+
+    src = tmp_path / "noperm.txt"
+    src.write_bytes(b"x")
+    monkeypatch.setattr(os, "access", lambda path, mode: False)
+
+    out = kt._handle_attach({"filename": "noperm.txt", "content_file": str(src)})
+    d = json.loads(out)
+    assert "error" in d
+    assert "not readable" in d["error"]
+
+
+def test_attach_content_file_and_base64_mutually_exclusive(worker_env, tmp_path):
+    from tools import kanban_tools as kt
+
+    src = tmp_path / "a.txt"
+    src.write_bytes(b"x")
+    out = kt._handle_attach(
+        {"filename": "a.txt", "content_file": str(src), "content_base64": "eA=="}
+    )
+    d = json.loads(out)
+    assert "error" in d
+    assert "mutually exclusive" in d["error"]
+
+
+def test_attach_requires_one_content_source(worker_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_attach({"filename": "x.bin"})
+    d = json.loads(out)
+    assert "error" in d
+    assert "content_file or content_base64" in d["error"]
+
+
+def test_attach_content_file_oversize_returns_error(worker_env, tmp_path, monkeypatch):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.setattr(kb, "KANBAN_ATTACHMENT_MAX_BYTES", 4)
+    src = tmp_path / "big.bin"
+    src.write_bytes(b"12345")
+
+    out = kt._handle_attach({"filename": "big.bin", "content_file": str(src)})
+    d = json.loads(out)
+    assert "error" in d
+    assert "exceeds" in d["error"]
+
+
+def test_attach_content_base64_legacy_still_works(worker_env):
+    import base64
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    payload = b"legacy-base64-bytes"
+    out = kt._handle_attach(
+        {"filename": "legacy.txt", "content_base64": base64.b64encode(payload).decode()}
+    )
+    d = json.loads(out)
+    assert d.get("ok") is True, out
+    assert d["size"] == len(payload)
+
+    conn = kb.connect()
+    try:
+        atts = kb.list_attachments(conn, worker_env)
+        assert [a.filename for a in atts] == ["legacy.txt"]
+    finally:
+        conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1116,7 +1116,14 @@ def _handle_comment(args: dict, **kw) -> str:
 
 
 def _handle_attach(args: dict, **kw) -> str:
-    """Attach an inline (base64) file to a task.
+    """Attach a file to a task.
+
+    Two mutually-exclusive content sources are accepted:
+
+    - ``content_file`` — a local file path; the tool reads the file
+      server-side and feeds the existing inline-bytes flow, so a worker
+      never has to hand-assemble a multi-KB base64 string;
+    - ``content_base64`` — inline base64-encoded bytes (legacy path, kept).
 
     Mirrors the dashboard's upload endpoint for the agent surface: decode
     the payload, enforce the shared size cap, write it under the per-task
@@ -1139,15 +1146,42 @@ def _handle_attach(args: dict, **kw) -> str:
     filename = args.get("filename")
     if not filename or not str(filename).strip():
         return tool_error("filename is required")
+    content_file = args.get("content_file")
     content_b64 = args.get("content_base64")
-    if not content_b64 or not str(content_b64).strip():
-        return tool_error("content_base64 is required")
-    import base64
-    import binascii
-    try:
-        data = base64.b64decode(str(content_b64), validate=True)
-    except (binascii.Error, ValueError) as e:
-        return tool_error(f"content_base64 is not valid base64: {e}")
+    if content_file and content_b64:
+        return tool_error(
+            "content_file and content_base64 are mutually exclusive; pass exactly one"
+        )
+    if content_file:
+        import os
+
+        path = str(content_file)
+        if not os.path.isfile(path):
+            return tool_error(f"content_file is not an existing file: {path}")
+        if not os.access(path, os.R_OK):
+            return tool_error(f"content_file is not readable: {path}")
+        if os.path.getsize(path) > kb.KANBAN_ATTACHMENT_MAX_BYTES:
+            limit_mb = kb.KANBAN_ATTACHMENT_MAX_BYTES // (1024 * 1024)
+            return tool_error(
+                f"kanban_attach: attachment exceeds {limit_mb} MB limit"
+            )
+        try:
+            with open(path, "rb") as fh:
+                data = fh.read()
+        except OSError as e:
+            return tool_error(f"content_file could not be read: {path}: {e}")
+    elif content_b64:
+        if not str(content_b64).strip():
+            return tool_error("content_base64 is required")
+        import base64
+        import binascii
+
+        try:
+            data = base64.b64decode(str(content_b64), validate=True)
+        except (binascii.Error, ValueError) as e:
+            return tool_error(f"content_base64 is not valid base64: {e}")
+    else:
+        return tool_error("content_file or content_base64 is required")
     content_type = args.get("content_type")
     board = args.get("board")
     try:
@@ -2036,11 +2070,12 @@ KANBAN_COMMENT_SCHEMA = {
 KANBAN_ATTACH_SCHEMA = {
     "name": "kanban_attach",
     "description": (
-        "Attach a file to a task by passing its bytes inline (base64). "
-        "Use for genuine file artifacts the next worker or a human should "
-        "be able to download — generated reports, images, exports. The "
-        "file is stored as a real attachment (not a comment link) under "
-        "the task's attachments dir, capped at 25 MB. Prefer "
+        "Attach a file to a task by passing its bytes inline (base64) or "
+        "by pointing at a local file path (content_file). Use for genuine "
+        "file artifacts the next worker or a human should be able to "
+        "download — generated reports, images, exports. The file is "
+        "stored as a real attachment (not a comment link) under the "
+        "task's attachments dir, capped at 25 MB. Prefer "
         "kanban_attach_url when you only have a URL."
     ),
     "parameters": {
@@ -2057,9 +2092,21 @@ KANBAN_ATTACH_SCHEMA = {
                     "Directory components are stripped; only the leaf is kept."
                 ),
             },
+            "content_file": {
+                "type": "string",
+                "description": (
+                    "Local file path to attach. The tool reads the file "
+                    "server-side and stores it, so you don't have to "
+                    "hand-assemble base64. Mutually exclusive with "
+                    "content_base64."
+                ),
+            },
             "content_base64": {
                 "type": "string",
-                "description": "The file contents, base64-encoded. Max 25 MB decoded.",
+                "description": (
+                    "The file contents, base64-encoded. Max 25 MB decoded. "
+                    "Mutually exclusive with content_file."
+                ),
             },
             "content_type": {
                 "type": "string",
@@ -2067,7 +2114,7 @@ KANBAN_ATTACH_SCHEMA = {
             },
             "board": _board_schema_prop(),
         },
-        "required": ["filename", "content_base64"],
+        "required": ["filename"],
     },
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a `content_file` input to the `kanban_attach` tool, so a kanban worker can
attach a file by pointing at a **local server-side path** instead of
hand-assembling a multi-KB base64 string inline. The tool reads the file
server-side and reuses the existing `store_attachment_bytes` flow — no change to
storage layout, filename sanitization, or the 25 MB cap.

`content_file` and `content_base64` are mutually exclusive (passing both is a
tool error), and `content_base64` is kept as the legacy path. Missing /
unreadable / over-cap files return an explicit `tool_error` rather than an
uncaught exception.

### Why

Workers attaching large artifacts (reports, images, exports) currently have to
base64-encode the bytes into the tool call, which is token-expensive and
error-prone. A local-path input is the natural sibling of the existing
`kanban_attach_url` (which already fetches server-side from a URL).

### Security note

`content_file` reads a path the gateway process can already read — it is
equivalent to `read_file` + base64 + `kanban_attach`, which the agent can already
do, so it adds ergonomics rather than a new capability. The size cap and
`store_attachment_bytes` flow are unchanged.

## Related Issue

No upstream issue filed — self-contained feature with a focused test suite.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/kanban_tools.py`: add a `content_file` branch to `_handle_attach`
  (file-exists / readable / size-cap checks, then read bytes and feed the shared
  `store_attachment_bytes` path); enforce `content_file`/`content_base64` mutual
  exclusion; relax the schema `required` list from
  `["filename", "content_base64"]` to `["filename"]` (exactly one content source
  is still enforced at runtime); document both params.
- `tests/tools/test_kanban_tools.py`: 7 new tests covering the happy path
  (byte-identical store), missing file, unreadable file, mutual exclusion,
  missing content source, over-cap rejection, and the legacy `content_base64`
  path.

## How to Test

Automated: `pytest tests/tools/test_kanban_tools.py -q` → 39 passed (32 existing
+ 7 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused suite (39 passed); full suite left to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — done (schema + descriptions updated)

## Screenshots / Logs

N/A