### PR TITLE
fix: align doctor checks with active configuration

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2883,17 +2883,33 @@ def run_doctor(args):
         try:
             from plugins.memory.mem0 import _load_config as _load_mem0_config
             mem0_cfg = _load_mem0_config()
-            mem0_key = mem0_cfg.get("api_key", "")
-            if mem0_key:
-                check_ok("Mem0 API key configured")
-                check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
+            mem0_mode = mem0_cfg.get("mode", "platform")
+            if mem0_mode == "oss":
+                vector_store = mem0_cfg.get("oss", {}).get("vector_store", {})
+                vector_provider = vector_store.get("provider", "vector store")
+                if vector_store:
+                    check_ok(f"Mem0 OSS configured", f"vector store={vector_provider}")
+                else:
+                    _fail_and_issue(
+                        "Mem0 OSS vector store not configured",
+                        "run: hermes memory setup",
+                        "Mem0 OSS is set as memory provider but no vector store is configured",
+                        issues,
+                    )
+                # OSS mode uses a local/self-hosted vector store and does not
+                # require the Mem0 Platform API key.
             else:
-                _fail_and_issue(
-                    "Mem0 API key not set",
-                    "(set MEM0_API_KEY in .env or run hermes memory setup)",
-                    "Mem0 is set as memory provider but API key is missing",
-                    issues,
-                )
+                mem0_key = mem0_cfg.get("api_key", "")
+                if mem0_key:
+                    check_ok("Mem0 API key configured")
+                    check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
+                else:
+                    _fail_and_issue(
+                        "Mem0 API key not set",
+                        "(set MEM0_API_KEY in .env or run hermes memory setup)",
+                        "Mem0 is set as memory provider but API key is missing",
+                        issues,
+                    )
         except ImportError:
             _fail_and_issue(
                 "Mem0 plugin not loadable",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1834,6 +1834,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1850,6 +1851,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1866,6 +1868,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1882,6 +1885,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1898,6 +1902,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1914,6 +1919,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1930,6 +1936,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1946,6 +1953,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1962,6 +1970,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1978,6 +1987,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1994,6 +2004,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2010,6 +2021,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2026,6 +2038,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2042,6 +2055,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2058,6 +2072,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2074,6 +2089,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2090,6 +2106,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2106,6 +2123,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2122,6 +2140,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2138,6 +2157,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2154,6 +2174,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2170,6 +2191,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2186,6 +2208,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2202,6 +2225,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2218,6 +2242,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2234,6 +2259,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16485,9 +16511,9 @@
       }
     },
     "node_modules/sanitize-html/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -17633,6 +17659,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -18325,9 +18352,9 @@
       }
     },
     "node_modules/vite/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,14 @@
     "mermaid": "11.16.1",
     "dompurify": "3.4.13",
     "ip-address": "10.3.1",
-    "nanoid@^3": "3.3.17",
+    "nanoid@^3": "3.3.18",
     "nanoid@^6": "6.0.0",
+    "sanitize-html": {
+      "nanoid": "3.3.18"
+    },
+    "vite": {
+      "nanoid": "3.3.18"
+    },
     "js-yaml@^4": "4.3.1",
     "undici@^6": "6.28.0",
     "undici@^7": "7.29.0",

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -279,6 +279,24 @@ class TestDoctorMemoryProviderSection:
         assert "Memory Provider" in out
         assert "Built-in memory active" not in out
 
+    def test_mem0_oss_does_not_require_platform_api_key(self, monkeypatch, tmp_path):
+        home = self._make_hermes_home(tmp_path, provider="mem0")
+        (home / "mem0.json").write_text(
+            '{"mode": "oss", "oss": {"vector_store": {"provider": "qdrant"}}}',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(
+            "plugins.memory.mem0._load_config",
+            lambda: {"mode": "oss", "oss": {"vector_store": {"provider": "qdrant"}}},
+        )
+
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+
+        assert "Mem0 OSS configured" in out
+        assert "Mem0 API key not set" not in out
+        assert "Mem0 OSS is set as memory provider but no vector store is configured" not in out
+
 
 def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):
     helper = TestDoctorMemoryProviderSection()

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -29,6 +29,7 @@
     "unicode-animations": "1.0.3"
   },
   "overrides": {
+    "nanoid": "3.3.18",
     "ink-text-input": {
       "ink": "npm:@hermes/ink@0.0.1"
     }

--- a/web/package.json
+++ b/web/package.json
@@ -50,5 +50,8 @@
     "typescript": "6.0.3",
     "vite": "8.2.0",
     "vitest": "4.1.10"
+  },
+  "overrides": {
+    "nanoid": "3.3.18"
   }
 }


### PR DESCRIPTION
## Summary

- Treat Mem0 OSS mode as valid without requiring a Mem0 Platform API key.
- Report a missing OSS vector store as a real configuration issue.
- Pin vulnerable NanoID 3.x transitive dependencies to 3.3.18 in the web and ui-tui workspaces.
- Add a regression test for Mem0 OSS doctor behavior.

## Verification

- `python3 -m pytest tests/hermes_cli/test_doctor.py -q -o addopts='' -k 'not opencode_go_skips_invalid_models'` — 51 passed, 2 deselected
- `python3 -m pytest tests/hermes_cli/test_doctor.py -q -o addopts='' -k 'mem0_oss_does_not_require_platform_api_key or mem0_provider_not_installed_shows_fail'` — 2 passed
- `ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py` — passed
- `npm audit --workspace web` — 0 vulnerabilities
- `npm audit --workspace ui-tui` — 0 vulnerabilities
