### PR TITLE
docs(state): soften stale SessionDB self-pin wording after #88063

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4350,15 +4350,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def __enter__(self) -> "SessionDB":
         """Enter a scope that closes this handle on the way out.
 
-        Ownership of a SessionDB has to be released explicitly: once the
-        background token writer starts, the instance pins ITSELF via
-        ``atexit.register(self._drain_token_queue_at_exit)`` and via the
-        writer thread's bound-method target, and only ``close()``
-        unregisters the former.  Dropping the last reference therefore does
-        NOT release the db/-wal/-shm descriptors the way plain refcounting
-        would suggest, and ``__del__`` never runs for exactly the instances
-        that leak.  That is why call sites owning a handle are expected to
-        close it (see the ownership comments in ``run_agent.py`` and
+        Ownership of a SessionDB should be released explicitly.
+        Historically an instance with a started token writer pinned ITSELF
+        (bound-method writer target plus a strong ``atexit`` drain hook), so
+        ``__del__`` never ran for exactly the instances that leaked
+        descriptors (#88033).  The writer now retires after an idle window
+        and the atexit hook holds only a weak reference, so abandoned
+        handles are eventually collectible — but "eventually, after the
+        idle window and a GC cycle" is not a release policy.  Call sites
+        owning a handle are still expected to close it deterministically
+        (see the ownership comments in ``run_agent.py`` and
         ``tui_gateway/methods_session.py``).
 
         This makes the correct usage the easy one, so an owning scope can be

--- a/tests/test_session_db_context_manager.py
+++ b/tests/test_session_db_context_manager.py
@@ -1,14 +1,15 @@
 """``SessionDB`` must support ``with``, so an owning scope releases its fds.
 
-A SessionDB handle cannot be released by dropping the last reference. Once its
-background token writer starts, the instance pins ITSELF two ways: the writer
-thread's target is a bound method, and ``queue_token_counts`` registers
-``atexit.register(self._drain_token_queue_at_exit)``, which only ``close()``
-unregisters. A dropped-but-pinned handle keeps its ``state.db``/``-wal``/
-``-shm`` descriptors for the life of the process, and ``__del__`` never runs
-for it -- so the safety net is dead code for exactly the instances that leak.
+Historically a SessionDB handle could not be released by dropping the last
+reference: once its background token writer started, the instance pinned
+ITSELF two ways (the writer thread's bound-method target, and a strong
+``atexit`` drain hook that only ``close()`` unregistered), so ``__del__``
+never ran for exactly the instances that leaked ``state.db``/``-wal``/
+``-shm`` descriptors (#88033). The writer now retires after an idle window
+and the atexit hook is a weak reference, so abandoned handles are eventually
+GC-collectible -- but eventual collection is not deterministic release.
 
-That is why owning call sites are expected to close explicitly; the ownership
+Owning call sites are still expected to close explicitly; the ownership
 comments in ``run_agent.py`` and ``tui_gateway/methods_session.py`` say so in
 those words. This module pins the ergonomic half of that contract: an owner can
 scope a handle with ``with`` and be exception-safe by construction, instead of


### PR DESCRIPTION
## Summary
Softens now-stale docstring wording from #88048 that described the SessionDB token-writer self-pin ("__del__ never runs for exactly the instances that leak", "only close() unregisters") as a permanent contract — #88063 removed both pins (idle writer retirement + weakref atexit hook), so the docs now present the pin as historical motivation and keep the "owners close deterministically" guidance. Docs-only, no code changes.

## Changes
- `hermes_state.py`: `__enter__` docstring — self-pin described as historical, notes idle retirement + weakref hook, explicit close still the policy
- `tests/test_session_db_context_manager.py`: module docstring — same rewording, cites #88033/#88063

## Validation
| | Result |
|---|---|
| `pytest tests/test_session_db_context_manager.py` | 4/4 pass |
| grep for stale phrasing ("pins ITSELF", "never runs for exactly") | 0 hits |

Follow-up agreed during the #88048/#88063 merge review.

## Infographic

![SessionDB docstring softening](https://v3b.fal.media/files/b/0aa6a5d0/Kgv-D6FTkEQuU_KZk4Sir_ACfg0rT3.png)
