### PR TITLE
fix(desktop): keep session tabs inside the selected profile context

### DIFF
--- a/apps/desktop/src/app/chat/composer/directive-actions.test.tsx
+++ b/apps/desktop/src/app/chat/composer/directive-actions.test.tsx
@@ -86,7 +86,7 @@ describe('ComposerDirectiveActions', () => {
     fireEvent.click(screen.getByRole('button'))
     // openSessionRef lazy-imports the navigator, so the call lands a tick later.
     await vi.waitFor(() =>
-      expect(openSession).toHaveBeenCalledWith('20260722_204335_d62c16', expect.any(Function), 'tab')
+      expect(openSession).toHaveBeenCalledWith('20260722_204335_d62c16', expect.any(Function), 'tab', 'default')
     )
   })
 

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -31,7 +31,14 @@ import { $introSplash } from '@/store/intro-splash'
 import { $pinnedSessionIds } from '@/store/layout'
 import { $petActive } from '@/store/pet'
 import { $petOverlayActive } from '@/store/pet-overlay'
-import { $activeGatewayProfile, $gatewaySwapTarget, $profiles } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $gatewaySwapTarget,
+  $profiles,
+  $profileScope,
+  ALL_PROFILES,
+  normalizeProfileKey
+} from '@/store/profile'
 import {
   $contextSuggestions,
   $freshDraftReady,
@@ -40,8 +47,8 @@ import {
   $introSeed,
   $resumeExhaustedSessionId,
   $sessions,
+  findSessionForProfile,
   resolveComposerSessionKey,
-  sessionMatchesStoredId,
   sessionPinId,
   shouldMigrateComposerScope
 } from '@/store/session'
@@ -124,9 +131,15 @@ function ChatHeader({
   const sessions = useStore($sessions)
   const pinnedSessionIds = useStore($pinnedSessionIds)
   const profiles = useStore($profiles)
+  const profileScope = useStore($profileScope)
+  const activeGatewayProfile = useStore($activeGatewayProfile)
 
-  const activeStoredSession =
-    (selectedSessionId && sessions.find(session => sessionMatchesStoredId(session, selectedSessionId))) || null
+  const foregroundProfile =
+    profileScope === ALL_PROFILES ? normalizeProfileKey(activeGatewayProfile) : profileScope
+
+  const activeStoredSession = selectedSessionId
+    ? (findSessionForProfile(sessions, selectedSessionId, foregroundProfile) ?? null)
+    : null
 
   const title = activeStoredSession ? sessionTitle(activeStoredSession) : NEW_SESSION_TITLE
 

--- a/apps/desktop/src/app/chat/pane-mirror.ts
+++ b/apps/desktop/src/app/chat/pane-mirror.ts
@@ -29,6 +29,8 @@ export interface PaneMirror<T> {
   anchor?: (tile: T) => string | undefined
   /** Center docks: the strip slot (stack before this pane id). */
   before?: (tile: T) => null | string | undefined
+  /** Optional owner metadata for profile-scoped panes. */
+  profile?: (tile: T) => string | undefined
   minWidth: string
   title: (key: string) => string
   /** Custom lead NODE for the tile's tab (rendered before the label). A live,
@@ -87,6 +89,7 @@ export function paneMirror<T>(cfg: PaneMirror<T>): () => void {
             pos: cfg.dir?.(tile) ?? 'right'
           },
           minWidth: cfg.minWidth,
+          profile: cfg.profile?.(tile),
           // Every mirrored tile is a full workspace surface docked beside main —
           // and closeable, which is what keeps its tab when it lands in a zone of
           // its own (see lone-header.ts).

--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -97,7 +97,7 @@ describe('session drop targeting across stacked tabs', () => {
 
     dragTo(row, 980, 400)
 
-    expect(openSessionTile).toHaveBeenCalledWith('dragged', 'right', 'session-tile:visible', undefined)
+    expect(openSessionTile).toHaveBeenCalledWith('dragged', 'right', 'session-tile:visible', undefined, 'default')
     expect(requestComposerInsertRefs).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -193,7 +193,7 @@ export function startSessionDrag(
 
     onCommit() {
       if (split) {
-        openSessionTile(payload.id, split.pos, split.anchor, split.before)
+        openSessionTile(payload.id, split.pos, split.anchor, split.before, payload.profile)
         // A tile for this session may already exist (openSessionTile is
         // idempotent — e.g. persisted from an earlier run): a drop must never
         // feel dead, so front/unhide/un-dismiss it either way.

--- a/apps/desktop/src/app/chat/session-tile-stored-row.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-stored-row.test.ts
@@ -1,0 +1,89 @@
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+// Keep the session-tile import focused on ownership resolution. The component's
+// normal gateway/project wiring is outside this pure lookup test.
+vi.mock('@/store/gateway', () => ({
+  $gateway: atom<unknown>(null),
+  activeGateway: () => null,
+  ensureGatewayForProfile: vi.fn(async () => undefined),
+  openGatewayForProfile: vi.fn(async () => undefined)
+}))
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  setApiRequestProfile: vi.fn()
+}))
+vi.mock('@/lib/query-client', () => ({
+  invalidateProfileScopedQueries: vi.fn(),
+  queryClient: { invalidateQueries: vi.fn() }
+}))
+vi.mock('@/store/starmap', () => ({ resetStarmapGraph: vi.fn() }))
+vi.mock('@/store/session-unread-remote', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/store/session-unread-remote')
+
+  return { ...actual, watchUnreadWriteGuard: vi.fn() }
+})
+
+const { tileStoredRow } = await import('./session-tile')
+const { $sessions } = await import('@/store/session')
+const { $activeGatewayProfile, $gatewaySwapTarget, $profileScope, $showAllProfiles } = await import('@/store/profile')
+
+const row = (id: string, profile: string, title: string): SessionInfo =>
+  ({
+    archived: false,
+    cwd: null,
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 0,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    profile,
+    source: 'desktop',
+    started_at: 0,
+    title,
+    tool_call_count: 0
+  }) as SessionInfo
+
+beforeEach(() => {
+  $sessions.set([])
+  $showAllProfiles.set(false)
+  $activeGatewayProfile.set('default')
+  $gatewaySwapTarget.set(null)
+})
+
+afterEach(() => {
+  $sessions.set([])
+  $gatewaySwapTarget.set(null)
+})
+
+describe('tileStoredRow ownership', () => {
+  it('never titles a tab with a same-id row owned by another profile', () => {
+    $activeGatewayProfile.set('work')
+    $sessions.set([
+      row('same-id', 'work', 'Work chat'),
+      row('same-id', 'default', 'Default chat'),
+      row('work-only', 'work', 'Work only')
+    ])
+
+    expect($profileScope.get()).toBe('work')
+    expect(tileStoredRow('same-id')?.title).toBe('Work chat')
+    expect(tileStoredRow('work-only')?.title).toBe('Work only')
+  })
+
+  it('resolves against the pending swap target, not the settled gateway', () => {
+    $activeGatewayProfile.set('default')
+    $gatewaySwapTarget.set('work')
+    $sessions.set([row('same-id', 'work', 'Work chat'), row('same-id', 'default', 'Default chat')])
+
+    // The scope follows the pending target the moment the rail is clicked,
+    // while the gateway is still settling on default.
+    expect($profileScope.get()).toBe('work')
+    expect(tileStoredRow('same-id')?.title).toBe('Work chat')
+  })
+})

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -36,13 +36,14 @@ import type { ChatMessage } from '@/lib/chat-messages'
 import { NEW_SESSION_TITLE, sessionTitle } from '@/lib/chat-runtime'
 import { createComposerAttachmentScope, draftTitleFor } from '@/store/composer'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
-import { $activeGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, $gatewaySwapTarget, $profileScope, ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
 import { $projectTree } from '@/store/projects'
 import { sessionAwaitingInput } from '@/store/prompts'
 import {
   $gatewayState,
   $selectedStoredSessionId,
   $sessions,
+  findSessionForProfile,
   sessionMatchesStoredId,
   sessionPinId
 } from '@/store/session'
@@ -61,6 +62,7 @@ import type { SessionDragPayload } from './composer/inline-refs'
 import { type ComposerScope, ComposerScopeProvider } from './composer/scope'
 import { useComposerActions } from './hooks/use-composer-actions'
 import { paneMirror } from './pane-mirror'
+import { ProfileTag } from './profile-tag'
 import { SessionDraftTitle } from './session-draft-title'
 import { startSessionDrag } from './session-drag'
 import { SessionStatusDot } from './session-status-dot'
@@ -236,8 +238,27 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const tile = tiles.find(t => t.storedSessionId === storedSessionId)
   const runtimeId = tile?.runtimeId ?? null
   const gatewayOpen = useStore($gatewayState) === 'open'
+  const activeGatewayProfile = useStore($activeGatewayProfile)
+  const gatewaySwapTarget = useStore($gatewaySwapTarget)
+  const profileScope = useStore($profileScope)
   const resumingRef = useRef(false)
   const view = useMemo(() => buildTileView(storedSessionId), [storedSessionId])
+
+  // A stale pane can survive one render while paneMirror removes it from the
+  // shared layout tree. It must not resume its old session against the new
+  // profile's socket during that hand-off. The pending target is the foreground
+  // profile; the gateway is ready for this tile only once both agree.
+  const foregroundProfile =
+    profileScope === ALL_PROFILES
+      ? normalizeProfileKey(activeGatewayProfile)
+      : normalizeProfileKey(gatewaySwapTarget ?? profileScope)
+
+  const tileProfile = normalizeProfileKey(tile?.profile ?? foregroundProfile)
+
+  const profileReady =
+    Boolean(tile) &&
+    tileProfile === foregroundProfile &&
+    tileProfile === normalizeProfileKey(activeGatewayProfile)
 
   // A tab-strip "+"/⌘T tab is created UNLISTED — its session stays out of
   // $sessions (no sidebar clutter) until it's actually used, so the tab shows
@@ -250,9 +271,10 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const hasMessages = useStore(view.$messagesEmpty) === false
 
   useEffect(() => {
-    const alreadyListed = () => $sessions.get().some(s => sessionMatchesStoredId(s, storedSessionId))
+    const alreadyListed = () =>
+      Boolean(tile && findSessionForProfile($sessions.get(), storedSessionId, tileProfile))
 
-    if (!runtimeId || !hasMessages || alreadyListed()) {
+    if (!runtimeId || !hasMessages || !profileReady || !tile || alreadyListed()) {
       return
     }
 
@@ -284,7 +306,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
         window.clearTimeout(timer)
       }
     }
-  }, [hasMessages, runtimeId, storedSessionId])
+  }, [hasMessages, profileReady, runtimeId, storedSessionId, tile, tileProfile])
 
   // Same gating as the primary's route resume (use-route-resume): never fire
   // session.resume before the gateway is OPEN. Persisted tiles mount at boot
@@ -292,7 +314,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   // latched every restored tile into the error card.
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    if (!gatewayOpen || runtimeId || tile?.error || resumingRef.current) {
+    if (!gatewayOpen || !profileReady || !tile || runtimeId || tile.error || resumingRef.current) {
       return
     }
 
@@ -303,11 +325,32 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
     }
 
     resumingRef.current = true
+    const resumeTile = tile
+    const resumeProfile = tileProfile
+
+    const isCurrentTile = () => {
+      const current = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
+      const foreground = normalizeProfileKey($gatewaySwapTarget.get() ?? $activeGatewayProfile.get())
+
+      return (
+        current === resumeTile &&
+        foreground === resumeProfile &&
+        normalizeProfileKey($activeGatewayProfile.get()) === resumeProfile
+      )
+    }
 
     delegate
-      .resumeTile(storedSessionId)
-      .then(id => patchSessionTile(storedSessionId, { error: undefined, runtimeId: id }))
+      .resumeTile(storedSessionId, resumeProfile)
+      .then(id => {
+        if (isCurrentTile()) {
+          patchSessionTile(storedSessionId, { error: undefined, runtimeId: id })
+        }
+      })
       .catch((err: unknown) => {
+        if (!isCurrentTile()) {
+          return
+        }
+
         const message = err instanceof Error ? err.message : String(err)
 
         // A gone session (404 / "Session not found") is terminal — a stale or
@@ -322,7 +365,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
       .finally(() => {
         resumingRef.current = false
       })
-  }, [gatewayOpen, runtimeId, storedSessionId, tile?.error])
+  }, [gatewayOpen, profileReady, runtimeId, storedSessionId, tile, tile?.error, tileProfile])
 
   // The gateway (re)opening invalidates any latched error — it likely came
   // from a not-yet-open gateway or the previous connection. Clearing it
@@ -335,7 +378,11 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gatewayOpen, storedSessionId])
 
-  if (tile?.error) {
+  if (!tile) {
+    return null
+  }
+
+  if (tile.error) {
     return (
       <div className="grid h-full place-items-center p-4">
         <div className="max-w-[24rem] space-y-2 text-center font-mono text-[11px]">
@@ -370,12 +417,24 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
  *  tree. A session opened as a tab from a project group is often older than
  *  the paginated recents page, so it has no `$sessions` row at all until new
  *  activity lands it there — resolving through the tree keeps its tab titled
- *  and tinted instead of a grey "Session" placeholder. */
+ *  and tinted instead of a grey "Session" placeholder.
+ *
+ *  Ownership is part of the match: the tile list is per-profile, and during a
+ *  profile swap the shared renderer cache can still hold another profile's
+ *  rows. A tab must never be titled/tinted by a same-id row that belongs to a
+ *  different bot. */
 export function tileStoredRow(storedSessionId: string): SessionInfo | undefined {
-  const match = (s: SessionInfo) => sessionMatchesStoredId(s, storedSessionId)
+  const scope = $profileScope.get()
+  const tileOwner = $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.profile
+  const profile = normalizeProfileKey(tileOwner ?? (scope === ALL_PROFILES ? $activeGatewayProfile.get() : scope))
+
+  const match = (s: SessionInfo) =>
+    sessionMatchesStoredId(s, storedSessionId) && normalizeProfileKey(s.profile) === profile
+
+  const matchByProfile = (rows: SessionInfo[]) => findSessionForProfile(rows, storedSessionId, profile)
 
   return (
-    $sessions.get().find(match) ??
+    matchByProfile($sessions.get()) ??
     $projectTree
       .get()
       .flatMap(p => [...p.repos.flatMap(r => r.groups.flatMap(g => g.sessions)), ...(p.previewSessions ?? [])])
@@ -593,15 +652,23 @@ export const watchSessionTiles = paneMirror<SessionTile>({
   dir: t => t.dir,
   anchor: t => t.anchor,
   before: t => t.before,
+  profile: t => t.profile,
   minWidth: '20rem',
   title: tileTitle,
   // The tab's status dot — the SAME primitive the sidebar row renders, keyed by
   // the stored id, so a session's status/color can never disagree between the
   // two surfaces. Self-subscribing (live state + resolved color), so the strip
   // needn't re-sync when it changes.
-  tabLead: storedSessionId => (
-    <SessionStatusDot session={tileStoredRow(storedSessionId)} storedSessionId={storedSessionId} />
-  ),
+  tabLead: storedSessionId => {
+    const stored = tileStoredRow(storedSessionId)
+
+    return (
+      <>
+        {stored && <ProfileTag aria-hidden="true" className="mr-1" profile={stored.profile} />}
+        <SessionStatusDot session={stored} storedSessionId={storedSessionId} />
+      </>
+    )
+  },
   // Until the first turn lists a row there is no title to register, so the tab
   // takes its name from the composer instead — live, without re-registering.
   tabTitle: storedSessionId => (tileStoredRow(storedSessionId) ? null : <SessionDraftTitle scope={storedSessionId} />),

--- a/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
@@ -40,6 +40,7 @@ vi.mock('@/i18n', () => ({
 
 vi.mock('@/store/profile', () => ({
   $activeGatewayProfile: atom('default'),
+  $gatewaySwapTarget: atom(null),
   $profileColors: atom({}),
   $profileCreateRequest: atom(0),
   $profileOrder: atom([]),

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -55,6 +55,7 @@ import { $hasMultipleConnections } from '@/store/connections'
 import { notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
+  $gatewaySwapTarget,
   $profileColors,
   $profileCreateRequest,
   $profileOrder,
@@ -122,6 +123,7 @@ export function ProfileRail() {
   const profiles = useStore($profiles)
   const scope = useStore($profileScope)
   const gatewayProfile = useStore($activeGatewayProfile)
+  const gatewaySwapTarget = useStore($gatewaySwapTarget)
   const order = useStore($profileOrder)
   const colors = useStore($profileColors)
   const multipleConnections = useStore($hasMultipleConnections)
@@ -164,7 +166,10 @@ export function ProfileRail() {
   }, [condensed])
 
   const isAll = scope === ALL_PROFILES
-  const activeKey = normalizeProfileKey(gatewayProfile)
+  // The pending target is the foreground identity immediately after a click;
+  // waiting for the backend socket to finish would leave the old bot looking
+  // selected while its session list is being re-homed.
+  const activeKey = normalizeProfileKey(gatewaySwapTarget ?? gatewayProfile)
   const defaultProfile = profiles.find(profile => profile.is_default)
   const onDefault = !isAll && activeKey === 'default'
 
@@ -597,8 +602,9 @@ function ProfilePill({ active, glyph, label, onSelect }: ProfilePillProps) {
         aria-pressed={active}
         className={cn(
           'bg-transparent text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground',
-          active && 'bg-(--ui-control-active-background) text-foreground'
+          active && 'bg-(--ui-control-active-background) text-foreground ring-1 ring-inset ring-(--theme-primary)'
         )}
+        data-active-profile={active || undefined}
         onClick={onSelect}
         size="icon-xs"
         type="button"
@@ -712,6 +718,7 @@ function ProfileSquare({
                     {...listeners}
                     aria-label={label}
                     aria-pressed={active}
+                    data-active-profile={active || undefined}
                     // Hold-to-recolor rides alongside the dnd pointer listener (call
                     // it first so drag tracking still arms), then a timer opens the
                     // picker and flags the trailing click so it doesn't also select.

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { atom, computed } from 'nanostores'
 import type { CSSProperties, ReactElement, PointerEvent as ReactPointerEvent } from 'react'
 
+import { ProfileTag } from '@/app/chat/profile-tag'
 import { SessionDraftTitle } from '@/app/chat/session-draft-title'
 import { SessionStatusDot } from '@/app/chat/session-status-dot'
 import { PALETTE_AREA, type PaletteContribution, paletteToggle } from '@/app/command-palette/contrib'
@@ -58,6 +59,7 @@ import {
   SIDEBAR_DEFAULT_WIDTH,
   SIDEBAR_MAX_WIDTH
 } from '@/store/layout'
+import { $activeGatewayProfile, $profileScope, ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
 import { runExportProfileFlow, runImportProfileFlow } from '@/store/profile-share'
 import {
   $reviewOpen,
@@ -67,7 +69,13 @@ import {
   openReview,
   REVIEW_PANE_ID
 } from '@/store/review'
-import { $currentCwd, $selectedStoredSessionId, $sessions, $yoloActive, sessionMatchesStoredId } from '@/store/session'
+import {
+  $currentCwd,
+  $selectedStoredSessionId,
+  $sessions,
+  $yoloActive,
+  findSessionForProfile
+} from '@/store/session'
 import { watchSessionPins } from '@/store/session-pin-sync'
 import { watchUnreadWriteGuard } from '@/store/session-unread-remote'
 import { $statusbarVisible } from '@/store/statusbar-prefs'
@@ -130,7 +138,9 @@ const workspaceDragPayload = (): SessionDragPayload | null => {
     return null
   }
 
-  const stored = $sessions.get().find(s => sessionMatchesStoredId(s, selected))
+  const scope = $profileScope.get()
+  const profile = scope === ALL_PROFILES ? normalizeProfileKey($activeGatewayProfile.get()) : scope
+  const stored = findSessionForProfile($sessions.get(), selected, profile)
 
   return { id: selected, profile: stored?.profile ?? '', title: stored ? storedSessionTitle(stored) : '' }
 }
@@ -459,13 +469,33 @@ watchSessionPins()
 // Release unread-write guards once a list page confirms the value we wrote.
 watchUnreadWriteGuard()
 
+/** The main tab's lead glyph: the loaded session's OWNER glyph, so the top
+ *  strip carries the active bot's identity beside the status dot (strict
+ *  profile context — the ring on the rail and the glyph on the tab agree).
+ *  Null profile (fresh draft / full-page view) renders nothing. */
+function WorkspaceTabLead({ profile, visible }: { profile: null | string | undefined; visible: boolean }) {
+  if (!visible) {
+    return null
+  }
+
+  return <ProfileTag aria-hidden="true" className="mr-1" profile={profile} />
+}
+
 // The main tab reads as its SESSION (the loaded title, "New session" on a
 // fresh draft) — a stack of main + tiles is then just a row of session names.
 // register() replaces same-id in place; the render fn is the shared constant
 // above, so the pane content never remounts.
 const syncWorkspaceTitle = () => {
   const selected = $selectedStoredSessionId.get()
-  const stored = selected ? $sessions.get().find(s => sessionMatchesStoredId(s, selected)) : null
+  // The workspace tab is the primary surface of the CURRENT foreground
+  // profile. A shared-cache same-id row from another bot must never title it
+  // (strict profile context — the old profile's tabs disappear on switch).
+  const scope = $profileScope.get()
+
+  const activeProfile =
+    scope === ALL_PROFILES ? normalizeProfileKey($activeGatewayProfile.get()) : scope
+
+  const stored = selected ? findSessionForProfile($sessions.get(), selected, activeProfile) : null
 
   registry.register({
     id: 'workspace',
@@ -477,8 +507,14 @@ const syncWorkspaceTitle = () => {
       // The tab's status dot — the SAME primitive the sidebar row and session
       // tiles render, so the main tab never disagrees with its sidebar row. A
       // fresh draft has no session to key by, which IS its status: the dot
-      // resolves to `draft` and marks the tab rather than leaving a hole.
-      tabLead: () => <SessionStatusDot session={stored} storedSessionId={selected} />,
+      // resolves to `draft` and marks the tab rather than leaving a hole. The
+      // owner glyph leads it, so the active bot reads off the strip itself.
+      tabLead: () => (
+        <>
+          <WorkspaceTabLead profile={stored?.profile} visible={Boolean(stored)} />
+          <SessionStatusDot session={stored} storedSessionId={selected} />
+        </>
+      ),
       // A draft's name lives in its composer, not in any session row, so the
       // label subscribes to it directly — typing renames the tab without
       // re-registering the pane.
@@ -497,6 +533,7 @@ const syncWorkspaceTitle = () => {
 
 $selectedStoredSessionId.listen(syncWorkspaceTitle)
 $sessions.listen(syncWorkspaceTitle)
+$profileScope.listen(syncWorkspaceTitle)
 $workspaceIsPage.listen(syncWorkspaceTitle)
 
 // Layout reset collapses every session tile into main as a tab (after the

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -106,7 +106,6 @@ describe('useSessionTileDelegate resumeTile', () => {
       omit_messages: true
     })
   })
-
   it('reuses a warm binding that still carries a transcript', async () => {
     const stateA = { busy: false, messages: [{ id: 'm1' }], storedSessionId: 'stored-a' }
     const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-a', 'runtime-a']]) }
@@ -166,6 +165,26 @@ describe('useSessionTileDelegate resumeTile', () => {
     // The next resume goes cold instead of reusing the dead binding.
     const runtimeId = await sessionTileDelegate()!.resumeTile('stored-c')
     expect(runtimeId).toBe('runtime-fresh')
+  })
+
+  it('rejects a cold tile resume that lands after the foreground profile moved', async () => {
+    // The tile's owner is 'ai-engineer'. The resume RPC resolves only AFTER the
+    // foreground has already switched away (gateway settled on 'default'), so
+    // publishing the response would bind a runtime into the wrong profile.
+    setSessions([row({ id: 'stored-z', profile: 'ai-engineer' })])
+    const { $activeGatewayProfile, $gatewaySwapTarget } = await import('@/store/profile')
+
+    $activeGatewayProfile.set('default')
+    $gatewaySwapTarget.set(null)
+
+    const requestGateway = vi.fn(async (method: string) =>
+      method === 'session.resume' ? ({ session_id: 'runtime-3' } as never) : ({} as never)
+    )
+
+    renderTile(requestGateway)
+    await expect(sessionTileDelegate()!.resumeTile('stored-z', 'ai-engineer')).rejects.toThrow(
+      'profile changed during tile resume'
+    )
   })
 })
 

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 
 import { getLatestSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { toChatMessages } from '@/lib/chat-messages'
+import { $activeGatewayProfile, $gatewaySwapTarget, normalizeProfileKey } from '@/store/profile'
 import { publishSessionState, setSessionTileDelegate } from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
 
@@ -112,7 +113,7 @@ export function useSessionTileDelegate({
           }
         )
       },
-      resumeTile: async storedSessionId => {
+      resumeTile: async (storedSessionId, profileHint) => {
         const existing = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
         const cached = existing ? sessionStateByRuntimeIdRef.current.get(existing) : undefined
 
@@ -133,7 +134,7 @@ export function useSessionTileDelegate({
         // reading messages) without a profile lets the gateway fall back to the
         // launch-profile DB and fork the conversation into the wrong profile —
         // the same cross-profile bleed the recovery resumes had (#67603).
-        const profile = await resolveSessionProfile(storedSessionId)
+        const profile = profileHint ?? (await resolveSessionProfile(storedSessionId))
 
         const [prefetch, resumed] = await Promise.all([
           getLatestSessionMessages(storedSessionId, profile).catch(() => null),
@@ -149,6 +150,20 @@ export function useSessionTileDelegate({
 
         if (!runtimeId) {
           throw new Error('resume returned no session id')
+        }
+
+        // The component refuses to start a resume while the gateway is on a
+        // different profile, but the swap can still happen while these two
+        // requests are in flight. Reject before publishing the response so an
+        // old profile cannot bind a runtime or patch a same-id tile in the new
+        // foreground context.
+        if (
+          profileHint &&
+          (normalizeProfileKey($activeGatewayProfile.get()) !== normalizeProfileKey(profileHint) ||
+            normalizeProfileKey($gatewaySwapTarget.get() ?? $activeGatewayProfile.get()) !==
+              normalizeProfileKey(profileHint))
+        ) {
+          throw new Error('profile changed during tile resume')
         }
 
         updateSessionState(

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -72,7 +72,8 @@ export function openSessionIntentFromModifiers(
 export function openSession(
   storedSessionId: string,
   navigate: OpenSessionNavigate,
-  intent: OpenSessionIntent = 'in-place'
+  intent: OpenSessionIntent = 'in-place',
+  profile?: string
 ): void {
   if (!storedSessionId) {
     return
@@ -132,7 +133,11 @@ export function openSession(
       return
     }
 
-    openSessionTile(storedSessionId, 'center')
+    if (profile) {
+      openSessionTile(storedSessionId, 'center', undefined, undefined, profile)
+    } else {
+      openSessionTile(storedSessionId, 'center')
+    }
 
     return
   }

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -454,7 +454,7 @@ const DirectiveImage: FC<{ id: string; label: string }> = ({ id, label }) => {
  *  from under the chat you're reading). Lazy-imports so the composer's rich
  *  editor can pull this module in without booting the profile/REST stack. */
 export function openSessionRef(value: string) {
-  const { sessionId } = parseSessionRefValue(value)
+  const { profile, sessionId } = parseSessionRefValue(value)
 
   if (!sessionId) {
     return
@@ -462,7 +462,7 @@ export function openSessionRef(value: string) {
 
   triggerHaptic('selection')
   // navigate is unused for the `tab` intent (focus-or-tile only).
-  void import('@/app/open-session').then(({ openSession }) => openSession(sessionId, () => undefined, 'tab'))
+  void import('@/app/open-session').then(({ openSession }) => openSession(sessionId, () => undefined, 'tab', profile))
 }
 
 /** What activating a directive of a given kind does. The single source of truth

--- a/apps/desktop/src/components/assistant-ui/session-ref-open.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/session-ref-open.test.tsx
@@ -32,7 +32,7 @@ describe('session refs open the session', () => {
 
     fireEvent.click(await screen.findByTitle('work/20260101_abc123'))
 
-    await vi.waitFor(() => expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab'))
+    await vi.waitFor(() => expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab', 'work'))
   })
 
   it('opens the session from a chip in the user transcript', async () => {
@@ -43,7 +43,7 @@ describe('session refs open the session', () => {
     expect(chip.tagName).toBe('BUTTON')
     fireEvent.click(chip)
 
-    await vi.waitFor(() => expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab'))
+    await vi.waitFor(() => expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab', 'work'))
   })
 })
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
@@ -3,10 +3,11 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { registry } from '@/contrib/registry'
+import { ALL_PROFILES } from '@/store/profile'
 
 import type { GroupNode } from '../model'
 
-import { TreeGroup } from './tree-group'
+import { paneMatchesForegroundProfile, profileToActivateForPane, TreeGroup } from './tree-group'
 
 let root: null | Root = null
 let container: HTMLDivElement | null = null
@@ -54,6 +55,19 @@ afterEach(() => {
 })
 
 describe('TreeGroup', () => {
+  it('hides a pane owned by another foreground profile but keeps shared chrome', () => {
+    expect(paneMatchesForegroundProfile({ profile: 'quill' }, 'default')).toBe(false)
+    expect(paneMatchesForegroundProfile({ profile: 'default' }, 'default')).toBe(true)
+    expect(paneMatchesForegroundProfile({ placement: 'main' }, 'default')).toBe(true)
+    expect(paneMatchesForegroundProfile({ profile: 'quill' }, ALL_PROFILES)).toBe(true)
+  })
+
+  it('routes a visible All Profiles tab to its owner before activation', () => {
+    expect(profileToActivateForPane({ profile: 'quill' }, ALL_PROFILES, 'default')).toBe('quill')
+    expect(profileToActivateForPane({ profile: 'default' }, ALL_PROFILES, 'default')).toBeNull()
+    expect(profileToActivateForPane({ profile: 'quill' }, 'default', 'default')).toBeNull()
+  })
+
   it('points the docked-zone chevron in the collapse or restore action direction', () => {
     disposePane = registry.register({
       area: 'panes',

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -29,6 +29,14 @@ import { ContribBoundary, ContribRender } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
+import {
+  $activeGatewayProfile,
+  $gatewaySwapTarget,
+  $profileScope,
+  ALL_PROFILES,
+  ensureGatewayProfile,
+  normalizeProfileKey
+} from '@/store/profile'
 
 import { $layoutEditMode } from '../../edit-mode'
 import { useWindowControlsOverlap } from '../../geometry'
@@ -75,6 +83,34 @@ import { type DoubleTapContext, startPaneDrag } from './drag-session'
 import { forceLoneHeaderForPanes } from './lone-header'
 import { useActiveTabVisible } from './tab-strip-scroll'
 import { paneChrome } from './track-model'
+
+/** A pane with no owner is shared chrome; an owned pane is visible only in its
+ *  foreground profile. Kept pure so the strict profile boundary is directly
+ *  testable without mounting the whole layout tree. */
+export function paneMatchesForegroundProfile(data: unknown, profile: string): boolean {
+  const owner = (data as { profile?: unknown } | undefined)?.profile
+
+  return profile === ALL_PROFILES || typeof owner !== 'string' || normalizeProfileKey(owner) === normalizeProfileKey(profile)
+}
+
+/** In the explicit All Profiles view, selecting a session tab must route the
+ * foreground gateway to that tab's owner before the tile resumes. Concrete
+ * profile scopes never expose foreign-owned panes, so they do not route here. */
+export function profileToActivateForPane(data: unknown, scope: string, activeProfile: string): null | string {
+  if (scope !== ALL_PROFILES) {
+    return null
+  }
+
+  const owner = (data as { profile?: unknown } | undefined)?.profile
+
+  if (typeof owner !== 'string') {
+    return null
+  }
+
+  const key = normalizeProfileKey(owner)
+
+  return key === normalizeProfileKey(activeProfile) ? null : key
+}
 
 /** Right-click zone menu: the tab verbs (close this / others / to the right /
  *  all) plus the strip's own chrome toggles. Same items and icons as a session
@@ -213,6 +249,9 @@ export function TreeGroup({
 
   const hiddenPanes = useStore($hiddenTreePanes)
   const narrow = useStore($narrowViewport)
+  const activeGatewayProfile = useStore($activeGatewayProfile)
+  const gatewaySwapTarget = useStore($gatewaySwapTarget)
+  const profileScope = useStore($profileScope)
   const newSessionTabAction = useStore($newSessionTabAction)
   const panesWithCloser = useStore($panesWithCloser)
   // Multi-tab selection (⌥/Ctrl-click, Shift-click) — null for every zone but
@@ -223,6 +262,8 @@ export function TreeGroup({
   const paneEpochs = useStore($treePaneEpochs)
 
   const paneFor = (id: string) => panes.find(p => p.id === id)
+  const foregroundProfile = profileScope === ALL_PROFILES ? ALL_PROFILES : normalizeProfileKey(profileScope)
+  const currentGatewayProfile = normalizeProfileKey(gatewaySwapTarget ?? activeGatewayProfile)
 
   // Unregistered (plugin not loaded), chrome-toggled-off, and narrow-collapsed
   // panes drop out of the header; the active pane falls back to the first
@@ -230,7 +271,10 @@ export function TreeGroup({
   // Edit mode forces toggle-hidden panes visible so they can be rearranged
   // (mirrors tree-split's paneGone) — restores itself on exit.
   const paneShown = (id: string) =>
-    Boolean(paneFor(id)) && (editMode || !hiddenPanes.has(id)) && !(narrow && paneChrome(paneFor(id)).collapsible)
+    Boolean(paneFor(id)) &&
+    paneMatchesForegroundProfile(paneFor(id)?.data, foregroundProfile) &&
+    (editMode || !hiddenPanes.has(id)) &&
+    !(narrow && paneChrome(paneFor(id)).collapsible)
 
   const shown = node.panes.filter(paneShown)
   const activeId = shown.includes(node.active) ? node.active : (shown[0] ?? node.active)
@@ -516,6 +560,12 @@ export function TreeGroup({
                     // selection back to the one tab (Chrome semantics).
                     const onTap = () => {
                       clearTabSelection()
+
+                      const owner = profileToActivateForPane(paneFor(paneId)?.data, profileScope, currentGatewayProfile)
+
+                      if (owner) {
+                        void ensureGatewayProfile(owner).catch(() => undefined)
+                      }
 
                       if (node.minimized) {
                         restoreTreePane(paneId)

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -22,11 +22,15 @@ vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
 const {
   $activeGatewayProfile,
+  $gatewaySwapTarget,
+  $profileScope,
   $profiles,
+  $showAllProfiles,
   ensureGatewayProfile,
   invalidateProfileListFetches,
   prewarmProfileBackend,
-  refreshProfiles
+  refreshProfiles,
+  selectProfile
 } = await import('./profile')
 
 const { $connection } = await import('./session')
@@ -57,6 +61,8 @@ beforeEach(() => {
   openGatewayForProfile.mockClear()
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
+  $gatewaySwapTarget.set(null)
+  $showAllProfiles.set(false)
   $connection.set(localConn())
   $profiles.set([])
   vi.stubGlobal('window', { hermesDesktop: { getConnection } })
@@ -123,6 +129,44 @@ describe('profile-scoped cache invalidation', () => {
 
     expect(invalidateProfileScopedQueries).toHaveBeenCalled()
     expect(resetStarmapGraph).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('selectProfile foreground scope', () => {
+  it('rehomes the concrete profile scope before the gateway swap settles', () => {
+    getConnection.mockResolvedValue(localConn({ profile: 'work' }))
+
+    selectProfile('work')
+
+    // The renderer must stop painting the previous profile immediately. Waiting
+    // for the backend swap leaves a window where the old session tabs can still
+    // appear above the newly selected bot.
+    expect($profileScope.get()).toBe('work')
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('work')
+  })
+
+  it('rehomes the visible session tabs to the target profile synchronously', async () => {
+    const { $sessionTiles } = await import('@/store/session-states')
+
+    $sessionTiles.set([{ storedSessionId: 'default-tab' }, { storedSessionId: 'other-tab' }])
+
+    selectProfile('work')
+
+    // The previous profile's open tabs must not linger above the newly
+    // selected bot while its backend boots.
+    expect($sessionTiles.get()).toEqual([])
+  })
+
+  it('does not emit the old concrete scope while leaving All Profiles', () => {
+    $showAllProfiles.set(true)
+    const scopes: string[] = []
+    const stop = $profileScope.listen(scope => scopes.push(scope))
+
+    selectProfile('work')
+    stop()
+
+    expect(scopes).not.toContain('default')
+    expect($profileScope.get()).toBe('work')
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -486,8 +486,9 @@ $showAllProfiles.subscribe(value => persistBoolean(SHOW_ALL_PROFILES_STORAGE_KEY
 // gateway so opening/selecting a profile (which swaps the gateway) moves the
 // whole sidebar with it — a real context switch, not a separate filter to keep
 // in sync.
-export const $profileScope = computed([$showAllProfiles, $activeGatewayProfile], (showAll, gateway) =>
-  showAll ? ALL_PROFILES : normalizeProfileKey(gateway)
+export const $profileScope = computed(
+  [$showAllProfiles, $activeGatewayProfile, $gatewaySwapTarget],
+  (showAll, gateway, swapTarget) => (showAll ? ALL_PROFILES : normalizeProfileKey(swapTarget ?? gateway))
 )
 
 // Switch the active context to `name`: leave "All profiles" mode, point new
@@ -498,14 +499,21 @@ export function selectProfile(name: string): void {
   // Switching profiles (or coming back from the all-profiles browse view) starts
   // fresh; re-tapping the profile you're already in leaves your session be.
   const switching = $showAllProfiles.get() || target !== normalizeProfileKey($activeGatewayProfile.get())
-  $showAllProfiles.set(false)
   $newChatProfile.set(target)
 
   if (switching) {
+    // The foreground identity changes the moment the click lands — not when the
+    // pooled backend finishes booting. Re-home the visible session tabs now so
+    // the previous profile's conversations cannot linger above the new bot.
     requestFreshSession()
   }
 
-  void ensureGatewayProfile(target)
+  // Set the pending target before leaving All Profiles. Otherwise the computed
+  // scope briefly emits the old concrete gateway profile and can repaint its
+  // tabs for one render before the async swap begins.
+  const swap = ensureGatewayProfile(target)
+  $showAllProfiles.set(false)
+  void swap
 }
 
 // Start a fresh session in `name` WITHOUT collapsing the "All profiles" browse

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -40,7 +40,7 @@ describe('resetTileRuntimeBindings', () => {
 
     expect(invalidateRuntimeBindings).toHaveBeenCalledTimes(1)
     expect($sessionTiles.get()).toEqual([
-      { anchor: undefined, before: undefined, dir: undefined, storedSessionId: 'stored-a' }
+      { anchor: undefined, before: undefined, dir: undefined, profile: 'default', storedSessionId: 'stored-a' }
     ])
   })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -33,7 +33,14 @@ import { stableArray } from '@/lib/stable-array'
 import { readJson, writeJson } from '@/lib/storage'
 import type { SessionInfo } from '@/types/hermes'
 
-import { $activeGatewayProfile, normalizeProfileKey } from './profile'
+import {
+  $activeGatewayProfile,
+  $gatewaySwapTarget,
+  $profileScope,
+  ALL_PROFILES,
+  ensureGatewayProfile,
+  normalizeProfileKey
+} from './profile'
 import { clearAllProviderWaits, clearSessionProviderWait } from './provider-wait'
 import {
   $activeSessionId,
@@ -522,6 +529,9 @@ export type TileDock = 'center' | SplitDir
 export interface SessionTile {
   /** Stored session id — the durable identity (runtime ids are ephemeral). */
   storedSessionId: string
+  /** Owning profile. Optional only for old in-memory/test values; persisted
+   *  tiles are normalized from their profile bucket on load. */
+  profile?: string
   /** Dock against `anchor` on adoption (default right; center = stack). */
   dir?: TileDock
   /** Pane to dock against (a drop's target zone) — default the workspace.
@@ -550,12 +560,13 @@ const TILE_PANE_PREFIX = 'session-tile:'
 /** Persisted placement — `dir` + strip slot (`before`) + dock `anchor` so a
  *  restart / profile swap re-adopts tiles in the same order, not all stacked
  *  right of workspace. */
-type StoredTile = Pick<SessionTile, 'anchor' | 'before' | 'dir' | 'storedSessionId'>
+type StoredTile = Pick<SessionTile, 'anchor' | 'before' | 'dir' | 'profile' | 'storedSessionId'>
 
 const toStored = (t: SessionTile): StoredTile => ({
   anchor: t.anchor,
   before: t.before,
   dir: t.dir,
+  profile: t.profile ?? profileKey(),
   storedSessionId: t.storedSessionId
 })
 
@@ -570,6 +581,7 @@ function parseTileList(value: unknown): StoredTile[] {
             anchor: typeof raw.anchor === 'string' ? raw.anchor : undefined,
             before: typeof raw.before === 'string' || raw.before === null ? raw.before : undefined,
             dir: raw.dir,
+            profile: typeof raw.profile === 'string' ? normalizeProfileKey(raw.profile) : undefined,
             storedSessionId: raw.storedSessionId
           }
         })
@@ -585,7 +597,8 @@ function loadTilesByProfile(): Record<string, StoredTile[]> {
       const tiles = parseTileList(list)
 
       if (tiles.length > 0) {
-        byProfile[normalizeProfileKey(profile)] = tiles
+        const key = normalizeProfileKey(profile)
+        byProfile[key] = tiles.map(tile => ({ ...tile, profile: key }))
       }
     }
   }
@@ -595,7 +608,7 @@ function loadTilesByProfile(): Record<string, StoredTile[]> {
 
   if (legacy.length > 0) {
     const key = normalizeProfileKey('default')
-    byProfile[key] = [...(byProfile[key] ?? []), ...legacy]
+    byProfile[key] = [...(byProfile[key] ?? []), ...legacy.map(tile => ({ ...tile, profile: key }))]
   }
 
   writeJson(LEGACY_TILES_KEY, null)
@@ -605,16 +618,33 @@ function loadTilesByProfile(): Record<string, StoredTile[]> {
 
 const tilesByProfile = loadTilesByProfile()
 // Keyed by the GATEWAY profile: the rail's profile switch is a soft swap
-// ($activeGatewayProfile moves, no reload) — $activeProfile mirrors the
-// window's primary backend and never changes on a rail switch, so keying on
-// it left the previous profile's tiles registered (phantom "Session" tabs).
-const profileKey = () => normalizeProfileKey($activeGatewayProfile.get())
+// ($activeGatewayProfile moves, no reload). While the swap is pending, the
+// foreground target wins so the previous profile's tabs disappear immediately.
+const profileKey = () => normalizeProfileKey($gatewaySwapTarget.get() ?? $activeGatewayProfile.get())
+
+function tilesForProfile(profile: string): SessionTile[] {
+  return [...(tilesByProfile[normalizeProfileKey(profile)] ?? [])]
+}
+
+/** Visible tile set for the current profile context. All Profiles is an
+ * explicit browse mode, so it is the only scope that aggregates every owner.
+ * Bucket keys supply ownership for legacy entries that predate the per-tile
+ * profile field. */
+function tilesForScope(scope: string): SessionTile[] {
+  if (scope === ALL_PROFILES) {
+    return Object.entries(tilesByProfile).flatMap(([owner, tiles]) =>
+      tiles.map(tile => ({ ...tile, profile: normalizeProfileKey(tile.profile ?? owner) }))
+    )
+  }
+
+  return tilesForProfile(scope)
+}
 
 // Runtime ids are process-scoped — never trust a persisted one, so the live
 // atom hydrates from the stored (runtime-less) tiles for the active profile.
 // A secondary window (single-chat pop-out) shows ONLY its routed session — no
 // tiles, and no repopulation on a profile switch.
-export const $sessionTiles = atom<SessionTile[]>(isSecondaryWindow() ? [] : [...(tilesByProfile[profileKey()] ?? [])])
+export const $sessionTiles = atom<SessionTile[]>(isSecondaryWindow() ? [] : tilesForScope($profileScope.get()))
 
 function persistTiles() {
   // Shares the origin's storage; a secondary window holds no tiles, so a write
@@ -628,25 +658,46 @@ function persistTiles() {
 
 function saveTiles(tiles: SessionTile[]) {
   $sessionTiles.set(tiles)
-  const stored = tiles.map(toStored)
 
-  if (stored.length > 0) {
-    tilesByProfile[profileKey()] = stored
+  if ($profileScope.get() === ALL_PROFILES) {
+    // In the aggregate view the atom contains every bucket. Rebuild the
+    // persisted buckets from the owner carried by each tile instead of writing
+    // all profiles under whichever gateway happens to be active.
+    for (const key of Object.keys(tilesByProfile)) {
+      delete tilesByProfile[key]
+    }
+
+    for (const tile of tiles) {
+      const owner = normalizeProfileKey(tile.profile ?? $activeGatewayProfile.get())
+
+      const stored = { ...toStored({ ...tile, profile: owner }), profile: owner }
+
+      ;(tilesByProfile[owner] ??= []).push(stored)
+    }
   } else {
-    delete tilesByProfile[profileKey()]
+    const owner = profileKey()
+    const stored = tiles.map(tile => ({ ...toStored({ ...tile, profile: owner }), profile: owner }))
+
+    if (stored.length > 0) {
+      tilesByProfile[owner] = stored
+    } else {
+      delete tilesByProfile[owner]
+    }
   }
 
   persistTiles()
 }
 
 // Profile switch: surface the new profile's tiles with runtime ids cleared so
-// they re-resume against the now-current gateway. (Fires immediately on
-// subscribe; harmless — the init value already matches.) A secondary window
-// never carries tiles, so it stays out of this entirely.
+// they re-resume against the now-current gateway. Subscribe to the pending
+// target as well as the settled gateway: the profile rail changes foreground
+// context before the pooled backend finishes booting, so old tabs must leave
+// the strip in the same synchronous turn. A secondary window never carries
+// tiles, so it stays out of this entirely.
 if (!isSecondaryWindow()) {
-  $activeGatewayProfile.subscribe(() => {
-    $sessionTiles.set([...(tilesByProfile[profileKey()] ?? [])])
-  })
+  const syncTilesForForegroundProfile = () => $sessionTiles.set(tilesForScope($profileScope.get()))
+
+  $profileScope.subscribe(syncTilesForForegroundProfile)
 }
 
 export function patchSessionTile(storedSessionId: string, patch: Partial<SessionTile>) {
@@ -712,8 +763,9 @@ export interface SessionTileDelegate {
    *  right pane" bug). Bindings re-record from live post-reconnect events. */
   invalidateRuntimeBindings?(): void
   /** Bind a live runtime id for a stored session (resume without touching
-   *  the main view). Returns the runtime id, or throws. */
-  resumeTile(storedSessionId: string): Promise<string>
+   *  the main view). Returns the runtime id, or throws. An optional owner
+   *  lets the delegate reject a late response after a profile switch. */
+  resumeTile(storedSessionId: string, profile?: string): Promise<string>
   /** Submit a prompt to a tile's live session. */
   submitToSession(runtimeId: string, text: string): Promise<void>
   /** THE session-state write path — routes through the wiring cache so the
@@ -795,8 +847,37 @@ export function openSessionTile(
   storedSessionId: string,
   dir: TileDock = 'right',
   anchor?: string,
-  before?: null | string
+  before?: null | string,
+  profile?: string
 ) {
+  const targetProfile = normalizeProfileKey(profile ?? profileKey())
+
+  // A session opened from an explicit All-profiles row carries its owner. Move
+  // the foreground to that owner before creating the tile; otherwise the tile
+  // would be stored under whichever profile happened to be active and resume
+  // against the wrong backend. The profile-swap atom makes the second call
+  // synchronous from the foreground's point of view, while the backend swap
+  // itself remains async and serialized by ensureGatewayProfile().
+  if (targetProfile !== profileKey() && $profileScope.get() !== ALL_PROFILES) {
+    void ensureGatewayProfile(targetProfile)
+      .then(() => {
+        if (profileKey() === targetProfile) {
+          openSessionTile(storedSessionId, dir, anchor, before, targetProfile)
+        }
+      })
+      .catch(() => undefined)
+
+    return
+  }
+
+  if (targetProfile !== profileKey()) {
+    // All Profiles is a browse context: make the owner-tagged pane visible now,
+    // then warm the owner gateway in the background. Clicking its tab will also
+    // route through profileToActivateForPane, but a restored/dragged tab must not
+    // disappear while that route is settling.
+    void ensureGatewayProfile(targetProfile).catch(() => undefined)
+  }
+
   const tiles = $sessionTiles.get()
 
   // Opening a session in a tab/tile is "reading" it — clear its unread dot
@@ -814,7 +895,7 @@ export function openSessionTile(
   const dock = anchor ?? focusedSessionTabAnchor() ?? undefined
 
   if (!tiles.some(t => t.storedSessionId === storedSessionId)) {
-    saveTiles([...tiles, { anchor: dock, before, dir, storedSessionId }])
+    saveTiles([...tiles, { anchor: dock, before, dir, profile: targetProfile, storedSessionId }])
     // Adoption is async via the registry — order sync runs after the move path
     // below; a brand-new tile's strip slot is already in `before`.
 
@@ -959,12 +1040,31 @@ export function reuseBlankDraftTile(storedSessionId: string): boolean {
 // profile's session. The tile's placement is remembered so it returns in place.
 const closedTilesByProfile: Record<string, SessionTile[]> = {}
 const closedStack = (): SessionTile[] => (closedTilesByProfile[profileKey()] ??= [])
+const closedStackFor = (profile: string): SessionTile[] => (closedTilesByProfile[normalizeProfileKey(profile)] ??= [])
+
+function popClosedTile(): SessionTile | undefined {
+  if ($profileScope.get() === ALL_PROFILES) {
+    const stacks = Object.values(closedTilesByProfile).filter(stack => stack.length > 0)
+
+    return stacks.at(-1)?.pop()
+  }
+
+  return closedStack().pop()
+}
 
 export function closeSessionTile(storedSessionId: string) {
   const tile = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)
 
   if (tile) {
-    closedStack().push({ anchor: tile.anchor, before: tile.before, dir: tile.dir, storedSessionId })
+    const owner = normalizeProfileKey(tile.profile ?? $activeGatewayProfile.get())
+
+    closedStackFor(owner).push({
+      anchor: tile.anchor,
+      before: tile.before,
+      dir: tile.dir,
+      profile: owner,
+      storedSessionId
+    })
   }
 
   saveTiles($sessionTiles.get().filter(t => t.storedSessionId !== storedSessionId))
@@ -1001,9 +1101,7 @@ export function discardSessionTile(storedSessionId: string) {
  *  front the pane explicitly. Skips ids that are live again (reopened / now
  *  the primary). */
 export function reopenLastClosedTile(): void {
-  const stack = closedStack()
-
-  for (let tile = stack.pop(); tile; tile = stack.pop()) {
+  for (let tile = popClosedTile(); tile; tile = popClosedTile()) {
     const { storedSessionId } = tile
 
     if (storedSessionId === $selectedStoredSessionId.get()) {
@@ -1011,7 +1109,7 @@ export function reopenLastClosedTile(): void {
     }
 
     if (!$sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
-      openSessionTile(storedSessionId, tile.dir, tile.anchor, tile.before)
+      openSessionTile(storedSessionId, tile.dir, tile.anchor, tile.before, tile.profile)
       focusOpenSession(storedSessionId)
 
       return

--- a/apps/desktop/src/store/session-tile-profile-scope.test.ts
+++ b/apps/desktop/src/store/session-tile-profile-scope.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const STORAGE_KEY = 'hermes.desktop.sessionTiles.v2'
+
+const storedTile = (storedSessionId: string, profile: string) => ({
+  profile,
+  storedSessionId
+})
+
+describe('profile-scoped session tile visibility', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('restores each owner set and aggregates every owner only in explicit All Profiles', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        default: [storedTile('default-tab', 'default')],
+        work: [storedTile('work-tab', 'work')]
+      })
+    )
+
+    const profile = await import('./profile')
+    const states = await import('./session-states')
+
+    expect(states.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['default-tab'])
+
+    profile.$activeGatewayProfile.set('work')
+    expect(states.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['work-tab'])
+
+    profile.$showAllProfiles.set(true)
+    expect(states.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['default-tab', 'work-tab'])
+
+    profile.$showAllProfiles.set(false)
+    expect(states.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['work-tab'])
+  })
+
+  it('preserves the owner when a foreign All Profiles tab is closed and reopened', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        default: [storedTile('default-tab', 'default')],
+        work: [storedTile('work-tab', 'work')]
+      })
+    )
+
+    const profile = await import('./profile')
+    const states = await import('./session-states')
+
+    profile.$showAllProfiles.set(true)
+    states.closeSessionTile('work-tab')
+    states.reopenLastClosedTile()
+
+    expect(states.$sessionTiles.get().find(tile => tile.storedSessionId === 'work-tab')?.profile).toBe('work')
+  })
+})

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -27,6 +27,7 @@ import {
   _resetLegacyDiscardForTests,
   applyConfiguredDefaultProjectDir,
   commitWorkspaceCwdForSelectedSession,
+  findSessionForProfile,
   getRememberedRoute,
   getRememberedSessionId,
   mergeSessionPage,
@@ -95,6 +96,22 @@ describe('sessionPinId', () => {
     // After auto-compression the entry surfaces under a fresh tip id but keeps
     // the original root — pinning on the root keeps the pin stable.
     expect(sessionPinId(session({ id: 'tip', _lineage_root_id: 'root' }))).toBe('root')
+  })
+})
+
+describe('findSessionForProfile', () => {
+  it('does not let a same-id row from another profile win', () => {
+    const rows = [
+      session({ id: 'same-id', profile: 'work', title: 'Work chat' }),
+      session({ id: 'same-id', profile: 'default', title: 'Default chat' })
+    ]
+
+    expect(findSessionForProfile(rows, 'same-id', 'default')?.title).toBe('Default chat')
+    expect(findSessionForProfile(rows, 'same-id', 'work')?.title).toBe('Work chat')
+  })
+
+  it('treats an empty owner as the default profile', () => {
+    expect(findSessionForProfile([session({ id: 'default-id', profile: '' })], 'default-id', 'default')).toBeTruthy()
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -263,6 +263,25 @@ export const sessionMatchesStoredId = (
   storedSessionId: string
 ): boolean => session.id === storedSessionId || session._lineage_root_id === storedSessionId
 
+/**
+ * Resolve a stored session only when both its durable/lineage id and its owning
+ * profile match. The Desktop renderer can hold an all-profile cache, so an id
+ * alone is not a safe identity at this boundary.
+ */
+export function findSessionForProfile(
+  sessions: readonly SessionInfo[],
+  storedSessionId: string,
+  profile: string
+): SessionInfo | undefined {
+  const owner = profile.trim() || 'default'
+
+  return sessions.find(session => {
+    const sessionOwner = (session.profile ?? '').trim() || 'default'
+
+    return sessionOwner === owner && sessionMatchesStoredId(session, storedSessionId)
+  })
+}
+
 // Alias lookup, memoized per sessions-list reference. `lineageAliases` runs
 // per cached session state per status projection per message delta — an
 // O(sessions) scan there multiplies out to states × sessions × ~30Hz per busy


### PR DESCRIPTION
## Summary

Keep Desktop session tabs and panes scoped to the selected profile.

Session IDs can collide across profiles, so profile ownership now travels through tab titles, drag payloads, `@session:<profile>/<id>` opens, pane filtering, and resume paths. Profile switches re-home tiles synchronously, and late resume responses are discarded if the foreground profile changed.

The branch was rebuilt on current `main` while preserving the upstream review-state changes.

Verification:
- Focused UI suites: 142 passed across 11 files
- Full UI suite before the upstream-only rebase: 559 files / 5,354 tests passed
- Typecheck passed; lint reported 0 errors
- `git diff --check` passed
