### PR TITLE
fix(tui): surface auto-compaction lifecycle status in transcript

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -196,6 +196,32 @@ describe('createGatewayEventHandler', () => {
     expect(ctx.system.sys).toHaveBeenCalledWith('compressing 968 messages (~123,400 tok)…')
   })
 
+  it('prints auto-compaction lifecycle status into the transcript', () => {
+    const ctx = buildCtx([])
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({
+      payload: {
+        kind: 'compacting',
+        text: '🗜️ Compacting context — summarizing earlier conversation so I can continue...'
+      },
+      type: 'status.update'
+    } as any)
+
+    expect(ctx.system.sys).toHaveBeenCalledWith(
+      '🗜️ Compacting context — summarizing earlier conversation so I can continue...'
+    )
+
+    onEvent({
+      payload: { kind: 'compacted', text: '✓ Context compaction complete — continuing turn...' },
+      type: 'status.update'
+    } as any)
+
+    expect(ctx.system.sys).toHaveBeenCalledWith(
+      '✓ Context compaction complete — continuing turn...'
+    )
+  })
+
   it('keeps goal verdict text in transcript but shows a brief idle status (#goal statusbar)', () => {
     const appended: Msg[] = []
     const ctx = buildCtx(appended)

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -847,7 +847,13 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         setStatus(p.text)
 
-        if (p.kind === 'compressing') {
+        // Compression lifecycle states go into the transcript so the user can
+        // see compaction progress instead of a silent status-bar blip:
+        //  - "compressing"  — manual /compress progress (tui_gateway)
+        //  - "compacting"   — auto-compaction in flight (tui_gateway re-tags
+        //                     agent "lifecycle" statuses; server.py)
+        //  - "compacted"    — auto-compaction completed (conversation_compression)
+        if (p.kind === 'compressing' || p.kind === 'compacting' || p.kind === 'compacted') {
           sys(p.text)
 
           return


### PR DESCRIPTION
## Problem

Automatic context compaction progress is effectively invisible in the TUI. Compaction status lines only flash in the status bar for ~4 seconds (`restoreStatusAfter(4000)`) and never land in the transcript, so during a long compaction (often 1–5 minutes) there is no persistent signal that compaction is running, and no completion signal afterwards.

Root cause is a kind mismatch between the two compaction paths:

- **Manual** `/compress` emits `status.update` with kind `compressing` (tui_gateway/methods_session.py) — the TUI matches this and injects it into the transcript via `sys()`.
- **Automatic** compaction emits kind `compacting` — tui_gateway/server.py `_status_update` re-tags agent `lifecycle` statuses containing the `Compacting context` marker (added in 715b69172 for the desktop "Summarizing…" indicator) — and kind `compacted` (agent/conversation_compression.py `_emit_compaction_done`).

`createGatewayEventHandler` only checks `p.kind === 'compressing'`, so auto-compaction statuses fall through to the generic branch: a 4-second status-bar blip plus an activity note.

## Fix

Include all three compression lifecycle kinds in the transcript path:

```ts
if (p.kind === 'compressing' || p.kind === 'compacting' || p.kind === 'compacted') {
  sys(p.text)
  return
}
```

The backend kinds are intentionally untouched — the desktop app consumes `compacting` for its explicit "Summarizing…" indicator.

## Test

Added a test case covering `compacting` and `compacted` kinds with the real status wording. Manual `/compress` (`compressing`) behavior is unchanged and already covered by the existing test.
