### PR TITLE
fix(kanban): route protected-instruction approvals back to author (#88057)

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1005,11 +1005,212 @@ class GatewayKanbanWatchersMixin:
                             )
             except Exception as exc:
                 logger.warning("kanban notifier tick failed: %s", exc)
+            # Approval relay (#88057): deliver protected-operation prompts
+            # originated by headless kanban workers to the originating
+            # channel. Kept in this tick so the relay shares the notifier's
+            # cadence and per-board DB iteration (near-zero idle cost: the
+            # per-board probe below is a single indexed COUNT).
+            try:
+                await self._deliver_kanban_approval_relays()
+            except Exception as exc:
+                logger.warning("kanban approval relay tick failed: %s", exc)
             # Sleep with cancellation checks.
             for _ in range(int(max(1, interval))):
                 if not self._running:
                     return
                 await asyncio.sleep(1)
+
+    async def _deliver_kanban_approval_relays(self) -> None:
+        """Deliver pending kanban approval-relay requests (issue #88057).
+
+        Headless kanban workers write one-use protected-operation approval
+        requests to ``kanban_approval_relay`` (see
+        ``tools.file_tools._try_kanban_relay_approval``). This pass:
+
+        * expires relay rows nobody resolved (the worker fails closed);
+        * delivers each still-pending request ONCE to the originating
+          channel via the same button-based approval prompt the interactive
+          path uses (``send_exec_approval``, or a plain-text fallback);
+        * enqueues a matching in-process gateway approval entry under the
+          origin session key so the user's approve/deny button resolves it
+          through the existing controls; ``resolve_gateway_approval`` then
+          persists the decision back to the relay row the worker polls.
+
+        Failures are per-request: a failed send is retried on the next tick
+        (the entry is dropped so a late click cannot resolve a request that
+        never reached the user), and a request whose origin has no
+        reachable adapter is left to expire.
+        """
+        from hermes_cli import kanban_db as _kb
+        from gateway.config import Platform as _Platform
+        from tools.approval import (
+            drop_gateway_approval,
+            enqueue_gateway_approval,
+        )
+
+        delivered_set: set[str] = getattr(
+            self, "_kanban_relay_delivered", set()
+        )
+        self._kanban_relay_delivered = delivered_set
+
+        def _collect_relays() -> list[dict]:
+            """Return pending relay requests (+ origin sub) per board."""
+            relays: list[dict] = []
+            try:
+                boards = _kb.list_boards(include_archived=False)
+            except Exception:
+                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            seen_db_paths: set[str] = set()
+            for board_meta in boards:
+                slug = board_meta.get("slug") or _kb.DEFAULT_BOARD
+                db_path = board_meta.get("db_path")
+                try:
+                    resolved_db_path = (
+                        str(Path(db_path).expanduser().resolve())
+                        if db_path else str(_kb.kanban_db_path(slug).resolve())
+                    )
+                except Exception:
+                    resolved_db_path = f"slug:{slug}"
+                if resolved_db_path in seen_db_paths:
+                    continue
+                seen_db_paths.add(resolved_db_path)
+                try:
+                    conn = _kb.connect(board=slug)
+                except Exception:
+                    continue
+                try:
+                    # Cheap zero-relay early exit (idle cost near zero).
+                    if _kb.count_pending_approval_relay_requests(conn) == 0:
+                        continue
+                    for req in _kb.list_pending_approval_relay_requests(conn):
+                        sub = None
+                        for candidate in _kb.list_notify_subs(
+                            conn, task_id=req["task_id"]
+                        ):
+                            if (
+                                candidate.get("platform") == req["platform"]
+                                and candidate.get("chat_id") == req["chat_id"]
+                            ):
+                                sub = candidate
+                                break
+                        relays.append({
+                            "request": req,
+                            "sub": sub,
+                            "board": slug,
+                        })
+                except Exception:
+                    continue
+                finally:
+                    conn.close()
+            return relays
+
+        # Expire rows nobody resolved; drop their queue entries so a late
+        # button click cannot resolve a request the worker already gave up
+        # on (and prune the delivered set to still-pending ids).
+        def _expire_stale() -> None:
+            try:
+                conn = _kb.connect()
+                try:
+                    _kb.expire_approval_relay_requests(conn)
+                finally:
+                    conn.close()
+            except Exception:
+                pass
+
+        await asyncio.to_thread(_expire_stale)
+
+        relays = await asyncio.to_thread(_collect_relays)
+        pending_ids = {r["request"]["request_id"] for r in relays}
+        delivered_set.intersection_update(pending_ids)
+
+        for item in relays:
+            req = item["request"]
+            request_id = req["request_id"]
+            board_slug = item["board"]
+            sub = item["sub"]
+            if request_id in delivered_set:
+                continue
+            platform_str = (req["platform"] or "").lower()
+            try:
+                plat = _Platform(platform_str)
+            except ValueError:
+                continue
+            session_key = req["session_key"] or ""
+            if not session_key:
+                continue
+            # Route via the same authorization chokepoint the notifier uses;
+            # the subscription's profile stamp (when present) selects the
+            # owning profile's adapter.
+            sub_profile = (sub or {}).get("notifier_profile") or None
+            adapter = self._authorization_adapter(plat, sub_profile)
+            if adapter is None:
+                continue  # leave to expire; no reachable channel
+            metadata: dict[str, Any] = {}
+            if req.get("thread_id"):
+                metadata["thread_id"] = req["thread_id"]
+            elif sub and isinstance(sub.get("delivery_metadata"), dict):
+                dm = sub["delivery_metadata"]
+                if dm.get("thread_id"):
+                    metadata["thread_id"] = dm["thread_id"]
+
+            approval_data = {
+                "command": req.get("command", ""),
+                "description": req.get("description", ""),
+                "pattern_key": "protected_instruction_file",
+                "pattern_keys": ["protected_instruction_file"],
+                "allow_permanent": False,
+                "allow_session": False,
+                "relay_request_id": request_id,
+            }
+
+            # Enqueue BEFORE sending so a fast button click can always
+            # resolve the entry; on a failed send the entry is dropped below.
+            enqueue_gateway_approval(session_key, approval_data)
+            try:
+                if getattr(type(adapter), "send_exec_approval", None) is not None:
+                    result = await adapter.send_exec_approval(
+                        chat_id=req["chat_id"],
+                        command=req.get("command", ""),
+                        session_key=session_key,
+                        description=req.get("description", ""),
+                        metadata=metadata,
+                        allow_permanent=False,
+                        allow_session=False,
+                    )
+                    if getattr(result, "success", True) is False:
+                        raise RuntimeError(
+                            "send_exec_approval reported failure: "
+                            f"{getattr(result, 'error', None) or 'unknown error'}"
+                        )
+                else:
+                    msg = (
+                        "⚠️ Approval required for kanban task "
+                        f"{req['task_id']}:\n\n{req.get('command', '')}\n\n"
+                        f"{req.get('description', '')}\n\n"
+                        "Reply `/approve` to allow this one operation, or "
+                        "`/deny` to deny it."
+                    )
+                    await adapter.send(req["chat_id"], msg, metadata=metadata)
+            except Exception as exc:
+                logger.warning(
+                    "kanban approval relay: delivery failed for %s on %s/%s "
+                    "(board %s): %s",
+                    request_id, platform_str, req["chat_id"], board_slug, exc,
+                )
+                # The prompt never reached the user; drop the entry so a
+                # later click cannot resolve it, and retry next tick.
+                try:
+                    drop_gateway_approval(session_key, request_id=request_id)
+                except Exception:
+                    pass
+                continue
+            delivered_set.add(request_id)
+            logger.info(
+                "kanban approval relay: delivered %s to %s/%s for task %s "
+                "(board %s, session %s)",
+                request_id, platform_str, req["chat_id"],
+                req["task_id"], board_slug, session_key,
+            )
 
     def _kanban_advance(
         self, sub: dict, cursor: int, board: Optional[str] = None,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1524,6 +1524,38 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+
+-- Approval relay (#88057): headless kanban workers run in a separate
+-- process with no gateway approval callback, so a protected-operation
+-- gate (e.g. a write to a protected agent-instruction file) cannot
+-- prompt the authenticated origin directly. The worker writes a
+-- one-use request here; the gateway's kanban-notifier watcher delivers
+-- the prompt to the originating channel and writes the decision back.
+-- Rows are strictly one-operation: a resolved/expired row is never
+-- re-delivered and never grants anything persistent.
+CREATE TABLE IF NOT EXISTS kanban_approval_relay (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id  TEXT NOT NULL,
+    task_id     TEXT NOT NULL,
+    run_id      INTEGER,
+    session_key TEXT NOT NULL,
+    platform    TEXT NOT NULL,
+    chat_id     TEXT NOT NULL,
+    thread_id   TEXT NOT NULL DEFAULT '',
+    command     TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    status      TEXT NOT NULL DEFAULT 'pending',
+    decision    TEXT,
+    created_at  INTEGER NOT NULL,
+    expires_at  INTEGER NOT NULL,
+    resolved_at INTEGER
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_relay_request
+    ON kanban_approval_relay(request_id);
+CREATE INDEX IF NOT EXISTS idx_approval_relay_pending
+    ON kanban_approval_relay(status, expires_at);
+CREATE INDEX IF NOT EXISTS idx_approval_relay_session
+    ON kanban_approval_relay(session_key, status);
 """
 
 
@@ -2763,6 +2795,44 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "delivery_metadata", "delivery_metadata TEXT"
             )
+
+    # Approval-relay table (#88057). New table on existing boards: unlike
+    # the additive-column migrations above, ``CREATE TABLE IF NOT EXISTS``
+    # is safe to run unconditionally on every first open of a legacy DB
+    # (fresh DBs already get it from SCHEMA_SQL).
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS kanban_approval_relay (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            request_id  TEXT NOT NULL,
+            task_id     TEXT NOT NULL,
+            run_id      INTEGER,
+            session_key TEXT NOT NULL,
+            platform    TEXT NOT NULL,
+            chat_id     TEXT NOT NULL,
+            thread_id   TEXT NOT NULL DEFAULT '',
+            command     TEXT NOT NULL,
+            description TEXT NOT NULL DEFAULT '',
+            status      TEXT NOT NULL DEFAULT 'pending',
+            decision    TEXT,
+            created_at  INTEGER NOT NULL,
+            expires_at  INTEGER NOT NULL,
+            resolved_at INTEGER
+        )
+        """
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_relay_request "
+        "ON kanban_approval_relay(request_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_approval_relay_pending "
+        "ON kanban_approval_relay(status, expires_at)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_approval_relay_session "
+        "ON kanban_approval_relay(session_key, status)"
+    )
 
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.
@@ -11752,3 +11822,159 @@ def latest_summaries(
         ids,
     ).fetchall()
     return {r["task_id"]: r["summary"] for r in rows}
+
+
+# ---------------------------------------------------------------------------
+# Approval relay (issue #88057)
+# ---------------------------------------------------------------------------
+# Headless kanban workers run in a separate process with no gateway approval
+# callback, so a protected-operation gate (e.g. a write to a protected
+# agent-instruction file) cannot prompt the authenticated origin directly.
+# The worker writes a one-use request below; the gateway's kanban-notifier
+# watcher delivers the prompt to the originating channel and writes the
+# decision back via :func:`resolve_approval_relay_request`. Rows are
+# strictly one-operation: a resolved/expired row is never re-delivered and
+# never grants anything persistent.
+
+_APPROVAL_RELAY_PENDING = "pending"
+_APPROVAL_RELAY_APPROVED = "approved"
+_APPROVAL_RELAY_DENIED = "denied"
+_APPROVAL_RELAY_EXPIRED = "expired"
+_APPROVAL_RELAY_STATUSES = (
+    _APPROVAL_RELAY_PENDING,
+    _APPROVAL_RELAY_APPROVED,
+    _APPROVAL_RELAY_DENIED,
+    _APPROVAL_RELAY_EXPIRED,
+)
+
+
+def create_approval_relay_request(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    run_id: Optional[int],
+    session_key: str,
+    platform: str,
+    chat_id: str,
+    thread_id: str = "",
+    command: str,
+    description: str = "",
+    timeout_seconds: int = 300,
+) -> str:
+    """Insert a pending approval-relay request and return its request_id.
+
+    ``request_id`` is an unguessable UUID so a chat reply can never be
+    forged from board metadata; the gateway resolves by this id (plus the
+    session-key FIFO fallback), and the worker polls for the decision.
+    ``timeout_seconds`` is bounded by the caller's canonical approval
+    timeout; a request the gateway never picks up expires and the worker
+    fails closed (silence is not consent).
+    """
+    import uuid as _uuid
+
+    now = int(time.time())
+    request_id = _uuid.uuid4().hex
+    conn.execute(
+        """
+        INSERT INTO kanban_approval_relay (
+            request_id, task_id, run_id, session_key,
+            platform, chat_id, thread_id,
+            command, description, status, decision,
+            created_at, expires_at, resolved_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, NULL)
+        """,
+        (
+            request_id, task_id, run_id, session_key or "",
+            platform, chat_id, thread_id or "",
+            command, description or "", _APPROVAL_RELAY_PENDING,
+            now, now + max(int(timeout_seconds), 1),
+        ),
+    )
+    return request_id
+
+
+def get_approval_relay_request(
+    conn: sqlite3.Connection, request_id: str
+) -> Optional[dict]:
+    """Return one relay request as a dict (or None when unknown)."""
+    row = conn.execute(
+        "SELECT * FROM kanban_approval_relay WHERE request_id = ?",
+        (request_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def list_pending_approval_relay_requests(
+    conn: sqlite3.Connection, now: Optional[int] = None
+) -> list[dict]:
+    """Return unexpired pending relay requests (newest first)."""
+    now = int(time.time()) if now is None else int(now)
+    rows = conn.execute(
+        "SELECT * FROM kanban_approval_relay "
+        "WHERE status = ? AND expires_at > ? "
+        "ORDER BY id ASC",
+        (_APPROVAL_RELAY_PENDING, now),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def count_pending_approval_relay_requests(
+    conn: sqlite3.Connection, now: Optional[int] = None
+) -> int:
+    """Cheap probe for the notifier watcher's zero-relay early exit."""
+    now = int(time.time()) if now is None else int(now)
+    row = conn.execute(
+        "SELECT COUNT(*) FROM kanban_approval_relay "
+        "WHERE status = ? AND expires_at > ?",
+        (_APPROVAL_RELAY_PENDING, now),
+    ).fetchone()
+    return int(row[0]) if row else 0
+
+
+def resolve_approval_relay_request(
+    conn: sqlite3.Connection,
+    request_id: str,
+    decision: str,
+    now: Optional[int] = None,
+) -> bool:
+    """Record a gateway decision for one relay request.
+
+    One-operation semantics: ``approved`` for any granted scope (the
+    protected gate never persists a session/permanent grant, matching the
+    interactive path), ``denied`` otherwise. Returns True when the row was
+    still pending and got resolved; False when it was already resolved or
+    expired (stale/duplicate decisions are rejected, never double-counted).
+    """
+    now = int(time.time()) if now is None else int(now)
+    status = (
+        _APPROVAL_RELAY_APPROVED
+        if decision in ("once", "session", "always")
+        else _APPROVAL_RELAY_DENIED
+    )
+    cur = conn.execute(
+        "UPDATE kanban_approval_relay "
+        "SET status = ?, decision = ?, resolved_at = ? "
+        "WHERE request_id = ? AND status = ?",
+        (status, decision, now, request_id, _APPROVAL_RELAY_PENDING),
+    )
+    return cur.rowcount > 0
+
+
+def expire_approval_relay_requests(
+    conn: sqlite3.Connection, now: Optional[int] = None
+) -> int:
+    """Mark overdue pending requests as expired; returns rows touched.
+
+    The gateway watcher runs this so a request nobody resolved (worker
+    died, delivery failed, user never answered) cannot linger as pending
+    forever — it also lets the watcher clean up its in-process queue
+    entries for those requests.
+    """
+    now = int(time.time()) if now is None else int(now)
+    cur = conn.execute(
+        "UPDATE kanban_approval_relay "
+        "SET status = ?, decision = 'deny', resolved_at = ? "
+        "WHERE status = ? AND expires_at <= ?",
+        (_APPROVAL_RELAY_EXPIRED, now, _APPROVAL_RELAY_PENDING, now),
+    )
+    return cur.rowcount

--- a/tests/hermes_cli/test_kanban_approval_relay.py
+++ b/tests/hermes_cli/test_kanban_approval_relay.py
@@ -1,0 +1,195 @@
+"""Tests for the kanban approval relay (issue #88057).
+
+The relay lets a headless kanban worker route a protected-operation
+approval (e.g. a write to a protected agent-instruction file) back to the
+originating gateway channel: the worker writes a one-use request to
+``kanban_approval_relay``, the gateway's kanban-notifier watcher delivers
+the prompt, and the decision is written back for the worker to poll.
+"""
+
+import os
+import time
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    """A real kanban DB pinned via HERMES_KANBAN_DB (the env the worker
+    process inherits from the dispatcher)."""
+    db_path = tmp_path / "board.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    conn = kb.connect()
+    yield conn, db_path
+    conn.close()
+
+
+@pytest.fixture
+def task_with_origin(db, monkeypatch):
+    """A running task with an origin session + a notify subscription."""
+    conn, _ = db
+    task_id = kb.create_task(
+        conn,
+        title="Relay test",
+        body="body",
+        assignee="worker-profile",
+        session_id="session-origin-1",
+        initial_status="running",
+    )
+    kb.add_notify_sub(
+        conn,
+        task_id=task_id,
+        platform="discord",
+        chat_id="123456789",
+        thread_id="111",
+        user_id="user-1",
+        chat_type="dm",
+        delivery_mode="notify",
+    )
+    return task_id
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+class TestRelayTableLifecycle:
+    def test_create_and_read_back(self, db, task_with_origin):
+        conn, _ = db
+        request_id = kb.create_approval_relay_request(
+            conn,
+            task_id=task_with_origin,
+            run_id=7,
+            session_key="session-origin-1",
+            platform="discord",
+            chat_id="123456789",
+            thread_id="111",
+            command="<write to AGENTS.md>",
+            description="Write to protected agent-instruction file(s).",
+            timeout_seconds=300,
+        )
+        row = kb.get_approval_relay_request(conn, request_id)
+        assert row is not None
+        assert row["status"] == "pending"
+        assert row["decision"] is None
+        assert row["task_id"] == task_with_origin
+        assert row["session_key"] == "session-origin-1"
+        assert row["command"] == "<write to AGENTS.md>"
+        assert row["expires_at"] >= _now() + 299
+        assert row["resolved_at"] is None
+        # Unguessable id: two requests never collide.
+        other = kb.create_approval_relay_request(
+            conn, task_id=task_with_origin, run_id=7,
+            session_key="session-origin-1", platform="discord",
+            chat_id="123456789", command="x",
+        )
+        assert other != request_id
+
+    def test_list_pending_excludes_resolved_and_expired(self, db, task_with_origin):
+        conn, _ = db
+        rid_a = kb.create_approval_relay_request(
+            conn, task_id=task_with_origin, run_id=1,
+            session_key="s", platform="discord", chat_id="1",
+            command="a", timeout_seconds=300,
+        )
+        rid_b = kb.create_approval_relay_request(
+            conn, task_id=task_with_origin, run_id=1,
+            session_key="s", platform="discord", chat_id="1",
+            command="b", timeout_seconds=300,
+        )
+        rid_c = kb.create_approval_relay_request(
+            conn, task_id=task_with_origin, run_id=1,
+            session_key="s", platform="discord", chat_id="1",
+            command="c", timeout_seconds=300,
+        )
+        assert kb.resolve_approval_relay_request(conn, rid_b, "once")
+        now = _now()
+        # Manually expire the third one.
+        conn.execute(
+            "UPDATE kanban_approval_relay SET expires_at = ? "
+            "WHERE request_id = ?",
+            (now - 10, rid_c),
+        )
+        pending = {r["request_id"] for r in kb.list_pending_approval_relay_requests(conn)}
+        assert pending == {rid_a}
+        assert kb.count_pending_approval_relay_requests(conn) == 1
+
+    def test_resolve_one_use_and_stale_rejection(self, db, task_with_origin):
+        conn, _ = db
+        rid = kb.create_approval_relay_request(
+            conn, task_id=task_with_origin, run_id=1,
+            session_key="s", platform="discord", chat_id="1",
+            command="x",
+        )
+        # Approve once: any granted scope maps to one-operation 'approved'.
+        assert kb.resolve_approval_relay_request(conn, rid, "once") is True
+        row = kb.get_approval_relay_request(conn, rid)
+        assert row["status"] == "approved"
+        assert row["decision"] == "once"
+        assert row["resolved_at"] is not None
+        # A duplicate/stale decision must be rejected, never double-counted.
+        assert kb.resolve_approval_relay_request(conn, rid, "deny") is False
+        assert kb.get_approval_relay_request(conn, rid)["status"] == "approved"
+
+    def test_resolve_deny(self, db, task_with_origin):
+        conn, _ = db
+        rid = kb.create_approval_relay_request(
+            conn, task_id=task_with_origin, run_id=1,
+            session_key="s", platform="discord", chat_id="1",
+            command="x",
+        )
+        assert kb.resolve_approval_relay_request(conn, rid, "deny") is True
+        row = kb.get_approval_relay_request(conn, rid)
+        assert row["status"] == "denied"
+        assert row["decision"] == "deny"
+
+    def test_expire_marks_overdue_pending(self, db, task_with_origin):
+        conn, _ = db
+        rid = kb.create_approval_relay_request(
+            conn, task_id=task_with_origin, run_id=1,
+            session_key="s", platform="discord", chat_id="1",
+            command="x", timeout_seconds=1,
+        )
+        expired = kb.expire_approval_relay_requests(conn, now=_now() + 60)
+        assert expired == 1
+        row = kb.get_approval_relay_request(conn, rid)
+        assert row["status"] == "expired"
+        assert row["decision"] == "deny"
+        # Idempotent sweep.
+        assert kb.expire_approval_relay_requests(conn, now=_now() + 60) == 0
+
+    def test_unknown_request_never_resolves(self, db, task_with_origin):
+        conn, _ = db
+        assert kb.resolve_approval_relay_request(conn, "nope", "once") is False
+        assert kb.get_approval_relay_request(conn, "nope") is None
+
+
+class TestLegacyBoardMigration:
+    def test_relay_table_created_on_legacy_db(self, tmp_path, monkeypatch):
+        """A board DB that predates the relay table gains it on connect."""
+        db_path = tmp_path / "legacy.db"
+        # Build a legacy-shaped DB WITHOUT the relay table using raw sqlite3
+        # (bypassing kb.connect so the path is never marked initialized in
+        # _INITIALIZED_PATHS — otherwise the migration pass is skipped on
+        # the second open in the same process).
+        import sqlite3 as _sqlite3
+
+        raw = _sqlite3.connect(str(db_path))
+        raw.execute("CREATE TABLE kanban_board (id INTEGER PRIMARY KEY)")
+        raw.execute("CREATE TABLE kanban_tasks (id INTEGER PRIMARY KEY)")
+        raw.commit()
+        raw.close()
+        # A fresh open of the never-initialized path runs the migration
+        # pass and creates the relay table.
+        conn2 = kb.connect(db_path=db_path)
+        try:
+            rid = kb.create_approval_relay_request(
+                conn2, task_id="t", run_id=None,
+                session_key="s", platform="discord", chat_id="1",
+                command="x",
+            )
+            assert kb.get_approval_relay_request(conn2, rid) is not None
+        finally:
+            conn2.close()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2631,6 +2631,93 @@ def unregister_gateway_notify(session_key: str) -> None:
         entry.event.set()
 
 
+def enqueue_gateway_approval(session_key: str, approval_data: dict) -> object:
+    """Enqueue a pending approval entry under a session key.
+
+    Used by the kanban notifier watcher (issue #88057) to register an
+    approval request that was originated by a headless kanban worker in a
+    SEPARATE process: the worker wrote the request to the kanban relay
+    table, the watcher delivers the prompt to the originating channel, and
+    this entry lets the user's /approve or button click resolve it through
+    the exact same in-process queue the interactive path uses. The entry
+    data carries ``relay_request_id`` so :func:`resolve_gateway_approval`
+    can persist the decision back to the relay row the worker polls.
+
+    Returns the created entry (callers only need it for identity checks).
+    """
+    entry = _ApprovalEntry(dict(approval_data))
+    with _lock:
+        _gateway_queues.setdefault(session_key, []).append(entry)
+    return entry
+
+
+def drop_gateway_approval(
+    session_key: str, request_id: Optional[str] = None,
+) -> int:
+    """Remove pending approval entries for a session (no resolution).
+
+    Used by the kanban relay watcher when a delivered prompt failed to send
+    or a relay request expired: the entry must disappear so a later click
+    cannot resolve a request the worker already gave up on. When
+    ``request_id`` is given, only entries carrying that ``relay_request_id``
+    are removed; otherwise the session's whole queue is cleared. Returns the
+    number of entries removed.
+    """
+    removed = 0
+    with _lock:
+        queue = _gateway_queues.get(session_key)
+        if not queue:
+            return 0
+        if request_id:
+            kept = []
+            for entry in queue:
+                data = entry.data if isinstance(entry.data, dict) else {}
+                if data.get("relay_request_id") == request_id:
+                    removed += 1
+                else:
+                    kept.append(entry)
+            queue[:] = kept
+            if not kept:
+                _gateway_queues.pop(session_key, None)
+        else:
+            removed = len(queue)
+            _gateway_queues.pop(session_key, None)
+    return removed
+
+
+def _write_relay_decision(entry: object, choice: str) -> None:
+    """Persist a resolved gateway approval back to a kanban relay request.
+
+    Entries created by the kanban notifier watcher (issue #88057) carry
+    ``relay_request_id``; the waiting worker polls the kanban DB for the
+    decision. Best-effort: a write failure is logged, never raised into the
+    gateway's approve/deny handler (the in-process resolution already
+    happened — the worker simply fails closed when no decision lands).
+    """
+    data = entry.data if isinstance(entry.data, dict) else {}
+    request_id = data.get("relay_request_id")
+    if not request_id:
+        return
+    try:
+        from hermes_cli import kanban_db as kb
+
+        conn = kb.connect()
+        try:
+            if not kb.resolve_approval_relay_request(conn, str(request_id), choice):
+                logger.info(
+                    "kanban relay request %s already resolved; ignoring stale "
+                    "decision %s",
+                    request_id, choice,
+                )
+        finally:
+            conn.close()
+    except Exception as exc:
+        logger.warning(
+            "kanban relay decision write-back failed for %s: %s",
+            request_id, exc,
+        )
+
+
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
                              reason: Optional[str] = None,
@@ -2670,6 +2757,9 @@ def resolve_gateway_approval(session_key: str, choice: str,
         if reason:
             entry.reason = reason
         entry.event.set()
+        # Kanban relay (#88057): persist the decision to the relay row the
+        # waiting headless worker polls. No-op for ordinary entries.
+        _write_relay_decision(entry, choice)
     return len(targets)
 
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -927,11 +927,162 @@ def _request_protected_instruction_approval(
                     "Silence is not consent.")
         return blocked.format(why="was denied by the user.")
 
+    # Kanban worker relay (#88057): a dispatcher-spawned kanban worker runs
+    # in a separate process with no gateway notify_cb registered here, but
+    # the task's origin (creator session + subscribed channel) is persisted
+    # in the board DB. Route the request through the kanban approval-relay
+    # table: the gateway's kanban-notifier watcher delivers the prompt to
+    # the originating channel and writes the decision back. Any failure in
+    # the relay itself returns None so the caller keeps its normal
+    # fail-closed behavior — a relay that cannot prove a decision never
+    # turns into an implicit grant.
+    relay = _try_kanban_relay_approval(display, description)
+    if relay is not None:
+        if relay.get("approved"):
+            return None
+        return blocked.format(
+            why=relay.get(
+                "block_reason",
+                "was denied via the originating gateway channel.",
+            )
+        )
+
     # No human channel at all (script, cron, background thread): fail
     # closed. Auto-approving here would recreate the persistence vector.
     return blocked.format(
         why="requires approval but no interactive user or gateway is "
             "present to approve it.")
+
+
+def _try_kanban_relay_approval(display: str, description: str) -> dict | None:
+    """Route a protected-operation approval through the kanban relay table.
+
+    Active only inside a dispatcher-spawned kanban worker
+    (``HERMES_KANBAN_TASK`` set). Returns ``None`` when there is no
+    trusted authenticated origin to route to (or any relay error) so the
+    caller's existing fail-closed path applies; otherwise a dict with
+    ``approved: bool`` and, on a denied/expired outcome, ``block_reason``.
+
+    Edge cases covered:
+    * No task env / unknown task / task without an origin ``session_id``
+      (CLI-created, dashboard-created, imported) -> None (no authority).
+    * No notification subscription (origin never asked for lifecycle
+      delivery, or the sub was purged) -> None (no reachable channel).
+    * Worker orphaned mid-wait (task no longer running) -> deny.
+    * Timeout / expiry / duplicate or stale resolution -> deny.
+    * Any DB or adapter error -> None (fail closed, never auto-approve).
+    """
+    import os
+    import time
+
+    task_id = os.environ.get("HERMES_KANBAN_TASK", "")
+    if not task_id:
+        return None
+    try:
+        from hermes_cli import kanban_db as kb
+        from tools.approval import _get_approval_timeout
+    except Exception:
+        return None
+
+    # Mirror the canonical gateway approval timeout so a headless worker
+    # never waits longer than an interactive session would.
+    try:
+        timeout = max(int(_get_approval_timeout()), 1)
+    except Exception:
+        timeout = 300
+
+    try:
+        conn = kb.connect()
+    except Exception:
+        return None
+    try:
+        task = kb.get_task(conn, task_id)
+        if task is None:
+            return None
+        origin_session = getattr(task, "session_id", None) or ""
+        if not origin_session:
+            return None
+        subs = kb.list_notify_subs(conn, task_id=task_id)
+        if not subs:
+            return None
+        # Prefer the first subscription that carries a real delivery
+        # destination (platform + chat id); subscriptions are the gateway's
+        # trusted authenticated-provenance record for this task.
+        sub = None
+        for candidate in subs:
+            if candidate.get("platform") and candidate.get("chat_id"):
+                sub = candidate
+                break
+        if sub is None:
+            return None
+        metadata = sub.get("delivery_metadata") or {}
+        thread_id = str(sub.get("thread_id") or metadata.get("thread_id") or "")
+        request_id = kb.create_approval_relay_request(
+            conn,
+            task_id=task_id,
+            run_id=getattr(task, "current_run_id", None),
+            session_key=origin_session,
+            platform=str(sub["platform"]),
+            chat_id=str(sub["chat_id"]),
+            thread_id=thread_id,
+            command=display,
+            description=description,
+            timeout_seconds=timeout,
+        )
+    except Exception:
+        return None
+    finally:
+        conn.close()
+
+    # Poll for the gateway's decision. The wait is bounded by the same
+    # approval timeout the interactive path uses, and every poll re-checks
+    # the task is still this worker's live run so an orphaned worker cannot
+    # harvest a decision for a task that already moved on.
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return {
+                "approved": False,
+                "block_reason": "approval prompt timed out without a user "
+                    "response. Silence is not consent.",
+            }
+        try:
+            conn = kb.connect()
+            try:
+                row = kb.get_approval_relay_request(conn, request_id)
+                task = kb.get_task(conn, task_id)
+                if row is None:
+                    return None  # row vanished; fail closed
+                status = row.get("status")
+                if status == "approved":
+                    return {"approved": True}
+                if status == "denied":
+                    return {
+                        "approved": False,
+                        "block_reason": "was denied via the originating "
+                            "gateway channel.",
+                    }
+                if status == "expired":
+                    return {
+                        "approved": False,
+                        "block_reason": "approval prompt expired without a "
+                            "user response. Silence is not consent.",
+                    }
+                # Still pending: a task that is no longer this worker's live
+                # run (completed/blocked/reclaimed while we waited) must not
+                # receive a grant — the run that asked is gone.
+                if task is not None and getattr(task, "status", "running") != "running":
+                    return {
+                        "approved": False,
+                        "block_reason": "task left the running state while "
+                            "awaiting approval; the write was not granted.",
+                    }
+            finally:
+                conn.close()
+        except Exception:
+            return None
+        time.sleep(min(1.0, max(remaining, 0.1)))
 
 
 def _check_protected_instruction_write(paths: list[str],


### PR DESCRIPTION
## What Changed

Kanban workers can now return protected-instruction approval prompts to their author. Adds an approval-relay table + routing so prompts are delivered back to the originating session/author instead of being dropped.

## Verification

- `tests/hermes_cli/test_kanban_approval_relay.py` — 7 passed (relay table migration on legacy DBs, create/get flow)
- Legacy-migration test rebuilt to exercise the real never-initialized path (raw sqlite3 fixture instead of drop+reconnect, which skipped the migration via _INITIALIZED_PATHS cache)

## Closes #88057