### PR TITLE
fix(desktop): resolve the e2e Electron binary per platform and layout

### DIFF
--- a/apps/desktop/e2e/electron-binary.ts
+++ b/apps/desktop/e2e/electron-binary.ts
@@ -1,0 +1,100 @@
+/**
+ * Locating the dev Electron binary for the e2e fixtures.
+ *
+ * Kept in its own module so the resolution rules can be unit-tested without
+ * importing the Playwright runner (fixtures.ts pulls in `_electron`, the mock
+ * server and the error-banner guard).
+ *
+ * Three rules the previous single-path probe got wrong:
+ *
+ *  1. The binary is not always under the REPO ROOT. This is an npm workspaces
+ *     repo, and npm only hoists a dependency to the root when nothing conflicts
+ *     — otherwise `electron` installs into `apps/desktop/node_modules`. Both
+ *     layouts are normal, so both have to be searched, nearest package first.
+ *  2. The binary is `electron.exe` on Windows. A bare `electron` never exists
+ *     there, so the probe could only ever miss.
+ *  3. `which` is not a command on Windows. The PATH fallback spawned it
+ *     unconditionally, so on Windows the fallback failed for the wrong reason
+ *     and the error message blamed a missing `npm install`.
+ */
+
+import { spawnSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import { createRequire } from 'node:module'
+import * as path from 'node:path'
+
+/** The dist file name: `electron.exe` on Windows, `electron` elsewhere. */
+export function electronBinaryName(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? 'electron.exe' : 'electron'
+}
+
+/**
+ * Where an npm install can leave the binary, in probe order: nearest package
+ * first, so a workspace-local install wins over a stale hoisted one.
+ */
+export function electronDistCandidates(roots: string[], platform: NodeJS.Platform = process.platform): string[] {
+  return roots.map((root) => path.join(root, 'node_modules', 'electron', 'dist', electronBinaryName(platform)))
+}
+
+/** The PATH-lookup command for this platform. Windows has `where`, not `which`. */
+export function pathLookupCommand(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? 'where' : 'which'
+}
+
+/**
+ * Ask the installed `electron` package where its own binary is.
+ *
+ * Its main export IS the absolute executable path, resolved from `path.txt`
+ * and honouring `ELECTRON_OVERRIDE_DIST_PATH`, so this covers layouts and
+ * overrides a hand-built path cannot know about. Returns null when the package
+ * is not resolvable from `from`, or when it does not hand back a path (the
+ * export is the Electron API object, not a path, when required from inside
+ * Electron itself).
+ */
+export function electronPackagePath(from: string): null | string {
+  try {
+    const resolved = createRequire(path.join(from, 'package.json'))('electron') as unknown
+
+    return typeof resolved === 'string' && resolved ? resolved : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve the Electron binary, or throw with the layouts that were searched.
+ *
+ * `roots` are searched in order; pass the desktop package before the repo root.
+ */
+export function resolveElectronBinary(roots: string[]): string {
+  for (const root of roots) {
+    const declared = electronPackagePath(root)
+
+    if (declared && fs.existsSync(declared)) {
+      return declared
+    }
+  }
+
+  for (const candidate of electronDistCandidates(roots)) {
+    if (fs.existsSync(candidate)) {
+      return candidate
+    }
+  }
+
+  // Nix devshells put `electron` on PATH with no node_modules copy at all.
+  const lookup = spawnSync(pathLookupCommand(), ['electron'], { encoding: 'utf8' })
+
+  if (lookup.status === 0 && lookup.stdout.trim()) {
+    // `where` reports every match, one per line; take the first.
+    const first = lookup.stdout.trim().split(/\r?\n/)[0].trim()
+
+    if (first) {
+      return first
+    }
+  }
+
+  throw new Error(
+    `Electron binary not found. Searched ${electronDistCandidates(roots).join(', ')} and PATH. ` +
+      'Run "npm install" from the repo root to install devDependencies.',
+  )
+}

--- a/apps/desktop/e2e/electron-binary.unit.test.ts
+++ b/apps/desktop/e2e/electron-binary.unit.test.ts
@@ -1,0 +1,54 @@
+import * as path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { electronBinaryName, electronDistCandidates, pathLookupCommand } from './electron-binary'
+
+// Platform is a parameter everywhere below rather than read from
+// process.platform, so the Windows rules are pinned on the Linux CI runner too.
+// Reading the real platform would leave every Windows-only rule untested.
+
+describe('electronBinaryName', () => {
+  it('asks for electron.exe on Windows', () => {
+    expect(electronBinaryName('win32')).toBe('electron.exe')
+  })
+
+  it('asks for a bare electron everywhere else', () => {
+    expect(electronBinaryName('linux')).toBe('electron')
+    expect(electronBinaryName('darwin')).toBe('electron')
+  })
+})
+
+describe('electronDistCandidates', () => {
+  const desktop = path.join('repo', 'apps', 'desktop')
+  const repo = 'repo'
+
+  it('probes the workspace-local install before the hoisted one', () => {
+    // npm only hoists `electron` to the repo root when nothing conflicts, so
+    // apps/desktop/node_modules is an ordinary outcome of `npm install`, not a
+    // broken tree. Probing only the repo root is what makes the suite refuse to
+    // start with "run npm install" on a tree that has electron installed.
+    expect(electronDistCandidates([desktop, repo], 'linux')).toEqual([
+      path.join(desktop, 'node_modules', 'electron', 'dist', 'electron'),
+      path.join(repo, 'node_modules', 'electron', 'dist', 'electron'),
+    ])
+  })
+
+  it('carries the platform binary name into every candidate', () => {
+    // A bare `electron` file never exists in a Windows dist, so a probe built
+    // from a hardcoded name cannot match there no matter which root it walks.
+    for (const candidate of electronDistCandidates([desktop, repo], 'win32')) {
+      expect(path.basename(candidate)).toBe('electron.exe')
+    }
+  })
+})
+
+describe('pathLookupCommand', () => {
+  it('uses where on Windows and which elsewhere', () => {
+    // `which` is not a command on Windows; spawning it unconditionally made the
+    // PATH fallback fail for a reason unrelated to whether electron is on PATH.
+    expect(pathLookupCommand('win32')).toBe('where')
+    expect(pathLookupCommand('linux')).toBe('which')
+    expect(pathLookupCommand('darwin')).toBe('which')
+  })
+})

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -20,13 +20,13 @@
  * Prerequisite: `npm run build` must have been run so that `dist/` exists.
  */
 
-import { spawnSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 
 import { _electron, type ElectronApplication, type Page } from '@playwright/test'
 
+import { resolveElectronBinary } from './electron-binary'
 import { startMockServer, type MockServerOptions } from './mock-server'
 import { installErrorBannerGuard } from './test'
 
@@ -281,30 +281,18 @@ function assertDistBuilt(): void {
 
 /**
  * Find the Electron binary. In the nix devshell, `electron` is on PATH.
- * As a fallback, use the node_modules/.bin/electron from the desktop package.
+ * As a fallback, use the node_modules/electron install from either package.
  */
 export function findElectron(): string {
   // In dev mode, we use the `electron` binary directly (not the packaged app).
   // The dev:electron script in package.json does exactly this: `electron .`
   // after building. We replicate that here.
-  const localElectron = path.join(REPO_ROOT, 'node_modules', 'electron', 'dist', 'electron')
-
-  if (fs.existsSync(localElectron)) {
-    return localElectron
-  }
-
-  // Fall back to PATH
-  const result = spawnSync('which', ['electron'], {
-    encoding: 'utf8',
-  })
-
-  if (result.status === 0 && result.stdout.trim()) {
-    return result.stdout.trim()
-  }
-
-  throw new Error(
-    'Electron binary not found. Run "npm install" from the repo root to install devDependencies.',
-  )
+  //
+  // The desktop package is searched first: npm workspaces only hoist
+  // `electron` to the repo root when nothing conflicts, so a workspace-local
+  // install is just as ordinary an outcome as a hoisted one. The rules live in
+  // ./electron-binary so they can be unit-tested per platform.
+  return resolveElectronBinary([DESKTOP_ROOT, REPO_ROOT])
 }
 
 /**

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -28,6 +28,10 @@ export default defineConfig({
   /* Test files live under e2e/ so they never collide with the vitest suite
    * under src/ or the node:test files under electron/. */
   testDir: './e2e',
+  /* ...except `*.unit.test.ts`, which covers the e2e HELPERS (no Electron, no
+   * app) and is owned by the vitest `electron` project. Without this the
+   * default testMatch would claim those files too and run them twice. */
+  testIgnore: '**/*.unit.test.ts',
   /* The desktop app can take a while to bootstrap on cold CI runners — 90 s
    * per test gives us headroom without masking real hangs. */
   timeout: 90_000,

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -20,7 +20,10 @@ const electronNative: TestProjectConfiguration = {
   test: {
     name: 'electron',
     environment: 'node',
-    include: ['electron/**/*.test.ts', 'scripts/**.test.{ts,mjs}'],
+    // `e2e/**/*.unit.test.ts` is the e2e HELPERS, not the specs: plain node
+    // modules that should be provable without booting Electron. Playwright
+    // ignores the same pattern so they run in exactly one runner.
+    include: ['electron/**/*.test.ts', 'scripts/**.test.{ts,mjs}', 'e2e/**/*.unit.test.ts'],
     exclude: ['scripts/run-short-session-hang-repro.test.mjs']
   }
 }


### PR DESCRIPTION
## What does this PR do?

`findElectron()` in the desktop e2e fixtures probed exactly one path, and got three things wrong at once for anyone not on a hoisted POSIX install:

1. **It looked only under the repo root.** This is an npm workspaces repo, and npm hoists a dependency to the root only when nothing conflicts. `electron` installing into `apps/desktop/node_modules` is an ordinary outcome of `npm install`, not a broken tree.
2. **It joined a bare `electron`.** On Windows the dist file is `electron.exe`, so the probe could never match there no matter which root it walked.
3. **Its PATH fallback spawned `which`.** That is not a command on Windows, so the fallback failed for a reason unrelated to whether electron is on PATH.

The three combine into a misleading failure: the suite refuses to start with `Electron binary not found. Run "npm install" from the repo root to install devDependencies.` on a tree that **has** electron installed. That is the environment blocker reported in #88036, where the reporter had to hand-symlink `node_modules/electron` before the suite would run at all.

Resolution now asks the installed `electron` package where its own binary is. Its main export IS the absolute executable path, resolved from `path.txt` and honouring `ELECTRON_OVERRIDE_DIST_PATH`, so it covers layouts and overrides a hand-built path cannot know about:

```js
// node_modules/electron/index.js
if (process.env.ELECTRON_OVERRIDE_DIST_PATH) {
  return path.join(process.env.ELECTRON_OVERRIDE_DIST_PATH, executablePath || 'electron');
}
if (executablePath) {
  return path.join(__dirname, 'dist', executablePath);   // path.txt, e.g. "electron.exe"
}
```

Then it falls back to explicit `dist` probes per root (desktop package first, repo root second), then to PATH with the platform's lookup command, and the error now names what was searched.

**Scope note:** this is deliberately a subset of #88036. It fixes the environment blocker the issue calls out, **not** the transcript-rendering bug the issue is about, which is why the trailer is `Refs` and not `Fixes`.

## Related Issue

Refs #88036

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/e2e/electron-binary.ts` (new) — `electronBinaryName`, `electronDistCandidates`, `pathLookupCommand`, `electronPackagePath` and `resolveElectronBinary`. Kept out of `fixtures.ts` so the rules can be unit-tested without importing the Playwright runner (`fixtures.ts` pulls in `_electron`, the mock server and the error-banner guard).
- `apps/desktop/e2e/fixtures.ts` — `findElectron()` is now `resolveElectronBinary([DESKTOP_ROOT, REPO_ROOT])`; the unused `spawnSync` import goes with it. No other line in the file is touched.
- `apps/desktop/e2e/electron-binary.unit.test.ts` (new) — 5 tests. The platform is a **parameter** in every one of them rather than read from `process.platform`: reading the real platform would leave every Windows-only rule untested on the Linux CI runner, which is the same class of blind spot that let this survive.
- `apps/desktop/vitest.config.ts` — the `electron` project also includes `e2e/**/*.unit.test.ts`.
- `apps/desktop/playwright.config.ts` — `testIgnore: '**/*.unit.test.ts'`, so helper unit tests run in exactly one runner. Playwright's default `testMatch` would otherwise claim them too.

No spec files and no product code are touched.

## How to Test

1. Reproduce the old failure on a workspace-local layout. On Windows 11 against this repo:

   ```
   apps/desktop/node_modules/electron/dist/electron.exe   exists
   node_modules/electron                                   does not exist
   ```

   The old body throws `Electron binary not found. Run "npm install" ...`; the new one returns the real `electron.exe`. I verified this side by side with the old function body reproduced verbatim next to the new one:

   ```
   OLD: threw: Electron binary not found. Run "npm install" from the repo root to install devDependencies.
   NEW: ...\apps\desktop\node_modules\electron\dist\electron.exe
   ```

2. Unit tests:

   ```
   cd apps/desktop
   npx vitest run --project electron e2e/electron-binary.unit.test.ts
   ```

   5 passed.

3. Mutation check, one rule at a time, to show each test is tied to its rule:

   | Mutation | Result |
   |---|---|
   | `electronBinaryName` always returns `electron` | 2 failed, 3 passed |
   | `electronDistCandidates` reverses the probe order | 1 failed, 4 passed |
   | `pathLookupCommand` always returns `which` | 1 failed, 4 passed |

4. Type-checks: `tsc -p . --noEmit` and `tsc -p tsconfig.e2e.json --noEmit` both clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, no Python is touched; the JS equivalents are in *How to Test*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new module documents the three rules and why each one exists
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this change **is** the cross-platform impact; macOS keeps the `electron` / `which` pair it had, Linux is unchanged in behaviour except that the desktop package is probed first
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Old vs new resolution on Windows 11, run from the same tree:

```
OLD: threw: Electron binary not found. Run "npm install" from the repo root to install devDependencies.
NEW: C:\...\apps\desktop\node_modules\electron\dist\electron.exe
```
