### PR TITLE
fix(gateway): stop secondary multiplex profiles from overwriting prim…

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3025,6 +3025,10 @@ class BasePlatformAdapter(ABC):
         self._fatal_error_code: Optional[str] = None
         self._fatal_error_message: Optional[str] = None
         self._fatal_error_retryable = True
+        # The process-level runtime status is owned by the primary adapter.
+        # Multiplexed secondary adapters disable publication when configured by
+        # GatewayRunner so their lifecycle cannot overwrite the primary state.
+        self._runtime_status_publication_enabled = True
         self._fatal_error_handler: Optional[Callable[["BasePlatformAdapter"], Awaitable[None] | None]] = None
         # Strong references to shielded fatal-error handler tasks that outlive
         # their carrier task (asyncio only keeps weak refs). Without this set,
@@ -3449,6 +3453,8 @@ class BasePlatformAdapter(ABC):
         surfaces the first failure per (platform, context) at warning level and
         downgrades subsequent failures to debug.
         """
+        if not getattr(self, "_runtime_status_publication_enabled", True):
+            return
         try:
             from gateway.status import write_runtime_status
             write_runtime_status(platform=self.platform.value, **kwargs)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14897,6 +14897,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         platform: Platform,
     ) -> None:
         """Install the profile-scoped handlers shared by startup and reconnect."""
+        # Runtime status is a process-global, platform-keyed record owned by the
+        # primary adapter. Secondary transitions must not clobber that record.
+        adapter._runtime_status_publication_enabled = False
         adapter.set_message_handler(self._make_profile_message_handler(profile_name))
         adapter.set_fatal_error_handler(
             self._make_profile_fatal_error_handler(profile_name, platform)

--- a/tests/gateway/test_multiplex_runtime_status.py
+++ b/tests/gateway/test_multiplex_runtime_status.py
@@ -1,0 +1,84 @@
+"""Regression coverage for multiplex profile runtime-status ownership (#88047)."""
+
+from unittest.mock import MagicMock
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.run import GatewayRunner
+from gateway.status import read_runtime_status
+
+
+class _StatusAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True), Platform.WHATSAPP)
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: str | None = None,
+        metadata: dict | None = None,
+    ) -> SendResult:
+        raise NotImplementedError
+
+    async def get_chat_info(self, chat_id: str) -> dict:
+        return {}
+
+
+def _profile_runner() -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.session_store = object()
+    runner._busy_text_mode = "queue"
+    runner._busy_text_modes_by_profile = {}
+    runner._recover_telegram_topic_thread_id = MagicMock()
+    runner._handle_reaction_event = MagicMock()
+    runner._make_profile_message_handler = MagicMock(return_value=MagicMock())
+    runner._make_profile_fatal_error_handler = MagicMock(return_value=MagicMock())
+    runner._make_profile_busy_session_handler = MagicMock(return_value=MagicMock())
+    runner._make_adapter_auth_check = MagicMock(return_value=MagicMock())
+    runner._make_profile_platform_event_handler = MagicMock(return_value=MagicMock())
+    return runner
+
+
+def test_secondary_profile_fatal_does_not_overwrite_primary_status(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    primary = _StatusAdapter()
+    primary._mark_connected()
+
+    secondary = _StatusAdapter()
+    _profile_runner()._configure_profile_adapter(
+        secondary, "secondary", Platform.WHATSAPP
+    )
+    secondary._set_fatal_error(
+        "whatsapp_not_paired",
+        "secondary profile has no session",
+        retryable=False,
+    )
+
+    runtime = read_runtime_status()
+    assert runtime is not None
+    assert runtime["platforms"]["whatsapp"]["state"] == "connected"
+
+
+def test_single_profile_adapter_still_publishes_status(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _StatusAdapter()
+
+    adapter._mark_connected()
+    connected = read_runtime_status()
+    assert connected is not None
+    assert connected["platforms"]["whatsapp"]["state"] == "connected"
+
+    adapter._set_fatal_error("auth_failed", "bad token", retryable=False)
+    fatal = read_runtime_status()
+    assert fatal is not None
+    assert fatal["platforms"]["whatsapp"]["state"] == "fatal"
+    assert fatal["platforms"]["whatsapp"]["error_code"] == "auth_failed"


### PR DESCRIPTION
…ary runtime status

When gateway.multiplex_profiles is on, secondary-profile adapters share the process-global, platform-keyed runtime status record. A secondary adapter's fatal/disconnected transitions (e.g. WhatsApp not paired on the secondary profile) could overwrite the primary adapter's healthy 'connected' state, leaving hermes status and the dashboard reporting the wrong platform state.

Secondary adapters now disable runtime-status publication (_runtime_status_publication_enabled = False) when configured by GatewayRunner._configure_profile_adapter, so the primary adapter remains the sole owner of each platform's status record. Primary adapters default to publication enabled and are untouched.

Closes #88047

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

