### PR TITLE
fix(desktop): keep cloud bot avatar eye catchlights inside the eyes

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1051,6 +1051,22 @@ function paintMathFace(svg, t) {
     er.setAttribute('cy', eyeY)
   }
 
+  // Catchlights ride the pupils (upper-left offset) — without this they
+  // stay at the circle-face position and drift outside e.g. the cloud's
+  // lower-set eyes.
+  const hl = svg.querySelector('[data-hb-hl-l]')
+  const hr = svg.querySelector('[data-hb-hl-r]')
+
+  if (hl) {
+    hl.setAttribute('cx', eyeL - 0.6)
+    hl.setAttribute('cy', eyeY - 0.7)
+  }
+
+  if (hr) {
+    hr.setAttribute('cx', eyeR - 0.6)
+    hr.setAttribute('cy', eyeY - 0.7)
+  }
+
   if (open) {
     open.setAttribute('opacity', pose.blink ? '0' : '1')
   }
@@ -1155,6 +1171,10 @@ function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle'
   const eyeFill = isDarkColor(color) ? 'rgba(232,220,195,0.95)' : 'rgba(0,0,0,0.85)'
   const ring = sampleFaceRing(shape)
   const rest = facePose(working ? 'work' : 'idle', 0)
+  // Shape-aware initial eye line — the cloud body sits lower, so its eyes
+  // (and their catchlights) start at the cloud position instead of jumping
+  // there on the first clock paint.
+  const eyeY0 = shape === 'cloud' ? 22 : 17.2
 
   return jsxs('svg', {
     'data-bot-face': name,
@@ -1177,15 +1197,15 @@ function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle'
       jsxs('g', {
         'data-hb-open': '1',
         children: [
-          jsx('ellipse', { 'data-hb-el': '1', cx: 15.4, cy: 17.2, rx: 2.2, ry: working ? 2.6 : 2.3, fill: eyeFill }),
-          jsx('ellipse', { 'data-hb-er': '1', cx: 24.6, cy: 17.2, rx: 2.2, ry: working ? 2.6 : 2.3, fill: eyeFill }),
-          jsx('circle', { cx: 14.8, cy: 16.5, r: 0.65, fill: 'rgba(255,255,255,0.85)' }),
-          jsx('circle', { cx: 24, cy: 16.5, r: 0.65, fill: 'rgba(255,255,255,0.85)' })
+          jsx('ellipse', { 'data-hb-el': '1', cx: 15.4, cy: eyeY0, rx: 2.2, ry: working ? 2.6 : 2.3, fill: eyeFill }),
+          jsx('ellipse', { 'data-hb-er': '1', cx: 24.6, cy: eyeY0, rx: 2.2, ry: working ? 2.6 : 2.3, fill: eyeFill }),
+          jsx('circle', { 'data-hb-hl-l': '1', cx: 14.8, cy: eyeY0 - 0.7, r: 0.65, fill: 'rgba(255,255,255,0.85)' }),
+          jsx('circle', { 'data-hb-hl-r': '1', cx: 24, cy: eyeY0 - 0.7, r: 0.65, fill: 'rgba(255,255,255,0.85)' })
         ]
       }),
       jsx('path', {
         'data-hb-shut': '1',
-        d: 'M12.8 17.2 L18 17.2 M22 17.2 L27.2 17.2',
+        d: `M12.8 ${eyeY0} L18 ${eyeY0} M22 ${eyeY0} L27.2 ${eyeY0}`,
         stroke: eyeFill,
         strokeWidth: 2,
         strokeLinecap: 'round',


### PR DESCRIPTION
## Summary
Cloud-shape bot avatars on the Desktop bots create page now render their white eye catchlights inside the eyes. Root cause: the catchlights were static circles pinned at the circle-face eye line (cy 16.5) while the face clock moves the pupils to a shape-aware line (cy 22 for the cloud), so on the cloud the highlights floated above the eyes.

## Changes
- `apps/desktop/src/plugins/hermes-bots/plugin.js`:
  - Tag the two catchlight circles (`data-hb-hl-l` / `data-hb-hl-r`) and reposition them in `paintMathFace` every frame, offset upper-left of each pupil center — they now follow gaze/mood movement too.
  - Render the initial eyes, catchlights, and shut-lid strokes at the shape-aware eye line (`eyeY0`) so the first frame matches the animated frames (no jump on first clock paint).

## Validation
| | Before | After |
|---|---|---|
| Cloud avatar | catchlights at cy 15.8, ~6px above the pupils | catchlights at pupil − (0.6, 0.7), inside the eyes |
| Other shapes | unchanged (eyeY0 = 17.2, same as prior literals) | unchanged |

Single render path (`BotFace`) covers picker, create page, roster, and chat header, so the fix applies everywhere the shape avatars draw.

## Infographic

![Cloud avatar catchlights fixed](https://v3b.fal.media/files/b/0aa6a60e/fwlt7ES1MxGT5yWIaWZDQ_w46I7M5x.png)
