### PR TITLE
docs(windows): correct gateway startup troubleshooting

### DIFF
--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -180,7 +180,7 @@ What happens under the hood:
 2. If you decline the UAC prompt or Scheduled Task setup is blocked, writes a `.vbs` login item into `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup`. Windows launches it through `wscript.exe`, so no console window appears.
 3. Starts the gateway with the environment's `python.exe` under a hidden-console launcher. This gives the gateway and its console-subsystem children one invisible console instead of letting each child flash a new window.
 
-Flags used when spawning: `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`.
+Flags used when spawning: `CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`.
 
 ### Manage
 

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -176,9 +176,9 @@ hermes gateway install
 
 What happens under the hood:
 
-1. `schtasks /Create /SC ONLOGON /RL LIMITED /TN HermesGateway` — registers a task that runs at your login with standard (non-elevated) permissions. No UAC prompt.
-2. If schtasks is blocked by group policy, falls back to writing a `start /min cmd.exe /d /c <wrapper>` shortcut into `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup`. Same effect, slightly cruder.
-3. Spawns the gateway **detached via `pythonw.exe`** — not `python.exe`. `pythonw.exe` has no console attached, which immunizes it against `CTRL_C_EVENT` broadcasts from sibling processes (a real issue that used to kill the gateway when you Ctrl+C'd anything in the same process group).
+1. Registers a profile-scoped Scheduled Task that runs at login with standard (non-elevated) permissions. The default profile uses `Hermes_Gateway`; named profiles use `Hermes_Gateway_<profile>`.
+2. If you decline the UAC prompt or Scheduled Task setup is blocked, writes a `.vbs` login item into `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup`. Windows launches it through `wscript.exe`, so no console window appears.
+3. Starts the gateway with the environment's `python.exe` under a hidden-console launcher. This gives the gateway and its console-subsystem children one invisible console instead of letting each child flash a new window.
 
 Flags used when spawning: `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`.
 
@@ -297,7 +297,7 @@ You hit a shebang-script invocation that bypassed the `.cmd` shim. Hermes resolv
 Your download of `install.ps1` picked up a UTF-8 BOM. The `irm | iex` form strips BOMs automatically; `[scriptblock]::Create((irm ...))` does not. Re-run with the simple `irm | iex` form, or download the script manually and save it without a BOM via `[IO.File]::WriteAllText($path, $text, (New-Object Text.UTF8Encoding $false))`.
 
 **Gateway won't stay running after restart.**
-Check `hermes gateway status` — it merges the schtasks entry, the Startup-folder shortcut (if used), and the live PID. If schtasks is registered but not running, group policy may be blocking `ONLOGON` triggers. Run `schtasks /Query /TN HermesGateway /V /FO LIST` to see the task's failure reason, or fall back to the Startup-folder path by uninstalling and reinstalling with `HERMES_GATEWAY_FORCE_STARTUP=1`.
+Check `hermes gateway status` — it merges the Scheduled Task, the Startup-folder login item (if used), and the live PID. If the default profile's task is registered but not running, run `schtasks /Query /TN Hermes_Gateway /V /FO LIST` to see its last result; for a named profile, query `Hermes_Gateway_<profile>` instead. If local policy prevents the task from starting, run `hermes gateway uninstall`, reinstall from a non-elevated PowerShell, and answer **No** when asked whether to open the UAC prompt. The installer will use the Startup-folder fallback instead.
 
 **`/edit` still does nothing after setting `$env:EDITOR`.**
 You set it in the current process only; close and reopen the shell, or set it at User scope in System Properties → Environment Variables. Verify with `echo $env:EDITOR` in a new PowerShell window.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/windows-native.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/windows-native.md
@@ -180,7 +180,7 @@ hermes gateway install
 2. 如果你拒绝 UAC 提示或计划任务设置被阻止，则在 `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup` 中写入一个 `.vbs` 登录项。Windows 通过 `wscript.exe` 启动它，因此不会显示控制台窗口。
 3. 通过隐藏控制台启动器使用当前环境的 `python.exe` 启动 gateway。这样 gateway 及其控制台子进程会共享一个不可见的控制台，而不是让每个子进程都闪现新窗口。
 
-生成时使用的标志：`DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`。
+生成时使用的标志：`CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`。
 
 ### 管理
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/windows-native.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/windows-native.md
@@ -176,9 +176,9 @@ hermes gateway install
 
 底层发生的事情：
 
-1. `schtasks /Create /SC ONLOGON /RL LIMITED /TN HermesGateway` — 注册一个在你登录时以标准（非提升）权限运行的任务。无 UAC 提示。
-2. 如果 schtasks 被组策略阻止，则回退到在 `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup` 中写入 `start /min cmd.exe /d /c <wrapper>` 快捷方式。效果相同，稍显粗糙。
-3. 通过 **`pythonw.exe`** 以分离方式生成 gateway——而非 `python.exe`。`pythonw.exe` 没有附加控制台，可免疫来自同一进程组中兄弟进程的 `CTRL_C_EVENT` 广播（这是一个真实问题，曾导致在同一进程组中 Ctrl+C 任何进程时 gateway 被杀死）。
+1. 注册一个按 profile 区分的计划任务，以标准（非提升）权限在登录时运行。默认 profile 使用 `Hermes_Gateway`，命名 profile 使用 `Hermes_Gateway_<profile>`。
+2. 如果你拒绝 UAC 提示或计划任务设置被阻止，则在 `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup` 中写入一个 `.vbs` 登录项。Windows 通过 `wscript.exe` 启动它，因此不会显示控制台窗口。
+3. 通过隐藏控制台启动器使用当前环境的 `python.exe` 启动 gateway。这样 gateway 及其控制台子进程会共享一个不可见的控制台，而不是让每个子进程都闪现新窗口。
 
 生成时使用的标志：`DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`。
 
@@ -296,7 +296,7 @@ Remove-Item -Recurse -Force "$env:LOCALAPPDATA\hermes"
 你下载的 `install.ps1` 携带了 UTF-8 BOM。`irm | iex` 形式会自动剥离 BOM；`[scriptblock]::Create((irm ...))` 不会。请改用简单的 `irm | iex` 形式，或手动下载脚本并通过 `[IO.File]::WriteAllText($path, $text, (New-Object Text.UTF8Encoding $false))` 保存为不带 BOM 的纯 UTF-8。
 
 **重启后 gateway 无法持续运行。**
-运行 `hermes gateway status`——它会合并 schtasks 条目、Startup 文件夹快捷方式（如有）和运行中的 PID。如果 schtasks 已注册但未运行，组策略可能阻止了 `ONLOGON` 触发器。运行 `schtasks /Query /TN HermesGateway /V /FO LIST` 查看任务失败原因，或通过卸载后使用 `HERMES_GATEWAY_FORCE_STARTUP=1` 重新安装来回退到 Startup 文件夹路径。
+运行 `hermes gateway status`——它会合并计划任务、Startup 文件夹登录项（如有）和运行中的 PID。如果默认 profile 的任务已注册但未运行，请运行 `schtasks /Query /TN Hermes_Gateway /V /FO LIST` 查看其上次运行结果；命名 profile 则查询 `Hermes_Gateway_<profile>`。如果本地策略阻止任务启动，请运行 `hermes gateway uninstall`，然后在非提升权限的 PowerShell 中重新安装，并在询问是否打开 UAC 提示时回答**否**。安装程序将改用 Startup 文件夹回退路径。
 
 **设置 `$env:EDITOR` 后 `/edit` 仍然无响应。**
 你只在当前进程中设置了它；请关闭并重新打开 shell，或在系统属性 → 环境变量中以用户作用域设置。在新 PowerShell 窗口中用 `echo $env:EDITOR` 验证。


### PR DESCRIPTION
## What does this PR do?

Corrects the native Windows gateway install and troubleshooting guide so recovery steps match the current implementation. Users are no longer directed to set an unsupported environment variable or query a nonexistent Scheduled Task, and both the English and Simplified Chinese guides now describe the profile-scoped task names, VBS Startup fallback, hidden-console launcher, and actual process flags.

## Related Issue

Closes #88077

## Type of Change

- [x] Documentation update

## Changes Made

- `website/docs/user-guide/windows-native.md` - document the current Scheduled Task and Startup-folder paths, correct the launcher flags, and replace the ineffective recovery command.
- `website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/windows-native.md` - keep the Simplified Chinese guide aligned with the corrected behavior.

## How to Test

1. Compare the documented task naming, VBS fallback, launcher, and recovery path with `hermes_cli/gateway_windows.py` and `hermes_cli/_subprocess_compat.py`.
2. Confirm the changed guides no longer contain the unsupported `HERMES_GATEWAY_FORCE_STARTUP`, stale `HermesGateway`, `pythonw.exe`, cmd-wrapper, or `DETACHED_PROCESS` guidance.
3. Build the documentation site:

```bash
cd website
npm run build:fast
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this documentation fix

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] Configuration examples are not affected
- [x] Architecture and contributor workflows are not affected
- [x] I've considered cross-platform impact; this change corrects Windows-specific guidance only
- [x] Tool descriptions and schemas are not affected
