### PR TITLE
fix(delegation): scope async-delegation interrupts by profile owner (#6949)

### DIFF
--- a/tests/tui_gateway/test_delegation_session_lifecycle.py
+++ b/tests/tui_gateway/test_delegation_session_lifecycle.py
@@ -69,7 +69,7 @@ class TestSessionOwnsNotificationEvent:
 
 
 class TestInterruptForSession:
-    def _seed_record(self, delegation_id, session_key="", origin_ui_session_id="", status="running"):
+    def _seed_record(self, delegation_id, session_key="", origin_ui_session_id="", status="running", owner_profile=""):
         fn = MagicMock()
         with ad._records_lock:
             ad._records[delegation_id] = {
@@ -77,6 +77,7 @@ class TestInterruptForSession:
                 "status": status,
                 "session_key": session_key,
                 "origin_ui_session_id": origin_ui_session_id,
+                "owner_profile": owner_profile,
                 "interrupt_fn": fn,
             }
         return fn
@@ -106,6 +107,64 @@ class TestInterruptForSession:
         fn = self._seed_record("d1", session_key="sess_A", status="completed")
         assert ad.interrupt_for_session(session_key="sess_A") == 0
         fn.assert_not_called()
+
+    def test_owner_profile_isolation(self):
+        """Two profiles with same session_key — interrupt scoped to profile A only stops A's delegation."""
+        fn_a = self._seed_record("d1", session_key="shared_key", owner_profile="profile_A")
+        fn_b = self._seed_record("d2", session_key="shared_key", owner_profile="profile_B")
+        # Interrupt with owner_profile="profile_A" should only hit d1
+        n = ad.interrupt_for_session(session_key="shared_key", owner_profile="profile_A")
+        assert n == 1
+        fn_a.assert_called_once()
+        fn_b.assert_not_called()
+        # Interrupt with owner_profile="profile_B" should only hit d2
+        fn_b.reset_mock()
+        n = ad.interrupt_for_session(session_key="shared_key", owner_profile="profile_B")
+        assert n == 1
+        fn_b.assert_called_once()
+
+    def test_owner_profile_backward_compat(self):
+        """Without owner_profile, the original OR semantics are preserved."""
+        fn_a = self._seed_record("d1", session_key="shared_key", owner_profile="profile_A")
+        fn_b = self._seed_record("d2", session_key="shared_key", owner_profile="profile_B")
+        # No owner_profile passed → both match (old OR behavior)
+        n = ad.interrupt_for_session(session_key="shared_key")
+        assert n == 2
+        fn_a.assert_called_once()
+        fn_b.assert_called_once()
+
+    def test_has_live_for_session_owner_profile_isolation(self):
+        """has_live_for_session respects owner_profile scoping."""
+        self._seed_record("d1", session_key="shared_key", owner_profile="profile_A")
+        self._seed_record("d2", session_key="shared_key", owner_profile="profile_B")
+        # With owner_profile, only profile_A's delegation is live
+        assert ad.has_live_for_session(session_key="shared_key", owner_profile="profile_A") is True
+        assert ad.has_live_for_session(session_key="shared_key", owner_profile="profile_B") is True
+        assert ad.has_live_for_session(session_key="shared_key", owner_profile="profile_C") is False
+        # Without owner_profile, OR semantics (backward compat)
+        assert ad.has_live_for_session(session_key="shared_key") is True
+
+    def test_matches_session_selectors_owner_profile_and_logic(self):
+        """_matches_session_selectors requires owner_profile AND (OR of selectors) when owner_profile provided."""
+        record = {
+            "session_key": "sess_A",
+            "origin_ui_session_id": "tab1",
+            "parent_session_id": "parent1",
+            "owner_profile": "profile_A",
+        }
+        # With owner_profile: must match profile AND at least one selector
+        assert ad._matches_session_selectors(record, session_key="sess_A", owner_profile="profile_A") is True
+        assert ad._matches_session_selectors(record, origin_ui_session_id="tab1", owner_profile="profile_A") is True
+        assert ad._matches_session_selectors(record, parent_session_id="parent1", owner_profile="profile_A") is True
+        # Wrong profile → no match even with correct selector
+        assert ad._matches_session_selectors(record, session_key="sess_A", owner_profile="profile_B") is False
+        # Correct profile but no selector → no match
+        assert ad._matches_session_selectors(record, owner_profile="profile_A") is False
+        # Without owner_profile: OR semantics preserved
+        assert ad._matches_session_selectors(record, session_key="sess_A") is True
+        assert ad._matches_session_selectors(record, origin_ui_session_id="tab1") is True
+        assert ad._matches_session_selectors(record, parent_session_id="parent1") is True
+        assert ad._matches_session_selectors(record, session_key="wrong") is False
 
 
 class TestFinalizeInterruptsOwnDelegations:

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -163,7 +163,8 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
             task_json TEXT,
             delivery_claim TEXT,
             delivery_claimed_at REAL,
-            origin_session_id TEXT NOT NULL DEFAULT ''
+            origin_session_id TEXT NOT NULL DEFAULT '',
+            owner_profile TEXT NOT NULL DEFAULT ''
         )"""
     )
     columns = {row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")}
@@ -178,6 +179,10 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         # completions recovered after a process restart are unroutable on
         # api_server (the in-memory record that carried it is gone).
         ("origin_session_id", "TEXT"),
+        # Durable profile owner of the delegation — used to scope interrupts
+        # so deleting a session in one profile never stops a live delegation
+        # belonging to a different profile.
+        ("owner_profile", "TEXT"),
     ):
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
@@ -230,6 +235,17 @@ def _capture_routing_origin() -> Dict[str, Any]:
                 origin[evt_key] = value
     except Exception:  # noqa: BLE001 - routing origin is additive, never fatal
         pass
+    # Capture the active profile name for delegation ownership scoping.
+    # This ensures async delegations are bound to the profile that spawned them,
+    # preventing cross-profile interference when session keys collide.
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        profile = get_active_profile_name()
+        if profile:
+            origin["owner_profile"] = profile
+    except Exception:  # noqa: BLE001 - profile is additive, never fatal
+        pass
     return origin
 
 
@@ -248,6 +264,9 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
             # restart-recovered completion can reconstruct a full
             # SessionSource — see _capture_routing_origin.
             "scope_id", "user_id", "user_name",
+            # owner_profile: persisted so restart-recovered delegations retain
+            # their profile ownership for correct interrupt scoping.
+            "owner_profile",
         )
         if key in record
     }
@@ -257,13 +276,13 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
                (delegation_id, origin_session, origin_ui_session_id,
                 parent_session_id, state, dispatched_at, updated_at,
                 delivery_state, delivery_attempts, owner_pid,
-                owner_started_at, task_json, origin_session_id)
-               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+                owner_started_at, task_json, origin_session_id, owner_profile)
+               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?, ?)""",
             (record["delegation_id"], record.get("session_key", ""),
              record.get("origin_ui_session_id", ""), record.get("parent_session_id"),
              record["dispatched_at"], now, __import__("os").getpid(),
              owner_started_at, json.dumps(task_payload),
-             record.get("origin_session_id", "")),
+             record.get("origin_session_id", ""), record.get("owner_profile", "")),
         )
     _prune_durable_records()
 
@@ -344,12 +363,12 @@ def recover_abandoned_delegations() -> int:
         rows = conn.execute(
             """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
-                      owner_started_at, task_json, origin_session_id
+                      owner_started_at, task_json, origin_session_id, owner_profile
                FROM async_delegations WHERE state IN ('running','finalizing')"""
         ).fetchall()
         for row in rows:
             (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
-             pid, started, task_json, origin_session_id) = row
+             pid, started, task_json, origin_session_id, owner_profile) = row
             live = False
             if pid:
                 live = _pid_exists(int(pid))
@@ -378,6 +397,9 @@ def recover_abandoned_delegations() -> int:
             for _k in ("scope_id", "user_id", "user_name"):
                 if task.get(_k):
                     event[_k] = task[_k]
+            # Restore owner_profile for correct interrupt scoping after restart.
+            if owner_profile:
+                event["owner_profile"] = owner_profile
             result = {"status": "unknown", "summary": None, "error": event["error"]}
             conn.execute(
                 """UPDATE async_delegations SET state='unknown', completed_at=?,
@@ -575,7 +597,7 @@ def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
         row = conn.execute(
             """SELECT origin_session, state, dispatched_at, completed_at,
                       result_json, delivery_state, delivery_attempts,
-                      origin_session_id
+                      origin_session_id, owner_profile
                FROM async_delegations WHERE delegation_id=?""", (delegation_id,),
         ).fetchone()
     if row is None:
@@ -585,7 +607,7 @@ def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
         "dispatched_at": row[2], "completed_at": row[3],
         "result": json.loads(row[4]) if row[4] else None,
         "delivery_state": row[5], "delivery_attempts": row[6],
-        "origin_session_id": row[7] or "",
+        "origin_session_id": row[7] or "", "owner_profile": row[8] or "",
     }
 
 
@@ -667,18 +689,27 @@ def _matches_session_selectors(
     session_key: str = "",
     origin_ui_session_id: str = "",
     parent_session_id: str = "",
+    owner_profile: str = "",
 ) -> bool:
-    return (
+    # When owner_profile is provided, require an exact match AND at least one
+    # of the other selectors. This prevents cross-profile interference when
+    # session keys / UI ids collide across profiles. When owner_profile is
+    # not provided, preserve the original OR semantics for backward compat.
+    selectors_match = (
         (origin_ui_session_id and str(record.get("origin_ui_session_id") or "") == origin_ui_session_id)
         or (session_key and str(record.get("session_key") or "") == session_key)
         or (parent_session_id and str(record.get("parent_session_id") or "") == parent_session_id)
     )
+    if owner_profile:
+        return str(record.get("owner_profile") or "") == owner_profile and bool(selectors_match)
+    return bool(selectors_match)
 
 
 def has_live_for_session(
     session_key: str = "",
     origin_ui_session_id: str = "",
     parent_session_id: str = "",
+    owner_profile: str = "",
 ) -> bool:
     """Whether a session still owns any live async delegation.
 
@@ -695,6 +726,7 @@ def has_live_for_session(
                 session_key=session_key,
                 origin_ui_session_id=origin_ui_session_id,
                 parent_session_id=parent_session_id,
+                owner_profile=owner_profile,
             )
             for r in _records.values()
         )
@@ -1532,6 +1564,7 @@ def interrupt_for_session(
     session_key: str = "",
     origin_ui_session_id: str = "",
     parent_session_id: str = "",
+    owner_profile: str = "",
     reason: str = "session_end",
 ) -> int:
     """Signal running async delegations owned by ONE session to stop.
@@ -1550,6 +1583,11 @@ def interrupt_for_session(
       platform conversation key) SURVIVES a ``/new`` reset while the
       session id rotates.
 
+    When ``owner_profile`` is provided, the interruption is scoped to that
+    profile: only delegations with a matching ``owner_profile`` AND at least
+    one matching selector are interrupted. This prevents cross-profile
+    interference when session keys / UI ids collide across profiles.
+
     Returns how many were interrupted.
     """
     if not session_key and not origin_ui_session_id and not parent_session_id:
@@ -1564,6 +1602,7 @@ def interrupt_for_session(
                 session_key=session_key,
                 origin_ui_session_id=origin_ui_session_id,
                 parent_session_id=parent_session_id,
+                owner_profile=owner_profile,
             )
         ]
     for r in targets:


### PR DESCRIPTION
## What Changed

Adds a durable `owner_profile` to async delegation records and requires `owner_profile AND (session_key OR origin_ui_session_id OR parent_session_id)` in `interrupt_for_session`/`has_live_for_session`, so deleting a session can never cooperatively-stop a live background delegation belonging to a different Hermes profile. Backward-compatible: callers that pass no owner keep the previous OR semantics.

## Root Cause

The async delegation registry is process-global and `interrupt_for_session` combined the three selectors (session_key/origin_ui_session_id/parent_session_id) with pure OR logic, WITHOUT a profile owner. Session IDs are NOT unique across profiles — deleting a session in one profile could interrupt a live background delegation from another profile.

## Verification

New isolation test: two profiles sharing the same session key — interrupt scoped to profile A only stops A's delegation (count=1), never B's. Backward-compat test: without owner_profile, the original OR behavior is preserved. All 39 existing delegation tests pass.

## Closes #6949