### PR TITLE
fix(cli): stop Shift+Space from inserting raw CSI bytes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -70,6 +70,7 @@ from prompt_toolkit.widgets import TextArea
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit import print_formatted_text as _pt_print
 from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
+from hermes_cli.pt_input_extras import bind_terminal_sequence_handlers
 try:
     from prompt_toolkit.cursor_shapes import CursorShape
     _STEADY_CURSOR = CursorShape.BLOCK  # Non-blinking block cursor
@@ -16709,32 +16710,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         _multiline_shortcuts_enabled = _cli_multiline_shortcuts_enabled(self.config or CLI_CONFIG)
 
-        from prompt_toolkit.keys import Keys as _IgnoreKeys
-
-        @kb.add(_IgnoreKeys.Ignore, eager=True)
-        def handle_ignored_terminal_sequence(event):
-            """Consume parser-level ignored terminal sequences before self-insert.
-
-            install_ignored_terminal_sequences() in hermes_cli.pt_input_extras
-            registers focus reports (CSI I / CSI O) as Keys.Ignore at the
-            VT100 parser level. Without this no-op binding the default
-            self-insert path would still fire and the bytes would land in
-            the buffer.
-
-            Focus-in (CSI I) additionally schedules a rate-limited full
-            repaint: while the tab/window was hidden the emulator may have
-            coalesced output or repainted the surface, so prompt_toolkit's
-            incremental diff would stack a fresh copy of the prompt chrome
-            on top of the stale one (#60920 focus-regain variant, #25337).
-            """
-            try:
-                for press in getattr(event, "key_sequence", None) or ():
-                    if getattr(press, "data", None) == "\x1b[I":
-                        self._schedule_focus_regain_redraw()
-                        break
-            except Exception:
-                pass
-            return None
+        # Consume parser-level terminal controls before self-insert. Focus-in
+        # additionally schedules a rate-limited repaint; Shift+Space is
+        # normalized to one plain space instead of its raw CSI payload.
+        bind_terminal_sequence_handlers(
+            kb,
+            on_focus_in=self._schedule_focus_regain_redraw,
+        )
 
         def handle_enter(event):
             """Handle Enter key - submit input.

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -413,6 +413,7 @@ def bind_terminal_sequence_handlers(kb, *, on_focus_in=None) -> None:
     reports without coupling this parser helper to ``HermesCLI``.
     """
     try:
+        from prompt_toolkit.key_binding.key_processor import KeyPress
         from prompt_toolkit.keys import Keys
     except Exception:
         return
@@ -424,7 +425,10 @@ def bind_terminal_sequence_handlers(kb, *, on_focus_in=None) -> None:
             for press in (getattr(event, "key_sequence", None) or ())
         }
         if payloads & _SHIFT_SPACE_SEQUENCES:
-            event.current_buffer.insert_text(" ")
+            # Re-feed a canonical keypress instead of mutating the buffer so
+            # active ``space`` bindings (for example clarify multi-select)
+            # retain their normal semantics. ``first`` preserves input order.
+            event.app.key_processor.feed(KeyPress(" ", " "), first=True)
         elif on_focus_in is not None and "\x1b[I" in payloads:
             try:
                 on_focus_in()

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -12,6 +12,12 @@ can be unit-tested without importing the whole CLI runtime.
 from __future__ import annotations
 
 
+_SHIFT_SPACE_SEQUENCES = frozenset({
+    "\x1b[27;2;32~",  # xterm modifyOtherKeys
+    "\x1b[32;2u",     # Kitty CSI-u
+})
+
+
 def _clear_vt100_prefix_cache() -> None:
     """Drop prompt_toolkit's memoized "is this a prefix of a longer match?"
     answers after mutating ``ANSI_SEQUENCES``.
@@ -187,7 +193,8 @@ def install_modify_other_keys_aliases() -> int:
       newline tuple; Shift+Tab → ``BackTab``; Ctrl+Tab → plain Tab;
       Ctrl/Alt+Backspace → ``(Escape, ControlH)`` (backward-kill-word,
       matching the Ink TUI and Desktop, #78285); Shift+Backspace → plain
-      backspace; Shift+Space → a plain space (#86866); Alt+Space →
+      backspace; Shift+Space → ``Keys.Ignore`` for canonical-space insertion
+      by ``bind_terminal_sequence_handlers`` (#86866, #88071); Alt+Space →
       ``(Escape, " ")``.
     * **Kitty functional keys** (Private Use Area codepoints): keypad keys
       → their non-keypad equivalents (KP_ENTER → Enter, KP_4 → '4',
@@ -332,7 +339,11 @@ def install_modify_other_keys_aliases() -> int:
     _install_paired(2, {
         9: Keys.BackTab,        # Shift+Tab — same as the legacy ESC[Z
         127: Keys.ControlH,     # Shift+Backspace — plain backspace
-        32: " ",                # Shift+Space — still a space (#86866)
+        # A literal " " key is unsafe here: Vt100Parser keeps the raw CSI
+        # bytes in KeyPress.data and prompt_toolkit's self-insert binding
+        # inserts that data. Route through a non-character key instead; the
+        # CLI binding below inserts exactly one canonical space (#88071).
+        32: Keys.Ignore,
     })
     _install_paired(3, {
         13: (Keys.Escape, Keys.ControlM),   # Alt+Enter — newline tuple
@@ -388,6 +399,37 @@ def install_modify_other_keys_aliases() -> int:
 
     return changed
 
+
+def bind_terminal_sequence_handlers(kb, *, on_focus_in=None) -> None:
+    """Bind parser-level terminal controls that need application behavior.
+
+    ``Keys.Ignore`` consumes terminal noise by default. Shift+Space is also
+    mapped to it because mapping an extended sequence directly to ``" "``
+    makes prompt_toolkit's self-insert handler insert the raw CSI payload.
+    Recognized Shift+Space payloads are normalized here to one plain space;
+    every other ignored sequence remains a no-op.
+
+    ``on_focus_in`` preserves the classic CLI's repaint hook for focus-in
+    reports without coupling this parser helper to ``HermesCLI``.
+    """
+    try:
+        from prompt_toolkit.keys import Keys
+    except Exception:
+        return
+
+    @kb.add(Keys.Ignore, eager=True)
+    def handle_terminal_sequence(event):
+        payloads = {
+            getattr(press, "data", None)
+            for press in (getattr(event, "key_sequence", None) or ())
+        }
+        if payloads & _SHIFT_SPACE_SEQUENCES:
+            event.current_buffer.insert_text(" ")
+        elif on_focus_in is not None and "\x1b[I" in payloads:
+            try:
+                on_focus_in()
+            except Exception:
+                pass
 
 def install_ignored_terminal_sequences() -> int:
     """Map terminal-emitted noise sequences to ``Keys.Ignore`` so they

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -15,13 +15,23 @@ the raw byte would.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
+from prompt_toolkit import Application
+from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.input.vt100_parser import Vt100Parser
 from prompt_toolkit.keys import Keys
+from prompt_toolkit.layout import BufferControl, HSplit, Layout, Window
+from prompt_toolkit.output import DummyOutput
 
-from hermes_cli.pt_input_extras import install_modify_other_keys_aliases
+from hermes_cli.pt_input_extras import (
+    bind_terminal_sequence_handlers,
+    install_modify_other_keys_aliases,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -361,9 +371,38 @@ def test_shift_backspace_is_plain_backspace():
 
 
 def test_shift_space_inserts_space():
-    """Shift+Space must insert a space, not leak escape text (#86866)."""
-    assert _parse("\x1b[32;2u") == [" "]
-    assert _parse("\x1b[27;2;32~") == [" "]
+    """Shift+Space must bypass prompt_toolkit's raw-data self-insert path."""
+    assert _parse("\x1b[32;2u") == [Keys.Ignore]
+    assert _parse("\x1b[27;2;32~") == [Keys.Ignore]
+
+
+@pytest.mark.parametrize("sequence", ["\x1b[32;2u", "\x1b[27;2;32~"])
+def test_shift_space_inserts_canonical_space_in_buffer(sequence):
+    """Exercise the real parser → key binding → Buffer path from #88071."""
+    async def run_probe():
+        buffer = Buffer()
+        with create_pipe_input() as pipe_input:
+            from prompt_toolkit.key_binding import KeyBindings
+
+            bindings = KeyBindings()
+            bind_terminal_sequence_handlers(bindings)
+            app = Application(
+                input=pipe_input,
+                output=DummyOutput(),
+                layout=Layout(HSplit([Window(BufferControl(buffer))])),
+                key_bindings=bindings,
+            )
+            run_task = asyncio.create_task(app.run_async())
+            pipe_input.send_text(f"ab{sequence}cd")
+            for _ in range(100):
+                if buffer.text.endswith("cd"):
+                    break
+                await asyncio.sleep(0.01)
+            app.exit()
+            await run_task
+        return buffer.text
+
+    assert asyncio.run(run_probe()) == "ab cd"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -24,6 +24,7 @@ from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
 from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.input.vt100_parser import Vt100Parser
+from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout import BufferControl, HSplit, Layout, Window
 from prompt_toolkit.output import DummyOutput
@@ -376,33 +377,49 @@ def test_shift_space_inserts_space():
     assert _parse("\x1b[27;2;32~") == [Keys.Ignore]
 
 
+async def _run_application_probe(sequence, bindings):
+    buffer = Buffer()
+    with create_pipe_input() as pipe_input:
+        app = Application(
+            input=pipe_input,
+            output=DummyOutput(),
+            layout=Layout(HSplit([Window(BufferControl(buffer))])),
+            key_bindings=bindings,
+        )
+        run_task = asyncio.create_task(app.run_async())
+        pipe_input.send_text(f"ab{sequence}cd")
+        for _ in range(100):
+            if buffer.text.endswith("cd"):
+                break
+            await asyncio.sleep(0.01)
+        app.exit()
+        await run_task
+    return buffer.text
+
+
 @pytest.mark.parametrize("sequence", ["\x1b[32;2u", "\x1b[27;2;32~"])
 def test_shift_space_inserts_canonical_space_in_buffer(sequence):
     """Exercise the real parser → key binding → Buffer path from #88071."""
-    async def run_probe():
-        buffer = Buffer()
-        with create_pipe_input() as pipe_input:
-            from prompt_toolkit.key_binding import KeyBindings
+    bindings = KeyBindings()
+    bind_terminal_sequence_handlers(bindings)
 
-            bindings = KeyBindings()
-            bind_terminal_sequence_handlers(bindings)
-            app = Application(
-                input=pipe_input,
-                output=DummyOutput(),
-                layout=Layout(HSplit([Window(BufferControl(buffer))])),
-                key_bindings=bindings,
-            )
-            run_task = asyncio.create_task(app.run_async())
-            pipe_input.send_text(f"ab{sequence}cd")
-            for _ in range(100):
-                if buffer.text.endswith("cd"):
-                    break
-                await asyncio.sleep(0.01)
-            app.exit()
-            await run_task
-        return buffer.text
+    assert asyncio.run(_run_application_probe(sequence, bindings)) == "ab cd"
 
-    assert asyncio.run(run_probe()) == "ab cd"
+
+@pytest.mark.parametrize("sequence", ["\x1b[32;2u", "\x1b[27;2;32~"])
+def test_shift_space_preserves_canonical_space_bindings(sequence):
+    """Shift+Space must honor active bindings instead of forcing self-insert."""
+    bindings = KeyBindings()
+    calls = []
+
+    @bindings.add("space")
+    def handle_space(event):
+        calls.append(event.data)
+
+    bind_terminal_sequence_handlers(bindings)
+
+    assert asyncio.run(_run_application_probe(sequence, bindings)) == "abcd"
+    assert calls == [" "]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -388,7 +388,9 @@ async def _run_application_probe(sequence, bindings):
         )
         run_task = asyncio.create_task(app.run_async())
         pipe_input.send_text(f"ab{sequence}cd")
-        for _ in range(100):
+        # Keep the fallback bound loose enough for contended CI workers; the
+        # condition normally becomes true immediately.
+        for _ in range(300):
             if buffer.text.endswith("cd"):
                 break
             await asyncio.sleep(0.01)


### PR DESCRIPTION
## What does this PR do?

Shift+Space from xterm modifyOtherKeys or Kitty CSI-u no longer inserts the raw escape sequence into the classic CLI input buffer. The fix converts only the two recognized Shift+Space payloads into a canonical space keypress, while preserving normal space key bindings and focus-report handling.

### Symptom

In affected terminals, pressing Shift+Space inserts text such as `\x1b[27;2;32~` or `\x1b[32;2u` into the prompt instead of one space.

### Impact

Users of the classic CLI through terminals that emit these extended sequences can have their prompt text corrupted by raw CSI bytes. Plain Space and other extended-key mappings are unaffected.

### Bug Cause

**Trigger:** `hermes_cli/pt_input_extras.py:339` / `install_modify_other_keys_aliases()` maps Shift+Space extended sequences.

**Causal chain:**
1. xterm or Kitty emits an extended Shift+Space sequence.
2. `Vt100Parser` resolves its key as a literal space but retains the full sequence in `KeyPress.data`.
3. prompt_toolkit's self-insert binding inserts `event.data`, leaking the raw CSI payload into the input buffer.

**Why it is wrong:** A literal character mapping is unsafe when the parser's key and data differ, because the default binding inserts the raw data rather than the mapped character.

**Working sibling / contrast:** Plain Space has identical key and data values, and Ctrl-modified mappings use non-character keys with dedicated bindings, so neither path leaks raw sequence text.

**Ruled out:** The parser's alias lookup was not missing: parser-only tests resolved Shift+Space as a space. Buffer-level reproduction showed that insertion behavior after parsing caused the corruption.

### Fix

Map the two Shift+Space sequences to a non-character ignored key and handle their exact payloads by re-feeding one canonical `KeyPress(" ", " ")`. Re-feeding preserves active space bindings, including modal selection behavior, instead of bypassing them with direct buffer insertion. The shared handler also preserves focus-in repaint callbacks and consumes unrelated ignored terminal reports without inserting text.

## Related Issue

Closes #88071

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/pt_input_extras.py` - normalize xterm and Kitty Shift+Space payloads through a canonical space keypress.
- `cli.py` - use the shared terminal-sequence handler while preserving focus-in redraw behavior.
- `tests/cli/test_modify_other_keys_aliases.py` - cover the real parser, key-binding, and Buffer path plus active space-binding behavior.

## How to Test

1. Feed `ESC[27;2;32~` and `ESC[32;2u` through the prompt_toolkit application path and verify the buffer contains `ab cd`.
2. Install an active `space` binding and verify either Shift+Space sequence invokes it once with canonical data.
3. Run the focused CLI test files:

```bash
scripts/run_tests.sh tests/cli/test_modify_other_keys_aliases.py
scripts/run_tests.sh tests/cli/test_cli_terminal_shortcuts.py
```

Verified results: 175 passed and 3 passed, respectively.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - this corrects existing input behavior and includes focused docstrings
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: both terminal protocol variants are covered without host-specific branching
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed

## Screenshots / Logs

The focused automated Buffer-level reproduction covers both reported terminal sequences; no screenshot is needed.
