### PR TITLE
fix(gateway): warn when API_SERVER_KEY is set but too short (#83750)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2241,6 +2241,23 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         api_server_model_name = getenv("API_SERVER_MODEL_NAME", "")
         if api_server_model_name:
             config.platforms[Platform.API_SERVER].extra["model_name"] = api_server_model_name
+    else:
+        # Warn when the user expressed intent (key set or ENABLED=true) but
+        # the key is not usable — without this, Gate 1 silently drops the
+        # platform and Gate 2's actionable error is unreachable.
+        _api_server_enabled_env = getenv("API_SERVER_ENABLED", "")
+        if api_server_key:
+            logger.warning(
+                "API_SERVER_KEY is set but too short (%d chars, minimum 16). "
+                "The API server will NOT start. Generate a strong key with: "
+                "openssl rand -hex 32",
+                len(str(api_server_key).strip()),
+            )
+        elif is_truthy_value(_api_server_enabled_env):
+            logger.warning(
+                "API_SERVER_ENABLED is set but no API_SERVER_KEY found. "
+                "The API server requires a key (minimum 16 characters) to start."
+            )
 
     # Webhook platform
     webhook_enabled = is_truthy_value(getenv("WEBHOOK_ENABLED", ""))


### PR DESCRIPTION
## Summary

Fixes #83750. Rebased on latest `upstream/main` to resolve CI failures.

When `API_SERVER_KEY` is set but shorter than 16 characters, Gate 1 (`_has_usable_api_server_key` in `gateway/config.py`) silently drops the API_SERVER platform — no warning is logged, and Gate 2's actionable error message (in `api_server.py`) is unreachable because it only runs for platforms Gate 1 enrolled.

This PR adds an `else` branch at Gate 1 that logs a clear warning when the user expressed intent (key set, or `API_SERVER_ENABLED=true`) but the key is not usable.

## Changes

- `gateway/config.py`: Add warning logs for short/missing API_SERVER_KEY

## Testing

- Syntax check: `python3 -m py_compile gateway/config.py` ✓
- Ruff lint: `python3 -m ruff check gateway/config.py` ✓

Supersedes #83826 (rebased to fix flaky CI on stale branch).
