### PR TITLE
fix(feishu): ignore @all for mention gating

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4445,10 +4445,8 @@ class FeishuAdapter(BasePlatformAdapter):
     # --- Mention detection ----------------------------------------------------
 
     def _mentions_self(self, message: Any) -> bool:
-        # @_all is Feishu's @everyone placeholder.
+        # @_all is Feishu's @everyone placeholder, not a mention of this bot.
         raw_content = getattr(message, "content", "") or ""
-        if "@_all" in raw_content:
-            return True
         mentions = getattr(message, "mentions", None) or []
         if mentions and self._message_mentions_bot(mentions):
             return True

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1660,21 +1660,45 @@ class TestDedupTTL(unittest.TestCase):
 class TestGroupMentionAtAll(unittest.TestCase):
     """Tests for @_all (Feishu @everyone) group mention routing."""
 
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_at_all_does_not_trigger_bot_without_explicit_mention(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(content='{"text":"@_all 请注意"}', mentions=[])
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertFalse(_admits_group(adapter, message, sender_id, ""))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_explicit_bot_mention_still_triggers_after_at_all_change(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._bot_open_id = "ou_bot"
+        message = SimpleNamespace(
+            content='{"text":"@_user_1"}',
+            mentions=[SimpleNamespace(
+                id=SimpleNamespace(open_id="ou_bot", user_id=None),
+                name="Hermes",
+            )],
+        )
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertTrue(_admits_group(adapter, message, sender_id, ""))
 
     @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "allowlist", "FEISHU_ALLOWED_USERS": "ou_allowed"}, clear=True)
-    def test_at_all_still_requires_policy_gate(self):
-        """@_all bypasses mention gating but NOT the allowlist policy."""
+    def test_at_all_does_not_bypass_mention_gate_or_policy_gate(self):
+        """@_all is not a bot mention and still respects the allowlist policy."""
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
         adapter = FeishuAdapter(PlatformConfig())
         message = SimpleNamespace(content='{"text":"@_all attention"}', mentions=[])
-        # Non-allowlisted user — should be blocked even with @_all.
         blocked_sender = SimpleNamespace(open_id="ou_blocked", user_id=None)
         self.assertFalse(_admits_group(adapter, message, blocked_sender, ""))
-        # Allowlisted user — should pass.
         allowed_sender = SimpleNamespace(open_id="ou_allowed", user_id=None)
-        self.assertTrue(_admits_group(adapter, message, allowed_sender, ""))
+        self.assertFalse(_admits_group(adapter, message, allowed_sender, ""))
 
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")


### PR DESCRIPTION
## Summary
- Stop treating Feishu `@all` (`@_all`) as a mention of every Hermes bot.
- Require an explicit mention of the target bot for group-message admission.
- Preserve explicit bot mention behavior and group policy checks.

## Motivation
When a user sends `@all` in a group, every Hermes profile could interpret the message as directed at itself and reply. This is noisy and causes multiple bots to respond to announcements.

## Test plan
- `python -m pytest tests/gateway/test_feishu.py::TestGroupMentionAtAll -q -o addopts=''`
- `python -m pytest tests/gateway/test_feishu.py -q -o addopts=''`

Results: 3 passed for the focused regression tests; 77 passed, 1 skipped for the Feishu gateway test module.
