### PR TITLE
fix(desktop): prevent deleted profile respawn

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -230,7 +230,14 @@ import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
-import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
+import {
+  assertLocalProfileCanStart,
+  decideProfileDeleteAction,
+  localProfilePoolKeys,
+  ProfileDeletionGate,
+  profileNameFromDeleteRequest,
+  resolveRouteProfile
+} from './profile-delete-routing'
 import {
   buildSidebarSessionSliceParams,
   fetchPrimaryProfileSessions,
@@ -1176,6 +1183,7 @@ let softRehomeInProgress = false
 // with no named profiles never populates this map, so their experience is
 // byte-for-byte the single-backend behavior.
 const backendPool = new Map() // profile -> { process, port, token, connectionPromise, lastActiveAt }
+const profileDeletionGate = new ProfileDeletionGate()
 // Keep the pool light: cap concurrent profile backends (LRU eviction) and reap
 // idle ones. A user idles at exactly the primary backend; pool backends only
 // exist while a non-primary profile is actively being chatted through.
@@ -9485,6 +9493,9 @@ function profileRouteOptions(profile) {
 // primary, so legacy callers are unchanged.
 async function ensureBackend(profile) {
   const key = profile && String(profile).trim() ? String(profile).trim() : primaryProfileKey()
+
+  profileDeletionGate.assertCanStart(key)
+
   const route = resolveProfileBackendRoute(key, profileRouteOptions(key))
 
   if (route.backend === 'primary') {
@@ -9560,6 +9571,8 @@ async function ensureRegistryBackend(connectionId, profile) {
     // child pooled under the composite 'conn:local::<profile>' key so it
     // can't collide with the v1 remote descriptor cached at the bare key.
     const profileKey = String(profile ?? '').trim() || 'default'
+
+    profileDeletionGate.assertCanStart(profileKey)
 
     const localRoute = resolveRegistryLocalRoute(profileKey, {
       globalRemote: globalRemoteActive(),
@@ -9813,6 +9826,8 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   const poolKey = opts.poolKey || profile
 
   await reapOrphanedBackendsOnce()
+  profileDeletionGate.assertCanStart(profile)
+
   // A profile may point at its OWN remote backend (connection.json
   // `profiles[name]`), or inherit the app-wide remote (env / global settings).
   // In either case there is no local child to spawn — we just verify the
@@ -9820,6 +9835,7 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // entry keeps `entry.process === null`, which stopPoolBackend/evict already
   // tolerate.
   const remote = opts.forceLocal ? null : await resolveRemoteBackend(profile)
+  profileDeletionGate.assertCanStart(profile)
 
   if (remote) {
     await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode, remote.headers)
@@ -9858,6 +9874,8 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
     })
   }
 
+  profileDeletionGate.assertCanStart(profile)
+
   // --profile wins over the inherited HERMES_HOME env (see _apply_profile_override
   // step 3 in hermes_cli/main.py), so the child re-homes to this profile.
   // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
@@ -9872,6 +9890,9 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)
 
   const parentStartMarker = await desktopParentStartMarker()
+  assertLocalProfileCanStart(profile, profileDeletionGate, key =>
+    directoryExists(path.join(HERMES_HOME, 'profiles', key))
+  )
   const backendNonce = crypto.randomBytes(16).toString('hex')
   const parentIdentityEnv = parentWatchdogEnv(process.pid, parentStartMarker, backendNonce)
 
@@ -9993,17 +10014,16 @@ function stopPoolBackend(profile) {
 }
 
 async function teardownPoolBackendAndWait(profile) {
-  const entry = backendPool.get(profile)
+  const entries = localProfilePoolKeys(profile)
+    .map(key => ({ entry: backendPool.get(key), key }))
+    .filter(item => item.entry)
 
-  if (!entry) {
-    return
+  for (const { entry, key } of entries) {
+    backendPool.delete(key)
+    stopBackendChild(entry.process)
   }
 
-  backendPool.delete(profile)
-
-  stopBackendChild(entry.process)
-
-  await waitForBackendExit(entry.process)
+  await Promise.all(entries.map(({ entry }) => waitForBackendExit(entry.process)))
 }
 
 function stopAllPoolBackends() {
@@ -10056,7 +10076,7 @@ async function prepareProfileDeleteRequest(request) {
 
   if (decision.action === 'teardown-primary') {
     writeActiveDesktopProfile('default')
-    await teardownPrimaryBackendAndWait()
+    await Promise.all([teardownPrimaryBackendAndWait(), teardownPoolBackendAndWait(decision.profile)])
 
     return decision.profile
   }
@@ -13026,7 +13046,7 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   }
 }
 
-ipcMain.handle('hermes:api', async (_event, request) => {
+async function handleHermesApiRequest(request) {
   // Registry-pinned request (request.connectionId): the renderer is working
   // against a REGISTERED gateway connection, so the data — cron jobs and their
   // run sessions included — lives in THAT host's state.db, not any local
@@ -13123,6 +13143,18 @@ ipcMain.handle('hermes:api', async (_event, request) => {
     upload: request?.upload,
     timeoutMs
   })
+}
+
+ipcMain.handle('hermes:api', async (_event, request) => {
+  const deletingProfile = profileNameFromDeleteRequest(request)
+
+  if (!deletingProfile) {
+    return handleHermesApiRequest(request)
+  }
+
+  const releaseProfileDeletion = profileDeletionGate.acquire(deletingProfile)
+
+  return handleHermesApiRequest(request).finally(releaseProfileDeletion)
 })
 
 // One deduper per cross-window cue — the choke point every window shares. Main

--- a/apps/desktop/electron/profile-delete-routing.test.ts
+++ b/apps/desktop/electron/profile-delete-routing.test.ts
@@ -2,7 +2,14 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
+import {
+  assertLocalProfileCanStart,
+  decideProfileDeleteAction,
+  localProfilePoolKeys,
+  ProfileDeletionGate,
+  profileNameFromDeleteRequest,
+  resolveRouteProfile
+} from './profile-delete-routing'
 
 // ---------------------------------------------------------------------------
 // profileNameFromDeleteRequest
@@ -79,4 +86,64 @@ test('resolveRouteProfile passes the requested profile through when nothing was 
 
 test('resolveRouteProfile passes through undefined when nothing was torn down and no profile was requested', () => {
   assert.equal(resolveRouteProfile(null, undefined), undefined)
+})
+
+// ---------------------------------------------------------------------------
+// ProfileDeletionGate / localProfilePoolKeys
+// ---------------------------------------------------------------------------
+
+test('ProfileDeletionGate blocks concurrent starts until deletion releases', () => {
+  const gate = new ProfileDeletionGate()
+  const release = gate.acquire('Selena')
+
+  assert.equal(gate.blocks('selena'), true)
+  assert.equal(gate.blocks('trina'), false)
+
+  release()
+  assert.equal(gate.blocks('selena'), false)
+})
+
+test('ProfileDeletionGate keeps overlapping deletion leases blocked', () => {
+  const gate = new ProfileDeletionGate()
+  const releaseFirst = gate.acquire('selena')
+  const releaseSecond = gate.acquire('selena')
+
+  releaseFirst()
+  assert.equal(gate.blocks('selena'), true)
+
+  releaseSecond()
+  assert.equal(gate.blocks('selena'), false)
+})
+
+test('ProfileDeletionGate rejects a deferred start when deletion begins while it waits', async () => {
+  const gate = new ProfileDeletionGate()
+  let continueStart = () => undefined
+
+  const waiting = new Promise<void>(resolve => {
+    continueStart = resolve
+  })
+
+  const start = (async () => {
+    await waiting
+    gate.assertCanStart('selena')
+  })()
+
+  const release = gate.acquire('selena')
+
+  continueStart()
+  await assert.rejects(start, /Profile "selena" is being deleted/)
+  release()
+})
+
+test('assertLocalProfileCanStart rejects a delayed retry after the profile directory is removed', () => {
+  const gate = new ProfileDeletionGate()
+
+  assert.throws(() => assertLocalProfileCanStart('selena', gate, () => false), /Profile "selena" no longer exists/)
+  assert.doesNotThrow(() => assertLocalProfileCanStart('default', gate, () => false))
+  assert.doesNotThrow(() => assertLocalProfileCanStart('selena', gate, profile => profile === 'selena'))
+})
+
+test('localProfilePoolKeys returns every local process scope for one profile', () => {
+  assert.deepEqual(localProfilePoolKeys('Selena'), ['selena', 'conn:local::selena'])
+  assert.deepEqual(localProfilePoolKeys(''), [])
 })

--- a/apps/desktop/electron/profile-delete-routing.ts
+++ b/apps/desktop/electron/profile-delete-routing.ts
@@ -1,9 +1,9 @@
 // Profile-delete routing logic for the `hermes:api` IPC handler.
 //
 // When the renderer issues DELETE /api/profiles/<name>, the handler must
-// tear down that profile's backend (primary window backend or pool backend)
-// and then route the *next* request away from the just-deleted profile's
-// pool backend -- spawning a fresh one would call ensure_hermes_home() and
+// tear down every local backend for that profile and route the DELETE itself
+// away from the just-deleted profile. Concurrent and delayed starts must also
+// be rejected: spawning a fresh backend would call ensure_hermes_home() and
 // recreate the profile directory the delete just removed, leaving a zombie
 // process behind (issue #52279).
 //
@@ -57,6 +57,97 @@ export interface ProfileDeleteDecisionDeps {
   isDefaultProfile: (profile: string) => boolean
   isValidProfileName: (profile: string) => boolean
   primaryProfileKey: () => string
+}
+
+/**
+ * Process-local barrier for profile deletion. Electron IPC handlers run
+ * concurrently, so tearing down a pooled backend is not enough by itself: a
+ * renderer reconnect can enter ensureBackend() while the DELETE request is
+ * still removing the profile and recreate its HERMES_HOME.
+ *
+ * Counts instead of a Set keep overlapping requests for the same profile
+ * blocked until the last request releases its lease.
+ */
+export class ProfileDeletionGate {
+  readonly #active = new Map<string, number>()
+
+  acquire(profile: unknown): () => void {
+    const key = String(profile ?? '')
+      .trim()
+      .toLowerCase()
+
+    if (!key) {
+      return () => undefined
+    }
+
+    this.#active.set(key, (this.#active.get(key) ?? 0) + 1)
+    let released = false
+
+    return () => {
+      if (released) {
+        return
+      }
+
+      released = true
+      const remaining = (this.#active.get(key) ?? 1) - 1
+
+      if (remaining > 0) {
+        this.#active.set(key, remaining)
+      } else {
+        this.#active.delete(key)
+      }
+    }
+  }
+
+  blocks(profile: unknown): boolean {
+    const key = String(profile ?? '')
+      .trim()
+      .toLowerCase()
+
+    return Boolean(key && this.#active.has(key))
+  }
+
+  assertCanStart(profile: unknown): void {
+    const key = String(profile ?? '').trim()
+
+    if (this.blocks(key)) {
+      throw new Error(`Profile "${key}" is being deleted.`)
+    }
+  }
+}
+
+/**
+ * Validate the final boundary before spawning a local profile backend. The
+ * deletion gate closes the in-flight race; the directory check rejects a
+ * delayed renderer retry after the DELETE request has already completed.
+ */
+export function assertLocalProfileCanStart(
+  profile: unknown,
+  gate: ProfileDeletionGate,
+  profileDirectoryExists: (profile: string) => boolean
+): void {
+  const key = String(profile ?? '')
+    .trim()
+    .toLowerCase()
+
+  gate.assertCanStart(key)
+
+  if (key && key !== 'default' && !profileDirectoryExists(key)) {
+    throw new Error(`Profile "${key}" no longer exists.`)
+  }
+}
+
+/**
+ * A local profile can occupy the legacy bare pool slot or the explicit-local
+ * registry slot when the v1 route points elsewhere. Both processes own the
+ * same on-disk profile and must be stopped before deleting it.
+ */
+export function localProfilePoolKeys(profile: unknown): string[] {
+  const key = String(profile ?? '')
+    .trim()
+    .toLowerCase()
+
+  return key ? [key, `conn:local::${key}`] : []
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes Desktop from recreating a named profile immediately after it is deleted.

The existing delete interception stopped only the legacy pool entry and routed the DELETE request itself away from the deleted profile. The connections registry can also hold an explicit-local backend under `conn:local::<profile>`, while concurrent or delayed renderer work can already be waiting to start another backend. Either path can run `ensure_hermes_home()` after the profile directory is removed and resurrect it.

This change:

- drains both local pool scopes, including the explicit-local registry entry;
- blocks concurrent starts for the profile for the lifetime of the DELETE request;
- rechecks the deletion barrier after awaited boot work; and
- verifies that a named profile directory still exists at the final local process-spawn boundary, rejecting delayed retries after deletion completes.

The fix is generic Desktop lifecycle coordination. It does not add plugin-specific behavior.

## Related Issue

Regression follow-up to #52279.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/main.ts`: coordinate deletion with both local backend pool scopes and guard the final local spawn boundary.
- `apps/desktop/electron/profile-delete-routing.ts`: add the process-local deletion gate, final local-start validation, and local pool-key enumeration.
- `apps/desktop/electron/profile-delete-routing.test.ts`: cover concurrent deletion leases, deferred starts, delayed retries after directory removal, and both pool-key shapes.

## How to Test

1. Create and warm a non-default local profile so Desktop has a pooled backend for it, including through the explicit-local connection route.
2. Delete the profile through Desktop or the Desktop SDK `host.deleteProfile` path while renderer connection work is active.
3. Confirm the profile directory stays absent and Desktop does not start another backend with `--profile <deleted-name>`.

Focused verification run:

- `npm run typecheck`
- `eslint electron/main.ts electron/profile-delete-routing.ts electron/profile-delete-routing.test.ts`
- `vitest run --project electron electron/profile-delete-routing.test.ts` (19 passed)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The full Electron project run completed with 1,259 passing tests and 28 pre-existing Windows-host failures in POSIX file-mode, SSH control-socket, POSIX path, and temp-directory cleanup cases. The focused regression suite, targeted lint, and complete Desktop typecheck pass.
