### PR TITLE
fix(updater): stop locked Windows launchers from breaking updates

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -70,6 +70,7 @@ from hermes_cli._subprocess_compat import suppress_platform_ver_console
 
 suppress_platform_ver_console()
 
+import ntpath
 import os
 import sys
 
@@ -8616,7 +8617,7 @@ def _recover_core_update_marker_locked() -> None:
 
 
 def _windows_running_hermes_launcher_locked() -> bool:
-    """True when a venv ``hermes*.exe`` shim is this process or an ancestor.
+    """True when an ancestral venv ``hermes*.exe`` blocks delete access.
 
     Best-effort: returns False when psutil is unavailable or inspection fails.
     """
@@ -8640,14 +8641,75 @@ def _windows_running_hermes_launcher_locked() -> bool:
         me = psutil.Process()
         for proc in [me] + list(me.parents()):
             try:
-                exe_norm = str(Path(proc.exe()).resolve()).lower()
+                exe_path = Path(proc.exe())
+                exe_norm = str(exe_path.resolve()).lower()
             except Exception:
                 continue
             if exe_norm in shim_set:
-                return True
+                return _windows_path_blocks_delete(exe_path)
     except Exception:
         return False
     return False
+
+
+def _windows_path_blocks_delete(path: Path) -> bool:
+    """Probe whether another Windows handle prevents replacing ``path``.
+
+    Opening the file with DELETE access is non-mutating, but Windows rejects it
+    with a sharing violation when an existing executable handle omitted
+    ``FILE_SHARE_DELETE``.  Fail open if the Win32 probe itself is unavailable;
+    the quarantine retry remains the downstream safety net.
+    """
+    if not _is_windows() or not path.is_file():
+        return False
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        DELETE = 0x00010000
+        FILE_SHARE_READ = 0x00000001
+        FILE_SHARE_WRITE = 0x00000002
+        FILE_SHARE_DELETE = 0x00000004
+        OPEN_EXISTING = 3
+        FILE_ATTRIBUTE_NORMAL = 0x00000080
+        ERROR_ACCESS_DENIED = 5
+        ERROR_SHARING_VIOLATION = 32
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        create_file = kernel32.CreateFileW
+        create_file.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        ]
+        create_file.restype = wintypes.HANDLE
+        close_handle = kernel32.CloseHandle
+        close_handle.argtypes = [wintypes.HANDLE]
+        close_handle.restype = wintypes.BOOL
+
+        handle = create_file(
+            str(path),
+            DELETE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            None,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            None,
+        )
+        invalid_handle = wintypes.HANDLE(-1).value
+        if handle == invalid_handle:
+            return ctypes.get_last_error() in {
+                ERROR_ACCESS_DENIED,
+                ERROR_SHARING_VIOLATION,
+            }
+        close_handle(handle)
+        return False
+    except Exception:
+        return False
 
 
 def _default_venv_install_target() -> tuple[list[str], dict[str, str] | None]:
@@ -8760,19 +8822,15 @@ def _quarantine_running_hermes_exe(
 
     1. Retry up to ``max_attempts`` times with exponential backoff
        (100/250/500/1000 ms). Handles the AV-scanner case.
-    2. If all retries fail, schedule the .exe for replacement on next
-       reboot via ``MoveFileExW(MOVEFILE_DELAY_UNTIL_REBOOT)``. This still
-       lets uv create a fresh shim at the original path (Windows will keep
-       the old file's content under a new name until the reboot), so the
-       update can complete; the user just needs to reboot to fully unload
-       the stale image.
+    2. If all retries fail, do not schedule a reboot rename. Scheduling does
+       not release the current handle, so the install still fails, and the
+       deferred operation can later move away a freshly installed shim.
     3. Print a clear warning naming the most likely culprit (running
-       Hermes Desktop / gateway / REPL) and pointing to ``--force``.
+       Hermes Desktop / gateway / REPL) and how to release the lock.
 
     Returns the list of (original, quarantined) pairs so the caller can roll
     back if the install itself fails before uv writes a replacement. Pairs
-    where we used ``MOVEFILE_DELAY_UNTIL_REBOOT`` are NOT returned — they
-    are already deferred and roll-back is meaningless.
+    Locked files are not returned because no rename occurred.
     """
     moved: list[tuple[Path, Path]] = []
     if not _is_windows():
@@ -8808,27 +8866,9 @@ def _quarantine_running_hermes_exe(
         if last_exc is None:
             continue
 
-        # All in-process renames failed. Try MoveFileEx with
-        # MOVEFILE_DELAY_UNTIL_REBOOT as a last resort. This succeeds in the
-        # exact case where the inline rename failed (another process holds
-        # the handle without share-delete), at the cost of requiring a
-        # reboot to fully reclaim the old .exe.
-        scheduled = _schedule_replace_on_reboot(shim, target)
-        if scheduled:
-            print(
-                f"  ⚠ {shim.name} is locked by another process; scheduled "
-                f"replacement on next reboot."
-            )
-            print(
-                "    The new shim was written at the same path, but a "
-                "reboot is needed to fully unload the old one."
-            )
-            # Do NOT append to ``moved``: we don't want roll-back to undo a
-            # reboot-deferred operation.
-            continue
-
-        # Truly couldn't budge the .exe. Print an actionable warning and let
-        # uv try its luck — sometimes uv's own retry handling pulls through.
+        # A reboot-deferred rename does not make the path replaceable in this
+        # process. Let uv surface the install failure without adding a stale
+        # PendingFileRenameOperations pair that could clobber a later repair.
         print(
             f"  ⚠ Could not quarantine {shim.name} ({last_exc.__class__.__name__}: "
             f"another process is holding it open)."
@@ -8841,39 +8881,75 @@ def _quarantine_running_hermes_exe(
     return moved
 
 
-def _schedule_replace_on_reboot(shim: Path, quarantine_target: Path) -> bool:
-    """Schedule ``shim`` -> ``quarantine_target`` via PendingFileRenameOperations.
+_PENDING_RENAME_KEY = r"SYSTEM\CurrentControlSet\Control\Session Manager"
+_PENDING_RENAME_VALUE = "PendingFileRenameOperations"
 
-    Uses Win32 ``MoveFileExW`` with ``MOVEFILE_REPLACE_EXISTING |
-    MOVEFILE_DELAY_UNTIL_REBOOT``. The OS persists the rename in
-    ``HKLM\\System\\CurrentControlSet\\Control\\Session Manager\\
-    PendingFileRenameOperations`` and applies it before any user-mode code
-    runs on next boot — at which point no process can hold the .exe.
 
-    Returns ``True`` if the schedule call succeeded, ``False`` otherwise
-    (non-Windows, ctypes failure, lack of privilege, etc.). Never raises.
-    """
-    if not _is_windows():
-        return False
-    try:
-        import ctypes
-        from ctypes import wintypes
+def _normalize_pending_rename_path(value: str) -> str:
+    """Normalize a Session Manager rename operand for path comparison."""
+    path = str(value).lstrip("!")
+    if path.startswith("\\??\\"):
+        path = path[4:]
+    return ntpath.normcase(ntpath.normpath(path))
 
-        MOVEFILE_REPLACE_EXISTING = 0x1
-        MOVEFILE_DELAY_UNTIL_REBOOT = 0x4
 
-        MoveFileExW = ctypes.windll.kernel32.MoveFileExW
-        MoveFileExW.argtypes = [wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD]
-        MoveFileExW.restype = wintypes.BOOL
-
-        ok = MoveFileExW(
-            str(shim),
-            str(quarantine_target),
-            MOVEFILE_REPLACE_EXISTING | MOVEFILE_DELAY_UNTIL_REBOOT,
+def _filter_pending_hermes_replacements(
+    entries: list[str], shims: list[Path]
+) -> tuple[list[str], int]:
+    """Drop only old shim-quarantine pairs, preserving unrelated operations."""
+    shim_paths = {_normalize_pending_rename_path(str(shim)) for shim in shims}
+    kept: list[str] = []
+    removed = 0
+    index = 0
+    while index + 1 < len(entries):
+        source, target = entries[index], entries[index + 1]
+        source_norm = _normalize_pending_rename_path(source)
+        target_norm = _normalize_pending_rename_path(target)
+        stale = source_norm in shim_paths and target_norm.startswith(
+            f"{source_norm}.old."
         )
-        return bool(ok)
-    except Exception:
-        return False
+        if stale:
+            removed += 1
+        else:
+            kept.extend((source, target))
+        index += 2
+    if index < len(entries):
+        kept.append(entries[index])
+    return kept, removed
+
+
+def _cleanup_pending_hermes_replacements(scripts_dir: Path | None = None) -> int:
+    """Best-effort removal of stale reboot renames created by older Hermes."""
+    if not _is_windows():
+        return 0
+    if scripts_dir is None:
+        scripts_dir = _venv_scripts_dir()
+    if scripts_dir is None:
+        return 0
+    try:
+        import winreg
+
+        access = winreg.KEY_QUERY_VALUE | winreg.KEY_SET_VALUE
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE, _PENDING_RENAME_KEY, 0, access
+        ) as key:
+            entries, value_type = winreg.QueryValueEx(key, _PENDING_RENAME_VALUE)
+            if value_type != winreg.REG_MULTI_SZ or not isinstance(entries, list):
+                return 0
+            kept, removed = _filter_pending_hermes_replacements(
+                entries, _hermes_exe_shims(scripts_dir)
+            )
+            if not removed:
+                return 0
+            if kept:
+                winreg.SetValueEx(
+                    key, _PENDING_RENAME_VALUE, 0, winreg.REG_MULTI_SZ, kept
+                )
+            else:
+                winreg.DeleteValue(key, _PENDING_RENAME_VALUE)
+            return removed
+    except (FileNotFoundError, OSError, ValueError):
+        return 0
 
 
 def _restore_quarantined_exes(moved: list[tuple[Path, Path]]) -> None:
@@ -8926,11 +9002,13 @@ def _run_quarantined_install(
 
 
 def _cleanup_quarantined_exes(scripts_dir: Path | None = None) -> None:
-    """Sweep ``hermes.exe.old.*`` left by prior updates.
+    """Sweep old shim files and stale deferred renames left by prior updates.
 
     Called early on every hermes invocation. The .old files are unlocked once
-    their owning process exited, so deletion succeeds the next run. Silent
-    no-op when nothing's there or on file-locked / permission errors.
+    their owning process exited, so deletion succeeds the next run. Old Hermes
+    versions may also have queued a reboot rename that would move a later fresh
+    shim away; remove only pairs matching this venv's quarantine naming scheme.
+    Silent no-op when nothing's there or on file-lock / permission errors.
     """
     if not _is_windows():
         return
@@ -8938,6 +9016,7 @@ def _cleanup_quarantined_exes(scripts_dir: Path | None = None) -> None:
         scripts_dir = _venv_scripts_dir()
     if scripts_dir is None:
         return
+    _cleanup_pending_hermes_replacements(scripts_dir)
     try:
         for stale in scripts_dir.glob("*.exe.old.*"):
             try:
@@ -9836,6 +9915,21 @@ def cmd_update(args):
             branch_explicit=bool(getattr(args, "branch", None)),
         )
         return
+
+    # A setuptools/uv Windows launcher stays alive as an ancestor of the
+    # Python process. If that launcher denies FILE_SHARE_DELETE, neither our
+    # rename retry nor uv can replace it while this command is running.
+    # Refuse before backup/git/install mutation; the module entry point runs
+    # under python.exe and therefore leaves the console-script shim unlocked.
+    if _is_windows() and _windows_running_hermes_launcher_locked():
+        _cleanup_pending_hermes_replacements()
+        module_cmd = subprocess.list2cmdline(
+            [sys.executable, "-m", "hermes_cli.main", *sys.argv[1:]]
+        )
+        print("✗ Windows cannot update a hermes.exe launcher that is currently in use.")
+        print("  Re-run the same update through the venv Python interpreter:")
+        print(f"    {module_cmd}")
+        sys.exit(2)
 
     gateway_mode = getattr(args, "gateway", False)
 

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -65,7 +65,7 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         "--force",
         action="store_true",
         default=False,
-        help="Windows: proceed with the update even when another hermes.exe is detected. The concurrent process will likely cause WinError 32 warnings and may leave a reboot-deferred .exe replacement. Does NOT bypass the venv-process guard (see --force-venv).",
+        help="Windows: proceed even when another hermes.exe is detected. This may still fail with WinError 32; it does not bypass a current-launcher self-lock or the venv-process guard (see --force-venv).",
     )
     update_parser.add_argument(
         "--force-venv",

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -1,5 +1,4 @@
-"""Tests for issue #26670 — concurrent hermes.exe detection and improved
-quarantine retry / reboot-deferred fallback during `hermes update` on Windows.
+"""Tests for Windows hermes.exe concurrency and update quarantine behavior.
 
 These tests force ``_is_windows`` to return ``True`` via patching so the
 Windows-specific code paths can be exercised on any host.
@@ -139,7 +138,7 @@ def test_detect_concurrent_parents_call_robust_to_one_bad_hop(_winp, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# _quarantine_running_hermes_exe — retry + reboot-deferred fallback
+# _quarantine_running_hermes_exe — retry without unsafe reboot fallback
 # ---------------------------------------------------------------------------
 
 
@@ -160,36 +159,49 @@ def test_quarantine_succeeds_first_attempt(_winp, tmp_path):
 
 
 @patch.object(cli_main, "_is_windows", return_value=True)
-def test_quarantine_falls_back_to_reboot_schedule(_winp, tmp_path, capsys, monkeypatch):
-    """When every retry fails, we schedule via MoveFileEx and warn helpfully."""
+def test_quarantine_does_not_schedule_locked_shim_for_reboot(
+    _winp, tmp_path, capsys, monkeypatch
+):
+    """A persistent lock fails without creating a stale reboot operation."""
     shim = tmp_path / "hermes.exe"
     shim.write_bytes(b"locked")
 
     def always_fails(self, target):
         raise OSError(32, "The process cannot access the file (simulated lock)")
 
-    scheduled_calls: list[tuple[Path, Path]] = []
-
-    def fake_schedule(s: Path, q: Path) -> bool:
-        scheduled_calls.append((s, q))
-        return True
-
     monkeypatch.setattr(cli_main, "_hermes_exe_shims", lambda d: [shim])
-    with patch.object(Path, "rename", always_fails), patch.object(
-        cli_main, "_schedule_replace_on_reboot", fake_schedule
-    ), patch("time.sleep", lambda *_a, **_k: None):
+    with patch.object(Path, "rename", always_fails), patch(
+        "time.sleep", lambda *_a, **_k: None
+    ):
         pairs = cli_main._quarantine_running_hermes_exe(tmp_path)
 
     captured = capsys.readouterr().out
 
-    # The reboot-deferred path was used.
-    assert scheduled_calls and scheduled_calls[0][0] == shim
-    # It is NOT added to the returned roll-back list (the issue calls this
-    # out — don't undo a deferred operation).
     assert pairs == []
-    # The user got a clear message, not raw [WinError 32].
-    assert "scheduled" in captured.lower()
-    assert "reboot" in captured.lower()
+    assert "could not quarantine hermes.exe" in captured.lower()
+    assert "scheduled" not in captured.lower()
+
+
+def test_pending_rename_filter_removes_only_hermes_quarantine_pairs(tmp_path):
+    scripts = tmp_path / "Scripts"
+    shim = scripts / "hermes.exe"
+    other = tmp_path / "other.exe"
+    entries = [
+        rf"\??\{shim}",
+        rf"!\??\{shim}.old.123",
+        rf"\??\{other}",
+        rf"\??\{other}.old",
+        rf"\??\{scripts / 'hermes-agent.exe'}",
+        rf"\??\{scripts / 'replacement.exe'}",
+        "odd-trailing-entry",
+    ]
+
+    kept, removed = cli_main._filter_pending_hermes_replacements(
+        entries, [shim, scripts / "hermes-agent.exe"]
+    )
+
+    assert removed == 1
+    assert kept == entries[2:]
 
 
 
@@ -523,6 +535,101 @@ def test_unreadable_argv_falls_back_to_the_captured_prefix(monkeypatch):
 # cmd_update integration — concurrent-instance gate
 # ---------------------------------------------------------------------------
 
+
+@pytest.mark.windows_only
+def test_cmd_update_self_locked_refuses_before_update_mutation(monkeypatch, capsys):
+    from hermes_cli import config as config_mod
+
+    monkeypatch.setattr(config_mod, "is_managed", lambda: False)
+    monkeypatch.setattr(config_mod, "detect_install_method", lambda _root: "git")
+    monkeypatch.setattr(
+        cli_main, "_windows_running_hermes_launcher_locked", lambda: True
+    )
+    cleaned = []
+    monkeypatch.setattr(
+        cli_main, "_cleanup_pending_hermes_replacements", lambda: cleaned.append(True)
+    )
+    monkeypatch.setattr(
+        cli_main,
+        "_cmd_update_impl",
+        lambda *_a, **_k: pytest.fail("update mutated state under a self-lock"),
+    )
+    monkeypatch.setattr(sys, "argv", ["hermes", "update", "-y"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.cmd_update(SimpleNamespace(check=False))
+
+    assert exc_info.value.code == 2
+    assert cleaned == [True]
+    output = capsys.readouterr().out
+    assert sys.executable in output
+    assert "-m hermes_cli.main update -y" in output
+
+
+@pytest.mark.windows_only
+def test_cmd_update_replaceable_launcher_reaches_update(monkeypatch):
+    from hermes_cli import config as config_mod
+
+    monkeypatch.setattr(config_mod, "is_managed", lambda: False)
+    monkeypatch.setattr(config_mod, "detect_install_method", lambda _root: "git")
+    monkeypatch.setattr(
+        cli_main, "_windows_running_hermes_launcher_locked", lambda: False
+    )
+    called = []
+    monkeypatch.setattr(
+        cli_main,
+        "_cmd_update_impl",
+        lambda args, *, gateway_mode: called.append((args, gateway_mode)),
+    )
+    monkeypatch.setattr(cli_main, "_install_hangup_protection", lambda **_k: None)
+    monkeypatch.setattr(cli_main, "_finalize_update_output", lambda _state: None)
+    monkeypatch.setattr("hermes_cli.update_lock.UpdateLock.acquire", lambda _self: True)
+    monkeypatch.setattr("hermes_cli.update_lock.UpdateLock.release", lambda _self: None)
+
+    args = SimpleNamespace(check=False, gateway=False)
+    cli_main.cmd_update(args)
+
+    assert called == [(args, False)]
+
+
+@pytest.mark.windows_only
+def test_windows_delete_probe_distinguishes_unshared_handle(tmp_path):
+    import ctypes
+    from ctypes import wintypes
+
+    target = tmp_path / "hermes.exe"
+    target.write_bytes(b"MZ-test")
+    assert cli_main._windows_path_blocks_delete(target) is False
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+    handle = create_file(
+        str(target),
+        0x80000000,
+        0x00000001,
+        None,
+        3,
+        0x00000080,
+        None,
+    )
+    assert handle != wintypes.HANDLE(-1).value
+    try:
+        assert cli_main._windows_path_blocks_delete(target) is True
+    finally:
+        close_handle(handle)
 
 
 


### PR DESCRIPTION
## What does this PR do?

Windows updates now stop before mutation when the active Hermes launcher cannot be replaced, and print an equivalent Python module command that can complete the update outside the locked executable. This prevents the updater from continuing into repeated uv failures and an unrelated ZIP fallback, while preserving normal updates through replaceable launchers.

### Symptom

Running `hermes update` on Windows can report `failed to remove ... Scripts/hermes.exe` with OS error 32 after the updater says it scheduled the shim for replacement on reboot. The install retries and the Git update then falls back to ZIP, but the update still cannot replace the locked executable.

### Impact

Windows users whose current or ancestral Hermes launcher was opened without delete sharing cannot complete the normal update flow. A deferred rename can also remain queued and later move away a freshly repaired launcher at reboot.

### Bug Cause

**Trigger:** `hermes_cli/main.py:8803` / `_quarantine_running_hermes_exe()` after every immediate rename attempt fails for a locked Windows launcher.

**Causal chain:**
1. A running or ancestral `hermes.exe` keeps the launcher open without `FILE_SHARE_DELETE`.
2. The updater schedules `MoveFileExW(..., MOVEFILE_DELAY_UNTIL_REBOOT)` and treats that future operation as if it immediately freed the current path.
3. uv reaches the same locked path, fails to remove `Scripts/hermes.exe`, retries, and then sends the Git update into the ZIP fallback.

**Why it is wrong:** A reboot-deferred rename neither releases the live handle nor makes the path replaceable in the current process. The queued operation can also outlive the failed update and target a later repaired shim.

**Working sibling / contrast:** When an immediate rename to `hermes.exe.old.<stamp>` succeeds, the original pathname is actually free before uv runs. Launchers that allow delete sharing also remain eligible for the normal update path.

**Ruled out:** Gateway shutdown is not the root cause. The reported flow completed gateway shutdown before uv failed, and native Windows verification reproduced the failure condition with a launcher handle that specifically omitted delete sharing.

### Fix

Probe ancestral Windows launchers for real DELETE access before update mutation. If the launcher is genuinely blocked, exit with an equivalent `python -m hermes_cli.main update ...` command instead of entering the failing install path. Remove the unsafe reboot-scheduled rename fallback, and clean only stale Hermes shim rename pairs from `PendingFileRenameOperations` while preserving unrelated entries.

## Related Issue

Closes #88078

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` - detect real Windows delete-sharing locks, refuse unsafe self-updates before mutation, remove deferred shim renames, and clean stale Hermes-only pending operations.
- `hermes_cli/subcommands/update.py` - clarify the update command behavior for locked Windows launchers.
- `tests/hermes_cli/test_update_concurrent_quarantine.py` - cover lock probing, early refusal, pending-rename filtering, and ordinary replaceable-launcher behavior.

## How to Test

1. Open a real Windows `hermes.exe` with a handle that omits `FILE_SHARE_DELETE`, invoke `hermes update`, and verify it exits before backup, fetch, or install while printing the module-entrypoint command.
2. Run that printed `venv/Scripts/python.exe -m hermes_cli.main update ...` command and verify the update completes without `failed to remove`, OS error 32, or ZIP fallback.
3. Run the related automated tests (40 passed locally):

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_concurrent_quarantine.py
scripts/run_tests.sh tests/hermes_cli/test_quarantine_noop_restore.py tests/hermes_cli/test_update_self_lock.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant updater tests and all 40 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; command help and in-code behavior descriptions were updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no configuration keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the new lock probe is Windows-gated and non-Windows behavior is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool behavior changed

## Screenshots / Logs

Native Windows verification reproduced the blocked launcher, confirmed refusal before update mutation, and confirmed the printed Python module command completed without OS error 32 or ZIP fallback.
