### PR TITLE
fix(dashboard-auth): honor X-Forwarded-Prefix in server-rendered login page

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -46,28 +46,28 @@ _LOGIN_HTML_TEMPLATE = """\
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('/fonts/Collapse-Regular.woff2') format('woff2');
+    src: url('{base_path}/fonts/Collapse-Regular.woff2') format('woff2');
   }}
   @font-face {{
     font-family: 'Collapse';
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url('/fonts/Collapse-Bold.woff2') format('woff2');
+    src: url('{base_path}/fonts/Collapse-Bold.woff2') format('woff2');
   }}
   @font-face {{
     font-family: 'Rules Compressed';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('/fonts/RulesCompressed-Regular.woff2') format('woff2');
+    src: url('{base_path}/fonts/RulesCompressed-Regular.woff2') format('woff2');
   }}
   @font-face {{
     font-family: 'Rules Compressed';
     font-style: normal;
     font-weight: 600;
     font-display: swap;
-    src: url('/fonts/RulesCompressed-Medium.woff2') format('woff2');
+    src: url('{base_path}/fonts/RulesCompressed-Medium.woff2') format('woff2');
   }}
 
   :root {{
@@ -412,6 +412,7 @@ auth gate (not recommended on untrusted networks).</p>
 _PASSWORD_FORM_SCRIPT = """\
 <script>
 (function () {
+  var base = (typeof window.__HERMES_BASE_PATH__ === 'string' && window.__HERMES_BASE_PATH__) || '';
   function handle(form) {
     form.addEventListener('submit', function (ev) {
       ev.preventDefault();
@@ -425,7 +426,7 @@ _PASSWORD_FORM_SCRIPT = """\
         password: (form.querySelector('input[name=password]') || {}).value || '',
         next: (form.querySelector('input[name=next]') || {}).value || ''
       };
-      fetch('/auth/password-login', {
+      fetch(base + '/auth/password-login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -433,7 +434,7 @@ _PASSWORD_FORM_SCRIPT = """\
       }).then(function (resp) {
         if (resp.ok) {
           return resp.json().then(function (data) {
-            window.location.assign((data && data.next) || '/');
+            window.location.assign(base + ((data && data.next) || '/'));
           });
         }
         var msg = resp.status === 429
@@ -455,7 +456,7 @@ _PASSWORD_FORM_SCRIPT = """\
 """
 
 
-def render_login_html(*, next_path: str = "") -> str:
+def render_login_html(*, next_path: str = "", base_path: str = "") -> str:
     """Return the full HTML for ``GET /login``.
 
     ``next_path`` — when set, the post-login landing path the user
@@ -464,6 +465,13 @@ def render_login_html(*, next_path: str = "") -> str:
     end-to-end. The caller (``routes.login_page``) is responsible for
     validating ``next_path`` against the same-origin rules before we
     emit it; we still HTML-escape it as defence in depth.
+
+    ``base_path`` — the normalised ``X-Forwarded-Prefix`` (e.g.
+    ``/hermes``) when the dashboard is served behind a path-prefix
+    reverse proxy, else ``""``. Prepended to every absolute URL (fonts,
+    the password-login endpoint, the post-login landing path, and OAuth
+    provider button hrefs) so the page works behind such a proxy — the
+    same mechanism the SPA uses via ``window.__HERMES_BASE_PATH__``.
     """
     providers = list_session_providers()
     if not providers:
@@ -488,13 +496,30 @@ def render_login_html(*, next_path: str = "") -> str:
         else:
             buttons.append(
                 f'      <a class="provider-btn" '
-                f'href="/auth/login?provider={html.escape(p.name, quote=True)}{next_qs}">'
+                f'href="{base_path}/auth/login?provider={html.escape(p.name, quote=True)}{next_qs}">'
                 f'Sign in with {html.escape(p.display_name)}</a>'
             )
     script = _PASSWORD_FORM_SCRIPT if needs_password_script else ""
+    if script and base_path:
+        # Mirror the SPA's __HERMES_BASE_PATH__ injection so the inline
+        # password-form script can build prefix-aware absolute URLs.
+        # NOTE: do NOT html.escape() here — inside a <script> element HTML
+        # entities are NOT decoded, so &quot; would be a JS SyntaxError and
+        # __HERMES_BASE_PATH__ would stay undefined. base_path comes from
+        # prefix.normalise_prefix(), which already rejects `..`, `//`,
+        # non-printable and other hostile characters, so raw JSON quoting
+        # (double quotes) is safe in this position.
+        import json
+        base_js = (
+            "<script>window.__HERMES_BASE_PATH__="
+            + json.dumps(base_path)
+            + ";</script>"
+        )
+        script = base_js + script
     return _LOGIN_HTML_TEMPLATE.format(
         provider_buttons="\n".join(buttons),
         password_script=script,
+        base_path=base_path,
     )
 
 

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -139,7 +139,7 @@ async def login_page(request: Request) -> HTMLResponse:
         request.query_params.get("next", "")
     )
     return HTMLResponse(
-        render_login_html(next_path=next_path),
+        render_login_html(next_path=next_path, base_path=_prefix(request)),
         headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
     )
 


### PR DESCRIPTION
## Problem

When the Hermes dashboard is served behind a **path-prefix reverse proxy** (e.g. Caddy `handle_path /<prefix>/*` with `header_up X-Forwarded-Prefix /<prefix>`), the **server-rendered `/login` page** cannot sign in with a password provider:

- The inline form script hardcodes `fetch('/auth/password-login')` and `window.location.assign('/')` as **root-absolute URLs** — the `/<prefix>` segment is dropped, so the browser hits the proxy's 404 catch-all instead of the backend.
- The frontend then shows the generic **"Sign-in failed. Please try again."** (a 404 is not 401), even with completely correct credentials.
- The `@font-face` `src: url('/fonts/...')` rules and the OAuth provider button `href="/auth/login?..."` have the same problem (broken fonts / broken OAuth round trip behind a prefix proxy).

The SPA already solves this via `window.__HERMES_BASE_PATH__` (injected by `mount_spa` in `web_server.py`); the server-rendered login page simply never got the same treatment.

## Fix

- `render_login_html()` gains a `base_path` parameter; `routes.login_page` passes `_prefix(request)` (the normalised `X-Forwarded-Prefix`).
- All absolute URLs in the page are now prefixed with `base_path`:
  - `@font-face` `src` URLs
  - `fetch(base + '/auth/password-login', ...)`
  - `window.location.assign(base + (data.next || '/'))` post-login navigation
  - OAuth provider button `href` (`{base_path}/auth/login?provider=...`)
- The inline script reads `window.__HERMES_BASE_PATH__` (injected as raw JSON — **not** `html.escape()`d, because HTML entities are not decoded inside `<script>` elements and `&quot;` would be a JS SyntaxError). When no prefix is set, `base` is `''` and behaviour is byte-identical to before.

## Verification

- `curl` against the prefixed URL confirms `__HERMES_BASE_PATH__="/<prefix>"` is injected with raw quotes and all URLs are prefixed.
- The page's inline script was executed verbatim in Node (mocked DOM + `fetch`): the submit handler calls `fetch('/<prefix>/auth/password-login')` with a valid JSON body, and post-login navigation targets `/<prefix>/`.
- End-to-end behind Caddy: `POST /<prefix>/auth/password-login` → 200, protected API with session cookie → 200, no-prefix path → 404 (as designed).
