### PR TITLE
fix: suppress lookalike_tld false positives for .dev

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -677,17 +677,19 @@ class TestAppTldSuppression:
 
 
 class TestIsAppTldFinding:
-    """Unit tests for the _is_app_tld_finding helper."""
+    """Unit tests for the _is_benign_tld_finding helper."""
 
     @pytest.mark.parametrize("finding, expected", [
         ({"rule_id": "lookalike_tld", "value": ".APP"}, True),   # case-insensitive
         ({"rule_id": "lookalike_tld", "message": "Domain uses '.app' TLD"}, True),
+        ({"rule_id": "lookalike_tld", "value": ".dev"}, True),   # explicit .dev suppression
+        ({"rule_id": "lookalike_tld", "message": "The '.DEV' TLD can be spoofed"}, True),
         ({"rule_id": "shortened_url", "value": ".app"}, False),  # wrong rule_id
         ({"rule_id": "lookalike_tld", "value": ".zip"}, False),  # other TLD
     ])
     def test_app_tld_detection(self, finding, expected):
-        from tools.tirith_security import _is_app_tld_finding
-        assert _is_app_tld_finding(finding) is expected
+        from tools.tirith_security import _is_benign_tld_finding
+        assert _is_benign_tld_finding(finding) is expected
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -841,12 +841,11 @@ def check_command_security(command: str) -> dict:
             summary = "security warning detected (details unavailable)"
 
     # Suppress warn verdicts that consist solely of a lookalike_tld finding for
-    # the .app TLD.  .app is a legitimate gTLD used by many production services
-    # and the "can be confused with file extensions" heuristic generates false
-    # positives for normal API calls.  Any other finding (including other
-    # lookalike_tld entries for non-.app TLDs) preserves the warn action.
+    # known benign TLDs. We currently treat .app and .dev as legitimate, avoiding
+    # false positives for production domains that use these extensions while keeping
+    # all other lookalike_tld findings as warnings.
     if action == "warn" and findings:
-        non_suppressible = [f for f in findings if not _is_app_tld_finding(f)]
+        non_suppressible = [f for f in findings if not _is_benign_tld_finding(f)]
         if not non_suppressible:
             action = "allow"
             findings = []
@@ -855,8 +854,11 @@ def check_command_security(command: str) -> dict:
     return {"action": action, "findings": findings, "summary": summary}
 
 
-def _is_app_tld_finding(finding: dict) -> bool:
-    """Return True if this finding is a lookalike_tld warning for the .app TLD only.
+_BENIGN_LOOKALIKE_TLDS = (".app", ".dev")
+
+
+def _is_benign_tld_finding(finding: dict) -> bool:
+    """Return True when a lookalike_tld finding targets an allowed benign TLD.
 
     Checks the rule_id and inspects common value/detail field names that
     Tirith may use to carry the TLD string.
@@ -867,6 +869,14 @@ def _is_app_tld_finding(finding: dict) -> bool:
         return False
     for field in ("value", "tld", "detail", "description", "message"):
         val = finding.get(field)
-        if val is not None and ".app" in str(val).lower():
+        if val is None:
+            continue
+        val_l = str(val).lower()
+        if any(tld in val_l for tld in _BENIGN_LOOKALIKE_TLDS):
             return True
     return False
+
+
+def _is_app_tld_finding(finding: dict) -> bool:
+    """Backward-compatible alias for the historical helper name."""
+    return _is_benign_tld_finding(finding)


### PR DESCRIPTION
## Summary
- Suppress `check_command_security` warn verdict downgrading when the only finding is a lookalike TLD warning on allowed benign TLDs.
- Extend benign lookalike TLD coverage from only `.app` to both `.app` and `.dev`.
- Refactor detection helper to support multiple benign TLDs and keep a compatibility alias for existing calls.

## Test Plan
- [x] `python3 -m py_compile tools/tirith_security.py tests/tools/test_tirith_security.py`
- [x] `python3 -m pytest tests/tools/test_tirith_security.py -k "TestAppTldSuppression or TestIsAppTldFinding" -q`
- [x] `ruff check tools/tirith_security.py tests/tools/test_tirith_security.py`

Closes #87489
