### PR TITLE
fix(delegate): keep the worktree when git inspection fails

### DIFF
--- a/tests/tools/test_subagent_worktree.py
+++ b/tests/tools/test_subagent_worktree.py
@@ -18,9 +18,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 from tools import subagent_worktree as sw  # noqa: E402
 
 
-def _git(args, cwd):
+def _git(args, cwd, check=True):
     return subprocess.run(
-        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=check
     )
 
 
@@ -131,6 +131,38 @@ class SubagentWorktreeTests(unittest.TestCase):
         self.assertFalse(payload["pruned"])
         self.assertTrue(payload["dirty"])
         self.assertTrue(os.path.isdir(info["path"]))
+
+    def test_finalize_keeps_worktree_when_git_inspection_fails(self):
+        """#88113: a non-zero git status exit must not be read as "clean".
+
+        Corrupting the index makes the real `git status --porcelain` probe
+        exit 128. The old code kept the payload defaults (commits=0,
+        dirty=False) and pruned on them — permanently deleting the child's
+        uncommitted work. A destructive cleanup requires affirmative proof
+        of a clean tree."""
+        repo = _make_repo(self.tmp)
+        info = sw.create_subagent_worktree(str(repo), "inspect-fail1")
+        assert info is not None
+        wt = Path(info["path"])
+        (wt / "UNCOMMITTED-WORK.txt").write_text(
+            "irreplaceable\n", encoding="utf-8"
+        )
+
+        git_dir = Path(_git(["rev-parse", "--git-dir"], wt).stdout.strip())
+        if not git_dir.is_absolute():
+            git_dir = (wt / git_dir).resolve()
+        (git_dir / "index").write_bytes(b"not-a-valid-git-index\n")
+        # Sanity: the probe really fails now.
+        broken = _git(["status", "--porcelain"], wt, check=False)
+        self.assertNotEqual(broken.returncode, 0)
+
+        payload = sw.finalize_subagent_worktree(info)
+
+        self.assertFalse(payload["pruned"])
+        self.assertTrue(os.path.isdir(info["path"]))
+        self.assertTrue((wt / "UNCOMMITTED-WORK.txt").exists())
+        branches = _git(["branch", "--list", info["branch"]], repo).stdout
+        self.assertNotEqual(branches.strip(), "")
 
     def test_finalize_missing_path_reports_pruned(self):
         payload = sw.finalize_subagent_worktree(

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -196,6 +196,7 @@ def finalize_subagent_worktree(
         payload["pruned"] = True  # nothing on disk to review
         return payload
 
+    inspection_ok = True
     try:
         if base_commit:
             counted = _run_git(
@@ -203,12 +204,31 @@ def finalize_subagent_worktree(
             )
             if counted.returncode == 0:
                 payload["commits"] = int(counted.stdout.strip() or 0)
+            else:
+                inspection_ok = False
         status = _run_git(["status", "--porcelain"], cwd=path)
         if status.returncode == 0:
             payload["dirty"] = bool(status.stdout.strip())
+        else:
+            inspection_ok = False
     except Exception as exc:
         logger.debug("subagent worktree: finalize inspection failed: %s", exc)
         # Unknown state — keep the worktree rather than risk deleting work.
+        return payload
+
+    if not inspection_ok:
+        # Fail-safe (#88113): a non-zero git exit proves nothing about the
+        # tree — the payload defaults (0 commits, clean) were never
+        # overwritten, and pruning on them permanently deleted uncommitted
+        # child work. A destructive cleanup requires affirmative proof of
+        # "zero commits + clean tree"; otherwise keep the worktree and
+        # branch for manual inspection.
+        logger.warning(
+            "subagent worktree: git inspection failed (rev-list/status "
+            "non-zero) — keeping %s (branch %s) for manual review",
+            path,
+            branch,
+        )
         return payload
 
     if prune and payload["commits"] == 0 and not payload["dirty"]:


### PR DESCRIPTION
## What does this PR do?

Stops `finalize_subagent_worktree()` from permanently deleting a delegated child's uncommitted work when its Git inspection probes fail. With `delegation.worktree_isolation: true`, the function ran `git rev-list --count` and `git status --porcelain` via `_run_git(check=False)`; on a non-zero exit it silently kept the payload defaults (`commits: 0`, `dirty: False`) and then read those defaults as *proven* clean state — running `git worktree remove --force` and `git branch -D`, so untracked/uncommitted files were irrecoverably lost and the result even reported `pruned: true` (#88113, P1 data loss).

The documented contract — only a worktree with **zero commits and a clean tree** is pruned, "anything holding work is kept" — is now enforced on the failure path too: a destructive cleanup requires **affirmative proof**. Any non-zero inspection result keeps the worktree and branch for manual review, with a WARNING naming both. The existing exception handler was already fail-safe; this closes the ordinary non-zero-exit gap beside it.

## Related Issue

Fixes #88113

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/subagent_worktree.py` — `finalize_subagent_worktree()` tracks an `inspection_ok` flag; a non-zero `rev-list` or `status` exit clears it, and a non-inspectable worktree returns un-pruned with a warning (worktree + branch named) instead of falling through to the prune condition.
- `tests/tools/test_subagent_worktree.py` — new regression reproducing the issue's deterministic offline scenario: a real git repo + worktree whose index is corrupted (making `git status --porcelain` exit 128) with uncommitted work on disk must stay intact — worktree present, WIP file present, branch not deleted, `pruned` false. The `_git` helper gained a `check` parameter for the non-zero-exit sanity probe.

## How to Test

1. `python -m pytest tests/tools/test_subagent_worktree.py -q`
2. Observed result: 16 passed (15 pre-existing + 1 new). A/B guard: with only the `tools/subagent_worktree.py` hunk stashed, the new test FAILS (worktree force-removed, WIP file gone, branch deleted — the data loss).
3. `python -m pytest tests/tools/test_delegate_subagent_timeout_diagnostic.py -q` — Observed result: 2 passed, 2 failed; both failures are pre-existing on clean main (verified via `git stash` A/B run) and unrelated to this change.
4. The issue's standalone reproduction script now reports `worktree_exists: true`, `wip_exists: true`, `branch_exists: true`, `pruned: false`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/tools/test_subagent_worktree.py -q                    # with fix
16 passed in 2.21s
$ git stash -- tools/subagent_worktree.py && pytest ... -q           # A/B guard
1 failed  (worktree force-removed; uncommitted work irrecoverable)
```
