### PR TITLE
fix(terminal): keep cloud-placeholder reads out of the lifecycle guard (salvage #88052)

### DIFF
--- a/contributors/emails/agent@Agents-Mac-mini.local
+++ b/contributors/emails/agent@Agents-Mac-mini.local
@@ -1,0 +1,1 @@
+skip-agent

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -110,18 +110,27 @@ _MAX_REFERENCED_SCRIPT_DEPTH = 8
 _CONTROL_CHARS = frozenset(";&|()")
 
 
-def _is_apple_file_provider_path(path: Path) -> bool:
-    """Return True for paths inside macOS's cloud-backed document root.
+# Directory names that sit directly under a `Library` path component and
+# mark a FileProvider-backed subtree: `Mobile Documents` is iCloud Drive;
+# `CloudStorage` hosts every third-party FileProvider domain (Dropbox,
+# OneDrive, Google Drive, Box, ...) on modern macOS.
+_CLOUD_PLACEHOLDER_MARKERS = frozenset({"Mobile Documents", "CloudStorage"})
+
+
+def _is_cloud_placeholder_path(path: Path) -> bool:
+    """Return True for paths inside a macOS FileProvider-backed subtree.
 
     ``O_NONBLOCK`` does not make regular-file reads non-blocking.  Opening an
-    evicted FileProvider placeholder below ``~/Library/Mobile Documents`` can
-    therefore wait indefinitely for hydration.  The lifecycle guard runs
-    before a terminal command's timeout starts, so it must identify this
-    boundary from path metadata and fail closed without opening the file.
+    evicted FileProvider placeholder below ``~/Library/Mobile Documents``
+    (iCloud Drive) or ``~/Library/CloudStorage`` (Dropbox / OneDrive /
+    Google Drive and other third-party providers) can therefore wait
+    indefinitely for hydration.  The lifecycle guard runs before a terminal
+    command's timeout starts, so it must identify this boundary from path
+    metadata and fail closed without opening the file.
     """
     parts = path.parts
     return any(
-        parts[index - 1] == "Library" and part == "Mobile Documents"
+        parts[index - 1] == "Library" and part in _CLOUD_PLACEHOLDER_MARKERS
         for index, part in enumerate(parts)
         if index
     )
@@ -443,7 +452,28 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
 
 
 def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
-    """Return ``(text, unsafe)`` using bounded, regular-file-only reads."""
+    """Return ``(text, unsafe)`` using bounded, regular-file-only reads.
+
+    This is the shared choke point for every local script read the guard
+    performs (the terminal walk in ``_contains_unsafe_gateway_action`` AND
+    the cron-script scan in ``_read_script_for_scanning``), so the
+    cloud-placeholder refusal lives here: a FileProvider path must never be
+    opened — not even to discover whether the file is hydrated — because an
+    evicted placeholder's ``open()`` can hang preflight indefinitely
+    (#88052). The lexical check covers direct cloud paths; the resolved
+    check covers local launchers that are symlinks into a cloud subtree.
+    """
+    if _is_cloud_placeholder_path(path):
+        return None, True
+    try:
+        resolved = path.resolve(strict=False)
+    except (OSError, ValueError):
+        # OSError: unreadable/long paths. ValueError: embedded NUL byte
+        # from a binary's decoded contents tokenized as a path — a
+        # guarded path must never crash the guard (#76762).
+        resolved = path
+    if _is_cloud_placeholder_path(resolved):
+        return None, True
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
@@ -549,10 +579,13 @@ def _contains_unsafe_gateway_action(
             return True
 
     for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
-        # Do not touch a FileProvider path even to discover whether the file is
-        # hydrated.  The lexical check covers direct cloud paths; the resolved
-        # check below covers local launchers that are symlinks into iCloud.
-        if _is_apple_file_provider_path(script_path):
+        # Do not touch a FileProvider path even to discover whether the file
+        # is hydrated. The lexical check covers direct cloud paths; the
+        # resolved check below covers local launchers that are symlinks into
+        # a cloud subtree. _read_referenced_script repeats both checks as the
+        # shared choke point, so every caller stays covered even if this
+        # walk-level short-circuit is bypassed.
+        if _is_cloud_placeholder_path(script_path):
             return True
         try:
             resolved = script_path.resolve(strict=False)
@@ -561,7 +594,7 @@ def _contains_unsafe_gateway_action(
             # from a binary's decoded contents tokenized as a path — a
             # guarded path must never crash the guard (#76762).
             resolved = script_path
-        if _is_apple_file_provider_path(resolved):
+        if _is_cloud_placeholder_path(resolved):
             return True
         if resolved in visited:
             continue

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -746,6 +746,29 @@ def check_gateway_lifecycle(
     python_script = False
     if script:
         resolved_script = _resolve_script_path(script)
+        if resolved_script is not None:
+            try:
+                real_script = resolved_script.resolve(strict=False)
+            except (OSError, ValueError):
+                real_script = resolved_script
+            if _is_cloud_placeholder_path(resolved_script) or _is_cloud_placeholder_path(
+                real_script
+            ):
+                # Attribute the refusal correctly: the script is not known to
+                # contain a lifecycle command — it lives on a cloud-synced
+                # FileProvider path (iCloud Drive / ~/Library/CloudStorage)
+                # that the guard refuses to open because an evicted
+                # placeholder can hang preflight indefinitely (#88052).
+                # Fail closed with the real reason instead of implying a
+                # dangerous lifecycle command.
+                raise GatewayLifecycleBlocked(
+                    "Blocked: the cron script lives on a cloud-synced path "
+                    "(iCloud Drive / ~/Library/CloudStorage). Opening an "
+                    "evicted FileProvider placeholder can hang the guard's "
+                    "preflight scan indefinitely, so it is refused without "
+                    "being read. Move the script to a local, non-cloud path "
+                    "(e.g. ~/.hermes/scripts/) and recreate the job."
+                )
         python_script = resolved_script is not None and resolved_script.suffix == ".py"
         script_text = _read_script_for_scanning(script)
         if script_text:

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -109,6 +109,23 @@ _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
 _MAX_REFERENCED_SCRIPT_DEPTH = 8
 _CONTROL_CHARS = frozenset(";&|()")
 
+
+def _is_apple_file_provider_path(path: Path) -> bool:
+    """Return True for paths inside macOS's cloud-backed document root.
+
+    ``O_NONBLOCK`` does not make regular-file reads non-blocking.  Opening an
+    evicted FileProvider placeholder below ``~/Library/Mobile Documents`` can
+    therefore wait indefinitely for hydration.  The lifecycle guard runs
+    before a terminal command's timeout starts, so it must identify this
+    boundary from path metadata and fail closed without opening the file.
+    """
+    parts = path.parts
+    return any(
+        parts[index - 1] == "Library" and part == "Mobile Documents"
+        for index, part in enumerate(parts)
+        if index
+    )
+
 # Executables whose arguments are DATA, not commands: search patterns, SQL
 # statements, log filters. None of these can execute their argument text, so
 # a lifecycle-shaped string inside their arguments (a grep pattern hunting
@@ -532,6 +549,11 @@ def _contains_unsafe_gateway_action(
             return True
 
     for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
+        # Do not touch a FileProvider path even to discover whether the file is
+        # hydrated.  The lexical check covers direct cloud paths; the resolved
+        # check below covers local launchers that are symlinks into iCloud.
+        if _is_apple_file_provider_path(script_path):
+            return True
         try:
             resolved = script_path.resolve(strict=False)
         except (OSError, ValueError):
@@ -539,6 +561,8 @@ def _contains_unsafe_gateway_action(
             # from a binary's decoded contents tokenized as a path — a
             # guarded path must never crash the guard (#76762).
             resolved = script_path
+        if _is_apple_file_provider_path(resolved):
+            return True
         if resolved in visited:
             continue
         visited.add(resolved)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -803,6 +803,61 @@ class TestLifecycleGuardModule:
             str(launcher)
         ) is True
 
+    def test_third_party_cloudstorage_path_fails_closed_without_opening(
+        self, tmp_path, monkeypatch
+    ):
+        """~/Library/CloudStorage (Dropbox/OneDrive/Google Drive) is the same
+        FileProvider hazard as iCloud's Mobile Documents: an evicted
+        placeholder's open() can hang preflight. The guard must fail closed
+        on the lexical path without opening the file."""
+        import cron.lifecycle_guard as lifecycle_guard
+
+        cloud_dir = (
+            tmp_path
+            / "Library"
+            / "CloudStorage"
+            / "Dropbox-Personal"
+            / "scripts"
+        )
+        cloud_dir.mkdir(parents=True)
+        script = cloud_dir / "helper.sh"
+        script.write_text("#!/bin/sh\necho safe\n", encoding="utf-8")
+
+        real_open = lifecycle_guard.os.open
+
+        def reject_cloud_open(path, flags, *args, **kwargs):
+            if str(path) == str(script):
+                pytest.fail("lifecycle guard opened a CloudStorage path")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(lifecycle_guard.os, "open", reject_cloud_open)
+
+        assert lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(
+            str(script)
+        ) is True
+
+    def test_read_referenced_script_choke_point_refuses_cloud_paths(
+        self, tmp_path, monkeypatch
+    ):
+        """The cloud refusal lives in _read_referenced_script itself so EVERY
+        caller (terminal walk AND cron-script scan) is covered — not just the
+        walk-level short-circuit in _contains_unsafe_gateway_action."""
+        import cron.lifecycle_guard as lifecycle_guard
+
+        cloud_dir = tmp_path / "Library" / "CloudStorage" / "OneDrive" / "s"
+        cloud_dir.mkdir(parents=True)
+        script = cloud_dir / "job.sh"
+        script.write_text("#!/bin/sh\necho safe\n", encoding="utf-8")
+
+        def forbid_open(path, flags, *args, **kwargs):  # pragma: no cover
+            pytest.fail("choke point opened a cloud placeholder path")
+
+        monkeypatch.setattr(lifecycle_guard.os, "open", forbid_open)
+
+        text, unsafe = lifecycle_guard._read_referenced_script(script)
+        assert text is None
+        assert unsafe is True
+
     # -- Whole-class regression tests (tilllt's T1-T4 on PR #79454) --------
 
     def test_tilde_nul_candidate_does_not_crash_terminal_walk(self):

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -761,6 +761,48 @@ class TestLifecycleGuardModule:
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily ops", str(script))
 
+    def test_cloud_backed_symlink_fails_closed_without_opening_target(
+        self, tmp_path, monkeypatch
+    ):
+        """A FileProvider placeholder must not block terminal preflight.
+
+        ``O_NONBLOCK`` has no effect on regular files.  On macOS, opening an
+        iCloud placeholder can therefore wait indefinitely for hydration,
+        before the terminal command's own timeout has even started.  Detect
+        the resolved FileProvider path from local metadata and fail closed
+        without opening it.
+        """
+        import cron.lifecycle_guard as lifecycle_guard
+
+        cloud_dir = (
+            tmp_path
+            / "Library"
+            / "Mobile Documents"
+            / "com~apple~CloudDocs"
+            / "scripts"
+        )
+        cloud_dir.mkdir(parents=True)
+        target = cloud_dir / "helper"
+        target.write_text("#!/bin/sh\necho safe\n", encoding="utf-8")
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        launcher = bin_dir / "helper"
+        launcher.symlink_to(target)
+
+        real_open = lifecycle_guard.os.open
+
+        def reject_cloud_open(path, flags, *args, **kwargs):
+            if str(path) == str(launcher):
+                pytest.fail("lifecycle guard opened a cloud-backed symlink")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(lifecycle_guard.os, "open", reject_cloud_open)
+
+        assert lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(
+            str(launcher)
+        ) is True
+
     # -- Whole-class regression tests (tilllt's T1-T4 on PR #79454) --------
 
     def test_tilde_nul_candidate_does_not_crash_terminal_walk(self):

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -858,6 +858,45 @@ class TestLifecycleGuardModule:
         assert text is None
         assert unsafe is True
 
+    def test_cron_script_scan_blocks_cloud_script_without_opening(
+        self, tmp_path, monkeypatch
+    ):
+        """The cron-script scan path (_read_script_for_scanning via
+        check_gateway_lifecycle) must also refuse a cloud-resident script
+        without opening it, and the surfaced reason must attribute the
+        refusal to the cloud-synced path — not to a lifecycle command."""
+        import cron.lifecycle_guard as lifecycle_guard
+        from cron.lifecycle_guard import (
+            GatewayLifecycleBlocked,
+            check_gateway_lifecycle,
+        )
+
+        cloud_dir = (
+            tmp_path
+            / "Library"
+            / "Mobile Documents"
+            / "com~apple~CloudDocs"
+            / "scripts"
+        )
+        cloud_dir.mkdir(parents=True)
+        script = cloud_dir / "nightly.sh"
+        script.write_text("#!/bin/sh\necho safe\n", encoding="utf-8")
+
+        real_open = lifecycle_guard.os.open
+
+        def reject_cloud_open(path, flags, *args, **kwargs):
+            if str(path) == str(script):
+                pytest.fail("cron-script scan opened a cloud-resident script")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(lifecycle_guard.os, "open", reject_cloud_open)
+
+        with pytest.raises(GatewayLifecycleBlocked) as excinfo:
+            check_gateway_lifecycle("nightly job", str(script))
+        message = str(excinfo.value)
+        assert "cloud-synced" in message
+        assert "lifecycle command" not in message
+
     # -- Whole-class regression tests (tilllt's T1-T4 on PR #79454) --------
 
     def test_tilde_nul_candidate_does_not_crash_terminal_walk(self):


### PR DESCRIPTION
Salvages #88052 onto current main and widens it per review so the lifecycle guard never opens a macOS FileProvider (cloud-placeholder) path on any code path — with the refusal correctly attributed.

Original fix by @skip-agent (first-time contributor) — their commit is cherry-picked with authorship preserved. Thank you!

## Changes

- **Cherry-picked from #88052** (`fix(terminal): avoid FileProvider reads in lifecycle guard`, author @skip-agent): lexical `Library/Mobile Documents` detection + short-circuit in `_contains_unsafe_gateway_action`'s referenced-script walk, failing closed before `os.open` can hang on an evicted iCloud placeholder (O_NONBLOCK has no effect on regular files).
- **Widening 1 — shared choke point + CloudStorage** (`fix(cron): move cloud-placeholder refusal into _read_referenced_script...`):
  - The walk-level guard left the sibling caller `_read_script_for_scanning` unprotected — a cloud-resident **cron script** could still hang preflight. The refusal (lexical + resolved-symlink checks) now lives inside `_read_referenced_script`, the shared choke point, so every caller is covered. Fail-closed semantics kept.
  - `_is_apple_file_provider_path` generalized to `_is_cloud_placeholder_path`: detects `~/Library/CloudStorage` (Dropbox / OneDrive / Google Drive and other third-party FileProvider domains) alongside iCloud's `Library/Mobile Documents`.
- **Widening 2 — honest refusal reason** (`fix(cron): attribute cloud-path refusals...`): when `check_gateway_lifecycle` refuses a cloud-resident cron script, the error now says the script lives on a cloud-synced path that could hang the preflight scan (with a "move it to a local path" remedy) instead of implying the job contained a dangerous gateway lifecycle command. Still fail-closed.
- **Attribution**: mapped @skip-agent's commit email in `contributors/emails/`; `audit_pr_attribution.py` is clean.

## Validation

| Check | Result |
|---|---|
| `tests/hermes_cli/test_gateway_restart_loop.py` (full file, incl. contributor's original test) | ✅ 131 passed |
| New: CloudStorage lexical path blocked without `os.open` | ✅ |
| New: `_read_referenced_script` choke point refuses cloud paths with `os.open` forbidden entirely | ✅ |
| New: cron-script scan path (`check_gateway_lifecycle` → `_read_script_for_scanning`) blocks a cloud-resident script without opening it, message names the cloud-synced path (asserts `"lifecycle command" not in message`) | ✅ |
| `git diff --stat origin/main..HEAD` touches only `cron/lifecycle_guard.py`, the test file, and the contributor email map | ✅ |
| Behind-main count at push time | 0 |

The new tests fail without the fix: the choke-point and cron-scan tests monkeypatch `os.open` to `pytest.fail` on the cloud path, so pre-fix code (which opened the file) trips them immediately.

Do **not** close #88052 automatically; it should be closed as salvaged once this merges.

## Infographic

![CLOUD PLACEHOLDER GUARD infographic](https://v3b.fal.media/files/b/0aa6a720/nVOg1NSRyeQ8pSifDHq9b_Tfmte00I.png)
