### PR TITLE
fix(desktop): recover incomplete transcript turns

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -595,11 +595,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // mutates the per-runtime cache entry, and syncSessionStateToView
         // guards the view publish to the active session, so this is safe.
         if (runningChanged && sessionId) {
-          // Set when THIS event released a turn that ended without ever
-          // producing an assistant payload, so the catch-up side effects below
-          // run on that edge only. The updater is invoked exactly once,
+          // Set when THIS event releases a confirmed live turn whose terminal
+          // message never arrived. The updater is invoked exactly once,
           // synchronously, by updateSessionState.
-          let recoveredWithoutPayload = false
+          let recoveredIncompleteTurn = false
 
           const nextState = updateSessionState(
             sessionId,
@@ -654,15 +653,14 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
               }
 
               // Past that gate the turn DID start and the backend now reports it
-              // finished. When no assistant payload ever arrived (gateway crash
-              // mid-stream, provider error before the first delta, agent-build
-              // failure) message.complete never fires, so this is the only event
-              // that can release the session. Bailing here instead left
+              // finished. When message.complete never fires (gateway crash
+              // mid-stream, provider error, reconnect gap), this is the only
+              // event that can release the session. Bailing here instead left
               // awaitingResponse/busy latched until app restart (#46517): the
               // per-session busy flag is authoritative for isTargetSessionBusy,
               // so submitPrompt and the slash dispatcher silently returned false
               // and the session accepted no further input.
-              recoveredWithoutPayload = state.awaitingResponse && !state.sawAssistantPayload
+              recoveredIncompleteTurn = state.turnLive
 
               return {
                 ...state,
@@ -687,13 +685,13 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             payload?.stored_session_id || undefined
           )
 
-          if (recoveredWithoutPayload) {
+          if (recoveredIncompleteTurn) {
             // Stays unscoped, like the settle above: a background session's
             // sidebar row has to drop its working dot without the user opening
-            // it. This fires on the recovery edge only — once awaitingResponse
-            // is false the `state.busy === busy` guard above short-circuits
-            // every later heartbeat — so it costs one coalesced refresh per
-            // broken turn, not one per tick.
+            // it. This fires on the recovery edge only — once turnLive is false
+            // the `state.busy === busy` guard above short-circuits every later
+            // heartbeat — so it costs one coalesced refresh per broken turn,
+            // not one per tick.
             scheduleSessionsRefresh()
 
             // The transcript catch-up IS scoped. The stream died, but the turn

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -730,7 +730,7 @@ export function useMessageStream({
         shouldHydrate =
           !completionError &&
           !hasInlineError &&
-          !unresolvedUserTail &&
+          (!unresolvedUserTail || !finalText) &&
           (state.adoptedRunningTurn || !state.sawAssistantPayload || !finalText)
 
         return {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
-import { chatMessageText } from '@/lib/chat-messages'
+import { chatMessageText, textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionTodos } from '@/store/todos'
 import type { RpcEvent } from '@/types/hermes'
@@ -15,17 +15,23 @@ const SID = 'session-1'
 
 let handleEvent: ((event: RpcEvent) => void) | null = null
 let sessionStates: Map<string, ClientSessionState>
+let initialSessionState: ClientSessionState | null
+let hydrateFromStoredSession: ReturnType<typeof vi.fn<() => Promise<void>>>
 let mockCompleteSound: ReturnType<typeof vi.fn>
 let mockHaptic: ReturnType<typeof vi.fn>
 
 function Harness() {
   const activeSessionIdRef = useRef<string | null>(SID)
-  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+
+  const sessionStateByRuntimeIdRef = useRef(
+    new Map<string, ClientSessionState>(initialSessionState ? [[SID, initialSessionState]] : [])
+  )
+
   const queryClientRef = useRef(new QueryClient())
 
   const stream = useMessageStream({
     activeSessionIdRef,
-    hydrateFromStoredSession: vi.fn(async () => undefined),
+    hydrateFromStoredSession,
     queryClient: queryClientRef.current,
     refreshHermesConfig: vi.fn(async () => undefined),
     refreshSessions: vi.fn(async () => undefined),
@@ -47,8 +53,9 @@ function Harness() {
   return null
 }
 
-async function mountStream() {
+async function mountStream(state: ClientSessionState | null = null) {
   sessionStates = new Map()
+  initialSessionState = state
   render(<Harness />)
   await waitFor(() => expect(handleEvent).not.toBeNull())
 }
@@ -88,6 +95,8 @@ function assistantMessages(): string[] {
 describe('useMessageStream interim text sealing', () => {
   beforeEach(() => {
     handleEvent = null
+    initialSessionState = null
+    hydrateFromStoredSession = vi.fn<() => Promise<void>>(async () => undefined)
     clearSessionTodos(SID)
   })
 
@@ -109,6 +118,19 @@ describe('useMessageStream interim text sealing', () => {
     const texts = assistantMessages()
     expect(texts).toContain('awaaaaa clean!! tsc zero errors')
     expect(texts).toContain('All checks passed.')
+  })
+
+  it('hydrates an empty completion when the live transcript still ends with the user message', async () => {
+    await mountStream(
+      createClientSessionState('stored-session-1', [
+        { id: 'user-1', role: 'user', parts: [textPart('finish the task')] }
+      ])
+    )
+    await start()
+
+    await complete('')
+
+    expect(hydrateFromStoredSession).toHaveBeenCalledWith(3, 'stored-session-1', SID)
   })
 
   it('marks sealed interim bubbles interim and leaves the final reply unmarked', async () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -146,7 +146,7 @@ describe('session.info model-options invalidation gating', () => {
   })
 })
 
-describe('session.info settles a turn that produced no assistant payload', () => {
+describe('session.info settles an incomplete live turn', () => {
   // #46517: a turn that ends without ever emitting an assistant payload (gateway
   // crash mid-stream, provider error before the first delta, agent-build
   // failure) never reaches message.complete, so session.info running=false is
@@ -233,6 +233,26 @@ describe('session.info settles a turn that produced no assistant payload', () =>
 
     expect(hydrateFromStoredSession).toHaveBeenCalledTimes(1)
     expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('hydrates a live turn that settles after an interim without message.complete', async () => {
+    await mountStream()
+
+    startTurn(ACTIVE_SID)
+    vi.useFakeTimers()
+    act(() =>
+      handleEvent!({
+        payload: { already_streamed: true, text: 'Now checking the details before answering.' },
+        session_id: ACTIVE_SID,
+        type: 'message.interim'
+      })
+    )
+
+    expect(sessionStates!.get(ACTIVE_SID)?.sawAssistantPayload).toBe(true)
+
+    sessionInfo(ACTIVE_SID, { running: false })
+
+    expect(hydrateFromStoredSession).toHaveBeenCalledWith(3, null, ACTIVE_SID)
   })
 })
 


### PR DESCRIPTION
## What does this PR do?

Recovers Desktop assistant output when a turn finishes without a usable terminal message.

There are two related failure paths:

- An empty `message.complete` can arrive while the live transcript still ends with the user message, even though the durable session already contains the assistant response. The completion handler now hydrates that durable response.
- A confirmed live turn can transition to `session.info running=false` without receiving `message.complete`, including after interim assistant output. The session handler now settles the pending bubble, refreshes session metadata, and hydrates the active transcript from durable history.

Foreground isolation remains intact: background sessions update their cached busy state and sidebar metadata without replacing the visible transcript.

The older #62504 and #41922 changes preserve assistant text that was already streamed into the renderer. This change covers the complementary cases where no final assistant text is visible and durable-history catch-up is required, or where the terminal event is missing entirely.

## Related Issue

Fixes #88036

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Updated `apps/desktop/src/app/session/hooks/use-message-stream/index.ts` to hydrate durable history when an empty completion leaves an unresolved user tail.
- Updated `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts` to recover any confirmed live turn that ends without `message.complete`, including turns with interim assistant output.
- Added regression coverage in `interim-sealing.test.tsx` and `session-info-side-effects.test.tsx` for both event sequences and active/background session isolation.

## How to Test

1. Run `cd apps/desktop && npx vitest run src/app/session/hooks/use-message-stream`.
2. Run `npm run typecheck`, `npm run lint`, and `npm run build` from `apps/desktop`.
3. Simulate an empty `message.complete` after `message.start`, and a `message.interim` followed by `session.info running=false` without `message.complete`; verify the active transcript hydrates from stored history and the composer is released.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A: Desktop TypeScript-only change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - event-state logic is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

```text
use-message-stream: 22 test files passed, 119 tests passed
typecheck: passed
lint: 0 errors (111 existing warnings)
build: passed, dist assertion passed
```
