### PR TITLE
fix: load web plugins before selecting extrsact backend

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -861,6 +861,7 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
+            _ensure_web_plugins_loaded()
             backend = _get_extract_backend()
 
             # All seven providers (brave-free, ddgs, searxng, exa, parallel,


### PR DESCRIPTION
## What does this PR do?

While looking through `web_extract_tool()`, I noticed that the extract backend was being resolved before the web plugins were explicitly loaded.

This can be a problem when the tool is called in a fresh process, since the backend lookup may happen before the plugin registry has been populated.

This PR moves `_ensure_web_plugins_loaded()` before `_get_extract_backend()`, so the plugins are available when the backend is selected.

The rest of the extraction flow is left unchanged.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `_ensure_web_plugins_loaded()` before backend selection
- Kept the existing backend dispatch logic unchanged

## How to Test

I checked the changed file with:

- `python3 -m py_compile tools/web_tools.py`
- `git diff --check`

I couldn't run the full pytest suite because `uv` isn't installed in my local environment.