### PR TITLE
fix(oauth): release the callback listener after a pasted redirect

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -946,6 +946,56 @@ class TestPasteCallbackReader:
 class TestWaitForCallbackPasteIntegration:
     """_wait_for_callback offers the paste prompt only when interactive."""
 
+    def test_paste_releases_fixed_callback_port(self, monkeypatch):
+        """A pasted redirect must stop the HTTP listener before returning."""
+        import socket
+        import tools.mcp_oauth as mod
+
+        port = _find_free_port()
+        mod._oauth_port = port
+        monkeypatch.setattr(mod, "_is_interactive", lambda: True)
+        monkeypatch.setattr(
+            "sys.stdin",
+            MagicMock(readline=lambda: "code=pasted&state=state123\n"),
+        )
+
+        assert asyncio.run(_wait_for_callback()) == ("pasted", "state123")
+
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            probe.bind(("127.0.0.1", port))
+        finally:
+            probe.close()
+
+    def test_consecutive_paste_flows_reuse_fixed_port(self, monkeypatch):
+        """A second flow on the same fixed port must bind after a paste.
+
+        This is the user-visible failure with a fixed ``oauth.redirect_port``:
+        on Linux, the previous flow's ``handle_request`` thread keeps the
+        closed listener's socket alive, so the next flow's own bind fails
+        with ``[Errno 98] Address already in use`` even though it sets
+        ``allow_reuse_address``. macOS does not reproduce this, so the
+        regression is only visible on Linux CI.
+        """
+        import tools.mcp_oauth as mod
+
+        port = _find_free_port()
+        monkeypatch.setattr(mod, "_is_interactive", lambda: True)
+
+        mod._oauth_port = port
+        monkeypatch.setattr(
+            "sys.stdin",
+            MagicMock(readline=lambda: "code=first&state=s1\n"),
+        )
+        assert asyncio.run(_wait_for_callback()) == ("first", "s1")
+
+        mod._oauth_port = port
+        monkeypatch.setattr(
+            "sys.stdin",
+            MagicMock(readline=lambda: "code=second&state=s2\n"),
+        )
+        assert asyncio.run(_wait_for_callback()) == ("second", "s2")
+
     def test_paste_prompt_shown_on_tty(self, monkeypatch, capsys):
         import tools.mcp_oauth as mod
         mod._oauth_port = _find_free_port()

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -911,7 +911,11 @@ def _make_callback_waiter(port: int):
                 "in the server config, then retry."
             ) from exc
 
-        server_thread = threading.Thread(target=server.handle_request, daemon=True)
+        server_thread = threading.Thread(
+            target=server.serve_forever,
+            kwargs={"poll_interval": 0.1},
+            daemon=True,
+        )
         server_thread.start()
 
         # Optional paste-fallback thread: only on interactive TTYs. Reads one
@@ -942,7 +946,9 @@ def _make_callback_waiter(port: int):
                 await asyncio.sleep(poll_interval)
                 elapsed += poll_interval
         finally:
+            server.shutdown()
             server.server_close()
+            server_thread.join(timeout=1.0)
 
         if result["error"] == _USER_SKIPPED_SENTINEL:
             raise OAuthNonInteractiveError("user_skipped")


### PR DESCRIPTION
## Problem

With a fixed `oauth.redirect_port`, completing an OAuth flow via the stdin paste fallback leaves the callback port unusable: the next flow on the same port fails at bind with `OSError: [Errno 98] Address already in use`.

`_wait_for_callback` runs `server.handle_request()` on a daemon thread. When the paste path wins the race, the finally block calls `server.server_close()` — but on Linux the thread blocked inside `handle_request()` keeps the listener's socket alive, so the port is never actually released. The `allow_reuse_address` added in #44590 does not help: `SO_REUSEADDR`/`SO_REUSEPORT` cannot rebind past a socket that is still held open by the stuck thread.

**Platform-dependent:** macOS releases the port and does not reproduce; Linux reproduces deterministically. Verified on v0.20.2 (`df4b65147`) on both platforms with the regression tests included here — on Linux both fail before this patch and pass after; the existing suite is unaffected.

## Fix

Run the listener with `serve_forever(poll_interval=0.1)` instead of `handle_request()`, and shut it down explicitly (`shutdown()` + `server_close()` + bounded `join()`) in the finally block. `serve_forever` polls, so the thread observes the shutdown request and exits, releasing the socket regardless of which path (HTTP callback, paste, timeout, or skip) completed the flow.

## Tests

- `test_paste_releases_fixed_callback_port` — after a pasted redirect, a plain bind (no `SO_REUSEADDR`) on the same port succeeds.
- `test_consecutive_paste_flows_reuse_fixed_port` — the user-visible scenario: a second `_wait_for_callback` flow on the same fixed port binds successfully.

Both are meaningful guards on Linux CI; macOS passes them even unpatched.

## Context

Found running Hermes as a NixOS service with a fixed `oauth.redirect_port` for a confidential-client MCP server, where every re-authorization after a pasted callback failed until restart. We have been carrying this patch in a fork since v0.19.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)