### PR TITLE
feat(desktop): play a think pose when the focused bot is working

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -969,8 +969,8 @@ function projectFacePoint(x, y, turn, tilt, roll) {
   const r = (roll * Math.PI) / 180
   const xr = dx * Math.cos(r) - dy * Math.sin(r)
   const yr = dx * Math.sin(r) + dy * Math.cos(r)
-  const sx = 0.74 + 0.26 * Math.abs(Math.cos((turn * Math.PI) / 180))
-  const sy = 0.8 + 0.2 * Math.abs(Math.cos((tilt * Math.PI) / 180))
+  const sx = 0.58 + 0.42 * Math.abs(Math.cos((turn * Math.PI) / 180))
+  const sy = 0.7 + 0.3 * Math.abs(Math.cos((tilt * Math.PI) / 180))
   return [20 + xr * sx, 20 + yr * sy]
 }
 
@@ -988,19 +988,40 @@ function ringToPath(pts) {
   return d + 'Z'
 }
 
-/** Grok-style pose. thinking/working lean and sway. idle is a small sine. */
+/** How the head moves. Think leans and shows dots. Work bobs.
+ *  Idle is a small sway. The moves are big so a tiny roster face still reads. */
 function facePose(mood, t) {
-  if (mood === 'work') {
+  if (mood === 'think') {
     return {
-      turn: -11 + Math.sin(t * 0.48) * 8,
-      tilt: Math.sin(t * 0.42) * 8 + Math.sin(t * 1.1) * 1.6,
-      roll: Math.sin(t * 0.75) * 4.2,
-      gazeX: Math.sin(t * 0.55) * 3.6,
-      gazeY: -1.6 + Math.sin(t * 0.38) * 2,
+      turn: -18 + Math.sin(t * 0.55) * 14,
+      tilt: Math.sin(t * 0.48) * 12 + Math.sin(t * 1.35) * 3,
+      roll: Math.sin(t * 0.95) * 10,
+      gazeX: Math.sin(t * 0.7) * 3.6,
+      gazeY: -2.2 + Math.sin(t * 0.4) * 2.2,
       blink: t % 1.45 > 1.26,
-      d0: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.6)),
-      d1: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.6 - 0.7)),
-      d2: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.6 - 1.4))
+      lift: Math.sin(t * 1.15) * 1.8,
+      scale: 1 + Math.sin(t * 0.95) * 0.045,
+      d0: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.4)),
+      d1: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.4 - 0.7)),
+      d2: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.4 - 1.4))
+    }
+  }
+
+  if (mood === 'work') {
+    const bob = Math.sin(t * Math.PI * 2 * 1.85)
+
+    return {
+      turn: 8 + bob * 9,
+      tilt: 5 + Math.sin(t * 2.4) * 5,
+      roll: 2 + Math.max(0, bob) * 10,
+      gazeX: Math.sin(t * 1.05) * 2.8,
+      gazeY: Math.sin(t * 0.7) * 2,
+      blink: t % 1.15 > 0.98,
+      lift: Math.max(0, bob) * 4,
+      scale: 1 - Math.max(0, bob) * 0.07,
+      d0: 0,
+      d1: 0,
+      d2: 0
     }
   }
 
@@ -1011,6 +1032,8 @@ function facePose(mood, t) {
     gazeX: 0,
     gazeY: 0,
     blink: t % 3.2 > 3.02,
+    lift: 0,
+    scale: 1,
     d0: 0,
     d1: 0,
     d2: 0
@@ -1020,7 +1043,7 @@ function facePose(mood, t) {
 function paintMathFace(svg, t) {
   const mood = svg.getAttribute('data-hb-mood') || 'idle'
   const shape = svg.getAttribute('data-hb-shape') || 'circle'
-  const pose = facePose(mood, t)
+  const pose = settlePose(svg, mood, facePose(mood, t))
   const body = svg.querySelector('[data-hb-body]')
   const open = svg.querySelector('[data-hb-open]')
   const shut = svg.querySelector('[data-hb-shut]')
@@ -1081,8 +1104,48 @@ function paintMathFace(svg, t) {
     dot.setAttribute('opacity', String(o))
   })
 
-  svg.style.transform = `rotate(${pose.tilt}deg)`
-  svg.style.transformOrigin = '50% 70%'
+  const lift = pose.lift || 0
+  const scale = pose.scale == null ? 1 : pose.scale
+  svg.style.transform = `translateY(${-lift}px) rotate(${pose.tilt}deg) rotate(${pose.roll * 0.35}deg) scale(${scale})`
+  svg.style.transformOrigin = '50% 80%'
+}
+
+const POSE_KEYS = ['turn', 'tilt', 'roll', 'gazeX', 'gazeY', 'lift', 'scale', 'd0', 'd1', 'd2']
+
+function mixPose(from, to, t) {
+  const out = { ...to }
+  const k = 1 - (1 - t) * (1 - t)
+
+  for (const key of POSE_KEYS) {
+    const a = from[key]
+    const b = to[key]
+
+    if (typeof a === 'number' && typeof b === 'number') {
+      out[key] = a + (b - a) * k
+    }
+  }
+
+  return out
+}
+
+/** Blend from the last pose so a mood change does not jump. */
+function settlePose(svg, mood, pose) {
+  if (svg.__hbMood !== mood) {
+    svg.__hbMood = mood
+    svg.__hbFrom = svg.__hbPose || pose
+    svg.__hbBlend = 0
+  }
+
+  let drawn = pose
+
+  if (svg.__hbFrom && svg.__hbBlend < 1) {
+    svg.__hbBlend = Math.min(1, svg.__hbBlend + 0.08)
+    drawn = mixPose(svg.__hbFrom, pose, svg.__hbBlend)
+  }
+
+  svg.__hbPose = drawn
+
+  return drawn
 }
 
 function walkMathFaces(root, acc) {
@@ -1167,11 +1230,12 @@ function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle'
     })
   }
 
-  const working = mood === 'work'
+  const live = mood === 'think' || mood === 'work'
+  const thinking = mood === 'think'
   const eyeFill = isDarkColor(color) ? 'rgba(232,220,195,0.95)' : 'rgba(0,0,0,0.85)'
   const ring = sampleFaceRing(shape)
-  const rest = facePose(working ? 'work' : 'idle', 0)
-  // Shape-aware initial eye line — the cloud body sits lower, so its eyes
+  const rest = facePose(mood === 'think' || mood === 'work' ? mood : 'idle', 0)
+  // Shape-aware initial eye line. The cloud body sits lower, so its eyes
   // (and their catchlights) start at the cloud position instead of jumping
   // there on the first clock paint.
   const eyeY0 = shape === 'cloud' ? 22 : 17.2
@@ -1179,7 +1243,7 @@ function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle'
   return jsxs('svg', {
     'data-bot-face': name,
     'data-hb-math': '1',
-    'data-hb-mood': working ? 'work' : 'idle',
+    'data-hb-mood': thinking ? 'think' : mood === 'work' ? 'work' : 'idle',
     'data-hb-shape': shape || 'circle',
     viewBox: '0 0 40 44',
     width: size,
@@ -1197,8 +1261,8 @@ function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle'
       jsxs('g', {
         'data-hb-open': '1',
         children: [
-          jsx('ellipse', { 'data-hb-el': '1', cx: 15.4, cy: eyeY0, rx: 2.2, ry: working ? 2.6 : 2.3, fill: eyeFill }),
-          jsx('ellipse', { 'data-hb-er': '1', cx: 24.6, cy: eyeY0, rx: 2.2, ry: working ? 2.6 : 2.3, fill: eyeFill }),
+          jsx('ellipse', { 'data-hb-el': '1', cx: 15.4, cy: eyeY0, rx: 2.2, ry: live ? 2.6 : 2.3, fill: eyeFill }),
+          jsx('ellipse', { 'data-hb-er': '1', cx: 24.6, cy: eyeY0, rx: 2.2, ry: live ? 2.6 : 2.3, fill: eyeFill }),
           jsx('circle', { 'data-hb-hl-l': '1', cx: 14.8, cy: eyeY0 - 0.7, r: 0.65, fill: 'rgba(255,255,255,0.85)' }),
           jsx('circle', { 'data-hb-hl-r': '1', cx: 24, cy: eyeY0 - 0.7, r: 0.65, fill: 'rgba(255,255,255,0.85)' })
         ]
@@ -1212,7 +1276,7 @@ function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle'
         fill: 'none',
         opacity: 0
       }),
-      working
+      thinking
         ? jsxs('g', {
             children: [
               jsx('circle', { 'data-hb-dot': '1', cx: 16.4, cy: 41.2, r: 1.15, fill: color, opacity: rest.d0 }),
@@ -3011,18 +3075,33 @@ function generatedSessionTitle(session, preview) {
  *  seconds is treated as "active now" (pulsing dot in its row). */
 const ACTIVE_WINDOW_S = 90
 
-/** Bots that are working right now: the profile the gateway is running a
- *  turn for (busy), plus any bot whose last message landed inside the
- *  liveness window. Pure — output follows the input roster's order, so
- *  presence never reorders or hides the normal list. */
-function activeBots(roster, activeProfile, gatewayState, now = Date.now()) {
+/** Bots that are working right now. The focused bot while a turn is live,
+ *  plus any bot that wrote in the last ACTIVE_WINDOW_S seconds.
+ *  Keeps the input roster order. */
+function activeBots(roster, activeProfile, turnBusy, now = Date.now()) {
   return (roster || []).filter(bot => {
-    const busyTurn = bot.name === activeProfile && gatewayState === 'busy'
+    const busyTurn = bot.name === activeProfile && Boolean(turnBusy)
     const last = bot.last_session?.last_active || 0
     const inWindow = Boolean(last && now / 1000 - last < ACTIVE_WINDOW_S)
 
     return busyTurn || inWindow
   })
+}
+
+/** Think only while this bot is the focused live turn. Else idle. */
+function botFaceMood({ isActive, turnBusy }) {
+  if (isActive && turnBusy) {
+    return 'think'
+  }
+
+  return 'idle'
+}
+
+const $idleTurn = atom(false)
+
+/** True while the focused chat is working. Old desktops have no busy flag. */
+function useTurnBusy() {
+  return Boolean(useValue(host.state.busy || $idleTurn))
 }
 
 // ── bot row ──────────────────────────────────────────────────────────────────
@@ -3035,12 +3114,9 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
   const { shape, color, image } = botAppearance(bot.name, meta)
   // Keep user photos/pets. Drop the 160px SVG backfill so the math face can move.
   const photo = Boolean(image && !isBackfilledFacePng(image))
-  const gatewayState = useValue(host.state.gateway)
+  const turnBusy = useTurnBusy()
   const activeNow = Boolean(last?.last_active && Date.now() / 1000 - last.last_active < ACTIVE_WINDOW_S)
-  // Work pose only when this bot is actually doing something: the active
-  // profile while the gateway is busy, or a bot that wrote within the
-  // liveness window. Not every bot whenever the gateway is busy.
-  const botMood = (isActive && gatewayState === 'busy') || activeNow ? 'work' : 'idle'
+  const botMood = botFaceMood({ activeNow, isActive, turnBusy })
   const unread = Boolean(useValue($botUnread)[bot.name])
   // WHO sent the last message (bot-to-bot DM vs human) — the full stored
   // history lives in the Sessions workspace (context menu), not inline.
@@ -5865,13 +5941,10 @@ function ProfileSessionsWorkspace({ bot }) {
 
 // ── roster pane ──────────────────────────────────────────────────────────────
 
-/** "Active now" presence strip above the roster: chips for every bot that is
- *  working right now (the gateway-busy selected profile + bots whose last
- *  message landed inside the liveness window). Reuses the row avatar; each
- *  chip opens that bot's canonical Bot Chat. Omitted entirely when nothing
- *  is active, and never reorders the roster below it. */
-function ActiveNowStrip({ roster, activeProfile, gatewayState, metaByName, onOpen }) {
-  const active = activeBots(roster, activeProfile, gatewayState)
+/** Strip above the roster. Chips for the live focused turn and bots that
+ *  just wrote. Hidden when nobody is active. Does not reorder the list. */
+function ActiveNowStrip({ roster, activeProfile, turnBusy, metaByName, onOpen }) {
+  const active = activeBots(roster, activeProfile, turnBusy)
 
   if (!active.length) {
     return null
@@ -5908,7 +5981,11 @@ function ActiveNowStrip({ roster, activeProfile, gatewayState, metaByName, onOpe
               image: photo ? image : null,
               size: 24,
               name: bot.name,
-              mood: 'work'
+              mood: botFaceMood({
+                activeNow: Boolean(bot.last_session?.last_active && Date.now() / 1000 - bot.last_session.last_active < ACTIVE_WINDOW_S),
+                isActive: bot.name === activeProfile,
+                turnBusy: Boolean(turnBusy)
+              })
             }),
             jsx('span', {
               className: 'max-w-28 truncate text-xs font-medium',
@@ -6132,6 +6209,7 @@ function BotsPane() {
   const { data, error, isLoading, refetch } = useRoster()
   const gatewayState = useValue(host.state.gateway)
   const gatewayUp = gatewayState === 'open'
+  const turnBusy = useTurnBusy()
   const activeProfile = (useValue(host.state.profile) || 'default').trim() || 'default'
   const [createOpen, setCreateOpen] = useState(false)
   const [editing, setEditing] = useState(null)
@@ -6259,7 +6337,7 @@ function BotsPane() {
       jsx(ActiveNowStrip, {
         roster,
         activeProfile,
-        gatewayState,
+        turnBusy,
         metaByName: allMeta,
         onOpen: bot => {
           haptic('tap')

--- a/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
@@ -13,7 +13,7 @@ function loadActiveBots() {
 
   assert.ok(start >= 0 && end > start, 'activeBots block must remain extractable')
 
-  const context = {}
+  const context = { atom: value => ({ get: () => value }) }
   vm.runInNewContext(
     `${source.slice(start, end)}\nglobalThis.__activeBots = activeBots;`,
     context
@@ -31,22 +31,22 @@ const roster = [
   { name: 'analyst', last_session: null }
 ]
 
-test('activeBots includes the gateway-busy selected profile before its first response lands', () => {
+test('activeBots includes the focused live-turn profile before its first response lands', () => {
   const activeBots = loadActiveBots()
-  // analyst has no last_session at all — a busy turn must still show it.
-  const names = activeBots(roster, 'analyst', 'busy', NOW).map(bot => bot.name)
+  // analyst has no last_session at all. A busy turn must still show it.
+  const names = activeBots(roster, 'analyst', true, NOW).map(bot => bot.name)
   assert.ok(names.includes('analyst'))
 })
 
 test('activeBots includes bots whose last message is inside the liveness window', () => {
   const activeBots = loadActiveBots()
-  const names = activeBots(roster, 'default', 'open', NOW).map(bot => bot.name)
+  const names = activeBots(roster, 'default', false, NOW).map(bot => bot.name)
   assert.ok(names.includes('researcher'))
 })
 
 test('activeBots excludes stale activity outside the window', () => {
   const activeBots = loadActiveBots()
-  const names = activeBots(roster, 'default', 'open', NOW).map(bot => bot.name)
+  const names = activeBots(roster, 'default', false, NOW).map(bot => bot.name)
   assert.ok(!names.includes('scribe'))
 })
 
@@ -54,7 +54,7 @@ test('activeBots preserves roster order and never hides other bots', () => {
   const activeBots = loadActiveBots()
   // Mixed window: only researcher qualifies, but the output stays in input
   // order and the full roster object is untouched.
-  const active = activeBots(roster, 'default', 'open', NOW)
+  const active = activeBots(roster, 'default', false, NOW)
   assert.deepEqual(active.map(bot => bot.name), ['researcher'])
   assert.equal(roster.length, 3)
 })
@@ -65,13 +65,13 @@ test('activeBots returns an empty list when nothing is active', () => {
     { name: 'scribe', last_session: { last_active: (NOW / 1000) - 400 } },
     { name: 'analyst', last_session: null }
   ]
-  assert.deepEqual(activeBots(quiet, 'default', 'open', NOW), [])
+  assert.deepEqual(activeBots(quiet, 'default', false, NOW), [])
 })
 
 test('roster without profiles never throws', () => {
   const activeBots = loadActiveBots()
-  assert.equal(activeBots(null, 'default', 'open', NOW).length, 0)
-  assert.equal(activeBots([], 'default', 'open', NOW).length, 0)
+  assert.equal(activeBots(null, 'default', false, NOW).length, 0)
+  assert.equal(activeBots([], 'default', false, NOW).length, 0)
 })
 
 test('ActiveNowStrip renders above the roster, is a live region, and is click-accessible', () => {
@@ -88,9 +88,8 @@ test('ActiveNowStrip renders above the roster, is a live region, and is click-ac
   // Chips are real buttons (keyboard/click accessible), reuse BotFace, and
   // open the canonical chat via the same path as roster rows.
   assert.match(source, /jsx\('button', \{\s*type: 'button',\s*title: `Open \$\{label\}'s chat`/)
-  // The key rides as jsx()'s third argument — the ONLY form React treats as
-  // a list key; a `key:` prop leaves chips unkeyed (index identity).
+  // The key rides as jsx()'s third argument. A key: prop does not count.
   assert.match(source, /\}, bot\.name\)\s*\}\)\s*\]\s*\}\)\s*\}\s*\/\*\* Assign a bot to a group/s)
-  assert.match(source, /jsx\(BotFace,\s*\{[\s\S]*?mood: 'work'/)
+  assert.match(source, /jsx\(BotFace,\s*\{[\s\S]*?mood: botFaceMood\(/)
   assert.match(source, /openBotCanonicalChat\(bot\.name, allMeta\[bot\.name\]\?\.chat\)/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/face-pose.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/face-pose.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadFacePose() {
+  const start = source.indexOf('function facePose(mood, t)')
+  const end = source.indexOf('function paintMathFace')
+
+  assert.ok(start >= 0 && end > start, 'facePose must remain extractable')
+
+  const context = {}
+  vm.runInNewContext(`${source.slice(start, end)}\nglobalThis.__facePose = facePose;`, context)
+
+  return context.__facePose
+}
+
+function loadBotFaceMood() {
+  const start = source.indexOf('const ACTIVE_WINDOW_S')
+  const end = source.indexOf('// ── bot row ─')
+
+  assert.ok(start >= 0 && end > start, 'botFaceMood block must remain extractable')
+
+  const context = { atom: value => ({ get: () => value, listen: () => () => undefined }) }
+  vm.runInNewContext(
+    `${source.slice(start, end)}\nglobalThis.__botFaceMood = botFaceMood;`,
+    context
+  )
+
+  return context.__botFaceMood
+}
+
+test('think pose leans left and shows marching dots', () => {
+  const facePose = loadFacePose()
+  const pose = facePose('think', 0)
+
+  assert.ok(pose.turn < -8)
+  assert.ok(Math.abs(pose.tilt) + Math.abs(pose.roll) > 0 || pose.lift !== undefined)
+  assert.ok(pose.d0 > 0)
+  assert.ok(pose.d1 > 0)
+})
+
+test('work pose bobs and hides the think dots', () => {
+  const facePose = loadFacePose()
+  const pose = facePose('work', 0)
+
+  assert.equal(pose.d0, 0)
+  assert.equal(pose.d1, 0)
+  assert.equal(pose.d2, 0)
+  assert.notEqual(pose.turn, facePose('think', 0).turn)
+})
+
+test('idle pose stays small and has no dots', () => {
+  const facePose = loadFacePose()
+  const pose = facePose('idle', 0)
+
+  assert.equal(pose.d0, 0)
+  assert.ok(Math.abs(pose.turn) < 2)
+})
+
+test('botFaceMood is think on a live focused turn', () => {
+  const botFaceMood = loadBotFaceMood()
+
+  assert.equal(botFaceMood({ isActive: true, turnBusy: true, activeNow: false }), 'think')
+  assert.equal(botFaceMood({ isActive: true, turnBusy: true, activeNow: true }), 'think')
+})
+
+test('botFaceMood is idle when the turn ends, even if the bot just wrote', () => {
+  const botFaceMood = loadBotFaceMood()
+
+  assert.equal(botFaceMood({ isActive: false, turnBusy: true, activeNow: true }), 'idle')
+  assert.equal(botFaceMood({ isActive: true, turnBusy: false, activeNow: true }), 'idle')
+  assert.equal(botFaceMood({ isActive: true, turnBusy: false, activeNow: false }), 'idle')
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -51,8 +51,10 @@ function renderBotRow(name = 'alpha') {
     A2A_PREFIX_RE: /^$/,
     useEffect: () => undefined,
     useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
+    botFaceMood: () => 'idle',
+    useTurnBusy: () => false,
     host: {
-      state: { gateway: atom('open'), profile: atom('default') },
+      state: { busy: atom(false), gateway: atom('open'), profile: atom('default') },
       warmProfile: profile => warmed.push(profile),
       request: async () => ({ sessions: [] }),
       notify: () => undefined,


### PR DESCRIPTION
## What does this PR do?

Bot Mode shape avatars used `host.state.gateway === 'busy'` as "the model is working." That value is the socket (`open` / `connecting`). It is never `busy`. So the face never moved on a real turn.

Desktop now exposes `host.state.busy` for the focused chat. This PR uses that flag.

While the focused bot is on a live turn, a shape avatar leans, looks up a bit, and shows three marching dots. When the turn ends, it eases back to idle. It does not snap into a bounce.

Older Desktop builds that lack `host.state.busy` still load. Those faces stay idle. Photo and pet avatars stay still. They cannot morph.

This is a port of [NousResearch/Hermes-Bot-Mode#101](https://github.com/NousResearch/Hermes-Bot-Mode/pull/101). Bot Mode now lives in-tree. The cloud catchlight fix that landed after that PR is kept.

## Related Issue

Fixes #88133

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`: read `host.state.busy` (with a fallback), add a `think` pose, ease think to idle, and only think on the focused live turn
- `apps/desktop/src/plugins/hermes-bots/tests/face-pose.test.mjs`: pose math and mood rules
- `apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs`: live-turn flag is a boolean, not `gateway === 'busy'`
- `apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs`: mock `host.state.busy`

## How to Test

1. Use a Desktop build that has `host.state.busy`
2. Put a shape avatar on a bot
3. Open that bot's chat and send a message
4. The face should rock while it waits and streams
5. When the turn ends, it should settle, not hop
6. Switch to another bot mid turn. Only the focused row should think

Plugin unit tests (from `apps/desktop`):

```
node --test src/plugins/hermes-bots/tests/*.test.mjs
```

On Windows 11, 144 passed. The 4 `sh -c` quoting tests need a POSIX shell. They are not part of this change.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (plugin unit tests)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
