### PR TITLE
fix(update): self-heal broken Git-for-Windows trampoline on Windows

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -37,7 +37,7 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
-from hermes_constants import venv_python_path
+from hermes_constants import get_default_hermes_root, venv_python_path
 
 logger = logging.getLogger(__name__)
 
@@ -4191,6 +4191,26 @@ def _git_is_trampoline(git_cmd: list) -> bool:
     return "fork bomb" in output
 
 
+def _portable_git_candidates() -> list:
+    """PortableGit candidate paths: shared root first, then profile home.
+
+    The Hermes-managed PortableGit tree lives under the SHARED root
+    (``<root>/git/...``), not the profile-scoped HERMES_HOME
+    (``<root>/profiles/<name>``), so a profile-scoped ``hermes update`` must
+    look there (monerostar review, #87876). The profile-home candidate is
+    kept as a fallback for custom layouts that place it there.
+    """
+    candidates = []
+    try:
+        for root in (get_default_hermes_root(), Path(get_hermes_home())):
+            candidates.append(
+                root / "git" / "mingw64" / "libexec" / "git-core" / "git.exe"
+            )
+    except Exception:
+        pass
+    return candidates
+
+
 def _locate_real_git() -> Optional[Path]:
     """Find a real Git-for-Windows binary that is not a broken trampoline.
 
@@ -4206,18 +4226,7 @@ def _locate_real_git() -> Optional[Path]:
     candidates = [
         Path(r"C:\Program Files\Git\mingw64\libexec\git-core\git.exe"),
         Path(r"C:\Program Files (x86)\Git\mingw64\libexec\git-core\git.exe"),
-    ]
-    try:
-        candidates.append(
-            Path(get_hermes_home())
-            / "git"
-            / "mingw64"
-            / "libexec"
-            / "git-core"
-            / "git.exe"
-        )
-    except Exception:
-        pass
+    ] + _portable_git_candidates()
     for candidate in candidates:
         if not candidate.exists():
             continue

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4167,6 +4167,105 @@ def _resume_windows_gateways_after_update(token: dict | None) -> None:
             f"  ✓ Restarting {unmapped_relaunched} unmapped Windows gateway process(es)"
         )
 
+def _git_is_trampoline(git_cmd: list) -> bool:
+    """Whether *git_cmd* resolves to a Git-for-Windows trampoline launcher.
+
+    Git for Windows ships two ~46KB shims (``bin\\git.exe``, ``cmd\\git.exe``)
+    that re-exec the real ``mingw64\\libexec\\git-core\\git.exe``. When the
+    shim's re-exec target is missing or PATH resolves to the shim in a
+    context where it cannot find git-core, every git call dies with the
+    launcher's own guard message instead of running — a broken PATH entry,
+    not a network or filesystem problem (#87876). Never raises; unknown
+    states report False so a probe failure can't block an update.
+    """
+    try:
+        result = subprocess.run(
+            git_cmd + ["--version"],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=15,
+        )
+    except Exception:
+        return False
+    output = ((result.stdout or "") + (result.stderr or "")).lower()
+    return "fork bomb" in output
+
+
+def _locate_real_git() -> Optional[Path]:
+    """Find a real Git-for-Windows binary that is not a broken trampoline.
+
+    The trampoline symptom is PATH-level: ``bin\\git.exe`` / ``cmd\\git.exe``
+    (both ~46KB shims) fail to re-exec git-core, while the real binary at
+    ``mingw64\\libexec\\git-core\\git.exe`` (≈4.4MB) works when invoked
+    directly (#87876). Check the standard Git for Windows locations plus the
+    Hermes-managed PortableGit copy; accept the first candidate that runs and
+    does NOT print the trampoline guard. Returns None when nothing suitable
+    is found — callers then keep the broken command and let the existing
+    fetch-failure ZIP fallback handle it.
+    """
+    candidates = [
+        Path(r"C:\Program Files\Git\mingw64\libexec\git-core\git.exe"),
+        Path(r"C:\Program Files (x86)\Git\mingw64\libexec\git-core\git.exe"),
+    ]
+    try:
+        candidates.append(
+            Path(get_hermes_home())
+            / "git"
+            / "mingw64"
+            / "libexec"
+            / "git-core"
+            / "git.exe"
+        )
+    except Exception:
+        pass
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        try:
+            result = subprocess.run(
+                [str(candidate), "--version"],
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=15,
+            )
+        except Exception:
+            continue
+        output = ((result.stdout or "") + (result.stderr or "")).lower()
+        if "fork bomb" in output:
+            continue
+        return candidate
+    return None
+
+
+def _ensure_non_trampoline_git(git_cmd: list) -> list:
+    """Swap a broken Git-for-Windows trampoline for a real git binary.
+
+    Runs up front, right after the git command is built. When the resolved
+    ``git`` is a broken trampoline, locate the real binary and rebuild the
+    command with it so fetch/pull/checkout keep working with a real git
+    instead of degrading to the ZIP fallback. When no real binary can be
+    found, leave the command untouched — the existing fetch-failure handler
+    already falls back to the ZIP path on Windows. No-op off Windows (the
+    trampoline is a Git-for-Windows artifact) and when git is healthy.
+    """
+    if sys.platform != "win32":
+        return git_cmd
+    if not _git_is_trampoline(git_cmd):
+        return git_cmd
+    real_git = _locate_real_git()
+    if real_git is None:
+        print(
+            "⚠ Detected a broken git trampoline and could not locate a real "
+            "git binary — the update will fall back to the ZIP path."
+        )
+        return git_cmd
+    print(
+        f"⚠ Detected a broken git trampoline; switching to real git at "
+        f"{real_git}"
+    )
+    return [str(real_git)] + list(git_cmd[1:])
+
+
 def _discard_lockfile_churn(git_cmd, repo_root):
     """Restore tracked ``package-lock.json`` files that npm dirtied locally.
 
@@ -4582,6 +4681,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
     git_cmd = ["git"]
     if sys.platform == "win32":
         git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+    # A broken Git-for-Windows trampoline refuses every git call with a
+    # "BUG (fork bomb)" guard instead of running; swap in a real binary up
+    # front so the normal git path survives instead of degrading to ZIP
+    # (#87876).
+    git_cmd = _ensure_non_trampoline_git(git_cmd)
 
     # Discard npm lockfile churn before any stash/branch logic. npm rewrites
     # tracked package-lock.json files non-deterministically at install/build

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1236,3 +1236,96 @@ class TestUpdateNodeDependencies:
         assert cwd_calls, "expected at least one npm call"
         for cwd in cwd_calls:
             assert cwd == tmp_path, f"npm must run from PROJECT_ROOT; got cwd={cwd}"
+
+
+class TestGitTrampolineSelfHeal:
+    """Proactive Git-for-Windows trampoline self-heal (#87876).
+
+    A broken bin\\git.exe / cmd\\git.exe shim (~46KB) refuses every git call
+    with a "BUG (fork bomb)" guard instead of re-execing the real git-core
+    binary. _ensure_non_trampoline_git detects this up front and swaps in a
+    real git binary when one can be located, so the normal git update path
+    survives instead of degrading to the ZIP fallback.
+    """
+
+    @staticmethod
+    def _fake_run_healthy(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command, 0, stdout="git version 2.50.0.windows.1\n", stderr=""
+        )
+
+    @staticmethod
+    def _fake_run_trampoline(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            stdout="",
+            stderr="BUG (fork bomb): tried to spawn itself, check your PATH\n",
+        )
+
+    def test_healthy_git_command_unchanged(self):
+        from hermes_cli import update_cmd
+
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+        with (
+            patch("sys.platform", "win32"),
+            patch(
+                "hermes_cli.update_cmd.subprocess.run",
+                side_effect=self._fake_run_healthy,
+            ),
+            patch("hermes_cli.update_cmd._locate_real_git") as locate,
+        ):
+            result = update_cmd._ensure_non_trampoline_git(git_cmd)
+        assert result == git_cmd
+        locate.assert_not_called()
+
+    def test_trampoline_swaps_to_real_git(self, capsys):
+        from pathlib import Path
+
+        from hermes_cli import update_cmd
+
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+        real = Path(r"C:\Program Files\Git\mingw64\libexec\git-core\git.exe")
+        with (
+            patch("sys.platform", "win32"),
+            patch(
+                "hermes_cli.update_cmd.subprocess.run",
+                side_effect=self._fake_run_trampoline,
+            ),
+            patch(
+                "hermes_cli.update_cmd._locate_real_git", return_value=real
+            ),
+        ):
+            result = update_cmd._ensure_non_trampoline_git(git_cmd)
+        assert result == [str(real), "-c", "windows.appendAtomically=false"]
+        out = capsys.readouterr().out
+        assert "switching to real git" in out
+
+    def test_trampoline_no_real_git_keeps_command(self, capsys):
+        from hermes_cli import update_cmd
+
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+        with (
+            patch("sys.platform", "win32"),
+            patch(
+                "hermes_cli.update_cmd.subprocess.run",
+                side_effect=self._fake_run_trampoline,
+            ),
+            patch("hermes_cli.update_cmd._locate_real_git", return_value=None),
+        ):
+            result = update_cmd._ensure_non_trampoline_git(git_cmd)
+        assert result == git_cmd
+        out = capsys.readouterr().out
+        assert "ZIP path" in out
+
+    def test_off_windows_noop(self):
+        from hermes_cli import update_cmd
+
+        git_cmd = ["git"]
+        with (
+            patch("sys.platform", "linux"),
+            patch("hermes_cli.update_cmd.subprocess.run") as run,
+        ):
+            result = update_cmd._ensure_non_trampoline_git(git_cmd)
+        assert result == git_cmd
+        run.assert_not_called()

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1329,3 +1329,24 @@ class TestGitTrampolineSelfHeal:
             result = update_cmd._ensure_non_trampoline_git(git_cmd)
         assert result == git_cmd
         run.assert_not_called()
+
+    def test_portable_git_candidates_check_shared_root_first(self, tmp_path, monkeypatch):
+        # Profile-scoped layout: HERMES_HOME = <root>/profiles/foo, but the
+        # PortableGit tree lives under the SHARED root (monerostar review on
+        # #88136). The candidate list must check get_default_hermes_root()
+        # before the profile home.
+        from hermes_cli import update_cmd
+
+        root = tmp_path / "root"
+        profile_home = root / "profiles" / "foo"
+
+        monkeypatch.setattr(update_cmd, "get_default_hermes_root", lambda: root)
+        monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: profile_home)
+
+        candidates = update_cmd._portable_git_candidates()
+        assert candidates[0] == (
+            root / "git" / "mingw64" / "libexec" / "git-core" / "git.exe"
+        )
+        assert candidates[1] == (
+            profile_home / "git" / "mingw64" / "libexec" / "git-core" / "git.exe"
+        )


### PR DESCRIPTION
## Summary

Fixes the Windows update breakage reported in #87876 where a Git-for-Windows **trampoline launcher** (the ~46KB `bin\git.exe` / `cmd\git.exe` shim) fails to re-exec the real git-core binary and refuses every git call with a `BUG (fork bomb)` guard instead of running it.

Complementary to #88046 (which falls back to ZIP download when `git fetch` reports the trampoline error): this PR detects the broken trampoline **up front** and keeps the normal git update path alive.

## Approach

- `_git_is_trampoline()`: probe `git --version` for the trampoline's "fork bomb" guard output (never raises; unknown states report False so a probe failure can't block an update).
- `_locate_real_git()`: search standard Git for Windows locations (`C:\Program Files\Git\mingw64\libexec\git-core\git.exe`, `(x86)`, and the Hermes-managed PortableGit under `<HERMES_HOME>/git`) for a binary that runs and does NOT print the trampoline guard.
- `_ensure_non_trampoline_git()`: rebuild `git_cmd` with the real binary when a trampoline is detected; when no real binary is found, leave the command untouched so the existing fetch-failure path (and #88046) still falls back to ZIP on Windows.

## Test Plan

- 4 new unit tests (`TestGitTrampolineSelfHeal`): healthy git unchanged / trampoline swapped to real git / trampoline with no real git keeps command / non-Windows no-op. All pass.
- `ruff check` clean on both files.
- Full `test_cmd_update.py` run: 2 pre-existing failures are environment-only (local node v24.15.0 + npm 11.12.1 fail the repo's engines range with EBADENGINE during `_update_node_dependencies`; unrelated to this change — the affected tests pass the git fetch/pull phases before reaching npm).

## Risk / Exclusions

- Windows-only behavior; off-Windows it's a strict no-op.
- Candidate paths are conservative; finding nothing degrades to the existing ZIP fallback exactly as before.
- No changes to the ZIP update path, fetch-failure handling, or venv logic.

References #87876