### PR TITLE
fix(gemini): preserve streamed tool argument order

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -809,7 +809,7 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
         if isinstance(fc, dict) and fc.get("name"):
             name = str(fc["name"])
             try:
-                args_str = json.dumps(fc.get("args") or {}, ensure_ascii=False, sort_keys=True)
+                args_str = json.dumps(fc.get("args") or {}, ensure_ascii=False)
             except (TypeError, ValueError):
                 args_str = "{}"
             thought_signature = part.get("thoughtSignature") if isinstance(part.get("thoughtSignature"), str) else ""

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -290,6 +290,45 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
     assert first[-1].choices[0].finish_reason == "tool_calls"
 
 
+def test_stream_event_translation_preserves_function_argument_key_order():
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = json.loads(
+        """
+        {
+          "candidates": [{
+            "content": {"parts": [
+              {"functionCall": {"name": "terminal", "args": {
+                "command": "echo one", "timeout": 10
+              }}},
+              {"functionCall": {"name": "terminal", "args": {
+                "timeout": 10, "command": "echo one"
+              }}}
+            ]},
+            "finishReason": "STOP"
+          }]
+        }
+        """
+    )
+
+    chunks = translate_stream_event(
+        event,
+        model="gemini-2.5-flash",
+        tool_call_indices={},
+    )
+    arguments = [
+        chunk.choices[0].delta.tool_calls[0].function.arguments
+        for chunk in chunks
+        if chunk.choices[0].delta.tool_calls
+    ]
+
+    assert arguments == [
+        '{"command": "echo one", "timeout": 10}',
+        '{"timeout": 10, "command": "echo one"}',
+    ]
+    assert arguments[0] != arguments[1]
+
+
 def test_build_gemini_request_preserves_explicit_max_tokens_without_thinking():
     from agent.gemini_native_adapter import build_gemini_request
 
@@ -342,7 +381,6 @@ def test_build_gemini_request_does_not_raise_when_thinking_is_disabled():
 # ---------------------------------------------------------------------------
 # X-Goog-Api-Client header tests
 # ---------------------------------------------------------------------------
-
 
 
 


### PR DESCRIPTION
fix(gemini): preserve streamed tool argument order

  ## What does this PR do?

 The native Gemini SSE parser preserves JSON member order. However, `translate_stream_event()` serializes `functionCall.args` with `sort_keys=True`. This makes arguments with different key orders identical before downstream handling. The non-streaming Gemini does not sort these keys.

  This PR removes only that streaming-specific sorting. It preserves the received argument order, matching the non-streaming path and the maintainer policy described in #86871. The sorting used for the internal stream-slot key is
  unchanged.

  ## Related Issue

  Related to #86871 and #87865.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - `agent/gemini_native_adapter.py` - preserve key order when serializing streamed Gemini function arguments.
  - `tests/agent/test_gemini_native_adapter.py` - verify that two argument objects with different key orders remain different after stream translation.

  ## How to Test

  1. Run:

     ```bash
     scripts/run_tests.sh tests/agent/test_gemini_native_adapter.py

  2. The regression test translates a native Gemini stream event containing two same-name calls whose argument objects differ only in key order.
  3. Verify that all 13 tests pass and both translated argument strings retain their received order.

  ## Checklist

  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit follows [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] I searched [existing PRs](https://github.com/NousResearch/hermes-agent/pulls)
  - [x] My PR contains only changes related to this fix
  - [x] I ran the complete affected test suite: 13 passed, 0 failed
  - [x] I've added a regression test for the change
  - [x] I've tested on Linux x86_64 with Python 3.11.16

  ### Documentation & Housekeeping

  - [x] Documentation update: N/A, no user-facing behavior or configuration changed
  - [x] cli-config.yaml.example update: N/A, no configuration keys changed
  - [x] CONTRIBUTING.md or AGENTS.md update: N/A, no architecture or workflow changed
  - [x] I've considered cross-platform impact using the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
  - [x] Tool descriptions or schemas update: N/A, no tool schema changed

  ## Validation

  tests/agent/test_gemini_native_adapter.py: 13 passed
  Ruff: All checks passed
  Windows footgun scan: No Windows footguns found