### PR TITLE
fix(dashboard-auth): persist auto-generated basic-auth signing secret so sessions survive restart

### DIFF
--- a/plugins/dashboard_auth/basic/__init__.py
+++ b/plugins/dashboard_auth/basic/__init__.py
@@ -66,6 +66,7 @@ import os
 import secrets
 import time
 from typing import Any, Optional
+from pathlib import Path
 
 from hermes_cli.dashboard_auth import (
     DashboardAuthProvider,
@@ -361,26 +362,8 @@ def _resolve(env_name: str, cfg_section: dict, cfg_key: str) -> str:
     return str(cfg_section.get(cfg_key, "") or "").strip()
 
 
-def _resolve_secret(cfg_section: dict) -> bytes:
-    """Resolve the token-signing secret.
-
-    Accepts base64 or hex or raw text from config/env. When unset,
-    generates a random per-process secret (sessions then don't survive a
-    restart or span multiple workers — logged at INFO).
-    """
-    raw = _resolve(
-        "HERMES_DASHBOARD_BASIC_AUTH_SECRET", cfg_section, "secret"
-    )
-    if not raw:
-        logger.info(
-            "dashboard-auth-basic: no 'secret' configured; generating a "
-            "random per-process signing key. Sessions will not survive a "
-            "restart or span multiple workers. Set dashboard.basic_auth."
-            "secret (or HERMES_DASHBOARD_BASIC_AUTH_SECRET) for stable "
-            "sessions."
-        )
-        return secrets.token_bytes(32)
-    # Try base64, then hex, then fall back to the raw UTF-8 bytes.
+def _decode_secret(raw: str) -> bytes:
+    """Decode a configured secret: try base64, then hex, then raw UTF-8."""
     for decoder in (base64.b64decode, bytes.fromhex):
         try:
             decoded = decoder(raw)
@@ -389,6 +372,91 @@ def _resolve_secret(cfg_section: dict) -> bytes:
         except (ValueError, TypeError):
             pass
     return raw.encode("utf-8")
+
+
+def _persisted_secret_path() -> Optional[str]:
+    """Stable on-disk location for an auto-generated signing secret.
+
+    Lives under HERMES_HOME (the shared data dir) so a dashboard restart —
+    or multiple worker processes sharing one home — keeps the SAME signing
+    key and sessions survive. Returns None when the home cannot be resolved
+    (caller then falls back to a per-process random secret).
+    """
+    try:
+        from hermes_cli.sessions_cmd import get_hermes_home
+
+        home = get_hermes_home()
+        if not home:
+            return None
+        return str(Path(home) / "dashboard-auth" / "basic-secret")
+    except Exception:  # noqa: BLE001 — resolution must never break auth
+        return None
+
+
+def _load_or_create_persisted_secret() -> Optional[bytes]:
+    """Return the persisted auto-generated secret, creating it if absent.
+
+    Atomic write (temp file + rename) so a concurrent first-boot can't
+    observe a half-written key. Returns None only if the path is
+    unavailable or the write fails — the caller then uses a per-process key.
+    """
+    path = _persisted_secret_path()
+    if not path:
+        return None
+    p = Path(path)
+    try:
+        if p.exists():
+            data = p.read_bytes()
+            if len(data) >= 16:
+                return data
+        parent = p.parent
+        parent.mkdir(parents=True, exist_ok=True)
+        secret = secrets.token_bytes(32)
+        tmp = p.with_name(f"{p.name}.tmp-{os.getpid()}")
+        tmp.write_bytes(secret)
+        os.replace(tmp, p)
+        try:
+            os.chmod(p, 0o600)
+        except OSError:
+            pass  # best-effort; Windows ignores POSIX modes
+        return secret
+    except OSError as exc:  # noqa: BLE001 — surface, don't fail auth
+        logger.warning(
+            "dashboard-auth-basic: could not persist auto-generated signing "
+            "secret to %s (%s); sessions will not survive a restart. Set "
+            "dashboard.basic_auth.secret (or HERMES_DASHBOARD_BASIC_AUTH_SECRET) "
+            "for stable sessions.",
+            path,
+            exc,
+        )
+        return None
+
+
+def _resolve_secret(cfg_section: dict) -> bytes:
+    """Resolve the token-signing secret.
+
+    Precedence: env/config explicit secret → persisted auto-generated secret
+    (stable across restarts) → random per-process secret. An explicit secret
+    (base64 / hex / raw text) is accepted from config/env. When unset, the
+    auto-generated secret is persisted to ``$HERMES_HOME/dashboard-auth/
+    basic-secret`` so a restart reuses the same key and sessions survive.
+    """
+    raw = _resolve(
+        "HERMES_DASHBOARD_BASIC_AUTH_SECRET", cfg_section, "secret"
+    )
+    if raw:
+        return _decode_secret(raw)
+    persisted = _load_or_create_persisted_secret()
+    if persisted is not None:
+        return persisted
+    logger.info(
+        "dashboard-auth-basic: no 'secret' configured; generating a "
+        "random per-process signing key. Sessions will not survive a "
+        "restart or span multiple workers. Set dashboard.basic_auth."
+        "secret (or HERMES_DASHBOARD_BASIC_AUTH_SECRET) for stable "
+        "sessions."
+    )
+    return secrets.token_bytes(32)
 
 
 def register(ctx) -> None:

--- a/tests/plugins/dashboard_auth/test_basic_provider.py
+++ b/tests/plugins/dashboard_auth/test_basic_provider.py
@@ -8,6 +8,7 @@ import path as a package) and exercises the provider behaviour + the
 
 from __future__ import annotations
 
+import base64
 import secrets
 from unittest.mock import MagicMock
 
@@ -219,3 +220,84 @@ class TestRegister:
         p2 = ctx2.register_dashboard_auth_provider.call_args.args[0]
         s = p1.complete_password_login(username="admin", password="hunter2")
         assert p2.verify_session(access_token=s.access_token) is not None
+
+
+# ---------------------------------------------------------------------------
+# Auto-generated signing-secret persistence (restart survival)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistedAutoSecret:
+    """When no secret is configured, the plugin should auto-generate one and
+    persist it to $HERMES_HOME/dashboard-auth/basic-secret so a dashboard
+    restart (or multiple workers sharing one home) reuses the same signing
+    key and sessions survive. Explicit secret must still win."""
+
+    def _patch_home(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            basic_plugin,
+            "_persisted_secret_path",
+            lambda: str(tmp_path / "basic-secret"),
+        )
+        return tmp_path / "basic-secret"
+
+    def test_auto_secret_is_stable_across_restarts(self, basic, monkeypatch, tmp_path):
+        secret_path = self._patch_home(monkeypatch, tmp_path)
+        # No explicit secret anywhere.
+        monkeypatch.setattr(basic, "_load_config_basic_auth_section", lambda: {})
+        s1 = basic._resolve_secret({})
+        # Simulate a restart: a fresh call (same persisted file) returns the same key.
+        s2 = basic._resolve_secret({})
+        assert s1 == s2
+        assert len(s1) >= 16
+        # The persisted file exists and matches.
+        assert secret_path.read_bytes() == s1
+
+    def test_auto_secret_lets_sessions_survive_restart(
+        self, basic, monkeypatch, tmp_path
+    ):
+        self._patch_home(monkeypatch, tmp_path)
+        monkeypatch.setattr(basic, "_load_config_basic_auth_section", lambda: {})
+        monkeypatch.setenv("HERMES_DASHBOARD_BASIC_AUTH_USERNAME", "admin")
+        monkeypatch.setenv("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD", "hunter2")
+
+        # First "boot": auto-generates + persists, registers provider.
+        ctx1 = MagicMock()
+        basic.register(ctx1)
+        p1 = ctx1.register_dashboard_auth_provider.call_args.args[0]
+        s = p1.complete_password_login(username="admin", password="hunter2")
+
+        # Second "boot" after a restart: same persisted secret → accepts the
+        # token minted before the restart.
+        ctx2 = MagicMock()
+        basic.register(ctx2)
+        p2 = ctx2.register_dashboard_auth_provider.call_args.args[0]
+        assert p2.verify_session(access_token=s.access_token) is not None
+
+    def test_explicit_secret_wins_over_persisted(
+        self, basic, monkeypatch, tmp_path
+    ):
+        secret_path = self._patch_home(monkeypatch, tmp_path)
+        # Pre-seed a persisted secret that MUST NOT be used.
+        secret_path.write_bytes(b"persisted-should-lose")
+        explicit = base64.b64encode(secrets.token_bytes(32)).decode()
+        monkeypatch.setattr(basic, "_load_config_basic_auth_section", lambda: {})
+        monkeypatch.setenv("HERMES_DASHBOARD_BASIC_AUTH_SECRET", explicit)
+        assert basic._resolve_secret({}) == base64.b64decode(explicit)
+
+    def test_unresolvable_home_falls_back_to_random(
+        self, basic, monkeypatch
+    ):
+        # When the persisted path is unavailable, fall back to a fresh random
+        # per-process secret (old behaviour) — never raises.
+        monkeypatch.setattr(basic, "_persisted_secret_path", lambda: None)
+        assert len(basic._resolve_secret({})) >= 16
+
+    def test_missing_env_and_config_uses_persisted(
+        self, basic, monkeypatch, tmp_path
+    ):
+        secret_path = self._patch_home(monkeypatch, tmp_path)
+        # Config section empty, env cleared (autouse fixture already cleared
+        # HERMES_DASHBOARD_BASIC_AUTH_SECRET). Must use/seed the persisted key.
+        s = basic._resolve_secret({})
+        assert s == secret_path.read_bytes()


### PR DESCRIPTION
## Problem

The `basic` dashboard auth provider signs every session token with a signing secret. When `dashboard.basic_auth.secret` is **unset** it generates a random **per-process** key that changes on **every dashboard restart**, silently invalidating all basic-auth sessions. Any client — the browser dashboard or the native **desktop app in remote mode** — connects fine, then drops after ANY restart/upgrade/`launchctl kickstart` with a confusing secondary error.

The provider itself logs this on every startup:
```
dashboard-auth-basic: no 'secret' configured; generating a random per-process
signing key. Sessions will not survive a restart or span multiple workers. Set
dashboard.basic_auth.secret (or HERMES_DASHBOARD_BASIC_AUTH_SECRET) for stable sessions.
```

### The confusing symptom it hides
Desktop in remote mode reports:
```
Desktop boot failed: Could not reach the remote Hermes gateway while refreshing its WebSocket ticket.
```
— a **stale-token transport error**, not a network fault. The gateway auth log is SILENT at the failure instant (the stored token never reaches the auth routes) even though fresh curl logins work. This footgun makes basic-auth sessions non-durable by default and sends operators down a desktop/network debugging rabbit hole.

## Fix

When no explicit secret is configured, **auto-generate one and persist it** to `$HERMES_HOME/dashboard-auth/basic-secret` (atomic temp-file + rename, `0600` best-effort), so a dashboard restart — or multiple worker processes sharing one home — reuses the same signing key and sessions survive.

- Precedence: explicit secret (config/env, base64/hex/raw) **wins** over the persisted key.
- If the persisted path is unavailable (home not resolvable / write fails), fall back to the old per-process random key so auth **never breaks**.
- This removes the operator footgun: sessions survive restarts by default, no config change required.

## Evidence

Reproduced and verified live (macOS dashboard + Windows desktop client):

1. **Root cause** — with no `secret` configured, the provider logs the "random per-process signing key" warning on every startup; `_resolve_secret` returned `secrets.token_bytes(32)` fresh each process.
2. **Client impact** — the desktop connected fine at 02:55Z against dashboard process A; after a dashboard restart (process B), every subsequent attempt failed with the ws-ticket transport error and the gateway auth log was silent at the failure instant.
3. **Config workaround confirmed** — setting `dashboard.basic_auth.secret` made sessions survive: a cookie signed pre-restart still minted a ws-ticket post-restart (before the fix this failed).
4. **This code fix** — with no explicit secret, a temp-HERMES_HOME E2E confirmed the persisted key is identical across two "process" invocations and reused after a simulated restart.

## Tests

Added `TestPersistedAutoSecret` to `tests/plugins/dashboard_auth/test_basic_provider.py`:
- auto-secret is stable across restarts (same key reused),
- sessions survive a simulated restart (token minted by "boot 1" verifies under "boot 2"),
- explicit secret wins over a pre-seeded persisted key,
- unavailable persisted path falls back to a fresh random key (never raises),
- missing env/config uses/seeds the persisted key.

Result: **24/24 in `test_basic_provider.py`, 104/104 in `tests/plugins/dashboard_auth/`** (on a clean `main` base).

## Checklist
- [x] Fixes the whole bug class (any basic-auth client dropping on restart), not just one site.
- [x] Preserves existing behaviour (explicit secret still authoritative; no auth break when persistence unavailable).
- [x] Tests cover the invariant (sessions survive restart), not a snapshot.
- [x] No new core-tool surface; change is confined to the bundled `basic` auth plugin + its tests.
- [x] Cross-platform safe: `os.replace` atomic rename works on POSIX + Windows; `chmod 0600` is best-effort and skipped on Windows.