### PR TITLE
system_prompt: omit identity lines on implicit-cache backends

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -847,12 +847,25 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         timestamp_line = f"Timezone: {', '.join(_zone_bits)}" if _zone_bits else ""
     if agent.pass_session_id and agent.session_id:
         timestamp_line += f"\nSession ID: {agent.session_id}"
-    if agent.model:
-        timestamp_line += f"\nModel: {agent.model}"
-    if agent.provider:
-        timestamp_line += f"\nProvider: {agent.provider}"
-    if agent.platform:
-        timestamp_line += f"\nPlatform: {agent.platform}"
+    # Model / Provider / Platform identity lines are informational only —
+    # they are surfaced to the user through the platform footer, not read
+    # from the prompt. On implicit longest-prefix-cache backends (local
+    # llama.cpp / Ollama / LM Studio) any byte change in the system prompt
+    # invalidates the KV-cache prefix for the ENTIRE conversation history,
+    # so a /model switch that rewrites these lines forces a full
+    # reprocess (measured 408s on a ~45k-token session, issue #88087).
+    # Omit them when the provider has no explicit cache_control breakpoint
+    # API, keeping the prompt byte-identical across model switches and
+    # preserving the cached prefix. Explicit cache_control backends
+    # (Anthropic-style) keep the lines: their cache layers are keyed
+    # independently, so the volatile tail change is cheap.
+    if getattr(agent, "_use_native_cache_layout", False):
+        if agent.model:
+            timestamp_line += f"\nModel: {agent.model}"
+        if agent.provider:
+            timestamp_line += f"\nProvider: {agent.provider}"
+        if agent.platform:
+            timestamp_line += f"\nPlatform: {agent.platform}"
     volatile_parts.append(timestamp_line)
 
     return {

--- a/tests/agent/test_implicit_cache_identity_88087.py
+++ b/tests/agent/test_implicit_cache_identity_88087.py
@@ -1,0 +1,85 @@
+"""Tests for issue #88087: model switch must not break implicit prefix cache.
+
+On implicit longest-prefix-cache backends (local llama.cpp / Ollama /
+LM Studio) a /model switch that rewrites the volatile ``Model:`` /
+``Provider:`` / ``Platform:`` lines in the system prompt invalidates the
+KV-cache prefix for the entire conversation history (measured 408s on a
+~45k-token session). The identity lines are informational only — they are
+surfaced through the platform footer, not read from the prompt — so they
+are omitted when the provider has no explicit ``cache_control`` breakpoint
+API (``_use_native_cache_layout`` False).
+"""
+
+from types import SimpleNamespace
+
+from agent.system_prompt import build_system_prompt_parts
+
+
+def _make_agent(**overrides):
+    """Minimal agent stub mirroring tests/agent/test_system_prompt.py."""
+    base = dict(
+        load_soul_identity=False,
+        skip_context_files=False,
+        valid_tool_names=[],
+        _task_completion_guidance=False,
+        _tool_use_enforcement=False,
+        _environment_probe=False,
+        _kanban_worker_guidance="",
+        _memory_store=None,
+        _memory_manager=None,
+        model="qwen-27b",
+        provider="custom:litellm",
+        platform="telegram",
+        pass_session_id=True,
+        session_id="sess-test",
+        _use_native_cache_layout=False,
+        _bot_chat_timeless_prompt=False,
+        _memory_enabled=False,
+        _user_profile_enabled=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestImplicitCacheIdentityOmission:
+    def test_implicit_cache_omits_identity_lines(self):
+        """Implicit backends must NOT embed Model/Provider/Platform lines."""
+        agent = _make_agent(_use_native_cache_layout=False)
+        volatile = build_system_prompt_parts(agent)["volatile"]
+        assert "Model:" not in volatile
+        assert "Provider:" not in volatile
+        assert "Platform:" not in volatile
+        assert "Session ID: sess-test" in volatile
+
+    def test_model_switch_prompt_byte_identical(self):
+        """A model/provider switch must not change the volatile tail."""
+        before = build_system_prompt_parts(
+            _make_agent(model="qwen-27b", provider="custom:litellm",
+                        _use_native_cache_layout=False)
+        )["volatile"]
+        after = build_system_prompt_parts(
+            _make_agent(model="deepseek-v4-flash", provider="custom:command-code",
+                        _use_native_cache_layout=False)
+        )["volatile"]
+        assert before == after, "volatile tail changed on model switch!"
+
+    def test_explicit_cache_keeps_identity_lines(self):
+        """Explicit cache_control backends keep the informational lines."""
+        agent = _make_agent(_use_native_cache_layout=True)
+        volatile = build_system_prompt_parts(agent)["volatile"]
+        assert "Model: qwen-27b" in volatile
+        assert "Provider: custom:litellm" in volatile
+        assert "Platform: telegram" in volatile
+
+    def test_switch_on_explicit_cache_changes_tail(self):
+        """On explicit-cache backends a model switch does change the tail."""
+        before = build_system_prompt_parts(
+            _make_agent(model="qwen-27b", provider="custom:litellm",
+                        _use_native_cache_layout=True)
+        )["volatile"]
+        after = build_system_prompt_parts(
+            _make_agent(model="deepseek-v4-flash", provider="custom:command-code",
+                        _use_native_cache_layout=True)
+        )["volatile"]
+        assert before != after
+        assert "Model: deepseek-v4-flash" in after


### PR DESCRIPTION
## system_prompt: omit identity lines on implicit-cache backends

Fixes: https://github.com/NousResearch/hermes-agent/issues/88087

### Problem

A mid-session /model switch forces a full, uncached reprocessing of the entire conversation history on implicit-prefix-cache backends (local llama.cpp, Ollama, LM Studio). Measured: **408s** for a single API call on a ~45k-token conversation.

### Root cause

`/model` switch calls `hermes_state.py::update_session_model()`, which nulls `sessions.system_prompt`. The next turn rebuilds the prompt via `build_system_prompt_parts()`, which appends `Model:` / `Provider:` / `Platform:` lines into the volatile tier. On implicit longest-prefix-cache backends there is no way to tell the server the stable+context tiers are still byte-identical — any byte change anywhere in the prompt invalidates the KV-cache match for everything after it, including the entire conversation history.

### Fix

Omit the `Model:` / `Provider:` / `Platform:` identity lines from the volatile tier when `_use_native_cache_layout` is False (implicit longest-prefix-cache backends: llama.cpp / Ollama / LM Studio). The lines are informational only — surfaced through the platform footer, not read from the prompt — so omitting them keeps the system prompt byte-identical across model switches, preserving the cached prefix.

Explicit `cache_control` backends (Anthropic-style, `_use_native_cache_layout` True) keep the lines: their cache layers are keyed independently, so the volatile tail change is cheap.

### Verification

- New regression tests: tests/agent/test_implicit_cache_identity_88087.py (4 tests)
  - implicit cache: lines omitted, prompt byte-identical across model switch
  - explicit cache: lines kept, tail changes on switch
- Existing suites pass: test_system_prompt (20), test_failover_identity (11)
