### PR TITLE
feat(doctor): report monthly per-provider API call counts

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1253,6 +1253,34 @@ def check_macos_full_disk_access() -> None:
     )
 
 
+def _monthly_provider_usage(db_path, month_start):
+    """Return per-provider ``(billing_provider, api_call_count)`` totals for
+    sessions first seen at or after ``month_start`` (a POSIX timestamp).
+
+    Reads ``session_model_usage`` from the read-only ``db_path``. Returns an
+    empty list (never raises) when the db is missing or the query fails.
+    """
+    import sqlite3 as _sqlite3
+
+    path = str(db_path)
+    if not os.path.exists(path):
+        return []
+    try:
+        conn = _sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=5)
+        try:
+            rows = conn.execute(
+                "SELECT billing_provider, SUM(api_call_count) "
+                "FROM session_model_usage WHERE first_seen >= ? "
+                "GROUP BY billing_provider ORDER BY 2 DESC",
+                (month_start,),
+            ).fetchall()
+        finally:
+            conn.close()
+    except _sqlite3.Error:
+        return []
+    return [(str(row[0]) if row[0] else "", int(row[1] or 0)) for row in rows]
+
+
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
@@ -3373,6 +3401,25 @@ def run_doctor(args):
                                 check_warn(f"Orphan alias: {wrapper.name} → profile '{_m.group(1)}' no longer exists")
                     except Exception:
                         pass
+
+            # Per-profile monthly provider call counts (local, from
+            # session_model_usage) — a directional usage signal; most providers
+            # expose no authoritative per-account quota API, so this reports what
+            # the gateway actually billed this month rather than a quota number.
+            import time as _time
+
+            _now = _time.localtime()
+            _month_start = _time.mktime(
+                (_now.tm_year, _now.tm_mon, 1, 0, 0, 0, 0, 0, -1)
+            )
+            for p in named_profiles:
+                usage = _monthly_provider_usage(p.path / "state.db", _month_start)
+                if not usage:
+                    continue
+                summary = ", ".join(
+                    f"{provider or 'unbilled'}={count}" for provider, count in usage
+                )
+                check_info(f"  {p.name}: {summary} call(s) this month (local count)")
     except ImportError:
         pass
     except Exception:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1664,3 +1664,50 @@ class TestMacOSTCCGrants:
         out = capsys.readouterr().out
         assert "could not read code-signing requirement" in out
         assert "stable" not in out
+
+
+class TestMonthlyProviderUsage:
+    def test_aggregates_per_provider_within_month(self, tmp_path):
+        import sqlite3
+        import time
+
+        db_path = tmp_path / "state.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE session_model_usage ("
+            "billing_provider TEXT DEFAULT '', "
+            "api_call_count INTEGER DEFAULT 0, "
+            "first_seen REAL)"
+        )
+        now = time.time()
+        month_start = now - 3600
+        conn.execute(
+            "INSERT INTO session_model_usage "
+            "(billing_provider, api_call_count, first_seen) VALUES (?, ?, ?)",
+            ("openai", 10, now),
+        )
+        conn.execute(
+            "INSERT INTO session_model_usage "
+            "(billing_provider, api_call_count, first_seen) VALUES (?, ?, ?)",
+            ("openai", 5, now),
+        )
+        conn.execute(
+            "INSERT INTO session_model_usage "
+            "(billing_provider, api_call_count, first_seen) VALUES (?, ?, ?)",
+            ("anthropic", 7, now),
+        )
+        # Outside the month window — must be excluded.
+        conn.execute(
+            "INSERT INTO session_model_usage "
+            "(billing_provider, api_call_count, first_seen) VALUES (?, ?, ?)",
+            ("openai", 99, month_start - 1),
+        )
+        conn.commit()
+        conn.close()
+
+        usage = doctor._monthly_provider_usage(db_path, month_start)
+        assert dict(usage) == {"openai": 15, "anthropic": 7}
+
+    def test_returns_empty_for_missing_db(self, tmp_path):
+        assert doctor._monthly_provider_usage(tmp_path / "nope.db", 0) == []
+


### PR DESCRIPTION
## What does this PR do?

Add a `doctor` report section showing **monthly per-provider API call counts**,
so a user can see at a glance how many calls went to each configured provider
in the current month.

## Related Issue

N/A (no issue exists). Related upstream work: #92716 (open) adds `hermes usage`
commands over the same usage-cache data — this PR is a different surface
(a `doctor` report, not a new CLI command tree).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/doctor.py` — new report section for monthly per-provider API call
  counts
- `tests/hermes_cli/test_doctor.py` — tests for the new section

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q`
2. `hermes doctor` and confirm the per-provider call counts section renders.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — focused test file passes locally; full suite runs in CI
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [ ] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

N/A