### PR TITLE
fix(gateway): tolerate stale adapter capabilities

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -788,11 +788,15 @@ class GatewayStreamConsumer:
         # Telegram 4096); native adapters return their scalar unchanged.
         # Gate on isinstance(BasePlatformAdapter) so test MagicMocks (whose
         # auto-attributes return mock objects, not callables) fall back to len.
-        _len_fn: "Callable[[str], int]" = (
-            self.adapter.message_len_fn_for_chat(self.chat_id)
-            if isinstance(self.adapter, _BasePlatformAdapter)
-            else len
-        )
+        if isinstance(self.adapter, _BasePlatformAdapter):
+            _per_chat_len_fn = getattr(self.adapter, "message_len_fn_for_chat", None)
+            _len_fn = (
+                _per_chat_len_fn(self.chat_id)
+                if callable(_per_chat_len_fn)
+                else self.adapter.message_len_fn
+            )
+        else:
+            _len_fn = len
         # Rich-capable adapters (Telegram rich messages) raise this above the
         # legacy per-message limit so a reply that fits one rich send/draft
         # isn't fragmented at 4096 while streaming.  See _raw_message_limit.

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -6,7 +6,40 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+class _StaleAdapter(BasePlatformAdapter):
+    """Adapter loaded before per-chat capability methods were added."""
+
+    def __getattribute__(self, name):
+        if name == "message_len_fn_for_chat":
+            raise AttributeError(name)
+        return super().__getattribute__(name)
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return None
+
+    async def send(self, chat_id: str, content: str, **kwargs) -> SendResult:
+        return SendResult(success=True, message_id="message-1")
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_falls_back_for_stale_adapter_without_per_chat_len():
+    """An in-place update must not crash streams created with an old adapter class."""
+    adapter = _StaleAdapter(PlatformConfig(enabled=True), Platform.DISCORD)
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+    consumer.finish()
+
+    await consumer.run()
 
 
 def test_stream_send_metadata_carries_original_reply_anchor():


### PR DESCRIPTION
## Summary
- fall back to the adapter-wide message length function when a live adapter predates `message_len_fn_for_chat`
- preserve per-chat capability resolution for current relay adapters
- add a regression test reproducing the stale `DiscordAdapter` crash seen after an in-place update

## Root cause
A long-lived gateway kept a `DiscordAdapter` class loaded before `message_len_fn_for_chat` was added, while the checkout and stream consumer advanced to code that called the new method unconditionally. The first streamed response then raised `AttributeError` and the gateway returned its generic unexpected-error message.

## Test plan
- `scripts/run_tests.sh tests/gateway/test_stream_consumer.py::test_stream_consumer_falls_back_for_stale_adapter_without_per_chat_len -q`
- `scripts/run_tests.sh tests/gateway/test_stream_consumer.py tests/gateway/relay/test_relay_per_platform_caps.py -q`
- `scripts/run_tests.sh tests/gateway/ -q` (5765 passed, 29 skipped)
- `.venv/bin/ruff check gateway/stream_consumer.py tests/gateway/test_stream_consumer.py`
- `git diff --check`