### PR TITLE
fix(gateway): keep strong refs to background watcher tasks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4484,6 +4484,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         task.add_done_callback(self._background_tasks.discard)
         return True
 
+    def _spawn_background_task(self, coro):
+        """Schedule a long-lived background task and keep a strong reference to it.
+
+        asyncio only holds a *weak* reference to a running task, so the result of
+        a bare ``asyncio.create_task(...)`` can be garbage-collected mid-flight if
+        nothing else references it. Registering the task in ``self._background_tasks``
+        keeps it alive and ensures it is cancelled during shutdown (see the
+        ``_background_tasks`` teardown in ``_stop_impl``).
+        """
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
+
     # Drain-timeout reasons set by _stop_impl() when a still-running turn is
     # force-interrupted; "restart_interrupted" is set by
     # SessionStore.suspend_recently_active() on crash recovery (no
@@ -5085,7 +5099,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Process in batches of 100 with event-loop yield points to avoid
             # O(n^2) event-loop blocking when recovering thousands of watchers.
             for i, watcher in enumerate(watchers):
-                asyncio.create_task(self._run_process_watcher(watcher))
+                self._spawn_background_task(self._run_process_watcher(watcher))
                 logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
                 if i % 100 == 99:
                     await asyncio.sleep(0)
@@ -5093,18 +5107,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.error("Recovered watcher setup error: %s", e)
 
         # Start background session expiry watcher to finalize expired sessions
-        asyncio.create_task(self._session_expiry_watcher())
+        self._spawn_background_task(self._session_expiry_watcher())
 
         # Start background kanban notifier — delivers `completed`, `blocked`,
         # `spawn_auto_blocked`, and `crashed` events to gateway subscribers
         # so human-in-the-loop workflows hear back without polling.
-        asyncio.create_task(self._kanban_notifier_watcher())
+        self._spawn_background_task(self._kanban_notifier_watcher())
 
         # Start background kanban dispatcher — spawns workers for ready
         # tasks. Gated by `kanban.dispatch_in_gateway` (default True).
         # When false, users run `hermes kanban daemon` externally or
         # simply don't use kanban; this loop becomes a no-op.
-        asyncio.create_task(self._kanban_dispatcher_watcher())
+        self._spawn_background_task(self._kanban_dispatcher_watcher())
 
         # Start background reconnection watcher for platforms that failed at startup
         if self._failed_platforms:
@@ -5113,13 +5127,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 len(self._failed_platforms),
                 ", ".join(p.value for p in self._failed_platforms),
             )
-        asyncio.create_task(self._platform_reconnect_watcher())
+        self._spawn_background_task(self._platform_reconnect_watcher())
 
         # Start background handoff watcher — picks up CLI sessions marked
         # handoff_state='pending' in state.db and re-binds them to the
         # destination platform's home channel, then forges a synthetic user
         # turn so the agent kicks off the new chat.
-        asyncio.create_task(self._handoff_watcher())
+        self._spawn_background_task(self._handoff_watcher())
 
         logger.info("Press Ctrl+C to stop")
         
@@ -8701,7 +8715,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 watchers = process_registry.pending_watchers
                 process_registry.pending_watchers = []
                 for i, watcher in enumerate(watchers):
-                    asyncio.create_task(self._run_process_watcher(watcher))
+                    self._spawn_background_task(self._run_process_watcher(watcher))
                     if i % 100 == 99:
                         await asyncio.sleep(0)
             except Exception as e:

--- a/tests/gateway/test_background_task_tracking.py
+++ b/tests/gateway/test_background_task_tracking.py
@@ -1,0 +1,60 @@
+"""Background tasks scheduled by the gateway must be strongly referenced.
+
+asyncio only keeps a *weak* reference to a running task, so the result of a
+bare ``asyncio.create_task(...)`` can be garbage-collected mid-flight. The
+gateway's long-lived watchers (session expiry, kanban notifier/dispatcher,
+platform reconnect, handoff, recovered process watchers) are scheduled via
+``GatewayRunner._spawn_background_task``, which registers them in
+``self._background_tasks`` so they stay alive and are cancelled on shutdown.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.config import GatewayConfig
+from gateway.run import GatewayRunner
+
+
+@pytest.mark.asyncio
+async def test_spawn_background_task_is_tracked_then_auto_discarded():
+    runner = GatewayRunner(GatewayConfig())
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _work():
+        started.set()
+        await release.wait()
+
+    task = runner._spawn_background_task(_work())
+    await started.wait()
+
+    # While running, a strong reference is held so asyncio cannot collect it.
+    assert task in runner._background_tasks
+
+    # When it finishes, the done-callback removes it (no unbounded growth).
+    release.set()
+    await task
+    await asyncio.sleep(0)  # allow done-callbacks to run
+    assert task not in runner._background_tasks
+
+
+@pytest.mark.asyncio
+async def test_spawn_background_task_is_cancellable_on_shutdown():
+    runner = GatewayRunner(GatewayConfig())
+
+    async def _forever():
+        while True:
+            await asyncio.sleep(3600)
+
+    task = runner._spawn_background_task(_forever())
+    await asyncio.sleep(0)
+    assert task in runner._background_tasks
+
+    # Mirror the shutdown teardown that cancels every registered task.
+    for tracked in list(runner._background_tasks):
+        tracked.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -58,6 +58,7 @@ def _make_runner():
     runner._exit_with_failure = False
     runner._exit_cleanly = False
     runner._failed_platforms = {}
+    runner._background_tasks = set()
     runner.adapters = {}
     runner.delivery_router = MagicMock()
     runner._running_agents = {}


### PR DESCRIPTION
This PR addresses: fix(gateway): keep strong refs to background watcher tasks