### PR TITLE
fix(desktop): keep the Bot Chat pin

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2201,12 +2201,9 @@ function createCanonicalChat(name) {
         if (!opened && sid && typeof host.openSession === 'function') {
           await host.openSession(sid, { profile: name })
         }
-      } catch (err) {
-        if (sid) {
-          saveBotMeta(name, { chat: null })
-        }
-
-        throw err
+      } catch {
+        // The chat already exists. Keep the pin so the next click
+        // opens it instead of making a second Bot Chat.
       }
     }
 
@@ -2235,8 +2232,14 @@ async function openBotCanonicalChat(name, pinned) {
     }
 
     if (!rows.some(session => session.id === id)) {
-      id = rows[0].id
-      saveBotMeta(name, { chat: id })
+      const titled = rows.find(session => session.title === 'Bot Chat')
+
+      if (titled) {
+        id = titled.id
+        saveBotMeta(name, { chat: id })
+      }
+      // Pin is not in this page and there is no Bot Chat title.
+      // Try the stored pin as-is. Do not steal the newest session.
     }
   } catch {
     // Gateway hiccup — try the stored pin as-is.

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
@@ -44,3 +44,19 @@ test('regression: navigation retries after the kickoff persists a new canonical 
   assert.equal(await runtime.createCanonicalChat('ops'), 'stored-1')
   assert.deepEqual(events, ['open:stored-1', 'kickoff:persisted', 'open:stored-1'])
 })
+
+test('regression: a failed intro keeps the pin', async () => {
+  const runtime = loadCanonicalCreation({
+    openSession: async () => undefined,
+    request: async method => {
+      if (method === 'session.create') return { stored_session_id: 'new-bot-chat', session_id: 'rt-1' }
+      if (method === 'prompt.submit') throw new Error('gateway timeout')
+      return {}
+    }
+  })
+
+  assert.equal(await runtime.createCanonicalChat('newbie'), 'new-bot-chat')
+  assert.deepEqual(JSON.parse(JSON.stringify(runtime.saved)), [
+    { name: 'newbie', patch: { chat: 'new-bot-chat' } }
+  ])
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-empty-recovery.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-empty-recovery.test.mjs
@@ -43,3 +43,47 @@ test('regression: an empty session list clears a stale pin and creates a replace
     { name: 'ops', patch: { chat: 'replacement' } }
   ])
 })
+
+test('regression: a missing pin reuses a Bot Chat instead of the newest session', async () => {
+  const opened = []
+  const runtime = loadCanonicalRecovery({
+    openSession: async id => opened.push(id),
+    request: async method => {
+      if (method === 'session.list') {
+        return {
+          sessions: [
+            { id: 'scratch-from-cli', title: 'scratch' },
+            { id: 'the-real-bot-chat', title: 'Bot Chat' }
+          ]
+        }
+      }
+      if (method === 'session.create') throw new Error('must not create')
+      return {}
+    }
+  })
+
+  assert.equal(await runtime.openBotCanonicalChat('ops', 'old-pin'), 'the-real-bot-chat')
+  assert.deepEqual(opened, ['the-real-bot-chat'])
+  assert.deepEqual(JSON.parse(JSON.stringify(runtime.saved)), [
+    { name: 'ops', patch: { chat: 'the-real-bot-chat' } }
+  ])
+})
+
+test('regression: a pin not in the last page is opened as-is when no Bot Chat title exists', async () => {
+  const opened = []
+  const runtime = loadCanonicalRecovery({
+    openSession: async id => opened.push(id),
+    request: async (method, params) => {
+      if (method === 'session.list') {
+        assert.equal(params.limit, 100)
+        return { sessions: [{ id: 'recent-0', title: 'scratch' }] }
+      }
+      if (method === 'session.create') throw new Error('must not create')
+      return {}
+    }
+  })
+
+  assert.equal(await runtime.openBotCanonicalChat('ops', 'old-pin-outside-page'), 'old-pin-outside-page')
+  assert.deepEqual(opened, ['old-pin-outside-page'])
+  assert.equal(runtime.saved.length, 0)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-pin.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-pin.test.mjs
@@ -18,9 +18,10 @@ const fnSource = source.slice(start, end === -1 ? undefined : end)
 test('regression: a pinned canonical chat found in the list is opened, not replaced', () => {
   // The pin is opened directly with its own id under the bot's profile.
   assert.match(fnSource, /host\.openSession\(id, \{ profile: name \}\)/)
-  // Replacement (rows[0].id) only happens when the pin is NOT in the list...
+  // A missing pin looks for a session titled Bot Chat, not the newest row.
   assert.match(fnSource, /if \(!rows\.some\(session => session\.id === id\)\)/)
-  assert.match(fnSource, /id = rows\[0\]\.id/)
+  assert.match(fnSource, /session\.title === 'Bot Chat'/)
+  assert.doesNotMatch(fnSource, /id = rows\[0\]\.id/)
   // ...and an empty list clears the stale pin before recreating (the #28 fix),
   // rather than opening a known-bad id.
   assert.match(fnSource, /if \(!rows\.length\)/)


### PR DESCRIPTION
## What does this PR do?

If the intro message fails after the Bot Chat is created, we used to clear the pin. The next click then made a second Bot Chat.

If the pin was not in the last 100 sessions, we grabbed the newest session, even when a real Bot Chat was sitting in that list.

A failed intro now keeps the pin. A missing pin looks for a session titled Bot Chat. If that is not there, we try the stored pin instead of the newest row.

An empty session list still clears a dead pin and makes a replacement.

This is a port of [NousResearch/Hermes-Bot-Mode#59](https://github.com/NousResearch/Hermes-Bot-Mode/pull/59). Bot Mode now lives in-tree.

## Related Issue

Fixes #88146

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`: keep the pin after a failed intro. A missing pin prefers a session titled Bot Chat. It no longer takes `rows[0]`
- `apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs`: failed intro keeps the pin
- `apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-empty-recovery.test.mjs`: reuse a titled Bot Chat, or open the stored pin as-is
- `apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-pin.test.mjs`: no longer expect `rows[0].id`

## How to Test

Failed intro:

1. Open a bot with no Bot Chat
2. Let create succeed and make the intro send fail
3. Click the bot again
4. The same chat should open. You should not get a second Bot Chat

Missing pin:

1. Have a scratch session and a session titled Bot Chat
2. Click a bot whose pin is not in the last 100 rows
3. It should open the Bot Chat, not the scratch session

Plugin unit tests (from `apps/desktop`):

```
node --test src/plugins/hermes-bots/tests/canonical-chat-*.test.mjs
```

6/6 passed on Windows 11.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (plugin unit tests)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
