### PR TITLE
fix(kanban): log silent artifact/thread drops; document ContextVar board tier

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -612,11 +612,14 @@ def get_current_board() -> str:
 
     Order (highest precedence first):
 
-    1. ``HERMES_KANBAN_BOARD`` env var (set by the dispatcher on worker
+    1. ``_CURRENT_BOARD_OVERRIDE`` (a ``ContextVar``, set via
+       ``scoped_current_board()``) — a per-conversation binding a caller can
+       pin for the duration of a scope.
+    2. ``HERMES_KANBAN_BOARD`` env var (set by the dispatcher on worker
        spawn, or manually for ad-hoc overrides).
-    2. ``<root>/kanban/current`` on disk (set by ``hermes kanban boards
+    3. ``<root>/kanban/current`` on disk (set by ``hermes kanban boards
        switch``), but only when that board still exists.
-    3. ``DEFAULT_BOARD`` (``"default"``).
+    4. ``DEFAULT_BOARD`` (``"default"``).
 
     A malformed or stale slug at any step falls through to the next layer
     with a best-effort warning — the dispatcher must never crash because a
@@ -5695,10 +5698,20 @@ def _persist_scratch_completion_artifacts(
         try:
             resolved_src = src.resolve()
         except OSError:
+            _log.warning(
+                "kanban complete_task(%s): artifact path could not be "
+                "resolved, will NOT be persisted before workspace cleanup: %r",
+                task_id, artifact,
+            )
             persisted.append(artifact)
             continue
 
         if not resolved_src.is_relative_to(workspace_root):
+            _log.warning(
+                "kanban complete_task(%s): artifact %r resolved to %s, which "
+                "is outside its workspace %s — not persisted before cleanup",
+                task_id, artifact, resolved_src, workspace_root,
+            )
             persisted.append(artifact)
             continue
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1589,6 +1589,14 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             if message_id:
                 delivery_metadata["telegram_reply_to_message_id"] = str(message_id)
 
+        if not thread_id and platform not in ("tui", ""):
+            logger.warning(
+                "kanban_notify_subs: subscribing task=%r platform=%r chat_id=%r "
+                "with EMPTY thread_id — on a threaded platform this can land "
+                "the completion notification on the wrong channel",
+                task_id, platform, chat_id,
+            )
+
         # Lazy-import to keep the module-level dependency light
         from hermes_cli import kanban_db as _kb
         _kb.add_notify_sub(
@@ -1676,12 +1684,16 @@ _DESC_TASK_ID_DEFAULT = (
 )
 
 _DESC_BOARD = (
-    "Kanban board slug to target. When omitted, the call resolves the "
-    "active board the usual way: HERMES_KANBAN_DB env → "
-    "HERMES_KANBAN_BOARD env → the 'current' symlink under the kanban "
-    "home → 'default'. Pass an explicit slug only when the caller (e.g. "
-    "a Telegram routing layer) needs to override the env-pinned active "
-    "board for this one call."
+    "Kanban board slug to target. Passing this OVERRIDES any per-conversation "
+    "board binding the current conversation already has — an explicit value "
+    "here always wins. Leave it omitted unless you specifically need to reach "
+    "a DIFFERENT board than the one this chat is bound to. When omitted, the "
+    "call resolves the active board via get_current_board()'s chain (highest "
+    "precedence first): the per-conversation binding (scoped_current_board) → "
+    "HERMES_KANBAN_BOARD env → the 'current' file under the kanban home → "
+    "'default'. Do not hardcode a board slug here from memory of a past task — "
+    "that silently defeats the per-conversation binding for every future "
+    "conversation on this thread."
 )
 
 


### PR DESCRIPTION
## What does this PR do?

Log kanban artifact/thread drops that were previously silent, and document the
ContextVar board tier, so operators can see when artifacts or threads are
silently dropped instead of having them vanish without a trace.

## Related Issue

N/A (no issue exists).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update

## Changes Made

- `hermes_cli/kanban_db.py` — log silent artifact/thread drops
- `tools/kanban_tools.py` — document the ContextVar board tier + related
  logging improvements

## How to Test

1. Trigger a kanban artifact/thread drop path and confirm a log line is now
   emitted (previously silent).
2. Confirm the board-tier docs render correctly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite runs in CI
- [ ] I've added tests for my changes — N/A (logging/documentation change)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings in `tools/kanban_tools.py`)
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [ ] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

N/A