### PR TITLE
fix(profiles): seed plugins/ for new profiles

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -50,6 +50,12 @@ _PROFILE_DIRS = [
     "plans",
     "workspace",
     "cron",
+    # User plugins (model-provider plugins under plugins/model-providers/,
+    # etc.). Without this directory, plugin discovery in
+    # providers/__init__.py::_user_plugins_dir() finds nothing for
+    # non-default profiles and a provider configured in the profile's
+    # config.yaml fails with "Unknown provider" (#88143).
+    "plugins",
     # Back-compat/Docker HOME for tool subprocesses. Host subprocesses keep
     # the user's real HOME by default so normal CLI credentials remain visible;
     # containers still use this directory for persistent HOME state.

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -132,6 +132,17 @@ class TestCreateProfile:
         mode = stat.S_IMODE(env_path.stat().st_mode)
         assert mode == 0o600
 
+    def test_seeds_plugins_dir(self, profile_env):
+        """#88143: a fresh profile must seed plugins/ alongside skills/ etc.
+        Without it, plugin discovery (_user_plugins_dir) finds nothing under
+        the profile HERMES_HOME and a provider configured in the profile's
+        config.yaml fails with "Unknown provider"."""
+        profile_dir = create_profile("coder", no_alias=True)
+        plugins_dir = profile_dir / "plugins"
+        assert plugins_dir.is_dir()
+        # The discovery path for model-provider plugins exists end-to-end.
+        assert (plugins_dir / "model-providers").parent.is_dir()
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Makes `hermes profile create` seed the `plugins/` directory for new profiles. `_PROFILE_DIRS` seeded `skills/`, `memories/`, `sessions/`, `skins/`, `logs/`, `plans/`, `workspace/`, `cron/`, and `home/` — but not `plugins/`. Plugin discovery resolves user plugins under `$HERMES_HOME/plugins/`, and a profile activation swaps `HERMES_HOME` to the profile directory, so for any profile created by `hermes profile create` the discovery path was simply absent: a model-provider plugin configured in the profile's `config.yaml` failed with `Unknown provider 'myprovider'` even though the same provider worked on the default profile (#88143).

The fix adds `"plugins"` to `_PROFILE_DIRS` (one line plus a comment documenting the discovery dependency). Cloned profiles were already covered — `--clone` copies the whole tree, and #69913 adds explicit `plugins/` clone handling — this closes the fresh-create gap.

## Related Issue

Fixes #88143

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` — `_PROFILE_DIRS` gains `"plugins"` with a comment naming `_user_plugins_dir()` discovery and the failure mode.
- `tests/hermes_cli/test_profiles.py` — `TestCreateProfile` gains `test_seeds_plugins_dir`: a fresh profile contains `plugins/`, so the discovery path exists end-to-end for model-provider plugins.

## How to Test

1. `python -m pytest tests/hermes_cli/test_profiles.py -q`
2. Observed result: 49 passed, 2 skipped (48 pre-existing + 1 new). A/B guard: with only the `hermes_cli/profiles.py` hunk stashed, `test_seeds_plugins_dir` FAILS (`plugins/` absent from the fresh profile).
3. Manual repro from the issue: install a model-provider plugin, `hermes profile create architect`, activate it — `plugins/` now exists under the profile home and the configured provider resolves.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/hermes_cli/test_profiles.py -q               # with fix
49 passed, 2 skipped in 1.41s
$ git stash -- hermes_cli/profiles.py && pytest ... -q      # A/B guard
1 failed  (plugins/ absent from the fresh profile)
```
