### PR TITLE
fix(discord): retry standalone REST sends on 429

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -9938,6 +9938,92 @@ async def _standalone_read_json_limited(resp: Any, limit_bytes: int) -> dict:
     return data if isinstance(data, dict) else {}
 
 
+_DISCORD_STANDALONE_RETRY_ATTEMPTS = 3
+_DISCORD_STANDALONE_MAX_RETRY_AFTER_SECONDS = 10.0
+
+
+def _standalone_retry_after_seconds(resp: Any, body: str) -> Optional[float]:
+    """Extract Discord retry_after seconds from a 429 response."""
+    try:
+        parsed = json.loads(body)
+        if isinstance(parsed, dict) and parsed.get("retry_after") is not None:
+            return max(float(parsed["retry_after"]), 0.0)
+    except (TypeError, ValueError):
+        pass
+
+    headers = getattr(resp, "headers", {}) or {}
+    header = headers.get("Retry-After") or headers.get("X-RateLimit-Reset-After")
+    if header is None:
+        return None
+    try:
+        return max(float(header), 0.0)
+    except (TypeError, ValueError):
+        return None
+
+
+def _standalone_noop_cleanup() -> None:
+    return None
+
+
+async def _standalone_post_with_retry(
+    session: Any,
+    url: str,
+    *,
+    headers: Dict[str, str],
+    req_kw: Dict[str, Any],
+    json_payload: Optional[dict] = None,
+    form_factory: Optional[Callable[[], Tuple[Any, Callable[[], None]]]] = None,
+    attempts: int = _DISCORD_STANDALONE_RETRY_ATTEMPTS,
+) -> Tuple[int, Any]:
+    """POST to Discord REST with bounded 429 retry for standalone sends.
+
+    Returns ``(status, data)`` where ``data`` is parsed JSON for success and
+    limited body text for errors. Multipart callers pass ``form_factory`` so
+    each retry gets a fresh body; aiohttp FormData cannot be reused.
+    """
+    body = ""
+    max_attempts = max(1, attempts)
+    for attempt in range(max_attempts):
+        kwargs = dict(req_kw)
+        cleanup = _standalone_noop_cleanup
+        if json_payload is not None:
+            kwargs["json"] = json_payload
+        if form_factory is not None:
+            form, cleanup = form_factory()
+            kwargs["data"] = form
+        try:
+            async with session.post(url, headers=headers, **kwargs) as resp:
+                status = resp.status
+                if status in {200, 201}:
+                    return status, await _standalone_read_json_limited(
+                        resp,
+                        _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
+                    )
+                body = await _standalone_read_text_limited(
+                    resp,
+                    _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
+                )
+                if status != 429 or attempt >= max_attempts - 1:
+                    return status, body
+                delay = _standalone_retry_after_seconds(resp, body)
+        finally:
+            with suppress(Exception):
+                cleanup()
+
+        if delay is None:
+            delay = float(2 ** attempt)
+        if delay > _DISCORD_STANDALONE_MAX_RETRY_AFTER_SECONDS:
+            return status, body
+        logger.warning(
+            "Discord standalone REST POST rate limited (attempt %d/%d), retrying in %.2fs",
+            attempt + 1,
+            max_attempts,
+            delay,
+        )
+        await asyncio.sleep(delay)
+    return 429, body
+
+
 async def _standalone_send(
     pconfig,
     chat_id: str,
@@ -10057,52 +10143,47 @@ async def _standalone_send(
                         starter_message = {"content": (caption or message), "attachments": attachments_meta}
                         payload_json = json.dumps({"name": thread_name, "message": starter_message})
 
-                        form = aiohttp.FormData()
-                        form.add_field("payload_json", payload_json, content_type="application/json")
-
                         try:
-                            for idx, media_path in enumerate(valid_media):
-                                with open(media_path, "rb") as fh:
+                            def _build_thread_form():
+                                handles = []
+                                form = aiohttp.FormData()
+                                form.add_field("payload_json", payload_json, content_type="application/json")
+                                for idx, media_path in enumerate(valid_media):
+                                    fh = open(media_path, "rb")
+                                    handles.append(fh)
                                     form.add_field(
                                         f"files[{idx}]",
-                                        fh.read(),
+                                        fh,
                                         filename=os.path.basename(media_path),
                                     )
-                            async with session.post(thread_url, headers=auth_headers, data=form, **_req_kw) as resp:
-                                if resp.status not in {200, 201}:
-                                    body = await _standalone_read_text_limited(
-                                        resp,
-                                        _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
-                                    )
-                                    return {"error": f"Discord forum thread creation error ({resp.status}): {body}"}
-                                data = await _standalone_read_json_limited(
-                                    resp,
-                                    _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
-                                )
+                                return form, lambda: [fh.close() for fh in handles]
+
+                            status, data = await _standalone_post_with_retry(
+                                session,
+                                thread_url,
+                                headers=auth_headers,
+                                req_kw=_req_kw,
+                                form_factory=_build_thread_form,
+                            )
+                            if status not in {200, 201}:
+                                return {"error": f"Discord forum thread creation error ({status}): {data}"}
                         except Exception as e:
                             return {"error": _standalone_sanitize_error(f"Discord forum thread upload failed: {e}")}
                     else:
                         # No media — simple JSON POST creates the thread with
                         # just the text starter.
-                        async with session.post(
+                        status, data = await _standalone_post_with_retry(
+                            session,
                             thread_url,
                             headers=json_headers,
-                            json={
+                            req_kw=_req_kw,
+                            json_payload={
                                 "name": thread_name,
                                 "message": {"content": message},
                             },
-                            **_req_kw,
-                        ) as resp:
-                            if resp.status not in {200, 201}:
-                                body = await _standalone_read_text_limited(
-                                    resp,
-                                    _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
-                                )
-                                return {"error": f"Discord forum thread creation error ({resp.status}): {body}"}
-                            data = await _standalone_read_json_limited(
-                                resp,
-                                _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
-                            )
+                        )
+                        if status not in {200, 201}:
+                            return {"error": f"Discord forum thread creation error ({status}): {data}"}
 
                 thread_id_created = data.get("id")
                 starter_msg_id = (data.get("message") or {}).get("id", thread_id_created)
@@ -10122,17 +10203,16 @@ async def _standalone_send(
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             # Send text message (skip if empty and media is present)
             if message.strip() or not media_files:
-                async with session.post(url, headers=json_headers, json={"content": message}, **_req_kw) as resp:
-                    if resp.status not in {200, 201}:
-                        body = await _standalone_read_text_limited(
-                            resp,
-                            _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
-                        )
-                        return {"error": f"Discord API error ({resp.status}): {body}"}
-                    last_data = await _standalone_read_json_limited(
-                        resp,
-                        _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
-                    )
+                status, data = await _standalone_post_with_retry(
+                    session,
+                    url,
+                    headers=json_headers,
+                    req_kw=_req_kw,
+                    json_payload={"content": message},
+                )
+                if status not in {200, 201}:
+                    return {"error": f"Discord API error ({status}): {data}"}
+                last_data = data
 
             # Send each media file as a separate multipart upload. When a
             # MEDIA:<path> caption was supplied, ride it as the message content
@@ -10148,44 +10228,50 @@ async def _standalone_send(
                     warnings.append(warning)
                     if caption_pending:
                         try:
-                            async with session.post(
-                                url, headers=json_headers,
-                                json={"content": caption}, **_req_kw,
-                            ) as resp:
-                                if resp.status in {200, 201}:
-                                    last_data = await _standalone_read_json_limited(
-                                        resp, _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
-                                    )
-                                    caption_pending = False
+                            status, data = await _standalone_post_with_retry(
+                                session,
+                                url,
+                                headers=json_headers,
+                                req_kw=_req_kw,
+                                json_payload={"content": caption},
+                            )
+                            if status in {200, 201}:
+                                last_data = data
+                                caption_pending = False
                         except Exception:
                             logger.warning("Discord caption-fallback send failed for missing media")
                     continue
                 try:
-                    form = aiohttp.FormData()
                     filename = os.path.basename(media_path)
+                    caption_for_upload = caption if caption_pending else None
                     if caption_pending:
-                        form.add_field(
-                            "payload_json",
-                            json.dumps({"content": caption}),
-                            content_type="application/json",
-                        )
                         caption_pending = False
-                    with open(media_path, "rb") as f:
-                        form.add_field("files[0]", f, filename=filename)
-                        async with session.post(url, headers=auth_headers, data=form, **_req_kw) as resp:
-                            if resp.status not in {200, 201}:
-                                body = await _standalone_read_text_limited(
-                                    resp,
-                                    _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
-                                )
-                                warning = _standalone_sanitize_error(f"Failed to send media {media_path}: Discord API error ({resp.status}): {body}")
-                                logger.error(warning)
-                                warnings.append(warning)
-                                continue
-                            last_data = await _standalone_read_json_limited(
-                                resp,
-                                _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
+
+                    def _build_media_form():
+                        form = aiohttp.FormData()
+                        if caption_for_upload:
+                            form.add_field(
+                                "payload_json",
+                                json.dumps({"content": caption_for_upload}),
+                                content_type="application/json",
                             )
+                        fh = open(media_path, "rb")
+                        form.add_field("files[0]", fh, filename=filename)
+                        return form, fh.close
+
+                    status, data = await _standalone_post_with_retry(
+                        session,
+                        url,
+                        headers=auth_headers,
+                        req_kw=_req_kw,
+                        form_factory=_build_media_form,
+                    )
+                    if status not in {200, 201}:
+                        warning = _standalone_sanitize_error(f"Failed to send media {media_path}: Discord API error ({status}): {data}")
+                        logger.error(warning)
+                        warnings.append(warning)
+                        continue
+                    last_data = data
                 except Exception as e:
                     warning = _standalone_sanitize_error(f"Failed to send media {media_path}: {e}")
                     logger.error(warning)

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1087,6 +1087,146 @@ class TestSendDiscordThreadId:
         response.json.assert_not_awaited()
         response.text.assert_not_awaited()
 
+
+class TestSendDiscord429Retry:
+    """Standalone Discord REST sends retry bounded 429s (#44468)."""
+
+    @staticmethod
+    def _resp(status, json_data=None, text="", headers=None):
+        resp = MagicMock()
+        resp.status = status
+        resp.json = AsyncMock(return_value=json_data or {"id": "msg123"})
+        resp.text = AsyncMock(return_value=text)
+        resp.headers = headers or {}
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=None)
+        return resp
+
+    @staticmethod
+    def _session(responses):
+        session = MagicMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=None)
+        session.post = MagicMock(side_effect=responses)
+        return session
+
+    @staticmethod
+    def _429_body(retry_after=None):
+        payload = {"message": "You are being rate limited.", "global": False}
+        if retry_after is not None:
+            payload["retry_after"] = retry_after
+        return json.dumps(payload)
+
+    def test_429_then_success_honors_body_retry_after(self):
+        mock_session = self._session([
+            self._resp(429, text=self._429_body(0.3)),
+            self._resp(200, json_data={"id": "777"}),
+        ])
+        sleep_mock = AsyncMock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session), \
+             patch("asyncio.sleep", sleep_mock):
+            result = asyncio.run(_send_discord("tok", "111", "hi", thread_id="999"))
+
+        assert result["success"] is True
+        assert result["message_id"] == "777"
+        assert mock_session.post.call_count == 2
+        sleep_mock.assert_awaited_once_with(0.3)
+
+    def test_429_then_success_honors_header_retry_after(self):
+        mock_session = self._session([
+            self._resp(429, text="not json", headers={"Retry-After": "0.4"}),
+            self._resp(200, json_data={"id": "888"}),
+        ])
+        sleep_mock = AsyncMock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session), \
+             patch("asyncio.sleep", sleep_mock):
+            result = asyncio.run(_send_discord("tok", "111", "hi", thread_id="999"))
+
+        assert result["success"] is True
+        assert result["message_id"] == "888"
+        sleep_mock.assert_awaited_once_with(0.4)
+
+    def test_429_without_retry_after_uses_backoff(self):
+        mock_session = self._session([
+            self._resp(429, text="not json"),
+            self._resp(200, json_data={"id": "999"}),
+        ])
+        sleep_mock = AsyncMock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session), \
+             patch("asyncio.sleep", sleep_mock):
+            result = asyncio.run(_send_discord("tok", "111", "hi", thread_id="999"))
+
+        assert result["success"] is True
+        assert result["message_id"] == "999"
+        sleep_mock.assert_awaited_once_with(1.0)
+
+    def test_429_exhausts_attempts_returns_error(self):
+        mock_session = self._session([
+            self._resp(429, text=self._429_body(0.1)),
+            self._resp(429, text=self._429_body(0.1)),
+            self._resp(429, text=self._429_body(0.1)),
+        ])
+
+        with patch("aiohttp.ClientSession", return_value=mock_session), \
+             patch("asyncio.sleep", AsyncMock()):
+            result = asyncio.run(_send_discord("tok", "111", "hi", thread_id="999"))
+
+        assert "error" in result
+        assert "429" in result["error"]
+        assert mock_session.post.call_count == 3
+
+    def test_huge_retry_after_gives_up_immediately(self):
+        mock_session = self._session([
+            self._resp(429, text=self._429_body(3600.0)),
+        ])
+        sleep_mock = AsyncMock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session), \
+             patch("asyncio.sleep", sleep_mock):
+            result = asyncio.run(_send_discord("tok", "111", "hi", thread_id="999"))
+
+        assert "error" in result
+        assert "429" in result["error"]
+        assert mock_session.post.call_count == 1
+        sleep_mock.assert_not_awaited()
+
+    def test_non_429_error_is_not_retried(self):
+        mock_session = self._session([
+            self._resp(403, text='{"message": "Forbidden"}'),
+        ])
+
+        with patch("aiohttp.ClientSession", return_value=mock_session), \
+             patch("asyncio.sleep", AsyncMock()):
+            result = asyncio.run(_send_discord("tok", "111", "hi", thread_id="999"))
+
+        assert "error" in result
+        assert "403" in result["error"]
+        assert mock_session.post.call_count == 1
+
+    def test_multipart_media_retry_rebuilds_form(self, tmp_path):
+        media = tmp_path / "photo.png"
+        media.write_bytes(b"fake image bytes")
+        mock_session = self._session([
+            self._resp(429, text=self._429_body(0.2)),
+            self._resp(200, json_data={"id": "media-msg"}),
+        ])
+
+        with patch("aiohttp.ClientSession", return_value=mock_session), \
+             patch("asyncio.sleep", AsyncMock()):
+            result = asyncio.run(
+                _send_discord("tok", "111", "", media_files=[(str(media), False)])
+            )
+
+        assert result["success"] is True
+        assert result["message_id"] == "media-msg"
+        assert mock_session.post.call_count == 2
+        first_form = mock_session.post.call_args_list[0].kwargs["data"]
+        second_form = mock_session.post.call_args_list[1].kwargs["data"]
+        assert first_form is not second_form
+
 class TestSendToPlatformDiscordThread:
     """_send_to_platform passes thread_id through to _send_discord."""
 


### PR DESCRIPTION
## What does this PR do?

Adds bounded retry/backoff for Discord standalone REST POSTs so transient 429 rate limits do not immediately abort `hermes send` / cron delivery.

This is the same failure mode described in #44468: standalone Discord delivery returns an error on the first 429, and the caller's chunk loop stops there, dropping remaining chunks. The retry now lives inside the Discord standalone adapter, preserving the existing `send_message_tool.py` chunk-loop contract: a transient 429 on chunk N can retry and then the loop continues to chunk N+1.

Duplicate check note: #44488 is the earlier canonical open PR for #44468. This branch is a current-`main` implementation and broadens the helper across standalone Discord REST POST sites, including text messages, forum thread creation, caption fallback, and per-file media uploads. If #44488 lands first, this PR can be closed or rebased as a follow-up.

## Related Issue

Partially addresses #44468

Related / duplicate context: #44488, #44542, #44558

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/discord/adapter.py`: add `_standalone_post_with_retry()` for bounded Discord REST 429 retries.
- `plugins/platforms/discord/adapter.py`: honor Discord `retry_after` from JSON first, then `Retry-After` / `X-RateLimit-Reset-After` headers, then exponential fallback.
- `plugins/platforms/discord/adapter.py`: cap long retry waits at 10 seconds so the blocking standalone send path fails fast on long/global limits.
- `plugins/platforms/discord/adapter.py`: route standalone text sends, forum JSON thread creation, forum multipart thread creation, caption fallback sends, and per-file media uploads through the helper.
- `tests/tools/test_send_message_tool.py`: add focused Discord 429 retry coverage, including body/header retry_after parsing, fallback backoff, exhausted attempts, fail-fast cap, non-429 behavior, and multipart form rebuild.

## How to Test

1. `uv run pytest tests/tools/test_send_message_tool.py::TestSendDiscord429Retry -q`
2. `uv run pytest tests/tools/test_send_message_tool.py -q`
3. `uv run python -m py_compile plugins/platforms/discord/adapter.py tests/tools/test_send_message_tool.py`
4. `uv run ruff check plugins/platforms/discord/adapter.py tests/tools/test_send_message_tool.py`

Validated locally on Windows and in the isolated `hermes-staging` Linux account. No production Hermes profile or service was modified.

Live Discord smoke validation was also run from `hermes-staging` against the configured test channel `discord:1538734203737477131`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 local checkout; Linux staging user on Fedora-family host

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local:

```text
tests/tools/test_send_message_tool.py::TestSendDiscord429Retry
7 passed in 10.83s

tests/tools/test_send_message_tool.py
55 passed in 21.01s
```

Staging:

```text
tests/tools/test_send_message_tool.py::TestSendDiscord429Retry
7 passed in 1.51s

tests/tools/test_send_message_tool.py
55 passed in 4.53s
```

Live Discord smoke:

```text
HERMES_HOME=/home/hermes-staging/.hermes hermes send --json --to discord:1538734203737477131 "Hermes PR A Discord standalone REST smoke test ..."
{
  "success": true,
  "platform": "discord",
  "chat_id": "1538734203737477131",
  "message_id": "1538772078952583239"
}

HERMES_HOME=/home/hermes-staging/.hermes hermes send --json --to discord:1538734203737477131 --file /tmp/pr-a-discord-smoke.txt
{
  "success": true,
  "platform": "discord",
  "chat_id": "1538734203737477131",
  "message_id": "1538772261346222090"
}
```
