### PR TITLE
feat(api): add OpenAI-compatible audio transcriptions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3,6 +3,7 @@ OpenAI-compatible API server platform adapter.
 
 Exposes an HTTP server with endpoints:
 - POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header; opt-in long-term memory scoping via X-Hermes-Session-Key header)
+- POST /v1/audio/transcriptions    — OpenAI Audio transcription format
 - POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id; X-Hermes-Session-Key supported)
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
@@ -55,6 +56,7 @@ import os
 import re
 import sqlite3
 import sys
+import tempfile
 import threading
 import time
 import uuid
@@ -2249,6 +2251,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream),
             ("POST", "/api/sessions/{session_id}/model", self._handle_session_model_lock),
             ("POST", "/v1/chat/completions", self._handle_chat_completions),
+            ("POST", "/v1/audio/transcriptions", self._handle_audio_transcriptions),
             ("POST", "/v1/responses", self._handle_responses),
             ("GET", "/v1/responses/{response_id}", self._handle_get_response),
             ("DELETE", "/v1/responses/{response_id}", self._handle_delete_response),
@@ -3362,7 +3365,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "jobs_admin": False,
                 "memory_write_api": False,
                 "skills_api": True,
-                "audio_api": False,
+                "audio_api": True,
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
@@ -3400,6 +3403,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "models": {"method": "GET", "path": "/v1/models"},
                 "model_options": {"method": "GET", "path": "/api/model/options"},
                 "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
+                "audio_transcriptions": {
+                    "method": "POST",
+                    "path": "/v1/audio/transcriptions",
+                },
                 "responses": {"method": "POST", "path": "/v1/responses"},
                 "runs": {"method": "POST", "path": "/v1/runs"},
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
@@ -5038,6 +5045,199 @@ class APIServerAdapter(BasePlatformAdapter):
             "session_id": session_id,
             "runtime": runtime,
         })
+
+    async def _handle_audio_transcriptions(self, request: "web.Request") -> "web.Response":
+        """POST /v1/audio/transcriptions — OpenAI-compatible speech to text."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        if not request.content_type.startswith("multipart/"):
+            return web.json_response(
+                _openai_error(
+                    "Request body must be multipart/form-data",
+                    code="invalid_content_type",
+                ),
+                status=400,
+            )
+
+        upload_path: Optional[str] = None
+        upload_suffix = ""
+        upload_size = 0
+        multipart_size = 0
+        fields: Dict[str, str] = {}
+
+        def multipart_too_large() -> bool:
+            buffered_size = int(getattr(request.content, "total_bytes", 0) or 0)
+            return max(multipart_size, buffered_size) > MAX_REQUEST_BYTES
+
+        def body_too_large_response() -> "web.Response":
+            return web.json_response(
+                _openai_error("Request body too large.", code="body_too_large"),
+                status=413,
+            )
+
+        try:
+            try:
+                reader = await request.multipart()
+                while True:
+                    part = await reader.next()
+                    if multipart_too_large():
+                        return body_too_large_response()
+                    if part is None:
+                        break
+                    if part.name == "file":
+                        if upload_path is not None:
+                            return web.json_response(
+                                _openai_error(
+                                    "Only one 'file' field is supported",
+                                    param="file",
+                                    code="duplicate_file",
+                                ),
+                                status=400,
+                            )
+                        suffix = Path(part.filename or "").suffix.lower()
+                        if not re.fullmatch(r"\.[a-z0-9]{1,10}", suffix):
+                            suffix = ""
+                        upload_suffix = suffix
+                        with tempfile.NamedTemporaryFile(
+                            prefix="hermes-api-stt-",
+                            suffix=suffix,
+                            delete=False,
+                        ) as upload:
+                            upload_path = upload.name
+                            while True:
+                                chunk = await part.read_chunk(size=64 * 1024)
+                                if not chunk:
+                                    break
+                                multipart_size += len(chunk)
+                                if multipart_too_large():
+                                    return body_too_large_response()
+                                upload_size += len(chunk)
+                                upload.write(chunk)
+                    elif part.name:
+                        value = bytearray()
+                        while True:
+                            chunk = await part.read_chunk(size=64 * 1024)
+                            if not chunk:
+                                break
+                            multipart_size += len(chunk)
+                            if multipart_too_large():
+                                return body_too_large_response()
+                            value.extend(chunk)
+                        fields[part.name] = value.decode(
+                            part.get_charset(default="utf-8"),
+                            errors="replace",
+                        ).strip()
+            except (AssertionError, KeyError, ValueError, web.HTTPBadRequest):
+                return web.json_response(
+                    _openai_error("Invalid multipart request body", code="invalid_multipart"),
+                    status=400,
+                )
+
+            if upload_path is None:
+                return web.json_response(
+                    _openai_error("Missing required 'file' field", param="file", code="missing_file"),
+                    status=400,
+                )
+            if upload_size == 0:
+                return web.json_response(
+                    _openai_error("Uploaded audio file is empty", param="file", code="empty_file"),
+                    status=400,
+                )
+
+            model = self._clean_runtime_id(fields.get("model"))
+            if not model:
+                return web.json_response(
+                    _openai_error("Missing required 'model' field", param="model", code="missing_model"),
+                    status=400,
+                )
+            response_format = fields.get("response_format", "json").lower()
+            if response_format not in {"json", "text", "verbose_json"}:
+                return web.json_response(
+                    _openai_error(
+                        "response_format must be one of: json, text, verbose_json",
+                        param="response_format",
+                        code="unsupported_response_format",
+                    ),
+                    status=400,
+                )
+
+            language = self._clean_runtime_id(fields.get("language"), max_len=32) or None
+            prompt = fields.get("prompt") or None
+            if prompt is not None and len(prompt) > 10_000:
+                return web.json_response(
+                    _openai_error("prompt is too long", param="prompt", code="invalid_prompt"),
+                    status=400,
+                )
+
+            from tools.transcription_tools import (
+                SUPPORTED_FORMATS,
+                _probe_audio_duration,
+                transcribe_audio,
+            )
+
+            if upload_suffix not in SUPPORTED_FORMATS and upload_suffix != ".silk":
+                return web.json_response(
+                    _openai_error(
+                        f"Unsupported audio format: {upload_suffix or '(none)'}",
+                        param="file",
+                        code="unsupported_audio_format",
+                    ),
+                    status=400,
+                )
+
+            result = await asyncio.to_thread(
+                transcribe_audio,
+                upload_path,
+                model=model,
+                language=language,
+                prompt=prompt,
+                source="api_server",
+            )
+            if not result.get("success"):
+                message = result.get("error") or "Audio transcription failed"
+                return web.json_response(
+                    _openai_error(
+                        message,
+                        err_type="api_error",
+                        code="transcription_failed",
+                    ),
+                    status=502,
+                )
+
+            transcript = str(result.get("transcript") or "")
+            if response_format == "text":
+                return web.Response(text=transcript, content_type="text/plain")
+            if response_format == "verbose_json":
+                result_segments = result.get("segments")
+                duration = await asyncio.to_thread(_probe_audio_duration, upload_path)
+                return web.json_response(
+                    {
+                        "task": "transcribe",
+                        "language": str(result.get("language") or language or "unknown"),
+                        "duration": float(result.get("duration") or duration or 0.0),
+                        "text": transcript,
+                        "segments": result_segments if isinstance(result_segments, list) else [],
+                    }
+                )
+            return web.json_response({"text": transcript})
+        except web.HTTPRequestEntityTooLarge:
+            raise
+        except Exception as exc:
+            logger.exception("API audio transcription failed")
+            return web.json_response(
+                _openai_error(
+                    _redact_api_error_text(exc),
+                    err_type="server_error",
+                    code="transcription_error",
+                ),
+                status=500,
+            )
+        finally:
+            if upload_path:
+                with suppress(OSError):
+                    os.unlink(upload_path)
+
     @_admit_api_agent_request
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -23,7 +23,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aiohttp import web
+from aiohttp import FormData, web
 from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
@@ -35,6 +35,7 @@ from gateway.platforms.api_server import (
     _hermes_version,
     _redact_api_error_text,
     _request_agent_overrides,
+    body_limit_middleware,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
@@ -315,6 +316,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
     app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post("/v1/audio/transcriptions", adapter._handle_audio_transcriptions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
@@ -868,9 +870,14 @@ class TestCapabilitiesEndpoint:
             assert data["runtime"]["split_runtime"] is False
             assert "API-server host" in data["runtime"]["description"]
             assert data["features"]["chat_completions"] is True
+            assert data["features"]["audio_api"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
             assert data["features"]["model_options"] is True
+            assert data["endpoints"]["audio_transcriptions"] == {
+                "method": "POST",
+                "path": "/v1/audio/transcriptions",
+            }
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["model_options"] == {"method": "GET", "path": "/api/model/options"}
@@ -953,6 +960,198 @@ class TestToolsetsEndpoint:
             call.kwargs["features"] is feature_snapshot
             for call in has_keys.call_args_list
         )
+
+
+# ---------------------------------------------------------------------------
+# /v1/audio/transcriptions endpoint
+# ---------------------------------------------------------------------------
+
+
+def _transcription_form(**fields):
+    form = FormData()
+    form.add_field(
+        "file",
+        fields.pop("file", b"ID3 test audio"),
+        filename=fields.pop("filename", "sample.mp3"),
+        content_type="audio/mpeg",
+    )
+    for name, value in fields.items():
+        form.add_field(name, value)
+    return form
+
+
+class TestAudioTranscriptionsEndpoint:
+    def test_route_is_registered_for_native_and_profile_surfaces(self, adapter):
+        routes = {(method, path) for method, path, _handler in adapter._http_route_table()}
+        assert ("POST", "/v1/audio/transcriptions") in routes
+
+    @pytest.mark.asyncio
+    async def test_json_transcription_forwards_openai_fields_and_cleans_upload(self, adapter):
+        app = _create_app(adapter)
+        uploaded_path = None
+
+        def fake_transcribe(path, **kwargs):
+            nonlocal uploaded_path
+            uploaded_path = path
+            assert os.path.exists(path)
+            with open(path, "rb") as uploaded:
+                assert uploaded.read() == b"ID3 test audio"
+            assert kwargs == {
+                "model": "whisper-large-v3",
+                "language": "zh",
+                "prompt": "FunASR SenseVoice",
+                "source": "api_server",
+            }
+            return {"success": True, "transcript": "hello world", "provider": "local"}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch("tools.transcription_tools.transcribe_audio", side_effect=fake_transcribe):
+                resp = await cli.post(
+                    "/v1/audio/transcriptions",
+                    data=_transcription_form(
+                        model="whisper-large-v3",
+                        language="zh",
+                        prompt="FunASR SenseVoice",
+                    ),
+                )
+                body = await resp.json()
+
+        assert resp.status == 200
+        assert body == {"text": "hello world"}
+        assert uploaded_path is not None
+        assert not os.path.exists(uploaded_path)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("response_format", ["text", "verbose_json"])
+    async def test_supported_response_formats(self, adapter, response_format):
+        app = _create_app(adapter)
+        result = {"success": True, "transcript": "hello", "provider": "groq"}
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("tools.transcription_tools.transcribe_audio", return_value=result),
+                patch("tools.transcription_tools._probe_audio_duration", return_value=1.25),
+            ):
+                resp = await cli.post(
+                    "/v1/audio/transcriptions",
+                    data=_transcription_form(
+                        model="whisper-large-v3",
+                        language="en",
+                        response_format=response_format,
+                    ),
+                )
+                body = await resp.text() if response_format == "text" else await resp.json()
+
+        assert resp.status == 200
+        if response_format == "text":
+            assert resp.content_type == "text/plain"
+            assert body == "hello"
+        else:
+            assert body == {
+                "task": "transcribe",
+                "language": "en",
+                "duration": 1.25,
+                "text": "hello",
+                "segments": [],
+            }
+
+    @pytest.mark.asyncio
+    async def test_auth_is_checked_before_multipart_body(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("tools.transcription_tools.transcribe_audio") as transcribe:
+                resp = await cli.post("/v1/audio/transcriptions", data=b"not multipart")
+
+        assert resp.status == 401
+        transcribe.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_chunked_upload_over_server_limit_returns_413(self, adapter):
+        seen_content_length = None
+
+        @web.middleware
+        async def capture_headers(request, handler):
+            nonlocal seen_content_length
+            seen_content_length = request.headers.get("Content-Length")
+            return await handler(request)
+
+        app = web.Application(middlewares=[capture_headers, body_limit_middleware])
+        app.router.add_post("/v1/audio/transcriptions", adapter._handle_audio_transcriptions)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server.MAX_REQUEST_BYTES", 64):
+                resp = await cli.post(
+                    "/v1/audio/transcriptions",
+                    data=_transcription_form(file=b"x" * 1024, model="whisper-1"),
+                    chunked=True,
+                )
+            body = await resp.json()
+
+        assert resp.status == 413
+        assert body["error"]["code"] == "body_too_large"
+        assert seen_content_length is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("form", "code"),
+        [
+            (_transcription_form(), "missing_model"),
+            (_transcription_form(model="whisper-1", response_format="srt"), "unsupported_response_format"),
+        ],
+    )
+    async def test_invalid_request_fields_return_openai_errors(self, adapter, form, code):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/audio/transcriptions", data=form)
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert body["error"]["code"] == code
+
+    @pytest.mark.asyncio
+    async def test_unsupported_audio_extension_returns_400_without_dispatch(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("tools.transcription_tools.transcribe_audio") as transcribe:
+                resp = await cli.post(
+                    "/v1/audio/transcriptions",
+                    data=_transcription_form(
+                        file=b"not audio",
+                        filename="notes.txt",
+                        model="whisper-1",
+                    ),
+                )
+                body = await resp.json()
+
+        assert resp.status == 400
+        assert body["error"]["code"] == "unsupported_audio_format"
+        transcribe.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_provider_failure_is_redacted_and_cleans_upload(self, adapter):
+        app = _create_app(adapter)
+        uploaded_path = None
+
+        def fail(path, **_kwargs):
+            nonlocal uploaded_path
+            uploaded_path = path
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "OPENAI_API_KEY=sk-secret-provider-value failed",
+            }
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch("tools.transcription_tools.transcribe_audio", side_effect=fail):
+                resp = await cli.post(
+                    "/v1/audio/transcriptions",
+                    data=_transcription_form(model="whisper-1"),
+                )
+                body = await resp.json()
+
+        assert resp.status == 502
+        assert body["error"]["code"] == "transcription_failed"
+        assert "sk-secret-provider-value" not in body["error"]["message"]
+        assert uploaded_path is not None
+        assert not os.path.exists(uploaded_path)
 
 
 # ---------------------------------------------------------------------------
@@ -2973,7 +3172,6 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-
     # ── Recovery-net alias guards (PR for #79101) ──────────────────────
 
     def test_create_agent_does_not_cache_virtual_alias(self, monkeypatch):

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1124,10 +1124,12 @@ class TestCafConversion:
         """_convert_caf_to_wav uses ffmpeg when available."""
         caf_path = tmp_path / "voice.caf"
         caf_path.write_bytes(b"caff\x00" * 20)
-        wav_path = str(tmp_path / "voice.wav")
+        converted_path = None
 
         def fake_run(cmd, **kwargs):
-            Path(wav_path).write_bytes(b"RIFF\x00\x00\x00\x00")
+            nonlocal converted_path
+            converted_path = cmd[-1]
+            Path(converted_path).write_bytes(b"RIFF\x00\x00\x00\x00")
             return MagicMock(returncode=0)
 
         monkeypatch.setattr(
@@ -1138,8 +1140,11 @@ class TestCafConversion:
 
         from tools.transcription_tools import _convert_caf_to_wav
         result = _convert_caf_to_wav(str(caf_path))
-        assert result == wav_path
+        assert result == converted_path
+        assert Path(result).parent != tmp_path
         assert Path(result).exists()
+        Path(result).unlink()
+        Path(result).parent.rmdir()
 
 
     def test_transcribe_caf_not_converted_for_local(self, tmp_path, monkeypatch):
@@ -1159,6 +1164,31 @@ class TestCafConversion:
 
         assert result["success"] is True
         mock_convert.assert_not_called()
+
+    def test_cloud_caf_conversion_directory_is_removed_after_dispatch(self, tmp_path):
+        caf_path = tmp_path / "voice.caf"
+        caf_path.write_bytes(b"caff\x00" * 20)
+        conversion_dir = tmp_path / "converted"
+        conversion_dir.mkdir()
+        converted = conversion_dir / "voice.wav"
+        converted.write_bytes(b"RIFF\x00\x00\x00\x00")
+
+        with (
+            patch("tools.transcription_tools._load_stt_config", return_value={"provider": "openai"}),
+            patch("tools.transcription_tools._get_provider", return_value="openai"),
+            patch("tools.transcription_tools._convert_caf_to_wav", return_value=str(converted)),
+            patch("tools.transcription_tools._trim_silence_for_cloud_stt", return_value=None),
+            patch(
+                "tools.transcription_tools._dispatch_stt_provider",
+                return_value={"success": True, "transcript": "hi", "provider": "openai"},
+            ),
+        ):
+            from tools.transcription_tools import transcribe_audio
+
+            result = transcribe_audio(str(caf_path))
+
+        assert result["success"] is True
+        assert not conversion_dir.exists()
 
 
 class TestTranscribeCredentialReadGuard:
@@ -1184,6 +1214,37 @@ class TestTranscribeCredentialReadGuard:
         # The error is the shared read-guard message, not an audio-validation
         # or provider error — proving the guard fired before dispatch.
         assert result["error"] == expected
+
+
+class TestRequestScopedTranscriptionOverrides:
+    def test_language_and_prompt_reach_provider_without_plugin_hooks(self):
+        from tools.transcription_tools import _dispatch_stt_provider
+
+        with (
+            patch("hermes_cli.plugins.has_hook", return_value=False),
+            patch("tools.transcription_tools._transcribe_openai") as transcribe_openai,
+        ):
+            transcribe_openai.return_value = {
+                "success": True,
+                "transcript": "ok",
+                "provider": "openai",
+            }
+            _dispatch_stt_provider(
+                "/tmp/request.wav",
+                "openai",
+                {"provider": "openai", "openai": {}},
+                model="whisper-1",
+                source="api_server",
+                language="zh",
+                prompt="FunASR SenseVoice",
+            )
+
+        transcribe_openai.assert_called_once_with(
+            "/tmp/request.wav",
+            "whisper-1",
+            language="zh",
+            prompt="FunASR SenseVoice",
+        )
 
 
 class TestRunCommandSttIdleTimeout:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2057,27 +2057,35 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
 def _convert_caf_to_wav(file_path: str) -> Optional[str]:
     """Convert CAF to WAV using ffmpeg or afconvert (macOS)."""
     audio_path = Path(file_path)
-    wav_path = os.path.join(audio_path.parent, f"{audio_path.stem}.wav")
-    ffmpeg = _find_ffmpeg_binary()
-    if ffmpeg:
-        try:
-            subprocess.run([ffmpeg, "-y", "-i", file_path, wav_path],
-                check=True, capture_output=True, text=True,
-                timeout=300, stdin=subprocess.DEVNULL,
-                creationflags=windows_hide_flags())
-            return wav_path
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-            logger.warning("ffmpeg CAF to WAV failed for %s: %s", file_path, e)
-    afconvert = shutil.which("afconvert")
-    if afconvert:
-        try:
-            subprocess.run([afconvert, file_path, wav_path, "-d", "LEI16", "-f", "WAVE"],
-                check=True, capture_output=True, text=True,
-                timeout=300, stdin=subprocess.DEVNULL)
-            return wav_path
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-            logger.warning("afconvert CAF to WAV failed for %s: %s", file_path, e)
-    return None
+    work_dir = tempfile.mkdtemp(prefix="hermes-caf-")
+    wav_path = os.path.join(work_dir, f"{audio_path.stem}.wav")
+    keep_result = False
+    try:
+        ffmpeg = _find_ffmpeg_binary()
+        if ffmpeg:
+            try:
+                subprocess.run([ffmpeg, "-y", "-i", file_path, wav_path],
+                    check=True, capture_output=True, text=True,
+                    timeout=300, stdin=subprocess.DEVNULL,
+                    creationflags=windows_hide_flags())
+                keep_result = True
+                return wav_path
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                logger.warning("ffmpeg CAF to WAV failed for %s: %s", file_path, e)
+        afconvert = shutil.which("afconvert")
+        if afconvert:
+            try:
+                subprocess.run([afconvert, file_path, wav_path, "-d", "LEI16", "-f", "WAVE"],
+                    check=True, capture_output=True, text=True,
+                    timeout=300, stdin=subprocess.DEVNULL)
+                keep_result = True
+                return wav_path
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                logger.warning("afconvert CAF to WAV failed for %s: %s", file_path, e)
+        return None
+    finally:
+        if not keep_result:
+            shutil.rmtree(work_dir, ignore_errors=True)
 
 
 def _transcribe_local_command(
@@ -2938,6 +2946,8 @@ def _transcribe_prepared_audio(
     file_path: str,
     model: Optional[str] = None,
     source: Optional[str] = None,
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Transcribe an audio file using the configured STT provider.
@@ -2952,6 +2962,8 @@ def _transcribe_prepared_audio(
         source:    Optional caller-surface label (e.g. ``"gateway"``,
                    ``"voice_mode"``) forwarded to the ``pre_transcription``
                    plugin hook for observability. Not used for dispatch.
+        language:  Optional request-scoped language override.
+        prompt:    Optional request-scoped vocabulary/context hint.
 
     Returns:
         dict with keys:
@@ -2992,10 +3004,12 @@ def _transcribe_prepared_audio(
             return error
 
     # Convert CAF (iMessage voice notes) to WAV for cloud STT providers.
+    caf_cleanup_dir: Optional[str] = None
     if Path(file_path).suffix.lower() == ".caf" and provider not in ("local", "local_command"):
         converted = _convert_caf_to_wav(file_path)
         if converted:
             file_path = converted
+            caf_cleanup_dir = os.path.dirname(converted)
         else:
             return {"success": False, "transcript": "",
                     "error": "CAF audio could not be converted to WAV."}
@@ -3012,10 +3026,20 @@ def _transcribe_prepared_audio(
             trim_cleanup_dir = os.path.dirname(trimmed)
 
     try:
-        return _dispatch_stt_provider(file_path, provider, stt_config, model, source)
+        return _dispatch_stt_provider(
+            file_path,
+            provider,
+            stt_config,
+            model,
+            source,
+            language=language,
+            prompt=prompt,
+        )
     finally:
         if trim_cleanup_dir:
             shutil.rmtree(trim_cleanup_dir, ignore_errors=True)
+        if caf_cleanup_dir:
+            shutil.rmtree(caf_cleanup_dir, ignore_errors=True)
 
 
 def _dispatch_stt_provider(
@@ -3024,13 +3048,15 @@ def _dispatch_stt_provider(
     stt_config: Dict[str, Any],
     model: Optional[str] = None,
     source: Optional[str] = None,
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Route *file_path* to the handler for *provider* (built-in > command > plugin)."""
     # Optional static transcription prompt (``stt.prompt`` in config.yaml):
     # vocabulary/context hints threaded to prompt-capable backends.
     # Ordering: config is the base; pre_transcription hook results mutate on
     # top, in registration order, so the last hook to set a field wins.
-    prompt = stt_config.get("prompt")
+    prompt = prompt or stt_config.get("prompt")
     if not isinstance(prompt, str) or not prompt.strip():
         prompt = None
 
@@ -3040,14 +3066,16 @@ def _dispatch_stt_provider(
     # read-only. The helper short-circuits on has_hook() so the no-hook
     # dispatch path stays byte-identical. ``language`` stays None unless a
     # hook overrides it — backends keep their own config/env resolution.
-    model, language, prompt = _apply_pre_transcription_hook(
+    base_language = language or _get_stt_section(stt_config, provider).get("language")
+    model, hook_language, prompt = _apply_pre_transcription_hook(
         file_path=file_path,
         provider=provider,
         model=model,
-        language=_get_stt_section(stt_config, provider).get("language"),
+        language=base_language,
         prompt=prompt,
         source=source,
     )
+    language = hook_language or base_language
 
     # Whisper-family prompt windows top out around 224 tokens — truncate
     # (keeping the tail) with a warning rather than erroring or letting a
@@ -3198,12 +3226,17 @@ def transcribe_audio(
     file_path: str,
     model: Optional[str] = None,
     source: Optional[str] = None,
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Safely validate, preprocess supported inputs, and dispatch transcription.
 
     ``source`` is an optional caller-surface label (e.g. ``"gateway"``,
     ``"voice_mode"``) forwarded to the ``pre_transcription`` plugin hook for
     observability. Not used for dispatch.
+
+    ``language`` and ``prompt`` are optional request-scoped overrides used by
+    API surfaces. Existing callers continue to use provider configuration.
     """
     # Refuse to feed a credential / secret store (auth.json, .env, OAuth
     # tokens, mcp-tokens/, ...) to an STT provider — before ANY validation or
@@ -3236,7 +3269,13 @@ def transcribe_audio(
         prepared_error = _validate_audio_file(prepared_path, enforce_size_limit=False)
         if prepared_error:
             return prepared_error
-        return _transcribe_prepared_audio(prepared_path, model, source)
+        return _transcribe_prepared_audio(
+            prepared_path,
+            model,
+            source,
+            language=language,
+            prompt=prompt,
+        )
     finally:
         if cleanup_dir:
             shutil.rmtree(cleanup_dir, ignore_errors=True)

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -104,6 +104,7 @@ Endpoints:
 
 ```
 POST /v1/chat/completions        OpenAI Chat Completions (streaming via SSE)
+POST /v1/audio/transcriptions    OpenAI Audio transcription (multipart upload)
 POST /v1/responses               OpenAI Responses API (stateful)
 POST /v1/runs                    Start a run, returns run_id (202)
 GET  /v1/runs/{id}               Run status
@@ -125,6 +126,12 @@ Browser extensions can opt into the disabled-by-default controller protocol to
 drive the exact browser session that opened the Hermes conversation. The API
 and dashboard transports share one principal-bound broker and one explicit
 capability allowlist; see [Browser-extension control](../user-guide/features/api-server#browser-extension-control).
+
+Audio clients can use the standard OpenAI request shape: bearer authentication,
+a multipart `file` and `model`, plus optional `language`, `prompt`, and
+`response_format` fields. The endpoint delegates to Hermes' configured STT
+pipeline, so the same local or cloud provider used by messaging gateways is
+available to SDK and HTTP clients.
 
 ### Model catalog surfaces
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -55,6 +55,30 @@ Or connect Open WebUI, LobeChat, or any other frontend — see the [Open WebUI i
 
 ## Endpoints
 
+### POST /v1/audio/transcriptions
+
+OpenAI-compatible speech-to-text. Send `multipart/form-data` with an audio
+`file` and a `model`. Hermes routes the upload through the STT provider in
+`config.yaml`, including local faster-whisper and OpenAI-compatible servers.
+The request's `model`, `language`, and `prompt` fields apply only to this
+transcription.
+
+```bash
+curl http://localhost:8642/v1/audio/transcriptions \
+  -H "Authorization: Bearer change-me-local-dev" \
+  -F "file=@meeting.webm" \
+  -F "model=whisper-large-v3" \
+  -F "language=en" \
+  -F "response_format=json"
+```
+
+`response_format` accepts `json` (default), `text`, or `verbose_json`. JSON
+responses contain `{"text": "..."}`; verbose JSON also includes the task,
+language, measured duration, and segments fields expected by OpenAI clients.
+Providers that do not return timestamp segments expose an empty `segments`
+array. Uploads share the API server's 10 MB request limit and are deleted after
+each request.
+
 ### POST /v1/chat/completions
 
 Standard OpenAI Chat Completions format. Stateless — the full conversation is included in each request via the `messages` array.
@@ -248,6 +272,7 @@ Returns a machine-readable description of the API server's stable surface for ex
   "auth": {"type": "bearer", "required": true},
   "features": {
     "chat_completions": true,
+    "audio_api": true,
     "responses_api": true,
     "run_submission": true,
     "run_status": true,
@@ -747,7 +772,7 @@ In Open WebUI, add each as a separate connection. The model dropdown shows `alic
 ## Limitations
 
 - **Response storage** — stored responses (for `previous_response_id`) are persisted in SQLite and survive gateway restarts. Max 100 stored responses (LRU eviction).
-- **No file upload** — inline images are supported on both `/v1/chat/completions` and `/v1/responses`, but uploaded files (`file`, `input_file`, `file_id`) and non-image document inputs are not supported through the API.
+- **Chat file uploads are not supported** — inline images work on both `/v1/chat/completions` and `/v1/responses`, but uploaded chat files (`file`, `input_file`, `file_id`) and non-image document inputs do not. Audio upload is supported separately by `/v1/audio/transcriptions`.
 - **Simple OpenAI clients still see an alias** — `/v1/models` advertises the
   stable Hermes alias (`hermes-agent` or the active profile name). Richer
   clients can send explicit `provider` / `model_options` overrides on requests.


### PR DESCRIPTION
## What does this PR do?

Adds the focused OpenAI-compatible `POST /v1/audio/transcriptions` endpoint requested in #86435.

This is intentionally narrower than #8199 and #29364: it implements transcription only and excludes TTS, compatibility aliases, and custom metadata headers. That avoids the unresolved TTS artifact/MIME contract while addressing the existing audio-upload review findings:

- preserves the API server's 10 MB limit for both Content-Length and genuinely chunked multipart uploads
- parses fields in any order and forwards request-scoped `model`, `language`, and `prompt`
- cleans uploaded audio, CAF conversion artifacts, and failed conversions
- returns authenticated OpenAI-style JSON, text, and verbose JSON responses
- advertises the endpoint through `/v1/capabilities`

## Related Issue

Closes #86435

Related prior work: #8199, #29364

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

- Add the authenticated `/v1/audio/transcriptions` route and profile mirrors in `gateway/platforms/api_server.py`.
- Stream multipart parts to a bounded temporary file, validate extensions, redact failures, and always clean artifacts.
- Extend `transcribe_audio()` with backward-compatible request-scoped language and prompt overrides.
- Move cloud CAF conversion to an owned temporary directory and clean it after dispatch.
- Document curl/SDK-compatible request and response formats in both API integration guides.
- Add endpoint, capability, chunked-limit, field propagation, response format, failure, and cleanup tests.

## How to Test

1. Configure any existing Hermes STT provider and start `hermes gateway`.
2. Run:
   ```bash
   curl http://localhost:8642/v1/audio/transcriptions \
     -H "Authorization: Bearer $API_SERVER_KEY" \
     -F "file=@sample.webm" \
     -F "model=whisper-large-v3" \
     -F "response_format=json"
   ```
3. Verify the response is `{"text":"..."}`.

Automated verification on Ubuntu:
- `scripts/run_tests.sh tests/gateway/test_api_server.py tests/tools/test_transcription.py -q` — 125 passed
- `scripts/run_tests.sh tests/tools/test_transcription_tools.py -k 'not stderr_progress_extends_beyond_timeout' -q` — 51 passed
- isolated existing timing-sensitive idle-timeout test — 1 passed
- Ruff, `py_compile`, and `git diff --check` — passed

## Checklist

### Code

- [x] My commit follows Conventional Commits
- [x] I searched existing PRs and documented the overlap above
- [x] My PR contains only changes related to this feature
- [ ] I ran the entire repository test suite
- [x] I added tests for the new behavior
- [x] Tested on Ubuntu Linux

### Documentation & Housekeeping

- [x] Updated relevant documentation and docstrings
- [x] `cli-config.yaml.example`: N/A, no config keys added
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no workflow change
- [x] Considered Windows and macOS temporary-file behavior
- [x] Tool descriptions/schemas: N/A, no agent tool schema changed

