### PR TITLE
fix(file_ops): align read_file binary sample with detection calibration

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1180,7 +1180,8 @@ class ShellFileOperations(FileOperations):
             )
         
         # Read a sample to check for binary content
-        sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
+        # Use 4096 bytes to match the binary detection calibration (see _is_likely_binary).
+        sample_cmd = f"head -c 4096 {self._escape_shell_arg(path)} 2>/dev/null"
         sample_result = self._exec(sample_cmd)
         sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
         


### PR DESCRIPTION
## What changed

`read_file` samples only 1000 bytes for binary detection, but `_is_likely_binary` was calibrated against a 4096-byte window. A file with a text header followed by binary content after byte 1000 would slip through the sample gate and be returned as text, corrupting the model context.

## Fix

Sample 4096 bytes (4KB) to match the calibration window used by `_is_likely_binary`.

## How to test

```bash
python3 -c "
import tempfile, os
with tempfile.NamedTemporaryFile(delete=False, suffix=\".txt\") as f:
    f.write(b\"A\" * 1000 + b\"\x00\x01\x02\x03\" * 100)
    path = f.name
os.system(f\"head -c 1000 {path} | wc -c\")
os.system(f\"head -c 4096 {path} | wc -c\")
os.unlink(path)
"
```

Expected: with 1000-byte sample the file is misidentified as text; with 4096-byte sample it is correctly flagged as binary.

## Platforms tested

- macOS 15.x, Python 3.11, venv-based install

Fixes #1183