### PR TITLE
fix(desktop): collect artifacts referenced with #media: markdown hrefs

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -1,4 +1,4 @@
-import { mediaExternalUrl, resolveMediaDisplaySrc } from '@/lib/media'
+import { mediaExternalUrl, mediaPathFromMarkdownHref, resolveMediaDisplaySrc } from '@/lib/media'
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
 export type ArtifactKind = 'image' | 'file' | 'link'
@@ -56,6 +56,16 @@ function artifactSessionTitle(session: SessionInfo): string {
 
 function normalizeValue(value: string): string {
   return value.trim().replace(/[),.;]+$/, '')
+}
+
+// Desktop renders media references as `[label](#media:...)` markdown links
+// (chat-messages.ts → mediaMarkdownHref), with the path percent-encoded
+// (`#media:D%3A%2FComfyUI%2Foutput%2Fa.png`). Decode such values back to a
+// real path before artifact matching so the Artifacts page collects them
+// exactly like the legacy `MEDIA:` form (#88084). Non-`#media:` values are
+// returned untouched; malformed encodings fall back to the raw value.
+function decodeMediaHrefValue(value: string): string {
+  return mediaPathFromMarkdownHref(value) ?? value
 }
 
 function unquoteMediaValue(value: string): string {
@@ -282,7 +292,7 @@ function collectArtifactsFromText(text: string, pushValue: (value: string) => vo
       continue
     }
 
-    const value = match[2] || ''
+    const value = decodeMediaHrefValue(match[2] || '')
 
     if (looksLikeArtifact(value)) {
       pushValue(value)
@@ -398,7 +408,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
     }
 
     collectArtifactsFromMessage(message, candidate => {
-      const value = normalizeValue(candidate)
+      const value = normalizeValue(decodeMediaHrefValue(candidate))
 
       if (!value || !looksLikeArtifact(value)) {
         return

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -394,4 +394,51 @@ describe('loadArtifactsForSessions', () => {
     expect(result.failures).toHaveLength(1)
     expect(result.failures[0]?.session.id).toBe('session-2')
   })
+
+  it('collects images referenced with the #media: markdown href format (#88084)', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Here is the render:\n\n[Image: nahida](#media:D%3A%5CComfyUI%5Coutput%5Cbrat4_nahida_lib_a_00001_.png)',
+        role: 'assistant',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({
+      kind: 'image',
+      value: 'D:\\ComfyUI\\output\\brat4_nahida_lib_a_00001_.png'
+    })
+  })
+
+  it('collects #media: hrefs with percent-encoded POSIX paths (#88084)', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: '[Audio: tts clip](#media:%2FUsers%2Fbrooklyn%2F.hermes%2Fcache%2Faudio%2Ftts_20260501_222725.mp3)',
+        role: 'assistant',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({
+      kind: 'file',
+      value: '/Users/brooklyn/.hermes/cache/audio/tts_20260501_222725.mp3'
+    })
+  })
+
+  it('leaves legacy MEDIA: values and plain links untouched (#88084)', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Old: **MEDIA: /tmp/generated/demo.png**\n\nLink: [docs](https://example.com/docs)',
+        role: 'assistant',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts.map(artifact => artifact.value)).toEqual([
+      '/tmp/generated/demo.png',
+      'https://example.com/docs'
+    ])
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #88084: after Desktop switched image/audio references from the legacy `MEDIA:` form to `#media:` markdown hrefs (`[Image: x](#media:D%3A%5C...`), the Artifacts page stopped collecting them — `collectArtifactsFromText` never recognized the new prefix, so every generated image silently vanished from the page.

## Approach

Decode `#media:` hrefs back to a real path before artifact matching, mirroring the existing `mediaPathFromMarkdownHref` used by the renderer:

- `decodeMediaHrefValue()` helper: `mediaPathFromMarkdownHref(value) ?? value` — decodes only `#media:`-prefixed values, returns everything else untouched, falls back to the raw value on malformed encodings.
- Applied in the markdown-link extractor (so `looksLikeArtifact` sees the decoded path) and in the `pushValue` callback (covers `![](...)` image syntax and tool-payload paths).

## Test Plan

- 3 new tests in `src/app/artifacts/index.test.ts`: Windows path via `#media:` (encoded backslashes), POSIX path via `#media:`, and a legacy `MEDIA:` + plain-link regression guard.
- Full file: 17/17 pass (`vitest run --project ui`).
- `eslint` clean on both files; `tsc -p tsconfig.json --noEmit` clean.

## Risk / Exclusions

- Behavior change only for `#media:`-prefixed values; legacy `MEDIA:`, URLs, and plain paths behave exactly as before.
- No changes to the renderer, media resolvers, or message formatting.

Closes #88084