### PR TITLE
fix(model-switch): resolve versioned family aliases and fail loudly on unknown names

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -180,7 +180,13 @@ def _normalize_for_deepseek(model_name: str) -> str:
       (covers future ``deepseek-v5-*`` and dated variants without a release).
     - Contains a reasoner keyword (r1, think, reasoning, cot, reasoner)
       -> ``deepseek-v4-flash``.
-    - Everything else -> ``deepseek-v4-flash``.
+    - Everything else -> the provider's **current** configured default via
+      :func:`normalize_for_default`.  The fold target is resolved
+      dynamically, never a hardcoded literal: what is DeepSeek's default
+      today (``deepseek-v4-flash``) may not be tomorrow, and folding to a
+      stale literal recreates the phantom-switch bug (unknown name
+      rewritten to a hardcoded id, validated clean, reported as success
+      while the session model never changed).
 
     Args:
         model_name: The bare model name (vendor prefix already stripped).
@@ -207,12 +213,107 @@ def _normalize_for_deepseek(model_name: str) -> str:
         if keyword in bare:
             return "deepseek-v4-flash"
 
-    return "deepseek-v4-flash"
+    # Everything else: fold to the provider's CURRENT configured default.
+    # Never a hardcoded literal — see normalize_for_default().
+    return normalize_for_default(bare, "deepseek")
 
 
 # ---------------------------------------------------------------------------
 # Helper utilities
 # ---------------------------------------------------------------------------
+
+def normalize_for_default(model_input: str, target_provider: str) -> str:
+    """Fold an unrecognized model name to the provider's CURRENT default.
+
+    The fold target is resolved dynamically from the configured
+    ``model.default`` (when it belongs to *target_provider*), falling back
+    to the provider's curated default. It is NEVER a hardcoded literal:
+    the model that is the default today (e.g. ``deepseek-v4-flash``) can
+    change without a code release, and a stale literal would silently
+    rewrite an unknown name to a model the user did not configure —
+    the phantom-switch bug.
+
+    Args:
+        model_input: The model name that failed to resolve.
+        target_provider: The provider the name is being normalized for.
+
+    Returns:
+        The provider's current default model id (or *model_input* when no
+        default can be determined).
+    """
+    name = (model_input or "").strip()
+    provider = _normalize_provider_alias(target_provider)
+
+    # 1) Configured default, scoped to this provider.  A default configured
+    #    for a DIFFERENT provider (e.g. ``anthropic/claude-sonnet-5`` while
+    #    folding for deepseek) must not leak across — the fold would land on
+    #    a model the target provider cannot serve.
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        model_cfg = cfg.get("model") or {}
+        if isinstance(model_cfg, dict):
+            configured_default = str(model_cfg.get("default") or "").strip()
+            configured_provider = str(model_cfg.get("provider") or "").strip()
+            if configured_default and configured_provider:
+                if _normalize_provider_alias(configured_provider) == provider:
+                    # A vendor-prefixed default must agree with the target
+                    # provider (e.g. ``deepseek/deepseek-v4-flash`` on
+                    # deepseek).  A bare name is used as-is.
+                    if "/" in configured_default:
+                        prefix, _ = configured_default.split("/", 1)
+                        if _normalize_provider_alias(prefix.strip()) == provider:
+                            return _strip_vendor_prefix(configured_default)
+                    else:
+                        return configured_default
+    except Exception:
+        pass
+
+    # 2) Provider-curated default (cost-safe for metered aggregators).
+    try:
+        from hermes_cli.models import get_default_model_for_provider
+
+        fallback = get_default_model_for_provider(provider)
+        if fallback:
+            return fallback
+    except Exception:
+        pass
+
+    return name
+
+
+def model_name_resolves_for_provider(model_input: str, target_provider: str) -> bool:
+    """Return True when *model_input* is a known id for the provider.
+
+    ``True`` means the name maps to a real model through canonical ids,
+    documented remaps (retired aliases, reasoner keywords), or pass-through
+    providers — i.e. the normalizer's catch-all will NOT silently swap the
+    identity.  ``False`` means the name only survived because the catch-all
+    folded it to the provider default — a phantom switch in the making.
+
+    Used by ``switch_model`` to fail loudly instead of reporting success
+    for a name that resolved nowhere.
+
+    Non-deepseek providers return ``True`` unconditionally: their
+    normalizers only convert form (dots↔hyphens, vendor-prefix stripping),
+    never identity.
+    """
+    name = (model_input or "").strip()
+    if not name:
+        return True
+    provider = _normalize_provider_alias(target_provider)
+    if provider != "deepseek":
+        return True
+    bare = _strip_vendor_prefix(name).lower()
+    if bare in _DEEPSEEK_RETIRED_ALIASES:
+        return True
+    if bare in _DEEPSEEK_CANONICAL_MODELS:
+        return True
+    if _DEEPSEEK_V_SERIES_RE.match(bare):
+        return True
+    return any(keyword in bare for keyword in _DEEPSEEK_REASONER_KEYWORDS)
+
 
 def _strip_vendor_prefix(model_name: str) -> str:
     """Remove a ``vendor/`` prefix if present.

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -38,6 +38,7 @@ from hermes_cli.providers import (
     resolve_provider_full,
 )
 from hermes_cli.model_normalize import (
+    model_name_resolves_for_provider,
     normalize_model_for_provider,
 )
 from agent.models_dev import (
@@ -950,6 +951,50 @@ def _ambiguous_alias_message(err: "AmbiguousAliasError") -> str:
     )
 
 
+def _match_family_alias_with_version(key: str) -> Optional[tuple[str, str]]:
+    """Return ``(alias_key, version)`` for a versioned family alias input.
+
+    Handles shorthand like ``sonnet-5`` -> ``("sonnet", "5")``,
+    ``glm-5.2`` -> ``("glm", "5.2")``, ``grok-3-fast`` ->
+    ``("grok", "3-fast")``.  The version suffix must look version-like
+    (starts with a digit or ``v``) so full model names that merely begin
+    with an alias family (``claude-sonnet-5`` -> alias ``claude``) are
+    NOT captured here — they already resolve through the catalog /
+    provider-detection paths.
+
+    Longest alias wins (``gpt5-mini`` prefers alias ``gpt5`` over ``gpt``).
+
+    The alias's *family* must end with the alias key itself (``sonnet`` ->
+    ``claude-sonnet``; ``glm`` -> ``glm``).  This excludes stale legacy
+    families whose models stopped using the alias stem (``deepseek`` ->
+    ``deepseek-chat``: real models are ``deepseek-v4-*``, so a versioned
+    ``deepseek-v4-pro`` must NOT be misread as an alias + version and
+    rejected by the fallback gate).
+
+    Args:
+        key: Lowercased, stripped model input.
+
+    Returns:
+        ``(alias_key, version)`` or ``None`` when the input is a bare alias
+        or carries no version-like suffix.
+    """
+    if not key or "-" not in key:
+        return None
+    for alias_key in sorted(MODEL_ALIASES, key=len, reverse=True):
+        if not key.startswith(alias_key + "-"):
+            continue
+        version = key[len(alias_key) + 1:]
+        if not version or not (version[0].isdigit() or version[0].lower() == "v"):
+            continue
+        identity = MODEL_ALIASES[alias_key]
+        if not identity.family.lower().endswith(alias_key):
+            # The family no longer uses the alias stem (e.g. deepseek's
+            # legacy ``deepseek-chat`` family vs ``deepseek-v4-*`` models).
+            continue
+        return (alias_key, version)
+    return None
+
+
 def resolve_alias(
     raw_input: str,
     current_provider: str,
@@ -960,6 +1005,12 @@ def resolve_alias(
     current provider's models.dev catalog for the model whose ID starts
     with ``vendor/family`` (or just ``family`` for non-aggregator
     providers) and has the **highest version**.
+
+    Versioned family shorthand (``sonnet-5``, ``glm-5.2``) resolves the
+    same way: the version suffix is appended to the family prefix
+    (``claude-sonnet-5``, ``glm-5.2``) and matched against the catalog.
+    This is what lets ``/model sonnet-5`` switch to ``anthropic/claude-sonnet-5``
+    instead of silently no-op'ing on a provider that doesn't serve it.
 
     Returns:
         ``(provider, resolved_model_id, alias_name)`` if a match is
@@ -982,6 +1033,13 @@ def resolve_alias(
             return (da.provider, da.model, alias_name)
 
     identity = MODEL_ALIASES.get(key)
+    version_suffix = ""
+    if identity is None:
+        # Versioned family alias: "sonnet-5" -> alias "sonnet" + version "5"
+        matched = _match_family_alias_with_version(key)
+        if matched is not None:
+            alias_key, version_suffix = matched
+            identity = MODEL_ALIASES[alias_key]
     if identity is None:
         return None
 
@@ -1007,19 +1065,33 @@ def resolve_alias(
 
     if aggregator:
         prefix = f"{vendor}/{family}".lower()
+    else:
+        prefix = family.lower()
+    if version_suffix:
+        prefix = f"{prefix}-{version_suffix}"
+
+    if aggregator:
         matches = [
             mid for mid in catalog
             if mid.lower().startswith(prefix)
         ]
     else:
-        family_lower = family.lower()
         matches = [
             mid for mid in catalog
-            if mid.lower().startswith(family_lower)
+            if mid.lower().startswith(prefix)
         ]
 
     if not matches:
         return None
+
+    # Versioned input: prefer the exact family-version entry (e.g.
+    # ``claude-sonnet-5``) over dated snapshots that share the prefix
+    # (``claude-sonnet-5-20250514``).  Only fall back to prefix matching
+    # when the exact id isn't catalogued.
+    if version_suffix:
+        exact = [m for m in matches if m.lower() == prefix]
+        if len(exact) == 1:
+            return (current_provider, exact[0], key)
 
     # Sort by version descending (best guess first) for display, but NEVER
     # silently pick among multiple candidates: version-sort heuristics have
@@ -1347,6 +1419,10 @@ def switch_model(
     new_model = raw_input.strip()
     target_provider = current_provider
     resolved_moa_preset = False
+    # Recognition tracking, shared across both paths (must be defined before
+    # the PATH A / PATH B split; the branches reassign as needed).
+    resolved_in_current_catalog = False
+    config_routed = False
 
     # =================================================================
     # PATH A: Explicit --provider given
@@ -1524,7 +1600,11 @@ def switch_model(
         else:
             # --- Step b: Alias exists but not on current provider -> fallback ---
             key = raw_input.strip().lower()
-            if key in MODEL_ALIASES:
+            alias_match = (
+                key in MODEL_ALIASES
+                or _match_family_alias_with_version(key) is not None
+            )
+            if alias_match:
                 authed = get_authenticated_provider_slugs(
                     current_provider=current_provider,
                     user_providers=user_providers,
@@ -1545,12 +1625,18 @@ def switch_model(
                         resolved_alias, new_model, target_provider,
                     )
                 else:
-                    identity = MODEL_ALIASES[key]
+                    identity = MODEL_ALIASES.get(key)
+                    if identity is None:
+                        _mv = _match_family_alias_with_version(key)
+                        if _mv is not None:
+                            identity = MODEL_ALIASES[_mv[0]]
+                    vendor = identity.vendor if identity else key
+                    family = identity.family if identity else key
                     return ModelSwitchResult(
                         success=False,
                         is_global=is_global,
                         error_message=(
-                            f"Alias '{key}' maps to {identity.vendor}/{identity.family} "
+                            f"Alias '{key}' maps to {vendor}/{family} "
                             f"but no matching model was found in any provider catalog. "
                             f"Try specifying the full model name."
                         ),
@@ -1578,7 +1664,6 @@ def switch_model(
         # Critical for flat-namespace resellers like opencode-go / opencode-zen
         # whose live /v1/models returns bare IDs (e.g. "deepseek-v4-flash") that
         # coincidentally match entries in native providers' static catalogs.
-        resolved_in_current_catalog = False
         if is_aggregator(target_provider) and not resolved_alias:
             catalog = list_provider_models(target_provider)
             if catalog:
@@ -1606,7 +1691,6 @@ def switch_model(
         # detection.  Unlike step e this is deliberately NOT gated on
         # ``not is_custom`` — switching from a local/custom provider A to a
         # configured provider B that declares the typed model is the point.
-        config_routed = False
         if (
             not resolved_alias
             and not resolved_in_current_catalog
@@ -1801,7 +1885,37 @@ def switch_model(
     new_model = _resolve_named_custom_model_id(
         new_model, target_provider, custom_providers
     )
+    pre_normalize = new_model
     new_model = normalize_model_for_provider(new_model, target_provider)
+
+    # --- Phantom-switch guard ---
+    # A name that resolved NOWHERE must fail loudly, never report a phantom
+    # success.  If no alias, catalog, configured-provider, or detection step
+    # recognized the user's input and the normalizer REWROTE it (deepseek's
+    # catch-all folding an unknown name to the configured default), the
+    # session model would not change yet we would report "switched" — a lie.
+    # Fail loudly so the user sees the real state and the actual model name.
+    if (
+        not resolved_alias
+        and not resolved_in_current_catalog
+        and not config_routed
+        and not resolved_moa_preset
+        and pre_normalize != new_model
+        and not model_name_resolves_for_provider(pre_normalize, target_provider)
+    ):
+        return ModelSwitchResult(
+            success=False,
+            new_model=new_model,
+            target_provider=target_provider,
+            provider_label=provider_label,
+            is_global=is_global,
+            error_message=(
+                f"Unknown model '{raw_input.strip()}': it did not match any model "
+                f"on {provider_label} or in the provider catalog, and Hermes would "
+                f"not silently rewrite it to '{new_model}'. Use /model "
+                f"<exact-model-name> or the model picker."
+            ),
+        )
 
     # --- Validate ---
     try:

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -138,6 +138,61 @@ class TestDeepseekCanonicalAndReasonerMapping:
         assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
 
 
+# ── Phantom-switch regression: unknown names must not silently fold ─────
+
+class TestDeepseekUnknownNameFoldTarget:
+    """The deepseek catch-all folds to the CURRENT configured default, never
+    a hardcoded literal — and switch_model fails loudly on names that
+    resolve nowhere (see test_model_switch_versioned_alias.py)."""
+
+    def test_unknown_name_folds_to_configured_default(self, monkeypatch):
+        """A typo'd/unknown name folds to the user's configured default,
+        resolved dynamically from config (not a hardcoded literal)."""
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"default": "deepseek-v4-flash", "provider": "deepseek"}},
+        )
+        assert _normalize_for_deepseek("sonnet-5") == "deepseek-v4-flash"
+        assert _normalize_for_deepseek("floobarp") == "deepseek-v4-flash"
+
+    def test_fold_target_follows_config_change(self, monkeypatch):
+        """Change the configured default; the fold follows — it must not be
+        baked in as today's literal."""
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"default": "deepseek-v4-pro", "provider": "deepseek"}},
+        )
+        assert _normalize_for_deepseek("sonnet-5") == "deepseek-v4-pro"
+
+    def test_foreign_provider_default_does_not_leak(self, monkeypatch):
+        """A default configured for another provider (anthropic) must not be
+        used as the deepseek fold target."""
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {
+                    "default": "anthropic/claude-sonnet-5",
+                    "provider": "anthropic",
+                }
+            },
+        )
+        # Falls back to deepseek's curated default (first entry).
+        assert _normalize_for_deepseek("sonnet-5") == "deepseek-v4-pro"
+
+    def test_model_name_resolves_for_provider(self):
+        """Recognition helper: known deepseek ids resolve; garbage does not."""
+        from hermes_cli.model_normalize import model_name_resolves_for_provider
+
+        assert model_name_resolves_for_provider("deepseek-v4-flash", "deepseek")
+        assert model_name_resolves_for_provider("deepseek-chat", "deepseek")
+        assert model_name_resolves_for_provider("deepseek-r1", "deepseek")
+        assert not model_name_resolves_for_provider("sonnet-5", "deepseek")
+        assert not model_name_resolves_for_provider("floobarp", "deepseek")
+        # Non-deepseek providers: pass-through only, always "resolves"
+        # (their normalizers never swap identity).
+        assert model_name_resolves_for_provider("whatever", "anthropic")
+
+
 # ── Regression: issue #78796 ───────────────────────────────────────────
 
 class TestIssue78796NvidiaPrefixRepair:

--- a/tests/hermes_cli/test_model_switch_versioned_alias.py
+++ b/tests/hermes_cli/test_model_switch_versioned_alias.py
@@ -1,0 +1,215 @@
+"""Versioned family-alias resolution + phantom-switch guard.
+
+Regression for the silent model-switch bug: typing ``sonnet-5`` while on a
+provider that doesn't serve it used to resolve NOWHERE, get folded to the
+provider default by ``_normalize_for_deepseek``'s catch-all, validate clean,
+and report "switched" while nothing changed.
+
+Two fixes under test:
+1. ``resolve_alias`` resolves versioned family shorthand (``sonnet-5`` ->
+   ``anthropic/claude-sonnet-5``) so the provider segment is inferred, and
+   ``switch_model`` falls back to authenticated providers that carry it.
+2. A name that resolves nowhere FAILS LOUDLY (success=False) instead of a
+   phantom success.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.model_switch import (
+    AmbiguousAliasError,
+    _match_family_alias_with_version,
+    resolve_alias,
+    switch_model,
+)
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+_MOCK_RUNTIME = {
+    "api_key": "sk-test",
+    "base_url": "",
+    "api_mode": "chat_completions",
+}
+
+
+@pytest.fixture(autouse=True)
+def _offline_model_catalog(monkeypatch):
+    """Keep catalog lookups offline and deterministic."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.models.cached_provider_model_ids", lambda *_a, **_k: []
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids", lambda *_a, **_k: []
+    )
+
+
+# ── Versioned family alias matching ─────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "input_str,expected",
+    [
+        ("sonnet-5", ("sonnet", "5")),
+        ("glm-5.2", ("glm", "5.2")),
+        ("gpt-5.4", ("gpt", "5.4")),
+        ("grok-3-fast", ("grok", "3-fast")),
+        ("mimo-v2.5-pro", ("mimo", "v2.5-pro")),
+    ],
+)
+def test_match_family_alias_with_version(input_str, expected):
+    assert _match_family_alias_with_version(input_str) == expected
+
+
+@pytest.mark.parametrize(
+    "input_str",
+    [
+        "sonnet",          # bare alias, no version
+        "claude-sonnet-5", # full model name — alias prefix "claude" but the
+                           # remainder "sonnet-5" is not version-like
+        "floobarp",
+        "gpt5",            # bare alias
+        "deepseek-v4-pro", # real V-series id — deepseek's alias family is the
+                           # stale legacy "deepseek-chat", so this must NOT be
+                           # misread as alias "deepseek" + version "v4-pro"
+        "deepseek-v4-flash",
+    ],
+)
+def test_match_family_alias_with_version_rejects(input_str):
+    assert _match_family_alias_with_version(input_str) is None
+
+
+def test_resolve_alias_versioned_sonnet5_on_anthropic():
+    """sonnet-5 resolves to claude-sonnet-5 on the anthropic provider."""
+    result = resolve_alias("sonnet-5", "anthropic")
+    assert result == ("anthropic", "claude-sonnet-5", "sonnet-5")
+
+
+def test_resolve_alias_versioned_glm52_on_zai():
+    """glm-5.2 resolves to glm-5.2 on the zai provider."""
+    result = resolve_alias("glm-5.2", "zai")
+    assert result == ("zai", "glm-5.2", "glm-5.2")
+
+
+def test_resolve_alias_versioned_sonnet5_not_on_deepseek():
+    """A provider that doesn't serve the family returns None — the caller
+    falls back to authenticated providers."""
+    assert resolve_alias("sonnet-5", "deepseek") is None
+
+
+def test_resolve_alias_versioned_prefers_exact_id():
+    """Versioned input prefers the exact family-version entry over dated
+    snapshots that share the prefix — never an ambiguous guess."""
+    catalog = ["claude-sonnet-5", "claude-sonnet-5-20250514"]
+    with (
+        patch("hermes_cli.model_switch.list_provider_models", return_value=catalog),
+        patch("hermes_cli.model_switch.is_aggregator", return_value=False),
+        patch("hermes_cli.models._PROVIDER_MODELS", {}),
+    ):
+        result = resolve_alias("sonnet-5", "anthropic")
+    assert result == ("anthropic", "claude-sonnet-5", "sonnet-5")
+
+
+def test_resolve_alias_versioned_ambiguous_without_exact_raises():
+    """No exact id, multiple dated variants — must not guess."""
+    catalog = ["claude-sonnet-5-20250514", "claude-sonnet-5-20250601"]
+    with (
+        patch("hermes_cli.model_switch.list_provider_models", return_value=catalog),
+        patch("hermes_cli.model_switch.is_aggregator", return_value=False),
+        patch("hermes_cli.models._PROVIDER_MODELS", {}),
+    ):
+        with pytest.raises(AmbiguousAliasError):
+            resolve_alias("sonnet-5", "anthropic")
+
+
+# ── switch_model: versioned alias fallback across providers ─────────────
+
+def test_switch_model_sonnet5_falls_back_to_anthropic(monkeypatch):
+    """Typing sonnet-5 while on deepseek switches to anthropic/claude-sonnet-5
+    via the authenticated-provider fallback — the TUI-like behavior."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kw: dict(_MOCK_RUNTIME),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_authenticated_provider_slugs",
+        lambda **kw: ["anthropic"],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: dict(_MOCK_VALIDATION),
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None
+    )
+
+    result = switch_model(
+        raw_input="sonnet-5",
+        current_provider="deepseek",
+        current_model="deepseek-v4-flash",
+    )
+
+    assert result.success is True
+    assert result.new_model == "claude-sonnet-5"
+    assert result.target_provider == "anthropic"
+    assert result.resolved_via_alias == "sonnet-5"
+
+
+def test_switch_model_unknown_name_fails_loudly(monkeypatch):
+    """A name that resolves NOWHERE must NOT report a phantom success on
+    deepseek (the old behavior: folded to deepseek-v4-flash, success=True)."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kw: dict(_MOCK_RUNTIME),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_authenticated_provider_slugs",
+        lambda **kw: [],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: dict(_MOCK_VALIDATION),
+    )
+
+    result = switch_model(
+        raw_input="floobarp",
+        current_provider="deepseek",
+        current_model="deepseek-v4-flash",
+    )
+
+    assert result.success is False
+    assert "floobarp" in result.error_message
+    # The failure must name the phantom target so the user sees the lie.
+    assert "deepseek-v4-flash" in result.error_message or "rewrite" in result.error_message
+
+
+def test_switch_model_known_deepseek_id_still_switches(monkeypatch):
+    """Legitimate deepseek ids still switch — the guard must not over-fire."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kw: dict(_MOCK_RUNTIME),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: dict(_MOCK_VALIDATION),
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None
+    )
+
+    result = switch_model(
+        raw_input="deepseek-v4-pro",
+        current_provider="deepseek",
+        current_model="deepseek-v4-flash",
+    )
+
+    assert result.success is True
+    assert result.new_model == "deepseek-v4-pro"
+    assert result.target_provider == "deepseek"


### PR DESCRIPTION
## Problem

`/model sonnet-5` while on a provider that doesn't serve it used to resolve **nowhere** (aliases carry no versions, catalog/detection miss), then `_normalize_for_deepseek`'s catch-all folded the name to `deepseek-v4-flash` — which validated clean and produced a **phantom success**: the gateway replied "switched" while nothing changed. Any typo'd or unknown model name silently no-op'd the same way, for deepseek and any other provider whose normalizer maps unknown → default.

Reproduced live: `switch_model("floobarp", current_provider="deepseek")` → `success=True, new_model="deepseek-v4-flash"`.

## Changes

**`hermes_cli/model_switch.py`**
- `_match_family_alias_with_version()` — NEW. Splits `sonnet-5` → (`sonnet`, `5`), `glm-5.2` → (`glm`, `5.2`). Requires a version-like suffix AND the alias family to end with the alias key (excludes deepseek's stale `deepseek-chat` family so real V-series ids like `deepseek-v4-pro` aren't misread as alias+version).
- `resolve_alias()` — versioned family shorthand resolves against the provider catalog, inferring the provider segment exactly like the TUI picker does: `sonnet-5` → `anthropic/claude-sonnet-5`. Exact id preferred over dated snapshots; ambiguity still raises `AmbiguousAliasError`.
- `switch_model()` — the authenticated-provider fallback gate now includes versioned aliases, so `sonnet-5` typed while on deepseek falls back across authed providers and lands on `claude-sonnet-5`. NEW **phantom-switch guard** after normalization: if no alias/catalog/config/detection step recognized the input AND the normalizer rewrote it AND `model_name_resolves_for_provider()` is False → `success=False` with a loud error naming the would-be phantom target.

**`hermes_cli/model_normalize.py`**
- `normalize_for_default()` — NEW. Folds an unrecognized name to the provider's **current configured default** (`model.default`, provider-scoped; else curated default). Never a hardcoded literal — folding to a stale literal recreates the phantom.
- `_normalize_for_deepseek()` — catch-all now calls `normalize_for_default()` instead of hardcoded `deepseek-v4-flash`. Retired-alias / reasoner-keyword rewrites unchanged.
- `model_name_resolves_for_provider()` — NEW recognition helper: known deepseek ids (canonical / V-series / retired aliases / reasoner keywords) resolve; garbage does not; other providers always "resolve" (their normalizers only convert form, never identity).

## Tests

16 new tests across `tests/hermes_cli/test_model_switch_versioned_alias.py` (new) and `test_model_normalize.py`: versioned alias matching/resolution, exact-id preference vs dated snapshots, ambiguity, fold-target-follows-config, cross-provider default isolation, phantom-guard firing, known-id pass-through. 204 tests pass on the relevant surface.