### PR TITLE
fix(tui): print the auto-compaction lifecycle into the transcript

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -196,6 +196,53 @@ describe('createGatewayEventHandler', () => {
     expect(ctx.system.sys).toHaveBeenCalledWith('compressing 968 messages (~123,400 tok)…')
   })
 
+  it('prints an auto-compaction start into the transcript (#88102)', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const onEvent = createGatewayEventHandler(ctx)
+    // Auto-compaction never says 'compressing'. It reaches the TUI as a
+    // 'lifecycle' status that tui_gateway re-tags to 'compacting', so matching
+    // only the manual /compress kind dropped it on the floor.
+    const text = '🗜️ Compacting context — summarizing earlier conversation so I can continue...'
+
+    onEvent({ payload: { kind: 'compacting', text }, type: 'status.update' } as any)
+
+    expect(ctx.system.sys).toHaveBeenCalledWith(text)
+    // Additive: the in-turn activity entry these kinds already got is still
+    // there. The transcript line is the durable record, not a replacement for
+    // the live indicator.
+    expect(getTurnState().activity.map(item => item.text)).toEqual([text])
+  })
+
+  it('prints the auto-compaction terminal edge into the transcript (#88102)', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const onEvent = createGatewayEventHandler(ctx)
+    // agent/conversation_compression.py::_emit_compaction_done sends this one
+    // directly, under a third kind again.
+    const text = '✓ Context compaction complete — continuing turn...'
+
+    onEvent({ payload: { kind: 'compacted', text }, type: 'status.update' } as any)
+
+    expect(ctx.system.sys).toHaveBeenCalledWith(text)
+    expect(getTurnState().activity.map(item => item.text)).toEqual([text])
+  })
+
+  it('keeps unrelated lifecycle statuses out of the transcript', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const onEvent = createGatewayEventHandler(ctx)
+    // The guard against fixing the kind mismatch by matching everything with a
+    // kind: ordinary lifecycle notes belong in the status bar and the activity
+    // strip, and a transcript line each would bury the conversation.
+    const text = 'Reconnecting to gateway…'
+
+    onEvent({ payload: { kind: 'lifecycle', text }, type: 'status.update' } as any)
+
+    expect(ctx.system.sys).not.toHaveBeenCalled()
+    expect(getTurnState().activity.map(item => item.text)).toEqual([text])
+  })
+
   it('keeps goal verdict text in transcript but shows a brief idle status (#goal statusbar)', () => {
     const appended: Msg[] = []
     const ctx = buildCtx(appended)

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -36,6 +36,24 @@ import { isWakeUserDisabled } from './wakeState.js'
 
 const NO_PROVIDER_RE = /\bNo (?:LLM|inference) provider configured\b/i
 
+// The compaction lifecycle reaches the TUI under three different `kind` values,
+// from three different producers, all meaning the same thing to the user — part
+// of the conversation was rewritten:
+//
+//   compressing  manual /compress progress    tui_gateway/methods_session.py
+//   compacting   auto-compaction started      tui_gateway/server.py re-tags the
+//                                             `lifecycle` status that carries
+//                                             COMPACTION_STATUS_MARKER
+//   compacted    auto-compaction finished     agent/conversation_compression.py
+//                                             (_emit_compaction_done)
+//
+// Only `compressing` used to be recognised here, so the compaction the user did
+// NOT ask for — the one that most needs explaining, because the transcript looks
+// like it reset itself — left no durable record at all: just a status-bar line
+// that restoreStatusAfter() wipes four seconds later (#88102). The desktop app
+// already handles all three (use-message-stream/gateway-event.ts).
+const COMPACTION_TRANSCRIPT_KINDS: ReadonlySet<string> = new Set(['compacted', 'compacting', 'compressing'])
+
 type VoiceSubmitMode = 'direct' | 'draft'
 
 const normalizeVoiceSubmitMode = (value: unknown): VoiceSubmitMode =>
@@ -847,9 +865,11 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         setStatus(p.text)
 
-        if (p.kind === 'compressing') {
+        if (COMPACTION_TRANSCRIPT_KINDS.has(p.kind ?? '')) {
           sys(p.text)
+        }
 
+        if (p.kind === 'compressing') {
           return
         }
 


### PR DESCRIPTION
## What does this PR do?

The compaction lifecycle reaches the TUI under **three** different `kind` values, from three different producers, all meaning the same thing to the user: *part of your conversation was rewritten.*

| `kind` | when | producer |
|---|---|---|
| `compressing` | manual `/compress` progress | `tui_gateway/methods_session.py` |
| `compacting` | auto-compaction started | `tui_gateway/server.py::_status_update` re-tags the generic `lifecycle` status that carries `COMPACTION_STATUS_MARKER` |
| `compacted` | auto-compaction finished | `agent/conversation_compression.py::_emit_compaction_done` |

The transcript branch in `createGatewayEventHandler` matched exactly one of them:

```ts
if (p.kind === 'compressing') {
  sys(p.text)
  return
}
```

So the compaction the user **did not ask for**, the one that most needs explaining because the transcript appears to reset itself mid-turn, left no durable record. It set the status bar and pushed a per-turn activity entry, and then `restoreStatusAfter(4000)` wiped the status four seconds later. Scroll up afterwards and there is nothing to say why the history changed. Manual `/compress`, the case the user already knows about, was the only one that left a line.

The desktop client already handles all three kinds (`apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts:1417-1420`, with tests in `compaction-event.test.tsx`), so this is the TUI catching up to a contract the other client already honors.

**On the "aborted compaction" half of the issue.** I did not fix that here, and I want to be precise about why rather than quietly narrowing scope. An aborted compaction is not silent: `conversation_compression.py` calls `agent._emit_warning("⚠ Compression aborted: ...")`, which reaches `status_callback("warn", ...)` and does land in the status bar and the activity strip. What it does not get is a transcript line, for the same reason as the other two. But `warn` is a **generic** kind carrying every warning the agent emits, so widening the match to `warn` would print every unrelated warning into the transcript, and giving the abort its own kind means changing the Python emitter for a value that the desktop app, the chat gateways and the gateway noise filter all consume. That is a cross-surface design call and it is yours to make. Happy to do it in a follow-up once you pick the shape.

## Related Issue

Refs #88102 (deliberately a **subset**: this fixes the kind mismatch, not the aborted-compaction half, so the issue should stay open).

Reported by @mayqhw. Note that the reporter opened #88098 for this and **closed it themselves one minute later** ("the fix is a stopgap; the proper solution needs upstream design"), so this PR does not duplicate live work. I have deliberately kept the change to the kind mismatch and left the richer "structured compaction progress event" idea from the issue to a maintainer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/app/createGatewayEventHandler.ts` — new module constant `COMPACTION_TRANSCRIPT_KINDS` (`compacted`, `compacting`, `compressing`) with a comment naming each producer, so the next person adding a kind sees the whole family in one place instead of rediscovering the re-tag in `server.py`. The membership test drives `sys(p.text)`.
- `ui-tui/src/__tests__/createGatewayEventHandler.test.ts` — 3 tests, added beside the existing `compressing` one.

**The two new kinds keep the status-bar and activity handling they have today.** This only *adds* the transcript line; `compressing` keeps its exact early return. Routing the new kinds through that early return instead would have been tidier code, but it drops their activity entry and pins `✓ Context compaction complete` in the status bar until the next status arrives, since the `compressing` path never calls `restoreStatusAfter`. Two of the new tests assert the activity entry precisely so that regression cannot be introduced later as a cleanup.

No Python is touched, and no other event kind changes behavior.

## How to Test

```
cd ui-tui
npm run build:ink
npx vitest run src/__tests__/createGatewayEventHandler.test.ts
```

104 passed (101 before this PR).

Mutation check, one rule at a time, to show each test is tied to its rule:

| Mutation | Result |
|---|---|
| Narrow the set back to `['compressing']` | **2 failed**, 102 passed (both new positive tests) |
| Match any non-empty kind (`if (Boolean(p.kind))`) | **1 failed**, 103 passed (the new negative test) |
| Route the new kinds through the `compressing` early return | **2 failed**, 102 passed (both activity assertions) |

Also clean:

- `tsc --noEmit -p tsconfig.json` — exit 0
- `eslint` on both files — exit 0
- `prettier --check` on both files — clean

Full `ui-tui` suite: 1645 passed, 10 failed, 5 skipped. **All 10 failures are pre-existing and unrelated** (`editor.test.ts` resolves `nano`/`vi` off `$PATH`, `terminalSetup`/`terminalParity` assert POSIX config dirs). I verified this by stashing only my two files and re-running those three files on a pristine tree: the same 10 fail identically. They are Windows-environment failures, not regressions.

Manual check of the real path, for anyone reproducing: the auto-compaction line the TUI now keeps is `🗜️ Compacting context — summarizing earlier conversation so I can continue...` followed by `✓ Context compaction complete — continuing turn...`, matching `COMPACTION_STATUS` / `COMPACTION_DONE_STATUS`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — checked the issue timeline, open and merged PR search, and every open PR with `compaction` in its title for overlap with `ui-tui/src/app/`; none touch this file
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, no Python is touched; the JS equivalents are in *How to Test*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new constant documents all three producers and why the family exists
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A. Worth noting that `compression.progress_notices` gates routine compression notices for *chat platforms* in `gateway/run.py`; it does not gate `tui_gateway`'s `status.update` stream, so this change adds no new config surface and prints only statuses the gateway already sends.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string matching on an event field, no platform-dependent behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before, on `main`, an auto-compaction leaves the transcript with nothing between the two turns it split:

```
status.update  { kind: 'compacting', text: '🗜️ Compacting context — ...' }   -> status bar only, gone after 4s
status.update  { kind: 'compacted',  text: '✓ Context compaction complete...' } -> status bar only, gone after 4s
```

After, both land via `sys()` alongside the manual `/compress` line that already worked, and the status bar and activity strip behave exactly as before.
