### PR TITLE
fix(desktop): re-resume session tiles with live runtime ids after sleep/wake

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -33,7 +33,14 @@ const row = (over: Partial<SessionInfo>): SessionInfo =>
     ...over
   }) as SessionInfo
 
-function renderTile(requestGateway: ReturnType<typeof vi.fn>) {
+function renderTile(
+  requestGateway: ReturnType<typeof vi.fn>,
+  refs?: {
+    runtimeIdByStoredSessionIdRef?: { current: Map<string, string> }
+    sessionStateByRuntimeIdRef?: { current: Map<string, unknown> }
+    updateSessionState?: ReturnType<typeof vi.fn>
+  }
+) {
   renderHook(() =>
     useSessionTileDelegate({
       archiveSession: vi.fn(async () => undefined),
@@ -41,9 +48,9 @@ function renderTile(requestGateway: ReturnType<typeof vi.fn>) {
       executeSlashCommand: vi.fn(async () => undefined) as never,
       removeSession: vi.fn(async () => undefined),
       requestGateway: requestGateway as never,
-      runtimeIdByStoredSessionIdRef: { current: new Map() },
-      sessionStateByRuntimeIdRef: { current: new Map() },
-      updateSessionState: vi.fn()
+      runtimeIdByStoredSessionIdRef: (refs?.runtimeIdByStoredSessionIdRef ?? { current: new Map() }) as never,
+      sessionStateByRuntimeIdRef: (refs?.sessionStateByRuntimeIdRef ?? { current: new Map() }) as never,
+      updateSessionState: (refs?.updateSessionState ?? vi.fn()) as never
     })
   )
 }
@@ -98,6 +105,67 @@ describe('useSessionTileDelegate resumeTile', () => {
       profile: 'default',
       omit_messages: true
     })
+  })
+
+  it('reuses a warm binding that still carries a transcript', async () => {
+    const stateA = { busy: false, messages: [{ id: 'm1' }], storedSessionId: 'stored-a' }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-a', 'runtime-a']]) }
+    const sessionStateByRuntimeIdRef = { current: new Map([['runtime-a', stateA]]) }
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    renderTile(requestGateway, { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef })
+    const runtimeId = await sessionTileDelegate()!.resumeTile('stored-a')
+
+    expect(runtimeId).toBe('runtime-a')
+    expect(requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('falls through to a real resume when the warm binding has no transcript (post-wake empty tile)', async () => {
+    // Sleep/wake regression: a released/stale cached state (messages: []) must
+    // NOT satisfy the warm path — reusing it re-bound the tile to a dead
+    // runtime id and painted the pane permanently empty.
+    setSessions([row({ id: 'stored-b', profile: 'default' })])
+
+    const staleState = { busy: false, messages: [], storedSessionId: 'stored-b' }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-b', 'runtime-dead']]) }
+    const sessionStateByRuntimeIdRef = { current: new Map([['runtime-dead', staleState]]) }
+
+    const requestGateway = vi.fn(async (method: string) =>
+      method === 'session.resume' ? ({ session_id: 'runtime-fresh' } as never) : ({} as never)
+    )
+
+    renderTile(requestGateway, { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef })
+    const runtimeId = await sessionTileDelegate()!.resumeTile('stored-b')
+
+    expect(runtimeId).toBe('runtime-fresh')
+    expect(requestGateway).toHaveBeenCalledWith('session.resume', {
+      session_id: 'stored-b',
+      cols: 96,
+      profile: 'default',
+      omit_messages: true
+    })
+  })
+
+  it('invalidateRuntimeBindings clears the stored→runtime map so tiles re-resume after reconnect', async () => {
+    setSessions([row({ id: 'stored-c', profile: 'default' })])
+
+    const liveState = { busy: false, messages: [{ id: 'm1' }], storedSessionId: 'stored-c' }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-c', 'runtime-dead']]) }
+    const sessionStateByRuntimeIdRef = { current: new Map([['runtime-dead', liveState]]) }
+
+    const requestGateway = vi.fn(async (method: string) =>
+      method === 'session.resume' ? ({ session_id: 'runtime-fresh' } as never) : ({} as never)
+    )
+
+    renderTile(requestGateway, { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef })
+
+    // Gateway reconnect (what resetTileRuntimeBindings calls on wake):
+    sessionTileDelegate()!.invalidateRuntimeBindings!()
+    expect(runtimeIdByStoredSessionIdRef.current.size).toBe(0)
+
+    // The next resume goes cold instead of reusing the dead binding.
+    const runtimeId = await sessionTileDelegate()!.resumeTile('stored-c')
+    expect(runtimeId).toBe('runtime-fresh')
   })
 })
 

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -84,6 +84,14 @@ export function useSessionTileDelegate({
       executeSlash: async (rawCommand, sessionId) => {
         await executeSlashCommand(rawCommand, { sessionId })
       },
+      // Gateway reconnect (sleep/wake, backend respawn): every stored→runtime
+      // binding recorded pre-reconnect points at a runtime id the respawned
+      // backend no longer knows. Drop the map so resumeTile's warm path can't
+      // re-bind a tile to a dead runtime; live bindings re-record from
+      // post-reconnect events and fresh resumes.
+      invalidateRuntimeBindings: () => {
+        runtimeIdByStoredSessionIdRef.current.clear()
+      },
       interruptSession: async runtimeId => {
         // Same cooldown as the primary chat's Stop (#83855): the gateway may
         // still be winding down after this interrupt, so a quick edit/resend
@@ -108,7 +116,17 @@ export function useSessionTileDelegate({
         const existing = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
         const cached = existing ? sessionStateByRuntimeIdRef.current.get(existing) : undefined
 
-        if (existing && cached?.storedSessionId === storedSessionId) {
+        // Warm path: reuse a live binding — but only when it still carries a
+        // transcript (or is mid-turn, where messages legitimately stream in).
+        // A binding whose cached state has no messages is either a released
+        // transcript or a stale pre-reconnect survivor; reusing it painted the
+        // post-sleep/wake tile permanently empty. Fall through to a real
+        // resume instead — it's idempotent for a genuinely live session.
+        if (
+          existing &&
+          cached?.storedSessionId === storedSessionId &&
+          (cached.busy || cached.messages.length > 0)
+        ) {
           publishSessionState(existing, cached)
 
           return existing

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -7,16 +7,48 @@ import { $selectedStoredSessionId } from '@/store/session'
 import type { SessionTile } from '@/store/session-states'
 import {
   $sessionStates,
+  $sessionTiles,
   blankDraftTile,
   focusedSessionNeedsRoute,
   markSelectionRestore,
   orderTilesByTree,
   releaseSessionTranscript,
-  selectionHomesToWorkspace
+  resetTileRuntimeBindings,
+  selectionHomesToWorkspace,
+  type SessionTileDelegate,
+  setSessionTileDelegate
 } from '@/store/session-states'
 
 const tile = (storedSessionId: string): SessionTile => ({ storedSessionId })
 const tilePane = (id: string) => `session-tile:${id}`
+
+describe('resetTileRuntimeBindings', () => {
+  afterEach(() => {
+    $sessionTiles.set([])
+  })
+
+  it('invalidates the delegate wiring cache AND drops tile runtime ids (sleep/wake reconnect)', () => {
+    // The reconnect path must bust BOTH layers: the tile atoms' runtimeId and
+    // the delegate's stored→runtime warm cache. Clearing only the atoms let
+    // resumeTile's warm path re-bind the same dead runtime id after wake.
+    const invalidateRuntimeBindings = vi.fn()
+    setSessionTileDelegate({ invalidateRuntimeBindings } as unknown as SessionTileDelegate)
+
+    $sessionTiles.set([{ runtimeId: 'runtime-dead', storedSessionId: 'stored-a' }])
+    resetTileRuntimeBindings()
+
+    expect(invalidateRuntimeBindings).toHaveBeenCalledTimes(1)
+    expect($sessionTiles.get()).toEqual([{ anchor: undefined, before: undefined, dir: undefined, storedSessionId: 'stored-a' }])
+  })
+
+  it('tolerates a delegate without invalidateRuntimeBindings (older wiring)', () => {
+    setSessionTileDelegate({} as unknown as SessionTileDelegate)
+    $sessionTiles.set([{ runtimeId: 'runtime-dead', storedSessionId: 'stored-a' }])
+
+    expect(() => resetTileRuntimeBindings()).not.toThrow()
+    expect($sessionTiles.get()[0]?.runtimeId).toBeUndefined()
+  })
+})
 
 describe('releaseSessionTranscript', () => {
   afterEach(() => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -611,8 +611,14 @@ export function patchSessionTile(storedSessionId: string, patch: Partial<Session
 }
 
 /** Drop live runtime bindings so every tile re-resumes — used on gateway
- *  reconnect, where a respawned backend re-mints (recycles) runtime ids. */
+ *  reconnect, where a respawned backend re-mints (recycles) runtime ids.
+ *  Also invalidates the wiring cache's stored→runtime map: clearing only the
+ *  tile atoms left `resumeTile`'s warm path free to re-bind the same dead
+ *  runtime id from the cache, so post-wake tiles repainted empty and never
+ *  actually re-resumed. */
 export function resetTileRuntimeBindings() {
+  sessionTileDelegate()?.invalidateRuntimeBindings?.()
+
   const tiles = $sessionTiles.get()
 
   if (tiles.some(t => t.runtimeId)) {
@@ -638,6 +644,12 @@ export interface SessionTileDelegate {
   executeSlash(rawCommand: string, sessionId: string): Promise<void>
   /** Interrupt a tile's running turn. */
   interruptSession(runtimeId: string): Promise<void>
+  /** Drop the wiring cache's stored→runtime bindings. Called on gateway
+   *  reconnect: a respawned backend re-mints runtime ids, so every binding
+   *  recorded before the reconnect is suspect — without this, `resumeTile`'s
+   *  warm path re-binds tiles to dead runtime ids (the sleep/wake "empty
+   *  right pane" bug). Bindings re-record from live post-reconnect events. */
+  invalidateRuntimeBindings?(): void
   /** Bind a live runtime id for a stored session (resume without touching
    *  the main view). Returns the runtime id, or throws. */
   resumeTile(storedSessionId: string): Promise<string>


### PR DESCRIPTION
## Summary
Desktop split-pane (session tile) views now recover correctly after sleep/wake — the tiles re-resume with a live runtime id instead of repainting as empty header-only panes.

Root cause: the reconnect path (`resetTileRuntimeBindings()`) cleared only the tile atoms' `runtimeId`, but `resumeTile()`'s warm path re-bound each tile from the wiring cache's stored→runtime map — the same dead pre-sleep runtime id, paired with a released (empty) cached transcript. Every pane except the primary showed only its header, and a prompt submitted to it recovered into the primary view instead. (Community report: 2-3 splits open, sleep, wake → only leftmost pane functional; reload/scroll/drag don't help; restart required.)

## Changes
- `store/session-states.ts`: `resetTileRuntimeBindings()` also invalidates the delegate's wiring cache via new optional `SessionTileDelegate.invalidateRuntimeBindings` (safe no-op for older wiring).
- `app/contrib/hooks/use-session-tile-delegate.ts`: implements `invalidateRuntimeBindings` (`runtimeIdByStoredSessionIdRef.clear()`); warm path now requires the cached state to carry a transcript or be mid-turn — a released/stale empty state falls through to a real `session.resume` + transcript hydration.
- Tests: 3 new regression tests (warm-path fall-through on empty transcript, cache invalidation forces cold resume, reset busts both layers) + 1 warm-path-reuse contract test.

## Validation
| | Before fix | After fix |
|---|---|---|
| New regression tests | 3 failed (sabotage run) | pass |
| Tile/session-state suites (4 files) | — | 46/46 pass |
| `tsc` / `check:lint` | — | 0 errors |

## Infographic

![Desktop split panes empty after sleep/wake — bug, why, fix, proven](https://v3b.fal.media/files/b/0aa6a8a9/gjLq-1b9PUFvwdlRas5A8_DMwFOlnO.png)
