### PR TITLE
fix(config): parse structured list/dict values in hermes config set (consolidates 8-PR cluster)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5292,6 +5292,33 @@ def set_config_value(key: str, value: str, force: bool = False):
             coerced_value = int(value)
         elif value.replace('.', '', 1).isdigit():
             coerced_value = float(value)
+        elif value.lstrip()[:1] in ('[', '{'):
+            # List/mapping literals -- e.g.
+            #   hermes config set platform_toolsets.line '["file","web"]'
+            # Without this, such values were stored as a raw STRING, and every
+            # reader that gates on isinstance(..., list) (``_get_platform_tools``,
+            # ``_get_enabled_set``, ...) silently ignored them and fell back to
+            # its default -- the setting looked saved but never took effect.
+            # Folded INSIDE the string-typed guard so a genuinely string-typed
+            # setting whose value merely starts with '[' or '{' is left intact
+            # (preserves the guard added in e4ea0a0ed).
+            try:
+                parsed = yaml.safe_load(value)
+                if isinstance(parsed, (list, dict)):
+                    coerced_value = parsed
+                else:
+                    print(
+                        f"Warning: value for '{key}' looks like a list/mapping but "
+                        f"parsed as {type(parsed).__name__}; storing as string.",
+                        file=sys.stderr,
+                    )
+            except yaml.YAMLError:
+                print(
+                    f"Warning: value for '{key}' looks like a list/mapping but is "
+                    f"not valid YAML/JSON; storing as string. Most isinstance-gated "
+                    f"readers will ignore a string here.",
+                    file=sys.stderr,
+                )
 
     value = coerced_value
     # Normalize a scalar ``model`` key before writing sub-keys so that

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5202,6 +5202,41 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     return True, None
 
 
+def _looks_structured_value(value: str) -> bool:
+    """Return True when *value* plausibly encodes a YAML/JSON list or mapping.
+
+    Used by :func:`set_config_value` to decide whether to attempt a
+    ``yaml.safe_load`` structured parse. Deliberately conservative so plain
+    scalars are never mangled:
+
+    - Flow style: the value starts with ``[`` or ``{`` (JSON is a YAML
+      subset, so both ``'["a","b"]'`` and ``'{a: 1}'`` qualify).
+    - Block style: the value spans multiple lines AND at least one line is
+      shaped like a YAML sequence item (``- item``) or mapping entry
+      (``key: value``).
+
+    A bare leading ``-`` is NOT a trigger on its own: ``-5``, ``--flag`` and
+    other dash-prefixed single-line scalars must remain strings.
+    """
+    stripped = value.lstrip()
+    if stripped[:1] in ('[', '{'):
+        return True
+    if '\n' not in value:
+        return False
+    for line in value.splitlines():
+        item = line.strip()
+        if item == '-' or item.startswith('- '):
+            return True
+        # ``key: value`` / ``key:`` mapping-entry shape (no whitespace in the
+        # key, colon followed by a space or end-of-line).
+        head, sep, _rest = item.partition(': ')
+        if sep and head and ' ' not in head and not head.startswith('#'):
+            return True
+        if item.endswith(':') and ' ' not in item[:-1] and item[:-1]:
+            return True
+    return False
+
+
 def set_config_value(key: str, value: str, force: bool = False):
     """Set a configuration value.
 
@@ -5292,16 +5327,21 @@ def set_config_value(key: str, value: str, force: bool = False):
             coerced_value = int(value)
         elif value.replace('.', '', 1).isdigit():
             coerced_value = float(value)
-        elif value.lstrip()[:1] in ('[', '{'):
+        elif _looks_structured_value(value):
             # List/mapping literals -- e.g.
             #   hermes config set platform_toolsets.line '["file","web"]'
+            # or a multi-line YAML block:
+            #   hermes config set custom_providers '- name: foo
+            #     base_url: https://...'
             # Without this, such values were stored as a raw STRING, and every
             # reader that gates on isinstance(..., list) (``_get_platform_tools``,
             # ``_get_enabled_set``, ...) silently ignored them and fell back to
             # its default -- the setting looked saved but never took effect.
             # Folded INSIDE the string-typed guard so a genuinely string-typed
             # setting whose value merely starts with '[' or '{' is left intact
-            # (preserves the guard added in e4ea0a0ed).
+            # (preserves the guard added in e4ea0a0ed).  The trigger is
+            # deliberately conservative (see _looks_structured_value): plain
+            # scalars like '-5' or '--flag' never reach the YAML parser.
             try:
                 parsed = yaml.safe_load(value)
                 if isinstance(parsed, (list, dict)):

--- a/tests/hermes_cli/test_config_set_list_values.py
+++ b/tests/hermes_cli/test_config_set_list_values.py
@@ -1,0 +1,71 @@
+"""``hermes config set`` must parse list/mapping literals, not store them as strings.
+
+Before this fix, ``hermes config set platform_toolsets.discord '["file","web"]'``
+stored the value as a raw STRING. Every reader that gates on
+``isinstance(..., list)`` — ``_get_platform_tools``, ``_get_enabled_set``,
+``_get_disabled_set`` — then silently ignored it and fell back to its default,
+so the setting looked saved but never took effect (observed in the wild as a
+platform running on the wrong toolset bundle for weeks).
+"""
+import pytest
+
+
+@pytest.fixture
+def user_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_MANAGED_DIR", raising=False)
+    import hermes_cli.config as cfg
+    from hermes_cli import managed_scope
+
+    cfg._LOAD_CONFIG_CACHE.clear()
+    cfg._RAW_CONFIG_CACHE.clear()
+    managed_scope.invalidate_managed_cache()
+    return home
+
+
+def test_list_literal_is_parsed_to_list(user_home):
+    from hermes_cli.config import set_config_value, read_raw_config
+
+    set_config_value("platform_toolsets.line", '["clarify", "file", "web"]')
+    raw = read_raw_config()
+    assert raw["platform_toolsets"]["line"] == ["clarify", "file", "web"]
+
+
+def test_mapping_literal_is_parsed_to_dict(user_home):
+    from hermes_cli.config import set_config_value, read_raw_config
+
+    set_config_value("display.tool_progress_overrides", '{"terminal": "off"}')
+    raw = read_raw_config()
+    assert raw["display"]["tool_progress_overrides"] == {"terminal": "off"}
+
+
+def test_yaml_flow_list_is_parsed(user_home):
+    from hermes_cli.config import set_config_value, read_raw_config
+
+    set_config_value("plugins.enabled", "[model-providers/gemini]")
+    raw = read_raw_config()
+    assert raw["plugins"]["enabled"] == ["model-providers/gemini"]
+
+
+def test_invalid_list_literal_warns_and_stores_string(user_home, capsys):
+    from hermes_cli.config import set_config_value, read_raw_config
+
+    set_config_value("platform_toolsets.line", '["unclosed')
+    captured = capsys.readouterr()
+    assert "not valid" in captured.err.lower() or "warning" in captured.err.lower()
+    raw = read_raw_config()
+    assert raw["platform_toolsets"]["line"] == '["unclosed'
+
+
+def test_scalar_values_unaffected(user_home):
+    from hermes_cli.config import set_config_value, read_raw_config
+
+    set_config_value("agent.max_turns", "300")
+    set_config_value("display.compact", "true")
+    set_config_value("tts.provider", "edge")
+    raw = read_raw_config()
+    assert raw["agent"]["max_turns"] == 300
+    assert raw["display"]["compact"] is True
+    assert raw["tts"]["provider"] == "edge"

--- a/tests/hermes_cli/test_config_set_list_values.py
+++ b/tests/hermes_cli/test_config_set_list_values.py
@@ -69,3 +69,93 @@ def test_scalar_values_unaffected(user_home):
     assert raw["agent"]["max_turns"] == 300
     assert raw["display"]["compact"] is True
     assert raw["tts"]["provider"] == "edge"
+
+
+# ---------------------------------------------------------------------------
+# Consolidated-cluster additions: multi-line YAML blocks, string-typed-key
+# guard, conservative trigger, and load_config round-trip.
+# ---------------------------------------------------------------------------
+
+
+def test_multiline_yaml_list_is_parsed(user_home):
+    """A multi-line YAML block list must be stored as a real list."""
+    from hermes_cli.config import set_config_value, read_raw_config
+
+    set_config_value(
+        "custom_providers",
+        "- name: foo\n  base_url: https://foo.example/v1\n"
+        "- name: bar\n  base_url: https://bar.example/v1",
+    )
+    raw = read_raw_config()
+    assert raw["custom_providers"] == [
+        {"name": "foo", "base_url": "https://foo.example/v1"},
+        {"name": "bar", "base_url": "https://bar.example/v1"},
+    ]
+
+
+def test_multiline_yaml_mapping_is_parsed(user_home):
+    from hermes_cli.config import set_config_value, read_raw_config
+
+    set_config_value(
+        "display.tool_progress_overrides",
+        "terminal: off\nbrowser: on",
+    )
+    raw = read_raw_config()
+    assert raw["display"]["tool_progress_overrides"] == {
+        "terminal": False,
+        "browser": True,
+    }
+
+
+def test_string_typed_key_bracket_value_stays_string(user_home):
+    """Keys whose DEFAULT_CONFIG type is str must never be coerced —
+    even when the value looks like a list literal."""
+    from hermes_cli.config import set_config_value, read_raw_config
+
+    set_config_value("approvals.mode", "[off]")
+    raw = read_raw_config()
+    assert raw["approvals"]["mode"] == "[off]"
+    assert isinstance(raw["approvals"]["mode"], str)
+
+
+def test_string_typed_key_negative_number_stays_string(user_home):
+    """'-5' for a string-typed key must remain the string '-5'."""
+    from hermes_cli.config import set_config_value, read_raw_config
+
+    set_config_value("approvals.mode", "-5")
+    raw = read_raw_config()
+    assert raw["approvals"]["mode"] == "-5"
+
+
+def test_dash_prefixed_scalar_not_treated_as_list(user_home):
+    """Single-line dash-prefixed scalars ('-5', '--flag') must stay strings
+    for non-string-typed keys too — the over-broad leading '-' trigger from
+    #88066 is deliberately avoided."""
+    from hermes_cli.config import set_config_value, read_raw_config
+
+    set_config_value("weird.flag", "--verbose")
+    raw = read_raw_config()
+    assert raw["weird"]["flag"] == "--verbose"
+
+
+def test_plain_scalar_that_parses_to_scalar_kept_as_string(user_home):
+    """If yaml.safe_load of a structured-looking value yields a plain scalar,
+    keep the original string."""
+    from hermes_cli.config import set_config_value, read_raw_config
+
+    # '{}' parses to an empty dict — that IS structured, so check a value
+    # that starts with '[' but parses to a scalar is impossible in YAML;
+    # instead use a multi-line value whose lines don't match list/dict shape.
+    set_config_value("some.note", "line one\nline two without yaml shape")
+    raw = read_raw_config()
+    assert raw["some"]["note"] == "line one\nline two without yaml shape"
+
+
+def test_round_trip_through_load_config(user_home):
+    """Structured values written by set_config_value must survive
+    load_config as real lists/dicts."""
+    from hermes_cli.config import set_config_value, load_config
+
+    set_config_value("platform_toolsets.line", '["clarify", "file", "web"]')
+    cfg = load_config()
+    assert cfg["platform_toolsets"]["line"] == ["clarify", "file", "web"]

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -288,12 +288,19 @@ model_aliases:
     provider: x-ai
 ```
 
-**Short string form (`model.aliases.<name>: provider/model`)** — convenient from the shell because `hermes config set` only writes scalar values, but it can't carry a custom `base_url`:
+**Short string form (`model.aliases.<name>: provider/model`)** — convenient from the shell because `hermes config set` writes scalars and now also parses inline list/mapping literals, though this short alias form still can't carry a custom `base_url`:
 
 ```bash
 hermes config set model.aliases.fav anthropic/claude-opus-4.6
 hermes config set model.aliases.grok x-ai/grok-4
 ```
+
+> `hermes config set` also accepts inline **list/mapping literals** (JSON/YAML flow style). Quote them so your shell passes them through intact:
+>
+> ```bash
+> hermes config set platform_toolsets.line '["clarify", "file", "web"]'
+> hermes config set display.tool_progress_overrides '{"terminal": "off"}'
+> ```
 
 Both paths feed the same loader (`hermes_cli/model_switch.py`). Entries declared in `model_aliases:` take precedence over `model.aliases:` entries with the same name.
 


### PR DESCRIPTION
`hermes config set` now parses structured list/dict values (JSON flow literals and multi-line YAML blocks) into real YAML structures instead of writing them verbatim as quoted strings — while keeping string-typed keys (e.g. `approvals.mode`) exempt from all coercion.

## Changes

- **Cherry-picked base (#59182, Sam Liu)**: folds a `yaml.safe_load` structured-parse branch INSIDE the existing string-typed-key guard in `set_config_value`, triggered on values starting with `[` / `{`. Warns to stderr and keeps the string when the value looks structured but doesn't parse to a list/mapping. Includes tests + docs update.
- **Consolidation follow-up**: new `_looks_structured_value()` helper extends the trigger to multi-line YAML block values (`- item` lines or `key: value` lines), so `hermes config set custom_providers '<multi-line yaml>'` stores a real list of mappings. The trigger is deliberately conservative: single-line dash-prefixed scalars (`-5`, `--flag`) never reach the YAML parser (avoids the over-broad leading-`-` trigger from #88066). If the parse yields a plain scalar, the original string is kept.
- Composes with the existing scalar coercion gate (`_default_value_for_key`) and the mapping-overwrite guard (#74995 lineage) — nested-key writes still go through `_set_nested`.

## Validation

| Check | Result |
| --- | --- |
| `pytest tests/hermes_cli/test_config_set_list_values.py tests/hermes_cli/test_set_config_value.py -o addopts="" -q` (py3.11, isolated `HERMES_HOME`) | **95 passed** |
| Sabotage-verify (new test file against main's `config.py`) | **7 failed without the fix**, all pass with it |
| `ruff check` on touched files | All checks passed |
| String-typed-key guard | `approvals.mode '[off]'` and `'-5'` stay strings (tested) |
| Round-trip | structured value survives `load_config` as a real list (tested) |

## Cluster

This PR consolidates an 8-PR duplicate cluster, all addressing "config set stores structured values as strings":

- #37460 — @liuhao1024 (**first submitter**, 2026-06-02): bracket-delimited list parsing via `yaml.safe_load`
- #44226 — @JEKABS1: JSON-array + comma-separated coercion
- #59182 — @sam7894604 (**cherry-picked as base** — closest to full scope, respects the string-typed-key guard): list/mapping literals via `yaml.safe_load`
- #60558 — @AIalliAI: JSON list/dict parsing
- #64389 — @kannishk: structured values with type validation against defaults
- #76470 — @thatssoheil: JSON array literals to YAML lists
- #82227 — @gtmacdonald: list literals in config set
- #88066 — @HouMinXi (already closed as dup): multi-line trigger idea adopted here in a narrowed form (its unconditional trigger bypassed the string-typed guard, and its leading-`-` trigger was over-broad)

Thanks to all eight contributors — @liuhao1024 reported/fixed this earliest; #59182 was picked as the base because it was the only variant already folded inside the string-typed-key guard.

## Infographic

![PR infographic](https://v3b.fal.media/files/b/0aa6a8d0/b2UTB8MKLVgMTPz9tyni5_n0MwxQZJ.png)
