### PR TITLE
fix(desktop): unbind session tiles from a reclaimed runtime so they self-recover (#85032 salvage)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -77,7 +77,7 @@ import {
   setWorkspaceCwdOwner,
   setYoloActive
 } from '@/store/session'
-import { dropSessionState } from '@/store/session-states'
+import { dropSessionState, unbindTileRuntime } from '@/store/session-states'
 import { pruneDelegateFallbackSubagents, pruneFinishedSessionSubagents, upsertSubagent } from '@/store/subagents'
 import { reportMcpToolResult } from '@/store/suggestion-providers/repair'
 import { invalidateSkillSuggestionIndex } from '@/store/suggestion-providers/skill'
@@ -473,6 +473,15 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
         if (reclaimedRuntimeId) {
           dropSessionState(reclaimedRuntimeId)
+          // A tile bound to the reclaimed runtime would otherwise render an
+          // empty transcript forever: its view reads $sessionStates[runtime]
+          // (just dropped) and its resume effect is gated on !runtimeId, so a
+          // bound tile never re-resumes (#82620). Unbind it so the effect
+          // refires against the intact stored session — and purge the wiring
+          // cache's entry, or resumeTile's warm path would hand the dead
+          // runtime straight back instead of cold-resuming a live one.
+          unbindTileRuntime(reclaimedRuntimeId)
+          sessionStateByRuntimeIdRef.current.delete(reclaimedRuntimeId)
         }
 
         // The row's ended_at moved, so refresh the lists that render it.

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-reclaimed.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-reclaimed.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { $sessionStates, publishSessionState } from '@/store/session-states'
+import { $sessionStates, $sessionTiles, publishSessionState } from '@/store/session-states'
 import type { RpcEvent } from '@/types/hermes'
 
 import { useMessageStream } from './index'
@@ -19,10 +19,13 @@ const ACTIVE_SID = 'session-active'
 const ACTIVE_PROFILE = 'compass'
 let handleEvent: ((event: RpcEvent) => void) | null = null
 let queryClient: QueryClient
+let wiringCache: Map<string, ClientSessionState>
 
 function Harness() {
   const activeSessionIdRef = useRef<string | null>(ACTIVE_SID)
   const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+
+  wiringCache = sessionStateByRuntimeIdRef.current
 
   const stream = useMessageStream({
     activeGatewayProfile: ACTIVE_PROFILE,
@@ -66,11 +69,13 @@ beforeEach(() => {
   handleEvent = null
   queryClient = new QueryClient()
   $sessionStates.set({})
+  $sessionTiles.set([])
 })
 
 afterEach(() => {
   cleanup()
   $sessionStates.set({})
+  $sessionTiles.set([])
   vi.restoreAllMocks()
 })
 
@@ -121,5 +126,40 @@ describe('session.reclaimed', () => {
 
       expect($sessionStates.get()['live-gone'], reason).toBeUndefined()
     }
+  })
+
+  // A TILE bound to the reclaimed runtime is the #82620 blank-pane case: the
+  // state drop above empties the tile's view, but with `runtimeId` still set
+  // the tile's resume effect (gated on !runtimeId) never refires — an empty
+  // transcript under live chrome, unrecoverable without closing the tab.
+  it('unbinds a tile holding the reclaimed runtime so its resume can refire', async () => {
+    await mountStream()
+    publishSessionState('live-gone', createClientSessionState('stored-1'))
+    $sessionTiles.set([
+      { runtimeId: 'live-gone', storedSessionId: 'stored-1' },
+      { runtimeId: 'live-kept', storedSessionId: 'stored-2' }
+    ])
+
+    reclaim('live-gone')
+
+    const tiles = $sessionTiles.get()
+    // The reclaimed tile survives as a pane (its stored session is intact) but
+    // sheds the dead runtime; the bystander tile keeps its live binding.
+    expect(tiles.find(t => t.storedSessionId === 'stored-1')?.runtimeId).toBeUndefined()
+    expect(tiles.find(t => t.storedSessionId === 'stored-2')?.runtimeId).toBe('live-kept')
+  })
+
+  // The wiring cache is resumeTile's warm path: a leftover entry for the dead
+  // runtime would be handed straight back on the re-resume, rebinding the tile
+  // to the same reclaimed id the backend just forgot.
+  it('purges the wiring cache entry for the reclaimed runtime', async () => {
+    await mountStream()
+    wiringCache.set('live-gone', createClientSessionState('stored-1'))
+    wiringCache.set('live-kept', createClientSessionState('stored-2'))
+
+    reclaim('live-gone')
+
+    expect(wiringCache.has('live-gone')).toBe(false)
+    expect(wiringCache.has('live-kept')).toBe(true)
   })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -626,6 +626,24 @@ export function resetTileRuntimeBindings() {
   }
 }
 
+/** Unbind ONE reclaimed runtime from whichever tile holds it — the targeted
+ *  sibling of resetTileRuntimeBindings. The reconnect-time reset can't cover a
+ *  backend reclaim: the WS re-dials immediately, but the orphan reaper fires a
+ *  grace window LATER, so the reclaim lands after every reconnect-path unbind
+ *  already ran. Without this, the tile keeps pointing at the dead runtime whose
+ *  state `session.reclaimed` just dropped — an empty transcript under live
+ *  chrome — and SessionTilePane's resume effect (gated on `!runtimeId`) never
+ *  re-resumes. Clearing the binding re-arms that effect, which rebinds a fresh
+ *  runtime from the stored row. The pane itself stays: the stored session is
+ *  intact, only its live runtime was reclaimed. */
+export function unbindTileRuntime(runtimeId: string) {
+  const tiles = $sessionTiles.get()
+
+  if (tiles.some(t => t.runtimeId === runtimeId)) {
+    $sessionTiles.set(tiles.map(t => (t.runtimeId === runtimeId ? { ...t, runtimeId: undefined } : t)))
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Delegate — the wiring layer (which owns the gateway + session cache) plugs
 // its actions in; tile UI calls through here. Same inversion as the tree


### PR DESCRIPTION
## Summary
Salvage of #85032 by @shl0ms: a session tile whose live runtime the backend reclaims (`ws_orphan_reap`, `idle_timeout`, `lru_evict`) no longer renders a permanently blank transcript — the tile unbinds and its existing resume effect refires against the intact stored session.

Root cause (their analysis, verified): `session.reclaimed` dropped the runtime's cached state but left the tile bound to the dead runtime id; the tile's resume effect is gated on `!runtimeId`, so it never re-resumed. The reconnect-path `resetTileRuntimeBindings()` can't cover this — the reap fires a grace window after the reconnect unbind already ran. Fixes #82620.

## Changes
- `use-message-stream/gateway-event.ts`: on `session.reclaimed`, `unbindTileRuntime(runtimeId)` + purge the wiring cache's `sessionStateByRuntimeIdRef` entry.
- `store/session-states.ts`: new `unbindTileRuntime()` — the targeted sibling of `resetTileRuntimeBindings()`.
- `session-reclaimed.test.tsx`: regression coverage.

Composes with #88161 (sleep/wake reconnect half): the two fixes clear different maps for different triggers; combined suites pass.

## Validation
| | Result |
|---|---|
| Tile/session-state/reclaim suites (5 files) | 156/156 pass |
| `tsc` / `check:lint` | 0 errors |
| Cherry-pick | clean, authorship preserved (@shl0ms) |

## Infographic

![Reclaimed runtime, recovered tile](https://v3b.fal.media/files/b/0aa6a8ef/vEmKpOdfLlZYRTUDjTOoX_3J0qDYtF.png)
