### PR TITLE
fix(transports): harmonize tool result name with assistant tool call in chat_completions

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -280,6 +280,25 @@ class ChatCompletionsTransport(ProviderTransport):
         strip_extra_content = not _model_consumes_thought_signature(
             kwargs.get("model")
         )
+
+        # Index tool call function names by call ID across the whole message list.
+        # This is needed to ensure role: 'tool' message names match the exact
+        # function.name that was called by the assistant (e.g. when bridge tools
+        # like `tool_call` are unwrapped internally to `mcp__*`, strict providers
+        # like Google AI Studio via OpenRouter reject the name mismatch with
+        # HTTP 400 INVALID_ARGUMENT).
+        tool_name_by_call_id: dict[str, str] = {}
+        for msg in messages:
+            if isinstance(msg, dict):
+                tcs = msg.get("tool_calls")
+                if isinstance(tcs, list):
+                    for tc in tcs:
+                        if isinstance(tc, dict):
+                            tcid = tc.get("id") or tc.get("call_id")
+                            fname = (tc.get("function") or {}).get("name") or tc.get("name")
+                            if tcid and fname:
+                                tool_name_by_call_id[str(tcid)] = str(fname)
+
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):
@@ -294,6 +313,12 @@ class ChatCompletionsTransport(ProviderTransport):
             ):
                 needs_sanitize = True
                 break
+            if msg.get("role") == "tool":
+                tcid = str(msg.get("tool_call_id") or "")
+                expected_name = tool_name_by_call_id.get(tcid)
+                if expected_name and msg.get("name") != expected_name:
+                    needs_sanitize = True
+                    break
             if any(isinstance(k, str) and k.startswith("_") for k in msg):
                 needs_sanitize = True
                 break
@@ -370,6 +395,17 @@ class ChatCompletionsTransport(ProviderTransport):
                 out_msg.pop("effect_disposition", None)
                 out_msg.pop("timestamp", None)  # #47868 — leak into strict providers
                 out_msg.pop("api_content", None)  # persist-what-you-send sidecar
+
+            # Harmonize tool result 'name' with the matching tool_call function name
+            # so strict providers (Google AI Studio / Gemini over OpenRouter) don't
+            # reject replayed turns with INVALID_ARGUMENT when bridge tools like
+            # `tool_call` are unwrapped internally.
+            if msg.get("role") == "tool":
+                tcid = str(msg.get("tool_call_id") or "")
+                expected_name = tool_name_by_call_id.get(tcid)
+                if expected_name and msg.get("name") != expected_name:
+                    out_msg = mutable_msg()
+                    out_msg["name"] = expected_name
 
 
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -109,6 +109,37 @@ class TestChatCompletionsBasic:
         assert msgs[1]["_empty_recovery_synthetic"] is True
 
 
+    def test_convert_messages_harmonizes_tool_result_name_with_call(self, transport):
+        """Tool result messages must match the exact function.name called by the
+        assistant (e.g. when `tool_call` bridge unwraps to `mcp__*`)."""
+        msgs = [
+            {"role": "user", "content": "fetch CRM reminders"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "tool_call",
+                            "arguments": '{"name": "mcp__crm__get_reminders"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "mcp__crm__get_reminders",
+                "tool_call_id": "call_123",
+                "content": "[]",
+            },
+        ]
+        result = transport.convert_messages(msgs)
+        assert result is not msgs
+        assert result[2]["name"] == "tool_call"
+        assert result[2]["tool_call_id"] == "call_123"
+
     def test_convert_messages_copy_on_write_for_dirty_history(self, transport):
         """Dirty provider metadata should not force a full-history deepcopy."""
         clean_tool_call = {


### PR DESCRIPTION
### Description

When tool progressive disclosure unwraps bridge tools like  to internal tool names (e.g. ), the  result message retains the unwrapped tool name. Strict OpenAI-compatible providers and proxies to Google AI Studio (e.g. Gemini 3.7 Flash via OpenRouter) reject this with HTTP 400  because the tool message  does not match the assistant  function name.

This PR ensures  indexes tool call IDs to their called function name and harmonizes the tool result message  before wire transmission.