### PR TITLE
fix(title): bound auto-title generation and avoid timeout amplification

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4207,6 +4207,17 @@ def _is_connection_error(exc: Exception) -> bool:
     return False
 
 
+def _title_timeout_should_stop(task: Optional[str], exc: Exception) -> bool:
+    """Title generation is cosmetic; a timeout should not amplify load.
+
+    Other auxiliary tasks may need provider retries or fallback to preserve
+    work. A session title already has a deterministic derived fallback, so a
+    full-budget timeout means "keep the derived title" rather than "send more
+    requests, possibly to the main model."
+    """
+    return task == "title_generation" and _is_timeout_error(exc)
+
+
 def _is_transient_transport_error(exc: Exception) -> bool:
     """Return True for a one-off transport blip worth retrying ON the
     same provider before any provider/model fallback.
@@ -8425,6 +8436,7 @@ def _build_call_kwargs(
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
         _is_moa = bool(task) and str(task) == "moa_reference"
+        _is_title_generation = bool(task) and str(task) == "title_generation"
         # Gemini's native generateContent maps max_tokens → maxOutputTokens and,
         # when it is omitted, applies a fixed 65,535-token ceiling rather than
         # "the model's full budget" (see gemini_native_adapter.build_gemini_request).
@@ -8450,6 +8462,7 @@ def _build_call_kwargs(
             or _nous_on_messages
             or _is_nvidia_nim
             or _is_moa
+            or _is_title_generation
             or _is_gemini_native
         ):
             # Use auxiliary_max_tokens_param() so models that require
@@ -9405,15 +9418,18 @@ def _call_llm_impl(
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
-            # Compression is on the critical preflight path: a user cannot
-            # continue or resume an oversized session until it compacts. A
-            # same-provider retry on a timeout means another full ``timeout``-
-            # long wall-clock block before the except-chain below can fall
-            # back — doubling the user-visible stall (issue #54465). Skip the
-            # same-provider retry for compression on a full-budget timeout and
-            # fall straight through to provider/model fallback; fast blips (a
-            # streaming-close or a 5xx) still retry, since those are cheap.
-            if task == "compression" and _is_timeout_error(transient_err):
+            # Full-budget timeouts are different from fast transport blips.
+            # Compression falls through to fallback because it is required for
+            # progress; title generation stops because it already has a
+            # deterministic derived title and must not amplify local load.
+            if task in {"compression", "title_generation"} and _is_timeout_error(transient_err):
+                if task == "title_generation":
+                    logger.info(
+                        "Auxiliary title_generation: timeout; skipping "
+                        "same-provider retry and fallback: %s",
+                        transient_err,
+                    )
+                    raise
                 logger.info(
                     "Auxiliary compression: timeout on the critical path; "
                     "skipping same-provider retry and falling back: %s",
@@ -9520,6 +9536,17 @@ def _call_llm_impl(
                 if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
                     raise
                 first_err = retry_err
+
+        if _title_timeout_should_stop(task, first_err):
+            if _is_connection_error(first_err):
+                try:
+                    _evict_cached_client_instance(client)
+                except Exception:
+                    logger.debug(
+                        "Auxiliary title_generation: cache eviction after timeout failed",
+                        exc_info=True,
+                    )
+            raise
 
         # ── Stale-model self-heal (Nous Portal recommendation drift) ───
         # A long-lived process can pin a Portal-recommended model that has
@@ -10147,10 +10174,16 @@ async def _async_call_llm_impl(
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
-            # See call_llm(): compression is on the critical preflight path,
-            # so skip the same-provider retry on a full-budget timeout and
-            # fall straight through to fallback (issue #54465).
-            if task == "compression" and _is_timeout_error(transient_err):
+            # See call_llm(): full-budget timeouts are not cheap blips. For
+            # title generation, stop immediately; the derived title remains.
+            if task in {"compression", "title_generation"} and _is_timeout_error(transient_err):
+                if task == "title_generation":
+                    logger.info(
+                        "Auxiliary title_generation (async): timeout; "
+                        "skipping same-provider retry and fallback: %s",
+                        transient_err,
+                    )
+                    raise
                 logger.info(
                     "Auxiliary compression (async): timeout on the critical "
                     "path; skipping same-provider retry and falling back: %s",
@@ -10232,6 +10265,17 @@ async def _async_call_llm_impl(
                 if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
                     raise
                 first_err = retry_err
+
+        if _title_timeout_should_stop(task, first_err):
+            if _is_connection_error(first_err):
+                try:
+                    _evict_cached_client_instance(client)
+                except Exception:
+                    logger.debug(
+                        "Auxiliary title_generation (async): cache eviction after timeout failed",
+                        exc_info=True,
+                    )
+            raise
 
         # ── Stale-model self-heal (Nous Portal recommendation drift) ───
         # See the sync call_llm() path for the rationale: a long-lived process

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1043,7 +1043,10 @@ DEFAULT_CONFIG = {
             "prefer_fast_model": False,  # opt in to provider fast tier; auto otherwise uses the main model
             "base_url": "",
             "api_key": "",
-            "timeout": 30,
+            "timeout": 10,
+            # Cosmetic background work: never let automatic titles occupy every
+            # slot on a shared local model server.
+            "max_concurrency": 1,
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
             "language": "",

--- a/tests/agent/test_auxiliary_transient_retry.py
+++ b/tests/agent/test_auxiliary_transient_retry.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import os
 import types
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -60,3 +60,75 @@ def test_model_participates_in_client_cache_key():
     assert k_opus == k_opus2
 
 
+def test_title_generation_timeout_does_not_retry_or_fallback(monkeypatch):
+    """A cosmetic title timeout should keep the derived title, not add load."""
+    from agent.auxiliary_client import call_llm
+
+    client = MagicMock()
+    client.base_url = "http://localhost:13305/v1"
+    client.chat.completions.create.side_effect = TimeoutError("request timed out")
+
+    monkeypatch.setattr("agent.auxiliary_client._TRANSIENT_RETRY_BACKOFF_BASE", 0)
+
+    with (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "tiny-title-model", None, None, None),
+        ),
+        patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "tiny-title-model"),
+        ),
+        patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"timeout": 1},
+        ),
+        patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+        ) as configured_fallback,
+        patch(
+            "agent.auxiliary_client._try_main_agent_model_fallback",
+        ) as main_model_fallback,
+        patch("agent.auxiliary_client._try_payment_fallback") as payment_fallback,
+        pytest.raises(TimeoutError, match="request timed out"),
+    ):
+        call_llm(
+            task="title_generation",
+            messages=[{"role": "user", "content": "fix title timeouts"}],
+        )
+
+    assert client.chat.completions.create.call_count == 1
+    configured_fallback.assert_not_called()
+    main_model_fallback.assert_not_called()
+    payment_fallback.assert_not_called()
+
+
+def test_title_generation_forwards_output_cap():
+    """The title task must stay bounded on OpenAI-compatible local servers."""
+    from agent.auxiliary_client import call_llm
+
+    client = MagicMock()
+    client.base_url = "http://localhost:13305/v1"
+    client.chat.completions.create.return_value = MagicMock()
+
+    with (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "tiny-title-model", None, None, None),
+        ),
+        patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "tiny-title-model"),
+        ),
+        patch(
+            "agent.auxiliary_client._validate_llm_response",
+            side_effect=lambda response, _task, **_kwargs: response,
+        ),
+    ):
+        call_llm(
+            task="title_generation",
+            messages=[{"role": "user", "content": "fix title timeouts"}],
+            max_tokens=64,
+        )
+
+    assert client.chat.completions.create.call_args.kwargs["max_tokens"] == 64

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -42,7 +42,8 @@ def test_title_generation_present_in_default_config():
     assert tg["provider"] == "auto"
     assert tg["model"] == ""
     assert tg["prefer_fast_model"] is False
-    assert tg["timeout"] > 0
+    assert tg["timeout"] == 10
+    assert tg["max_concurrency"] == 1
     assert tg["extra_body"] == {}
 
 


### PR DESCRIPTION
## What does this PR do?

Bounds automatic title generation so a cosmetic title request cannot keep decoding after Hermes has already given up, then amplify load through retries or fallback.

The fix is intentionally scoped to the title-generation auxiliary task:

- title-generation calls now forward their configured output cap to OpenAI-compatible/custom providers
- full-budget title-generation timeouts stop after the first timeout instead of retrying the same provider or falling back to another provider
- the default title-generation timeout is reduced to 10s
- title-generation auxiliary work is serialized by default with `max_concurrency: 1`

This keeps title generation cheap and fallback-driven while preserving the deterministic derived title path when the model returns unusable output.

## Related Issue

No linked issue.

Related PRs checked while preparing this change:

- #56322 made auxiliary calls honor configured timeouts; this follows up by preventing title timeouts from triggering extra auxiliary attempts.
- #83186 and #83725 focus on title JSON/schema parsing quality; this focuses on bounding the title-generation workload.
- #46390 isolates title-generation client/cache behavior; this limits per-request decode work and retry amplification.
- #21569 raises local auxiliary timeouts; this takes the opposite approach for cosmetic titles by keeping them fast-fail and fallback-driven.
- #60454 forwarded `max_tokens` more broadly but is closed; this narrows the output-cap forwarding to title generation to avoid changing general auxiliary behavior.
- #23510 explored per-task auxiliary concurrency; this applies only the small default concurrency guard needed for title generation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`: forward the configured title-generation output cap to OpenAI-compatible/custom providers, and stop title-generation retry/fallback amplification after a full-budget timeout.
- `hermes_cli/config_defaults.py`: reduce the default title-generation timeout to 10s and add a title-generation default `max_concurrency` of 1.
- `tests/agent/test_auxiliary_transient_retry.py`: cover timeout short-circuiting and output-cap forwarding for title generation.
- `tests/hermes_cli/test_aux_config.py`: cover the updated title-generation defaults.

## How to Test

1. Run the focused regression suite: `venv/bin/python -m pytest tests/agent/test_title_generator.py tests/agent/test_auxiliary_concurrency.py tests/agent/test_auxiliary_transient_retry.py tests/hermes_cli/test_aux_config.py`
2. Configure Hermes staging auxiliary title generation against an OpenAI-compatible local endpoint, for example Lemonade at `http://bubbles:13305/v1` with `Qwen3.5-0.8B-GGUF`.
3. Compare clean `upstream/main` with this branch using the same title-generation prompt, timeout, endpoint, and model.

Observed before/after on staging against Lemonade:

| Branch | Payload cap | Hermes elapsed | Lemonade after |
| --- | --- | ---: | --- |
| `upstream/main` | no `max_tokens` / no `max_completion_tokens` | 33.814s, title timed out internally | `requests_processing=3`, `requests_deferred=0` |
| `fix/title-generation-bounds` | `max_tokens=64` | 4.042s, no timeout | `requests_processing=0`, `requests_deferred=0` |

The patched branch still returned `llm_title=None` for this 0.8B model because the model output was not parseable as a valid title. That is expected: Hermes keeps the deterministic derived title instead of storing invalid model output.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass; not run, focused regression suite passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Hermes staging on Linux against local Lemonade server at `http://bubbles:13305/v1`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: N/A, behavior covered by config defaults and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: N/A, changed defaults only; no new user-facing config key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: no platform-specific code added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: N/A

## Screenshots / Logs

Focused regression suite on staging:

```text
65 passed in 2.64s
```

Before smoke on clean `upstream/main`:

```text
PAYLOADS=[{"has_max_completion_tokens": false, "has_max_tokens": false, "max_completion_tokens": null, "max_tokens": null, "model": "Qwen3.5-0.8B-GGUF", "provider": "custom", "task": "title_generation", "temperature": 0.3, "timeout": 10}]
RESULT={"elapsed": 33.814, "error": null, "llm_title": null, "ok": true}
METRICS_AFTER: requests_processing=3, requests_deferred=0
```

After smoke on this branch, with Lemonade restarted first:

```text
PAYLOADS=[{"has_max_completion_tokens": false, "has_max_tokens": true, "max_completion_tokens": null, "max_tokens": 64, "model": "Qwen3.5-0.8B-GGUF", "provider": "custom", "task": "title_generation", "temperature": 0.3, "timeout": 10}]
RESULT={"elapsed": 4.042, "error": null, "llm_title": null, "ok": true}
METRICS_AFTER: requests_processing=0, requests_deferred=0
```
