### PR TITLE
fix(bot-mode): route bot-to-bot sends through --create-if-missing

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2837,21 +2837,20 @@ function messagingProtocolSection(name, roster) {
     'into it, like a DM. To message a teammate, run:',
     '',
     '```',
-    'hermes -p <agent-name> chat --in ~ -c "Bot Chat" -Q -q "Message from \uD83E\uDD16 ' + handle + ' (@' + handle + '): your message"',
+    'hermes -p <agent-name> chat --in ~ -c "Bot Chat" --create-if-missing -Q -q "Message from \uD83E\uDD16 ' + handle + ' (@' + handle + '): your message"',
     '',
     'Run the send with background=true and notify_on_complete=true on the',
     'terminal tool, then finish your turn — the reply arrives later as a',
     'background process notification. Never block waiting for it.',
     '```',
     '',
-    '(`--in ~ -c "Bot Chat"` resumes their canonical conversation in the home',
-    'workspace. `-Q` keeps output clean. Always open with the',
+    '(`--in ~ -c "Bot Chat" --create-if-missing` resumes their canonical',
+    'conversation in the home workspace, creating it if the target has no',
+    '"Bot Chat" yet. `-Q` keeps output clean. Always open with the',
     '"Message from \uD83E\uDD16 ' + handle + ' (@' + handle + '):" prefix so they know',
     'who is talking (the @handle lets the app show your avatar to them).',
     'Their reply prints to stdout — relay the relevant part back to the',
-    'user, and say which agent it came from. In the rare case the target',
-    'has no "Bot Chat" yet, send once WITHOUT -c, then',
-    '`hermes -p <agent-name> sessions rename <session-id> "Bot Chat"`.)',
+    'user, and say which agent it came from.)',
     '',
     'If a message in YOUR chat starts with "Message from \uD83E\uDD16 <name>", it is',
     'a teammate messaging you, not the user. Answer it directly — your reply',
@@ -6682,8 +6681,8 @@ export default {
           const note =
             '\n\n[@mention handoff — for each mentioned agent (' + mentioned.map(botHandle).join(', ') + '): ' +
             'COMPOSE a message from you (' + senderName + ') to that agent conveying what the user wants — do not forward this text verbatim (avoid double quotes in your composed message). Send it with exactly one terminal call, run with background=true AND notify_on_complete=true (the recipient may take minutes; the user must not be blocked):\n' +
-            mentioned.map(n => '`hermes -p ' + shellQuote(n) + ' chat --in ~ -c "Bot Chat" -Q -q "Message from \uD83E\uDD16 ' + shellDoubleQuote(senderName) + ' (@' + shellDoubleQuote(botHandle(active)) + '): <your composed message>"`').join('\n') +
-            '\nAfter dispatching, tell the user the message was sent and END YOUR TURN — do not wait or poll; when the background process completes, its notification carries the reply — relay it then, attributed to that agent. If it fails with "No session found matching \'Bot Chat\'", send once without the -c flag, then run `hermes -p <agent> sessions rename <session_id from the output> "Bot Chat"`. ' +
+            mentioned.map(n => '`hermes -p ' + shellQuote(n) + ' chat --in ~ -c "Bot Chat" --create-if-missing -Q -q "Message from \uD83E\uDD16 ' + shellDoubleQuote(senderName) + ' (@' + shellDoubleQuote(botHandle(active)) + '): <your composed message>"`').join('\n') +
+            '\nAfter dispatching, tell the user the message was sent and END YOUR TURN — do not wait or poll; when the background process completes, its notification carries the reply — relay it then, attributed to that agent. ' +
             'Relay the reply back to the user, attributed to that agent.]'
 
           return { ...draft, text: text + note }

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -129,7 +129,7 @@ def _build_section(home: Path) -> str:
         "terminal tool (background=true, notify_on_complete=true), then finish your "
         "turn — the reply arrives later as a new message:\n"
         "```\n"
-        f'hermes -p <agent-name> chat --in ~ -c "Bot Chat" -Q -q "Message from 🤖 {handle} (@{handle}): your message"\n'
+        f'hermes -p <agent-name> chat --in ~ -c "Bot Chat" --create-if-missing -Q -q "Message from 🤖 {handle} (@{handle}): your message"\n'
         "```\n"
         f'Always open with the "Message from 🤖 {handle} (@{handle}):" prefix so they '
         "know who is talking. When YOU receive a message with that prefix, you are "


### PR DESCRIPTION
## Summary
Bot-to-bot messages now deliver on first contact to any profile: the teammate-messaging protocol sends with `--create-if-missing`, so a target with no "Bot Chat" session gets one created in the same invocation instead of the reply silently vanishing (background sends swallowed the CLI error) or the model running a manual two-step rename dance.

Root cause: the protocol text predated the CLI's `--create-if-missing` primitive (#86794) — the capability existed; the instructions never used it. Bots-panel-born profiles were covered by the birth flow (`createCanonicalChat`), but CLI-created, pre-Bot-Mode, and remote-source roster profiles hit the miss on every first contact. Fixes #88059 (ported from Hermes-Bot-Mode#48 Bug 1).

## Changes
- `tools/bot_mode_probe.py`: protocol command gains `--create-if-missing` (system-prompt section for every Bot Mode session)
- `apps/desktop/src/plugins/hermes-bots/plugin.js`: Bot Chat prompt section + @mention handoff note use the flag; the "send without -c, then sessions rename" workaround instructions deleted (both sites)

Cache-safety: the capability epoch hashes the protocol section, so existing eternal Bot Chat sessions pick up the new instructions via the established once-per-change rebuild — no per-turn drift.

## Validation
| Check | Result |
|---|---|
| test_bot_mode_probe.py + test_chat_c_fail_loudly.py | 16/16 |
| Bundled plugin suite (node --test) | 143/143 |
| Live E2E: fresh profile, zero sessions, real model send | "Bot Chat" created + PONG round-trip delivered |
| Live E2E: second send | resolved same session by title — no duplicate |
| Live E2E: missing title WITHOUT flag | still errors loudly on stderr |

## Infographic

![Bot-to-bot delivery: create on missing](https://v3b.fal.media/files/b/0aa6a93f/xyBVrfsbW9zj7vEeHfTF7_vpQ75jbO.png)
