### PR TITLE
fix(contributors): retire the case-colliding mapping twin from contributors/emails

### DIFF
--- a/contributors/emails/agent@Agents-Mac-mini.local
+++ b/contributors/emails/agent@Agents-Mac-mini.local
@@ -1,1 +1,0 @@
-skip-agent

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -44,6 +44,10 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 # This dict is kept only so existing history keeps resolving; the effective
 # AUTHOR_MAP below merges it with the directory (directory wins).
 LEGACY_AUTHOR_MAP = {
+    "agent@Agents-Mac-mini.local": "skip-agent",  # moved here from contributors/emails/: its filename case-collides
+    # with agent@agents-Mac-mini.local on case-insensitive filesystems (NTFS/APFS), which leaves Windows
+    # checkouts permanently dirty (#88168). The directory keeps the lowercase spelling; this mixed-case
+    # twin cannot exist as a file there. The audit/workflow text fallbacks also treat an entry here as mapped.
     "declanbatesmith@outlook.com": "cat-thats-fat",  # PR #60489 (desktop: first-run remote connection option)
     "drbs2004@me.com": "cat-thats-fat",  # PR #60489 (desktop: first-run remote connection option; historical merge email)
     "122438640+ragingbulld@users.noreply.github.com": "ragingbulld",  # PR #65606 salvage (non-finite API wait deadlines; #65746)

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -116,3 +116,37 @@ def test_cli_entrypoint_end_to_end(tmp_path):
     assert proc.returncode == 0, proc.stderr
     out = (tmp_path / "contributors" / "emails" / "cli@example.com").read_text(encoding="utf-8")
     assert out.splitlines()[0] == "cliperson"
+
+
+def test_no_case_colliding_mapping_filenames():
+    """#88168: two contributors/emails/ files differing only by letter case
+    cannot coexist on case-insensitive filesystems (NTFS, default APFS) —
+    the checkout stays permanently dirty on Windows and breaks release
+    gates. Mixed-case emails that collide with a directory entry belong in
+    LEGACY_AUTHOR_MAP instead (the audit/workflow text fallbacks accept that).
+    """
+    import subprocess as _sp
+
+    proc = _sp.run(
+        ["git", "ls-tree", "-r", "--name-only", "HEAD", "contributors/emails/"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    )
+    names = [line for line in proc.stdout.splitlines() if line.strip()]
+    folded: dict[str, str] = {}
+    collisions = []
+    for name in names:
+        key = name.lower()
+        if key in folded:
+            collisions.append(f"{folded[key]} <-> {name}")
+        folded.setdefault(key, name)
+    assert not collisions, (
+        "case-colliding contributors/emails/ filenames (they break Windows "
+        f"checkouts): {collisions}"
+    )
+
+
+def test_mixed_case_mapping_twin_resolves_via_legacy_map():
+    """The mixed-case twin retired from the directory (#88168) must still
+    resolve for release-notes attribution via LEGACY_AUTHOR_MAP."""
+    assert release.AUTHOR_MAP.get("agent@Agents-Mac-mini.local") == "skip-agent"
+    assert release.AUTHOR_MAP.get("agent@agents-Mac-mini.local") == "momomojo"


### PR DESCRIPTION
## What does this PR do?

Fixes permanently-dirty checkouts on case-insensitive filesystems. `contributors/emails/` contained two filenames differing only by letter case — `agent@Agents-Mac-mini.local` (skip-agent, added in 55db6187e) and `agent@agents-Mac-mini.local` (momomojo, since v0.19.0). NTFS and default APFS cannot materialize both paths: during checkout one file overwrites the other on disk and `git status --porcelain` reports a permanent modification that `git reset --hard` recreates on every checkout. This breaks Windows release gates that require a clean embedded checkout and pushes `hermes update` on Windows into the "Restore local changes now?" stash prompt on perfectly clean installs (#88168).

The mixed-case mapping moves into `LEGACY_AUTHOR_MAP` in `scripts/release.py` (with a comment documenting why it cannot live in the directory), and the colliding file is deleted. No attribution is lost:

- release-notes attribution resolves via `AUTHOR_MAP` (legacy dict merged with the directory) — both spellings still resolve, verified below;
- `audit_pr_attribution.py` and the `contributor-check.yml` workflow both treat an email appearing as `"..."` in `scripts/release.py` as mapped (their existing text fallback for legacy entries).

A regression test walks `git ls-tree -r HEAD contributors/emails/` and fails on any pair of filenames that collide case-insensitively, so this class of breakage cannot silently return.

## Related Issue

Fixes #88168

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `contributors/emails/agent@Agents-Mac-mini.local` — deleted (its filename cannot coexist with the lowercase twin on NTFS/APFS).
- `scripts/release.py` — `LEGACY_AUTHOR_MAP` gains the `agent@Agents-Mac-mini.local → skip-agent` entry with a comment explaining the case-collision constraint.
- `tests/scripts/test_contributor_map.py` — `test_no_case_colliding_mapping_filenames` (ls-tree case-fold collision guard) and `test_mixed_case_mapping_twin_resolves_via_legacy_map` (both spellings still resolve after the move).

## How to Test

1. `python -m pytest tests/scripts/test_contributor_map.py -q`
2. Observed result: 9 passed (7 pre-existing + 2 new). A/B guard: on unmodified `main` the collision test FAILS listing `agent@Agents-Mac-mini.local <-> agent@agents-Mac-mini.local`; on this branch it passes.
3. Checkout-cleanliness repro (the issue's core symptom, verifiable on default APFS as well as NTFS): a fresh worktree of `main` reports ` M contributors/emails/agent@Agents-Mac-mini.local` immediately; after this change `git status --porcelain` is empty.
4. Attribution intact: `python -c "import sys; sys.path.insert(0,'scripts'); import release; print(release.AUTHOR_MAP['agent@Agents-Mac-mini.local'], release.AUTHOR_MAP['agent@agents-Mac-mini.local'])"` — Observed result: `skip-agent momomojo`.
5. `python -m pytest tests/scripts/ -q` — Observed result: 25 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64, case-insensitive APFS)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
# worktree of upstream/main (case-insensitive APFS), before:
 M contributors/emails/agent@Agents-Mac-mini.local
# after this change:
(empty — clean)
```
