### PR TITLE
fix(gemini): translate video_url content parts to inlineData in the native adapter

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -264,6 +264,19 @@ def _coerce_content_to_text(content: Any) -> str:
     return str(content)
 
 
+def _decode_data_url(url: Any) -> Optional[Dict[str, str]]:
+    """Split a `data:<mime>;base64,<...>` URL into mimeType + base64 data, or None."""
+    if not isinstance(url, str) or not url.startswith("data:"):
+        return None
+    try:
+        header, encoded = url.split(",", 1)
+        mime = header.split(":", 1)[1].split(";", 1)[0]
+        raw = base64.b64decode(encoded)
+    except Exception:
+        return None
+    return {"mimeType": mime, "data": base64.b64encode(raw).decode("ascii")}
+
+
 def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
     if not isinstance(content, list):
         text = _coerce_content_to_text(content)
@@ -282,23 +295,18 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             if isinstance(text, str) and text:
                 parts.append({"text": text})
         elif ptype == "image_url":
-            url = ((item.get("image_url") or {}).get("url") or "")
-            if not isinstance(url, str) or not url.startswith("data:"):
-                continue
-            try:
-                header, encoded = url.split(",", 1)
-                mime = header.split(":", 1)[1].split(";", 1)[0]
-                raw = base64.b64decode(encoded)
-            except Exception:
-                continue
-            parts.append(
-                {
-                    "inlineData": {
-                        "mimeType": mime,
-                        "data": base64.b64encode(raw).decode("ascii"),
-                    }
-                }
-            )
+            inline_data = _decode_data_url((item.get("image_url") or {}).get("url"))
+            if inline_data is not None:
+                parts.append({"inlineData": inline_data})
+        elif ptype == "video_url":
+            # tools/vision_tools.py's video_analyze_tool sends this custom part
+            # type (mirroring image_url) — not an OpenAI-standard shape, so only
+            # Gemini's native inlineData path understands it. Without this branch
+            # the part is silently dropped and the model answers from the text
+            # prompt alone with no video attached.
+            inline_data = _decode_data_url((item.get("video_url") or {}).get("url"))
+            if inline_data is not None:
+                parts.append({"inlineData": inline_data})
     return parts
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -457,3 +457,54 @@ class TestGemini3ToolCallIds:
         result = translate_gemini_response(resp, model="gemini-2.5-flash")
         tool_calls = result.choices[0].message.tool_calls
         assert tool_calls[0].id.startswith("call_")
+
+def test_extract_multimodal_parts_translates_video_url_to_inline_data():
+    """video_url parts (what video_analyze_tool sends) must become Gemini
+    inlineData, not be silently dropped."""
+    import base64
+
+    from agent.gemini_native_adapter import _extract_multimodal_parts
+
+    video_bytes = b"\x00\x01fake-video-bytes"
+    data_url = "data:video/mp4;base64," + base64.b64encode(video_bytes).decode("ascii")
+    content = [{"type": "video_url", "video_url": {"url": data_url}}]
+
+    parts = _extract_multimodal_parts(content)
+
+    assert parts == [
+        {
+            "inlineData": {
+                "mimeType": "video/mp4",
+                "data": base64.b64encode(video_bytes).decode("ascii"),
+            }
+        }
+    ]
+
+
+def test_extract_multimodal_parts_image_url_still_works():
+    """The image_url path must survive the refactor to the shared helper."""
+    import base64
+
+    from agent.gemini_native_adapter import _extract_multimodal_parts
+
+    img_bytes = b"fake-image-bytes"
+    data_url = "data:image/png;base64," + base64.b64encode(img_bytes).decode("ascii")
+    content = [{"type": "image_url", "image_url": {"url": data_url}}]
+
+    parts = _extract_multimodal_parts(content)
+
+    assert parts == [
+        {
+            "inlineData": {
+                "mimeType": "image/png",
+                "data": base64.b64encode(img_bytes).decode("ascii"),
+            }
+        }
+    ]
+
+
+def test_decode_data_url_rejects_non_data_urls():
+    from agent.gemini_native_adapter import _decode_data_url
+
+    assert _decode_data_url("https://example.com/video.mp4") is None
+    assert _decode_data_url(None) is None


### PR DESCRIPTION
## What does this PR do?

The native Gemini adapter's multimodal translator (`_extract_multimodal_parts`)
only handled `image_url` content parts. `video_url` parts — which
`tools/vision_tools.py`'s `video_analyze_tool` sends (as a custom part type
mirroring `image_url`) — were silently dropped, so a video-analysis request
reached Gemini with no video attached and the model answered from the text
prompt alone.

The fix extracts a `_decode_data_url()` helper (shared by both part types) and
adds a `video_url` branch that maps the `data:` URL to Gemini's `inlineData`
shape, exactly as `image_url` already did.

## Why

Silent data loss: `video_analyze_tool` → Gemini-native path was quietly losing
the video payload, with no error and no way for the agent to notice.

## Related Issue

No upstream issue filed — self-contained bugfix with focused regression tests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/gemini_native_adapter.py`: add `_decode_data_url()`; refactor the
  `image_url` branch to use it; add a `video_url` branch that maps to
  `inlineData`.
- `tests/agent/test_gemini_native_adapter.py`: 3 tests — video_url → inlineData,
  image_url regression (shared helper), and `_decode_data_url` rejecting
  non-`data:` URLs.

## How to Test

Automated: `pytest tests/agent/test_gemini_native_adapter.py -q` → 21 passed
(18 existing + 3 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused adapter suite (21 passed); full suite left to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A