### PR TITLE
fix(cli): require npm for the desktop build, not for the launch

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7827,14 +7827,18 @@ def cmd_gui(args: argparse.Namespace):
 
     packaged_executable = _desktop_packaged_executable(desktop_dir)
 
-    if source_mode or not skip_build:
-        npm = _resolve_node_runtime_npm()
-        if not npm:
-            print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
-            print("Install Node.js, then run:  hermes gui")
-            sys.exit(1)
-    else:
-        npm = None
+    # A source-mode run needs npm no matter what: the launch itself is
+    # `npm exec -- electron .`, so even --skip-build cannot avoid it.
+    #
+    # A packaged run never uses npm to LAUNCH — it execs the packed binary — so
+    # its npm requirement belongs to the BUILD, and is resolved lazily below,
+    # after the content stamp has decided a build is actually going to run.
+    # Demanding it up front made an up-to-date packaged app refuse to start on
+    # any PATH without npm, which is exactly what a cold application-menu
+    # launch looks like: the XDG/systemd session PATH has no login-shell
+    # additions, so a Homebrew/Linuxbrew Node is invisible to it and the app
+    # exits 1 without a window, having had no build work to do (#88004).
+    npm = _require_node_runtime_npm() if source_mode else None
 
     if skip_build:
         if source_mode:
@@ -7868,6 +7872,8 @@ def cmd_gui(args: argparse.Namespace):
             build_label = "source build" if source_mode else "packaged app"
             print(f"✓ Desktop {build_label} is up to date (content stamp matches)")
         else:
+            if npm is None:
+                npm = _require_node_runtime_npm(packaged_executable)
             print("→ Installing desktop workspace dependencies...")
             # Put the Hermes-managed Node on PATH so npm's child scripts (which
             # shell out to bare `node`, e.g. electron-winstaller's
@@ -9634,6 +9640,25 @@ def _is_windows_npm_path(npm_path: str) -> bool:
         or low.startswith("/mnt/")
         or "\\" in npm_path
     )
+
+
+def _require_node_runtime_npm(packaged_executable: Path | None = None) -> str:
+    """Resolve npm or exit 1 with the install hint. Never returns ``None``.
+
+    ``packaged_executable`` is the already-built app, when there is one. Its
+    presence changes the advice rather than the outcome: npm is still needed to
+    REBUILD, but the user has a launchable app right now and does not have to
+    install a Node toolchain to get a window back.
+    """
+    npm = _resolve_node_runtime_npm()
+    if npm:
+        return npm
+    print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
+    print("Install Node.js, then run:  hermes gui")
+    if packaged_executable is not None:
+        print("Or launch the existing app without rebuilding:  hermes desktop --skip-build")
+        print(f"  ({packaged_executable})")
+    sys.exit(1)
 
 
 def _resolve_node_runtime_npm() -> str | None:

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -132,6 +132,91 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 
 
+def test_gui_launches_up_to_date_packaged_app_without_npm(tmp_path, monkeypatch):
+    """Regression (#88004): an up-to-date packaged app must launch on a PATH
+    with no npm at all.
+
+    This is what a cold application-menu launch looks like on Linux — the
+    XDG/systemd session PATH has none of the login shell's additions, so a
+    Homebrew/Linuxbrew Node is simply not there. The packaged app is launched by
+    exec'ing the packed binary and never shells out to npm, and the content
+    stamp says there is no build to run, so npm must not be consulted at all.
+    Before the fix it was resolved before the stamp was ever read and the
+    process exited 1 without a window.
+    """
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value=None) as mock_npm, \
+         patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._run_npm_install_deterministic") as mock_install, \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main._register_linux_desktop_entry"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[launch_ok]) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    assert mock_run.call_args_list[0].args[0] == [str(packaged_exe)]
+    mock_install.assert_not_called()
+    # Not merely "did not exit on it": the lookup never happens, which is what
+    # makes the launch independent of the session PATH rather than lucky.
+    mock_npm.assert_not_called()
+    assert desktop_dir.exists()
+
+
+def test_gui_still_requires_npm_when_a_packaged_build_must_run(tmp_path, monkeypatch, capsys):
+    """The npm requirement moves, it does not go away.
+
+    A stale content stamp means a real ``npm ci`` + ``npm run pack``, so a
+    missing npm still has to fail loudly there. It should also say that the
+    already-packaged app can be launched as-is, or a menu user with no Node
+    toolchain reads the message as unrecoverable.
+    """
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value=None), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._run_npm_install_deterministic") as mock_install, \
+         patch("hermes_cli.main._register_linux_desktop_entry"), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 1
+    mock_install.assert_not_called()
+    out = capsys.readouterr().out
+    assert "npm was not found on PATH" in out
+    assert "--skip-build" in out
+    assert str(packaged_exe) in out
+
+
+def test_gui_source_mode_requires_npm_even_with_skip_build(tmp_path, monkeypatch):
+    """A source-mode launch IS ``npm exec -- electron .``.
+
+    So npm stays a hard, up-front requirement there even when --skip-build
+    means no build runs — the packaged path is the only one that can launch
+    without it. Pinned separately because the fix narrowed the up-front gate,
+    and narrowing it one branch too far would strand source mode with
+    ``npm = None`` all the way into the launch call.
+    """
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value=None) as mock_npm, \
+         patch("hermes_cli.main._register_linux_desktop_entry"), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(source=True, skip_build=True))
+
+    assert exc.value.code == 1
+    mock_npm.assert_called_once()
+
+
 def test_gui_install_env_prepends_managed_node_on_bare_path(tmp_path, monkeypatch):
     """Regression: npm's child scripts (electron-winstaller's select-7z-arch.js)
     shell out to bare ``node``. When Desktop is launched from the updater chain


### PR DESCRIPTION
## What does this PR do?

`cmd_gui` resolved npm and exited **before** it asked whether a build was needed:

```python
packaged_executable = _desktop_packaged_executable(desktop_dir)

if source_mode or not skip_build:
    npm = _resolve_node_runtime_npm()
    if not npm:
        print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
        print("Install Node.js, then run:  hermes gui")
        sys.exit(1)

...
build_needed = force_build or _desktop_build_needed(desktop_dir, PROJECT_ROOT, source_mode=source_mode)
if not build_needed:
    print(f"✓ Desktop {build_label} is up to date (content stamp matches)")
```

So a run that was about to do **no build work at all** still died on a missing npm. The packaged launch is `subprocess.run([str(packaged_executable)])` and never shells out to npm.

`npm` is used in exactly three places in that function:

| use | needs npm? |
|---|---|
| `_run_npm_install_deterministic(npm, ...)` | only when `build_needed` |
| `[npm, "run", build_script]` | only when `build_needed` |
| `[npm, "exec", "--", "electron", "."]` | **source mode only**, and at launch |

This moves the requirement to match. Packaged mode resolves npm lazily, once the content stamp has said a build is really going to run. Source mode keeps the hard up-front requirement, because its *launch* is an npm invocation and `--skip-build` cannot avoid it.

**Why this is safe against a stamp that lies about the artifact:** `_desktop_build_needed` already returns `True` when the packaged executable is missing, so `build_needed == False` implies a launchable app exists. There is no path where the fix skips the npm check and then finds nothing to launch.

## Related Issue

Fixes #88004

Reported by @gclawes as a Linux application-menu launch on Universal Blue / Aurora: Plasma starts the app through the user systemd session, whose `PATH` has none of the login shell's additions, so a Linuxbrew `node` is invisible and the app already sitting in `apps/desktop/release/linux-unpacked/` exits 1 without a window. The menu is the loudest way in, not the only one — any `hermes desktop` on a stripped `PATH` fails the same way, and the message ("Install Node.js, then run: `hermes gui`") names the command that just failed.

**On the issue's other suggestion, deliberately not taken.** The issue proposes putting `--skip-build` in the generated desktop entry's `Exec=`. That fixes the symptom but makes every menu launch permanently skip the rebuild-on-change check, so after a `hermes update` the menu would silently start the stale packaged app while a terminal launch rebuilt. Fixing the gate keeps both properties: an up-to-date app launches with no Node toolchain in sight, and a stale one still rebuilds when npm is there. It also leaves `hermes_cli/linux_desktop_entry.py` untouched, which matters because **#87416** is already open against that file for the separate cold-launch `Exec=` interpreter problem.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`
  - New `_require_node_runtime_npm(packaged_executable=None)` beside `_resolve_node_runtime_npm`: resolves or exits 1, so the gate reads the same at both call sites and cannot drift.
  - `cmd_gui`'s up-front gate narrows to `npm = _require_node_runtime_npm() if source_mode else None`, with a comment naming the three npm uses so the next person can see why the branch is asymmetric.
  - The `build_needed` arm resolves npm lazily before the install.
  - When npm really is required and a packaged app exists, the error adds that it can be launched as-is with `hermes desktop --skip-build`, and prints its path. Without that, the message reads as unrecoverable to exactly the user who has a working app on disk.
- `tests/hermes_cli/test_gui_command.py` — 3 tests.

No behavior changes for `--force-build`, `--build-only`, `--source`, or any run on a PATH that has npm.

## How to Test

```
python -m pytest tests/hermes_cli/test_gui_command.py -q -k "npm or up_to_date"
```

3 passed.

Mutation check, one rule at a time:

| Mutation | Result |
|---|---|
| Restore the eager gate (`if source_mode or not skip_build`) | **2 failed** — the up-to-date launch, and the `--skip-build` hint that is only reachable once the gate is lazy |
| Delete the lazy `if npm is None: npm = _require_node_runtime_npm(...)` | **1 failed** — npm stays `None` and reaches the install call instead of exiting (in production this is `subprocess.run([None, "ci"])`) |
| Drop the source-mode arm (`npm = None` unconditionally) | **1 failed** — source mode strands `npm = None` all the way into `npm exec -- electron .` |

Each mutation kills exactly the test that owns the rule, and no others.

Full file: 22 passed, 1 failed. The one failure, `test_gui_installs_packages_and_launches_desktop_app`, is **pre-existing and unrelated** — it writes a 0-byte `Hermes.exe` and the Windows integrity gate (`_ensure_desktop_exe_launchable`) correctly rejects it, so the test only passes on non-Windows hosts. Verified by stashing both of my files and re-running: 19 passed, the same 1 failed.

`ruff check` on both files: clean.

Type of verification I could **not** do: I am on Windows 11, so I have not reproduced the Aurora/Plasma launch itself. What the tests pin is the platform-independent half — that the packaged path launches without ever calling the npm resolver — and `_make_packaged_executable` in that file already keys its layout off the real `sys.platform`, so the test exercises the host's genuine packaged-app branch rather than a faked one.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — checked the issue timeline, open and merged PR search, and the three open PRs on the related #80439 (#80547, #80563, #87416); all three touch only `hermes_cli/linux_desktop_entry.py` and none change the npm gate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran the desktop/CLI-launcher subset rather than the whole suite; results and the one pre-existing Windows failure are in *How to Test*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper and the narrowed gate both carry the reasoning
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is platform-neutral, but the class of failure is not: macOS launched from Finder/Dock and Windows launched from a Start Menu shortcut inherit the same reduced environment as an XDG/systemd session, so an app-launcher start on any of the three now stops depending on a Node toolchain being visible to it
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

From the issue, on Aurora with `apps/desktop/release/linux-unpacked/Hermes` present and up to date:

```
systemd[…]: Started app-hermes@….service - Hermes - Hermes Desktop.
hermes[…]: Desktop GUI requires Node.js/npm, but npm was not found on PATH.
hermes[…]: Install Node.js, then run:  hermes gui
systemd[…]: app-hermes@….service: Main process exited, code=exited, status=1/FAILURE
```

After this change that run prints `✓ Desktop packaged app is up to date (content stamp matches)` and launches the packed binary, having never looked for npm.
