### PR TITLE
feat(skills): add NocoDB skill and MCP catalog entry

### DIFF
--- a/optional-mcps/nocodb/manifest.yaml
+++ b/optional-mcps/nocodb/manifest.yaml
@@ -1,0 +1,70 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: nocodb
+description: >-
+  Read and write records in your NocoDB bases.
+source: https://nocodb.com/docs/product-docs/developer-resources/mcp
+
+# Official vendor-hosted remote MCP (URL-only — Hermes never spawns a local
+# process for this entry). NocoDB advertises OAuth 2.1 + Dynamic Client
+# Registration at the instance root, so Hermes's MCP client +
+# mcp_oauth_manager handle discovery, PKCE, token exchange, and refresh
+# with no client_id to paste. Verified against app.nocodb.com (2026-08-17):
+#
+#   /.well-known/oauth-protected-resource
+#     resource: https://app.nocodb.com/mcp
+#     authorization_servers: [https://app.nocodb.com]
+#     bearer_methods_supported: [header]
+#
+#   /.well-known/oauth-authorization-server
+#     registration_endpoint: /api/v2/oauth/register   (DCR — no allowlist)
+#     code_challenge_methods_supported: [S256]
+#     grant_types_supported: [authorization_code, refresh_token]
+#     token_endpoint_auth_methods_supported: [none, client_secret_post]
+transport:
+  type: http
+  url: https://app.nocodb.com/mcp
+
+auth:
+  type: oauth
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - nocodb
+  hosts:
+    - nocodb.com
+
+post_install: |
+  On first connection Hermes opens a browser to authorize with
+  NocoDB (or run `hermes mcp login nocodb`). Approve access, then
+  restart the session so tools load.
+
+  Scope: this server is record-level only — create, read, update, and
+  delete rows. It does not create tables, add fields, or make any other
+  schema change. For schema work, workspace/base administration, views,
+  filters, or attachments, install the `nocodb` skill instead
+  (`hermes skills install nocodb`), which drives the NocoDB v3 REST API.
+
+  Self-hosted instances: the OAuth metadata is served from your own
+  instance root, so point the URL at it after install —
+
+    hermes mcp configure nocodb
+
+  and set url to https://nocodb.example.com/mcp. The browser flow then
+  authorizes against that instance.
+
+  Per-base token alternative: NocoDB also exposes a scoped endpoint at
+  /mcp/<mcpTokenId> authenticated with an `xc-mcp-token` header instead
+  of OAuth. That custom header is not expressible in this manifest
+  format, so configure it directly in ~/.hermes/config.yaml:
+
+    mcp_servers:
+      nocodb:
+        url: https://app.nocodb.com/mcp/<mcpTokenId>
+        headers:
+          xc-mcp-token: "${NOCODB_MCP_TOKEN}"
+
+  Treat that token as full control over the base it is scoped to.

--- a/optional-mcps/nocodb/manifest.yaml
+++ b/optional-mcps/nocodb/manifest.yaml
@@ -8,21 +8,9 @@ description: >-
 source: https://nocodb.com/docs/product-docs/developer-resources/mcp
 
 # Official vendor-hosted remote MCP (URL-only — Hermes never spawns a local
-# process for this entry). NocoDB advertises OAuth 2.1 + Dynamic Client
-# Registration at the instance root, so Hermes's MCP client +
-# mcp_oauth_manager handle discovery, PKCE, token exchange, and refresh
-# with no client_id to paste. Verified against app.nocodb.com (2026-08-17):
-#
-#   /.well-known/oauth-protected-resource
-#     resource: https://app.nocodb.com/mcp
-#     authorization_servers: [https://app.nocodb.com]
-#     bearer_methods_supported: [header]
-#
-#   /.well-known/oauth-authorization-server
-#     registration_endpoint: /api/v2/oauth/register   (DCR — no allowlist)
-#     code_challenge_methods_supported: [S256]
-#     grant_types_supported: [authorization_code, refresh_token]
-#     token_endpoint_auth_methods_supported: [none, client_secret_post]
+# process for this entry). NocoDB serves OAuth 2.1 discovery with DCR and
+# PKCE S256 at the instance root, so mcp_oauth_manager handles registration,
+# token exchange, and refresh with no client_id to paste.
 transport:
   type: http
   url: https://app.nocodb.com/mcp

--- a/optional-skills/productivity/nocodb/SKILL.md
+++ b/optional-skills/productivity/nocodb/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: nocodb
+description: Manage NocoDB bases, tables, fields, and records.
+version: 1.0.0
+author: Anbarasu (DarkPhoenix2704)
+license: MIT
+platforms: [macos, linux, windows]
+required_environment_variables:
+  - name: NOCODB_TOKEN
+    prompt: NocoDB API token
+    help: "NocoDB → account menu → Account Settings → Tokens → Add New Token. Sent as the xc-token header."
+    required_for: every command
+  - name: NOCODB_URL
+    prompt: NocoDB instance URL (default https://app.nocodb.com)
+    help: "Self-hosted instances only — the origin, with no /api suffix and no trailing slash."
+    required_for: self-hosted instances
+prerequisites:
+  env_vars: [NOCODB_TOKEN]
+  commands: [curl, jq]
+metadata:
+  hermes:
+    tags: [NocoDB, Database, Spreadsheet, No-Code, API, Records]
+    related_skills: [airtable]
+    requires_toolsets: [terminal]
+    homepage: https://nocodb.com/docs/product-docs
+---
+
+# NocoDB Skill
+
+Drive the NocoDB v3 REST API from the command line: browse workspaces and
+bases, read and write records, and change schema (tables, fields, views,
+filters, sorts). This is the full admin surface — the NocoDB MCP server, by
+contrast, is record-CRUD only.
+
+It does not run NocoDB itself, sync external data sources, or manage billing.
+Workspace, view, script, team, and API-token endpoints are Enterprise-plan
+features (self-hosted or cloud) and error out on the free plan.
+
+## When to Use
+
+- The user names a NocoDB base, table, or record, or pastes an `app.nocodb.com`
+  (or self-hosted NocoDB) link.
+- Bulk record work: import, backfill, deduplicate, or export rows.
+- Schema work the MCP server cannot do: create tables, add fields, build views,
+  attach filters and sorts.
+- The user wants a lightweight database for tracking something and has NocoDB
+  available.
+
+Prefer the `nocodb` MCP server when the task is plain record CRUD on a single
+base and the user already authorized it — it needs no token handling. Use this
+skill for everything structural.
+
+## Prerequisites
+
+- `NOCODB_TOKEN` — API token. NocoDB → account menu → **Account Settings** →
+  **Tokens** → **Add New Token**. Sent as the `xc-token` header.
+- `NOCODB_URL` — only for self-hosted instances. Defaults to
+  `https://app.nocodb.com`. Use the bare origin: `https://nocodb.example.com`,
+  no `/api` suffix, no trailing slash.
+- `NOCODB_VERBOSE=1` — optional; prints each name→ID resolution to stderr.
+- `curl` and `jq` on `PATH` for the Bash script. The PowerShell script uses
+  `Invoke-RestMethod` and needs neither.
+
+The token grants full access to every base it can reach. Never echo it into
+transcripts or commit it.
+
+## How to Run
+
+Invoke through the `terminal` tool from the skill directory. Pick the script
+that matches the platform — both expose an identical 72-command surface:
+
+- macOS / Linux: `scripts/nocodb.sh <command> [args...]`
+- Windows: `pwsh -File scripts/nocodb.ps1 <command> [args...]`
+
+Every example below uses the Bash form. There is no `nc` binary — do not
+shorten the invocation, since `nc` is netcat.
+
+Arguments are always hierarchical, widest scope first:
+
+```
+WORKSPACE → BASE → TABLE → VIEW/FIELD → RECORD
+```
+
+Names or IDs both work. Names cost an extra lookup per level; IDs are exact.
+ID prefixes: `w`=workspace, `p`=base, `m`=table, `c`=field, `vw`=view.
+
+## Quick Reference
+
+| Command | Args | Notes |
+|---|---|---|
+| `workspace:list` | — | Enterprise |
+| `base:list` | `WORKSPACE` | → `p…` base IDs |
+| `base:create` | `WORKSPACE` `'{"title":"…"}'` | |
+| `table:list` | `BASE` | → `m…` table IDs |
+| `table:create` | `BASE` `'{"title":"…"}'` | |
+| `field:list` | `BASE` `TABLE` | title, type, `c…` ID |
+| `field:create` | `BASE` `TABLE` `'{"title":"…","type":"…"}'` | |
+| `view:list` | `BASE` `TABLE` | Enterprise |
+| `record:list` | `BASE` `TABLE` `[PAGE] [SIZE] [WHERE] [SORT] [FIELDS]` | 25/page default |
+| `record:get` | `BASE` `TABLE` `RECORD_ID [FIELDS]` | |
+| `record:create` | `BASE` `TABLE` `'{"fields":{…}}'` | |
+| `record:update` | `BASE` `TABLE` `RECORD_ID` `'{…}'` | |
+| `record:update-many` | `BASE` `TABLE` `'[{"id":1,"fields":{…}}]'` | |
+| `record:delete` | `BASE` `TABLE` `ID` or `'[{"id":31}]'` | |
+| `record:count` | `BASE` `TABLE` `[WHERE]` | |
+| `link:list` \| `link:add` \| `link:remove` | `BASE` `TABLE` `FIELD` `RECORD_ID` `[…]` | link payload `[{"id":42}]` |
+| `filter:create` \| `sort:create` | `BASE` `TABLE` `VIEW` `'{…}'` | view-level, Enterprise |
+| `attachment:upload` | `BASE` `TABLE` `RECORD_ID` `FIELD` `PATH` | multipart |
+| `where:help` | — | full filter syntax |
+
+Field types: `SingleLineText`, `LongText`, `Number`, `Decimal`, `Currency`,
+`Percent`, `Email`, `URL`, `PhoneNumber`, `Date`, `DateTime`, `Time`,
+`SingleSelect`, `MultiSelect`, `Checkbox`, `Rating`, `Attachment`, `Links`,
+`User`, `JSON`.
+
+Run `scripts/nocodb.sh` with no arguments for the complete command list.
+
+### Where-filter syntax
+
+```
+(field,operator,value)              (name,eq,John)
+(field,operator)                    (notes,blank)
+(field,operator,sub_op[,value])     (created_at,isWithin,pastWeek)
+```
+
+Operators: `eq`, `neq`, `like`, `nlike`, `in`, `gt`, `lt`, `gte`, `lte`,
+`blank`, `notblank`, `checked`, `notchecked`.
+
+Combine with a **tilde** prefix — `~and`, `~or`, `~not`. Plain `and`/`or` is
+the single most common mistake and the script rejects it:
+
+```bash
+scripts/nocodb.sh record:list MyBase Tasks 1 25 \
+  "(due_date,lt,today)~and(priority,eq,high)~and(completed,notchecked)"
+```
+
+## Procedure
+
+1. **Confirm credentials are loaded.** Run the Verification command below. A
+   `NOCODB_TOKEN required` error means the env var never reached the shell.
+
+2. **Resolve the target once, then reuse IDs.** Passing a name instead of an ID
+   costs a lookup on every call, and resolving a *base* name scans every
+   workspace the token can see:
+
+   ```bash
+   scripts/nocodb.sh base:list wabc1234xyz        # → pdef5678uvw
+   scripts/nocodb.sh table:list pdef5678uvw       # → mghi9012rst
+   scripts/nocodb.sh field:list pdef5678uvw mghi9012rst
+   ```
+
+   On a free plan there is no `workspace:list` to seed step one. Read the base
+   ID out of the NocoDB URL instead — `app.nocodb.com/#/<workspace>/<baseId>/…`
+   — and start at `table:list`.
+
+3. **Inspect the schema before writing.** `field:list` gives exact titles,
+   types, and IDs. Guessed field names are silently dropped by the API rather
+   than rejected.
+
+4. **Read before you write.** Preview the affected rows with the same filter
+   you are about to mutate:
+
+   ```bash
+   scripts/nocodb.sh record:count pdef5678uvw mghi9012rst "(status,eq,stale)"
+   scripts/nocodb.sh record:list  pdef5678uvw mghi9012rst 1 5 "(status,eq,stale)"
+   ```
+
+5. **Batch mutations.** Use `record:update-many` and array-form
+   `record:delete` instead of a call per row.
+
+6. **Page explicitly.** `record:list` returns 25 rows per page. Drive
+   `record:count` first, then loop pages — never assume one page is the whole
+   table.
+
+7. **Write results with `write_file`** when the user wants an export. Pipe the
+   JSON through `jq` inside the command rather than reformatting it yourself.
+
+## Pitfalls
+
+- **`nc` is netcat.** Always invoke `scripts/nocodb.sh`.
+- **Plain `and`/`or` in filters.** Must be `~and` / `~or` / `~not`.
+- **`record:create` wraps fields.** Payload is `{"fields":{…}}`; `record:update`
+  takes the bare object `{…}`. Mixing them up returns a 400.
+- **Unknown field names do not error.** They are dropped. Verify with
+  `field:list` and re-read the record after writing.
+- **Enterprise-gated endpoints.** Workspace, view, script, team, and API-token
+  commands need an Enterprise plan (self-hosted or cloud). On the free plan
+  `workspace:list` fails — pass the base ID directly instead.
+- **`base:list` takes a workspace argument** and is therefore Enterprise-gated
+  in practice. Free-plan users should skip it and read the base ID from the
+  NocoDB URL.
+- **Passing a base *name*** makes the script enumerate every workspace looking
+  for it — another Enterprise-only path. Pass the `p…` ID.
+- **Self-hosted URL shape.** `NOCODB_URL` is the origin only. A trailing slash
+  or an `/api` suffix produces 404s on every call.
+- **Record IDs are per-table integers**, not the `p…`/`m…` nanoid strings.
+- **Deletes are immediate.** There is no undo through the API.
+
+## Verification
+
+```bash
+scripts/nocodb.sh table:list <BASE_ID>
+```
+
+Prints one `title<TAB>id` row per table. Any output means the token, the URL,
+and the dependencies are all correct. `NOCODB_TOKEN required` means the env var
+never reached the shell; an HTML or 401 body means the token or `NOCODB_URL` is
+wrong.
+
+On Enterprise plans `scripts/nocodb.sh workspace:list` verifies the same thing
+without needing a base ID up front.
+
+## Attribution
+
+Ported from [nocodb/agent-skills](https://github.com/nocodb/agent-skills)
+(MIT). The `scripts/` files are vendored from that repository.

--- a/optional-skills/productivity/nocodb/SKILL.md
+++ b/optional-skills/productivity/nocodb/SKILL.md
@@ -177,7 +177,6 @@ scripts/nocodb.sh record:list MyBase Tasks 1 25 \
 
 ## Pitfalls
 
-- **`nc` is netcat.** Always invoke `scripts/nocodb.sh`.
 - **Plain `and`/`or` in filters.** Must be `~and` / `~or` / `~not`.
 - **`record:create` wraps fields.** Payload is `{"fields":{…}}`; `record:update`
   takes the bare object `{…}`. Mixing them up returns a 400.

--- a/optional-skills/productivity/nocodb/scripts/nocodb.ps1
+++ b/optional-skills/productivity/nocodb/scripts/nocodb.ps1
@@ -1,0 +1,944 @@
+###############################################################################
+# nocodb.ps1 - NocoDB v3 CLI (PowerShell)
+#
+# Vendored verbatim from https://github.com/nocodb/agent-skills (MIT).
+# Fixes belong upstream first; re-vendor rather than patching in place.
+###############################################################################
+$ErrorActionPreference = "Stop"
+
+$NC_URL = if ($env:NOCODB_URL) { $env:NOCODB_URL } else { "https://app.nocodb.com" }
+$NC_TOKEN = $env:NOCODB_TOKEN
+$NC_VERBOSE = $env:NOCODB_VERBOSE -eq "1"
+
+if (-not $NC_TOKEN) { Write-Error "NOCODB_TOKEN required"; exit 1 }
+
+function _v($msg) { if ($NC_VERBOSE) { Write-Host "→ $msg" -ForegroundColor DarkGray } }
+
+###############################################################################
+# HTTP helpers
+###############################################################################
+$headers = @{ "xc-token" = $NC_TOKEN; "Content-Type" = "application/json" }
+
+function _get($path) {
+    Invoke-RestMethod -Uri "$NC_URL/api/v3/$path" -Headers $headers -Method Get
+}
+function _post($path, $body) {
+    Invoke-RestMethod -Uri "$NC_URL/api/v3/$path" -Headers $headers -Method Post -Body $body
+}
+function _patch($path, $body) {
+    Invoke-RestMethod -Uri "$NC_URL/api/v3/$path" -Headers $headers -Method Patch -Body $body
+}
+function _put($path, $body) {
+    Invoke-RestMethod -Uri "$NC_URL/api/v3/$path" -Headers $headers -Method Put -Body $body
+}
+function _delete($path, $body) {
+    $params = @{ Uri = "$NC_URL/api/v3/$path"; Headers = $headers; Method = "Delete" }
+    if ($body) { $params.Body = $body }
+    Invoke-RestMethod @params
+}
+function _upload($path, $filePath) {
+    $form = @{ file = Get-Item $filePath }
+    Invoke-RestMethod -Uri "$NC_URL/api/v3/$path" -Headers @{ "xc-token" = $NC_TOKEN } -Method Post -Form $form
+}
+
+function _enc($s) { [System.Uri]::EscapeDataString($s) }
+
+function _jqf($list, $name) {
+    $lower = $name.ToLower()
+    $match = $list | Where-Object { $_.title.ToLower() -eq $lower } | Select-Object -First 1
+    if ($match) { return $match.id }
+    return $null
+}
+
+###############################################################################
+# Validation helpers
+###############################################################################
+function _err($msg) { Write-Error "error: $msg"; exit 1 }
+
+function _require($name, $val) {
+    if (-not $val) { _err "$name is required" }
+}
+
+function _require_json($name, $val) {
+    if (-not $val) { _err "$name is required" }
+    try { $null = $val | ConvertFrom-Json } catch { _err "$name must be valid JSON" }
+}
+
+function _require_json_obj($name, $val) {
+    if (-not $val) { _err "$name is required" }
+    try { $obj = $val | ConvertFrom-Json; if ($obj -is [array]) { _err "$name must be a JSON object" } } catch { _err "$name must be valid JSON" }
+}
+
+function _require_json_arr($name, $val) {
+    if (-not $val) { _err "$name is required" }
+    try { $obj = $val | ConvertFrom-Json; if ($obj -isnot [array]) { _err "$name must be a JSON array" } } catch { _err "$name must be valid JSON" }
+}
+
+function _require_int($name, $val) {
+    if (-not $val) { return }
+    if ($val -notmatch '^\d+$') { _err "$name must be a positive integer" }
+}
+
+function _require_nonempty($name, $val) {
+    if (-not $val) { _err "$name is required and cannot be empty" }
+}
+
+function _require_file($path) {
+    if (-not $path) { _err "file path is required" }
+    if (-not (Test-Path $path)) { _err "file not found: $path" }
+}
+
+function _validate_where($val) {
+    if (-not $val) { return }
+    if ($val -notmatch '^\(.*\)$' -and $val -notmatch '^~not\(') {
+        Write-Warning "where clause should be in format (field,op,value)"
+        Write-Warning "  Examples: (name,eq,John) (status,in,active,pending) (age,gte,18)"
+        Write-Warning "  Combine:  (field1,eq,x)~and(field2,eq,y)  or  (f1,eq,x)~or(f2,eq,y)"
+    }
+    if ($val -match '\)and\(' -or $val -match '\)or\(') {
+        _err "use ~and and ~or (with tilde), not plain 'and'/'or'. Example: (a,eq,1)~and(b,eq,2)"
+    }
+}
+
+function _validate_workspace_json($json, $op) {
+    _require_json_obj "json" $json
+    if ($op -eq "create") {
+        $obj = $json | ConvertFrom-Json
+        if (-not $obj.title) { _err "json must contain 'title' field" }
+    }
+}
+
+function _validate_base_json($json, $op) {
+    _require_json_obj "json" $json
+    if ($op -eq "create") {
+        $obj = $json | ConvertFrom-Json
+        if (-not $obj.title) { _err "json must contain 'title' field" }
+    }
+}
+
+function _validate_table_json($json, $op) {
+    _require_json_obj "json" $json
+    if ($op -eq "create") {
+        $obj = $json | ConvertFrom-Json
+        if (-not $obj.title) { _err "json must contain 'title' field" }
+    }
+}
+
+function _validate_field_json($json, $op) {
+    _require_json_obj "json" $json
+    if ($op -eq "create") {
+        $obj = $json | ConvertFrom-Json
+        if (-not $obj.title) { _err "json must contain 'title' field" }
+        if (-not $obj.type) { _err "json must contain 'type' field" }
+    }
+}
+
+function _validate_view_json($json, $op) {
+    _require_json_obj "json" $json
+    if ($op -eq "create") {
+        $obj = $json | ConvertFrom-Json
+        if (-not $obj.title) { _err "json must contain 'title' field" }
+        if (-not $obj.type) { _err "json must contain 'type' field (grid, gallery, form, kanban, calendar)" }
+    }
+}
+
+function _validate_filter_json($json) {
+    _require_json_obj "json" $json
+    $obj = $json | ConvertFrom-Json
+    if (-not $obj.group_operator) {
+        if (-not $obj.field_id) { _err "json must contain 'field_id'" }
+        if (-not $obj.operator) { _err "json must contain 'operator' (eq|neq|gt|lt|gte|lte|like|nlike|is|isnot|empty|notempty|null|notnull)" }
+    }
+}
+
+function _validate_sort_json($json) {
+    _require_json_obj "json" $json
+    $obj = $json | ConvertFrom-Json
+    if (-not $obj.field_id) { _err "json must contain 'field_id'" }
+    if ($obj.direction -and $obj.direction -ne "asc" -and $obj.direction -ne "desc") {
+        _err "direction must be 'asc' or 'desc'"
+    }
+}
+
+function _validate_record_json($json) {
+    _require_json "json" $json
+    $obj = $json | ConvertFrom-Json
+    if ($obj -is [array]) {
+        if ($obj.Count -eq 0) { _err "json array must not be empty" }
+    }
+}
+
+function _validate_link_json($json) {
+    _require_json "json" $json
+    $obj = $json | ConvertFrom-Json
+    if ($obj -isnot [array] -or -not $obj[0].id) {
+        _err 'json must be array of objects with ''id'' field, e.g. [{"id":42}]'
+    }
+}
+
+function _validate_members_json($json) {
+    _require_json "json" $json
+    $obj = $json | ConvertFrom-Json
+    if (-not ($obj.email -or $obj.emails -or ($obj -is [array] -and $obj[0].email))) {
+        _err "json must contain email(s)"
+    }
+}
+
+###############################################################################
+# ID resolvers
+###############################################################################
+function _is_ws_id($id) { $id -match '^w[a-z0-9]+$' }
+function _is_base_id($id) { $id -match '^p[a-z0-9]+$' }
+function _is_tbl_id($id) { $id -match '^m[a-z0-9]+$' }
+function _is_view_id($id) { $id -match '^vw[a-z0-9]+$' }
+function _is_fld_id($id) { $id -match '^c[a-z0-9]+$' }
+
+function _ws($name) {
+    if (_is_ws_id $name) { _v "workspace: $name"; return $name }
+    $r = _jqf (_get "meta/workspaces").list $name
+    if ($r) { _v "workspace: $name → $r"; return $r }
+    _err "workspace not found: $name"
+}
+
+function _base($name) {
+    if (_is_base_id $name) { _v "base: $name"; return $name }
+    $wl = (_get "meta/workspaces").list
+    foreach ($w in $wl) {
+        $bl = (_get "meta/workspaces/$($w.id)/bases").list
+        $r = _jqf $bl $name
+        if ($r) { _v "base: $name → $r"; return $r }
+    }
+    _err "base not found: $name"
+}
+
+function _tbl($baseId, $name) {
+    if (_is_tbl_id $name) { _v "table: $name"; return $name }
+    $r = _jqf (_get "meta/bases/$baseId/tables").list $name
+    if ($r) { _v "table: $name → $r"; return $r }
+    _err "table not found: $name"
+}
+
+function _view($baseId, $tableId, $name) {
+    if (_is_view_id $name) { _v "view: $name"; return $name }
+    $r = _jqf (_get "meta/bases/$baseId/tables/$tableId/views").list $name
+    if ($r) { _v "view: $name → $r"; return $r }
+    _err "view not found: $name"
+}
+
+function _fld($baseId, $tableId, $name) {
+    if (_is_fld_id $name) { _v "field: $name"; return $name }
+    $lower = $name.ToLower()
+    $tbl = _get "meta/bases/$baseId/tables/$tableId"
+    $match = $tbl.fields | Where-Object { $_.title.ToLower() -eq $lower } | Select-Object -First 1
+    if ($match) { _v "field: $name → $($match.id)"; return $match.id }
+    _err "field not found: $name"
+}
+
+###############################################################################
+# Output helper
+###############################################################################
+function _json($obj) { $obj | ConvertTo-Json -Depth 20 }
+function _tsv($list, $fields) {
+    foreach ($item in $list) {
+        ($fields | ForEach-Object { $item.$_ }) -join "`t"
+    }
+}
+
+###############################################################################
+# Commands
+###############################################################################
+$cmd = $args[0]
+$a = $args[1..($args.Length)]
+
+switch ($cmd) {
+
+    #=========================================================================
+    # WORKSPACES
+    #=========================================================================
+    "workspace:list" {
+        _tsv (_get "meta/workspaces").list @("title","id")
+    }
+    "workspace:get" {
+        _require "workspace" $a[0]
+        _json (_get "meta/workspaces/$(_ws $a[0])")
+    }
+    "workspace:create" {
+        _require "json" $a[0]
+        _validate_workspace_json $a[0] "create"
+        _json (_post "meta/workspaces" $a[0])
+    }
+    "workspace:update" {
+        _require "workspace" $a[0]; _require "json" $a[1]
+        _validate_workspace_json $a[1] "update"
+        _json (_patch "meta/workspaces/$(_ws $a[0])" $a[1])
+    }
+    "workspace:delete" {
+        _require "workspace" $a[0]
+        _json (_delete "meta/workspaces/$(_ws $a[0])")
+    }
+    "workspace:members" {
+        _require "workspace" $a[0]
+        _json (_get "meta/workspaces/$(_ws $a[0])?include[]=members").members
+    }
+    "workspace:members:add" {
+        _require "workspace" $a[0]; _require "json" $a[1]
+        _validate_members_json $a[1]
+        _json (_post "meta/workspaces/$(_ws $a[0])/members" $a[1])
+    }
+    "workspace:members:update" {
+        _require "workspace" $a[0]; _require "json" $a[1]
+        _validate_members_json $a[1]
+        _json (_patch "meta/workspaces/$(_ws $a[0])/members" $a[1])
+    }
+    "workspace:members:remove" {
+        _require "workspace" $a[0]; _require "json" $a[1]
+        _validate_members_json $a[1]
+        _json (_delete "meta/workspaces/$(_ws $a[0])/members" $a[1])
+    }
+
+    #=========================================================================
+    # BASES
+    #=========================================================================
+    "base:list" {
+        _require "workspace" $a[0]
+        _tsv (_get "meta/workspaces/$(_ws $a[0])/bases").list @("title","id")
+    }
+    "base:get" {
+        _require "base" $a[0]
+        _json (_get "meta/bases/$(_base $a[0])")
+    }
+    "base:create" {
+        _require "workspace" $a[0]; _require "json" $a[1]
+        _validate_base_json $a[1] "create"
+        _json (_post "meta/workspaces/$(_ws $a[0])/bases" $a[1])
+    }
+    "base:update" {
+        _require "base" $a[0]; _require "json" $a[1]
+        _validate_base_json $a[1] "update"
+        _json (_patch "meta/bases/$(_base $a[0])" $a[1])
+    }
+    "base:delete" {
+        _require "base" $a[0]
+        _json (_delete "meta/bases/$(_base $a[0])")
+    }
+    "base:members" {
+        _require "base" $a[0]
+        _json (_get "meta/bases/$(_base $a[0])?include[]=members").members
+    }
+    "base:members:add" {
+        _require "base" $a[0]; _require "json" $a[1]
+        _validate_members_json $a[1]
+        _json (_post "meta/bases/$(_base $a[0])/members" $a[1])
+    }
+    "base:members:update" {
+        _require "base" $a[0]; _require "json" $a[1]
+        _validate_members_json $a[1]
+        _json (_patch "meta/bases/$(_base $a[0])/members" $a[1])
+    }
+    "base:members:remove" {
+        _require "base" $a[0]; _require "json" $a[1]
+        _validate_members_json $a[1]
+        _json (_delete "meta/bases/$(_base $a[0])/members" $a[1])
+    }
+
+    #=========================================================================
+    # TABLES
+    #=========================================================================
+    "table:list" {
+        _require "base" $a[0]
+        $b = _base $a[0]
+        _tsv (_get "meta/bases/$b/tables").list @("title","id")
+    }
+    "table:get" {
+        _require "base" $a[0]; _require "table" $a[1]
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        _json (_get "meta/bases/$b/tables/$t")
+    }
+    "table:create" {
+        _require "base" $a[0]; _require "json" $a[1]
+        _validate_table_json $a[1] "create"
+        _json (_post "meta/bases/$(_base $a[0])/tables" $a[1])
+    }
+    "table:update" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "json" $a[2]
+        _validate_table_json $a[2] "update"
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        _json (_patch "meta/bases/$b/tables/$t" $a[2])
+    }
+    "table:delete" {
+        _require "base" $a[0]; _require "table" $a[1]
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        _json (_delete "meta/bases/$b/tables/$t")
+    }
+
+    #=========================================================================
+    # FIELDS
+    #=========================================================================
+    "field:list" {
+        _require "base" $a[0]; _require "table" $a[1]
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        _tsv (_get "meta/bases/$b/tables/$t").fields @("title","type","id")
+    }
+    "field:get" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "field" $a[2]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $f = _fld $b $t $a[2]
+        _json (_get "meta/bases/$b/fields/$f")
+    }
+    "field:create" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "json" $a[2]
+        _validate_field_json $a[2] "create"
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        _json (_post "meta/bases/$b/tables/$t/fields" $a[2])
+    }
+    "field:update" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "field" $a[2]; _require "json" $a[3]
+        _validate_field_json $a[3] "update"
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $f = _fld $b $t $a[2]
+        _json (_patch "meta/bases/$b/fields/$f" $a[3])
+    }
+    "field:delete" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "field" $a[2]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $f = _fld $b $t $a[2]
+        _json (_delete "meta/bases/$b/fields/$f")
+    }
+
+    #=========================================================================
+    # VIEWS
+    #=========================================================================
+    "view:list" {
+        _require "base" $a[0]; _require "table" $a[1]
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        _tsv (_get "meta/bases/$b/tables/$t/views").list @("title","type","id")
+    }
+    "view:get" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "view" $a[2]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $v = _view $b $t $a[2]
+        _json (_get "meta/bases/$b/views/$v")
+    }
+    "view:create" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "json" $a[2]
+        _validate_view_json $a[2] "create"
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        _json (_post "meta/bases/$b/tables/$t/views" $a[2])
+    }
+    "view:update" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "view" $a[2]; _require "json" $a[3]
+        _validate_view_json $a[3] "update"
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $v = _view $b $t $a[2]
+        _json (_patch "meta/bases/$b/views/$v" $a[3])
+    }
+    "view:delete" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "view" $a[2]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $v = _view $b $t $a[2]
+        _json (_delete "meta/bases/$b/views/$v")
+    }
+
+    #=========================================================================
+    # VIEW FILTERS
+    #=========================================================================
+    "filter:list" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "view" $a[2]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $v = _view $b $t $a[2]
+        _json (_get "meta/bases/$b/views/$v/filters")
+    }
+    "filter:create" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "view" $a[2]; _require "json" $a[3]
+        _validate_filter_json $a[3]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $v = _view $b $t $a[2]
+        _json (_post "meta/bases/$b/views/$v/filters" $a[3])
+    }
+    "filter:replace" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "view" $a[2]; _require "json" $a[3]
+        _require_json "json" $a[3]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $v = _view $b $t $a[2]
+        _json (_put "meta/bases/$b/views/$v/filters" $a[3])
+    }
+    "filter:update" {
+        _require "base" $a[0]; _require "filterId" $a[1]; _require "json" $a[2]
+        _validate_filter_json $a[2]
+        _json (_patch "meta/bases/$(_base $a[0])/filters/$($a[1])" $a[2])
+    }
+    "filter:delete" {
+        _require "base" $a[0]; _require "filterId" $a[1]
+        _json (_delete "meta/bases/$(_base $a[0])/filters/$($a[1])")
+    }
+
+    #=========================================================================
+    # VIEW SORTS
+    #=========================================================================
+    "sort:list" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "view" $a[2]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $v = _view $b $t $a[2]
+        _json (_get "meta/bases/$b/views/$v/sorts")
+    }
+    "sort:create" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "view" $a[2]; _require "json" $a[3]
+        _validate_sort_json $a[3]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $v = _view $b $t $a[2]
+        _json (_post "meta/bases/$b/views/$v/sorts" $a[3])
+    }
+    "sort:update" {
+        _require "base" $a[0]; _require "sortId" $a[1]; _require "json" $a[2]
+        _validate_sort_json $a[2]
+        _json (_patch "meta/bases/$(_base $a[0])/sorts/$($a[1])" $a[2])
+    }
+    "sort:delete" {
+        _require "base" $a[0]; _require "sortId" $a[1]
+        _json (_delete "meta/bases/$(_base $a[0])/sorts/$($a[1])")
+    }
+
+    #=========================================================================
+    # RECORDS
+    #=========================================================================
+    "record:list" {
+        _require "base" $a[0]; _require "table" $a[1]
+        _require_int "page" $a[2]; _require_int "size" $a[3]
+        _validate_where $a[4]; _require_int "nestedPage" $a[8]
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        $pg = if ($a[2]) { $a[2] } else { "1" }
+        $sz = if ($a[3]) { $a[3] } else { "25" }
+        $wh = $a[4]; $so = $a[5]; $fl = $a[6]; $vi = $a[7]; $np = $a[8]
+        $q = "page=$pg&pageSize=$sz"
+        if ($wh) { $q += "&where=$(_enc $wh)" }
+        if ($so) { $q += "&sort=$(_enc $so)" }
+        if ($fl) { $q += "&fields=$(_enc $fl)" }
+        if ($vi) { $q += "&viewId=$vi" }
+        if ($np) { $q += "&nestedPage=$np" }
+        _json (_get "data/$b/$t/records?$q").records
+    }
+    "record:get" {
+        _require "base" $a[0]; _require "table" $a[1]; _require_nonempty "id" $a[2]
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        $q = ""; if ($a[3]) { $q = "?fields=$(_enc $a[3])" }
+        _json (_get "data/$b/$t/records/$($a[2])$q")
+    }
+    "record:create" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "json" $a[2]
+        _validate_record_json $a[2]
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        _json (_post "data/$b/$t/records" $a[2])
+    }
+    "record:update" {
+        _require "base" $a[0]; _require "table" $a[1]; _require_nonempty "id" $a[2]; _require "json" $a[3]
+        _require_json_obj "json" $a[3]
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        $body = "[{`"id`":$($a[2]),`"fields`":$($a[3])}]"
+        $result = _patch "data/$b/$t/records" $body
+        _json $result.records[0]
+    }
+    "record:update-many" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "json" $a[2]
+        _require_json_arr "json" $a[2]
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        _json (_patch "data/$b/$t/records" $a[2])
+    }
+    "record:delete" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "id" $a[2]
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        if ($a[2] -match '^\[') {
+            try {
+                $arr = $a[2] | ConvertFrom-Json
+                if ($arr[0].id) { $ids = $a[2] }
+                else { $ids = ($arr | ForEach-Object { "{`"id`":`"$_`"}" }) -join ","; $ids = "[$ids]" }
+            } catch { _err "array must contain strings or objects with 'id' field" }
+        } else {
+            _require_nonempty "id" $a[2]
+            $ids = "[{`"id`":`"$($a[2])`"}]"
+        }
+        _json (_delete "data/$b/$t/records" $ids)
+    }
+    "record:count" {
+        _require "base" $a[0]; _require "table" $a[1]
+        _validate_where $a[2]
+        $b = _base $a[0]; $t = _tbl $b $a[1]
+        $q = @()
+        if ($a[2]) { $q += "where=$(_enc $a[2])" }
+        if ($a[3]) { $q += "viewId=$($a[3])" }
+        $qs = if ($q.Count -gt 0) { "?" + ($q -join "&") } else { "" }
+        (_get "data/$b/$t/count$qs").count
+    }
+
+    #=========================================================================
+    # LINKED RECORDS
+    #=========================================================================
+    "link:list" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "linkField" $a[2]; _require_nonempty "recordId" $a[3]
+        _require_int "page" $a[4]; _require_int "size" $a[5]; _validate_where $a[6]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $f = _fld $b $t $a[2]
+        $pg = if ($a[4]) { $a[4] } else { "1" }
+        $sz = if ($a[5]) { $a[5] } else { "25" }
+        $q = "page=$pg&pageSize=$sz"
+        if ($a[6]) { $q += "&where=$(_enc $a[6])" }
+        if ($a[7]) { $q += "&sort=$(_enc $a[7])" }
+        if ($a[8]) { $q += "&fields=$(_enc $a[8])" }
+        _json (_get "data/$b/$t/links/$f/$($a[3])?$q")
+    }
+    "link:add" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "linkField" $a[2]; _require_nonempty "recordId" $a[3]; _require "json" $a[4]
+        _validate_link_json $a[4]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $f = _fld $b $t $a[2]
+        _json (_post "data/$b/$t/links/$f/$($a[3])" $a[4])
+    }
+    "link:remove" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "linkField" $a[2]; _require_nonempty "recordId" $a[3]; _require "json" $a[4]
+        _validate_link_json $a[4]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $f = _fld $b $t $a[2]
+        _json (_delete "data/$b/$t/links/$f/$($a[3])" $a[4])
+    }
+
+    #=========================================================================
+    # ATTACHMENTS
+    #=========================================================================
+    "attachment:upload" {
+        _require "base" $a[0]; _require "table" $a[1]; _require_nonempty "recordId" $a[2]; _require "field" $a[3]; _require_file $a[4]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $f = _fld $b $t $a[3]
+        _json (_upload "data/$b/$t/records/$($a[2])/fields/$f/upload" $a[4])
+    }
+
+    #=========================================================================
+    # BUTTON ACTIONS
+    #=========================================================================
+    "action:trigger" {
+        _require "base" $a[0]; _require "table" $a[1]; _require "buttonField" $a[2]; _require_nonempty "recordId" $a[3]
+        $b = _base $a[0]; $t = _tbl $b $a[1]; $f = _fld $b $t $a[2]
+        _json (_post "data/$b/$t/actions/$f" "{`"recordId`":`"$($a[3])`"}")
+    }
+
+    #=========================================================================
+    # SCRIPTS
+    #=========================================================================
+    "script:list" {
+        _require "base" $a[0]
+        _tsv (_get "meta/bases/$(_base $a[0])/scripts").list @("title","id")
+    }
+    "script:get" {
+        _require "base" $a[0]; _require "scriptId" $a[1]
+        _json (_get "meta/bases/$(_base $a[0])/scripts/$($a[1])")
+    }
+    "script:create" {
+        _require "base" $a[0]; _require "json" $a[1]
+        _require_json_obj "json" $a[1]
+        $obj = $a[1] | ConvertFrom-Json
+        if (-not $obj.title) { _err "json must contain 'title' field" }
+        _json (_post "meta/bases/$(_base $a[0])/scripts" $a[1])
+    }
+    "script:update" {
+        _require "base" $a[0]; _require "scriptId" $a[1]; _require "json" $a[2]
+        _require_json_obj "json" $a[2]
+        _json (_patch "meta/bases/$(_base $a[0])/scripts/$($a[1])" $a[2])
+    }
+    "script:delete" {
+        _require "base" $a[0]; _require "scriptId" $a[1]
+        _json (_delete "meta/bases/$(_base $a[0])/scripts/$($a[1])")
+    }
+
+    #=========================================================================
+    # TEAMS
+    #=========================================================================
+    "team:list" {
+        _require "workspace" $a[0]
+        _tsv (_get "meta/workspaces/$(_ws $a[0])/teams").list @("title","id")
+    }
+    "team:get" {
+        _require "workspace" $a[0]; _require "teamId" $a[1]
+        _json (_get "meta/workspaces/$(_ws $a[0])/teams/$($a[1])")
+    }
+    "team:create" {
+        _require "workspace" $a[0]; _require "json" $a[1]
+        _require_json_obj "json" $a[1]
+        $obj = $a[1] | ConvertFrom-Json
+        if (-not $obj.title) { _err "json must contain 'title' field" }
+        _json (_post "meta/workspaces/$(_ws $a[0])/teams" $a[1])
+    }
+    "team:update" {
+        _require "workspace" $a[0]; _require "teamId" $a[1]; _require "json" $a[2]
+        _require_json_obj "json" $a[2]
+        _json (_patch "meta/workspaces/$(_ws $a[0])/teams/$($a[1])" $a[2])
+    }
+    "team:delete" {
+        _require "workspace" $a[0]; _require "teamId" $a[1]
+        _json (_delete "meta/workspaces/$(_ws $a[0])/teams/$($a[1])")
+    }
+    "team:members:add" {
+        _require "workspace" $a[0]; _require "teamId" $a[1]; _require "json" $a[2]
+        _validate_members_json $a[2]
+        _json (_post "meta/workspaces/$(_ws $a[0])/teams/$($a[1])/members" $a[2])
+    }
+    "team:members:update" {
+        _require "workspace" $a[0]; _require "teamId" $a[1]; _require "json" $a[2]
+        _require_json "json" $a[2]
+        _json (_patch "meta/workspaces/$(_ws $a[0])/teams/$($a[1])/members" $a[2])
+    }
+    "team:members:remove" {
+        _require "workspace" $a[0]; _require "teamId" $a[1]; _require "json" $a[2]
+        _require_json "json" $a[2]
+        _json (_delete "meta/workspaces/$(_ws $a[0])/teams/$($a[1])/members" $a[2])
+    }
+
+    #=========================================================================
+    # API TOKENS
+    #=========================================================================
+    "token:list" {
+        _tsv (_get "meta/tokens").list @("title","id")
+    }
+    "token:create" {
+        _require "json" $a[0]
+        _require_json_obj "json" $a[0]
+        $obj = $a[0] | ConvertFrom-Json
+        if (-not $obj.title) { _err "json must contain 'title' field" }
+        _json (_post "meta/tokens" $a[0])
+    }
+    "token:delete" {
+        _require "tokenId" $a[0]
+        _json (_delete "meta/tokens/$($a[0])")
+    }
+
+    #=========================================================================
+    # WHERE FILTER HELP
+    #=========================================================================
+    { $_ -eq "where:help" -or $_ -eq "filter:help" } {
+        @"
+WHERE FILTER SYNTAX
+===================
+
+BASIC SYNTAX:
+  (field,operator,value)           Basic filter
+  (field,operator)                 No-value operators (blank, null, checked, etc.)
+  (field,op,sub_op)                Date with sub-operator
+  (field,op,sub_op,value)          Date with sub-operator and value
+  (field,operator,val1,val2,val3)  Multiple values
+
+OPERATORS:
+
+  Text/General:
+    eq        Equal to                    (name,eq,John)
+    neq       Not equal to                (status,neq,archived)
+    like      Contains (use % wildcard)   (name,like,%john%)
+    nlike     Does not contain            (name,nlike,%test%)
+    in        In list of values           (status,in,active,pending,review)
+
+  Numeric:
+    gt        Greater than (>)            (price,gt,100)
+    lt        Less than (<)               (stock,lt,10)
+    gte       Greater than or equal (>=)  (rating,gte,4)
+    lte       Less than or equal (<=)     (age,lte,65)
+
+  Range:
+    btw       Between (inclusive)         (price,btw,10,100)
+    nbtw      Not between                 (score,nbtw,0,50)
+
+  Null/Empty (no value needed):
+    blank     Is blank (null or empty)    (notes,blank)
+    notblank  Is not blank                (email,notblank)
+    null      Is null                     (deleted_at,null)
+    notnull   Is not null                 (created_by,notnull)
+    empty     Is empty string             (description,empty)
+    notempty  Is not empty string         (title,notempty)
+
+  Boolean/Checkbox (no value needed):
+    checked      Is checked/true          (is_active,checked)
+    notchecked   Is not checked/false     (is_archived,notchecked)
+
+  Multi-Select/Tags:
+    allof     Contains all of             (tags,allof,urgent,important)
+    anyof     Contains any of             (tags,anyof,bug,feature)
+    nallof    Does not contain all of     (tags,nallof,spam,junk)
+    nanyof    Does not contain any of     (categories,nanyof,draft,deleted)
+
+DATE/TIME FILTERING:
+
+  isWithin - Date falls within time range:
+    Sub-ops (no value): pastWeek, pastMonth, pastYear, nextWeek, nextMonth, nextYear
+    Sub-ops (with days): pastNumberOfDays, nextNumberOfDays
+    Examples:
+      (created_at,isWithin,pastWeek)
+      (due_date,isWithin,pastNumberOfDays,14)
+
+  eq, neq, gt, lt, gte, lte - Date comparisons:
+    Sub-ops (no value): today, tomorrow, yesterday, oneWeekAgo, oneWeekFromNow
+    Sub-ops (with days): daysAgo, daysFromNow
+    Sub-op (with YYYY-MM-DD): exactDate
+    Examples:
+      (created_at,eq,today)
+      (due_date,lt,today)                      # Overdue
+      (event_date,eq,exactDate,2024-06-15)
+      (created_at,gte,daysAgo,7)
+
+  btw - Date range:
+      (event_date,btw,2024-01-01,2024-12-31)
+
+LOGICAL OPERATIONS:
+
+  IMPORTANT: Use ~and, ~or, ~not (with tilde prefix)
+
+  AND: (filter1)~and(filter2)
+  OR:  (filter1)~or(filter2)
+  NOT: ~not(filter)
+
+  Examples:
+    (name,eq,John)~and(age,gte,18)
+    (status,eq,active)~or(status,eq,pending)
+    ~not(is_deleted,checked)
+    (status,in,active,pending)~and(country,eq,USA)
+
+SPECIAL VALUES:
+  NULL value:         (field,eq,null)
+  Empty string:       (field,eq,'') or (field,eq,"")
+  Value with comma:   (field,eq,"hello, world")
+  Value with quotes:  (field,eq,"it's here")
+
+COMPLEX EXAMPLES:
+  Active users this month:
+    (status,eq,active)~and(created_at,isWithin,pastMonth)
+
+  Overdue high-priority:
+    (due_date,lt,today)~and(priority,eq,high)~and(completed,notchecked)
+
+  Orders `$100-`$500 pending:
+    (amount,gte,100)~and(amount,lte,500)~and(status,in,pending,processing)
+
+  Updated recently, not archived:
+    (updated_at,isWithin,pastNumberOfDays,14)~and~not(is_archived,checked)
+"@
+    }
+
+    #=========================================================================
+    # HELP
+    #=========================================================================
+    default {
+        @"
+nocodb.ps1 - NocoDB v3 CLI (PowerShell)
+
+ARGUMENT ORDER: Commands follow a hierarchical pattern:
+  workspace -> base -> table -> view/field -> record
+
+  Most commands accept NAMES or IDs. Use IDs directly for faster execution.
+  Set `$env:NOCODB_VERBOSE=1 to see resolved IDs.
+
+WORKSPACES  (Enterprise plans only: self-hosted or cloud-hosted)
+  workspace:list
+  workspace:get        WORKSPACE
+  workspace:create     JSON
+  workspace:update     WORKSPACE  JSON
+  workspace:delete     WORKSPACE
+
+WORKSPACE COLLABORATION  (self-hosted Enterprise only)
+  workspace:members    WORKSPACE
+  workspace:members:add/update/remove  WORKSPACE  JSON
+
+BASES
+  base:list    WORKSPACE
+  base:get     BASE
+  base:create  WORKSPACE  JSON
+  base:update  BASE  JSON
+  base:delete  BASE
+
+BASE COLLABORATION  (Enterprise only: self-hosted or cloud-hosted)
+  base:members BASE
+  base:members:add/update/remove  BASE  JSON
+
+TABLES
+  table:list    BASE
+  table:get     BASE  TABLE
+  table:create  BASE  JSON
+  table:update  BASE  TABLE  JSON
+  table:delete  BASE  TABLE
+
+FIELDS
+  field:list    BASE  TABLE
+  field:get     BASE  TABLE  FIELD
+  field:create  BASE  TABLE  JSON
+  field:update  BASE  TABLE  FIELD  JSON
+  field:delete  BASE  TABLE  FIELD
+
+VIEWS  (Enterprise only: self-hosted or cloud-hosted)
+  view:list    BASE  TABLE
+  view:get     BASE  TABLE  VIEW
+  view:create  BASE  TABLE  JSON
+  view:update  BASE  TABLE  VIEW  JSON
+  view:delete  BASE  TABLE  VIEW
+
+FILTERS
+  filter:list     BASE  TABLE  VIEW
+  filter:create   BASE  TABLE  VIEW  JSON
+  filter:replace  BASE  TABLE  VIEW  JSON
+  filter:update   BASE  FILTER_ID  JSON
+  filter:delete   BASE  FILTER_ID
+
+SORTS
+  sort:list    BASE  TABLE  VIEW
+  sort:create  BASE  TABLE  VIEW  JSON
+  sort:update  BASE  SORT_ID  JSON
+  sort:delete  BASE  SORT_ID
+
+RECORDS
+  record:list        BASE  TABLE  [PAGE] [SIZE] [WHERE] [SORT] [FIELDS] [VIEW_ID] [NESTED_PAGE]
+  record:get         BASE  TABLE  RECORD_ID  [FIELDS]
+  record:create      BASE  TABLE  JSON
+  record:update      BASE  TABLE  RECORD_ID  JSON
+  record:update-many BASE  TABLE  JSON_ARRAY
+  record:delete      BASE  TABLE  RECORD_ID_OR_ARRAY
+  record:count       BASE  TABLE  [WHERE] [VIEW_ID]
+
+LINKED RECORDS
+  link:list    BASE  TABLE  LINK_FIELD  RECORD_ID  [PAGE] [SIZE] [WHERE] [SORT] [FIELDS]
+  link:add     BASE  TABLE  LINK_FIELD  RECORD_ID  JSON_ARRAY
+  link:remove  BASE  TABLE  LINK_FIELD  RECORD_ID  JSON_ARRAY
+
+ATTACHMENTS
+  attachment:upload  BASE  TABLE  RECORD_ID  FIELD  FILEPATH
+
+BUTTON ACTIONS
+  action:trigger  BASE  TABLE  BUTTON_FIELD  RECORD_ID
+
+SCRIPTS  (Enterprise only: self-hosted or cloud-hosted)
+  script:list    BASE
+  script:get     BASE  SCRIPT_ID
+  script:create  BASE  JSON
+  script:update  BASE  SCRIPT_ID  JSON
+  script:delete  BASE  SCRIPT_ID
+
+TEAMS  (Enterprise only: self-hosted or cloud-hosted)
+  team:list    WORKSPACE
+  team:get     WORKSPACE  TEAM_ID
+  team:create  WORKSPACE  JSON
+  team:update  WORKSPACE  TEAM_ID  JSON
+  team:delete  WORKSPACE  TEAM_ID
+  team:members:add/update/remove  WORKSPACE  TEAM_ID  JSON
+
+API TOKENS  (Enterprise only: self-hosted or cloud-hosted)
+  token:list
+  token:create  JSON
+  token:delete  TOKEN_ID
+
+WHERE HELP
+  where:help    Show where filter syntax and operators
+
+ENVIRONMENT
+  `$env:NOCODB_URL      Base URL (default: https://app.nocodb.com)
+  `$env:NOCODB_TOKEN    API token (required)
+  `$env:NOCODB_VERBOSE  Set to 1 to show resolved IDs
+
+EXAMPLES
+  # IDs: w=workspace, p=base, m=table, c=column, vw=view (all lowercase alphanumeric)
+
+  # List workspaces, bases, tables (use IDs from output)
+  .\nocodb.ps1 workspace:list                                   # -> wabc1234xyz
+  .\nocodb.ps1 base:list wabc1234xyz                            # -> pdef5678uvw
+  .\nocodb.ps1 table:list pdef5678uvw                           # -> mghi9012rst
+  .\nocodb.ps1 field:list pdef5678uvw mghi9012rst               # -> cjkl3456opq
+  .\nocodb.ps1 view:list pdef5678uvw mghi9012rst                # -> vwmno7890abc
+
+  # Records (BASE_ID TABLE_ID ...)
+  .\nocodb.ps1 record:list pdef5678uvw mghi9012rst 1 50 "(Status,eq,active)"
+  .\nocodb.ps1 record:get pdef5678uvw mghi9012rst 31
+  .\nocodb.ps1 record:create pdef5678uvw mghi9012rst '{"fields":{"Name":"Alice"}}'
+  .\nocodb.ps1 record:update pdef5678uvw mghi9012rst 31 '{"Status":"done"}'
+  .\nocodb.ps1 record:delete pdef5678uvw mghi9012rst 31
+
+  # Names also work (resolved to IDs automatically)
+  .\nocodb.ps1 record:list MyBase Users
+  `$env:NOCODB_VERBOSE="1"; .\nocodb.ps1 field:list MyBase Users   # shows resolved IDs
+"@
+    }
+}

--- a/optional-skills/productivity/nocodb/scripts/nocodb.sh
+++ b/optional-skills/productivity/nocodb/scripts/nocodb.sh
@@ -1,0 +1,958 @@
+#!/usr/bin/env bash
+###############################################################################
+# nocodb.sh - NocoDB v3 CLI
+#
+# Vendored verbatim from https://github.com/nocodb/agent-skills (MIT).
+# Fixes belong upstream first; re-vendor rather than patching in place.
+###############################################################################
+set -euo pipefail
+
+NC_URL="${NOCODB_URL:-https://app.nocodb.com}"
+NC_TOKEN="${NOCODB_TOKEN:-}"
+NC_VERBOSE="${NOCODB_VERBOSE:-0}"
+
+[[ -z "$NC_TOKEN" ]] && { echo "NOCODB_TOKEN required" >&2; exit 1; }
+
+# Verbose helper - shows resolved IDs
+_v() { [[ "$NC_VERBOSE" == "1" ]] && echo "→ $*" >&2 || true; }
+
+###############################################################################
+# HTTP helpers
+###############################################################################
+_get()    { curl -sS -H "xc-token: $NC_TOKEN" "$NC_URL/api/v3/$1"; }
+_post()   { curl -sS -X POST -H "xc-token: $NC_TOKEN" -H "Content-Type: application/json" "$NC_URL/api/v3/$1" -d "${2:-}"; }
+_patch()  { curl -sS -X PATCH -H "xc-token: $NC_TOKEN" -H "Content-Type: application/json" "$NC_URL/api/v3/$1" -d "${2:-}"; }
+_put()    { curl -sS -X PUT -H "xc-token: $NC_TOKEN" -H "Content-Type: application/json" "$NC_URL/api/v3/$1" -d "${2:-}"; }
+_delete() { curl -sS -X DELETE -H "xc-token: $NC_TOKEN" -H "Content-Type: application/json" "$NC_URL/api/v3/$1" ${2:+-d "$2"}; }
+_upload() { curl -sS -X POST -H "xc-token: $NC_TOKEN" -F "file=@$2" "$NC_URL/api/v3/$1"; }
+
+_enc() {
+    local s="$1" o="" c
+    for ((i=0; i<${#s}; i++)); do c="${s:i:1}"; [[ "$c" =~ [a-zA-Z0-9._~-] ]] && o+="$c" || o+=$(printf '%%%02X' "'$c"); done
+    echo "$o"
+}
+
+_jqf() { jq -r --arg n "$2" '.[]|select(.title|ascii_downcase==($n|ascii_downcase))|.id' <<< "$1" | head -1; }
+
+###############################################################################
+# Validation helpers
+###############################################################################
+_err() { echo "error: $1" >&2; exit 1; }
+
+_require() {
+    local name="$1" val="${2:-}"
+    [[ -z "$val" ]] && _err "$name is required"
+    return 0
+}
+
+_require_json() {
+    local name="$1" val="$2"
+    [[ -z "$val" ]] && _err "$name is required"
+    echo "$val" | jq . >/dev/null 2>&1 || _err "$name must be valid JSON"
+}
+
+_require_json_obj() {
+    local name="$1" val="$2"
+    [[ -z "$val" ]] && _err "$name is required"
+    echo "$val" | jq -e 'type == "object"' >/dev/null 2>&1 || _err "$name must be a JSON object"
+}
+
+_require_json_arr() {
+    local name="$1" val="$2"
+    [[ -z "$val" ]] && _err "$name is required"
+    echo "$val" | jq -e 'type == "array"' >/dev/null 2>&1 || _err "$name must be a JSON array"
+}
+
+_require_int() {
+    local name="$1" val="$2"
+    [[ -z "$val" ]] && return 0
+    [[ "$val" =~ ^[0-9]+$ ]] || _err "$name must be a positive integer"
+    return 0
+}
+
+_require_nonempty() {
+    local name="$1" val="$2"
+    [[ -z "$val" ]] && _err "$name is required and cannot be empty"
+    return 0
+}
+
+_require_file() {
+    local path="$1"
+    [[ -z "$path" ]] && _err "file path is required"
+    [[ -f "$path" ]] || _err "file not found: $path"
+    [[ -r "$path" ]] || _err "file not readable: $path"
+    return 0
+}
+
+_validate_where() {
+    local val="$1"
+    [[ -z "$val" ]] && return 0
+    # Basic format check - should start with ( or ~not(
+    if [[ ! "$val" =~ ^\(.*\)$ ]] && [[ ! "$val" =~ ^~not\( ]]; then
+        echo "warning: where clause should be in format (field,op,value)" >&2
+        echo "  Examples: (name,eq,John) (status,in,active,pending) (age,gte,18)" >&2
+        echo "  Combine:  (field1,eq,x)~and(field2,eq,y)  or  (f1,eq,x)~or(f2,eq,y)" >&2
+    fi
+    # Check for common mistakes
+    if [[ "$val" =~ \)and\( ]] || [[ "$val" =~ \)or\( ]]; then
+        _err "use ~and and ~or (with tilde), not plain 'and'/'or'. Example: (a,eq,1)~and(b,eq,2)"
+    fi
+}
+
+# Field-specific validators for JSON payloads
+_validate_workspace_json() {
+    local json="$1" op="$2"
+    _require_json_obj "json" "$json"
+    if [[ "$op" == "create" ]]; then
+        echo "$json" | jq -e '.title' >/dev/null 2>&1 || _err "json must contain 'title' field"
+    fi
+}
+
+_validate_base_json() {
+    local json="$1" op="$2"
+    _require_json_obj "json" "$json"
+    if [[ "$op" == "create" ]]; then
+        echo "$json" | jq -e '.title' >/dev/null 2>&1 || _err "json must contain 'title' field"
+    fi
+}
+
+_validate_table_json() {
+    local json="$1" op="$2"
+    _require_json_obj "json" "$json"
+    if [[ "$op" == "create" ]]; then
+        echo "$json" | jq -e '.title' >/dev/null 2>&1 || _err "json must contain 'title' field"
+    fi
+}
+
+_validate_field_json() {
+    local json="$1" op="$2"
+    _require_json_obj "json" "$json"
+    if [[ "$op" == "create" ]]; then
+        echo "$json" | jq -e '.title' >/dev/null 2>&1 || _err "json must contain 'title' field"
+        echo "$json" | jq -e '.type' >/dev/null 2>&1 || _err "json must contain 'type' field"
+    fi
+}
+
+_validate_view_json() {
+    local json="$1" op="$2"
+    _require_json_obj "json" "$json"
+    if [[ "$op" == "create" ]]; then
+        echo "$json" | jq -e '.title' >/dev/null 2>&1 || _err "json must contain 'title' field"
+        echo "$json" | jq -e '.type' >/dev/null 2>&1 || _err "json must contain 'type' field (grid, gallery, form, kanban, calendar)"
+    fi
+}
+
+_validate_filter_json() {
+    local json="$1"
+    _require_json_obj "json" "$json"
+    # Either a simple filter with field_id+operator, or a group with group_operator+filters
+    if ! echo "$json" | jq -e '.group_operator' >/dev/null 2>&1; then
+        echo "$json" | jq -e '.field_id' >/dev/null 2>&1 || _err "json must contain 'field_id'"
+        echo "$json" | jq -e '.operator' >/dev/null 2>&1 || _err "json must contain 'operator' (eq|neq|gt|lt|gte|lte|like|nlike|is|isnot|empty|notempty|null|notnull)"
+    fi
+}
+
+_validate_sort_json() {
+    local json="$1"
+    _require_json_obj "json" "$json"
+    echo "$json" | jq -e '.field_id' >/dev/null 2>&1 || _err "json must contain 'field_id'"
+    # direction is optional, defaults to 'asc'
+    if echo "$json" | jq -e '.direction' >/dev/null 2>&1; then
+        local dir; dir=$(echo "$json" | jq -r '.direction')
+        [[ "$dir" == "asc" || "$dir" == "desc" ]] || _err "direction must be 'asc' or 'desc'"
+    fi
+}
+
+_validate_record_json() {
+    local json="$1"
+    _require_json "json" "$json"
+    # Can be object with fields, or array of objects with fields
+    if echo "$json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        echo "$json" | jq -e '.fields // keys[0]' >/dev/null 2>&1 || _err "json object must contain field data"
+    elif echo "$json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        echo "$json" | jq -e '.[0]' >/dev/null 2>&1 || _err "json array must not be empty"
+    fi
+}
+
+_validate_link_json() {
+    local json="$1"
+    _require_json "json" "$json"
+    # Must be array of objects with id field: [{"id": ...}]
+    if ! echo "$json" | jq -e 'type == "array" and .[0].id' >/dev/null 2>&1; then
+        _err "json must be array of objects with 'id' field, e.g. [{\"id\":42}]"
+    fi
+}
+
+_validate_members_json() {
+    local json="$1"
+    _require_json "json" "$json"
+    echo "$json" | jq -e '.email // .emails // .[0].email' >/dev/null 2>&1 || _err "json must contain email(s)"
+}
+
+###############################################################################
+# ID resolvers (with verbose output)
+# NocoDB IDs: prefix + nanoid (lowercase alphanumeric 0-9a-z)
+###############################################################################
+_is_ws_id()   { [[ "$1" =~ ^w[a-z0-9]+$ ]]; }
+_is_base_id() { [[ "$1" =~ ^p[a-z0-9]+$ ]]; }
+_is_tbl_id()  { [[ "$1" =~ ^m[a-z0-9]+$ ]]; }
+_is_view_id() { [[ "$1" =~ ^vw[a-z0-9]+$ ]]; }
+_is_fld_id()  { [[ "$1" =~ ^c[a-z0-9]+$ ]]; }
+
+_ws() {
+    if _is_ws_id "$1"; then
+        _v "workspace: $1"; echo "$1"; return
+    fi
+    local r; r=$(_jqf "$(_get meta/workspaces | jq -c .list)" "$1")
+    [[ -n "$r" ]] && { _v "workspace: $1 → $r"; echo "$r"; } || { echo "workspace not found: $1" >&2; exit 1; }
+}
+
+_base() {
+    if _is_base_id "$1"; then
+        _v "base: $1"; echo "$1"; return
+    fi
+    local wl bl r; wl=$(_get meta/workspaces | jq -c .list)
+    for w in $(jq -r '.[].id' <<< "$wl"); do
+        bl=$(_get "meta/workspaces/$w/bases" | jq -c .list)
+        r=$(_jqf "$bl" "$1"); [[ -n "$r" ]] && { _v "base: $1 → $r"; echo "$r"; return; }
+    done
+    echo "base not found: $1" >&2; exit 1
+}
+
+_tbl() {
+    if _is_tbl_id "$2"; then
+        _v "table: $2"; echo "$2"; return
+    fi
+    local r; r=$(_jqf "$(_get "meta/bases/$1/tables" | jq -c .list)" "$2")
+    [[ -n "$r" ]] && { _v "table: $2 → $r"; echo "$r"; } || { echo "table not found: $2" >&2; exit 1; }
+}
+
+_view() {
+    if _is_view_id "$3"; then
+        _v "view: $3"; echo "$3"; return
+    fi
+    local r; r=$(_jqf "$(_get "meta/bases/$1/tables/$2/views" | jq -c .list)" "$3")
+    [[ -n "$r" ]] && { _v "view: $3 → $r"; echo "$r"; } || { echo "view not found: $3" >&2; exit 1; }
+}
+
+_fld() {
+    if _is_fld_id "$3"; then
+        _v "field: $3"; echo "$3"; return
+    fi
+    local r; r=$(_get "meta/bases/$1/tables/$2" | jq -r --arg n "$3" '.fields[]|select(.title|ascii_downcase==($n|ascii_downcase))|.id' | head -1)
+    [[ -n "$r" ]] && { _v "field: $3 → $r"; echo "$r"; } || { echo "field not found: $3" >&2; exit 1; }
+}
+
+###############################################################################
+# Commands
+###############################################################################
+cmd=$1; shift || true
+
+case "$cmd" in
+
+#=============================================================================
+# WORKSPACES
+#=============================================================================
+workspace:list)
+    _get meta/workspaces | jq -r '.list[]|[.title,.id]|@tsv'
+    ;;
+workspace:get)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh workspace:get <workspace>" >&2; exit 1; }
+    _get "meta/workspaces/$(_ws "$1")" | jq .
+    ;;
+workspace:create)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh workspace:create '<json>'" >&2; exit 1; }
+    _validate_workspace_json "$1" "create"
+    _post meta/workspaces "$1" | jq .
+    ;;
+workspace:update)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh workspace:update <workspace> '<json>'" >&2; exit 1; }
+    _validate_workspace_json "$2" "update"
+    _patch "meta/workspaces/$(_ws "$1")" "$2" | jq .
+    ;;
+workspace:delete)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh workspace:delete <workspace>" >&2; exit 1; }
+    _delete "meta/workspaces/$(_ws "$1")" | jq .
+    ;;
+workspace:members)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh workspace:members <workspace>" >&2; exit 1; }
+    _get "meta/workspaces/$(_ws "$1")?include[]=members" | jq .members
+    ;;
+workspace:members:add)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh workspace:members:add <workspace> '<json>'" >&2; exit 1; }
+    _validate_members_json "$2"
+    _post "meta/workspaces/$(_ws "$1")/members" "$2" | jq .
+    ;;
+workspace:members:update)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh workspace:members:update <workspace> '<json>'" >&2; exit 1; }
+    _validate_members_json "$2"
+    _patch "meta/workspaces/$(_ws "$1")/members" "$2" | jq .
+    ;;
+workspace:members:remove)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh workspace:members:remove <workspace> '<json>'" >&2; exit 1; }
+    _validate_members_json "$2"
+    _delete "meta/workspaces/$(_ws "$1")/members" "$2" | jq .
+    ;;
+
+#=============================================================================
+# BASES
+#=============================================================================
+base:list)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh base:list <workspace>" >&2; exit 1; }
+    _get "meta/workspaces/$(_ws "$1")/bases" | jq -r '.list[]|[.title,.id]|@tsv'
+    ;;
+base:get)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh base:get <base>" >&2; exit 1; }
+    _get "meta/bases/$(_base "$1")" | jq .
+    ;;
+base:create)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh base:create <workspace> '<json>'" >&2; exit 1; }
+    _validate_base_json "$2" "create"
+    _post "meta/workspaces/$(_ws "$1")/bases" "$2" | jq .
+    ;;
+base:update)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh base:update <base> '<json>'" >&2; exit 1; }
+    _validate_base_json "$2" "update"
+    _patch "meta/bases/$(_base "$1")" "$2" | jq .
+    ;;
+base:delete)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh base:delete <base>" >&2; exit 1; }
+    _delete "meta/bases/$(_base "$1")" | jq .
+    ;;
+base:members)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh base:members <base>" >&2; exit 1; }
+    _get "meta/bases/$(_base "$1")?include[]=members" | jq .members
+    ;;
+base:members:add)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh base:members:add <base> '<json>'" >&2; exit 1; }
+    _validate_members_json "$2"
+    _post "meta/bases/$(_base "$1")/members" "$2" | jq .
+    ;;
+base:members:update)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh base:members:update <base> '<json>'" >&2; exit 1; }
+    _validate_members_json "$2"
+    _patch "meta/bases/$(_base "$1")/members" "$2" | jq .
+    ;;
+base:members:remove)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh base:members:remove <base> '<json>'" >&2; exit 1; }
+    _validate_members_json "$2"
+    _delete "meta/bases/$(_base "$1")/members" "$2" | jq .
+    ;;
+
+#=============================================================================
+# TABLES
+#=============================================================================
+table:list)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh table:list <base>" >&2; exit 1; }
+    b=$(_base "$1")
+    _get "meta/bases/$b/tables" | jq -r '.list[]|[.title,.id]|@tsv'
+    ;;
+table:get)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh table:get <base> <table>" >&2; exit 1; }
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    _get "meta/bases/$b/tables/$t" | jq .
+    ;;
+table:create)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh table:create <base> '<json>'" >&2; exit 1; }
+    _validate_table_json "$2" "create"
+    _post "meta/bases/$(_base "$1")/tables" "$2" | jq .
+    ;;
+table:update)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh table:update <base> <table> '<json>'" >&2; exit 1; }
+    _validate_table_json "$3" "update"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    _patch "meta/bases/$b/tables/$t" "$3" | jq .
+    ;;
+table:delete)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh table:delete <base> <table>" >&2; exit 1; }
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    _delete "meta/bases/$b/tables/$t" | jq .
+    ;;
+
+#=============================================================================
+# FIELDS
+#=============================================================================
+field:list)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh field:list <base> <table>" >&2; exit 1; }
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    _get "meta/bases/$b/tables/$t" | jq -r '.fields[]|[.title,.type,.id]|@tsv'
+    ;;
+field:get)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh field:get <base> <table> <field>" >&2; exit 1; }
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); f=$(_fld "$b" "$t" "$3")
+    _get "meta/bases/$b/fields/$f" | jq .
+    ;;
+field:create)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh field:create <base> <table> '<json>'" >&2; exit 1; }
+    _validate_field_json "$3" "create"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    _post "meta/bases/$b/tables/$t/fields" "$3" | jq .
+    ;;
+field:update)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" || -z "${4:-}" ]] && { echo "usage: nocodb.sh field:update <base> <table> <field> '<json>'" >&2; exit 1; }
+    _validate_field_json "$4" "update"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); f=$(_fld "$b" "$t" "$3")
+    _patch "meta/bases/$b/fields/$f" "$4" | jq .
+    ;;
+field:delete)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh field:delete <base> <table> <field>" >&2; exit 1; }
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); f=$(_fld "$b" "$t" "$3")
+    _delete "meta/bases/$b/fields/$f" | jq .
+    ;;
+
+#=============================================================================
+# VIEWS
+#=============================================================================
+view:list)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh view:list <base> <table>" >&2; exit 1; }
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    _get "meta/bases/$b/tables/$t/views" | jq -r '.list[]|[.title,.type,.id]|@tsv'
+    ;;
+view:get)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh view:get <base> <table> <view>" >&2; exit 1; }
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); v=$(_view "$b" "$t" "$3")
+    _get "meta/bases/$b/views/$v" | jq .
+    ;;
+view:create)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh view:create <base> <table> '<json>'" >&2; exit 1; }
+    _validate_view_json "$3" "create"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    _post "meta/bases/$b/tables/$t/views" "$3" | jq .
+    ;;
+view:update)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" || -z "${4:-}" ]] && { echo "usage: nocodb.sh view:update <base> <table> <view> '<json>'" >&2; exit 1; }
+    _validate_view_json "$4" "update"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); v=$(_view "$b" "$t" "$3")
+    _patch "meta/bases/$b/views/$v" "$4" | jq .
+    ;;
+view:delete)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh view:delete <base> <table> <view>" >&2; exit 1; }
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); v=$(_view "$b" "$t" "$3")
+    _delete "meta/bases/$b/views/$v" | jq .
+    ;;
+
+#=============================================================================
+# VIEW FILTERS
+#=============================================================================
+filter:list)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh filter:list <base> <table> <view>" >&2; exit 1; }
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); v=$(_view "$b" "$t" "$3")
+    _get "meta/bases/$b/views/$v/filters" | jq .
+    ;;
+filter:create)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" || -z "${4:-}" ]] && { echo "usage: nocodb.sh filter:create <base> <table> <view> '<json>'" >&2; exit 1; }
+    _validate_filter_json "$4"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); v=$(_view "$b" "$t" "$3")
+    _post "meta/bases/$b/views/$v/filters" "$4" | jq .
+    ;;
+filter:replace)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" || -z "${4:-}" ]] && { echo "usage: nocodb.sh filter:replace <base> <table> <view> '<json>'" >&2; exit 1; }
+    _require_json "json" "$4"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); v=$(_view "$b" "$t" "$3")
+    _put "meta/bases/$b/views/$v/filters" "$4" | jq .
+    ;;
+filter:update)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh filter:update <base> <filterId> '<json>'" >&2; exit 1; }
+    _validate_filter_json "$3"
+    _patch "meta/bases/$(_base "$1")/filters/$2" "$3" | jq .
+    ;;
+filter:delete)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh filter:delete <base> <filterId>" >&2; exit 1; }
+    _delete "meta/bases/$(_base "$1")/filters/$2" | jq .
+    ;;
+
+#=============================================================================
+# VIEW SORTS
+#=============================================================================
+sort:list)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh sort:list <base> <table> <view>" >&2; exit 1; }
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); v=$(_view "$b" "$t" "$3")
+    _get "meta/bases/$b/views/$v/sorts" | jq .
+    ;;
+sort:create)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" || -z "${4:-}" ]] && { echo "usage: nocodb.sh sort:create <base> <table> <view> '<json>'" >&2; exit 1; }
+    _validate_sort_json "$4"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); v=$(_view "$b" "$t" "$3")
+    _post "meta/bases/$b/views/$v/sorts" "$4" | jq .
+    ;;
+sort:update)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh sort:update <base> <sortId> '<json>'" >&2; exit 1; }
+    _validate_sort_json "$3"
+    _patch "meta/bases/$(_base "$1")/sorts/$2" "$3" | jq .
+    ;;
+sort:delete)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh sort:delete <base> <sortId>" >&2; exit 1; }
+    _delete "meta/bases/$(_base "$1")/sorts/$2" | jq .
+    ;;
+
+#=============================================================================
+# RECORDS
+#=============================================================================
+record:list)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh record:list <base> <table> [page] [size] [where] [sort] [fields] [viewId] [nestedPage]" >&2; exit 1; }
+    _require_int "page" "${3:-}"
+    _require_int "size" "${4:-}"
+    _validate_where "${5:-}"
+    _require_int "nestedPage" "${9:-}"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    pg="${3:-1}"; sz="${4:-25}"; wh="${5:-}"; so="${6:-}"; fl="${7:-}"; vi="${8:-}"; np="${9:-}"
+    q="page=$pg&pageSize=$sz"
+    [[ -n "$wh" ]] && q+="&where=$(_enc "$wh")"
+    [[ -n "$so" ]] && q+="&sort=$(_enc "$so")"
+    [[ -n "$fl" ]] && q+="&fields=$(_enc "$fl")"
+    [[ -n "$vi" ]] && q+="&viewId=$vi"
+    [[ -n "$np" ]] && q+="&nestedPage=$np"
+    _get "data/$b/$t/records?$q" | jq .records
+    ;;
+record:get)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh record:get <base> <table> <id> [fields]" >&2; exit 1; }
+    _require_nonempty "id" "$3"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    q=""; [[ -n "${4:-}" ]] && q="?fields=$(_enc "$4")"
+    _get "data/$b/$t/records/$3$q" | jq .
+    ;;
+record:create)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh record:create <base> <table> '<json>'" >&2; exit 1; }
+    _validate_record_json "$3"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    _post "data/$b/$t/records" "$3" | jq .
+    ;;
+record:update)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" || -z "${4:-}" ]] && { echo "usage: nocodb.sh record:update <base> <table> <id> '<json>'" >&2; exit 1; }
+    _require_nonempty "id" "$3"
+    _require_json_obj "json" "$4"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    _patch "data/$b/$t/records" "[{\"id\":$3,\"fields\":$4}]" | jq '.records[0]'
+    ;;
+record:update-many)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh record:update-many <base> <table> '<json-array>'" >&2; exit 1; }
+    _require_json_arr "json" "$3"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    _patch "data/$b/$t/records" "$3" | jq .
+    ;;
+record:delete)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh record:delete <base> <table> <id|json-array>" >&2; exit 1; }
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    if [[ "$3" =~ ^\[ ]]; then
+        # Array format: [{"id":"x"},{"id":"y"}] or ["x","y"]
+        if echo "$3" | jq -e '.[0].id' >/dev/null 2>&1; then
+            ids="$3"
+        elif echo "$3" | jq -e '.[0]|type == "string"' >/dev/null 2>&1; then
+            # Convert ["x","y"] to [{"id":"x"},{"id":"y"}]
+            ids=$(echo "$3" | jq '[.[]|{id:.}]')
+        else
+            _err "array must contain strings or objects with 'id' field"
+        fi
+    else
+        _require_nonempty "id" "$3"
+        ids="[{\"id\":\"$3\"}]"
+    fi
+    _delete "data/$b/$t/records" "$ids" | jq .
+    ;;
+record:count)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh record:count <base> <table> [where] [viewId]" >&2; exit 1; }
+    _validate_where "${3:-}"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2")
+    q=""; [[ -n "${3:-}" ]] && q="where=$(_enc "$3")"; [[ -n "${4:-}" ]] && q+="${q:+&}viewId=$4"
+    _get "data/$b/$t/count${q:+?$q}" | jq -r .count
+    ;;
+
+#=============================================================================
+# LINKED RECORDS
+#=============================================================================
+link:list)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" || -z "${4:-}" ]] && { echo "usage: nocodb.sh link:list <base> <table> <linkField> <recordId> [page] [size] [where] [sort] [fields]" >&2; exit 1; }
+    _require_nonempty "recordId" "$4"
+    _require_int "page" "${5:-}"
+    _require_int "size" "${6:-}"
+    _validate_where "${7:-}"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); f=$(_fld "$b" "$t" "$3")
+    pg="${5:-1}"; sz="${6:-25}"; wh="${7:-}"; so="${8:-}"; fl="${9:-}"
+    q="page=$pg&pageSize=$sz"
+    [[ -n "$wh" ]] && q+="&where=$(_enc "$wh")"
+    [[ -n "$so" ]] && q+="&sort=$(_enc "$so")"
+    [[ -n "$fl" ]] && q+="&fields=$(_enc "$fl")"
+    _get "data/$b/$t/links/$f/$4?$q" | jq .
+    ;;
+link:add)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" || -z "${4:-}" || -z "${5:-}" ]] && { echo "usage: nocodb.sh link:add <base> <table> <linkField> <recordId> '<ids-json>'" >&2; exit 1; }
+    _require_nonempty "recordId" "$4"
+    _validate_link_json "$5"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); f=$(_fld "$b" "$t" "$3")
+    _post "data/$b/$t/links/$f/$4" "$5" | jq .
+    ;;
+link:remove)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" || -z "${4:-}" || -z "${5:-}" ]] && { echo "usage: nocodb.sh link:remove <base> <table> <linkField> <recordId> '<ids-json>'" >&2; exit 1; }
+    _require_nonempty "recordId" "$4"
+    _validate_link_json "$5"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); f=$(_fld "$b" "$t" "$3")
+    _delete "data/$b/$t/links/$f/$4" "$5" | jq .
+    ;;
+
+#=============================================================================
+# ATTACHMENTS
+#=============================================================================
+attachment:upload)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" || -z "${4:-}" || -z "${5:-}" ]] && { echo "usage: nocodb.sh attachment:upload <base> <table> <recordId> <field> <filepath>" >&2; exit 1; }
+    _require_nonempty "recordId" "$3"
+    _require_file "$5"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); f=$(_fld "$b" "$t" "$4")
+    _upload "data/$b/$t/records/$3/fields/$f/upload" "$5" | jq .
+    ;;
+
+#=============================================================================
+# BUTTON ACTIONS
+#=============================================================================
+action:trigger)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" || -z "${4:-}" ]] && { echo "usage: nocodb.sh action:trigger <base> <table> <buttonField> <recordId>" >&2; exit 1; }
+    _require_nonempty "recordId" "$4"
+    b=$(_base "$1"); t=$(_tbl "$b" "$2"); f=$(_fld "$b" "$t" "$3")
+    _post "data/$b/$t/actions/$f" "{\"recordId\":\"$4\"}" | jq .
+    ;;
+
+#=============================================================================
+# SCRIPTS
+#=============================================================================
+script:list)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh script:list <base>" >&2; exit 1; }
+    _get "meta/bases/$(_base "$1")/scripts" | jq -r '.list[]|[.title,.id]|@tsv'
+    ;;
+script:get)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh script:get <base> <scriptId>" >&2; exit 1; }
+    _get "meta/bases/$(_base "$1")/scripts/$2" | jq .
+    ;;
+script:create)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh script:create <base> '<json>'" >&2; exit 1; }
+    _require_json_obj "json" "$2"
+    echo "$2" | jq -e '.title' >/dev/null 2>&1 || _err "json must contain 'title' field"
+    _post "meta/bases/$(_base "$1")/scripts" "$2" | jq .
+    ;;
+script:update)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh script:update <base> <scriptId> '<json>'" >&2; exit 1; }
+    _require_json_obj "json" "$3"
+    _patch "meta/bases/$(_base "$1")/scripts/$2" "$3" | jq .
+    ;;
+script:delete)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh script:delete <base> <scriptId>" >&2; exit 1; }
+    _delete "meta/bases/$(_base "$1")/scripts/$2" | jq .
+    ;;
+
+#=============================================================================
+# TEAMS
+#=============================================================================
+team:list)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh team:list <workspace>" >&2; exit 1; }
+    _get "meta/workspaces/$(_ws "$1")/teams" | jq -r '.list[]|[.title,.id]|@tsv'
+    ;;
+team:get)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh team:get <workspace> <teamId>" >&2; exit 1; }
+    _get "meta/workspaces/$(_ws "$1")/teams/$2" | jq .
+    ;;
+team:create)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh team:create <workspace> '<json>'" >&2; exit 1; }
+    _require_json_obj "json" "$2"
+    echo "$2" | jq -e '.title' >/dev/null 2>&1 || _err "json must contain 'title' field"
+    _post "meta/workspaces/$(_ws "$1")/teams" "$2" | jq .
+    ;;
+team:update)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh team:update <workspace> <teamId> '<json>'" >&2; exit 1; }
+    _require_json_obj "json" "$3"
+    _patch "meta/workspaces/$(_ws "$1")/teams/$2" "$3" | jq .
+    ;;
+team:delete)
+    [[ -z "${1:-}" || -z "${2:-}" ]] && { echo "usage: nocodb.sh team:delete <workspace> <teamId>" >&2; exit 1; }
+    _delete "meta/workspaces/$(_ws "$1")/teams/$2" | jq .
+    ;;
+team:members:add)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh team:members:add <workspace> <teamId> '<json>'" >&2; exit 1; }
+    _validate_members_json "$3"
+    _post "meta/workspaces/$(_ws "$1")/teams/$2/members" "$3" | jq .
+    ;;
+team:members:update)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh team:members:update <workspace> <teamId> '<json>'" >&2; exit 1; }
+    _require_json "json" "$3"
+    _patch "meta/workspaces/$(_ws "$1")/teams/$2/members" "$3" | jq .
+    ;;
+team:members:remove)
+    [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ]] && { echo "usage: nocodb.sh team:members:remove <workspace> <teamId> '<json>'" >&2; exit 1; }
+    _require_json "json" "$3"
+    _delete "meta/workspaces/$(_ws "$1")/teams/$2/members" "$3" | jq .
+    ;;
+
+#=============================================================================
+# API TOKENS
+#=============================================================================
+token:list)
+    _get meta/tokens | jq -r '.list[]|[.title,.id]|@tsv'
+    ;;
+token:create)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh token:create '<json>'" >&2; exit 1; }
+    _require_json_obj "json" "$1"
+    echo "$1" | jq -e '.title' >/dev/null 2>&1 || _err "json must contain 'title' field"
+    _post meta/tokens "$1" | jq .
+    ;;
+token:delete)
+    [[ -z "${1:-}" ]] && { echo "usage: nocodb.sh token:delete <tokenId>" >&2; exit 1; }
+    _delete "meta/tokens/$1" | jq .
+    ;;
+
+#=============================================================================
+# WHERE FILTER HELP
+#=============================================================================
+where:help|filter:help)
+    cat <<'WHEREHELP'
+WHERE FILTER SYNTAX
+===================
+
+BASIC SYNTAX:
+  (field,operator,value)           Basic filter
+  (field,operator)                 No-value operators (blank, null, checked, etc.)
+  (field,op,sub_op)                Date with sub-operator
+  (field,op,sub_op,value)          Date with sub-operator and value
+  (field,operator,val1,val2,val3)  Multiple values
+
+OPERATORS:
+
+  Text/General:
+    eq        Equal to                    (name,eq,John)
+    neq       Not equal to                (status,neq,archived)
+    like      Contains (use % wildcard)   (name,like,%john%)
+    nlike     Does not contain            (name,nlike,%test%)
+    in        In list of values           (status,in,active,pending,review)
+
+  Numeric:
+    gt        Greater than (>)            (price,gt,100)
+    lt        Less than (<)               (stock,lt,10)
+    gte       Greater than or equal (>=)  (rating,gte,4)
+    lte       Less than or equal (<=)     (age,lte,65)
+
+  Range:
+    btw       Between (inclusive)         (price,btw,10,100)
+    nbtw      Not between                 (score,nbtw,0,50)
+
+  Null/Empty (no value needed):
+    blank     Is blank (null or empty)    (notes,blank)
+    notblank  Is not blank                (email,notblank)
+    null      Is null                     (deleted_at,null)
+    notnull   Is not null                 (created_by,notnull)
+    empty     Is empty string             (description,empty)
+    notempty  Is not empty string         (title,notempty)
+
+  Boolean/Checkbox (no value needed):
+    checked      Is checked/true          (is_active,checked)
+    notchecked   Is not checked/false     (is_archived,notchecked)
+
+  Multi-Select/Tags:
+    allof     Contains all of             (tags,allof,urgent,important)
+    anyof     Contains any of             (tags,anyof,bug,feature)
+    nallof    Does not contain all of     (tags,nallof,spam,junk)
+    nanyof    Does not contain any of     (categories,nanyof,draft,deleted)
+
+DATE/TIME FILTERING:
+
+  isWithin - Date falls within time range:
+    Sub-ops (no value): pastWeek, pastMonth, pastYear, nextWeek, nextMonth, nextYear
+    Sub-ops (with days): pastNumberOfDays, nextNumberOfDays
+    Examples:
+      (created_at,isWithin,pastWeek)
+      (due_date,isWithin,pastNumberOfDays,14)
+
+  eq, neq, gt, lt, gte, lte - Date comparisons:
+    Sub-ops (no value): today, tomorrow, yesterday, oneWeekAgo, oneWeekFromNow
+    Sub-ops (with days): daysAgo, daysFromNow
+    Sub-op (with YYYY-MM-DD): exactDate
+    Examples:
+      (created_at,eq,today)
+      (due_date,lt,today)                      # Overdue
+      (event_date,eq,exactDate,2024-06-15)
+      (created_at,gte,daysAgo,7)
+
+  btw - Date range:
+      (event_date,btw,2024-01-01,2024-12-31)
+
+LOGICAL OPERATIONS:
+
+  IMPORTANT: Use ~and, ~or, ~not (with tilde prefix)
+
+  AND: (filter1)~and(filter2)
+  OR:  (filter1)~or(filter2)
+  NOT: ~not(filter)
+
+  Examples:
+    (name,eq,John)~and(age,gte,18)
+    (status,eq,active)~or(status,eq,pending)
+    ~not(is_deleted,checked)
+    (status,in,active,pending)~and(country,eq,USA)
+
+SPECIAL VALUES:
+  NULL value:         (field,eq,null)
+  Empty string:       (field,eq,'') or (field,eq,"")
+  Value with comma:   (field,eq,"hello, world")
+  Value with quotes:  (field,eq,"it's here")
+
+COMPLEX EXAMPLES:
+  Active users this month:
+    (status,eq,active)~and(created_at,isWithin,pastMonth)
+
+  Overdue high-priority:
+    (due_date,lt,today)~and(priority,eq,high)~and(completed,notchecked)
+
+  Orders $100-$500 pending:
+    (amount,gte,100)~and(amount,lte,500)~and(status,in,pending,processing)
+
+  Updated recently, not archived:
+    (updated_at,isWithin,pastNumberOfDays,14)~and~not(is_archived,checked)
+WHEREHELP
+    ;;
+
+#=============================================================================
+# HELP
+#=============================================================================
+*)
+    cat <<'HELP'
+nocodb.sh - NocoDB v3 CLI (Feature Complete)
+
+ARGUMENT ORDER: Commands follow a hierarchical pattern:
+  workspace → base → table → view/field → record
+
+  Most commands accept NAMES or IDs. Use IDs directly for faster execution.
+  Set NOCODB_VERBOSE=1 to see resolved IDs.
+
+WORKSPACES  (Enterprise plans only: self-hosted or cloud-hosted)
+  workspace:list
+  workspace:get        WORKSPACE
+  workspace:create     JSON
+  workspace:update     WORKSPACE  JSON
+  workspace:delete     WORKSPACE
+
+WORKSPACE COLLABORATION  (self-hosted Enterprise only)
+  workspace:members    WORKSPACE
+  workspace:members:add/update/remove  WORKSPACE  JSON
+
+BASES
+  base:list    WORKSPACE
+  base:get     BASE
+  base:create  WORKSPACE  JSON
+  base:update  BASE  JSON
+  base:delete  BASE
+
+BASE COLLABORATION  (Enterprise only: self-hosted or cloud-hosted)
+  base:members BASE
+  base:members:add/update/remove  BASE  JSON
+
+TABLES
+  table:list    BASE
+  table:get     BASE  TABLE
+  table:create  BASE  JSON
+  table:update  BASE  TABLE  JSON
+  table:delete  BASE  TABLE
+
+FIELDS
+  field:list    BASE  TABLE
+  field:get     BASE  TABLE  FIELD
+  field:create  BASE  TABLE  JSON
+  field:update  BASE  TABLE  FIELD  JSON
+  field:delete  BASE  TABLE  FIELD
+
+VIEWS  (Enterprise only: self-hosted or cloud-hosted)
+  view:list    BASE  TABLE
+  view:get     BASE  TABLE  VIEW
+  view:create  BASE  TABLE  JSON
+  view:update  BASE  TABLE  VIEW  JSON
+  view:delete  BASE  TABLE  VIEW
+
+FILTERS
+  filter:list     BASE  TABLE  VIEW
+  filter:create   BASE  TABLE  VIEW  JSON
+  filter:replace  BASE  TABLE  VIEW  JSON
+  filter:update   BASE  FILTER_ID  JSON
+  filter:delete   BASE  FILTER_ID
+
+SORTS
+  sort:list    BASE  TABLE  VIEW
+  sort:create  BASE  TABLE  VIEW  JSON
+  sort:update  BASE  SORT_ID  JSON
+  sort:delete  BASE  SORT_ID
+
+RECORDS
+  record:list        BASE  TABLE  [PAGE] [SIZE] [WHERE] [SORT] [FIELDS] [VIEW_ID] [NESTED_PAGE]
+  record:get         BASE  TABLE  RECORD_ID  [FIELDS]
+  record:create      BASE  TABLE  JSON
+  record:update      BASE  TABLE  RECORD_ID  JSON
+  record:update-many BASE  TABLE  JSON_ARRAY
+  record:delete      BASE  TABLE  RECORD_ID_OR_ARRAY
+  record:count       BASE  TABLE  [WHERE] [VIEW_ID]
+
+LINKED RECORDS
+  link:list    BASE  TABLE  LINK_FIELD  RECORD_ID  [PAGE] [SIZE] [WHERE] [SORT] [FIELDS]
+  link:add     BASE  TABLE  LINK_FIELD  RECORD_ID  JSON_ARRAY
+  link:remove  BASE  TABLE  LINK_FIELD  RECORD_ID  JSON_ARRAY
+
+ATTACHMENTS
+  attachment:upload  BASE  TABLE  RECORD_ID  FIELD  FILEPATH
+
+BUTTON ACTIONS
+  action:trigger  BASE  TABLE  BUTTON_FIELD  RECORD_ID
+
+SCRIPTS  (Enterprise only: self-hosted or cloud-hosted)
+  script:list    BASE
+  script:get     BASE  SCRIPT_ID
+  script:create  BASE  JSON
+  script:update  BASE  SCRIPT_ID  JSON
+  script:delete  BASE  SCRIPT_ID
+
+TEAMS  (Enterprise only: self-hosted or cloud-hosted)
+  team:list    WORKSPACE
+  team:get     WORKSPACE  TEAM_ID
+  team:create  WORKSPACE  JSON
+  team:update  WORKSPACE  TEAM_ID  JSON
+  team:delete  WORKSPACE  TEAM_ID
+  team:members:add/update/remove  WORKSPACE  TEAM_ID  JSON
+
+API TOKENS  (Enterprise only: self-hosted or cloud-hosted)
+  token:list
+  token:create  JSON
+  token:delete  TOKEN_ID
+
+WHERE HELP
+  where:help    Show where filter syntax and operators
+
+ENVIRONMENT
+  NOCODB_URL      Base URL (default: https://app.nocodb.com)
+  NOCODB_TOKEN    API token (required)
+  NOCODB_VERBOSE  Set to 1 to show resolved IDs
+
+EXAMPLES
+  # IDs: w=workspace, p=base, m=table, c=column, vw=view (all lowercase alphanumeric)
+
+  # List workspaces, bases, tables (use IDs from output)
+  nocodb.sh workspace:list                                   # → wabc1234xyz
+  nocodb.sh base:list wabc1234xyz                            # → pdef5678uvw
+  nocodb.sh table:list pdef5678uvw                           # → mghi9012rst
+  nocodb.sh field:list pdef5678uvw mghi9012rst               # → cjkl3456opq
+  nocodb.sh view:list pdef5678uvw mghi9012rst                # → vwmno7890abc
+
+  # Records (BASE_ID TABLE_ID ...)
+  nocodb.sh record:list pdef5678uvw mghi9012rst 1 50 "(Status,eq,active)"
+  nocodb.sh record:list pdef5678uvw mghi9012rst 1 50 "" "" "Name,Email" "" 2  # with fields and nestedPage
+  nocodb.sh record:get pdef5678uvw mghi9012rst 31
+  nocodb.sh record:create pdef5678uvw mghi9012rst '{"fields":{"Name":"Alice"}}'
+  nocodb.sh record:update pdef5678uvw mghi9012rst 31 '{"Status":"done"}'
+  nocodb.sh record:delete pdef5678uvw mghi9012rst 31
+
+  # Linked records (BASE_ID TABLE_ID FIELD_ID RECORD_ID [PAGE] [SIZE] [WHERE] [SORT] [FIELDS])
+  nocodb.sh link:list pdef5678uvw mghi9012rst cjkl3456opq 31 1 25 "(Status,eq,active)" "-CreatedAt" "Name,Email"
+  nocodb.sh link:add pdef5678uvw mghi9012rst cjkl3456opq 31 '[{"id":42}]'
+
+  # View filters/sorts (BASE_ID TABLE_ID VIEW_ID JSON)
+  nocodb.sh filter:create pdef5678uvw mghi9012rst vwmno7890abc '{"field_id":"cjkl3456opq","operator":"eq","value":"active"}'
+
+  # Attachments (BASE_ID TABLE_ID RECORD_ID FIELD_ID FILEPATH)
+  nocodb.sh attachment:upload pdef5678uvw mghi9012rst 31 cjkl3456opq ./report.pdf
+
+  # Names also work (resolved to IDs automatically)
+  nocodb.sh record:list MyBase Users
+  NOCODB_VERBOSE=1 nocodb.sh field:list MyBase Users   # shows resolved IDs
+HELP
+    ;;
+esac

--- a/tests/skills/test_nocodb_skill.py
+++ b/tests/skills/test_nocodb_skill.py
@@ -2,11 +2,16 @@
 Smoke tests for the nocodb optional skill.
 
 Validates:
-  - SKILL.md frontmatter conforms to the authoring standards
   - Both platform scripts ship and expose an identical command surface
+    (which is what makes the three-platform `platforms:` claim honest)
   - Every command named in SKILL.md prose is one the scripts implement
     (catches doc drift when the vendored scripts are refreshed upstream)
   - The scripts only ever talk to the configured NocoDB origin
+  - The MIT provenance of the vendored scripts survives
+
+Generic frontmatter conformance (required fields, the 60-char description
+hardline, tags, related_skills) is not repeated here — tests/skills/
+test_authoring_standards.py already sweeps every skill in the repo for it.
 
 No network. Everything here is static analysis of the shipped files.
 """
@@ -81,17 +86,16 @@ def test_bash_script_is_executable() -> None:
     assert SH.stat().st_mode & 0o111, "scripts/nocodb.sh is not executable"
 
 
-def test_required_frontmatter_fields(frontmatter: dict) -> None:
-    for field in ("name", "description", "version", "author", "license", "platforms"):
-        assert field in frontmatter, f"missing frontmatter field: {field}"
-    assert frontmatter["name"] == "nocodb"
+def test_mit_provenance_recorded(frontmatter: dict) -> None:
+    # The scripts are vendored from an MIT upstream that ships no LICENSE
+    # file, so the attribution lives in the frontmatter and in a header on
+    # each script. Losing either silently drops the only notice we carry.
     assert frontmatter["license"] == "MIT"
-
-
-def test_description_hardline(frontmatter: dict) -> None:
-    desc = frontmatter["description"]
-    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline 60)"
-    assert desc.endswith("."), "description must end with a period"
+    for script in (SH, PS1):
+        head = script.read_text(encoding="utf-8")[:600]
+        assert "github.com/nocodb/agent-skills" in head, (
+            f"{script.name} lost its upstream provenance header"
+        )
 
 
 def test_declares_token_env_var(frontmatter: dict) -> None:
@@ -105,10 +109,6 @@ def test_platforms_match_shipped_scripts(frontmatter: dict) -> None:
     # the Bash one. If nocodb.ps1 is ever dropped, this fails loudly.
     assert set(frontmatter["platforms"]) == {"macos", "linux", "windows"}
     assert PS1.is_file()
-
-
-def test_tags_present(frontmatter: dict) -> None:
-    assert frontmatter["metadata"]["hermes"]["tags"], "no metadata.hermes.tags"
 
 
 def test_both_scripts_expose_the_same_commands(sh_commands: set[str]) -> None:

--- a/tests/skills/test_nocodb_skill.py
+++ b/tests/skills/test_nocodb_skill.py
@@ -1,19 +1,13 @@
 """
 Smoke tests for the nocodb optional skill.
 
-Validates:
-  - Both platform scripts ship and expose an identical command surface
-    (which is what makes the three-platform `platforms:` claim honest)
-  - Every command named in SKILL.md prose is one the scripts implement
-    (catches doc drift when the vendored scripts are refreshed upstream)
-  - The scripts only ever talk to the configured NocoDB origin
-  - The MIT provenance of the vendored scripts survives
+Generic frontmatter conformance is not repeated here — test_authoring_
+standards.py already sweeps every skill in the repo for it. These are the
+nocodb-specific checks: the two platform scripts staying in lockstep, the
+SKILL.md command reference staying true to them, and the vendored scripts
+keeping their origin and their attribution.
 
-Generic frontmatter conformance (required fields, the 60-char description
-hardline, tags, related_skills) is not repeated here — tests/skills/
-test_authoring_standards.py already sweeps every skill in the repo for it.
-
-No network. Everything here is static analysis of the shipped files.
+No network. Static analysis of the shipped files only.
 """
 from __future__ import annotations
 
@@ -34,22 +28,16 @@ SKILL_DIR = (
 SH = SKILL_DIR / "scripts" / "nocodb.sh"
 PS1 = SKILL_DIR / "scripts" / "nocodb.ps1"
 
-# `case` labels in the Bash dispatcher, at column 0. Some labels alternate:
-#   record:update-many)
-#   where:help|filter:help)
+# Bash `case` labels, which may alternate: `where:help|filter:help)`.
 _SH_COMMAND = re.compile(r"^([a-z][a-z:|-]*)\)", re.MULTILINE)
-# `switch` labels in the PowerShell dispatcher, either a plain literal
-#   "record:update-many" {
-# or a script-block condition covering several aliases
-#   { $_ -eq "where:help" -or $_ -eq "filter:help" } {
+# PowerShell `switch` labels: a plain literal, or a script-block condition
+# (`{ $_ -eq "where:help" -or $_ -eq "filter:help" }`) covering aliases.
 _PS1_COMMAND = re.compile(r'^\s+"([a-z][a-z:-]*)"\s*\{', re.MULTILINE)
 _PS1_ALIAS = re.compile(r'\$_ -eq "([a-z][a-z:-]*)"')
-# Commands as written in SKILL.md prose/tables: `record:update-many`.
 _DOC_COMMAND = re.compile(r"`(?:scripts/nocodb\.sh )?([a-z][a-z-]+:[a-z:-]+)`")
 
 
 def _sh_commands_from(src: str) -> set[str]:
-    """Flatten `a|b)` alternation labels into individual command names."""
     return {c for label in _SH_COMMAND.findall(src) for c in label.split("|")}
 
 
@@ -81,15 +69,12 @@ def test_skill_dir_and_scripts_exist() -> None:
 
 
 def test_bash_script_is_executable() -> None:
-    # The skill documents `scripts/nocodb.sh <command>` as the entry point,
-    # so the mode bit has to survive the commit.
     assert SH.stat().st_mode & 0o111, "scripts/nocodb.sh is not executable"
 
 
 def test_mit_provenance_recorded(frontmatter: dict) -> None:
-    # The scripts are vendored from an MIT upstream that ships no LICENSE
-    # file, so the attribution lives in the frontmatter and in a header on
-    # each script. Losing either silently drops the only notice we carry.
+    # Upstream ships no LICENSE file, so the header on each script and this
+    # frontmatter field are the only MIT notice travelling with the code.
     assert frontmatter["license"] == "MIT"
     for script in (SH, PS1):
         head = script.read_text(encoding="utf-8")[:600]
@@ -105,8 +90,7 @@ def test_declares_token_env_var(frontmatter: dict) -> None:
 
 
 def test_platforms_match_shipped_scripts(frontmatter: dict) -> None:
-    # Windows is only claimable because the PowerShell port ships alongside
-    # the Bash one. If nocodb.ps1 is ever dropped, this fails loudly.
+    # Windows is only claimable while the PowerShell port ships alongside.
     assert set(frontmatter["platforms"]) == {"macos", "linux", "windows"}
     assert PS1.is_file()
 
@@ -140,10 +124,7 @@ def test_documented_command_count_matches(skill_src: str, sh_commands: set[str])
 
 @pytest.mark.parametrize("script", [SH, PS1], ids=["sh", "ps1"])
 def test_scripts_contact_only_nocodb_default_origin(script: Path) -> None:
-    # Every request is built off $NOCODB_URL, whose only default is the NocoDB
-    # cloud origin. A second literal host on an executable line would mean
-    # exfiltration or an unreviewed upstream change. Comment lines are skipped
-    # so the provenance header can cite the upstream repo.
+    # Comment lines are skipped so the provenance header can cite upstream.
     code = "\n".join(
         line
         for line in script.read_text(encoding="utf-8").splitlines()

--- a/tests/skills/test_nocodb_skill.py
+++ b/tests/skills/test_nocodb_skill.py
@@ -1,0 +1,163 @@
+"""
+Smoke tests for the nocodb optional skill.
+
+Validates:
+  - SKILL.md frontmatter conforms to the authoring standards
+  - Both platform scripts ship and expose an identical command surface
+  - Every command named in SKILL.md prose is one the scripts implement
+    (catches doc drift when the vendored scripts are refreshed upstream)
+  - The scripts only ever talk to the configured NocoDB origin
+
+No network. Everything here is static analysis of the shipped files.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "productivity"
+    / "nocodb"
+)
+SH = SKILL_DIR / "scripts" / "nocodb.sh"
+PS1 = SKILL_DIR / "scripts" / "nocodb.ps1"
+
+# `case` labels in the Bash dispatcher, at column 0. Some labels alternate:
+#   record:update-many)
+#   where:help|filter:help)
+_SH_COMMAND = re.compile(r"^([a-z][a-z:|-]*)\)", re.MULTILINE)
+# `switch` labels in the PowerShell dispatcher, either a plain literal
+#   "record:update-many" {
+# or a script-block condition covering several aliases
+#   { $_ -eq "where:help" -or $_ -eq "filter:help" } {
+_PS1_COMMAND = re.compile(r'^\s+"([a-z][a-z:-]*)"\s*\{', re.MULTILINE)
+_PS1_ALIAS = re.compile(r'\$_ -eq "([a-z][a-z:-]*)"')
+# Commands as written in SKILL.md prose/tables: `record:update-many`.
+_DOC_COMMAND = re.compile(r"`(?:scripts/nocodb\.sh )?([a-z][a-z-]+:[a-z:-]+)`")
+
+
+def _sh_commands_from(src: str) -> set[str]:
+    """Flatten `a|b)` alternation labels into individual command names."""
+    return {c for label in _SH_COMMAND.findall(src) for c in label.split("|")}
+
+
+def _ps1_commands_from(src: str) -> set[str]:
+    return set(_PS1_COMMAND.findall(src)) | set(_PS1_ALIAS.findall(src))
+
+
+@pytest.fixture(scope="module")
+def skill_src() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_src: str) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", skill_src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+@pytest.fixture(scope="module")
+def sh_commands() -> set[str]:
+    return _sh_commands_from(SH.read_text(encoding="utf-8"))
+
+
+def test_skill_dir_and_scripts_exist() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+    assert SH.is_file(), "missing scripts/nocodb.sh"
+    assert PS1.is_file(), "missing scripts/nocodb.ps1"
+
+
+def test_bash_script_is_executable() -> None:
+    # The skill documents `scripts/nocodb.sh <command>` as the entry point,
+    # so the mode bit has to survive the commit.
+    assert SH.stat().st_mode & 0o111, "scripts/nocodb.sh is not executable"
+
+
+def test_required_frontmatter_fields(frontmatter: dict) -> None:
+    for field in ("name", "description", "version", "author", "license", "platforms"):
+        assert field in frontmatter, f"missing frontmatter field: {field}"
+    assert frontmatter["name"] == "nocodb"
+    assert frontmatter["license"] == "MIT"
+
+
+def test_description_hardline(frontmatter: dict) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline 60)"
+    assert desc.endswith("."), "description must end with a period"
+
+
+def test_declares_token_env_var(frontmatter: dict) -> None:
+    names = {e["name"] for e in frontmatter["required_environment_variables"]}
+    assert "NOCODB_TOKEN" in names
+    assert frontmatter["prerequisites"]["commands"] == ["curl", "jq"]
+
+
+def test_platforms_match_shipped_scripts(frontmatter: dict) -> None:
+    # Windows is only claimable because the PowerShell port ships alongside
+    # the Bash one. If nocodb.ps1 is ever dropped, this fails loudly.
+    assert set(frontmatter["platforms"]) == {"macos", "linux", "windows"}
+    assert PS1.is_file()
+
+
+def test_tags_present(frontmatter: dict) -> None:
+    assert frontmatter["metadata"]["hermes"]["tags"], "no metadata.hermes.tags"
+
+
+def test_both_scripts_expose_the_same_commands(sh_commands: set[str]) -> None:
+    ps1_commands = _ps1_commands_from(PS1.read_text(encoding="utf-8"))
+    assert sh_commands, "no commands parsed out of nocodb.sh"
+    assert sh_commands == ps1_commands, (
+        "Bash/PowerShell command surfaces diverged — "
+        f"sh-only={sorted(sh_commands - ps1_commands)} "
+        f"ps1-only={sorted(ps1_commands - sh_commands)}"
+    )
+
+
+def test_documented_commands_all_exist(skill_src: str, sh_commands: set[str]) -> None:
+    documented = {
+        c for c in _DOC_COMMAND.findall(skill_src) if not c.startswith("app.nocodb")
+    }
+    assert documented, "no commands found in SKILL.md — regex drift?"
+    unknown = documented - sh_commands
+    assert not unknown, f"SKILL.md documents commands the scripts lack: {sorted(unknown)}"
+
+
+def test_documented_command_count_matches(skill_src: str, sh_commands: set[str]) -> None:
+    m = re.search(r"identical (\d+)-command surface", skill_src)
+    assert m, "SKILL.md no longer states the command-surface size"
+    assert int(m.group(1)) == len(sh_commands), (
+        f"SKILL.md claims {m.group(1)} commands, scripts implement {len(sh_commands)}"
+    )
+
+
+@pytest.mark.parametrize("script", [SH, PS1], ids=["sh", "ps1"])
+def test_scripts_contact_only_nocodb_default_origin(script: Path) -> None:
+    # Every request is built off $NOCODB_URL, whose only default is the NocoDB
+    # cloud origin. A second literal host on an executable line would mean
+    # exfiltration or an unreviewed upstream change. Comment lines are skipped
+    # so the provenance header can cite the upstream repo.
+    code = "\n".join(
+        line
+        for line in script.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    hosts = set(re.findall(r"https?://[\w.-]+", code))
+    assert hosts == {"https://app.nocodb.com"}, f"unexpected hosts: {sorted(hosts)}"
+
+
+def test_bash_script_parses() -> None:
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("bash not available")
+    proc = subprocess.run(
+        [bash, "-n", str(SH)], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, f"bash -n failed:\n{proc.stderr}"

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -193,6 +193,7 @@ hermes skills uninstall <skill-name>
 | [**canvas**](/docs/user-guide/skills/optional/productivity/productivity-canvas) | Fetch Canvas LMS courses and assignments via API token. |
 | [**here-now**](/docs/user-guide/skills/optional/productivity/productivity-here-now) | Publish sites to &#123;slug&#125;.here.now and store files in Drives. |
 | [**memento-flashcards**](/docs/user-guide/skills/optional/productivity/productivity-memento-flashcards) | Spaced-repetition flashcards: create, review, quiz, export. |
+| [**nocodb**](/docs/user-guide/skills/optional/productivity/productivity-nocodb) | Manage NocoDB bases, tables, fields, and records. |
 | [**shop**](/docs/user-guide/skills/optional/productivity/productivity-shop) | Shop catalog search, checkout, order tracking, returns. |
 | [**shopify**](/docs/user-guide/skills/optional/productivity/productivity-shopify) | Query Shopify Admin/Storefront GraphQL APIs via curl. |
 | [**siyuan**](/docs/user-guide/skills/optional/productivity/productivity-siyuan) | Query and edit a SiYuan knowledge base via its API. |

--- a/website/docs/user-guide/skills/optional/productivity/productivity-nocodb.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-nocodb.md
@@ -1,0 +1,220 @@
+---
+title: "Nocodb — Manage NocoDB bases, tables, fields, and records"
+sidebar_label: "Nocodb"
+description: "Manage NocoDB bases, tables, fields, and records"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Nocodb
+
+Manage NocoDB bases, tables, fields, and records.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/productivity/nocodb` |
+| Path | `optional-skills/productivity/nocodb` |
+| Version | `1.0.0` |
+| Author | Anbarasu (DarkPhoenix2704) |
+| License | MIT |
+| Platforms | macos, linux, windows |
+| Tags | `NocoDB`, `Database`, `Spreadsheet`, `No-Code`, `API`, `Records` |
+| Related skills | [`airtable`](/docs/user-guide/skills/bundled/productivity/productivity-airtable) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# NocoDB Skill
+
+Drive the NocoDB v3 REST API from the command line: browse workspaces and
+bases, read and write records, and change schema (tables, fields, views,
+filters, sorts). This is the full admin surface — the NocoDB MCP server, by
+contrast, is record-CRUD only.
+
+It does not run NocoDB itself, sync external data sources, or manage billing.
+Workspace, view, script, team, and API-token endpoints are Enterprise-plan
+features (self-hosted or cloud) and error out on the free plan.
+
+## When to Use
+
+- The user names a NocoDB base, table, or record, or pastes an `app.nocodb.com`
+  (or self-hosted NocoDB) link.
+- Bulk record work: import, backfill, deduplicate, or export rows.
+- Schema work the MCP server cannot do: create tables, add fields, build views,
+  attach filters and sorts.
+- The user wants a lightweight database for tracking something and has NocoDB
+  available.
+
+Prefer the `nocodb` MCP server when the task is plain record CRUD on a single
+base and the user already authorized it — it needs no token handling. Use this
+skill for everything structural.
+
+## Prerequisites
+
+- `NOCODB_TOKEN` — API token. NocoDB → account menu → **Account Settings** →
+  **Tokens** → **Add New Token**. Sent as the `xc-token` header.
+- `NOCODB_URL` — only for self-hosted instances. Defaults to
+  `https://app.nocodb.com`. Use the bare origin: `https://nocodb.example.com`,
+  no `/api` suffix, no trailing slash.
+- `NOCODB_VERBOSE=1` — optional; prints each name→ID resolution to stderr.
+- `curl` and `jq` on `PATH` for the Bash script. The PowerShell script uses
+  `Invoke-RestMethod` and needs neither.
+
+The token grants full access to every base it can reach. Never echo it into
+transcripts or commit it.
+
+## How to Run
+
+Invoke through the `terminal` tool from the skill directory. Pick the script
+that matches the platform — both expose an identical 72-command surface:
+
+- macOS / Linux: `scripts/nocodb.sh <command> [args...]`
+- Windows: `pwsh -File scripts/nocodb.ps1 <command> [args...]`
+
+Every example below uses the Bash form. There is no `nc` binary — do not
+shorten the invocation, since `nc` is netcat.
+
+Arguments are always hierarchical, widest scope first:
+
+```
+WORKSPACE → BASE → TABLE → VIEW/FIELD → RECORD
+```
+
+Names or IDs both work. Names cost an extra lookup per level; IDs are exact.
+ID prefixes: `w`=workspace, `p`=base, `m`=table, `c`=field, `vw`=view.
+
+## Quick Reference
+
+| Command | Args | Notes |
+|---|---|---|
+| `workspace:list` | — | Enterprise |
+| `base:list` | `WORKSPACE` | → `p…` base IDs |
+| `base:create` | `WORKSPACE` `'{"title":"…"}'` | |
+| `table:list` | `BASE` | → `m…` table IDs |
+| `table:create` | `BASE` `'{"title":"…"}'` | |
+| `field:list` | `BASE` `TABLE` | title, type, `c…` ID |
+| `field:create` | `BASE` `TABLE` `'{"title":"…","type":"…"}'` | |
+| `view:list` | `BASE` `TABLE` | Enterprise |
+| `record:list` | `BASE` `TABLE` `[PAGE] [SIZE] [WHERE] [SORT] [FIELDS]` | 25/page default |
+| `record:get` | `BASE` `TABLE` `RECORD_ID [FIELDS]` | |
+| `record:create` | `BASE` `TABLE` `'{"fields":{…}}'` | |
+| `record:update` | `BASE` `TABLE` `RECORD_ID` `'{…}'` | |
+| `record:update-many` | `BASE` `TABLE` `'[{"id":1,"fields":{…}}]'` | |
+| `record:delete` | `BASE` `TABLE` `ID` or `'[{"id":31}]'` | |
+| `record:count` | `BASE` `TABLE` `[WHERE]` | |
+| `link:list` \| `link:add` \| `link:remove` | `BASE` `TABLE` `FIELD` `RECORD_ID` `[…]` | link payload `[{"id":42}]` |
+| `filter:create` \| `sort:create` | `BASE` `TABLE` `VIEW` `'{…}'` | view-level, Enterprise |
+| `attachment:upload` | `BASE` `TABLE` `RECORD_ID` `FIELD` `PATH` | multipart |
+| `where:help` | — | full filter syntax |
+
+Field types: `SingleLineText`, `LongText`, `Number`, `Decimal`, `Currency`,
+`Percent`, `Email`, `URL`, `PhoneNumber`, `Date`, `DateTime`, `Time`,
+`SingleSelect`, `MultiSelect`, `Checkbox`, `Rating`, `Attachment`, `Links`,
+`User`, `JSON`.
+
+Run `scripts/nocodb.sh` with no arguments for the complete command list.
+
+### Where-filter syntax
+
+```
+(field,operator,value)              (name,eq,John)
+(field,operator)                    (notes,blank)
+(field,operator,sub_op[,value])     (created_at,isWithin,pastWeek)
+```
+
+Operators: `eq`, `neq`, `like`, `nlike`, `in`, `gt`, `lt`, `gte`, `lte`,
+`blank`, `notblank`, `checked`, `notchecked`.
+
+Combine with a **tilde** prefix — `~and`, `~or`, `~not`. Plain `and`/`or` is
+the single most common mistake and the script rejects it:
+
+```bash
+scripts/nocodb.sh record:list MyBase Tasks 1 25 \
+  "(due_date,lt,today)~and(priority,eq,high)~and(completed,notchecked)"
+```
+
+## Procedure
+
+1. **Confirm credentials are loaded.** Run the Verification command below. A
+   `NOCODB_TOKEN required` error means the env var never reached the shell.
+
+2. **Resolve the target once, then reuse IDs.** Passing a name instead of an ID
+   costs a lookup on every call, and resolving a *base* name scans every
+   workspace the token can see:
+
+   ```bash
+   scripts/nocodb.sh base:list wabc1234xyz        # → pdef5678uvw
+   scripts/nocodb.sh table:list pdef5678uvw       # → mghi9012rst
+   scripts/nocodb.sh field:list pdef5678uvw mghi9012rst
+   ```
+
+   On a free plan there is no `workspace:list` to seed step one. Read the base
+   ID out of the NocoDB URL instead — `app.nocodb.com/#/<workspace>/<baseId>/…`
+   — and start at `table:list`.
+
+3. **Inspect the schema before writing.** `field:list` gives exact titles,
+   types, and IDs. Guessed field names are silently dropped by the API rather
+   than rejected.
+
+4. **Read before you write.** Preview the affected rows with the same filter
+   you are about to mutate:
+
+   ```bash
+   scripts/nocodb.sh record:count pdef5678uvw mghi9012rst "(status,eq,stale)"
+   scripts/nocodb.sh record:list  pdef5678uvw mghi9012rst 1 5 "(status,eq,stale)"
+   ```
+
+5. **Batch mutations.** Use `record:update-many` and array-form
+   `record:delete` instead of a call per row.
+
+6. **Page explicitly.** `record:list` returns 25 rows per page. Drive
+   `record:count` first, then loop pages — never assume one page is the whole
+   table.
+
+7. **Write results with `write_file`** when the user wants an export. Pipe the
+   JSON through `jq` inside the command rather than reformatting it yourself.
+
+## Pitfalls
+
+- **`nc` is netcat.** Always invoke `scripts/nocodb.sh`.
+- **Plain `and`/`or` in filters.** Must be `~and` / `~or` / `~not`.
+- **`record:create` wraps fields.** Payload is `{"fields":{…}}`; `record:update`
+  takes the bare object `{…}`. Mixing them up returns a 400.
+- **Unknown field names do not error.** They are dropped. Verify with
+  `field:list` and re-read the record after writing.
+- **Enterprise-gated endpoints.** Workspace, view, script, team, and API-token
+  commands need an Enterprise plan (self-hosted or cloud). On the free plan
+  `workspace:list` fails — pass the base ID directly instead.
+- **`base:list` takes a workspace argument** and is therefore Enterprise-gated
+  in practice. Free-plan users should skip it and read the base ID from the
+  NocoDB URL.
+- **Passing a base *name*** makes the script enumerate every workspace looking
+  for it — another Enterprise-only path. Pass the `p…` ID.
+- **Self-hosted URL shape.** `NOCODB_URL` is the origin only. A trailing slash
+  or an `/api` suffix produces 404s on every call.
+- **Record IDs are per-table integers**, not the `p…`/`m…` nanoid strings.
+- **Deletes are immediate.** There is no undo through the API.
+
+## Verification
+
+```bash
+scripts/nocodb.sh table:list <BASE_ID>
+```
+
+Prints one `title<TAB>id` row per table. Any output means the token, the URL,
+and the dependencies are all correct. `NOCODB_TOKEN required` means the env var
+never reached the shell; an HTML or 401 body means the token or `NOCODB_URL` is
+wrong.
+
+On Enterprise plans `scripts/nocodb.sh workspace:list` verifies the same thing
+without needing a base ID up front.
+
+## Attribution
+
+Ported from [nocodb/agent-skills](https://github.com/nocodb/agent-skills)
+(MIT). The `scripts/` files are vendored from that repository.

--- a/website/docs/user-guide/skills/optional/productivity/productivity-nocodb.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-nocodb.md
@@ -181,7 +181,6 @@ scripts/nocodb.sh record:list MyBase Tasks 1 25 \
 
 ## Pitfalls
 
-- **`nc` is netcat.** Always invoke `scripts/nocodb.sh`.
 - **Plain `and`/`or` in filters.** Must be `~and` / `~or` / `~not`.
 - **`record:create` wraps fields.** Payload is `{"fields":{…}}`; `record:update`
   takes the bare object `{…}`. Mixing them up returns a 400.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -552,6 +552,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/productivity/productivity-canvas',
                     'user-guide/skills/optional/productivity/productivity-here-now',
                     'user-guide/skills/optional/productivity/productivity-memento-flashcards',
+                    'user-guide/skills/optional/productivity/productivity-nocodb',
                     'user-guide/skills/optional/productivity/productivity-shop',
                     'user-guide/skills/optional/productivity/productivity-shopify',
                     'user-guide/skills/optional/productivity/productivity-siyuan',


### PR DESCRIPTION
## What does this PR do?

Adds NocoDB in the two places Hermes expects a third-party data platform to land:

1. **`optional-mcps/nocodb/`** — a catalog entry for NocoDB's vendor-hosted remote MCP.
2. **`optional-skills/productivity/nocodb/`** — the NocoDB v3 REST CLI as an official optional skill, ported from [nocodb/agent-skills](https://github.com/nocodb/agent-skills) (MIT).

They are complementary, not duplicative, and the SKILL.md says so explicitly so the model picks correctly:

| | MCP entry | Skill |
|---|---|---|
| Auth | Browser OAuth, no token handling | `NOCODB_TOKEN` (`xc-token` header) |
| Scope | Record CRUD only — NocoDB's server does not do table, field, or other metadata changes | Full v3 admin surface: workspaces, bases, tables, fields, views, filters, sorts, links, attachments |

### Why `http` + `auth: oauth` for the manifest

NocoDB serves complete OAuth 2.1 discovery at the instance root, so this is a URL-only entry in the same shape as `airtable`, `supabase`, and `intercom` — nothing for the user to paste. Verified against `app.nocodb.com` on 2026-08-17:

```
/.well-known/oauth-protected-resource
  resource: https://app.nocodb.com/mcp
  authorization_servers: [https://app.nocodb.com]

/.well-known/oauth-authorization-server
  registration_endpoint: /api/v2/oauth/register    (DCR, no client_name allowlist)
  code_challenge_methods_supported: [S256]
  grant_types_supported: [authorization_code, refresh_token]
```

NocoDB also exposes a per-base endpoint at `/mcp/<mcpTokenId>` authenticated with a custom `xc-mcp-token` header. Manifest schema v1 can only emit `Authorization: Bearer` for `http` transports, so rather than widen the schema in this PR, `post_install` documents that path as a hand-written `~/.hermes/config.yaml` block. Happy to split a schema change for custom headers into its own PR if you'd prefer that shape instead.

### Why `optional-skills/` and not `skills/`

Specific-service integration that needs an API token — "official and useful but not universally needed" per the Contributing Guide. Sits next to the bundled `airtable` skill it's the closest analogue to.

## Related Issue

No existing issue or PR — `gh search issues/prs --repo NousResearch/hermes-agent "nocodb"` returns nothing.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-mcps/nocodb/manifest.yaml` — `http` + `oauth` catalog entry, `suggest` triggers, `post_install` covering self-hosted URLs and the token-header alternative.
- `optional-skills/productivity/nocodb/SKILL.md` — authored to the hardline standards: 48-char description, modern section order, ~215 lines, all invocation framed through the `terminal` tool.
- `optional-skills/productivity/nocodb/scripts/nocodb.sh` + `nocodb.ps1` — vendored verbatim from upstream under a provenance header. Both dispatchers expose an identical 72-command surface, which is what makes `platforms: [macos, linux, windows]` honest.
- `tests/skills/test_nocodb_skill.py` — 14 tests, stdlib + pytest only, no network.
- `website/` — regenerated skill page, catalog row, sidebar entry.

The docs generator rewrites ~30 unrelated pages against current `main` (mostly `python3` → `python` normalization, plus four skill pages that were merged without regenerating). Those are left out of this PR — only the three NocoDB-related docs changes are included.

## How to Test

```bash
# 1. Skill tests + the repo-wide authoring standards sweep
scripts/run_tests.sh tests/skills/test_nocodb_skill.py tests/skills/test_authoring_standards.py -q

# 2. Manifest parses and satisfies the shipped-catalog contract
scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q

# 3. Catalog entry is visible and installable
hermes mcp catalog | grep nocodb
hermes mcp install nocodb          # opens the browser OAuth flow

# 4. Skill, offline paths (no token needed for the guards)
hermes skills install official/productivity/nocodb
cd optional-skills/productivity/nocodb
./scripts/nocodb.sh where:help                                     # prints filter syntax
NOCODB_TOKEN=x ./scripts/nocodb.sh record:list p1 m1 1 25 "(a,eq,1)and(b,eq,2)"
#   → error: use ~and and ~or (with tilde), not plain 'and'/'or'

# 5. Skill, live (needs a token)
export NOCODB_TOKEN=...            # NocoDB → Account Settings → Tokens
./scripts/nocodb.sh table:list <BASE_ID>
```

**What I actually ran:** items 1, 2, and 4 on macOS 15 (Darwin 25.5.0) — 1240 tests pass, and the three offline script paths behave as documented. Item 5 against NocoDB cloud.

**What I did not run:** the full `pytest tests/ -q` suite (no project venv on this machine — I ran the three relevant modules in an isolated env), and the OAuth handshake in item 3 end-to-end. The manifest is built from NocoDB's advertised discovery metadata quoted above rather than from an observed token exchange, so that flow is worth a smoke test on your side before merge. The Windows PowerShell path is likewise unverified at runtime — it is included because it is byte-for-byte the upstream port and matches the Bash command surface exactly.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the three relevant modules only; see above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` — N/A, no new config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture change
- [x] I've considered cross-platform impact — both scripts ship; `platforms` is asserted against them in tests
- [x] Tool descriptions/schemas — N/A

## For New Skills

- [x] Broadly useful — filed as optional, not bundled, per the placement rule
- [x] SKILL.md follows the standard format
- [x] No external dependencies beyond `curl` and `jq` (the PowerShell port needs neither)
- [ ] `hermes --toolsets skills -q "..."` end-to-end — not run; no Hermes install on this machine

## Notes for reviewers

- Scope: happy to split this into two PRs (manifest / skill) if the focused-PR rule is read strictly here.
- Attribution: the upstream repo states MIT in its README but ships no `LICENSE` file, so there is no copyright notice text to carry over. Provenance is recorded in a header on each vendored script and in an Attribution section in SKILL.md.
- I work on NocoDB, so treat the product claims as first-party but the Hermes-side placement decisions as open to correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
