### PR TITLE
fix(curator): read-before-write marks lost across tool worker threads (unwinnable retry loop)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -890,6 +890,7 @@ def _run_review_in_thread(
         pass
 
     review_agent = None
+    review_fork_key: Optional[str] = None
     review_messages: List[Dict] = []
     review_usage: Dict[str, Any] = {}
 
@@ -1036,6 +1037,13 @@ def _run_review_in_thread(
             )
             review_agent._memory_write_origin = "background_review"
             review_agent._memory_write_context = "background_review"
+            # Futile-loop circuit breaker: the review runs unattended, so a
+            # tool that keeps failing identically (e.g. a guard refusal the
+            # model can't satisfy) would otherwise be retried until the
+            # 16-iteration budget is gone — each retry a full-context
+            # inference call keeping the local GPU pinned. Three identical
+            # consecutive failures of the same tool abort the review.
+            review_agent._repeated_tool_failure_limit = 3
             # The review fork pins the parent's cached system prompt and keeps
             # ``tools[]`` byte-identical to the parent so its outbound request
             # hits the same provider cache prefix (see the toolset-parity note
@@ -1165,10 +1173,16 @@ def _run_review_in_thread(
                     "{tool_name}. Only memory/skill tools are allowed."
                 ),
             )
+            # Start this fork's read-before-write ledger from a clean slate.
+            # The marks live in a process-global store keyed by the fork id
+            # (turn_context binds str(id(agent)) for every turn this fork
+            # runs); remember the key so the outer finally can drop the entry
+            # even after review_agent itself is torn down.
+            review_fork_key = str(id(review_agent))
             try:
-                from tools.skill_manager_tool import _reset_background_review_read_marks
+                from tools.skill_manager_tool import clear_background_review_read_marks
 
-                _reset_background_review_read_marks()
+                clear_background_review_read_marks(review_fork_key)
             except Exception:
                 pass
 
@@ -1272,6 +1286,17 @@ def _run_review_in_thread(
                     )
                 except Exception:
                     pass
+        elif str(getattr(agent, "memory_notifications", "on") or "on").lower() != "off":
+            # Close the loop opened by the spawn announcement in
+            # _spawn_background_review: an empty review used to end in total
+            # silence, leaving the user no way to tell when the model (and a
+            # local GPU serving it) was actually free again. Best-effort — a
+            # print failure must not fall into the outer except and be
+            # miscounted as a failed review.
+            try:
+                agent._safe_print("  💭 Background review finished (no changes).")
+            except Exception:
+                pass
 
     except Exception as e:
         logger.warning("Background memory/skill review failed: %s", e)
@@ -1291,6 +1316,15 @@ def _run_review_in_thread(
         # so calling it again here after the primary call site already ran is
         # a harmless no-op.
         _unregister_review_agent(review_agent)
+        # Drop this fork's read-before-write marks from the process-global
+        # store so entries never outlive their fork.
+        if review_fork_key is not None:
+            try:
+                from tools.skill_manager_tool import clear_background_review_read_marks
+
+                clear_background_review_read_marks(review_fork_key)
+            except Exception:
+                pass
         if review_agent is not None:
             try:
                 with thread_scoped_silence():

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7133,6 +7133,34 @@ def run_conversation(
                     failed = True
                     break
 
+                _futile_trip = getattr(agent, "_repeated_tool_failure_tripped", None)
+                if _futile_trip is not None:
+                    # Futile-loop circuit breaker (opt-in, unattended forks
+                    # only — see AIAgent._note_tool_failure_repetition): the
+                    # same tool failed N times in a row with an identical
+                    # error, so re-prompting the model to retry it cannot
+                    # converge. Abort the turn instead of burning the rest of
+                    # the iteration budget on full-context inference calls.
+                    _futile_tool, _futile_count = _futile_trip
+                    agent._repeated_tool_failure_tripped = None
+                    _turn_exit_reason = "repeated_tool_failure"
+                    final_response = (
+                        f"Aborted: tool {_futile_tool} failed {_futile_count} "
+                        "consecutive times with an identical error; stopping "
+                        "instead of retrying a call that cannot succeed."
+                    )
+                    logger.warning(
+                        "Futile-loop circuit breaker: %s failed %d times with "
+                        "an identical error; aborting turn after API call #%d",
+                        _futile_tool, _futile_count, api_call_count,
+                    )
+                    agent._emit_status(
+                        f"⚠️ Aborted: {_futile_tool} kept failing with the "
+                        f"same error ({_futile_count}×)"
+                    )
+                    append_message(messages, {"role": "assistant", "content": final_response})
+                    break
+
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
                     _turn_exit_reason = "guardrail_halt"

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -477,7 +477,20 @@ def build_turn_context(
     set_session_context(agent.session_id)
 
     # Bind the skill write-origin ContextVar for this thread.
-    set_current_write_origin(getattr(agent, "_memory_write_origin", "assistant_tool"))
+    _origin = getattr(agent, "_memory_write_origin", "assistant_tool")
+    set_current_write_origin(_origin)
+    # Bind the review fork's identity too, so per-fork state that must survive
+    # tool worker threads (e.g. the skill read-before-write marks) can key a
+    # process-global store instead of a ContextVar that dies with each
+    # worker's context snapshot. background_review.py clears the fork's
+    # entries with this same key when the review thread finishes.
+    try:
+        from tools.skill_provenance import BACKGROUND_REVIEW, set_current_review_fork_id
+        set_current_review_fork_id(
+            str(id(agent)) if _origin == BACKGROUND_REVIEW else None
+        )
+    except Exception:
+        pass
 
     # Restore the primary runtime if the previous turn activated fallback.
     agent._restore_primary_runtime()

--- a/run_agent.py
+++ b/run_agent.py
@@ -1850,6 +1850,26 @@ class AIAgent:
             focus=focus,
             task_cfg=task_cfg,
         )
+        # Announce the spawn. The review itself is silenced until completion
+        # (thread_scoped_silence + suppress_status_output), so without this
+        # line the user at an idle prompt has NO indication hermes is still
+        # driving the model — on a local inference server that reads as the
+        # GPU inexplicably pinned for minutes after the answer already
+        # arrived. Gated on the same memory_notifications switch as the
+        # completion summary.
+        try:
+            if str(getattr(self, "memory_notifications", "on") or "on").lower() != "off":
+                _review_kind = (
+                    "memory/skill" if (review_memory and review_skills)
+                    else "memory" if review_memory else "skill"
+                )
+                self._safe_print(
+                    f"  💭 Background {_review_kind} review started — the model "
+                    "stays busy for a few minutes; a summary appears when it "
+                    "finishes."
+                )
+        except Exception:
+            pass
         # Carry the active profile into the review thread so MEMORY.md / skill
         # review writes land in the right profile (#54937).
         t = threading.Thread(
@@ -8127,6 +8147,46 @@ class AIAgent:
             "to change strategy instead of repeating the same call."
         )
 
+    def _note_tool_failure_repetition(
+        self,
+        tool_name: str,
+        function_result: Any,
+        *,
+        failed: bool,
+    ) -> None:
+        """Futile-loop circuit breaker: count identical repeated failures.
+
+        Opt-in via ``_repeated_tool_failure_limit`` (int > 0) — set only on
+        unattended forks (background review) where nobody is watching the
+        transcript. When the SAME tool fails ``limit`` times in a row with the
+        SAME error signature, ``_repeated_tool_failure_tripped`` is set and the
+        conversation loop aborts the turn instead of letting the model burn the
+        remaining iteration budget re-issuing a call that cannot succeed (the
+        curator view→patch→refused loop kept a 27B model pinned at ~100% GPU
+        for 10+ minutes this way). A success of the same tool resets its
+        counter — interleaved successes of OTHER tools (e.g. skill_view
+        between refused skill_manage calls) deliberately do not.
+        """
+        limit = getattr(self, "_repeated_tool_failure_limit", 0)
+        if not limit:
+            return
+        try:
+            store = getattr(self, "_repeated_tool_failures", None)
+            if store is None:
+                store = self._repeated_tool_failures = {}
+            if not failed:
+                store.pop(tool_name, None)
+                return
+            text = function_result if isinstance(function_result, str) else str(function_result)
+            sig = text[:300]
+            prev_sig, count = store.get(tool_name, (None, 0))
+            count = count + 1 if sig == prev_sig else 1
+            store[tool_name] = (sig, count)
+            if count >= limit:
+                self._repeated_tool_failure_tripped = (tool_name, count)
+        except Exception:
+            logger.debug("repeated-tool-failure tracking failed", exc_info=True)
+
     def _append_guardrail_observation(
         self,
         tool_name: str,
@@ -8135,6 +8195,9 @@ class AIAgent:
         *,
         failed: bool,
     ) -> str:
+        # Observe the RAW result before any guardrail guidance is appended so
+        # the repetition signature stays stable across iterations.
+        self._note_tool_failure_repetition(tool_name, function_result, failed=failed)
         decision = self._tool_guardrails.after_call(
             tool_name,
             function_args,

--- a/tests/test_repeated_tool_failure_breaker.py
+++ b/tests/test_repeated_tool_failure_breaker.py
@@ -1,0 +1,86 @@
+"""Tests for the futile-loop circuit breaker (AIAgent._note_tool_failure_repetition).
+
+The background review fork runs unattended: when a tool kept failing with an
+identical error (the curator's view→patch→refused loop against the skill
+read-before-write guard), the model retried the same call until the
+16-iteration budget was exhausted — every retry a full-context inference call
+that kept the local GPU pinned for minutes. The breaker counts consecutive
+identical failures PER TOOL and trips ``_repeated_tool_failure_tripped`` at
+the opt-in limit; agent/conversation_loop.py aborts the turn when it is set.
+
+Keyed per tool on purpose: in the observed incident, successful ``skill_view``
+calls were interleaved between the refused ``skill_manage`` calls, so any
+"consecutive failing iterations" scheme would never have tripped.
+"""
+
+from run_agent import AIAgent
+
+
+class _StubAgent:
+    """Bare object carrying only the attributes the breaker reads/writes."""
+
+    note = AIAgent._note_tool_failure_repetition
+
+    def __init__(self, limit=3):
+        if limit:
+            self._repeated_tool_failure_limit = limit
+
+
+ERR = '{"success": false, "error": "Refusing background curator patch"}'
+OK = '{"success": true}'
+
+
+class TestRepeatedToolFailureBreaker:
+    def test_trips_after_limit_identical_failures(self):
+        agent = _StubAgent(limit=3)
+        agent.note("skill_manage", ERR, failed=True)
+        agent.note("skill_manage", ERR, failed=True)
+        assert getattr(agent, "_repeated_tool_failure_tripped", None) is None
+        agent.note("skill_manage", ERR, failed=True)
+        assert agent._repeated_tool_failure_tripped == ("skill_manage", 3)
+
+    def test_interleaved_success_of_other_tool_does_not_reset(self):
+        """The incident pattern: skill_view succeeds between skill_manage
+        refusals. Only a success of the SAME tool shows progress."""
+        agent = _StubAgent(limit=3)
+        agent.note("skill_manage", ERR, failed=True)
+        agent.note("skill_view", OK, failed=False)
+        agent.note("skill_manage", ERR, failed=True)
+        agent.note("skill_view", OK, failed=False)
+        agent.note("skill_manage", ERR, failed=True)
+        assert agent._repeated_tool_failure_tripped == ("skill_manage", 3)
+
+    def test_success_of_same_tool_resets_counter(self):
+        agent = _StubAgent(limit=3)
+        agent.note("skill_manage", ERR, failed=True)
+        agent.note("skill_manage", ERR, failed=True)
+        agent.note("skill_manage", OK, failed=False)
+        agent.note("skill_manage", ERR, failed=True)
+        agent.note("skill_manage", ERR, failed=True)
+        assert getattr(agent, "_repeated_tool_failure_tripped", None) is None
+
+    def test_different_error_restarts_count(self):
+        """A changing error message means the model IS making progress
+        (e.g. fixing one validation complaint and hitting the next)."""
+        agent = _StubAgent(limit=3)
+        agent.note("skill_manage", "error: description too long", failed=True)
+        agent.note("skill_manage", "error: description too long", failed=True)
+        agent.note("skill_manage", "error: name invalid", failed=True)
+        assert getattr(agent, "_repeated_tool_failure_tripped", None) is None
+        agent.note("skill_manage", "error: name invalid", failed=True)
+        agent.note("skill_manage", "error: name invalid", failed=True)
+        assert agent._repeated_tool_failure_tripped == ("skill_manage", 3)
+
+    def test_disabled_without_opt_in(self):
+        agent = _StubAgent(limit=0)
+        for _ in range(10):
+            agent.note("skill_manage", ERR, failed=True)
+        assert getattr(agent, "_repeated_tool_failure_tripped", None) is None
+        assert getattr(agent, "_repeated_tool_failures", None) is None
+
+    def test_non_string_result_is_stringified(self):
+        agent = _StubAgent(limit=2)
+        payload = [{"type": "text", "text": "err"}]
+        agent.note("vision_tool", payload, failed=True)
+        agent.note("vision_tool", payload, failed=True)
+        assert agent._repeated_tool_failure_tripped == ("vision_tool", 2)

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -947,3 +947,107 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+    @staticmethod
+    def _run_in_worker_snapshot(fn, *args, **kwargs):
+        """Mimic agent.tool_executor dispatch: run one tool call on its own
+        worker thread inside a copy_context() snapshot of the caller's
+        context (what propagate_context_to_thread installs), so ContextVar
+        writes made by the call are discarded when it returns."""
+        import contextvars
+        import threading
+
+        ctx = contextvars.copy_context()
+        out = {}
+
+        def _target():
+            out["result"] = ctx.run(fn, *args, **kwargs)
+
+        t = threading.Thread(target=_target)
+        t.start()
+        t.join()
+        return out["result"]
+
+    def test_read_marks_survive_worker_thread_dispatch(self, tmp_path, monkeypatch):
+        """Regression: every tool call runs on a worker thread with a SNAPSHOT
+        of the loop thread's context, so a ContextVar-backed read ledger lost
+        skill_view's mark the moment the call returned — the read-before-write
+        guard became unsatisfiable and the review fork burned its entire
+        iteration budget in a view→patch→refused loop. The marks must survive
+        across per-call context snapshots."""
+        from tools.skills_tool import skill_view
+        from tools.skill_manager_tool import _reset_background_review_read_marks
+
+        _reset_background_review_read_marks()
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch):
+            _create_curator_skill("reviewed", _skill_content("reviewed"))
+
+            viewed = json.loads(self._run_in_worker_snapshot(skill_view, "reviewed"))
+            assert viewed["success"] is True
+
+            edited = json.loads(self._run_in_worker_snapshot(
+                skill_manage,
+                action="edit",
+                name="reviewed",
+                content=_skill_content("reviewed") + "\nUpdated by review.\n",
+            ))
+            assert edited["success"] is True, edited
+        _reset_background_review_read_marks()
+
+    def test_read_marks_isolated_between_forks(self, tmp_path, monkeypatch):
+        """A mark recorded by one review fork must not unlock writes for a
+        concurrently running fork — each fork must load the content its own
+        model actually saw."""
+        from tools.skills_tool import skill_view
+        from tools.skill_manager_tool import _reset_background_review_read_marks
+
+        _reset_background_review_read_marks()
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch):
+            _create_curator_skill("reviewed", _skill_content("reviewed"))
+
+            with patch(
+                "tools.skill_provenance.get_current_review_fork_id",
+                return_value="fork-a",
+            ):
+                assert json.loads(skill_view("reviewed"))["success"] is True
+
+            with patch(
+                "tools.skill_provenance.get_current_review_fork_id",
+                return_value="fork-b",
+            ):
+                blocked = json.loads(skill_manage(
+                    action="edit",
+                    name="reviewed",
+                    content=_skill_content("reviewed") + "\nUpdated.\n",
+                ))
+            assert blocked["success"] is False
+            assert blocked.get("_read_before_write_required") is True
+        _reset_background_review_read_marks()
+
+    def test_clear_background_review_read_marks_drops_fork_entry(self, tmp_path, monkeypatch):
+        """background_review.py clears a finished fork's ledger entry by key;
+        a later fork that happens to reuse the key must start locked."""
+        from tools.skills_tool import skill_view
+        from tools.skill_manager_tool import (
+            _reset_background_review_read_marks,
+            clear_background_review_read_marks,
+        )
+
+        _reset_background_review_read_marks()
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch):
+            _create_curator_skill("reviewed", _skill_content("reviewed"))
+
+            with patch(
+                "tools.skill_provenance.get_current_review_fork_id",
+                return_value="fork-a",
+            ):
+                assert json.loads(skill_view("reviewed"))["success"] is True
+                clear_background_review_read_marks("fork-a")
+                blocked = json.loads(skill_manage(
+                    action="edit",
+                    name="reviewed",
+                    content=_skill_content("reviewed") + "\nUpdated.\n",
+                ))
+            assert blocked["success"] is False
+            assert blocked.get("_read_before_write_required") is True
+        _reset_background_review_read_marks()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -36,6 +36,7 @@ import json
 import logging
 import re
 import shutil
+import threading as _threading
 import contextvars as _ctxvars
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -52,9 +53,30 @@ from agent.skill_utils import (
 
 logger = logging.getLogger(__name__)
 
-_background_review_read_paths: "_ctxvars.ContextVar[frozenset[str]]" = _ctxvars.ContextVar(
-    "background_review_read_paths", default=frozenset()
-)
+# Read-before-write marks for background-review forks, keyed by fork id.
+#
+# PROCESS-GLOBAL ON PURPOSE (issue: curator stuck in an unwinnable
+# view→patch→refused loop). These marks were originally a ContextVar, but
+# agent.tool_executor dispatches every tool call on a worker thread whose
+# context is a propagate_context_to_thread() SNAPSHOT of the loop thread's
+# context: a ContextVar.set() inside skill_view mutated only that snapshot
+# and was discarded when the tool returned. The next skill_manage call got a
+# fresh snapshot with an empty read-set, so the read-before-write guard could
+# never be satisfied and the review fork burned its whole iteration budget
+# retrying. Marks must therefore live in cross-thread storage; isolation
+# between concurrent review forks comes from keying on the fork id that
+# turn_context binds per fork (falling back to a shared key when absent).
+_background_review_read_lock = _threading.Lock()
+_background_review_read_paths_by_fork: Dict[str, "set[str]"] = {}
+_FALLBACK_REVIEW_FORK_KEY = "background_review"
+
+
+def _current_review_fork_key() -> str:
+    try:
+        from tools.skill_provenance import get_current_review_fork_id
+        return get_current_review_fork_id() or _FALLBACK_REVIEW_FORK_KEY
+    except Exception:
+        return _FALLBACK_REVIEW_FORK_KEY
 
 
 def mark_background_review_skill_read(path: Path) -> None:
@@ -77,9 +99,9 @@ def mark_background_review_skill_read(path: Path) -> None:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    current = set(_background_review_read_paths.get())
-    current.add(resolved)
-    _background_review_read_paths.set(frozenset(current))
+    key = _current_review_fork_key()
+    with _background_review_read_lock:
+        _background_review_read_paths_by_fork.setdefault(key, set()).add(resolved)
 
 
 def _background_review_has_read(path: Path) -> bool:
@@ -87,12 +109,27 @@ def _background_review_has_read(path: Path) -> bool:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    return resolved in _background_review_read_paths.get()
+    key = _current_review_fork_key()
+    with _background_review_read_lock:
+        return resolved in _background_review_read_paths_by_fork.get(key, ())
+
+
+def clear_background_review_read_marks(fork_id: Optional[str] = None) -> None:
+    """Drop a review fork's read marks (its whole entry) when it finishes.
+
+    background_review.py calls this from the review thread's finally with the
+    fork's key so entries never outlive their fork; with no argument the
+    current context's fork entry is cleared.
+    """
+    key = fork_id or _current_review_fork_key()
+    with _background_review_read_lock:
+        _background_review_read_paths_by_fork.pop(key, None)
 
 
 def _reset_background_review_read_marks() -> None:
-    """Test helper: clear read-before-write marks for the current context."""
-    _background_review_read_paths.set(frozenset())
+    """Test helper: clear all read-before-write marks."""
+    with _background_review_read_lock:
+        _background_review_read_paths_by_fork.clear()
 
 # Import security scanner — external hub installs always get scanned;
 # agent-created skills only get scanned when skills.guard_agent_created is on.

--- a/tools/skill_provenance.py
+++ b/tools/skill_provenance.py
@@ -39,6 +39,18 @@ _write_origin: contextvars.ContextVar[str] = contextvars.ContextVar(
     default="foreground",
 )
 
+# Identity of the active background-review fork, bound alongside the write
+# origin at turn setup. Tool dispatch runs each call on a worker thread with a
+# *snapshot* of the loop thread's context (propagate_context_to_thread), so
+# any per-fork state a tool needs to persist across calls must live in
+# process-global storage keyed by this id — ContextVar writes made inside a
+# worker die with the snapshot. The read-before-write marks in
+# skill_manager_tool are the canonical consumer.
+_review_fork_id: contextvars.ContextVar["str | None"] = contextvars.ContextVar(
+    "skill_review_fork_id",
+    default=None,
+)
+
 # The sentinel value the background review fork uses; mirrors
 # run_agent.py's AIAgent._memory_write_origin override in
 # _spawn_background_review().
@@ -76,3 +88,17 @@ def is_background_review() -> bool:
     """Convenience: True iff the current write origin is the background
     review fork."""
     return get_current_write_origin() == BACKGROUND_REVIEW
+
+
+def set_current_review_fork_id(fork_id: "str | None") -> "contextvars.Token[str | None]":
+    """Bind the active review fork's identity to the current context.
+
+    Pass a stable per-fork value (turn_context uses ``str(id(agent))``) when
+    the origin is ``background_review``, or ``None`` for foreground turns.
+    """
+    return _review_fork_id.set(fork_id)
+
+
+def get_current_review_fork_id() -> "str | None":
+    """Return the active review fork id, or None outside a review fork."""
+    return _review_fork_id.get()


### PR DESCRIPTION
## Bug

The background review fork's skill read-before-write guard stores its "which files were loaded" marks in a `ContextVar` (`tools/skill_manager_tool.py`). But `agent/tool_executor.py` dispatches every tool call on a worker thread running a `propagate_context_to_thread()` **snapshot** of the loop thread's context — so the mark `skill_view` sets is discarded the moment the call returns, and the next `skill_manage` call always sees an empty read-set.

The guard is therefore **permanently unsatisfiable**: the curator does exactly what the refusal message asks (`Call skill_view(name) ... then retry`), gets refused again, and loops view→patch→refused until the 16-iteration budget is exhausted. Each retry is a full-context inference call — observed in the wild as a local 27B model pinned at ~99% GPU for 10+ minutes after the user's session had already ended.

The existing unit tests missed this because they call `skill_view` and `skill_manage` in the same context; production never does.

## Fix

- **Root cause**: moved the read marks to a process-global, lock-protected store keyed by a per-fork id (new ContextVar in `tools/skill_provenance.py`, bound in `agent/turn_context.py` as `str(id(agent))` when the origin is `background_review`). Reads/writes work from any worker thread; concurrent review forks stay isolated; `agent/background_review.py` clears the fork's entry in its `finally` so entries never outlive their fork.
- **Defense in depth**: opt-in futile-loop circuit breaker (`_repeated_tool_failure_limit`, set to 3 on the review fork). When the same tool fails N consecutive times with an identical error signature, the turn aborts instead of burning the remaining budget. Keyed per tool because interleaved `skill_view` successes would defeat any consecutive-failing-iterations scheme — that is exactly the observed failure pattern.
- **Visibility**: the review fork announces its start and (when it made no changes) its completion, gated on the existing `memory_notifications` switch. Without this, an idle prompt gives no hint that hermes is still driving the model — on a local inference server that reads as the GPU inexplicably burning for minutes.

## Tests

- New regression tests dispatch each tool call on its own worker thread with a `copy_context()` snapshot, mirroring production dispatch (`tests/tools/test_skill_manager_tool.py`) — the original bug reproduces under them.
- Fork-isolation and lifecycle-cleanup tests for the new store.
- `tests/test_repeated_tool_failure_breaker.py` covers the circuit breaker (trip, per-tool reset, changing-error reset, opt-in gating).
- Full `tests/run_agent/` + `tests/tools/test_skill_manager_tool.py` + background-review suites pass: 1698 + 67 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)