### PR TITLE
fix(desktop): widen Linux scrollbars swallowed by WM resize edge

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -30,6 +30,10 @@ import { ThemeProvider } from './themes/context'
 
 installClipboardShim()
 
+if (/linux/i.test(navigator.platform)) {
+  document.documentElement.classList.add('platform-linux')
+}
+
 // The perf probe ships in dev, and in a production build ONLY when explicitly
 // opted in (VITE_PERF_PROBE=1) — this lets the perf harness measure a real,
 // minified production renderer for representative absolute numbers. Normal

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1155,6 +1155,12 @@ body.guest-pointer-lock :is(webview, iframe) {
     height: 0.25rem;
   }
 
+  html.platform-linux .scrollbar-dt::-webkit-scrollbar,
+  html.platform-linux .scrollbar-dt *:not(.scrollbar-overlay)::-webkit-scrollbar {
+    width: 0.625rem;
+    height: 0.625rem;
+  }
+
   .scrollbar-dt::-webkit-scrollbar-track,
   .scrollbar-dt::-webkit-scrollbar-corner,
   .scrollbar-dt *:not(.scrollbar-overlay)::-webkit-scrollbar-track,


### PR DESCRIPTION
## Problem

On GNOME (and other Linux window managers), the desktop app's scrollbars are effectively ungrabbable at the window edge. The app themes scrollbars to 4px (`0.25rem` in `styles.css`), and on Linux the WM's interactive-resize zone is the ~4px strip immediately **inside** the window edge — for a frameless Electron window there is no OS-drawn frame, so the grab overlaps the client area. An edge-flush 4px scrollbar sits entirely inside that zone, so every attempt to drag the thread or sidebar scrollbar resizes the window instead.

macOS and Windows are unaffected: their resize grips live outside the client area, so the thin bar is reachable there.

## Fix

- `apps/desktop/src/main.tsx` — add a `platform-linux` class to `<html>` when the renderer runs on Linux (same `navigator.platform` sniffing the codebase already uses in `geometry.ts` / `file-actions.tsx`).
- `apps/desktop/src/styles.css` — scope the scrollbar gutter to `0.625rem` (10px) on Linux only. The inner ~4px of the gutter may still overlap the WM resize zone; the remaining ~6px is a real grab target.

macOS/Windows keep the existing `0.25rem` look and fade behavior unchanged.

## Test plan

- GNOME: grab the conversation-thread scrollbar and the left sidebar scrollbar at the window edge → scrolls, does not resize.
- macOS/Windows: scrollbar appearance unchanged.

## Notes

The width is a platform fix, not a style preference — the thin bar is fine on platforms whose resize handles don't intrude into the client area. Portal scrollbars (dropdowns/popovers) float away from window edges and are intentionally left untouched.
