### PR TITLE
docs: route getting-started and updating readers to backup/export migration paths

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -82,6 +82,10 @@ hermes setup --portal
 That logs you in, sets Nous as your provider, and turns on the Tool Gateway in one command.
 :::
 
+:::tip Already running Hermes on another machine?
+You don't need to rebuild your setup from scratch. Restore a full backup with `hermes import` (see [Exporting Hermes to another machine](/reference/faq#exporting-hermes-to-another-machine)), or bring over a single agent with `hermes profile import` (see [Moving a single profile to another machine](/reference/faq#moving-a-single-profile-to-another-machine)). Note that a profile export excludes credentials by design, so an export alone is not a full backup — [`hermes backup` vs `hermes profile export`](/reference/faq#hermes-backup-vs-hermes-profile-export) explains which to use.
+:::
+
 ---
 
 ## Prerequisites

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -247,6 +247,10 @@ hermes uninstall
 
 The uninstaller gives you the option to keep your configuration files (`~/.hermes/`) for a future reinstall.
 
+:::tip Moving to a new machine rather than leaving?
+Take your setup with you before removing anything: `hermes backup` captures the entire `~/.hermes` directory including credentials, while `hermes profile export` packs a single profile with credentials excluded by design (so an export alone is not a full backup). See [`hermes backup` vs `hermes profile export`](/reference/faq#hermes-backup-vs-hermes-profile-export).
+:::
+
 ### Manual Uninstall
 
 ```bash


### PR DESCRIPTION
## What

- `getting-started/installation.md`: adds an "Already running Hermes on another machine?" tip after the post-install section, pointing at the FAQ's restore paths (`hermes import` for a full backup, `hermes profile import` for a single profile) and stating that a profile export excludes credentials by design, so an export alone is not a full backup.
- `getting-started/updating.md`: adds a matching tip at the top of the Uninstalling section (the moving-away moment), pointing at the FAQ's `hermes backup` vs `hermes profile export` comparison.

## Why

"How do I move / clone my working setup to another machine" is one of the most recurring questions in community support channels (r/hermesagent, roughly weekly). The answers exist in the FAQ (Exporting Hermes to another machine, Moving a single profile to another machine, and the backup-vs-export table), but the two pages a mover actually lands on -- installation and updating/uninstalling -- do not link to them. The updating page already routes mid-page (the `--backup` section tip); this adds the same routing at the two entry points that miss it.

All linked FAQ anchors verified against current main (2026-08-17). The credentials-excluded wording follows the existing FAQ table ("Excluded (stripped for safe sharing)") and profiles.md ("API keys are stripped"). 8 insertions, 0 deletions, docs only.