### PR TITLE
fix(completion): recommend the bash-completion lazy-load dir, not ~/.bashrc

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -98,8 +98,12 @@ def generate_bash(parser: argparse.ArgumentParser) -> str:
     cases_str = "\n".join(cases)
 
     return f"""# Hermes Agent bash completion
-# Add to ~/.bashrc:
-#   eval "$(hermes completion bash)"
+# Install where bash-completion lazy-loads it (preferred — keeps startup
+# fast and never touches ~/.bashrc):
+#   mkdir -p ~/.local/share/bash-completion/completions
+#   hermes completion bash > ~/.local/share/bash-completion/completions/hermes
+# Fallback (systems without the bash-completion package):
+#   eval "$(hermes completion bash)"   # add to ~/.bashrc
 
 _hermes_profiles() {{
     local profiles_dir="$HOME/.hermes/profiles"

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -83,6 +83,19 @@ class TestGenerateBash:
         assert "_hermes_completion()" in out
         assert "complete -F _hermes_completion hermes" in out
 
+    def test_header_recommends_bash_completion_dir_not_bashrc(self):
+        """#88201: the header must recommend the lazy-load completions dir
+        as the primary install path. Directing users to paste completion
+        code into ~/.bashrc is the documented anti-pattern (#9785's own
+        warning) — it slows every shell start and breaks the
+        bash-completion autoload convention."""
+        out = generate_bash(_make_parser())
+        assert "~/.local/share/bash-completion/completions" in out
+        # The bare "Add to ~/.bashrc" guidance must be gone; the bashrc
+        # eval may only appear as a labeled fallback.
+        assert "Add to ~/.bashrc" not in out
+        assert "eval" in out  # fallback still shown
+
 
     def test_valid_bash_syntax(self):
         """Script must pass `bash -n` syntax check."""


### PR DESCRIPTION
## What does this PR do?

Stops the generated bash completion from directing users into the documented anti-pattern. `hermes completion bash` prints a script whose header says:

```
# Add to ~/.bashrc:
#   eval "$(hermes completion bash)"
```

— the exact thing #9785's own issue warns against ("Never, ever add completion code to `.bashrc`!"): it evaluates the whole generator on every interactive shell start and bypasses the bash-completion autoload convention (#88201).

The header now recommends the location bash-completion 2.x lazy-loads automatically as the primary install — `~/.local/share/bash-completion/completions/hermes` — with the `bashrc` `eval` kept as a clearly-labeled fallback for systems without the bash-completion package. The emitted completion logic itself is unchanged.

## Related Issue

Fixes #88201

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/completion.py` — `generate_bash()` header: primary guidance is now `mkdir -p ~/.local/share/bash-completion/completions && hermes completion bash > .../completions/hermes`; the `eval` line is retained as a labeled fallback only.
- `tests/hermes_cli/test_completion.py` — new `test_header_recommends_bash_completion_dir_not_bashrc`: asserts the completions-dir path appears, the bare "Add to ~/.bashrc" guidance is gone, and the fallback `eval` is still shown.

## How to Test

1. `python -m pytest tests/hermes_cli/test_completion.py -q`
2. Observed result: 9 passed (8 pre-existing + 1 new). A/B guard: with only the `hermes_cli/completion.py` hunk stashed, the new test FAILS (the old header carries the "Add to ~/.bashrc" guidance).
3. `hermes completion bash | head -6` — Observed result: the header recommends `~/.local/share/bash-completion/completions` first; `bash -n` syntax validation still passes (covered by the existing `test_valid_bash_syntax`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/hermes_cli/test_completion.py -q                 # with fix
9 passed in 0.64s
$ git stash -- hermes_cli/completion.py && pytest ... -q        # A/B guard
1 failed  (header still directs to ~/.bashrc)
```
