### PR TITLE
fix(banner): route deferred update notice through cprint to avoid ANSI garbling

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -731,7 +731,26 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
             behind = _update_result
             if behind is None or behind == 0:
                 return
-            console.print(_format_update_notice(behind))
+            # Route through prompt_toolkit's native renderer (cprint)
+            # instead of console.print(). This fires from a daemon
+            # thread while patch_stdout() may be active in the
+            # interactive chat loop; a plain Rich console.print()
+            # writes raw ANSI to stdout, which prompt_toolkit's
+            # StdoutProxy mangles into garbled '?[1;33m...?[0m' text.
+            # Render the Rich markup to ANSI first, then let cprint()
+            # feed it through print_formatted_text(ANSI(...)) which
+            # prompt_toolkit parses and renders correctly.
+            from io import StringIO
+            from rich.console import Console as _RenderConsole
+            markup = _format_update_notice(behind)
+            buf = StringIO()
+            rc = _RenderConsole(
+                file=buf, force_terminal=True, color_system="truecolor",
+                highlight=False,
+            )
+            rc.width = shutil.get_terminal_size((80, 24)).columns
+            rc.print(markup)
+            cprint(buf.getvalue().rstrip("\n"))
         except Exception:
             pass  # never break the session over an update notice
 

--- a/tests/tools/test_startup_latency_regressions.py
+++ b/tests/tools/test_startup_latency_regressions.py
@@ -179,10 +179,14 @@ class TestBannerUpdateCheckNonBlocking:
             def print(self, msg, *a, **k):
                 printed.append(msg)
 
+        def _capture(text):
+            printed.append(text)
+
         done = threading.Event()
         with patch.object(banner, "_update_check_done", done), \
              patch.object(banner, "_update_result", None), \
-             patch.object(banner, "_deferred_update_notice_started", False):
+             patch.object(banner, "_deferred_update_notice_started", False), \
+             patch.object(banner, "cprint", _capture):
             banner._defer_update_notice(_Console(), max_wait=5.0)
             banner._update_result = 3
             done.set()
@@ -190,7 +194,9 @@ class TestBannerUpdateCheckNonBlocking:
             while not printed and time.time() < deadline:
                 time.sleep(0.02)
         assert printed, "deferred update notice never printed"
-        assert "3 commits behind" in printed[0]
+        # cprint receives ANSI-rendered text, not Rich markup; the
+        # "3 commits behind" text must still be present in the output.
+        assert any("3 commits behind" in line for line in printed)
 
     def test_deferred_notice_silent_when_up_to_date(self):
         import hermes_cli.banner as banner
@@ -201,10 +207,14 @@ class TestBannerUpdateCheckNonBlocking:
             def print(self, msg, *a, **k):
                 printed.append(msg)
 
+        def _capture(text):
+            printed.append(text)
+
         done = threading.Event()
         with patch.object(banner, "_update_check_done", done), \
              patch.object(banner, "_update_result", 0), \
-             patch.object(banner, "_deferred_update_notice_started", False):
+             patch.object(banner, "_deferred_update_notice_started", False), \
+             patch.object(banner, "cprint", _capture):
             banner._defer_update_notice(_Console(), max_wait=2.0)
             done.set()
             time.sleep(0.3)


### PR DESCRIPTION
## Problem

The deferred update notice (`_defer_update_notice` in `hermes_cli/banner.py`) fires from a daemon thread that calls `console.print()` on a plain Rich `Console`. When the interactive chat loop's `patch_stdout()` is active, prompt_toolkit's `StdoutProxy` mangles the ESC bytes into `?`, producing garbled output like:

```
?[1;33m⚠ 127 commits behind?[0m?[2;33m — run ?[0m?[1;2;33mhermes update?[0m?[2;33m to update?[0m
```

This happens when the update check completes after the banner has already rendered (the common case — the check does git/network work that rarely finishes before the banner paints). The deferred notice thread then prints while `patch_stdout` is wrapping stdout.

## Root cause

This is the same `patch_stdout` StdoutProxy mangling documented and worked around at multiple other call sites in the codebase:
- `cli_commands_mixin.py:707` — `tools_disable_enable_command` output
- `cli_commands_mixin.py:543` — `/journey` command output
- `cli_agent_setup_mixin.py:556` — ANSI sequences in agent setup

All of those route through `_cprint` / `ChatConsole` (which use prompt_toolkit's `print_formatted_text(ANSI(...))`) instead of raw `console.print()`. The deferred update notice was simply missed.

## Fix

Render the Rich markup to ANSI via a throwaway `Console` into a `StringIO` buffer, then route the resulting ANSI string through `cprint()`. This is the same pattern `ChatConsole` uses in `cli.py` (capture Rich output, strip OSC, feed through `print_formatted_text`).

```python
# Before (broken under patch_stdout):
console.print(_format_update_notice(behind))

# After (patch_stdout-safe):
from io import StringIO
from rich.console import Console as _RenderConsole
markup = _format_update_notice(behind)
buf = StringIO()
rc = _RenderConsole(file=buf, force_terminal=True, color_system="truecolor", highlight=False)
rc.width = shutil.get_terminal_size((80, 24)).columns
rc.print(markup)
cprint(buf.getvalue().rstrip("\n"))
```

`cprint()` already exists in `banner.py` (line 39) for exactly this purpose — it wraps `print_formatted_text(ANSI(...))` with a fallback to plain `print()`.

## Tests

Updated `test_deferred_notice_prints_when_result_lands` and `test_deferred_notice_silent_when_up_to_date` in `tests/tools/test_startup_latency_regressions.py` to patch `cprint` instead of mocking `console.print`, since the output path now goes through `cprint`. The assertion checks that `"3 commits behind"` still appears in the ANSI-rendered output.

All 16 tests in `test_startup_latency_regressions.py` pass.

## Verification

Confirmed the exact garbled byte sequence by reproducing Rich's ANSI output for the `_format_update_notice` markup and replacing `\x1b` with `?`:

```
MANGLED: ?[1;33m⚠ 127 commits behind?[0m?[2;33m — run ?[0m?[1;2;33mhermes update?[0m?[2;33m to update?[0m
```

This matches the reported garbled output exactly. After the fix, `cprint` receives `\x1b[1;33m⚠ 127 commits behind\x1b[0m...` — proper ESC sequences that prompt_toolkit parses and renders as real colors.