### PR TITLE
fix(hermes-cli): allow typed kanban block reason flags after id

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -624,9 +624,6 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     p_block = sub.add_parser("block", help="Mark one or more tasks blocked")
     p_block.add_argument("task_id")
-    p_block.add_argument("reason", nargs="*", help="Reason (also appended as a comment)")
-    p_block.add_argument("--ids", nargs="+", default=None,
-                         help="Additional task ids to block with the same reason (bulk mode)")
     p_block.add_argument(
         "--kind", default=None, choices=sorted(kb.VALID_BLOCK_KINDS),
         help=(
@@ -637,6 +634,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "triage to break unblock loops. Omit for a generic block."
         ),
     )
+    p_block.add_argument("--ids", nargs="+", default=None,
+                         help="Additional task ids to block with the same reason (bulk mode)")
+    p_block.add_argument("reason", nargs="*", help="Reason (also appended as a comment)")
 
     p_schedule = sub.add_parser("schedule", help="Park one or more tasks in Scheduled (waiting on time, not human input)")
     p_schedule.add_argument("task_id")

--- a/tests/hermes_cli/test_kanban_parser.py
+++ b/tests/hermes_cli/test_kanban_parser.py
@@ -1,0 +1,49 @@
+"""Parser-level regression tests for `hermes kanban` CLI options."""
+
+from __future__ import annotations
+
+import argparse
+
+from hermes_cli import kanban
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    kanban.build_parser(subparsers)
+    return parser
+
+
+def test_kanban_block_parses_kind_with_reason_tokens():
+    parser = _build_parser()
+    args = parser.parse_args(["kanban", "block", "task123", "--kind", "needs_input", "multi", "word"])
+
+    assert args.command == "kanban"
+    assert args.kanban_action == "block"
+    assert args.task_id == "task123"
+    assert args.kind == "needs_input"
+    assert args.reason == ["multi", "word"]
+    assert args.ids is None
+
+
+def test_kanban_block_without_kind_keeps_reason_optional():
+    parser = _build_parser()
+    args = parser.parse_args(["kanban", "block", "task123", "fix", "this", "task"])
+
+    assert args.kanban_action == "block"
+    assert args.task_id == "task123"
+    assert args.reason == ["fix", "this", "task"]
+    assert args.kind is None
+
+
+def test_kanban_block_with_kind_and_bulk_ids_still_parses():
+    parser = _build_parser()
+    args = parser.parse_args(
+        ["kanban", "block", "task123", "--kind", "dependency", "--ids", "task124", "task125"]
+    )
+
+    assert args.kanban_action == "block"
+    assert args.task_id == "task123"
+    assert args.ids == ["task124", "task125"]
+    assert args.kind == "dependency"
+    assert args.reason == []


### PR DESCRIPTION
## Summary
- Fixes CLI argument parsing for `hermes kanban block` so `--kind` can be placed before free-form reason text.
- Kept parser behavior scoped: `--kind` and `--ids` now appear before the positional `reason` argument.
- Added regression tests for parser behavior to prevent the regression from reappearing.

## Test Plan
- [x] `python3 -m py_compile hermes_cli/kanban.py tests/hermes_cli/test_kanban_parser.py`
- [x] `python3 -m pytest tests/hermes_cli/test_kanban_parser.py -q`
- [x] `ruff check hermes_cli/kanban.py tests/hermes_cli/test_kanban_parser.py`

Closes #88135
