### PR TITLE
fix(state): exclude tool calls from trigram FTS

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -34,6 +34,7 @@ from hermes_cli.colors import Colors, color
 from hermes_cli.models import _HERMES_USER_AGENT
 from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
+from hermes_state_common import FTS_STORAGE_VERSION
 from utils import base_url_host_matches
 
 
@@ -372,21 +373,20 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
             "",
         ))
 
-    # Advisory: oversized database. Suggest auto_prune, and — when the v23
-    # FTS rebuild is pending OR the DB still carries the legacy inline
-    # trigram layout (fts_storage_version marker absent) — the offline
+    # Advisory: oversized database. Suggest auto_prune, and — when the FTS
+    # rebuild is pending OR the DB predates the current trigram layout — the offline
     # optimize-storage pass that migrates/compacts the FTS indexes.
     if logical is not None and logical > STATE_DB_SIZE_WARN_BYTES:
         detail = (
             "consider enabling sessions.auto_prune in config.yaml "
             "to bound growth"
         )
-        legacy_trigram = (
+        stale_trigram = (
             fts is not None
             and fts.get("messages_fts_trigram")
-            and stats.get("fts_storage_version") is None
+            and (stats.get("fts_storage_version") or 0) < FTS_STORAGE_VERSION
         )
-        if stats.get("fts_rebuild_pending") or legacy_trigram:
+        if stats.get("fts_rebuild_pending") or stale_trigram:
             detail += (
                 "; run 'hermes sessions optimize-storage' offline "
                 "(with the gateway stopped) to compact FTS storage"

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -438,9 +438,9 @@ def _print_curator_first_run_notice() -> None:
 def _print_fts_optimize_available_notice() -> None:
     """Advertise the opt-in v23 search-index optimization after `hermes update`.
 
-    Only fires when the current profile's state.db is still on the legacy
-    (pre-v23) inline FTS layout. Leads with the reclaimable-space figure and
-    points at the exact command. Honors ``sessions.fts_optimize_notice``:
+    Only fires when the current profile's state.db still needs an FTS storage
+    rebuild. Leads with the reclaimable-space figure and points at the exact
+    command. Honors ``sessions.fts_optimize_notice``:
     ``advise`` (default) prints an advisory notice, ``require`` prints a
     firmer required-upgrade notice, ``off`` suppresses it. Silent for
     fresh/already-optimized installs.
@@ -476,13 +476,17 @@ def _print_fts_optimize_available_notice() -> None:
         return
     db = None
     interrupted = False
+    needs_upgrade = False
     try:
         db = SessionDB(db_path=db_path, read_only=True)
-        # read_only opens skip schema init, so probe the layout directly.
+        # read_only opens skip schema init, so probe the stored layout directly.
         row = db._conn.execute(
             "SELECT sql FROM sqlite_master "
             "WHERE type = 'table' AND name = 'messages_fts'"
         ).fetchone()
+        needs_upgrade = bool(row) and getattr(
+            db, "_db_needs_fts_storage_upgrade"
+        )(db._conn)
         # An interrupted `optimize-storage` run: the table is already the
         # v23 shape, but backfill markers / demoted trash tables remain.
         # Offer the command again — re-running resumes and finishes it.
@@ -508,9 +512,8 @@ def _print_fts_optimize_available_notice() -> None:
                 db.close()
             except Exception:
                 pass
-    sql = (row[0] if row else "") or ""
-    if not sql or ("tool_name" in sql and not interrupted):
-        # v23 layout already present (fresh/optimized) — nothing to offer.
+    if not needs_upgrade and not interrupted:
+        # Current layout already present (fresh/optimized) — nothing to offer.
         return
 
     if interrupted:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3783,6 +3783,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # means a legacy shape that doesn't index tool metadata → optimize.
         return "tool_name" not in sql
 
+    @staticmethod
+    def _db_has_trigram_tool_calls_projection(cursor: sqlite3.Cursor) -> bool:
+        """True when the trigram vtable still includes tool_calls payload."""
+        row = cursor.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'messages_fts_trigram'"
+        ).fetchone()
+        if row is None:
+            return False
+        sql = (row[0] if not isinstance(row, sqlite3.Row) else row["sql"]) or ""
+        return "tool_calls" in sql.lower()
+
+    @classmethod
+    def _db_needs_fts_storage_upgrade(
+        cls, cursor: sqlite3.Cursor
+    ) -> bool:
+        """True when the current FTS storage layout should be treated as stale."""
+        return (
+            cls._db_has_legacy_inline_fts(cursor)
+            or cls._db_has_trigram_tool_calls_projection(cursor)
+        )
+
     def _warn_trigram_unavailable(self, exc: sqlite3.OperationalError) -> None:
         """Log once that the trigram tokenizer is missing; base FTS5 stays enabled."""
         if getattr(self, "_trigram_unavailable_warned", False):

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -225,9 +225,9 @@ SCHEMA_VERSION = 26
 # reaches the current version when a DB is either born fresh or explicitly
 # optimized via ``hermes sessions optimize-storage``. A legacy DB sits at
 # layout 0 (marker absent) with a working inline index until the user opts in.
-#   1 = v23 external-content layout (content/tool_name/tool_calls,
-#       tool-row-excluded trigram)
-FTS_STORAGE_VERSION = 1
+#   1 = v23 external-content layout with a tool-row-excluded trigram
+#   2 = trigram also excludes structured tool_calls JSON
+FTS_STORAGE_VERSION = 2
 
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
@@ -544,16 +544,17 @@ END;
 # ``messages_fts`` index; they just don't get trigram (CJK substring)
 # treatment.  ``search_messages`` routes CJK queries that filter on
 # ``role='tool'`` to the LIKE fallback for the same reason.
+# Structured ``tool_calls`` JSON stays searchable through ``messages_fts``;
+# excluding it here avoids indexing repetitive JSON syntax as trigrams.
 FTS_TRIGRAM_SQL = """
 CREATE VIEW IF NOT EXISTS messages_fts_trigram_src AS
-    SELECT id, role, content, tool_name, tool_calls
+    SELECT id, role, content, tool_name
     FROM messages
     WHERE role <> 'tool';
 
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_trigram USING fts5(
     content,
     tool_name,
-    tool_calls,
     content='messages_fts_trigram_src',
     content_rowid='id',
     tokenize='trigram'
@@ -566,8 +567,8 @@ WHEN new.role <> 'tool'
      OR new.id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
-    INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
-    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+    INSERT INTO messages_fts_trigram(rowid, content, tool_name)
+    VALUES (new.id, new.content, new.tool_name);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_delete AFTER DELETE ON messages
@@ -577,26 +578,25 @@ WHEN old.role <> 'tool'
      OR old.id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
-    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
-    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name)
+    VALUES ('delete', old.id, old.content, old.tool_name);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update
-AFTER UPDATE OF content, tool_name, tool_calls, role ON messages
+AFTER UPDATE OF content, tool_name, role ON messages
 WHEN (old.content IS NOT new.content
     OR old.tool_name IS NOT new.tool_name
-    OR old.tool_calls IS NOT new.tool_calls
     OR old.role IS NOT new.role)
    AND (old.id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
                            WHERE key = 'fts_rebuild_high_water'), -1)
      OR old.id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
-    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
-    SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
+    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name)
+    SELECT 'delete', old.id, old.content, old.tool_name
     WHERE old.role <> 'tool';
-    INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
-    SELECT new.id, new.content, new.tool_name, new.tool_calls
+    INSERT INTO messages_fts_trigram(rowid, content, tool_name)
+    SELECT new.id, new.content, new.tool_name
     WHERE new.role <> 'tool';
 END;
 """

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1110,7 +1110,10 @@ class SessionSchemaMixin:
                 # advances to SCHEMA_VERSION here like every other migration —
                 # future v24+ migrations land automatically for legacy-FTS
                 # users too. Only the FTS *layout* waits for opt-in.
-                if fts5_available and self._db_has_legacy_inline_fts(cursor):
+                if (
+                    fts5_available
+                    and self._db_needs_fts_storage_upgrade(cursor)
+                ):
                     self.set_meta("fts_optimize_available", "1", cursor=cursor)
 
             if current_version < 25:
@@ -1134,7 +1137,7 @@ class SessionSchemaMixin:
             # transition actually completes.
             if (
                 fts5_available
-                and not self._db_has_legacy_inline_fts(cursor)
+                and not self._db_needs_fts_storage_upgrade(cursor)
                 and cursor.execute(
                     "SELECT 1 FROM state_meta "
                     "WHERE key = 'fts_rebuild_high_water' LIMIT 1"

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -337,7 +337,9 @@ class SessionSearchMixin:
             return True  # transient (lock contention) — caller retries
         if more is False:
             status = self.fts_rebuild_status()
-            if status is not None and status["indexed"] >= status["total"]:
+            if high_water <= 0 or (
+                status is not None and status["indexed"] >= status["total"]
+            ):
                 self._fts_rebuild_finish()
             return False
         return bool(more)

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -157,8 +157,8 @@ class SessionSearchMixin:
                 )
                 if include_trigram:
                     conn.execute(
-                        "INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls) "
-                        "SELECT m.id, m.content, m.tool_name, m.tool_calls "
+                        "INSERT INTO messages_fts_trigram(rowid, content, tool_name) "
+                        "SELECT m.id, m.content, m.tool_name "
                         "FROM messages m "
                         "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
                         "AND NOT EXISTS (SELECT 1 FROM messages_fts_trigram_docsize d WHERE d.id = m.id)",
@@ -316,8 +316,8 @@ class SessionSearchMixin:
             if include_trigram:
                 conn.execute(
                     "INSERT INTO messages_fts_trigram"
-                    "(rowid, content, tool_name, tool_calls) "
-                    "SELECT id, content, tool_name, tool_calls FROM messages "
+                    "(rowid, content, tool_name) "
+                    "SELECT id, content, tool_name FROM messages "
                     "WHERE id > ? AND id <= ? AND role <> 'tool'",
                     (progress, upper),
                 )
@@ -640,16 +640,19 @@ class SessionSearchMixin:
         is a legacy inline-FTS install that can be optimized to the v23
         external-content schema, or a previous optimize run was interrupted
         (legacy vtables already demoted, but backfill markers and/or trash
-        tables remain) and re-running would resume it, or the CJK-bigram
-        index needs a backfill/rebuild on this tokenizer-capable host, or
-        a prior demote left an empty external-content index without markers
-        (healable on re-run).
+        tables remain) and re-running would resume it, or this DB is v23 with the
+        old tool-calls-inclusive trigram projection (repairable via this same
+        migration flow), or the CJK-bigram index needs a backfill/rebuild on this
+        tokenizer-capable host, or a prior demote left an empty external-content
+        index without markers (healable on re-run).
         False for fresh and fully-optimized installs (and when FTS5 is
         unavailable)."""
         if not self._fts_enabled or self.read_only:
             return False
         with self._lock:
             if self._db_has_legacy_inline_fts(self._conn):
+                return True
+            if self._db_has_trigram_tool_calls_projection(self._conn):
                 return True
             # Interrupted optimize: demotion already removed the legacy
             # vtables (so the check above is False), but the transition is
@@ -677,7 +680,7 @@ class SessionSearchMixin:
             return self._fts_external_index_empty_with_messages(self._conn)
 
     def _demote_legacy_fts_to_trash(self) -> int:
-        """Demote the legacy inline FTS vtables and stage their shadow tables
+        """Demote upgrade-eligible FTS vtables and stage their shadow tables
         for chunked teardown. Returns MAX(messages.id) as the rebuild high
         water. O(1) schema surgery — the heavy delete is deferred to the
         chunked teardown, exactly as the validated auto path did.
@@ -750,9 +753,16 @@ class SessionSearchMixin:
         progress_cb: Optional[Callable[[Dict[str, Any]], None]] = None,
         vacuum: bool = True,
     ) -> Dict[str, Any]:
-        """Migrate a legacy v22 inline-FTS DB to the v23 external-content
-        schema, foreground and to completion. Safe to re-run: if a previous
-        attempt was interrupted it resumes from the progress marker.
+        """Repair an older FTS layout into the current v23-compatible shape,
+        foreground and to completion.
+
+        Supports two paths:
+        - legacy-v22 inline -> demote to v23 external-content
+        - v23 installs where ``messages_fts_trigram`` still stores
+          ``tool_calls`` payloads
+
+        Safe to re-run: if a previous attempt was interrupted it resumes from
+        the progress marker.
 
         ``progress_cb`` receives {"phase", "percent", "indexed", "total"}
         dicts for a CLI progress bar. Returns a summary dict.
@@ -776,11 +786,13 @@ class SessionSearchMixin:
         # finishing the backfill + teardown — this is what makes re-running
         # after an interruption safe.
         with self._lock:
-            legacy = self._db_has_legacy_inline_fts(self._conn)
+            needs_storage_upgrade = self._db_needs_fts_storage_upgrade(
+                self._conn
+            )
         pending = self.get_meta("fts_rebuild_high_water") is not None
-        if legacy and not pending:
+        if needs_storage_upgrade and not pending:
             self._demote_legacy_fts_to_trash()
-        elif pending and not legacy:
+        elif pending and not needs_storage_upgrade:
             # Resume mid-demote: markers exist, empty v23 tables may still be
             # missing if the process died between the staged demote commit and
             # schema ensure. Re-ensure is IF NOT EXISTS and cheap.

--- a/tests/hermes_cli/test_fts_optimize_notice.py
+++ b/tests/hermes_cli/test_fts_optimize_notice.py
@@ -1,0 +1,42 @@
+"""Regression coverage for FTS storage upgrade discoverability."""
+
+import sqlite3
+from types import SimpleNamespace
+
+
+def test_update_notice_offers_v1_trigram_tool_calls_rebuild(tmp_path, monkeypatch, capsys):
+    """A deployed v1 trigram projection still receives the opt-in notice."""
+    from hermes_cli import update_cmd
+    import hermes_constants
+    import hermes_state
+
+    db_path = tmp_path / "state.db"
+    db_path.touch()
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE messages_fts (content TEXT, tool_name TEXT, tool_calls TEXT);
+        CREATE TABLE messages_fts_trigram (content TEXT, tool_name TEXT, tool_calls TEXT);
+        """
+    )
+
+    class FakeSessionDB:
+        def __init__(self, **_kwargs):
+            self._conn = conn
+
+        def close(self):
+            pass
+
+        _db_needs_fts_storage_upgrade = staticmethod(
+            hermes_state.SessionDB._db_needs_fts_storage_upgrade
+        )
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(hermes_state, "SessionDB", FakeSessionDB)
+    monkeypatch.setattr(update_cmd.Path, "stat", lambda _path: SimpleNamespace(st_size=512 * 1024 ** 2))
+
+    update_cmd._print_fts_optimize_available_notice()
+
+    assert "hermes sessions optimize-storage" in capsys.readouterr().out
+    conn.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3111,7 +3111,10 @@ class TestFTSExternalContentMigration:
         finally:
             db.close()
 
-    def test_v23_rebuild_from_trigram_tool_calls_projection(self, tmp_path):
+    @pytest.mark.parametrize("with_message", [False, True])
+    def test_v23_rebuild_from_trigram_tool_calls_projection(
+        self, tmp_path, with_message
+    ):
         """v23 installs built with historical trigram projection should be
         repaired via optimize-storage: trigram must drop tool_calls while
         standard messages_fts keeps indexing them."""
@@ -3184,28 +3187,29 @@ class TestFTSExternalContentMigration:
         conn.commit()
         conn.close()
 
-        conn = sqlite3.connect(str(db_path))
-        conn.execute(
-            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
-            ("s1", "cli", time.time()),
-        )
-        conn.execute(
-            "INSERT INTO messages (session_id, timestamp, role, content, tool_name, tool_calls) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                "s1",
-                time.time(),
-                "assistant",
-                "部署完成 assistant content",
-                "legacyTool",
-                '{"name": "legacy", "arguments": "UNIQUE_TOOLCALL_TOKEN_43701"}',
-            ),
-        )
-        conn.commit()
-        assert conn.execute(
-            "SELECT rowid FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'UNIQUE_TOOLCALL_TOKEN_43701'"
-        ).fetchall()
-        conn.close()
+        if with_message:
+            conn = sqlite3.connect(str(db_path))
+            conn.execute(
+                "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+                ("s1", "cli", time.time()),
+            )
+            conn.execute(
+                "INSERT INTO messages (session_id, timestamp, role, content, tool_name, tool_calls) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    "s1",
+                    time.time(),
+                    "assistant",
+                    "部署完成 assistant content",
+                    "legacyTool",
+                    '{"name": "legacy", "arguments": "UNIQUE_TOOLCALL_TOKEN_43701"}',
+                ),
+            )
+            conn.commit()
+            assert conn.execute(
+                "SELECT rowid FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'UNIQUE_TOOLCALL_TOKEN_43701'"
+            ).fetchall()
+            conn.close()
 
         db = SessionDB(db_path=db_path)
         try:
@@ -3223,24 +3227,35 @@ class TestFTSExternalContentMigration:
             db._ensure_fts_schema = interrupt_after_demote
             with pytest.raises(RuntimeError, match="injected trigram"):
                 db.optimize_fts_storage(vacuum=False)
-            assert db.get_meta("fts_rebuild_high_water") is not None
+
+            db.close()
+            db = SessionDB(db_path=db_path)
+            assert db._conn is not None
+            assert db.get_meta("fts_rebuild_high_water") is None
+            assert db.get_meta("fts_rebuild_progress") is None
+            assert db._has_fts_trash(db._conn) is True
             assert db.fts_optimize_available() is True
             assert db.get_meta("fts_storage_version") == "1"
+            if with_message:
+                assert db._conn.execute(
+                    "SELECT 1 FROM messages_fts_trigram "
+                    "WHERE messages_fts_trigram MATCH '部署完成' LIMIT 1"
+                ).fetchone()
 
-            db._ensure_fts_schema = original_ensure
             result = db.optimize_fts_storage(vacuum=False)
             assert result["ok"] is True
 
-            # messages_fts stays in the tool-calls search path.
-            assert len(db.search_messages("UNIQUE_TOOLCALL_TOKEN_43701")) == 1
-            # New trigram schema excludes tool_calls from trigram projection.
-            assert not db._conn.execute(
-                "SELECT 1 FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'UNIQUE_TOOLCALL_TOKEN_43701' LIMIT 1"
-            ).fetchone()
-            assert db._conn.execute(
-                "SELECT 1 FROM messages_fts_trigram "
-                "WHERE messages_fts_trigram MATCH '部署完成' LIMIT 1"
-            ).fetchone()
+            if with_message:
+                # messages_fts stays in the tool-calls search path.
+                assert len(db.search_messages("UNIQUE_TOOLCALL_TOKEN_43701")) == 1
+                # New trigram schema excludes tool_calls from trigram projection.
+                assert not db._conn.execute(
+                    "SELECT 1 FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'UNIQUE_TOOLCALL_TOKEN_43701' LIMIT 1"
+                ).fetchone()
+                assert db._conn.execute(
+                    "SELECT 1 FROM messages_fts_trigram "
+                    "WHERE messages_fts_trigram MATCH '部署完成' LIMIT 1"
+                ).fetchone()
             trigger_sql = db._conn.execute(
                 "SELECT sql FROM sqlite_master "
                 "WHERE type = 'trigger' AND name = 'messages_fts_trigram_update'"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -11,7 +11,13 @@ import pytest
 
 import hermes_state
 from agent.session_activity import ActivityProvenance
-from hermes_state import SCHEMA_SQL, SCHEMA_VERSION, SessionDB
+from hermes_state import (
+    FTS_SQL,
+    FTS_STORAGE_VERSION,
+    SCHEMA_SQL,
+    SCHEMA_VERSION,
+    SessionDB,
+)
 
 
 class _NoFtsCursor(sqlite3.Cursor):
@@ -3102,6 +3108,145 @@ class TestFTSExternalContentMigration:
             # A new write is indexed live by the legacy triggers.
             db.append_message("s1", role="user", content="AFTEROPEN token")
             assert len(db.search_messages("AFTEROPEN")) == 1
+        finally:
+            db.close()
+
+    def test_v23_rebuild_from_trigram_tool_calls_projection(self, tmp_path):
+        """v23 installs built with historical trigram projection should be
+        repaired via optimize-storage: trigram must drop tool_calls while
+        standard messages_fts keeps indexing them."""
+        db_path = tmp_path / "v23-toolcalls.db"
+
+        # Build an external-content DB that is already at schema version 23,
+        # but with the old tool_calls-inclusive trigram projection.
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(SCHEMA_SQL)
+        conn.executescript(FTS_SQL)
+        conn.executescript(
+            """
+            DROP TRIGGER IF EXISTS messages_fts_trigram_insert;
+            DROP TRIGGER IF EXISTS messages_fts_trigram_delete;
+            DROP TRIGGER IF EXISTS messages_fts_trigram_update;
+            DROP TABLE IF EXISTS messages_fts_trigram;
+            DROP VIEW IF EXISTS messages_fts_trigram_src;
+
+            CREATE VIEW IF NOT EXISTS messages_fts_trigram_src AS
+                SELECT id, role, content, tool_name, tool_calls
+                FROM messages
+                WHERE role <> 'tool';
+
+            CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(
+                content,
+                tool_name,
+                tool_calls,
+                content='messages_fts_trigram_src',
+                content_rowid='id',
+                tokenize='trigram'
+            );
+
+            CREATE TRIGGER messages_fts_trigram_insert AFTER INSERT ON messages
+            WHEN new.role <> 'tool'
+            BEGIN
+                INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
+                VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+            END;
+
+            CREATE TRIGGER messages_fts_trigram_delete AFTER DELETE ON messages
+            WHEN old.role <> 'tool'
+            BEGIN
+                INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
+                VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+            END;
+
+            CREATE TRIGGER messages_fts_trigram_update
+            AFTER UPDATE OF content, tool_name, tool_calls, role ON messages
+            WHEN (old.content IS NOT new.content
+                OR old.tool_name IS NOT new.tool_name
+                OR old.tool_calls IS NOT new.tool_calls
+                OR old.role IS NOT new.role)
+            BEGIN
+                INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
+                SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
+                WHERE old.role <> 'tool';
+                INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
+                SELECT new.id, new.content, new.tool_name, new.tool_calls
+                WHERE new.role <> 'tool';
+            END;
+            """
+        )
+        # Simulate the historical v23 projection shipped before this fix.
+        conn.execute(
+            "INSERT OR REPLACE INTO state_meta (key, value) VALUES ('fts_storage_version', '1')"
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO state_meta (key, value) VALUES ('fts_optimize_available', '1')"
+        )
+        conn.commit()
+        conn.close()
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            ("s1", "cli", time.time()),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, timestamp, role, content, tool_name, tool_calls) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "s1",
+                time.time(),
+                "assistant",
+                "部署完成 assistant content",
+                "legacyTool",
+                '{"name": "legacy", "arguments": "UNIQUE_TOOLCALL_TOKEN_43701"}',
+            ),
+        )
+        conn.commit()
+        assert conn.execute(
+            "SELECT rowid FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'UNIQUE_TOOLCALL_TOKEN_43701'"
+        ).fetchall()
+        conn.close()
+
+        db = SessionDB(db_path=db_path)
+        try:
+            assert db._conn is not None
+            assert db.fts_optimize_available() is True
+            assert db.get_meta("fts_storage_version") == "1"
+
+            original_ensure = db._ensure_fts_schema
+
+            def interrupt_after_demote(cursor, table_name, ddl):
+                if table_name == "messages_fts_trigram":
+                    raise RuntimeError("injected trigram rebuild interruption")
+                return original_ensure(cursor, table_name, ddl)
+
+            db._ensure_fts_schema = interrupt_after_demote
+            with pytest.raises(RuntimeError, match="injected trigram"):
+                db.optimize_fts_storage(vacuum=False)
+            assert db.get_meta("fts_rebuild_high_water") is not None
+            assert db.fts_optimize_available() is True
+            assert db.get_meta("fts_storage_version") == "1"
+
+            db._ensure_fts_schema = original_ensure
+            result = db.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True
+
+            # messages_fts stays in the tool-calls search path.
+            assert len(db.search_messages("UNIQUE_TOOLCALL_TOKEN_43701")) == 1
+            # New trigram schema excludes tool_calls from trigram projection.
+            assert not db._conn.execute(
+                "SELECT 1 FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'UNIQUE_TOOLCALL_TOKEN_43701' LIMIT 1"
+            ).fetchone()
+            assert db._conn.execute(
+                "SELECT 1 FROM messages_fts_trigram "
+                "WHERE messages_fts_trigram MATCH '部署完成' LIMIT 1"
+            ).fetchone()
+            trigger_sql = db._conn.execute(
+                "SELECT sql FROM sqlite_master "
+                "WHERE type = 'trigger' AND name = 'messages_fts_trigram_update'"
+            ).fetchone()[0]
+            assert "tool_calls" not in trigger_sql
+            assert db.get_meta("fts_storage_version") == str(FTS_STORAGE_VERSION)
         finally:
             db.close()
 

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -208,6 +208,20 @@ def test_render_large_db_legacy_trigram_suggests_optimize():
     assert "optimize-storage" in blob
 
 
+def test_render_large_db_v1_trigram_suggests_optimize():
+    from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
+
+    lines = _render_state_db_stats(
+        _base_stats(
+            logical_size_bytes=STATE_DB_SIZE_WARN_BYTES + 1,
+            fts_storage_version=1,
+        ),
+        holders=None,
+    )
+    blob = " ".join(" ".join(str(p) for p in line) for line in lines)
+    assert "optimize-storage" in blob
+
+
 def test_render_does_not_duplicate_legacy_wal_warning():
     """A large WAL must NOT warn here: doctor's pre-existing WAL check
     (50 MB threshold, with a --fix checkpoint) already covers it, and a


### PR DESCRIPTION
## What does this PR do?

Removes structured `tool_calls` JSON from the trigram FTS projection while preserving it in the standard FTS index. On a production 7.39 GiB `state.db`, `tool_calls` supplied 216 MiB (72%) of the trigram source corpus and expanded into a 1.66 GiB trigram index.

This ports the intent of the closed, unmerged #43701 onto the current external-content FTS architecture. Existing layout-v1 databases are detected from their actual trigram schema and offered the established, crash-safe `hermes sessions optimize-storage` rebuild; fresh and rebuilt databases stamp layout v2 only after completion.

## Related Issue

Follow-up to #43690 and #43701.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state_common.py`: define layout v2 and remove `tool_calls` from the trigram view, vtable, and sync triggers.
- `hermes_state.py` / `hermes_state_schema.py`: detect the shipped tool-call-inclusive trigram schema without falsely stamping it current.
- `hermes_state_search.py`: exclude `tool_calls` from every backfill path and reuse the existing resumable optimize-storage migration.
- `tests/test_hermes_state.py`: inject interrupted empty and populated v1 rebuilds, close/reopen the database, and prove persisted trash state resumes before checking standard/trigram search behavior and the v2 trigger shape.

## How to Test

1. Apply only the regression test to current `main`; it fails because `fts_optimize_available()` does not recognize the v1 trigram projection.
2. Run `python -m pytest tests/test_hermes_state.py::TestFTSExternalContentMigration tests/hermes_cli/test_session_recovery.py tests/hermes_cli/test_resolve_last_session.py -q -o 'addopts='` — 21 passed.
3. Run the complete state/recovery/resolve cluster — 245 passed, 2 skipped.
4. Run `ruff check hermes_state.py hermes_state_common.py hermes_state_schema.py hermes_state_search.py tests/test_hermes_state.py` and `git diff --check` — pass.
5. Run `scripts/run_tests.sh` in the clean documented `[all,dev]` environment. The main migration candidate and exact base `cecb3a6ed7` finish with the same 92 failures in the same 30 unrelated files (missing lazy optional SDKs plus existing macOS/platform assumptions). After the four-line empty-database marker follow-up, the canonical rerun again completed with failures confined to unrelated optional-SDK/platform files; the 245-test state cluster and frozen scratch gate remained green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full canonical run matches the current-main baseline exactly; see How to Test
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; schema and migration docstrings were updated in code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — SQLite DDL and existing rebuild primitives are platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. This changes derived SQLite indexing only.
