### PR TITLE
feat(slack): support outbound-only cron delivery

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -9454,6 +9454,8 @@ def interactive_setup() -> None:
     )
     if app_token:
         save_env_value("SLACK_APP_TOKEN", app_token)
+    else:
+        remove_env_value("SLACK_APP_TOKEN")
     print_success("Slack tokens saved")
 
     print()

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -893,11 +893,11 @@ def _is_slack_voice_clip(file_obj: Dict[str, Any]) -> bool:
 
 class SlackAdapter(BasePlatformAdapter):
     """
-    Slack bot adapter using Socket Mode.
+    Slack bot adapter using the Web API and optional Socket Mode ingress.
 
-    Requires two tokens:
-      - SLACK_BOT_TOKEN (xoxb-...) for API calls
-      - SLACK_APP_TOKEN (xapp-...) for Socket Mode connection
+    ``SLACK_BOT_TOKEN`` (xoxb-...) enables outbound API calls. When
+    ``SLACK_APP_TOKEN`` (xapp-...) is also configured, the adapter opens a
+    Socket Mode connection for inbound events.
 
     Features:
       - DMs and channel messages (mention-gated in channels)
@@ -1808,7 +1808,7 @@ class SlackAdapter(BasePlatformAdapter):
             pass
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
-        """Connect to Slack via Socket Mode."""
+        """Authenticate Slack Web API clients and optionally start Socket Mode."""
         if not SLACK_AVAILABLE:
             logger.error(
                 "[Slack] slack-bolt not installed. Run: pip install slack-bolt",
@@ -1844,22 +1844,6 @@ class SlackAdapter(BasePlatformAdapter):
                 retryable=False,
             )
             return False
-        if not app_token:
-            logger.error(
-                "[Slack] SLACK_APP_TOKEN not set — this is a permanent config "
-                "error; set SLACK_APP_TOKEN via `hermes gateway setup` "
-                "or in the active profile's ~/.hermes/.env file, then restart "
-                "the gateway.",
-            )
-            self._set_fatal_error(
-                "missing_slack_app_token",
-                "SLACK_APP_TOKEN not configured. Use `hermes gateway setup` "
-                "or add it to your active profile's ~/.hermes/.env file, "
-                "then restart the gateway.",
-                retryable=False,
-            )
-            return False
-
         proxy_url = _resolve_slack_proxy_url()
         if proxy_url:
             logger.info(
@@ -1901,11 +1885,12 @@ class SlackAdapter(BasePlatformAdapter):
 
         lock_acquired = False
         try:
-            if not self._acquire_platform_lock(
-                "slack-app-token", app_token, "Slack app token"
-            ):
-                return False
-            lock_acquired = True
+            if app_token:
+                if not self._acquire_platform_lock(
+                    "slack-app-token", app_token, "Slack app token"
+                ):
+                    return False
+                lock_acquired = True
             self._running = False
 
             # Tear down any prior reconnect state before flipping ``_running``
@@ -1993,6 +1978,18 @@ class SlackAdapter(BasePlatformAdapter):
                 self._warn_if_missing_group_dm_scopes(auth_response, team_name)
                 self._warn_if_not_bot_token(auth_response, team_name)
                 self._warn_if_inchannel_without_flat_reply(team_name)
+
+            if not app_token:
+                # Bot-token-only profiles are valid outbound transports. Keep
+                # the authenticated Web API clients live for cron and explicit
+                # sends, but do not register handlers or open Socket Mode.
+                self._running = True
+                logger.info(
+                    "[Slack] Outbound-only mode ready (%d workspace(s)); "
+                    "SLACK_APP_TOKEN is not configured, so inbound events are disabled",
+                    len(self._team_clients),
+                )
+                return True
 
             # Register message event handler
             @self._app.event("message")
@@ -9433,8 +9430,9 @@ def interactive_setup() -> None:
     print_info("Steps to create a Slack app:")
     print_info("   1. Go to https://api.slack.com/apps → Create New App")
     print_info("      Pick 'From an app manifest' — we'll generate one for you below.")
-    print_info("   2. Enable Socket Mode: Settings → Socket Mode → Enable")
+    print_info("   2. For inbound messages, enable Socket Mode: Settings → Socket Mode → Enable")
     print_info("      • Create an App-Level Token with 'connections:write' scope")
+    print_info("      • Skip this step for outbound-only cron and notification delivery")
     print_info("   3. Install to Workspace: Settings → Install App")
     print_info("   4. After installing, invite the bot to channels: /invite @YourBot")
     print()
@@ -9451,7 +9449,9 @@ def interactive_setup() -> None:
     if not bot_token:
         return
     save_env_value("SLACK_BOT_TOKEN", bot_token)
-    app_token = prompt("Slack App Token (xapp-...)", password=True)
+    app_token = prompt(
+        "Slack App Token (xapp-..., leave empty for outbound-only)", password=True
+    )
     if app_token:
         save_env_value("SLACK_APP_TOKEN", app_token)
     print_success("Slack tokens saved")
@@ -9580,7 +9580,7 @@ def register(ctx) -> None:
         check_fn=slack_deps_present,
         ensure_deps_fn=check_slack_requirements,
         is_connected=_is_connected,
-        required_env=["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
+        required_env=["SLACK_BOT_TOKEN"],
         install_hint="Run `hermes setup` to install Slack support.",
         # Interactive setup wizard — replaces hermes_cli/setup.py::_setup_slack
         # and the static _PLATFORMS["slack"] dict in hermes_cli/gateway.py.

--- a/plugins/platforms/slack/plugin.yaml
+++ b/plugins/platforms/slack/plugin.yaml
@@ -4,10 +4,10 @@ kind: platform
 version: 1.0.0
 description: >
   Slack gateway adapter for Hermes Agent.
-  Connects to Slack via slack-bolt in Socket Mode and relays messages
-  between Slack channels/DMs and the Hermes agent. Supports slash
-  commands, threads, mrkdwn rendering, approval blocks, free-response
-  channels, mention gating, and channel skill bindings.
+  Sends messages through the Slack Web API and, when a Socket Mode app
+  token is configured, relays inbound Slack channels/DMs to the Hermes
+  agent. Supports slash commands, threads, mrkdwn rendering, approval
+  blocks, free-response channels, mention gating, and channel skill bindings.
 author: NousResearch
 requires_env:
   - name: SLACK_BOT_TOKEN
@@ -15,12 +15,12 @@ requires_env:
     prompt: "Slack Bot Token (xoxb-...)"
     url: "https://api.slack.com/apps"
     password: true
+optional_env:
   - name: SLACK_APP_TOKEN
-    description: "Slack app-level token for Socket Mode (xapp-..., scope connections:write)"
-    prompt: "Slack App Token (xapp-...)"
+    description: "Optional Slack app-level token for inbound Socket Mode (xapp-..., scope connections:write)"
+    prompt: "Slack App Token for inbound events (xapp-...)"
     url: "https://api.slack.com/apps"
     password: true
-optional_env:
   - name: SLACK_ALLOWED_USERS
     description: "Comma-separated Slack member IDs allowed to talk to the bot"
     prompt: "Allowed users (comma-separated)"

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -496,6 +496,40 @@ class TestDeliverResultWrapping:
 class TestDeliverResultErrorReturns:
     """Verify _deliver_result returns error strings on failure, None on success."""
 
+    def test_bot_token_only_slack_explicit_target_uses_standalone_sender(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.config import Platform, load_gateway_config
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-outbound")
+        monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+
+        config = load_gateway_config()
+        slack_config = config.platforms[Platform.SLACK]
+        assert slack_config.enabled is True
+        assert slack_config.token == "xoxb-outbound"
+
+        send = AsyncMock(return_value={"success": True})
+        with (
+            patch("gateway.config.load_gateway_config", return_value=config),
+            patch(
+                "cron.scheduler.load_config",
+                return_value={"cron": {"wrap_response": False}},
+            ),
+            patch("tools.send_message_tool._send_to_platform", new=send),
+        ):
+            result = _deliver_result(
+                {"id": "slack-outbound", "deliver": "slack:C123"},
+                "scheduled result",
+            )
+
+        assert result is None
+        send.assert_awaited_once()
+        assert send.await_args.args[:3] == (Platform.SLACK, slack_config, "C123")
+
     def test_returns_error_when_platform_disabled(self):
         from gateway.config import Platform
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3974,39 +3974,48 @@ class TestThreadContextAppMessages:
 
 
 # ---------------------------------------------------------------------------
-# Missing-credential handling — fatal-error contract
+# Outbound-only connection mode
 # ---------------------------------------------------------------------------
 
 
-class TestMissingCredentials:
-    """Missing SLACK_BOT_TOKEN or SLACK_APP_TOKEN must set a non-retryable fatal error."""
+class TestOutboundOnlyConnection:
+    """A bot token alone provides Web API delivery without an inbound listener."""
 
 
     @pytest.mark.asyncio
-    async def test_missing_app_token_sets_fatal_error(self):
-        """When SLACK_APP_TOKEN is absent but SLACK_BOT_TOKEN is present,
-        connect() must set fatal_error with code 'missing_slack_app_token'
-        and retryable=False."""
+    async def test_bot_token_without_app_token_connects_outbound_only(self):
         config = PlatformConfig(enabled=True, token="xoxb-fake")
         adapter = SlackAdapter(config)
 
-        fatal_errors = []
-
-        def capture_fatal(code, message, *, retryable):
-            fatal_errors.append({"code": code, "message": message, "retryable": retryable})
+        mock_app = MagicMock()
+        mock_app.client = AsyncMock()
+        mock_web_client = AsyncMock()
+        mock_web_client.auth_test = AsyncMock(
+            return_value={
+                "user_id": "U_BOT",
+                "user": "testbot",
+                "team_id": "T_FAKE",
+                "team": "FakeTeam",
+            }
+        )
 
         with (
-            patch.object(adapter, "_set_fatal_error", side_effect=capture_fatal),
-            patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-fake"}, clear=True),
+            patch.object(_slack_mod, "AsyncApp", return_value=mock_app),
+            patch.object(_slack_mod, "AsyncWebClient", return_value=mock_web_client),
+            patch.object(_slack_mod, "AsyncSocketModeHandler") as socket_handler,
+            patch.object(_slack_mod, "get_secret", return_value=None),
+            patch("gateway.status.acquire_scoped_lock") as acquire_lock,
+            patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-fake"}, clear=False),
         ):
             result = await adapter.connect()
 
-        assert result is False
-        assert len(fatal_errors) == 1
-        assert fatal_errors[0]["code"] == "missing_slack_app_token"
-        assert fatal_errors[0]["retryable"] is False
-        assert "SLACK_APP_TOKEN" in fatal_errors[0]["message"]
-        assert "hermes gateway setup" in fatal_errors[0]["message"].lower() or ".env" in fatal_errors[0]["message"]
+        assert result is True
+        assert adapter.is_connected
+        assert adapter._app_token is None
+        assert adapter._team_clients == {"T_FAKE": mock_web_client}
+        socket_handler.assert_not_called()
+        acquire_lock.assert_not_called()
+        mock_app.event.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack_plugin_setup.py
+++ b/tests/gateway/test_slack_plugin_setup.py
@@ -52,6 +52,24 @@ def test_interactive_setup_saves_home_channel(monkeypatch, tmp_path):
     assert "SLACK_HOME_CHANNEL" not in removed
 
 
+def test_blank_app_token_clears_existing_inbound_credential(monkeypatch, tmp_path):
+    """Selecting outbound-only mode must remove a stale Socket Mode token."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    saved, removed = {}, []
+    _patch_setup_io(
+        monkeypatch,
+        ["«redacted:xox…»", "", "", ""],
+        saved,
+        removed,
+        existing={"SLACK_APP_TOKEN": "xapp-existing"},
+    )
+
+    interactive_setup()
+
+    assert "SLACK_APP_TOKEN" in removed
+    assert "SLACK_APP_TOKEN" not in saved
+
+
 class TestSlackHomeChannelClear:
     """Blank home-channel answer must clear SLACK_HOME_CHANNEL (#12423)."""
 


### PR DESCRIPTION
## What does this PR do?

This PR allows Slack to operate as an outbound-only transport when a bot token is configured without a Socket Mode app token. Scheduled jobs and explicit sends can use the existing Slack Web API delivery path without forcing the gateway to start an inbound listener, while configurations with an app token retain full Socket Mode behavior.

## Related Issue

Closes #88191

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/slack/adapter.py` - authenticate bot-token-only configurations for outbound delivery, skip Socket Mode listener setup without an app token, and clear stale app tokens when setup selects outbound-only mode.
- `plugins/platforms/slack/plugin.yaml` - document the app token as an optional credential for inbound events.
- `tests/cron/test_scheduler.py` - cover explicit Slack cron delivery with only a bot token.
- `tests/gateway/test_slack.py` - cover outbound-only adapter startup without listener registration or token locking.
- `tests/gateway/test_slack_plugin_setup.py` - cover inbound-to-outbound setup reconfiguration.

## How to Test

1. Configure `SLACK_BOT_TOKEN` without `SLACK_APP_TOKEN`, start the gateway, and confirm Slack becomes ready without opening Socket Mode.
2. Deliver a cron result to an explicit `slack:<conversation-id>` target and confirm the Web API sender is used.
3. Configure both tokens and confirm the existing inbound Socket Mode path still starts.
4. Run the related automated tests:

```bash
scripts/run_tests.sh tests/gateway/test_slack_plugin_setup.py tests/gateway/test_slack.py tests/cron/test_scheduler.py tests/gateway/test_config.py tests/gateway/test_plugin_platform_interface.py
```

Result: 319 passed, 2 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the related test files and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; the plugin manifest and setup guidance describe the new mode
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the change is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool behavior changed

## Screenshots / Logs

The related test suite completed with 319 passed and 2 skipped.
