### PR TITLE
fix(state): stop unbounded state.db repair loop from filling the disk

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1858,12 +1858,27 @@ _MAX_MALFORMED_BACKUPS = 3
 # header on any real recovery), while staying O(1) on a multi-GB file.
 _FINGERPRINT_SAMPLE_BYTES = 65536
 
-# Free-space floor for the pre-repair forensic backup. The backup is a full
-# raw copy of the damaged DB, so a repair loop on a large state.db is a disk
-# amplifier: the reported incident wrote 98MB every ~10s until the volume was
-# nearly full, which would have taken down every agent on the host. Refuse
-# the copy unless the volume would still hold this much afterwards.
-_REPAIR_BACKUP_MIN_FREE_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
+# Free-space headroom for the pre-repair forensic backup. The backup is a
+# full raw copy of the damaged DB (plus its -wal/-shm sidecars), so a repair
+# loop on a large state.db is a disk amplifier: the reporting incident wrote
+# ~98MB every ~10s until the volume was nearly full, which would have taken
+# down every agent on the host.
+#
+# Proportional, not a flat floor: an absolute multi-GB reserve would refuse
+# backups that fit comfortably on small container/VM volumes, and because a
+# refused backup is a HARD STOP (#69603) that would silently convert "repair
+# loops" into "repair never runs" for those deployments. Require the copy
+# itself plus a small slice of the volume, clamped to a modest floor.
+_REPAIR_BACKUP_MIN_FREE_BYTES = 256 * 1024 * 1024  # 256 MiB absolute floor
+_REPAIR_BACKUP_FREE_FRACTION = 0.02  # plus 2% of the volume
+
+
+def _repair_backup_headroom_bytes(total_bytes: int) -> int:
+    """Free space required *beyond* the copy itself, for a volume of *total_bytes*."""
+    return max(
+        _REPAIR_BACKUP_MIN_FREE_BYTES,
+        int(total_bytes * _REPAIR_BACKUP_FREE_FRACTION),
+    )
 
 
 def _repair_ledger_path(db_path: Path) -> Path:
@@ -2069,31 +2084,70 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
                     return existing, None
         except OSError:
             pass
-        # Disk guard: this is a full raw copy of a possibly multi-GB DB. On a
-        # host whose volume is already nearly full — which a preceding repair
-        # loop may itself have caused — taking it can finish off the disk and
-        # take down every process on the machine. Refuse while there is still
-        # room to refuse in.
+        # Disk guard: this is a full raw copy of a possibly multi-GB DB plus
+        # its sidecars. On a host whose volume is already nearly full — which
+        # a preceding repair loop may itself have caused — taking it can
+        # finish off the disk and take down every process on the machine.
+        # Refuse while there is still room to refuse in.
         try:
-            src_size = db_path.stat().st_size
-            free = shutil.disk_usage(db_path.parent).free
-            if free - src_size < _REPAIR_BACKUP_MIN_FREE_BYTES:
+            need = db_path.stat().st_size
+            for suffix in ("-wal", "-shm"):
+                sidecar = db_path.with_name(db_path.name + suffix)
+                if sidecar.exists():
+                    need += sidecar.stat().st_size
+            usage = shutil.disk_usage(db_path.parent)
+            headroom = _repair_backup_headroom_bytes(usage.total)
+            if usage.free - need < headroom:
                 reason = (
-                    f"only {free / 1e9:.1f}GB free on {db_path.parent}; copying "
-                    f"the {src_size / 1e9:.1f}GB damaged DB would leave less than "
-                    f"{_REPAIR_BACKUP_MIN_FREE_BYTES / 1e9:.1f}GB. Free disk space, "
-                    "then retry (or recover manually with `sqlite3 "
-                    f"{db_path} \".recover\"`)."
+                    f"only {usage.free / 1e9:.2f}GB free on {db_path.parent}; "
+                    f"copying the damaged DB needs {need / 1e9:.2f}GB and must "
+                    f"leave {headroom / 1e9:.2f}GB headroom. Free disk space, "
+                    f"then retry (or recover manually with `sqlite3 {db_path} "
+                    '".recover"`).'
                 )
                 logger.error("Refusing forensic backup of %s: %s", db_path, reason)
                 return None, reason
         except OSError:
             pass
-        shutil.copy2(db_path, backup_path)
-        for suffix in ("-wal", "-shm"):
-            sidecar = db_path.with_name(db_path.name + suffix)
-            if sidecar.exists():
-                shutil.copy2(sidecar, backup_path.with_name(backup_path.name + suffix))
+        # Copy to a staging name that does NOT match the backup prefix, then
+        # rename into place only once every copy has succeeded. A copy that
+        # fails partway (ENOSPC, kill) would otherwise leave a prefix-matching
+        # partial that `_prune_malformed_backups` never reaches — prune runs
+        # only on the success path — so debris accumulated unbounded and, on a
+        # later successful pass, the newest-by-name partials were KEPT while
+        # intact forensic copies were pruned away.
+        staging = db_path.with_name(f"{backup_path.name}.incomplete")
+        staged: "List[Tuple[Path, Path]]" = []
+        try:
+            # Clear debris from an earlier interrupted pass (kill mid-copy).
+            # Matches sidecar staging names (``.incomplete-wal``) too.
+            for old in db_path.parent.glob(
+                f"{db_path.name}.malformed-backup-*.incomplete*"
+            ):
+                old.unlink(missing_ok=True)
+            shutil.copy2(db_path, staging)
+            staged.append((staging, backup_path))
+            for suffix in ("-wal", "-shm"):
+                sidecar = db_path.with_name(db_path.name + suffix)
+                if sidecar.exists():
+                    side_staging = staging.with_name(staging.name + suffix)
+                    shutil.copy2(sidecar, side_staging)
+                    staged.append(
+                        (side_staging, backup_path.with_name(backup_path.name + suffix))
+                    )
+            for src, dst in staged:
+                os.replace(src, dst)
+        except Exception:
+            for src, _ in staged:
+                try:
+                    src.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            try:
+                staging.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
         # Retention cap (#86747): keep only the newest few forensic copies.
         _prune_malformed_backups(db_path)
         return backup_path, None

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1853,22 +1853,55 @@ def _bump_schema_cookie(conn: sqlite3.Connection) -> None:
 _MAX_PERSISTENT_REPAIR_ATTEMPTS = 3
 _MAX_MALFORMED_BACKUPS = 3
 
+# Head/tail bytes sampled by ``_db_fingerprint``. Enough to change whenever
+# the DB is genuinely repaired, truncated or restored (SQLite rewrites the
+# header on any real recovery), while staying O(1) on a multi-GB file.
+_FINGERPRINT_SAMPLE_BYTES = 65536
+
+# Free-space floor for the pre-repair forensic backup. The backup is a full
+# raw copy of the damaged DB, so a repair loop on a large state.db is a disk
+# amplifier: the reported incident wrote 98MB every ~10s until the volume was
+# nearly full, which would have taken down every agent on the host. Refuse
+# the copy unless the volume would still hold this much afterwards.
+_REPAIR_BACKUP_MIN_FREE_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
+
 
 def _repair_ledger_path(db_path: Path) -> Path:
     return db_path.with_name(db_path.name + ".repair-attempts.json")
 
 
 def _db_fingerprint(db_path: Path) -> "Optional[str]":
-    """Cheap identity for a damaged DB file: size + mtime_ns.
+    """Cheap identity for a damaged DB file: size + a bounded content sample.
 
-    Hashing a multi-GB corrupt file on every open is exactly the kind of
-    repeated cost this ledger exists to avoid; size+mtime is stable for a
-    file nothing can successfully write to, and any successful repair,
-    truncation or manual restore changes it (resetting the attempt count).
+    Deliberately EXCLUDES mtime. The original ledger keyed on
+    ``size:mtime_ns`` on the assumption that "nothing can successfully write
+    to a damaged file", but that does not hold for the malformed-schema
+    class: the DB still opens and accepts writes (only ``sqlite_master`` is
+    unreadable), so live writers, WAL checkpoints and the in-place repair
+    strategies themselves all move mtime between passes. Every pass then
+    looked like a NEW file — the attempt counter reset to 1 forever, never
+    reaching ``_MAX_PERSISTENT_REPAIR_ATTEMPTS``, and the ``_backup_db_file``
+    dedupe (which compares mtime too) never matched, so each pass wrote
+    another full-size forensic copy. Observed: a repair every ~10s, a fresh
+    98MB copy each time, 2.3GB in 20 minutes, disk heading to zero.
+
+    Hashing a multi-GB corrupt file on every open is the repeated cost this
+    ledger exists to avoid, so sample instead of digesting the whole file:
+    size plus the head/tail slices that any real repair, truncation or
+    restore necessarily changes. Stable across passes that merely touch
+    mtime; still resets the attempt count after genuine recovery.
     """
     try:
         st = db_path.stat()
-        return f"{st.st_size}:{st.st_mtime_ns}"
+        with open(db_path, "rb") as fh:
+            head = fh.read(_FINGERPRINT_SAMPLE_BYTES)
+            if st.st_size > _FINGERPRINT_SAMPLE_BYTES:
+                fh.seek(max(0, st.st_size - _FINGERPRINT_SAMPLE_BYTES))
+                tail = fh.read(_FINGERPRINT_SAMPLE_BYTES)
+            else:
+                tail = b""
+        digest = hashlib.sha256(head + tail).hexdigest()[:32]
+        return f"{st.st_size}:{digest}"
     except OSError:
         return None
 
@@ -2017,20 +2050,43 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
         # Dedupe (#86747): a repair loop used to copy the SAME damaged bytes
         # on every restart — ~900MB a pass, 89GB over 11 days in the
         # reporting install. If the newest existing backup already matches
-        # this file (size + mtime preserved by copy2), reuse it.
+        # this file, reuse it.
+        #
+        # Matching on mtime made this dedupe miss exactly when it mattered
+        # most: the malformed-SCHEMA class still accepts writes, so live
+        # writers and the in-place repair strategies move mtime between
+        # passes and every pass wrote another full-size copy (2.3GB in 20
+        # minutes). Compare the content fingerprint instead, which is stable
+        # while the damaged bytes are.
         try:
-            src_stat = db_path.stat()
+            src_fp = _db_fingerprint(db_path)
             for existing in _existing_malformed_backups(db_path)[:1]:
-                est = existing.stat()
-                if (
-                    est.st_size == src_stat.st_size
-                    and est.st_mtime_ns == src_stat.st_mtime_ns
-                ):
+                if src_fp is not None and _db_fingerprint(existing) == src_fp:
                     logger.info(
                         "Reusing existing forensic backup %s (identical to the "
                         "damaged DB).", existing,
                     )
                     return existing, None
+        except OSError:
+            pass
+        # Disk guard: this is a full raw copy of a possibly multi-GB DB. On a
+        # host whose volume is already nearly full — which a preceding repair
+        # loop may itself have caused — taking it can finish off the disk and
+        # take down every process on the machine. Refuse while there is still
+        # room to refuse in.
+        try:
+            src_size = db_path.stat().st_size
+            free = shutil.disk_usage(db_path.parent).free
+            if free - src_size < _REPAIR_BACKUP_MIN_FREE_BYTES:
+                reason = (
+                    f"only {free / 1e9:.1f}GB free on {db_path.parent}; copying "
+                    f"the {src_size / 1e9:.1f}GB damaged DB would leave less than "
+                    f"{_REPAIR_BACKUP_MIN_FREE_BYTES / 1e9:.1f}GB. Free disk space, "
+                    "then retry (or recover manually with `sqlite3 "
+                    f"{db_path} \".recover\"`)."
+                )
+                logger.error("Refusing forensic backup of %s: %s", db_path, reason)
+                return None, reason
         except OSError:
             pass
         shutil.copy2(db_path, backup_path)

--- a/tests/test_state_db_repair_loop_mtime.py
+++ b/tests/test_state_db_repair_loop_mtime.py
@@ -22,6 +22,7 @@ missing free-space refusal.
 from __future__ import annotations
 
 import os
+import shutil
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -36,6 +37,7 @@ from hermes_state import (
     _existing_malformed_backups,
     _persistent_repair_attempts_exhausted,
     _record_repair_outcome,
+    _repair_backup_headroom_bytes,
 )
 
 
@@ -137,13 +139,88 @@ def test_backup_refused_when_disk_would_be_exhausted(tmp_path):
     """A nearly-full volume must not be finished off by the forensic copy."""
     db = _damaged_db(tmp_path)
     tight = type(
-        "Usage", (), {"total": 0, "used": 0, "free": _REPAIR_BACKUP_MIN_FREE_BYTES // 2}
+        "Usage",
+        (),
+        {"total": 10_000_000_000, "used": 0, "free": _REPAIR_BACKUP_MIN_FREE_BYTES // 2},
     )()
     with patch("shutil.disk_usage", return_value=tight):
         path, reason = _backup_db_file(db)
     assert path is None
     assert reason is not None and "free" in reason.lower()
     assert not _existing_malformed_backups(db)
+
+
+def test_backup_allowed_on_small_volume_with_room(tmp_path):
+    """A flat multi-GB floor would disable repair on small VMs/containers.
+
+    50MB DB on a 10GB volume with 1.5GB free fits with ~30x headroom; the
+    guard must allow it rather than hard-stopping repair forever.
+    """
+    db = _damaged_db(tmp_path, size=50_000_000)
+    small_vm = type(
+        "Usage", (), {"total": 10_000_000_000, "used": 8_500_000_000, "free": 1_500_000_000}
+    )()
+    with patch("shutil.disk_usage", return_value=small_vm):
+        path, reason = _backup_db_file(db)
+    assert reason is None and path is not None
+
+
+def test_headroom_scales_with_volume_size():
+    """Big volumes reserve proportionally; small ones keep a modest floor."""
+    assert _repair_backup_headroom_bytes(1_000_000_000) == _REPAIR_BACKUP_MIN_FREE_BYTES
+    assert _repair_backup_headroom_bytes(1_000_000_000_000) > _REPAIR_BACKUP_MIN_FREE_BYTES
+
+
+def test_disk_guard_accounts_for_sidecars(tmp_path):
+    """The copy includes -wal/-shm, so the space check must count them."""
+    db = _damaged_db(tmp_path, size=1_000_000)
+    db.with_name(db.name + "-wal").write_bytes(os.urandom(400_000_000))
+    usage = type(
+        "Usage",
+        (),
+        {"total": 10_000_000_000, "used": 0, "free": _REPAIR_BACKUP_MIN_FREE_BYTES + 300_000_000},
+    )()
+    with patch("shutil.disk_usage", return_value=usage):
+        path, reason = _backup_db_file(db)
+    assert path is None, "sidecar bytes were ignored by the free-space check"
+    assert reason is not None
+
+
+def test_failed_copy_leaves_no_countable_debris(tmp_path):
+    """Prune only runs on success, so a failed copy must self-clean.
+
+    Otherwise partials matching the backup prefix accumulate unbounded and,
+    on a later successful pass, are KEPT (newest by name) while intact
+    forensic copies get pruned away.
+    """
+    db = _damaged_db(tmp_path, size=1_000_000)
+    db.with_name(db.name + "-wal").write_bytes(os.urandom(1_000_000))
+    roomy = type(
+        "Usage", (), {"total": 500_000_000_000, "used": 0, "free": 400_000_000_000}
+    )()
+    real_copy2 = shutil.copy2
+
+    def sidecar_fails(src, dst, *a, **kw):
+        if str(src).endswith("-wal"):
+            Path(dst).write_bytes(b"PARTIAL" * 100)
+            raise OSError(28, "No space left on device")
+        return real_copy2(src, dst, *a, **kw)
+
+    with patch("shutil.disk_usage", return_value=roomy), \
+            patch("shutil.copy2", sidecar_fails):
+        for _ in range(6):
+            _backup_db_file(db)
+            time.sleep(0.01)
+            os.utime(db, None)
+
+    assert len(_existing_malformed_backups(db)) <= _MAX_MALFORMED_BACKUPS
+
+    # a later successful pass must sweep any staging debris
+    with patch("shutil.disk_usage", return_value=roomy):
+        path, reason = _backup_db_file(db)
+    assert reason is None and path is not None
+    strays = list(tmp_path.glob("*.incomplete*"))
+    assert not strays, f"staging debris survived: {strays}"
 
 
 def test_backup_allowed_with_ample_disk(tmp_path):

--- a/tests/test_state_db_repair_loop_mtime.py
+++ b/tests/test_state_db_repair_loop_mtime.py
@@ -1,0 +1,168 @@
+"""Regression: the state.db repair-loop guards must survive an mtime change.
+
+Incident (2026-08-17): a malformed-SCHEMA state.db sent Hermes into an
+unbounded repair loop that wrote a fresh 98MB forensic copy every ~10s —
+2.3GB in 20 minutes, disk heading to zero, whole agent fleet at risk.
+
+The #86747 guards were already present and did NOT hold, because both keyed
+on ``size:mtime_ns``:
+
+* ``_db_fingerprint`` -> the ledger's attempt counter reset to 1 on every
+  pass, so ``_MAX_PERSISTENT_REPAIR_ATTEMPTS`` was never reached;
+* ``_backup_db_file``'s dedupe compared mtime, so it never matched and each
+  pass wrote another full-size copy.
+
+Unlike the b-tree damage of #86747, the malformed-SCHEMA class still opens
+and accepts writes (only ``sqlite_master`` is unreadable), so live writers,
+WAL checkpoints and the in-place repair strategies all move mtime between
+passes. These tests pin the guards to content, not mtime, and add the
+missing free-space refusal.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import hermes_state
+from hermes_state import (
+    _MAX_MALFORMED_BACKUPS,
+    _MAX_PERSISTENT_REPAIR_ATTEMPTS,
+    _REPAIR_BACKUP_MIN_FREE_BYTES,
+    _backup_db_file,
+    _db_fingerprint,
+    _existing_malformed_backups,
+    _persistent_repair_attempts_exhausted,
+    _record_repair_outcome,
+)
+
+
+def _damaged_db(tmp_path: Path, size: int = 200_000) -> Path:
+    db = tmp_path / "state.db"
+    db.write_bytes(b"SQLite format 3\x00" + os.urandom(size))
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint stability
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_survives_mtime_change(tmp_path):
+    """A touched-but-unchanged file keeps its identity (the incident's core)."""
+    db = _damaged_db(tmp_path)
+    before = _db_fingerprint(db)
+    time.sleep(0.01)
+    os.utime(db, None)  # live writer / WAL checkpoint / in-place repair pass
+    assert _db_fingerprint(db) == before
+
+
+def test_fingerprint_changes_when_contents_change(tmp_path):
+    """Genuine recovery must still reset the attempt budget."""
+    db = _damaged_db(tmp_path)
+    before = _db_fingerprint(db)
+    db.write_bytes(b"SQLite format 3\x00" + os.urandom(200_000))
+    assert _db_fingerprint(db) != before
+
+
+def test_fingerprint_changes_on_truncation(tmp_path):
+    db = _damaged_db(tmp_path)
+    before = _db_fingerprint(db)
+    with open(db, "r+b") as fh:
+        fh.truncate(1024)
+    assert _db_fingerprint(db) != before
+
+
+# ---------------------------------------------------------------------------
+# Attempt ledger
+# ---------------------------------------------------------------------------
+
+
+def test_attempt_budget_exhausts_despite_mtime_churn(tmp_path):
+    """The loop must terminate even when every pass touches the file."""
+    db = _damaged_db(tmp_path)
+    for _ in range(_MAX_PERSISTENT_REPAIR_ATTEMPTS):
+        assert not _persistent_repair_attempts_exhausted(db)
+        _record_repair_outcome(db, repaired=False)
+        time.sleep(0.01)
+        os.utime(db, None)
+    assert _persistent_repair_attempts_exhausted(db)
+
+
+def test_successful_repair_clears_budget(tmp_path):
+    db = _damaged_db(tmp_path)
+    for _ in range(_MAX_PERSISTENT_REPAIR_ATTEMPTS):
+        _record_repair_outcome(db, repaired=False)
+    assert _persistent_repair_attempts_exhausted(db)
+    _record_repair_outcome(db, repaired=True)
+    assert not _persistent_repair_attempts_exhausted(db)
+
+
+# ---------------------------------------------------------------------------
+# Backup dedupe
+# ---------------------------------------------------------------------------
+
+
+def test_backup_dedupes_across_mtime_change(tmp_path):
+    """Repeated passes over identical bytes must not each write a new copy."""
+    db = _damaged_db(tmp_path)
+    first, err = _backup_db_file(db)
+    assert err is None and first is not None
+    for _ in range(5):
+        time.sleep(0.01)
+        os.utime(db, None)
+        again, err = _backup_db_file(db)
+        assert err is None
+        assert again == first, "a touched-but-identical DB was copied again"
+    assert len(_existing_malformed_backups(db)) == 1
+
+
+def test_backup_retention_cap_still_holds(tmp_path):
+    """Genuinely different damaged states are kept, but bounded."""
+    db = _damaged_db(tmp_path)
+    for _ in range(_MAX_MALFORMED_BACKUPS + 3):
+        db.write_bytes(b"SQLite format 3\x00" + os.urandom(200_000))
+        _backup_db_file(db)
+    assert len(_existing_malformed_backups(db)) <= _MAX_MALFORMED_BACKUPS
+
+
+# ---------------------------------------------------------------------------
+# Free-space guard
+# ---------------------------------------------------------------------------
+
+
+def test_backup_refused_when_disk_would_be_exhausted(tmp_path):
+    """A nearly-full volume must not be finished off by the forensic copy."""
+    db = _damaged_db(tmp_path)
+    tight = type(
+        "Usage", (), {"total": 0, "used": 0, "free": _REPAIR_BACKUP_MIN_FREE_BYTES // 2}
+    )()
+    with patch("shutil.disk_usage", return_value=tight):
+        path, reason = _backup_db_file(db)
+    assert path is None
+    assert reason is not None and "free" in reason.lower()
+    assert not _existing_malformed_backups(db)
+
+
+def test_backup_allowed_with_ample_disk(tmp_path):
+    db = _damaged_db(tmp_path)
+    roomy = type(
+        "Usage", (), {"total": 0, "used": 0, "free": _REPAIR_BACKUP_MIN_FREE_BYTES * 10}
+    )()
+    with patch("shutil.disk_usage", return_value=roomy):
+        path, reason = _backup_db_file(db)
+    assert reason is None and path is not None
+
+
+def test_repair_aborts_when_backup_refused_for_disk(tmp_path):
+    """Refused backup is a HARD STOP — never mutate the only damaged copy."""
+    db = _damaged_db(tmp_path)
+    tight = type(
+        "Usage", (), {"total": 0, "used": 0, "free": _REPAIR_BACKUP_MIN_FREE_BYTES // 2}
+    )()
+    with patch("shutil.disk_usage", return_value=tight):
+        report = hermes_state.repair_state_db_schema(db)
+    assert not report.get("repaired")
+    assert "free" in (report.get("error") or "").lower()


### PR DESCRIPTION
## Symptom

A malformed-**schema** `state.db` sent Hermes into a repair loop that never terminated: 98 repair passes over ~20 minutes on a ~98MB DB, each taking a fresh full-size forensic copy, on a host running an agent fleet.

```
ERROR hermes_state: state.db schema is malformed (malformed database schema ()) — attempting automatic repair (a backup copy is made first).
... every ~10s, never reaching a terminal state
```

The data itself was fine — `.recover` → rebuild → `integrity_check: ok`, 15,196 messages intact. The risk came entirely from the repair path's amplification.

## Why the #86747 guards didn't hold

#86747 added a persistent attempt ledger and a backup retention cap for exactly this shape of failure. Both were present and both were structurally dead here, because they key on `size:mtime_ns`.

That key's stated validity condition is *"size+mtime is stable for a file nothing can successfully write to"* — true for the b-tree page damage of #86747, false for the malformed-**schema** class: the DB still opens and accepts writes (only `sqlite_master` is unreadable), so live writers, WAL checkpoints and the in-place repair strategies themselves all move mtime between passes. Each pass therefore looked like a brand-new file:

- `_record_repair_outcome` took the `else 1` branch every time → the counter could never exceed 1 → the `>= _MAX_PERSISTENT_REPAIR_ATTEMPTS` gate never tripped → **the loop never terminated**;
- the dedupe compared mtime → never matched → **a fresh full-size copy every pass**.

Reproduced against unpatched `hermes_state.py`:

```
=== A: stable mtime (the assumption #86747 was tested under) ===
  pass 1: failed_attempts=1   pass 2: failed_attempts=2
  pass 3: failed_attempts=3   pass 4: BLOCKED by ledger (guard held)

=== B: mtime moves between passes (this incident) ===
  pass 1..8: failed_attempts=1 (every pass)
  NEVER BLOCKED — loop would run forever
```

## Severity, stated precisely

Being explicit about what is measured vs. inferred, because the two regimes differ:

1. **While copies succeed, the retention cap does hold** at 3 (~300MB steady state). Verified, including under 8-way concurrency. The damage in this regime is not disk: it is a non-terminating loop rewriting ~98MB every ~10s (~850GB/day of pointless writes) and re-running `writable_schema` surgery / VACUUM / FTS rebuild against a live, half-broken DB every 10s, forever, until a human intervenes.

2. **Once any copy fails, disk growth is unbounded and self-reinforcing.** `_prune_malformed_backups` runs only on the success path, inside the `try`, after `copy2`. Every failure mode — ENOSPC mid-copy, sidecar (`-wal`) copy failing after the main copy succeeded, process killed mid-copy — skips prune *and* leaves a partial file that still matches the `malformed-backup-` prefix. Measured on the unpatched tree: capped at 3 while copies succeed, **13 and climbing** once `copy2` raises. Each partial consumes the free space that guarantees the next failure.

   Worse: partials sort newest-by-name, so if a later pass succeeds, prune's keep-3-newest slice retains the garbage partials and **deletes the intact forensic copies**.

3. `-wal`/`-shm` sidecar copies are excluded from the cap's count, so on a WAL-mode DB the bytes on disk are ~2x what the cap accounts for (measured: 3 counted files, 9 files actually on disk).

The originating report was "31 copies / 2.3GB in ~20 min". Those files were deleted before I could examine them, so I treat that as a user report consistent with mechanism (2)+(3), **not** as verified evidence. What is verified is above.

## Fix

- **Fingerprint on content, not mtime** — size + sha256 of the first and last 64KB, for both the ledger and the backup dedupe. Stable across passes that merely touch the file; still changes on genuine repair/truncation/restore so recovery resets the budget; O(1) on a multi-GB DB (the reason mtime was originally chosen). The first 64KB covers page 1, where the header and `sqlite_master` root live — i.e. exactly where this corruption class sits.
- **Atomic backups** — copy to a `.incomplete` staging name that does *not* match the backup prefix, `os.replace` into place only once every copy (DB + sidecars) has succeeded, unlink staging on failure, and sweep stale staging debris on entry. This, not the space check, is what actually closes the runaway in (2) and stops prune from ever preferring partials over intact copies.
- **Proportional free-space guard** — refuse the pre-repair copy when free space minus the copy (now including its sidecars) would fall below `max(256MiB, 2% of volume)`. A flat multi-GB floor was a small-volume regression: a 50MB DB on a 10GB volume with 1.5GB free was refused, and because refusal is the #69603 hard stop, that silently converts "repair loops" into "repair never runs".

## On the hard-stop / termination interaction

Worth stating since it looks like a hole: a refused backup does **not** leave the loop spinning. `repair_state_db_schema` records the outcome on the result returned by `_repair_state_db_schema_locked`, which is where the hard stop returns — so refusals count toward the ledger. Verified on a simulated low-disk host: terminal at pass 4, zero backups written.

## Tests

`tests/test_state_db_repair_loop_mtime.py`, 15 tests: fingerprint stability across `utime` vs. sensitivity to real content change/truncation; attempt-budget exhaustion under mtime churn; backup dedupe across mtime change; retention cap; disk guard (refuse / allow / small-volume allow / proportional headroom / sidecar accounting / repair-aborts-on-refusal); failed-copy leaves no countable debris and staging is swept.

The three loop-critical assertions fail on the unfixed tree and pass with the fix:

```
FAIL  fingerprint survives mtime change
FAIL  attempt budget exhausts despite mtime churn (cap=3)
FAIL  identical DB backed up once, not 3 times
```

`tests/test_state_db_repair_loop_cap.py` (the #86747 suite) stays green — 23 pass together — and `tests/test_hermes_state.py` 252 passed.

Pre-existing failures on this machine, unrelated and reproducing on the base commit: `test_state_db_malformed_repair.py::test_repair_skips_surgery_while_another_process_holds_the_lock`, `::test_repair_reports_success_when_the_holder_already_healed_the_db` (conftest live-system kill guard), and `TestFTS5Search::test_search_projection_skips_context_enrichment_queries`.

## Caveats

- The reproduction simulates mtime movement with `os.utime` rather than driving a checkpoint end-to-end. The mechanism (writes still succeed on a schema-corrupt DB; repair strategies mutate in place before failing) is argued from the code, and the 98-pass field log confirms the guard did not trip — but the specific mover was not isolated.
- The trigger of the corruption itself is unproven. On the reporting host the likely candidate was `hermes update` force-restarting the gateway with a **0s drain** (`⚠ Gateway PID N still running after 0.0s — forcing launchd restart`; `agent.restart_drain_timeout` defaults to `0`) while sessions were mid-WAL-write. That is a separate question from this PR, which fixes the amplification regardless of what damages the file.
