### PR TITLE
fix(desktop): prevent stale update marker self-deadlock

### DIFF
--- a/apps/desktop/electron/update-marker.test.ts
+++ b/apps/desktop/electron/update-marker.test.ts
@@ -40,6 +40,13 @@ function writeMarker(home, pid, startedAtSec) {
 
 const ALIVE: typeof process.kill = () => true // injected kill that "succeeds" => pid alive
 
+function foreignPid(preferred) {
+  return preferred === process.pid ? preferred + 1 : preferred
+}
+
+const LIVE_OWNER_PID = foreignPid(4242)
+const CONFLICT_OWNER_PID = foreignPid(1010)
+
 const DEAD: typeof process.kill = () => {
   const err = new Error('no such process')
 
@@ -55,10 +62,10 @@ test('absent marker => no live update', () => {
 test('live pid within age ceiling => live update reported', () => {
   const home = tmpHome('live')
   const now = 1_000_000_000_000
-  writeMarker(home, 4242, Math.floor(now / 1000) - 5) // 5s old
+  writeMarker(home, LIVE_OWNER_PID, Math.floor(now / 1000) - 5) // 5s old
   const res = readLiveUpdateMarker(home, { kill: ALIVE, now: () => now })
   assert.ok(res, 'a fresh, alive marker is a live update')
-  assert.equal(res.pid, 4242)
+  assert.equal(res.pid, LIVE_OWNER_PID)
   assert.ok(res.ageMs >= 0 && res.ageMs < 10_000)
   assert.ok(fs.existsSync(markerPath(home)), 'a live marker is NOT deleted')
 })
@@ -70,10 +77,18 @@ test('dead pid => no live update and marker is pruned', () => {
   assert.ok(!fs.existsSync(markerPath(home)), 'a dead-pid marker self-heals (deleted)')
 })
 
+test('marker whose pid was reused by this desktop => no live update and marker is pruned', () => {
+  const home = tmpHome('self-pid')
+  writeMarker(home, process.pid, Math.floor(Date.now() / 1000))
+
+  assert.equal(readLiveUpdateMarker(home), null)
+  assert.ok(!fs.existsSync(markerPath(home)), 'a marker cannot be owned by the desktop reading it')
+})
+
 test('expired marker (past age ceiling) => no live update and pruned', () => {
   const home = tmpHome('expired')
   const now = 1_000_000_000_000
-  writeMarker(home, 4242, Math.floor((now - UPDATE_MARKER_MAX_AGE_MS - 60_000) / 1000))
+  writeMarker(home, LIVE_OWNER_PID, Math.floor((now - UPDATE_MARKER_MAX_AGE_MS - 60_000) / 1000))
   // Even though the pid is "alive", the marker is too old to trust.
   assert.equal(readLiveUpdateMarker(home, { kill: ALIVE, now: () => now }), null)
   assert.ok(!fs.existsSync(markerPath(home)), 'an expired marker self-heals (deleted)')
@@ -107,11 +122,11 @@ test('isPidAlive: EPERM counts as alive (process owned by another user)', () => 
 test('writeUpdateMarker writes a marker that readLiveUpdateMarker accepts', () => {
   const home = tmpHome('write')
   const now = 1_000_000_000_000
-  writeUpdateMarker(home, 4242, { now: () => now })
+  writeUpdateMarker(home, LIVE_OWNER_PID, { now: () => now })
   // The marker should be readable and report the same pid.
   const res = readLiveUpdateMarker(home, { kill: ALIVE, now: () => now })
   assert.ok(res, 'marker written by writeUpdateMarker should be detected as live')
-  assert.equal(res.pid, 4242)
+  assert.equal(res.pid, LIVE_OWNER_PID)
   assert.ok(fs.existsSync(markerPath(home)), 'marker file should exist after write')
 })
 
@@ -147,12 +162,12 @@ test('no marker => hand-off is not blocked', () => {
 test('a different live updater already owns the marker => hand-off is blocked', () => {
   const home = tmpHome('conflict-live')
   const now = 1_000_000_000_000
-  writeMarker(home, 1010, Math.floor(now / 1000) - 6) // 6s old
+  writeMarker(home, CONFLICT_OWNER_PID, Math.floor(now / 1000) - 6) // 6s old
   const conflict = updateHandoffConflict(home, { kill: ALIVE, now: () => now })
   assert.ok(conflict, 'a live foreign updater must block a new hand-off')
-  assert.equal(conflict.pid, 1010)
+  assert.equal(conflict.pid, CONFLICT_OWNER_PID)
   assert.match(conflict.message, /already running/)
-  assert.match(conflict.message, /PID 1010/)
+  assert.ok(conflict.message.includes(`PID ${CONFLICT_OWNER_PID}`))
   assert.match(conflict.message, /6s/)
 })
 
@@ -165,14 +180,14 @@ test('a dead-pid marker does not block a hand-off (self-heals)', () => {
 test('an expired marker does not block a hand-off (self-heals)', () => {
   const home = tmpHome('conflict-expired')
   const now = 1_000_000_000_000
-  writeMarker(home, 1010, Math.floor((now - UPDATE_MARKER_MAX_AGE_MS - 60_000) / 1000))
+  writeMarker(home, CONFLICT_OWNER_PID, Math.floor((now - UPDATE_MARKER_MAX_AGE_MS - 60_000) / 1000))
   assert.equal(updateHandoffConflict(home, { kill: ALIVE, now: () => now }), null)
 })
 
 test('minutes-scale elapsed time is formatted as "Nm Ss"', () => {
   const home = tmpHome('conflict-minutes')
   const now = 1_000_000_000_000
-  writeMarker(home, 1010, Math.floor(now / 1000) - 125) // 2m 5s old
+  writeMarker(home, CONFLICT_OWNER_PID, Math.floor(now / 1000) - 125) // 2m 5s old
   const conflict = updateHandoffConflict(home, { kill: ALIVE, now: () => now })
   assert.ok(conflict)
   assert.match(conflict.message, /2m 5s/)

--- a/apps/desktop/electron/update-marker.ts
+++ b/apps/desktop/electron/update-marker.ts
@@ -68,11 +68,13 @@ export function readLiveUpdateMarker(
   {
     kill,
     now = Date.now,
-    maxAgeMs = UPDATE_MARKER_MAX_AGE_MS
+    maxAgeMs = UPDATE_MARKER_MAX_AGE_MS,
+    ownPid = process.pid
   }: {
     now?: () => number
     maxAgeMs?: number
     kill?: typeof process.kill
+    ownPid?: number
   } = {}
 ) {
   const file = markerPath(hermesHome)
@@ -88,7 +90,11 @@ export function readLiveUpdateMarker(
   const pid = Number.parseInt((pidLine || '').trim(), 10)
   const startedAt = Number.parseInt((startedLine || '').trim(), 10)
   const ageMs = Number.isFinite(startedAt) ? now() - startedAt * 1000 : Infinity
-  const alive = Number.isInteger(pid) && isPidAlive(pid, kill)
+  // This module runs in the Desktop process, but every legitimate marker is
+  // owned by a separate updater process. Windows can reuse a crashed updater's
+  // pid for the newly relaunched Desktop; an existence-only probe would then
+  // mistake the Desktop for its updater and make it wait on itself.
+  const alive = Number.isInteger(pid) && pid !== ownPid && isPidAlive(pid, kill)
 
   if (!alive || ageMs > maxAgeMs) {
     try {


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes Desktop from waiting on itself after a failed Windows updater hand-off leaves `.hermes-update-in-progress` behind.

Issue #88204 is currently labeled official `P1`, `type/bug`, `comp/cli`, `comp/gateway`, `platform/windows`, and `area/install-update`. The failure blocks normal Desktop startup; the only reported recovery is manually finding and deleting an internal marker file, which is not an in-product workaround.

The marker records the updater PID, and the Desktop gate currently treats any existing process with that PID as the live updater. Windows can reuse the dead updater's PID for the newly relaunched Desktop. The existence probe then sees the Desktop itself and makes the app wait on its own process.

Every legitimate marker is owned by a separate updater process: Desktop writes the detached updater child PID, and the updater later overwrites it with its own PID. The minimal fix therefore treats `marker pid === process.pid` as unambiguously stale and sends it through the existing marker-pruning path.

Safety boundary: this does not terminate or signal any process, weaken the live foreign-updater gate, change authentication, or delete user state. A different live updater PID continues to block startup exactly as before; only the impossible self-owned marker is pruned.

## Related Issue

Closes #88204

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/update-marker.ts`: reject the current Desktop PID as a valid updater marker owner.
- `apps/desktop/electron/update-marker.test.ts`: reproduce the PID-reuse self-deadlock with a real temporary marker and the current test process PID.
- Keep all mocked live-updater fixtures distinct from the actual test worker PID, so the suite remains deterministic under arbitrary worker PIDs.

Codex review caught the fixture-PID collision edge case after the runtime fix; it is addressed in this revision, and the full validation set below was rerun afterward. A follow-up Codex review completed with no findings.

## How to Test

1. Before the fix, write a fresh marker containing `process.pid` and call `readLiveUpdateMarker()`; the regression test fails because the marker is returned as live (`actual: { pid, ageMs }`, expected `null`).
2. Apply the fix and rerun the focused test; the marker is rejected and pruned, with 16/16 tests passing.
3. Run the adjacent gate tests, the complete Electron platform suite, formatting, lint, and all Desktop TypeScript typechecks.

Commands run:

```text
npx vitest run electron/update-marker.test.ts
npx vitest run electron/update-marker.test.ts electron/update-gate.test.ts
npm run test:desktop:platforms
npm run typecheck
npx eslint electron/update-marker.ts electron/update-marker.test.ts
npx prettier --check electron/update-marker.ts electron/update-marker.test.ts
git diff --check
```

Results:

- focused pre-fix regression: 1 failed, 15 passed (expected red)
- focused post-fix regression: 16 passed
- marker + gate tests: 24 passed
- full Electron platform suite: 1283 passed, 2 skipped
- typecheck, ESLint, Prettier, and diff checks: passed

GitHub Actions note for the current PR head: the upstream [CI run](https://github.com/NousResearch/hermes-agent/actions/runs/32007244733) ended before scheduling any job (0 jobs, 0 check-runs, and no logs), exactly like the [latest `main` push run](https://github.com/NousResearch/hermes-agent/actions/runs/32005904016) for this PR's parent SHA. The Docker workflow is `action_required`, awaiting the repository's fork-workflow approval. There is no code-level CI failure log to address.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: this is a TypeScript-only Desktop change; the complete Electron Vitest project passed.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS host, using platform-independent marker logic with real temp-file I/O and the current process PID. The affected Windows lifecycle remains covered by the same pure boundary.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A: behavior is internal and documented inline at the invariant.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual change. The regression is captured as a behavior test against the real marker file format.

Prepared with OpenAI Codex. I understand and reviewed the implementation, its invariant, the two-file diff, and the test evidence before requesting review.
