### PR TITLE
fix(email): honor EMAIL_IMAP_SSL/EMAIL_SMTP_SSL for local relays

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -7,8 +7,14 @@ Uses IMAP to receive and SMTP to send messages.
 Environment variables:
     EMAIL_IMAP_HOST     — IMAP server host (e.g., imap.gmail.com)
     EMAIL_IMAP_PORT     — IMAP server port (default: 993)
+    EMAIL_IMAP_SSL      — Use SSL/TLS for IMAP (default: true). Set false for
+                          local relays (e.g. ProtonMail Bridge) serving plaintext
+                          IMAP on a non-SSL port (e.g. 1143).
     EMAIL_SMTP_HOST     — SMTP server host (e.g., smtp.gmail.com)
     EMAIL_SMTP_PORT     — SMTP server port (default: 587)
+    EMAIL_SMTP_SSL      — Use STARTTLS for SMTP (default: true). Set false for
+                          local relays (e.g. ProtonMail Bridge) serving plaintext
+                          SMTP on a non-SSL port (e.g. 1025) with a self-signed cert.
     EMAIL_ADDRESS       — Email address for the agent
     EMAIL_PASSWORD      — Email password or app-specific password
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
@@ -88,7 +94,10 @@ def _esecret_int(name: str, default: int) -> int:
 
 def _esecret_bool(name: str, default: bool = False) -> bool:
     """Scope-aware boolean read (``env_bool`` variant of ``_get_esecret``)."""
-    return is_truthy_value(_get_esecret(name, ""), default=default)
+    raw = _get_esecret(name, "").strip()
+    if not raw:
+        return default
+    return is_truthy_value(raw, default=default)
 
 
 # Automated sender patterns — emails from these are silently ignored
@@ -554,8 +563,16 @@ class EmailAdapter(BasePlatformAdapter):
         self._password = _get_secret("EMAIL_PASSWORD", "")
         self._imap_host = (_get_secret("EMAIL_IMAP_HOST", "") or extra.get("imap_host", "")).strip()
         self._imap_port = _esecret_int("EMAIL_IMAP_PORT", 993)
+        # ProtonMail Bridge and other local relays serve plaintext IMAP on a
+        # non-SSL port (e.g. 1143). Default is SSL (True) to preserve the
+        # historical behaviour for remote IMAP servers (993).
+        self._imap_ssl = _esecret_bool("EMAIL_IMAP_SSL", True)
         self._smtp_host = (_get_secret("EMAIL_SMTP_HOST", "") or extra.get("smtp_host", "")).strip()
         self._smtp_port = _esecret_int("EMAIL_SMTP_PORT", 587)
+        # ProtonMail Bridge and other local relays serve plaintext SMTP on a
+        # non-SSL port (e.g. 1025) with a self-signed cert. Default is SSL
+        # (True) so remote servers still use STARTTLS.
+        self._smtp_ssl = _esecret_bool("EMAIL_SMTP_SSL", True)
         self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", 15)
 
         # Skip attachments — configured via config.yaml:
@@ -653,11 +670,15 @@ class EmailAdapter(BasePlatformAdapter):
             if port == 465:
                 return smtp_ssl_cls(host, port, timeout=SMTP_CONNECT_TIMEOUT, context=ctx)
             smtp = smtp_cls(host, port, timeout=SMTP_CONNECT_TIMEOUT)
-            try:
-                smtp.starttls(context=ctx)
-            except Exception:
-                smtp.close()
-                raise
+            # ProtonMail Bridge and other local relays serve plaintext SMTP.
+            # Skip STARTTLS when EMAIL_SMTP_SSL=false so the self-signed
+            # bridge certificate does not fail cert validation.
+            if self._smtp_ssl:
+                try:
+                    smtp.starttls(context=ctx)
+                except Exception:
+                    smtp.close()
+                    raise
             return smtp
 
         try:
@@ -668,6 +689,16 @@ class EmailAdapter(BasePlatformAdapter):
             # Connection-level failure (may be unreachable IPv6).
             # Retry with IPv4 only.
             return _connect(ipv4_only=True)
+
+    def _connect_imap(self) -> "imaplib.IMAP4":
+        """Create an IMAP connection, honouring ``EMAIL_IMAP_SSL``.
+
+        ``IMAP4_SSL`` for remote servers (993). ``IMAP4`` for local relays
+        such as ProtonMail Bridge that serve plaintext on a non-SSL port.
+        """
+        if self._imap_ssl:
+            return imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+        return imaplib.IMAP4(self._imap_host, self._imap_port, timeout=30)
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
@@ -711,7 +742,7 @@ class EmailAdapter(BasePlatformAdapter):
             # (#79889).
             imap = None
             try:
-                imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+                imap = self._connect_imap()
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
                 imap.select("INBOX")
@@ -853,7 +884,7 @@ class EmailAdapter(BasePlatformAdapter):
         results = []
         imap: Optional[imaplib.IMAP4] = None
         try:
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            imap = self._connect_imap()
             try:
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
@@ -1460,7 +1491,10 @@ async def _standalone_send(
         msg["Date"] = formatdate(localtime=True)
 
         server = smtplib.SMTP(smtp_host, smtp_port)
-        server.starttls(context=_ssl.create_default_context())
+        # Skip STARTTLS for local relays (ProtonMail Bridge) whose self-signed
+        # cert fails ssl.create_default_context() validation.
+        if _esecret_bool("EMAIL_SMTP_SSL", True):
+            server.starttls(context=_ssl.create_default_context())
         server.login(address, password)
         server.send_message(msg)
         server.quit()

--- a/plugins/platforms/email/plugin.yaml
+++ b/plugins/platforms/email/plugin.yaml
@@ -29,6 +29,14 @@ optional_env:
     description: "IMAP host for inbound polling (e.g. imap.gmail.com)"
     prompt: "IMAP host"
     password: false
+  - name: EMAIL_IMAP_SSL
+    description: "Use SSL/TLS for IMAP (default true). Set false for local relays like ProtonMail Bridge that serve plaintext IMAP on a non-SSL port (e.g. 1143)."
+    prompt: "IMAP SSL (true/false)"
+    password: false
+  - name: EMAIL_SMTP_SSL
+    description: "Use STARTTLS for SMTP (default true). Set false for local relays like ProtonMail Bridge that serve plaintext SMTP on a non-SSL port (e.g. 1025) with a self-signed cert."
+    prompt: "SMTP SSL (true/false)"
+    password: false
   - name: EMAIL_ALLOWED_USERS
     description: "Comma-separated email addresses allowed to talk to the bot"
     prompt: "Allowed users (comma-separated)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,6 +364,16 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "EMAIL_ALLOW_ALL_USERS",
     "SMS_ALLOW_ALL_USERS",
     "PHOTON_ALLOW_ALL_USERS",
+    # Email connection settings leak from ~/.hermes/.env on developer
+    # machines and change adapter behavior (SSL vs plaintext IMAP, host
+    # selection). Tests that need them set them explicitly via patch.dict.
+    "EMAIL_IMAP_SSL",
+    "EMAIL_SMTP_SSL",
+    "EMAIL_IMAP_HOST",
+    "EMAIL_IMAP_PORT",
+    "EMAIL_SMTP_HOST",
+    "EMAIL_SMTP_PORT",
+    "EMAIL_POLL_INTERVAL",
     # Gateway home channels are set by /sethome in real profiles. Tests that
     # exercise dashboard notification toggles must opt in explicitly or they
     # can accidentally subscribe against a developer's real home channel.

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -963,6 +963,71 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         self.assertLess(names.index("login"), names.index("xatom"))
 
 
+class TestConnectImapSslToggle(unittest.TestCase):
+    """``EMAIL_IMAP_SSL`` controls IMAP4_SSL vs IMAP4 selection.
+
+    ProtonMail Bridge and other local relays serve plaintext IMAP on a
+    non-SSL port (e.g. 1143).  The adapter must honour ``EMAIL_IMAP_SSL=false``
+    and use ``imaplib.IMAP4`` instead of ``IMAP4_SSL`` — otherwise every
+    connection fails with ``[SSL: WRONG_VERSION_NUMBER]``.
+    """
+
+    def _make_adapter(self, imap_ssl=None):
+        from gateway.config import PlatformConfig
+        env = {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "127.0.0.1",
+            "EMAIL_IMAP_PORT": "1143",
+            "EMAIL_SMTP_HOST": "127.0.0.1",
+            "EMAIL_SMTP_PORT": "1025",
+        }
+        if imap_ssl is not None:
+            env["EMAIL_IMAP_SSL"] = imap_ssl
+        with patch.dict(os.environ, env, clear=False):
+            from plugins.platforms.email.adapter import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def test_ssl_default_is_true(self):
+        """Without EMAIL_IMAP_SSL set, default is SSL (IMAP4_SSL)."""
+        adapter = self._make_adapter(imap_ssl=None)
+        self.assertTrue(adapter._imap_ssl)
+
+    def test_ssl_false_uses_plaintext_imap(self):
+        """EMAIL_IMAP_SSL=false selects imaplib.IMAP4 (plaintext)."""
+        adapter = self._make_adapter(imap_ssl="false")
+        self.assertFalse(adapter._imap_ssl)
+        with patch("imaplib.IMAP4") as mock_imap4, \
+             patch("imaplib.IMAP4_SSL") as mock_imap4_ssl:
+            mock_imap4.return_value = MagicMock()
+            adapter._connect_imap()
+            mock_imap4.assert_called_once()
+            mock_imap4_ssl.assert_not_called()
+
+    def test_ssl_true_uses_imap4_ssl(self):
+        """EMAIL_IMAP_SSL=true selects imaplib.IMAP4_SSL."""
+        adapter = self._make_adapter(imap_ssl="true")
+        self.assertTrue(adapter._imap_ssl)
+        with patch("imaplib.IMAP4") as mock_imap4, \
+             patch("imaplib.IMAP4_SSL") as mock_imap4_ssl:
+            mock_imap4_ssl.return_value = MagicMock()
+            adapter._connect_imap()
+            mock_imap4_ssl.assert_called_once()
+            mock_imap4.assert_not_called()
+
+    def test_fetch_new_messages_uses_plaintext_when_ssl_false(self):
+        """_fetch_new_messages honours EMAIL_IMAP_SSL=false (ProtonMail Bridge)."""
+        adapter = self._make_adapter(imap_ssl="false")
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+
+        with patch("imaplib.IMAP4", return_value=mock_imap) as mock_imap4, \
+             patch("imaplib.IMAP4_SSL") as mock_imap4_ssl:
+            adapter._fetch_new_messages()
+            mock_imap4.assert_called_once()
+            mock_imap4_ssl.assert_not_called()
+
+
 class TestConnectSmtp(unittest.TestCase):
     """Test _connect_smtp() helper: protocol selection and IPv6 fallback."""
 


### PR DESCRIPTION
## What does this PR do?

The email platform adapter hardcoded `imaplib.IMAP4_SSL` and SMTP `STARTTLS` on every connection, ignoring the `EMAIL_IMAP_SSL` / `EMAIL_SMTP_SSL` env vars. ProtonMail Bridge and other local relays serve **plaintext** IMAP/SMTP on non-SSL ports (1143/1025) with a self-signed certificate, so every poll failed with `[SSL: WRONG_VERSION_NUMBER]` and the gateway reported the platform as not connected — even though the operator had set the toggles to `false`.

This is a real bug class: the vars were never implemented in the adapter, so users with a local relay (ProtonMail Bridge is a common headless email setup) cannot use the email gateway at all.

## Related Issue

No existing issue. Supersedes #81857 (same fix, rebased onto current `main` and with the `plugin.yaml` manifest + module docstring gaps closed).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/email/adapter.py`
  - Read `_imap_ssl` / `_smtp_ssl` from env in `__init__` (default `True` — preserves historical SSL behavior for remote servers on 993/465)
  - Add `_connect_imap()` helper that selects `IMAP4_SSL` vs plaintext `IMAP4`; use it at both connection sites (`connect()`, `_fetch_new_messages()`)
  - Gate SMTP `starttls()` on `_smtp_ssl` in `_connect_smtp()` and `_standalone_send()` (the bridge's self-signed cert fails `ssl.create_default_context()` validation)
  - Fix latent `_esecret_bool` bug: the `default` parameter was silently ignored when the env var was unset (empty string fell through to `is_truthy_value` instead of returning the default)
  - Document `EMAIL_IMAP_SSL` / `EMAIL_SMTP_SSL` in the module docstring env list
- `plugins/platforms/email/plugin.yaml` — declare `EMAIL_IMAP_SSL` / `EMAIL_SMTP_SSL` under `optional_env` (with descriptions and the SSL-on default)
- `tests/conftest.py` — add `EMAIL_IMAP_SSL`, `EMAIL_SMTP_SSL`, and the IMAP/SMTP host/port vars to the hermetic env blocklist (they were leaking from developer `.env` files into the test process and flipping the adapter to plaintext mode, bypassing the `IMAP4_SSL` mocks)
- `tests/gateway/test_email.py` — add `TestConnectImapSslToggle` (4 tests): default-SSL, `false` → plaintext `IMAP4`, `true` → `IMAP4_SSL`, and the `_fetch_new_messages` plaintext path

## How to Test

```bash
python -m pytest tests/gateway/test_email.py -o 'addopts=' -q
# 43 passed
```

Manual verification against a local relay (ProtonMail Bridge):

```bash
export EMAIL_IMAP_HOST=127.0.0.1 EMAIL_IMAP_PORT=1143 EMAIL_IMAP_SSL=false
export EMAIL_SMTP_HOST=127.0.0.1 EMAIL_SMTP_PORT=1025 EMAIL_SMTP_SSL=false
# gateway connects and polls without [SSL: WRONG_VERSION_NUMBER]
```

## Checklist

- [x] Tests pass locally
- [x] No unrelated changes included
- [x] Conventional commit message
