### PR TITLE
fix(compression): stop an aborted rotation from growing the parent it could not publish

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3476,6 +3476,13 @@ def compress_context(
                     # the current-turn user message before preflight runs, so
                     # messages[:idx] is exactly the persisted prefix; only the
                     # current turn's new messages get written.
+                    #
+                    # Bound to old_session_id, hoisted above the flush: the
+                    # ``except`` handler below keys its in-memory rollback off
+                    # this name, so anything that fails from here on rolls the
+                    # transcript back instead of leaving the failed attempt's
+                    # compacted snapshot in place.
+                    old_session_id = agent.session_id
                     current_idx = getattr(agent, "_persist_user_message_idx", None)
                     persisted_history = (
                         messages[:current_idx]
@@ -3483,6 +3490,44 @@ def compress_context(
                         and 0 <= current_idx <= len(messages)
                         else None
                     )
+                    # The #47202 flush below is a DURABLE append to the parent
+                    # and it is NOT undone when the rotation aborts: the
+                    # ``except`` handler restores the in-memory transcript and
+                    # keeps agent.session_id on the parent, but the rows it just
+                    # wrote stay. Survivable for a one-off failure; pathological
+                    # for a STICKY one. A parent row that already carries
+                    # ``ended_at`` fails publish_compression_child on every
+                    # attempt and nothing in this path clears it, so each
+                    # auto-compaction appends another copy of the current turn to
+                    # the transcript it was supposed to shrink — the session grows
+                    # until the provider rejects the request outright (#88197:
+                    # 303 unique messages stored as 2,611 rows after 7 aborted
+                    # attempts, ~1.66M tokens, HTTP 400).
+                    #
+                    # So check that one precondition BEFORE writing. It is a plain
+                    # read of the row the publish is about to read anyway, it
+                    # raises the publish's own message so the log line, telemetry
+                    # and rollback path are all unchanged, and it cannot mask a
+                    # real rotation — a live parent reaches the flush exactly as
+                    # before. Deliberately NOT extended to the compression lease:
+                    # a lease is re-acquirable, so a transient miss here would
+                    # abort a rotation that would otherwise have committed.
+                    _parent_row_reader = getattr(agent._session_db, "get_session", None)
+                    _parent_already_ended = False
+                    if callable(_parent_row_reader):
+                        try:
+                            _parent_row = _parent_row_reader(old_session_id) or {}
+                            _parent_already_ended = (
+                                _parent_row.get("ended_at") is not None
+                            )
+                        except Exception:
+                            # Fail OPEN: an unreadable row must not turn a cheap
+                            # guard into a new way to lose compression.
+                            _parent_already_ended = False
+                    if _parent_already_ended:
+                        raise RuntimeError(
+                            f"Compression parent already ended: {old_session_id}"
+                        )
                     # Foreign-tail ceiling (#75316): the flush below writes OUR
                     # OWN input transcript to the parent — those rows are
                     # already represented in the compacted handoff and must
@@ -3523,7 +3568,6 @@ def compress_context(
                     except Exception:
                         _profile_for_child = None
                     old_title = agent._session_db.get_session_title(agent.session_id)
-                    old_session_id = agent.session_id
                     new_session_id = (
                         f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_"
                         f"{uuid.uuid4().hex[:6]}"

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -736,3 +736,94 @@ class TestArchivedParentActivityLabelsCleared:
         assert not prov or prov == ActivityProvenance.UNKNOWN.value, (
             f"archived parent kept terminal provenance {prov!r}"
         )
+
+
+class TestAbortedRotationDoesNotGrowParent:
+    """#88197 — a rotation that cannot publish must not have already written.
+
+    The rotation flushes its un-persisted current-turn transcript to the parent
+    (#47202) and only then calls ``publish_compression_child``. The abort
+    handler rolls back memory but not that flush, so every failed rotation
+    leaves the parent transcript longer than it found it. When the failure is
+    STICKY -- a parent row stamped ``ended_at`` by something that ended the
+    process rather than the conversation, e.g. the TUI gateway's
+    ``_shutdown_sessions`` stamping ``end_reason='tui_shutdown'`` while the
+    agent keeps running -- every subsequent auto-compaction repeats it, and the
+    session grows instead of shrinking until the provider rejects the request.
+    """
+
+    @staticmethod
+    def _durable_len(db: SessionDB, session_id: str) -> int:
+        return len(db.get_messages_as_conversation(session_id))
+
+    def test_ended_parent_aborts_before_the_prepublish_flush(self, tmp_path: Path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_ENDED_NO_GROWTH"
+        db.create_session(parent, source="cli")
+        agent = _build_agent_with_db(db, parent)
+
+        # The lie at the heart of #88197: the row says ended, the agent is live.
+        # ``tui_shutdown`` is not a lineage boundary -- nothing forked off this
+        # session -- so durable writes to it are still permitted, which is
+        # exactly why the flush lands and the publish still refuses.
+        db.end_session(parent, "tui_shutdown")
+        assert db.get_session(parent)["ended_at"] is not None
+
+        before = self._durable_len(db, parent)
+
+        # Three consecutive auto-compactions, as the reported incident saw.
+        for attempt in range(1, 4):
+            original = _msgs()
+            returned, _sp = agent._compress_context(
+                original, "sys", approx_tokens=120_000
+            )
+            assert self._durable_len(db, parent) == before, (
+                f"attempt {attempt} appended to the parent it could not "
+                "publish; repeated attempts grow the transcript compression "
+                "exists to shrink"
+            )
+            # Rotation refused: the agent stays on the parent with its
+            # transcript intact, same contract as any other publish failure.
+            assert agent.session_id == parent
+            assert returned is original
+            assert [(m["role"], m["content"]) for m in returned] == [
+                (m["role"], m["content"]) for m in _msgs()
+            ]
+
+        assert db.find_live_compression_child(parent) is None
+
+    def test_live_parent_still_gets_the_prepublish_flush(self, tmp_path: Path):
+        """The guard must not cost a real rotation its #47202 tail."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_LIVE_FLUSH"
+        db.create_session(parent, source="cli")
+        agent = _build_agent_with_db(db, parent)
+
+        agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+        assert agent.session_id != parent  # rotation happened
+
+        # The current-turn messages survive in the preserved parent transcript.
+        assert self._durable_len(db, parent) >= len(_msgs())
+
+    def test_unreadable_parent_row_fails_open(self, tmp_path: Path):
+        """A guard that cannot read the row must not become a way to lose
+        compression -- an unreadable parent rotates exactly as before."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_UNREADABLE_ROW"
+        db.create_session(parent, source="cli")
+        agent = _build_agent_with_db(db, parent)
+
+        real_get_session = db.get_session
+        calls = {"n": 0}
+
+        def _flaky_get_session(session_id: str):
+            if session_id == parent and calls["n"] == 0:
+                calls["n"] += 1
+                raise RuntimeError("simulated read failure")
+            return real_get_session(session_id)
+
+        with patch.object(db, "get_session", side_effect=_flaky_get_session):
+            agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+
+        assert calls["n"] == 1, "the pre-flush guard never read the parent row"
+        assert agent.session_id != parent  # rotation still happened


### PR DESCRIPTION
## What does this PR do?

The compression rotation path flushes its un-persisted transcript to the parent (#47202) and *then* publishes:

```python
try:
    agent._flush_messages_to_session_db(messages, conversation_history=persisted_history)
except Exception:
    pass  # best-effort — don't block compression on a flush error
...
agent._session_db.publish_compression_child(...)   # can still refuse
```

The abort handler rolls back the in-memory transcript and keeps `agent.session_id` on the parent. Its own comment says *"keep the parent live and discard the stale compacted snapshot"* — but the rows the flush just committed are not part of what it discards. **Every failed rotation leaves the parent transcript longer than it found it, whatever the failure was.**

Survivable once. Pathological when the failure is *sticky*: `publish_compression_child` refuses any parent whose row carries `ended_at`, nothing in this path clears it, so each auto-compaction appends another copy of the current turn to the transcript it was supposed to shrink. And the growth is then self-feeding — it satisfies this same file's

```python
if _preflush_ok and isinstance(durable_parent, list) and len(durable_parent) > len(messages):
    messages = durable_parent
```

so the next attempt adopts the inflated snapshot as if it were genuine concurrent activity, and the in-memory transcript doubles too.

Three consecutive auto-compactions on such a parent, from the regression test's own log:

```
attempt 1  messages=20  -> aborted (failure_class=session_split_failed, "Compression parent already ended")
attempt 2  messages=20  -> aborted
attempt 3  compression: session=... grew before lease (20 -> 40 msgs); adopting durable snapshot
           messages=40->40  -> aborted
```

This checks that precondition **before** writing. A live parent reaches the flush exactly as before.

**Why this is a safe place to check.** It is a plain read of the row `publish_compression_child` is about to read anyway, and it raises the publish's own message, so `split_status=aborted`, `failure_class=session_split_failed`, the `"Compression rotation aborted and rolled back to the parent session"` warning and the in-memory rollback are byte-identical to today's post-publish abort. `old_session_id` moves above the flush for that reason: the `except` handler keys its rollback off that name, so hoisting it means a failure raised from here rolls the transcript back instead of leaving the failed attempt's compacted snapshot in place.

**Deliberately not extended to the compression lease.** A lease is re-acquirable and its loss is transient, so pre-checking it would abort rotations that would otherwise have committed. The ended-parent check is the opposite shape — it is sticky by construction, which is exactly what makes it worth paying for up front.

## Related Issue

Refs #88197

Reported by @mayqhw: a live session went from ~52% to 166% of context in ~15 minutes and hit `400 invalid_request_error`, with 303 unique messages stored as 2,611 rows (88% duplicate) after 7 aborted compression attempts. Their `ended_at` came from `tui_gateway/server.py::_shutdown_sessions()` stamping `end_reason="tui_shutdown"` on a still-active session when the TUI server auto-reloaded.

**Scope — this is one of the two halves, and not the one in the title of the issue.** It does not fix what marks a live session as ended. An affected session still aborts every attempt; it just stops making itself larger while it does. That half needs a maintainer decision (should `_shutdown_sessions()` stamp at all, should the publish guard read `end_reason` the way `_check_transcript_write_guards` does, or should the attach path reopen the way all eight `reopen_session` call sites do?) and the analysis is on the issue rather than in this PR.

**Relationship to #85141**, which is open against the same two files: it introduces `_LINEAGE_CLOSED_END_REASONS` and makes the *write* guard use it, deliberately leaving hygiene ends writable. `tui_shutdown` is a hygiene end by that taxonomy and #85141 does not touch the publish guard, so the two do not overlap — but #85141 reports this same amplification independently (25k → 126k messages on a `/new` parent), which is the second production sighting of an aborted rotation inflating the row it aborted on. That is the part this PR generalises: it holds for *any* abort cause, including the ones #85141 is fixing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_compression.py` — in the rotation branch: hoist `old_session_id = agent.session_id` above the #47202 flush, and read the parent row before flushing. If it already carries `ended_at`, raise the publish's own `RuntimeError` so nothing durable has been written. Fails **open** on an unreadable row — a cheap guard must not become a new way to lose compression.
- `tests/agent/test_compression_rotation_state.py` — `TestAbortedRotationDoesNotGrowParent`, 3 tests, driving the real `_compress_context` against a real `SessionDB`.

No behavior change for in-place compaction, for a rotation whose parent is live, or for any other publish failure (lease loss, busy, ambiguous lineage) — those still abort after the flush exactly as before.

## How to Test

```
python -m pytest tests/agent/test_compression_rotation_state.py -q -k AbortedRotation
```

3 passed.

Mutation check, one rule at a time:

| Mutation | Result |
|---|---|
| Never raise (`if False and _parent_already_ended:`) — i.e. today's behavior | **1 failed** — `attempt 3 appended to the parent it could not publish`, and the log shows the adoption firing at `20 -> 40 msgs` |
| Always raise (`if True:`) — skip the flush unconditionally | **2 failed** — the live parent loses its #47202 tail, and the fail-open case stops rotating |
| Fail **closed** on an unreadable row (`except Exception: _parent_already_ended = True`) | **1 failed** — a transient read error becomes a lost rotation |

Each mutation kills exactly the test that owns the rule, and no others.

Neighbouring suites, all on this branch:

```
pytest tests/agent/test_compression_rotation_state.py \
       tests/agent/test_compression_concurrent_fork.py \
       tests/agent/test_compression_orphan_recovery.py \
       tests/agent/test_compression_adoption_preserves_live_tail.py \
       tests/agent/test_compression_attempt_telemetry.py \
       tests/agent/test_preflight_compression_gate.py -q
  -> 73 passed

pytest tests/agent -q -k "compress or compact or rotation"
  -> 1 failed, 529 passed, 1 skipped
```

The one failure is `test_compression_review_76354.py::TestF6ExecutorSaturation::test_cancelled_fence_skips_summary_work_before_start`, and it is **pre-existing and unrelated** — verified by stashing both of my files and re-running it on pristine `main` (`b20229312`), where it fails identically with `failure_class=commit_fence_cancelled`.

`ruff check` on both files: clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — issue timeline (no cross-references), PR search for `88197` and `publish_compression_child`, and a topic sweep of all 21,600 open PR titles for compaction/abort/duplicate/rotation terms. The nearest hits are #85141 (different guard, different end-reason class — relationship spelled out above), #86409 and #79763 (both about *adopting* a live child when a flush hits a closed session, not about the rotation's own pre-publish write), and #87561 (`archive_and_compact` replay duplicates — the in-place path, which this PR does not touch).
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran the compression/rotation subset rather than the whole suite; results and the one pre-existing failure are in *How to Test*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the guard carries its own reasoning inline, including why the lease is excluded
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is pure Python against `SessionDB` with no path, process or filesystem behavior. The reported incident is macOS and I verified the DB-level chain on Windows 11, so the fix is platform-neutral in both directions
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

From the issue, `agent.log` on the affected session:

```
compression attempt: failure_class=session_split_failed
  "Compression parent already ended: 20260817_100814_a25286"
  x7 between 13:28 and 13:52
303 unique messages -> 2,611 rows (88% duplicate)
522K tokens -> 1,783,431 -> request 1,663,655 -> 400 (max 1,048,576)
```

After this change those seven attempts still abort — the parent is still marked ended — but the row count stays at 303 and the session stays usable instead of bricking at the context limit.
