### PR TITLE
fix(mcp): read the elicitation schema under the SDK's real field name (salvage of #76737)

### DIFF
--- a/tests/tools/test_mcp_elicitation.py
+++ b/tests/tools/test_mcp_elicitation.py
@@ -282,3 +282,51 @@ class TestElicitationHandlerContextBridge:
             result = asyncio.run(handler(context=None, params=params))
 
         assert result.action == "decline"
+
+
+class TestRequestedSchemaFieldName:
+    """The requested schema must be read off the *real* SDK model.
+
+    Every other test in this file builds a duck-typed ``SimpleNamespace``
+    stand-in for the params object. That keeps them cheap, but it means none
+    of them can catch the handler reading a field name the SDK model does not
+    actually have -- the stand-in simply has whatever name the test wrote.
+
+    The SDK spells this field ``requestedSchema`` on mcp 1.x and
+    ``requested_schema`` on 2.0 (which renamed model fields to snake_case and
+    kept camelCase only as a serialization alias, which pydantic does not
+    expose to attribute access). Constructing with the camelCase spelling
+    works on both -- 2.0 accepts it as the alias -- so this test pins the
+    behaviour to the real model on whichever SDK is installed.
+    """
+
+    def test_real_sdk_params_schema_reaches_the_consent_description(self):
+        from mcp.types import ElicitRequestFormParams
+
+        params = ElicitRequestFormParams(
+            message="authorize a payment of $0.50",
+            requestedSchema={
+                "type": "object",
+                "properties": {
+                    "card_number": {
+                        "type": "string",
+                        "description": "card to charge",
+                    },
+                },
+            },
+        )
+        handler = ElicitationHandler("pay", {"timeout": 5})
+        captured: dict = {}
+
+        def _capture(*args, **kwargs):
+            captured["description"] = kwargs.get("description") or (
+                args[1] if len(args) > 1 else ""
+            )
+            return "decline"
+
+        with patch("tools.approval.request_elicitation_consent", _capture):
+            asyncio.run(handler(context=None, params=params))
+
+        # An empty schema renders the generic "Approval requested by ..."
+        # fallback, so the field name is what proves the schema was read.
+        assert "card_number" in (captured.get("description") or ""), captured

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2144,7 +2144,19 @@ class ElicitationHandler:
         message = getattr(params, "message", "") or (
             f"MCP server '{self.server_name}' is requesting your approval"
         )
-        schema = getattr(params, "requested_schema", {}) or {}
+        # The SDK model spells this field ``requestedSchema`` on mcp 1.x (the
+        # pinned version) and ``requested_schema`` on 2.0, which renamed model
+        # fields to snake_case and kept camelCase only as a serialization
+        # alias -- and pydantic aliases do not apply to attribute access. A
+        # single-spelling read therefore returns the ``{}`` default on the
+        # other generation, and _format_elicitation_schema_summary degrades to
+        # its generic "Approval requested by ..." line, so the user is asked to
+        # approve without being told which fields the server wants.
+        schema = (
+            getattr(params, "requestedSchema", None)
+            or getattr(params, "requested_schema", None)
+            or {}
+        )
         description = _format_elicitation_schema_summary(schema, self.server_name)
 
         logger.info(


### PR DESCRIPTION
## Summary
The MCP elicitation consent prompt now reads the requested schema under both SDK generations' field spellings, so the user is told which fields a server wants regardless of installed SDK. Salvage of #76737 by @elphamale onto current main (post-#88180).

Root cause: the SDK spells the field `requestedSchema` on mcp 1.x and `requested_schema` on 2.0; pydantic serialization aliases don't apply to attribute access, so a single-spelling `getattr` silently returns `{}` on the other generation and the consent prompt degrades to the generic "Approval requested by ..." line — the user approves without seeing the requested fields.

## Changes
- `tools/mcp_tool.py`: elicitation handler reads `requestedSchema` → `requested_schema` → `{}`
- `tests/tools/test_mcp_elicitation.py`: pins the behavior to the real SDK model (not a SimpleNamespace stub), so a future field rename can't silently pass

## Validation
| Check | Result |
|---|---|
| `test_mcp_elicitation.py` on mcp==2.0.0 | 14/14 passed |
| `test_mcp_elicitation.py` on mcp==1.28.1 | 13 passed + 1 pre-existing failure from #88180's own real-model test, which constructs with the snake_case name (2.0-only — we pin 2.0.0; the salvaged test constructs via camelCase, valid on both generations) |

Credit: @elphamale (#76737, cherry-picked with authorship).

## Infographic

![MCP elicitation schema field read](https://v3b.fal.media/files/b/0aa6abe9/GxXiVoIAJd2f1Js-CjaRL_lvzpiMaQ.png)
