### PR TITLE
fix(acp): preserve configured MCP call timeout for ACP-supplied servers

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -402,6 +402,33 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             session_id, update, fail_msg="Could not send ACP session info update for %s", level=logging.DEBUG
         )
 
+    async def _load_configured_mcp_timeouts(self) -> dict[str, object]:
+        """Load per-server ``timeout`` values from the operator's config.
+
+        Returns a mapping of server name → configured ``timeout`` for the
+        servers that declare one. Config load failures are fail-open (an
+        empty map), matching the defensive style of the rest of this adapter:
+        a broken config must not break ACP session startup.
+        """
+        try:
+            from hermes_cli.config import load_config
+        except ImportError:
+            return {}
+
+        try:
+            cfg = await asyncio.to_thread(load_config)
+            raw = cfg.get("mcp_servers") if isinstance(cfg, dict) else None
+        except Exception:
+            logger.debug("Could not read MCP config for ACP timeouts", exc_info=True)
+            return {}
+
+        configured: dict[str, object] = {}
+        if isinstance(raw, dict):
+            for server_name, entry in raw.items():
+                if isinstance(entry, dict) and entry.get("timeout") is not None:
+                    configured[server_name] = entry["timeout"]
+        return configured
+
     async def _register_session_mcp_servers(
         self, state: SessionState, mcp_servers: list[McpServerStdio | McpServerHttp | McpServerSse] | None
     ) -> None:
@@ -411,7 +438,20 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         try:
             from tools.mcp_tool_discovery import register_mcp_servers
 
-            await asyncio.to_thread(register_mcp_servers, {s.name: _mcp_server_config(s) for s in mcp_servers})
+            # The ACP client is authoritative for the transport (command, args,
+            # env, url, headers), but the operator-configured per-tool call
+            # ``timeout`` must survive reconstruction — otherwise every
+            # ACP-supplied server silently falls back to the 300 s default and
+            # legitimate calls longer than that fail. Copy only ``timeout``
+            # from an exact server-name match in config.yaml.
+            config_map = {s.name: _mcp_server_config(s) for s in mcp_servers}
+            configured_timeouts = await self._load_configured_mcp_timeouts()
+            for name, config in config_map.items():
+                timeout = configured_timeouts.get(name)
+                if timeout is not None:
+                    config["timeout"] = timeout
+
+            await asyncio.to_thread(register_mcp_servers, config_map)
         except Exception:
             logger.warning("Session %s: failed to register ACP MCP servers", state.session_id, exc_info=True)
             return

--- a/contributors/emails/diwak4r.comp@gmail.com
+++ b/contributors/emails/diwak4r.comp@gmail.com
@@ -1,0 +1,2 @@
+diwak4r
+# fix(acp): preserve configured MCP call timeout for ACP-supplied servers (#88230)

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -109,6 +109,56 @@ class TestMcpRegistrationE2E:
         }
 
     @pytest.mark.asyncio
+    async def test_session_with_mcp_servers_preserves_configured_timeout(
+        self, acp_agent, mock_manager, monkeypatch, tmp_path
+    ):
+        """ACP-supplied servers inherit the operator-configured ``timeout``.
+
+        The ACP client stays authoritative for the transport (command, args,
+        env), but a matching server in config.yaml with a ``timeout`` must not
+        be dropped during reconstruction — otherwise the registration falls
+        back to the 300 s default and legitimate long tool calls fail.
+        """
+        (tmp_path / "config.yaml").write_text(
+            "mcp_servers:\n"
+            "  test-fs:\n"
+            "    command: /usr/bin/mcp-fs\n"
+            "    timeout: 28800\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        servers = [
+            McpServerStdio(
+                name="test-fs",
+                command="/usr/bin/mcp-fs",
+                args=["--root", "/tmp"],
+                env=[EnvVariable(name="DEBUG", value="1")],
+            ),
+        ]
+
+        registered_configs = {}
+
+        def mock_register(config_map):
+            registered_configs.update(config_map)
+            return ["mcp_test_fs_read"]
+
+        fake_tools = [{"function": {"name": "mcp_test_fs_read"}}]
+
+        with patch("tools.mcp_tool_discovery.register_mcp_servers", side_effect=mock_register), \
+             patch("model_tools.get_tool_definitions", return_value=fake_tools):
+            resp = await acp_agent.new_session(cwd="/tmp", mcp_servers=servers)
+
+        assert isinstance(resp, NewSessionResponse)
+        fs_cfg = registered_configs["test-fs"]
+        # Transport fields stay ACP-authoritative ...
+        assert fs_cfg["command"] == "/usr/bin/mcp-fs"
+        assert fs_cfg["args"] == ["--root", "/tmp"]
+        assert fs_cfg["env"] == {"DEBUG": "1"}
+        # ... while the configured per-tool-call timeout is preserved.
+        assert fs_cfg["timeout"] == 28800
+
+    @pytest.mark.asyncio
     async def test_prompt_with_tool_calls_emits_acp_events(self, acp_agent, mock_manager):
         """Prompt → agent fires callbacks → ACP ToolCallStart + ToolCallUpdate events."""
         resp = await acp_agent.new_session(cwd="/tmp")


### PR DESCRIPTION
## Summary

ACP sessions ignore a configured MCP server's per-tool-call `timeout`. When an ACP client supplies a server through `session/new`, `_register_session_mcp_servers` rebuilt the registration from the client's transport fields only, so the reconstructed config omitted `timeout` and every tool call fell back to the 300-second default — legitimate calls longer than that failed despite a larger value in `config.yaml`.

This change loads the existing MCP configuration off the event loop and copies only `timeout` from an exact server-name match in `mcp_servers`. Command, arguments, environment, URL, and headers still come from the ACP request (the client stays authoritative for the transport; only the operator-configured timeout is merged in).

## Changes

- `acp_adapter/server.py` — add `_load_configured_mcp_timeouts()` (fail-open on config errors) and merge the matched `timeout` into each reconstructed server config before registration.
- `tests/acp/test_mcp_e2e.py` — regression test: an isolated `config.yaml` declaring `mcp_servers.test-fs.timeout: 28800` asserts the reconstructed config keeps the transport fields from the ACP request **and** preserves the configured timeout.

## Test Plan

- [x] `python -m pytest tests/acp/test_mcp_e2e.py -q` — 8 passed (7 existing + new regression)
- [x] `python -m pytest tests/acp -q` — 125 passed; 6 pre-existing Windows-environment failures (symlink/stderr/cwd tests) reproduce identically without this change (verified via stash)
- [x] `python -m ruff check acp_adapter/server.py tests/acp/test_mcp_e2e.py` — clean

## Related Issue

Fixes #88213
