### PR TITLE
fix(desktop): validate SSH host input and redact credentials in ssh target logging

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -265,6 +265,27 @@ test('normalizeSshConfig handles IPv6 and strict port bounds', () => {
   })
 })
 
+test('normalizeSshConfig strips a pasted "ssh " command prefix', () => {
+  assert.deepEqual(normalizeSshConfig({ mode: 'ssh', host: 'ssh root@box' }), {
+    mode: 'ssh',
+    host: 'box',
+    user: 'root'
+  })
+  assert.deepEqual(normalizeSshConfig({ mode: 'ssh', host: 'SSH root@box:2222' }), {
+    mode: 'ssh',
+    host: 'box',
+    user: 'root',
+    port: 2222
+  })
+  // "ssh " with no destination trims to a bare "ssh" host — same as the
+  // legitimately-named case below; the strip only fires on "ssh <dest>".
+  // A host legitimately named "ssh" (no space) is untouched.
+  assert.deepEqual(normalizeSshConfig({ mode: 'ssh', host: 'ssh' }), {
+    mode: 'ssh',
+    host: 'ssh'
+  })
+})
+
 test('localProfileEntry preserves inactive SSH drafts but drops Cloud state', () => {
   const ssh = { mode: 'ssh', host: 'box', user: 'alice', remoteHermesPath: '/hermes' }
   assert.deepEqual(localProfileEntry(ssh), { mode: 'local', savedSsh: ssh })

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -314,6 +314,9 @@ function normalizeSshConfig(entry) {
 
   let host = String(entry.host || '').trim()
 
+  // Tolerate a pasted command: "ssh root@box" → "root@box".
+  host = host.replace(/^ssh\s+/i, '').trim()
+
   if (!host) {
     return null
   }

--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -56,6 +56,27 @@ test('redactSecrets handles null/undefined and non-secret text untouched', () =>
   assert.equal(redactSecrets('uname -s -m'), 'uname -s -m')
 })
 
+test('redactSecrets masks a credential glued into an ssh target string', () => {
+  // Real incident: password typed into the host field surfaced verbatim in
+  // desktop.log and a public debug share.
+  const line = 'connecting (no-mux) to root@100.84.204.123:Luisclawy2026:22'
+  const out = redactSecrets(line)
+  assert.ok(!out.includes('Luisclawy2026'), 'credential must be masked')
+  assert.match(out, /root@100\.84\.204\.123:<redacted>:22/)
+
+  // Comma-mangled IP variant from the same incident.
+  const mangled = redactSecrets('connecting (no-mux) to root@100,84,204,123:Luisclawy2026:22')
+  assert.ok(!mangled.includes('Luisclawy2026'))
+})
+
+test('redactSecrets leaves legitimate ssh target logging untouched', () => {
+  assert.equal(
+    redactSecrets('connecting (no-mux) to root@100.84.204.123:22'),
+    'connecting (no-mux) to root@100.84.204.123:22'
+  )
+  assert.equal(redactSecrets('opening control master to alice@box.example.com:2222'), 'opening control master to alice@box.example.com:2222')
+})
+
 test('controlSocketPath is stable, short, and host-distinct', () => {
   const a = controlSocketPath('me', 'box1', 22, '/tmp/d')
   const a2 = controlSocketPath('me', 'box1', 22, '/tmp/d')
@@ -651,6 +672,43 @@ test('validateSshTarget rejects ports outside 1-65535', () => {
   assert.throws(() => validateSshTarget('box', '', 65536), /port/i)
   assert.throws(() => validateSshTarget('box', '', -1), /port/i)
   assert.throws(() => validateSshTarget('box', '', NaN), /port/i)
+})
+
+test('validateSshTarget rejects commas in host (mistyped IP)', () => {
+  assert.throws(() => validateSshTarget('100,84,204,123', 'root', 22), /commas/i)
+})
+
+test('validateSshTarget rejects whitespace in host (pasted ssh command)', () => {
+  assert.throws(() => validateSshTarget('ssh root@box', '', 22), /whitespace/i)
+  assert.throws(() => validateSshTarget('box extra', '', 22), /whitespace/i)
+})
+
+test('validateSshTarget rejects a password glued into the host field', () => {
+  // Real incident shape: user typed host:PASSWORD (port parsed off upstream).
+  assert.throws(() => validateSshTarget('100.84.204.123:hunter2', 'root', 22), /password|":" segment/i)
+  // The thrown message must not echo the credential verbatim.
+  try {
+    validateSshTarget('100.84.204.123:hunter2', 'root', 22)
+    assert.fail('expected throw')
+  } catch (err) {
+    assert.ok(!String(err.message).includes('hunter2'), 'error message must not leak the credential')
+  }
+})
+
+test('validateSshTarget rejects garbage hostnames', () => {
+  assert.throws(() => validateSshTarget('host!bad', '', 22), /not a valid hostname/i)
+  assert.throws(() => validateSshTarget('host/path', '', 22), /not a valid hostname/i)
+})
+
+test('validateSshTarget rejects @ or whitespace in user', () => {
+  assert.throws(() => validateSshTarget('box', 'root@extra', 22), /user/i)
+  assert.throws(() => validateSshTarget('box', 'ro ot', 22), /user/i)
+})
+
+test('validateSshTarget still accepts bare IPv6 hosts', () => {
+  assert.doesNotThrow(() => validateSshTarget('::1', 'root', 22))
+  assert.doesNotThrow(() => validateSshTarget('fe80::1%eth0', '', 22))
+  assert.doesNotThrow(() => validateSshTarget('2001:db8::42', '', 22))
 })
 
 test('validateSshTarget accepts valid targets', () => {

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -44,6 +44,12 @@ const CONTROL_PERSIST_SECONDS = 300
 // eslint-disable-next-line no-control-regex -- deliberately reject control chars in ssh targets
 const _CONTROL_CHAR_RE = /[\x00-\x1f\x7f]/
 
+// Hostname / IPv4 shape: letters, digits, dots, hyphens, underscores.
+const _HOSTNAME_RE = /^[A-Za-z0-9._-]+$/
+// IPv6 shape (optionally with a %zone). Loose on purpose — ssh does the real
+// parse; this only has to separate "plausible address" from pasted garbage.
+const _IPV6_RE = /^[0-9A-Fa-f:.]+(?:%[A-Za-z0-9._-]+)?$/
+
 function validateSshTarget(host, user, port) {
   if (!host || typeof host !== 'string') {
     throw new Error('Unsafe SSH target: host is required.')
@@ -57,12 +63,45 @@ function validateSshTarget(host, user, port) {
     throw new Error('Unsafe SSH target: host contains control characters.')
   }
 
+  if (/\s/.test(host)) {
+    throw new Error(
+      'Invalid SSH host: contains whitespace. Enter only the destination (user@host or host) — no "ssh " prefix or extra options.'
+    )
+  }
+
+  if (host.includes(',')) {
+    throw new Error(`Invalid SSH host "${host}": commas are not valid in a hostname or IP (use dots, e.g. 192.168.1.10).`)
+  }
+
+  if (host.includes(':')) {
+    // Only a bare IPv6 address may contain colons here — ports are parsed off
+    // upstream. A single-colon host is almost always "host:port" that failed
+    // to parse, or worse, a pasted credential.
+    const colons = (host.match(/:/g) || []).length
+
+    if (colons < 2 || !_IPV6_RE.test(host)) {
+      // Never echo the suspect segment — it may be a pasted credential.
+      throw new Error(
+        `Invalid SSH host "${host.split(':')[0]}:<hidden>": unexpected ":" segment. ` +
+          'Use host or host:port — and never put a password in the host field; Desktop SSH authenticates with keys.'
+      )
+    }
+  } else if (!_HOSTNAME_RE.test(host)) {
+    throw new Error(`Invalid SSH host "${redactSecrets(host)}": not a valid hostname or IP address.`)
+  }
+
   if (user && _CONTROL_CHAR_RE.test(user)) {
     throw new Error('Unsafe SSH target: user contains control characters.')
   }
 
   if (user && user.startsWith('-')) {
     throw new Error(`Unsafe SSH target: user must not start with a dash ("${user}").`)
+  }
+
+  if (user && /[\s@]/.test(user)) {
+    throw new Error(
+      `Invalid SSH user "${user}": contains whitespace or "@". Enter only the destination (user@host) — no "ssh " prefix.`
+    )
   }
 
   const p = Number(port)
@@ -92,7 +131,11 @@ const _REDACTIONS: Array<[RegExp, string]> = [
   [/(HERMES_DASHBOARD_SESSION_TOKEN=)(\S+)/g, '$1<redacted>'],
   [/(X-Hermes-Session-Token["']?\s*[:=]\s*["']?)([^\s"'&]+)/gi, '$1<redacted>'],
   [/(Authorization["']?\s*:\s*Bearer\s+)(\S+)/gi, '$1<redacted>'],
-  [/([?&](?:token|ticket)=)([^\s&"']+)/gi, '$1<redacted>']
+  [/([?&](?:token|ticket)=)([^\s&"']+)/gi, '$1<redacted>'],
+  // SSH target with a non-numeric segment where a port belongs
+  // (user@host:SECRET or user@host:SECRET:22). A mistyped password in the
+  // host field must never reach logs / debug shares verbatim.
+  [/(\S+@[^\s:]+):(?!\d+\b)[^\s:]+/g, '$1:<redacted>']
 ]
 
 function redactSecrets(text) {


### PR DESCRIPTION
## Summary
Desktop SSH now rejects malformed host input before dialing, and credential-shaped segments in ssh target strings can never reach desktop.log or debug shares.

Root cause (live incident, Discord support, Aug 16): a user typed `root@IP:PASSWORD` into the host field. `normalizeSshConfig` only strips a `:<segment>` when numeric, so the password stayed glued to the hostname, `validateSshTarget` (injection-only checks) passed it, ssh dialed garbage silently 5x, and the connect log line put the password verbatim into desktop.log — which then landed in a public debug-share paste.

## Changes
- `electron/ssh-connection.ts` — `validateSshTarget()`: reject whitespace (pasted `ssh ...` commands), commas in host (mistyped IPs), non-numeric `:<segment>` leftovers (with a "never put a password in the host field" hint that does not echo the credential), and garbage hostnames; bare IPv6 (`::1`, `fe80::1%eth0`) still accepted; user must not contain whitespace/`@`.
- `electron/ssh-connection.ts` — `redactSecrets()`: new pattern masks any non-numeric segment where a port belongs in `user@host:...` strings — defense in depth so future parse gaps can't leak credentials into logs.
- `electron/connection-config.ts` — `normalizeSshConfig()`: strip a pasted leading `ssh ` prefix.
- Tests covering the exact incident shapes (comma-IP, `host:password`, credential-free error messages, redaction of the literal incident line) plus IPv6/legit-target regressions.

## Validation
| | Before | After |
|---|---|---|
| `root@100.84.204.123:pass:22` in log | password verbatim | `root@100.84.204.123:<redacted>:22` |
| host `100,84,204,123` | silent dial failure | rejected with actionable error |
| host `ssh root@box` | silent dial failure | prefix stripped, connects |
| targeted vitest (2 files) | — | 159/159 pass |
| `npm run check:lint` | — | 0 errors |

## Infographic

![Desktop SSH: validate the host, redact the log](https://v3b.fal.media/files/b/0aa6ac1d/R3nOZIyUy1_ni9YYXXQuY_vT2EKja7.png)
