### PR TITLE
fix(desktop): recover missing get-windows binding

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -518,7 +518,6 @@ export function stageGetWindowsInto(
       throw new Error(
         `[stage-native-deps] get-windows has no win32-${arch} prebuilt binding under lib/binding. ` +
           'Recover from the checkout root with:\n' +
-          '  npm install-scripts approve get-windows\n' +
           '  npm rebuild get-windows'
       )
     }

--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -437,7 +437,7 @@ const GET_WINDOWS_VERSION = '9.3.0'
 export function stageGetWindowsInto(
   srcRoot,
   destRoot,
-  { platform = process.platform, arch = process.arch, rebuild } = {}
+  { platform = process.platform, arch = process.arch, install } = {}
 ) {
   // The STAGED_WINDOWS_JS rewrite mirrors this exact version's export surface.
   // A version bump must fail the build here until the rewrite is re-verified —
@@ -495,6 +495,7 @@ export function stageGetWindowsInto(
           )
         : []
     let bindingDirs = scanBindingDirs()
+    let installAttempted = false
     if (bindingDirs.length === 0 && arch === 'arm64') {
       // get-windows 9.3.0 publishes win32 prebuilds for ia32/x64 only.
       // The staged windows.js deliberately fails soft when binding/ is absent,
@@ -503,23 +504,25 @@ export function stageGetWindowsInto(
         '[stage-native-deps] get-windows has no win32-arm64 prebuilt binding; ' +
           'staging the fail-soft JS surface without native window enumeration.'
       )
-    } else if (bindingDirs.length === 0 && typeof rebuild === 'function') {
+    } else if (bindingDirs.length === 0 && typeof install === 'function') {
       // A plain `npm install` won't re-run an install script for a package
       // that is already on disk, so every checkout that installed while
       // get-windows was missing from allowScripts stays bricked even after
-      // the allowlist is fixed. `npm rebuild` re-runs it.
+      // the allowlist is fixed. Invoke node-pre-gyp directly: npm treats this
+      // optional dependency's failed lifecycle as non-fatal and can report a
+      // successful rebuild without producing the Windows binding.
       console.log(
-        '[stage-native-deps] get-windows has no win32 binding; running `npm rebuild get-windows`...'
+        '[stage-native-deps] get-windows has no win32 binding; running its native installer...'
       )
-      rebuild()
+      installAttempted = true
+      install()
       bindingDirs = scanBindingDirs()
     }
     if (bindingDirs.length === 0 && arch !== 'arm64') {
-      throw new Error(
-        `[stage-native-deps] get-windows has no win32-${arch} prebuilt binding under lib/binding. ` +
-          'Recover from the checkout root with:\n' +
-          '  npm rebuild get-windows'
-      )
+      const reason = installAttempted
+        ? `native installer completed without producing a win32-${arch} binding under lib/binding`
+        : `has no win32-${arch} prebuilt binding under lib/binding`
+      throw new Error(`[stage-native-deps] get-windows ${reason}`)
     }
     for (const dir of bindingDirs) {
       const dest = join(destRoot, 'lib', 'binding', dir)
@@ -541,15 +544,35 @@ export function stageGetWindowsInto(
   return destRoot
 }
 
-function rebuildGetWindowsViaNpm() {
-  const result = spawnSync('npm', ['rebuild', 'get-windows'], {
-    cwd: resolve(projectRoot, '..', '..'),
-    stdio: 'inherit',
-    // npm resolves to npm.cmd on Windows, which needs a shell.
-    shell: process.platform === 'win32'
+export function installGetWindowsNativeBinding(
+  srcRoot,
+  { resolveInstaller, spawn = spawnSync } = {}
+) {
+  let installerPath
+  try {
+    const resolveNodePreGyp =
+      resolveInstaller ??
+      (() =>
+        require.resolve('@mapbox/node-pre-gyp/bin/node-pre-gyp', {
+          paths: [srcRoot]
+        }))
+    installerPath = resolveNodePreGyp()
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error(`[stage-native-deps] cannot resolve get-windows native installer: ${detail}`)
+  }
+
+  const result = spawn(process.execPath, [installerPath, 'install', '--fallback-to-build'], {
+    cwd: srcRoot,
+    stdio: 'inherit'
   })
+  if (result.error) {
+    throw new Error(
+      `[stage-native-deps] get-windows native installer could not start: ${result.error.message}`
+    )
+  }
   if (result.status !== 0) {
-    console.warn(`[stage-native-deps] npm rebuild get-windows exited with ${result.status}`)
+    throw new Error(`[stage-native-deps] get-windows native installer exited with ${result.status}`)
   }
 }
 
@@ -584,10 +607,12 @@ export function stageGetWindows(
   }
 
   // Only a win32 host can produce the win32 binding, so a cross-platform pack
-  // has nothing to gain from the rebuild.
-  const rebuild =
-    platform === 'win32' && process.platform === 'win32' ? rebuildGetWindowsViaNpm : undefined
-  return stageGetWindowsInto(srcRoot, destRoot, { platform, arch, rebuild })
+  // has nothing to gain from the native installer.
+  const install =
+    platform === 'win32' && process.platform === 'win32'
+      ? () => installGetWindowsNativeBinding(srcRoot)
+      : undefined
+  return stageGetWindowsInto(srcRoot, destRoot, { platform, arch, install })
 }
 
 // Allow direct CLI invocation: node scripts/stage-native-deps.mjs [platform] [arch]

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -547,7 +547,7 @@ test('get-windows native install invokes node-pre-gyp directly from the package 
     assert.deepEqual(calls, [
       {
         command: process.execPath,
-        args: [installer, 'install', '--fallback-to-build'],
+        args: [fs.realpathSync(installer), 'install', '--fallback-to-build'],
         options: { cwd: srcRoot, stdio: 'inherit' }
       }
     ])

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url'
 import { test } from 'vitest'
 
 import {
+  installGetWindowsNativeBinding,
   stageGetWindows,
   stageGetWindowsInto,
   stageNodePtyInto,
@@ -460,7 +461,7 @@ test('win32-arm64 staging omits incompatible bindings and keeps the fail-soft JS
   }
 })
 
-test('win32 staging self-heals through the rebuild hook when the binding is missing', () => {
+test('win32 staging self-heals through the native installer when the binding is missing', () => {
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
   try {
     const srcRoot = join(tmp, 'get-windows')
@@ -471,7 +472,7 @@ test('win32 staging self-heals through the rebuild hook when the binding is miss
     makeFakeGetWindows(srcRoot, { bindings: [] })
 
     let calls = 0
-    const rebuild = () => {
+    const install = () => {
       calls += 1
       makeFakeNode(
         join(srcRoot, 'lib', 'binding', 'napi-9-win32-unknown-x64', 'node-get-windows.node'),
@@ -479,7 +480,7 @@ test('win32 staging self-heals through the rebuild hook when the binding is miss
       )
     }
 
-    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', arch: 'x64', rebuild })
+    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', arch: 'x64', install })
 
     assert.equal(calls, 1)
     assert.ok(
@@ -490,7 +491,7 @@ test('win32 staging self-heals through the rebuild hook when the binding is miss
   }
 })
 
-test('win32 staging reports the recovery steps when the rebuild hook produces nothing', () => {
+test('win32 staging rejects a successful installer that produces no binding', () => {
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
   try {
     const srcRoot = join(tmp, 'get-windows')
@@ -503,17 +504,67 @@ test('win32 staging reports the recovery steps when the rebuild hook produces no
         stageGetWindowsInto(srcRoot, destRoot, {
           platform: 'win32',
           arch: 'x64',
-          rebuild: () => {}
+          install: () => {}
         }),
       (error) => {
-        assert.match(error.message, /npm rebuild get-windows/)
-        assert.doesNotMatch(error.message, /npm install-scripts/)
+        assert.match(error.message, /installer completed without producing a win32-x64 binding/)
+        assert.doesNotMatch(error.message, /npm rebuild/)
         return true
       }
     )
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true })
   }
+})
+
+test('get-windows native install invokes node-pre-gyp directly from the package root', () => {
+  const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
+  try {
+    const srcRoot = join(tmp, 'get-windows')
+    const installer = join(
+      srcRoot,
+      'node_modules',
+      '@mapbox',
+      'node-pre-gyp',
+      'bin',
+      'node-pre-gyp'
+    )
+    fs.mkdirSync(path.dirname(installer), { recursive: true })
+    fs.writeFileSync(
+      join(srcRoot, 'node_modules', '@mapbox', 'node-pre-gyp', 'package.json'),
+      JSON.stringify({ name: '@mapbox/node-pre-gyp', version: '1.0.11' })
+    )
+    fs.writeFileSync(installer, '')
+
+    const calls = []
+    installGetWindowsNativeBinding(srcRoot, {
+      spawn: (command, args, options) => {
+        calls.push({ command, args, options })
+        return { status: 0 }
+      }
+    })
+
+    assert.deepEqual(calls, [
+      {
+        command: process.execPath,
+        args: [installer, 'install', '--fallback-to-build'],
+        options: { cwd: srcRoot, stdio: 'inherit' }
+      }
+    ])
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('get-windows native install surfaces node-pre-gyp failure', () => {
+  assert.throws(
+    () =>
+      installGetWindowsNativeBinding('C:\\fake\\get-windows', {
+        resolveInstaller: () => 'C:\\fake\\node-pre-gyp',
+        spawn: () => ({ status: 1 })
+      }),
+    /native installer exited with 1/
+  )
 })
 
 test('staging refuses a get-windows version the lib/windows.js rewrite was not verified against', () => {

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -505,7 +505,11 @@ test('win32 staging reports the recovery steps when the rebuild hook produces no
           arch: 'x64',
           rebuild: () => {}
         }),
-      /npm rebuild get-windows/
+      (error) => {
+        assert.match(error.message, /npm rebuild get-windows/)
+        assert.doesNotMatch(error.message, /npm install-scripts/)
+        return true
+      }
     )
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true })


### PR DESCRIPTION
## What does this PR do?

Repairs Desktop packaging when `get-windows@9.3.0` is installed without its Windows native binding.

The staging script previously ran `npm rebuild get-windows`. Because `get-windows` is optional, npm can report that rebuild as successful even when the package's native lifecycle fails and no `napi-9-win32-unknown-x64` payload is produced. The resulting error then recommended the same ineffective command.

The staging path now resolves the package's own `@mapbox/node-pre-gyp` installer and runs `install --fallback-to-build` directly inside `get-windows`. It fails on a process error or non-zero exit, rescans `lib/binding`, and also fails accurately if the installer exits successfully without producing the requested Windows binding.

## Related Issue

Closes #88251.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replace the npm rebuild recovery hook with direct execution of `@mapbox/node-pre-gyp` from the installed `get-windows` package.
- Surface installer process failures instead of allowing npm's optional-dependency handling to hide them.
- Verify the requested binding exists and is staged after the installer completes.
- Remove both invalid manual recovery instructions.
- Cover successful recovery, installer failure, and a zero exit that produces no binding.

## How to Test

From `apps/desktop`:

`npm exec -- vitest run scripts/stage-native-deps.test.mjs --testNamePattern "win32 staging|native install"`

The focused Windows staging tests pass: `6 passed | 24 skipped`.

A disposable Windows verification also started with no `lib/binding`, downloaded the official `v9.3.0/napi-9-win32-unknown-x64.tar.gz` asset through the direct installer, produced `node-get-windows.node`, and classified it as a Windows binary.

The full test file reaches `28 passed | 1 skipped`; its existing Darwin executable-mode assertion fails on Windows with `438 !== 493`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Missing-binding Windows verification:

`before: false`

`node-pre-gyp ... napi-9-win32-unknown-x64.tar.gz`

`after: true, classification: win32`

