### PR TITLE
fix(agent): honor Retry-After on retryable 5xx

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -85,6 +85,7 @@ from agent.retry_utils import (
     adaptive_rate_limit_backoff,
     is_zai_coding_overload_error,
     jittered_backoff,
+    parse_retry_after_seconds,
     zai_coding_overload_retry_ceiling,
 )
 from agent.repetition_guard import is_repetition_dominated
@@ -6325,22 +6326,28 @@ def run_conversation(
                         "billing_block": _billing_block,
                     }
 
-                # For rate limits, respect the Retry-After header if present
+                # Respect Retry-After on every retryable provider error, not
+                # just 429s. Retryable 5xx responses can also carry a standard
+                # header or a structured ``retry_after`` problem-detail field;
+                # ignoring either turns an origin outage into a retry storm.
                 _retry_after = None
-                if is_rate_limited:
-                    _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
-                    if _resp_headers and hasattr(_resp_headers, "get"):
-                        _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
-                        if _ra_raw:
-                            try:
-                                # Cap at 10 minutes. Anthropic Tier 1 input-token
-                                # buckets reset in ~171s, so a 120s cap caused us to
-                                # retry before the actual reset window and re-trip the
-                                # limit. 600s covers all realistic provider reset
-                                # windows while still rejecting pathological values. (#26293)
-                                _retry_after = min(float(_ra_raw), 600)
-                            except (TypeError, ValueError):
-                                pass
+                _resp_headers = getattr(
+                    getattr(api_error, "response", None), "headers", None
+                )
+                _retry_after = parse_retry_after_seconds(_resp_headers)
+                if _retry_after is None:
+                    _error_body = getattr(api_error, "body", None)
+                    if isinstance(_error_body, dict):
+                        _retry_after = parse_retry_after_seconds(
+                            _error_body.get("retry_after")
+                        )
+                if _retry_after is not None:
+                    # Cap at 10 minutes. Anthropic Tier 1 input-token buckets
+                    # reset in ~171s, so a 120s cap caused us to retry before
+                    # the actual reset window and re-trip the limit. 600s
+                    # covers realistic provider reset windows while rejecting
+                    # pathological values. (#26293)
+                    _retry_after = min(_retry_after, 600)
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 _backoff_policy = None
                 if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1781,9 +1781,10 @@ class TestExecuteToolCalls:
 
 
 class TestRetryAfterCap:
-    """#26293: the conversation loop owns rate-limit backoff and honors the
-    Retry-After header up to a 600s ceiling (was 120s, which retried before
-    Tier-1 reset windows of ~171s and re-tripped the limit)."""
+    """The loop honors provider cooldowns up to a 600-second ceiling.
+
+    This covers rate-limit headers (#26293) and retryable 5xx responses.
+    """
 
     def _drive_once(self, agent, retry_after_value):
         """Raise one 429 carrying ``Retry-After`` and capture the wait the loop
@@ -1823,6 +1824,50 @@ class TestRetryAfterCap:
         # 300s > old 120s cap but < new 600s cap → used verbatim.
         status = self._drive_once(agent, 300)
         assert "Waiting 300.0s" in status
+
+    @pytest.mark.parametrize(
+        ("headers", "body"),
+        [
+            ({"Retry-After": "120"}, {}),
+            ({}, {"status": 524, "retry_after": 120}),
+        ],
+        ids=("header", "problem-detail-body"),
+    )
+    def test_retry_after_on_cloudflare_524_is_honored(
+        self, agent, headers, body
+    ):
+        """A retryable 5xx must not bypass the provider's cooldown."""
+
+        class _CloudflareTimeout(Exception):
+            status_code = 524
+
+            def __str__(self):
+                return "Error code: 524 - origin response timeout"
+
+        error = _CloudflareTimeout()
+        error.response = SimpleNamespace(headers=headers)
+        error.body = body
+
+        def _fake_api_call(api_kwargs):
+            raise error
+
+        agent._interruptible_api_call = _fake_api_call
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+
+        captured = []
+        original_buffer = agent._buffer_status
+
+        def _capture_status(msg, *args, **kwargs):
+            captured.append(msg)
+            if "Retrying in" in msg:
+                agent._interrupt_requested = True
+            return original_buffer(msg, *args, **kwargs)
+
+        agent._buffer_status = _capture_status
+        agent.run_conversation("hello")
+
+        assert any("Retrying in 120.0s" in msg for msg in captured)
 
 
 


### PR DESCRIPTION
## Summary

Honor provider-directed retry cooldowns on every retryable API error, not only HTTP 429.

Cloudflare now returns `Retry-After` on retryable 5xx responses (500, 502, 504, and 520-524). On current `main`, the conversation loop reads that header only when `is_rate_limited`, so a 520/524 response requesting a 60/120-second cooldown is retried after the generic short jitter instead.

## Reproduction

Observed against an OpenAI-compatible endpoint behind Cloudflare:

- HTTP 520 requested a 60-second cooldown, but Hermes retried after about 3 seconds.
- HTTP 524 requested a 120-second cooldown, but Hermes retried after about 5 seconds.
- The short retry sequence exhausted all attempts while the origin was still recovering.

The regression test drives HTTP 524 through the real `run_conversation` path and covers both the standard response header and the structured problem-detail body.

## Fix

- Resolve `Retry-After` for any error that reaches the retry path.
- Reuse `parse_retry_after_seconds` so numeric and HTTP-date values share existing parsing semantics.
- Fall back to a structured `retry_after` body field when the header is unavailable.
- Retain the existing 600-second cap and jittered backoff when no provider cooldown exists.
- Leave provider and fallback selection unchanged.

Cloudflare contract: https://developers.cloudflare.com/fundamentals/reference/error-responses/#retry-after-header

## Test plan

- [x] `scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/test_retry_utils.py -q` (274 passed)
- [x] `ruff check agent/conversation_loop.py tests/run_agent/test_run_agent.py`
- [x] Python byte-compilation
- [x] `git diff --check`

## Related

Distinct from #68886: that PR changes when Hermes switches fallback providers after 5xx responses; this change only respects the active provider cooldown before retrying.