### PR TITLE
fix(cache): honor custom provider prompt cache capability

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2072,6 +2072,19 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     # Strip image parts for non-vision models (no-op when vision-capable).
     _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)
 
+    try:
+        from hermes_cli.route_identity import normalize_route_base_url
+
+        _route = normalize_route_base_url(agent.base_url)
+        _supports_prompt_cache_key = any(
+            isinstance(entry, dict)
+            and normalize_route_base_url(entry.get("base_url")) == _route
+            and entry.get("supports_prompt_cache_key") is True
+            for entry in getattr(agent, "_custom_providers", [])
+        )
+    except Exception:
+        _supports_prompt_cache_key = False
+
     return _ct.build_kwargs(
         model=agent.model,
         messages=_msgs_for_chat,
@@ -2108,6 +2121,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         lmstudio_reasoning_options=agent._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
+        supports_prompt_cache_key=_supports_prompt_cache_key,
     )
 
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2029,6 +2029,28 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     except Exception:
         _profile = None
 
+    # Resolve custom-provider prompt-cache capability once for both paths.
+    # Custom providers (provider="custom" or "custom:<name>") go through the
+    # profile path (CustomProfile) which hardcodes supports_prompt_cache_key=False,
+    # so the config-level flag would be ignored without this lookup.  Named
+    # custom providers ("custom:<name>") have no profile and hit the legacy
+    # path, where the same value must be passed through.
+    _supports_prompt_cache_key = False
+    _provider_norm = (agent.provider or "").strip().lower()
+    if _provider_norm == "custom" or _provider_norm.startswith("custom:"):
+        try:
+            from hermes_cli.route_identity import normalize_route_base_url
+
+            _route = normalize_route_base_url(agent.base_url)
+            _supports_prompt_cache_key = any(
+                isinstance(entry, dict)
+                and normalize_route_base_url(entry.get("base_url")) == _route
+                and entry.get("supports_prompt_cache_key") is True
+                for entry in getattr(agent, "_custom_providers", [])
+            )
+        except Exception:
+            _supports_prompt_cache_key = False
+
     if _profile:
         _ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
         if _ephemeral_out is not None:
@@ -2060,6 +2082,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             anthropic_max_output=_ant_max,
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,
+            supports_prompt_cache_key=_supports_prompt_cache_key,
         )
 
     # ── Legacy flag path ────────────────────────────────────────────
@@ -2071,19 +2094,6 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
 
     # Strip image parts for non-vision models (no-op when vision-capable).
     _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)
-
-    try:
-        from hermes_cli.route_identity import normalize_route_base_url
-
-        _route = normalize_route_base_url(agent.base_url)
-        _supports_prompt_cache_key = any(
-            isinstance(entry, dict)
-            and normalize_route_base_url(entry.get("base_url")) == _route
-            and entry.get("supports_prompt_cache_key") is True
-            for entry in getattr(agent, "_custom_providers", [])
-        )
-    except Exception:
-        _supports_prompt_cache_key = False
 
     return _ct.build_kwargs(
         model=agent.model,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -837,7 +837,10 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs,
             messages=sanitized,
             tools=api_kwargs.get("tools"),
-            supports_prompt_cache_key=bool(getattr(profile, "supports_prompt_cache_key", False)),
+            supports_prompt_cache_key=bool(
+                params.get("supports_prompt_cache_key")
+                or getattr(profile, "supports_prompt_cache_key", False)
+            ),
             session_id=params.get("session_id"),
             cache_scope_id=params.get("cache_scope_id"),
         )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1365,6 +1365,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
+        "supports_prompt_cache_key",
         "ssl_ca_cert", "ssl_verify",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -1489,6 +1490,10 @@ def _normalize_custom_provider_entry(
     if isinstance(discover_models, bool):
         normalized["discover_models"] = discover_models
 
+    supports_prompt_cache_key = entry.get("supports_prompt_cache_key")
+    if isinstance(supports_prompt_cache_key, bool):
+        normalized["supports_prompt_cache_key"] = supports_prompt_cache_key
+
     extra_body = entry.get("extra_body")
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
@@ -1538,6 +1543,7 @@ def _custom_provider_entry_to_provider_config(
         "discover_models",
         "extra_body",
         "extra_headers",
+        "supports_prompt_cache_key",
         "ssl_ca_cert",
         "ssl_verify",
     ):
@@ -1975,6 +1981,7 @@ _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
     "context_length", "rate_limit_delay", "extra_body",
+    "supports_prompt_cache_key",
     "ssl_ca_cert", "ssl_verify",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.

--- a/tests/agent/test_custom_provider_prompt_cache_key.py
+++ b/tests/agent/test_custom_provider_prompt_cache_key.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import build_api_kwargs
+from hermes_cli.config import _normalize_custom_provider_entry
+
+
+class _RecordingTransport:
+    def build_kwargs(self, **kwargs):
+        return kwargs
+
+
+def test_custom_provider_cache_capability_reaches_chat_transport():
+    provider = _normalize_custom_provider_entry({
+        "name": "cliproxy",
+        "base_url": "https://cliproxy.example/v1",
+        "supports_prompt_cache_key": True,
+    })
+    assert provider is not None
+
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        tools=[],
+        model="deepseek-v4-flash",
+        base_url=provider["base_url"],
+        provider="custom:cliproxy",
+        _base_url_lower=provider["base_url"].lower(),
+        _custom_providers=[provider],
+        providers_allowed=None,
+        providers_ignored=None,
+        providers_order=None,
+        provider_sort=None,
+        provider_require_parameters=False,
+        provider_data_collection=None,
+        session_id="stable-session",
+        max_tokens=None,
+        reasoning_config=None,
+        request_overrides={},
+        _ollama_num_ctx=None,
+        _max_tokens_param=lambda value: {"max_tokens": value},
+        openrouter_min_coding_score=None,
+        _get_transport=lambda: _RecordingTransport(),
+        _is_qwen_portal=lambda: False,
+        _is_openrouter_url=lambda: False,
+        _prepare_messages_for_non_vision_model=lambda messages: messages,
+        _resolved_api_call_timeout=lambda: 30,
+        _supports_reasoning_extra_body=lambda: False,
+        _github_models_reasoning_extra_body=lambda: None,
+    )
+
+    kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hello"}])
+
+    assert kwargs["supports_prompt_cache_key"] is True

--- a/tests/agent/test_custom_provider_prompt_cache_key.py
+++ b/tests/agent/test_custom_provider_prompt_cache_key.py
@@ -50,3 +50,49 @@ def test_custom_provider_cache_capability_reaches_chat_transport():
     kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hello"}])
 
     assert kwargs["supports_prompt_cache_key"] is True
+
+
+def test_bare_custom_provider_cache_capability_reaches_profile_path():
+    """Bare provider='custom' takes the CustomProfile path, not the legacy
+    path.  The config-level supports_prompt_cache_key must still propagate
+    through _build_kwargs_from_profile via the params override."""
+    provider = _normalize_custom_provider_entry({
+        "name": "cliproxy",
+        "base_url": "https://cliproxy.example/v1",
+        "supports_prompt_cache_key": True,
+    })
+    assert provider is not None
+
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        tools=[],
+        model="deepseek-v4-flash",
+        base_url=provider["base_url"],
+        provider="custom",
+        _base_url_lower=provider["base_url"].lower(),
+        _custom_providers=[provider],
+        providers_allowed=None,
+        providers_ignored=None,
+        providers_order=None,
+        provider_sort=None,
+        provider_require_parameters=False,
+        provider_data_collection=None,
+        session_id="stable-session",
+        max_tokens=None,
+        reasoning_config=None,
+        request_overrides={},
+        _ollama_num_ctx=None,
+        _max_tokens_param=lambda value: {"max_tokens": value},
+        openrouter_min_coding_score=None,
+        _get_transport=lambda: _RecordingTransport(),
+        _is_qwen_portal=lambda: False,
+        _is_openrouter_url=lambda: False,
+        _prepare_messages_for_non_vision_model=lambda messages: messages,
+        _resolved_api_call_timeout=lambda: 30,
+        _supports_reasoning_extra_body=lambda: False,
+        _github_models_reasoning_extra_body=lambda: None,
+    )
+
+    kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hello"}])
+
+    assert kwargs["supports_prompt_cache_key"] is True

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -681,6 +681,27 @@ class TestPromptCacheKeyCapability:
 
         assert body["prompt_cache_key"] == kwargs["prompt_cache_key"]
 
+    def test_custom_provider_config_capability_reaches_request_body(self, transport):
+        from hermes_cli.config import _normalize_custom_provider_entry
+
+        provider = _normalize_custom_provider_entry({
+            "name": "cliproxy",
+            "base_url": "https://cliproxy.example/v1",
+            "supports_prompt_cache_key": True,
+        })
+        assert provider is not None
+
+        kwargs = transport.build_kwargs(
+            model="cache-model",
+            messages=self._messages(),
+            tools=self._tools(),
+            session_id="stable-session",
+            base_url=provider["base_url"],
+            supports_prompt_cache_key=provider["supports_prompt_cache_key"],
+        )
+
+        assert self._request_body(kwargs)["prompt_cache_key"] == kwargs["prompt_cache_key"]
+
     def test_openai_api_base_url_implies_capability(self, transport):
         """api.openai.com gets the key WITHOUT an explicit flag (exact host)."""
         kwargs = transport.build_kwargs(

--- a/tests/hermes_cli/test_custom_provider_prompt_cache_key.py
+++ b/tests/hermes_cli/test_custom_provider_prompt_cache_key.py
@@ -1,0 +1,22 @@
+from hermes_cli.config import (
+    _VALID_CUSTOM_PROVIDER_FIELDS,
+    _custom_provider_entry_to_provider_config,
+    _normalize_custom_provider_entry,
+)
+
+
+def test_prompt_cache_capability_survives_normalization_and_migration():
+    raw = {
+        "name": "cliproxy",
+        "base_url": "https://cliproxy.example/v1",
+        "supports_prompt_cache_key": True,
+    }
+
+    normalized = _normalize_custom_provider_entry(raw, provider_key="cliproxy")
+    migrated = _custom_provider_entry_to_provider_config(raw, provider_key="cliproxy")
+
+    assert normalized is not None
+    assert normalized["supports_prompt_cache_key"] is True
+    assert migrated is not None
+    assert migrated["supports_prompt_cache_key"] is True
+    assert "supports_prompt_cache_key" in _VALID_CUSTOM_PROVIDER_FIELDS


### PR DESCRIPTION
## Summary

Custom providers (config.yaml `custom_providers:`) that declare `supports_prompt_cache_key: true` now get the body-level `prompt_cache_key` field on their Chat Completions API calls — through **both** the legacy flag path and the CustomProfile path.

Salvage of #83299 by @shunkakinoki, with a follow-up fix for the profile path.

## Root cause

`ProviderProfile` and the Chat Completions transport already supported `prompt_cache_key`, but `_normalize_custom_provider_entry` in `hermes_cli/config.py` classified the configured key as unknown and dropped it. The original PR fixed config normalization but only wired the capability through the **legacy flag path** — bare `provider="custom"` (the standard config pattern) takes the `CustomProfile` path via `get_provider_profile("custom")`, where `supports_prompt_cache_key` was hardcoded `False`.

## Changes

**Contributor commit (cherry-picked from #83299):**
- `hermes_cli/config.py`: Add `supports_prompt_cache_key` to `_normalize_custom_provider_entry`, `_custom_provider_entry_to_provider_config`, and `_VALID_CUSTOM_PROVIDER_FIELDS`
- `agent/chat_completion_helpers.py`: Resolve capability from `agent._custom_providers` and pass to transport (was legacy-path-only)
- 3 test files: config normalization, transport body field, end-to-end build_api_kwargs

**Follow-up fix:**
- `agent/chat_completion_helpers.py`: Move `_supports_prompt_cache_key` resolution **before** the profile/legacy branch so both paths use it
- `agent/transports/chat_completions.py`: In `_build_kwargs_from_profile`, OR `params.get("supports_prompt_cache_key")` with `getattr(profile, ...)` so the config-level flag overrides the profile's hardcoded default
- `tests/agent/test_custom_provider_prompt_cache_key.py`: Add `test_bare_custom_provider_cache_capability_reaches_profile_path`

## Validation

| | Before | After |
|---|---|---|
| `custom:xxx` (legacy path) | capability dropped at config normalization | ✅ `prompt_cache_key` emitted |
| `custom` (profile path) | capability dropped at config normalization | ✅ `prompt_cache_key` emitted |
| `provider="openrouter"` etc. | unchanged | unchanged |

- ruff: clean on all modified files
- 5/5 targeted tests pass (including new profile-path test)
- 14/14 TestPromptCacheKeyCapability suite pass

Closes #83299
