### PR TITLE
fix(computer-use): default the cursor overlay off on Linux X11

### DIFF
--- a/tests/computer_use/test_cua_no_overlay.py
+++ b/tests/computer_use/test_cua_no_overlay.py
@@ -1,9 +1,10 @@
 """Tests for the cua-driver --no-overlay policy.
 
 cua-driver's cursor overlay rendering loop can consume CPU indefinitely when
-idle (#28152, #47032). Hermes passes ``--no-overlay`` to suppress it when the
-``computer_use.no_overlay`` config is enabled (or auto-detected on macOS and
-headless Linux / WSL2).
+idle (#28152, #47032), and on Linux/X11 its fullscreen always-on-top overlay
+window can wedge the desktop when a session ends uncleanly. Hermes passes
+``--no-overlay`` to suppress it when the ``computer_use.no_overlay`` config is
+enabled (or auto-detected on macOS, headless Linux / WSL2, and Linux X11).
 
 These assert the behavior contract (auto-detect, explicit override, version
 probe), not specific config snapshots.
@@ -51,6 +52,52 @@ class TestNoOverlayFlag:
         with patch("hermes_cli.config.load_config",
                    side_effect=RuntimeError("boom")):
             assert cua_backend._cua_no_overlay() is True
+
+    @pytest.mark.linux_only
+    def test_linux_x11_auto_detects_off(self, monkeypatch):
+        """X11 desktop (DISPLAY set, no Wayland) defaults the overlay off.
+
+        The X11 overlay is a fullscreen always-on-top all-workspaces window
+        that can get stuck over every workspace after an unclean session end,
+        wedging desktop input until the app restarts. Config must not need to
+        opt out per-machine.
+        """
+        monkeypatch.setenv("DISPLAY", ":0")
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert cua_backend._cua_no_overlay() is True
+
+    @pytest.mark.linux_only
+    def test_linux_x11_explicit_session_type_also_off(self, monkeypatch):
+        """XDG_SESSION_TYPE=x11 without Wayland env is still X11."""
+        monkeypatch.setenv("DISPLAY", ":0")
+        monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert cua_backend._cua_no_overlay() is True
+
+    @pytest.mark.linux_only
+    def test_linux_wayland_keeps_overlay(self, monkeypatch):
+        """Wayland desktop keeps the overlay: the compositor owns the
+        overlay surface lifecycle, so it cannot get stuck above every
+        workspace the way an X11 window can."""
+        monkeypatch.setenv("DISPLAY", ":0")
+        monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+        monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert cua_backend._cua_no_overlay() is False
+
+    @pytest.mark.linux_only
+    def test_linux_x11_explicit_false_overrides_auto_detect(self, monkeypatch):
+        """An explicit ``no_overlay: false`` must restore the cursor even on
+        X11 — auto-detection is the default, never a hard lock."""
+        monkeypatch.setenv("DISPLAY", ":0")
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+        with patch("hermes_cli.config.load_config",
+                   return_value={"computer_use": {"no_overlay": False}}):
+            assert cua_backend._cua_no_overlay() is False
 
 
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -227,10 +227,12 @@ def _cua_no_overlay() -> bool:
     """True when Hermes should pass ``--no-overlay`` to cua-driver.
 
     Reads ``computer_use.no_overlay``. Default ``None`` (auto-detect):
-    disable the overlay where idle CPU burn is a known failure mode —
-    macOS (cursor-overlay vImage redraw loop, #28152/#47032), headless
-    Linux / WSL2 / containers — and keep it on Windows / desktop Linux
-    with a display. Explicit ``True`` / ``False`` overrides auto-detection.
+    disable the overlay where idle CPU burn or an X11 desktop wedge is a
+    known failure mode — macOS (cursor-overlay vImage redraw loop,
+    #28152/#47032), headless Linux / WSL2 / containers, and Linux X11
+    (fullscreen always-on-top overlay window that can get stuck over every
+    workspace after an unclean session end) — and keep it on Windows and
+    Linux Wayland. Explicit ``True`` / ``False`` overrides auto-detection.
     """
     val = _computer_use_cfg().get("no_overlay")
     if val is not None:
@@ -250,6 +252,17 @@ def _cua_no_overlay() -> bool:
                 return True
     except Exception:
         pass
+    # Linux/X11: the cursor overlay is a fullscreen, always-on-top,
+    # all-workspaces X11 window (save-unders path). An unclean session end
+    # (agent interrupted mid-capture, stale target window) can leave it stuck
+    # above every app on every workspace, wedging desktop input until the app
+    # restarts — the same failure class as the HUD window on Mutter/X11
+    # (#83473). There is no compositor-owned surface to tear down with the
+    # client connection, so default the overlay off on X11 too; set
+    # computer_use.no_overlay: false to keep the cursor. Wayland keeps it: the
+    # compositor owns the overlay surface lifecycle there.
+    if os.environ.get("XDG_SESSION_TYPE") != "wayland" and not os.environ.get("WAYLAND_DISPLAY"):
+        return True
     return False
 
 
@@ -810,9 +823,9 @@ def _resolve_mcp_invocation(
     expose ``manifest``, or any indeterminate failure — the wrapper must
     not refuse to start just because the discovery hop failed.
 
-    When ``computer_use.no_overlay`` is enabled (or auto-detected on
-    Linux), ``--no-overlay`` is appended to suppress the cursor overlay
-    rendering loop that can consume CPU indefinitely when idle
+    When ``computer_use.no_overlay`` is enabled (or auto-detected — macOS,
+    headless/WSL2/X11 Linux), ``--no-overlay`` is appended to suppress the
+    cursor overlay rendering loop that can consume CPU indefinitely when idle
     (#28152, #47032).  Older drivers that don't recognise the flag will
     reject it; callers should fall back to the no-overlay invocation on
     spawn failure.


### PR DESCRIPTION
## Problem

On Linux/X11, cua-driver maps the agent-cursor overlay as a **fullscreen, always-on-top, all-workspaces X11 window** (save-unders composited). When a computer-use session ends uncleanly — agent interrupted mid-capture, stale target window, driver error — that window can be left **stuck above every app on every workspace**, wedging desktop input until the app is restarted.

Real-world repro (GNOME/Mutter X11, NVIDIA hybrid):
1. Run a `computer_use` capture against a window, then interrupt the agent turn mid-capture.
2. cua-driver's session dies uncleanly; the overlay window stays mapped.
3. Desktop input/repaint wedges; switching apps or workspaces doesn't help — the overlay follows everywhere. Only killing the app (which kills the driver child) recovers.

Verified live: after such an interrupted run, `xwininfo -root -tree` showed a `1920x1080+0+0` `Cua.AgentCursorOverlay` window mapped at the top of the stack with no `_NET_WM_DESKTOP` (sticky across workspaces), and the desktop log showed the interrupted capture (`cua-driver get_window_state failed: window stale`) followed by an app restart. Same failure class as the HUD's transparent always-on-top window on Mutter/X11 (#83473).

## Fix

Extend the existing `_cua_no_overlay()` auto-detect (currently macOS + headless/WSL2 Linux) to also default the overlay **off on Linux X11 desktop sessions**. The overlay is cosmetic (a tinted cursor sprite); captures, synthetic input, and all driver features work without it. On raw X11 there is no compositor-owned surface to tear down with the driver's connection, so the safe default is off.

**Wayland keeps the overlay**: the compositor owns the layer-surface lifecycle, so a dead driver cannot leave a stuck top window there.

Behavior contract unchanged:
- `computer_use.no_overlay: true` — forced off (as before).
- `computer_use.no_overlay: false` — cursor restored on any platform, including X11 (explicit opt-in wins over auto-detect).
- Unset — off on macOS, headless/WSL2/X11 Linux; on everywhere else.

## Tests

Added to `tests/computer_use/test_cua_no_overlay.py` (all `linux_only`):
- X11 (DISPLAY set, no Wayland env) → overlay auto-detected off
- `XDG_SESSION_TYPE=x11` → off
- Wayland (`WAYLAND_DISPLAY` + `XDG_SESSION_TYPE=wayland`) → overlay kept
- Explicit `no_overlay: false` on X11 → overrides auto-detect, cursor restored

```
13 passed, 1 skipped (macos-only) in 0.73s
```
