### PR TITLE
feat(desktop): Discord-style group chat creation in Bot Mode

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -35,6 +35,10 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   EmptyState,
   GlyphSpinner,
   haptic,
@@ -6020,6 +6024,169 @@ function GroupDialog({ bot, onClose }) {
   })
 }
 
+/** Discord-style group chat creation: pick 2+ bots via checkboxes (with
+ *  search), name the group, create. Assignment is the existing per-bot
+ *  `group` meta field, so the room appears in the roster and syncs
+ *  cross-machine via ui_meta exactly like Move-to-group. */
+function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
+  const allMeta = useValue($botMeta)
+  const [query, setQuery] = useState('')
+  const [checked, setChecked] = useState({})
+  const [name, setName] = useState('')
+
+  // Reset per open so a cancelled draft doesn't leak into the next one.
+  useEffect(() => {
+    if (open) {
+      setQuery('')
+      setChecked({})
+      setName('')
+    }
+  }, [open])
+
+  const selected = roster.filter(bot => checked[bot.name])
+  const visible = filterBots(roster, allMeta, query)
+  const atCap = selected.length >= GROUP_CHAT_MAX_MEMBERS
+  const placeholder = selected.length
+    ? selected.map(bot => displayName(bot, allMeta[bot.name])).join(', ')
+    : 'Group name'
+  const canCreate = selected.length >= 2 && Boolean(name.trim() || selected.length)
+
+  const create = () => {
+    const groupName = (name.trim() || placeholder).slice(0, 64)
+
+    if (selected.length < 2 || !groupName) {
+      return
+    }
+
+    for (const bot of selected) {
+      void saveBotMeta(bot.name, { group: groupName })
+    }
+
+    host.notify({ kind: 'info', message: `“${groupName}” created with ${selected.length} bots` })
+    onClose()
+    onCreated?.(groupName)
+  }
+
+  return jsx(Dialog, {
+    open,
+    onOpenChange: value => {
+      if (!value) {
+        onClose()
+      }
+    },
+    children: jsxs(DialogContent, {
+      className: 'max-w-md',
+      children: [
+        jsxs(DialogHeader, {
+          children: [
+            jsx(DialogTitle, { children: 'New Group Chat' }),
+            jsx(DialogDescription, {
+              children: `Pick 2–${GROUP_CHAT_MAX_MEMBERS} bots. The room lives in the Bots roster and syncs to every machine.`
+            })
+          ]
+        }),
+        jsx(SearchField, {
+          'aria-label': 'Search bots to add',
+          autoFocus: true,
+          containerClassName: 'w-full',
+          inputClassName: 'w-full',
+          placeholder: 'Search bots to add…',
+          value: query,
+          onChange: setQuery
+        }),
+        selected.length
+          ? jsx('div', {
+              className: 'flex flex-wrap gap-1',
+              children: selected.map(bot =>
+                jsxs('button', {
+                  type: 'button',
+                  className:
+                    'flex items-center gap-1 rounded-full bg-(--chrome-action-hover) py-0.5 pl-2 pr-1.5 text-[0.6875rem] text-(--ui-text-secondary) transition-colors hover:text-foreground',
+                  title: 'Remove from selection',
+                  onClick: () => setChecked(prev => ({ ...prev, [bot.name]: false })),
+                  children: [displayName(bot, allMeta[bot.name]), jsx(Codicon, { name: 'close', className: 'text-[0.6rem]' })]
+                }, bot.name)
+              )
+            })
+          : null,
+        jsx(ScrollArea, {
+          className: 'max-h-64 min-h-0',
+          children: jsx('div', {
+            className: 'grid gap-0.5 pr-2',
+            children: visible.length
+              ? visible.map(bot => {
+                  const meta = allMeta[bot.name]
+                  const { shape, color, image } = botAppearance(bot.name, meta)
+                  const isChecked = Boolean(checked[bot.name])
+                  const disabled = !isChecked && atCap
+                  const currentGroup = (meta?.group || '').trim()
+
+                  return jsxs('label', {
+                    className: cn(
+                      'flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-(--chrome-action-hover)',
+                      disabled && 'cursor-not-allowed opacity-50'
+                    ),
+                    children: [
+                      jsx(BotFace, {
+                        shape,
+                        color,
+                        image: image && !isBackfilledFacePng(image) ? image : null,
+                        size: 24,
+                        name: bot.name
+                      }),
+                      jsxs('div', {
+                        className: 'min-w-0 flex-1',
+                        children: [
+                          jsx('div', { className: 'truncate text-xs text-foreground', children: displayName(bot, meta) }),
+                          jsx('div', {
+                            className: 'truncate text-[0.625rem] text-(--ui-text-quaternary)',
+                            children: currentGroup ? `@${bot.name} · in “${currentGroup}”` : `@${bot.name}`
+                          })
+                        ]
+                      }),
+                      jsx(Checkbox, {
+                        checked: isChecked,
+                        disabled,
+                        onCheckedChange: value => setChecked(prev => ({ ...prev, [bot.name]: Boolean(value) }))
+                      })
+                    ]
+                  }, bot.name)
+                })
+              : jsx('div', {
+                  className: 'px-1.5 py-3 text-center text-xs text-(--ui-text-tertiary)',
+                  children: query.trim() ? `No bots match “${query.trim()}”` : 'No bots yet — create agents first.'
+                })
+          })
+        }),
+        jsx('form', {
+          onSubmit: event => {
+            event.preventDefault()
+            create()
+          },
+          children: jsx(Input, {
+            'aria-label': 'Group name',
+            maxLength: 64,
+            placeholder,
+            value: name,
+            onChange: event => setName(event.target.value)
+          })
+        }),
+        jsxs(DialogFooter, {
+          children: [
+            jsx(Button, { variant: 'secondary', onClick: onClose, children: 'Cancel' }),
+            jsx(Button, {
+              disabled: !canCreate,
+              title: selected.length < 2 ? 'Pick at least 2 bots' : undefined,
+              onClick: create,
+              children: `Create Group${selected.length ? ` (${selected.length})` : ''}`
+            })
+          ]
+        })
+      ]
+    })
+  })
+}
+
 /** Merged room view for one group: shared timeline with per-member
  *  attribution, a composer that drives the round-robin, and a working
  *  indicator while member turns run. */
@@ -6148,6 +6315,7 @@ function BotsPane() {
   const gatewayUp = gatewayState === 'open'
   const activeProfile = (useValue(host.state.profile) || 'default').trim() || 'default'
   const [createOpen, setCreateOpen] = useState(false)
+  const [groupCreateOpen, setGroupCreateOpen] = useState(false)
   const [editing, setEditing] = useState(null)
   const [deleting, setDeleting] = useState(null)
   const [grouping, setGrouping] = useState(null)
@@ -6256,15 +6424,36 @@ function BotsPane() {
                   children: jsx(Codicon, { name: hideBotChats ? 'eye-closed' : 'eye' })
                 })
               }),
-              jsx(Tip, {
-                label: 'New Agent',
-                children: jsx('button', {
-                  type: 'button',
-                  className:
-                    'flex size-6 items-center justify-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
-                  onClick: () => setCreateOpen(true),
-                  children: jsx(Codicon, { name: 'add' })
-                })
+              jsxs(DropdownMenu, {
+                children: [
+                  jsx(Tip, {
+                    label: 'New…',
+                    children: jsx(DropdownMenuTrigger, {
+                      asChild: true,
+                      children: jsx('button', {
+                        type: 'button',
+                        'aria-label': 'New agent or group chat',
+                        className:
+                          'flex size-6 items-center justify-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
+                        children: jsx(Codicon, { name: 'add' })
+                      })
+                    })
+                  }),
+                  jsxs(DropdownMenuContent, {
+                    align: 'end',
+                    children: [
+                      jsxs(DropdownMenuItem, {
+                        onSelect: () => setCreateOpen(true),
+                        children: [jsx(Codicon, { name: 'hubot', className: 'mr-1.5' }), 'New Agent']
+                      }),
+                      jsxs(DropdownMenuItem, {
+                        disabled: roster.length < 2,
+                        onSelect: () => setGroupCreateOpen(true),
+                        children: [jsx(Codicon, { name: 'organization', className: 'mr-1.5' }), 'New Group Chat']
+                      })
+                    ]
+                  })
+                ]
               })
             ]
           })
@@ -6409,6 +6598,12 @@ function BotsPane() {
           void refetch()
         },
         roster
+      }),
+      jsx(CreateGroupChatDialog, {
+        open: groupCreateOpen,
+        roster,
+        onClose: () => setGroupCreateOpen(false),
+        onCreated: groupName => $groupChatWorkspace.set(groupName)
       }),
       jsx(EditProfileDialog, {
         bot: editing,

--- a/apps/desktop/src/plugins/hermes-bots/tests/create-group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/create-group-chat.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+// Discord-style creation flow: the header "+" is a dropdown (New Agent /
+// New Group Chat), and New Group Chat opens a checkbox-picker modal with
+// search, a name input, and a Create button. Source-contract style, like
+// the other roster affordance tests.
+
+test('source contract: header + is a dropdown offering agent and group chat', () => {
+  assert.match(pluginSource, /DropdownMenuTrigger/)
+  assert.match(pluginSource, /'New Agent'/)
+  assert.match(pluginSource, /'New Group Chat'/)
+})
+
+test('source contract: create-group modal has search, checkboxes, name, create', () => {
+  assert.match(pluginSource, /function CreateGroupChatDialog\(/)
+  // Reuses the roster search filter so name/@handle/title all match.
+  assert.match(pluginSource, /const visible = filterBots\(roster, allMeta, query\)/)
+  // Selection is checkbox-driven and capped at the room member limit.
+  assert.match(pluginSource, /const atCap = selected\.length >= GROUP_CHAT_MAX_MEMBERS/)
+  // Create requires 2+ members and writes the existing group meta field,
+  // so the room rides the ui_meta sync path (no new persistence).
+  assert.match(pluginSource, /selected\.length >= 2/)
+  assert.match(pluginSource, /saveBotMeta\(bot\.name, \{ group: groupName \}\)/)
+  // Creating drops the user straight into the room.
+  assert.match(pluginSource, /onCreated: groupName => \$groupChatWorkspace\.set\(groupName\)/)
+})
+
+test('source contract: group name falls back to member names, Discord-style', () => {
+  assert.match(pluginSource, /selected\.map\(bot => displayName\(bot, allMeta\[bot\.name\]\)\)\.join\(', '\)/)
+})


### PR DESCRIPTION
## Summary
Bot Mode group chats now have a Discord-style creation flow: the Bots pane "+" opens a dropdown (New Agent / New Group Chat), and New Group Chat opens a searchable checkbox picker that creates the room and drops you straight into it.

Previously the only way to form a group chat was assigning bots one-by-one via "Move to group…" and then spotting a small "Open chat" affordance on the roster section divider — effectively undiscoverable.

## Changes
- `plugins/hermes-bots/plugin.js`:
  - Header "+" button → `DropdownMenu` with **New Agent** and **New Group Chat** (the latter disabled until 2+ bots exist).
  - New `CreateGroupChatDialog`: search field (reuses `filterBots`, so display name / @handle / connection all match), checkbox rows with bot avatars, selected-member chips, member cap at `GROUP_CHAT_MAX_MEMBERS`, group-name input defaulting to the selected members' names (Discord-style), and a Create button requiring 2+ members.
  - Create assigns the existing per-bot `group` meta field via `saveBotMeta` — the room rides the existing ui_meta sync path unchanged (no new persistence, no new RPC) — then opens the room via `$groupChatWorkspace`.
- `tests/create-group-chat.test.mjs`: source-contract tests for the dropdown, the picker modal wiring, and the member-names name fallback.

## Validation
| | Before | After |
|---|---|---|
| plugin test suite | 146 pass | 146 pass (incl. 3 new) |
| group chat creation | per-bot "Move to group…" only | + dropdown → picker modal → room opens |

## Infographic

![Group chats for your bots — comic-style walkthrough](https://v3b.fal.media/files/b/0aa6ac83/V7PanMtQ9ARW1DaBA4awE_ZAaEenYB.png)
