### PR TITLE
fix(compression): name the main model when aux summary falls back

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3169,7 +3169,46 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             telemetry["fallback_used"] = True
             telemetry["failure_class"] = telemetry.get("failure_class") or "aux_model_fallback"
         self.summary_model = ""  # empty = use main model
+        # The aux failure that triggered this fallback must not survive into the
+        # main-model retry: a terminal access/quota class error recorded here
+        # would make compress() abort even when the main model summarises fine.
+        # A genuine main-model access/quota failure re-sets it in the retry.
+        self._last_summary_auth_failure = False
         self._clear_compression_failure_cooldown()  # no cooldown — retry immediately
+
+    def _apply_summary_route(self, call_kwargs: dict) -> None:
+        """Pin the auxiliary-summary wire route onto ``call_kwargs``.
+
+        Both compression entry points (``_call_summary_llm`` and
+        ``MicroCompactionMixin._micro_summarize_one``) call
+        ``call_llm(task="compression", ...)``.
+        When a distinct ``summary_model`` is configured, naming it is enough.
+
+        After :meth:`_fallback_to_main_for_compression` clears
+        ``summary_model``, however, omitting the route is NOT equivalent to
+        "use the main model": ``call_llm`` resolves an unspecified route from
+        ``auxiliary.compression`` in the config, which is the very model that
+        just failed. The fallback then re-calls it, fails identically, and —
+        because ``_summary_model_fallen_back`` is already set — no second
+        fallback is allowed, so the summary aborts and compression is skipped.
+
+        Naming the main runtime explicitly makes the fallback actually reach
+        the main model.
+        """
+        if self.summary_model:
+            call_kwargs["model"] = self.summary_model
+            return
+        if not getattr(self, "_summary_model_fallen_back", False):
+            return
+        for key, value in (
+            ("provider", self.provider),
+            ("model", self.model),
+            ("base_url", self.base_url),
+            ("api_key", self.api_key),
+            ("api_mode", getattr(self, "api_mode", "")),
+        ):
+            if value:
+                call_kwargs[key] = value
 
     def _call_summary_llm(self, prompt: str, prompt_started_at: float) -> str:
         """Issue the single aux summary call; return validated content text.
@@ -3187,8 +3226,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             # NO max_tokens: Anthropic/NIM wires forward it and a hard cap truncates summaries
             # (thinking models burn it on reasoning). Timeout comes from call_llm config.
         }
-        if self.summary_model:
-            call_kwargs["model"] = self.summary_model
+        self._apply_summary_route(call_kwargs)
         # Pinned route (stall fallback) overrides task routing so the retry leaves the stalled backend.
         call_kwargs.update(_pinned_summary_call_kwargs())
         # Compression is atomic: protect the in-flight summary call from a mid-turn gateway interrupt.

--- a/agent/micro_compaction.py
+++ b/agent/micro_compaction.py
@@ -123,8 +123,7 @@ class MicroCompactionMixin:
             "max_tokens": min(1500, self.max_summary_tokens or 1500),
             "temperature": 0.1,
         }
-        if self.summary_model:
-            call_kwargs["model"] = self.summary_model
+        self._apply_summary_route(call_kwargs)
         if self.model:
             call_kwargs.setdefault("main_runtime", {
                 "model": self.model, "provider": self.provider or "", "base_url": self.base_url or "",

--- a/tests/agent/test_compression_aux_fallback_route.py
+++ b/tests/agent/test_compression_aux_fallback_route.py
@@ -1,0 +1,143 @@
+"""Auxiliary-summary fallback must actually reach the main model.
+
+``_fallback_to_main_for_compression`` clears ``summary_model`` to mean "use the
+main model". But ``call_llm(task="compression", ...)`` resolves an unspecified
+route from ``auxiliary.compression`` in the config -- i.e. the model that just
+failed. Without an explicit route the fallback re-calls the failing auxiliary
+model, and since a second fallback is not allowed the summary aborts and
+compression is skipped entirely.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import ContextCompressor
+
+
+def _compressor(**kwargs):
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        return ContextCompressor(quiet_mode=True, **kwargs)
+
+
+def _ok_response(text="summary via main model"):
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = text
+    return response
+
+
+def _quota_error():
+    error = Exception("Error code: 429 - usage_limit_reached")
+    error.status_code = 429
+    return error
+
+
+def _turns():
+    return [
+        {"role": "user", "content": "do something"},
+        {"role": "assistant", "content": "ok"},
+    ]
+
+
+def test_quota_exhausted_aux_falls_back_to_named_main_model():
+    """A 429 on the aux model must retry on an explicitly named main model."""
+    compressor = _compressor(
+        model="main-model",
+        provider="main-provider",
+        summary_model_override="quota-exhausted-aux",
+    )
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        side_effect=[_quota_error(), _ok_response()],
+    ) as mock_call:
+        summary = compressor._generate_summary(_turns())
+
+    assert summary is not None
+    assert "summary via main model" in summary
+    assert mock_call.call_count == 2
+
+    first, second = mock_call.call_args_list
+    assert first.kwargs.get("model") == "quota-exhausted-aux"
+    # Without an explicit route the retry resolves auxiliary.compression again
+    # and re-calls the exhausted model.
+    assert second.kwargs.get("model") == "main-model"
+    assert second.kwargs.get("provider") == "main-provider"
+    main_runtime = second.kwargs.get("main_runtime")
+    assert main_runtime is not None
+    assert main_runtime["model"] == "main-model"
+    assert main_runtime["provider"] == "main-provider"
+
+
+def test_aux_quota_failure_does_not_stick_when_main_succeeds():
+    """A terminal access/quota flag from the aux attempt must not survive a
+    successful main-model retry, otherwise compress() aborts anyway."""
+    compressor = _compressor(
+        model="main-model",
+        provider="main-provider",
+        summary_model_override="quota-exhausted-aux",
+    )
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        side_effect=[_quota_error(), _ok_response()],
+    ):
+        summary = compressor._generate_summary(_turns())
+
+    assert summary is not None
+    assert compressor._last_summary_auth_failure is False
+
+
+def test_route_is_untouched_before_any_fallback():
+    """No fallback yet: the configured aux route must be preserved verbatim."""
+    compressor = _compressor(
+        model="main-model",
+        provider="main-provider",
+        summary_model_override="healthy-aux",
+    )
+
+    call_kwargs = {"task": "compression"}
+    compressor._apply_summary_route(call_kwargs)
+
+    assert call_kwargs["model"] == "healthy-aux"
+    assert "provider" not in call_kwargs
+
+
+def test_route_is_untouched_when_no_aux_model_is_configured():
+    """No aux model and no fallback: leave task resolution to call_llm."""
+    compressor = _compressor(model="main-model", provider="main-provider")
+
+    call_kwargs = {"task": "compression"}
+    compressor._apply_summary_route(call_kwargs)
+
+    assert call_kwargs == {"task": "compression"}
+
+
+def test_micro_summarize_also_names_main_model_after_fallback():
+    """The micro-summarization entry point shares the same defect and fix."""
+    compressor = _compressor(
+        model="main-model",
+        provider="main-provider",
+        summary_model_override="quota-exhausted-aux",
+    )
+    compressor._fallback_to_main_for_compression(_quota_error(), "failed")
+
+    captured = {}
+
+    def _capture(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="merged"))]
+        )
+
+    with patch("agent.auxiliary_client.call_llm", side_effect=_capture), patch.object(
+        compressor, "_build_micro_summary_prompt", return_value=[{"role": "user", "content": "x"}]
+    ):
+        compressor._micro_summarize_one("an exchange")
+
+    assert captured.get("model") == "main-model"
+    assert captured.get("provider") == "main-provider"
+    main_runtime = captured.get("main_runtime")
+    assert main_runtime is not None
+    assert main_runtime["model"] == "main-model"
+    assert main_runtime["provider"] == "main-provider"

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1103,8 +1103,9 @@ class TestSummaryFallbackToMainModel:
         assert mock_call.call_count == 2
         # First call used the misconfigured aux model
         assert mock_call.call_args_list[0].kwargs.get("model") == "broken-aux-model"
-        # Second call used the main model (no model kwarg → call_llm uses main)
-        assert "model" not in mock_call.call_args_list[1].kwargs
+        # Second call names the main model explicitly: omitting it would let
+        # call_llm re-resolve auxiliary.compression, i.e. the failing aux model.
+        assert mock_call.call_args_list[1].kwargs.get("model") == "main-model"
         assert result is not None
         assert "summary via main model" in result
         # Aux-model failure is recorded even though retry succeeded — this is
@@ -1138,7 +1139,7 @@ class TestSummaryFallbackToMainModel:
 
         assert mock_call.call_count == 2
         assert mock_call.call_args_list[0].kwargs.get("model") == "flaky-aux-model"
-        assert "model" not in mock_call.call_args_list[1].kwargs
+        assert mock_call.call_args_list[1].kwargs.get("model") == "main-model"
         assert result is not None
         assert "summary via main model after empty aux" in result
         assert c._last_aux_model_failure_model == "flaky-aux-model"
@@ -1201,7 +1202,7 @@ class TestSummaryFallbackToMainModel:
 
         assert mock_call.call_count == 2
         assert mock_call.call_args_list[0].kwargs.get("model") == "aux-via-broken-proxy"
-        assert "model" not in mock_call.call_args_list[1].kwargs
+        assert mock_call.call_args_list[1].kwargs.get("model") == "main-model"
         assert result is not None
         assert "summary via main model" in result
         # Aux-model failure recorded so /usage / gateway warnings can surface it
@@ -1258,7 +1259,7 @@ class TestStreamingClosedFallback:
 
         assert mock_call.call_count == 2
         assert mock_call.call_args_list[0].kwargs.get("model") == "aux-stream-model"
-        assert "model" not in mock_call.call_args_list[1].kwargs
+        assert mock_call.call_args_list[1].kwargs.get("model") == "main-model"
         assert result is not None
         assert "summary via main model" in result
 


### PR DESCRIPTION
## Problem

`_fallback_to_main_for_compression` clears `summary_model` to mean "use the main model".

But the retry then calls `call_llm(task="compression", ...)` **without naming a route**, and
`_resolve_task_provider_model` resolves an unspecified route from `auxiliary.compression` in
the config — which is exactly the auxiliary model that just failed.

So the "fallback to the main model" re-calls the failing auxiliary model. Since
`_summary_model_fallen_back` is already set, the second fallback branch is gated off,
`_generate_summary` returns `None`, and with `compression.abort_on_summary_failure` the
entire compression is skipped.

Anyone with a configured `auxiliary.compression` model is exposed: once that model returns
429 / 404 / a timeout, compression silently stops working and the session keeps growing.

## Observed

An auxiliary compression model whose weekly quota was exhausted:

```
Auxiliary compression: rate limit on <aux> (429 usage_limit_reached), trying fallback
Auxiliary compression: rate limit on <aux> — falling back to main agent model <main>
compression_attempt: commit_status=aborted, split_status=aborted,
                     failure_class=summary_generation_aborted, fallback_used=false,
                     current_estimated_tokens=637557, effective_threshold=192000
```

Two identical 429s on the same auxiliary model, `fallback_used=false`, and a session left
uncompressed at ~3.3x its threshold.

## Fix

`_apply_summary_route()` becomes the single place that pins the summary wire route:

- a configured `summary_model` is named, as before;
- after a fallback, the main runtime (`provider`, `model`, `base_url`, `api_key`, `api_mode`)
  is named explicitly, so `call_llm` cannot re-resolve `auxiliary.compression`;
- with no aux model and no fallback, nothing is set and task resolution is left untouched.

Both compression entry points now go through it. `_micro_summarize_one` had the **same
defect** and is fixed by the same chokepoint rather than a parallel edit.

`_fallback_to_main_for_compression` also clears `_last_summary_auth_failure`: a terminal
access/quota class error recorded during the auxiliary attempt otherwise survives into the
retry and makes `compress()` abort even when the main model summarised fine. A genuine
main-model access/quota failure re-sets the flag in the retry.

## Note for reviewers — existing tests encoded the bug

Three tests asserted the buggy contract:

```python
# Second call used the main model (no model kwarg → call_llm uses main)
assert "model" not in mock_call.call_args_list[1].kwargs
```

That comment is the defect itself: omitting the kwarg does **not** select the main model when
`auxiliary.compression` is configured. They now assert the main model is named explicitly.

## Verification

RED before / GREEN after, on `origin/main`:

- with the upstream behaviour restored, `test_quota_exhausted_aux_falls_back_to_named_main_model`
  and `test_micro_summarize_also_names_main_model_after_fallback` fail (2 failed, 3 passed);
- with the fix, 5 passed.

Compression / summary / auxiliary suites (67 files): **772 passed, 2 failed**.

The 2 failures are `test_auxiliary_main_first.py::TestResolveVisionCustomProvider` (vision
routing, unrelated). They are **pre-existing on unmodified `origin/main`**: the file passes
17/17 in isolation both with and without this patch, and reproduces the same 2 failures in the
full-suite run with the patch reverted — a test-ordering leak, not a regression from this change.
