### PR TITLE
fix(cron): evaluate cron next_run_at in UTC to prevent TZ-skewed early fires

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -31,7 +31,7 @@ try:
     import msvcrt
 except ImportError:  # pragma: no cover - non-Windows
     msvcrt = None
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Optional, Dict, List, Any, Set, Tuple, Union, Collection
@@ -948,12 +948,24 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         # with interval jobs.  This ensures that after a crash/restart,
         # the next run is anchored to the actual last execution time
         # rather than to an arbitrary restart time.
-        base_time = now
+        #
+        # IMPORTANT: evaluate the expression in UTC, matching the ticker's
+        # due-check, which compares next_run_at against the wall clock in
+        # UTC terms. `_hermes_now()` returns the *configured* zone (e.g.
+        # Asia/Shanghai), so using it as the croniter base would interpret
+        # "30 14 * * *" as 14:30 Shanghai and persist
+        # "2026-08-17T14:30:00+08:00" — an absolute instant 8h earlier than
+        # the intended 14:30 UTC fire. On restart the stored instant is
+        # already past and the job fires 8h early (#88220). Normalize to
+        # UTC so the persisted next_run_at is the correct absolute instant.
+        base_time = now.astimezone(timezone.utc)
         if last_run_at:
             try:
-                base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
+                base_time = _ensure_aware(
+                    datetime.fromisoformat(last_run_at)
+                ).astimezone(timezone.utc)
             except Exception:
-                base_time = now
+                base_time = now.astimezone(timezone.utc)
         cron = croniter(expr, base_time)
         next_run = cron.get_next(datetime)
         return next_run.isoformat()

--- a/tests/cron/test_compute_next_run_utc_tz.py
+++ b/tests/cron/test_compute_next_run_utc_tz.py
@@ -1,0 +1,72 @@
+"""Regression test for #88220: cron next_run_at must be evaluated in UTC.
+
+The ticker's due-check compares next_run_at against the wall clock in UTC
+terms, but compute_next_run() used _hermes_now() (the *configured* zone) as
+the croniter base. With timezone: Asia/Shanghai and a system UTC clock, a
+"30 14 * * *" job persisted "2026-08-17T14:30:00+08:00" — an absolute
+instant 8h earlier than the intended 14:30 UTC fire — so a gateway restart
+made the job fire 8h early.
+"""
+import pytest
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+pytest.importorskip("croniter")
+
+from cron.jobs import compute_next_run
+
+
+class TestCronNextRunUTCBaseline:
+    """compute_next_run MUST evaluate cron expressions in UTC so the
+    persisted next_run_at is the correct absolute instant regardless of the
+    configured timezone."""
+
+    def test_shanghai_config_system_utc(self, monkeypatch):
+        shanghai = ZoneInfo("Asia/Shanghai")
+        # 2026-08-17 15:51 Shanghai == 07:51 UTC (system clock).
+        now = datetime(2026, 8, 17, 15, 51, 3, tzinfo=shanghai)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {"kind": "cron", "expr": "30 14 * * *"}
+        result = compute_next_run(schedule)
+        assert result is not None
+        next_dt = datetime.fromisoformat(result)
+
+        # Intended fire: next 14:30 UTC (2026-08-17, since now is 07:51 UTC).
+        assert next_dt.utcoffset().total_seconds() == 0, (
+            f"next_run_at must be UTC, got {result}"
+        )
+        assert next_dt == datetime(2026, 8, 17, 14, 30, 0, tzinfo=timezone.utc), (
+            f"Expected 2026-08-17T14:30:00+00:00, got {result}"
+        )
+
+    def test_shanghai_restart_with_last_run_at(self, monkeypatch):
+        shanghai = ZoneInfo("Asia/Shanghai")
+        # Gateway restarted at 06:25 UTC == 14:25 Shanghai; last run was
+        # 2026-08-16 14:30 UTC (== 22:30 Shanghai).
+        now = datetime(2026, 8, 17, 14, 25, 0, tzinfo=shanghai)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        last_run = datetime(2026, 8, 16, 22, 30, 0, tzinfo=shanghai)
+
+        schedule = {"kind": "cron", "expr": "30 14 * * *"}
+        result = compute_next_run(schedule, last_run_at=last_run.isoformat())
+        assert result is not None
+        next_dt = datetime.fromisoformat(result)
+
+        # Next fire is 2026-08-17 14:30 UTC — NOT 8h early at 06:30 UTC.
+        assert next_dt == datetime(2026, 8, 17, 14, 30, 0, tzinfo=timezone.utc), (
+            f"Expected 2026-08-17T14:30:00+00:00, got {result}"
+        )
+
+    def test_utc_config_unchanged(self, monkeypatch):
+        """A UTC-configured environment must be unaffected (no behavior
+        change when configured zone already is UTC)."""
+        utc = timezone.utc
+        now = datetime(2026, 8, 17, 7, 51, 3, tzinfo=utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {"kind": "cron", "expr": "30 14 * * *"}
+        result = compute_next_run(schedule)
+        assert result is not None
+        next_dt = datetime.fromisoformat(result)
+        assert next_dt == datetime(2026, 8, 17, 14, 30, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Problem

Cron jobs **fire 8 hours early** after a gateway restart when the configured timezone (`config.yaml` → `timezone`) is ahead of UTC (e.g. `Asia/Shanghai`, UTC+8) while the system clock runs UTC.

## Root cause

`compute_next_run()` in `cron/jobs.py` uses `_hermes_now()` — which resolves to the **configured** zone (Asia/Shanghai) — as the croniter base. The ticker's due-check, however, compares `next_run_at` in UTC terms (the job fires at the correct UTC wall-clock time, verified in production).

With `timezone: Asia/Shanghai` and a UTC system clock, a `30 14 * * *` job persisted `2026-08-17T14:30:00+08:00` — an absolute instant **8h earlier** than the intended 14:30 UTC fire. On the next gateway restart the stored instant is already past, so the job fires 8h early, and `next_run_at` keeps re-anchoring to the same wrong offset after each early fire.

Repro (before):
```
hermes_now (configured): 2026-08-17T15:51:03+08:00   (== 07:51 UTC)
fresh next_run_at:       2026-08-18T14:30:00+08:00   → 06:30 UTC (wrong)
true next fire (UTC):    2026-08-17T14:30:00+00:00
```

## Fix

Normalize the croniter base to UTC (and UTC-convert `last_run_at` when present) so the persisted `next_run_at` is the correct absolute instant:

```python
base_time = now.astimezone(timezone.utc)
if last_run_at:
    base_time = _ensure_aware(datetime.fromisoformat(last_run_at)).astimezone(timezone.utc)
```

After:
```
fixed next_run_at: 2026-08-17T14:30:00+00:00   ✓ (exactly the true UTC fire)
```

UTC-configured environments are unaffected (`astimezone(utc)` is a no-op there).

## Tests

- `tests/cron/test_compute_next_run_utc_tz.py` (new): Shanghai-config/system-UTC fresh + restart-with-`last_run_at` paths assert the exact UTC instant; UTC-config path asserts no behavior change.
- Existing suite: `test_compute_next_run_last_run_at.py` (Casablanca, ~UTC — still passes, `next_dt.hour == 18`), `test_jobs.py` + `test_timezone.py`: **83/83 pass**.
