### PR TITLE
feat: transport optional completed-turn memory provenance

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -25,10 +25,11 @@ Usage in run_agent.py:
 
 from __future__ import annotations
 
+import copy
+import inspect
 import json
 import logging
 import re
-import inspect
 import threading
 from concurrent.futures import Future, ThreadPoolExecutor, wait
 from typing import Any, Callable, Dict, List, Optional
@@ -724,8 +725,8 @@ class MemoryManager:
         user_content = clean_user_content
         # The worker may run after the caller mutates its turn buffers. Freeze
         # optional context at submission so providers observe one exact turn.
-        messages_snapshot = list(messages) if messages is not None else None
-        metadata_snapshot = dict(metadata) if metadata is not None else None
+        messages_snapshot = copy.deepcopy(messages) if messages is not None else None
+        metadata_snapshot = copy.deepcopy(metadata) if metadata is not None else None
 
         def _run() -> None:
             for provider in providers:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -672,6 +672,18 @@ class MemoryManager:
             return True
         return "messages" in signature.parameters
 
+    @staticmethod
+    def _provider_sync_accepts_metadata(provider: MemoryProvider) -> bool:
+        """Return whether sync_turn accepts a metadata keyword."""
+        try:
+            signature = inspect.signature(provider.sync_turn)
+        except (TypeError, ValueError):
+            return True
+        params = list(signature.parameters.values())
+        if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params):
+            return True
+        return "metadata" in signature.parameters
+
     def sync_all(
         self,
         user_content: str,
@@ -679,6 +691,7 @@ class MemoryManager:
         *,
         session_id: str = "",
         messages: Optional[List[Dict[str, Any]]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Sync a completed turn to all providers.
 
@@ -709,19 +722,16 @@ class MemoryManager:
         def _run() -> None:
             for provider in providers:
                 try:
+                    sync_kwargs: Dict[str, Any] = {"session_id": session_id}
                     if messages is not None and self._provider_sync_accepts_messages(provider):
-                        provider.sync_turn(
-                            user_content,
-                            assistant_content,
-                            session_id=session_id,
-                            messages=messages,
-                        )
-                    else:
-                        provider.sync_turn(
-                            user_content,
-                            assistant_content,
-                            session_id=session_id,
-                        )
+                        sync_kwargs["messages"] = messages
+                    if metadata is not None and self._provider_sync_accepts_metadata(provider):
+                        sync_kwargs["metadata"] = metadata
+                    provider.sync_turn(
+                        user_content,
+                        assistant_content,
+                        **sync_kwargs,
+                    )
                 except Exception as e:
                     logger.warning(
                         "Memory provider '%s' sync_turn failed: %s",

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -666,7 +666,9 @@ class MemoryManager:
         try:
             signature = inspect.signature(provider.sync_turn)
         except (TypeError, ValueError):
-            return True
+            # Optional context must be opt-in. An uninspectable legacy
+            # callable may reject new keywords, dropping the whole sync.
+            return False
         params = list(signature.parameters.values())
         if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params):
             return True
@@ -678,7 +680,9 @@ class MemoryManager:
         try:
             signature = inspect.signature(provider.sync_turn)
         except (TypeError, ValueError):
-            return True
+            # Fail closed for optional transport when signature discovery is
+            # unavailable; the required legacy call remains fully usable.
+            return False
         params = list(signature.parameters.values())
         if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params):
             return True
@@ -718,15 +722,19 @@ class MemoryManager:
         if not clean_user_content:
             return
         user_content = clean_user_content
+        # The worker may run after the caller mutates its turn buffers. Freeze
+        # optional context at submission so providers observe one exact turn.
+        messages_snapshot = list(messages) if messages is not None else None
+        metadata_snapshot = dict(metadata) if metadata is not None else None
 
         def _run() -> None:
             for provider in providers:
                 try:
                     sync_kwargs: Dict[str, Any] = {"session_id": session_id}
-                    if messages is not None and self._provider_sync_accepts_messages(provider):
-                        sync_kwargs["messages"] = messages
-                    if metadata is not None and self._provider_sync_accepts_metadata(provider):
-                        sync_kwargs["metadata"] = metadata
+                    if messages_snapshot is not None and self._provider_sync_accepts_messages(provider):
+                        sync_kwargs["messages"] = messages_snapshot
+                    if metadata_snapshot is not None and self._provider_sync_accepts_metadata(provider):
+                        sync_kwargs["metadata"] = metadata_snapshot
                     provider.sync_turn(
                         user_content,
                         assistant_content,

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -205,6 +205,7 @@ class MemoryProvider(ABC):
         *,
         session_id: str = "",
         messages: Optional[List[Dict[str, Any]]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Persist a completed turn to the backend.
 
@@ -214,6 +215,10 @@ class MemoryProvider(ABC):
         ``messages`` is the OpenAI-style conversation message list as of the
         completed turn, including any assistant tool calls and tool results.
         Providers that do not need raw turn context can ignore it.
+
+        ``metadata`` contains optional platform-agnostic runtime provenance
+        (session lineage, platform, chat/thread and account identifiers). Only
+        fields known by the runtime are included. Providers may ignore it.
         """
 
     @abstractmethod

--- a/run_agent.py
+++ b/run_agent.py
@@ -4376,6 +4376,18 @@ class AIAgent:
             sync_kwargs = {"session_id": self.session_id or ""}
             if messages is not None:
                 sync_kwargs["messages"] = messages
+            metadata = {
+                "session_id": self.session_id or "",
+                "parent_session_id": getattr(self, "_parent_session_id", "") or "",
+                "lineage_key": getattr(self, "_gateway_session_key", "") or "",
+                "platform": getattr(self, "platform", "") or "",
+                "chat_id": getattr(self, "_chat_id", "") or "",
+                "thread_id": getattr(self, "_thread_id", "") or "",
+                "origin_kind": "direct",
+            }
+            sync_kwargs["metadata"] = {
+                key: value for key, value in metadata.items() if value != ""
+            }
             self._memory_manager.sync_all(
                 user_text,
                 response_text,

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -94,6 +94,13 @@ class MessagesMemoryProvider(FakeMemoryProvider):
         self.synced_turns.append((user_content, assistant_content, session_id, messages))
 
 
+class TurnMetadataMemoryProvider(FakeMemoryProvider):
+    """Provider that opts into completed-turn provenance metadata."""
+
+    def sync_turn(self, user_content, assistant_content, *, session_id="", metadata=None):
+        self.synced_turns.append((user_content, assistant_content, session_id, metadata))
+
+
 class BlockingPrefetchProvider(FakeMemoryProvider):
     """External provider whose prefetch call blocks until released."""
 
@@ -235,6 +242,19 @@ class TestMemoryManager:
         mgr.flush_pending(timeout=5)
 
         assert legacy_provider.synced_turns == [("user", "assistant")]
+
+    def test_sync_all_forwards_generic_metadata_to_opted_in_provider(self):
+        mgr = MemoryManager()
+        provider = TurnMetadataMemoryProvider()
+        mgr.add_provider(provider)
+        metadata = {"platform": "telegram", "chat_id": "chat-42"}
+
+        mgr.sync_all("user", "assistant", metadata=metadata)
+        assert mgr.flush_pending(timeout=2)
+
+        assert provider.synced_turns == [
+            ("user", "assistant", "", metadata),
+        ]
 
     # -- Tool routing -------------------------------------------------------
 

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -98,8 +98,21 @@ class MessagesMemoryProvider(FakeMemoryProvider):
 class TurnMetadataMemoryProvider(FakeMemoryProvider):
     """Provider that opts into completed-turn provenance metadata."""
 
-    def sync_turn(self, user_content, assistant_content, *, session_id="", metadata=None):
+    def __init__(self, name="external"):
+        super().__init__(name=name)
+        self.synced_messages = []
+
+    def sync_turn(
+        self,
+        user_content,
+        assistant_content,
+        *,
+        session_id="",
+        messages=None,
+        metadata=None,
+    ):
         self.synced_turns.append((user_content, assistant_content, session_id, metadata))
+        self.synced_messages.append(messages)
 
 
 class BlockingPrefetchProvider(FakeMemoryProvider):
@@ -279,21 +292,31 @@ class TestMemoryManager:
 
         assert provider.synced_turns == [("user", "assistant")]
 
-    def test_sync_all_snapshots_metadata_before_background_execution(self):
+    def test_sync_all_deeply_snapshots_optional_context_before_background_execution(self):
         mgr = MemoryManager()
         provider = TurnMetadataMemoryProvider()
         mgr.add_provider(provider)
         blocker = threading.Event()
         mgr._submit_background(lambda: blocker.wait(timeout=2))
-        metadata = {"platform": "telegram", "chat_id": "original"}
+        messages = [{"role": "user", "content": {"text": "original"}}]
+        metadata = {"platform": "telegram", "scope": {"chat_id": "original"}}
 
-        mgr.sync_all("user", "assistant", metadata=metadata)
-        metadata["chat_id"] = "mutated"
+        mgr.sync_all("user", "assistant", messages=messages, metadata=metadata)
+        messages[0]["content"]["text"] = "mutated"
+        metadata["scope"]["chat_id"] = "mutated"
         blocker.set()
         assert mgr.flush_pending(timeout=2)
 
         assert provider.synced_turns == [
-            ("user", "assistant", "", {"platform": "telegram", "chat_id": "original"}),
+            (
+                "user",
+                "assistant",
+                "",
+                {"platform": "telegram", "scope": {"chat_id": "original"}},
+            ),
+        ]
+        assert provider.synced_messages == [
+            [{"role": "user", "content": {"text": "original"}}],
         ]
 
     # -- Tool routing -------------------------------------------------------

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1,5 +1,6 @@
 """Tests for the memory provider interface, manager, and builtin provider."""
 
+import inspect
 import json
 import threading
 import time
@@ -254,6 +255,45 @@ class TestMemoryManager:
 
         assert provider.synced_turns == [
             ("user", "assistant", "", metadata),
+        ]
+
+    def test_sync_all_omits_optional_context_when_signature_is_uninspectable(self, monkeypatch):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("legacy")
+        mgr.add_provider(provider)
+        original_signature = inspect.signature
+
+        def fail_for_provider(callable_obj):
+            if callable_obj == provider.sync_turn:
+                raise ValueError("signature unavailable")
+            return original_signature(callable_obj)
+
+        monkeypatch.setattr(inspect, "signature", fail_for_provider)
+        mgr.sync_all(
+            "user",
+            "assistant",
+            messages=[{"role": "user", "content": "user"}],
+            metadata={"platform": "telegram"},
+        )
+        assert mgr.flush_pending(timeout=2)
+
+        assert provider.synced_turns == [("user", "assistant")]
+
+    def test_sync_all_snapshots_metadata_before_background_execution(self):
+        mgr = MemoryManager()
+        provider = TurnMetadataMemoryProvider()
+        mgr.add_provider(provider)
+        blocker = threading.Event()
+        mgr._submit_background(lambda: blocker.wait(timeout=2))
+        metadata = {"platform": "telegram", "chat_id": "original"}
+
+        mgr.sync_all("user", "assistant", metadata=metadata)
+        metadata["chat_id"] = "mutated"
+        blocker.set()
+        assert mgr.flush_pending(timeout=2)
+
+        assert provider.synced_turns == [
+            ("user", "assistant", "", {"platform": "telegram", "chat_id": "original"}),
         ]
 
     # -- Tool routing -------------------------------------------------------

--- a/tests/run_agent/test_memory_sync_interrupted.py
+++ b/tests/run_agent/test_memory_sync_interrupted.py
@@ -35,6 +35,12 @@ def _bare_agent():
     # providers that cache per-session state can update it mid-process
     # (see #6672).
     agent.session_id = "test_session_001"
+    agent.platform = "telegram"
+    agent._chat_id = "chat-42"
+    agent._thread_id = "thread-7"
+    agent._gateway_session_key = "agent:main:telegram:profile:group:chat-42:thread-7"
+    agent._parent_session_id = "parent-session"
+    agent._user_id = "user-9"
     return agent
 
 
@@ -53,6 +59,26 @@ class TestSyncExternalMemoryForTurn:
         )
         agent._memory_manager.sync_all.assert_not_called()
         agent._memory_manager.queue_prefetch_all.assert_not_called()
+
+    def test_completed_turn_forwards_runtime_provenance_metadata(self):
+        agent = _bare_agent()
+
+        agent._sync_external_memory_for_turn(
+            original_user_message="원문을 찾아줘",
+            final_response="원문을 찾았어",
+            interrupted=False,
+        )
+
+        _, kwargs = agent._memory_manager.sync_all.call_args
+        assert kwargs["metadata"] == {
+            "session_id": "test_session_001",
+            "parent_session_id": "parent-session",
+            "lineage_key": "agent:main:telegram:profile:group:chat-42:thread-7",
+            "platform": "telegram",
+            "chat_id": "chat-42",
+            "thread_id": "thread-7",
+            "origin_kind": "direct",
+        }
 
 
     # --- Normal completed turn still syncs ------------------------------


### PR DESCRIPTION
## Summary
- extend completed-turn memory sync with optional platform-agnostic provenance metadata
- preserve compatibility with providers that do not accept metadata
- forward only runtime-known session, lineage, platform, chat, and thread fields

## Verification
- `python -m pytest tests/agent/test_memory_provider.py tests/run_agent/test_memory_sync_interrupted.py -q`
- 69 passed

## Safety
- no account/user identifier is inferred from cached group-agent state
- metadata is opt-in by provider signature