### PR TITLE
fix(desktop): restore bot row actions

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3219,7 +3219,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
   })
 
   return jsxs('div', {
-    className: 'group relative',
+    className: 'group relative w-full min-w-0 max-w-full',
     onContextMenu: event => {
       event.preventDefault()
       event.stopPropagation()

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3019,6 +3019,11 @@ function activeBots(roster, activeProfile, gatewayState, now = Date.now()) {
   })
 }
 
+function botRosterKey(bot) {
+  const source = bot.remoteSource ? bot.connectionId || bot.connectionLabel || bot.handle || 'remote' : 'local'
+  return `${source}:${bot.name}`
+}
+
 // ── bot row ──────────────────────────────────────────────────────────────────
 
 function BotRow({ bot, onDelete, onEdit, onGroup }) {
@@ -5979,7 +5984,7 @@ function ActiveNowStrip({ roster, activeProfile, gatewayState, metaByName, onOpe
               children: label
             })
           ]
-        }, bot.name)
+        }, botRosterKey(bot))
       })
     ]
   })
@@ -6438,7 +6443,7 @@ function BotsPane() {
                           }, `group:${section.group}`)
                         : null,
                       ...section.bots.map(bot =>
-                        jsx(BotRow, { bot, onDelete: setDeleting, onEdit: setEditing, onGroup: setGrouping }, bot.name)
+                        jsx(BotRow, { bot, onDelete: setDeleting, onEdit: setEditing, onGroup: setGrouping }, botRosterKey(bot))
                       )
                     ])
                   })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -23,11 +23,6 @@ import {
   cn,
   Codicon,
   COMPOSER_AREAS,
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuTrigger,
   ConfirmDialog,
   Dialog,
   DialogContent,
@@ -3027,6 +3022,7 @@ function activeBots(roster, activeProfile, gatewayState, now = Date.now()) {
 // ── bot row ──────────────────────────────────────────────────────────────────
 
 function BotRow({ bot, onDelete, onEdit, onGroup }) {
+  const [actionsOpen, setActionsOpen] = useState(false)
   const activeProfile = useValue(host.state.profile)
   const meta = useValue($botMeta)[bot.name]
   const last = bot.last_session
@@ -3128,7 +3124,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
     onPointerEnter: warm,
     onClick: open,
     className: cn(
-      'flex w-full min-w-0 max-w-full items-center gap-2.5 overflow-hidden rounded-md px-2 py-2 text-left transition-colors',
+      'flex w-full min-w-0 max-w-full items-center gap-2.5 overflow-hidden rounded-md py-2 pr-9 pl-2 text-left transition-colors',
       'hover:bg-(--chrome-action-hover)',
       isActive && 'bg-(--chrome-action-hover)'
     ),
@@ -3217,64 +3213,118 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
     ]
   })
 
-  return jsxs(ContextMenu, {
+  return jsxs('div', {
+    className: 'group relative',
+    onContextMenu: event => {
+      event.preventDefault()
+      event.stopPropagation()
+      setActionsOpen(true)
+    },
     children: [
-      jsx(ContextMenuTrigger, { asChild: true, children: row }),
-      jsxs(ContextMenuContent, {
-        children: [
-          jsx(ContextMenuItem, {
-            onSelect: () => {
-              const pinned = Boolean($botMeta.get()[bot.name]?.pinned)
-              saveBotMeta(bot.name, { pinned: !pinned })
-              host.notify({
-                kind: 'info',
-                message: `${displayName(bot, meta)} ${pinned ? 'unpinned' : 'pinned to top'}`
-              })
-            },
-            children: meta?.pinned ? 'Unpin' : 'Pin to top'
-          }),
-          jsx(ContextMenuSeparator, {}),
-          jsx(ContextMenuItem, {
-            onSelect: () => openBotSessionsWorkspace(bot),
-            children: 'Sessions'
-          }),
-          jsx(ContextMenuItem, { onSelect: () => onEdit(bot), children: 'Edit Profile' }),
-          jsx(ContextMenuItem, {
-            onSelect: () => onGroup(bot),
-            children: meta?.group ? `Group: ${meta.group}…` : 'Move to group…'
-          }),
-          jsx(ContextMenuItem, {
-            onSelect: () => {
-              host.notify({ kind: 'info', message: `Duplicating ${displayName(bot, meta)}…` })
-              duplicateBot(bot, $lastRoster.get())
-                .then(name => {
-                  queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
-                  host.notify({ kind: 'success', message: `Created ${name} — full copy of ${bot.name}` })
-                })
-                .catch(err => host.notifyError(err, 'Duplicate failed'))
-            },
-            children: 'Duplicate'
-          }),
-          jsx(ContextMenuSeparator, {}),
-          jsx(ContextMenuItem, {
-            onSelect: () => {
-              $selectedBot.set(bot.name)
+      row,
+      jsx('button', {
+        type: 'button',
+        'aria-label': `Actions for ${displayName(bot, meta)}`,
+        className:
+          'absolute top-1/2 right-1 flex size-7 -translate-y-1/2 items-center justify-center rounded-md text-(--ui-text-quaternary) opacity-70 transition hover:bg-(--chrome-action-hover) hover:text-foreground hover:opacity-100 focus-visible:opacity-100',
+        onClick: event => {
+          event.stopPropagation()
+          setActionsOpen(true)
+        },
+        children: jsx(Codicon, { name: 'ellipsis' })
+      }),
+      jsx(Dialog, {
+        open: actionsOpen,
+        onOpenChange: setActionsOpen,
+        children: jsxs(DialogContent, {
+          className: 'max-w-xs',
+          children: [
+            jsxs(DialogHeader, {
+              children: [
+                jsx(DialogTitle, { children: 'Bot actions' }),
+                jsx(DialogDescription, { children: displayName(bot, meta) })
+              ]
+            }),
+            jsxs('div', {
+              className: 'grid gap-1.5',
+              children: [
+                jsx(Button, {
+                  variant: 'secondary',
+                  onClick: () => {
+                    setActionsOpen(false)
+                    const pinned = Boolean($botMeta.get()[bot.name]?.pinned)
+                    saveBotMeta(bot.name, { pinned: !pinned })
+                    host.notify({
+                      kind: 'info',
+                      message: `${displayName(bot, meta)} ${pinned ? 'unpinned' : 'pinned to top'}`
+                    })
+                  },
+                  children: meta?.pinned ? 'Unpin' : 'Pin to top'
+                }),
+                jsx(Button, {
+                  variant: 'secondary',
+                  onClick: () => {
+                    setActionsOpen(false)
+                    openBotSessionsWorkspace(bot)
+                  },
+                  children: 'Sessions'
+                }),
+                jsx(Button, {
+                  variant: 'secondary',
+                  onClick: () => {
+                    setActionsOpen(false)
+                    onEdit(bot)
+                  },
+                  children: 'Edit Profile'
+                }),
+                jsx(Button, {
+                  variant: 'secondary',
+                  onClick: () => {
+                    setActionsOpen(false)
+                    onGroup(bot)
+                  },
+                  children: meta?.group ? `Group: ${meta.group}…` : 'Move to group…'
+                }),
+                jsx(Button, {
+                  variant: 'secondary',
+                  onClick: () => {
+                    setActionsOpen(false)
+                    host.notify({ kind: 'info', message: `Duplicating ${displayName(bot, meta)}…` })
+                    duplicateBot(bot, $lastRoster.get())
+                      .then(name => {
+                        queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
+                        host.notify({ kind: 'success', message: `Created ${name} — full copy of ${bot.name}` })
+                      })
+                      .catch(err => host.notifyError(err, 'Duplicate failed'))
+                  },
+                  children: 'Duplicate'
+                }),
+                jsx(Button, {
+                  variant: 'secondary',
+                  onClick: () => {
+                    setActionsOpen(false)
+                    $selectedBot.set(bot.name)
 
-              if (typeof host.newChat === 'function') {
-                host.newChat(bot.name)
-              }
-            },
-            children: 'New chat with this agent'
-          }),
-          bot.is_default ? null : jsx(ContextMenuSeparator, {}),
-          bot.is_default
-            ? null
-            : jsx(ContextMenuItem, {
-                onSelect: () => onDelete(bot),
-                variant: 'destructive',
-                children: 'Delete'
-              })
-        ]
+                    if (typeof host.newChat === 'function') {
+                      host.newChat(bot.name)
+                    }
+                  },
+                  children: 'New chat with this agent'
+                }),
+                bot.is_default
+                  ? null
+                  : jsx(Button, {
+                      onClick: () => {
+                        setActionsOpen(false)
+                        onDelete(bot)
+                      },
+                      variant: 'destructive',
+                      children: 'Delete'
+                    })
+              ]
+            })
+          ]
+        })
       })
     ]
   })

--- a/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
@@ -90,7 +90,7 @@ test('ActiveNowStrip renders above the roster, is a live region, and is click-ac
   assert.match(source, /jsx\('button', \{\s*type: 'button',\s*title: `Open \$\{label\}'s chat`/)
   // The key rides as jsx()'s third argument — the ONLY form React treats as
   // a list key; a `key:` prop leaves chips unkeyed (index identity).
-  assert.match(source, /\}, bot\.name\)\s*\}\)\s*\]\s*\}\)\s*\}\s*\/\*\* Assign a bot to a group/s)
+  assert.match(source, /\}, botRosterKey\(bot\)\)\s*\}\)\s*\]\s*\}\)\s*\}\s*\/\*\* Assign a bot to a group/s)
   assert.match(source, /jsx\(BotFace,\s*\{[\s\S]*?mood: 'work'/)
   assert.match(source, /openBotCanonicalChat\(bot\.name, allMeta\[bot\.name\]\?\.chat\)/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-delete.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-delete.test.mjs
@@ -95,9 +95,8 @@ test('integration: a deleted bot is removed from plugin-local state and the rost
   assert.equal(invalidations.length, 1)
 })
 
-test('regression: the bot context menu exposes a destructive delete action and confirmation', () => {
-  assert.match(pluginSource, /ContextMenuItem, \{[\s\S]*?variant: 'destructive'[\s\S]*?children: 'Delete'/)
-  assert.match(pluginSource, /bot\.is_default \? null : jsx\(ContextMenuSeparator/)
+test('regression: bot actions expose a destructive delete action and confirmation', () => {
+  assert.match(pluginSource, /bot\.is_default[\s\S]*?variant: 'destructive'[\s\S]*?children: 'Delete'/)
   assert.match(pluginSource, /ConfirmDialog/)
   assert.match(pluginSource, /title: 'Delete bot and profile\?'/)
   assert.match(pluginSource, /This will permanently delete the bot[\s\S]*?and its associated Hermes profile at[\s\S]*?This cannot be undone\./)

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -26,7 +26,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__filterBots = filterBots;'
+      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__filterBots = filterBots;'
     )
   vm.runInNewContext(code, context)
   return context
@@ -82,6 +82,13 @@ test('merge: local rows are annotated, remote rows appended with source tags', (
   const coder = out.profiles.find(p => p.name === 'coder')
   assert.equal(coder.remoteSource, true)
   assert.equal(coder.handle, 'coder')
+})
+
+test('botRosterKey keeps same-named local and remote rows distinct', () => {
+  const { __botRosterKey: key } = runtime()
+
+  assert.equal(key({ name: 'research' }), 'local:research')
+  assert.equal(key({ name: 'research', remoteSource: true, connectionId: 'homelab' }), 'homelab:research')
 })
 
 test('merge: union-only local profiles are NOT invented as thin rows', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -18,6 +18,7 @@ function sourceBetween(start, end) {
 function renderBotRow(name = 'alpha') {
   const botRowSource = sourceBetween('function BotRow(', '// ── model picker')
   const warmed = []
+  const actionStates = []
   const atom = value => ({
     get: () => value,
     set: next => {
@@ -27,11 +28,13 @@ function renderBotRow(name = 'alpha') {
   const node = (type, props = {}) => ({ type, props })
   const context = {
     BotFace: 'BotFace',
-    ContextMenu: 'ContextMenu',
-    ContextMenuContent: 'ContextMenuContent',
-    ContextMenuItem: 'ContextMenuItem',
-    ContextMenuSeparator: 'ContextMenuSeparator',
-    ContextMenuTrigger: 'ContextMenuTrigger',
+    Button: 'Button',
+    Codicon: 'Codicon',
+    Dialog: 'Dialog',
+    DialogContent: 'DialogContent',
+    DialogDescription: 'DialogDescription',
+    DialogHeader: 'DialogHeader',
+    DialogTitle: 'DialogTitle',
     ROSTER_KEY: ['hermes-bots', 'roster'],
     $botMeta: atom({}),
     $botUnread: atom({}),
@@ -50,7 +53,7 @@ function renderBotRow(name = 'alpha') {
     ACTIVE_WINDOW_S: 90,
     A2A_PREFIX_RE: /^$/,
     useEffect: () => undefined,
-    useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
+    useState: initial => [typeof initial === 'function' ? initial() : initial, value => actionStates.push(value)],
     host: {
       state: { gateway: atom('open'), profile: atom('default') },
       warmProfile: profile => warmed.push(profile),
@@ -71,9 +74,9 @@ function renderBotRow(name = 'alpha') {
   vm.runInNewContext(`${botRowSource}\nglobalThis.BotRow = BotRow`, context)
 
   const tree = context.BotRow({ bot: { name }, onEdit: context.onEdit })
-  const row = tree.props.children[0].props.children
+  const row = tree.props.children[0]
 
-  return { row, warmed }
+  return { actionStates, row, tree, warmed }
 }
 
 test('regression: rendering BotsPane does not prewarm the entire roster', () => {
@@ -89,4 +92,23 @@ test('behavior: pointer entry prewarms only the hovered bot', () => {
   assert.equal(typeof row.props.onPointerEnter, 'function')
   row.props.onPointerEnter()
   assert.deepEqual(warmed, ['alpha'])
+})
+
+test('behavior: right-click opens bot actions', () => {
+  const { actionStates, tree } = renderBotRow('alpha')
+  let prevented = false
+  let stopped = false
+
+  tree.props.onContextMenu({
+    preventDefault: () => {
+      prevented = true
+    },
+    stopPropagation: () => {
+      stopped = true
+    }
+  })
+
+  assert.equal(prevented, true)
+  assert.equal(stopped, true)
+  assert.deepEqual(actionStates, [true])
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -112,3 +112,19 @@ test('behavior: right-click opens bot actions', () => {
   assert.equal(stopped, true)
   assert.deepEqual(actionStates, [true])
 })
+
+test('behavior: the visible actions button opens bot actions without opening the chat', () => {
+  const { actionStates, tree } = renderBotRow('alpha')
+  const actionsButton = tree.props.children[1]
+  let stopped = false
+
+  actionsButton.props.onClick({
+    stopPropagation: () => {
+      stopped = true
+    }
+  })
+
+  assert.equal(actionsButton.props['aria-label'], 'Actions for alpha')
+  assert.equal(stopped, true)
+  assert.deepEqual(actionStates, [true])
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs
@@ -100,11 +100,11 @@ function renderRuntime() {
     Button: 'Button',
     BotFace: 'BotFace',
     Codicon: 'Codicon',
-    ContextMenu: 'ContextMenu',
-    ContextMenuContent: 'ContextMenuContent',
-    ContextMenuItem: 'ContextMenuItem',
-    ContextMenuSeparator: 'ContextMenuSeparator',
-    ContextMenuTrigger: 'ContextMenuTrigger',
+    Dialog: 'Dialog',
+    DialogContent: 'DialogContent',
+    DialogDescription: 'DialogDescription',
+    DialogHeader: 'DialogHeader',
+    DialogTitle: 'DialogTitle',
     haptic: () => undefined,
     host: {
       state: {


### PR DESCRIPTION
## Summary

- replace the nonfunctional bot-row context menu with a controlled Bot actions dialog
- open the actions dialog from either right-click or a visible ellipsis button
- keep the ellipsis inside the visible sidebar at narrow pane widths
- key local and remote bot rows by source so same-named profiles retain independent React state
- preserve pin, sessions, edit, grouping, duplicate, new-chat, and delete actions
- add behavior coverage for right-click, ellipsis activation, and source-aware identity

## Problem

The plugin SDK context-menu trigger rendered around each bot row but did not open in a live Desktop renderer. Same-named local and remote profiles also produced duplicate React keys, which discarded row state updates, and intrinsic row width could place the ellipsis beyond the visible edge of a narrow Bots pane. Together these left Move to group and every other row action inaccessible.

The controlled dialog uses the plugin dialog path already used elsewhere in Hermes Bots, source-aware keys keep each row stable, and the clamped wrapper gives pointer users a persistent action target at every pane width.

## Testing

- `node --test src/plugins/hermes-bots/tests/*.test.mjs`
- 146 tests passed
- `git diff --check origin/main..HEAD`
- live Electron verification at a 563px Bots pane: the ellipsis remained inside the viewport and opened Bot actions with Move to group available