### PR TITLE
feat(state): auto-close stale OPEN sessions during auto-prune maintenance

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8781,18 +8781,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # OOM, crash, container restart) BEFORE the ended-only prune:
             # _prune_filter_where hard-codes ended_at IS NOT NULL, so the
             # built-in retention machinery never sees these rows and they
-            # accumulate forever. Safe: only rows with no activity for
-            # STALE_OPEN_CLOSE_DAYS (7), so live sessions and the rotating
-            # gateway signal session are untouched. Rows are CLOSED, never
-            # deleted — messages stay searchable and the ended-only prune
-            # below can then reclaim them via retention.
+            # accumulate forever. Safe: only rows idle for
+            # STALE_OPEN_CLOSE_DAYS (7), where idle = the freshest of
+            # last_activity_at and started_at (COALESCE), so live sessions,
+            # the rotating gateway signal session, and brand-new rows whose
+            # first activity touch hasn't landed yet are untouched. Rows are
+            # CLOSED, never deleted — messages stay searchable and the
+            # ended-only prune below can then reclaim them via retention.
             try:
                 _stale_cutoff = time.time() - 7 * 86400
                 def _close_stale_open(conn):
                     return conn.execute(
                         "UPDATE sessions SET ended_at=?, end_reason='idle_auto_close' "
                         "WHERE ended_at IS NULL "
-                        "AND (last_activity_at IS NULL OR last_activity_at < ?)",
+                        "AND COALESCE(last_activity_at, started_at) < ?",
                         (time.time(), _stale_cutoff),
                     ).rowcount
                 _stale_closed = self._execute_write(_close_stale_open)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8777,6 +8777,33 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 except (TypeError, ValueError):
                     pass  # corrupt meta; treat as no prior run
 
+            # Close stale OPEN rows left by hard-killed processes (kill -9,
+            # OOM, crash, container restart) BEFORE the ended-only prune:
+            # _prune_filter_where hard-codes ended_at IS NOT NULL, so the
+            # built-in retention machinery never sees these rows and they
+            # accumulate forever. Safe: only rows with no activity for
+            # STALE_OPEN_CLOSE_DAYS (7), so live sessions and the rotating
+            # gateway signal session are untouched. Rows are CLOSED, never
+            # deleted — messages stay searchable and the ended-only prune
+            # below can then reclaim them via retention.
+            try:
+                _stale_cutoff = time.time() - 7 * 86400
+                def _close_stale_open(conn):
+                    return conn.execute(
+                        "UPDATE sessions SET ended_at=?, end_reason='idle_auto_close' "
+                        "WHERE ended_at IS NULL "
+                        "AND (last_activity_at IS NULL OR last_activity_at < ?)",
+                        (time.time(), _stale_cutoff),
+                    ).rowcount
+                _stale_closed = self._execute_write(_close_stale_open)
+                if _stale_closed:
+                    logger.info(
+                        "state.db auto-maintenance: closed %d stale OPEN session(s) "
+                        "inactive > 7 days (hard-kill orphans)",
+                        _stale_closed,
+                    )
+            except Exception as _exc:
+                logger.warning("stale-OPEN session close failed: %s", _exc)
             pruned = self.prune_sessions(
                 older_than_days=retention_days,
                 sessions_dir=sessions_dir,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2232,6 +2232,40 @@ class TestAutoMaintenanceStaleOpenClose:
         assert db.get_session("old") is None
         assert result["pruned"] >= 1
 
+    def test_brand_new_null_activity_survives(self, db):
+        """A fresh OPEN row with last_activity_at NULL must NOT be closed.
+
+        New rows are inserted with last_activity_at = NULL (_insert_session_row
+        doesn't set it); the first _touch_activity heartbeat lands after the
+        agent starts. Idle is the freshest of last_activity_at and
+        started_at (COALESCE), so a brand-new row is treated as its creation
+        time and survives the stale-OPEN close.
+        """
+        db.create_session(session_id="fresh", source="cli")
+
+        result = db.maybe_auto_prune_and_vacuum(retention_days=90)
+
+        row = db.get_session("fresh")
+        assert row is not None
+        assert row["ended_at"] is None  # closed? would be a false positive
+
+    def test_old_null_activity_still_closed(self, db):
+        """A truly dead row (NULL activity, started long ago) is still closed."""
+        db.create_session(session_id="dead", source="cli")
+        # backdate started_at beyond the stale cutoff — mimics a hard-kill
+        # orphan whose process died before any activity touch landed
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (time.time() - 30 * 86400, "dead"),
+        )
+        db._conn.commit()
+
+        db.maybe_auto_prune_and_vacuum(retention_days=90)
+
+        row = db.get_session("dead")
+        assert row is not None  # closed, not deleted
+        assert row["ended_at"] is not None
+
 
 # =========================================================================
 # FTS5 indexing of tool_calls / tool_name (#16751)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2179,6 +2179,60 @@ class TestAutoMaintenance:
 
 
 
+class TestAutoMaintenanceStaleOpenClose:
+    """The stale-OPEN close step inside maybe_auto_prune_and_vacuum."""
+
+    def _make_open_idle(self, db, sid: str, days_idle: int = 30):
+        """Create an OPEN (never-ended) session idle for `days_idle` days."""
+        db.create_session(session_id=sid, source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+            (time.time() - days_idle * 86400, sid),
+        )
+        db._conn.commit()
+
+    def _make_open_active(self, db, sid: str):
+        """Create an OPEN session with recent activity (must survive)."""
+        db.create_session(session_id=sid, source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+            (time.time() - 60, sid),
+        )
+        db._conn.commit()
+
+    def test_closes_stale_open_rows(self, db):
+        self._make_open_idle(db, "stale1", days_idle=30)
+        self._make_open_idle(db, "stale2", days_idle=7)
+        self._make_open_active(db, "live")
+
+        result = db.maybe_auto_prune_and_vacuum(retention_days=90)
+
+        # The two idle OPEN rows are closed (ended_at set, idle_auto_close).
+        for sid in ("stale1", "stale2"):
+            row = db.get_session(sid)
+            assert row is not None  # closed, not deleted
+            assert row["ended_at"] is not None
+        # The active OPEN row is untouched.
+        assert db.get_session("live")["ended_at"] is None
+
+    def test_stale_open_close_then_prune_reclaims(self, db):
+        """Closed stale rows become eligible for normal ended-only pruning."""
+        self._make_open_idle(db, "old", days_idle=30)
+        # backdate started_at beyond retention too
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (time.time() - 100 * 86400, "old"),
+        )
+        db._conn.commit()
+
+        result = db.maybe_auto_prune_and_vacuum(retention_days=90)
+
+        # The stale OPEN row was closed first, then the ended-only prune
+        # could reclaim it because its last activity is > 90 days old.
+        assert db.get_session("old") is None
+        assert result["pruned"] >= 1
+
+
 # =========================================================================
 # FTS5 indexing of tool_calls / tool_name (#16751)
 # =========================================================================


### PR DESCRIPTION
Adds a stale-OPEN-session close step to `maybe_auto_prune_and_vacuum`, which runs at every long-lived entrypoint (CLI start, gateway start, cron scheduler). OPEN rows with no activity for 7 days are closed with `end_reason='idle_auto_close'`.

Why: `end_session()` only runs on graceful teardown. Hard kills (kill -9, OOM, crash, container restart) skip it, and the row stays OPEN forever. `_prune_filter_where` hard-codes `ended_at IS NOT NULL`, so the retention machinery never sees those rows. They accumulate: a real install had 171 stale OPEN rows, the oldest four months old.

Safety: only rows idle 7+ days are touched, so live sessions and the rotating gateway signal session are unaffected. Rows are closed, not deleted, so messages stay searchable and the ended-only prune can reclaim them later. Runs inside the existing idempotent maintenance sweep.

This is the automated complement to the manual `--include-live` archive (#87638 / #87662) and `repair-stale-open` (#40288). It also covers the DB-row accumulation half of #64488. No process or signal handling, so the failure mode that made #65998 unsafe does not apply.

Tests: existing auto-maintenance and prune tests pass (164 in test_hermes_state.py), plus two new tests covering the stale-OPEN close and the closed-then-prune path. The 3 failures in test_async_session_db.py are pre-existing on main.
