### PR TITLE
feat(desktop): add kanban new-task metadata helpers

### DIFF
--- a/apps/desktop/src/plugins/kanban/new-task-form.test.ts
+++ b/apps/desktop/src/plugins/kanban/new-task-form.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildCreateTaskMetadata, toggleSkill } from './new-task-form'
+
+describe('new task form metadata helpers', () => {
+  it('maps the explicit project choice into the create payload', () => {
+    expect(
+      buildCreateTaskMetadata({
+        priority: '2',
+        projectId: 'p_123',
+        selectedSkills: ['sam-project-orchestration'],
+        skillsText: ''
+      })
+    ).toEqual({
+      priority: 2,
+      project_id: 'p_123',
+      skills: ['sam-project-orchestration']
+    })
+  })
+
+  it('falls back to comma-separated custom skills and dedupes', () => {
+    expect(
+      buildCreateTaskMetadata({
+        priority: '',
+        projectId: '',
+        selectedSkills: ['github'],
+        skillsText: 'github, wordpress, wordpress'
+      })
+    ).toEqual({
+      priority: 0,
+      skills: ['github', 'wordpress']
+    })
+  })
+
+  it('toggles a skill without duplicates', () => {
+    expect(toggleSkill(['github'], 'sam-project-orchestration')).toEqual(['github', 'sam-project-orchestration'])
+    expect(toggleSkill(['github', 'sam-project-orchestration'], 'github')).toEqual(['sam-project-orchestration'])
+  })
+})

--- a/apps/desktop/src/plugins/kanban/new-task-form.ts
+++ b/apps/desktop/src/plugins/kanban/new-task-form.ts
@@ -1,0 +1,58 @@
+export interface NewTaskMetadataInput {
+  priority: string
+  projectId: string
+  selectedSkills: string[]
+  skillsText: string
+}
+
+export interface NewTaskMetadata {
+  priority: number
+  project_id?: string
+  skills?: string[]
+}
+
+export const DEFAULT_SKILL_SUGGESTIONS = [
+  'sam-project-orchestration',
+  'hermes-agent',
+  'github-pr-workflow',
+  'systematic-debugging',
+  'test-driven-development',
+  'deferred-reminders',
+  'user-facing-agent-communication',
+  'youtube-content',
+  'recording-transcription-pipelines',
+  'yootheme-development'
+]
+
+export function parseSkills(selectedSkills: string[], skillsText: string): string[] {
+  const seen = new Set<string>()
+
+  const values = [...selectedSkills, ...skillsText.split(',')]
+    .map(value => value.trim())
+    .filter(Boolean)
+
+  return values.filter(value => {
+    if (seen.has(value)) {
+      return false
+    }
+
+    seen.add(value)
+
+    return true
+  })
+}
+
+export function toggleSkill(selectedSkills: string[], skill: string): string[] {
+  return selectedSkills.includes(skill) ? selectedSkills.filter(value => value !== skill) : [...selectedSkills, skill]
+}
+
+export function buildCreateTaskMetadata(input: NewTaskMetadataInput): NewTaskMetadata {
+  const priority = Number(input.priority) || 0
+  const skills = parseSkills(input.selectedSkills, input.skillsText)
+
+  return {
+    priority,
+    ...(input.projectId ? { project_id: input.projectId } : {}),
+    ...(skills.length ? { skills } : {})
+  }
+}


### PR DESCRIPTION
## Summary
- Add reusable helpers for Kanban new-task metadata payload construction
- Add default skill suggestions for durable-agent task creation
- Cover project id, skill parsing/deduplication, and skill toggling behavior with Vitest tests

## Verification
- `cd apps/desktop && npm run test:ui -- new-task-form`
- `cd apps/desktop && npm run typecheck`
- `git diff --cached --check` before commit
- Static staged-line security scan: no findings

## Notes
- Prepared from a clean clone of current `origin/main` to avoid mutating the live Hermes source checkout.