### PR TITLE
fix(cli): decode kitty CSI-u lock-key modifier bits (NumLock/CapsLock)

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -246,16 +246,26 @@ def install_modify_other_keys_aliases() -> int:
 
     def _install_paired(modifier: int, mapping: dict) -> None:
         """Install both modifyOtherKeys (ESC[27;N;CP~) and CSI-u (ESC[CP;Nu)
-        mappings for the given modifier and codepoint→key mapping."""
+        mappings for the given modifier and codepoint→key mapping.
+
+        kitty ORs lock-key state into the modifier field of EVERY CSI-u
+        key event while a lock is on (CapsLock=64, NumLock=128, both=192),
+        so e.g. Backspace with NumLock arrives as ``ESC[127;129u`` instead
+        of ``ESC[127;5u``.  Install the lock-offset variants
+        (mod+64/+128/+192) for every registered mapping so locked keys
+        don't leak as literal text (#88221).
+        """
         nonlocal changed
         for codepoint, key_val in mapping.items():
-            for seq in (
-                f"\x1b[27;{modifier};{codepoint}~",
-                f"\x1b[{codepoint};{modifier}u",
-            ):
-                if seq not in ANSI_SEQUENCES:
-                    ANSI_SEQUENCES[seq] = key_val
-                    changed += 1
+            for lock_offset in (0, 64, 128, 192):
+                mod = modifier + lock_offset
+                for seq in (
+                    f"\x1b[27;{mod};{codepoint}~",
+                    f"\x1b[{codepoint};{mod}u",
+                ):
+                    if seq not in ANSI_SEQUENCES:
+                        ANSI_SEQUENCES[seq] = key_val
+                        changed += 1
 
     # Ctrl+letter / Ctrl+digit / Ctrl+symbol (modifier 5)
     _install_paired(5, ctrl_key_map)
@@ -321,7 +331,15 @@ def install_modify_other_keys_aliases() -> int:
     # (#56684 — previously leaked "[27u" as literal text into the prompt).
     # Modifiers run to 16 because kitty reports Cmd as the super bit
     # (mod 9+) — same reason install_cmd_backspace_alias maps 9/10.
-    for seq in ["\x1b[27u"] + [f"\x1b[27;{m}u" for m in range(2, 17)]:
+    # Also install the lock-offset variants (mod+64/+128/+192, plus the
+    # lock-only 65/129/193) so Esc keeps working with NumLock/CapsLock on
+    # (#88221).
+    esc_mods = set(range(2, 17))
+    for m in range(2, 17):
+        for lock in (64, 128, 192):
+            esc_mods.add(m + lock)
+    esc_mods.update((65, 129, 193))
+    for seq in ["\x1b[27u"] + [f"\x1b[27;{m}u" for m in sorted(esc_mods)]:
         if seq not in ANSI_SEQUENCES:
             ANSI_SEQUENCES[seq] = Keys.Escape
             changed += 1
@@ -343,6 +361,20 @@ def install_modify_other_keys_aliases() -> int:
         9: Keys.ControlI,                   # Ctrl+Tab — degrade to Tab
         127: (Keys.Escape, Keys.ControlH),  # Ctrl+Backspace — backward-kill-word,
                                             # matching Ink TUI + Desktop (#78285)
+    })
+
+    # -- Lock-only forms for the plain keys (modifier 1 + lock bits) ----
+    # Enter/Tab/Backspace/Space have NO modifier-1 CSI-u entries (plain
+    # keys are sent as bare ESC[13u / ESC[9u / ESC[127u / ESC[32u).  With
+    # NumLock/CapsLock on, kitty sends ESC[13;129u / ESC[9;129u /
+    # ESC[127;129u / ESC[32;129u (129 = 1|128, etc.), which would
+    # otherwise leak as literal text.  Install via the lock-offset loop in
+    # _install_paired (mod 1 -> 65/129/193) (#88221).
+    _install_paired(1, {
+        13: Keys.ControlM,      # Enter
+        9: Keys.ControlI,       # Tab
+        127: Keys.Backspace,    # Backspace
+        32: " ",                # Space
     })
 
     # -- Kitty functional keys (Private Use Area codepoints) ----

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -433,3 +433,31 @@ def test_cmd_backspace_alias_not_clobbered():
     install_cmd_backspace_alias()
     install_modify_other_keys_aliases()
     assert _parse("\x1b[127;9u") == [Keys.ControlU]
+
+
+# ---------------------------------------------------------------------------
+# Kitty lock-key state bits (NumLock/CapsLock) — #88221
+# ---------------------------------------------------------------------------
+# kitty ORs CapsLock (64), NumLock (128), both (192) into the modifier
+# field of EVERY CSI-u event while the lock is on, so e.g. Backspace with
+# NumLock arrives as ESC[127;129u instead of ESC[127u. Those lock-offset
+# variants must decode to the same key as the base modifier — never leak
+# as literal text.
+
+@pytest.mark.parametrize("seq,expected", [
+    ("\x1b[127;129u", Keys.Backspace),          # Backspace + NumLock (1|128)
+    ("\x1b[127;65u",  Keys.Backspace),          # Backspace + CapsLock (1|64)
+    ("\x1b[127;193u", Keys.Backspace),          # Backspace + both (1|192)
+    ("\x1b[99;133u",  Keys.ControlC),           # Ctrl+C + NumLock (5|128)
+    ("\x1b[99;197u",  Keys.ControlC),           # Ctrl+C + both (5|192)
+    ("\x1b[13;129u",  Keys.ControlM),           # Enter + NumLock (1|128)
+    ("\x1b[9;129u",   Keys.ControlI),           # Tab + NumLock
+    ("\x1b[32;129u",  " "),                     # Space + NumLock
+    ("\x1b[27;129u",  Keys.Escape),             # Esc + NumLock
+    ("\x1b[27;65u",   Keys.Escape),             # Esc + CapsLock
+    ("\x1b[97;133u",  Keys.ControlA),           # Ctrl+A + NumLock
+])
+def test_lock_key_state_bits_do_not_leak(seq, expected):
+    """Lock-offset CSI-u variants must decode to the base key, not leak
+    as literal escape text (#88221)."""
+    assert _parse(seq) == [expected], f"{seq!r} leaked: {_parse(seq)!r}"


### PR DESCRIPTION
## Problem

In kitty with NumLock on, the CLI inserts raw CSI-u escape codes into the input box instead of acting on the keys: Backspace types `[127;129u`, Ctrl+C types `[99;133u` (the leading ESC is consumed, the rest lands as text). Plain letters keep working; with NumLock off everything works.

## Root cause

kitty ORs lock-key state into the modifier field of **every** CSI-u key event while a lock is on (CapsLock=64, NumLock=128, both=192). So Backspace with NumLock arrives as `ESC[127;129u` (modifier 129 = 1|128) instead of `ESC[127;5u`, and Ctrl+C as `ESC[99;133u` (modifier 133 = 5|128). The registrations in `hermes_cli/pt_input_extras.py` are exact-string entries — no lock-offset variant is in `ANSI_SEQUENCES`, so the VT100 parser leaks the sequence as literal text. Same failure class as zellij-org/zellij#4178.

Repro (real prompt_toolkit VT100 parser, before):
```
Backspace+NumLock (ESC[127;129u) -> [<Escape>, '[', '1', '2', '7', ';', '1', '2', '9', 'u']  (leaks)
Ctrl+C+NumLock    (ESC[99;133u)  -> [<Escape>, '[', '9', '9', ';', '1', '3', '3', 'u']       (leaks)
```

## Fix

Install **lock-offset variants** (`mod+64`, `mod+128`, `mod+192`) for every CSI-u / modifyOtherKeys mapping `_install_paired` registers, so the locked forms decode to the same key as the base modifier. Plus:

- **Lock-only forms (modifier 65/129/193)** for Enter/Tab/Backspace/Space, which have no modifier-1 entries (plain keys are sent bare `ESC[13u` etc.) — with a lock on, kitty sends `ESC[13;129u` / `ESC[127;129u` / `ESC[32;129u`.
- The **Esc-key loop** (`ESC[27;Nu`) gets the same lock-offset treatment.

After:
```
Backspace+NumLock -> [Keys.Backspace]  (was: 10 literal keypresses)
Ctrl+C+NumLock    -> [Keys.ControlC]
Enter+NumLock     -> [Keys.ControlM]
Esc+NumLock       -> [Keys.Escape]
```

## Tests

- 11 new parametrized cases in `tests/cli/test_modify_other_keys_aliases.py`: Backspace/Ctrl+C/Enter/Tab/Space/Esc under NumLock, CapsLock and both-locks variants, plus Ctrl+A+NumLock.
- Full file: **182/182 pass** (171 pre-existing + 11 new); sibling files `test_cli_cmd_backspace.py` + `test_cli_terminal_shortcuts.py`: **16/16 pass**.
