### PR TITLE
fix(models): recognize tilde-prefixed OpenRouter redirect aliases

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -6345,6 +6345,13 @@ def validate_requested_model(
             requested,
             api_key=api_key,
         ) or requested
+    # OpenRouter redirect aliases use a tilde prefix (~vendor/model) that is
+    # equivalent to vendor/model on the wire. Normalize it away for catalog
+    # and API lookups so a redirect alias is recognized instead of surfacing
+    # a false "not found" warning (#88181). The original name is kept for
+    # display, so users still see exactly what they typed.
+    if requested_for_lookup.startswith("~") and "/" in requested_for_lookup[1:]:
+        requested_for_lookup = requested_for_lookup[1:]
 
     if not requested:
         return {

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -487,6 +487,7 @@ class TestFormatPricePerMtok:
 
 
 
+
     def test_nous_list_includes_sonnet_5(self):
         from hermes_cli.models import _PROVIDER_MODELS
         assert "anthropic/claude-sonnet-5" in _PROVIDER_MODELS["nous"]
@@ -1482,3 +1483,74 @@ class TestLocalOllamaModelDiscovery:
 
         assert result.success is True
         assert result.api_key == "no-key-required"
+
+
+class TestTildeRedirectAliasLookup:
+    """OpenRouter redirect aliases (~vendor/model) must be recognized as the
+    equivalent vendor/model instead of surfacing a false not-found warning
+    (#88181)."""
+
+    def test_tilde_alias_matches_redirect_target_directly(self):
+        # The /v1/models listing returns the redirect TARGET (no tilde).
+        # The tilde prefix must be normalized away for lookup so the alias
+        # hits the set-membership check instead of relying on auto-correct.
+        with patch.object(
+            _models_mod, "fetch_api_models",
+            return_value=["deepseek/deepseek-v4-flash-latest", "deepseek/deepseek-v4-flash"],
+        ):
+            result = _models_mod.validate_requested_model(
+                "~deepseek/deepseek-v4-flash-latest",
+                "openrouter",
+                api_key="sk-test",
+                base_url="https://openrouter.ai/api/v1",
+            )
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+        assert result.get("corrected_model") is None
+        assert result.get("message") is None
+
+    def test_tilde_alias_matches_tilde_form(self):
+        with patch.object(
+            _models_mod, "fetch_api_models",
+            return_value=["~deepseek/deepseek-v4-flash-latest"],
+        ):
+            result = _models_mod.validate_requested_model(
+                "~deepseek/deepseek-v4-flash-latest",
+                "openrouter",
+                api_key="sk-test",
+                base_url="https://openrouter.ai/api/v1",
+            )
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+
+    def test_non_tilde_vendor_model_name_unchanged(self):
+        with patch.object(
+            _models_mod, "fetch_api_models",
+            return_value=["deepseek/deepseek-v4-flash-latest"],
+        ):
+            result = _models_mod.validate_requested_model(
+                "deepseek/deepseek-v4-flash-latest",
+                "openrouter",
+                api_key="sk-test",
+                base_url="https://openrouter.ai/api/v1",
+            )
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+
+    def test_tilde_without_vendor_slash_kept_for_lookup(self):
+        # A tilde-prefixed name with no vendor/ part is not an OpenRouter
+        # redirect alias — leave it untouched so a matching literal entry
+        # still resolves.
+        with patch.object(
+            _models_mod, "fetch_api_models",
+            return_value=["~weird"],
+        ):
+            result = _models_mod.validate_requested_model(
+                "~weird",
+                "openrouter",
+                api_key="sk-test",
+                base_url="https://openrouter.ai/api/v1",
+            )
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+


### PR DESCRIPTION
## Summary

Fixes #88181: OpenRouter redirect aliases use a tilde prefix (`~vendor/model`) that is equivalent to `vendor/model` on the wire, but `validate_requested_model` looked up the raw name. When the redirect target was listed in /v1/models (or a curated catalog), the alias surfaced a false "not found" warning while the switch itself succeeded.

## Approach

Normalize the tilde prefix away for catalog/API lookups in `validate_requested_model`, keeping the original name for display so users still see exactly what they typed:

- `~deepseek/deepseek-v4-flash-latest` → lookup `deepseek/deepseek-v4-flash-latest`
- Only applied when the name starts with `~` AND contains a `/` (a genuine `~vendor/model` redirect); a bare tilde name with no vendor part is left untouched.
- Non-tilde names are unaffected.

Reproduction (local, mocked API): before the fix, with /v1/models returning `deepseek/deepseek-v4-flash-latest` (the redirect target), validating `~deepseek/deepseek-v4-flash-latest` only passed via the auto-correct path; with the fix it hits the set-membership check deterministically (recognized=True, no corrected_model, no message).

## Test Plan

- 4 new tests in `TestTildeRedirectAliasLookup`: redirect-target match / tilde-form match / non-tilde unchanged / tilde-without-vendor kept.
- `tests/hermes_cli/test_models.py`: 34/34 pass.
- model_switch callers (configured-provider-routing, copilot-api-mode, custom-providers, base-url-host-identity): 64/64 pass.
- `ruff check` clean; `scripts/check-windows-footguns.py` clean.

## Risk / Exclusions

- Lookup-only change; the stored/displayed model name keeps the tilde exactly as configured.
- No changes to normalization, provider routing, or the switch flow.

References #88181