### PR TITLE
fix: stop OpenAI-only extra_body keys 400ing native Anthropic calls

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -3114,7 +3114,85 @@ _RESPONSES_ONLY_KWARGS = frozenset(
 )
 
 
-def sanitize_anthropic_kwargs(api_kwargs: Any, *, log_prefix: str = "") -> Any:
+# Keys that belong exclusively to the OpenAI *chat.completions* wire shape.
+# Unlike ``_RESPONSES_ONLY_KWARGS`` these do not raise locally: the SDK
+# forwards ``extra_body`` verbatim into the request body, so they reach
+# api.anthropic.com and come back as a hard, non-retryable::
+#
+#     400 invalid_request_error: <key>: Extra inputs are not permitted
+#
+# Callers legitimately pass these for OpenAI-wire providers (auxiliary tasks
+# reuse one call site across every provider — e.g. title generation asks for
+# ``response_format`` JSON-schema output), so the caller is not wrong; the
+# translation boundary is. Verified live against api.anthropic.com: every key
+# below returns the 400 above, as does any unrecognised vendor key.
+_OPENAI_ONLY_EXTRA_BODY_KEYS = frozenset(
+    {
+        "response_format",
+        "frequency_penalty",
+        "presence_penalty",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "n",
+        "seed",
+        "modalities",
+        "prediction",
+        "stream_options",
+        "max_completion_tokens",
+        "parallel_tool_calls",
+    }
+)
+
+
+def _strip_openai_only_extra_body(
+    api_kwargs: dict, *, base_url: Any = None, log_prefix: str = ""
+) -> None:
+    """Drop OpenAI-chat-only ``extra_body`` keys on native Anthropic calls.
+
+    Only applies to first-party ``api.anthropic.com``. Anthropic-compatible
+    gateways (Bedrock, Foundry, Kimi, DeepSeek, MiniMax, self-hosted proxies)
+    deliberately accept vendor-specific body fields, and several Hermes
+    features depend on that passthrough — stripping there would break them.
+    """
+    extra_body = api_kwargs.get("extra_body")
+    if not isinstance(extra_body, dict) or not extra_body:
+        return
+    if _is_third_party_anthropic_endpoint(
+        base_url if isinstance(base_url, str) else (str(base_url) if base_url else None)
+    ):
+        return
+    leaked = _OPENAI_ONLY_EXTRA_BODY_KEYS.intersection(extra_body)
+    if not leaked:
+        return
+    remaining = {k: v for k, v in extra_body.items() if k not in leaked}
+    if remaining:
+        api_kwargs["extra_body"] = remaining
+    else:
+        api_kwargs.pop("extra_body", None)
+    logger.debug(
+        "%sStripped OpenAI-only extra_body key(s) %s from a native Anthropic "
+        "Messages call; the API rejects them with 400 'Extra inputs are not "
+        "permitted'. Callers that share one code path across providers (e.g. "
+        "auxiliary title generation requesting response_format) are expected "
+        "to hit this and degrade to prose parsing.",
+        log_prefix,
+        sorted(leaked),
+    )
+
+
+def _client_base_url(client: Any) -> Optional[str]:
+    """Best-effort base_url for an Anthropic SDK client (never raises)."""
+    try:
+        value = getattr(client, "base_url", None)
+        return str(value) if value else None
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def sanitize_anthropic_kwargs(
+    api_kwargs: Any, *, log_prefix: str = "", base_url: Any = None
+) -> Any:
     """Drop Responses-API-only keys before an Anthropic Messages SDK call.
 
     Defensive boundary guard for #31673: under rare api_mode-flip races
@@ -3128,9 +3206,19 @@ def sanitize_anthropic_kwargs(api_kwargs: Any, *, log_prefix: str = "") -> Any:
     Mutates ``api_kwargs`` in place and returns it. When a foreign key is
     present we log a WARNING so the underlying race stays visible in the
     wild instead of being silently papered over.
+
+    ``base_url`` enables the second guard: OpenAI-chat-only ``extra_body``
+    keys are stripped for first-party ``api.anthropic.com`` calls, which
+    reject them with a hard 400. Anthropic-compatible gateways keep their
+    passthrough. Omitting it means "direct Anthropic", matching
+    ``_is_third_party_anthropic_endpoint``'s own convention, so the default
+    call path is protected rather than exempt.
     """
     if not isinstance(api_kwargs, dict):
         return api_kwargs
+    _strip_openai_only_extra_body(
+        api_kwargs, base_url=base_url, log_prefix=log_prefix
+    )
     leaked = _RESPONSES_ONLY_KWARGS.intersection(api_kwargs)
     if leaked:
         for _key in leaked:
@@ -3190,7 +3278,9 @@ def create_anthropic_message(
     in particular. Only fires on the streaming path, which is the one the main
     turn loop takes.
     """
-    sanitize_anthropic_kwargs(api_kwargs, log_prefix=log_prefix)
+    sanitize_anthropic_kwargs(
+        api_kwargs, log_prefix=log_prefix, base_url=_client_base_url(client)
+    )
 
     messages_api = getattr(client, "messages", None)
     stream_fn = getattr(messages_api, "stream", None)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4487,7 +4487,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         base_final_message = None
 
         from agent import relay_llm
-        from agent.anthropic_adapter import sanitize_anthropic_kwargs
+        from agent.anthropic_adapter import (
+            _client_base_url,
+            sanitize_anthropic_kwargs,
+        )
 
         accumulator = relay_llm.AnthropicStreamAccumulator()
 
@@ -4496,6 +4499,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             sanitize_anthropic_kwargs(
                 final_kwargs,
                 log_prefix=getattr(agent, "log_prefix", ""),
+                base_url=_client_base_url(request_client),
             )
             manager = request_client.messages.stream(**final_kwargs)
             _stream_context["manager"] = manager

--- a/tests/agent/test_anthropic_kwargs_sanitize.py
+++ b/tests/agent/test_anthropic_kwargs_sanitize.py
@@ -7,11 +7,15 @@ non-retryable ``TypeError`` on any of them, killing the whole turn.
 """
 
 import logging
+from types import SimpleNamespace
 
 import pytest
 
 from agent.anthropic_adapter import (
+    _OPENAI_ONLY_EXTRA_BODY_KEYS,
     _RESPONSES_ONLY_KWARGS,
+    _client_base_url,
+    create_anthropic_message,
     sanitize_anthropic_kwargs,
 )
 
@@ -63,6 +67,168 @@ def test_warns_when_keys_are_stripped(caplog):
         "31673" in r.message and "[pfx] " in r.message
         for r in caplog.records
     ), caplog.records
+
+
+class TestOpenAIOnlyExtraBodyStripping:
+    """OpenAI chat-shape ``extra_body`` keys must not reach api.anthropic.com.
+
+    These differ from the Responses-only kwargs above: the SDK accepts them
+    locally and forwards ``extra_body`` verbatim, so the failure is a hard
+    remote 400 ``<key>: Extra inputs are not permitted`` rather than a local
+    TypeError. Verified live against api.anthropic.com for every key in
+    ``_OPENAI_ONLY_EXTRA_BODY_KEYS``.
+
+    Real-world symptom: session title generation passes
+    ``extra_body={"response_format": {...json_schema...}}`` because it shares
+    one call site across all providers; on an Anthropic-routed auxiliary task
+    every title request 400s and sessions fall back to derived titles.
+    """
+
+    ANTHROPIC = "https://api.anthropic.com"
+
+    def test_response_format_stripped_for_native_anthropic(self):
+        payload = {
+            "model": "claude-opus-5",
+            "extra_body": {
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {"name": "session_title"},
+                }
+            },
+        }
+        sanitize_anthropic_kwargs(payload, base_url=self.ANTHROPIC)
+        assert "extra_body" not in payload, (
+            "extra_body should be dropped entirely once its only key is "
+            "removed -- an empty dict is pointless request weight"
+        )
+
+    def test_every_known_openai_only_key_is_stripped(self):
+        for key in sorted(_OPENAI_ONLY_EXTRA_BODY_KEYS):
+            payload = {"model": "m", "extra_body": {key: "x"}}
+            sanitize_anthropic_kwargs(payload, base_url=self.ANTHROPIC)
+            assert "extra_body" not in payload, f"{key} survived stripping"
+
+    def test_anthropic_native_extra_body_keys_survive(self):
+        """Only the OpenAI-shaped keys go; genuine passthrough is preserved."""
+        payload = {
+            "model": "m",
+            "extra_body": {
+                "response_format": {"type": "json_object"},
+                "speed": "fast",
+                "metadata": {"user_id": "abc"},
+            },
+        }
+        sanitize_anthropic_kwargs(payload, base_url=self.ANTHROPIC)
+        assert payload["extra_body"] == {
+            "speed": "fast",
+            "metadata": {"user_id": "abc"},
+        }
+
+    def test_third_party_gateways_keep_their_passthrough(self):
+        """Anthropic-compatible proxies deliberately accept vendor fields."""
+        for base_url in (
+            "https://api.moonshot.ai/anthropic",
+            "https://api.deepseek.com/anthropic",
+            "https://bedrock-runtime.eu-west-2.amazonaws.com",
+            "https://my-proxy.internal/v1",
+        ):
+            payload = {
+                "model": "m",
+                "extra_body": {"response_format": {"type": "json_object"}},
+            }
+            sanitize_anthropic_kwargs(payload, base_url=base_url)
+            assert payload["extra_body"] == {
+                "response_format": {"type": "json_object"}
+            }, f"{base_url} lost its vendor passthrough"
+
+    def test_omitted_base_url_defaults_to_native_anthropic(self):
+        """No base_url means direct api.anthropic.com, so the guard applies.
+
+        This matches ``_is_third_party_anthropic_endpoint``'s own documented
+        convention ("No base_url = direct Anthropic API"). Defaulting the
+        other way would leave the default call path -- the one that actually
+        400s in production -- unprotected.
+        """
+        payload = {
+            "model": "m",
+            "extra_body": {"response_format": {"type": "json_object"}},
+        }
+        sanitize_anthropic_kwargs(payload)
+        assert "extra_body" not in payload
+
+    def test_non_dict_and_empty_extra_body_are_safe(self):
+        for value in (None, {}, "not-a-dict", 42):
+            payload = {"model": "m", "extra_body": value}
+            sanitize_anthropic_kwargs(payload, base_url=self.ANTHROPIC)
+        payload = {"model": "m"}
+        sanitize_anthropic_kwargs(payload, base_url=self.ANTHROPIC)
+        assert payload == {"model": "m"}
+
+    def test_both_guards_apply_in_one_call(self):
+        """Responses-only kwargs and OpenAI extra_body keys strip together."""
+        payload = {
+            "model": "m",
+            "instructions": "sys",
+            "extra_body": {"seed": 7, "speed": "fast"},
+        }
+        sanitize_anthropic_kwargs(payload, base_url=self.ANTHROPIC)
+        assert payload == {"model": "m", "extra_body": {"speed": "fast"}}
+
+    def test_parallel_tool_calls_covered_by_both_lists(self):
+        """It is a top-level Responses kwarg AND an OpenAI body key."""
+        assert "parallel_tool_calls" in _RESPONSES_ONLY_KWARGS
+        assert "parallel_tool_calls" in _OPENAI_ONLY_EXTRA_BODY_KEYS
+        payload = {
+            "model": "m",
+            "parallel_tool_calls": True,
+            "extra_body": {"parallel_tool_calls": True},
+        }
+        sanitize_anthropic_kwargs(payload, base_url=self.ANTHROPIC)
+        assert payload == {"model": "m"}
+
+
+class TestClientBaseUrlHelper:
+    def test_reads_base_url_from_client(self):
+        client = SimpleNamespace(base_url="https://api.anthropic.com")
+        assert _client_base_url(client) == "https://api.anthropic.com"
+
+    def test_missing_or_raising_attribute_returns_none(self):
+        assert _client_base_url(SimpleNamespace()) is None
+
+        class Exploding:
+            @property
+            def base_url(self):
+                raise RuntimeError("boom")
+
+        assert _client_base_url(Exploding()) is None
+
+
+class TestCreateAnthropicMessageIntegration:
+    """The guard must be wired into the real dispatch path, not just callable."""
+
+    def test_create_anthropic_message_strips_before_dispatch(self):
+        seen = {}
+
+        class FakeMessages:
+            def stream(self, **kwargs):
+                seen.update(kwargs)
+                raise RuntimeError("stop-after-capture")
+
+        client = SimpleNamespace(
+            base_url="https://api.anthropic.com", messages=FakeMessages()
+        )
+        payload = {
+            "model": "claude-opus-5",
+            "max_tokens": 8,
+            "messages": [{"role": "user", "content": "hi"}],
+            "extra_body": {"response_format": {"type": "json_object"}},
+        }
+        with pytest.raises(RuntimeError, match="stop-after-capture"):
+            create_anthropic_message(client, payload)
+        assert "extra_body" not in seen, (
+            "create_anthropic_message must strip OpenAI-only extra_body keys "
+            "before they reach the Anthropic SDK"
+        )
 
 
 


### PR DESCRIPTION
## Problem

Auxiliary tasks share one call site across every provider, so callers pass OpenAI chat-shape request fields via `extra_body`. The Anthropic SDK forwards `extra_body` verbatim into the request body, so on a native `api.anthropic.com` route these reach the API and come back as a hard, non-retryable error:

```
400 invalid_request_error: response_format: Extra inputs are not permitted
```

Observed in production as **every session title failing** on an Anthropic-routed `title_generation` task — `agent/title_generator.py:404` passes a `json_schema` `response_format`:

```
WARNING agent.title_generator: Title generation failed: Error code: 400 -
{'type': 'error', 'error': {'type': 'invalid_request_error',
 'message': 'response_format: Extra inputs are not permitted'}}
```

Sessions silently degrade to derived titles. The caller is not wrong — it is provider-agnostic by design — the **translation boundary** is missing a guard.

## Fix

`sanitize_anthropic_kwargs` already guards this exact dispatch point against Responses-API-only kwargs (#31673). This extends it to the `extra_body` dict. Responses-only kwargs raise a local `TypeError`; these fail remotely — but it is the same boundary and the same class of bug, so it belongs in the same place rather than in a new one.

**Scoped to first-party Anthropic** via the existing `_is_third_party_anthropic_endpoint` check. Bedrock, Foundry, Kimi, DeepSeek, MiniMax and self-hosted proxies deliberately accept vendor body fields, and Hermes features depend on that passthrough — stripping there would break them. Both dispatch sites (`create_anthropic_message` and the streaming path in `chat_completion_helpers`) now pass the client `base_url` so the guard can tell them apart.

Native Anthropic `extra_body` keys (`speed`, `metadata`) are untouched.

## Verified live against api.anthropic.com

Every key below returns the 400, as does any unrecognised vendor key:

`response_format`, `frequency_penalty`, `presence_penalty`, `logit_bias`, `logprobs`, `top_logprobs`, `n`, `seed`, `modalities`, `prediction`, `stream_options`, `max_completion_tokens`, `parallel_tool_calls`

## Tests

11 new cases in `tests/agent/test_anthropic_kwargs_sanitize.py`:

- every listed key is stripped
- third-party gateways keep their passthrough (4 endpoint shapes)
- mixed native/OpenAI dicts keep only the native keys
- both guards firing in one call
- `parallel_tool_calls` covered by both lists
- non-dict / empty / missing `extra_body` are safe
- `_client_base_url` helper incl. a raising property
- integration test asserting `create_anthropic_message` strips **before** the SDK sees the payload

**RED verified behaviourally on unpatched `main`** — `extra_body` reaches the SDK carrying `response_format`. **GREEN after:** 14 passed.

Regression sweep over all anthropic/auxiliary/title/chat_completion suites: **591 passed, 8 skipped**. Two pre-existing failures in `test_auxiliary_main_first.py::TestResolveVisionCustomProvider` (test-ordering pollution) reproduce identically on pristine `main` with this patch stashed — unrelated to this change.
