### PR TITLE
feat(desktop): collapse completed file edit diffs by default

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -369,7 +369,10 @@ function ToolEntry({ part }: ToolEntryProps) {
   const sideDiff = useStore($toolInlineDiff(toolCallId ?? ''))
   const inlineDiff = stripInlineDiffChrome(sideDiff) || inlineDiffFromResult(result)
   const isFileEdit = isFileEditTool(toolName)
-  const defaultOpen = Boolean(inlineDiff)
+  // Completed edits stay compact in the transcript; an in-flight edit with a
+  // streamed diff remains open so progress is not hidden. Other tools keep
+  // their existing reviewable-output default.
+  const defaultOpen = Boolean(inlineDiff) && (!isFileEdit || isPending)
   const open = useDisclosureOpen(disclosureId, defaultOpen)
   const canDismiss = !isPending && !embedded
   // Only animate entries that mount while their message is actively

--- a/apps/desktop/src/components/assistant-ui/tool/tool-group.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-group.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { $displayTimestamps } from '@/store/display-timestamps'
 import { clearAllPrompts, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
+import { recordToolDiff } from '@/store/tool-diffs'
 import { clearDismissedToolRows } from '@/store/tool-dismiss'
 import { $toolDisclosureStates } from '@/store/tool-view'
 
@@ -292,6 +293,31 @@ function editBetweenRunsMessage(): ThreadMessage {
   } as unknown as ThreadMessage
 }
 
+function streamingFileEditMessage(): ThreadMessage {
+  return {
+    id: 'assistant-streaming-file-edit',
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'patch-streaming',
+        toolName: 'patch',
+        args: { path: '/repo/src/live.ts' },
+        argsText: JSON.stringify({ path: '/repo/src/live.ts' })
+      }
+    ],
+    status: { type: 'running' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as unknown as ThreadMessage
+}
+
 // A finished turn that left a call without a result — interrupted, or the
 // result landed elsewhere. The run is history and has to behave like it.
 function abandonedRunMessage(): ThreadMessage {
@@ -478,12 +504,44 @@ describe('a file edit among ordinary activity', () => {
     expect(shape).toEqual(['summary', 'row', 'summary'])
   })
 
-  it('keeps the diff itself on screen rather than behind the summary', async () => {
+  it('keeps the edit row visible, starts it collapsed, and expands its diff on click', async () => {
     const { container } = render(<GroupHarness message={editBetweenRunsMessage()} />)
 
-    await waitFor(() => {
-      expect(container.querySelector('[data-tool-row][data-file-edit]')).not.toBeNull()
+    const row = await waitFor(() => {
+      const candidate = container.querySelector('[data-tool-row]')
+      expect(candidate).not.toBeNull()
+
+      return candidate as HTMLElement
     })
+
+    const trigger = row.querySelector('button[aria-expanded]') as HTMLButtonElement
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(row.hasAttribute('data-file-edit')).toBe(false)
+    expect(row.hasAttribute('data-tool-open')).toBe(false)
+
+    fireEvent.click(trigger)
+
+    expect(row.hasAttribute('data-file-edit')).toBe(true)
+    expect(row.hasAttribute('data-tool-open')).toBe(true)
+  })
+
+  it('keeps an in-flight file edit open while its diff is streaming', async () => {
+    recordToolDiff('patch-streaming', '--- a\n+++ b\n+streamed line')
+    const { container } = render(<GroupHarness message={streamingFileEditMessage()} />)
+
+    const row = await waitFor(() => {
+      const candidate = container.querySelector('[data-tool-row]')
+      expect(candidate).not.toBeNull()
+
+      return candidate as HTMLElement
+    })
+
+    const trigger = row.querySelector('button[aria-expanded]') as HTMLButtonElement
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(row.hasAttribute('data-file-edit')).toBe(true)
+    expect(row.hasAttribute('data-tool-open')).toBe(true)
   })
 })
 


### PR DESCRIPTION
## What does this PR do?

Keeps completed file-edit entries visible in the Desktop transcript, but starts their inline diff disclosure collapsed. The full diff remains one click away.

In-flight file edits with a streamed diff remain open so active progress is never hidden. Other tool cards keep their existing default disclosure behavior.

## Why?

Long tool-heavy sessions can accumulate several expanded patch/write diffs. Once an edit has completed, the compact row already communicates the edited file and line counts; keeping every full diff open makes the final answer harder to reach.

This is intentionally smaller than a general "response-only" or "hide tool activity" preference. It does not hide file edits, approvals, errors, or tool history.

Related: #86133 and #76147.

## Type of Change

- [x] UI/UX improvement
- [x] Tests

## Changes Made

- Collapse file-edit disclosures after completion even when an inline diff is available.
- Keep in-flight file edits open when a streamed diff is present.
- Preserve the existing expanded-only `data-file-edit` marker and spacing behavior.
- Update the transcript grouping test to verify that the edit row remains visible and its diff can still be expanded.

## How to Test

```bash
cd apps/desktop
npm run test:ui
npm run typecheck
npm run lint -- src/components/assistant-ui/tool/fallback.tsx src/components/assistant-ui/tool/tool-group.test.tsx
```

Local results:

- UI: 492 test files passed, 4,566 tests passed.
- Focused tool-group suite: 21 tests passed.
- Typecheck: passed.
- Focused ESLint: passed with no warnings. Full project lint completed with 0 errors and 110 pre-existing warnings.

## Safety / Compatibility

- No tool execution, approval, persistence, or backend behavior changes.
- No file edit is removed from the transcript.
- Errors retain their existing behavior.
- Active streamed diffs remain visible.
- No configuration migration is required.

## Checklist

- [x] Searched for existing issues and PRs.
- [x] Kept the change focused on one Desktop behavior.
- [x] Added regression coverage.
- [x] Verified the full Desktop UI suite locally.
- [x] Typecheck and lint pass on the final diff.
