### PR TITLE
fix(contributors): case-collision sidecar for emails differing only by letter case

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -27,6 +27,27 @@ jobs:
           # Get the merge base between this PR and main
           MERGE_BASE=$(git merge-base origin/main HEAD)
 
+          # Reject case-only filename collisions in contributors/emails/:
+          # two entries differing only by letter case are the same file on
+          # macOS/Windows checkouts, which dirties every working tree and
+          # blocks rebase/merge (see #88257). Colliding mappings belong in
+          # contributors/emails.caseless.json instead.
+          python3 - <<'PY'
+          import sys
+          from pathlib import Path
+          d = Path("contributors/emails")
+          seen = {}
+          for p in sorted(d.iterdir()) if d.is_dir() else []:
+              key = p.name.casefold()
+              if key in seen:
+                  sys.exit(
+                      f"contributors/emails: case-only collision between "
+                      f"{seen[key]!r} and {p.name!r}; move one into "
+                      f"contributors/emails.caseless.json (#88257)"
+                  )
+              seen[key] = p.name
+          PY
+
           # Find any new author emails in this PR's commits
           NEW_EMAILS=$(git log ${MERGE_BASE}..HEAD --format='%ae' --no-merges | sort -u)
 
@@ -38,8 +59,9 @@ jobs:
           fi
 
           # An email is mapped if it has a file in contributors/emails/
-          # (one file per email — conflict-free) or an entry in the frozen
-          # legacy AUTHOR_MAP in scripts/release.py.
+          # (one file per email — conflict-free), an entry in the frozen
+          # legacy AUTHOR_MAP in scripts/release.py, or an entry in
+          # contributors/emails.caseless.json (case-colliding emails).
           MISSING=""
           while IFS= read -r email; do
             # Skip teknium and bot emails
@@ -54,6 +76,10 @@ jobs:
 
             if [ -f "contributors/emails/${email}" ]; then
               continue  # mapped via the contributors directory
+            fi
+
+            if grep -qF "\"${email}\"" contributors/emails.caseless.json 2>/dev/null; then
+              continue  # mapped via the case-collision sidecar
             fi
 
             if ! grep -qF "\"${email}\"" scripts/release.py 2>/dev/null; then

--- a/contributors/README.md
+++ b/contributors/README.md
@@ -32,6 +32,14 @@ janedoe
 - Do NOT add new entries to `AUTHOR_MAP` in `scripts/release.py`. That dict
   is frozen legacy data; the release tooling merges it with this directory
   (directory entries win on duplicates).
+- **Case-colliding emails go in `emails.caseless.json`, not the directory.**
+  Two emails that differ only by letter case (e.g. `agent@Agents-Mac-mini.local`
+  and `agent@agents-Mac-mini.local`) are two distinct git identities but the
+  *same file* on case-insensitive filesystems (macOS APFS, Windows NTFS), so
+  the directory can never hold both. Such mappings live as `"email": "login"`
+  entries in `contributors/emails.caseless.json`; `scripts/add_contributor.py`
+  detects the collision and writes there automatically, and the CI job rejects
+  new case-only filename collisions in `emails/` (#88257).
 - GitHub noreply emails (`<id>+<login>@users.noreply.github.com` and
   `<login>@users.noreply.github.com`) auto-resolve — no file needed.
 - The `Contributor Attribution Check` CI job fails a PR whose commits carry

--- a/contributors/emails.caseless.json
+++ b/contributors/emails.caseless.json
@@ -1,0 +1,3 @@
+{
+  "agent@Agents-Mac-mini.local": "skip-agent"
+}

--- a/contributors/emails/agent@Agents-Mac-mini.local
+++ b/contributors/emails/agent@Agents-Mac-mini.local
@@ -1,1 +1,0 @@
-skip-agent

--- a/scripts/add_contributor.py
+++ b/scripts/add_contributor.py
@@ -55,6 +55,56 @@ def _legacy_login(email: str) -> str | None:
         return None
 
 
+# Emails whose filename would differ from another entry only by letter case
+# cannot live in contributors/emails/ (same file on macOS/Windows): they go
+# in this sidecar instead. See contributors/README.md and #88257.
+CASELESS_SIDECAR = REPO_ROOT / "contributors" / "emails.caseless.json"
+
+
+def _dir_names(emails_dir: Path | None = None) -> set[str]:
+    """Actual on-disk mapping filenames (case as stored by the filesystem)."""
+    emails_dir = emails_dir or EMAILS_DIR
+    if not emails_dir.is_dir():
+        return set()
+    return {p.name for p in emails_dir.iterdir()}
+
+
+def _caseless_collision(email: str, emails_dir: Path | None = None) -> bool:
+    """True when another mapping file differs from ``email`` only by case."""
+    names = _dir_names(emails_dir)
+    return any(
+        name != email and name.casefold() == email.casefold() for name in names
+    )
+
+
+def _sidecar_login(email: str) -> str | None:
+    """Look the email up in contributors/emails.caseless.json."""
+    try:
+        import json
+
+        data = json.loads(CASELESS_SIDECAR.read_text(encoding="utf-8"))
+        login = data.get(email) if isinstance(data, dict) else None
+        return str(login).lstrip("@") if login else None
+    except (OSError, ValueError):
+        return None
+
+
+def _write_sidecar(email: str, login: str) -> None:
+    import json
+
+    try:
+        data = json.loads(CASELESS_SIDECAR.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            data = {}
+    except (OSError, ValueError):
+        data = {}
+    data[email] = login
+    CASELESS_SIDECAR.parent.mkdir(parents=True, exist_ok=True)
+    CASELESS_SIDECAR.write_text(
+        json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
 def add_contributor(email: str, login: str, comment: str = "") -> int:
     email = email.strip()
     login = login.strip().lstrip("@")
@@ -66,8 +116,21 @@ def add_contributor(email: str, login: str, comment: str = "") -> int:
         print(f"error: {login!r} is not a valid GitHub login", file=sys.stderr)
         return 2
 
-    path = EMAILS_DIR / email
-    existing = read_mapping_file(path) if path.is_file() else None
+    dir_names = _dir_names()
+    colliding = any(
+        name != email and name.casefold() == email.casefold()
+        for name in dir_names
+    )
+    existing = None
+    # Existence is checked against the on-disk NAME LIST, not path.is_file():
+    # on case-insensitive filesystems the path of a case-variant email
+    # resolves to the variant's file and would read the WRONG login. On
+    # case-sensitive filesystems where both variants exist as files, the
+    # exact-name mapping must still be honored (refuse-on-different-login).
+    if email in dir_names:
+        existing = read_mapping_file(EMAILS_DIR / email)
+    if existing is None:
+        existing = _sidecar_login(email)
     if existing is None:
         existing = _legacy_login(email)
     if existing is not None:
@@ -81,7 +144,17 @@ def add_contributor(email: str, login: str, comment: str = "") -> int:
         )
         return 1
 
+    if colliding:
+        # Writing contributors/emails/<email> would either clobber the
+        # case-variant mapping on case-insensitive filesystems or recreate
+        # the collision the sidecar exists to avoid.
+        _write_sidecar(email, login)
+        print(f"added: contributors/emails.caseless.json[{email}] -> {login} "
+              "(case-collides with an existing mapping)")
+        return 0
+
     EMAILS_DIR.mkdir(parents=True, exist_ok=True)
+    path = EMAILS_DIR / email
     body = login + "\n"
     if comment:
         body += f"# {comment}\n"

--- a/scripts/audit_pr_attribution.py
+++ b/scripts/audit_pr_attribution.py
@@ -68,6 +68,16 @@ def is_mapped(email: str) -> bool:
         return True
     if (REPO_ROOT / "contributors" / "emails" / email).is_file():
         return True
+    # Case-colliding emails live in the sidecar, not the directory (#88257).
+    sidecar = REPO_ROOT / "contributors" / "emails.caseless.json"
+    try:
+        import json
+
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and email in data:
+            return True
+    except (OSError, ValueError):
+        pass
     release_py = REPO_ROOT / "scripts" / "release.py"
     try:
         if f'"{email}"' in release_py.read_text(encoding="utf-8", errors="replace"):

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2077,6 +2077,11 @@ LEGACY_AUTHOR_MAP = {
 # Directory-based mappings: contributors/emails/<email> → login
 # ──────────────────────────────────────────────────────────────────────
 CONTRIBUTORS_EMAILS_DIR = REPO_ROOT / "contributors" / "emails"
+# Collision-free store for emails whose filename would differ from another
+# entry only by letter case (e.g. agent@Agents vs agent@agents): on
+# case-insensitive filesystems (macOS APFS, Windows NTFS) those two names
+# are the same file, so a directory entry can never be checked out cleanly.
+CONTRIBUTORS_CASELESS_SIDECAR = REPO_ROOT / "contributors" / "emails.caseless.json"
 
 
 def _load_contributor_dir(directory: "Path | None" = None) -> dict:
@@ -2104,8 +2109,38 @@ def _load_contributor_dir(directory: "Path | None" = None) -> dict:
     return mapping
 
 
-# Effective map: frozen legacy dict + directory entries (directory wins).
-AUTHOR_MAP = {**LEGACY_AUTHOR_MAP, **_load_contributor_dir()}
+def _load_caseless_sidecar(path: "Path | None" = None) -> dict:
+    """Load contributors/emails.caseless.json (email → login).
+
+    Holds mappings whose email case-collides with another entry and so
+    cannot live in the one-file-per-email directory. Malformed or missing
+    file yields an empty dict; a non-string value is skipped rather than
+    crashing the release tooling.
+    """
+    import json
+
+    path = path or CONTRIBUTORS_CASELESS_SIDECAR
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {
+        email: str(login).lstrip("@")
+        for email, login in data.items()
+        if isinstance(email, str) and login
+    }
+
+
+# Effective map: frozen legacy dict + directory entries (directory wins)
+# + case-colliding sidecar entries (sidecar wins: deterministic for the
+# exact emails it exists for).
+AUTHOR_MAP = {
+    **LEGACY_AUTHOR_MAP,
+    **_load_contributor_dir(),
+    **_load_caseless_sidecar(),
+}
 
 
 def git(*args, cwd=None):

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -69,6 +69,99 @@ def test_add_creates_mapping_file(emails_dir):
     assert "# PR #999 salvage" in path.read_text()
 
 
+# ── case-collision sidecar behavior (#88257) ──────────────────────────
+
+
+@pytest.fixture()
+def sidecar(tmp_path, monkeypatch):
+    import add_contributor
+
+    path = tmp_path / "contributors" / "emails.caseless.json"
+    monkeypatch.setattr(add_contributor, "CASELESS_SIDECAR", path)
+    return path
+
+
+def test_sidecar_loader_reads_json_and_skips_malformed(tmp_path):
+    good = tmp_path / "caseless.json"
+    good.write_text('{"A@x.com": "alice", "empty@x.com": ""}\n')
+    assert release._load_caseless_sidecar(good) == {"A@x.com": "alice"}
+    assert release._load_caseless_sidecar(tmp_path / "missing.json") == {}
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json")
+    assert release._load_caseless_sidecar(bad) == {}
+    wrong = tmp_path / "wrong.json"
+    wrong.write_text('["not", "a", "dict"]')
+    assert release._load_caseless_sidecar(wrong) == {}
+
+
+def test_effective_map_includes_sidecar():
+    sidecar_map = release._load_caseless_sidecar()
+    for email, login in sidecar_map.items():
+        assert release.AUTHOR_MAP[email] == login
+
+
+def test_case_colliding_email_goes_to_sidecar(emails_dir, sidecar):
+    # A case-variant of an existing mapping cannot become a file (it would
+    # clobber the other entry on case-insensitive filesystems).
+    emails_dir.mkdir(parents=True, exist_ok=True)
+    (emails_dir / "agent@agents-mac-mini.local").write_text("momomojo\n")
+    rc = add_contributor("agent@Agents-Mac-mini.local", "skip-agent")
+    assert rc == 0
+    # is_file() on the capital path is unusable on case-insensitive
+    # filesystems (it resolves to the lowercase file); the on-disk name
+    # list is the FS-neutral check: no capital-case entry was created.
+    on_disk_names = [p.name for p in emails_dir.iterdir()]
+    assert "agent@Agents-Mac-mini.local" not in on_disk_names
+    import json
+
+    data = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert data["agent@Agents-Mac-mini.local"] == "skip-agent"
+    # The pre-existing mapping is untouched.
+    assert read_mapping_file(emails_dir / "agent@agents-mac-mini.local") == "momomojo"
+
+
+def test_sidecar_entry_is_idempotent(emails_dir, sidecar):
+    emails_dir.mkdir(parents=True, exist_ok=True)
+    (emails_dir / "agent@agents-mac-mini.local").write_text("momomojo\n")
+    assert add_contributor("agent@Agents-Mac-mini.local", "skip-agent") == 0
+    assert add_contributor("agent@Agents-Mac-mini.local", "skip-agent") == 0  # present
+    # Same email asking for a DIFFERENT login still refuses.
+    assert add_contributor("agent@Agents-Mac-mini.local", "someoneelse") == 1
+
+
+def test_collision_detection_is_case_insensitive(emails_dir):
+    from add_contributor import _caseless_collision
+
+    emails_dir.mkdir(parents=True, exist_ok=True)
+    (emails_dir / "Jane@Example.com").write_text("janedoe\n")
+    # On case-sensitive filesystems iterdir() shows the distinct name; on
+    # case-insensitive ones it may show the requested name instead — both
+    # must detect the collision via the casefold comparison.
+    assert _caseless_collision("jane@example.com", emails_dir) is True
+    assert _caseless_collision("other@example.com", emails_dir) is False
+
+
+def test_exact_name_file_still_refuses_when_variant_also_exists(
+    emails_dir, sidecar, monkeypatch
+):
+    """Case-sensitive state where BOTH files exist (origin/main was in this
+    state): the exact-name mapping must still be honored — a different
+    login must be refused instead of silently reassigning via the sidecar.
+    Simulated by injecting the on-disk name list (both files cannot coexist
+    on case-insensitive dev machines)."""
+    import add_contributor as _ac
+
+    emails_dir.mkdir(parents=True, exist_ok=True)
+    (emails_dir / "agent@Agents-Mac-mini.local").write_text("skip-agent\n")
+    monkeypatch.setattr(
+        _ac,
+        "_dir_names",
+        lambda d=None: {"agent@Agents-Mac-mini.local", "agent@agents-mac-mini.local"},
+    )
+    assert _ac.add_contributor("agent@Agents-Mac-mini.local", "someoneelse") == 1
+    assert _ac.add_contributor("agent@Agents-Mac-mini.local", "skip-agent") == 0
+
+
 
 
 


### PR DESCRIPTION
Fixes #88257.

## Problem

`contributors/emails/` maps one file per commit-author email, but two emails that differ only by letter case (`agent@Agents-Mac-mini.local` vs `agent@agents-Mac-mini.local`, two distinct git identities) are the **same file** on case-insensitive filesystems (macOS APFS, Windows NTFS default). Every checkout of current main is born dirty, and `git rebase`/`git merge` refuse to run. Details and reproduction in the issue.

## Fix

- New `contributors/emails.caseless.json` sidecar (`email -> login`) for case-colliding mappings; the offending `agent@Agents-Mac-mini.local` entry moves there and the colliding directory file is deleted, which alone makes checkouts clean again on APFS/NTFS.
- `scripts/release.py`: `_load_caseless_sidecar()` merged into `AUTHOR_MAP` (sidecar wins; malformed/missing file degrades to empty).
- `scripts/add_contributor.py`: detects case collisions on both filesystem kinds (existence checks go through the on-disk name list, never `path.is_file()`, which resolves to the variant's file and reads the wrong login) and routes colliding emails to the sidecar. Refuse-on-different-login still honors an exact-name file even when a case variant also exists (verified for the case-sensitive state origin/main is currently in).
- `scripts/audit_pr_attribution.py`: `is_mapped` consults the sidecar.
- `.github/workflows/contributor-check.yml`: mapping loop checks the sidecar; a new guard rejects future case-only filename collisions in the directory, so this class of breakage cannot land again.
- `contributors/README.md` documents the rule; `casefold()` is used for the comparisons (closes the non-ASCII gap `.lower()` misses).

## Test plan

- [x] `tests/scripts/test_contributor_map.py`: 13 passed, covering sidecar loading (malformed/missing/non-dict), collision routing, idempotency + conflicting-login refusal, FS-neutral collision detection, and the both-variants-exist refusal case.
- [x] Verified on a case-insensitive checkout (macOS/APFS): the working tree is clean after this PR, `AUTHOR_MAP` resolves both emails, the audit script passes, and the CI mapping loop resolves both (simulated for the case-sensitive Linux runner where the check actually runs).
- [x] The collision guard fires against origin/main's current tree and passes against this branch's.