### PR TITLE
fix(relay): stop importing gateway.run from non-gateway hosts (#87183)

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -173,11 +173,13 @@ def _segments_config() -> dict[str, Any]:
                 try:
                     # Do NOT import gateway.run from a non-gateway host: its
                     # module top level sets os.environ["_HERMES_GATEWAY"] /
-                    # HERMES_QUIET / HERMES_EXEC_ASK — gateway-process
-                    # semantics. Dragged into a CLI/TUI/desktop/cron process,
-                    # HERMES_EXEC_ASK=1 flips tools/approval.py onto the
-                    # gateway approval path with no notify_cb, so dangerous
-                    # commands hang forever in pending_approval (#87183).
+                    # HERMES_QUIET — gateway-process semantics. Dragged into a
+                    # CLI/TUI/desktop/cron process, _HERMES_GATEWAY flips
+                    # tools/approval.py onto the gateway approval path with no
+                    # notify_cb, so dangerous commands hang forever in
+                    # pending_approval (#87183). (HERMES_EXEC_ASK was already
+                    # moved to start_gateway() by #86043, but _HERMES_GATEWAY
+                    # and HERMES_QUIET remain at module level.)
                     # read_raw_config() + managed overlay reproduce
                     # gateway.run._load_gateway_config() for this read without
                     # the import side effects.

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -171,14 +171,21 @@ def _segments_config() -> dict[str, Any]:
                 on_compaction = False
                 max_turns = 0
                 try:
-                    from gateway.run import _load_gateway_config  # late import
+                    # Do NOT import gateway.run from a non-gateway host: its
+                    # module top level sets os.environ["_HERMES_GATEWAY"] /
+                    # HERMES_QUIET / HERMES_EXEC_ASK — gateway-process
+                    # semantics. Dragged into a CLI/TUI/desktop/cron process,
+                    # HERMES_EXEC_ASK=1 flips tools/approval.py onto the
+                    # gateway approval path with no notify_cb, so dangerous
+                    # commands hang forever in pending_approval (#87183).
+                    # read_raw_config() + managed overlay reproduce
+                    # gateway.run._load_gateway_config() for this read without
+                    # the import side effects.
+                    from hermes_cli import managed_scope
+                    from hermes_cli.config import read_raw_config
 
-                    telemetry = (
-                        (_load_gateway_config().get("gateway") or {}).get(
-                            "telemetry"
-                        )
-                        or {}
-                    )
+                    raw = managed_scope.apply_managed_overlay(read_raw_config())
+                    telemetry = ((raw.get("gateway") or {}).get("telemetry")) or {}
                     segments = telemetry.get("session_segments") or {}
                     on_compaction = bool(segments.get("on_compaction", False))
                     try:

--- a/tests/agent/test_relay_session_segments.py
+++ b/tests/agent/test_relay_session_segments.py
@@ -42,6 +42,7 @@ def _run_isolated(code: str) -> subprocess.CompletedProcess[str]:
         text=True,
         cwd=str(repo_root),
         env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        timeout=30,
     )
 
 

--- a/tests/agent/test_relay_session_segments.py
+++ b/tests/agent/test_relay_session_segments.py
@@ -121,8 +121,11 @@ def _default_config(monkeypatch):
 
 
 def _set_segments(monkeypatch, *, on_compaction=False, max_turns=0):
+    # _segments_config() reads via read_raw_config() (+ managed overlay)
+    # instead of importing gateway.run (whose module top-level setenv
+    # pollutes the calling process's environment, see #87183).
     monkeypatch.setattr(
-        "gateway.run._load_gateway_config",
+        "hermes_cli.config.read_raw_config",
         lambda: {
             "gateway": {
                 "telemetry": {

--- a/tests/agent/test_relay_session_segments.py
+++ b/tests/agent/test_relay_session_segments.py
@@ -17,7 +17,11 @@ consumed at the next begin_turn before the turn scope pushes.
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 import threading
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -27,6 +31,18 @@ from agent.relay_runtime import (
     RelayRuntime,
     RelaySessionCoordinator,
 )
+
+
+def _run_isolated(code: str) -> subprocess.CompletedProcess[str]:
+    """Run a Python snippet in the repo root (not tests/) in a fresh process."""
+    repo_root = Path(__file__).parent.parent.parent
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
 
 
 class _ScopeHandle:
@@ -115,7 +131,7 @@ def _fast_scope_timeout(monkeypatch):
 def _default_config(monkeypatch):
     """No config on disk by default; tests override _segments_config directly."""
     monkeypatch.setattr(
-        "hermes_cli.config.read_raw_config", lambda: {}, raising=False
+        "hermes_cli.config.read_raw_config", lambda: {}
     )
     relay_runtime._reset_segments_config_for_tests()
 
@@ -136,7 +152,6 @@ def _set_segments(monkeypatch, *, on_compaction=False, max_turns=0):
                 }
             }
         },
-        raising=False,
     )
     relay_runtime._reset_segments_config_for_tests()
 
@@ -411,3 +426,41 @@ class TestRotationSafety:
         assert child_push["parent"] is new_handle, (
             "post-rotation children must parent to the new segment handle"
         )
+
+
+class TestGatewayRunStaysUnimported:
+    """Guard against re-importing gateway.run from a non-gateway host.
+
+    relay_runtime._segments_config() must NEVER trigger ``gateway.run`` —
+    its module top level sets _HERMES_GATEWAY / HERMES_QUIET / HERMES_EXEC_ASK,
+    which flips a CLI/TUI/desktop/cron process onto the gateway path and hangs
+    dangerous commands in pending_approval (#87183). A plain monkeypatch of
+    read_raw_config wouldn't catch a future refactor that adds the import, so
+    this runs the real path in a fresh subprocess and asserts gateway.run never
+    enters sys.modules.
+    """
+
+    def test_relay_runtime_never_imports_gateway_run(self) -> None:
+        result = _run_isolated(
+            """
+import sys
+
+import agent.relay_runtime as rr
+
+# _segments_config() is the only relay path that used to import gateway.run.
+rr._segments_config()
+rr._segments_config()  # cached path too
+
+if "gateway.run" in sys.modules:
+    print("FAIL: gateway.run was imported by a non-gateway host")
+    sys.exit(1)
+print("PASS: gateway.run stays out of sys.modules")
+sys.exit(0)
+"""
+        )
+        assert result.returncode == 0, (
+            f"relay_runtime imported gateway.run:\\n"
+            f"stdout: {result.stdout}\\n"
+            f"stderr: {result.stderr}"
+        )
+        assert "PASS" in result.stdout

--- a/tests/agent/test_relay_session_segments.py
+++ b/tests/agent/test_relay_session_segments.py
@@ -115,7 +115,7 @@ def _fast_scope_timeout(monkeypatch):
 def _default_config(monkeypatch):
     """No config on disk by default; tests override _segments_config directly."""
     monkeypatch.setattr(
-        "gateway.run._load_gateway_config", lambda: {}, raising=False
+        "hermes_cli.config.read_raw_config", lambda: {}, raising=False
     )
     relay_runtime._reset_segments_config_for_tests()
 


### PR DESCRIPTION
## Summary
Non-gateway processes (CLI/TUI/desktop/cron) no longer get `_HERMES_GATEWAY=1` and `HERMES_QUIET=1` poisoned into their environment from a late import of `gateway.run` inside `relay_runtime._segments_config()`.

## Problem
`agent/relay_runtime.py::_segments_config()` late-imported `gateway.run._load_gateway_config` to read the gateway telemetry config. But `gateway/run.py` sets `os.environ["_HERMES_GATEWAY"] = "1"` and `os.environ["HERMES_QUIET"] = "1"` at **module top level** (lines 1876, 2410). Any non-gateway process that imports `gateway.run` gets these gateway-process env vars written into its own `os.environ`.

`_segments_config()` is called on every relay turn begin — so every CLI session that uses relay gets poisoned. `_HERMES_GATEWAY=1` then routes dangerous-command approvals onto the gateway async path (`tools/approval.py`), where the CLI has no `notify_cb` — the approval panel never renders and commands hang forever in `pending_approval`.

Root cause: #87183. Same env-leak family as #83626, #86878, #63183, #62905.

## Changes
- `agent/relay_runtime.py`: Replace `from gateway.run import _load_gateway_config` with `read_raw_config() + managed_scope.apply_managed_overlay()` — reproduces the same config read without import side effects.
- `tests/agent/test_relay_session_segments.py`: Monkeypatch targets updated from `gateway.run._load_gateway_config` to `hermes_cli.config.read_raw_config`. Added `TestGatewayRunStaysUnimported` subprocess regression guard that runs the real `_segments_config()` path in a fresh process and asserts `gateway.run` never enters `sys.modules`.
- Follow-up fixes on top of contributor's commits:
  1. Corrected the comment — `HERMES_EXEC_ASK` was already moved to `start_gateway()` by #86043, so only `_HERMES_GATEWAY` and `HERMES_QUIET` remain at module level.
  2. Added `timeout=30` to the `subprocess.run` in `_run_isolated` test helper to prevent CI hangs if the subprocess deadlocks.

## Attribution
Salvage of #87187 by @a1398394385 (Mr.XYS). Contributor's 3 commits cherry-picked with authorship preserved; follow-up fixes added on top.

Closes #87183
Closes #87187

## Validation
| | Before | After |
|---|---|---|
| `gateway.run` in `sys.modules` after `_segments_config()` | Yes | No |
| `_HERMES_GATEWAY` in env after relay turn | `1` | unset |
| `HERMES_QUIET` in env after relay turn | `1` | unset |
| Tests | 12 passed | 13 passed (+1 subprocess guard) |
| Ruff | clean | clean |
