### PR TITLE
fix(desktop): show no-project sessions when project filter is active

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -152,6 +152,7 @@ import { ProjectDialog } from './project-dialog'
 import {
   excludeProjectSessions,
   liveSessionProjectId,
+  NO_PROJECT_ID,
   orderProjectsByIds,
   overlayLiveLanes,
   overlayLivePreviews,
@@ -502,7 +503,7 @@ export function ChatSidebar({
 
       // Same membership the sidebar groups and colors by, so a filtered row
       // lands in the lane the user picked it from.
-      return !projectFilter.length || projectFilter.includes(liveSessionProjectId(session, projects) ?? '')
+      return !projectFilter.length || projectFilter.includes(liveSessionProjectId(session, projects) ?? NO_PROJECT_ID)
     },
     [statusFilter, projectFilter, profileFilter, showAllProfiles, prFilter, pullRequests, projects, dotStates]
   )


### PR DESCRIPTION
## Summary

Project-filter matching in the sidebar used `''` as the fallback id for sessions with no cwd/repo root, but the Home bucket's filter id is `NO_PROJECT_ID` (`'__no_project__'`). With **any** project filter enabled — including Home itself — every project-less session failed the `includes()` check and vanished from the sidebar.

This aligns the fallback with `overlayLivePreviews` (workspace-groups.ts:725), which already maps detached sessions to `NO_PROJECT_ID`.

## Repro

1. Open Hermes Desktop sidebar
2. Start a new chat with no workspace/folder (no cwd)
3. Open the sidebar filter menu and enable any project filter (e.g. Home / 主页)
4. The project-less session disappears from the list

## Fix

```diff
- return !projectFilter.length || projectFilter.includes(liveSessionProjectId(session, projects) ?? '')
+ return !projectFilter.length || projectFilter.includes(liveSessionProjectId(session, projects) ?? NO_PROJECT_ID)
```

Plus importing `NO_PROJECT_ID` from workspace-groups.

## Test Plan

- [x] Verified the predicate mismatch in source (project filter id `__no_project__` vs fallback `''`)
- [x] `overlayLivePreviews` already uses `NO_PROJECT_ID` for the same class of sessions — the fix matches that convention
