### PR TITLE
fix(test): make lazy-secrets update-check E2E tests network-independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
-# ci: cache-bust re-parse
 name: CI
 
 # Orchestrator workflow. Runs ``detect-changes`` once, then conditionally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+# ci: cache-bust re-parse
 name: CI
 
 # Orchestrator workflow. Runs ``detect-changes`` once, then conditionally

--- a/tests/test_lazy_secrets_dispatch.py
+++ b/tests/test_lazy_secrets_dispatch.py
@@ -11,6 +11,7 @@ run the actual commands and verify exit codes — the exact paths the
 reviewer flagged as unproven.
 """
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -19,13 +20,40 @@ import pytest
 
 
 def _run_hermes(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess[str]:
-    """Run hermes CLI as a subprocess from repo root."""
+    """Run hermes CLI as a subprocess from repo root.
+
+    The child runs with all git remote URLs rewritten to an unreachable
+    local path (GIT_CONFIG_* env overrides). These tests assert the
+    lazy-crypto / no-self-lock invariants of the dispatch path, NOT update
+    connectivity — but ``hermes update --check`` really does ``git fetch``
+    against github.com when run bare. Under remote throttling that fetch
+    can exceed the subprocess timeout and TimeoutExpired the test (exactly
+    what happened on CI during the 2026-08-17 GitHub incident: both update
+    tests red on main for hours with no code change). Rewriting the URLs
+    makes the fetch fail instantly and deterministically; the update path
+    still exercises its full parser/dispatch/fetch code and exits 1, which
+    the assertions already accept.
+    """
     repo_root = Path(__file__).parent.parent
+    env = dict(os.environ)
+    env.update(
+        {
+            "GIT_CONFIG_COUNT": "2",
+            # Rewrite every https:// and ssh remote to a nonexistent local
+            # path so any fetch fails in milliseconds without touching the
+            # network. insteadOf matching is prefix-based.
+            "GIT_CONFIG_KEY_0": "url.file:///nonexistent-hermes-test-remote/.insteadOf",
+            "GIT_CONFIG_VALUE_0": "https://",
+            "GIT_CONFIG_KEY_1": "url.file:///nonexistent-hermes-test-remote/.insteadOf",
+            "GIT_CONFIG_VALUE_1": "git@",
+        }
+    )
     return subprocess.run(
         [sys.executable, "-m", "hermes_cli.main"] + args,
         capture_output=True,
         text=True,
         cwd=str(repo_root),
+        env=env,
         timeout=timeout,
     )
 


### PR DESCRIPTION
## Summary

The lazy-secrets `update --check` E2E tests no longer touch the network, so a GitHub outage can't turn main red — the exact failure that made CI red for hours today with zero code change.

Root cause: `tests/test_lazy_secrets_dispatch.py::TestUpdatePathE2E` ran the real `hermes update --check` bare, whose `git fetch origin main` hits github.com. During today's GitHub incident the fetch stalled past the 30s subprocess timeout → `TimeoutExpired` → both tests FAILED on main (runs 32003200300, 32011520139) and on every PR slice 11/12.

## Changes

- `tests/test_lazy_secrets_dispatch.py`: `_run_hermes()` now rewrites all git remote URLs in the child to an unreachable `file://` path via `GIT_CONFIG_*` env overrides. The update path still exercises its full parser/dispatch/fetch code (the invariants under test are lazy-crypto and no-self-lock, not connectivity); the fetch fails in milliseconds, deterministically, offline. Exit 1 was already accepted by the assertions.

## Validation

| | Before | After |
|---|---|---|
| Blackhole-proxy outage simulation | TimeoutExpired at 20s (reproduces CI red) | completes in 0.2s, exit 1 |
| `tests/test_lazy_secrets_dispatch.py` | 2 failed on CI | 8/8 pass in 1.7s |

## Infographic

![TESTS OFF THE NETWORK — lazy-secrets update-check E2E](https://v3b.fal.media/files/b/0aa6ae3f/DDCYnTCxtiCapRHzGDnz1_ahkQH4vi.png)
