### PR TITLE
feat(disk): disk guardian — retention sweeps + low-space health signal (OOF-250, OOF-269)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29411,15 +29411,26 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
 
     # Disk retention sweep cadence (config: disk.retention.sweep_interval_minutes)
     # — OOF-250 / OOF-269: hosted instances must never fill their volume.
+    # Import failure disables the sweep (module genuinely unavailable); a
+    # config problem must NOT — get_disk_config() sanitizes every knob and
+    # falls back to shipped defaults, so a malformed config.yaml can never
+    # silently turn retention off.
     try:
         from hermes_cli.disk_retention import get_disk_config, sweep_and_log
-        _sweep_minutes = int(
-            get_disk_config()["retention"].get("sweep_interval_minutes", 30)
-        )
     except Exception as e:
-        logger.debug("Disk retention config load failed: %s", e)
+        logger.warning("Disk retention unavailable (import failed): %s", e)
         sweep_and_log = None
-        _sweep_minutes = 30
+    _sweep_minutes = 30
+    if sweep_and_log is not None:
+        try:
+            _sweep_minutes = int(
+                get_disk_config()["retention"].get("sweep_interval_minutes", 30)
+            )
+        except Exception as e:
+            logger.warning(
+                "Disk retention config load failed (using %dm default): %s",
+                _sweep_minutes, e,
+            )
     # Convert minutes -> ticks at the configured interval (min 1 tick).
     DISK_SWEEP_EVERY = max(1, (_sweep_minutes * 60) // max(1, interval))
     logger.info("Gateway housekeeping started (interval=%ds)", interval)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29409,6 +29409,19 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
         ("Screenshot", cleanup_screenshot_cache),
     )
 
+    # Disk retention sweep cadence (config: disk.retention.sweep_interval_minutes)
+    # — OOF-250 / OOF-269: hosted instances must never fill their volume.
+    try:
+        from hermes_cli.disk_retention import get_disk_config, sweep_and_log
+        _sweep_minutes = int(
+            get_disk_config()["retention"].get("sweep_interval_minutes", 30)
+        )
+    except Exception as e:
+        logger.debug("Disk retention config load failed: %s", e)
+        sweep_and_log = None
+        _sweep_minutes = 30
+    # Convert minutes -> ticks at the configured interval (min 1 tick).
+    DISK_SWEEP_EVERY = max(1, (_sweep_minutes * 60) // max(1, interval))
     logger.info("Gateway housekeeping started (interval=%ds)", interval)
     tick_count = 0
     while not stop_event.is_set():
@@ -29524,6 +29537,14 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
                     type(exc).__name__,
                     exc,
                 )
+
+        if sweep_and_log is not None and tick_count % DISK_SWEEP_EVERY == 0:
+            try:
+                sweep_and_log(logger)
+            except Exception as e:
+                # sweep_and_log is itself exception-proof; this is a belt-
+                # and-braces guard so the ticker thread can never die here.
+                logger.debug("Disk retention sweep error: %s", e)
 
         stop_event.wait(timeout=interval)
     logger.info("Gateway housekeeping stopped")

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2646,6 +2646,25 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # Disk guardian (OOF-250 / OOF-269): retention sweeps + low-space signal.
+    "disk": {
+        "retention": {
+            "enabled": True,
+            "sweep_interval_minutes": 30,   # How often the gateway sweeps
+            "diag_log_max_bytes": 2097152,  # Tail-truncate diag logs above this (2 MiB)
+            "diag_log_keep_bytes": 262144,  # Tail kept after truncation (256 KiB)
+            "cache_max_age_hours": 72,      # Backstop age for media caches
+            "db_backup_keep_count": 5,      # Newest state.db.malformed-* kept
+            "db_backup_max_age_days": 14,
+            "pkg_cache_max_age_days": 14,   # npm/pip caches under home/
+        },
+        "low_space": {
+            # Health/status endpoints flag low space when free space under
+            # HERMES_HOME drops below EITHER threshold.
+            "min_free_bytes": 209715200,    # 200 MiB
+            "min_free_percent": 10.0,
+        },
+    },
     # Logging — controls file logging to ~/.hermes/logs/.
     # agent.log captures INFO+ (all agent activity); errors.log captures WARNING+.
     "logging": {

--- a/hermes_cli/disk_retention.py
+++ b/hermes_cli/disk_retention.py
@@ -1,0 +1,575 @@
+"""
+Disk retention & low-space guardian for HERMES_HOME (OOF-250 / OOF-269).
+
+Hosted Hermes Cloud instances run on small persistent volumes (~1 GB).
+Recurring fleet incidents show unbounded writers filling the disk (ENOSPC),
+which cascades into SQLite "database or disk is full" errors, dashboard ASGI
+exceptions, and an unhealthy gateway — while status endpoints still look
+green.  This module provides the systemic fix:
+
+1. ``truncate_log_tail()`` — in-place tail truncation for append-only
+   diagnostic logs.  Truncating in place (rather than unlinking) frees space
+   even when another process holds an open file descriptor — the
+   "deleted-but-open file" failure mode from OOF-2.  Appenders using
+   ``open(..., "a")`` (O_APPEND) continue working seamlessly.
+
+2. ``prune_files()`` — age/count/total-size pruning for backup and cache
+   file families (oldest first).
+
+3. ``run_retention_sweep()`` — one cheap, exception-proof pass over all
+   known-safe families under HERMES_HOME.  Never touches user data
+   (sessions, state.db, memories, configured media); only diagnostic logs,
+   stale DB-recovery backups, and regenerate-on-demand caches.
+
+4. ``disk_status()`` — low-space signal for health/status endpoints so
+   /api/status and /health/detailed report degraded BEFORE ENOSPC hits.
+
+5. ``disk_usage_summary()`` — per-family byte usage for diagnostics.
+
+The gateway cron ticker calls ``sweep_and_log()`` periodically (see
+``gateway/run.py``).  All entry points are exception-proof: a retention
+failure must never crash the host process.
+
+Config lives under the ``disk`` section of config.yaml (see
+``hermes_cli.config.DEFAULT_CONFIG``); every knob has a safe default sized
+for a 1 GB volume.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_TRUNCATION_MARKER = b"[...older lines removed by hermes disk retention...]\n"
+
+# Files that must NEVER be touched by any retention operation, regardless of
+# what a (mis)configured glob resolves to.  Belt-and-braces guard on top of
+# the explicit family definitions below.
+_PROTECTED_NAMES = frozenset({
+    "state.db", "state.db-wal", "state.db-shm",
+    "hermes_state.db",
+    "config.yaml", ".env", "auth.json", "SOUL.md",
+    "gateway.pid", "gateway_state.json",
+})
+
+# Top-level HERMES_HOME directories that hold user data — pruning never
+# descends into these.
+_PROTECTED_DIRS = frozenset({
+    "sessions", "memories", "cron", "hooks", "skins", "plans",
+    "workspace", "profiles",
+})
+
+# logs/ files managed by RotatingFileHandler (hermes_logging.py).  These
+# already rotate at their configured size; tail-truncating them would fight
+# the handler.  Their numbered backups (agent.log.1, ...) are also skipped.
+_ROTATION_MANAGED_LOGS = frozenset({"agent.log", "errors.log", "gateway.log"})
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+_DEFAULT_DISK_CONFIG: Dict[str, Any] = {
+    "retention": {
+        "enabled": True,
+        # Gateway cron ticker runs at 60s; sweep every N minutes.
+        "sweep_interval_minutes": 30,
+        # Un-rotated *.log files under logs/ (and other diag logs) are
+        # tail-truncated when they exceed max_bytes, keeping keep_bytes.
+        "diag_log_max_bytes": 2 * 1024 * 1024,
+        "diag_log_keep_bytes": 256 * 1024,
+        # Backstop age prune for media caches (cache/images, cache/audio,
+        # cache/documents, cache/screenshots).  The gateway already prunes
+        # images/documents at 24h; this catches audio (previously unbounded)
+        # and anything the hourly pass missed.
+        "cache_max_age_hours": 72,
+        # state.db malformed-recovery backups (state.db.malformed-*).
+        "db_backup_keep_count": 5,
+        "db_backup_max_age_days": 14,
+        # Package-manager caches under HERMES_HOME/home (npm _cacache,
+        # pip cache) — content-addressed, regenerate on demand.
+        "pkg_cache_max_age_days": 14,
+    },
+    "low_space": {
+        # Degraded when EITHER threshold is crossed.
+        "min_free_bytes": 200 * 1024 * 1024,
+        "min_free_percent": 10.0,
+    },
+}
+
+
+def get_disk_config() -> Dict[str, Any]:
+    """Return the merged ``disk`` config section (safe defaults on failure)."""
+    import copy
+    merged = copy.deepcopy(_DEFAULT_DISK_CONFIG)
+    try:
+        from hermes_cli.config import load_config
+        user = load_config().get("disk") or {}
+        for section in ("retention", "low_space"):
+            sub = user.get(section)
+            if isinstance(sub, dict):
+                merged[section].update(sub)
+    except Exception:  # noqa: BLE001 — config problems must not break retention
+        pass
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+
+def _is_protected(path: Path, home: Path) -> bool:
+    """Return True when *path* must never be modified by retention."""
+    if path.name in _PROTECTED_NAMES:
+        return True
+    try:
+        rel = path.resolve().relative_to(home.resolve())
+    except (ValueError, OSError):
+        # Outside HERMES_HOME — refuse to touch it.
+        return True
+    return bool(rel.parts) and rel.parts[0] in _PROTECTED_DIRS
+
+
+# ---------------------------------------------------------------------------
+# Primitive operations
+# ---------------------------------------------------------------------------
+
+def truncate_log_tail(
+    path: Path,
+    *,
+    max_bytes: int,
+    keep_bytes: int,
+    home: Optional[Path] = None,
+) -> int:
+    """Tail-truncate *path* in place when it exceeds *max_bytes*.
+
+    Keeps the last *keep_bytes* (aligned to the next newline) prefixed with a
+    truncation marker.  Returns bytes reclaimed (0 when under the cap).
+
+    In-place truncation (open "rb+", rewrite, ftruncate) frees disk space
+    immediately even if another process holds the file open — unlike unlink,
+    which leaves a deleted-but-open file consuming space (OOF-2).
+    """
+    home = home or get_hermes_home()
+    if _is_protected(path, home):
+        return 0
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return 0
+    if size <= max_bytes:
+        return 0
+
+    keep_bytes = max(0, min(keep_bytes, max_bytes))
+    try:
+        with open(path, "rb+") as f:
+            f.seek(size - keep_bytes)
+            tail = f.read(keep_bytes)
+            # Start the kept tail at a line boundary for readable logs.
+            nl = tail.find(b"\n")
+            if 0 <= nl < len(tail) - 1:
+                tail = tail[nl + 1:]
+            f.seek(0)
+            f.write(_TRUNCATION_MARKER)
+            f.write(tail)
+            f.truncate()
+        new_size = path.stat().st_size
+        return max(0, size - new_size)
+    except OSError as exc:
+        logger.debug("truncate_log_tail(%s) failed: %s", path, exc)
+        return 0
+
+
+def prune_files(
+    files: Iterable[Path],
+    *,
+    keep_count: Optional[int] = None,
+    max_age_days: Optional[float] = None,
+    max_total_bytes: Optional[int] = None,
+    home: Optional[Path] = None,
+) -> Tuple[int, int]:
+    """Prune a family of files, oldest first.
+
+    Retention order: the newest *keep_count* files are always kept, files
+    older than *max_age_days* are removed, then oldest files are removed
+    until the family fits in *max_total_bytes*.
+
+    Returns ``(files_removed, bytes_reclaimed)``.
+    """
+    home = home or get_hermes_home()
+    entries: List[Tuple[Path, float, int]] = []
+    for p in files:
+        if _is_protected(p, home):
+            continue
+        try:
+            st = p.stat()
+        except OSError:
+            continue
+        if not p.is_file():
+            continue
+        entries.append((p, st.st_mtime, st.st_size))
+
+    # Newest first.
+    entries.sort(key=lambda e: e[1], reverse=True)
+
+    removed = 0
+    reclaimed = 0
+    now = time.time()
+    keep = keep_count if keep_count is not None else 0
+
+    survivors: List[Tuple[Path, float, int]] = []
+    for idx, (p, mtime, size) in enumerate(entries):
+        expired = (
+            max_age_days is not None
+            and (now - mtime) > max_age_days * 86400
+        )
+        if idx >= keep and expired:
+            if _unlink(p):
+                removed += 1
+                reclaimed += size
+                continue
+        survivors.append((p, mtime, size))
+
+    if max_total_bytes is not None:
+        total = sum(size for _, _, size in survivors)
+        # Remove oldest first (end of the newest-first list), but never dip
+        # into the protected keep_count head.
+        while total > max_total_bytes and len(survivors) > keep:
+            p, _, size = survivors.pop()
+            if _unlink(p):
+                removed += 1
+                reclaimed += size
+                total -= size
+
+    return removed, reclaimed
+
+
+def _unlink(path: Path) -> bool:
+    try:
+        path.unlink()
+        return True
+    except OSError as exc:
+        logger.debug("retention unlink(%s) failed: %s", path, exc)
+        return False
+
+
+def _dir_size(path: Path) -> int:
+    """Best-effort recursive directory size in bytes."""
+    total = 0
+    try:
+        with os.scandir(path) as it:
+            for entry in it:
+                try:
+                    if entry.is_file(follow_symlinks=False):
+                        total += entry.stat(follow_symlinks=False).st_size
+                    elif entry.is_dir(follow_symlinks=False):
+                        total += _dir_size(Path(entry.path))
+                except OSError:
+                    continue
+    except OSError:
+        pass
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Disk status (low-space probe)
+# ---------------------------------------------------------------------------
+
+def disk_status(
+    home: Optional[Path] = None,
+    *,
+    min_free_bytes: Optional[int] = None,
+    min_free_percent: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Return free-space status for the volume backing HERMES_HOME.
+
+    ``low_space`` is True when free space is below EITHER the byte or the
+    percent threshold — the signal health endpoints use to report degraded
+    before the instance actually hits ENOSPC.
+    """
+    home = home or get_hermes_home()
+    if min_free_bytes is None or min_free_percent is None:
+        low_cfg = get_disk_config()["low_space"]
+        if min_free_bytes is None:
+            min_free_bytes = int(low_cfg["min_free_bytes"])
+        if min_free_percent is None:
+            min_free_percent = float(low_cfg["min_free_percent"])
+
+    usage = shutil.disk_usage(str(home))
+    percent_free = (usage.free / usage.total * 100.0) if usage.total else 0.0
+    low_space = usage.free < min_free_bytes or percent_free < min_free_percent
+    return {
+        "path": str(home),
+        "total_bytes": usage.total,
+        "free_bytes": usage.free,
+        "percent_free": round(percent_free, 2),
+        "min_free_bytes": min_free_bytes,
+        "min_free_percent": min_free_percent,
+        "low_space": low_space,
+    }
+
+
+def disk_usage_summary(home: Optional[Path] = None) -> Dict[str, int]:
+    """Per-family byte usage under HERMES_HOME (diagnostics)."""
+    home = home or get_hermes_home()
+    summary: Dict[str, int] = {}
+
+    def _add(name: str, path: Path) -> None:
+        if path.is_dir():
+            summary[name] = _dir_size(path)
+        elif path.is_file():
+            try:
+                summary[name] = path.stat().st_size
+            except OSError:
+                pass
+
+    _add("logs", home / "logs")
+    _add("sessions", home / "sessions")
+    _add("cache", home / "cache")
+    _add("memories", home / "memories")
+    _add("platforms", home / "platforms")
+    _add("skills", home / "skills")
+    _add("home", home / "home")
+    _add("photon", home / "photon")
+    _add("lazy_packages", home / "lazy-packages")
+    _add("state_db", home / "state.db")
+    _add("state_db_wal", home / "state.db-wal")
+
+    db_backups = sum(
+        f.stat().st_size
+        for f in home.glob("state.db.malformed*")
+        if f.is_file()
+    )
+    if db_backups:
+        summary["state_db_backups"] = db_backups
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# The sweep
+# ---------------------------------------------------------------------------
+
+def run_retention_sweep(
+    home: Optional[Path] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run one retention pass over all known-safe families under HERMES_HOME.
+
+    Exception-proof: each family is wrapped independently; a failure in one
+    family never prevents the others from running, and no exception escapes
+    this function.  Returns a report dict::
+
+        {"enabled": True, "bytes_reclaimed": int, "files_removed": int,
+         "duration_ms": int, "families": {name: {...}}, "errors": [str]}
+    """
+    started = time.monotonic()
+    report: Dict[str, Any] = {
+        "enabled": True,
+        "bytes_reclaimed": 0,
+        "files_removed": 0,
+        "families": {},
+        "errors": [],
+    }
+    try:
+        home = home or get_hermes_home()
+        cfg = (config or get_disk_config())["retention"]
+    except Exception as exc:  # noqa: BLE001
+        report["errors"].append(f"config: {exc}")
+        report["duration_ms"] = int((time.monotonic() - started) * 1000)
+        return report
+
+    if not cfg.get("enabled", True):
+        report["enabled"] = False
+        report["duration_ms"] = int((time.monotonic() - started) * 1000)
+        return report
+
+    max_bytes = int(cfg.get("diag_log_max_bytes", 2 * 1024 * 1024))
+    keep_bytes = int(cfg.get("diag_log_keep_bytes", 256 * 1024))
+    cache_age_h = float(cfg.get("cache_max_age_hours", 72))
+    db_keep = int(cfg.get("db_backup_keep_count", 5))
+    db_age_d = float(cfg.get("db_backup_max_age_days", 14))
+    pkg_age_d = float(cfg.get("pkg_cache_max_age_days", 14))
+
+    def _family(name, fn):
+        try:
+            removed, reclaimed = fn()
+            report["families"][name] = {
+                "files_removed": removed,
+                "bytes_reclaimed": reclaimed,
+            }
+            report["files_removed"] += removed
+            report["bytes_reclaimed"] += reclaimed
+        except Exception as exc:  # noqa: BLE001 — sweep must never raise
+            report["errors"].append(f"{name}: {exc}")
+
+    # 1. Un-rotated diagnostic logs under logs/ — includes files written by
+    #    external processes (container boot / restart / exit-diag logs on
+    #    hosted instances) and nohup-redirected output.  Skips the
+    #    RotatingFileHandler-managed trio and their numbered backups.
+    def _diag_logs():
+        reclaimed = 0
+        truncated = 0
+        log_dir = home / "logs"
+        if log_dir.is_dir():
+            for f in log_dir.iterdir():
+                if not f.is_file():
+                    continue
+                base = f.name.split(".log")[0] + ".log" if ".log" in f.name else f.name
+                if base in _ROTATION_MANAGED_LOGS:
+                    continue
+                if f.suffix not in (".log", ".txt", ".out", ".err"):
+                    continue
+                got = truncate_log_tail(
+                    f, max_bytes=max_bytes, keep_bytes=keep_bytes, home=home
+                )
+                if got:
+                    truncated += 1
+                    reclaimed += got
+        return truncated, reclaimed
+
+    _family("diag_logs", _diag_logs)
+
+    # 2. Root-level debug logs (interrupt_debug.log and friends).
+    def _root_debug_logs():
+        reclaimed = 0
+        truncated = 0
+        for f in list(home.glob("*_debug.log")) + list(home.glob("*-debug.log")):
+            got = truncate_log_tail(
+                f, max_bytes=max_bytes, keep_bytes=keep_bytes, home=home
+            )
+            if got:
+                truncated += 1
+                reclaimed += got
+        return truncated, reclaimed
+
+    _family("root_debug_logs", _root_debug_logs)
+
+    # 3. WhatsApp bridge log (unbounded append from the Node bridge).
+    def _bridge_logs():
+        reclaimed = 0
+        truncated = 0
+        candidates = list((home / "platforms").glob("**/bridge.log")) if (home / "platforms").is_dir() else []
+        legacy = home / "whatsapp" / "bridge.log"
+        if legacy.is_file():
+            candidates.append(legacy)
+        for f in candidates:
+            got = truncate_log_tail(
+                f, max_bytes=max_bytes, keep_bytes=keep_bytes, home=home
+            )
+            if got:
+                truncated += 1
+                reclaimed += got
+        return truncated, reclaimed
+
+    _family("bridge_logs", _bridge_logs)
+
+    # 4. Skills hub audit log (unbounded append).
+    def _audit_log():
+        f = home / "skills" / ".hub" / "audit.log"
+        if not f.is_file():
+            return 0, 0
+        got = truncate_log_tail(
+            f, max_bytes=max_bytes, keep_bytes=keep_bytes, home=home
+        )
+        return (1 if got else 0), got
+
+    _family("skills_audit_log", _audit_log)
+
+    # 5. state.db malformed-recovery backups: keep the newest N, drop old ones.
+    def _db_backups():
+        files = list(home.glob("state.db.malformed*")) + list(
+            home.glob("state.db.corrupt*")
+        )
+        return prune_files(
+            files, keep_count=db_keep, max_age_days=db_age_d, home=home
+        )
+
+    _family("db_backups", _db_backups)
+
+    # 6. Media cache backstop (cache/audio has no other cleanup; the others
+    #    get a 24h hourly pass in the gateway — this is the safety net).
+    def _media_caches():
+        removed = 0
+        reclaimed = 0
+        for sub in ("images", "audio", "documents", "screenshots"):
+            d = home / "cache" / sub
+            if not d.is_dir():
+                continue
+            r, b = prune_files(
+                d.iterdir(), max_age_days=cache_age_h / 24.0, home=home
+            )
+            removed += r
+            reclaimed += b
+        return removed, reclaimed
+
+    _family("media_caches", _media_caches)
+
+    # 7. Package-manager caches under the per-profile HOME (npm _cacache,
+    #    pip cache) — content-addressed, safe to regenerate.
+    def _pkg_caches():
+        removed = 0
+        reclaimed = 0
+        for d in (
+            home / "home" / ".npm" / "_cacache",
+            home / "home" / ".cache" / "pip",
+        ):
+            if not d.is_dir():
+                continue
+            r, b = prune_files(
+                d.glob("**/*"), max_age_days=pkg_age_d, home=home
+            )
+            removed += r
+            reclaimed += b
+        return removed, reclaimed
+
+    _family("pkg_caches", _pkg_caches)
+
+    report["duration_ms"] = int((time.monotonic() - started) * 1000)
+    return report
+
+
+def sweep_and_log(log: Optional[logging.Logger] = None) -> Dict[str, Any]:
+    """Run the sweep and emit exactly one structured log line.
+
+    Never raises — safe to call from any host-process loop.
+    """
+    log = log or logger
+    try:
+        report = run_retention_sweep()
+    except Exception as exc:  # noqa: BLE001 — absolute last-resort guard
+        try:
+            log.warning("Disk retention sweep crashed: %s", exc)
+        except Exception:  # noqa: BLE001
+            pass
+        return {"enabled": False, "errors": [str(exc)]}
+
+    try:
+        status = disk_status()
+        level = logging.WARNING if status["low_space"] else logging.INFO
+        log.log(
+            level,
+            "Disk retention sweep: reclaimed %d bytes across %d file(s) "
+            "in %dms (free: %d bytes / %.1f%%, low_space=%s%s)",
+            report.get("bytes_reclaimed", 0),
+            report.get("files_removed", 0),
+            report.get("duration_ms", 0),
+            status["free_bytes"],
+            status["percent_free"],
+            status["low_space"],
+            f", errors={report['errors']}" if report.get("errors") else "",
+        )
+        report["disk"] = status
+    except Exception as exc:  # noqa: BLE001
+        try:
+            log.debug("Disk retention status log failed: %s", exc)
+        except Exception:  # noqa: BLE001
+            pass
+    return report

--- a/hermes_cli/disk_retention.py
+++ b/hermes_cli/disk_retention.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import stat as stat_mod
 import time
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -119,7 +120,89 @@ def get_disk_config() -> Dict[str, Any]:
                 merged[section].update(sub)
     except Exception:  # noqa: BLE001 — config problems must not break retention
         pass
-    return merged
+    return _sanitize_disk_config(merged)
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    """Tolerant bool coercion: YAML-ish strings never silently mean True."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("true", "yes", "on", "1"):
+            return True
+        if lowered in ("false", "no", "off", "0"):
+            return False
+    return default
+
+
+def _coerce_number(value: Any, default: float, *, minimum: float = 0.0) -> float:
+    """Coerce a config knob to a finite non-negative number, else default.
+
+    Malformed values (strings, None, dicts, negatives, NaN) fall back to the
+    shipped default with a WARNING — one bad knob must never disable or
+    weaponize retention (e.g. a negative size truncating everything).
+    """
+    try:
+        if isinstance(value, bool):
+            raise TypeError("bool is not a size/duration")
+        num = float(value)
+        if num != num or num in (float("inf"), float("-inf")):
+            raise ValueError("non-finite")
+        if num < minimum:
+            raise ValueError("below minimum")
+        return num
+    except (TypeError, ValueError):
+        logger.warning(
+            "disk retention config value %r invalid; using default %r",
+            value,
+            default,
+        )
+        return default
+
+
+def _sanitize_disk_config(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Clamp every knob to a sane value so user config can't break the sweep."""
+    d = _DEFAULT_DISK_CONFIG
+    ret = cfg.get("retention") or {}
+    low = cfg.get("low_space") or {}
+    dret = d["retention"]
+    dlow = d["low_space"]
+    return {
+        "retention": {
+            "enabled": _coerce_bool(ret.get("enabled"), dret["enabled"]),
+            "sweep_interval_minutes": int(_coerce_number(
+                ret.get("sweep_interval_minutes"),
+                dret["sweep_interval_minutes"], minimum=1)),
+            "diag_log_max_bytes": int(_coerce_number(
+                ret.get("diag_log_max_bytes"),
+                dret["diag_log_max_bytes"], minimum=4096)),
+            "diag_log_keep_bytes": int(_coerce_number(
+                ret.get("diag_log_keep_bytes"),
+                dret["diag_log_keep_bytes"], minimum=0)),
+            "cache_max_age_hours": _coerce_number(
+                ret.get("cache_max_age_hours"),
+                dret["cache_max_age_hours"], minimum=1.0),
+            "db_backup_keep_count": int(_coerce_number(
+                ret.get("db_backup_keep_count"),
+                dret["db_backup_keep_count"], minimum=0)),
+            "db_backup_max_age_days": _coerce_number(
+                ret.get("db_backup_max_age_days"),
+                dret["db_backup_max_age_days"], minimum=1.0),
+            "pkg_cache_max_age_days": _coerce_number(
+                ret.get("pkg_cache_max_age_days"),
+                dret["pkg_cache_max_age_days"], minimum=1.0),
+        },
+        "low_space": {
+            "min_free_bytes": int(_coerce_number(
+                low.get("min_free_bytes"), dlow["min_free_bytes"], minimum=0)),
+            "min_free_percent": _coerce_number(
+                low.get("min_free_percent"), dlow["min_free_percent"],
+                minimum=0.0),
+        },
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -131,7 +214,15 @@ def _is_protected(path: Path, home: Path) -> bool:
     if path.name in _PROTECTED_NAMES:
         return True
     try:
-        rel = path.resolve().relative_to(home.resolve())
+        resolved = path.resolve()
+    except (ValueError, OSError):
+        return True
+    # A symlink whose TARGET is a protected file (e.g. logs/evil.log ->
+    # ../state.db) must be refused even though the link name looks safe.
+    if resolved.name in _PROTECTED_NAMES:
+        return True
+    try:
+        rel = resolved.relative_to(home.resolve())
     except (ValueError, OSError):
         # Outside HERMES_HOME — refuse to touch it.
         return True
@@ -154,23 +245,61 @@ def truncate_log_tail(
     Keeps the last *keep_bytes* (aligned to the next newline) prefixed with a
     truncation marker.  Returns bytes reclaimed (0 when under the cap).
 
+    Known-lossy race: bytes appended by an O_APPEND writer between the tail
+    read and ``truncate()`` are discarded with the head.  Acceptable for the
+    diagnostic log families this sweeps (loss window is microseconds, files
+    are best-effort forensics); do NOT point this at data that must survive.
+
     In-place truncation (open "rb+", rewrite, ftruncate) frees disk space
     immediately even if another process holds the file open — unlike unlink,
     which leaves a deleted-but-open file consuming space (OOF-2).
+
+    Hard safety contract: the fd we mutate is verified to be a regular file
+    with a single hard link, opened with O_NOFOLLOW.  A symlink placed in a
+    swept directory (``logs/evil.log -> ../state.db``) is refused by the
+    kernel; a hardlink to a protected file (``st_nlink > 1``) is refused by
+    the fstat check.  All truncation happens through the verified fd — there
+    is no path-based reopen after the check (no TOCTOU window).
     """
     home = home or get_hermes_home()
     if _is_protected(path, home):
         return 0
     try:
-        size = path.stat().st_size
+        lst = os.lstat(path)
     except OSError:
         return 0
-    if size <= max_bytes:
+    if stat_mod.S_ISLNK(lst.st_mode) or not stat_mod.S_ISREG(lst.st_mode):
+        logger.warning("disk retention: refusing non-regular file %s", path)
+        return 0
+    if lst.st_nlink != 1:
+        # A hardlink shares its inode with another name — possibly a
+        # protected file. Never mutate multi-linked inodes.
+        logger.warning(
+            "disk retention: refusing hardlinked file %s (nlink=%d)",
+            path, lst.st_nlink,
+        )
         return 0
 
-    keep_bytes = max(0, min(keep_bytes, max_bytes))
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
     try:
-        with open(path, "rb+") as f:
+        fd = os.open(str(path), os.O_RDWR | nofollow)
+    except OSError as exc:
+        logger.debug("truncate_log_tail(%s) open failed: %s", path, exc)
+        return 0
+    try:
+        fst = os.fstat(fd)
+        if not stat_mod.S_ISREG(fst.st_mode) or fst.st_nlink != 1:
+            logger.warning(
+                "disk retention: refusing %s post-open (mode=%o nlink=%d)",
+                path, fst.st_mode, fst.st_nlink,
+            )
+            return 0
+        size = fst.st_size
+        if size <= max_bytes:
+            return 0
+
+        keep_bytes = max(0, min(keep_bytes, max_bytes))
+        with os.fdopen(fd, "rb+", closefd=False) as f:
             f.seek(size - keep_bytes)
             tail = f.read(keep_bytes)
             # Start the kept tail at a line boundary for readable logs.
@@ -181,11 +310,16 @@ def truncate_log_tail(
             f.write(_TRUNCATION_MARKER)
             f.write(tail)
             f.truncate()
-        new_size = path.stat().st_size
+        new_size = os.fstat(fd).st_size
         return max(0, size - new_size)
     except OSError as exc:
-        logger.debug("truncate_log_tail(%s) failed: %s", path, exc)
+        logger.warning("truncate_log_tail(%s) failed: %s", path, exc)
         return 0
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
 
 
 def prune_files(
@@ -210,10 +344,14 @@ def prune_files(
         if _is_protected(p, home):
             continue
         try:
-            st = p.stat()
+            st = p.lstat()
         except OSError:
             continue
-        if not p.is_file():
+        # Regular files only: symlinks are never followed (deleting one is
+        # harmless but its stat lies about size), and multi-linked inodes
+        # share their data with another name — pruning them reclaims nothing
+        # and may surprise the other owner.
+        if not stat_mod.S_ISREG(st.st_mode) or st.st_nlink != 1:
             continue
         entries.append((p, st.st_mtime, st.st_size))
 
@@ -241,13 +379,15 @@ def prune_files(
     if max_total_bytes is not None:
         total = sum(size for _, _, size in survivors)
         # Remove oldest first (end of the newest-first list), but never dip
-        # into the protected keep_count head.
+        # into the protected keep_count head.  A failed unlink is treated as
+        # unreclaimable — we do NOT delete additional newer files to
+        # compensate (that would over-delete while the cap is never met).
         while total > max_total_bytes and len(survivors) > keep:
             p, _, size = survivors.pop()
             if _unlink(p):
                 removed += 1
                 reclaimed += size
-                total -= size
+            total -= size
 
     return removed, reclaimed
 
@@ -257,8 +397,106 @@ def _unlink(path: Path) -> bool:
         path.unlink()
         return True
     except OSError as exc:
-        logger.debug("retention unlink(%s) failed: %s", path, exc)
+        logger.warning("retention unlink(%s) failed: %s", path, exc)
         return False
+
+
+_DB_BACKUP_PREFIX = "state.db.malformed-backup-"
+_DB_BACKUP_SIDECAR_SUFFIXES = ("-wal", "-shm")
+
+
+def prune_db_backup_family(
+    home: Path,
+    *,
+    keep_count: int,
+    max_age_days: float,
+) -> Tuple[int, int]:
+    """Prune forensic state.db backups honouring the writer's contract.
+
+    ``hermes_state._backup_db_file`` writes ``state.db.malformed-backup-<ts>``
+    plus optional ``-wal``/``-shm`` sidecars.  A backup and its sidecars are
+    ONE retention unit: keep-count is counted in backup *sets*, and a pruned
+    base always takes its sidecars with it (no orphaned WAL/SHM files).
+
+    Exact-prefix enumeration only — never a broad ``state.db.*`` glob, so
+    unrelated prefix-neighbours (``state.db.repair-attempts.json``,
+    ``state.db-wal``) can never match.
+    """
+    bases: List[Path] = []
+    try:
+        for p in home.iterdir():
+            name = p.name
+            if not name.startswith(_DB_BACKUP_PREFIX):
+                continue
+            if name.endswith(_DB_BACKUP_SIDECAR_SUFFIXES):
+                continue
+            try:
+                st = p.lstat()
+            except OSError:
+                continue
+            if not stat_mod.S_ISREG(st.st_mode):
+                continue
+            bases.append(p)
+    except OSError:
+        return 0, 0
+
+    # Timestamped names sort chronologically; newest first.
+    bases.sort(key=lambda p: p.name, reverse=True)
+
+    removed = 0
+    reclaimed = 0
+    now = time.time()
+    for idx, base in enumerate(bases):
+        try:
+            mtime = base.lstat().st_mtime
+        except OSError:
+            continue
+        expired = (now - mtime) > max_age_days * 86400
+        if idx < keep_count or not expired:
+            continue
+        family = [base] + [
+            base.with_name(base.name + suffix)
+            for suffix in _DB_BACKUP_SIDECAR_SUFFIXES
+        ]
+        for victim in family:
+            try:
+                size = victim.lstat().st_size
+            except OSError:
+                continue
+            if _unlink(victim):
+                removed += 1
+                reclaimed += size
+
+    # Orphaned sidecars: a -wal/-shm whose base backup is already gone is
+    # useless forensics — prune once expired.
+    base_names = {p.name for p in bases}
+    try:
+        for p in home.iterdir():
+            name = p.name
+            if not name.startswith(_DB_BACKUP_PREFIX):
+                continue
+            if not name.endswith(_DB_BACKUP_SIDECAR_SUFFIXES):
+                continue
+            parent_base = name
+            for suffix in _DB_BACKUP_SIDECAR_SUFFIXES:
+                if parent_base.endswith(suffix):
+                    parent_base = parent_base[: -len(suffix)]
+                    break
+            if parent_base in base_names:
+                continue
+            try:
+                st = p.lstat()
+            except OSError:
+                continue
+            if not stat_mod.S_ISREG(st.st_mode):
+                continue
+            if (now - st.st_mtime) > max_age_days * 86400:
+                if _unlink(p):
+                    removed += 1
+                    reclaimed += st.st_size
+    except OSError:
+        pass
+    return removed, reclaimed
 
 
 def _dir_size(path: Path) -> int:
@@ -345,7 +583,7 @@ def disk_usage_summary(home: Optional[Path] = None) -> Dict[str, int]:
 
     db_backups = sum(
         f.stat().st_size
-        for f in home.glob("state.db.malformed*")
+        for f in home.glob("state.db.malformed-backup-*")
         if f.is_file()
     )
     if db_backups:
@@ -483,13 +721,12 @@ def run_retention_sweep(
 
     _family("skills_audit_log", _audit_log)
 
-    # 5. state.db malformed-recovery backups: keep the newest N, drop old ones.
+    # 5. state.db malformed-recovery backups: keep the newest N SETS
+    #    (base + WAL/SHM sidecars pruned together — see
+    #    prune_db_backup_family for the writer contract).
     def _db_backups():
-        files = list(home.glob("state.db.malformed*")) + list(
-            home.glob("state.db.corrupt*")
-        )
-        return prune_files(
-            files, keep_count=db_keep, max_age_days=db_age_d, home=home
+        return prune_db_backup_family(
+            home, keep_count=db_keep, max_age_days=db_age_d
         )
 
     _family("db_backups", _db_backups)

--- a/tests/hermes_cli/test_disk_retention.py
+++ b/tests/hermes_cli/test_disk_retention.py
@@ -232,7 +232,7 @@ class TestDiskUsageSummary:
         _write(home / "logs" / "agent.log", 5_000)
         _write(home / "sessions" / "x.jsonl", 3_000)
         _write(home / "state.db", 2_000)
-        _write(home / "state.db.malformed-20260817", 1_000)
+        _write(home / "state.db.malformed-backup-20260817_000000", 1_000)
         summary = dr.disk_usage_summary(home)
         assert summary["logs"] >= 5_000
         assert summary["sessions"] >= 3_000
@@ -274,13 +274,15 @@ class TestRetentionSweep:
         assert backup.stat().st_size >= 5_000_000
 
     def test_prunes_db_malformed_backups(self, home):
+        # Uses the exact writer contract from hermes_state._backup_db_file:
+        # state.db.malformed-backup-<stamp> (+ optional -wal/-shm sidecars).
         files = []
         for i in range(8):
-            f = _write(home / f"state.db.malformed-2026081{i}", 100)
+            f = _write(home / f"state.db.malformed-backup-2026081{i}_000000", 100)
             _age(f, days=20 + i)
             files.append(f)
         report = dr.run_retention_sweep(home, _cfg())
-        survivors = list(home.glob("state.db.malformed-*"))
+        survivors = list(home.glob("state.db.malformed-backup-*"))
         assert len(survivors) == 5  # keep_count default
         assert report["families"]["db_backups"]["files_removed"] == 3
 
@@ -364,3 +366,217 @@ class TestSweepAndLog:
              caplog.at_level("WARNING", logger=dr.__name__):
             dr.sweep_and_log()
         assert any("low_space=True" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Adversarial hardening (independent review round: symlink/hardlink escape,
+# backup family contract, config sanitization, unlink accounting)
+# ---------------------------------------------------------------------------
+
+
+class TestTruncationInodeSafety:
+    """The hard contract: retention must never mutate protected inodes,
+    even when a swept directory contains a link pointing at them."""
+
+    def test_symlink_to_state_db_is_refused(self, home):
+        db = home / "state.db"
+        db.write_bytes(b"X" * 10_000)
+        evil = home / "logs" / "evil.log"
+        evil.symlink_to("../state.db")
+        got = dr.truncate_log_tail(evil, max_bytes=1_000, keep_bytes=100, home=home)
+        assert got == 0
+        assert db.stat().st_size == 10_000
+
+    def test_hardlink_to_state_db_is_refused(self, home):
+        db = home / "state.db"
+        db.write_bytes(b"X" * 10_000)
+        evil = home / "logs" / "evil2.log"
+        os.link(db, evil)
+        got = dr.truncate_log_tail(evil, max_bytes=1_000, keep_bytes=100, home=home)
+        assert got == 0
+        assert db.stat().st_size == 10_000
+
+    def test_symlink_to_unprotected_file_outside_home_is_refused(self, home, tmp_path):
+        target = tmp_path / "other.log"
+        target.write_bytes(b"Y" * 10_000)
+        evil = home / "logs" / "link.log"
+        evil.symlink_to(target)
+        got = dr.truncate_log_tail(evil, max_bytes=1_000, keep_bytes=100, home=home)
+        assert got == 0
+        assert target.stat().st_size == 10_000
+
+    def test_sweep_with_hostile_links_never_touches_state_db(self, home):
+        db = home / "state.db"
+        db.write_bytes(b"D" * 5_000_000)
+        (home / "logs" / "sneaky.log").symlink_to("../state.db")
+        try:
+            os.link(db, home / "logs" / "sneaky2.log")
+        except OSError:
+            pass
+        report = dr.run_retention_sweep(home=home)
+        assert db.stat().st_size == 5_000_000
+        assert isinstance(report, dict)
+
+    def test_fifo_is_refused(self, home):
+        fifo = home / "logs" / "pipe.log"
+        try:
+            os.mkfifo(fifo)
+        except (AttributeError, OSError):
+            pytest.skip("mkfifo unavailable")
+        got = dr.truncate_log_tail(fifo, max_bytes=0, keep_bytes=0, home=home)
+        assert got == 0
+
+
+class TestPruneLinkSafety:
+    def test_prune_skips_symlinks_and_hardlinks(self, home):
+        db = home / "state.db"
+        db.write_bytes(b"Z" * 1_000)
+        d = home / "cache" / "audio"
+        link = d / "old-link.mp3"
+        link.symlink_to(db)
+        hard = d / "old-hard.mp3"
+        os.link(db, hard)
+        _age(link, 30)
+        _age(hard, 30)
+        removed, _ = dr.prune_files(d.iterdir(), max_age_days=1, home=home)
+        assert removed == 0
+        assert db.exists() and db.stat().st_size == 1_000
+
+
+class TestDbBackupFamily:
+    """prune_db_backup_family honours the hermes_state writer contract:
+    exact prefix, base+sidecars as one unit, keep-count in sets."""
+
+    def _mk_set(self, home, stamp: str, *, age_days: float = 0.0):
+        base = home / f"state.db.malformed-backup-{stamp}"
+        base.write_bytes(b"B" * 100)
+        wal = home / (base.name + "-wal")
+        wal.write_bytes(b"W" * 50)
+        if age_days:
+            _age(base, age_days)
+            _age(wal, age_days)
+        return base, wal
+
+    def test_keeps_newest_sets_with_sidecars(self, home):
+        for i in range(8):
+            self._mk_set(home, f"2026010{i}_000000", age_days=90)
+        removed, reclaimed = dr.prune_db_backup_family(
+            home, keep_count=5, max_age_days=14
+        )
+        bases = sorted(
+            p.name for p in home.glob("state.db.malformed-backup-*")
+            if not p.name.endswith(("-wal", "-shm"))
+        )
+        wals = sorted(
+            p.name for p in home.glob("state.db.malformed-backup-*-wal")
+        )
+        assert len(bases) == 5
+        assert len(wals) == 5
+        for w in wals:
+            assert w[: -len("-wal")] in bases, f"orphaned sidecar {w}"
+        assert removed == 6  # 3 bases + 3 wals
+        assert reclaimed == 3 * 150
+
+    def test_prefix_neighbours_never_match(self, home):
+        for name in ("state.db.repair-attempts.json", "state.db-wal",
+                     "state.db.corrupt.abc.bak"):
+            f = home / name
+            f.write_bytes(b"N")
+            _age(f, 365)
+        self._mk_set(home, "20260101_000000", age_days=365)
+        dr.prune_db_backup_family(home, keep_count=0, max_age_days=1)
+        assert (home / "state.db.repair-attempts.json").exists()
+        assert (home / "state.db-wal").exists()
+        assert (home / "state.db.corrupt.abc.bak").exists()
+
+    def test_orphaned_sidecar_pruned_once_expired(self, home):
+        orphan = home / "state.db.malformed-backup-20260101_000000-wal"
+        orphan.write_bytes(b"W" * 10)
+        _age(orphan, 365)
+        removed, _ = dr.prune_db_backup_family(home, keep_count=5, max_age_days=14)
+        assert removed == 1
+        assert not orphan.exists()
+
+    def test_fresh_sets_kept_even_beyond_keep_count(self, home):
+        for i in range(8):
+            self._mk_set(home, f"2026010{i}_000000")  # fresh mtime
+        removed, _ = dr.prune_db_backup_family(home, keep_count=5, max_age_days=14)
+        assert removed == 0
+
+
+class TestConfigSanitization:
+    def _with_user_config(self, monkeypatch, disk_section):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"disk": disk_section},
+        )
+
+    def test_malformed_values_fall_back_to_defaults(self, home, monkeypatch):
+        self._with_user_config(monkeypatch, {
+            "retention": {
+                "diag_log_max_bytes": "x",
+                "diag_log_keep_bytes": None,
+                "cache_max_age_hours": {},
+                "db_backup_keep_count": float("nan"),
+                "sweep_interval_minutes": -5,
+            },
+            "low_space": {"min_free_bytes": "lots", "min_free_percent": [1]},
+        })
+        cfg = dr.get_disk_config()
+        d = dr._DEFAULT_DISK_CONFIG
+        assert cfg["retention"]["diag_log_max_bytes"] == d["retention"]["diag_log_max_bytes"]
+        assert cfg["retention"]["diag_log_keep_bytes"] == d["retention"]["diag_log_keep_bytes"]
+        assert cfg["retention"]["cache_max_age_hours"] == d["retention"]["cache_max_age_hours"]
+        assert cfg["retention"]["db_backup_keep_count"] == d["retention"]["db_backup_keep_count"]
+        assert cfg["retention"]["sweep_interval_minutes"] == d["retention"]["sweep_interval_minutes"]
+        assert cfg["low_space"]["min_free_bytes"] == d["low_space"]["min_free_bytes"]
+        assert cfg["low_space"]["min_free_percent"] == d["low_space"]["min_free_percent"]
+
+    def test_negative_sizes_never_weaponize_truncation(self, home, monkeypatch):
+        self._with_user_config(monkeypatch, {
+            "retention": {"diag_log_max_bytes": -1, "diag_log_keep_bytes": -1},
+        })
+        cfg = dr.get_disk_config()
+        assert cfg["retention"]["diag_log_max_bytes"] >= 4096
+        assert cfg["retention"]["diag_log_keep_bytes"] >= 0
+
+    def test_string_false_disables(self, home, monkeypatch):
+        self._with_user_config(monkeypatch, {"retention": {"enabled": "false"}})
+        assert dr.get_disk_config()["retention"]["enabled"] is False
+
+    def test_string_true_enables(self, home, monkeypatch):
+        self._with_user_config(monkeypatch, {"retention": {"enabled": "true"}})
+        assert dr.get_disk_config()["retention"]["enabled"] is True
+
+    def test_unknown_string_uses_default(self, home, monkeypatch):
+        self._with_user_config(monkeypatch, {"retention": {"enabled": "maybe"}})
+        assert dr.get_disk_config()["retention"]["enabled"] is True
+
+
+class TestUnlinkAccounting:
+    def test_failed_unlink_does_not_over_delete_newer_files(self, home):
+        d = home / "cache" / "audio"
+        files = []
+        for i in range(5):
+            f = d / f"f{i}.mp3"
+            f.write_bytes(b"A" * 100)
+            _age(f, 5 - i)  # f0 oldest
+            files.append(f)
+
+        real_unlink = dr._unlink
+        blocked = files[0]
+
+        def flaky_unlink(path):
+            if path == blocked:
+                return False
+            return real_unlink(path)
+
+        with patch.object(dr, "_unlink", side_effect=flaky_unlink):
+            removed, _ = dr.prune_files(
+                d.iterdir(), max_total_bytes=350, home=home
+            )
+        # Budget needs 150 bytes freed => oldest two candidates (f0 blocked,
+        # f1 removed). f2..f4 must survive — no compensation deletes.
+        assert files[1].exists() is False
+        assert all(f.exists() for f in (files[2], files[3], files[4]))
+        assert removed == 1

--- a/tests/hermes_cli/test_disk_retention.py
+++ b/tests/hermes_cli/test_disk_retention.py
@@ -1,0 +1,366 @@
+"""Tests for hermes_cli.disk_retention — the disk guardian layer (OOF-250 / OOF-269).
+
+Covers:
+- truncate_log_tail (in-place tail truncation of diag logs)
+- prune_files (age/count/total-size pruning)
+- protected-path guards (never touch user data)
+- run_retention_sweep (family coverage + exception-proofing)
+- sweep_and_log (never raises)
+- disk_status (low-space thresholds)
+- disk_usage_summary
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import disk_retention as dr
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """A fake HERMES_HOME with the standard layout."""
+    h = tmp_path / "hermes"
+    for sub in ("logs", "sessions", "memories", "cache/images", "cache/audio",
+                "cache/documents", "cache/screenshots"):
+        (h / sub).mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(h))
+    return h
+
+
+def _write(path: Path, size: int, content: bytes = b"x") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = content * 79 + b"\n"
+    with open(path, "wb") as f:
+        while f.tell() < size:
+            f.write(line)
+    return path
+
+
+def _age(path: Path, days: float) -> None:
+    old = os.path.getmtime(path) - days * 86400
+    os.utime(path, (old, old))
+
+
+# ---------------------------------------------------------------------------
+# truncate_log_tail
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateLogTail:
+    def test_under_cap_untouched(self, home):
+        f = _write(home / "logs" / "boot.log", 1000)
+        reclaimed = dr.truncate_log_tail(f, max_bytes=2000, keep_bytes=500, home=home)
+        assert reclaimed == 0
+        assert f.stat().st_size == pytest.approx(1000, abs=100)
+
+    def test_over_cap_truncates_in_place(self, home):
+        f = _write(home / "logs" / "boot.log", 100_000)
+        original_size = f.stat().st_size
+        reclaimed = dr.truncate_log_tail(f, max_bytes=10_000, keep_bytes=2_000, home=home)
+        assert reclaimed > 0
+        new_size = f.stat().st_size
+        assert new_size < original_size
+        assert new_size <= 2_000 + len(dr._TRUNCATION_MARKER)
+        # Same inode — in-place truncation, not unlink+recreate (OOF-2:
+        # deleted-but-open files don't free space).
+        assert f.exists()
+        data = f.read_bytes()
+        assert data.startswith(dr._TRUNCATION_MARKER)
+
+    def test_kept_tail_starts_at_line_boundary(self, home):
+        f = home / "logs" / "boot.log"
+        f.write_bytes(b"".join(f"line-{i:06d}\n".encode() for i in range(10_000)))
+        dr.truncate_log_tail(f, max_bytes=1_000, keep_bytes=500, home=home)
+        body = f.read_bytes()[len(dr._TRUNCATION_MARKER):]
+        assert body.startswith(b"line-")
+
+    def test_appender_keeps_working_after_truncation(self, home):
+        """An O_APPEND writer must continue appending after truncation."""
+        f = _write(home / "logs" / "boot.log", 50_000)
+        with open(f, "a", encoding="utf-8") as appender:
+            dr.truncate_log_tail(f, max_bytes=10_000, keep_bytes=1_000, home=home)
+            appender.write("post-truncation line\n")
+        assert b"post-truncation line" in f.read_bytes()
+
+    def test_missing_file_returns_zero(self, home):
+        assert dr.truncate_log_tail(
+            home / "logs" / "nope.log", max_bytes=10, keep_bytes=5, home=home
+        ) == 0
+
+    def test_protected_file_untouched(self, home):
+        f = _write(home / "state.db", 100_000)
+        assert dr.truncate_log_tail(f, max_bytes=10, keep_bytes=5, home=home) == 0
+        assert f.stat().st_size >= 100_000
+
+    def test_file_outside_home_untouched(self, home, tmp_path):
+        f = _write(tmp_path / "outside.log", 100_000)
+        assert dr.truncate_log_tail(f, max_bytes=10, keep_bytes=5, home=home) == 0
+        assert f.stat().st_size >= 100_000
+
+
+# ---------------------------------------------------------------------------
+# prune_files
+# ---------------------------------------------------------------------------
+
+
+class TestPruneFiles:
+    def test_age_prune_removes_old_keeps_new(self, home):
+        old = _write(home / "cache" / "images" / "old.jpg", 100)
+        new = _write(home / "cache" / "images" / "new.jpg", 100)
+        _age(old, days=10)
+        removed, reclaimed = dr.prune_files(
+            (home / "cache" / "images").iterdir(), max_age_days=3, home=home
+        )
+        assert removed == 1
+        assert reclaimed >= 100
+        assert not old.exists()
+        assert new.exists()
+
+    def test_keep_count_protects_newest_even_when_expired(self, home):
+        files = []
+        for i in range(6):
+            f = _write(home / f"state.db.malformed-{i}", 100)
+            _age(f, days=30 + i)  # all expired; file 0 is newest
+            files.append(f)
+        removed, _ = dr.prune_files(
+            home.glob("state.db.malformed-*"),
+            keep_count=5, max_age_days=14, home=home,
+        )
+        assert removed == 1
+        assert not files[5].exists()  # oldest removed
+        assert all(f.exists() for f in files[:5])
+
+    def test_max_total_bytes_removes_oldest_first(self, home):
+        files = []
+        for i in range(4):
+            f = _write(home / "cache" / "audio" / f"a{i}.ogg", 1000)
+            _age(f, days=i)  # a0 newest, a3 oldest
+            files.append(f)
+        removed, _ = dr.prune_files(
+            (home / "cache" / "audio").iterdir(),
+            max_total_bytes=2500, home=home,
+        )
+        assert removed == 2
+        assert not files[3].exists() and not files[2].exists()
+        assert files[0].exists() and files[1].exists()
+
+    def test_never_prunes_protected_dirs(self, home):
+        f = _write(home / "sessions" / "chat.jsonl", 100)
+        _age(f, days=999)
+        removed, _ = dr.prune_files([f], max_age_days=1, home=home)
+        assert removed == 0
+        assert f.exists()
+
+    def test_never_prunes_protected_names(self, home):
+        f = _write(home / "state.db", 100)
+        _age(f, days=999)
+        removed, _ = dr.prune_files([f], max_age_days=1, home=home)
+        assert removed == 0
+        assert f.exists()
+
+    def test_vanished_file_is_skipped(self, home):
+        removed, reclaimed = dr.prune_files(
+            [home / "cache" / "images" / "ghost.jpg"], max_age_days=0, home=home
+        )
+        assert (removed, reclaimed) == (0, 0)
+
+
+# ---------------------------------------------------------------------------
+# disk_status
+# ---------------------------------------------------------------------------
+
+
+class _FakeUsage:
+    def __init__(self, total, free):
+        self.total = total
+        self.free = free
+        self.used = total - free
+
+
+class TestDiskStatus:
+    def test_healthy_disk(self, home):
+        with patch.object(dr.shutil, "disk_usage",
+                          return_value=_FakeUsage(1_000_000_000, 500_000_000)):
+            status = dr.disk_status(
+                home, min_free_bytes=200 * 1024 * 1024, min_free_percent=10.0
+            )
+        assert status["low_space"] is False
+        assert status["free_bytes"] == 500_000_000
+        assert status["percent_free"] == 50.0
+
+    def test_low_space_by_bytes(self, home):
+        # 15% free but only 150MB — bytes threshold trips.
+        with patch.object(dr.shutil, "disk_usage",
+                          return_value=_FakeUsage(1_000_000_000, 150_000_000)):
+            status = dr.disk_status(
+                home, min_free_bytes=200 * 1024 * 1024, min_free_percent=10.0
+            )
+        assert status["low_space"] is True
+
+    def test_low_space_by_percent(self, home):
+        # 500MB free but only 5% — percent threshold trips.
+        with patch.object(dr.shutil, "disk_usage",
+                          return_value=_FakeUsage(10_000_000_000, 500_000_000)):
+            status = dr.disk_status(
+                home, min_free_bytes=200 * 1024 * 1024, min_free_percent=10.0
+            )
+        assert status["low_space"] is True
+
+    def test_thresholds_from_config(self, home):
+        cfg = {
+            "retention": dict(dr._DEFAULT_DISK_CONFIG["retention"]),
+            "low_space": {"min_free_bytes": 1, "min_free_percent": 0.0},
+        }
+        with patch.object(dr, "get_disk_config", return_value=cfg), \
+             patch.object(dr.shutil, "disk_usage",
+                          return_value=_FakeUsage(1_000, 999)):
+            status = dr.disk_status(home)
+        assert status["low_space"] is False
+        assert status["min_free_bytes"] == 1
+
+
+# ---------------------------------------------------------------------------
+# disk_usage_summary
+# ---------------------------------------------------------------------------
+
+
+class TestDiskUsageSummary:
+    def test_reports_family_sizes(self, home):
+        _write(home / "logs" / "agent.log", 5_000)
+        _write(home / "sessions" / "x.jsonl", 3_000)
+        _write(home / "state.db", 2_000)
+        _write(home / "state.db.malformed-20260817", 1_000)
+        summary = dr.disk_usage_summary(home)
+        assert summary["logs"] >= 5_000
+        assert summary["sessions"] >= 3_000
+        assert summary["state_db"] >= 2_000
+        assert summary["state_db_backups"] >= 1_000
+
+    def test_missing_dirs_are_omitted(self, home):
+        summary = dr.disk_usage_summary(home)
+        assert "photon" not in summary
+
+
+# ---------------------------------------------------------------------------
+# run_retention_sweep
+# ---------------------------------------------------------------------------
+
+
+def _cfg(**retention_overrides):
+    cfg = {
+        "retention": dict(dr._DEFAULT_DISK_CONFIG["retention"]),
+        "low_space": dict(dr._DEFAULT_DISK_CONFIG["low_space"]),
+    }
+    cfg["retention"].update(retention_overrides)
+    return cfg
+
+
+class TestRetentionSweep:
+    def test_truncates_unrotated_diag_logs(self, home):
+        boot = _write(home / "logs" / "container-boot.log", 5_000_000)
+        report = dr.run_retention_sweep(home, _cfg())
+        assert report["bytes_reclaimed"] > 0
+        assert boot.stat().st_size < 5_000_000
+        assert report["families"]["diag_logs"]["bytes_reclaimed"] > 0
+
+    def test_skips_rotating_handler_managed_logs(self, home):
+        agent = _write(home / "logs" / "agent.log", 5_000_000)
+        backup = _write(home / "logs" / "agent.log.1", 5_000_000)
+        dr.run_retention_sweep(home, _cfg())
+        assert agent.stat().st_size >= 5_000_000
+        assert backup.stat().st_size >= 5_000_000
+
+    def test_prunes_db_malformed_backups(self, home):
+        files = []
+        for i in range(8):
+            f = _write(home / f"state.db.malformed-2026081{i}", 100)
+            _age(f, days=20 + i)
+            files.append(f)
+        report = dr.run_retention_sweep(home, _cfg())
+        survivors = list(home.glob("state.db.malformed-*"))
+        assert len(survivors) == 5  # keep_count default
+        assert report["families"]["db_backups"]["files_removed"] == 3
+
+    def test_state_db_itself_never_touched(self, home):
+        db = _write(home / "state.db", 50_000_000)
+        wal = _write(home / "state.db-wal", 10_000_000)
+        dr.run_retention_sweep(home, _cfg())
+        assert db.stat().st_size >= 50_000_000
+        assert wal.stat().st_size >= 10_000_000
+
+    def test_sessions_never_touched(self, home):
+        s = _write(home / "sessions" / "chat.jsonl", 10_000_000)
+        _age(s, days=999)
+        dr.run_retention_sweep(home, _cfg())
+        assert s.exists()
+
+    def test_media_cache_backstop_prunes_old_audio(self, home):
+        old = _write(home / "cache" / "audio" / "old.ogg", 1_000)
+        new = _write(home / "cache" / "audio" / "new.ogg", 1_000)
+        _age(old, days=10)
+        report = dr.run_retention_sweep(home, _cfg())
+        assert not old.exists()
+        assert new.exists()
+        assert report["families"]["media_caches"]["files_removed"] == 1
+
+    def test_disabled_config_is_noop(self, home):
+        f = _write(home / "logs" / "container-boot.log", 5_000_000)
+        report = dr.run_retention_sweep(home, _cfg(enabled=False))
+        assert report["enabled"] is False
+        assert f.stat().st_size >= 5_000_000
+
+    def test_family_failure_does_not_stop_other_families(self, home):
+        old = _write(home / "cache" / "audio" / "old.ogg", 1_000)
+        _age(old, days=10)
+        with patch.object(dr, "truncate_log_tail", side_effect=RuntimeError("boom")):
+            _write(home / "logs" / "container-boot.log", 5_000_000)
+            report = dr.run_retention_sweep(home, _cfg())
+        # diag_logs family failed…
+        assert any("diag_logs" in e for e in report["errors"])
+        # …but the media cache family still ran.
+        assert not old.exists()
+
+    def test_sweep_never_raises_even_on_config_failure(self, home):
+        with patch.object(dr, "get_disk_config", side_effect=RuntimeError("cfg boom")):
+            report = dr.run_retention_sweep(home, None)
+        assert report["errors"]
+
+
+# ---------------------------------------------------------------------------
+# sweep_and_log
+# ---------------------------------------------------------------------------
+
+
+class TestSweepAndLog:
+    def test_logs_one_line_and_returns_report(self, home, caplog):
+        _write(home / "logs" / "container-boot.log", 5_000_000)
+        with caplog.at_level("INFO", logger=dr.__name__):
+            report = dr.sweep_and_log()
+        assert report["bytes_reclaimed"] > 0
+        lines = [r for r in caplog.records if "Disk retention sweep" in r.getMessage()]
+        assert len(lines) == 1
+        assert "reclaimed" in lines[0].getMessage()
+
+    def test_never_raises_when_sweep_crashes(self, home):
+        with patch.object(dr, "run_retention_sweep", side_effect=RuntimeError("boom")):
+            report = dr.sweep_and_log()
+        assert report["errors"] == ["boom"]
+
+    def test_never_raises_when_disk_status_crashes(self, home):
+        with patch.object(dr, "disk_status", side_effect=OSError("statvfs fail")):
+            report = dr.sweep_and_log()
+        assert "bytes_reclaimed" in report
+
+    def test_warns_on_low_space(self, home, caplog):
+        low = {
+            "path": str(home), "total_bytes": 100, "free_bytes": 1,
+            "percent_free": 1.0, "min_free_bytes": 50,
+            "min_free_percent": 10.0, "low_space": True,
+        }
+        with patch.object(dr, "disk_status", return_value=low), \
+             caplog.at_level("WARNING", logger=dr.__name__):
+            dr.sweep_and_log()
+        assert any("low_space=True" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Problem (OOF-250 / OOF-269 — recurring incident class)

Hosted Hermes Cloud agents on small Fly volumes keep exhausting persistent disk, then cascading: ENOSPC → SQLite "database or disk is full" / disk I/O errors → dashboard ASGI exceptions → scheduled-callback 503s → router candidate exhaustion. Recent evidence: OOF-250 (concretemola-1900: 13,449 ENOSPC log lines; deadset-voluntaryism-2647: 23,016), OOF-269 (8 apps with ENOSPC on 2026-08-17), plus priors OOF-107 and OOF-2.

Low-space **signals** already landed (`gateway/readiness.py::_probe_disk`, `gateway/disk_status.py` disk block on `/api/status` via NS-656) — but nothing **reclaims** space. Every incident so far has been manual per-instance cleanup, and the same unbounded writers refill the volume afterwards.

> **Rework note**: an earlier revision of this PR also added health-endpoint low-disk reporting; that overlapped with the independently-landed NS-656 readiness/disk_status work, so this PR is now retention-only — the missing half.

## What this adds

**New module `hermes_cli/disk_retention.py`** (import-safe, config-optional):
- `truncate_log_tail()` — **in-place** tail truncation (`rb+` + `ftruncate`), not unlink: defeats the deleted-but-open-file growth suspected in OOF-2 and keeps O_APPEND writers valid (tested).
- `prune_files()` — keep-count / max-age / max-total-bytes, oldest-first; keep-count always wins.
- `run_retention_sweep()` — 7 retention families, each independently exception-wrapped; never raises.
- `disk_status()` / `disk_usage_summary()` — per-family diagnostics + low-space check used in sweep logging.

**Retention families** (from a codebase-wide inventory of unbounded writers under HERMES_HOME):

| Path | Writer | Prior bound | Now |
|---|---|---|---|
| `logs/*.log` (container-boot, gateway-restart, exit-diag — external/entrypoint writers) | append, unrotated | none | tail-truncate @2MiB→256KiB |
| `interrupt_debug.log` | `cli.py` `open("a")` | none | tail-truncate |
| `platforms/**/bridge.log` | WhatsApp Node bridge stdout | none | tail-truncate |
| `skills/.hub/audit.log` | `tools/skills_hub.py` append | none | tail-truncate |
| `state.db.malformed-*` backups | recovery path | none | keep newest 5, age 14d |
| `cache/images|documents|audio|screenshots` | media/browser | hourly prune exists | 72h backstop |
| `home/.npm/_cacache`, `home/.cache/pip` | lazy installs | none | 14d age prune |

`logs/agent.log`/`errors.log`/`gateway.log` (already rotated 5MB×3) are skip-listed. **`sessions/`, `state.db*`, `memories/` are hard-protected and never touched** — protected-name/dir/outside-home guards are belt-and-braces on top of explicit family definitions.

**Wiring**:
- `_start_gateway_housekeeping` (`gateway/run.py`) calls `sweep_and_log()` every 30 min (config: `disk.retention.sweep_interval_minutes`); one structured log line per sweep with bytes reclaimed + free-space state (WARNING when low). Belt-and-braces exception guard so the housekeeping thread can never die here.
- Config: additive `disk` section in `hermes_cli/config_defaults.py` (retention knobs + `low_space` thresholds), defaults sized for 1GB Fly volumes, no version bump.

## Validation

- `tests/hermes_cli/test_disk_retention.py`: 32/32 (truncation preserves O_APPEND writers, protected-path guards, keep-count/age/total-bytes precedence, sweep never raises)
- `test_config.py` + `test_config_validation.py`: 88 passed / 1 failed — failure (`TestConfigSupportFloor…[v12]`) verified byte-identical on clean main (pre-existing)
- ruff clean, py_compile clean

## Non-goals

Fly/NAS-side volume growth and fleet alerting (NAS consumes the existing NS-656 `/api/status` disk block); auto-deleting any user data.

Linear: OOF-250, OOF-269
