### PR TITLE
fix(matrix): blank bare media filenames from m.audio/m.file/m.video body

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -625,6 +625,13 @@ _MATRIX_IMAGE_FILENAME_EXTS = frozenset({
     ".avif",
 })
 
+# Extensions for audio/video/file msgtypes whose ``content.body`` is
+# the uploaded filename when the sender adds no caption.
+_MATRIX_MEDIA_FILENAME_EXTS = frozenset({
+    ".ogg", ".oga", ".opus", ".m4a", ".mp3", ".wav", ".flac", ".aac", ".amr",
+    ".mp4", ".webm", ".mov", ".mkv",
+})
+
 _MATRIX_MODEL_PICKER_REACTIONS = (
     "1\ufe0f\u20e3",
     "2\ufe0f\u20e3",
@@ -691,6 +698,36 @@ def _looks_like_matrix_image_filename(text: str) -> bool:
     if guessed_type and guessed_type.startswith("image/"):
         return True
     return suffix in _MATRIX_IMAGE_FILENAME_EXTS
+
+
+def _looks_like_matrix_media_filename(text: str) -> bool:
+    """Return True when Matrix audio/video/file body text is a transport filename.
+
+    Matrix ``m.audio``/``m.file``/``m.video`` events populate ``content.body``
+    with the uploaded filename when the sender adds no caption.  Same
+    conservative heuristic as :func:`_looks_like_matrix_image_filename` but
+    for non-image media types.
+    """
+    candidate = str(text or "").strip()
+    if not candidate or "\n" in candidate or candidate.endswith("/"):
+        return False
+    # A genuine caption essentially always contains whitespace; a bare
+    # transport filename does not.
+    if any(ch.isspace() for ch in candidate):
+        return False
+
+    name = Path(candidate).name
+    if not name or name != candidate:
+        return False
+
+    suffix = Path(name).suffix.lower()
+    if not suffix:
+        return False
+
+    guessed_type, _ = mimetypes.guess_type(name)
+    if guessed_type and guessed_type.startswith(("audio/", "video/")):
+        return True
+    return suffix in _MATRIX_MEDIA_FILENAME_EXTS
 
 
 def _matrix_event_timestamp_seconds(event: Any) -> float:
@@ -3711,6 +3748,8 @@ class MatrixAdapter(BasePlatformAdapter):
                 )
 
         if msgtype == "m.image" and _looks_like_matrix_image_filename(body):
+            body = ""
+        elif msgtype in ("m.audio", "m.file", "m.video") and _looks_like_matrix_media_filename(body):
             body = ""
 
         allow_http_fallback = bool(http_url) and not is_encrypted_media

--- a/tests/gateway/test_matrix_media_filename.py
+++ b/tests/gateway/test_matrix_media_filename.py
@@ -1,0 +1,94 @@
+"""Tests for Matrix adapter media-filename blanking.
+
+Matrix ``m.image`` events were already handled (PR #16821, issue #13482).
+These tests verify that ``m.audio``, ``m.file``, and ``m.video`` events
+also have their transport filename stripped from ``body`` when no caption
+is present, so the filename doesn't leak into ``event.text`` and get fed
+to the model as user message text.
+"""
+
+import pytest
+
+from plugins.platforms.matrix.adapter import (
+    _looks_like_matrix_image_filename,
+    _looks_like_matrix_media_filename,
+)
+
+
+class TestLooksLikeMatrixMediaFilename:
+    """Unit tests for _looks_like_matrix_media_filename()."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "voice-20260725-114233.ogg",
+            "recording.wav",
+            "clip.opus",
+            "audio.amr",
+            "data.m4a",
+            "clip.webm",
+            "video.mkv",
+            "video.mov",
+            "CaPtIoN.mp3",
+        ],
+    )
+    def test_bare_media_filenames_detected(self, text):
+        assert _looks_like_matrix_media_filename(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "remind me to call the dentist",
+            "voice note.m4a",
+            "document.pdf",
+            "file.txt",
+            "noextension",
+            "data.csv",
+            "",
+            "  ",
+            None,
+        ],
+    )
+    def test_non_filenames_rejected(self, text):
+        assert _looks_like_matrix_media_filename(text) is False
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "/tmp/voice.ogg",
+            "./audio.mp3",
+        ],
+    )
+    def test_paths_with_separators_rejected(self, text):
+        assert _looks_like_matrix_media_filename(text) is False
+
+    def test_trailing_whitespace_stripped(self):
+        assert _looks_like_matrix_media_filename("audio.ogg\n") is True
+        assert _looks_like_matrix_media_filename("  photo.mp3  ") is True
+
+    def test_multi_token_filename_rejected(self):
+        """A filename with a space is treated as a caption, not a bare token."""
+        assert _looks_like_matrix_media_filename("my recording.ogg") is False
+
+    def test_newline_in_text_rejected(self):
+        """Multi-line text is never a bare filename."""
+        assert _looks_like_matrix_media_filename("voice.ogg\nmore text") is False
+
+    def test_image_extension_not_detected_by_media_function(self):
+        """Image extensions are handled by the image function, not the media function."""
+        assert _looks_like_matrix_media_filename("photo.jpg") is False
+        assert _looks_like_matrix_image_filename("photo.jpg") is True
+
+    def test_audio_extension_not_detected_by_image_function(self):
+        """Audio extensions are handled by the media function, not the image function."""
+        assert _looks_like_matrix_image_filename("voice.ogg") is False
+        assert _looks_like_matrix_media_filename("voice.ogg") is True
+
+    def test_mimetypes_audio_detected(self):
+        """mimetypes.guess_type catches audio types not in the hardcoded set."""
+        # .aiff is audio/x-aiff, NOT in _MATRIX_MEDIA_FILENAME_EXTS
+        assert _looks_like_matrix_media_filename("song.aiff") is True
+
+    def test_mimetypes_video_detected(self):
+        """mimetypes.guess_type catches video types."""
+        assert _looks_like_matrix_media_filename("clip.avi") is True


### PR DESCRIPTION
## Summary
Matrix `m.audio`/`m.file`/`m.video` events populate `content.body` with the uploaded filename when the sender adds no caption. The adapter already blanks that for `m.image` (PR #16821, issue #13482) but not for audio, file, or video — so the filename survives into `event.text` and gets fed to the model as user message text.

This extends the existing adapter-level blanking to cover `m.audio`, `m.file`, and `m.video` using the same conservative heuristic (single token, no whitespace, no path separators, known media suffix or mimetypes match).

## Changes
- `plugins/platforms/matrix/adapter.py`: Add `_MATRIX_MEDIA_FILENAME_EXTS` frozenset + `_looks_like_matrix_media_filename()` function. Extend the blanking condition at the media message handler to cover `m.audio`, `m.file`, `m.video`.
- `tests/gateway/test_matrix_media_filename.py`: 27 tests covering positive cases (bare filenames), negative cases (real captions, paths, non-media extensions), and cross-checks that image/audio extensions are handled by the correct function.

## Why adapter-level, not shared gateway
The original PR #87968 placed the guard in the shared gateway enrichment path. This salvage reworks it to the adapter level for consistency with the existing `m.image` blanking (PR #16821). The bug is Matrix-specific — no other adapter leaks filenames into `event.text` (Telegram uses `msg.caption`, Discord uses a placeholder string).

## Attribution
Salvage of #87968 by @AiwendilInTheWoods — reworked from shared gateway path to adapter-level fix per the original PR author's own suggestion ("Happy to rework it as adapter-side blanking if you'd rather").

Closes #87968
