### PR TITLE
fix: preserve task-scoped Multica token across dotenv loading

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -339,25 +339,51 @@ def _sanitize_loaded_credentials() -> None:
         )
 
 
+_TASK_SCOPED_MULTICA_TOKEN_PREFIX = "mat_"
+
+
+def _capture_task_scoped_multica_token() -> str | None:
+    """Capture a daemon-provided task token before dotenv can override it.
+
+    Multica's daemon passes the task-scoped ``mat_`` token in the child
+    process environment, while the task Hermes home also contains the user's
+    workspace ``.env`` with a ``mul_`` token.  Hermes loads that file with
+    ``override=True`` for normal profile semantics, so without this guard the
+    less-privileged-looking file value silently replaces the task credential.
+    """
+    token = os.environ.get("MULTICA_TOKEN", "")
+    if token.startswith(_TASK_SCOPED_MULTICA_TOKEN_PREFIX):
+        return token
+    return None
+
+
 def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
+    # A Multica task token is a capability for this one task, not a profile
+    # setting. Preserve it across every dotenv load, including the managed-env
+    # overlay, so a workspace ``mul_`` value cannot downgrade the child.
+    task_token = _capture_task_scoped_multica_token()
     try:
-        # utf-8-sig strips a leading UTF-8 BOM if present (PowerShell 5.1
-        # Set-Content -Encoding UTF8 / Notepad) and is a no-op for BOM-less
-        # UTF-8. Plain "utf-8" would keep U+FEFF on the first key name and
-        # silently drop it from os.environ under its canonical name.
-        load_dotenv(dotenv_path=path, override=override, encoding="utf-8-sig")
-    except UnicodeDecodeError:
-        # utf-8-sig can't strip a BOM once we fall back to latin-1 decode.
-        raw = path.read_bytes()
-        if raw.startswith(codecs.BOM_UTF8):
-            raw = raw[len(codecs.BOM_UTF8) :]
-        load_dotenv(stream=io.StringIO(raw.decode("latin-1")), override=override)
-    # Strip non-ASCII characters from credential env vars that were just
-    # loaded.  API keys must be pure ASCII since they're sent as HTTP
-    # header values (httpx encodes headers as ASCII).  Non-ASCII chars
-    # typically come from copy-pasting keys from PDFs or rich-text editors
-    # that substitute Unicode lookalike glyphs (e.g. ʋ U+028B for v).
-    _sanitize_loaded_credentials()
+        try:
+            # utf-8-sig strips a leading UTF-8 BOM if present (PowerShell 5.1
+            # Set-Content -Encoding UTF8 / Notepad) and is a no-op for BOM-less
+            # UTF-8. Plain "utf-8" would keep U+FEFF on the first key name and
+            # silently drop it from os.environ under its canonical name.
+            load_dotenv(dotenv_path=path, override=override, encoding="utf-8-sig")
+        except UnicodeDecodeError:
+            # utf-8-sig can't strip a BOM once we fall back to latin-1 decode.
+            raw = path.read_bytes()
+            if raw.startswith(codecs.BOM_UTF8):
+                raw = raw[len(codecs.BOM_UTF8) :]
+            load_dotenv(stream=io.StringIO(raw.decode("latin-1")), override=override)
+        # Strip non-ASCII characters from credential env vars that were just
+        # loaded.  API keys must be pure ASCII since they're sent as HTTP
+        # header values (httpx encodes headers as ASCII).  Non-ASCII chars
+        # typically come from copy-pasting keys from PDFs or rich-text editors
+        # that substitute Unicode lookalike glyphs (e.g. ʋ U+028B for v).
+        _sanitize_loaded_credentials()
+    finally:
+        if task_token is not None:
+            os.environ["MULTICA_TOKEN"] = task_token
 
 
 def _sanitize_env_file_if_needed(path: Path) -> None:

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -176,6 +176,22 @@ def test_latin1_fallback_stream_honors_override(tmp_path, monkeypatch):
     assert os.getenv("OVERRIDE_PROBE") == "from-file"
     assert os.getenv("LATIN1_VALUE") == "café"
 
+def test_task_scoped_multica_token_survives_dotenv_override(tmp_path, monkeypatch):
+    """A daemon-provided ``mat_`` token must beat the workspace ``.env``."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("MULTICA_TOKEN=mul_workspace\n", encoding="utf-8")
+
+    monkeypatch.setenv("MULTICA_TOKEN", "mat_task_scoped")
+    monkeypatch.setenv("MULTICA_TASK_ID", "task-123")
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.environ["MULTICA_TOKEN"] == "mat_task_scoped"
+
+
 def test_latin1_fallback_stream_preserves_interpolation(tmp_path, monkeypatch):
     """Stream/latin-1 path must still expand ${VAR} like the dotenv_path form."""
     home = tmp_path / "hermes"


### PR DESCRIPTION
# PR draft: preserve Multica task-scoped tokens across dotenv loading

## Title

fix: preserve task-scoped Multica token across dotenv loading

## Summary

Multica's daemon already claimed a task-scoped `mat_...` token and passed it to
Hermes in the child process environment. Hermes then loaded the task `.env` with
`override=True`, replacing that capability with the workspace `mul_...` token.
The worker could start, but Multica rejected its issue read/comment operations.

This patch preserves an existing `MULTICA_TOKEN` beginning with `mat_` across
every dotenv load, including managed-env overlays. Normal dotenv override
semantics remain unchanged for other credentials and settings.

## Changes

- Add a small task-token capture/restore guard in `hermes_cli/env_loader.py`.
- Add a regression test proving that a `.env` `mul_` value cannot overwrite a
  process `mat_` value.

## Verification

- `uv run --no-project --with pytest --with python-dotenv python -m pytest tests/hermes_cli/test_env_loader.py -q`
- Result: `27 passed`
- Fresh Multica E2E task `VEGA-49` independently verified:
  - claim returned a task-scoped token;
  - Hermes ACP completed through the daemon;
  - worker proof: `ACP_ENV_FIX_OK`;
  - `MULTICA_TOKEN_CLASS=task-scoped`;
  - `MULTICA_TASK_ID_PRESENT=true`;
  - issue reached `in_review`, was read back through the API, reviewed by the
    Lead, and moved to `done`.

No secret values are included. The task `.env` may still contain the workspace
credential by design; the process-level task credential takes precedence.

## Local commits

- Hermes: `54ce27e0c fix: preserve task-scoped Multica token`
- DevOps documentation: `bd044f4 docs: record verified ACP token handoff`

The commits and patch are local only. No remote push was performed.
