### PR TITLE
fix(gateway): exit 0 on double-run so supervisors stop restart-looping

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -19647,9 +19647,14 @@ def main(
     # Handle gateway mode (messaging + cron)
     if gateway:
         import asyncio
-        from gateway.run import start_gateway
+        from gateway.run import start_gateway, GatewayAlreadyRunningError
         print("Starting Hermes Gateway (messaging platforms)...")
-        asyncio.run(start_gateway())
+        try:
+            asyncio.run(start_gateway())
+        except GatewayAlreadyRunningError:
+            # Another gateway instance already owns the runtime lock: nothing
+            # to do. Exit cleanly (code 0) — this is not a crash.
+            print("Gateway is already running in another process. Exiting.")
         return
 
     # Skip worktree for list commands (they exit immediately)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29588,6 +29588,19 @@ def _gateway_stderr_formatter() -> logging.Formatter:
     return RedactingFormatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
 
 
+class GatewayAlreadyRunningError(RuntimeError):
+    """Raised by start_gateway() when another gateway instance already owns the
+    runtime lock / PID file (a benign double-run).
+
+    The CLI wrappers map this to a clean exit code 0 ("nothing to do") instead
+    of the generic failure code 1, so supervisors — systemd ``Restart=
+    on-failure``, s6 finish scripts, Windows wrapper loops, Task Scheduler
+    retry policies — do NOT mistake a second instance for a crashed one and
+    restart-loop it forever (observed: 52k+ respawns on a Windows box from
+    escaped auto-restart wrappers each re-spawning a lock-losing gateway).
+    """
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -29778,7 +29791,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 f"   or 'hermes gateway stop' to kill it first.\n"
                 f"   Or use 'hermes gateway run --replace' to auto-replace.\n"
             )
-            return False
+            raise GatewayAlreadyRunningError(
+                f"Gateway already running (PID {existing_pid})"
+            )
 
     # Sync bundled skills on gateway start (fast -- skips unchanged)
     try:
@@ -30002,12 +30017,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             "Another gateway instance (PID %d) started during our startup. "
             "Exiting to avoid double-running.", _current_pid
         )
-        return False
+        raise GatewayAlreadyRunningError(
+            f"Another gateway instance (PID {_current_pid}) is already running"
+        )
     if not acquire_gateway_runtime_lock():
         logger.error(
             "Gateway runtime lock is already held by another instance. Exiting."
         )
-        return False
+        raise GatewayAlreadyRunningError(
+            "Gateway runtime lock is already held by another instance"
+        )
     try:
         write_pid_file()
     except FileExistsError:
@@ -30015,7 +30034,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         logger.error(
             "PID file race lost to another gateway instance. Exiting."
         )
-        return False
+        raise GatewayAlreadyRunningError(
+            "PID file race lost to another gateway instance"
+        )
     atexit.register(remove_pid_file)
     atexit.register(release_gateway_runtime_lock)
 
@@ -30310,6 +30331,11 @@ def main():
     try:
         success = asyncio.run(start_gateway(config))
         exit_code = 0 if success else 1
+    except GatewayAlreadyRunningError:
+        # Another instance owns the gateway (benign double-run): exit cleanly
+        # so supervisors (systemd Restart=on-failure, s6, Windows wrapper
+        # loops) do not treat this as a crash and restart-loop forever.
+        exit_code = 0
     except SystemExit as e:
         # e.code may be None (→ 0), an int, or a str (→ 1, like CPython).
         if e.code is None:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5611,7 +5611,7 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
         except Exception:
             pass  # best-effort; don't block gateway startup
 
-    from gateway.run import start_gateway
+    from gateway.run import start_gateway, GatewayAlreadyRunningError
 
     print("┌─────────────────────────────────────────────────────────┐")
     print("│           ⚕ Hermes Gateway Starting...                 │")
@@ -5752,6 +5752,14 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
     try:
         success = asyncio.run(start_gateway(replace=replace, verbosity=verbosity))
         _exit_diag("asyncio.run.returned", success=success)
+    except GatewayAlreadyRunningError:
+        # Another instance already owns the gateway (benign double-run): exit
+        # cleanly so auto-restart supervisors (Windows wrapper loops, Task
+        # Scheduler retry, systemd) do not mistake it for a crash and
+        # restart-loop a second instance forever.
+        _exit_diag("gateway.already_running")
+        _hard_exit_after_gateway_teardown(0)
+        return
     except KeyboardInterrupt:
         # On Windows-detached runs this shouldn't fire (we absorb SIGINT above),
         # but keep the handler for console runs.

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -413,3 +413,81 @@ async def test_start_gateway_propagates_fatal_config_exit_code(monkeypatch, tmp_
     assert exc_info.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
 
 
+class _StubRunner:
+    """Minimal GatewayRunner stand-in for the duplicate-instance guard tests:
+    the guard fires before runner.start(), so only the attributes the
+    planned-stop watcher thread reads are needed."""
+
+    def __init__(self, config):
+        self.config = config
+        self.should_exit_cleanly = False
+        self.exit_reason = None
+        self.exit_code = None
+        self.adapters = {}
+        self._running = False
+        self._draining = False
+
+    async def start(self):
+        raise AssertionError("start() must not be reached")
+
+    async def stop(self):
+        return None
+
+
+def _patch_guard_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", _StubRunner)
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_raises_when_another_instance_running(monkeypatch, tmp_path):
+    """A plain (non-replace) start while another gateway's PID file is live
+    must raise GatewayAlreadyRunningError — a benign double-run, not a crash —
+    so the CLI wrappers map it to a clean exit 0 instead of the generic
+    failure exit 1 that auto-restart supervisors restart-loop forever."""
+    _patch_guard_env(monkeypatch, tmp_path)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 42)
+    monkeypatch.setattr("gateway.run.os.getpid", lambda: 100)
+
+    from gateway.run import start_gateway, GatewayAlreadyRunningError
+
+    with pytest.raises(GatewayAlreadyRunningError):
+        await start_gateway(config=GatewayConfig(), replace=False, verbosity=None)
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_raises_when_runtime_lock_held(monkeypatch, tmp_path):
+    """start_gateway must raise GatewayAlreadyRunningError (not return False)
+    when the cross-process runtime lock is held by another instance."""
+    _patch_guard_env(monkeypatch, tmp_path)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: False)
+
+    from gateway.run import start_gateway, GatewayAlreadyRunningError
+
+    with pytest.raises(GatewayAlreadyRunningError):
+        await start_gateway(config=GatewayConfig(), replace=False, verbosity=None)
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_raises_on_pidfile_race_loss(monkeypatch, tmp_path):
+    """start_gateway must raise GatewayAlreadyRunningError (not return False)
+    when the PID-file O_CREAT|O_EXCL race is lost to another instance."""
+    _patch_guard_env(monkeypatch, tmp_path)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+
+    def _race_pidfile(*args, **kwargs):
+        raise FileExistsError()
+
+    monkeypatch.setattr("gateway.status.write_pid_file", _race_pidfile)
+
+    from gateway.run import start_gateway, GatewayAlreadyRunningError
+
+    with pytest.raises(GatewayAlreadyRunningError):
+        await start_gateway(config=GatewayConfig(), replace=False, verbosity=None)
+
+


### PR DESCRIPTION
## Problem

A second gateway instance that loses the startup race exits with code **1**, which auto-restart supervisors (systemd `Restart=on-failure`, s6, Windows wrapper loops / Task Scheduler retry) interpret as a crash — so they keep restarting the redundant instance **forever**.

Real-world evidence: on a Windows machine using the recommended `Hermes_Gateway.cmd` wrapper, a stale wrapper chain survived a restart and both instances kept losing the runtime-lock race to each other. The wrapper log recorded **52,323 crash-restart cycles in ~3 days** (`Starting gateway...` / `Gateway exited (code 1), restarting in 10s...`), with `gateway.log` showing `Gateway runtime lock is already held by another instance. Exiting.` on every cycle. The host was noticeably slowed by the constant process churn on a mechanical HDD.

The in-process respawn-storm breaker (#74874-style mitigations) doesn't help here: each supervisor-spawned attempt is a **fresh process** with no memory of previous failures.

## Fix

Introduce `GatewayAlreadyRunningError` and raise it at **all four** double-run detection points in `gateway/run.py`:

1. Early PID-file check (`existing_pid` live, non-`--replace`)
2. Mid-startup PID re-check ("Another gateway instance started during our startup")
3. Cross-process runtime lock already held
4. PID-file `O_CREAT|O_EXCL` race loss

All three CLI entry points (`hermes gateway run`, `hermes --gateway`, `gateway/run.py::main()`) catch it and **exit 0** with a clean message — a benign double-run is not a failure, so supervisors stop restarting.

Behavior for genuinely-failing startups is unchanged: they still return `False` → exit 1 → supervisor retries as before. `--replace` / `restart` takeover paths are untouched (verified safe: `release_gateway_runtime_lock` is a no-op for non-owners, so the losing process cannot drop the winner's lock).

## Tests

- 3 new cases in `tests/gateway/test_runner_startup_failures.py` covering the early-PID, runtime-lock, and PID-race raise paths
- Targeted suites green: `test_runner_startup_failures.py` + `test_gateway_process_exit.py` + `test_startup_restart_race.py` = 15/15 pass (Windows 11, Python 3.11)
- Full `tests/gateway/` run: 5,663 passed / 71 failed — the 71 failures are **pre-existing Windows-environment failures** (systemd/setsid/terminal-rendering expectations in `test_systemd_notify`, `test_update_command`, `test_runtime_footer`, etc.), verified unchanged by re-running the failing subsets on the base commit with this change stashed
