### PR TITLE
Fix lean tail budget after runtime context/model recalculation

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2259,6 +2259,22 @@ class ContextCompressor(ContextEngine):
     def tail_token_budget(self, value: int) -> None:
         self._tail_token_budget = value
 
+    def recalibrate_tail_budget(self) -> None:
+        """Re-derive the tail budget through the mode-aware policy.
+
+        Runtime recalibration paths (update_model, the aux compression-model
+        threshold sync) must call this instead of writing
+        ``threshold_tokens * summary_target_ratio`` themselves: that legacy
+        formula is only one branch of the ``tail_token_budget`` property.
+        Caching it unconditionally overwrote the lean clamp
+        ([LEAN_TAIL_FLOOR_TOKENS, LEAN_TAIL_CAP_TOKENS]) after model
+        switches, fallback activations, and context-window refreshes while
+        ``tail_mode`` still claimed "lean". Invalidating the cache keeps the
+        property as the single source of truth for both modes — the same
+        pattern the ``context_length`` setter uses.
+        """
+        self._tail_token_budget = None
+
     @property
     def max_summary_tokens(self) -> int:
         if self._max_summary_tokens is None:
@@ -2805,8 +2821,11 @@ class ContextCompressor(ContextEngine):
         self._apply_threshold_tokens_cap()
         # Recalculate token budgets for the new context length so the
         # compressor stays calibrated after a model switch (e.g. 200K → 32K).
-        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
-        self.tail_token_budget = target_tokens
+        # Invalidate the cached tail budget so the mode-aware property
+        # re-derives it: lean re-clamps to [10K, 25K] of the new window,
+        # legacy recomputes threshold_tokens * summary_target_ratio. Writing
+        # the legacy formula here directly overwrote the lean clamp.
+        self.recalibrate_tail_budget()
         self.max_summary_tokens = min(
             int(context_length * 0.05), _SUMMARY_TOKENS_CEILING,
         )

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1738,16 +1738,18 @@ def check_compression_model_feasibility(agent: Any) -> None:
             # ``tail_token_budget`` is derived from the trigger threshold, not
             # directly from the model window. Keep it in lockstep with this
             # just-in-time correction exactly as ContextCompressor.update_model()
-            # does. Leaving the old budget behind can make the tail's 1.5x soft
-            # ceiling wider than the lowered trigger, so compression preserves
-            # nearly the entire request and repeatedly re-fires.
-            summary_target_ratio = getattr(
-                agent.context_compressor, "summary_target_ratio", None
+            # does: invalidate the cache so the mode-aware property re-derives
+            # it (legacy recomputes threshold_tokens * summary_target_ratio;
+            # lean keeps its clamped window-based budget). Writing the legacy
+            # formula here directly would overwrite the lean clamp. Leaving
+            # the old budget behind can make the tail's 1.5x soft ceiling
+            # wider than the lowered trigger, so compression preserves nearly
+            # the entire request and repeatedly re-fires.
+            _recalibrate_tail = getattr(
+                agent.context_compressor, "recalibrate_tail_budget", None
             )
-            if isinstance(summary_target_ratio, (int, float)):
-                agent.context_compressor.tail_token_budget = int(
-                    new_threshold * summary_target_ratio
-                )
+            if callable(_recalibrate_tail):
+                _recalibrate_tail()
             # Keep threshold_percent in sync so future main-model
             # context_length changes (update_model) re-derive from a
             # sensible number rather than the original too-high value.

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -9,6 +9,8 @@ from unittest.mock import patch, MagicMock
 from agent.context_compressor import (
     ContextCompressor,
     HISTORICAL_TASK_HEADING,
+    LEAN_TAIL_CAP_TOKENS,
+    LEAN_TAIL_FLOOR_TOKENS,
     SUMMARY_PREFIX,
     COMPRESSED_SUMMARY_METADATA_KEY,
     _PRUNE_MIN_CHARS,
@@ -1939,6 +1941,87 @@ class TestUpdateModelBudgets:
         comp.update_model("model-b", context_length=10_000)
         assert comp.tail_token_budget == int(comp.threshold_tokens * comp.summary_target_ratio)
         assert comp.max_summary_tokens == min(int(10_000 * 0.05), 4000)
+
+
+class TestUpdateModelLeanTailBudget:
+    """Regression: update_model() must not overwrite the lean tail budget.
+
+    The tail policy lives in the mode-aware ``tail_token_budget`` property:
+    lean mode clamps ``context_length * 0.025`` to
+    [LEAN_TAIL_FLOOR_TOKENS, LEAN_TAIL_CAP_TOKENS]. update_model() used to
+    unconditionally cache ``threshold_tokens * summary_target_ratio`` (the
+    legacy formula), so a lean compressor on a 1M window jumped from 25K to
+    195K (ratio .30) after any model switch / fallback / context-window
+    refresh — while ``tail_mode`` still claimed "lean".
+    """
+
+    @staticmethod
+    def _lean_comp(ratio: float, context: int = 1_000_000) -> ContextCompressor:
+        return ContextCompressor(
+            "test-model",
+            threshold_percent=0.65,
+            summary_target_ratio=ratio,
+            config_context_length=context,
+            tail_mode="lean",
+            quiet_mode=True,
+        )
+
+    def test_lean_tail_survives_update_model_same_model(self):
+        """1M/.65/.30/lean: 25K before, 25K after — even when the same
+        model and context are re-reported (no-op refresh)."""
+        comp = self._lean_comp(0.30)
+        assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS  # 25K on 1M
+        comp.update_model("test-model", context_length=1_000_000)
+        assert comp.tail_mode == "lean"
+        assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+
+    def test_lean_tail_survives_update_model_low_ratio(self):
+        """ratio .10 must not shrink or inflate the lean clamp either."""
+        comp = self._lean_comp(0.10)
+        assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+        comp.update_model("test-model", context_length=1_000_000)
+        assert comp.tail_mode == "lean"
+        assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+
+    def test_lean_tail_recalculated_on_context_change(self):
+        """A genuine window change re-derives the budget through the
+        canonical clamp: 1M -> 25K cap, 372K -> floor (9,300 < 10K),
+        back to 1M -> 25K again."""
+        comp = self._lean_comp(0.30)
+        assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+
+        comp.update_model("small-model", context_length=372_000)
+        expected = max(
+            LEAN_TAIL_FLOOR_TOKENS,
+            min(LEAN_TAIL_CAP_TOKENS, int(372_000 * 0.025)),
+        )
+        assert expected == LEAN_TAIL_FLOOR_TOKENS  # 9,300 clamps to 10K
+        assert comp.tail_mode == "lean"
+        assert comp.tail_token_budget == expected
+
+        comp.update_model("big-model", context_length=1_000_000)
+        assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+
+    def test_legacy_tail_recalculated_on_update_model(self):
+        """Legacy behavior is unchanged: budget stays threshold*ratio
+        across update_model()."""
+        comp = ContextCompressor(
+            "test-model",
+            threshold_percent=0.65,
+            summary_target_ratio=0.30,
+            config_context_length=1_000_000,
+            tail_mode="legacy",
+            quiet_mode=True,
+        )
+        before = comp.tail_token_budget
+        assert before == int(comp.threshold_tokens * comp.summary_target_ratio)
+        comp.update_model("test-model", context_length=1_000_000)
+        assert comp.tail_mode == "legacy"
+        assert comp.tail_token_budget == before
+        comp.update_model("small-model", context_length=372_000)
+        assert comp.tail_token_budget == int(
+            comp.threshold_tokens * comp.summary_target_ratio
+        )
 
 
 class TestUpdateModelResetsCalibration:

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -13,7 +13,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from run_agent import AIAgent
-from agent.context_compressor import ContextCompressor
+from agent.context_compressor import (
+    ContextCompressor,
+    LEAN_TAIL_CAP_TOKENS,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -31,8 +34,16 @@ def _make_agent(
     compression_enabled: bool = True,
     threshold_percent: float = 0.50,
     main_context: int = 200_000,
+    tail_mode: str = "legacy",
+    real_compressor: bool = False,
 ) -> AIAgent:
-    """Build a minimal AIAgent with a compressor, skipping __init__."""
+    """Build a minimal AIAgent with a compressor, skipping __init__.
+
+    The default MagicMock compressor is enough for warning/message tests.
+    ``real_compressor=True`` builds a REAL ContextCompressor so the
+    mode-aware tail policy is exercised end to end — a mock would silently
+    accept any budget the aux-context sync writes.
+    """
     agent = AIAgent.__new__(AIAgent)
     agent.model = "test-main-model"
     agent.provider = "openrouter"
@@ -54,13 +65,30 @@ def _make_agent(
     agent._custom_providers = []
     agent.tools = []
 
-    compressor = MagicMock(spec=ContextCompressor)
-    compressor.context_length = main_context
-    compressor.threshold_tokens = int(main_context * threshold_percent)
-    compressor.summary_target_ratio = 0.20
-    compressor.tail_token_budget = int(
-        compressor.threshold_tokens * compressor.summary_target_ratio
-    )
+    if real_compressor:
+        compressor = ContextCompressor(
+            model=agent.model,
+            threshold_percent=threshold_percent,
+            summary_target_ratio=0.20,
+            config_context_length=main_context,
+            tail_mode=tail_mode,
+            quiet_mode=True,
+        )
+    else:
+        compressor = MagicMock(spec=ContextCompressor)
+        compressor.context_length = main_context
+        compressor.threshold_tokens = int(main_context * threshold_percent)
+        compressor.summary_target_ratio = 0.20
+        compressor.tail_token_budget = int(
+            compressor.threshold_tokens * compressor.summary_target_ratio
+        )
+        # Mimic the real legacy policy: recalibration re-derives the tail
+        # from the CURRENT threshold at the configured ratio (the real
+        # method invalidates a cache the mode-aware property re-fills).
+        compressor.recalibrate_tail_budget.side_effect = lambda: setattr(
+            compressor, "tail_token_budget",
+            int(compressor.threshold_tokens * compressor.summary_target_ratio),
+        )
     agent.context_compressor = compressor
 
     return agent
@@ -108,8 +136,74 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     # Every threshold-derived budget must move with it. Keeping the original
     # 20K tail here would protect 25% of the lowered threshold instead of the
     # configured 20%, and larger real-world mismatches can make the tail's 1.5x
-    # soft ceiling wider than the entire compression trigger.
+    # soft ceiling wider than the entire compression trigger. The sync goes
+    # through the canonical mode-aware hook; the mock's side_effect re-derives
+    # the legacy budget from the lowered threshold.
+    agent.context_compressor.recalibrate_tail_budget.assert_called_once()
     assert agent.context_compressor.tail_token_budget == 16_000
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_aux_sync_keeps_lean_tail_policy(mock_get_client, mock_ctx_len):
+    """Regression: the aux-context threshold sync must not cache a legacy
+    threshold*ratio tail when tail_mode is lean.
+
+    Real compressor, 1M main window (lean tail = 25K cap), aux context 80K
+    lowers the live threshold to 80K. The legacy formula would write
+    80K * 0.20 = 16K into the tail budget; lean must stay at its canonical
+    clamp (25K on a 1M window) and keep tail_mode == "lean".
+    """
+    agent = _make_agent(
+        main_context=1_000_000,
+        threshold_percent=0.65,
+        tail_mode="lean",
+        real_compressor=True,
+    )
+    comp = agent.context_compressor
+    assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS  # 25K on 1M
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+    agent._emit_status = lambda msg: None
+
+    agent._check_compression_model_feasibility()
+
+    # The threshold was lowered to the aux context...
+    assert comp.threshold_tokens == 80_000
+    # ...but the lean tail policy survived the sync.
+    assert comp.tail_mode == "lean"
+    assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_aux_sync_legacy_tail_follows_lowered_threshold(mock_get_client, mock_ctx_len):
+    """Legacy behavior on the same sync path is unchanged: the tail budget
+    follows the lowered threshold at the configured ratio (80K * 0.20)."""
+    agent = _make_agent(
+        main_context=1_000_000,
+        threshold_percent=0.65,
+        tail_mode="legacy",
+        real_compressor=True,
+    )
+    comp = agent.context_compressor
+    before = comp.tail_token_budget
+    assert before == int(comp.threshold_tokens * comp.summary_target_ratio)
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+    agent._emit_status = lambda msg: None
+
+    agent._check_compression_model_feasibility()
+
+    assert comp.threshold_tokens == 80_000
+    assert comp.tail_mode == "legacy"
+    assert comp.tail_token_budget == int(80_000 * comp.summary_target_ratio)
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=32_768)


### PR DESCRIPTION
## Problem

`tail_mode=lean` initially computes the correct tail budget — `clamp(context_length * 0.025, 10K, 25K)` via the mode-aware `tail_token_budget` property — but two runtime recalibration paths bypass that policy and cache the legacy formula (`threshold_tokens * summary_target_ratio`) directly:

- `ContextCompressor.update_model()` — reachable from model switches, fallback activations/restores, and provider-reported context-window refreshes (including same-model refreshes)
- `check_compression_model_feasibility()` aux-context threshold sync

On a 1M window with `threshold: 0.65` and `target_ratio: 0.30`, the lean tail jumps from 25K to 195K after any such event while `tail_mode` still claims `"lean"` (ratio 0.10 → 65K).

## Fix

Add `ContextCompressor.recalibrate_tail_budget()`, which invalidates the cached budget so the mode-aware property re-derives it — the same pattern the `context_length` setter already uses. Both recalibration paths now call it instead of re-implementing the legacy formula, keeping the property the single source of truth for both modes.

Legacy behavior is unchanged: the property's legacy branch recomputes `threshold_tokens * summary_target_ratio` on the next read.

## Tests

- `update_model()` in lean: same-model refresh, low ratio, and window-change re-clamping (1M → 25K cap, 372K → 10K floor, back to 1M → 25K)
- `update_model()` in legacy: budget stays `threshold * ratio`
- aux-context sync path in both modes via a real compressor (lean keeps the clamp; legacy follows the lowered threshold)

All new tests fail on the pre-fix code with the exact buggy values (195K/65K/16K) and pass with the fix.
