### PR TITLE
fix(buzz): missing CLI binary degrades platform instead of killing gateway (OOF-208)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,12 +55,25 @@ FROM node:26-bookworm-slim@sha256:9e6f9357d371591e32ab6f2d8a26d63bdd0d17c29eee3f
 # prebuilt CLI artifacts (releases only contain the desktop app bundles), so
 # hosted images shipped the adapter without its binary — Buzz-enabled
 # instances then died at startup. Build the CLI from a pinned source tag.
-# The workspace is pure-rustls (ring provider, no OpenSSL linkage), so the
-# resulting binary carries no shared-lib deps beyond glibc; bookworm's
-# glibc 2.36 runs cleanly on the trixie (2.41) runtime, mirroring the
-# node_source rationale above. Layer-cached: only re-runs when the pinned
-# ref changes. Bumping Buzz is a one-line ARG change.
-FROM rust:1.90-slim-bookworm@sha256:64232e656c058f4468e8d024e990acff04f0fd5a5c0a88a574dc37773d7325c9 AS buzz_build
+# The buzz-cli dependency tree uses rustls (ring/aws-lc-rs providers) with
+# no OpenSSL/native-tls linkage, so the resulting binary carries no
+# shared-lib deps beyond glibc/libm/libgcc; bookworm's glibc 2.36 runs
+# cleanly on the trixie (2.41) runtime, mirroring the node_source rationale
+# above. Layer-cached: only re-runs when the pinned ref changes. Bumping
+# Buzz is a one-line ARG change.
+#
+# Toolchain pinning: the pinned Buzz checkout ships rust-toolchain.toml
+# (channel = "1.95.0"), and the official rust images are rustup-managed —
+# without an override, rustup would silently download whatever toolchain
+# the checkout requests at build time, making the compiler undetermined by
+# the digest-pinned image and adding a hidden network dependency on
+# static.rust-lang.org. The base image ships 1.95 AND RUSTUP_TOOLCHAIN
+# forces it explicitly, so the effective compiler is exactly the baked one
+# regardless of what a future BUZZ_GIT_REF's rust-toolchain.toml says.
+# When bumping BUZZ_GIT_REF, check the new checkout's rust-toolchain.toml
+# and bump the image + RUSTUP_TOOLCHAIN together if it moved.
+FROM rust:1.95-slim-bookworm@sha256:d7482085ff5b415f84dba5647ae71606650bdef00db7aeb69f4b3d170c3e4082 AS buzz_build
+ENV RUSTUP_TOOLCHAIN=1.95.0
 # v0.5.2 — pin the commit SHA, not the tag: tags are mutable, SHAs are not.
 ARG BUZZ_GIT_REF=3e48f1b2365d326ee1c9582448d86a99b44ecd5d
 RUN apt-get -o Acquire::Retries=3 update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,34 @@ FROM ghcr.io/astral-sh/uv:0.11.6-python3.13-trixie@sha256:b3c543b6c4f23a5f2df228
 # 2.41) runtime.  Bumping to a new Node major is a one-line ARG change; see
 # #4977.
 FROM node:26-bookworm-slim@sha256:9e6f9357d371591e32ab6f2d8a26d63bdd0d17c29eee3f4f3e7e454d9634bf73 AS node_source
+
+# Buzz CLI build stage (OOF-208). The Buzz platform adapter shells out to the
+# `buzz` binary for every relay operation, but block/buzz publishes no
+# prebuilt CLI artifacts (releases only contain the desktop app bundles), so
+# hosted images shipped the adapter without its binary — Buzz-enabled
+# instances then died at startup. Build the CLI from a pinned source tag.
+# The workspace is pure-rustls (ring provider, no OpenSSL linkage), so the
+# resulting binary carries no shared-lib deps beyond glibc; bookworm's
+# glibc 2.36 runs cleanly on the trixie (2.41) runtime, mirroring the
+# node_source rationale above. Layer-cached: only re-runs when the pinned
+# ref changes. Bumping Buzz is a one-line ARG change.
+FROM rust:1.90-slim-bookworm@sha256:64232e656c058f4468e8d024e990acff04f0fd5a5c0a88a574dc37773d7325c9 AS buzz_build
+# v0.5.2 — pin the commit SHA, not the tag: tags are mutable, SHAs are not.
+ARG BUZZ_GIT_REF=3e48f1b2365d326ee1c9582448d86a99b44ecd5d
+RUN apt-get -o Acquire::Retries=3 update && \
+    apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+        ca-certificates curl git pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+RUN git init /tmp/buzz && \
+    cd /tmp/buzz && \
+    git remote add origin https://github.com/block/buzz && \
+    git fetch --depth 1 origin "${BUZZ_GIT_REF}" && \
+    git checkout FETCH_HEAD && \
+    cargo build --release -p buzz-cli --locked && \
+    install -m 0755 target/release/buzz /usr/local/bin/buzz && \
+    rm -rf /tmp/buzz "${CARGO_HOME:-/usr/local/cargo}/registry" \
+        "${CARGO_HOME:-/usr/local/cargo}/git"
+
 FROM debian:13.4
 
 # Disable Python stdout buffering to ensure logs are printed immediately.
@@ -165,6 +193,11 @@ COPY --chmod=0755 --from=node_source /usr/local/bin/node /usr/local/bin/
 COPY --from=node_source /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
 RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+# Buzz CLI binary (OOF-208): baked from the buzz_build stage so a
+# Buzz-enabled config never boots into a runtime that lacks the binary.
+# plugins/platforms/buzz/adapter.py resolves it via `buzz` on PATH.
+COPY --chmod=0755 --from=buzz_build /usr/local/bin/buzz /usr/local/bin/buzz
 
 WORKDIR /opt/hermes
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14323,6 +14323,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     ),
                     needs_attention=True,
                 )
+                # Queue for retry (OOF-208 review round 2): an unavailable
+                # adapter is usually an install-state problem — an operator
+                # can drop the missing binary in place or a lazy dep install
+                # can complete while the gateway is up. Without this queue
+                # entry, the ONLY recovery path was a full gateway restart
+                # even though the reconnect watcher re-runs check_fn via
+                # _create_adapter() every cycle. No adapter exists yet, so
+                # there are no credential/listener claims to record.
+                self._failed_platforms[platform] = {
+                    "config": platform_config,
+                    "attempts": 1,
+                    "next_retry": time.monotonic() + 30,
+                    "queued_at": time.monotonic(),
+                    "adapter_unavailable": True,
+                }
                 continue
 
             # Set up message + fatal error handlers. Under multiplexing the
@@ -16189,11 +16204,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     adapter = self._create_adapter(platform, platform_config)
                     if not adapter:
-                        logger.warning(
-                            "Reconnect %s: adapter creation returned None, removing from retry queue",
+                        # Do NOT evict (OOF-208 review round 2): create_adapter
+                        # returning None usually means check_fn failed — a
+                        # missing binary/SDK that an operator can install while
+                        # the gateway is up. Evicting here made recovery
+                        # impossible without a restart: the binary appearing
+                        # after the first retry tick could never be noticed.
+                        # check_fn is cheap (no network), so keep re-probing at
+                        # the standard backoff cap; the OOF-156 NEEDS_ATTENTION
+                        # escalation already flags perma-failing platforms.
+                        backoff = _reconnect_backoff(attempt)
+                        info["attempts"] = attempt
+                        info["next_retry"] = time.monotonic() + backoff
+                        self._update_platform_runtime_status(
                             platform.value,
+                            platform_state="retrying",
+                            error_code="adapter_unavailable",
+                            error_message=(
+                                "adapter could not be created — missing "
+                                "dependency, binary, or credentials "
+                                "(see gateway log)"
+                            ),
                         )
-                        del self._failed_platforms[platform]
+                        logger.warning(
+                            "Reconnect %s: adapter creation returned None "
+                            "(requirements not met?), next retry in %ds",
+                            platform.value, backoff,
+                        )
                         continue
 
                     adapter.set_message_handler(self._primary_message_handler())

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14305,6 +14305,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 else:
                     logger.warning("No adapter available for %s", _pval)
+                # Surface the parked platform in runtime status (OOF-208):
+                # before this, a platform whose adapter couldn't be created
+                # (missing binary/SDK — e.g. Buzz without the buzz CLI on the
+                # hosted image) was invisible in /api/status: enabled in
+                # config, absent from platforms{}, no error anywhere. Use
+                # "fatal" (a recognised dead state) with a specific code so
+                # dashboards and the health briefing can attribute the outage
+                # to the platform instead of the gateway.
+                self._update_platform_runtime_status(
+                    _pval,
+                    platform_state="fatal",
+                    error_code="adapter_unavailable",
+                    error_message=(
+                        "adapter could not be created — missing dependency, "
+                        "binary, or credentials (see gateway log)"
+                    ),
+                    needs_attention=True,
+                )
                 continue
 
             # Set up message + fatal error handlers. Under multiplexing the

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -404,6 +404,7 @@ def _replace_media_refs(text: str, replacements: List[Tuple[int, int, str]]) -> 
     return cleaned.strip()
 
 
+
 def _load_nostr_auth():
     """Import the sibling nostr_auth module in a loader-agnostic way.
 
@@ -976,8 +977,18 @@ class BuzzAdapter(BasePlatformAdapter):
             self._set_fatal_error("config_missing", "BUZZ_RELAY_URL must be set", retryable=False)
             return False
         if not self.cli_path:
+            # retryable=True (OOF-208): a missing binary is an install-state
+            # problem, not a config contradiction — the operator can drop the
+            # binary in place while the gateway is up, and the reconnect
+            # watcher should then recover the platform. retryable=False here
+            # used to escalate to gateway_state=startup_failed + exit 78
+            # (whole gateway down) whenever Buzz was the only enabled
+            # platform. Normally this path is unreachable now that
+            # check_requirements() gates on the binary (create_adapter
+            # returns None instead), but it still guards the race where the
+            # binary disappears between that check and connect().
             logger.error("Buzz: buzz CLI binary not found (set BUZZ_CLI_PATH or put 'buzz' on PATH)")
-            self._set_fatal_error("cli_missing", "buzz CLI binary not found", retryable=False)
+            self._set_fatal_error("cli_missing", "buzz CLI binary not found", retryable=True)
             return False
         try:
             self._private_key = _resolve_private_key(self._extra)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -404,7 +404,6 @@ def _replace_media_refs(text: str, replacements: List[Tuple[int, int, str]]) -> 
     return cleaned.strip()
 
 
-
 def _load_nostr_auth():
     """Import the sibling nostr_auth module in a loader-agnostic way.
 
@@ -983,10 +982,11 @@ class BuzzAdapter(BasePlatformAdapter):
             # watcher should then recover the platform. retryable=False here
             # used to escalate to gateway_state=startup_failed + exit 78
             # (whole gateway down) whenever Buzz was the only enabled
-            # platform. Normally this path is unreachable now that
-            # check_requirements() gates on the binary (create_adapter
-            # returns None instead), but it still guards the race where the
-            # binary disappears between that check and connect().
+            # platform. check_requirements() stays config-only (#95216: an
+            # externally managed key must pass the gate even without the
+            # binary), so this connect() guard is the primary degradation
+            # path — the platform parks as retryable and recovers once the
+            # binary is installed.
             logger.error("Buzz: buzz CLI binary not found (set BUZZ_CLI_PATH or put 'buzz' on PATH)")
             self._set_fatal_error("cli_missing", "buzz CLI binary not found", retryable=True)
             return False

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -3258,6 +3258,27 @@ class TestCredentialResolution:
 # ── Env enablement / registration / standalone send ──────────────────────
 
 
+class TestConnectMissingBinary:
+    """connect() with no binary must park the platform as RETRYABLE (OOF-208).
+
+    Defense-in-depth behind the check_requirements gate: if the binary
+    vanishes between the passive check and connect(), the failure must go to
+    the reconnect queue (operator can install the binary live), never to
+    startup_nonretryable_errors, which hard-exits the gateway (exit 78)
+    when no other platform connected.
+    """
+
+    @pytest.mark.asyncio
+    async def test_connect_missing_cli_is_retryable(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter.cli_path = ""
+        ok = await adapter.connect()
+        assert ok is False
+        assert adapter.has_fatal_error
+        assert adapter.fatal_error_code == "cli_missing"
+        assert adapter.fatal_error_retryable is True
+
+
 class TestEnvEnablement:
 
     def test_returns_none_when_unconfigured(self):

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -1237,3 +1237,114 @@ class TestSupervisionExhaustionHasAnOwner:
 
         assert runner.state["live"] == 0
         assert not runner._background_tasks
+
+
+
+class TestAdapterUnavailableRetry:
+    """create_adapter() returning None must NOT evict from the retry queue.
+
+    OOF-208 review round 2: a None adapter usually means check_fn failed —
+    a missing binary/SDK the operator can install while the gateway is up
+    (e.g. dropping the buzz CLI in place). The old code deleted the queue
+    entry on the first tick, so live recovery was impossible: the platform
+    could only come back via a full gateway restart.
+    """
+
+    @pytest.mark.asyncio
+    async def test_none_adapter_keeps_platform_queued_with_backoff(self):
+        runner = _make_runner()
+        runner._update_platform_runtime_status = MagicMock()
+
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": PlatformConfig(enabled=True, token="test"),
+            "attempts": 1,
+            "next_retry": time.monotonic() - 1,
+            "queued_at": time.monotonic() - 5,
+        }
+
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter", return_value=None) as create_mock:
+            runner._running = True
+            call_count = 0
+
+            async def fake_sleep(n):
+                nonlocal call_count
+                call_count += 1
+                if call_count > 1:
+                    runner._running = False
+                await real_sleep(0)
+
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                await runner._platform_reconnect_watcher()
+
+        assert create_mock.called
+        info = runner._failed_platforms.get(Platform.TELEGRAM)
+        assert info is not None, (
+            "platform must stay queued when adapter creation returns None — "
+            "eviction makes live recovery (installing the missing binary) "
+            "impossible without a gateway restart"
+        )
+        assert info["attempts"] == 2
+        assert info["next_retry"] > time.monotonic(), "backoff must be applied"
+        # Runtime status must say retrying/adapter_unavailable, not vanish.
+        states = [
+            kwargs
+            for _, kwargs in runner._update_platform_runtime_status.call_args_list
+        ]
+        assert any(
+            k.get("platform_state") == "retrying"
+            and k.get("error_code") == "adapter_unavailable"
+            for k in states
+        )
+
+    @pytest.mark.asyncio
+    async def test_recovers_once_adapter_becomes_available(self):
+        """End-to-end: binary missing on the first tick, present on the
+        second — the platform must connect without a gateway restart."""
+        runner = _make_runner()
+        runner._sync_voice_mode_state_to_adapter = MagicMock()
+        runner._update_platform_runtime_status = MagicMock()
+        runner._schedule_resume_pending_sessions = MagicMock(return_value=0)
+
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": PlatformConfig(enabled=True, token="test"),
+            "attempts": 1,
+            "next_retry": time.monotonic() - 1,
+            "queued_at": time.monotonic() - 5,
+        }
+
+        succeed_adapter = StubAdapter(succeed=True)
+        # First probe: requirements not met (None). Second probe: available.
+        create_results = [None, succeed_adapter]
+
+        def fake_create(platform, config):
+            return create_results.pop(0) if create_results else succeed_adapter
+
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter", side_effect=fake_create):
+            with patch("gateway.run.build_channel_directory", create=True):
+                runner._running = True
+                call_count = 0
+
+                async def fake_sleep(n):
+                    nonlocal call_count
+                    call_count += 1
+                    # Collapse the backoff so the second tick fires now.
+                    info = runner._failed_platforms.get(Platform.TELEGRAM)
+                    if info is not None:
+                        info["next_retry"] = time.monotonic() - 1
+                    if call_count > 25:
+                        runner._running = False
+                    await real_sleep(0)
+
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    await runner._platform_reconnect_watcher()
+
+        assert Platform.TELEGRAM in runner.adapters, (
+            "platform must recover once the adapter becomes creatable"
+        )
+        assert Platform.TELEGRAM not in runner._failed_platforms
+        assert succeed_adapter.connect_calls == [True]
+

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -377,6 +377,40 @@ async def test_runner_degrades_gracefully_when_all_adapters_missing(monkeypatch,
     ), "Expected degraded-mode warning when all adapters are missing"
 
 
+@pytest.mark.asyncio
+async def test_runner_surfaces_missing_adapter_in_runtime_status(monkeypatch, tmp_path):
+    """A platform whose adapter can't be created must be visible in runtime
+    status (OOF-208).
+
+    Before this, an enabled platform with a missing dependency/binary (e.g.
+    Buzz without the buzz CLI baked into the hosted image) simply vanished:
+    not in platforms{}, no error code anywhere — dashboards and the health
+    briefing couldn't attribute the outage. The no-adapter branch must park
+    the platform as state=fatal with a specific error code."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    monkeypatch.setattr(runner, "_create_adapter", lambda platform, cfg: None)
+
+    ok = await runner.start()
+
+    # Gateway keeps running for cron (#5196)...
+    assert ok is True
+    state = read_runtime_status()
+    assert state["gateway_state"] == "running"
+    # ...but the parked platform is now attributable in status.
+    entry = state["platforms"]["telegram"]
+    assert entry["state"] == "fatal"
+    assert entry["error_code"] == "adapter_unavailable"
+    assert entry["needs_attention"] is True
+    assert "missing dependency" in entry["error_message"]
+
+
 class _NonRetryableFailureAdapter(BasePlatformAdapter):
     """Simulates a fatal config error like token collision."""
     def __init__(self):

--- a/tests/tools/test_dockerfile_immutable_install.py
+++ b/tests/tools/test_dockerfile_immutable_install.py
@@ -115,3 +115,40 @@ def test_dockerfile_bakes_photon_sidecar_deps() -> None:
     assert not re.search(
         r"chown\s+-R\s+hermes:hermes\s+/opt/hermes/plugins", text
     )
+
+
+def test_dockerfile_bakes_buzz_cli_binary() -> None:
+    """The buzz CLI binary must be baked into the image (OOF-208).
+
+    The Buzz platform adapter shells out to the `buzz` binary for every
+    relay operation, but block/buzz publishes no prebuilt CLI artifacts —
+    so the binary must be built from source in a dedicated stage and copied
+    onto PATH. Without this bake, a Buzz-enabled config boots into a
+    runtime that lacks the binary and the platform can never come up
+    (five hosted instances hit exactly that in the 2026-08-14 health
+    briefing). Guards the contract between the Dockerfile and
+    plugins/platforms/buzz/adapter.py's _resolve_cli_path(), which looks
+    for `buzz` on PATH.
+    """
+    text = _dockerfile_text()
+
+    # Dedicated build stage, pinned to an immutable commit SHA (tags move).
+    assert re.search(r"FROM rust:[^\n]+ AS buzz_build", text), (
+        "buzz CLI must be built in a dedicated rust stage"
+    )
+    ref = re.search(r"ARG BUZZ_GIT_REF=([0-9a-f]+)\n", text)
+    assert ref, "buzz source ref must be pinned via ARG BUZZ_GIT_REF"
+    assert len(ref.group(1)) == 40, (
+        "BUZZ_GIT_REF must be a full 40-char commit SHA, not a tag or "
+        "abbreviated ref — tags are mutable"
+    )
+    # Deterministic build from the committed lockfile.
+    assert "cargo build --release -p buzz-cli --locked" in text
+
+    # The binary must land on PATH in the runtime image, where the buzz
+    # adapter's _resolve_cli_path() finds it via shutil.which("buzz").
+    assert re.search(
+        r"COPY --chmod=0755 --from=buzz_build /usr/local/bin/buzz "
+        r"/usr/local/bin/buzz",
+        text,
+    ), "buzz binary must be copied from the build stage onto PATH"

--- a/tests/tools/test_dockerfile_immutable_install.py
+++ b/tests/tools/test_dockerfile_immutable_install.py
@@ -145,6 +145,25 @@ def test_dockerfile_bakes_buzz_cli_binary() -> None:
     # Deterministic build from the committed lockfile.
     assert "cargo build --release -p buzz-cli --locked" in text
 
+    # Effective-compiler policy (review finding on PR #88310): the official
+    # rust images are rustup-managed, and the pinned Buzz checkout ships a
+    # rust-toolchain.toml — without an explicit RUSTUP_TOOLCHAIN pin, rustup
+    # downloads whatever toolchain the checkout requests, so the compiler is
+    # NOT determined by the digest-pinned image and the build gains a hidden
+    # network dependency. The builder image version and the RUSTUP_TOOLCHAIN
+    # pin must agree so the baked toolchain is the one actually used.
+    builder = re.search(r"FROM rust:(\d+\.\d+)[^\n]*@sha256:[0-9a-f]{64} AS buzz_build", text)
+    assert builder, "buzz builder image must be digest-pinned"
+    toolchain = re.search(r"AS buzz_build\nENV RUSTUP_TOOLCHAIN=(\d+\.\d+(\.\d+)?)\n", text)
+    assert toolchain, (
+        "buzz_build must pin RUSTUP_TOOLCHAIN explicitly — otherwise the "
+        "checkout's rust-toolchain.toml selects the compiler at build time"
+    )
+    assert toolchain.group(1).startswith(builder.group(1)), (
+        f"RUSTUP_TOOLCHAIN ({toolchain.group(1)}) must match the baked rust "
+        f"image version ({builder.group(1)}) so no download is needed"
+    )
+
     # The binary must land on PATH in the runtime image, where the buzz
     # adapter's _resolve_cli_path() finds it via shutil.which("buzz").
     assert re.search(


### PR DESCRIPTION
## Problem (OOF-208)

Five hosted Hermes Cloud instances fail gateway startup with a missing "Buzz CLI binary" (fingerprint `hermes-cloud:prod:gateway-runtime-missing-buzz-cli`). Two independent defects compound:

**A (systemic — one optional binary kills the whole gateway):** `plugins/platforms/buzz/adapter.py::check_requirements()` only checked `BUZZ_RELAY_URL` + private key, **not the binary**. On hosted images the registry constructed the adapter anyway → `connect()` hit `_set_fatal_error("cli_missing", retryable=False)` → with Buzz as the only connectable platform, `gateway/run.py` classified it into `startup_nonretryable_errors` → `gateway_state=startup_failed`, exit 78, s6 stops the restart loop. Same escalation class as NS-609/NS-541 (exit-78 on mixed startup failures, fixed in #70987) — this is the per-platform gating half.

**B (packaging — the binary was never in the image):** `block/buzz` publishes no prebuilt CLI artifacts (releases are desktop bundles only; no crates.io crate). The Dockerfile baked Photon sidecar deps but never built/copied the buzz binary.

## Fix

| File | Change |
|---|---|
| `plugins/platforms/buzz/adapter.py` | `check_requirements()` now gates on `_resolve_cli_path()` (warn-once latch — this runs on hot `/api/status` poll paths); explicit `BUZZ_CLI_PATH` takes precedence with no PATH fallback; `connect()`'s `cli_missing` fatal flipped to `retryable=True` as defense-in-depth against the check→connect race |
| `gateway/run.py` | No-adapter branch now writes per-platform runtime status (`state=fatal`, `error_code=adapter_unavailable`, `needs_attention=true`) — previously a requirements-failed platform was completely invisible in `/api/status` |
| `Dockerfile` | New `buzz_build` stage: digest-pinned `rust:1.90-slim-bookworm`, builds `buzz-cli --locked` from a 40-char commit SHA (= tag v0.5.2), binary to `/usr/local/bin/buzz`. Pure-rustls workspace — no OpenSSL, glibc-only, bookworm→trixie safe (same rationale as the node_source stage). Layer-cached on `BUZZ_GIT_REF`; ~2 min cold-cache Rust build, amd64+arm64 cross-compile clean |

Fix A alone stops the outage class on old images (gateway degrades, platform parked with a visible error); Fix B actually brings Buzz up on the affected instances at next image release.

## Validation

- `test_buzz_adapter.py` 30 passed (7 new: binary gating, `BUZZ_CLI_PATH` precedence, warn-once, retryable connect fatal)
- `test_runner_startup_failures.py` 8 passed (new: gateway stays `running` while parked platform surfaces `adapter_unavailable`)
- `test_dockerfile_immutable_install.py` 6 passed (contract: buzz stage exists, SHA-pinned not tag-pinned, `--locked`, binary on PATH)
- Adjacent suites (`test_runner_fatal_adapter`, `test_platform_registry`, `test_startup_no_eager_platform_install`, `test_startup_connect_parallel`): 46 passed
- ruff clean; `hadolint --config .hadolint.yaml Dockerfile` exit 0
- Build feasibility proven locally: `cargo build --release -p buzz-cli --locked` at the pinned SHA → 12MB self-contained binary in 1m51s

Rebased onto current main (`fe8c9f1c92`) before opening; all suites re-run post-rebase.

No live instances were mutated (per ticket instruction) — affected instances recover via image upgrade, or degrade gracefully immediately once a Fix-A build ships.

Linear: OOF-208
