### PR TITLE
fix(desktop): avoid stale restore ordinals

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -472,7 +472,7 @@ describe('runRewindSubmit durable-address discipline (#87059)', () => {
     expect(submit?.params?.confirm_truncate).toBeUndefined()
   })
 
-  it('leaves a bound durable rowId untouched (no extra history call)', async () => {
+  it('uses a bound durable rowId without the redundant client ordinal', async () => {
     const calls: Call[] = []
 
     await runRewindSubmit(makeGateway(calls), 'sid', 'fixed prompt', 1, undefined, false, undefined, 13, 'typo prompt')
@@ -482,6 +482,9 @@ describe('runRewindSubmit durable-address discipline (#87059)', () => {
     const submit = calls.find(call => call.method === 'prompt.submit')
 
     expect(submit?.params?.truncate_before_row_id).toBe(13)
-    expect(submit?.params?.truncate_before_user_ordinal).toBe(1)
+    // A row id is authoritative. The visible ordinal can be stale after an
+    // interrupted/optimistic turn, so sending both can only trigger a safe
+    // backend refusal — never improve the cut address.
+    expect(submit?.params?.truncate_before_user_ordinal).toBeUndefined()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -262,6 +262,15 @@ export async function runRewindSubmit(
     resolvedMessageId = undefined
   }
 
+  // A durable row id is the authoritative truncation address. The client
+  // ordinal is only a redundant cross-check and can become stale when the
+  // renderer retains an interrupted/optimistic user bubble that never reached
+  // the durable transcript. Sending both then produces a safe but recurring
+  // 4030 refusal, while the row id alone still aims the exact same turn.
+  if (typeof resolvedRowId === 'number') {
+    resolvedOrdinal = undefined
+  }
+
   const interrupt = async () => {
     try {
       await requestGateway('session.interrupt', { session_id: liveSessionId })


### PR DESCRIPTION
## Summary
- use `truncate_before_row_id` as the sole authoritative Restore target
- omit the redundant client ordinal when it may have drifted after optimistic or interrupted turns
- add a regression test for the bound-row-ID path

## Problem
Restore could repeatedly fail with `truncate_before_user_ordinal (...) does not match truncate_before_row_id target turn (...)`. The row ID was correct, but the renderer ordinal was stale; the gateway safely refused to truncate.

## Verification
- `npm test -- src/app/session/hooks/use-prompt-actions/rewind.test.ts` — 28 passed
- `npm run typecheck` — passed
- independent review — approved
- `git diff --check` — passed