### PR TITLE
fix(whatsapp): format message edits

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1008,12 +1008,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return SendResult(success=False, error=bridge_exit)
         try:
             import aiohttp
+            formatted = self.format_message(content)
             async with self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/edit",
                 json={
                     "chatId": to_whatsapp_jid(chat_id),
                     "messageId": message_id,
-                    "message": content,
+                    "message": formatted,
                 },
                 timeout=aiohttp.ClientTimeout(total=15)
             ) as resp:

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -111,6 +111,26 @@ class TestFormatMessage:
         assert adapter.format_message("_italic_") == "_italic_"
 
 
+class TestEditMessage:
+    """WhatsApp edits use the same formatting pipeline as sends."""
+
+    @pytest.mark.asyncio
+    async def test_formats_markdown_before_delivery(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.edit_message(
+            "chat1",
+            "msg1",
+            "**Findings** and **59 passed**",
+        )
+
+        assert result.success
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == "*Findings* and *59 passed*"
+
+
 # ---------------------------------------------------------------------------
 # MAX_MESSAGE_LENGTH tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug Description

WhatsApp's normal send path converts standard Markdown to WhatsApp syntax, but edits sent through the bridge bypass that conversion. During edit-based streaming, completed Markdown such as `**Findings**` therefore reaches WhatsApp unchanged and can render with literal asterisks.

## Root Cause

`WhatsAppAdapter.send()` passes content through `format_message()`, while `WhatsAppAdapter.edit_message()` puts the raw `content` directly into the bridge `/edit` payload.

## Fix

- Format edit content with the adapter's existing `format_message()` implementation before constructing the bridge payload.
- Add a regression test at the bridge payload boundary proving standard Markdown is converted for edits.

## How to Verify

1. Call `WhatsAppAdapter.edit_message()` with `**Findings** and **59 passed**`.
2. Inspect the JSON sent to the bridge `/edit` endpoint.
3. Confirm `message` is `*Findings* and *59 passed*`, matching WhatsApp syntax and the normal send path.

## Test Plan

- [x] Added regression test for this bug
- [x] `scripts/run_tests.sh tests/gateway/test_whatsapp_formatting.py` — 11 passed
- [x] WhatsApp, stream-consumer, and suppression suites — 222 passed, 2 skipped, 1 expected failure
- [x] `scripts/check-windows-footguns.py` — passed

A full-suite attempt reached 28% with nine unrelated collection errors because the local development environment does not contain the optional `acp` package; no additional test failures had appeared when the run was stopped.

## Risk Assessment

Low — the change reuses the established WhatsApp formatter and makes the edit path consistent with the existing send path. It does not change bridge APIs, streaming orchestration, or the formatter itself.
