### PR TITLE
fix(terminal): don't let empty config collections override env vars

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3490,6 +3490,26 @@ def apply_terminal_config_to_env(
             ):
                 value = os.path.expanduser(value)
         if (should_override and cfg_key in explicit_keys) or env_var not in target:
+            # Don't let an empty collection in config override a non-empty env var.
+            # Empty list/dict is almost never intentional — it's usually a serialized
+            # default from `hermes setup` that should not clobber env-driven mounts.
+            if (
+                should_override
+                and cfg_key in explicit_keys
+                and isinstance(value, (list, dict))
+                and not value
+                and env_var in target
+                and target[env_var]
+            ):
+                logger.warning(
+                    "terminal.%s is an empty %s in config.yaml but %s is set in env — "
+                    "keeping the env value to avoid silently dropping mounts. "
+                    "Set a non-empty value in config.yaml to override.",
+                    cfg_key,
+                    type(value).__name__,
+                    env_var,
+                )
+                continue
             target[env_var] = _terminal_env_value(value)
     return target
 

--- a/tests/hermes_cli/test_terminal_empty_volumes.py
+++ b/tests/hermes_cli/test_terminal_empty_volumes.py
@@ -1,0 +1,87 @@
+"""Tests for empty-collection guard in apply_terminal_config_to_env."""
+
+import os
+from unittest.mock import patch
+
+from hermes_cli import config as config_mod
+
+
+def test_empty_docker_volumes_does_not_override_env():
+    """An empty docker_volumes list in config.yaml must not clobber
+    a non-empty TERMINAL_DOCKER_VOLUMES env var."""
+    raw_config = {
+        "terminal": {
+            "backend": "docker",
+            "docker_volumes": [],
+        }
+    }
+    env = {
+        "TERMINAL_ENV": "docker",
+        "TERMINAL_DOCKER_VOLUMES": '["/host/data:/data"]',
+    }
+
+    with patch.object(config_mod, "read_raw_config", return_value=raw_config):
+        with patch.object(config_mod, "load_config_readonly", return_value=raw_config):
+            result = config_mod.apply_terminal_config_to_env(env=dict(env))
+
+    assert result["TERMINAL_DOCKER_VOLUMES"] == '["/host/data:/data"]'
+
+
+def test_non_empty_does_override_env():
+    """A non-empty docker_volumes list in config.yaml should override env."""
+    raw_config = {
+        "terminal": {
+            "backend": "docker",
+            "docker_volumes": ["/custom:/path"],
+        }
+    }
+    env = {
+        "TERMINAL_ENV": "docker",
+        "TERMINAL_DOCKER_VOLUMES": '["/host/data:/data"]',
+    }
+
+    with patch.object(config_mod, "read_raw_config", return_value=raw_config):
+        with patch.object(config_mod, "load_config_readonly", return_value=raw_config):
+            result = config_mod.apply_terminal_config_to_env(env=dict(env))
+
+    assert result["TERMINAL_DOCKER_VOLUMES"] == '["/custom:/path"]'
+
+
+def test_empty_env_not_overwritten_by_empty_config():
+    """If env is also empty, the empty config value is fine (applied)."""
+    raw_config = {
+        "terminal": {
+            "backend": "docker",
+            "docker_volumes": [],
+        }
+    }
+    env = {
+        "TERMINAL_ENV": "docker",
+        "TERMINAL_DOCKER_VOLUMES": "",
+    }
+
+    with patch.object(config_mod, "read_raw_config", return_value=raw_config):
+        with patch.object(config_mod, "load_config_readonly", return_value=raw_config):
+            result = config_mod.apply_terminal_config_to_env(env=dict(env))
+
+    # Empty config value is applied when env is empty (no clobbering concern)
+    assert result["TERMINAL_DOCKER_VOLUMES"] == "[]"
+
+
+def test_no_env_var_gets_empty_config():
+    """If env var is not set, empty config value is applied."""
+    raw_config = {
+        "terminal": {
+            "backend": "docker",
+            "docker_volumes": [],
+        }
+    }
+    env = {
+        "TERMINAL_ENV": "docker",
+    }
+
+    with patch.object(config_mod, "read_raw_config", return_value=raw_config):
+        with patch.object(config_mod, "load_config_readonly", return_value=raw_config):
+            result = config_mod.apply_terminal_config_to_env(env=dict(env))
+
+    assert result["TERMINAL_DOCKER_VOLUMES"] == "[]"


### PR DESCRIPTION
## Summary

Fixes #88176

Since v2026.8.3, `apply_terminal_config_to_env` makes `terminal.*` keys that are explicitly present in `config.yaml` override the corresponding `TERMINAL_*` environment variables. Combined with the fact that `hermes setup` / `hermes config set` serialize every default key into `config.yaml` (so nearly every real-world config carries an explicit `terminal.docker_volumes: []`), this silently unmounts the sandbox for any deployment that injects mounts via the environment.

## Root cause

The commit's intent is sound for keys a user consciously set. But `config.yaml` explicitness is not user intent: `hermes setup` and every `hermes config set <other.key>` write the full merged config, materializing all defaults as explicit keys. So the override fires for values the user never touched.

## Fix

Don't let an empty collection (`[]`, `{}`) in config.yaml override a non-empty env var. An empty list/dict is almost never intentional — it's usually a serialized default from `hermes setup`. A warning is logged when this case is detected.

## Changes

- `hermes_cli/config.py`: Add empty-collection guard in `apply_terminal_config_to_env`
- `tests/hermes_cli/test_terminal_empty_volumes.py`: 4 new tests

## Testing

- 4 new tests pass
- 9 existing terminal env bridge tests pass (no regressions)