### PR TITLE
fix(dashboard): restore verified principal transfer into gateway sessions

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -910,19 +910,14 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # prompt) — build from scratch.
     agent._cached_system_prompt = agent._build_system_prompt(system_message)
 
-    # Plugin hook: on_session_start — fired once when a brand-new
-    # session is created (not on continuation).  Plugins can use this
-    # to initialise session-scoped state (e.g. warm a memory cache).
-    try:
-        from hermes_cli.lifecycle import invoke_hook as _invoke_hook
-        _invoke_hook(
-            "on_session_start",
-            session_id=agent.session_id,
-            model=agent.model,
-            platform=getattr(agent, "platform", None) or "",
-        )
-    except Exception as exc:
-        logger.warning("on_session_start hook failed: %s", exc)
+    # NOTE (Issue #149): the on_session_start plugin hook was historically
+    # fired here, but the whole function is gated by
+    # ``agent._cached_system_prompt is None`` in build_turn_context, and the
+    # tui_gateway desktop path pre-warms that attribute at agent build — so
+    # desktop sessions silently skipped the hook. The trigger now lives in
+    # build_turn_context (first-turn condition + _session_start_fired guard),
+    # which every run_conversation path passes through. Keep this block
+    # hook-free so the hook fires exactly once regardless of cache state.
 
     # Cold-start credits seed (L3) — fallback for the first-turn path. The TUI/
     # desktop build seeds at session OPEN (see seed_credits_at_session_start in

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1168,6 +1168,27 @@ def build_turn_context(
         )
         agent._persist_user_message_idx = current_turn_user_idx
 
+    # Plugin hook: on_session_start — fired exactly once when a brand-new
+    # session produces its first turn, independent of system-prompt caching.
+    # (Issue #149: tui_gateway pre-warms _cached_system_prompt at agent build,
+    # so the legacy trigger inside restore_or_build_system_prompt was skipped
+    # on the desktop path. The first-turn condition here mirrors the
+    # pre_llm_call is_first_turn convention; _session_start_fired guards
+    # against duplicate firing when the restore path also builds fresh.)
+    try:
+        if (not bool(conversation_history)) and not getattr(agent, "_session_start_fired", False):
+            agent._session_start_fired = True
+            from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+
+            _invoke_hook(
+                "on_session_start",
+                session_id=agent.session_id,
+                model=agent.model,
+                platform=getattr(agent, "platform", None) or "",
+            )
+    except Exception:
+        logger.warning("on_session_start hook failed", exc_info=True)
+
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""
     try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15748,8 +15748,12 @@ def _ws_auth_mode() -> str:
     return "loopback"
 
 
-def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
-    """Validate WS-upgrade auth; return ``(reason, credential)``.
+def _ws_auth_with_info(ws: "WebSocket") -> tuple[Optional[str], str, Optional[dict]]:
+    """Validate WS-upgrade auth; return ``(reason, credential, auth_info)``.
+
+    ``auth_info`` is the identity dict (``{user_id, provider, ...}``) returned
+    by ``consume_ticket`` / ``consume_internal_credential`` when the credential
+    is a dashboard ticket or server-internal credential, else ``None``.
 
     ``reason`` is None when the credential is accepted, else a short
     machine-parseable token explaining the rejection (``no_credential``,
@@ -15797,8 +15801,8 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
         internal = ws.query_params.get("internal", "")
         if internal:
             try:
-                consume_internal_credential(internal)
-                return None, "internal"
+                info = consume_internal_credential(internal)
+                return None, "internal", info
             except TicketInvalid as exc:
                 audit_log(
                     AuditEvent.WS_TICKET_REJECTED,
@@ -15806,15 +15810,15 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                     ip=(ws.client.host if ws.client else ""),
                     path=ws.url.path,
                 )
-                return "internal_invalid", "internal"
+                return "internal_invalid", "internal", None
 
         ticket = ws.query_params.get("ticket", "")
         if not ticket:
-            return "no_credential", "none"
+            return "no_credential", "none", None
 
         try:
-            consume_ticket(ticket)
-            return None, "ticket"
+            info = consume_ticket(ticket)
+            return None, "ticket", info
         except TicketInvalid as exc:
             audit_log(
                 AuditEvent.WS_TICKET_REJECTED,
@@ -15822,14 +15826,24 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                 ip=(ws.client.host if ws.client else ""),
                 path=ws.url.path,
             )
-            return "ticket_invalid", "ticket"
+            return "ticket_invalid", "ticket", None
 
     token = ws.query_params.get("token", "")
     if not token:
-        return "no_credential", "none"
+        return "no_credential", "none", None
     if hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
-        return None, "token"
-    return "token_mismatch", "token"
+        return None, "token", None
+    return "token_mismatch", "token", None
+
+
+def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
+    """Validate WS-upgrade auth; return ``(reason, credential)``.
+
+    Boolean-outcome form of :func:`_ws_auth_with_info` — discards the
+    authenticated identity info. See there for the full contract.
+    """
+    reason, credential, _info = _ws_auth_with_info(ws)
+    return reason, credential
 
 
 def _ws_auth_ok(ws: "WebSocket") -> bool:
@@ -16924,7 +16938,8 @@ async def gateway_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
-    if not _ws_auth_ok(ws):
+    auth_reason, _credential, auth_info = _ws_auth_with_info(ws)
+    if auth_reason is not None:
         await ws.close(code=4401)
         return
 
@@ -16934,7 +16949,7 @@ async def gateway_ws(ws: WebSocket) -> None:
 
     from tui_gateway.ws import handle_ws
 
-    await handle_ws(ws)
+    await handle_ws(ws, principal_info=auth_info)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_identity_restore.py
+++ b/tests/hermes_cli/test_dashboard_identity_restore.py
@@ -1,0 +1,143 @@
+"""Regression tests for restoring the #62549 dashboard-identity transfer.
+
+The 08-15 upstream refactor collapsed ``_ws_auth_reason`` back to a boolean
+outcome and dropped the ``consume_ticket`` identity dict, so the gateway
+WebSocket stopped carrying the authenticated user into session records. These
+tests pin the restored contract:
+
+- ``_ws_auth_with_info`` returns ``(reason, credential, auth_info)`` with the
+  identity dict for ticket / internal credentials and ``None`` otherwise.
+- ``_ws_auth_reason`` keeps its legacy two-tuple shape (backward compatible).
+- ``tui_gateway.ws._bind_connection_identity`` rewrites session-create params
+  with the server-verified ``pty_user_id`` / ``pty_provider`` (and strips them
+  for ``server-internal``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth.ws_tickets import (
+    INTERNAL_USER_ID,
+    TicketInvalid,
+    _reset_for_tests,
+    internal_ws_credential,
+    mint_ticket,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_tickets():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def fake_ws(query: str = "") -> SimpleNamespace:
+    values = parse_qs(query, keep_blank_values=True)
+    params = {key: items[0] for key, items in values.items()}
+    return SimpleNamespace(
+        query_params=SimpleNamespace(get=lambda key, default="": params.get(key, default)),
+        client=SimpleNamespace(host="127.0.0.1"),
+        url=SimpleNamespace(path="/api/ws"),
+    )
+
+
+def set_auth_required(monkeypatch, value: bool) -> None:
+    monkeypatch.setattr(web_server.app.state, "auth_required", value, raising=False)
+
+
+# ── _ws_auth_with_info ────────────────────────────────────────────────
+
+
+def test_ticket_auth_returns_identity(monkeypatch):
+    set_auth_required(monkeypatch, True)
+    ticket = mint_ticket(user_id="alice", provider="oauth")
+
+    reason, credential, info = web_server._ws_auth_with_info(fake_ws(f"ticket={ticket}"))
+    assert (reason, credential) == (None, "ticket")
+    assert info["user_id"] == "alice"
+    assert info["provider"] == "oauth"
+    assert isinstance(info["minted_at"], int)
+
+
+def test_internal_auth_returns_server_internal_identity(monkeypatch):
+    set_auth_required(monkeypatch, True)
+    reason, credential, info = web_server._ws_auth_with_info(
+        fake_ws(f"internal={internal_ws_credential()}")
+    )
+    assert (reason, credential) == (None, "internal")
+    assert info["user_id"] == INTERNAL_USER_ID
+
+
+def test_rejected_credentials_have_no_identity(monkeypatch):
+    set_auth_required(monkeypatch, True)
+    assert web_server._ws_auth_with_info(fake_ws("ticket=bad")) == (
+        "ticket_invalid",
+        "ticket",
+        None,
+    )
+
+    set_auth_required(monkeypatch, False)
+    assert web_server._ws_auth_with_info(fake_ws("token=bad")) == (
+        "token_mismatch",
+        "token",
+        None,
+    )
+
+
+def test_loopback_token_has_no_identity(monkeypatch):
+    set_auth_required(monkeypatch, False)
+    reason, credential, info = web_server._ws_auth_with_info(
+        fake_ws(f"token={web_server._SESSION_TOKEN}")
+    )
+    assert (reason, credential) == (None, "token")
+    assert info is None
+
+
+def test_ws_auth_reason_stays_binary_backward_compatible(monkeypatch):
+    """Legacy callers unpack two values and must not break."""
+    set_auth_required(monkeypatch, True)
+    ticket = mint_ticket(user_id="alice", provider="oauth")
+    reason, credential = web_server._ws_auth_reason(fake_ws(f"ticket={ticket}"))
+    assert (reason, credential) == (None, "ticket")
+
+
+# ── _bind_connection_identity ─────────────────────────────────────────
+
+
+def test_bind_injects_pty_identity_into_params():
+    from tui_gateway.ws import _bind_connection_identity
+
+    request = {"method": "session.create", "params": {"title": "hello"}}
+    bound = _bind_connection_identity(request, {"user_id": "alice", "provider": "oauth"})
+    assert bound["params"]["pty_user_id"] == "alice"
+    assert bound["params"]["pty_provider"] == "oauth"
+    # Original request is not mutated.
+    assert request["params"] == {"title": "hello"}
+
+
+def test_bind_strips_pty_identity_for_server_internal():
+    from tui_gateway.ws import _bind_connection_identity
+
+    request = {
+        "method": "session.create",
+        "params": {"pty_user_id": "forged", "pty_provider": "forged"},
+    }
+    bound = _bind_connection_identity(
+        request, {"user_id": "server-internal", "provider": "server-internal"}
+    )
+    assert "pty_user_id" not in bound["params"]
+    assert "pty_provider" not in bound["params"]
+
+
+def test_bind_no_info_is_passthrough():
+    from tui_gateway.ws import _bind_connection_identity
+
+    request = {"method": "session.create", "params": {"title": "hello"}}
+    bound = _bind_connection_identity(request, None)
+    assert bound is request

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -42,6 +42,13 @@ def _(rid, params: dict) -> dict:
     profile = (params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
 
+    # Server-verified connection identity, bound by
+    # tui_gateway.ws._bind_connection_identity from the dashboard WS-ticket auth.
+    # Retained on the live session record so plugins (e.g. session-title-owner)
+    # can attribute a session to its authenticated operator.
+    pty_user_id = str(params.get("pty_user_id") or "").strip() or None
+    pty_provider = str(params.get("pty_provider") or "").strip() or None
+
     # The desktop composer owns its model/effort/fast as plain UI state and ships
     # it on every session.create. Honor each as a PER-SESSION override (built into
     # the agent below) — never a global config write, so picking a model/effort
@@ -100,6 +107,8 @@ def _(rid, params: dict) -> dict:
             "pending_title": title or None,
             "pending_hidden": is_truthy_value(params.get("hidden", False)),
             "profile_home": str(profile_home) if profile_home is not None else None,
+            "pty_user_id": pty_user_id,
+            "pty_provider": pty_provider,
             "running": False,
             "session_key": key,
             "show_reasoning": _load_show_reasoning(),

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -283,7 +283,25 @@ def _disable_nagle(ws: Any) -> None:
         _log.debug("ws TCP_NODELAY skip: %s", exc)
 
 
-async def handle_ws(ws: Any) -> None:
+def _bind_connection_identity(request: dict, info: dict | None) -> dict:
+    """Copy the server-verified identity over client-supplied RPC fields."""
+    if not info:
+        return request
+    params = dict(request.get("params") or {})
+    if info.get("user_id") == "server-internal":
+        params.pop("pty_user_id", None)
+        params.pop("pty_provider", None)
+    else:
+        params.update(
+            pty_user_id=str(info["user_id"]),
+            pty_provider=str(info.get("provider") or ""),
+        )
+    bound = dict(request)
+    bound["params"] = params
+    return bound
+
+
+async def handle_ws(ws: Any, principal_info: dict | None = None) -> None:
     """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``."""
     peer = _ws_peer_label(ws)
     transport: WSTransport | None = None
@@ -388,6 +406,8 @@ async def handle_ws(ws: Any) -> None:
             # response dict, which we write here from the loop.
             req_id = req.get("id") if isinstance(req, dict) else None
             req_method = req.get("method") if isinstance(req, dict) else None
+            if isinstance(req, dict):
+                req = _bind_connection_identity(req, principal_info)
             try:
                 resp = await asyncio.to_thread(server.dispatch, req, transport)
             except Exception:


### PR DESCRIPTION
## Summary

Fixes #88112

Commit #62549 carried the dashboard WS-ticket identity through the gateway WebSocket into session records. A later refactor of the WS-auth path collapsed this back to a boolean outcome, discarding the identity dict. Downstream consumers broke silently — the session-title-owner plugin can no longer read pty_user_id because the field is never populated.

## Root cause

The 08-15 WS-auth refactor changed _ws_auth_reason to return only (reason, credential), dropping the consume_ticket identity dict. The gateway stopped carrying the authenticated user into session records.

## Fix

Restore the identity hand-off:
- _ws_auth_with_info returns (reason, credential, auth_info); gateway_ws passes principal_info into handle_ws
- tui_gateway.ws.handle_ws(principal_info=...) + _bind_connection_identity rewrites session-create params with server-verified pty_user_id
- methods_session.session.create retains pty_user_id/pty_provider on the live session record
- on_session_start hook moved to build_turn_context (fires once regardless of cache state)

## Changes

- hermes_cli/web_server.py: _ws_auth_with_info returns identity dict
- tui_gateway.ws: handle_ws accepts principal_info, _bind_connection_identity injects pty_user_id
- tui_gateway/methods_session.py: retain pty_user_id/pty_provider on session record
- agent/conversation_loop.py: on_session_start hook moved to build_turn_context
- agent/turn_context.py: fire on_session_start on first turn
- tests/hermes_cli/test_dashboard_identity_restore.py: 8 new tests

## Testing

- 8 new tests pass
- No regressions in existing test suite

## Credits

Original patch by @29206394 (https://github.com/29206394/hermes-agent/commit/42e7fb7de8c1c29ef0ab38d3720e3de33ca83ccb)