### PR TITLE
fix(gateway): resume pending clarifies from text replies

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6105,13 +6105,14 @@ class BasePlatformAdapter(ABC):
             # Same shape as the /approve deadlock fix (PR #4926) — both
             # cases are "agent thread blocked on Event.wait, message must
             # reach the resolver before being treated as a new turn."
-            if not cmd and event.allow_gateway_control:
+            if event.allow_gateway_control and not should_bypass_active_session(cmd):
                 try:
                     from tools import clarify_gateway as _clarify_mod
                     _has_text_clarify = (
                         _clarify_mod.get_pending_for_session(
                             session_key,
                             include_choice_prompts=True,
+                            source_identity=_clarify_mod.source_identity(event.source),
                         ) is not None
                     )
                 except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5683,6 +5683,7 @@ class TurnRunner:
         # rather than hang forever).
         # ------------------------------------------------------------------
         def _clarify_callback_sync(question: str, choices, multi_select: bool = False) -> str:
+            from gateway.session import is_shared_multi_user_session
             from tools import clarify_gateway as _clarify_mod
             import uuid as _uuid
 
@@ -5696,6 +5697,20 @@ class TurnRunner:
                 question=question,
                 choices=list(choices) if choices else None,
                 multi_select=bool(multi_select),
+                source_identity=_clarify_mod.source_identity(ctx.source),
+                shared_multi_user_session=is_shared_multi_user_session(
+                    ctx.source,
+                    group_sessions_per_user=getattr(
+                        ctx._status_adapter.config,
+                        "extra",
+                        {},
+                    ).get("group_sessions_per_user", True),
+                    thread_sessions_per_user=getattr(
+                        ctx._status_adapter.config,
+                        "extra",
+                        {},
+                    ).get("thread_sessions_per_user", False),
+                ),
             )
 
             # Pause typing — like approval, we don't want a "thinking..."
@@ -5751,10 +5766,12 @@ class TurnRunner:
                     send_ok = False
 
             if not send_ok:
-                # Couldn't deliver the prompt — clean up and return
-                # sentinel so the agent can fall back to a sensible
-                # default rather than hanging.
-                _clarify_mod.clear_session(ctx.session_key or "")
+                # Delivery failure loses to an answer that already won while
+                # transport was in flight. Otherwise cancel and clean the
+                # registered entry because no waiter will own that cleanup.
+                winning_response = _clarify_mod.finish_failed_delivery(clarify_id)
+                if winning_response is not None:
+                    return winning_response
                 return "[clarify prompt could not be delivered]"
 
             timeout = _clarify_mod.get_clarify_timeout()
@@ -16351,14 +16368,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # direct replies to multi-choice prompts are accepted too ("2" maps
         # to the second option). Slash
         # commands still bypass this path so /stop and friends keep working.
-        _clarify_mod = None
         try:
             from tools import clarify_gateway as _clarify_mod
+            _clarify_identity = _clarify_mod.source_identity(source)
             _pending_clarify = _clarify_mod.get_pending_for_session(
-                _quick_key, include_choice_prompts=True,
+                _quick_key,
+                include_choice_prompts=True,
+                source_identity=_clarify_identity,
             )
         except Exception:
+            _clarify_mod = None
             _pending_clarify = None
+        if (
+            allow_gateway_control
+            and _clarify_mod is not None
+            and _clarify_mod.is_clarify_message_consumed(event.message_id or "")
+        ):
+            logger.info(
+                "Gateway suppressed duplicate clarify message delivery (message_id=%s)",
+                event.message_id,
+            )
+            return ""
         if (
             allow_gateway_control
             and _pending_clarify is not None
@@ -16374,15 +16404,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _pending_clarify.clarify_id,
                 )
                 return ""
-            # Skip slash commands — the user clearly wanted to issue a
-            # command, not answer the clarify.  Leave the clarify pending
-            # so the user can retry; if it times out, the agent unblocks
-            # with an empty response.
-            if _raw_clarify_reply and not _raw_clarify_reply.startswith("/"):
-                _text_outcome = _clarify_mod.attempt_text_response_for_session(
-                    _quick_key, _raw_clarify_reply,
+            # Only recognized slash commands bypass clarify. Unknown slash
+            # text is an ordinary answer candidate, matching the adapter's
+            # active-session bypass decision.
+            import hermes_cli.commands as _clarify_commands
+            _clarify_cmd = event.get_command()
+            _clarify_command_known = _clarify_commands.is_gateway_known_command(
+                _clarify_cmd
+            )
+            if _raw_clarify_reply and not _clarify_command_known:
+                _resolved = _clarify_mod.resolve_message_text_for_session(
+                    _quick_key,
+                    _raw_clarify_reply,
+                    event.message_id or "",
+                    source_identity=_clarify_identity,
                 )
-                if _text_outcome == _clarify_mod.TEXT_RESOLVED:
+                if _resolved in {"consumed", "duplicate"}:
                     logger.info(
                         "Gateway intercepted clarify text response (session=%s, id=%s)",
                         _quick_key, _pending_clarify.clarify_id,
@@ -16406,27 +16443,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.
                     return ""
-                if _text_outcome == _clarify_mod.TEXT_REJECTED_SELECTION:
-                    # Selection-shaped but invalid (out-of-range number,
-                    # unrecognised comma-list). Keep the clarify armed so
-                    # the user can retry — do not cancel and do not treat
-                    # this as an unrelated follow-up turn.
-                    logger.info(
-                        "Gateway retained pending clarify after invalid "
-                        "selection attempt (session=%s, id=%s)",
-                        _quick_key, _pending_clarify.clarify_id,
-                    )
-                    return ""
-                if _text_outcome == _clarify_mod.TEXT_REJECTED_PROSE:
-                    # Native-choice prompts deliberately reject unmatched
-                    # prose so it can continue through normal busy-message
-                    # routing. Release this clarify first: redirect()
-                    # degrades to steer() while tools are executing, and
-                    # that steer cannot drain until the clarify tool returns.
-                    _clarify_mod.resolve_gateway_clarify(
-                        _pending_clarify.clarify_id,
-                        "",
-                    )
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are
@@ -16545,10 +16561,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # hermes_cli/commands.py) and dispatched through the single
             # resolver _dispatch_busy_slash_command below — no per-command
             # if-chain here.
-            from hermes_cli.commands import resolve_command as _resolve_cmd_inner
+            from hermes_cli.commands import (
+                is_gateway_known_command as _is_known_cmd_inner,
+                resolve_command as _resolve_cmd_inner,
+            )
             _evt_cmd = event.get_command()
             _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
-
+            _plugin_cmd_inner = bool(
+                _evt_cmd
+                and _cmd_def_inner is None
+                and _is_known_cmd_inner(_evt_cmd)
+            )
             # /status and /context are intentionally pre-gate so users
             # always see session state.
             if _cmd_def_inner and _cmd_def_inner.name == "status":
@@ -16562,8 +16585,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # /status above is intentionally pre-gate so users always see
             # session state. /help and /whoami fall under the always-allowed
             # floor inside _check_slash_access.
-            if _evt_cmd and _cmd_def_inner is not None:
-                _denied = self._check_slash_access(source, _cmd_def_inner.name)
+            if _evt_cmd and (_cmd_def_inner is not None or _plugin_cmd_inner):
+                _canonical_inner = (
+                    _cmd_def_inner.name if _cmd_def_inner is not None else _evt_cmd
+                )
+                _denied = self._check_slash_access(source, _canonical_inner)
                 if _denied is not None:
                     return _denied
 
@@ -16575,6 +16601,64 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return await self._dispatch_busy_slash_command(
                     event, _cmd_def_inner, _quick_key, source,
                 )
+            if _plugin_cmd_inner:
+                # Plugin commands have no CommandDef/busy policy. Execute the
+                # same hook and handler contract without interrupting the
+                # clarify worker.
+                from hermes_cli.plugins import get_plugin_command_handler
+
+                _plugin_handler = get_plugin_command_handler(
+                    _evt_cmd.replace("_", "-")
+                )
+                if _plugin_handler is not None:
+                    _plugin_args = event.get_command_args().strip()
+                    try:
+                        _plugin_hook_results = await self.hooks.emit_collect(
+                            f"command:{_evt_cmd}",
+                            {
+                                "platform": (
+                                    source.platform.value if source.platform else ""
+                                ),
+                                "user_id": source.user_id,
+                                "command": _evt_cmd,
+                                "raw_command": _evt_cmd,
+                                "args": _plugin_args,
+                                "raw_args": _plugin_args,
+                            },
+                        )
+                    except Exception as exc:
+                        logger.debug(
+                            "command:%s hook dispatch failed (non-fatal): %s",
+                            _evt_cmd,
+                            exc,
+                        )
+                        _plugin_hook_results = []
+                    for _plugin_hook_result in _plugin_hook_results:
+                        if not isinstance(_plugin_hook_result, dict):
+                            continue
+                        _plugin_decision = str(
+                            _plugin_hook_result.get("decision", "")
+                        ).strip().lower()
+                        if _plugin_decision == "deny":
+                            _plugin_message = _plugin_hook_result.get("message")
+                            return (
+                                _plugin_message
+                                if isinstance(_plugin_message, str)
+                                and _plugin_message
+                                else f"Command `/{_evt_cmd}` was blocked by a hook."
+                            )
+                        if _plugin_decision == "handled":
+                            _plugin_message = _plugin_hook_result.get("message")
+                            return (
+                                _plugin_message
+                                if isinstance(_plugin_message, str)
+                                and _plugin_message
+                                else None
+                            )
+                    _plugin_result = _plugin_handler(_plugin_args)
+                    if asyncio.iscoroutine(_plugin_result):
+                        _plugin_result = await _plugin_result
+                    return str(_plugin_result) if _plugin_result else None
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
@@ -16744,6 +16828,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # The actual interrupt message is delivered via adapter._pending_messages
             # which is read by _run_agent. Removed to prevent unbounded growth.
             return None
+
 
         # Check for commands
         command = event.get_command()

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1062,7 +1062,7 @@ def is_shared_multi_user_session(
     """
     if source.chat_type == "dm":
         return False
-    if source.thread_id:
+    if source.thread_id or source.prospective_thread_id:
         return not thread_sessions_per_user
     return not group_sessions_per_user
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -543,7 +543,7 @@ def should_bypass_active_session(command_name: str | None) -> bool:
     ACTIVE_SESSION_BYPASS_COMMANDS remains the subset of commands with
     explicit Level-2 handlers; the rest fall through to the catch-all.
     """
-    return resolve_command(command_name) is not None if command_name else False
+    return is_gateway_known_command(command_name)
 
 
 def _resolve_config_gates() -> set[str]:

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -32,15 +32,21 @@ class _ClarifyBypassAdapter(BasePlatformAdapter):
         return {"id": chat_id, "type": "private"}
 
 
-def _event(text="custom answer"):
+def _event(
+    text="custom answer",
+    *,
+    user_id="user1",
+    chat_id="12345",
+    chat_type="private",
+):
     return MessageEvent(
         text=text,
         message_type=MessageType.TEXT,
         source=SessionSource(
             platform=Platform.TELEGRAM,
-            chat_id="12345",
-            chat_type="private",
-            user_id="user1",
+            chat_id=chat_id,
+            chat_type=chat_type,
+            user_id=user_id,
         ),
         message_id="msg1",
     )
@@ -79,6 +85,8 @@ async def test_active_session_routes_typed_choice_clarify_reply_to_runner_not_bu
     )
     adapter._active_sessions[session_key] = asyncio.Event()
     cm.register("clarify-1", session_key, "Pick one", ["A", "B"])
+    entry = cm._entries["clarify-1"]
+    entry.source_identity = cm.source_identity(event.source)
 
     await adapter.handle_message(event)
 
@@ -137,6 +145,155 @@ async def test_active_session_bypass_uses_profile_namespaced_key_under_multiplex
 
     adapter._message_handler.assert_awaited_once_with(event)
     adapter._busy_session_handler.assert_not_awaited()
-    assert adapter._pending_messages == {}
 
 
+@pytest.mark.asyncio
+async def test_active_private_session_does_not_route_other_requester_to_pending_clarify():
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _ClarifyBypassAdapter()
+    adapter.config.extra["group_sessions_per_user"] = False
+    adapter._message_handler = AsyncMock(return_value="")
+    adapter._busy_session_handler = AsyncMock(return_value=True)
+    owner_event = _event(user_id="owner")
+    other_event = _event("unrelated", user_id="other")
+    session_key = build_session_key(
+        owner_event.source,
+        group_sessions_per_user=False,
+        thread_sessions_per_user=False,
+    )
+    adapter._active_sessions[session_key] = asyncio.Event()
+    cm.register(
+        "clarify-owner",
+        session_key,
+        "Pick one",
+        ["A", "B"],
+        source_identity=cm.source_identity(owner_event.source),
+    )
+
+    await adapter.handle_message(other_event)
+
+    adapter._message_handler.assert_not_awaited()
+    adapter._busy_session_handler.assert_awaited_once_with(other_event, session_key)
+
+
+@pytest.mark.asyncio
+async def test_active_shared_group_routes_other_member_to_pending_clarify():
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _ClarifyBypassAdapter()
+    adapter.config.extra["group_sessions_per_user"] = False
+    adapter._message_handler = AsyncMock(return_value="")
+    adapter._busy_session_handler = AsyncMock(return_value=True)
+    owner_event = _event(user_id="owner", chat_id="group-1", chat_type="group")
+    member_event = _event(
+        "the answer from another member",
+        user_id="member",
+        chat_id="group-1",
+        chat_type="group",
+    )
+    session_key = build_session_key(
+        owner_event.source,
+        group_sessions_per_user=False,
+        thread_sessions_per_user=False,
+    )
+    adapter._active_sessions[session_key] = asyncio.Event()
+    entry = cm.register(
+        "clarify-shared-group",
+        session_key,
+        "Pick one",
+        ["A", "B"],
+        source_identity=cm.source_identity(owner_event.source),
+        shared_multi_user_session=True,
+    )
+
+    await adapter.handle_message(member_event)
+
+    adapter._message_handler.assert_awaited_once_with(member_event)
+    adapter._busy_session_handler.assert_not_awaited()
+    assert cm.resolve_text_response_for_session(
+        session_key,
+        member_event.text,
+        source_identity=cm.source_identity(member_event.source),
+    ) is True
+    assert entry.response == member_event.text
+
+
+@pytest.mark.asyncio
+async def test_active_per_user_group_does_not_route_other_member_to_owner_clarify():
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _ClarifyBypassAdapter()
+    adapter.config.extra["group_sessions_per_user"] = True
+    adapter._message_handler = AsyncMock(return_value="")
+    adapter._busy_session_handler = AsyncMock(return_value=True)
+    owner_event = _event(user_id="owner", chat_id="group-1", chat_type="group")
+    member_event = _event(
+        "unrelated",
+        user_id="member",
+        chat_id="group-1",
+        chat_type="group",
+    )
+    owner_session_key = build_session_key(
+        owner_event.source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+    member_session_key = build_session_key(
+        member_event.source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+    adapter._active_sessions[member_session_key] = asyncio.Event()
+    cm.register(
+        "clarify-isolated-group",
+        owner_session_key,
+        "Pick one",
+        ["A", "B"],
+        source_identity=cm.source_identity(owner_event.source),
+    )
+
+    await adapter.handle_message(member_event)
+
+    adapter._message_handler.assert_not_awaited()
+    adapter._busy_session_handler.assert_awaited_once_with(
+        member_event,
+        member_session_key,
+    )
+
+
+@pytest.mark.asyncio
+async def test_active_session_routes_plugin_command_as_command_not_clarify() -> None:
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _ClarifyBypassAdapter()
+    adapter._message_handler = AsyncMock(return_value="refreshed")
+    adapter._busy_session_handler = AsyncMock(return_value=True)
+    event = _event("/octo-refresh")
+    session_key = build_session_key(
+        event.source,
+        group_sessions_per_user=adapter.config.extra.get("group_sessions_per_user", True),
+        thread_sessions_per_user=adapter.config.extra.get("thread_sessions_per_user", False),
+    )
+    adapter._active_sessions[session_key] = asyncio.Event()
+    cm.register(
+        "clarify-plugin-command",
+        session_key,
+        "Pick one",
+        ["A", "B"],
+        source_identity=cm.source_identity(event.source),
+    )
+
+    with patch(
+        "hermes_cli.commands._iter_plugin_command_entries",
+        return_value=[("octo-refresh", "Refresh", "")],
+    ):
+        await adapter.handle_message(event)
+
+    adapter._message_handler.assert_awaited_once_with(event)
+    assert cm.has_pending(session_key) is True
+    adapter._busy_session_handler.assert_not_awaited()

--- a/tests/gateway/test_clarify_thread_followup_not_swallowed.py
+++ b/tests/gateway/test_clarify_thread_followup_not_swallowed.py
@@ -1,25 +1,13 @@
-"""Regression tests for #62034 — pending multi-choice clarify prompts must not
-swallow unrelated thread follow-up messages.
+"""Pending clarify prompts consume the requester's next message as the answer.
 
-When a NATIVE interactive multi-choice clarify (buttons rendered,
-``awaiting_text=False``) is pending, the gateway text-intercept used to
-consume ANY non-command message in the session as the clarify answer —
-arbitrary prose vanished into clarify resolution and the agent appeared to
-ignore the user's thread messages.
-
-After the fix (``tools/clarify_gateway._coerce_text_response`` rejects
-arbitrary prose for native multi-choice prompts):
-
-  * numeric selections ("2") and exact choice labels still resolve, and
-  * arbitrary prose falls through the intercept and continues as a normal
-    message-handling turn.
-
-Open-ended clarifies, explicit "Other" text-capture mode, and the base
-adapter's numbered-text fallback (which flips ``awaiting_text`` at send time)
-keep accepting free text.
+Native controls are optional input conveniences. Arbitrary prose from the
+bound requester resolves the active clarify instead of falling into busy-run
+handling, where an interrupt cannot wake the worker blocked on Event.wait.
 """
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from dataclasses import replace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -53,8 +41,6 @@ class _StubAdapter(BasePlatformAdapter):
         return {"id": chat_id, "type": "im"}
 
 
-class _FellThroughIntercept(Exception):
-    """Sentinel: _handle_message got PAST the clarify text-intercept."""
 
 
 def _event(text):
@@ -78,6 +64,7 @@ def _clear_clarify_state():
     with cm._lock:
         cm._entries.clear()
         cm._session_index.clear()
+        getattr(cm, "_consumed_message_ids").clear()
         cm._notify_cbs.clear()
 
 
@@ -95,152 +82,34 @@ def _make_runner(adapter):
 
 
 async def _dispatch(runner, event):
-    """Run _handle_message with a tripwire installed AFTER the clarify
-    intercept (the slash-confirm pending lookup is the next statement), so a
-    raised ``_FellThroughIntercept`` proves the message was NOT swallowed."""
-    import tools.slash_confirm as slash_confirm_mod
-
-    def _tripwire(_key):
-        raise _FellThroughIntercept()
-
-    with patch("hermes_cli.plugins.invoke_hook", return_value=[]), \
-            patch.object(slash_confirm_mod, "get_pending", _tripwire):
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
         return await runner._handle_message(event)
 
 
 @pytest.mark.asyncio
-async def test_thread_prose_not_swallowed_by_native_multi_choice_clarify():
-    """Arbitrary prose during a pending button-clarify continues as a normal turn."""
+async def test_thread_prose_resolves_native_multi_choice_clarify():
     _clear_clarify_state()
     from tools import clarify_gateway as cm
 
     adapter = _StubAdapter()
     runner = _make_runner(adapter)
-    # Native interactive multi-choice prompt: awaiting_text stays False.
-    entry = cm.register("cl-native", SESSION_KEY, "Pick a UI variant", ["buttons", "dropdown"])
-    assert entry.awaiting_text is False
+    event = _event("just checking the visual UI, no need to pass any data")
+    cm.register(
+        "cl-native",
+        SESSION_KEY,
+        "Pick a UI variant",
+        ["buttons", "dropdown"],
+        source_identity=cm.source_identity(event.source),
+    )
 
-    with pytest.raises(_FellThroughIntercept):
-        await _dispatch(runner, _event("just checking the visual UI, no need to pass any data"))
+    result = await _dispatch(runner, event)
 
-    # The prose is not accepted as the answer, but the clarify must be
-    # released before normal busy routing so redirect-to-steer can drain.
+    assert result == ""
     with cm._lock:
         entry = cm._entries.get("cl-native")
     assert entry is not None
     assert entry.event.is_set()
-    assert entry.response == ""
-    _clear_clarify_state()
-
-
-@pytest.mark.asyncio
-async def test_thread_prose_does_not_overwrite_concurrent_button_choice():
-    """A button result that wins the race remains the clarify response."""
-    _clear_clarify_state()
-    from tools import clarify_gateway as cm
-
-    adapter = _StubAdapter()
-    runner = _make_runner(adapter)
-    entry = cm.register(
-        "cl-button-race",
-        SESSION_KEY,
-        "Pick a UI variant",
-        ["buttons", "dropdown"],
-    )
-    assert cm.resolve_gateway_clarify("cl-button-race", "buttons") is True
-
-    with pytest.raises(_FellThroughIntercept):
-        await _dispatch(runner, _event("one more unrelated thought"))
-
-    assert entry.event.is_set()
-    assert entry.response == "buttons"
-    _clear_clarify_state()
-
-
-@pytest.mark.asyncio
-async def test_native_multi_select_out_of_range_keeps_clarify_pending():
-    """Out-of-range multi-select numbers must not cancel the pending prompt."""
-    _clear_clarify_state()
-    from tools import clarify_gateway as cm
-
-    adapter = _StubAdapter()
-    runner = _make_runner(adapter)
-    entry = cm.register(
-        "cl-ms-oor",
-        SESSION_KEY,
-        "Pick some targets",
-        ["staging", "prod", "canary"],
-        multi_select=True,
-    )
-    assert entry.awaiting_text is False
-
-    result = await _dispatch(runner, _event("99"))
-
-    assert result == ""
-    with cm._lock:
-        still = cm._entries.get("cl-ms-oor")
-    assert still is not None
-    assert not still.event.is_set()
-    assert still.response is None
-    _clear_clarify_state()
-
-
-@pytest.mark.asyncio
-async def test_native_multi_select_bad_comma_list_keeps_clarify_pending():
-    """Unrecognised comma-lists are retryable selection attempts, not prose."""
-    _clear_clarify_state()
-    from tools import clarify_gateway as cm
-
-    adapter = _StubAdapter()
-    runner = _make_runner(adapter)
-    entry = cm.register(
-        "cl-ms-bad",
-        SESSION_KEY,
-        "Pick some targets",
-        ["staging", "prod", "canary"],
-        multi_select=True,
-    )
-    assert entry.awaiting_text is False
-
-    result = await _dispatch(runner, _event("1,99"))
-
-    assert result == ""
-    with cm._lock:
-        still = cm._entries.get("cl-ms-bad")
-    assert still is not None
-    assert not still.event.is_set()
-    assert still.response is None
-    _clear_clarify_state()
-
-
-@pytest.mark.asyncio
-async def test_native_multi_select_prose_releases_clarify_before_routing():
-    """Free prose on multi-select still breaks the redirect/steer deadlock."""
-    _clear_clarify_state()
-    from tools import clarify_gateway as cm
-
-    adapter = _StubAdapter()
-    runner = _make_runner(adapter)
-    cm.register(
-        "cl-ms-prose",
-        SESSION_KEY,
-        "Pick some targets",
-        ["staging", "prod"],
-        multi_select=True,
-    )
-
-    with pytest.raises(_FellThroughIntercept):
-        await _dispatch(
-            runner,
-            _event("just checking the visual UI, no need to pass any data"),
-        )
-
-    with cm._lock:
-        entry = cm._entries.get("cl-ms-prose")
-    assert entry is not None
-    assert entry.event.is_set()
-    assert entry.response == ""
-    _clear_clarify_state()
+    assert entry.response == "just checking the visual UI, no need to pass any data"
 
 
 @pytest.mark.asyncio
@@ -251,10 +120,17 @@ async def test_prose_still_accepted_after_other_flips_text_capture():
 
     adapter = _StubAdapter()
     runner = _make_runner(adapter)
-    cm.register("cl-other", SESSION_KEY, "Pick a UI variant", ["buttons", "dropdown"])
+    event = _event("a carousel actually")
+    cm.register(
+        "cl-other",
+        SESSION_KEY,
+        "Pick a UI variant",
+        ["buttons", "dropdown"],
+        source_identity=cm.source_identity(event.source),
+    )
     assert cm.mark_awaiting_text("cl-other") is True
 
-    result = await _dispatch(runner, _event("a carousel actually"))
+    result = await _dispatch(runner, event)
 
     assert result == ""
     with cm._lock:
@@ -262,5 +138,55 @@ async def test_prose_still_accepted_after_other_flips_text_capture():
     assert entry is not None
     assert entry.event.is_set()
     assert entry.response == "a carousel actually"
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_dispatches_while_clarify_run_is_active():
     _clear_clarify_state()
+    adapter = _StubAdapter()
+    runner = _make_runner(adapter)
+    is_running = patch.object(runner, "_is_session_running", return_value=True)
+    runner.config = SimpleNamespace(quick_commands={})  # type: ignore[assignment]
+    emit_collect = AsyncMock(return_value=[])
+    runner.hooks = SimpleNamespace(emit_collect=emit_collect)  # type: ignore[assignment]
+    runner._check_slash_access = lambda source, canonical_cmd: None
+    handler = AsyncMock(return_value="refreshed")
+    event = _event("/octo-refresh")
+
+    with (
+        is_running,
+        patch(
+            "hermes_cli.commands._iter_plugin_command_entries",
+            return_value=[("octo-refresh", "Refresh", "")],
+        ),
+        patch(
+            "hermes_cli.plugins.get_plugin_command_handler",
+            return_value=handler,
+        ),
+    ):
+        result = await runner._handle_message(event)
+
+    assert result == "refreshed"
+    handler.assert_awaited_once_with("")
+    emit_collect.assert_awaited_once()
+
+
+def test_prospective_thread_is_shared_when_thread_policy_is_shared():
+    from gateway.session import is_shared_multi_user_session
+
+    source = replace(
+        SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="channel-1",
+            chat_type="channel",
+            user_id="owner",
+        ),
+        prospective_thread_id="thread-1",
+    )
+
+    assert is_shared_multi_user_session(
+        source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    ) is True
 

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -19,6 +19,7 @@ def _clear_clarify_state():
     with cm._lock:
         cm._entries.clear()
         cm._session_index.clear()
+        cm._consumed_message_ids.clear()
         cm._notify_cbs.clear()
 
 
@@ -381,82 +382,222 @@ class TestMultiSelectTextFallback:
         assert cm._coerce_text_response(entry, "b") == "B"
 
 
-class TestNativeRejectClassification:
-    """Rejected typed replies must distinguish free prose from bad selections.
-
-    Free prose cancels/falls through (deadlock break). Selection-shaped but
-    invalid replies (out-of-range number, unrecognised comma-list) keep the
-    pending clarify armed so the user can retry.
-    """
+class TestClarifyTerminalRaces:
+    """A clarify entry has exactly one terminal outcome."""
 
     def setup_method(self):
         _clear_clarify_state()
 
-    def test_multi_select_out_of_range_is_invalid_selection(self):
+    def test_first_answer_wins_and_entry_stops_being_pending(self):
         from tools import clarify_gateway as cm
 
-        entry = cm.register(
-            "ms-oor", "sk-ms", "Pick some", ["A", "B", "C"], multi_select=True,
-        )
-        assert entry.awaiting_text is False
-        value, reason = cm._coerce_text_response_detailed(entry, "99")
-        assert value is None
-        assert reason == "invalid_selection"
-        assert cm.attempt_text_response_for_session("sk-ms", "99") == (
-            cm.TEXT_REJECTED_SELECTION
-        )
-        pending = cm.get_pending_for_session("sk-ms", include_choice_prompts=True)
-        assert pending is not None
-        assert not pending.event.is_set()
+        cm.register("race-answer", "sk", "Pick", ["A", "B"])
 
-    def test_multi_select_bad_comma_list_is_invalid_selection(self):
+        assert cm.resolve_gateway_clarify("race-answer", "A") is True
+        assert cm.resolve_gateway_clarify("race-answer", "B") is False
+        assert cm.get_pending_for_session("sk", include_choice_prompts=True) is None
+        assert cm.wait_for_response("race-answer", timeout=1) == "A"
+
+    def test_answer_wins_over_later_session_clear(self):
         from tools import clarify_gateway as cm
 
-        entry = cm.register(
-            "ms-bad", "sk-ms2", "Pick some", ["A", "B", "C"], multi_select=True,
-        )
-        value, reason = cm._coerce_text_response_detailed(entry, "1,99")
-        assert value is None
-        assert reason == "invalid_selection"
-        assert cm.attempt_text_response_for_session("sk-ms2", "nope,nope") == (
-            cm.TEXT_REJECTED_SELECTION
-        )
-        pending = cm.get_pending_for_session("sk-ms2", include_choice_prompts=True)
-        assert pending is not None
-        assert not pending.event.is_set()
+        cm.register("race-clear", "sk", "Pick", ["A", "B"])
 
-    def test_multi_select_free_prose_is_rejected_prose(self):
+        assert cm.resolve_gateway_clarify("race-clear", "A") is True
+        assert cm.clear_session("sk") == 0
+        assert cm.wait_for_response("race-clear", timeout=1) == "A"
+
+    def test_timeout_wins_over_later_answer(self):
         from tools import clarify_gateway as cm
 
-        entry = cm.register(
-            "ms-prose", "sk-ms3", "Pick some", ["A", "B"], multi_select=True,
-        )
-        value, reason = cm._coerce_text_response_detailed(
-            entry, "just checking the visual UI, no need to pass any data",
-        )
-        assert value is None
-        assert reason == "prose"
-        assert cm.attempt_text_response_for_session(
-            "sk-ms3", "just checking the visual UI, no need to pass any data",
-        ) == cm.TEXT_REJECTED_PROSE
+        cm.register("race-timeout", "sk", "Pick", ["A", "B"])
 
-    def test_single_select_out_of_range_is_invalid_selection(self):
+        assert cm.wait_for_response("race-timeout", timeout=0.01) is None
+        assert cm.resolve_gateway_clarify("race-timeout", "A") is False
+
+    def test_delivery_failure_returns_winning_answer_and_cleans_entry(self):
         from tools import clarify_gateway as cm
 
-        entry = cm.register("ss-oor", "sk-ss", "Pick one", ["A", "B"])
-        value, reason = cm._coerce_text_response_detailed(entry, "9")
-        assert value is None
-        assert reason == "invalid_selection"
-        assert cm.attempt_text_response_for_session("sk-ss", "9") == (
-            cm.TEXT_REJECTED_SELECTION
-        )
+        cm.register("race-delivery-answer", "sk", "Pick", ["A", "B"])
+        assert cm.resolve_gateway_clarify("race-delivery-answer", "custom") is True
 
-    def test_single_select_prose_is_rejected_prose(self):
+        assert cm.finish_failed_delivery("race-delivery-answer") == "custom"
+        assert "race-delivery-answer" not in cm._entries
+        assert "sk" not in cm._session_index
+
+    def test_delivery_failure_cancels_pending_entry_and_cleans_indices(self):
         from tools import clarify_gateway as cm
 
-        entry = cm.register("ss-prose", "sk-ss2", "Pick one", ["A", "B"])
-        value, reason = cm._coerce_text_response_detailed(
-            entry, "one more unrelated thought",
+        cm.register("race-delivery-cancel", "sk", "Pick", ["A", "B"])
+
+        assert cm.finish_failed_delivery("race-delivery-cancel") is None
+        assert "race-delivery-cancel" not in cm._entries
+        assert "sk" not in cm._session_index
+
+    def test_shared_thread_accepts_other_participant_on_same_route(self):
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+        from tools import clarify_gateway as cm
+
+        owner = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="channel-1",
+            chat_type="channel",
+            thread_id=None,
+            prospective_thread_id="thread-1",
+            user_id="owner",
         )
-        assert value is None
-        assert reason == "prose"
+        member = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="channel-1",
+            chat_type="thread",
+            thread_id="thread-1",
+            user_id="member",
+        )
+        cm.register(
+            "shared-thread",
+            "sk",
+            "Pick",
+            ["A", "B"],
+            source_identity=cm.source_identity(owner),
+            shared_multi_user_session=True,
+        )
+
+        assert cm.resolve_text_response_for_session(
+            "sk",
+            "member answer",
+            source_identity=cm.source_identity(member),
+        ) is True
+
+    def test_isolated_thread_rejects_other_participant(self):
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+        from tools import clarify_gateway as cm
+
+        owner = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="channel-1",
+            chat_type="thread",
+            thread_id="thread-1",
+            user_id="owner",
+        )
+        member = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="channel-1",
+            chat_type="thread",
+            thread_id="thread-1",
+            user_id="member",
+        )
+        cm.register(
+            "isolated-thread",
+            "sk",
+            "Pick",
+            ["A", "B"],
+            source_identity=cm.source_identity(owner),
+            shared_multi_user_session=False,
+        )
+
+        assert cm.resolve_text_response_for_session(
+            "sk",
+            "member answer",
+            source_identity=cm.source_identity(member),
+        ) is False
+
+
+    def test_source_identity_canonicalizes_whatsapp_alias_flip(self, monkeypatch):
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+        from tools import clarify_gateway as cm
+
+        monkeypatch.setattr(
+            "gateway.whatsapp_identity.expand_whatsapp_aliases",
+            lambda _value: {"12345", "6012345"},
+        )
+        phone = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="6012345@s.whatsapp.net",
+            user_id="6012345@s.whatsapp.net",
+        )
+        lid = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="12345@lid",
+            user_id_alt="12345@lid",
+        )
+
+        assert cm.source_identity(phone) == cm.source_identity(lid)
+
+class TestNativeChoiceFreeText:
+    """Typed prose always answers an active native clarify."""
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    def test_single_select_accepts_custom_text_without_other(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("custom-single", "sk", "Pick", ["A", "B"])
+
+        assert cm.resolve_text_response_for_session("sk", "something else") is True
+        assert cm.wait_for_response("custom-single", timeout=1) == "something else"
+
+    def test_multi_select_keeps_unmatched_comma_text_as_one_custom_answer(self):
+        import json
+        from tools import clarify_gateway as cm
+
+        cm.register(
+            "custom-multi",
+            "sk",
+            "Pick several",
+            ["A", "B"],
+            multi_select=True,
+        )
+
+        assert cm.resolve_text_response_for_session("sk", "later, after lunch") is True
+        assert json.loads(cm.wait_for_response("custom-multi", timeout=1)) == [
+            "later, after lunch"
+        ]
+
+
+class TestClarifyMessageConsumption:
+    """Realtime and Bot-event delivery share one message-id decision."""
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    def test_message_id_is_consumed_once_across_delivery_paths(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("dedup", "sk", "Pick", ["A", "B"])
+
+        assert cm.resolve_message_text_for_session("sk", "custom", "message-1") == "consumed"
+        assert cm.resolve_message_text_for_session("sk", "custom", "message-1") == "duplicate"
+        assert cm.is_clarify_message_consumed("message-1") is True
+        assert cm.wait_for_response("dedup", timeout=1) == "custom"
+
+    def test_failed_message_resolution_does_not_consume_message_id(self):
+        from tools import clarify_gateway as cm
+
+        assert cm.resolve_message_text_for_session("missing", "custom", "message-2") == "not_resolved"
+        assert cm.is_clarify_message_consumed("message-2") is False
+
+    def test_message_claim_and_answer_are_atomic_against_competing_answer(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("race-message", "sk", "Pick", ["A", "B"])
+        outcomes = []
+        barrier = threading.Barrier(3)
+
+        def resolve(message_id, answer):
+            barrier.wait()
+            outcomes.append(cm.resolve_message_text_for_session("sk", answer, message_id))
+
+        first = threading.Thread(target=resolve, args=("message-a", "A"))
+        second = threading.Thread(target=resolve, args=("message-b", "B"))
+        first.start()
+        second.start()
+        barrier.wait()
+        first.join(timeout=5)
+        second.join(timeout=5)
+
+        assert sorted(outcomes) == ["consumed", "not_resolved"]
+        assert sum(cm.is_clarify_message_consumed(mid) for mid in ("message-a", "message-b")) == 1

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -35,7 +35,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +54,9 @@ class _ClarifyEntry:
     multi_select: bool = False
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
+    state: str = "pending"
+    source_identity: Optional[Tuple[str, ...]] = None
+    shared_multi_user_session: bool = False
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
 
     def signature(self) -> Dict[str, object]:
@@ -71,18 +74,89 @@ _lock = threading.RLock()
 _entries: Dict[str, _ClarifyEntry] = {}
 # session_key → list[clarify_id]  (FIFO; for text-fallback intercept and session cleanup)
 _session_index: Dict[str, List[str]] = {}
+# Octo delivers the same ordinary message over realtime transport and Bot
+# events. Keep only messages that actually resolved clarify; failed claims are
+# never retained, so the realtime path can continue as an ordinary turn.
+_consumed_message_ids: Dict[str, float] = {}
+_CONSUMED_MESSAGE_TTL_SECONDS = 24 * 60 * 60
 
+
+def _prune_consumed_messages(now: float) -> None:
+    cutoff = now - _CONSUMED_MESSAGE_TTL_SECONDS
+    expired = [
+        message_id
+        for message_id, consumed_at in _consumed_message_ids.items()
+        if consumed_at < cutoff
+    ]
+    for message_id in expired:
+        _consumed_message_ids.pop(message_id, None)
+
+
+def source_identity(source: Any) -> Tuple[str, ...]:
+    """Return the trusted canonical route and participant identity."""
+    platform = getattr(source, "platform", None)
+    platform_value = getattr(platform, "value", platform)
+    chat_id = str(getattr(source, "chat_id", None) or "")
+    participant_id = str(
+        getattr(source, "user_id_alt", None)
+        or getattr(source, "user_id", None)
+        or ""
+    )
+    if platform_value == "whatsapp":
+        from gateway.whatsapp_identity import canonical_whatsapp_identifier
+
+        chat_id = canonical_whatsapp_identifier(chat_id) or chat_id
+        participant_id = (
+            canonical_whatsapp_identifier(participant_id) or participant_id
+        )
+    effective_thread_id = (
+        getattr(source, "thread_id", None)
+        or getattr(source, "prospective_thread_id", None)
+    )
+    chat_type = str(getattr(source, "chat_type", None) or "")
+    if getattr(source, "prospective_thread_id", None) and not getattr(
+        source,
+        "thread_id",
+        None,
+    ):
+        chat_type = "thread"
+    return (
+        str(platform_value or ""),
+        str(getattr(source, "profile", None) or ""),
+        str(getattr(source, "scope_id", None) or ""),
+        chat_id,
+        str(effective_thread_id or ""),
+        chat_type,
+        participant_id,
+    )
+
+
+def _source_identity_matches(
+    registered: Tuple[str, ...],
+    candidate: Tuple[str, ...],
+    *,
+    shared_multi_user_session: bool,
+) -> bool:
+    """Match one participant, or any participant on an authoritative shared route."""
+    if registered == candidate:
+        return True
+    if not shared_multi_user_session:
+        return False
+    if len(registered) != 7 or len(candidate) != 7:
+        return False
+    return registered[:6] == candidate[:6]
 
 # =========================================================================
 # Public API — agent-thread side
 # =========================================================================
-
 def register(
     clarify_id: str,
     session_key: str,
     question: str,
     choices: Optional[List[str]],
     multi_select: bool = False,
+    source_identity: Optional[Tuple[str, ...]] = None,
+    shared_multi_user_session: bool = False,
 ) -> _ClarifyEntry:
     """Register a pending clarify request and return the entry.
 
@@ -95,6 +169,8 @@ def register(
         question=question,
         choices=list(choices) if choices else None,
         multi_select=bool(multi_select) and bool(choices),
+        source_identity=source_identity,
+        shared_multi_user_session=shared_multi_user_session,
         # Open-ended (no choices) → next message IS the response, no buttons needed.
         awaiting_text=not bool(choices),
     )
@@ -116,7 +192,7 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
     heartbeat still fires each slice so inactivity watchdogs don't kill a live
     prompt.
 
-    Returns the resolved response string, or ``None`` on timeout.
+    Returns the resolved response string, or ``None`` when timeout wins.
     """
     with _lock:
         entry = _entries.get(clarify_id)
@@ -146,7 +222,10 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
             touch_activity_if_due(activity_state, "waiting for user clarify response")
 
     with _lock:
-        # Remove from indices regardless of resolution outcome.
+        if entry.state == "pending":
+            entry.state = "timed_out"
+        # Remove from indices regardless of resolution outcome.  The waiter
+        # owns final cleanup; resolvers only choose the terminal state.
         _entries.pop(clarify_id, None)
         ids = _session_index.get(entry.session_key)
         if ids and clarify_id in ids:
@@ -154,7 +233,7 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
             if not ids:
                 _session_index.pop(entry.session_key, None)
 
-    return entry.response
+        return entry.response if entry.state in {"answered", "cancelled"} else None
 
 
 # =========================================================================
@@ -162,24 +241,21 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
 # =========================================================================
 
 def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
-    """Unblock the agent thread waiting on ``clarify_id``.
-
-    Returns True if an entry was found and resolved, False otherwise
-    (already resolved, expired, or never existed).
-    """
+    """Atomically resolve a pending clarify; the first terminal outcome wins."""
     with _lock:
         entry = _entries.get(clarify_id)
-        if entry is None or entry.event.is_set():
+        if entry is None or entry.state != "pending":
             return False
         entry.response = str(response) if response is not None else ""
+        entry.state = "answered"
         entry.event.set()
         return True
-
 
 def get_pending_for_session(
     session_key: str,
     *,
     include_choice_prompts: bool = False,
+    source_identity: Optional[Tuple[str, ...]] = None,
 ) -> Optional[_ClarifyEntry]:
     """Return the oldest pending clarify entry for a session, or None.
 
@@ -194,7 +270,17 @@ def get_pending_for_session(
         ids = _session_index.get(session_key) or []
         for cid in ids:
             entry = _entries.get(cid)
-            if entry is None:
+            if entry is None or entry.state != "pending":
+                continue
+            if (
+                source_identity is not None
+                and entry.source_identity is not None
+                and not _source_identity_matches(
+                    entry.source_identity,
+                    source_identity,
+                    shared_multi_user_session=entry.shared_multi_user_session,
+                )
+            ):
                 continue
             if include_choice_prompts or entry.awaiting_text:
                 return entry
@@ -214,163 +300,43 @@ def _label_matches(text: str, choice: object) -> bool:
     return strip_recommended(text).casefold() == strip_recommended(str(choice)).casefold()
 
 
-# Outcomes for typed clarify replies. Gateway uses these to decide whether to
-# cancel a pending prompt (free prose deadlock break) or keep it armed so the
-# user can retry a selection-like invalid reply (out-of-range / bad list).
-TEXT_RESOLVED = "resolved"
-TEXT_REJECTED_PROSE = "rejected_prose"
-TEXT_REJECTED_SELECTION = "rejected_selection"
-TEXT_NO_PENDING = "no_pending"
-
-
-def _selection_attempt_tokens(
-    text: str,
-    choices: Optional[List[str]] = None,
-) -> Optional[List[str]]:
-    """Return tokens when ``text`` looks like a typed selection attempt.
-
-    Selection-shaped input includes:
-      - a bare integer ("2", "99")
-      - comma-separated numbers/labels ("1,3", "staging, prod", "1,99")
-      - space-separated all-numeric lists ("1 3")
-
-    Free prose ("just checking the visual UI, no need to pass any data") returns
-    None even when it contains commas, so the gateway can release the clarify
-    and continue normal routing instead of forcing a retry.
-
-    Multi-word choice labels are allowed in comma-lists up to the longest
-    choice's word count (e.g. "Send to SOL, Keep with Enoch").
-    """
-    stripped = str(text).strip()
-    if not stripped:
-        return None
-
-    max_choice_words = 1
-    if choices:
-        max_choice_words = max(
-            (len(str(choice).split()) for choice in choices),
-            default=1,
-        )
-        max_choice_words = max(1, max_choice_words)
-
-    if "," in stripped:
-        tokens = [t.strip() for t in stripped.split(",") if t.strip()]
-        if not tokens:
-            return None
-        # Natural-language clauses with commas are not selection lists.
-        # Each selection token is either a number or at most as many words
-        # as the longest configured choice label.
-        for token in tokens:
-            if token.isdigit():
-                continue
-            words = token.split()
-            if len(words) == 0 or len(words) > max_choice_words:
-                return None
-        return tokens
-
-    parts = stripped.split()
-    if len(parts) > 1 and all(p.strip().isdigit() for p in parts):
-        return [p.strip() for p in parts]
-
-    # Bare integer (in-range or out-of-range) is always a selection attempt.
-    if stripped.isdigit() or (stripped.startswith("-") and stripped[1:].isdigit()):
-        return [stripped]
-
-    try:
-        int(stripped)
-        return [stripped]
-    except ValueError:
-        return None
 
 
 def _coerce_text_response(entry: _ClarifyEntry, response: str) -> Optional[str]:
-    """Map typed choice replies to canonical choice text, otherwise keep or reject custom text.
+    """Map typed choices to canonical values and preserve other user text.
 
-    Thin wrapper over :func:`_coerce_text_response_detailed` for callers that
-    only need the accepted value (or ``None`` on any rejection).
-    """
-    coerced, _reason = _coerce_text_response_detailed(entry, response)
-    return coerced
-
-
-def _coerce_text_response_detailed(
-    entry: _ClarifyEntry,
-    response: str,
-) -> tuple[Optional[str], Optional[str]]:
-    """Map typed replies and classify rejections.
-
-    Returns ``(value, None)`` when the reply is accepted.
-
-    Returns ``(None, reason)`` when rejected:
-      - ``"invalid_selection"`` — selection-shaped but unusable (out-of-range
-        number, unrecognised comma-list). Keep the pending clarify so the
-        user can retry.
-      - ``"prose"`` — free text that is not a selection attempt. Gateway may
-        cancel the clarify and continue normal busy-message routing so a
-        redirect-to-steer path cannot deadlock behind the waiting tool.
-
-    For native interactive multi-choice clarifies (button UI, awaiting_text=False):
-      - Accept numeric selections ("2" → choice[1])
-      - Accept exact choice label matches (case-insensitive)
-      - Reject arbitrary prose so the message can continue as a normal turn
-
-    For multi-select clarifies (entry.multi_select=True):
-      - Accept several numbers separated by commas and/or spaces ("1,3" / "1 3")
-      - Accept exact choice label matches (single or comma-separated)
-      - Out-of-range numbers / unrecognised lists reject the whole reply so the
-        user can retry instead of silently getting a partial selection
-      - Selections are returned as a JSON array string, which the clarify
-        tool's ``_parse_multi_select_response`` decodes back into a list
-
-    For text fallback or awaiting_text mode:
-      - Accept any text (numeric/label/custom) after passing through coercion
-
-    For open-ended clarifies (no choices):
-      - Accept any text
+    Numeric and exact-label replies retain their canonical choice behavior.
+    Any other non-empty text is a custom answer even when native controls are
+    visible; the card is an input convenience, not the only way to unblock the
+    pending clarify. Multi-select custom prose is encoded as one JSON item so
+    commas in natural language never become accidental selections.
     """
     text = str(response).strip()
 
     if not entry.choices:
-        # Open-ended: accept any text
-        return text, None
+        return text
 
     if entry.multi_select:
         coerced = _coerce_multi_select_text(entry, text)
         if coerced is not None:
-            return coerced, None
-        # Not a parseable selection — accept as custom text only in
-        # awaiting_text mode (the "Other" path); otherwise classify reject.
-        if entry.awaiting_text:
-            return text, None
-        if _selection_attempt_tokens(text, entry.choices) is not None:
-            return None, "invalid_selection"
-        return None, "prose"
+            return coerced
+        import json as _json
 
-    # Try numeric selection first (always valid for multi-choice)
+        return _json.dumps([text], ensure_ascii=False) if text else None
+
     try:
         idx = int(text) - 1
-        is_int = True
     except ValueError:
         idx = -1
-        is_int = False
 
-    if is_int and 0 <= idx < len(entry.choices):
-        return entry.choices[idx], None
+    if 0 <= idx < len(entry.choices):
+        return entry.choices[idx]
 
-    # Try exact choice label match (always valid for multi-choice)
     for choice in entry.choices:
         if _label_matches(text, choice):
-            return str(choice).strip(), None
+            return str(choice).strip()
 
-    # For text fallback or awaiting_text mode, accept custom text
-    # For native interactive multi-choice mode, reject with a reason
-    if entry.awaiting_text:
-        return text, None
-
-    # Out-of-range / non-canonical integer is a failed selection, not prose.
-    if is_int:
-        return None, "invalid_selection"
-    return None, "prose"
+    return text if text else None
 
 
 def _coerce_multi_select_text(entry: _ClarifyEntry, text: str) -> Optional[str]:
@@ -425,42 +391,81 @@ def _coerce_multi_select_text(entry: _ClarifyEntry, text: str) -> Optional[str]:
     return _json.dumps(selected, ensure_ascii=False)
 
 
-def attempt_text_response_for_session(session_key: str, response: str) -> str:
-    """Try to resolve the oldest pending clarify in ``session_key`` from typed text.
-
-    Returns one of:
-      - ``TEXT_RESOLVED`` — accepted; waiter unblocked
-      - ``TEXT_REJECTED_PROSE`` — free prose on a native choice prompt; caller
-        may cancel the clarify and continue ordinary message routing
-      - ``TEXT_REJECTED_SELECTION`` — selection-shaped but invalid; leave the
-        pending clarify armed so the user can retry
-      - ``TEXT_NO_PENDING`` — no interceptable clarify for this session
-    """
-    entry = get_pending_for_session(session_key, include_choice_prompts=True)
+def resolve_text_response_for_session(
+    session_key: str,
+    response: str,
+    *,
+    source_identity: Optional[Tuple[str, ...]] = None,
+) -> bool:
+    """Resolve the oldest eligible pending clarify from typed text."""
+    entry = get_pending_for_session(
+        session_key,
+        include_choice_prompts=True,
+        source_identity=source_identity,
+    )
     if entry is None:
-        return TEXT_NO_PENDING
+        return False
 
-    coerced, reason = _coerce_text_response_detailed(entry, response)
+    coerced = _coerce_text_response(entry, response)
     if coerced is None:
-        if reason == "invalid_selection":
-            return TEXT_REJECTED_SELECTION
-        return TEXT_REJECTED_PROSE
+        return False
 
-    if resolve_gateway_clarify(entry.clarify_id, coerced):
-        return TEXT_RESOLVED
-    # Lost a race with a button/callback resolution — treat as no work left.
-    return TEXT_NO_PENDING
+    return resolve_gateway_clarify(entry.clarify_id, coerced)
 
 
-def resolve_text_response_for_session(session_key: str, response: str) -> bool:
-    """Resolve the oldest pending clarify in ``session_key`` from typed text.
+def resolve_message_text_for_session(
+    session_key: str,
+    response: str,
+    message_id: str,
+    *,
+    source_identity: Optional[Tuple[str, ...]] = None,
+) -> Literal["consumed", "duplicate", "not_resolved"]:
+    """Atomically resolve clarify and retain one cross-transport consumption result."""
+    if not isinstance(message_id, str) or not message_id:
+        return "not_resolved"
+    with _lock:
+        now = time.monotonic()
+        _prune_consumed_messages(now)
+        if message_id in _consumed_message_ids:
+            return "duplicate"
+        ids = _session_index.get(session_key) or []
+        entry = next(
+            (
+                candidate
+                for clarify_id in ids
+                if (candidate := _entries.get(clarify_id)) is not None
+                and candidate.state == "pending"
+                and (
+                    source_identity is None
+                    or candidate.source_identity is None
+                    or _source_identity_matches(
+                        candidate.source_identity,
+                        source_identity,
+                        shared_multi_user_session=candidate.shared_multi_user_session,
+                    )
+                )
+            ),
+            None,
+        )
+        if entry is None:
+            return "not_resolved"
+        coerced = _coerce_text_response(entry, response)
+        if coerced is None or entry.state != "pending":
+            return "not_resolved"
+        entry.response = coerced
+        entry.state = "answered"
+        _consumed_message_ids[message_id] = now
+        entry.event.set()
+        return "consumed"
 
-    Returns True only when the reply was accepted and the waiter unblocked.
-    Rejected prose, rejected selections, and missing prompts all return False;
-    use :func:`attempt_text_response_for_session` when the caller must
-    distinguish those cases (gateway deadlock vs multi-select retry).
-    """
-    return attempt_text_response_for_session(session_key, response) == TEXT_RESOLVED
+
+def is_clarify_message_consumed(message_id: str) -> bool:
+    """Return whether this Octo message already answered clarify in this process."""
+    if not isinstance(message_id, str) or not message_id:
+        return False
+    with _lock:
+        _prune_consumed_messages(time.monotonic())
+        return message_id in _consumed_message_ids
 
 
 def mark_awaiting_text(clarify_id: str) -> bool:
@@ -470,58 +475,56 @@ def mark_awaiting_text(clarify_id: str) -> bool:
     """
     with _lock:
         entry = _entries.get(clarify_id)
-        if entry is None:
+        if entry is None or entry.state != "pending":
             return False
         entry.awaiting_text = True
         return True
+
+
+def finish_failed_delivery(clarify_id: str) -> Optional[str]:
+    """Cancel an undelivered clarify or return an answer that already won."""
+    with _lock:
+        entry = _entries.get(clarify_id)
+        if entry is None:
+            return None
+        if entry.state == "pending":
+            entry.response = ""
+            entry.state = "cancelled"
+            entry.event.set()
+        response = entry.response if entry.state == "answered" else None
+        _entries.pop(clarify_id, None)
+        ids = _session_index.get(entry.session_key)
+        if ids and clarify_id in ids:
+            ids.remove(clarify_id)
+            if not ids:
+                _session_index.pop(entry.session_key, None)
+        return response
 
 
 def has_pending(session_key: str) -> bool:
     """Return True when this session has at least one pending clarify entry."""
     with _lock:
         ids = _session_index.get(session_key) or []
-        return any(_entries.get(cid) is not None for cid in ids)
+        return any(
+            (entry := _entries.get(cid)) is not None and entry.state == "pending"
+            for cid in ids
+        )
 
 
 def clear_session(session_key: str) -> int:
-    """Resolve and drop every pending clarify for a session.
-
-    Used by session-boundary cleanup (e.g. ``/new``, gateway shutdown,
-    cached-agent eviction) so blocked agent threads don't hang past the
-    end of their session.  Returns the number of entries actually
-    cancelled (i.e. whose event had not yet been set).  Already-resolved
-    entries are dropped from the registry but their response is preserved.
-
-    First-writer-wins: an entry whose event is already set has been resolved
-    by a real response (button callback or text intercept).  Session cleanup
-    must NOT overwrite that response with the empty cancellation sentinel —
-    the waiting agent thread would observe a cancelled prompt even though the
-    user answered.  Only unresolved entries are cancelled here.
-    """
+    """Cancel pending entries while preserving completed waiter results."""
     with _lock:
-        ids = list(_session_index.pop(session_key, []) or [])
-        entries = [_entries.pop(cid, None) for cid in ids]
-        # The mutation loop must stay inside the lock: the pop above and the
-        # event.is_set() check below have to be atomic with respect to
-        # resolve_gateway_clarify, or a button callback could win between the
-        # pop and the check and have its answer clobbered by the sentinel.
+        ids = list(_session_index.get(session_key, []) or [])
         cancelled = 0
-        for entry in entries:
-            if entry is None:
+        for clarify_id in ids:
+            entry = _entries.get(clarify_id)
+            if entry is None or entry.state != "pending":
                 continue
-            # Entry is removed from the global registry regardless of its
-            # state — a cleared session must not be resurrected by late
-            # callbacks — but a resolved entry keeps its real response.
-            if entry.event.is_set():
-                continue
-            # Empty string sentinel — agent code can distinguish from a real
-            # response by inspecting the wait_for_response return value
-            # alongside its own timeout deadline.  Most callers just treat any
-            # falsy result as "user did not respond".
             entry.response = ""
+            entry.state = "cancelled"
             entry.event.set()
             cancelled += 1
-    return cancelled
+        return cancelled
 
 
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

A gateway agent waiting in `clarify` can remain blocked until timeout when a user answers with ordinary text instead of a native card/button response. The active-run guard then treats subsequent input as busy input, but interrupting the agent does not wake the clarify event wait.

This change makes the next eligible text message resolve the pending clarify directly. It keeps recognized slash commands on the command path, preserves session/participant identity boundaries, and makes clarify completion first-writer-wins across text, card callbacks, timeout, and session cleanup.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- extend `tools/clarify_gateway.py` with explicit pending/answered/cancelled state, source identity binding, typed-answer coercion, and cross-transport consumption tracking
- intercept eligible clarify replies before ordinary active-run busy handling in `gateway/run.py`
- let recognized commands dispatch while a clarify is pending
- align shared group/thread session identity with gateway routing policy
- preserve first terminal outcome during timeout, cleanup, text, and callback races
- add gateway and clarify state-machine regressions

## How to Test

1. `uv run --frozen pytest -q tests/tools/test_clarify_gateway.py tests/gateway/test_clarify_active_session_bypass.py tests/gateway/test_clarify_thread_followup_not_swallowed.py`
2. `uv run --frozen ruff check gateway/platforms/base.py gateway/run.py gateway/session.py hermes_cli/commands.py tools/clarify_gateway.py tests/gateway/test_clarify_active_session_bypass.py tests/gateway/test_clarify_thread_followup_not_swallowed.py tests/tools/test_clarify_gateway.py`
3. Start a gateway clarify, reply with prose or a typed option, and verify the original run resumes; verify `/stop` and registered commands remain commands.

Focused result: 46 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — the complete upstream suite has unrelated environment-sensitive failures; focused changed-contract tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS 26 (arm64)

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered; implementation uses existing threading/asyncio primitives
- [x] Tool schema update N/A

## Screenshots / Logs

Not applicable; behavior is covered by gateway state-machine tests.

Companion Octo integration PR will link here after creation.