### PR TITLE
fix(fuzzy_match): don't double-indent when old_string has column-0 first line

### DIFF
--- a/tests/tools/test_fuzzy_match_crlf_indent.py
+++ b/tests/tools/test_fuzzy_match_crlf_indent.py
@@ -1,0 +1,76 @@
+"""Tests for fuzzy_find_and_replace CRLF/indentation edge cases."""
+
+from tools.fuzzy_match import fuzzy_find_and_replace
+
+
+def test_crlf_column0_first_line_preserves_indent():
+    """When old_string's first line is at column 0, the reindent logic
+    should NOT double-indent the new_string's indented body lines."""
+    content = (
+        "def outer():\r\n"
+        "    x = 1\r\n"
+        "    if x:\r\n"
+        "        y = 2\r\n"
+        "        print(y)\r\n"
+        "    return x\r\n"
+    )
+    old_string = "if x:\n        y = 2\n        print(y)"
+    new_string = "if x:\n        y = 999\n        print(y * 2)"
+
+    new_content, count, strategy, err = fuzzy_find_and_replace(
+        content, old_string, new_string, False
+    )
+
+    assert err is None, f"unexpected error: {err}"
+    assert count == 1
+    indents = [len(l) - len(l.lstrip(" ")) for l in new_content.splitlines()]
+    # Expected: [0, 4, 4, 8, 8, 4] — body lines stay at 8 spaces
+    assert indents == [0, 4, 4, 8, 8, 4], f"indentation corrupted: {indents}"
+
+
+def test_lf_column0_first_line_preserves_indent():
+    """Same bug on LF files — column-0 anchor should not double-indent."""
+    content = (
+        "def outer():\n"
+        "    x = 1\n"
+        "    if x:\n"
+        "        y = 2\n"
+        "        print(y)\n"
+        "    return x\n"
+    )
+    old_string = "if x:\n        y = 2\n        print(y)"
+    new_string = "if x:\n        y = 999\n        print(y * 2)"
+
+    new_content, count, strategy, err = fuzzy_find_and_replace(
+        content, old_string, new_string, False
+    )
+
+    assert err is None
+    assert count == 1
+    indents = [len(l) - len(l.lstrip(" ")) for l in new_content.splitlines()]
+    assert indents == [0, 4, 4, 8, 8, 4], f"indentation corrupted: {indents}"
+
+
+def test_non_empty_old_indent_still_works():
+    """When old_string has a non-empty base indent, the existing swap
+    behavior should still work (regression check)."""
+    content = (
+        "def outer():\n"
+        "    x = 1\n"
+        "    if x:\n"
+        "        y = 2\n"
+        "        print(y)\n"
+        "    return x\n"
+    )
+    # old_string has 4-space base indent
+    old_string = "    if x:\n        y = 2\n        print(y)"
+    new_string = "    if x:\n        y = 999\n        print(y * 2)"
+
+    new_content, count, strategy, err = fuzzy_find_and_replace(
+        content, old_string, new_string, False
+    )
+
+    assert err is None
+    assert count == 1
+    indents = [len(l) - len(l.lstrip(" ")) for l in new_content.splitlines()]
+    assert indents == [0, 4, 4, 8, 8, 4], f"indentation corrupted: {indents}"

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -444,11 +444,15 @@ def _reindent_replacement(file_region: str, old_string: str, new_string: str) ->
             out_lines.append(line)
             continue
         line_indent = _leading_whitespace(line)
-        if line_indent.startswith(old_indent):
+        if old_indent and line_indent.startswith(old_indent):
             # Common case: line has the LLM's base indent (possibly plus
             # extra). Swap base prefix for the file's base prefix.
             remainder = line[len(old_indent):]
             out_lines.append(file_indent + remainder)
+        elif old_indent == "":
+            # No base prefix to swap — preserve the line's own indentation,
+            # anchored to the file's base for lines at column 0.
+            out_lines.append(file_indent + line.lstrip(" \t") if not line_indent else line)
         else:
             # Line is less-indented than the LLM's base — e.g. a dedent at
             # the start of new_string. Anchor to the file's base.


### PR DESCRIPTION
## Summary

Fixes #88264

patch/fuzzy_find_and_replace corrupts indentation (doubles it) on CRLF files when the model's old_string starts with a non-indented first line while the file's matched region is indented. Silent source corruption — err: None, success looks clean.

## Root cause

In _reindent_replacement (tools/fuzzy_match.py:447), when old_string's first line is at column 0, old_indent is . str.startswith() is always True, so every line of new_string gets file_indent prepended to its existing indent. An 8-space line becomes 12 spaces.

## Fix

Guard the empty base-indent case: when old_indent is , preserve the line's own indentation (anchored to file's base for column-0 lines).

## Changes

- tools/fuzzy_match.py: Guard empty old_indent in _reindent_replacement
- tests/tools/test_fuzzy_match_crlf_indent.py: 3 new tests

## Testing

- 3 new tests pass