### PR TITLE
fix(agent): keep tool results when a server reuses one tool_call_id (#70724)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3678,9 +3678,21 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # tool result. This is the final pre-API chokepoint, so dedup defensively
     # here even though repair_message_sequence also consumes matched ids.
     #   (a) collapse duplicate tool_calls WITHIN an assistant message
-    #   (b) drop later tool result messages reusing an already-seen id
+    #   (b) drop tool results that answer no OUTSTANDING tool call
+    #
+    # (b) tracks outstanding calls rather than every id ever seen, because
+    # ``tool_call_id`` is NOT globally unique in practice: llama.cpp emits a
+    # single constant id for every tool call it ever returns (verified: three
+    # separate completions from one server all carry the same id). A
+    # seen-once-drop-forever rule reads the SECOND legitimate tool result of
+    # such a session as a duplicate and deletes it, so from the second tool
+    # call onward the model never sees any result — it announces its next
+    # action and the turn dies with the work unfinished. Outstanding-call
+    # semantics keep both protections intact: a re-emitted result still
+    # answers no pending call and is still dropped, while a genuine new call
+    # that reuses the id re-arms that id first.
     seen_assistant_call_ids: set = set()
-    seen_result_call_ids: set = set()
+    outstanding_call_ids: set = set()
     deduped: List[Dict[str, Any]] = []
     removed_dupes = 0
     for msg in messages:
@@ -3694,6 +3706,7 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     continue
                 if cid:
                     seen_assistant_call_ids.add(cid)
+                    outstanding_call_ids.add(cid)
                 kept_tcs.append(tc)
             if kept_tcs:
                 msg = {**msg, "tool_calls": kept_tcs}
@@ -3702,11 +3715,15 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()
-            if cid and cid in seen_result_call_ids:
+            if cid and cid not in outstanding_call_ids:
                 removed_dupes += 1
                 continue
             if cid:
-                seen_result_call_ids.add(cid)
+                # Answered: this id is no longer outstanding, so a second
+                # result replaying it is still caught above.
+                outstanding_call_ids.discard(cid)
+                # A reused id must be re-armable by the next assistant call.
+                seen_assistant_call_ids.discard(cid)
             deduped.append(msg)
         else:
             deduped.append(msg)

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -394,6 +394,57 @@ def test_sanitize_still_drops_replayed_result_for_retired_call():
     assert [m["content"] for m in out if m.get("role") == "tool"] == ["real"]
 
 
+def test_sanitize_preserves_deterministic_local_ids_across_turns():
+    """Hermes' own deterministic call ids (fn-name+args hashes / local
+    counters) legitimately repeat across turns — both must survive.
+
+    Scenario surfaced in #76632: two image_generate rounds emit the same
+    local ids (``image_generate:0``/``:1``) in successive assistant turns.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    def _tc(cid):
+        return {"id": cid, "type": "function",
+                "function": {"name": "image_generate", "arguments": "{}"}}
+
+    messages = [{"role": "user", "content": "make images"}]
+    for turn in ("one", "two"):
+        messages.append({"role": "assistant", "content": turn,
+                         "tool_calls": [_tc("image_generate:0"), _tc("image_generate:1")]})
+        messages.append({"role": "tool", "tool_call_id": "image_generate:0",
+                         "content": f"imgA-{turn}"})
+        messages.append({"role": "tool", "tool_call_id": "image_generate:1",
+                         "content": f"imgB-{turn}"})
+
+    out = sanitize_api_messages(list(messages))
+    assistants = [m for m in out if m.get("role") == "assistant" and m.get("tool_calls")]
+    assert len(assistants) == 2
+    for a in assistants:
+        assert [tc["id"] for tc in a["tool_calls"]] == [
+            "image_generate:0", "image_generate:1"]
+    tool_ids = sorted(m["tool_call_id"] for m in out if m.get("role") == "tool")
+    assert tool_ids == ["image_generate:0", "image_generate:0",
+                        "image_generate:1", "image_generate:1"]
+
+
+def test_sanitize_keeps_all_results_over_fifty_turn_constant_id_session():
+    """Kimi K3 / llama.cpp field repro (#70724, #70734): 50 sequential calls
+    all sharing one id must all survive — stock behavior kept 1/50."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [{"role": "user", "content": "Run 50 steps."}]
+    for step in range(50):
+        messages.append(_call(CONSTANT_ID))
+        messages.append(_result(CONSTANT_ID, f"completed-step-{step}"))
+
+    out = sanitize_api_messages(list(messages))
+    calls = [m for m in out if m.get("role") == "assistant" and m.get("tool_calls")]
+    results = [m for m in out if m.get("role") == "tool"]
+    assert len(calls) == 50
+    assert len(results) == 50
+    assert results[-1]["content"] == "completed-step-49"
+
+
 def test_sanitize_drops_result_with_no_preceding_call():
     """A tool result that never had a call is an orphan regardless of id."""
     from agent.agent_runtime_helpers import sanitize_api_messages
@@ -478,21 +529,24 @@ def test_sanitize_dedup_drops_tool_calls_key_when_all_removed():
     """
     from agent.agent_runtime_helpers import sanitize_api_messages
 
-    # Simulate a long conversation where the same tool_call_id appears
-    # in multiple assistant messages (e.g., crash/resume glitch or
-    # compression window re-emission). The first occurrence is kept,
-    # later duplicates are removed.
+    # Simulate a crash/resume glitch or compression-window re-emission that
+    # replays the SAME assistant call while the first is still outstanding
+    # (no tool result has answered it yet). That is a true duplicate: the
+    # first occurrence is kept, the replay is removed. NOTE: a reuse AFTER
+    # the call was answered is NOT a duplicate — servers with per-turn or
+    # constant ids (llama.cpp, Kimi K3) legitimately re-issue ids across
+    # turns (#70724), which outstanding-call semantics now preserve.
     messages = [
         {"role": "user", "content": "step 1"},
         {"role": "assistant", "content": "running",
          "tool_calls": [{"id": "call_A", "type": "function",
                          "function": {"name": "foo", "arguments": "{}"}}]},
-        {"role": "tool", "tool_call_id": "call_A", "content": "result 1"},
-        # Simulate a later assistant message that reuses call_A
-        # (this would be invalid, but the dedup pass handles it)
+        # Replayed assistant call BEFORE the result answers call_A —
+        # a duplicate of a still-outstanding call, so it must be removed.
         {"role": "assistant", "content": "retrying",
          "tool_calls": [{"id": "call_A", "type": "function",
                          "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_A", "content": "result 1"},
     ]
 
     out = sanitize_api_messages(list(messages))

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -336,6 +336,75 @@ def test_sanitize_preserves_distinct_tool_call_ids():
     assert sorted(m["tool_call_id"] for m in out if m.get("role") == "tool") == ["call_A", "call_B"]
 
 
+# ── tool_call_id reuse by local servers (#70724) ────────────────────────────
+# llama.cpp emits ONE constant tool_call_id for every tool call it returns, so
+# ``tool_call_id`` is not globally unique in practice. The #58327 dedup pass
+# must key off outstanding calls, not "seen at any point", or every result
+# after the first is deleted and the agent stops mid-task.
+
+
+CONSTANT_ID = "ZsSt4SkIFMRz0HtqT7MTlimNvzlKM896"
+
+
+def _call(cid, name="terminal"):
+    return {"role": "assistant", "content": None,
+            "tool_calls": [{"id": cid, "type": "function",
+                            "function": {"name": name, "arguments": "{}"}}]}
+
+
+def _result(cid, content):
+    return {"role": "tool", "tool_call_id": cid, "name": "terminal",
+            "content": content}
+
+
+def test_sanitize_keeps_results_when_server_reuses_one_tool_call_id():
+    """Every answered call survives even when all of them share one id.
+
+    Contract: a tool result is dropped for being unanswerable, never for
+    reusing an id that an earlier call already retired.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [{"role": "user", "content": "do three steps"}]
+    for i in range(3):
+        messages.append(_call(CONSTANT_ID))
+        messages.append(_result(CONSTANT_ID, f"step {i} output"))
+
+    out = sanitize_api_messages(list(messages))
+    results = [m for m in out if m.get("role") == "tool"]
+    assert [m["content"] for m in results] == [
+        "step 0 output", "step 1 output", "step 2 output",
+    ]
+    calls = [m for m in out if m.get("role") == "assistant" and m.get("tool_calls")]
+    assert len(calls) == 3
+
+
+def test_sanitize_still_drops_replayed_result_for_retired_call():
+    """The #58327 protection holds: a second result for an already-answered
+    call answers nothing outstanding and is still dropped."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        _call(CONSTANT_ID),
+        _result(CONSTANT_ID, "real"),
+        _result(CONSTANT_ID, "replayed by a retry/resume glitch"),
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert [m["content"] for m in out if m.get("role") == "tool"] == ["real"]
+
+
+def test_sanitize_drops_result_with_no_preceding_call():
+    """A tool result that never had a call is an orphan regardless of id."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    out = sanitize_api_messages([
+        {"role": "user", "content": "hi"},
+        _result("id_never_requested", "orphan"),
+    ])
+    assert [m for m in out if m.get("role") == "tool"] == []
+
+
 def test_sanitize_drops_empty_tool_calls_array():
     """sanitize_api_messages strips ``tool_calls: []`` from assistant messages.
 


### PR DESCRIPTION
## Summary

Tool results now survive when a provider reuses one `tool_call_id` across turns — the pre-API sanitizer keys its dedup off **outstanding** calls instead of every id ever seen. Salvage of #70734 by @flaviovargasbrandao (earliest of a 4-PR duplicate cluster), rebased onto current main with authorship preserved.

Root cause: #58327's seen-once-drop-forever rule assumed `tool_call_id` is globally unique. llama.cpp emits one constant id for every call, and Kimi K3 reuses ids across turns (@Marsmensch measured 196/374 legitimate tool results deleted across 5 real Desktop sessions; his 50-step repro keeps 1/50 on stock v0.20.2). Hermes' own deterministic local-counter ids repeat across turns too. From the second call onward the model never sees tool output — the agent narrates its next step and silently stops.

Fixes #70724.

## Changes

- `agent/agent_runtime_helpers.py`: in `sanitize_api_messages`, an assistant call ARMS its id, a tool result CONSUMES it, and only results answering nothing outstanding are dropped. Answering also retires the id from `seen_assistant_call_ids` so a later legitimate call may re-arm it. (@flaviovargasbrandao's commit, cherry-picked.)
- `tests/run_agent/test_message_sequence_repair.py`:
  - contributor's 3 regression tests (constant-id survival, replay-drop, orphan-drop)
  - follow-up: adapted `test_sanitize_dedup_drops_tool_calls_key_when_all_removed` — it encoded the old global-uniqueness assumption (reuse *after* answer is now a legal new call); the replayed call now precedes the result, preserving the #64335 empty-`tool_calls` key-drop coverage
  - follow-up: cross-turn deterministic local-id test (the #76632 scenario) and the 50-step constant-id field repro from #70724

## Validation

| | Before (main `5975aff8a1`) | After |
|---|---|---|
| 50-step constant-id session | 1/50 results kept | 50/50 |
| Replayed result for answered call | dropped | dropped |
| Orphan result | dropped | dropped |
| Intra-message duplicate calls | collapsed | collapsed |
| Empty `tool_calls: []` key-drop (#64335) | keyed off | preserved |

- `tests/run_agent/test_message_sequence_repair.py`: 21/21 pass
- All 9 test files touching `sanitize_api_messages`: 386 passed
- Sabotage run: restoring main's sanitizer makes exactly the 3 new regression tests fail (`1 == 50`), proving they pin the bug
- E2E real-import check: role alternation clean on the 50-step output; both #58327 protections verified live

## Protections preserved from #58327

- A replayed second result answers no pending call → still dropped (DeepSeek duplicate-id 400 protection)
- Duplicate `tool_calls` within one assistant message → still collapsed
- `repair_message_sequence` needs no change (already resets per assistant message)

## Duplicate cluster

- #70734 @flaviovargasbrandao (Jul 24, earliest) — salvaged here
- #70843 @ms-alan (Jul 24) — per-message scoping; weaker (would keep true cross-turn replays); also bundles an unrelated reasoning_content change
- #76632 @martintin90 (Aug 2) — same outstanding-call approach; its cross-turn local-id scenario is covered by a follow-up test here
- #79221 @zhantss (Aug 5) — per-turn scoping; same weakness as #70843

## Infographic

![Tool results survive reused call IDs](https://v3b.fal.media/files/b/0aa6afc4/bEQtNRrjWSAm7xFuYqaCk_MU6MlxBe.png)
