### PR TITLE
fix(desktop): report packaged client identity consistently

### DIFF
--- a/apps/desktop/electron/about-version.test.ts
+++ b/apps/desktop/electron/about-version.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+
+import { describe, it } from 'vitest'
+
+import { buildAboutPanelVersionOptions } from './about-version'
+
+describe('native About version', () => {
+  it('uses the Hermes version and immutable bundle commit', () => {
+    assert.deepEqual(
+      buildAboutPanelVersionOptions({
+        applicationVersion: '0.20.3',
+        installCommit: 'a'.repeat(40)
+      }),
+      {
+        applicationVersion: '0.20.3',
+        version: 'aaaaaaa'
+      }
+    )
+  })
+
+  it('keeps the bundle-skew warning in secondary text', () => {
+    assert.deepEqual(
+      buildAboutPanelVersionOptions({
+        applicationVersion: '0.20.3',
+        installCommit: 'b'.repeat(40),
+        bundleOutOfSync: true
+      }),
+      {
+        applicationVersion: '0.20.3',
+        credits: 'App build out of date. Update the desktop app.',
+        version: 'bbbbbbb'
+      }
+    )
+  })
+
+  it('omits missing, malformed, and fallback build stamps', () => {
+    for (const installCommit of [null, 'not-a-sha', '0'.repeat(40)]) {
+      assert.deepEqual(buildAboutPanelVersionOptions({ applicationVersion: '0.20.3', installCommit }), {
+        applicationVersion: '0.20.3'
+      })
+    }
+  })
+
+  it('marks locally modified builds', () => {
+    assert.equal(
+      buildAboutPanelVersionOptions({
+        applicationVersion: '0.20.3',
+        installCommit: 'c'.repeat(40),
+        installDirty: true
+      }).version,
+      'ccccccc-dirty'
+    )
+  })
+})

--- a/apps/desktop/electron/about-version.ts
+++ b/apps/desktop/electron/about-version.ts
@@ -1,0 +1,24 @@
+import { isValidInstallCommit } from './install-stamp-identity'
+
+export interface AboutPanelVersionInput {
+  applicationVersion: string
+  installCommit?: string | null
+  installDirty?: boolean
+  bundleOutOfSync?: boolean
+}
+
+export function buildAboutPanelVersionOptions({
+  applicationVersion,
+  installCommit,
+  installDirty = false,
+  bundleOutOfSync = false
+}: AboutPanelVersionInput) {
+  const validCommit = isValidInstallCommit(installCommit)
+  const buildVersion = validCommit ? `${installCommit!.slice(0, 7)}${installDirty ? '-dirty' : ''}` : null
+
+  return {
+    applicationVersion,
+    ...(buildVersion ? { version: buildVersion } : {}),
+    ...(bundleOutOfSync ? { credits: 'App build out of date. Update the desktop app.' } : {})
+  }
+}

--- a/apps/desktop/electron/install-stamp-identity.ts
+++ b/apps/desktop/electron/install-stamp-identity.ts
@@ -1,0 +1,5 @@
+const FULL_GIT_SHA = /^[0-9a-f]{40}$/i
+
+export function isValidInstallCommit(value: unknown): value is string {
+  return typeof value === 'string' && FULL_GIT_SHA.test(value) && !/^0{40}$/.test(value)
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -30,6 +30,7 @@ import {
   systemPreferences
 } from 'electron'
 
+import { buildAboutPanelVersionOptions } from './about-version'
 import { classifyActiveRuntime } from './active-runtime-state'
 import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } from './api-transport'
 import { appIconCandidates, resolveAppIcon } from './app-icon'
@@ -1302,15 +1303,9 @@ if (IS_WINDOWS) {
   app.setAppUserModelId('com.nousresearch.hermes')
 }
 
-// Seed the native About panel with the live Hermes version. This is refreshed
-// on every open via the explicit "About" menu handler (refreshAboutPanel), so
-// an in-place `hermes update` mid-session is reflected without an app restart;
-// the seed here just covers the first open and any non-menu invocation path.
-app.setAboutPanelOptions({
-  applicationName: APP_NAME,
-  applicationVersion: resolveHermesVersion(),
-  copyright: 'Copyright © 2026 Nous Research'
-})
+// Seed the native About panel before app readiness. The menu handler refreshes
+// the live runtime version and renderer-skew warning before every open.
+app.setAboutPanelOptions(currentAboutPanelOptions())
 
 // Custom scheme for streaming audio/video into the renderer. Local paths read
 // from this machine; remote paths are proxied through the configured gateway
@@ -16928,19 +16923,24 @@ async function detectRendererSkew() {
   return detectBundleSkew(INSTALL_STAMP, runGit, resolveUpdateRoot())
 }
 
-// Re-resolve the live Hermes version and push it into the native About panel
-// just before showing it, so an in-place `hermes update` is reflected without
-// an app restart. macOS only — `showAboutPanel()` is a no-op elsewhere, and the
-// other platforms don't use this menu item.
+function currentAboutPanelOptions(bundleOutOfSync = false) {
+  return {
+    applicationName: APP_NAME,
+    ...buildAboutPanelVersionOptions({
+      applicationVersion: resolveHermesVersion(),
+      installCommit: INSTALL_STAMP?.commit,
+      installDirty: INSTALL_STAMP?.dirty,
+      bundleOutOfSync
+    }),
+    copyright: 'Copyright © 2026 Nous Research'
+  }
+}
+
+// Refresh the live Hermes version and renderer-skew warning before opening.
+// macOS only — `showAboutPanel()` is a no-op elsewhere.
 function showAboutPanelFresh() {
   void detectRendererSkew().then(skew => {
-    app.setAboutPanelOptions({
-      applicationName: APP_NAME,
-      applicationVersion: skew.outOfSync
-        ? `${resolveHermesVersion()} — app build out of date, update the desktop app`
-        : resolveHermesVersion(),
-      copyright: 'Copyright © 2026 Nous Research'
-    })
+    app.setAboutPanelOptions(currentAboutPanelOptions(skew.outOfSync))
     app.showAboutPanel()
   })
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -362,10 +362,12 @@ import {
   windowOpacityOptions
 } from './translucency'
 import {
+  commitRangeRevision,
   compareApiUrl,
   parseCompareBehindCount,
   resolveBehindCount,
   resolveCommitLogSelection,
+  resolveRunningClientSha,
   shouldCountCommits
 } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
@@ -2920,12 +2922,14 @@ async function checkUpdates() {
   if (isOfficialSshRemote(originUrl)) {
     const git = args => runGit(args, { cwd: updateRoot }).then(r => r.stdout.trim())
 
-    const [currentSha, target, dirtyStr, currentBranch] = await Promise.all([
+    const [checkoutSha, target, dirtyStr, currentBranch] = await Promise.all([
       git(['rev-parse', 'HEAD']),
       runGit(['ls-remote', OFFICIAL_REPO_HTTPS_URL, `refs/heads/${branch}`], { cwd: updateRoot }),
       git(['status', '--porcelain']),
       git(['rev-parse', '--abbrev-ref', 'HEAD'])
     ])
+
+    const currentSha = resolveRunningClientSha({ checkoutSha, installStamp: INSTALL_STAMP, isPackaged: IS_PACKAGED })
 
     const targetSha = firstLine(target.stdout).split(/\s+/)[0] || ''
 
@@ -2945,7 +2949,7 @@ async function checkUpdates() {
     // compare API when possible; otherwise behind stays null ("update
     // available, count unknown") and updateAvailable carries the signal.
     // ahead_by === 0 with differing tips means the remote tip is reachable
-    // from our HEAD — a local carried commit sitting AHEAD, not behind:
+    // from the running client — a locally carried commit sitting AHEAD, not behind:
     // flagging that as an update nudges the user into wiping their work.
     const tipsEqual = Boolean(currentSha && currentSha === targetSha)
 
@@ -2991,7 +2995,7 @@ async function checkUpdates() {
 
   const git = args => runGit(args, { cwd: updateRoot }).then(r => r.stdout.trim())
 
-  const [currentSha, targetSha, dirtyStr, currentBranch, shallowStr] = await Promise.all([
+  const [checkoutSha, targetSha, dirtyStr, currentBranch, shallowStr] = await Promise.all([
     git(['rev-parse', 'HEAD']),
     git(['rev-parse', `origin/${branch}`]),
     git(['status', '--porcelain']),
@@ -2999,25 +3003,34 @@ async function checkUpdates() {
     git(['rev-parse', '--is-shallow-repository'])
   ])
 
+  const currentSha = resolveRunningClientSha({ checkoutSha, installStamp: INSTALL_STAMP, isPackaged: IS_PACKAGED })
+
   const isShallow = shallowStr === 'true'
 
-  // A shallow graph cannot provide a trustworthy exact count, even when it has
-  // a visible merge-base. Skip the ancestry walk and use the SHA fallback.
-  const countStr = shouldCountCommits({ isShallow }) ? await git(['rev-list', `HEAD..origin/${branch}`, '--count']) : ''
+  // Count from the code this packaged app is actually running, not from the
+  // checkout that happens to stage its next update. A shallow graph cannot
+  // provide a trustworthy exact count even when it has a visible merge-base.
+  const countResult = shouldCountCommits({ isShallow })
+    ? await runGit(['rev-list', commitRangeRevision({ currentSha, branch }), '--count'], { cwd: updateRoot })
+    : null
+
+  const countAvailable = countResult?.code === 0
+  const countStr = countAvailable ? countResult.stdout.trim() : ''
 
   // A positive directional ancestry result remains trustworthy in a shallow
   // graph and prevents a local commit on top of origin from looking outdated.
-  const targetIsAncestorOfHead =
+  const targetIsAncestorOfCurrent =
     isShallow &&
     currentSha !== targetSha &&
-    (await runGit(['merge-base', '--is-ancestor', `origin/${branch}`, 'HEAD'], { cwd: updateRoot })).code === 0
+    (await runGit(['merge-base', '--is-ancestor', `origin/${branch}`, currentSha], { cwd: updateRoot })).code === 0
 
   let behind = resolveBehindCount({
     countStr,
     currentSha,
     targetSha,
     isShallow,
-    targetIsAncestorOfHead
+    countAvailable,
+    targetIsAncestorOfCurrent
   })
 
   // Recover the exact count a shallow clone can't compute: the GitHub compare
@@ -3032,7 +3045,7 @@ async function checkUpdates() {
   // clone): still list what origin offers — resolveCommitLogSelection keeps
   // the shallow log to the fetched tip so the range walk can't enumerate the
   // contaminated ancestry — so "See what's new" stays useful and honest.
-  const commits = behind !== 0 ? await readCommitLog(updateRoot, branch, isShallow) : []
+  const commits = behind !== 0 ? await readCommitLog(updateRoot, branch, isShallow, currentSha) : []
 
   return {
     supported: true,
@@ -3103,10 +3116,10 @@ async function fetchCompareBehindCount({ currentSha, originUrl, targetSha }) {
   }
 }
 
-async function readCommitLog(cwd, branch, isShallow) {
+async function readCommitLog(cwd, branch, isShallow, currentSha) {
   const SEP = '\x1f'
   const REC = '\x1e'
-  const { limit, revision } = resolveCommitLogSelection({ branch, isShallow })
+  const { limit, revision } = resolveCommitLogSelection({ branch, isShallow, currentSha })
 
   const { stdout } = await runGit(
     ['log', revision, `--pretty=format:%H${SEP}%s${SEP}%an${SEP}%at${REC}`, '-n', String(limit)],

--- a/apps/desktop/electron/update-count.test.ts
+++ b/apps/desktop/electron/update-count.test.ts
@@ -7,10 +7,12 @@ import path from 'node:path'
 import { test } from 'vitest'
 
 import {
+  commitRangeRevision,
   compareApiUrl,
   parseCompareBehindCount,
   resolveBehindCount,
   resolveCommitLogSelection,
+  resolveRunningClientSha,
   shouldCountCommits
 } from './update-count'
 
@@ -31,6 +33,72 @@ function createTempGitRepo() {
     throw error
   }
 }
+
+test('packaged clients report the commit recorded in their install stamp', () => {
+  assert.equal(
+    resolveRunningClientSha({
+      checkoutSha: 'a'.repeat(40),
+      installStamp: { commit: 'b'.repeat(40) },
+      isPackaged: true
+    }),
+    'b'.repeat(40)
+  )
+})
+
+test('commit ranges start from the running client instead of the update checkout', () => {
+  assert.equal(commitRangeRevision({ currentSha: 'b'.repeat(40), branch: 'main' }), `${'b'.repeat(40)}..origin/main`)
+})
+
+test('packaged revision drives both count and changelog when the update checkout is stale', () => {
+  const { cwd, git } = createTempGitRepo()
+
+  try {
+    git('commit', '--allow-empty', '-m', 'stale checkout')
+
+    const checkoutSha = git('rev-parse', 'HEAD')
+
+    git('commit', '--allow-empty', '-m', 'packaged client')
+
+    const packagedSha = git('rev-parse', 'HEAD')
+
+    git('commit', '--allow-empty', '-m', 'available update')
+
+    const targetSha = git('rev-parse', 'HEAD')
+
+    git('update-ref', 'refs/remotes/origin/main', targetSha)
+    git('checkout', '--quiet', '--detach', checkoutSha)
+
+    const revision = commitRangeRevision({ currentSha: packagedSha, branch: 'main' })
+    const logSelection = resolveCommitLogSelection({ branch: 'main', isShallow: false, currentSha: packagedSha })
+
+    assert.equal(git('rev-list', 'HEAD..origin/main', '--count'), '2')
+    assert.equal(git('rev-list', revision, '--count'), '1')
+    assert.equal(logSelection.revision, revision)
+    assert.equal(git('log', logSelection.revision, '--format=%H'), targetSha)
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+test('dev clients keep reporting the live checkout commit', () => {
+  assert.equal(
+    resolveRunningClientSha({
+      checkoutSha: 'a'.repeat(40),
+      installStamp: { commit: 'b'.repeat(40) },
+      isPackaged: false
+    }),
+    'a'.repeat(40)
+  )
+})
+
+test('packaged clients fall back to the checkout when the stamp is unusable', () => {
+  for (const installStamp of [null, {}, { commit: 'not-a-sha' }, { commit: '0'.repeat(40) }]) {
+    assert.equal(
+      resolveRunningClientSha({ checkoutSha: 'a'.repeat(40), installStamp, isPackaged: true }),
+      'a'.repeat(40)
+    )
+  }
+})
 
 // FAIL-BEFORE: pre-fix the function did `Number.parseInt(countStr) || 0`
 // unconditionally, so a shallow checkout with no merge-base surfaced the bogus
@@ -70,7 +138,7 @@ test('shallow local-ahead checkout reports up-to-date when origin is a known anc
       currentSha: 'local-child',
       targetSha: 'origin-parent',
       isShallow: true,
-      targetIsAncestorOfHead: true
+      targetIsAncestorOfCurrent: true
     }),
     0
   )
@@ -98,7 +166,7 @@ test('shallow Git graph proves the remote tip is an ancestor of a local commit',
         currentSha,
         targetSha,
         isShallow: true,
-        targetIsAncestorOfHead: true
+        targetIsAncestorOfCurrent: true
       }),
       0
     )
@@ -163,6 +231,19 @@ test('shallow checkout with a merge-base still uses presence-only status', () =>
       currentSha: 'aaa',
       targetSha: 'bbb',
       isShallow: true
+    }),
+    null
+  )
+})
+
+test('full checkout reports unknown when the packaged commit is absent from its graph', () => {
+  assert.equal(
+    resolveBehindCount({
+      countStr: '',
+      currentSha: 'a'.repeat(40),
+      targetSha: 'b'.repeat(40),
+      isShallow: false,
+      countAvailable: false
     }),
     null
   )

--- a/apps/desktop/electron/update-count.ts
+++ b/apps/desktop/electron/update-count.ts
@@ -1,3 +1,18 @@
+import { isValidInstallCommit } from './install-stamp-identity'
+
+const FULL_GIT_SHA = /^[0-9a-f]{40}$/i
+
+// A packaged client executes the assets recorded by its build stamp. The
+// checkout used to stage the next update may legitimately be older, so using
+// that checkout's HEAD makes a freshly installed app look behind. Dev runs do
+// execute from the checkout and keep using its live HEAD.
+function resolveRunningClientSha({ checkoutSha, installStamp, isPackaged }) {
+  const stampedSha = installStamp?.commit
+  const hasUsableStamp = isValidInstallCommit(stampedSha)
+
+  return isPackaged && hasUsableStamp ? stampedSha : checkoutSha
+}
+
 // Whether `git rev-list HEAD..origin/<branch> --count` produces a meaningful
 // number worth computing. Installer checkouts are shallow (`--depth 1`), so
 // their visible graph is incomplete even when `merge-base` happens to find a
@@ -9,12 +24,23 @@ function shouldCountCommits({ isShallow }) {
   return !isShallow
 }
 
-// Resolve how many commits the local checkout is behind origin for the desktop
+function commitRangeRevision({ currentSha, branch }) {
+  return `${currentSha || 'HEAD'}..origin/${branch}`
+}
+
+// Resolve how many commits the running client is behind origin for the desktop
 // update indicator. Shallow checkouts use SHA equality plus any positively
 // proven local-ahead ancestry; exact counts remain exclusive to full clones.
-function resolveBehindCount({ countStr, currentSha, targetSha, isShallow, targetIsAncestorOfHead = false }) {
+function resolveBehindCount({
+  countStr,
+  currentSha,
+  targetSha,
+  isShallow,
+  countAvailable = true,
+  targetIsAncestorOfCurrent = false
+}) {
   if (!shouldCountCommits({ isShallow })) {
-    if (currentSha && targetSha && (currentSha === targetSha || targetIsAncestorOfHead)) {
+    if (currentSha && targetSha && (currentSha === targetSha || targetIsAncestorOfCurrent)) {
       return 0
     }
 
@@ -25,28 +51,36 @@ function resolveBehindCount({ countStr, currentSha, targetSha, isShallow, target
     return null
   }
 
+  // A packaged stamp can name a commit that is not present in the update
+  // checkout (for example a locally built client). Do not turn a failed
+  // rev-list into zero; let the compare API recover the count, or surface the
+  // honest unknown-count state when the commit is not published.
+  if (!countAvailable) {
+    return null
+  }
+
   return Number.parseInt(countStr, 10) || 0
 }
 
 // Shallow history can also contaminate the changelog range. Trust the fetched
 // remote tip itself, but do not walk its ancestry. Full clones retain the
 // detailed range used by the existing update overlay.
-function resolveCommitLogSelection({ branch, isShallow }) {
+function resolveCommitLogSelection({ branch, isShallow, currentSha = null }) {
   const remote = `origin/${branch}`
 
-  return isShallow ? { limit: 1, revision: remote } : { limit: 40, revision: `HEAD..${remote}` }
+  return isShallow
+    ? { limit: 1, revision: remote }
+    : { limit: 40, revision: commitRangeRevision({ currentSha, branch }) }
 }
 
 // When the local graph can't count (behind === null), the GitHub compare API
 // still can: `GET /repos/<owner>/<repo>/compare/<current>...<target>` returns
-// `ahead_by` — how many commits the remote tip is ahead of the local HEAD,
+// `ahead_by` — how many commits the remote tip is ahead of the running client,
 // i.e. exactly the behind count the shallow clone lost. Unauthenticated, no
 // clone depth required. Pure URL builder + response parser here; the network
 // call lives with the caller.
 function compareApiUrl({ currentSha, originUrl, targetSha }) {
-  const sha = /^[0-9a-f]{40}$/i
-
-  if (!sha.test(currentSha || '') || !sha.test(targetSha || '')) {
+  if (!FULL_GIT_SHA.test(currentSha || '') || !FULL_GIT_SHA.test(targetSha || '')) {
     return null
   }
 
@@ -89,4 +123,12 @@ function parseCompareBehindCount(payload) {
   return ahead
 }
 
-export { compareApiUrl, parseCompareBehindCount, resolveBehindCount, resolveCommitLogSelection, shouldCountCommits }
+export {
+  commitRangeRevision,
+  compareApiUrl,
+  parseCompareBehindCount,
+  resolveBehindCount,
+  resolveCommitLogSelection,
+  resolveRunningClientSha,
+  shouldCountCommits
+}


### PR DESCRIPTION
## Identify The Packaged Desktop That Is Actually Running

Update status and macOS About should agree on the running client. A packaged app executes the renderer recorded in `install-stamp.json`, not necessarily the checkout used to stage its next update. Using that checkout's HEAD could report a current app hundreds of commits behind or show stale About metadata.

This PR makes the validated packaged commit authoritative for those two surfaces. Development builds keep live-checkout behavior.

## Changes And Scope

- Accept only full, non-zero 40-hex install commits.
- Use the packaged commit for drift and changelog calculations; fall back to GitHub compare or an honest unknown count when it is absent from the staging checkout.
- Retain development and missing/malformed-stamp fallback behavior.
- Show the Hermes version and short packaged commit in macOS About without removing the bundle-skew warning.

This changes client identity, not fleet/update authority or package-content verification. No Python source, persistence or routing contract changes.

## Validation And How To Test

Head `73bc841cb4`, based on `7eee066c30`: **29 focused update-count/About tests passed**; Desktop typecheck, six-file ESLint, diff/attribution checks and selected exact-head CI passed. An equivalent-tree Electron/platform run recorded **1,745 passes and 3 skips**; it is separate from the focused count, not a new exact-head total.

In a packaged macOS app, compare About and update status with the install stamp while the staging checkout is behind, ahead, or missing that commit. Confirm both report the packaged identity; then verify development and malformed/missing-stamp fallbacks. Run the focused Electron update/About tests and Desktop typecheck.

## Related And Attribution

#91277 coordinates update architecture. #91283 and merged #92780 own backend identity and update outcomes; #70612 owns client-versus-backend targeting; #91525 owns package-to-source verification. #93042 touches neighboring update files and is not a dependency; composition must preserve packaged identity.

Two commits remain: packaged-revision reporting and the preserved #88665 native About implementation. No contributor work was dropped. Related identity symptoms include #77657, #53776, #88641 and #63167.

## Screenshot

<img src="https://raw.githubusercontent.com/dokterdok/hermes-agent/pr-assets/.github/pr-assets/pr-88665/about-version-identity.jpg" alt="Native macOS About panel showing the Hermes version with its packaged client commit" width="284">

## Type Of Change

- [x] Desktop bug fix
- [x] Tests
