### PR TITLE
chore: add kstawiski to AUTHOR_MAP

### DIFF
--- a/contributors/emails/konrad.stawiski@umed.lodz.pl
+++ b/contributors/emails/konrad.stawiski@umed.lodz.pl
@@ -1,0 +1,2 @@
+kstawiski
+# PR #88323 salvage (cron: warn agent when scheduler is unavailable)


### PR DESCRIPTION
Maps contributor email konrad.stawiski@umed.lodz.pl to GitHub login kstawiski for salvage PR #88323 (cron: warn agent when scheduler is unavailable).