### PR TITLE
fix(cron): use stable session key per job instead of timestamped key

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4642,7 +4642,7 @@ def run_job(
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return True, "", SILENT_MARKER, None
-    _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    _cron_session_id = f"cron_{job_id}_latest"
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])

--- a/tests/cron/test_cron_stable_session.py
+++ b/tests/cron/test_cron_stable_session.py
@@ -1,0 +1,41 @@
+"""Tests for stable cron session IDs (issue #88268)."""
+
+from unittest.mock import patch, MagicMock
+from cron.scheduler import run_job
+
+
+def test_cron_uses_latest_session_key():
+    """A recurring cron job should map to ONE stable session key
+    (cron_<job_id>_latest) instead of a new timestamped key per tick."""
+    job = {
+        "id": "test-job",
+        "name": "Test Job",
+        "prompt": "Say hello",
+        "schedule": "*/15 * * * *",
+    }
+
+    fake_db = MagicMock()
+    fake_db.get_compression_tip.return_value = None
+
+    with patch("cron.scheduler._hermes_home", "/tmp/hermes"), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+             "api_key": "test-key",
+             "base_url": "https://example.invalid/v1",
+             "provider": "openrouter",
+             "api_mode": "chat_completions",
+         }), \
+         patch("run_agent.AIAgent") as mock_agent_cls:
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent_cls.return_value = mock_agent
+        success, output, final, error = run_job(job)
+
+    assert success
+    # The session_id should be stable (no timestamp)
+    call_kwargs = mock_agent_cls.call_args.kwargs
+    session_id = call_kwargs["session_id"]
+    assert session_id == "cron_test-job_latest", f"unexpected session_id: {session_id}"


### PR DESCRIPTION
## Summary

Fixes #88268

When a cron job runs, Hermes creates a new session record on every tick rather than reusing a single stable session per job. On a busy deployment this produces hundreds of duplicate sessions in state.db and makes the Desktop BOTS/SESSIONS list show the same bot repeated many times.

## Root cause

Each cron tick generates a new session key with a timestamp: cron_<job_id>_<YYYYMMDD_HHMMSS>. This means every execution creates a new session row instead of reusing the existing one.

## Fix

Use a stable session key per job: cron_<job_id>_latest. This ensures a recurring job maps to one session that gets reused across ticks.

## Changes

- cron/scheduler.py: Change _cron_session_id to use _latest suffix instead of timestamp
- tests/cron/test_cron_stable_session.py: 1 new test

## Testing

- 1 new test passes
- 94 existing cron scheduler tests pass