### PR TITLE
Document delegation.worktree_isolation and its working-directory requirement

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/configuration.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/configuration.md
@@ -17,9 +17,25 @@ Full reference: https://hermes-agent.nousresearch.com/docs/user-guide/configurat
 | `tts` | `provider` (edge/elevenlabs/openai/minimax/mistral/neutts/gemini/piper/kittentts/deepinfra/xai) |
 | `memory` | `memory_enabled`, `user_profile_enabled`, `provider`, `write_approval` |
 | `security` | `redact_secrets`, `tirith_enabled`, `website_blocklist` |
-| `delegation` | `model`, `provider`, `max_concurrent_children`, `max_iterations` (50), `max_spawn_depth` |
+| `delegation` | `model`, `provider`, `max_concurrent_children`, `max_iterations` (50), `max_spawn_depth`, `worktree_isolation` |
 | `checkpoints` | `enabled`, `max_snapshots` (50) |
 | `curator` | `enabled`, `consolidate` (false, opt-in aux-model consolidation), `interval_hours`, `stale_after_days` |
+
+**`delegation.worktree_isolation`** (default `false`) — give each delegated child its own
+git worktree, branched from the parent repo's `HEAD` under `<repo>/.worktrees/subagent-<id>`
+on branch `hermes-subagent/<id>`. The parent reviews or merges each branch; a worktree with
+no new commits and a clean tree is pruned automatically.
+
+> Requires **all** of: a git repository, `terminal.backend: local`, **and a resolvable parent
+> working directory**. Resolution reads `$TERMINAL_CWD` first, so launch from inside the repo,
+> set `terminal.cwd` to an **absolute** path, or use `-w`. **Passing `--in <dir>` does NOT
+> satisfy this** — it does not change the process working directory.
+>
+> A parent on an **orphan branch with no commit** also fails: `git rev-parse HEAD` does not
+> resolve, so the child worktree cannot be branched from it.
+>
+> When the parent directory cannot be resolved the setting is ignored and children share the
+> parent checkout, committing to its branch.
 
 `hermes config check` reports sections missing from an older config.
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2570,12 +2570,25 @@ def _run_single_child(
                         _parent_cwd or _resolve_workspace_hint(parent_agent),
                         subagent_id=_subagent_id,
                     )
+                    if _worktree_info is None:
+                        logger.warning(
+                            "worktree isolation is enabled but produced no worktree "
+                            "for %s: could not resolve a usable parent repo from cwd "
+                            "%r. Children will SHARE the parent checkout.",
+                            _subagent_id,
+                            _parent_cwd or _resolve_workspace_hint(parent_agent),
+                        )
                 else:
-                    logger.debug(
+                    logger.warning(
                         "worktree isolation skipped: non-local terminal backend"
                     )
             except Exception as e:
-                logger.debug("worktree isolation setup failed: %s", e)
+                logger.warning(
+                    "worktree isolation setup failed: %s. Usual causes: the process "
+                    "working directory is not inside the target repo (--in does not "
+                    "change it; set terminal.cwd to an absolute path or use -w), or "
+                    "the parent HEAD is unborn (orphan branch with no commit).", e
+                )
             if _worktree_info is not None:
                 try:
                     from tools.terminal_tool import record_session_cwd as _rsc


### PR DESCRIPTION
## What

`delegation.worktree_isolation` is undocumented in `references/configuration.md`, and when it cannot resolve a parent working directory it fails **silently** — every error on that path is `logger.debug`. An explicitly-enabled setting then does nothing, with no signal at all: children share the parent checkout and commit to its branch.

Two changes:

1. Document the key, and state the requirement that is not obvious.
2. Promote three swallowed `logger.debug` calls to `logger.warning`, including a new one for the case that produces no exception at all.

## Why

Measured on hermes 0.20.1 (Linux, local terminal backend, DeepSeek orchestrator with two local 27B workers), judged from `git` on disk rather than from the agent's own report:

| Configuration | Isolation fires |
|---|---|
| `--in <repo>` alone, no `TERMINAL_CWD` | **No** — children commit to the parent checkout |
| `TERMINAL_CWD=<absolute repo path>` | Yes |

`--in` is not sufficient. `_resolve_workspace_hint()` reads `$TERMINAL_CWD` first, and `get_session_cwd(parent_task_id)` is commonly `None` on the background delegation path, so `create_subagent_worktree(None)` fails and is swallowed.

A second, related trap: on an **orphan branch with no commit**, `git rev-parse HEAD` does not resolve, so `git worktree add ... HEAD` refuses and isolation is skipped the same silent way.

Neither is visible at default log level, so a misconfigured run and a working run are indistinguishable from outside. In our case that hid the problem across two releases, and one consequence was a child agent running `git init` in a home directory because it could not tell where it was.

`tests/tools/test_subagent_worktree.py` calls `create_subagent_worktree()` directly and never exercises the resolution path from `delegate_task`, so the builder tests green even when delegation produces no worktree at all.

## Not included

No behaviour change beyond log levels and one new warning. The resolution logic itself is untouched — this only makes its failures observable.
