### PR TITLE
fix(terminal): avoid lifecycle guard false positives

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -43,6 +43,8 @@ import stat
 from pathlib import Path
 from typing import Callable, Iterator, Optional
 
+from tools.shell_heredoc import strip_inert_heredoc_bodies
+
 logger = logging.getLogger(__name__)
 
 
@@ -77,8 +79,8 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch D: pkill / kill targeting the hermes gateway process. Both
     # token orders because real reproductions show both.
-    r"|(?:p?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
-    r"|(?:p?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
+    r"|(?:(?<![A-Za-z0-9_])p?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
+    r"|(?:(?<![A-Za-z0-9_])p?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
 )
 
 
@@ -104,10 +106,27 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
 
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})
+_NON_SHELL_SHEBANG_EXECUTABLES = frozenset(
+    {"bun", "deno", "node", "perl", "php", "python", "python2", "python3", "ruby", "tsx"}
+)
 _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "+O", "-o", "+o"})
 _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
 _MAX_REFERENCED_SCRIPT_DEPTH = 8
-_CONTROL_CHARS = frozenset(";&|()")
+_CONTROL_CHARS = frozenset(";&|()\n")
+_CAT_HEREDOC_REDIRECTS = (
+    re.compile(
+        r"(?m)^\s*cat\s+>\s*(?P<quote>['\"]?)(?P<path>[^\s<>'\"]+)"
+        r"(?P=quote)\s+<<"
+    ),
+    re.compile(
+        r"(?m)^\s*cat\s+<<-?\s*(?:'[^']+'|\"[^\"]+\"|\S+)\s+>\s*"
+        r"(?P<quote>['\"]?)(?P<path>[^\s<>'\"]+)(?P=quote)"
+    ),
+)
+_NON_SHELL_PROCESS_CALL = re.compile(
+    r"(?:child_process\.)?(?:execFile|execFileSync|spawn|spawnSync)\s*\(\s*"
+    r"(?P<quote>['\"])(?P<path>[^'\"]+)(?P=quote)"
+)
 
 
 # Directory names that sit directly under a `Library` path component and
@@ -180,29 +199,31 @@ _ReadRemoteScriptFn = Callable[[str], Optional[str]]
 def _iter_command_segments(command: str) -> Iterator[list[str]]:
     """Yield shell-tokenized command segments, honoring quotes and comments."""
     normalized = command.replace("\\\n", "")
-    for line in normalized.splitlines() or [normalized]:
-        try:
-            lexer = shlex.shlex(
-                line,
-                posix=True,
-                punctuation_chars=";&|()",
-            )
-            lexer.whitespace_split = True
-            lexer.commenters = "#"
-            tokens = list(lexer)
-        except ValueError:
-            continue
+    try:
+        lexer = shlex.shlex(
+            normalized,
+            posix=True,
+            punctuation_chars=";&|()\n",
+        )
+        # Keep unquoted newlines as command separators while preserving
+        # newlines inside a quoted `sh -c` payload as part of that token.
+        lexer.whitespace = " \t\r"
+        lexer.whitespace_split = True
+        lexer.commenters = "#"
+        tokens = list(lexer)
+    except ValueError:
+        return
 
-        segment: list[str] = []
-        for token in tokens:
-            if token and set(token) <= _CONTROL_CHARS:
-                if segment:
-                    yield segment
-                    segment = []
-                continue
-            segment.append(token)
-        if segment:
-            yield segment
+    segment: list[str] = []
+    for token in tokens:
+        if token and set(token) <= _CONTROL_CHARS:
+            if segment:
+                yield segment
+                segment = []
+            continue
+        segment.append(token)
+    if segment:
+        yield segment
 
 
 def _command_token_index(segment: list[str]) -> Optional[int]:
@@ -331,6 +352,62 @@ def _direct_lifecycle_scan(command: str) -> bool:
     ) or contains_launchctl_submit_command(command)
 
 
+def _direct_lifecycle_evidence(command: str) -> Optional[dict]:
+    """Return bounded diagnostic evidence for a direct lifecycle match."""
+    normalized = _SHELL_LINE_CONTINUATION.sub(" ", command)
+    candidate = _mask_data_sink_arguments(normalized)
+    match = _GATEWAY_LIFECYCLE_PATTERN.search(candidate)
+    if match is not None:
+        fragment = match.group(0)[:240]
+        lowered = fragment.lower().lstrip()
+        if lowered.startswith("hermes"):
+            rule_id = "hermes_gateway_lifecycle"
+        elif lowered.startswith("systemctl"):
+            rule_id = "systemctl_gateway_lifecycle"
+        elif lowered.startswith("launchctl"):
+            rule_id = "launchctl_gateway_lifecycle"
+        else:
+            rule_id = "signal_gateway_process"
+        return {
+            "ruleId": rule_id,
+            "evidenceSource": "shell_command",
+            "matchedFragment": fragment,
+            "referencedPath": None,
+        }
+    if contains_launchctl_submit_command(command):
+        return {
+            "ruleId": "launchctl_persistent_job",
+            "evidenceSource": "shell_command",
+            "matchedFragment": "launchctl submit/bootstrap",
+            "referencedPath": None,
+        }
+    return None
+
+
+def _non_shell_shebang(text: str) -> bool:
+    """Return True for a known non-shell interpreter shebang."""
+    first_line = text.splitlines()[0] if text else ""
+    if not first_line.startswith("#!"):
+        return False
+    try:
+        tokens = shlex.split(first_line[2:].strip())
+    except ValueError:
+        return False
+    if not tokens:
+        return False
+    interpreter = Path(tokens[0]).name.lower()
+    if interpreter == "env":
+        arguments = [token for token in tokens[1:] if not token.startswith("-")]
+        if not arguments:
+            return False
+        interpreter = Path(arguments[0]).name.lower()
+    if interpreter in _SHELL_EXECUTABLES:
+        return False
+    if interpreter.startswith("python"):
+        interpreter = "python3" if interpreter.startswith("python3") else "python"
+    return interpreter in _NON_SHELL_SHEBANG_EXECUTABLES
+
+
 def _expand_candidate_path(candidate: str) -> Optional[Path]:
     """Sanitize a tokenized path candidate at the ingestion boundary.
 
@@ -438,6 +515,49 @@ def _iter_shell_command_payloads(command: str) -> Iterator[str]:
             if argument in {"-c", "--command"}:
                 yield arguments[arg_index + 1]
                 break
+
+
+def _cat_heredoc_output_is_executed(command: str) -> bool:
+    """Return whether a cat heredoc target is subsequently shell-executed."""
+    for pattern in _CAT_HEREDOC_REDIRECTS:
+        for match in pattern.finditer(command):
+            path = match.group("path")
+            executed = re.compile(
+                rf"(?m)^\s*(?:(?:/[^\s]+/)?(?:sh|bash|dash|ksh|zsh)\s+)?"
+                rf"{re.escape(path)}(?:\s|$)"
+            )
+            if executed.search(command, match.end()):
+                return True
+    return False
+
+
+def _is_explicit_shell_script_reference(
+    command: str, script_path: Path, *, cwd: Optional[str]
+) -> bool:
+    """Return whether a POSIX shell explicitly interprets *script_path*."""
+    target = script_path.resolve(strict=False)
+    for segment in _iter_command_segments(command):
+        index = _command_token_index(segment)
+        if index is None or Path(segment[index]).name not in _SHELL_EXECUTABLES:
+            continue
+        for argument in segment[index + 1 :]:
+            if argument in {"-c", "--command"}:
+                break
+            if argument.startswith("-"):
+                continue
+            resolved = _resolve_terminal_script_path(argument, cwd)
+            if resolved is not None and resolved.resolve(strict=False) == target:
+                return True
+            break
+    return False
+
+
+def _iter_non_shell_process_paths(text: str, *, cwd: Optional[str]) -> Iterator[Path]:
+    """Yield literal paths passed to known Node process-execution APIs."""
+    for match in _NON_SHELL_PROCESS_CALL.finditer(text):
+        resolved = _resolve_terminal_script_path(match.group("path"), cwd)
+        if resolved is not None:
+            yield resolved
 
 
 def _resolve_script_directory(script_path: str) -> Optional[str]:
@@ -555,6 +675,117 @@ def _sanitize_remote_script_text(text: Optional[str]) -> tuple[Optional[str], bo
     return text, False
 
 
+def _find_unsafe_gateway_action(
+    command: str,
+    *,
+    cwd: Optional[str],
+    depth: int,
+    visited: set[Path],
+    read_remote_script: Optional[_ReadRemoteScriptFn] = None,
+) -> Optional[dict]:
+    direct_evidence = _direct_lifecycle_evidence(command)
+    if direct_evidence is not None:
+        return direct_evidence
+    # Heredoc bodies may still execute direct lifecycle literals (checked above),
+    # but their data/path tokens are inert for referenced-script discovery.
+    if not _cat_heredoc_output_is_executed(command):
+        command = strip_inert_heredoc_bodies(command)
+    if depth >= _MAX_REFERENCED_SCRIPT_DEPTH:
+        return {
+            "ruleId": "referenced_script_depth_limit",
+            "evidenceSource": "recursive_scan",
+            "matchedFragment": "maximum referenced-script depth reached",
+            "referencedPath": None,
+        }
+
+    for payload in _iter_shell_command_payloads(command):
+        evidence = _find_unsafe_gateway_action(
+            payload,
+            cwd=cwd,
+            depth=depth + 1,
+            visited=visited,
+            read_remote_script=read_remote_script,
+        )
+        if evidence is not None:
+            if evidence["evidenceSource"] == "shell_command":
+                evidence = {**evidence, "evidenceSource": "shell_payload"}
+            return evidence
+
+    for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
+        try:
+            resolved = script_path.resolve(strict=False)
+        except (OSError, ValueError):
+            resolved = script_path
+        if resolved in visited:
+            continue
+        visited.add(resolved)
+        script_text, unsafe = _read_referenced_script(script_path)
+        if unsafe:
+            return {
+                "ruleId": "unsafe_referenced_script",
+                "evidenceSource": "referenced_script",
+                "matchedFragment": "non-regular or oversized referenced script",
+                "referencedPath": str(script_path)[:500],
+            }
+        if script_text is None and read_remote_script is not None:
+            script_text, unsafe = _sanitize_remote_script_text(
+                read_remote_script(str(script_path))
+            )
+            if unsafe:
+                return {
+                    "ruleId": "unsafe_referenced_script",
+                    "evidenceSource": "referenced_script",
+                    "matchedFragment": "oversized referenced script",
+                    "referencedPath": str(script_path)[:500],
+                }
+        if not script_text:
+            continue
+        explicit_shell = _is_explicit_shell_script_reference(
+            command, script_path, cwd=cwd
+        )
+        if _non_shell_shebang(script_text) and not explicit_shell:
+            evidence = _direct_lifecycle_evidence(script_text)
+            if evidence is not None:
+                return {
+                    **evidence,
+                    "evidenceSource": "referenced_script",
+                    "referencedPath": str(script_path)[:500],
+                }
+            script_dir = _resolve_script_directory(str(resolved)) or cwd
+            for process_path in _iter_non_shell_process_paths(
+                script_text, cwd=script_dir
+            ):
+                evidence = _find_unsafe_gateway_action(
+                    f"sh {shlex.quote(str(process_path))}",
+                    cwd=script_dir,
+                    depth=depth + 1,
+                    visited=visited,
+                    read_remote_script=read_remote_script,
+                )
+                if evidence is not None:
+                    return {
+                        **evidence,
+                        "evidenceSource": "referenced_script",
+                        "referencedPath": str(process_path)[:500],
+                    }
+            continue
+        script_dir = _resolve_script_directory(str(resolved)) or cwd
+        evidence = _find_unsafe_gateway_action(
+            script_text,
+            cwd=script_dir,
+            depth=depth + 1,
+            visited=visited,
+            read_remote_script=read_remote_script,
+        )
+        if evidence is not None:
+            return {
+                **evidence,
+                "evidenceSource": "referenced_script",
+                "referencedPath": str(script_path)[:500],
+            }
+    return None
+
+
 def _contains_unsafe_gateway_action(
     command: str,
     *,
@@ -563,69 +794,48 @@ def _contains_unsafe_gateway_action(
     visited: set[Path],
     read_remote_script: Optional[_ReadRemoteScriptFn] = None,
 ) -> bool:
-    if _direct_lifecycle_scan(command):
-        return True
-    if depth >= _MAX_REFERENCED_SCRIPT_DEPTH:
-        return True
+    """Compatibility bool wrapper for callers and fault-injection tests."""
+    return _find_unsafe_gateway_action(
+        command,
+        cwd=cwd,
+        depth=depth,
+        visited=visited,
+        read_remote_script=read_remote_script,
+    ) is not None
 
-    for payload in _iter_shell_command_payloads(command):
-        if _contains_unsafe_gateway_action(
-            payload,
+
+def find_gateway_lifecycle_violation(
+    command: str,
+    *,
+    cwd: Optional[str] = None,
+    read_remote_script: Optional[_ReadRemoteScriptFn] = None,
+) -> Optional[dict]:
+    """Return structured evidence when *command* would self-stop the gateway."""
+    try:
+        return _find_unsafe_gateway_action(
+            command,
             cwd=cwd,
-            depth=depth + 1,
-            visited=visited,
+            depth=0,
+            visited=set(),
             read_remote_script=read_remote_script,
-        ):
-            return True
-
-    for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
-        # Do not touch a FileProvider path even to discover whether the file
-        # is hydrated. The lexical check covers direct cloud paths; the
-        # resolved check below covers local launchers that are symlinks into
-        # a cloud subtree. _read_referenced_script repeats both checks as the
-        # shared choke point, so every caller stays covered even if this
-        # walk-level short-circuit is bypassed.
-        if _is_cloud_placeholder_path(script_path):
-            return True
+        )
+    except Exception:
+        logger.warning(
+            "lifecycle guard referenced-script walk failed; "
+            "falling back to direct-scan verdict",
+            exc_info=True,
+        )
         try:
-            resolved = script_path.resolve(strict=False)
-        except (OSError, ValueError):
-            # OSError: unreadable/long paths. ValueError: embedded NUL byte
-            # from a binary's decoded contents tokenized as a path — a
-            # guarded path must never crash the guard (#76762).
-            resolved = script_path
-        if _is_cloud_placeholder_path(resolved):
-            return True
-        if resolved in visited:
-            continue
-        visited.add(resolved)
-        script_text, unsafe = _read_referenced_script(script_path)
-        if unsafe:
-            return True
-        if script_text is None and read_remote_script is not None:
-            # Local path missing; try the remote backend if one is available.
-            # The callback's output crosses the same trust boundary as a
-            # local read — sanitize it identically before it enters the
-            # recursion (binary skip + size fail-closed).
-            script_text, unsafe = _sanitize_remote_script_text(
-                read_remote_script(str(script_path))
-            )
-            if unsafe:
-                return True
-        if not script_text:
-            continue
-        # Relative references inside a script resolve against that script's
-        # directory, not the original command's cwd.
-        script_dir = _resolve_script_directory(str(resolved)) or cwd
-        if _contains_unsafe_gateway_action(
-            script_text,
-            cwd=script_dir,
-            depth=depth + 1,
-            visited=visited,
-            read_remote_script=read_remote_script,
-        ):
-            return True
-    return False
+            return _direct_lifecycle_evidence(command)
+        except Exception:
+            if contains_gateway_lifecycle_command(command):
+                return {
+                    "ruleId": "gateway_lifecycle_fallback",
+                    "evidenceSource": "shell_command",
+                    "matchedFragment": "gateway lifecycle command",
+                    "referencedPath": None,
+                }
+            return None
 
 
 def contains_gateway_lifecycle_command_or_referenced_script(
@@ -634,23 +844,8 @@ def contains_gateway_lifecycle_command_or_referenced_script(
     cwd: Optional[str] = None,
     read_remote_script: Optional[_ReadRemoteScriptFn] = None,
 ) -> bool:
-    """Detect lifecycle/submit commands, including bounded nested scripts.
-
-    Total by construction: this function returns a verdict for *every*
-    input and never raises. The direct scans below are pure string
-    operations; the referenced-script walk touches the filesystem, remote
-    backends, and shlex on arbitrary decoded bytes, so it is best-effort
-    defense-in-depth — any unexpected failure inside it is logged and
-    treated as "walk found nothing" rather than crashing the caller.
-
-    This is the contract #76762 established ("a guarded path must never
-    crash the guard") enforced at the boundary instead of per-syscall: a
-    guard crash propagates out of ``tools/terminal_tool.py`` and breaks
-    every terminal command until the gateway restarts (#77780, #78256),
-    which is strictly worse than either verdict.
-    """
+    """Detect lifecycle/submit commands, including bounded nested scripts."""
     try:
-        # Includes the direct regex/submit scans at depth 0.
         return _contains_unsafe_gateway_action(
             command,
             cwd=cwd,
@@ -664,13 +859,9 @@ def contains_gateway_lifecycle_command_or_referenced_script(
             "falling back to direct-scan verdict",
             exc_info=True,
         )
-        # Pure string scans of the top-level command — cannot raise.
         try:
             return _direct_lifecycle_scan(command)
         except Exception:
-            # The data-argument masker tokenizes arbitrary text; if even
-            # that fails, fall to the raw regex + submit scan so the guard
-            # stays total.
             return contains_gateway_lifecycle_command(
                 command
             ) or contains_launchctl_submit_command(command)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -296,6 +296,21 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
 
+    def test_block_reports_structured_guard_evidence(self, monkeypatch):
+        """A rejection must identify the rule instead of forcing trial-and-error."""
+        import tools.terminal_tool as tt
+
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+
+        result = json.loads(tt.terminal_tool(command="hermes gateway restart"))
+
+        assert result["guard"] == {
+            "ruleId": "hermes_gateway_lifecycle",
+            "evidenceSource": "shell_command",
+            "matchedFragment": "hermes gateway restart",
+            "referencedPath": None,
+        }
+
     def test_blocks_lifecycle_command_hidden_in_referenced_script(
         self, monkeypatch, tmp_path
     ):
@@ -344,6 +359,12 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
         assert "KeepAlive" in result["error"]
+        assert result["guard"] == {
+            "ruleId": "launchctl_persistent_job",
+            "evidenceSource": "shell_command",
+            "matchedFragment": "launchctl submit/bootstrap",
+            "referencedPath": None,
+        }
 
     @pytest.mark.parametrize("command", [
         "launchctl submit -l com.foo -- /path/gateway",
@@ -694,6 +715,162 @@ class TestLifecycleGuardModule:
             '/usr/bin/python3 -c "print(1)"'
         )
         assert result is False
+
+    def test_skill_filename_before_gateway_path_does_not_match_kill(self):
+        """SKILL.md is a data path, not a kill command token."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        command = (
+            "git add skills/example/SKILL.md "
+            "skills/hermes/hermes-gateway-runtime/SKILL.md"
+        )
+        assert not contains_gateway_lifecycle_command_or_referenced_script(command)
+
+    def test_quoted_python_heredoc_body_is_not_shell_scanned(self, tmp_path):
+        """Directory-looking Python values in an inert body are not scripts."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        data_dir = tmp_path / "profile" / "plugins" / "web-search-pool"
+        data_dir.mkdir(parents=True)
+        command = (
+            "env -u BASH_ENV bash --noprofile --norc -c \"python3 <<'PY'\n"
+            "from pathlib import Path\n"
+            f"plugin_dir = Path('{data_dir}')\n"
+            "print(plugin_dir)\n"
+            "PY\""
+        )
+        assert not contains_gateway_lifecycle_command_or_referenced_script(command)
+
+    def test_python_heredoc_lifecycle_literal_is_still_blocked(self):
+        """Masking heredoc data must not hide an executable lifecycle literal."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        command = (
+            "python3 <<'PY'\n"
+            "import os\n"
+            "os.system('hermes gateway restart')\n"
+            "PY"
+        )
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(command)
+
+    def test_non_shell_shebang_executable_is_not_recursively_scanned(self, tmp_path):
+        """Node/Python executables are programs, not referenced shell scripts."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        data_dir = tmp_path / "gateway-runtime-data"
+        data_dir.mkdir()
+        executable = tmp_path / "tsc"
+        executable.write_text(
+            "#!/usr/bin/env node\n"
+            f"/{str(data_dir).lstrip('/')}/\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o700)
+
+        assert not contains_gateway_lifecycle_command_or_referenced_script(
+            f"{executable} -p tsconfig.json --noEmit"
+        )
+
+    def test_non_shell_shebang_literal_lifecycle_command_still_blocks(self, tmp_path):
+        """Skipping shell recursion must not hide a direct process-control literal."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        executable = tmp_path / "unsafe.py"
+        executable.write_text(
+            "#!/usr/bin/env python3\n"
+            "import os\n"
+            "os.system('hermes gateway restart')\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o700)
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(str(executable))
+
+    def test_generated_shell_wrapper_keeps_referenced_script_visible(self, tmp_path):
+        """A cat heredoc executed later in the command is code, not inert data."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        restart = tmp_path / "restart.sh"
+        restart.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        generated = tmp_path / "generated.sh"
+        command = (
+            f"cat > {generated} <<'EOF'\n"
+            "#!/bin/sh\n"
+            f"/bin/sh {restart}\n"
+            "EOF\n"
+            f"/bin/sh {generated}"
+        )
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(command)
+
+    def test_generated_shell_wrapper_with_heredoc_first_is_scanned(self, tmp_path):
+        """Equivalent heredoc/redirection ordering keeps generated code visible."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        restart = tmp_path / "restart.sh"
+        restart.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        generated = tmp_path / "generated.sh"
+        command = (
+            f"cat <<'EOF' > {generated}\n"
+            f"/bin/sh {restart}\n"
+            "EOF\n"
+            f"/bin/sh {generated}"
+        )
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(command)
+
+    def test_node_execfile_referenced_shell_script_is_scanned(self, tmp_path):
+        """Explicit Node process execution is scanned without treating data paths as code."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        restart = tmp_path / "restart.sh"
+        restart.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        wrapper = tmp_path / "wrapper.js"
+        wrapper.write_text(
+            "#!/usr/bin/env node\n"
+            "const child_process = require('child_process');\n"
+            f"child_process.execFile('{restart}');\n",
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o700)
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(str(wrapper))
+
+    def test_explicit_shell_interpreter_overrides_non_shell_shebang(self, tmp_path):
+        """bash executes a file as shell regardless of its misleading shebang."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        restart = tmp_path / "restart.sh"
+        restart.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        wrapper = tmp_path / "wrapper.py"
+        wrapper.write_text(
+            "#!/usr/bin/env python3\n"
+            f"{restart}\n",
+            encoding="utf-8",
+        )
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            f"bash {wrapper}"
+        )
 
     def test_nul_byte_in_path_token_does_not_crash_guard(self):
         """Residual #76762 class: when a NUL byte survives into the *path

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2856,8 +2856,8 @@ def terminal_tool(
         if os.environ.get("_HERMES_GATEWAY") == "1":
             from cron.lifecycle_guard import (
                 _MAX_REFERENCED_SCRIPT_BYTES,
-                contains_gateway_lifecycle_command_or_referenced_script,
                 contains_launchctl_submit_command,
+                find_gateway_lifecycle_violation,
             )
             if contains_launchctl_submit_command(command):
                 return json.dumps({
@@ -2869,6 +2869,12 @@ def terminal_tool(
                         "Use Hermes cron for one-shot delayed work, or install an "
                         "explicit LaunchAgent from a separate shell."
                     ),
+                    "guard": {
+                        "ruleId": "launchctl_persistent_job",
+                        "evidenceSource": "shell_command",
+                        "matchedFragment": "launchctl submit/bootstrap",
+                        "referencedPath": None,
+                    },
                     "status": "error",
                 }, ensure_ascii=False)
             guard_cwd_base = get_session_cwd(session_key)
@@ -2936,11 +2942,12 @@ def terminal_tool(
                     pass
                 return None
 
-            if contains_gateway_lifecycle_command_or_referenced_script(
+            lifecycle_violation = find_gateway_lifecycle_violation(
                 command,
                 cwd=guard_cwd,
                 read_remote_script=_read_script_in_env,
-            ):
+            )
+            if lifecycle_violation is not None:
                 return json.dumps({
                     "output": "",
                     "exit_code": 1,
@@ -2951,6 +2958,7 @@ def terminal_tool(
                         "to child processes). Run `hermes gateway restart` from a "
                         "separate shell outside the running gateway."
                     ),
+                    "guard": lifecycle_violation,
                     "status": "error",
                 }, ensure_ascii=False)
 


### PR DESCRIPTION
## Summary
- avoid gateway lifecycle-guard false positives from `SKILL.md` paths, inert quoted Python heredocs, and non-shell executables such as `tsc`
- preserve blocking for direct lifecycle commands, referenced shell scripts, explicit non-shell process execution, and generate-then-execute heredoc wrappers
- return bounded structured guard evidence for all Terminal lifecycle blocks

## Verification
- `bash scripts/run_tests.sh tests/hermes_cli/test_gateway_restart_loop.py tests/tools/test_terminal*.py tests/tools/test_ssh_environment.py tests/tools/test_execute_code_approval_cluster.py tests/tools/test_session_cwd_store.py -q`
  - 422 passed, 0 failed, 5 skipped across 26 files
- `uv run ruff check cron/lifecycle_guard.py tools/terminal_tool.py tests/hermes_cli/test_gateway_restart_loop.py`
- `git diff --check 9adc6071904dba099b667700f3ec177b3fb95eca...HEAD`
- independent final review of commit `2b5a57a59aee22e001e2ff0c58c905b3283d7483`: No BLOCK

## Regression coverage
- SKILL path before gateway-like path does not match `kill`
- quoted Python data heredoc is not shell-recursively scanned
- Python heredoc containing a direct lifecycle literal still blocks
- Node/Python shebang executables are not treated as shell scripts
- Node `execFile` and explicit `bash` referenced scripts still block
- both `cat > file <<EOF` and `cat <<EOF > file` generate-then-execute forms block
- launchctl submit/bootstrap returns structured evidence
