### PR TITLE
fix(cron): clear run_claim for one-shot jobs on dispatch failure (salvage #87591)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2538,6 +2538,34 @@ def heartbeat_run_claim(job_id: str, *, expected_owner: str) -> bool:
     return False
 
 
+def clear_run_claim(job_id: str) -> bool:
+    """Clear a one-shot job's ``run_claim`` when its dispatch fails.
+
+    ``get_due_jobs`` stamps a ``run_claim`` before returning a one-shot as
+    due (#59229).  ``mark_job_run`` clears it on *successful* completion.
+    When dispatch itself fails (interpreter shutdown, executor submit error,
+    execution-creation error) the job never reaches ``mark_job_run`` and the
+    stale claim blocks re-dispatch until the TTL expires (default 30 min).
+
+    Calling this on every early-exit path restores the "the job stays due
+    and will fire on the next healthy tick" invariant that the scheduler
+    comment promises (#86522).
+    """
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job.get("id") != job_id:
+                continue
+            if job.get("schedule", {}).get("kind") != "once":
+                return False
+            if job.get("run_claim") is not None:
+                job["run_claim"] = None
+                save_jobs(jobs)
+                return True
+            return False  # already cleared
+    return False
+
+
 def advance_next_runs(job_ids) -> int:
     """Batch form of :func:`advance_next_run` for the due-dispatch loop.
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6668,12 +6668,20 @@ def tick(
             def _clear_run_claim_best_effort() -> None:
                 """Best-effort claim cleanup on the dispatch-failure paths.
 
-                clear_run_claim does load_jobs/save_jobs file I/O; on the
-                interpreter-shutdown path (or with a corrupt store) it can
-                itself raise, and these early-exit paths exist precisely to
-                skip cleanly — a stale claim expiring at the TTL is a better
-                outcome than crashing the tick (#86522).
+                Only one-shot jobs carry a ``run_claim`` (stamped by
+                get_due_jobs, #59229), so recurring jobs skip the call
+                entirely — clear_run_claim acquires _jobs_lock (blocking
+                cross-process flock) and does a full load_jobs read, and the
+                dispatch-failure paths fire exactly when the process can
+                least afford N pointless lock/read round-trips (interpreter
+                shutdown, EMFILE).  clear_run_claim itself does
+                load_jobs/save_jobs file I/O; on those degraded paths it can
+                raise, and these early-exits exist precisely to skip cleanly
+                — a stale claim expiring at the TTL is a better outcome than
+                crashing the tick (#86522).
                 """
+                if (job.get("schedule") or {}).get("kind") != "once":
+                    return
                 try:
                     clear_run_claim(job_id)
                 except Exception as claim_err:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6664,6 +6664,26 @@ def tick(
             membership is released in the worker's finally block.
             """
             job_id = job["id"]
+
+            def _clear_run_claim_best_effort() -> None:
+                """Best-effort claim cleanup on the dispatch-failure paths.
+
+                clear_run_claim does load_jobs/save_jobs file I/O; on the
+                interpreter-shutdown path (or with a corrupt store) it can
+                itself raise, and these early-exit paths exist precisely to
+                skip cleanly — a stale claim expiring at the TTL is a better
+                outcome than crashing the tick (#86522).
+                """
+                try:
+                    clear_run_claim(job_id)
+                except Exception as claim_err:
+                    logger.warning(
+                        "Could not clear run_claim for job '%s' after dispatch "
+                        "failure: %s (claim will expire at TTL)",
+                        job.get("name", job_id),
+                        claim_err,
+                    )
+
             # A tick can race gateway teardown: once the interpreter is
             # finalizing, ``pool.submit`` raises "cannot schedule new futures
             # after interpreter shutdown" and crashes the tick. Skip cleanly —
@@ -6674,7 +6694,7 @@ def tick(
                     "Job '%s' not dispatched — interpreter is shutting down",
                     job.get("name", job_id),
                 )
-                clear_run_claim(job_id)
+                _clear_run_claim_best_effort()
                 return None
             if not try_register_running_job(job_id):
                 logger.info("Job '%s' already running — skipping", job.get("name", job_id))
@@ -6692,7 +6712,7 @@ def tick(
                 # audit requirement: every add is paired with guaranteed
                 # cleanup).
                 release_running_job(job_id)
-                clear_run_claim(job_id)
+                _clear_run_claim_best_effort()
                 logger.exception(
                     "Job '%s' not dispatched: execution creation failed: %s",
                     job.get("name", job_id),
@@ -6710,7 +6730,7 @@ def tick(
                 fut = pool.submit(_run_and_release)
             except Exception as submit_err:
                 release_running_job(job_id)
-                clear_run_claim(job_id)
+                _clear_run_claim_best_effort()
                 finish_execution(
                     execution["id"],
                     success=False,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6680,7 +6680,8 @@ def tick(
                 — a stale claim expiring at the TTL is a better outcome than
                 crashing the tick (#86522).
                 """
-                if (job.get("schedule") or {}).get("kind") != "once":
+                _schedule = job.get("schedule")
+                if not (isinstance(_schedule, dict) and _schedule.get("kind") == "once"):
                     return
                 try:
                     clear_run_claim(job_id)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -496,6 +496,7 @@ from cron.jobs import (
     claim_dispatch,
     claim_job_for_fire,
     fire_claim_fence,
+    clear_run_claim,
     get_due_jobs,
     heartbeat_fire_claim,
     heartbeat_run_claim,
@@ -6673,6 +6674,7 @@ def tick(
                     "Job '%s' not dispatched — interpreter is shutting down",
                     job.get("name", job_id),
                 )
+                clear_run_claim(job_id)
                 return None
             if not try_register_running_job(job_id):
                 logger.info("Job '%s' already running — skipping", job.get("name", job_id))
@@ -6690,6 +6692,7 @@ def tick(
                 # audit requirement: every add is paired with guaranteed
                 # cleanup).
                 release_running_job(job_id)
+                clear_run_claim(job_id)
                 logger.exception(
                     "Job '%s' not dispatched: execution creation failed: %s",
                     job.get("name", job_id),
@@ -6707,6 +6710,7 @@ def tick(
                 fut = pool.submit(_run_and_release)
             except Exception as submit_err:
                 release_running_job(job_id)
+                clear_run_claim(job_id)
                 finish_execution(
                     execution["id"],
                     success=False,

--- a/tests/cron/test_oneshot_dispatch_failure_run_claim.py
+++ b/tests/cron/test_oneshot_dispatch_failure_run_claim.py
@@ -1,0 +1,131 @@
+"""Regression tests for #86522 — one-shot run_claim cleared on dispatch failure.
+
+``get_due_jobs`` stamps a ``run_claim`` on one-shot jobs before returning them
+as due (#59229); ``mark_job_run`` clears it on completion.  When dispatch
+itself fails (interpreter shutdown, execution-creation error, executor submit
+error) the job never reaches ``mark_job_run`` and the stale claim blocked
+re-dispatch until the TTL expired (default 30 min) — a precisely-timed
+one-shot reminder arrived up to 30 minutes late with no error surfaced.
+
+The fix (salvaged from PR #87591 by @RelaxJonh) adds
+``cron.jobs.clear_run_claim`` and calls it on all three ``_submit_with_guard``
+early-exit paths, wrapped best-effort so a failing store can never crash the
+tick these paths exist to protect.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import cron.jobs as jobs_mod
+from cron.jobs import clear_run_claim
+
+
+@pytest.fixture
+def cron_store(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    (hermes_home / "cron").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", hermes_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
+    return hermes_home
+
+
+def _make_oneshot(claimed: bool = True) -> dict:
+    job = jobs_mod.create_job(prompt="remind me", schedule="30m")
+    if claimed:
+        jobs = jobs_mod.load_jobs()
+        for j in jobs:
+            if j["id"] == job["id"]:
+                j["run_claim"] = {"at": "2026-08-17T10:00:00+00:00", "by": "test:1"}
+        jobs_mod.save_jobs(jobs)
+    return job
+
+
+class TestClearRunClaim:
+    def test_clears_claim_on_oneshot(self, cron_store):
+        job = _make_oneshot(claimed=True)
+        assert clear_run_claim(job["id"]) is True
+        reloaded = [j for j in jobs_mod.load_jobs() if j["id"] == job["id"]][0]
+        assert reloaded.get("run_claim") is None
+
+    def test_noop_when_already_clear(self, cron_store):
+        job = _make_oneshot(claimed=False)
+        assert clear_run_claim(job["id"]) is False
+
+    def test_never_touches_recurring_jobs(self, cron_store):
+        job = jobs_mod.create_job(prompt="tick", schedule="every 10m")
+        jobs = jobs_mod.load_jobs()
+        for j in jobs:
+            if j["id"] == job["id"]:
+                j["run_claim"] = {"at": "2026-08-17T10:00:00+00:00", "by": "test:1"}
+        jobs_mod.save_jobs(jobs)
+        assert clear_run_claim(job["id"]) is False
+        reloaded = [j for j in jobs_mod.load_jobs() if j["id"] == job["id"]][0]
+        assert reloaded.get("run_claim") is not None  # untouched
+
+    def test_unknown_job_id_returns_false(self, cron_store):
+        assert clear_run_claim("no-such-job") is False
+
+
+class TestDispatchFailurePathsClearClaim:
+    """Each _submit_with_guard early-exit must clear the one-shot claim so the
+    next healthy tick re-dispatches instead of waiting out the 30-min TTL."""
+
+    def _tick_one(self, job):
+        from cron import scheduler as sched
+        with patch.object(sched, "get_due_jobs", return_value=[dict(job)]):
+            return sched.tick(verbose=False, sync=True)
+
+    def test_interpreter_shutdown_path_clears_claim(self, cron_store):
+        from cron import scheduler as sched
+        job = _make_oneshot(claimed=True)
+        with patch.object(sched, "_interpreter_shutting_down", return_value=True):
+            self._tick_one(job)
+        reloaded = [j for j in jobs_mod.load_jobs() if j["id"] == job["id"]][0]
+        assert reloaded.get("run_claim") is None, (
+            "shutdown-path dispatch failure must clear run_claim (#86522)"
+        )
+
+    def test_execution_creation_failure_clears_claim(self, cron_store):
+        from cron import scheduler as sched
+        job = _make_oneshot(claimed=True)
+        with patch.object(sched, "create_execution", side_effect=RuntimeError("db gone")):
+            self._tick_one(job)
+        reloaded = [j for j in jobs_mod.load_jobs() if j["id"] == job["id"]][0]
+        assert reloaded.get("run_claim") is None
+        assert job["id"] not in sched.get_running_job_ids()
+
+    def test_submit_failure_clears_claim(self, cron_store):
+        from cron import scheduler as sched
+        job = _make_oneshot(claimed=True)
+
+        class _ExplodingPool:
+            def submit(self, *a, **k):
+                raise RuntimeError("cannot schedule new futures")
+
+        pool = _ExplodingPool()
+        with patch.object(sched, "_get_parallel_pool", return_value=pool), \
+             patch.object(sched, "_get_sequential_pool", return_value=pool):
+            self._tick_one(job)
+        reloaded = [j for j in jobs_mod.load_jobs() if j["id"] == job["id"]][0]
+        assert reloaded.get("run_claim") is None
+        assert job["id"] not in sched.get_running_job_ids()
+
+    def test_clear_failure_is_best_effort_not_fatal(self, cron_store):
+        """A raising clear_run_claim (corrupt store, teardown I/O error) must
+        not crash the tick — these early-exit paths exist to skip cleanly; the
+        claim then simply expires at the TTL."""
+        from cron import scheduler as sched
+        job = _make_oneshot(claimed=True)
+        with patch.object(sched, "_interpreter_shutting_down", return_value=True), \
+             patch.object(sched, "clear_run_claim", side_effect=OSError(24, "Too many open files")):
+            n = self._tick_one(job)  # must not raise
+        assert n == 0

--- a/tests/cron/test_oneshot_dispatch_failure_run_claim.py
+++ b/tests/cron/test_oneshot_dispatch_failure_run_claim.py
@@ -129,3 +129,15 @@ class TestDispatchFailurePathsClearClaim:
              patch.object(sched, "clear_run_claim", side_effect=OSError(24, "Too many open files")):
             n = self._tick_one(job)  # must not raise
         assert n == 0
+
+    def test_recurring_dispatch_failure_skips_claim_io(self, cron_store):
+        """Recurring jobs carry no run_claim, so the dispatch-failure paths
+        must not pay clear_run_claim's lock acquisition + full jobs-file read
+        for a guaranteed no-op — the failure paths fire exactly when the
+        process can least afford pointless I/O (shutdown, EMFILE)."""
+        from cron import scheduler as sched
+        job = jobs_mod.create_job(prompt="hourly", schedule="every 1h")
+        with patch.object(sched, "_interpreter_shutting_down", return_value=True), \
+             patch.object(sched, "clear_run_claim") as mock_clear:
+            self._tick_one(job)
+        mock_clear.assert_not_called()


### PR DESCRIPTION
## Summary
A one-shot cron job whose dispatch fails (gateway shutting down at fire time, execution-creation error, executor submit error) now fires on the next healthy tick instead of arriving up to 30 minutes late — salvage of #87591 by @RelaxJonh with a robustness follow-up and the missing tests.

Root cause (#86522): `get_due_jobs` stamps a `run_claim` on one-shots before returning them as due (#59229); `mark_job_run` clears it on completion. All three `_submit_with_guard` early-exit paths released the in-flight running set but left `run_claim` intact, so the next tick's fresh-claim check skipped the job until the TTL (default 30 min) expired. The scheduler comment's "the job stays due and will fire on the next healthy tick" was only true for recurring jobs.

## Changes
- `cron/jobs.py` (@RelaxJonh): new `clear_run_claim(job_id)` — clears a one-shot's `run_claim` under the existing `_jobs_lock` + load/save pattern; no-ops for recurring jobs and already-clear claims.
- `cron/scheduler.py` (@RelaxJonh): call it on the interpreter-shutdown, execution-creation-failure, and submit-failure paths.
- Follow-up (ours): the three call sites now go through a best-effort wrapper — `clear_run_claim` does file I/O and could itself raise on the very teardown/corrupt-store paths these early exits protect; a failed clear logs and falls back to TTL expiry instead of crashing the tick.
- `tests/cron/test_oneshot_dispatch_failure_run_claim.py` (new, ours): 8 tests — unit contract (cleared / noop / recurring untouched / unknown id), all three dispatch-failure paths through a real `tick()`, and the best-effort guard. Mutation-verified: reverting the production fix fails the suite; restore goes green.

## Validation
| Check | Result |
|---|---|
| New regression tests | 8 passed |
| Mutation check (fix reverted) | suite fails, restore green |
| Full tests/cron/ with fix | 732 passed; only pre-existing test_monitor_kind failures (reproduce on clean main) |
| ruff on touched files | clean |

## Credit
Based on #87591 by @RelaxJonh — commit cherry-picked with authorship preserved. Closes #86522. Closes #87591.

Note: open PR #87623 bundles a one-shot run_claim release into a broader store-path/UTC change for the same issue; this focused 3-site fix should supersede that slice.
