### PR TITLE
fix(wake): tokenize each KWS phrase case-adaptively, not blanket-upper

### DIFF
--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -391,6 +391,78 @@ def _install_fake_sherpa(monkeypatch, tmp_path):
 # ── Multi-profile phrase routing ─────────────────────────────────────────
 
 
+def _build_sherpa_engine(monkeypatch, tmp_path, phrase, enrolled=None, tokenizable=None):
+    """Build a _SherpaKwsEngine offline against a fake model dir.
+
+    ``tokenizable`` is the set of case variants the fake BPE vocabulary can
+    tokenize; anything outside it returns an empty token list, mirroring
+    sherpa's ``text2token`` behaviour for phrases with no pieces in the
+    vocabulary (#88245). Returns (engine, attempted-variant-calls).
+    """
+    calls, model_dir = _install_fake_sherpa(monkeypatch, tmp_path)
+    attempted: list[list[str]] = []
+
+    def fake_text2token(phrases, tokens, tokens_type, bpe_model):
+        attempted.append(list(phrases))
+        return [p.split() if p in (tokenizable or set()) else [] for p in phrases]
+
+    sys.modules["sherpa_onnx"].text2token = fake_text2token
+    monkeypatch.setattr(ww, "_active_profile_name", lambda: "default")
+    monkeypatch.setattr(ww, "enrolled_profile_phrases", lambda: dict(enrolled or {}))
+    cfg = {"provider": "sherpa", "phrase": phrase, "sherpa": {"model_dir": str(model_dir)}}
+    return ww._SherpaKwsEngine(cfg), attempted
+
+
+def test_sherpa_uppercase_variant_still_wins_first_for_bundled_model(monkeypatch, tmp_path):
+    # The bundled English model tokenizes uppercased phrases — one call, no
+    # fallback, behaviour unchanged for every existing user.
+    eng, attempted = _build_sherpa_engine(
+        monkeypatch, tmp_path, "hey hermes", tokenizable={"HEY HERMES"}
+    )
+    assert attempted == [["HEY HERMES"]]
+    content = Path(eng._keywords_file).read_text(encoding="utf-8")
+    assert content.strip() == "HEY HERMES @HEY_HERMES"
+    os.unlink(eng._keywords_file)
+
+
+def test_sherpa_lowercase_bpe_vocab_falls_back_to_configured_case(monkeypatch, tmp_path):
+    # Lowercase-only vocabulary (e.g. a Spanish KWS model): the uppercased
+    # variant yields no tokens, the phrase as configured tokenizes fine.
+    # The old blanket .upper() wrote a blank keyword line here and the wake
+    # word never fired (#88245).
+    eng, attempted = _build_sherpa_engine(
+        monkeypatch, tmp_path, "Hola hermes", tokenizable={"Hola hermes"}
+    )
+    assert attempted == [["HOLA HERMES"], ["Hola hermes"]]
+    content = Path(eng._keywords_file).read_text(encoding="utf-8")
+    assert content.strip() == "Hola hermes @HOLA_HERMES"
+    assert eng._display_to_profile == {"HOLA_HERMES": "default"}
+    os.unlink(eng._keywords_file)
+
+
+def test_sherpa_untokenizable_enrolled_phrase_is_skipped_not_blank(monkeypatch, tmp_path, caplog):
+    # One profile's phrase has no BPE pieces in any case: it is dropped with
+    # an error log instead of poisoning the keywords file with a blank line.
+    with caplog.at_level("ERROR", logger="tools.wake_word"):
+        eng, _attempted = _build_sherpa_engine(
+            monkeypatch,
+            tmp_path,
+            "hey hermes",
+            enrolled={"coder": "Bonjour"},
+            tokenizable={"hey hermes"},
+        )
+    lines = [ln for ln in Path(eng._keywords_file).read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert lines == ["hey hermes @HEY_HERMES"]
+    assert eng._display_to_profile == {"HEY_HERMES": "default"}
+    assert any("Bonjour" in r.message for r in caplog.records)
+    os.unlink(eng._keywords_file)
+
+
+def test_sherpa_raises_when_no_phrase_tokenizes(monkeypatch, tmp_path):
+    with pytest.raises(RuntimeError, match="no tokens for any wake phrase"):
+        _build_sherpa_engine(monkeypatch, tmp_path, "Привет", tokenizable=set())
+
+
 # ── Detector loop ────────────────────────────────────────────────────────
 
 

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -656,6 +656,35 @@ def _ensure_sherpa_model(root: Optional[Path] = None) -> Path:
     return target
 
 
+def _tokenize_kws_phrase(text2token, phrase: str, model_dir: Path) -> list[str]:
+    """Tokenize one wake phrase case-adaptively against the KWS BPE vocabulary.
+
+    The bundled English model's BPE vocabulary happens to carry uppercase
+    pieces, and the historical blanket ``.upper()`` relied on that accident.
+    Community KWS models trained on lowercase text have no uppercase pieces
+    at all: sentencepiece emits one unknown piece, sherpa's ``text2token``
+    skips it and returns an empty token list, and the keyword line written
+    to the keywords file is blank — the wake word dies silently (#88245).
+    Try the uppercased form first (bundled-model compatibility), then the
+    phrase as configured, then lowercase, and keep the first case variant
+    that yields at least one token.
+    """
+    seen: set[str] = set()
+    for variant in (phrase.upper(), phrase, phrase.lower()):
+        if variant in seen:
+            continue
+        seen.add(variant)
+        toks = text2token(
+            [variant],
+            tokens=str(model_dir / "tokens.txt"),
+            tokens_type="bpe",
+            bpe_model=str(model_dir / "bpe.model"),
+        )
+        if toks and toks[0]:
+            return toks[0]
+    return []
+
+
 class _SherpaKwsEngine(_Engine):
     """sherpa-onnx open-vocabulary keyword spotting — any typed phrase, zero training.
 
@@ -695,12 +724,29 @@ class _SherpaKwsEngine(_Engine):
 
         phrases = list(phrase_map)
         # Runtime tokenization of the arbitrary phrases — the open-vocab core.
-        tokens = text2token(
-            [p.upper() for p in phrases],
-            tokens=str(d / "tokens.txt"),
-            tokens_type="bpe",
-            bpe_model=str(d / "bpe.model"),
-        )
+        # Per-phrase case-adaptive tokenization (see _tokenize_kws_phrase):
+        # the old blanket `.upper()` silently blanked phrases for models
+        # whose BPE vocabulary has no uppercase pieces (#88245).
+        tokens: list[list[str]] = []
+        for p in phrases:
+            toks = _tokenize_kws_phrase(text2token, p, d)
+            if not toks:
+                logger.error(
+                    "sherpa KWS model at %s has no BPE tokens for wake "
+                    "phrase %r (tried upper/original/lower case) — the wake "
+                    "word would never fire; skipping this phrase",
+                    d,
+                    p,
+                )
+                phrases = [q for q in phrases if q != p]
+                del phrase_map[p]
+                continue
+            tokens.append(toks)
+        if not phrases:
+            raise RuntimeError(
+                f"sherpa KWS model at {d} produced no tokens for any wake "
+                "phrase (tried upper/original/lower case)"
+            )
         import tempfile
 
         # sherpa keyword entries reject spaces in the @display-name; underscore


### PR DESCRIPTION
## What does this PR do?

The sherpa open-vocabulary engine uppercased every configured wake phrase before BPE tokenization. That only works for the bundled English model because its vocabulary happens to carry uppercase pieces. Community KWS models trained on lowercase text (e.g. the Spanish zipformer model verified in the issue) have no uppercase pieces at all: sentencepiece emits one unknown piece, sherpa `text2token` skips the phrase and returns an empty token list, the temporary keywords file gets a blank keyword line, and the `KeywordSpotter` can never fire — the wake word is silently dead while the icon still shows "listening".

Instead of the blanket `.upper()`, each phrase is now tokenized case-adaptively: try the uppercased form first (unchanged behaviour for the bundled model), then the phrase exactly as configured, then lowercase, and keep the first variant that yields at least one token. Phrases that fail in every case are logged and skipped instead of poisoning the keywords file with a blank line, and if no phrase tokenizes at all the engine now raises a clear `RuntimeError` instead of building a spotter that can never fire. The `@display-name` routing still uses the uppercased form, so match routing is unchanged.

## Related Issue

Fixes #88245

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/wake_word.py`: added `_tokenize_kws_phrase()` — per-phrase case-adaptive tokenization (upper → as-configured → lower, first non-empty wins)
- `tools/wake_word.py`: `_SherpaKwsEngine.__init__` now tokenizes phrases through the helper, logs-and-skips phrases with no tokens in any case, and raises `RuntimeError` when every phrase fails (previously: blank keyword lines, silent dead wake word)

## How to Test

1. `python -m pytest tests/tools/test_wake_word.py -q` — Observed result: 30 passed, 2 skipped (one unrelated openwakeword/tflite test deselected locally: it requires `ai-edge-litert` on macOS ARM64 and is unrelated to this change).
2. New regression tests in `tests/tools/test_wake_word.py`:
   - `test_sherpa_uppercase_variant_still_wins_first_for_bundled_model` — bundled-model path makes exactly one uppercased call, keywords line unchanged (`HEY HERMES @HEY_HERMES`)
   - `test_sherpa_lowercase_bpe_vocab_falls_back_to_configured_case` — lowercase-only vocabulary falls back from `HOLA HERMES` to `Hola hermes` and the keywords line carries real tokens (the old code wrote a blank line here)
   - `test_sherpa_untokenizable_enrolled_phrase_is_skipped_not_blank` — a multi-profile phrase with no tokens in any case is skipped with an error log; other phrases still work
   - `test_sherpa_raises_when_no_phrase_tokenizes` — clear `RuntimeError` instead of a silently dead spotter

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/tools/test_wake_word.py -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config keys, tool schemas, or docs changed; the helper carries a docstring explaining the case-fallback order

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/tools/test_wake_word.py -q --deselect tests/tools/test_wake_word.py::test_openwakeword_ensures_base_models_for_custom_path
30 passed, 2 skipped, 1 deselected in 1.28s
```