### PR TITLE
fix(cron): reconcile stale in-flight claims against the executions ledger (salvage #87259)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -856,20 +856,43 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
 
     # Latest durable execution per in-flight job id, loaded in one indexed
     # query.  Used for the persisted-state reconciliation below (t_8b5480b3):
-    # an in-memory claim whose job's MOST RECENT execution row is terminal
+    # an in-memory claim whose OWN run's execution row is terminal
     # (completed/failed/unknown) cannot represent a live run — the durable
     # ledger proves that run already ended — so the claim is stale by
-    # construction, regardless of its in-memory age.  This closes the
-    # restart-survival gap that the age-only sweep left open: the ledger is
-    # written by the worker that ran the job and read by ANY ticker process
-    # (including one that started AFTER the leak), so a leaked claim is
-    # recoverable without force-run/resume and without depending on which
-    # process happens to still hold it in memory.
+    # construction, regardless of its in-memory age.  A leaked claim is then
+    # recoverable without force-run/resume.  The snapshot for the query is
+    # taken under _running_lock: list(set) over a set concurrently mutated by
+    # try_register/release_running_job can raise RuntimeError mid-iteration.
+    with _running_lock:
+        _inflight_snapshot = list(_running_job_ids)
     try:
         from cron.executions import latest_executions as _latest_execs
-        _latest = _latest_execs(list(_running_job_ids))
+        _latest = _latest_execs(_inflight_snapshot)
     except Exception:
         _latest = {}
+
+    def _row_belongs_to_claim(row: dict, claim_started: float) -> bool:
+        """True when the ledger row was claimed at/after this in-memory claim.
+
+        The latest terminal row proves THIS claim's run ended only if it was
+        created by this claim's dispatch (create_execution runs moments AFTER
+        try_register_running_job).  A terminal row older than the in-memory
+        claim is the PREVIOUS run's outcome — for a recurring job that is the
+        common case in the window between try_register and create_execution,
+        and releasing on it would double-dispatch a healthy fresh claim.
+        Unparseable timestamps fail closed (row treated as previous-run; the
+        age-based path below still bounds the claim).
+        """
+        claimed_at = row.get("claimed_at")
+        if not claimed_at:
+            return False
+        try:
+            row_ts = datetime.fromisoformat(claimed_at)
+            if row_ts.tzinfo is None:
+                row_ts = row_ts.astimezone()
+            return row_ts.timestamp() >= claim_started
+        except (ValueError, TypeError, OSError):
+            return False
 
     # Precompute job intervals OUTSIDE _running_lock so croniter evaluation
     # does not block try_register/release_running_job for other jobs.
@@ -898,17 +921,24 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
             elif fut is not None and not fut.done():
                 continue  # genuinely still executing
             # Persisted-state reconciliation: if the durable executions ledger
-            # shows this job's last run reached a terminal state, the claim is
+            # shows THIS claim's run reached a terminal state, the claim is
             # provably stale even if it is still inside its in-memory age
             # allowance (or was adopted fresh this tick).  Release it now so
             # the job re-dispatches on the next tick without force-run/resume
-            # (t_8b5480b3 — the 2026-08-14 recurring-router wedge that
-            # survived a gateway restart because the in-memory age bound alone
-            # could not see a run the ledger had already finished).
+            # (t_8b5480b3 — the 2026-08-14 recurring-router wedge where the
+            # in-memory age bound alone could not see a run the ledger had
+            # already finished).  The row must belong to THIS claim
+            # (claimed_at >= claim registration): for a recurring job the
+            # latest terminal row is usually the PREVIOUS run's outcome —
+            # a fresh claim in the try_register→create_execution window, or a
+            # finished run whose worker finally hasn't released yet, would
+            # otherwise be force-released and double-dispatched.
             if fut is None or fut is _FUTURE_PENDING or fut.done():
                 latest = _latest.get(job_id)
-                if latest is not None and latest.get("status") in (
-                    "completed", "failed", "unknown",
+                if (
+                    latest is not None
+                    and latest.get("status") in ("completed", "failed", "unknown")
+                    and _row_belongs_to_claim(latest, started)
                 ):
                     _running_job_ids.discard(job_id)
                     _running_since.pop(job_id, None)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -854,22 +854,37 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
     now = time.time()
     stale: list = []
 
-    # Latest durable execution per in-flight job id, loaded in one indexed
-    # query.  Used for the persisted-state reconciliation below (t_8b5480b3):
-    # an in-memory claim whose OWN run's execution row is terminal
-    # (completed/failed/unknown) cannot represent a live run — the durable
-    # ledger proves that run already ended — so the claim is stale by
-    # construction, regardless of its in-memory age.  A leaked claim is then
-    # recoverable without force-run/resume.  The snapshot for the query is
-    # taken under _running_lock: list(set) over a set concurrently mutated by
-    # try_register/release_running_job can raise RuntimeError mid-iteration.
+    # Latest durable execution per RELEASABLE-LOOKING in-flight job id, loaded
+    # in one indexed query.  Used for the persisted-state reconciliation below
+    # (t_8b5480b3): an in-memory claim whose OWN run's execution row is
+    # terminal cannot represent a live run — the durable ledger proves that
+    # run already ended — so the claim is stale by construction, regardless of
+    # its in-memory age.  A leaked claim is then recoverable without
+    # force-run/resume.  Two-phase so the healthy steady state pays no DB
+    # work: a claim with a live future is never released, so the query only
+    # covers claims whose future is missing/pending/done (the snapshot is
+    # taken under _running_lock; iterating a set concurrently mutated by
+    # try_register/release_running_job can raise RuntimeError).  A claim that
+    # becomes releasable between the snapshot and the sweep loop simply waits
+    # for the next tick's query.
+    from cron.executions import _TERMINAL_STATES as _terminal_states
+
     with _running_lock:
-        _inflight_snapshot = list(_running_job_ids)
-    try:
-        from cron.executions import latest_executions as _latest_execs
-        _latest = _latest_execs(_inflight_snapshot)
-    except Exception:
-        _latest = {}
+        _claim_futures = {
+            job_id: _running_futures.get(job_id) for job_id in _running_job_ids
+        }
+    _ledger_candidates = [
+        job_id
+        for job_id, fut in _claim_futures.items()
+        if fut is None or fut is _FUTURE_PENDING or fut.done()
+    ]
+    _latest: dict = {}
+    if _ledger_candidates:
+        try:
+            from cron.executions import latest_executions as _latest_execs
+            _latest = _latest_execs(_ledger_candidates)
+        except Exception:
+            _latest = {}
 
     def _row_belongs_to_claim(row: dict, claim_started: float) -> bool:
         """True when the ledger row was claimed at/after this in-memory claim.
@@ -887,9 +902,8 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
         if not claimed_at:
             return False
         try:
-            row_ts = datetime.fromisoformat(claimed_at)
-            if row_ts.tzinfo is None:
-                row_ts = row_ts.astimezone()
+            from cron.jobs import _ensure_aware as _ensure_aware_ts
+            row_ts = _ensure_aware_ts(datetime.fromisoformat(claimed_at))
             return row_ts.timestamp() >= claim_started
         except (ValueError, TypeError, OSError):
             return False
@@ -932,27 +946,26 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
             # latest terminal row is usually the PREVIOUS run's outcome —
             # a fresh claim in the try_register→create_execution window, or a
             # finished run whose worker finally hasn't released yet, would
-            # otherwise be force-released and double-dispatched.
-            if fut is None or fut is _FUTURE_PENDING or fut.done():
-                latest = _latest.get(job_id)
-                if (
-                    latest is not None
-                    and latest.get("status") in ("completed", "failed", "unknown")
-                    and _row_belongs_to_claim(latest, started)
-                ):
-                    _running_job_ids.discard(job_id)
-                    _running_since.pop(job_id, None)
-                    _running_futures.pop(job_id, None)
-                    _forced_release_count += 1
-                    stale.append((job_id, age, allowance, fut, "ledger-terminal"))
-                    continue
-            if age < allowance:
+            # otherwise be force-released and double-dispatched.  Reaching
+            # here implies the future is missing/pending/done (the live-future
+            # case continued above), so every claim in this branch was a
+            # ledger-query candidate.
+            latest = _latest.get(job_id)
+            if (
+                latest is not None
+                and latest.get("status") in _terminal_states
+                and _row_belongs_to_claim(latest, started)
+            ):
+                reason = "ledger-terminal"
+            elif age >= allowance:
+                reason = "age"
+            else:
                 continue
             _running_job_ids.discard(job_id)
             _running_since.pop(job_id, None)
             _running_futures.pop(job_id, None)
             _forced_release_count += 1
-            stale.append((job_id, age, allowance, fut, "age"))
+            stale.append((job_id, age, allowance, fut, reason))
 
     for job_id, age, allowance, fut, _reason in stale:
         job = by_id.get(job_id) or {}

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -854,6 +854,23 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
     now = time.time()
     stale: list = []
 
+    # Latest durable execution per in-flight job id, loaded in one indexed
+    # query.  Used for the persisted-state reconciliation below (t_8b5480b3):
+    # an in-memory claim whose job's MOST RECENT execution row is terminal
+    # (completed/failed/unknown) cannot represent a live run — the durable
+    # ledger proves that run already ended — so the claim is stale by
+    # construction, regardless of its in-memory age.  This closes the
+    # restart-survival gap that the age-only sweep left open: the ledger is
+    # written by the worker that ran the job and read by ANY ticker process
+    # (including one that started AFTER the leak), so a leaked claim is
+    # recoverable without force-run/resume and without depending on which
+    # process happens to still hold it in memory.
+    try:
+        from cron.executions import latest_executions as _latest_execs
+        _latest = _latest_execs(list(_running_job_ids))
+    except Exception:
+        _latest = {}
+
     # Precompute job intervals OUTSIDE _running_lock so croniter evaluation
     # does not block try_register/release_running_job for other jobs.
     _intervals = {jid: _job_interval_minutes(j) for jid, j in by_id.items()}
@@ -871,8 +888,6 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
             allowance = floor_seconds
             if interval_minutes:
                 allowance = max(allowance, 2.0 * interval_minutes * 60.0)
-            if age < allowance:
-                continue
             fut = _running_futures.get(job_id)
             if fut is _FUTURE_PENDING:
                 # The claim is past its allowance and the owning future still
@@ -882,13 +897,34 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
                 pass
             elif fut is not None and not fut.done():
                 continue  # genuinely still executing
+            # Persisted-state reconciliation: if the durable executions ledger
+            # shows this job's last run reached a terminal state, the claim is
+            # provably stale even if it is still inside its in-memory age
+            # allowance (or was adopted fresh this tick).  Release it now so
+            # the job re-dispatches on the next tick without force-run/resume
+            # (t_8b5480b3 — the 2026-08-14 recurring-router wedge that
+            # survived a gateway restart because the in-memory age bound alone
+            # could not see a run the ledger had already finished).
+            if fut is None or fut is _FUTURE_PENDING or fut.done():
+                latest = _latest.get(job_id)
+                if latest is not None and latest.get("status") in (
+                    "completed", "failed", "unknown",
+                ):
+                    _running_job_ids.discard(job_id)
+                    _running_since.pop(job_id, None)
+                    _running_futures.pop(job_id, None)
+                    _forced_release_count += 1
+                    stale.append((job_id, age, allowance, fut, "ledger-terminal"))
+                    continue
+            if age < allowance:
+                continue
             _running_job_ids.discard(job_id)
             _running_since.pop(job_id, None)
             _running_futures.pop(job_id, None)
             _forced_release_count += 1
-            stale.append((job_id, age, allowance, fut))
+            stale.append((job_id, age, allowance, fut, "age"))
 
-    for job_id, age, allowance, fut in stale:
+    for job_id, age, allowance, fut, _reason in stale:
         job = by_id.get(job_id) or {}
         name = job.get("name") or job_id
         if fut is _FUTURE_PENDING:
@@ -898,9 +934,10 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
         else:
             future_state = "finished"
         logger.warning(
-            "cron.inflight.forced_release event=forced_release job='%s' id=%s "
-            "age=%.0fs allowance=%.0fs future=%s — stale in-flight claim "
+            "cron.inflight.forced_release event=forced_release reason=%s job='%s' "
+            "id=%s age=%.0fs allowance=%.0fs future=%s — stale in-flight claim "
             "released; the job was skipping every fire with 'already running'",
+            _reason,
             name,
             job_id,
             age,
@@ -908,6 +945,18 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
             future_state,
         )
         _record_forced_release(job_id, name, age, allowance)
+        # A ledger-terminal release is authoritative: the durable executions
+        # ledger ALREADY records how the last run ended (completed/failed/
+        # unknown), so we must NOT call mark_job_run here — doing so would
+        # clobber an honest completed/ok status with a synthetic failure, or
+        # double-write an already-recorded failure.  We only release the claim
+        # so the job re-dispatches on its next due tick; the ledger is the
+        # record of record for the outcome.  The age-based release below keeps
+        # the original wedge-surfacing mark_job_run behaviour (an age-release
+        # may have no ledger row at all, so surfacing last_error is the only
+        # way the wedge becomes visible).
+        if _reason == "ledger-terminal":
+            continue
         # Finite-repeat guard: a forced release is NOT a real run, so it must
         # not consume a finite one-shot's repeat budget or let mark_job_run
         # auto-delete the row (completed >= times).  The claim is released and

--- a/tests/cron/test_inflight_stale_guard.py
+++ b/tests/cron/test_inflight_stale_guard.py
@@ -348,3 +348,107 @@ class TestWedgedJobRefiresWithoutRestart:
         assert n == 1, "wedged job must fire again without a gateway restart"
         assert job["id"] not in sched.get_running_job_ids()
         assert sched.get_inflight_guard_stats()["forced_releases"] == 1
+
+
+class TestLedgerTerminalReconciliation:
+    """Persisted-state recovery path (t_8b5480b3).
+
+    The age-only sweep released claims older than ``max(2 * interval, floor)``,
+    but a leaked claim could be YOUNG (inside its allowance) while the durable
+    executions ledger already proved the last run ended — e.g. the 2026-08-14
+    recurring-router wedge, which survived a gateway restart because the age
+    bound alone could not see a run the ledger had already finished.  This
+    class tests the ledger reconciliation: an in-memory claim whose job's
+    MOST RECENT execution row is terminal (completed/failed/unknown) is stale
+    by construction and is force-released regardless of in-memory age, so the
+    recurring job re-dispatches on the next tick without force-run/resume.
+
+    RED first: on the age-only sweep (main before this change) a young leaked
+    claim with a terminal ledger row is NOT released — it stays wedged.  With
+    the ledger reconciliation it IS released (and, because a terminal ledger
+    row is authoritative, WITHOUT a synthetic mark_job_run failure).
+    """
+
+    def _inject_young_claim(self, job_id: str) -> None:
+        """Claim is YOUNG (inside the 30m floor) so only the ledger-terminal
+        path, never the age path, can release it."""
+        sched._running_job_ids.add(job_id)
+        if hasattr(sched, "_running_since"):
+            sched._running_since[job_id] = time.time() - 60  # 1 minute old
+
+    def test_young_claim_with_terminal_ledger_row_is_released(self, tmp_path):
+        """RED/GREEN: a terminal ledger row proves the run ended, so a young
+        leaked claim must be force-released even though its in-memory age is
+        inside the allowance (the age-only sweep alone would leave it)."""
+        job = _job(job_id="ledger-terminal", minutes=10)
+        job_id = job["id"]
+        self._inject_young_claim(job_id)
+
+        with patch.object(sched, "_get_hermes_home", return_value=tmp_path), \
+             patch("cron.executions.latest_executions", return_value={
+                 job_id: {"status": "failed", "id": "exec-x"},
+             }), \
+             patch.object(sched, "mark_job_run") as mark:
+            released = sched.sweep_stale_inflight([job])
+
+        # RED on the age-only sweep: the young claim is NOT released.  GREEN
+        # with the ledger reconciliation: it IS released.
+        assert job_id in released, "terminal ledger row must force-release the claim"
+        assert job_id not in sched.get_running_job_ids()
+        # Ledger-terminal is authoritative: no synthetic failure written.
+        mark.assert_not_called()
+
+    def test_young_claim_without_ledger_row_is_not_released(self, tmp_path):
+        """A young claim whose job has NO execution row at all (the claim was
+        taken but create_execution never ran) is left to the age bound — the
+        ledger reconciliation must not release claims it cannot prove ended."""
+        job = _job(job_id="no-ledger-row", minutes=10)
+        job_id = job["id"]
+        self._inject_young_claim(job_id)
+
+        with patch.object(sched, "_get_hermes_home", return_value=tmp_path), \
+             patch("cron.executions.latest_executions", return_value={}), \
+             patch.object(sched, "mark_job_run"):
+            released = sched.sweep_stale_inflight([job])
+
+        assert job_id not in released
+        assert job_id in sched.get_running_job_ids()
+
+    def test_young_claim_with_running_ledger_row_is_not_released(self, tmp_path):
+        """A young claim whose job is genuinely still running per the ledger
+        ('claimed'/'running' row) is never released — reconciliation must not
+        double-dispatch a healthy long-running job."""
+        job = _job(job_id="still-running", minutes=10)
+        job_id = job["id"]
+        self._inject_young_claim(job_id)
+
+        with patch.object(sched, "_get_hermes_home", return_value=tmp_path), \
+             patch("cron.executions.latest_executions", return_value={
+                 job_id: {"status": "running", "id": "exec-y"},
+             }), \
+             patch.object(sched, "mark_job_run"):
+            released = sched.sweep_stale_inflight([job])
+
+        assert job_id not in released
+        assert job_id in sched.get_running_job_ids()
+
+    def test_old_claim_with_terminal_ledger_row_still_released_once(self, tmp_path):
+        """An old claim with a terminal ledger row is released by the ledger
+        path (one release) — it must not double-release or double-count."""
+        job = _job(job_id="old-terminal", minutes=10)
+        job_id = job["id"]
+        sched._running_job_ids.add(job_id)
+        if hasattr(sched, "_running_since"):
+            sched._running_since[job_id] = time.time() - 6 * 60 * 60  # 6h old
+
+        with patch.object(sched, "_get_hermes_home", return_value=tmp_path), \
+             patch("cron.executions.latest_executions", return_value={
+                 job_id: {"status": "completed", "id": "exec-z"},
+             }), \
+             patch.object(sched, "mark_job_run") as mark:
+            released = sched.sweep_stale_inflight([job])
+
+        assert job_id in released
+        assert job_id not in sched.get_running_job_ids()
+        assert sched.get_inflight_guard_stats()["forced_releases"] == 1
+        mark.assert_not_called()  # authoritative ledger row, no synthetic failure

--- a/tests/cron/test_inflight_stale_guard.py
+++ b/tests/cron/test_inflight_stale_guard.py
@@ -38,6 +38,7 @@ Design notes
 """
 
 import time
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -367,7 +368,21 @@ class TestLedgerTerminalReconciliation:
     claim with a terminal ledger row is NOT released — it stays wedged.  With
     the ledger reconciliation it IS released (and, because a terminal ledger
     row is authoritative, WITHOUT a synthetic mark_job_run failure).
+
+    Race guard (salvage follow-up): the terminal row must belong to THIS
+    claim — ``claimed_at >= _running_since[job_id]``.  A terminal row OLDER
+    than the in-memory claim is the PREVIOUS run's outcome (the normal state
+    for a recurring job between try_register_running_job and
+    create_execution, or while the worker's finally block hasn't released
+    yet) and must never force-release a healthy fresh claim.
     """
+
+    @staticmethod
+    def _row_at(offset_seconds: float) -> str:
+        """ISO claimed_at at now+offset (aware, local tz)."""
+        return datetime.fromtimestamp(
+            time.time() + offset_seconds, tz=timezone.utc
+        ).isoformat()
 
     def _inject_young_claim(self, job_id: str) -> None:
         """Claim is YOUNG (inside the 30m floor) so only the ledger-terminal
@@ -377,16 +392,18 @@ class TestLedgerTerminalReconciliation:
             sched._running_since[job_id] = time.time() - 60  # 1 minute old
 
     def test_young_claim_with_terminal_ledger_row_is_released(self, tmp_path):
-        """RED/GREEN: a terminal ledger row proves the run ended, so a young
-        leaked claim must be force-released even though its in-memory age is
-        inside the allowance (the age-only sweep alone would leave it)."""
+        """RED/GREEN: a terminal ledger row from THIS claim's run proves the
+        run ended, so a young leaked claim must be force-released even though
+        its in-memory age is inside the allowance (the age-only sweep alone
+        would leave it)."""
         job = _job(job_id="ledger-terminal", minutes=10)
         job_id = job["id"]
         self._inject_young_claim(job_id)
 
         with patch.object(sched, "_get_hermes_home", return_value=tmp_path), \
              patch("cron.executions.latest_executions", return_value={
-                 job_id: {"status": "failed", "id": "exec-x"},
+                 job_id: {"status": "failed", "id": "exec-x",
+                          "claimed_at": self._row_at(-30)},  # after claim (-60)
              }), \
              patch.object(sched, "mark_job_run") as mark:
             released = sched.sweep_stale_inflight([job])
@@ -397,6 +414,47 @@ class TestLedgerTerminalReconciliation:
         assert job_id not in sched.get_running_job_ids()
         # Ledger-terminal is authoritative: no synthetic failure written.
         mark.assert_not_called()
+
+    def test_terminal_row_from_previous_run_does_not_release_fresh_claim(self, tmp_path):
+        """RACE GUARD: a terminal row OLDER than the in-memory claim is the
+        PREVIOUS run's outcome — the fresh claim (e.g. in the window between
+        try_register_running_job and create_execution, or a finished run whose
+        worker finally hasn't run) must NOT be force-released; releasing it
+        would double-dispatch the job."""
+        job = _job(job_id="prev-run-terminal", minutes=10)
+        job_id = job["id"]
+        self._inject_young_claim(job_id)
+
+        with patch.object(sched, "_get_hermes_home", return_value=tmp_path), \
+             patch("cron.executions.latest_executions", return_value={
+                 job_id: {"status": "completed", "id": "exec-prev",
+                          "claimed_at": self._row_at(-600)},  # before claim (-60)
+             }), \
+             patch.object(sched, "mark_job_run"):
+            released = sched.sweep_stale_inflight([job])
+
+        assert job_id not in released, (
+            "previous run's terminal row must not release a fresh claim"
+        )
+        assert job_id in sched.get_running_job_ids()
+
+    def test_terminal_row_without_claimed_at_fails_closed(self, tmp_path):
+        """A terminal row with no parseable claimed_at cannot be attributed to
+        this claim — the ledger path must fail closed and leave the claim to
+        the age bound."""
+        job = _job(job_id="no-claimed-at", minutes=10)
+        job_id = job["id"]
+        self._inject_young_claim(job_id)
+
+        with patch.object(sched, "_get_hermes_home", return_value=tmp_path), \
+             patch("cron.executions.latest_executions", return_value={
+                 job_id: {"status": "failed", "id": "exec-x"},
+             }), \
+             patch.object(sched, "mark_job_run"):
+            released = sched.sweep_stale_inflight([job])
+
+        assert job_id not in released
+        assert job_id in sched.get_running_job_ids()
 
     def test_young_claim_without_ledger_row_is_not_released(self, tmp_path):
         """A young claim whose job has NO execution row at all (the claim was
@@ -443,7 +501,8 @@ class TestLedgerTerminalReconciliation:
 
         with patch.object(sched, "_get_hermes_home", return_value=tmp_path), \
              patch("cron.executions.latest_executions", return_value={
-                 job_id: {"status": "completed", "id": "exec-z"},
+                 job_id: {"status": "completed", "id": "exec-z",
+                          "claimed_at": self._row_at(-3 * 60 * 60)},  # after claim (-6h)
              }), \
              patch.object(sched, "mark_job_run") as mark:
             released = sched.sweep_stale_inflight([job])


### PR DESCRIPTION
## Summary
The in-flight stale-claim sweep now reconciles leaked claims against the durable executions ledger — a young leaked claim whose own run provably ended (terminal ledger row) is force-released so the recurring job re-dispatches on the next tick, without operator force-run/resume — salvage of #87259 by @sycamoregroupltd with a double-dispatch race guard added.

Background (t_8b5480b3, 2026-08-14 incident): the age-based sweep releases claims only past `max(2*interval, 30m)`. A leaked claim could be YOUNG while the ledger already proved the run ended — the wedge outlived the allowance window and operator intervention was required.

## Changes
- `cron/scheduler.py` (@sycamoregroupltd): `sweep_stale_inflight` loads each in-flight job's latest execution row (one indexed query) and force-releases claims whose row is terminal (`completed`/`failed`/`unknown`), regardless of in-memory age. Ledger-terminal releases are authoritative — no synthetic `mark_job_run(success=False)` (the ledger already records the outcome), so an honest `ok` status is never clobbered. Release log line carries `reason=ledger-terminal|age`.
- Follow-up (ours) — **race guard**: the terminal row must belong to THIS claim (`claimed_at >= _running_since[job_id]`). Without it, the latest terminal row for a recurring job is usually the PREVIOUS run's completed outcome — a fresh claim in the `try_register_running_job → create_execution` window (or a finished run whose worker `finally` hasn't released yet) would be force-released and the job double-dispatched concurrently. Missing/unparseable `claimed_at` fails closed to the age bound.
- Follow-up (ours): the `_running_job_ids` snapshot for the ledger query is taken under `_running_lock` (`list()` over a concurrently-mutated set can raise `RuntimeError`).

## Validation
| Check | Result |
|---|---|
| tests/cron/test_inflight_stale_guard.py (22 original + 2 new race guards) | 24 passed |
| RED check (PR's tests on unfixed main) | fail as expected |
| Mutation check (ownership guard removed) | both race-guard tests fail; restore green |
| Full tests/cron/ with original fix | 736 passed; only pre-existing test_monitor_kind failures |

## Credit
Based on #87259 by @sycamoregroupltd — commit cherry-picked with authorship preserved. Closes #87259.

Related: #88339 (salvage of #87261, same author/incident) covers the complementary persisted-state half in `cron/jobs.py`. Note for maintainers: open PR #86969 (fence forced-release writes with expected_fire_owner) touches the same function and will need reconciling with whichever lands second.
