### PR TITLE
chore: release v0.20.3 (2026.8.16.2)

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.20.2"
-__release_date__ = "2026.8.16"
+__version__ = "0.20.3"
+__release_date__ = "2026.8.16.2"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "hermes-agent"
-version = "0.20.2"
+version = "0.20.3"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-02T17:24:01.616235358Z"
+exclude-newer = "2026-08-03T10:31:33.382785373Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -1569,7 +1569,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.20.2"
+version = "0.20.3"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
Version bump for the v0.20.3 rollup patch release (CalVer v2026.8.16.2, same-day suffix after v2026.8.16). Rolls up the ~120 PRs (241 commits) merged since v0.20.2 earlier today into a stable tagged release. Full curated notes for the whole 0.20.x window ship with v0.21.0 per standing patch-release policy.

## Changes
- `hermes_cli/__init__.py`: `__version__` 0.20.2 → 0.20.3, `__release_date__` → 2026.8.16.2
- `pyproject.toml`: version 0.20.3
- `uv.lock`: regenerated (self-reference bump; `uv lock --check` clean under uv 0.9.28, the CI pin)

## Validation
| Gate | Result |
|---|---|
| Anchored stale-version grep (`0.20.2`) | zero hits |
| `uv lock --check` (uv 0.9.28) | clean |
| Revert scan (window) | ci re-parse revert pairs + 2 agent-fix reverts, all self-contained; no shipped-feature loss implied in notes |
| Commit staged set | exactly `__init__.py` + `pyproject.toml` + `uv.lock` |

## Infographic

![v0.20.3 patch release](https://v3b.fal.media/files/b/0aa6b095/Fqn-hpSd4TvEJvpCgs0LV_gGjd10il.png)
