### PR TITLE
fix(desktop): never start a first-run install from a pool backend (remote/VPS users get a silent second engine)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -230,6 +230,7 @@ import {
   undialedSshRouteSeeds
 } from './plugin-profile-routes'
 import { selectPoolEvictions } from './pool-eviction'
+import { assertPoolRuntimeInstalled } from './pool-runtime-guard'
 import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
@@ -9885,7 +9886,16 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // step 3 in hermes_cli/main.py), so the child re-homes to this profile.
   // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
   const backendArgs = ['--profile', profile, 'serve', '--host', '127.0.0.1', '--port', '0']
-  const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
+  const resolvedPoolBackend = resolveHermesBackend(backendArgs)
+
+  // A pool backend is a SECONDARY source (a background profile, or a row in
+  // the connections registry). Enumerating the agent roster must never start
+  // a first-run platform install -- the same rule hermes:window:openInTerminal
+  // already follows. Report the unresolved runtime instead; the roster catches
+  // this per-source and renders an unreachable row.
+  assertPoolRuntimeInstalled(resolvedPoolBackend)
+
+  const backend = await ensureRuntime(resolvedPoolBackend)
   // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
   backend.args = getBackendArgsForRuntime(backend)
   const hermesCwd = resolveHermesCwd()

--- a/apps/desktop/electron/pool-runtime-guard.test.ts
+++ b/apps/desktop/electron/pool-runtime-guard.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { POOL_LOCAL_RUNTIME_MISSING, assertPoolRuntimeInstalled, poolBackendNeedsBootstrap } from './pool-runtime-guard'
+import { assertPoolRuntimeInstalled, POOL_LOCAL_RUNTIME_MISSING, poolBackendNeedsBootstrap } from './pool-runtime-guard'
 
 test('poolBackendNeedsBootstrap detects the unresolved runtime', () => {
   assert.equal(poolBackendNeedsBootstrap({ kind: 'bootstrap-needed' }), true)

--- a/apps/desktop/electron/pool-runtime-guard.test.ts
+++ b/apps/desktop/electron/pool-runtime-guard.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { POOL_LOCAL_RUNTIME_MISSING, assertPoolRuntimeInstalled, poolBackendNeedsBootstrap } from './pool-runtime-guard'
+
+test('poolBackendNeedsBootstrap detects the unresolved runtime', () => {
+  assert.equal(poolBackendNeedsBootstrap({ kind: 'bootstrap-needed' }), true)
+})
+
+test('poolBackendNeedsBootstrap accepts a resolved runtime and tolerates junk', () => {
+  assert.equal(poolBackendNeedsBootstrap({ kind: 'active' }), false)
+  assert.equal(poolBackendNeedsBootstrap({}), false)
+  assert.equal(poolBackendNeedsBootstrap(null), false)
+  assert.equal(poolBackendNeedsBootstrap(undefined), false)
+})
+
+test('assertPoolRuntimeInstalled refuses to install for a pool backend', () => {
+  assert.throws(() => assertPoolRuntimeInstalled({ kind: 'bootstrap-needed' }), {
+    message: POOL_LOCAL_RUNTIME_MISSING
+  })
+})
+
+test('assertPoolRuntimeInstalled is a no-op once a local runtime exists', () => {
+  assert.doesNotThrow(() => assertPoolRuntimeInstalled({ kind: 'active' }))
+})

--- a/apps/desktop/electron/pool-runtime-guard.ts
+++ b/apps/desktop/electron/pool-runtime-guard.ts
@@ -1,0 +1,43 @@
+/**
+ * pool-runtime-guard.ts
+ *
+ * Pool backends are SECONDARY agent sources: background profiles and the
+ * multi-connection registry's rows. They are started by enumeration and by
+ * UI affordances, not by the user asking to install Hermes.
+ *
+ * They must therefore never reach the first-run bootstrap. This is the same
+ * rule the `hermes:window:openInTerminal` handler already states in main.ts —
+ * "Resolution only -- never ensureRuntime(), which would kick off a first-run
+ * install from a menu click; an unresolved runtime is reported instead."
+ *
+ * Without this guard, a remote-primary install with no local runtime has a
+ * full platform install (clone + venv + dependency install) started by the
+ * agent roster merely ENUMERATING the registry's 'local' row.
+ */
+
+export interface ResolvedBackendLike {
+  kind?: unknown
+}
+
+/** Message surfaced on the unreachable source row instead of installing. */
+export const POOL_LOCAL_RUNTIME_MISSING =
+  'No local Hermes runtime is installed on this machine. Install Hermes locally to use "This device" as an agent source.'
+
+/**
+ * True when resolveHermesBackend() found nothing to spawn and would hand off
+ * to the bootstrap runner.
+ */
+export function poolBackendNeedsBootstrap(backend: null | ResolvedBackendLike | undefined): boolean {
+  return Boolean(backend && typeof backend === 'object' && (backend as ResolvedBackendLike).kind === 'bootstrap-needed')
+}
+
+/**
+ * Refuse rather than install. Callers spawning a POOL backend must call this
+ * before ensureRuntime(); the thrown error is caught per-source by the roster
+ * enumeration and rendered as an unreachable row.
+ */
+export function assertPoolRuntimeInstalled(backend: null | ResolvedBackendLike | undefined): void {
+  if (poolBackendNeedsBootstrap(backend)) {
+    throw new Error(POOL_LOCAL_RUNTIME_MISSING)
+  }
+}


### PR DESCRIPTION
## Listing your agents installs a second Hermes engine on your machine

If your Hermes Desktop talks to a **remote backend** — a VPS, a droplet, a homelab box — this build silently installs and starts a **second, redundant Hermes engine on the client machine**, with its own `config.yaml`, its own `.env`, and its own `state.db`, sitting beside the canonical one you deliberately put on your server.

Nobody asked for it. No prompt, no consent, no setting to decline. Opening the app is enough.

### Why this is serious for remote/VPS deployments

The entire point of running the engine on a server is that there is **exactly one** canonical installation: one config, one database, one set of credentials, one place where state lives. That is the deployment model, not a preference.

This change breaks that invariant on every client. After one launch you have two engines and two divergent state stores, and the one you never asked for was created by the app on the machine you specifically chose *not* to run an engine on. For anyone managing this centrally, "the client silently provisions its own shadow engine" is not a cosmetic bug — it is a violation of the deployment's core assumption.

It is also not a small install: a full repository clone, a Python virtualenv, a dependency install, platform SDKs, and a **messaging gateway start** — kicked off by nothing more than the agent list rendering.

### Root cause

`spawnPoolBackend()` passes an unresolved runtime straight into `ensureRuntime()`:

```js
const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
```

When `resolveHermesBackend()` returns `kind: 'bootstrap-needed'`, `ensureRuntime()` hands off to the bootstrap runner and installs Hermes.

That is reachable without any user intent:

1. `resolveRegistryLocalRoute()` returns `delegate: false` whenever `globalRemoteActive()` or a per-profile remote override is set — i.e. **for every remote-backend user**. So the registry's `local` row takes the forced-local path by design.
2. `enumerateRegistryAgentSources()` eagerly resolves **every** registered source, including `local`, via `ensureRegistryBackend(connection.id, null)`.
3. That enumeration is driven by the `hermes:agents:roster` IPC — the agent list.

So on a machine that has only ever spoken to a remote backend, there is no local runtime, and **enumerating the roster installs one**.

Worth noting: `globalRemoteActive()` returns `true` for the `HERMES_DESKTOP_REMOTE_URL` env override as well as `connection.json` mode, and a per-profile override trips the same branch. There is therefore **no supported configuration** in which a remote user avoids this — I checked all three inputs.

### The rule this breaks is already yours

`hermes:window:openInTerminal` states it explicitly:

```js
// Resolution only -- never ensureRuntime(), which would kick off a first-run
// install from a menu click; an unresolved runtime is reported instead.
```

Exactly right. A pool backend is started by *enumeration* and by UI affordances — even less of a user intent than a menu click — and it does the opposite.

### The fix

Apply the same rule to pool backends: resolve, and refuse if nothing is installed.

- New `pool-runtime-guard.ts` with `poolBackendNeedsBootstrap()` / `assertPoolRuntimeInstalled()`, in the style of the existing small pure electron modules.
- `spawnPoolBackend()` calls the guard before `ensureRuntime()`.
- `enumerateRegistryAgentSources()` already catches per-source failures and renders an unreachable row, so the roster degrades gracefully to a "not installed" **This device** entry instead of installing an engine.

Primary boot is deliberately untouched: `startHermes()` / `runPrimaryBackendStartup()` still owns first-run bootstrap, which is the one place a user actually opts in.

### Verification

- `npx vitest run electron/pool-runtime-guard.test.ts electron/active-runtime-state.test.ts` — 11 passed
- `npx tsc --build tsconfig.electron.json` — clean
- `npx prettier --check` on all three changed files — clean

### Please also consider

The guard stops the unwanted *install*. The deeper question is whether a remote-primary deployment should be shown a `local` row at all. `normalizeRegistry()` force-injects one on every read:

```js
if (!connections.some(c => c.kind === 'local')) {
  connections.unshift(localEntry())
}
```

and the module header states it "cannot be removed". For a centrally-managed fleet where the client is deliberately engine-less, an undeletable "This device" source is the wrong default. A way to declare a client as remote-only would close this properly.


---

## This contradicts today's closure of #83021

#83021 was closed a few hours ago as *already shipped*, with this verification:

> Verified on current main: with a saved remote connection, `runPrimaryBackendStartup` returns before any local runtime probe/download/spawn — remote-only installs never bootstrap the local Python runtime.

**The first clause is correct. The conclusion is not.** `runPrimaryBackendStartup` stopped being the only route to the bootstrap on **Aug 16**, when `d905954634a2` added the forced-local registry path — one day before that verification was written.

Measured on a remote-only Windows client this morning:

```text
09:01:23.772 [boot] Connecting to remote Hermes backend at https://<redacted>
09:01:24.219 [boot] Remote Hermes backend is ready      <- primary path returned early, exactly as described
09:01:31.628 [bootstrap] no Hermes install found; starting first-launch bootstrap   <- 7s later, via the pool path
```

Install completed 09:09:03 and wrote a second `config.yaml`, `.env` and `state.db` to a machine deliberately kept engine-less.

**Why it won't reproduce on a dev machine:** any workstation with a local Hermes install has `isActiveRuntimeUsable() === true`, so the forced-local spawn quietly reuses it and nothing visible happens. It only bites clients that have *never* had a local runtime — precisely the thin-client population of #38602 / #61329 / #50643 / #58799 / #83021.

Those issues were closed on the understanding that thin-client works. It did, until Aug 16. Please consider reopening them alongside this fix.
