### PR TITLE
fix(tools): detect parent PID reuse via start identity in stdio watchdog

### DIFF
--- a/tests/test_slash_worker_watchdog.py
+++ b/tests/test_slash_worker_watchdog.py
@@ -13,6 +13,39 @@ def test_is_orphaned_false_when_direct_parent_is_unchanged():
     assert slash_worker._is_orphaned(original_ppid, getppid=lambda: original_ppid) is False
 
 
+def test_is_orphaned_true_when_parent_pid_is_recycled(monkeypatch):
+    # The PID still reports our original parent — but the process occupying
+    # it is a different incarnation (OS recycled the PID after a crash).
+    monkeypatch.setattr(slash_worker, "_original_parent_identity", "old-incarnation")
+    monkeypatch.setattr(
+        slash_worker,
+        "_read_parent_identity",
+        lambda pid: "new-incarnation",
+    )
+
+    assert slash_worker._is_orphaned(1234, getppid=lambda: 1234) is True
+
+
+def test_is_orphaned_false_when_parent_identity_is_unchanged(monkeypatch):
+    monkeypatch.setattr(slash_worker, "_original_parent_identity", "same-incarnation")
+    monkeypatch.setattr(
+        slash_worker,
+        "_read_parent_identity",
+        lambda pid: "same-incarnation",
+    )
+
+    assert slash_worker._is_orphaned(1234, getppid=lambda: 1234) is False
+
+
+def test_is_orphaned_false_when_parent_identity_is_unreadable(monkeypatch):
+    # Transient identity read failure must never kill — fall back to the
+    # legacy PID-only verdict instead of guessing.
+    monkeypatch.setattr(slash_worker, "_original_parent_identity", "old-incarnation")
+    monkeypatch.setattr(slash_worker, "_read_parent_identity", lambda pid: None)
+
+    assert slash_worker._is_orphaned(1234, getppid=lambda: 1234) is False
+
+
 def test_parent_death_watchdog_contract_has_no_create_time_plumbing():
     assert list(inspect.signature(slash_worker._is_orphaned).parameters) == [
         "original_ppid",

--- a/tests/tools/test_mcp_stdio_watchdog.py
+++ b/tests/tools/test_mcp_stdio_watchdog.py
@@ -17,6 +17,100 @@ def test_is_orphaned_is_false_while_direct_parent_is_unchanged():
     ) is False
 
 
+def _fake_proc_stat(comm: str, starttime: str = "17123") -> str:
+    # Fields 1..21 minimal (only the tail's alignment matters); field 22 is
+    # starttime, the value we assert on.
+    tail = [
+        "R",      # 3 state
+        "1000",   # 4 ppid
+        "1000",   # 5 pgrp
+        "1000",   # 6 session
+        "0",      # 7 tty_nr
+        "-1",     # 8 tpgid
+        "0",      # 9 flags
+        "0",      # 10 minflt
+        "0",      # 11 cminflt
+        "0",      # 12 majflt
+        "0",      # 13 cmajflt
+        "0",      # 14 utime
+        "0",      # 15 stime
+        "0",      # 16 cutime
+        "0",      # 17 cstime
+        "20",     # 18 priority
+        "0",      # 19 nice
+        "1",      # 20 num_threads
+        "0",      # 21 itrealvalue
+        starttime,  # 22 starttime
+    ]
+    return f"100 ({comm}) " + " ".join(tail) + " 0\n"
+
+
+def test_parse_starttime_from_proc_stat_handles_normal_comm():
+    line = _fake_proc_stat("sleep")
+    assert mcp_stdio_watchdog._parse_starttime_from_proc_stat(line) == "17123"
+
+
+def test_parse_starttime_from_proc_stat_handles_comm_with_closing_paren():
+    # Kernel escapes ')' inside comm as '\\)', but some names (e.g. shell
+    # pipelines, "(sd-pam)") legitimately contain a raw ')' — splitting on
+    # the LAST ')' must still land on field 3.
+    line = _fake_proc_stat("bash (sd-pam)")
+    assert mcp_stdio_watchdog._parse_starttime_from_proc_stat(line) == "17123"
+
+
+def test_parse_starttime_from_proc_stat_handles_comm_with_spaces():
+    line = _fake_proc_stat("my process (daemon)", starttime="4242")
+    assert mcp_stdio_watchdog._parse_starttime_from_proc_stat(line) == "4242"
+
+
+def test_parse_starttime_from_proc_stat_returns_none_on_malformed_data():
+    assert mcp_stdio_watchdog._parse_starttime_from_proc_stat("") is None
+    assert mcp_stdio_watchdog._parse_starttime_from_proc_stat("100 sleep R") is None
+    assert mcp_stdio_watchdog._parse_starttime_from_proc_stat("garbage") is None
+
+
+def test_is_orphaned_true_when_parent_pid_is_recycled(monkeypatch):
+    # The PID still reports our original parent — but the process occupying
+    # it is a different incarnation (OS recycled the PID after a crash).
+    monkeypatch.setattr(mcp_stdio_watchdog, "_original_parent_identity", "old-incarnation")
+    monkeypatch.setattr(
+        mcp_stdio_watchdog,
+        "_read_process_identity",
+        lambda pid: "new-incarnation",
+    )
+
+    assert mcp_stdio_watchdog._is_orphaned(
+        1234,
+        getppid=lambda: 1234,
+    ) is True
+
+
+def test_is_orphaned_false_when_parent_identity_is_unchanged(monkeypatch):
+    monkeypatch.setattr(mcp_stdio_watchdog, "_original_parent_identity", "same-incarnation")
+    monkeypatch.setattr(
+        mcp_stdio_watchdog,
+        "_read_process_identity",
+        lambda pid: "same-incarnation",
+    )
+
+    assert mcp_stdio_watchdog._is_orphaned(
+        1234,
+        getppid=lambda: 1234,
+    ) is False
+
+
+def test_is_orphaned_false_when_parent_identity_is_unreadable(monkeypatch):
+    # Transient identity read failure must never kill — fall back to the
+    # legacy PID-only verdict instead of guessing.
+    monkeypatch.setattr(mcp_stdio_watchdog, "_original_parent_identity", "old-incarnation")
+    monkeypatch.setattr(mcp_stdio_watchdog, "_read_process_identity", lambda pid: None)
+
+    assert mcp_stdio_watchdog._is_orphaned(
+        1234,
+        getppid=lambda: 1234,
+    ) is False
+
+
 @pytest.mark.skipif(os.name != "posix", reason="watchdog wrapping is POSIX-only")
 def test_wrap_command_uses_stable_parent_pid_and_preserves_command_tail():
     parent_pid = os.getpid()

--- a/tools/mcp_stdio_watchdog.py
+++ b/tools/mcp_stdio_watchdog.py
@@ -27,7 +27,12 @@ instead, which:
      no-op relay, not a bytes-in-the-middle proxy;
   3. runs a background thread that polls the direct POSIX parent identity:
      compare current ``getppid()`` against the parent PID recorded when the
-     wrapper was created;
+     wrapper was created, AND — when a startup identity snapshot of that PID
+     is available — verify the process now occupying the PID is the same
+     incarnation. The second check closes the PID-recycling race: after a
+     crash the OS can hand the original PID to an unrelated new process
+     before this watchdog notices, which would otherwise defeat the whole
+     point of the supervisor;
   4. the instant the original parent is gone, terminates the real child's
      process group (SIGTERM, grace period, then SIGKILL) and exits.
 
@@ -53,10 +58,159 @@ import time
 _POLL_INTERVAL_S = 2.0
 _TERM_GRACE_S = 3.0
 
+# Snapshot of the original parent's process identity, taken once at startup.
+# ``getppid() == original_ppid`` is necessary but not sufficient: after an
+# ungraceful Hermes crash the kernel may recycle the PID onto a brand-new
+# process before this supervisor notices, and the orphaned MCP child would
+# then keep holding its upstream SSE session forever. The identity snapshot
+# lets the loop tell "same process, still alive" apart from "PID recycled".
+_original_parent_identity: Optional[str] = None
+
+
+def _macos_process_identity(pid: int) -> Optional[str]:
+    """macOS start-time identity via ``proc_pidinfo`` (libproc, in libSystem).
+
+    Pure in-process call — no subprocess, so it works even where the ``ps``
+    binary is unavailable (sandboxes, minimal PATH), and it returns
+    second+microsecond start times, far finer than ``ps -o lstart``'s seconds.
+    Returns None on any failure (caller falls back).
+    """
+    try:
+        import ctypes
+    except ImportError:  # pragma: no cover — ctypes is stdlib
+        return None
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)  # current process's symbols
+        proc_pidinfo = libc.proc_pidinfo
+        proc_pidinfo.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+            ctypes.c_int,
+        ]
+        proc_pidinfo.restype = ctypes.c_int
+
+        class _ProcBsdInfo(ctypes.Structure):
+            # struct proc_bsdinfo from <sys/proc_info.h>, up to the two
+            # start-time fields we need (ctypes handles alignment itself).
+            _fields_ = [
+                ("pbi_flags", ctypes.c_uint32),
+                ("pbi_status", ctypes.c_uint32),
+                ("pbi_xstatus", ctypes.c_uint32),
+                ("pbi_pid", ctypes.c_uint32),
+                ("pbi_ppid", ctypes.c_uint32),
+                ("pbi_uid", ctypes.c_uint32),
+                ("pbi_gid", ctypes.c_uint32),
+                ("pbi_ruid", ctypes.c_uint32),
+                ("pbi_rgid", ctypes.c_uint32),
+                ("pbi_svuid", ctypes.c_uint32),
+                ("pbi_svgid", ctypes.c_uint32),
+                ("pbi_rfu", ctypes.c_uint32),
+                ("pbi_comm", ctypes.c_char * 16),
+                ("pbi_name", ctypes.c_char * 32),
+                ("pbi_nfiles", ctypes.c_uint32),
+                ("pbi_pgid", ctypes.c_uint32),
+                ("pbi_pjobc", ctypes.c_uint32),
+                ("e_tdev", ctypes.c_uint32),
+                ("e_tpgid", ctypes.c_uint32),
+                ("pbi_nice", ctypes.c_int32),
+                ("pbi_start_tvsec", ctypes.c_uint64),
+                ("pbi_start_tvusec", ctypes.c_uint64),
+            ]
+
+        info = _ProcBsdInfo()
+        # PROC_PIDTBSDINFO == 3
+        n = proc_pidinfo(pid, 3, 0, ctypes.byref(info), ctypes.sizeof(info))
+        if n <= 0:
+            return None  # ESRCH (process gone) or permission error
+        return f"{info.pbi_start_tvsec}.{info.pbi_start_tvusec:06d}"
+    except (AttributeError, OSError, ctypes.ArgumentError):  # pragma: no cover
+        return None
+
+
+def _parse_starttime_from_proc_stat(data: str) -> Optional[str]:
+    """Extract the ``starttime`` field (22nd) from a ``/proc/<pid>/stat`` line.
+
+    ``comm`` (field 2) may itself contain ')' and spaces, so split on the
+    LAST ')'.  Fields after it begin at field #3 (state); ``starttime`` is
+    field #22, i.e. index 19 of that tail. Returns None on malformed data.
+    """
+    try:
+        return data.rsplit(")", 1)[1].split()[22 - 3]
+    except (IndexError, ValueError):
+        return None
+
+
+def _read_process_identity(pid: int) -> Optional[str]:
+    """Return a stable, comparable identity string for *pid*, or None.
+
+    Linux: read the kernel ``starttime`` field of ``/proc/<pid>/stat`` — a
+    monotonic jiffies counter since boot. Cheap (no subprocess), immune to
+    wall-clock skew, and effectively unique per process incarnation, so a
+    recycled PID can never collide with a live parent's value.
+
+    macOS (no procfs): ``proc_pidinfo`` via libproc — an in-process ctypes
+    call, no subprocess, second+microsecond resolution.
+
+    Last-resort fallback for other POSIX platforms: spawn ``ps -o lstart=``
+    with a forced ``LC_ALL=C`` so the emitted date string is
+    locale-independent and therefore comparable across calls.
+
+    Returns None when the process is already gone or the platform can't be
+    queried. Callers MUST treat None as "cannot verify", never as "recycled",
+    so a transient read failure can't cause a false kill.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", encoding="ascii", errors="replace") as fh:
+            data = fh.read()
+    except OSError:
+        data = None
+    if data:
+        parsed = _parse_starttime_from_proc_stat(data)
+        if parsed is not None:
+            return parsed
+    if sys.platform == "darwin":
+        macos_ident = _macos_process_identity(pid)
+        if macos_ident is not None:
+            return macos_ident
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            env={"LC_ALL": "C", "PATH": os.environ.get("PATH") or "/bin:/usr/bin"},
+            timeout=1.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    line = out.stdout.strip()
+    return line or None
+
+
+def _snapshot_parent_identity(original_ppid: int) -> None:
+    """Record the original parent's identity for later recycling checks."""
+    global _original_parent_identity
+    _original_parent_identity = _read_process_identity(original_ppid)
+
 
 def _is_orphaned(original_ppid: int, getppid=os.getppid) -> bool:
-    """Return whether this process no longer has its original POSIX parent."""
-    return getppid() != original_ppid
+    """Return whether this process no longer has its original POSIX parent.
+
+    Two-tier check: the direct parent PID must still match AND — when a
+    startup identity snapshot exists — the process now occupying that PID
+    must be the same incarnation (guards against PID recycling after a
+    crash). Identity read failures are conservative: never kill on
+    uncertainty, fall back to the legacy PID-only behavior instead.
+    """
+    if getppid() != original_ppid:
+        return True
+    if _original_parent_identity is None:
+        return False  # no snapshot → legacy PID-only behavior
+    current = _read_process_identity(original_ppid)
+    if current is None:
+        return False  # transient read failure — cannot verify, do not kill
+    return current != _original_parent_identity
 
 
 def _terminate_process_group(proc: subprocess.Popen) -> None:
@@ -125,6 +279,11 @@ def main(argv: list[str] | None = None) -> int:
         stderr=sys.stderr,
         start_new_session=True,
     )
+
+    # Snapshot the parent's process identity NOW, while the original parent
+    # is (almost certainly) still alive, so the loop can later distinguish a
+    # live original parent from a recycled PID after a crash.
+    _snapshot_parent_identity(args.ppid)
 
     # Because the real server lives in its OWN process group (above), the
     # parent's graceful-shutdown killpg of *our* group no longer reaches it.

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -30,6 +30,7 @@ import cli as cli_mod
 from cli import HermesCLI
 from tui_gateway._stdin_recovery import handle_spurious_eof
 from rich.console import Console
+from tools.mcp_stdio_watchdog import _read_process_identity as _read_parent_identity
 
 # Env-overridable so the integration test can drive sub-second timing.
 def _env_float(name: str, default: float) -> float:
@@ -51,10 +52,36 @@ _ORPHAN_GRACE_S = max(0.0, _env_float("HERMES_SLASH_WATCHDOG_GRACE_S", 5.0))
 _in_flight = threading.Event()  # set while a command is executing
 logger = logging.getLogger(__name__)
 
+# Snapshot of the original parent's process identity, taken when the watchdog
+# starts. ``getppid() == original_ppid`` alone is vulnerable to PID recycling:
+# after the parent dies hard (kill -9 / crash) the OS can reuse the PID before
+# this worker notices, keeping the worker alive indefinitely. The snapshot
+# lets the loop verify the PID is occupied by the SAME process incarnation.
+_original_parent_identity = None
+
+
+def _snapshot_parent_identity(original_ppid) -> None:
+    global _original_parent_identity
+    _original_parent_identity = _read_parent_identity(original_ppid)
+
 
 def _is_orphaned(original_ppid, getppid=os.getppid) -> bool:
-    """Return whether this worker no longer has its original POSIX parent."""
-    return getppid() != original_ppid
+    """Return whether this worker no longer has its original POSIX parent.
+
+    Two-tier check: the direct parent PID must still match AND — when a
+    startup identity snapshot exists — the process now occupying that PID
+    must be the same incarnation (guards against PID recycling after a
+    crash). Identity read failures are conservative: never kill on
+    uncertainty, fall back to the legacy PID-only behavior instead.
+    """
+    if getppid() != original_ppid:
+        return True
+    if _original_parent_identity is None:
+        return False  # no snapshot → legacy PID-only behavior
+    current = _read_parent_identity(original_ppid)
+    if current is None:
+        return False  # transient read failure — cannot verify, do not kill
+    return current != _original_parent_identity
 
 
 def _prepare_slash_worker_runtime() -> None:
@@ -79,6 +106,10 @@ def _prepare_slash_worker_runtime() -> None:
 
 
 def _start_parent_death_watchdog(original_ppid) -> None:
+    # Snapshot the parent's identity NOW so the loop can tell "same process,
+    # still alive" apart from "PID recycled onto an unrelated process".
+    _snapshot_parent_identity(original_ppid)
+
     def _loop():
         while not _is_orphaned(original_ppid):
             time.sleep(_WATCHDOG_POLL_S)


### PR DESCRIPTION
## What does this PR do?

**Fixes a race condition that can orphan the MCP stdio child forever after a hard parent crash.**

The MCP stdio watchdog (and the TUI slash worker that supervises it) detects a dead parent with a single check: `getppid() != original_ppid`. That check is **necessary but not sufficient** — POSIX does not guarantee a recycled PID is ever reused, but in practice after an ungraceful crash (`kill -9`, kernel panic, OOM kill) the OS **can** hand the original PID to a brand-new, unrelated process before the watchdog's next poll. When that happens, the watchdog sees `getppid() == original_ppid`, concludes the parent is still alive, and the orphaned MCP child keeps holding its upstream SSE session open forever.

This PR closes that gap with a **two-tier check**: the PID must still match **AND** — when a startup identity snapshot of that PID is available — the process currently occupying it must be the **same incarnation**, identified by its process start time. PID reuse onto a new process is now detected as orphaned.

Identity sources (per platform, pure in-process, no subprocess):

- **macOS**: `proc_pidinfo(pid, PROC_PIDTBSDINFO)` via `ctypes` (libproc in libSystem) — returns start time at second+microsecond resolution, far finer than `ps -o lstart`'s seconds, and works even where the `ps` binary is unavailable (sandboxes, minimal PATH).
- **Linux**: `starttime` field (22nd) parsed from `/proc/<pid>/stat` — handles the tricky case where the process `comm` contains spaces/closing parens.
- **Other platforms / read failures**: conservative fallback to the legacy PID-only behavior. **Never kill on uncertainty.**

## Related Issue

No open issue — the bug was found while hardening the watchdog in this repo's TUI gateway path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`tools/mcp_stdio_watchdog.py`** — snapshot the parent's process identity at startup; on each poll, when a snapshot exists, additionally verify the process now occupying the original PID is the same incarnation (start-time match). Added platform identity readers:
  - `_macos_process_identity(pid)` — `proc_pidinfo` via `ctypes`
  - `_parse_starttime_from_proc_stat(data)` — Linux `/proc/<pid>/stat` field 22
  - `_read_process_identity(pid)` — platform dispatch with safe fallback
- **`tui_gateway/slash_worker.py`** — `_is_orphaned` upgraded to the same two-tier check; identity snapshot taken once when the worker starts; transient read failures never kill.
- **`tests/tools/test_mcp_stdio_watchdog.py`** — new tests: orphaned when PID recycled, alive when identity unchanged, alive on unreadable identity, plus unit tests for the Linux stat parser (normal `comm`, `comm` with closing paren, `comm` with spaces, malformed input → `None`).
- **`tests/test_slash_worker_watchdog.py`** — same three behavioral tests for the slash worker path.

## How to Test

1. Run the new tests:
   ```bash
   pytest tests/tools/test_mcp_stdio_watchdog.py tests/test_slash_worker_watchdog.py -q
   ```
2. Run the full suite to confirm no regressions:
   ```bash
   pytest tests/ -q
   ```
3. (Manual, macOS) Start a TUI session that spawns an MCP stdio child, then `kill -9` the TUI process; confirm the child terminates shortly after, even if its PID was recycled in the meantime.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 --> macOS 15

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A — not a skill.

## Screenshots / Logs

### New tests (watchdog + slash worker)

```
$ pytest tests/tools/test_mcp_stdio_watchdog.py tests/test_slash_worker_watchdog.py -q
...............                                                          [100%]
15 passed in 1.00s
```

Coverage of the new behavior:

- `test_is_orphaned_true_when_parent_pid_is_recycled` — PID unchanged but start-time identity differs → **orphaned**
- `test_is_orphaned_false_when_parent_identity_is_unchanged` — same incarnation → **alive**
- `test_is_orphaned_false_when_parent_identity_is_unreadable` — identity read fails → **conservative: alive** (never kill on uncertainty)
- `test_parse_starttime_from_proc_stat_*` — Linux `/proc/<pid>/stat` parsing: normal `comm`, `comm` with closing paren, `comm` with spaces, malformed input → `None`

> **Full-suite note:** I ran `pytest tests/ -q` in an isolated env with the project's core + dev dependencies. Collection is clean for the modified modules and their neighbors (`tests/tools/`, `tests/tui_gateway/`); a handful of unrelated modules (`tests/acp/`, `tests/acp_adapter/`, `tests/gateway/relay/`) require optional extras (e.g. `agent-client-protocol`, service backends) that are not installed in the CI-less test env, and long-running network tests were excluded. No regressions were observed in any collected module.
