### PR TITLE
docs(codebase-inspection): replace pip --break-system-packages with uvx

### DIFF
--- a/skills/github/codebase-inspection/SKILL.md
+++ b/skills/github/codebase-inspection/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-inspection
 description: "Inspect codebases w/ pygount: LOC, languages, ratios."
-version: 1.0.0
+version: 1.1.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -10,7 +10,7 @@ metadata:
     tags: [LOC, Code Analysis, pygount, Codebase, Metrics, Repository]
     related_skills: [github-repo-management]
 prerequisites:
-  commands: [pygount]
+  commands: [uvx]
 ---
 
 # Codebase Inspection with pygount
@@ -27,9 +27,13 @@ Analyze repositories for lines of code, language breakdown, file counts, and cod
 
 ## Prerequisites
 
+`pygount` runs via `uvx` in an isolated environment — no system-wide installation needed:
+
 ```bash
-pip install --break-system-packages pygount 2>/dev/null || pip install pygount
+uvx pygount --help
 ```
+
+If `uvx` is not available, install it with `uv` (`pip install uv`) or install pygount directly in a virtualenv (`pip install pygount`).
 
 ## 1. Basic Summary (Most Common)
 
@@ -37,7 +41,7 @@ Get a full language breakdown with file counts, code lines, and comment lines:
 
 ```bash
 cd /path/to/repo
-pygount --format=summary \
+uvx pygount --format=summary \
   --folders-to-skip=".git,node_modules,venv,.venv,__pycache__,.cache,dist,build,.next,.tox,.eggs,*.egg-info" \
   .
 ```
@@ -63,33 +67,33 @@ Adjust based on the project type:
 
 ```bash
 # Only count Python files
-pygount --suffix=py --format=summary .
+uvx pygount --suffix=py --format=summary .
 
 # Only count Python and YAML
-pygount --suffix=py,yaml,yml --format=summary .
+uvx pygount --suffix=py,yaml,yml --format=summary .
 ```
 
 ## 4. Detailed File-by-File Output
 
 ```bash
 # Default format shows per-file breakdown
-pygount --folders-to-skip=".git,node_modules,venv" .
+uvx pygount --folders-to-skip=".git,node_modules,venv" .
 
 # Sort by code lines (pipe through sort)
-pygount --folders-to-skip=".git,node_modules,venv" . | sort -t$'\t' -k1 -nr | head -20
+uvx pygount --folders-to-skip=".git,node_modules,venv" . | sort -t$'\t' -k1 -nr | head -20
 ```
 
 ## 5. Output Formats
 
 ```bash
 # Summary table (default recommendation)
-pygount --format=summary .
+uvx pygount --format=summary .
 
 # JSON output for programmatic use
-pygount --format=json .
+uvx pygount --format=json .
 
 # Pipe-friendly: Language, file count, code, docs, empty, string
-pygount --format=summary . 2>/dev/null
+uvx pygount --format=summary . 2>/dev/null
 ```
 
 ## 6. Interpreting Results

--- a/website/docs/user-guide/skills/bundled/github/github-codebase-inspection.md
+++ b/website/docs/user-guide/skills/bundled/github/github-codebase-inspection.md
@@ -16,7 +16,7 @@ Inspect codebases w/ pygount: LOC, languages, ratios.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/github/codebase-inspection` |
-| Version | `1.0.0` |
+| Version | `1.1.0` |
 | Author | Hermes Agent |
 | License | MIT |
 | Platforms | linux, macos, windows |
@@ -43,9 +43,13 @@ Analyze repositories for lines of code, language breakdown, file counts, and cod
 
 ## Prerequisites
 
+`pygount` runs via `uvx` in an isolated environment — no system-wide installation needed:
+
 ```bash
-pip install --break-system-packages pygount 2>/dev/null || pip install pygount
+uvx pygount --help
 ```
+
+If `uvx` is not available, install it with `uv` (`pip install uv`) or install pygount directly in a virtualenv (`pip install pygount`).
 
 ## 1. Basic Summary (Most Common)
 
@@ -53,7 +57,7 @@ Get a full language breakdown with file counts, code lines, and comment lines:
 
 ```bash
 cd /path/to/repo
-pygount --format=summary \
+uvx pygount --format=summary \
   --folders-to-skip=".git,node_modules,venv,.venv,__pycache__,.cache,dist,build,.next,.tox,.eggs,*.egg-info" \
   .
 ```
@@ -79,33 +83,33 @@ Adjust based on the project type:
 
 ```bash
 # Only count Python files
-pygount --suffix=py --format=summary .
+uvx pygount --suffix=py --format=summary .
 
 # Only count Python and YAML
-pygount --suffix=py,yaml,yml --format=summary .
+uvx pygount --suffix=py,yaml,yml --format=summary .
 ```
 
 ## 4. Detailed File-by-File Output
 
 ```bash
 # Default format shows per-file breakdown
-pygount --folders-to-skip=".git,node_modules,venv" .
+uvx pygount --folders-to-skip=".git,node_modules,venv" .
 
 # Sort by code lines (pipe through sort)
-pygount --folders-to-skip=".git,node_modules,venv" . | sort -t$'\t' -k1 -nr | head -20
+uvx pygount --folders-to-skip=".git,node_modules,venv" . | sort -t$'\t' -k1 -nr | head -20
 ```
 
 ## 5. Output Formats
 
 ```bash
 # Summary table (default recommendation)
-pygount --format=summary .
+uvx pygount --format=summary .
 
 # JSON output for programmatic use
-pygount --format=json .
+uvx pygount --format=json .
 
 # Pipe-friendly: Language, file count, code, docs, empty, string
-pygount --format=summary . 2>/dev/null
+uvx pygount --format=summary . 2>/dev/null
 ```
 
 ## 6. Interpreting Results


### PR DESCRIPTION
## Summary

The `codebase-inspection` skill used `pip install --break-system-packages pygount` to install pygount. This flag bypasses PEP 668 externally-managed environment protections and can corrupt the system Python installation.

**Change:** Replace with `uvx pygount` which runs pygount in an isolated ephemeral environment with no system-wide installation. Updated:
- Skill prerequisite from `pygount` to `uvx`
- All command examples from `pygount` to `uvx pygount`
- The Prerequisites install section
- Skill version bumped 1.0.0 → 1.1.0
- Website docs (auto-generated mirror) updated to match

## Why

`--break-system-packages` is a packaging anti-pattern. `uvx` provides the same functionality with zero system mutation, and `uv` is already a core Hermes dependency (used by `scripts/run_tests.sh` and the install script).

## Verification

- `scripts/run_tests.sh tests/skills/test_authoring_standards.py -q`: **1196 passed, 0 failed**
- `git diff --check`: **clean** (no whitespace errors)
- No secrets, no private model names, no config changes
- No behavioral change — pygount arguments and output are identical

## Files changed

- `skills/github/codebase-inspection/SKILL.md`
- `website/docs/user-guide/skills/bundled/github/github-codebase-inspection.md`