### PR TITLE
docs(arxiv): use python3 instead of bare python in commands

### DIFF
--- a/skills/research/arxiv/SKILL.md
+++ b/skills/research/arxiv/SKILL.md
@@ -26,7 +26,7 @@ Search and retrieve academic papers from arXiv via their free REST API. No API k
 
 ## Searching Papers
 
-The API returns Atom XML. Parse with `grep`/`sed` or pipe through `python` for clean output.
+The API returns Atom XML. Parse with `grep`/`sed` or pipe through `python3` for clean output.
 
 ### Basic search
 
@@ -37,7 +37,7 @@ curl -s "https://export.arxiv.org/api/query?search_query=all:GRPO+reinforcement+
 ### Clean output (parse XML to readable format)
 
 ```bash
-curl -s "https://export.arxiv.org/api/query?search_query=all:GRPO+reinforcement+learning&max_results=5&sortBy=submittedDate&sortOrder=descending" | python -c "
+curl -s "https://export.arxiv.org/api/query?search_query=all:GRPO+reinforcement+learning&max_results=5&sortBy=submittedDate&sortOrder=descending" | python3 -c "
 import sys, xml.etree.ElementTree as ET
 ns = {'a': 'http://www.w3.org/2005/Atom'}
 root = ET.parse(sys.stdin).getroot()
@@ -117,7 +117,7 @@ After fetching metadata for a paper, generate a BibTeX entry:
 
 {% raw %}
 ```bash
-curl -s "https://export.arxiv.org/api/query?id_list=1706.03762" | python -c "
+curl -s "https://export.arxiv.org/api/query?id_list=1706.03762" | python3 -c "
 import sys, xml.etree.ElementTree as ET
 ns = {'a': 'http://www.w3.org/2005/Atom', 'arxiv': 'http://arxiv.org/schemas/atom'}
 root = ET.parse(sys.stdin).getroot()
@@ -177,12 +177,12 @@ Full list: https://arxiv.org/category_taxonomy
 The `scripts/search_arxiv.py` script handles XML parsing and provides clean output:
 
 ```bash
-python scripts/search_arxiv.py "GRPO reinforcement learning"
-python scripts/search_arxiv.py "transformer attention" --max 10 --sort date
-python scripts/search_arxiv.py --author "Yann LeCun" --max 5
-python scripts/search_arxiv.py --category cs.AI --sort date
-python scripts/search_arxiv.py --id 2402.03300
-python scripts/search_arxiv.py --id 2402.03300,2401.12345
+python3 scripts/search_arxiv.py "GRPO reinforcement learning"
+python3 scripts/search_arxiv.py "transformer attention" --max 10 --sort date
+python3 scripts/search_arxiv.py --author "Yann LeCun" --max 5
+python3 scripts/search_arxiv.py --category cs.AI --sort date
+python3 scripts/search_arxiv.py --id 2402.03300
+python3 scripts/search_arxiv.py --id 2402.03300,2401.12345
 ```
 
 No dependencies — uses only Python stdlib.
@@ -197,7 +197,7 @@ arXiv doesn't provide citation data or recommendations. Use the **Semantic Schol
 
 ```bash
 # By arXiv ID
-curl -s "https://api.semanticscholar.org/graph/v1/paper/arXiv:2402.03300?fields=title,authors,citationCount,referenceCount,influentialCitationCount,year,abstract" | python -m json.tool
+curl -s "https://api.semanticscholar.org/graph/v1/paper/arXiv:2402.03300?fields=title,authors,citationCount,referenceCount,influentialCitationCount,year,abstract" | python3 -m json.tool
 
 # By Semantic Scholar paper ID or DOI
 curl -s "https://api.semanticscholar.org/graph/v1/paper/DOI:10.1234/example?fields=title,citationCount"
@@ -206,19 +206,19 @@ curl -s "https://api.semanticscholar.org/graph/v1/paper/DOI:10.1234/example?fiel
 ### Get citations OF a paper (who cited it)
 
 ```bash
-curl -s "https://api.semanticscholar.org/graph/v1/paper/arXiv:2402.03300/citations?fields=title,authors,year,citationCount&limit=10" | python -m json.tool
+curl -s "https://api.semanticscholar.org/graph/v1/paper/arXiv:2402.03300/citations?fields=title,authors,year,citationCount&limit=10" | python3 -m json.tool
 ```
 
 ### Get references FROM a paper (what it cites)
 
 ```bash
-curl -s "https://api.semanticscholar.org/graph/v1/paper/arXiv:2402.03300/references?fields=title,authors,year,citationCount&limit=10" | python -m json.tool
+curl -s "https://api.semanticscholar.org/graph/v1/paper/arXiv:2402.03300/references?fields=title,authors,year,citationCount&limit=10" | python3 -m json.tool
 ```
 
 ### Search papers (alternative to arXiv search, returns JSON)
 
 ```bash
-curl -s "https://api.semanticscholar.org/graph/v1/paper/search?query=GRPO+reinforcement+learning&limit=5&fields=title,authors,year,citationCount,externalIds" | python -m json.tool
+curl -s "https://api.semanticscholar.org/graph/v1/paper/search?query=GRPO+reinforcement+learning&limit=5&fields=title,authors,year,citationCount,externalIds" | python3 -m json.tool
 ```
 
 ### Get paper recommendations
@@ -226,13 +226,13 @@ curl -s "https://api.semanticscholar.org/graph/v1/paper/search?query=GRPO+reinfo
 ```bash
 curl -s -X POST "https://api.semanticscholar.org/recommendations/v1/papers/" \
   -H "Content-Type: application/json" \
-  -d '{"positivePaperIds": ["arXiv:2402.03300"], "negativePaperIds": []}' | python -m json.tool
+  -d '{"positivePaperIds": ["arXiv:2402.03300"], "negativePaperIds": []}' | python3 -m json.tool
 ```
 
 ### Author profile
 
 ```bash
-curl -s "https://api.semanticscholar.org/graph/v1/author/search?query=Yann+LeCun&fields=name,hIndex,citationCount,paperCount" | python -m json.tool
+curl -s "https://api.semanticscholar.org/graph/v1/author/search?query=Yann+LeCun&fields=name,hIndex,citationCount,paperCount" | python3 -m json.tool
 ```
 
 ### Useful Semantic Scholar fields
@@ -243,7 +243,7 @@ curl -s "https://api.semanticscholar.org/graph/v1/author/search?query=Yann+LeCun
 
 ## Complete Research Workflow
 
-1. **Discover**: `python scripts/search_arxiv.py "your topic" --sort date --max 10`
+1. **Discover**: `python3 scripts/search_arxiv.py "your topic" --sort date --max 10`
 2. **Assess impact**: `curl -s "https://api.semanticscholar.org/graph/v1/paper/arXiv:ID?fields=citationCount,influentialCitationCount"`
 3. **Read abstract**: `web_extract(urls=["https://arxiv.org/abs/ID"])`
 4. **Read full paper**: `web_extract(urls=["https://arxiv.org/pdf/ID"])`
@@ -261,7 +261,7 @@ curl -s "https://api.semanticscholar.org/graph/v1/author/search?query=Yann+LeCun
 ## Notes
 
 - arXiv returns Atom XML — use the helper script or parsing snippet for clean output
-- Semantic Scholar returns JSON — pipe through `python -m json.tool` for readability
+- Semantic Scholar returns JSON — pipe through `python3 -m json.tool` for readability
 - arXiv IDs: old format (`hep-th/0601001`) vs new (`2402.03300`)
 - PDF: `https://arxiv.org/pdf/{id}` — Abstract: `https://arxiv.org/abs/{id}`
 - HTML (when available): `https://arxiv.org/html/{id}`

--- a/website/docs/user-guide/skills/bundled/research/research-arxiv.md
+++ b/website/docs/user-guide/skills/bundled/research/research-arxiv.md
@@ -195,12 +195,12 @@ Full list: https://arxiv.org/category_taxonomy
 The `scripts/search_arxiv.py` script handles XML parsing and provides clean output:
 
 ```bash
-python scripts/search_arxiv.py "GRPO reinforcement learning"
-python scripts/search_arxiv.py "transformer attention" --max 10 --sort date
-python scripts/search_arxiv.py --author "Yann LeCun" --max 5
-python scripts/search_arxiv.py --category cs.AI --sort date
-python scripts/search_arxiv.py --id 2402.03300
-python scripts/search_arxiv.py --id 2402.03300,2401.12345
+python3 scripts/search_arxiv.py "GRPO reinforcement learning"
+python3 scripts/search_arxiv.py "transformer attention" --max 10 --sort date
+python3 scripts/search_arxiv.py --author "Yann LeCun" --max 5
+python3 scripts/search_arxiv.py --category cs.AI --sort date
+python3 scripts/search_arxiv.py --id 2402.03300
+python3 scripts/search_arxiv.py --id 2402.03300,2401.12345
 ```
 
 No dependencies — uses only Python stdlib.
@@ -261,7 +261,7 @@ curl -s "https://api.semanticscholar.org/graph/v1/author/search?query=Yann+LeCun
 
 ## Complete Research Workflow
 
-1. **Discover**: `python scripts/search_arxiv.py "your topic" --sort date --max 10`
+1. **Discover**: `python3 scripts/search_arxiv.py "your topic" --sort date --max 10`
 2. **Assess impact**: `curl -s "https://api.semanticscholar.org/graph/v1/paper/arXiv:ID?fields=citationCount,influentialCitationCount"`
 3. **Read abstract**: `web_extract(urls=["https://arxiv.org/abs/ID"])`
 4. **Read full paper**: `web_extract(urls=["https://arxiv.org/pdf/ID"])`

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/research/research-arxiv.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/research/research-arxiv.md
@@ -195,12 +195,12 @@ web_extract(urls=["https://arxiv.org/pdf/2402.03300"])
 `scripts/search_arxiv.py` 脚本负责处理 XML 解析并提供整洁输出：
 
 ```bash
-python scripts/search_arxiv.py "GRPO reinforcement learning"
-python scripts/search_arxiv.py "transformer attention" --max 10 --sort date
-python scripts/search_arxiv.py --author "Yann LeCun" --max 5
-python scripts/search_arxiv.py --category cs.AI --sort date
-python scripts/search_arxiv.py --id 2402.03300
-python scripts/search_arxiv.py --id 2402.03300,2401.12345
+python3 scripts/search_arxiv.py "GRPO reinforcement learning"
+python3 scripts/search_arxiv.py "transformer attention" --max 10 --sort date
+python3 scripts/search_arxiv.py --author "Yann LeCun" --max 5
+python3 scripts/search_arxiv.py --category cs.AI --sort date
+python3 scripts/search_arxiv.py --id 2402.03300
+python3 scripts/search_arxiv.py --id 2402.03300,2401.12345
 ```
 
 无需额外依赖——仅使用 Python 标准库。
@@ -261,7 +261,7 @@ curl -s "https://api.semanticscholar.org/graph/v1/author/search?query=Yann+LeCun
 
 ## 完整研究工作流
 
-1. **发现论文**：`python scripts/search_arxiv.py "your topic" --sort date --max 10`
+1. **发现论文**：`python3 scripts/search_arxiv.py "your topic" --sort date --max 10`
 2. **评估影响力**：`curl -s "https://api.semanticscholar.org/graph/v1/paper/arXiv:ID?fields=citationCount,influentialCitationCount"`
 3. **阅读摘要**：`web_extract(urls=["https://arxiv.org/abs/ID"])`
 4. **阅读完整论文**：`web_extract(urls=["https://arxiv.org/pdf/ID"])`


### PR DESCRIPTION
## Summary

Replace all bare `python` invocations with `python3` in the `arxiv` skill for cross-platform portability.

On many Linux distributions `python` is either not aliased or points to Python 2, causing command failures. `python3` is universally available on all platforms Hermes supports (linux, macos, windows).

## Changes

- XML parsing snippets: `python -c` → `python3 -c` (2 instances)
- Helper script invocations: `python scripts/search_arxiv.py` → `python3 scripts/search_arxiv.py` (7 instances)
- JSON formatting: `python -m json.tool` → `python3 -m json.tool` (8 instances)
- Updated SKILL.md, website docs, and zh-Hans i18n docs (17 lines total)

## Why

`python3` is the standard portable interpreter command. The Hermes AGENTS.md and all project tooling already use `python3` exclusively. This brings the skill docs in line with the project convention.

## Verification

- `scripts/run_tests.sh tests/skills/test_authoring_standards.py -q`: **1196 passed, 0 failed**
- `git diff --check`: **clean**
- No secrets, no private model names, no config changes
- No behavioral change — `python3` is the standard interpreter

## Files changed

- `skills/research/arxiv/SKILL.md`
- `website/docs/user-guide/skills/bundled/research/research-arxiv.md`
- `website/i18n/zh-Hans/.../research-arxiv.md`