### PR TITLE
docs(domain-intel): use python3 instead of bare python in commands

### DIFF
--- a/optional-skills/research/domain-intel/SKILL.md
+++ b/optional-skills/research/domain-intel/SKILL.md
@@ -22,23 +22,23 @@ This skill includes `scripts/domain_intel.py` — a complete CLI tool for all do
 
 ```bash
 # Subdomain discovery via Certificate Transparency logs
-python SKILL_DIR/scripts/domain_intel.py subdomains example.com
+python3 SKILL_DIR/scripts/domain_intel.py subdomains example.com
 
 # SSL certificate inspection (expiry, cipher, SANs, issuer)
-python SKILL_DIR/scripts/domain_intel.py ssl example.com
+python3 SKILL_DIR/scripts/domain_intel.py ssl example.com
 
 # WHOIS lookup (registrar, dates, name servers — 100+ TLDs)
-python SKILL_DIR/scripts/domain_intel.py whois example.com
+python3 SKILL_DIR/scripts/domain_intel.py whois example.com
 
 # DNS records (A, AAAA, MX, NS, TXT, CNAME)
-python SKILL_DIR/scripts/domain_intel.py dns example.com
+python3 SKILL_DIR/scripts/domain_intel.py dns example.com
 
 # Domain availability check (passive: DNS + WHOIS + SSL signals)
-python SKILL_DIR/scripts/domain_intel.py available coolstartup.io
+python3 SKILL_DIR/scripts/domain_intel.py available coolstartup.io
 
 # Bulk analysis — multiple domains, multiple checks in parallel
-python SKILL_DIR/scripts/domain_intel.py bulk example.com github.com google.com
-python SKILL_DIR/scripts/domain_intel.py bulk example.com github.com --checks ssl,dns
+python3 SKILL_DIR/scripts/domain_intel.py bulk example.com github.com google.com
+python3 SKILL_DIR/scripts/domain_intel.py bulk example.com github.com --checks ssl,dns
 ```
 
 `SKILL_DIR` is the directory containing this SKILL.md file. All output is structured JSON.


### PR DESCRIPTION
## Summary

Replace all bare `python` invocations with `python3` in the `domain-intel` optional skill for cross-platform portability.

On many Linux distributions `python` is either not aliased or points to Python 2, causing the helper script commands to fail. `python3` is universally available on all platforms Hermes supports.

## Changes

- 7 command lines in the helper script usage section: `python SKILL_DIR/scripts/domain_intel.py` → `python3 SKILL_DIR/scripts/domain_intel.py`
- Only the SKILL.md changed (website docs already had `python3`)

## Why

`python3` is the standard portable interpreter command. The Hermes AGENTS.md and all project tooling already use `python3` exclusively. This brings the optional skill docs in line with the project convention.

## Verification

- `scripts/run_tests.sh tests/skills/test_authoring_standards.py -q`: **1196 passed, 0 failed**
- `git diff --check`: **clean**
- No secrets, no private model names, no config changes
- No behavioral change — `python3` is the standard interpreter

## Files changed

- `optional-skills/research/domain-intel/SKILL.md`