### PR TITLE
fix(profiles): release memory-store handles before rmtree on profile delete

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1614,6 +1614,22 @@ def delete_profile(name: str, yes: bool = False) -> Path:
     # guard — resurrected the deleted tree.
     _stop_profile_backends(canon, profile_dir)
 
+    # 2c. Release this process's holographic memory-store connections into
+    # the profile. The Desktop's *main* serve process opens memory_store.db
+    # for every known profile and is deliberately not stopped above, so on
+    # Windows its open handles make the rmtree below fail with WinError 32
+    # (#88347). When this delete runs inside serve (the DELETE
+    # /api/profiles/<name> route) the handles live in this process and are
+    # closed here; from the CLI this finds nothing and is a no-op.
+    try:
+        from plugins.memory.holographic.store import MemoryStore as _MemoryStore
+
+        _released = _MemoryStore.release_all_under(profile_dir)
+        if _released:
+            print(f"✓ Released {_released} memory-store connection(s) held by this process")
+    except Exception:
+        pass  # best-effort: never block the delete on the release path
+
     # 3. Remove wrapper script
     if has_wrapper:
         if remove_wrapper_script(canon):

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -3,6 +3,7 @@ SQLite-backed fact store with entity resolution and trust scoring.
 Single-user Hermes memory store plugin.
 """
 
+import os
 import re
 import sqlite3
 import threading
@@ -615,6 +616,42 @@ class MemoryStore:
     def _row_to_dict(self, row: sqlite3.Row) -> dict:
         """Convert a sqlite3.Row to a plain dict."""
         return dict(row)
+
+    @classmethod
+    def release_all_under(cls, directory: "str | Path") -> int:
+        """Force-close every shared connection whose database lives under ``directory``.
+
+        ``close()`` is refcount-driven, so a live holder (e.g. an agent's
+        memory provider) keeps a profile's SQLite handle open indefinitely.
+        That is exactly what a profile delete must break on Windows: the
+        desktop's main ``serve`` process opens ``memory_store.db`` for every
+        known profile, and ``rmtree`` of the profile directory fails with
+        ``WinError 32`` while any of those handles is open (#88347). This
+        closes the matching connections unconditionally — the directory is
+        going away, so later use by a stale holder is expected to fail — and
+        returns how many were closed. In a process that holds none (e.g. the
+        CLI deleting from outside serve) this is a harmless no-op returning 0.
+        """
+        root = os.path.normcase(str(Path(directory).expanduser().resolve())) + os.sep
+        with cls._shared_guard:
+            # Snapshot the keys first so the registry stays stable while
+            # connections are closed inside their per-database locks (closing
+            # can run no user code, but this keeps the invariant obvious).
+            doomed = [
+                key
+                for key in cls._shared
+                if os.path.normcase(key).startswith(root)
+            ]
+            for key in doomed:
+                entry = cls._shared.pop(key)
+                try:
+                    with entry["lock"]:
+                        entry["conn"].close()
+                except Exception:
+                    # A connection that is already closed or broken must not
+                    # abort releasing its siblings.
+                    pass
+        return len(doomed)
 
     def close(self) -> None:
         """Release this instance's reference to the shared connection.

--- a/tests/plugins/memory/test_holographic_shutdown_closes_db.py
+++ b/tests/plugins/memory/test_holographic_shutdown_closes_db.py
@@ -46,3 +46,48 @@ def test_shutdown_closes_store_connection(tmp_path):
         conn.execute("SELECT 1")
 
 
+def test_release_all_under_closes_connections_inside_directory_only(tmp_path):
+    """Regression test for #88347 — profile delete must break refcounted handles.
+
+    ``close()`` alone can never free a database held by a live agent (refs >= 1),
+    and on Windows an open SQLite handle makes rmtree of the profile directory
+    fail with WinError 32. ``release_all_under`` force-closes exactly the shared
+    connections under the doomed directory and leaves everything else alone.
+    """
+    from plugins.memory.holographic.store import MemoryStore
+
+    profile_dir = tmp_path / "profiles" / "default-2"
+    profile_dir.mkdir(parents=True)
+    inside = MemoryStore(db_path=profile_dir / "memory_store.db", hrr_dim=64)
+    outside = MemoryStore(db_path=tmp_path / "other" / "memory_store.db", hrr_dim=64)
+    inside_conn = inside._conn
+    outside_conn = outside._conn
+    # Both live before the release; the inside one is held "forever" (refs=1,
+    # like a live agent's provider — nobody calls close()).
+    inside_conn.execute("SELECT 1").fetchone()
+    outside_conn.execute("SELECT 1").fetchone()
+
+    try:
+        released = MemoryStore.release_all_under(profile_dir)
+        assert released == 1
+
+        # The doomed connection is really closed despite refs > 0 ...
+        with pytest.raises(sqlite3.ProgrammingError):
+            inside_conn.execute("SELECT 1")
+        # ... and the registry entry is gone, so a second release finds
+        # nothing (the CLI-process no-op case).
+        assert str((profile_dir / "memory_store.db").resolve()) not in MemoryStore._shared
+        assert MemoryStore.release_all_under(profile_dir) == 0
+        # A new store on the same path reopens fresh instead of reusing
+        # the dead connection.
+        reopened = MemoryStore(db_path=profile_dir / "memory_store.db", hrr_dim=64)
+        reopened._conn.execute("SELECT 1").fetchone()
+
+        # The sibling outside the directory is untouched.
+        outside_conn.execute("SELECT 1").fetchone()
+    finally:
+        inside.close()
+        reopened.close()
+        outside.close()
+
+


### PR DESCRIPTION
## What does this PR do?

Deleting a profile on Windows always fails with `WinError 32` (both `hermes profile delete <name> -y` and the Desktop UI path) because the desktop main `serve` process opens `memory_store.db` for **every** known profile and nothing closes those connections before `delete_profile()` runs its `rmtree` — an open SQLite handle makes directory removal fail hard on Windows (verified via the Restart Manager API in #88347). On POSIX, unlinking an open file succeeds, which is why the same leak is invisible on macOS/Linux.

`MemoryStore.close()` cannot fix this: it is refcount-driven, so a live holder (an agent memory provider) keeps its handle open forever. This PR adds `MemoryStore.release_all_under(directory)`, which force-closes every shared connection whose database lives under a directory (the directory is going away, so later use by a stale holder is expected to fail), and calls it from `delete_profile()` after the profile backends are stopped. When the delete runs inside serve (the `DELETE /api/profiles/<name>` route) the handles live in that very process and are released before the `rmtree`; when run from the CLI, this process holds none of them and the call is a harmless no-op. No Electron-side change is needed.

## Related Issue

Fixes #88347

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/holographic/store.py`: added `MemoryStore.release_all_under(directory)` — closes every shared-registry connection under a directory (path-normalized prefix match, per-connection lock, closes unconditionally like a resource going away) and returns how many
- `hermes_cli/profiles.py`: `delete_profile()` now releases this process's memory-store connections under the profile dir (new step 2c, after `_stop_profile_backends`, before the `rmtree`); best-effort and quiet when nothing is held
- `tests/plugins/memory/test_holographic_shutdown_closes_db.py`: regression test for the forced release semantics

## How to Test

1. `python -m pytest tests/plugins/memory/ tests/plugins/test_holographic_vector_storage.py tests/hermes_cli/test_profiles.py tests/hermes_cli/test_profiles_s6_hooks.py -q` — Observed result: 420 passed, 2 skipped.
2. New regression test `test_release_all_under_closes_connections_inside_directory_only` pins: a connection held with refs>0 (like a live agent provider) is force-closed, its registry entry is removed, a same-path store reopens a fresh connection, a sibling database outside the directory is untouched, and a repeat release is a no-op.
3. On Windows, the scenario from the issue: launch the Desktop app (which holds `memory_store.db` per profile), create `default-2`, then delete it via Bot Mode → Delete — should pass now that the serve-side handles are released before `rmtree` (verified at the connection level by the test above; the WinError itself is Windows-only and not reproducible on the CI runner).

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the relevant test suites and all tests pass (420 passed, 2 skipped)
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed; the new class method carries a docstring explaining the force-release semantics

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/plugins/memory/ tests/plugins/test_holographic_vector_storage.py tests/hermes_cli/test_profiles.py tests/hermes_cli/test_profiles_s6_hooks.py -q
420 passed, 2 skipped in 24.21s
```