### PR TITLE
fix(agent): count a parallel tool-call batch as one guardrail failure observation

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -368,10 +368,44 @@ class ToolCallGuardrailController:
         # single agent loop rather than accumulating across the session.
         self._turn_web_search_count = 0
         self._turn_subagent_count = 0
+        # Tool-call batch bookkeeping for the failure counters below. A batch
+        # is one assistant message's worth of tool calls; `None` means the
+        # runtime never declared one, in which case every call is counted.
+        self._tool_batch_seq = 0
+        self._tool_batch_token: int | None = None
+        self._counted_failure_batch: dict[tuple[str, Any], int] = {}
 
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
         return self._halt_decision
+
+    def begin_tool_batch(self) -> None:
+        """Open a new tool-call batch (one assistant message's tool calls).
+
+        The failure counters treat a batch as a single observation: the model
+        emits every call in a batch *before* any of their results exist, so
+        N failures inside one batch are not N retries — it never saw the
+        first failure. Counting them individually lets one bad argument,
+        fanned out over a parallel batch, reach a halt threshold that is
+        meant to catch a model stubbornly repeating a call it knows failed.
+        """
+        self._tool_batch_seq += 1
+        self._tool_batch_token = self._tool_batch_seq
+
+    def _count_failure_once_per_batch(self, key: tuple[str, Any]) -> bool:
+        """Return True when this failure should bump `key`'s counter.
+
+        Without a declared batch the answer is always True, so any dispatch
+        path that does not call `begin_tool_batch` keeps the pre-existing
+        per-call counting rather than silently capping every counter at 1.
+        """
+        batch = self._tool_batch_token
+        if batch is None:
+            return True
+        if self._counted_failure_batch.get(key) == batch:
+            return False
+        self._counted_failure_batch[key] = batch
+        return True
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
@@ -442,12 +476,16 @@ class ToolCallGuardrailController:
             failed, _ = classify_tool_failure(tool_name, result)
 
         if failed:
-            exact_count = self._exact_failure_counts.get(signature, 0) + 1
-            self._exact_failure_counts[signature] = exact_count
+            exact_count = self._exact_failure_counts.get(signature, 0)
+            if self._count_failure_once_per_batch(("exact", signature)):
+                exact_count += 1
+                self._exact_failure_counts[signature] = exact_count
             self._no_progress.pop(signature, None)
 
-            same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
-            self._same_tool_failure_counts[tool_name] = same_count
+            same_count = self._same_tool_failure_counts.get(tool_name, 0)
+            if self._count_failure_once_per_batch(("tool", tool_name)):
+                same_count += 1
+                self._same_tool_failure_counts[tool_name] = same_count
 
             if self.config.hard_stop_enabled and same_count >= self.config.same_tool_failure_halt_after:
                 decision = ToolGuardrailDecision(
@@ -492,6 +530,10 @@ class ToolCallGuardrailController:
 
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
+        # Drop the batch markers too, so a later failure in the same batch is
+        # counted afresh instead of being mistaken for an already-counted one.
+        self._counted_failure_batch.pop(("exact", signature), None)
+        self._counted_failure_batch.pop(("tool", tool_name), None)
 
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)

--- a/contributors/emails/adrien.didot@gmail.com
+++ b/contributors/emails/adrien.didot@gmail.com
@@ -1,0 +1,2 @@
+Adridot
+# fix(agent): parallel tool-call batch counted as one guardrail failure observation

--- a/run_agent.py
+++ b/run_agent.py
@@ -8306,6 +8306,15 @@ class AIAgent:
         """
         tool_calls = assistant_message.tool_calls
 
+        # One assistant message = one guardrail batch. Its calls are emitted
+        # before any result comes back, so the loop detector must not read
+        # several failures from this batch as several retries. Advisory only:
+        # never let the bookkeeping abort dispatch for an agent that has no
+        # controller (partially constructed instances, test stubs).
+        _guardrails = getattr(self, "_tool_guardrails", None)
+        if _guardrails is not None:
+            _guardrails.begin_tool_batch()
+
         # Allow _vprint during tool execution even with stream consumers
         self._executing_tools = True
         try:

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -119,6 +119,123 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
 
 
 
+_TOOL_ERROR = '{"error":"server is unreachable"}'
+
+
+def _batch_controller(**overrides):
+    """Controller that halts on same-tool failures and warns from the first."""
+    kwargs = {
+        "hard_stop_enabled": True,
+        "same_tool_failure_warn_after": 1,
+        "same_tool_failure_halt_after": 8,
+        # Keep the exact-args counters out of the way so the decisions we read
+        # back are always the same-tool ones.
+        "exact_failure_warn_after": 99,
+        "exact_failure_block_after": 99,
+    }
+    kwargs.update(overrides)
+    return ToolCallGuardrailController(ToolCallGuardrailConfig(**kwargs))
+
+
+def test_parallel_batch_failures_count_as_one_observation():
+    # A batch is emitted before any of its results exist, so eight failures
+    # inside it are one observation, not eight retries.
+    controller = _batch_controller()
+    controller.begin_tool_batch()
+
+    for i in range(8):
+        decision = controller.after_call(
+            "mcp_odoo_search_records", {"domain": i}, _TOOL_ERROR, failed=True
+        )
+        assert decision.action == "warn"
+        assert decision.code == "same_tool_failure_warning"
+        assert decision.count == 1
+
+    assert controller.halt_decision is None
+
+
+def test_sequential_failures_across_batches_still_halt():
+    controller = _batch_controller(same_tool_failure_halt_after=3)
+
+    for i in range(2):
+        controller.begin_tool_batch()
+        assert controller.after_call(
+            "terminal", {"command": i}, _TOOL_ERROR, failed=True
+        ).action != "halt"
+
+    controller.begin_tool_batch()
+    decision = controller.after_call(
+        "terminal", {"command": 99}, _TOOL_ERROR, failed=True
+    )
+
+    assert decision.action == "halt"
+    assert decision.code == "same_tool_failure_halt"
+    assert decision.count == 3
+
+
+def test_partially_failed_batch_counts_once():
+    controller = _batch_controller(same_tool_failure_halt_after=2)
+
+    controller.begin_tool_batch()
+    controller.after_call("terminal", {"command": 1}, '{"ok":true}', failed=False)
+    controller.after_call("terminal", {"command": 2}, _TOOL_ERROR, failed=True)
+    controller.after_call("terminal", {"command": 3}, _TOOL_ERROR, failed=True)
+    assert controller.halt_decision is None
+
+    controller.begin_tool_batch()
+    decision = controller.after_call(
+        "terminal", {"command": 4}, _TOOL_ERROR, failed=True
+    )
+
+    assert decision.action == "halt"
+    assert decision.count == 2
+
+
+def test_distinct_tools_in_one_batch_keep_separate_counters():
+    controller = _batch_controller()
+    controller.begin_tool_batch()
+
+    first = controller.after_call("terminal", {"command": 1}, _TOOL_ERROR, failed=True)
+    second = controller.after_call("web_search", {"query": "x"}, _TOOL_ERROR, failed=True)
+
+    assert first.count == 1
+    assert second.count == 1
+
+
+def test_failures_without_declared_batch_count_per_call():
+    # Fail-safe: a dispatch path that never declares a batch keeps the
+    # pre-existing per-call counting instead of capping every counter at 1.
+    controller = _batch_controller(same_tool_failure_halt_after=3)
+
+    for i in range(2):
+        assert controller.after_call(
+            "terminal", {"command": i}, _TOOL_ERROR, failed=True
+        ).action != "halt"
+
+    decision = controller.after_call(
+        "terminal", {"command": 9}, _TOOL_ERROR, failed=True
+    )
+
+    assert decision.action == "halt"
+    assert decision.count == 3
+
+
+def test_reset_for_turn_clears_batch_bookkeeping():
+    controller = _batch_controller(same_tool_failure_halt_after=2)
+    controller.begin_tool_batch()
+    controller.after_call("terminal", {"command": 1}, _TOOL_ERROR, failed=True)
+
+    controller.reset_for_turn()
+
+    controller.begin_tool_batch()
+    decision = controller.after_call(
+        "terminal", {"command": 1}, _TOOL_ERROR, failed=True
+    )
+
+    assert decision.action != "halt"
+    assert decision.count == 1
+
+
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)


### PR DESCRIPTION
## What does this PR do?

The per-turn loop guardrail counts tool failures **once per tool result**, with no notion of which assistant message a result came from. But `_execute_tool_calls` deliberately dispatches parallel-safe calls concurrently — so one mistake, fanned out across a single batch, registers as N separate failures that the model **could not possibly have reacted to**: every call in a batch is emitted before any of its results exist.

With `hard_stop_enabled`, a batch as wide as `same_tool_failure_halt_after` therefore halts the turn on the spot. The halt message then tells the model *"it failed N times this turn — stop retrying the same failing tool path"* about a path it had not retried even once.

Real trace that motivated this (cron job, `hard_stop_after.same_tool_failure: 8`):

```
06:01:18.093  ✅ mcp_odoo_search_records      3 712 chars   ← one assistant message,
        .186  ✅ mcp_odoo_aggregate_records  13 018 chars     one batch: the server is
        .284  ✅ mcp_odoo_search_records        217 chars     healthy and answering
        .439  ✅ mcp_odoo_search_records     49 743 chars
        .478  ❌ mcp_odoo_aggregate_records  "groupby must not be empty"
        .535  ❌ mcp_odoo_aggregate_records  "groupby must not be empty"   3 strikes
        .547  ❌ mcp_odoo_aggregate_records  "groupby must not be empty"   in 69 ms

06:02:02.672  ❌ ×8 mcp_odoo_search_records  (8 calls, one batch, all within 84 ms)
        .770  🛑 Turn ended: reason=guardrail_halt   ← 5 of 150 allowed API calls used
```

The model had actually done the right thing — it changed approach between the two messages. It was halted for the 8 concurrent calls of its *new* approach, because their failures were counted as 8 retries.

The fix makes the counters record **one observation per (counting key, batch)**, so they measure what they were designed to measure: failures the model *saw* and then repeated. Genuine sequential retries still reach the same thresholds and still halt.

Deliberately **fail-safe**: a dispatch path that never calls `begin_tool_batch()` keeps the previous per-call counting. An unconverted caller degrades to today's behavior rather than silently capping every counter at 1 and disarming the hard stop.

## Related Issue

No existing issue tracks this defect. Searched open **and** merged issues/PRs before writing any code, per [CONTRIBUTING → Before You Start: Search First](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#before-you-start-search-first): `guardrail`, `same_tool_failure`, `same_tool_failure_halt`, `parallel batch`, `concurrent tool calls`, `failure count` — no PR addresses the batch-counting behavior.

Related but **not** the same ask: #53959 asks for *fallback strategies* instead of a hard stop after repeated **sequential** failures (a feature request). This PR keeps the hard stop exactly as it is and only stops miscounting concurrent calls as retries — a bug fix. The two are compatible.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/tool_guardrails.py`
  - `ToolCallGuardrailController.begin_tool_batch()` — opens a batch (one assistant message's tool calls); batch state is reset by `reset_for_turn()`.
  - `_count_failure_once_per_batch()` — returns whether a failure should bump its counter; always `True` when no batch has been declared (fail-safe).
  - `after_call()` — both failure counters (`same_tool_failure` and `exact_failure`) now increment at most once per batch. Same causal argument applies to both: emitting the same call five times in one batch is a model defect worth warning about, but it is not retrying-after-being-told, so it must not end the turn.
  - The success path also clears the batch markers, so a later failure in the same batch is counted afresh instead of being mistaken for an already-counted one.
- `run_agent.py` — `_execute_tool_calls()` declares the batch. This is the single dispatch entry point that receives `assistant_message`, so it covers both the sequential and concurrent paths. The call is resolved via `getattr(self, "_tool_guardrails", None)` and skipped when absent: this bookkeeping is advisory and must never abort tool dispatch for a partially constructed agent. `tests/run_agent/test_image_generate_parallel.py` drives `_execute_tool_calls` on a `SimpleNamespace` stub and passes **unmodified**, which is what pins that guarantee.
- `tests/agent/test_tool_guardrails.py` — 6 tests (below).
- `contributors/emails/adrien.didot@gmail.com` — email → login mapping, added with `scripts/add_contributor.py` so `Contributor Attribution Check` passes.

No config keys, no schema changes, no public API removals. Cross-platform: pure in-memory bookkeeping, no OS-dependent code.

## How to Test

**1. Reproduce the miscount on `main`** (mirrors the trace above — 8 failures that in production came from one concurrent batch):

```python
from agent.tool_guardrails import ToolCallGuardrailConfig, ToolCallGuardrailController

c = ToolCallGuardrailController(ToolCallGuardrailConfig(
    hard_stop_enabled=True, same_tool_failure_warn_after=3, same_tool_failure_halt_after=8,
    exact_failure_warn_after=2, exact_failure_block_after=5))

for i in range(8):
    d = c.after_call('mcp_odoo_search_records', {'domain': i}, '{"error":"boom"}', failed=True)
    print(i + 1, d.action, d.code, d.count)
print('HALTED:', c.halt_decision is not None)
```

On `main` this escalates `allow → warn … → halt` and prints `HALTED: True`. With this PR, wrap the loop in `c.begin_tool_batch()` and the count stays `1` with `HALTED: False`; without a `begin_tool_batch()` call the old output is preserved exactly (the fail-safe path).

**2. Run the tests:**

```bash
pytest tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py -q
```

New tests, each mapping to one behavior:

| Test | Pins |
|---|---|
| `test_parallel_batch_failures_count_as_one_observation` | 8 failures in one batch → count 1, no halt |
| `test_sequential_failures_across_batches_still_halt` | **non-regression**: 1 failure × 3 batches → halt at 3 |
| `test_partially_failed_batch_counts_once` | mixed success/failure batch contributes exactly 1 |
| `test_distinct_tools_in_one_batch_keep_separate_counters` | per-tool counters stay independent |
| `test_failures_without_declared_batch_count_per_call` | fail-safe path unchanged |
| `test_reset_for_turn_clears_batch_bookkeeping` | batch state is per-turn |

5 of the 6 fail on unpatched `main` (`AttributeError: … has no attribute 'begin_tool_batch'`); the 6th passes both before and after **by design** — it pins the behavior this PR must *not* change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — open and merged, terms listed under *Related Issue*
- [x] My PR contains **only** changes related to this fix (one commit, 4 files, +170/−4)
- [x] I've run the tests — see *Test scope* below for exactly what was run and how it was verified
- [x] I've added tests for my changes (6 new, 5 RED on `main`)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS (aarch64), Python 3.11.15

**Test scope — stated precisely rather than implying a clean full-repo run.**

Suites covering the changed code are green: `tests/agent/test_tool_guardrails.py`, `tests/run_agent/test_tool_call_guardrail_runtime.py`, `tests/run_agent/test_tool_batch_segmentation.py`, `tests/run_agent/test_image_generate_parallel.py`, `tests/agent/test_turn_context.py` → **77 passed, 1 skipped**.

I also ran the two directories this change touches in full, **and ran the identical command on my merge base (`5229975438`) to separate my effects from my environment's**:

| Run | passed | failed |
|---|---|---|
| merge base `5229975438` | 6089 | 239 |
| this branch, first attempt | 6094 | **240** |

Diffing the two failure sets gave exactly **one** test failing on my branch and not on the base — `test_image_generate_batch_routes_to_concurrent_executor` — with none fixed by accident. That was a genuine regression in my first attempt: it drives `_execute_tool_calls` on a `SimpleNamespace` stub, and an unconditional `self._tool_guardrails.begin_tool_batch()` raised `AttributeError`. Rather than adjust that test, I made the batch declaration advisory (`getattr` + skip when absent), because guardrail bookkeeping must never be able to abort tool dispatch. The test passes unmodified now.

The remaining **239** failures are identical on the merge base and are environmental: optional extras absent (`ImportError: The 'anthropic' package is required …`) plus ordering effects from a single-process bulk run — I did not reproduce CI's hermetic `env -i` + per-file subprocess isolation from `scripts/run_tests.sh`. Sampled in isolation, the non-guardrail files among them drop from 10 failures to 1. I did not run the entire `tests/` tree; CI is authoritative there.

`ruff check`, `python -m py_compile`, `git diff --check` (on `HEAD~1..HEAD`) and `scripts/check-windows-footguns.py` all pass on the changed files.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on both new methods explain the causal reasoning; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A in substance: in-memory counters only, no paths, processes, signals or encodings; footgun scanner clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schema touched

## Screenshots / Logs

Production log of the halt this PR prevents — note the 84 ms spread across 8 calls, and that the run ended with 145 of its 150 API calls unused:

```
06:02:02,672 WARNING agent.tool_executor: Tool mcp__odoo__search_records returned error (0.00s)
06:02:02,678 WARNING agent.tool_executor: Tool mcp__odoo__search_records returned error (0.00s)
06:02:02,685 WARNING agent.tool_executor: Tool mcp__odoo__search_records returned error (0.00s)
06:02:02,692 WARNING agent.tool_executor: Tool mcp__odoo__search_records returned error (0.00s)
06:02:02,699 WARNING agent.tool_executor: Tool mcp__odoo__search_records returned error (0.00s)
06:02:02,705 WARNING agent.tool_executor: Tool mcp__odoo__search_records returned error (0.00s)
06:02:02,746 WARNING agent.tool_executor: Tool mcp__odoo__search_records returned error (0.00s)
06:02:02,756 WARNING agent.tool_executor: Tool mcp__odoo__search_records returned error (0.00s)
06:02:02,770 INFO agent.conversation_loop: Turn ended: reason=guardrail_halt api_calls=5/150 tool_turns=5
```

For context on why those 8 calls all failed instantly: the MCP server breaker had been armed by three *argument-validation* errors from a healthy server. That is a separate defect with existing open PRs (#68669, #75511, #79298, #79645) and is intentionally **out of scope** here — this PR is only about the guardrail counting concurrent calls as retries. Both defects had to line up to kill the run, and either fix alone would have prevented it.
