### PR TITLE
fix(memory): avoid re-shipping retained turns on session switch

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -2292,20 +2292,9 @@ class HindsightMemoryProvider(MemoryProvider):
         # everything before mutating self._* so metadata + tags + doc_id
         # all reference the old session consistently.
         if self._session_turns:
-            old_turns = list(self._session_turns)
             old_session_id = self._session_id
             old_parent_session_id = self._parent_session_id
             old_turn_index = self._turn_index
-            old_metadata = self._build_metadata(
-                message_count=len(old_turns) * 2,
-                turn_index=old_turn_index,
-            )
-            old_lineage_tags: list[str] = []
-            if old_session_id:
-                old_lineage_tags.append(f"session:{old_session_id}")
-            if old_parent_session_id:
-                old_lineage_tags.append(f"parent:{old_parent_session_id}")
-            old_content = "[" + ",".join(old_turns) + "]"
             # Resolve doc_id + update_mode against the OLD session BEFORE
             # we rotate _session_id, so the flush lands in the old
             # session's document either way (legacy: per-process unique;
@@ -2313,44 +2302,68 @@ class HindsightMemoryProvider(MemoryProvider):
             old_document_id, old_update_mode = self._resolve_retain_target(
                 self._document_id
             )
+            # Only flush turns a completed retain hasn't already persisted.
+            # The watermark tracks that for both APIs: on append-capable
+            # servers ship just the delta since the last boundary (the
+            # server appends); on overwrite APIs re-send the whole session
+            # because each retain replaces the document. Skip entirely when
+            # nothing new is buffered so we never re-ship / duplicate
+            # already-retained turns at switch time.
+            turns_since_retain = self._session_turns[self._last_retained_turn_count:]
+            if turns_since_retain:
+                old_turns = (
+                    turns_since_retain
+                    if old_update_mode == "append"
+                    else list(self._session_turns)
+                )
+                old_metadata = self._build_metadata(
+                    message_count=len(old_turns) * 2,
+                    turn_index=old_turn_index,
+                )
+                old_lineage_tags: list[str] = []
+                if old_session_id:
+                    old_lineage_tags.append(f"session:{old_session_id}")
+                if old_parent_session_id:
+                    old_lineage_tags.append(f"parent:{old_parent_session_id}")
+                old_content = "[" + ",".join(old_turns) + "]"
 
-            def _flush():
-                try:
-                    item = self._build_retain_kwargs(
-                        old_content,
-                        context=self._retain_context,
-                        metadata=old_metadata,
-                        tags=old_lineage_tags or None,
-                    )
-                    item.pop("bank_id", None)
-                    item.pop("retain_async", None)
-                    if old_update_mode is not None:
-                        item["update_mode"] = old_update_mode
-                    logger.debug(
-                        "Hindsight flush-on-switch: bank=%s, doc=%s, mode=%s, num_turns=%d",
-                        self._bank_id, old_document_id, old_update_mode, len(old_turns),
-                    )
-                    self._run_hindsight_operation(
-                        lambda client: client.aretain_batch(
-                            bank_id=self._bank_id,
-                            items=[item],
-                            document_id=old_document_id,
-                            retain_async=self._retain_async,
+                def _flush():
+                    try:
+                        item = self._build_retain_kwargs(
+                            old_content,
+                            context=self._retain_context,
+                            metadata=old_metadata,
+                            tags=old_lineage_tags or None,
                         )
-                    )
-                except Exception as e:
-                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
+                        item.pop("bank_id", None)
+                        item.pop("retain_async", None)
+                        if old_update_mode is not None:
+                            item["update_mode"] = old_update_mode
+                        logger.debug(
+                            "Hindsight flush-on-switch: bank=%s, doc=%s, mode=%s, num_turns=%d",
+                            self._bank_id, old_document_id, old_update_mode, len(old_turns),
+                        )
+                        self._run_hindsight_operation(
+                            lambda client: client.aretain_batch(
+                                bank_id=self._bank_id,
+                                items=[item],
+                                document_id=old_document_id,
+                                retain_async=self._retain_async,
+                            )
+                        )
+                    except Exception as e:
+                        logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
 
-            # Route the flush through the same writer queue sync_turn
-            # uses. That serializes it behind any still-queued retains
-            # from the old session (FIFO by document_id), avoids racing
-            # two threads on aretain_batch against the same document, and
-            # keeps shutdown's drain semantics intact. Skip enqueue if
-            # shutdown has already fired — the writer is draining/gone.
-            if not self._shutting_down.is_set():
-                self._ensure_writer()
-                self._register_atexit()
-                self._retain_queue.put(_flush)
+                # Route the flush through the same writer queue sync_turn
+                # uses. That serializes it behind any still-queued retains
+                # from the old session (FIFO by document_id), avoids racing
+                # two threads on aretain_batch against the same document,
+                # and keeps shutdown's drain semantics intact. Skip enqueue
+                # if shutdown has already fired — the writer is draining/gone.
+                if not self._shutting_down.is_set():
+                    self._ensure_writer()
+                    self._register_atexit()
+                    self._retain_queue.put(_flush)
 
         # 2. Drain any in-flight prefetch from the old session and drop
         # its cached result so the new session doesn't see stale recall.

--- a/tests/agent/test_memory_session_switch.py
+++ b/tests/agent/test_memory_session_switch.py
@@ -166,6 +166,11 @@ def _make_hindsight_provider():
     provider._session_turns = ["turn-1", "turn-2"]
     provider._turn_counter = 2
     provider._turn_index = 2
+    # Retain watermark — set unconditionally by __init__ (and updated on
+    # every retain) so the buffer-flush path knows which turns have already
+    # been persisted. Seeded here gate-consistent with a provider that has
+    # not yet retained anything.
+    provider._last_retained_turn_count = 0
     # Attrs read by _build_metadata / _build_retain_kwargs when the
     # buffer-flush path on session switch fires. Empty strings keep the
     # metadata minimal but well-formed.

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1212,6 +1212,59 @@ class TestUpdateModeAppendCapability:
 
 
 # ---------------------------------------------------------------------------
+
+class TestSessionSwitchBufferFlushNoReship:
+    """The session-switch flush must also respect the append watermark:
+    once a boundary retain persisted turns 1..N, a later switch must only
+    flush the partial block since the boundary — re-shipping the whole
+    buffer would duplicate already-retained turns in the document (same
+    data-loss/dup class as shutdown)."""
+
+    @staticmethod
+    def _force_append(monkeypatch):
+        from plugins.memory.hindsight import (
+            _append_capability_cache,
+            _append_capability_lock,
+        )
+        with _append_capability_lock:
+            _append_capability_cache.clear()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+
+    def test_switch_flush_does_not_reship_retained_turns(
+        self, provider_with_config, monkeypatch
+    ):
+        self._force_append(monkeypatch)
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        client = p._client
+
+        # Turn 3 hits the boundary -> retain dispatched, watermark advances.
+        p.sync_turn("t1-user", "t1-asst")
+        p.sync_turn("t2-user", "t2-asst")
+        p.sync_turn("t3-user", "t3-asst")
+        p._retain_queue.join()
+        assert client.aretain_batch.call_count == 1
+
+        # One more buffered turn, then a session switch.
+        p.sync_turn("t4-user", "t4-asst")
+        p.on_session_switch(
+            "new-sid", parent_session_id="test-session", reset=True
+        )
+        p._retain_queue.join()
+
+        # Exactly one extra aretain_batch, carrying ONLY the partial block.
+        assert client.aretain_batch.call_count == 2
+        last_kw = client.aretain_batch.call_args_list[-1].kwargs
+        flat = json.dumps(last_kw["items"][0]["content"])
+        assert "t4-user" in flat
+        assert "t1-user" not in flat
+        assert "t2-user" not in flat
+        assert "t3-user" not in flat
+
+
+# ---------------------------------------------------------------------------
 # System prompt tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Fixes a silent data-duplication bug in the Hindsight memory provider's
`on_session_switch()` flush path.

With `retain_every_n_turns > 1` and an append-capable Hindsight API
(≥ 0.5.0), `sync_turn()` persists a delta at every Nth-turn boundary and
advances the append watermark. The `on_session_switch()` flush, however,
re-shipped the **entire** `_session_turns` buffer regardless of that
watermark. So once turns 1..N had already been retained at a boundary, a
later session switch (`/new`, `/reset`, `/undo`, context compression)
would **append the whole buffer again into the same document** — silently
duplicating already-retained turns.

The fix makes the switch flush respect the watermark: on append-capable
APIs it ships only the delta since the last boundary, on overwrite APIs it
re-sends the full session (each retain replaces the document there), and it
skips entirely when nothing new is buffered — so no already-retained turn
is ever re-shipped at switch time.

## Related Issue

N/A — reported in this PR. (Note: several sibling PRs on the general
Hindsight turn-flush topic are open upstream — e.g. `#77454`, `#55936`,
`#55046`, `#80503`. Those target the shutdown/session-exit data-loss class;
this PR targets a distinct defect: the *session-switch* flush re-shipping
already-retained turns. None of the open PRs address this duplication, and
one (`#55936`) explicitly preserves the "switch sends all turns" behavior
that this PR corrects.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py`: in `on_session_switch()`, the
  buffered-turn flush now computes `turns_since_retain` from the append
  watermark, ships only the delta on append-capable APIs (full session on
  overwrite APIs), and no-ops when nothing new is buffered — instead of
  always re-shipping every buffered turn.
- `tests/plugins/memory/test_hindsight_provider.py`: new
  `TestSessionSwitchBufferFlushNoReship` test — after a boundary retain
  persisted turns 1..N, a switch must flush only the partial block (N+1..),
  never re-shipping already-retained turns.
- `tests/agent/test_memory_session_switch.py`: seeds the retain watermark
  (`_last_retained_turn_count`) in the bare-provider test helper, which
  `on_session_switch()` now reads.

## How to Test

1. **Unit test** (CI parity — do not call plain `pytest`):
   ```bash
   cd <repo> && source .venv/bin/activate
   scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py -q
   ```
2. To reproduce the bug directly: configure a Hindsight provider with
   `retain_every_n_turns > 1` on an append-capable server, run past one
   retain boundary (so the watermark advances), buffer a few more turns,
   then call `on_session_switch()`. Before the fix the flush carries the
   whole buffer (duplicating turns 1..N in the document); after the fix it
   carries only the partial block.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the tests via `scripts/run_tests.sh` (whole `tests/plugins/memory/` + `tests/agent/test_memory_session_switch.py`): **343 passed, 0 failed**
- [x] I've added tests for my changes
- [x] I've tested on my platform: Arch Linux (CachyOS), Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (code-level fix, docstring updated in `on_session_switch()`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Test run (canonical runner, reduced scope — the three prior shutdown tests
were intentionally dropped from this PR since that work is covered by
sibling open PRs):

```
=== Summary: 25 files, 343 tests passed, 0 failed, 1 skipped ===
```

---

*AI Tools were used to speed-up the development. Tools used are 100%
compatible with the project license.*
