### PR TITLE
fix(update): warn when the Desktop app was not rebuilt

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1131,7 +1131,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
 
     node_failures = _update_node_dependencies()
     _m()._build_web_ui(_m().PROJECT_ROOT / "web")
-    _rebuild_desktop_after_update(
+    desktop_rebuilt = _rebuild_desktop_after_update(
         _m().PROJECT_ROOT / "apps" / "desktop",
         had_desktop_app_before_update=had_desktop_app_before_update,
     )
@@ -1246,6 +1246,12 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
         print("  be in a mixed state until the Node deps are rebuilt.")
     else:
         _print_update_completion(_update_complete_message(pre_update_version))
+    if not desktop_rebuilt:
+        # A failed desktop pack is non-fatal, but the success banner above
+        # must not imply the Electron app shipped with this update — it is
+        # still running the previous build (#88251).
+        print("⚠ The Desktop app was NOT rebuilt — it is still running the")
+        print("  previous build. Run `hermes desktop` to retry the build.")
     try:
         _print_curator_first_run_notice()
     except Exception as e:
@@ -4371,8 +4377,16 @@ def _desktop_app_present(desktop_dir: Path) -> bool:
 
 def _rebuild_desktop_after_update(
     desktop_dir: Path, *, had_desktop_app_before_update: bool
-) -> None:
-    """Rebuild an installed Desktop app when its source or artifact changed."""
+) -> bool:
+    """Rebuild an installed Desktop app when its source or artifact changed.
+
+    Returns ``False`` only when a rebuild was attempted and failed, so the
+    caller can flag in the final summary that the Desktop app is still
+    running the previous build — an update that prints only ``✓ Update
+    complete!`` over a failed desktop pack silently leaves the app stale
+    (#88251). Every other outcome (nothing to rebuild, up to date, build
+    succeeded, Desktop never installed) returns ``True``.
+    """
     # The release tree is ignored by git and can disappear during an update.
     # Its pre-update presence is enough to restore it; do not make people who
     # have never used Desktop pay for an Electron build.
@@ -4382,7 +4396,7 @@ def _rebuild_desktop_after_update(
         and _m()._resolve_node_runtime_npm()
         and has_desktop_app
     ):
-        return
+        return True
 
     print("→ Checking if desktop app needs rebuilding...")
     # Consult the content-hash stamp IN-PROCESS first. The spawned
@@ -4401,7 +4415,7 @@ def _rebuild_desktop_after_update(
         skip_desktop_build = False
     if skip_desktop_build:
         print("  ✓ Desktop app up to date")
-        return
+        return True
 
     desktop_build_cmd = [sys.executable, "-m", "hermes_cli.main", "desktop", "--build-only"]
     # Capture the (very loud) Electron/vite build output into update.log
@@ -4433,8 +4447,9 @@ def _rebuild_desktop_after_update(
         from hermes_constants import display_hermes_home as _dhh
 
         print(f"  Full build log: {_dhh()}/logs/update.log")
-    else:
-        print("  ✓ Desktop app up to date")
+        return False
+    print("  ✓ Desktop app up to date")
+    return True
 
 
 def _cmd_update_impl(args, gateway_mode: bool):
@@ -5239,13 +5254,19 @@ def _cmd_update_impl(args, gateway_mode: bool):
         node_failures = _update_node_dependencies()
         _m()._build_web_ui(_m().PROJECT_ROOT / "web")
 
-        _rebuild_desktop_after_update(
+        desktop_rebuilt = _rebuild_desktop_after_update(
             desktop_dir,
             had_desktop_app_before_update=had_desktop_app_before_update,
         )
 
         print()
         print("✓ Code updated!")
+        if not desktop_rebuilt:
+            # Non-fatal, but the user must not walk away thinking the
+            # Electron app updated with the code — it is still running the
+            # previous build (#88251).
+            print("⚠ The Desktop app was NOT rebuilt — it is still running the")
+            print("  previous build. Run `hermes desktop` to retry the build.")
 
         # ── Post-update state.db integrity guard (#68474) ─────────────────
         # Verify that state.db survived the update intact.  If the live file

--- a/tests/hermes_cli/test_update_desktop_stale_warning.py
+++ b/tests/hermes_cli/test_update_desktop_stale_warning.py
@@ -1,0 +1,122 @@
+"""``hermes update`` must flag a Desktop app that was NOT rebuilt.
+
+Regression test for #88251: a failed desktop pack is non-fatal, but the
+success banner used to be the last thing the user saw — implying the
+Electron app shipped with the update while it silently stayed on the
+previous build. ``_rebuild_desktop_after_update`` now returns ``False``
+only when a rebuild was attempted and failed, so both update paths (zip
+and git) can append a prominent stale-app warning after the summary.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import hermes_cli.update_cmd as update_cmd
+from hermes_cli.update_cmd import _rebuild_desktop_after_update
+
+
+class _Result:
+    def __init__(self, returncode: int, stdout: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+@pytest.fixture()
+def desktop_env(tmp_path, monkeypatch):
+    """A desktop dir that looks installed and a faked CLI main module."""
+    desktop_dir = tmp_path / "apps" / "desktop"
+    desktop_dir.mkdir(parents=True)
+    (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
+
+    calls = {"builds": 0, "build_needed": True}
+
+    class _FakeMain:
+        PROJECT_ROOT = tmp_path
+
+        @staticmethod
+        def _resolve_node_runtime_npm():
+            return "/fake/npm"
+
+        @staticmethod
+        def _desktop_build_needed(*_a, **_kw):
+            return calls["build_needed"]
+
+        @staticmethod
+        def _run_logged_subprocess(cmd, cwd=None, env=None):
+            calls["builds"] += 1
+            return _Result(1, stdout="Error: [stage-native-deps] boom")
+
+    monkeypatch.setattr(update_cmd, "_m", lambda: _FakeMain)
+    monkeypatch.setattr(
+        "hermes_constants.with_hermes_node_path", lambda: {}, raising=False
+    )
+    monkeypatch.setattr(
+        "hermes_constants.display_hermes_home", lambda: str(tmp_path), raising=False
+    )
+    return desktop_dir, calls
+
+
+def _run(desktop_dir):
+    return _rebuild_desktop_after_update(
+        desktop_dir, had_desktop_app_before_update=True
+    )
+
+
+def test_failed_rebuild_returns_false_and_keeps_the_non_fatal_hint(
+    desktop_env, capsys
+):
+    desktop_dir, calls = desktop_env
+    # Both the initial build and the retry fail (returncode=1 every time).
+    assert _run(desktop_dir) is False
+    assert calls["builds"] == 2
+    out = capsys.readouterr().out
+    assert "Desktop build failed (non-fatal" in out
+    assert "stage-native-deps" in out
+
+
+def test_successful_rebuild_returns_true(desktop_env, monkeypatch, capsys):
+    desktop_dir, _calls = desktop_env
+    # `_m()` yields the fake main class itself; patch the build result on it.
+    builds = []
+    monkeypatch.setattr(
+        update_cmd._m(),
+        "_run_logged_subprocess",
+        staticmethod(
+            lambda cmd, cwd=None, env=None: builds.append(cmd) or _Result(0)
+        ),
+    )
+    assert _run(desktop_dir) is True
+    assert len(builds) == 1
+    assert "Desktop app up to date" in capsys.readouterr().out
+
+
+def test_up_to_date_desktop_returns_true_without_spawning(desktop_env):
+    desktop_dir, calls = desktop_env
+    calls["build_needed"] = False
+    assert _run(desktop_dir) is True
+    assert calls["builds"] == 0
+
+
+def test_desktop_never_installed_returns_true(tmp_path, monkeypatch):
+    # No package.json → nothing to rebuild; must not spawn anything either.
+    spawned = []
+    monkeypatch.setattr(
+        update_cmd,
+        "_m",
+        lambda: type(
+            "_M",
+            (),
+            {
+                "PROJECT_ROOT": tmp_path,
+                "_resolve_node_runtime_npm": staticmethod(lambda: "/fake/npm"),
+                "_run_logged_subprocess": staticmethod(
+                    lambda *a, **k: spawned.append(1) or _Result(0)
+                ),
+            },
+        ),
+    )
+    missing = tmp_path / "apps" / "desktop"
+    missing.mkdir(parents=True)
+    assert _run(missing) is True
+    assert spawned == []


### PR DESCRIPTION
## What does this PR do?

`hermes update` treats a failed desktop pack as non-fatal: it prints an early `⚠ Desktop build failed (non-fatal; ...)` line mid-run and then still ends with the `✓ Update complete!` banner. The user walks away believing the Electron app shipped with the update while it silently stays on the previous build — desktop-side fixes never reach them and nothing in the success output says the app is stale (#88251, the summary half of the issue).

`_rebuild_desktop_after_update()` now returns `False` only when a rebuild was actually attempted and failed (every other outcome — up to date, build succeeded, Desktop never installed — returns `True`), and both update paths (zip and git) append a prominent warning right after their summary lines:

```
✓ Update complete! (v0.20.1 → v0.20.2)
⚠ The Desktop app was NOT rebuilt — it is still running the
  previous build. Run `hermes desktop` to retry the build.
```

The success-path output is byte-for-byte unchanged when the desktop rebuild succeeds or is not needed. This addresses the second (and per the issue, more important) half of #88251 — the misleading success summary. The win32 binding staging failure itself is the first half and is being tracked separately (staging script changes are in #88233 territory).

## Related Issue

Fixes #88251

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py`: `_rebuild_desktop_after_update()` returns `bool` (`False` = rebuild attempted and failed); docstring documents the contract
- `hermes_cli/update_cmd.py`: zip path (`_update_via_zip`) prints the stale-app warning after the completion banner when the rebuild failed
- `hermes_cli/update_cmd.py`: git path prints the same warning after `✓ Code updated!` when the rebuild failed
- `tests/hermes_cli/test_update_desktop_stale_warning.py`: pins the return-value contract (failed → False + non-fatal hint + build tail, success → True, up-to-date → True without spawning, no desktop installed → True without spawning)

## How to Test

1. `python -m pytest tests/hermes_cli/test_update_desktop_stale_warning.py -q` — Observed result: 4 passed.
2. `python -m pytest tests/hermes_cli/ tests/gateway/test_update_command.py -q` — Observed result: 113+ passed (no regressions in the update/gateway suites; the `✓ Update complete!` ordering other tests depend on is untouched).
3. Manual: force a desktop build failure (e.g. break the staging script) and run `hermes update` — should pass now end with the `⚠ The Desktop app was NOT rebuilt` warning after the completion banner instead of a bare success line.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate (#88233 only fixes the invalid recovery command printed by the staging script — different code path)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the update/gateway test suites and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config keys or docs changed; the return contract is documented in the function docstring

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/hermes_cli/test_update_desktop_stale_warning.py -q
4 passed in 0.22s
$ python -m pytest tests/hermes_cli/ tests/gateway/test_update_command.py -q
113 passed, 1 warning in 42.59s   (pre-existing suite; new file adds 4)
```