### PR TITLE
fix(x_search): retry HTTP 429 honoring Retry-After and surface x_search_calls

### DIFF
--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -432,3 +432,222 @@ def test_x_search_bearer_requests_prefer_api_key_from_shared_resolver(monkeypatc
     assert captured.get("prefer_api_key") is True
     assert source == "xai"
 
+
+# ---------------------------------------------------------------------------
+# New tests for #88284: 429 retry, Retry-After, x_search_calls, degraded logic
+# ---------------------------------------------------------------------------
+
+
+def test_x_search_retries_on_429_then_succeeds(monkeypatch):
+    """HTTP 429 should trigger retry with exponential backoff, then succeed on next attempt."""
+    from tools.x_search_tool import x_search_tool
+
+    call_count = {"n": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # First call: 429
+            resp = _FakeResponse({"error": "rate limited"}, status_code=429)
+            return resp
+        # Second call: success
+        return _FakeResponse(
+            {
+                "output_text": "Success after retry",
+                "citations": [{"url": "https://x.com/example/status/1"}],
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(x_search_tool(query="test query"))
+
+    assert result["success"] is True
+    assert result["answer"] == "Success after retry"
+    assert call_count["n"] == 2
+
+
+def test_x_search_retries_on_429_honors_retry_after(monkeypatch):
+    """HTTP 429 with Retry-After header should honor the header value."""
+    from tools.x_search_tool import x_search_tool
+
+    call_count = {"n": 0}
+    sleep_times = []
+
+    def _fake_sleep(seconds):
+        sleep_times.append(seconds)
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # First call: 429 with Retry-After: 2.5
+            resp = _FakeResponse({"error": "rate limited"}, status_code=429)
+            resp.headers = {"Retry-After": "2.5"}
+            return resp
+        # Second call: success
+        return _FakeResponse({"output_text": "Success after retry"})
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("time.sleep", _fake_sleep)
+
+    result = json.loads(x_search_tool(query="test query"))
+
+    assert result["success"] is True
+    assert call_count["n"] == 2
+    # Should honor Retry-After: 2.5 (not the exponential backoff)
+    assert sleep_times == [2.5]
+
+
+def test_x_search_surfaces_x_search_calls_in_result(monkeypatch):
+    """x_search_calls from usage.server_side_tool_usage_details should be in result JSON."""
+    from tools.x_search_tool import x_search_tool
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(
+            {
+                "output_text": "Found some posts",
+                "citations": [{"url": "https://x.com/example/status/1"}],
+                "usage": {
+                    "server_side_tool_usage_details": {"x_search_calls": 3}
+                },
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(x_search_tool(query="test query"))
+
+    assert result["success"] is True
+    assert result["x_search_calls"] == 3
+
+
+def test_x_search_degraded_when_x_search_calls_zero(monkeypatch):
+    """degraded=true when x_search_calls==0 (index never ran) and usage present."""
+    from tools.x_search_tool import x_search_tool
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(
+            {
+                "output_text": "Synthesized answer from model memory",
+                "citations": [],
+                "usage": {
+                    "server_side_tool_usage_details": {"x_search_calls": 0}
+                },
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(x_search_tool(query="test query"))
+
+    assert result["success"] is True
+    assert result["x_search_calls"] == 0
+    assert result["degraded"] is True
+    assert result["degraded_reason"] == "x_search index returned no results (x_search_calls=0)"
+
+
+def test_x_search_degraded_when_x_search_calls_positive_but_no_citations(monkeypatch):
+    """degraded=true when x_search_calls>0 but both citation channels empty."""
+    from tools.x_search_tool import x_search_tool
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(
+            {
+                "output_text": "No posts found matching filters",
+                "citations": [],
+                "usage": {
+                    "server_side_tool_usage_details": {"x_search_calls": 2}
+                },
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(x_search_tool(query="from:nonexistent_handle latest"))
+
+    assert result["success"] is True
+    assert result["x_search_calls"] == 2
+    assert result["degraded"] is True
+    assert "x_search_calls=2" in result["degraded_reason"]
+
+
+def test_x_search_not_degraded_when_x_search_calls_positive_with_citations(monkeypatch):
+    """degraded=false when x_search_calls>0 and citations exist."""
+    from tools.x_search_tool import x_search_tool
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(
+            {
+                "output_text": "Found posts",
+                "citations": [{"url": "https://x.com/example/status/1"}],
+                "usage": {
+                    "server_side_tool_usage_details": {"x_search_calls": 1}
+                },
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(x_search_tool(query="test query"))
+
+    assert result["success"] is True
+    assert result["x_search_calls"] == 1
+    assert result["degraded"] is False
+    assert result["degraded_reason"] is None
+
+
+def test_x_search_retries_on_408_425_502_503_504(monkeypatch):
+    """Other retryable codes (408, 425, 502, 503, 504) should also trigger retry."""
+    from tools.x_search_tool import x_search_tool
+
+    for code in (408, 425, 502, 503, 504):
+        call_count = {"n": 0}
+
+        def _make_fake_post(code):
+            def _fake_post(url, headers=None, json=None, timeout=None):
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    resp = _FakeResponse({"error": f"{code} error"}, status_code=code)
+                    return resp
+                return _FakeResponse({"output_text": "Success after retry"})
+
+            return _fake_post
+
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+        monkeypatch.setattr("requests.post", _make_fake_post(code))
+
+        result = json.loads(x_search_tool(query="test query"))
+
+        assert result["success"] is True, f"Failed for code {code}"
+        assert call_count["n"] == 2, f"Did not retry for code {code}"
+
+
+def test_x_search_no_retry_on_400_401_403_404(monkeypatch):
+    """Client errors (400, 401, 403, 404) should NOT trigger retry."""
+    from tools.x_search_tool import x_search_tool
+
+    for code in (400, 401, 403, 404):
+        call_count = {"n": 0}
+
+        def _make_fake_post(code):
+            def _fake_post(url, headers=None, json=None, timeout=None):
+                call_count["n"] += 1
+                resp = _FakeResponse({"error": f"{code} error"}, status_code=code)
+                return resp
+
+            return _fake_post
+
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+        monkeypatch.setattr("requests.post", _make_fake_post(code))
+
+        result = json.loads(x_search_tool(query="test query"))
+
+        assert result["success"] is False, f"Should fail for code {code}"
+        assert call_count["n"] == 1, f"Should not retry for code {code}"
+

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -379,15 +379,30 @@ def x_search_tool(
                 break
             except requests.HTTPError as e:
                 status_code = getattr(getattr(e, "response", None), "status_code", None)
-                if status_code is None or status_code < 500 or attempt >= max_retries:
+                # Retry on transient/server errors: 408, 425, 429, 500, 502, 503, 504
+                retryable_codes = {408, 425, 429, 500, 502, 503, 504}
+                if status_code is None or status_code not in retryable_codes or attempt >= max_retries:
                     raise
+                # Honor Retry-After header if present
+                retry_after = None
+                if e.response is not None:
+                    response_headers = getattr(e.response, "headers", {})
+                    retry_after_header = response_headers.get("Retry-After")
+                    if retry_after_header:
+                        try:
+                            retry_after = float(retry_after_header)
+                        except ValueError:
+                            # Non-numeric Retry-After (e.g., HTTP-date); fall back to backoff
+                            pass
+                sleep_time = retry_after if retry_after is not None else min(5.0, 1.5 * (attempt + 1))
                 logger.warning(
-                    "x_search upstream failure on attempt %s/%s: %s",
+                    "x_search upstream failure on attempt %s/%s: %s (retrying in %.1fs)",
                     attempt + 1,
                     max_retries + 1,
                     _http_error_message(e),
+                    sleep_time,
                 )
-                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+                time.sleep(sleep_time)
             except (requests.ReadTimeout, requests.ConnectionError) as e:
                 if attempt >= max_retries:
                     raise
@@ -408,6 +423,14 @@ def x_search_tool(
         citations = list(data.get("citations") or [])
         inline_citations = _extract_inline_citations(data)
 
+        # Extract x_search_calls from usage.server_side_tool_usage_details
+        x_search_calls = None
+        usage = data.get("usage")
+        if usage and isinstance(usage, dict):
+            server_side = usage.get("server_side_tool_usage_details")
+            if server_side and isinstance(server_side, dict):
+                x_search_calls = server_side.get("x_search_calls")
+
         # Degraded-result detection.
         #
         # xAI returns 200 OK with a synthesized answer even when its X index
@@ -417,6 +440,15 @@ def x_search_tool(
         # any narrowing filter is active AND both citation channels came back
         # empty, mark the response as degraded so callers can decide to
         # broaden filters, retry, or fall back to a different source.
+        #
+        # Additionally, if the response includes x_search_calls (from usage),
+        # we can determine if the X index actually ran:
+        # - x_search_calls == 0: index never ran → degraded (unsourced prose)
+        # - x_search_calls > 0 and both citation channels empty: index ran but
+        #   found nothing matching → degraded
+        # - x_search_calls > 0 and citations exist: not degraded
+        # If x_search_calls is not present in the response, fall back to the
+        # filter-based heuristic for backward compatibility.
         active_filters: List[str] = []
         if allowed:
             active_filters.append("allowed_x_handles")
@@ -426,12 +458,29 @@ def x_search_tool(
             active_filters.append("from_date")
         if to_date.strip():
             active_filters.append("to_date")
-        degraded = bool(active_filters) and not citations and not inline_citations
-        degraded_reason = (
-            f"no citations returned despite filters: {', '.join(active_filters)}"
-            if degraded
-            else None
-        )
+
+        if x_search_calls is not None:
+            # Usage data present: base degraded on whether the index ran and found results
+            if x_search_calls == 0:
+                degraded = True
+                degraded_reason = "x_search index returned no results (x_search_calls=0)"
+            elif not citations and not inline_citations:
+                degraded = True
+                degraded_reason = (
+                    f"no citations returned despite x_search_calls={x_search_calls}"
+                    + (f" and filters: {', '.join(active_filters)}" if active_filters else "")
+                )
+            else:
+                degraded = False
+                degraded_reason = None
+        else:
+            # No usage data: fall back to filter-based heuristic
+            degraded = bool(active_filters) and not citations and not inline_citations
+            degraded_reason = (
+                f"no citations returned despite filters: {', '.join(active_filters)}"
+                if degraded
+                else None
+            )
 
         return json.dumps(
             {
@@ -444,6 +493,7 @@ def x_search_tool(
                 "answer": answer,
                 "citations": citations,
                 "inline_citations": inline_citations,
+                "x_search_calls": x_search_calls,
                 "degraded": degraded,
                 "degraded_reason": degraded_reason,
             },


### PR DESCRIPTION
## Summary
Fixes GitHub issue #88284: x_search now retries HTTP 429 (and other transient codes) honoring `Retry-After`, surfaces `x_search_calls` from the response, and correctly marks results as `degraded` when the X index didn't run or returned no results.

## Root Cause
- The retry gate at `tools/x_search_tool.py:382` only retried on 5xx (`status_code < 500`), so xAI's 429 rate-limit errors failed immediately.
- The result builder never read `usage.server_side_tool_usage_details.x_search_calls`, so callers couldn't distinguish live X index results from synthesized prose.
- `degraded` only flipped when a handle/date filter was active AND both citation channels were empty, missing the case where the index never ran (`x_search_calls == 0`).

## Change
1. **Retry logic** (`tools/x_search_tool.py:379-404`): Expanded retryable status codes to `{408, 425, 429, 500, 502, 503, 504}`. Added `Retry-After` header parsing with fallback to existing exponential backoff (`min(5.0, 1.5 * (attempt + 1))`).
2. **x_search_calls extraction** (`tools/x_search_tool.py:423-430`): Parses `usage.server_side_tool_usage_details.x_search_calls` from the 200 JSON response.
3. **Degraded logic** (`tools/x_search_tool.py:440-480`): 
   - If `x_search_calls` is present: `degraded=true` when `x_search_calls==0` (index never ran) OR when `x_search_calls>0` but both citation channels empty.
   - If `x_search_calls` is absent: falls back to original filter-based heuristic (preserves `test_x_search_not_degraded_when_no_filters_active`).
4. **Result JSON** (`tools/x_search_tool.py:496`): Added `x_search_calls` field to the returned JSON.

## Verification
- All 11 existing tests pass (no regressions)
- 8 new tests added covering:
  - `test_x_search_retries_on_429_then_succeeds`: 429 triggers retry then success
  - `test_x_search_retries_on_429_honors_retry_after`: 429 with `Retry-After` honored
  - `test_x_search_surfaces_x_search_calls_in_result`: x_search_calls in result JSON
  - `test_x_search_degraded_when_x_search_calls_zero`: degraded=true when x_search_calls==0
  - `test_x_search_degraded_when_x_search_calls_positive_but_no_citations`: degraded=true when index ran but no citations
  - `test_x_search_not_degraded_when_x_search_calls_positive_with_citations`: degraded=false when citations exist
  - `test_x_search_retries_on_408_425_502_503_504`: other retryable codes work
  - `test_x_search_no_retry_on_400_401_403_404`: client errors don't retry
- Test run: `uv run pytest tests/tools/test_x_search_tool.py -q -p no:cacheprovider` → 19 passed in 9.55s

Closes #88284