### PR TITLE
test(update): isolate yes-flag gateway discovery

### DIFF
--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -12,7 +12,18 @@ import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli.main import cmd_update
+
+
+@pytest.fixture(autouse=True)
+def _patch_gateway_discovery():
+    """Keep updater gateway restarts isolated from live system services."""
+    with patch("hermes_cli.gateway.find_gateway_pids", return_value=[]), \
+         patch("hermes_cli.gateway.supports_systemd_services", return_value=False), \
+         patch("hermes_cli.gateway.find_profile_gateway_processes", return_value=[]):
+        yield
 
 
 def _make_run_side_effect(


### PR DESCRIPTION
## What does this PR do?

Prevents `tests/hermes_cli/test_update_yes_flag.py` from discovering, signaling,
or restarting real host gateways while exercising `cmd_update()`.

The file tests `--yes` prompt behavior, not gateway lifecycle behavior. On current
`main`, three tests reached the updater's real PID/systemd discovery boundary;
the repository live-system guard correctly blocked attempts to act on the
running gateway. This adds a file-local autouse fixture that makes the unrelated
gateway-discovery phase a no-op by patching:

- `hermes_cli.gateway.find_gateway_pids` → `[]`
- `hermes_cli.gateway.supports_systemd_services` → `False`
- `hermes_cli.gateway.find_profile_gateway_processes` → `[]`

Production updater code and the suite-wide live-system guard are unchanged.

This is complementary to #61752, not a duplicate: that PR suppresses the later
Windows-only detached pause/resume respawn path suite-wide. This PR isolates the
cross-platform PID/systemd discovery reached by this one yes-flag test module.

## Related Issue

Related: #61752

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/hermes_cli/test_update_yes_flag.py`
  - imports `pytest`;
  - adds one file-local autouse fixture around the three established gateway
    discovery seams;
  - leaves all six behavioral tests and production code unchanged.

## How to Test

1. On unmodified main at `17fa4e2944a7ba746f26bd81ef104bb1a5f28ab4`,
   run the file under the repository live-system guard:
   `3 failed, 3 passed`; the three `cmd_update()` tests fail at real host
   gateway discovery while the three direct helper tests pass.
   The complete no-retry run was frozen at
   `df68cc1c1ab621353d1caa744f24e15bd5718ea8`. The final candidate was then
   refreshed to `b52b725f625d4bd380201b7f655dae0f6cf87ffa`; the subsequent delta is
   Telegram-only and does not change this test, its adjacent head-moved test,
   the updater entry path, or `hermes_cli/gateway.py`.
2. Apply this patch on `b52b725f625d4bd380201b7f655dae0f6cf87ffa` and
   run the file three times with a fresh `HERMES_HOME` and
   `HERMES_TEST_ISOLATION` each time: each run reports `6 passed`.
3. Run the file together with
   `tests/hermes_cli/test_update_head_moved_gate.py`: `8 passed`.
4. Run the canonical per-file wrapper for the focused file with retries disabled:
   `6 tests passed, 0 failed`.
5. Run Ruff, `py_compile`, and `git diff --check`: all pass.
6. On the frozen `df68cc1...` candidate, run the complete canonical suite with
   `-j 4 --file-retries 0`:
   the candidate completed with 26 failures across 16 unrelated files plus one
   Teams collection error. The changed updater file was not among them. Isolated
   reruns cleared 12 files with bridge DNS/writable XDG paths; five host-sensitive
   surfaces passed 32/32 under a temporary Hermes home with live-state invariants;
   and the remaining Teams, MCP, and Doctor failures reproduced on the unmodified
   base. The Honcho mtime-sensitive test varied independently and is already tracked
   by #80579. Candidate HEAD, diff hash, live service PID/state, and
   `gateway_state.json` checksum remained unchanged.
7. After the `b52b725...` refresh, repeat the focused, adjacent, and static gates,
   then run the three test files changed by the Telegram-only delta: focused
   `3 × 6 passed`, adjacent `8 passed`, and delta `38 passed, 0 failed`.

All host-side focused/adjacent runs preserved the live gateway PID, active/running
systemd state, `gateway_state.json` checksum, and one-file source diff. The broad
suite ran in a no-network container with private PIDs and an ephemeral
`~/.hermes`; candidate source, venv, Git metadata, and Python runtime are mounted
read-only from the host.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — the complete no-retry run is classified above; all observed failures are unrelated baseline/environment failures
- [x] I've added tests for my changes (the existing six-test module is the RED/GREEN regression surface)
- [x] I've tested on my platform: Ubuntu 24.04 x86_64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; test-only fixture has a focused docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — file-local discovery seams are cross-platform; no production behavior changes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused current-main RED:

```text
3 failed, 3 passed, 1 warning in 2.82s
```

Candidate repeated GREEN:

```text
focused run 1: 6 passed
focused run 2: 6 passed
focused run 3: 6 passed
adjacent combined: 8 passed
canonical focused wrapper: 6 tests passed, 0 failed
```
