### PR TITLE
fix(web/xai): strip internal render_inline_citation markers from results

### DIFF
--- a/plugins/web/xai/provider.py
+++ b/plugins/web/xai/provider.py
@@ -55,6 +55,23 @@ _MAX_DOMAIN_FILTERS = 5  # xAI hard cap on allowed_domains / excluded_domains
 # even when explicitly asked not to.
 _JSON_BLOCK_RE = re.compile(r"\{[\s\S]*\}", re.MULTILINE)
 
+# xAI's internal citation render placeholder. Despite requesting
+# ``include: ["no_inline_citations"]``, some Grok web-search replies still
+# inject ``{render_inline_citation citation_id="17"}`` markers into the
+# message text and into the JSON fields the model emits — they carry no URL,
+# are not the documented ``[[N]](url)`` citation format, and leak verbatim
+# into the agent's answers when passed through (#88363).
+_INLINE_CITATION_MARKER_RE = re.compile(r"\s*\{render_inline_citation\b[^}]*\}")
+
+
+def _strip_inline_citation_markers(text: str) -> str:
+    """Remove xAI's internal ``{render_inline_citation ...}`` render markers."""
+    stripped = _INLINE_CITATION_MARKER_RE.sub(" ", text)
+    if stripped != text:
+        # Adjacent markers each contribute a replacement space — collapse them.
+        stripped = re.sub(r" {2,}", " ", stripped)
+    return stripped.strip()
+
 
 # ---------------------------------------------------------------------------
 # Config
@@ -329,6 +346,16 @@ class XAIWebSearchProvider(WebSearchProvider):
             return {"success": False, "error": f"xAI returned an error: {err_msg}"}
 
         web_results = self._extract_results(data, limit=limit)
+        # Defensively strip xAI's internal citation render markers from
+        # every text field we return — regardless of which extraction path
+        # produced the row (JSON, annotations, or the raw citations list)
+        # — so they can never leak into the agent's tool results and from
+        # there into its user-facing answer (#88363).
+        for row in web_results:
+            for field in ("title", "description"):
+                value = row.get(field)
+                if isinstance(value, str) and "render_inline_citation" in value:
+                    row[field] = _strip_inline_citation_markers(value)
         if not web_results:
             # Successful call, just no usable rows — return success with an
             # empty list so the model can decide whether to retry. Matches

--- a/tests/tools/test_web_providers_xai.py
+++ b/tests/tools/test_web_providers_xai.py
@@ -212,6 +212,81 @@ class TestXAIProviderSearchFallbacks:
         assert result["data"]["web"] == []
 
 
+class TestXAIProviderStripsCitationMarkers:
+    """#88363 — some Grok web-search replies inject internal
+    ``{render_inline_citation ...}`` placeholders despite
+    ``include: ["no_inline_citations"]``. They carry no URL and must never
+    reach the agent's tool results, regardless of extraction path."""
+
+    _GROK_JSON = json.dumps({
+        "results": [
+            {
+                "title": "Birthday dinner spot",
+                "url": "https://example.com/food",
+                "description": 'Nice restaurant {render_inline_citation citation_id="17"}',
+            },
+            {
+                "title": 'Another place{render_inline_citation citation_id="3"}',
+                "url": "https://example.com/2",
+                "description": 'a{render_inline_citation citation_id="1"}{render_inline_citation citation_id="2"}b',
+            },
+        ]
+    })
+
+    def test_markers_stripped_from_json_path_results(self):
+        from plugins.web.xai import provider as xai_provider
+
+        with patch.object(xai_provider, "resolve_xai_http_credentials", return_value=_creds()), \
+             patch.object(xai_provider, "_load_xai_web_config", return_value={}), \
+             patch("httpx.post", return_value=_mock_resp(_responses_payload(self._GROK_JSON))):
+            result = xai_provider.XAIWebSearchProvider().search("birthday dinner", limit=5)
+
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert web[0]["description"] == "Nice restaurant"
+        assert web[1]["title"] == "Another place"
+        # Adjacent markers collapse to a single space, not empty glue.
+        assert web[1]["description"] == "a b"
+
+    def test_markers_stripped_from_annotation_fallback_text(self):
+        """The annotation path derives descriptions from the raw message body,
+        which is exactly where Grok drops these markers."""
+        from plugins.web.xai import provider as xai_provider
+
+        body = 'xAI is an AI company {render_inline_citation citation_id="17"}founded in 2023.'
+        annotations = [
+            {
+                "type": "url_citation",
+                "url": "https://x.ai/about",
+                "title": "1",
+                "start_index": 4,
+                "end_index": 9,
+            },
+        ]
+        with patch.object(xai_provider, "resolve_xai_http_credentials", return_value=_creds()), \
+             patch.object(xai_provider, "_load_xai_web_config", return_value={}), \
+             patch("httpx.post", return_value=_mock_resp(_responses_payload(body, annotations=annotations))):
+            result = xai_provider.XAIWebSearchProvider().search("xai", limit=5)
+
+        assert result["success"] is True
+        for row in result["data"]["web"]:
+            for field in ("title", "description"):
+                assert "render_inline_citation" not in (row[field] or "")
+
+    def test_marker_regex_variants(self):
+        from plugins.web.xai.provider import _strip_inline_citation_markers
+
+        assert (
+            _strip_inline_citation_markers('a {render_inline_citation citation_id="12"} b')
+            == "a b"
+        )
+        assert (
+            _strip_inline_citation_markers('tail {render_inline_citation citation_id="26"}')
+            == "tail"
+        )
+        assert _strip_inline_citation_markers("clean text") == "clean text"
+
+
 # ---------------------------------------------------------------------------
 # Request payload shape
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Grok web-search replies sometimes inject xAI-internal `{render_inline_citation citation_id="17"}` placeholders into the response text — even though the provider already sends `include: ["no_inline_citations"]` (the marker is not a repo string; the reporter confirmed it does not exist in the source tree, and it is not the documented `[[N]](url)` citation format). These markers carry no URL, cannot be clicked, and currently pass through the provider into the agent tool results, from where they leak verbatim into the user-facing answer (#88363).

This PR strips them defensively at the `search()` exit: every `title`/`description` field returned to the agent is run through `_strip_inline_citation_markers()` (regex + adjacent-marker whitespace collapse), so all three extraction paths — JSON results, `url_citation` annotation fallback (whose descriptions are derived from the raw message body, exactly where Grok drops these markers), and the raw citations list — are covered. Fields without the marker are untouched.

## Related Issue

Fixes #88363

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/web/xai/provider.py`: added `_INLINE_CITATION_MARKER_RE` + `_strip_inline_citation_markers()` helper
- `plugins/web/xai/provider.py`: `search()` now strips the markers from every result row before returning, after `_extract_results` and for all extraction paths
- `tests/tools/test_web_providers_xai.py`: new `TestXAIProviderStripsCitationMarkers` — JSON path (mid-string, trailing, and adjacent markers), annotation-fallback path, and regex variants

## How to Test

1. `python -m pytest tests/tools/test_web_providers_xai.py -q` — Observed result: 26 passed.
2. `python -m pytest tests/tools/test_web_providers_xai.py tests/tools/test_x_search_tool.py tests/tools/test_xai_http_credentials.py -q` — Observed result: 43 passed.
3. New tests pin: a trailing marker in a description is removed without leftover whitespace; a marker glued to a title is removed; adjacent markers collapse to a single space (`a{m}{m}b` → `a b`); annotation-fallback rows never contain `render_inline_citation` in any returned field.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the xAI-related test suites and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed; the helper carries a docstring and the regex comment explains the leak (#88363)

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/tools/test_web_providers_xai.py -q
26 passed in 0.77s
$ python -m pytest tests/tools/test_web_providers_xai.py tests/tools/test_x_search_tool.py tests/tools/test_xai_http_credentials.py -q
43 passed in 1.17s
```
