### PR TITLE
fix(cron): treat a tool-guardrail halt as a failed run

### DIFF
--- a/contributors/emails/adrien.didot@gmail.com
+++ b/contributors/emails/adrien.didot@gmail.com
@@ -1,0 +1,1 @@
+Adridot

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5749,6 +5749,27 @@ def run_job(
                 or "agent reported failure"
             )
             raise RuntimeError(_err_text)
+        # A tool-guardrail halt ends the turn with an *explanation of the halt*
+        # in `final_response`, while leaving `failed`/`completed` untouched.
+        # Interactive surfaces deliberately show that text, but for a scheduled
+        # job it is not the report the job was asked to produce: delivering it
+        # ships guardrail internals to the recipient and records the run as
+        # `last_status: "ok"`, so no health check ever notices the job produced
+        # nothing. Classify it as a failure like the paths above, keeping the
+        # guardrail's own code and tool in the error for diagnosis.
+        if turn_exit_reason == "guardrail_halt":
+            _guardrail = result.get("guardrail")
+            if not isinstance(_guardrail, dict):
+                _guardrail = {}
+            _detail = ", ".join(
+                f"{_key}={_guardrail[_key]}"
+                for _key in ("code", "tool_name")
+                if _guardrail.get(_key)
+            )
+            raise RuntimeError(
+                "agent run halted by tool guardrail"
+                + (f" ({_detail})" if _detail else "")
+            )
         if max_iteration_summary:
             logger.warning(
                 "Job '%s' reached the iteration limit but produced a final fallback response; "

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -607,6 +607,94 @@ class TestRunJobSessionPersistence:
             yield fake_db, mock_agent_cls
 
 
+    def test_run_job_guardrail_halt_is_a_failure_not_a_report(self, tmp_path):
+        """A guardrail halt must fail the run, not be delivered as its output.
+
+        The turn ends with an explanation of the halt in `final_response` while
+        `failed`/`completed` stay untouched, so without this the halt text is
+        delivered to the recipient and the run is recorded as a success.
+        """
+        job = {
+            "id": "guardrail-job",
+            "name": "guardrail job",
+            "prompt": "use a guarded tool",
+        }
+
+        with self._run_job_patches(tmp_path) as (fake_db, mock_agent_cls):
+            mock_agent_cls.return_value.run_conversation.return_value = {
+                "final_response": (
+                    "I stopped retrying search_records because it hit the "
+                    "tool-call guardrail (same_tool_failure_halt)."
+                ),
+                "completed": True,
+                "failed": False,
+                "turn_exit_reason": "guardrail_halt",
+                "guardrail": {
+                    "action": "halt",
+                    "code": "same_tool_failure_halt",
+                    "message": "Stopped search_records: it failed 8 times this turn.",
+                    "tool_name": "search_records",
+                    "count": 8,
+                },
+            }
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is False
+        assert final_response == "", (
+            "the guardrail explanation must not be handed over as the report"
+        )
+        assert error is not None
+        assert "guardrail" in error
+        # The guardrail's own code and tool travel with the error so a failed
+        # run can be diagnosed without re-reading the agent transcript.
+        assert "same_tool_failure_halt" in error
+        assert "search_records" in error
+
+    def test_run_job_guardrail_halt_without_metadata_still_fails(self, tmp_path):
+        """The classification must not depend on the metadata being present."""
+        job = {
+            "id": "guardrail-bare-job",
+            "name": "guardrail bare job",
+            "prompt": "use a guarded tool",
+        }
+
+        with self._run_job_patches(tmp_path) as (fake_db, mock_agent_cls):
+            mock_agent_cls.return_value.run_conversation.return_value = {
+                "final_response": "halted",
+                "completed": True,
+                "failed": False,
+                "turn_exit_reason": "guardrail_halt",
+            }
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is False
+        assert final_response == ""
+        assert error is not None and "guardrail" in error
+
+    def test_run_job_normal_response_still_succeeds(self, tmp_path):
+        """Non-regression: an ordinary turn is unaffected by the halt check."""
+        job = {
+            "id": "normal-job",
+            "name": "normal job",
+            "prompt": "hello",
+        }
+
+        with self._run_job_patches(tmp_path) as (fake_db, mock_agent_cls):
+            mock_agent_cls.return_value.run_conversation.return_value = {
+                "final_response": "the report",
+                "completed": True,
+                "failed": False,
+                "turn_exit_reason": "text_response(1)",
+            }
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "the report"
+
     def test_run_job_memory_toolset_disabled_in_cron(self, tmp_path):
         """memory toolset must be disabled in cron sessions — issue #38129.
 


### PR DESCRIPTION
## What does this PR do?

When the tool-call guardrail halts a turn, the loop sets `_turn_exit_reason = "guardrail_halt"` and puts an **explanation of the halt** into `final_response` — but leaves `failed` and `completed` untouched:

```python
if agent._tool_guardrail_halt_decision is not None:
    decision = agent._tool_guardrail_halt_decision
    _turn_exit_reason = "guardrail_halt"
    final_response = agent._toolguard_controlled_halt_response(decision)
```

Compare the branch immediately above it, which sets `failed = True` and blanks the response:

```python
_turn_exit_reason = "session_persistence_failed"
final_response = ""
failed = True
```

For interactive surfaces the guardrail behavior is intentional — the loop even pushes the text through the stream callback "so it's not indistinguishable from a crash". For a **scheduled job** it is not: `run_job` sees a completed turn with text, so it delivers the guardrail explanation to the job's recipient as if it were the report, and records the run as `last_status: "ok"` with `last_error: null`. Nothing alerts, because from the scheduler's point of view the job succeeded — it simply produced none of its actual output.

Observed in production: a daily reporting job delivered this to its Telegram recipient instead of the report, and was logged as a success —

```
I stopped retrying mcp__odoo__search_records because it hit the tool-call
guardrail (same_tool_failure_halt) after 8 repeated non-progressing attempts.
```

```
jobs.json   →  "last_status": "ok",  "last_error": null
executions  →  status: "completed"
```

The job had been running fine for weeks; the failure was found by a human reading the chat, not by any health check.

This PR classifies `guardrail_halt` as a failed run through the **same path the other agent-reported failures already use** (the `RuntimeError` → failure-tuple handler added for issue #17855), so the halt text is never delivered and the run is recorded as failed with a diagnosable error.

## Related Issue

**Prior art, stated openly:** #85800 is an open PR addressing this same defect. It has no review at the time of writing and the defect is still on `main`. I'm submitting this rather than piling on because it differs in three concrete ways, and I'd rather a reviewer compare them than discover the overlap:

1. **It reads only the key that actually exists.** #85800 probes five candidate key names (`guardrail`, `guardrail_metadata`, `guardrail_code`, `guardrail_tool`, `guardrail_tool_name`). `agent/turn_finalizer.py` populates exactly one:

   ```python
   if agent._tool_guardrail_halt_decision is not None:
       result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
   ```

   The other four are dead branches. This PR reads `result["guardrail"]` and the `code` / `tool_name` fields that `ToolGuardrailDecision.to_metadata()` really emits.
2. **It reuses the existing failure idiom** instead of adding a separate 23-line block — the change is a single `if` next to the `failed`/`completed` check it belongs with.
3. **It adds a non-regression test** pinning that an ordinary turn still succeeds, so the new check can't silently start swallowing healthy runs.

If a maintainer prefers #85800, close this one — the goal is the fix landing, not this diff. I'm happy to port these tests over to it instead.

Complementary, not overlapping: #88357 (loop guardrail counting one parallel batch as N retries) and #88368 (MCP breaker armed by argument-validation errors) fix the *causes* of the halt in the trace above. This PR fixes the reporting: even with a legitimate halt, a scheduled job must fail loudly rather than deliver guardrail internals and call it a success.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — in `run_job`, raise on `turn_exit_reason == "guardrail_halt"` so the existing except handler builds the failure tuple (`success=False`, `final_response=""`, `error` set, output marked FAILED). The guardrail's `code` and `tool_name` are folded into the error message when present.
- `tests/cron/test_scheduler.py` — 3 tests (below), using the file's existing `_run_job_patches` harness.

Scope is deliberately the cron path only. Interactive/gateway behavior is unchanged — the loop keeps emitting the halt text where a human is watching. Making the *loop* mark the halt as `failed=True` (mirroring `session_persistence_failed`, which would also give the gateway a `failure_reason`) is arguably the deeper fix, but it changes behavior for every consumer at once and belongs in its own PR.

No config keys, no schema changes, no public API changes. Cross-platform: control flow only.

## How to Test

**Reproduce on `main`:**

```bash
pytest "tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_run_job_guardrail_halt_is_a_failure_not_a_report" -q
```

On `main` this fails with `assert True is False` — `run_job` returns `success=True` for a halted run. With this PR it passes.

**All three:**

```bash
pytest tests/cron/test_scheduler.py -q -k "guardrail or normal_response"
```

| Test | Pins |
|---|---|
| `test_run_job_guardrail_halt_is_a_failure_not_a_report` | halt → `success=False`, `final_response == ""`, error carries `same_tool_failure_halt` and the tool name |
| `test_run_job_guardrail_halt_without_metadata_still_fails` | classification does not depend on the metadata being present |
| `test_run_job_normal_response_still_succeeds` | **non-regression**: an ordinary turn is untouched |

2 of the 3 fail on `main`; the non-regression test passes both before and after **by design**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cron):`)
- [x] I searched for existing PRs — **and found #85800 covering the same defect**; it is named and compared under *Related Issue* rather than glossed over
- [x] My PR contains **only** changes related to this fix (one commit, 3 files, production diff +21/−0)
- [x] I've run the tests — scope below
- [x] I've added tests for my changes (3 new, 2 RED on `main`)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS (aarch64), Python 3.11.15

**Test scope.** The full `tests/cron/` directory: **742 passed, 1 skipped, 0 failed**. `ruff check` and `git diff --check` clean on the changed files. `scripts/check-windows-footguns.py` reports pre-existing `read_text`/`write_text` encoding hits elsewhere in these files; my diff adds none. I did not run the entire `tests/` tree; CI is authoritative.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the added comment explains why the cron path must diverge from the interactive one; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, control flow only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (production): the run is a success and the recipient gets guardrail internals.

```
Turn ended: reason=guardrail_halt api_calls=5/150 tool_turns=5
jobs.json:  "last_status": "ok", "last_error": null
delivered:  "I stopped retrying mcp__odoo__search_records because it hit
             the tool-call guardrail (same_tool_failure_halt)…"
```

After: nothing is delivered, and the run carries a diagnosable error —
`agent run halted by tool guardrail (code=same_tool_failure_halt, tool_name=search_records)`.
