### PR TITLE
fix(desktop): keep Home new sessions detached

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -78,7 +78,7 @@ function deferred<T>() {
 
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
-  'createBackendSessionForSend' | 'selectSidebarItem' | 'startFreshSessionDraft'
+  'createBackendSessionForSend' | 'openNewSessionTile' | 'selectSidebarItem' | 'startFreshSessionDraft'
 >
 
 function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
@@ -1691,6 +1691,53 @@ describe('createBackendSessionForSend workspace target', () => {
     )
 
     expect(params).toMatchObject({ cwd: '/clicked-workspace' })
+  })
+})
+
+describe('openNewSessionTile workspace target', () => {
+  afterEach(() => {
+    cleanup()
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
+    vi.restoreAllMocks()
+  })
+
+  it('omits cwd for a Home tile even when project scope resolves to a repo', async () => {
+    $projectScope.set('p_voice')
+    $projectTree.set([
+      {
+        id: 'p_voice',
+        label: 'Voice Assistant',
+        path: '/Users/oschmidt/Checkouts/voice-assistant',
+        repos: [],
+        sessionCount: 0
+      } as never
+    ])
+
+    let createParams: Record<string, unknown> | undefined
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return {
+          info: { cwd: '', model: 'test-model', tools: {}, skills: {} },
+          session_id: RUNTIME_SESSION_ID,
+          stored_session_id: 'stored-home-tile'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('center', { cwd: null, listed: false })
+    })
+
+    expect(createParams).not.toHaveProperty('cwd')
   })
 })
 describe('selectSidebarItem', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -499,9 +499,15 @@ export function useSessionActions({
 
       try {
         // Fresh tile → the caller's workspace when one was named (the sidebar
-        // "+" on a project/worktree lane), else the resolved new-session cwd
-        // (project scope → configured default).
-        const params = await desktopSessionCreateParams((options?.cwd || resolveNewSessionCwd()).trim())
+        // "+" on a project/worktree lane), explicit null means Home/detached,
+        // else the resolved new-session cwd (project scope → configured default).
+        const cwd =
+          options?.cwd === null
+            ? ''
+            : typeof options?.cwd === 'string'
+              ? options.cwd.trim()
+              : resolveNewSessionCwd()
+        const params = await desktopSessionCreateParams(cwd)
         const created = await requestGateway<SessionCreateResponse>('session.create', params)
         const stored = created.stored_session_id
 

--- a/apps/desktop/src/app/session/workspace-session-target.test.ts
+++ b/apps/desktop/src/app/session/workspace-session-target.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $currentBranch,
   $currentCwd,
   $newChatWorkspaceTarget,
+  type NewChatWorkspaceTarget,
   setCurrentBranch,
   setCurrentCwd,
   setNewChatWorkspaceTarget
@@ -26,6 +28,8 @@ describe('startWorkspaceSession', () => {
     setCurrentBranch('')
     setCurrentCwd('')
     setNewChatWorkspaceTarget(undefined)
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
     vi.restoreAllMocks()
   })
 
@@ -40,7 +44,7 @@ describe('startWorkspaceSession', () => {
 
     const activeSessionIdRef = { current: null }
 
-    const startFreshSessionDraft = vi.fn((options?: { workspaceTarget: string }) => {
+    const startFreshSessionDraft = vi.fn((options?: { workspaceTarget: NewChatWorkspaceTarget }) => {
       setNewChatWorkspaceTarget(options?.workspaceTarget)
       setCurrentCwd(options?.workspaceTarget || '')
     })
@@ -77,5 +81,37 @@ describe('startWorkspaceSession', () => {
     expect($newChatWorkspaceTarget.get()).toBe('/normalized-b')
     expect($currentCwd.get()).toBe('/normalized-b')
     expect($currentBranch.get()).toBe('main')
+  })
+
+  it('keeps a Home new-session request detached even when another project scope is active', () => {
+    $projectScope.set('p_voice')
+    $projectTree.set([
+      {
+        id: 'p_voice',
+        label: 'Voice Assistant',
+        path: '/Users/oschmidt/Checkouts/voice-assistant',
+        repos: [],
+        sessionCount: 0
+      }
+    ])
+
+    const requestGateway = vi.fn()
+    const activeSessionIdRef = { current: null }
+    const startFreshSessionDraft = vi.fn((options?: { workspaceTarget: NewChatWorkspaceTarget }) => {
+      setNewChatWorkspaceTarget(options?.workspaceTarget)
+      setCurrentCwd(options?.workspaceTarget || '')
+    })
+
+    startWorkspaceSession({
+      activeSessionIdRef,
+      path: null,
+      requestGateway,
+      startFreshSessionDraft
+    })
+
+    expect(startFreshSessionDraft).toHaveBeenCalledWith({ workspaceTarget: null })
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect($newChatWorkspaceTarget.get()).toBeNull()
+    expect($currentCwd.get()).toBe('')
   })
 })

--- a/apps/desktop/src/app/session/workspace-session-target.ts
+++ b/apps/desktop/src/app/session/workspace-session-target.ts
@@ -3,6 +3,7 @@ import type { MutableRefObject } from 'react'
 import { followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
 import {
   $newChatWorkspaceTargetGeneration,
+  type NewChatWorkspaceTarget,
   setCurrentBranch,
   setCurrentCwd,
   setNewChatWorkspaceTarget
@@ -14,7 +15,7 @@ interface WorkspaceSessionOptions {
   onExplicitWorkspace?: (cwd: string) => void
   path: null | string
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
-  startFreshSessionDraft: (options?: { workspaceTarget: string }) => void
+  startFreshSessionDraft: (options?: { workspaceTarget: NewChatWorkspaceTarget }) => void
 }
 
 export function startWorkspaceSession({
@@ -25,9 +26,16 @@ export function startWorkspaceSession({
   requestGateway,
   startFreshSessionDraft
 }: WorkspaceSessionOptions): void {
-  // A worktree lane carries its own path; a project trunk can be path-less, so
-  // fall back to the active project's root for that existing controller path.
-  const explicitTarget = path?.trim()
+  if (path === null) {
+    startFreshSessionDraft({ workspaceTarget: null })
+
+    return
+  }
+
+  // A worktree lane carries its own path. Empty string (legacy/path-less trunk)
+  // can fall back to the active project's root, but null is reserved for Home's
+  // explicit no-workspace request and was handled above.
+  const explicitTarget = path.trim()
   const target = explicitTarget || resolveNewSessionCwd()
 
   startFreshSessionDraft(target ? { workspaceTarget: target } : undefined)


### PR DESCRIPTION
## Summary
- Treat Home project new-session requests (`path === null`) as an explicit detached workspace target.
- Preserve detached Home behavior for both the foreground draft path and occupied-chat tile path.
- Add regression coverage for Home sessions not inheriting an active project scope.

## Test Plan
- `npm run test:ui -- src/app/session/workspace-session-target.test.ts src/app/session/hooks/use-session-actions.test.tsx`
- `npm run typecheck`
