### PR TITLE
fix(mcp): complete the mcp 2.x attribute-name migration audit

### DIFF
--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -245,3 +245,96 @@ class TestAnnotationCaptureAtDiscovery:
         assert mcp_tool._annotation_read_only_hint(
             SimpleNamespace()
         ) is False
+
+    def test_real_sdk_annotations_read_only_hint_survives_2x_rename(self):
+        """mcp 2.0 renamed ``readOnlyHint`` -> ``read_only_hint`` on the SDK
+        model; camelCase survives only as a pydantic serialization alias,
+        which attribute access does not see. Every other case here builds a
+        duck-typed ``SimpleNamespace``, which cannot catch that rename —
+        pin one case to the actual SDK model, mirroring
+        test_mcp_elicitation.py's requestedSchema regression guard.
+        """
+        pytest.importorskip("mcp.types")
+        from mcp.types import ToolAnnotations
+
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(annotations=ToolAnnotations(readOnlyHint=True))
+        ) is True
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(annotations=ToolAnnotations(readOnlyHint=False))
+        ) is False
+
+    def test_real_sdk_tool_read_only_hint_captured_at_registration(self):
+        """End-to-end through _register_server_tools with real SDK Tool /
+        ToolAnnotations objects, not the SimpleNamespace stand-ins every
+        other test in this class uses — those cannot catch a field rename
+        in the installed SDK.
+        """
+        pytest.importorskip("mcp.types")
+        from mcp.types import Tool, ToolAnnotations
+        from tools.registry import ToolRegistry
+
+        server = mcp_tool.MCPServerTask("srv")
+        server.session = MagicMock()
+        server._tools = [
+            Tool(
+                name="list_repos", description="",
+                inputSchema={"type": "object"},
+                annotations=ToolAnnotations(readOnlyHint=True),
+            ),
+            Tool(
+                name="delete_repo", description="",
+                inputSchema={"type": "object"},
+                annotations=ToolAnnotations(readOnlyHint=False),
+            ),
+        ]
+        config = {
+            "trust": "untrusted",
+            "tools": {"resources": False, "prompts": False},
+        }
+        with patch("tools.registry.registry", ToolRegistry()), \
+             patch("tools.mcp_tool._track_mcp_tool_server"):
+            mcp_tool._register_server_tools("srv", server, config)
+
+        hints = mcp_tool._tool_read_only_hints["srv"]
+        assert hints.get("list_repos") is True
+        assert not hints.get("delete_repo")
+
+    def test_real_sdk_tool_input_schema_survives_2x_rename_in_cache_write_through(self):
+        """The on-disk schema cache write-through (#56832) must persist the
+        real inputSchema off a genuine SDK Tool object, not silently fall
+        back to {} because mcp 2.x renamed the attribute to input_schema. A
+        cache-registered tool that starts from an empty schema loses every
+        argument on the next lazy-start (no server spawn to notice).
+        """
+        pytest.importorskip("mcp.types")
+        from mcp.types import Tool
+        from tools.registry import ToolRegistry
+
+        real_schema = {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        }
+        server = mcp_tool.MCPServerTask("srv")
+        server.session = MagicMock()
+        server._tools = [
+            Tool(name="read_file", description="Read a file", inputSchema=real_schema),
+        ]
+        config = {"tools": {"resources": False, "prompts": False}}
+
+        captured = {}
+
+        def _capture_write(name, fingerprint, *, tools, utility_tools,
+                            ttl_ms=None, cache_scope=None):
+            captured["tools"] = tools
+
+        with patch("tools.registry.registry", ToolRegistry()), \
+             patch("tools.mcp_tool._track_mcp_tool_server"), \
+             patch("tools.mcp_schema_cache.write_cache_entry",
+                   side_effect=_capture_write):
+            mcp_tool._register_server_tools("srv", server, config)
+
+        assert captured, "write_cache_entry was never called"
+        entry = next(t for t in captured["tools"] if t["name"] == "read_file")
+        assert entry["inputSchema"] == real_schema

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4339,7 +4339,7 @@ def _annotation_read_only_hint(mcp_tool: Any) -> bool:
     if isinstance(annotations, dict):
         hint = annotations.get("readOnlyHint")
     else:
-        hint = getattr(annotations, "readOnlyHint", None)
+        hint = mcp_field(annotations, "read_only_hint", "readOnlyHint")
     return hint is True
 
 
@@ -6927,7 +6927,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             for mcp_tool in server._tools:
                 if not _should_register(mcp_tool.name):
                     continue
-                schema_obj = getattr(mcp_tool, "inputSchema", None)
+                schema_obj = mcp_field(mcp_tool, "input_schema", "inputSchema")
                 tools_payload.append({
                     "name": mcp_tool.name,
                     "description": mcp_tool.description or "",


### PR DESCRIPTION
## Summary
The recent "migrate to the mcp 2.x SDK" work renamed model fields to snake_case (camelCase survives only as a pydantic serialization alias, which attribute access does not see) and fixed several call sites with the shared `mcp_field(obj, snake, camel)` helper. Two sites in `tools/mcp_tool.py` still read the pre-2.0 camelCase spelling directly via bare `getattr()`, so they silently regressed on the pinned 2.x SDK:

- **`_annotation_read_only_hint()`** reads `annotations.readOnlyHint`, which does not exist on a real 2.x `ToolAnnotations` object (only `.read_only_hint` does). `getattr(..., None)` returns `None`, so every tool on every `trust: untrusted` MCP server is misclassified as write-capable — users get an unnecessary approval prompt on every call. Fails toward *more* prompts, not a bypass, but it's a real regression of the `readOnlyHint` trust-tier gate (#81151).
- **`_register_server_tools()`'s schema-cache write-through** (#56832) reads `mcp_tool.inputSchema`, which does not exist on a real 2.x `Tool` object (only `.input_schema` does). The cached tool entry silently gets `"inputSchema": {}`. The next startup's lazy (cache-registered) path then exposes that tool with zero parameters — the model loses every argument, with no server spawn to surface an error.

Both are fixed the same way `_convert_mcp_schema()` (and the elicitation-schema read) already handle this exact rename — read through `mcp_field()`, which checks both spellings so the read is correct on either installed SDK generation.

## Root cause of why this stayed uncaught
Existing coverage for both sites only exercised `SimpleNamespace` stand-ins with the attribute set directly under its camelCase name — which cannot catch a real SDK field rename, since `SimpleNamespace` answers to whatever attribute name you set on it. Confirmed empirically against the installed `mcp==2.0.0` SDK:

```
>>> from mcp.types import Tool, ToolAnnotations
>>> hasattr(Tool(name='x', description='d', inputSchema={'type':'object'}), 'inputSchema')
False
>>> hasattr(ToolAnnotations(readOnlyHint=True), 'readOnlyHint')
False
```

## Changes
- `tools/mcp_tool.py`: both sites now read through `mcp_field()`.
- `tests/tools/test_mcp_trust_gating.py`: 3 new tests pin one case each to the actual installed `mcp` SDK's `Tool`/`ToolAnnotations` models (guarded with `pytest.importorskip("mcp.types")`), mirroring the pattern `test_mcp_elicitation.py` already established for the sibling `requestedSchema` rename.

## Test plan
- [x] New tests reproduce the gap against pre-fix code and pass after the fix
- [x] Mutation-verified: reverting the fix (`git stash`) makes all 3 new tests fail against pre-fix code — the schema-cache test shows the cached `inputSchema` landing as `{}` instead of the real schema
- [x] Broader MCP suite (167 tests: `test_mcp_tool.py`, `test_mcp_schema_cache*.py`, `test_mcp_lazy_start.py`, `test_mcp_dynamic_discovery.py`, `test_mcp_elicitation.py`, `test_mcp_structured_content.py`, `test_mcp_streamable_http_arity.py`) passes unchanged
- [x] `ruff check` clean on both changed files