### PR TITLE
fix(doctor): recognise providers declared by provider plugins

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -130,6 +130,35 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
+def resolve_registered_provider_id(provider: str) -> str | None:
+    """Return the canonical provider name when a ProviderProfile is registered.
+
+    The ``model.provider`` validation below resolves names against the static
+    model catalog in ``hermes_cli/providers.py``. Provider *plugins* never
+    reach that catalog: bundled ones under ``plugins/model-providers/`` and
+    user ones under ``$HERMES_HOME/plugins/model-providers/`` register a
+    ``ProviderProfile`` with the separate ``providers/`` registry instead.
+    Catalog resolution alone therefore reports every plugin-declared provider
+    as unknown — including the ones the doctor itself lists as known, since
+    that list is built from the runtime registry.
+
+    Aliases resolve to the canonical name, so ``pm`` yields ``privatemode``.
+    Returns None when nothing is registered for *provider*.
+    """
+    name = (provider or "").strip().lower()
+    if not name:
+        return None
+    try:
+        from providers import get_provider_profile
+    except Exception:
+        return None
+    try:
+        profile = get_provider_profile(name)
+    except Exception:
+        return None
+    return getattr(profile, "name", None) or None
+
+
 def _honcho_is_configured_for_doctor() -> bool:
     """Return True when Honcho is configured, even if this process has no active session."""
     try:
@@ -1044,6 +1073,11 @@ def run_doctor(args):
             ):
                 provider_def = _resolve_provider_full(provider, user_providers, custom_providers)
                 catalog_provider = provider_def.id if provider_def is not None else None
+                if catalog_provider is None:
+                    # Not in the static catalog — fall back to the runtime
+                    # ProviderProfile registry, which is where every provider
+                    # plugin declares itself.
+                    catalog_provider = resolve_registered_provider_id(provider)
                 if catalog_provider is not None:
                     provider_ids_to_accept.add(catalog_provider)
 

--- a/tests/hermes_cli/test_doctor_provider_plugin_recognition.py
+++ b/tests/hermes_cli/test_doctor_provider_plugin_recognition.py
@@ -1,0 +1,72 @@
+"""Doctor must recognise providers declared by provider plugins.
+
+Provider plugins register a ``ProviderProfile`` with the ``providers/``
+registry; they never appear in the static model catalog in
+``hermes_cli/providers.py``. Doctor's ``model.provider`` validation used to
+resolve names against that catalog alone, so a provider authored per the
+documented plugin recipe failed with "not a recognised provider" while being
+listed among the known providers in the very same message.
+
+These assert the relationship — "registered profile ⇒ recognised" — rather
+than snapshotting which providers happen to ship today.
+"""
+
+import pytest
+
+from hermes_cli.doctor import resolve_registered_provider_id
+
+
+@pytest.fixture
+def registered_profile():
+    """Register a throwaway provider profile.
+
+    No cleanup needed: the suite runs one subprocess per test file, so the
+    process-global provider registry cannot leak into another file.
+    """
+    from providers import register_provider
+    from providers.base import ProviderProfile
+
+    profile = ProviderProfile(
+        name="doctor-test-provider",
+        aliases=("dtp",),
+        base_url="http://127.0.0.1:9/v1",
+        auth_type="api_key",
+    )
+    register_provider(profile)
+    return profile
+
+
+def test_registered_provider_is_recognised(registered_profile):
+    assert resolve_registered_provider_id("doctor-test-provider") == "doctor-test-provider"
+
+
+def test_alias_resolves_to_canonical_name(registered_profile):
+    assert resolve_registered_provider_id("dtp") == "doctor-test-provider"
+
+
+def test_lookup_is_case_insensitive(registered_profile):
+    assert resolve_registered_provider_id("  Doctor-Test-Provider  ") == "doctor-test-provider"
+
+
+def test_unregistered_provider_is_not_recognised():
+    assert resolve_registered_provider_id("no-such-provider-anywhere") is None
+
+
+@pytest.mark.parametrize("value", ["", "   ", None])
+def test_blank_input_is_not_recognised(value):
+    assert resolve_registered_provider_id(value) is None
+
+
+def test_every_bundled_provider_passes_the_check():
+    """Invariant: anything the registry lists must satisfy the validation.
+
+    This is what actually broke — the doctor's own "known providers" list is
+    built from this registry, so a provider it advertises must never be
+    rejected as unknown.
+    """
+    from providers import list_providers
+
+    registered = list_providers()
+    assert registered, "provider discovery returned nothing — registry is not wired"
+    for profile in registered:
+        assert resolve_registered_provider_id(profile.name) == profile.name


### PR DESCRIPTION
## Symptom

`hermes doctor` rejects a provider it lists as known, in the same message:

```
✗ model.provider 'privatemode' is not a recognised provider
  (known: ai-gateway, …, pm, privatemode, privatemode-ai, …)
```

Reproduced on current `main` with a provider plugin authored exactly per
`website/docs/developer-guide/model-provider-plugin.md`. The provider works
at runtime — a real completion succeeds — only the doctor check fails.

## Cause

Two registries, and the check consults the wrong one.

`hermes_cli/doctor.py` resolves `model.provider` via `resolve_provider_full()`
from `hermes_cli/providers.py` — a static model catalog. Provider *plugins*
never reach it: bundled ones under `plugins/model-providers/` and user ones
under `$HERMES_HOME/plugins/model-providers/` register a `ProviderProfile`
with the separate `providers/` registry.

```
hermes_cli.providers.resolve_provider_full('privatemode') -> None
providers.get_provider_profile('privatemode')             -> privatemode
```

`catalog_provider is None` then trips the failure branch. The "known" list in
the very same message is built from `hermes_cli.auth.PROVIDER_REGISTRY`, which
*is* extended from the runtime registry — hence the self-contradiction.

This affects every provider plugin, not one specific provider.

## Fix

Fall back to the runtime registry when the catalog has no entry, resolving
aliases to canonical names. The catalog path is untouched; this only adds a
second attempt after it returns `None`.

The check lived inline in a ~100-line branch, so it was untestable without
reading source text. Extracted as `resolve_registered_provider_id()`.

## Tests

`tests/hermes_cli/test_doctor_provider_plugin_recognition.py` — 8 tests,
written as invariants rather than a snapshot of the shipped provider list.
The load-bearing one is `test_every_bundled_provider_passes_the_check`:
anything the registry lists must satisfy the validation, which is exactly
the relationship that was broken.

```
scripts/run_tests.sh tests/hermes_cli/test_doctor_provider_plugin_recognition.py -q
=== Summary: 1 files, 8 tests passed, 0 failed ===
```

Regression — the three existing doctor files, 50 tests, all green:

```
scripts/run_tests.sh tests/hermes_cli/test_doctor.py \
  tests/hermes_cli/test_doctor_dedicated_provider_skip.py \
  tests/hermes_cli/test_doctor_command_install.py -q
=== Summary: 3 files, 50 tests passed, 0 failed ===
```

Verified end to end: the false failure is gone; the remaining doctor issues on
that profile are pre-existing npm advisories in `web` / `ui-tui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
