### PR TITLE
feat(desktop): extract SessionSurface from session tiles, export from plugin-sdk (re-open)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
@@ -25,14 +25,15 @@ vi.mock('@assistant-ui/react', () => ({
 
 interface ProbeHarnessProps {
   activeQueueSessionKey: string | null
+  focusKey?: string | null
   onLayoutSnapshot: (attachments: ComposerAttachment[]) => void
   sessionId: string
 }
 
-function ProbeHarness({ activeQueueSessionKey, onLayoutSnapshot, sessionId }: ProbeHarnessProps) {
+function ProbeHarness({ activeQueueSessionKey, focusKey = null, onLayoutSnapshot, sessionId }: ProbeHarnessProps) {
   useComposerDraft({
     activeQueueSessionKey,
-    focusKey: null,
+    focusKey,
     inputDisabled: false,
     queueEditRef: { current: null as QueueEditState | null },
     sessionId
@@ -264,6 +265,7 @@ describe('useComposerDraft — a closing composer hands the focus-bus key back',
       <ComposerScopeProvider value={scope}>
         <ProbeHarness
           activeQueueSessionKey="session-tile"
+          focusKey={target}
           onLayoutSnapshot={() => undefined}
           sessionId="session-tile"
         />

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -182,7 +182,7 @@ export function useComposerDraft({
   )
 
   useEffect(() => {
-    if (!inputDisabled) {
+    if (!inputDisabled && focusKey !== null) {
       focusInput()
     }
   }, [focusInput, focusKey, focusRequestId, inputDisabled])

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -75,6 +75,7 @@ import {
 import { advanceTranscriptWindow, type TranscriptWindowState } from './transcript-window'
 
 interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
+  focusOnSessionChange?: boolean
   gateway: HermesGateway | null
   modelMenuContent?: React.ReactNode
   onToggleSelectedPin: () => void
@@ -322,6 +323,7 @@ function ChatRuntimeBoundary({
 // useCallback at the call sites) memo() lets the whole chat shell skip those.
 export const ChatView = memo(function ChatView({
   className,
+  focusOnSessionChange = true,
   gateway,
   modelMenuContent,
   onToggleSelectedPin,
@@ -652,7 +654,7 @@ export const ChatView = memo(function ChatView({
               busy={busy}
               cwd={currentCwd}
               disabled={!gatewayOpen}
-              focusKey={activeSessionId}
+              focusKey={focusOnSessionChange ? activeSessionId : null}
               gateway={gateway}
               maxRecordingSeconds={maxVoiceRecordingSeconds}
               onAddContextRef={onAddContextRef}

--- a/apps/desktop/src/app/chat/session-surface-chat.tsx
+++ b/apps/desktop/src/app/chat/session-surface-chat.tsx
@@ -139,6 +139,7 @@ export function SessionSurfaceChat({ profile, runtimeSessionId, storedSessionId 
     <SessionViewProvider value={view}>
       <ComposerScopeProvider value={scope}>
         <ChatView
+          focusOnSessionChange={false}
           gateway={gateway}
           modelMenuContent={
             <ModelMenuPanel

--- a/apps/desktop/src/app/chat/session-surface-chat.tsx
+++ b/apps/desktop/src/app/chat/session-surface-chat.tsx
@@ -44,7 +44,11 @@ function buildSessionSurfaceView(profile: string, runtimeSessionId: string, stor
     $provider: computed($state, state => state?.provider ?? ''),
     $reasoningEffort: computed($state, state => state?.reasoningEffort ?? ''),
     $runtimeId,
-    $storedId: atom(storedSessionId)
+    $storedId: atom(storedSessionId),
+    // Per-surface turn clock (mirrors the tile refactor): a surface must time
+    // ITS OWN turn, never the primary chat's, so the clock lives beside the
+    // other per-surface signals on SessionView.
+    $turnStartedAt: computed($state, state => state?.turnStartedAt ?? null)
   }
 }
 

--- a/apps/desktop/src/app/chat/session-surface-chat.tsx
+++ b/apps/desktop/src/app/chat/session-surface-chat.tsx
@@ -1,0 +1,173 @@
+import { useStore } from '@nanostores/react'
+import { useQueryClient } from '@tanstack/react-query'
+import { atom, computed } from 'nanostores'
+import { useCallback, useMemo, useRef } from 'react'
+
+import type { GatewayRequester } from '@/app/contrib/types'
+import { useModelControls } from '@/app/session/hooks/use-model-controls'
+import { blobToDataUrl } from '@/app/session/hooks/use-prompt-actions/utils'
+import { ModelMenuPanel } from '@/app/shell/model-menu-panel'
+import { formatRefValue } from '@/components/assistant-ui/directive-text'
+import { transcribeAudio } from '@/hermes'
+import type { ChatMessage } from '@/lib/chat-messages'
+import { createComposerAttachmentScope } from '@/store/composer'
+import { profileGatewayState, requestGatewayForProfile } from '@/store/gateway'
+import { sessionAwaitingInput } from '@/store/prompts'
+import { $sessionStates, sessionRuntimeState } from '@/store/session-states'
+
+import { type ComposerScope, ComposerScopeProvider } from './composer/scope'
+import { useComposerActions } from './hooks/use-composer-actions'
+import { useSessionTileActions } from './session-tile-actions'
+import { type SessionView, SessionViewProvider } from './session-view'
+import { lastVisibleMessageIsUser } from './thread-loading'
+
+import { ChatView } from '.'
+
+const NO_MESSAGES: ChatMessage[] = []
+const noop = () => undefined
+
+function buildSessionSurfaceView(profile: string, runtimeSessionId: string, storedSessionId: string): SessionView {
+  const $runtimeId = atom<null | string>(runtimeSessionId)
+  const $state = computed($sessionStates, states => sessionRuntimeState(states, profile, runtimeSessionId))
+  const $messages = computed($state, state => state?.messages ?? NO_MESSAGES)
+
+  return {
+    kind: 'tile',
+    $awaitingResponse: computed($state, state => Boolean(state?.awaitingResponse)),
+    $busy: computed($state, state => Boolean(state?.busy)),
+    $cwd: computed($state, state => state?.cwd ?? ''),
+    $fast: computed($state, state => Boolean(state?.fast)),
+    $lastVisibleIsUser: computed($messages, lastVisibleMessageIsUser),
+    $messages,
+    $messagesEmpty: computed($messages, messages => messages.length === 0),
+    $model: computed($state, state => state?.model ?? ''),
+    $provider: computed($state, state => state?.provider ?? ''),
+    $reasoningEffort: computed($state, state => state?.reasoningEffort ?? ''),
+    $runtimeId,
+    $storedId: atom(storedSessionId)
+  }
+}
+
+export interface SessionSurfaceChatProps {
+  profile: string
+  runtimeSessionId: string
+  storedSessionId: string
+}
+
+/** The native transcript/composer tree shared by plugin surfaces and tiles. */
+export function SessionSurfaceChat({ profile, runtimeSessionId, storedSessionId }: SessionSurfaceChatProps) {
+  const view = useMemo(
+    () => buildSessionSurfaceView(profile, runtimeSessionId, storedSessionId),
+    [profile, runtimeSessionId, storedSessionId]
+  )
+
+  // A surface-scoped requester that routes every call through the owning
+  // profile's socket without foregrounding it (main calls straight into
+  // useGatewayRequest's active gateway; SessionSurface must not activate a
+  // profile just to submit a prompt).
+  const requestSurfaceGateway = useCallback(
+    <T,>(method: string, params: Record<string, unknown> = {}) =>
+      requestGatewayForProfile<T>(profile, method, { ...params, profile }),
+    [profile]
+  ) as unknown as GatewayRequester
+
+  const gateway = profileGatewayState(profile)
+  const queryClient = useQueryClient()
+  const modelControls = useModelControls({ profile, queryClient, requestGateway: requestSurfaceGateway })
+  const cwd = useStore(view.$cwd)
+
+  const attachments = useRef(createComposerAttachmentScope()).current
+
+  const scope = useMemo<ComposerScope>(
+    () => ({
+      $awaitingInput: sessionAwaitingInput(runtimeSessionId),
+      $messages: view.$messages,
+      attachments,
+      target: `surface:${profile}:${storedSessionId}`
+    }),
+    [attachments, profile, runtimeSessionId, storedSessionId, view.$messages]
+  )
+
+  const actions = useSessionTileActions({
+    profile,
+    requestGateway: requestSurfaceGateway,
+    runtimeId: runtimeSessionId,
+    scope,
+    storedSessionId
+  })
+
+  const composer = useComposerActions({
+    activeSessionId: runtimeSessionId,
+    currentCwd: cwd,
+    requestGateway: requestSurfaceGateway,
+    scope: {
+      add: attachments.add,
+      remove: attachments.remove,
+      target: scope.target,
+      update: attachments.update,
+      updateIfCurrent: attachments.updateIfCurrent
+    }
+  })
+
+  const { addContextRefAttachment, pasteClipboardImage, pickContextPaths, pickImages, removeAttachment } = composer
+
+  const onAddUrl = useCallback(
+    (url: string) => addContextRefAttachment(`@url:${formatRefValue(url)}`, url),
+    [addContextRefAttachment]
+  )
+
+  const onPasteClipboardImage = useCallback(
+    (opts?: { silent?: boolean }) => pasteClipboardImage(opts),
+    [pasteClipboardImage]
+  )
+
+  const onPickFiles = useCallback(() => void pickContextPaths('file'), [pickContextPaths])
+  const onPickFolders = useCallback(() => void pickContextPaths('folder'), [pickContextPaths])
+  const onPickImages = useCallback(() => void pickImages(), [pickImages])
+  const onRemoveAttachment = useCallback((id: string) => void removeAttachment(id), [removeAttachment])
+
+  const onTranscribeAudio = useCallback(
+    async (audio: Blob) => (await transcribeAudio(await blobToDataUrl(audio), audio.type)).transcript,
+    []
+  )
+
+  return (
+    <SessionViewProvider value={view}>
+      <ComposerScopeProvider value={scope}>
+        <ChatView
+          gateway={gateway}
+          modelMenuContent={
+            <ModelMenuPanel
+              gateway={gateway || undefined}
+              onSelectModel={modelControls.selectModel}
+              profile={profile}
+              requestGateway={requestSurfaceGateway}
+            />
+          }
+          onAddContextRef={addContextRefAttachment}
+          onAddUrl={onAddUrl}
+          onAttachDroppedItems={composer.attachDroppedItems}
+          onAttachImageBlob={composer.attachImageBlob}
+          onAttachPrCommentUrl={composer.attachPrCommentUrl}
+          onCancel={actions.cancelRun}
+          onDeleteSelectedSession={noop}
+          onDismissError={actions.dismissError}
+          onEdit={actions.editMessage}
+          onPasteClipboardImage={onPasteClipboardImage}
+          onPickFiles={onPickFiles}
+          onPickFolders={onPickFolders}
+          onPickImages={onPickImages}
+          onReload={actions.reloadFromMessage}
+          onRemoveAttachment={onRemoveAttachment}
+          onRestoreToMessage={actions.restoreToMessage}
+          onRetryResume={noop}
+          onSteer={actions.steerPrompt}
+          onSubmit={actions.submitText}
+          onThreadMessagesChange={actions.handleThreadMessagesChange}
+          onToggleSelectedPin={noop}
+          onTranscribeAudio={onTranscribeAudio}
+        />
+      </ComposerScopeProvider>
+    </SessionViewProvider>
+  )
+}

--- a/apps/desktop/src/app/chat/session-surface-model-menu.test.tsx
+++ b/apps/desktop/src/app/chat/session-surface-model-menu.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile } from '@/store/profile'
+import { $activeSessionId, $currentModel, $currentProvider, setCurrentModel, setCurrentProvider } from '@/store/session'
+
+import { SessionSurfaceChat } from './session-surface-chat'
+
+const requestGatewayForProfile = vi.fn(async (..._args: unknown[]) => ({}))
+
+vi.mock('@/store/gateway', () => ({
+  profileGatewayState: () => ({ connectionState: 'open' }),
+  subscribeProfileGateway: () => () => undefined,
+  requestGatewayForProfile: (
+    profile: string,
+    method: string,
+    params?: Record<string, unknown>,
+    timeout?: number,
+    signal?: AbortSignal
+  ) => requestGatewayForProfile(profile, method, params, timeout, signal)
+}))
+
+vi.mock('@/app/shell/model-menu-panel', () => ({
+  ModelMenuPanel: ({ onSelectModel }: { onSelectModel: (selection: unknown) => Promise<boolean> }) => (
+    <button
+      onClick={() =>
+        void onSelectModel({ model: 'claude-sonnet-4.6', provider: 'anthropic', sessionId: 'shared-runtime' })
+      }
+      type="button"
+    >
+      Select surface model
+    </button>
+  )
+}))
+
+vi.mock('./hooks/use-composer-actions', () => ({
+  useComposerActions: () => ({
+    addContextRefAttachment: vi.fn(),
+    attachDroppedItems: vi.fn(),
+    attachImageBlob: vi.fn(),
+    attachPrCommentUrl: vi.fn(),
+    pasteClipboardImage: vi.fn(),
+    pickContextPaths: vi.fn(),
+    pickImages: vi.fn(),
+    removeAttachment: vi.fn()
+  })
+}))
+
+vi.mock('./session-tile-actions', () => ({
+  useSessionTileActions: () => ({
+    cancelRun: vi.fn(),
+    dismissError: vi.fn(),
+    editMessage: vi.fn(),
+    handleThreadMessagesChange: vi.fn(),
+    reloadFromMessage: vi.fn(),
+    restoreToMessage: vi.fn(),
+    steerPrompt: vi.fn(),
+    submitText: vi.fn()
+  })
+}))
+
+vi.mock('.', () => ({
+  ChatView: ({ modelMenuContent }: { modelMenuContent?: React.ReactNode }) => <div>{modelMenuContent}</div>
+}))
+
+describe('SessionSurface model control', () => {
+  beforeEach(() => {
+    requestGatewayForProfile.mockClear()
+    $activeGatewayProfile.set('profile-a')
+    $activeSessionId.set('shared-runtime')
+    setCurrentModel('foreground-model')
+    setCurrentProvider('foreground-provider')
+  })
+
+  it('selects through the owner profile requester without mutating the colliding foreground', async () => {
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <SessionSurfaceChat profile="profile-b" runtimeSessionId="shared-runtime" storedSessionId="stored-b" />
+      </QueryClientProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select surface model' }))
+
+    await waitFor(() =>
+      expect(requestGatewayForProfile).toHaveBeenCalledWith(
+        'profile-b',
+        'config.set',
+        {
+          key: 'model',
+          profile: 'profile-b',
+          session_id: 'shared-runtime',
+          value: 'claude-sonnet-4.6 --provider anthropic --session'
+        },
+        undefined,
+        undefined
+      )
+    )
+    expect($currentModel.get()).toBe('foreground-model')
+    expect($currentProvider.get()).toBe('foreground-provider')
+  })
+})

--- a/apps/desktop/src/app/chat/session-surface-profile-runtime.test.tsx
+++ b/apps/desktop/src/app/chat/session-surface-profile-runtime.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
+import {
+  $sessionStates,
+  $sessionSurfaceProfiles,
+  $sessionTiles,
+  bindSessionSurfaceRuntime,
+  publishSessionState,
+  releaseSessionSurfaceReference,
+  retainSessionSurfaceReference,
+  sessionSurfaceReferenceCount
+} from '@/store/session-states'
+
+const state = (storedId: string, patch: Partial<ReturnType<typeof createClientSessionState>> = {}) => ({
+  ...createClientSessionState(storedId),
+  ...patch
+})
+
+/**
+ * The embedded surface's durable identity is PROFILE + stored id, never the
+ * stored id alone. These tests exercise the reference-counted surface binding
+ * and its inclusion in the publish-time eviction path (without the surface,
+ * a settled session's transcript is released; with it, the surface keeps the
+ * runtime alive until it unmounts).
+ */
+describe('SessionSurface references: profile-bound durable identity', () => {
+  beforeEach(() => {
+    $sessionStates.set({})
+    $sessionTiles.set([])
+    $activeSessionId.set(null)
+    $selectedStoredSessionId.set(null)
+    $sessionSurfaceProfiles.set([])
+  })
+
+  afterEach(() => {
+    $sessionStates.set({})
+    $sessionTiles.set([])
+    $sessionSurfaceProfiles.set([])
+  })
+
+  it('counts references per profile-qualified durable identity', () => {
+    retainSessionSurfaceReference('profile-a', 'stored-a')
+    retainSessionSurfaceReference('profile-a', 'stored-a')
+    expect(sessionSurfaceReferenceCount('profile-a', 'stored-a')).toBe(2)
+    expect($sessionSurfaceProfiles.get()).toContain('profile-a')
+
+    releaseSessionSurfaceReference('profile-a', 'stored-a')
+    expect(sessionSurfaceReferenceCount('profile-a', 'stored-a')).toBe(1)
+
+    releaseSessionSurfaceReference('profile-a', 'stored-a')
+    expect(sessionSurfaceReferenceCount('profile-a', 'stored-a')).toBe(0)
+    expect($sessionSurfaceProfiles.get()).not.toContain('profile-a')
+  })
+
+  it('treats the same stored id on two profiles as distinct surfaces', () => {
+    retainSessionSurfaceReference('profile-a', 'stored-same')
+    retainSessionSurfaceReference('profile-b', 'stored-same')
+
+    expect(sessionSurfaceReferenceCount('profile-a', 'stored-same')).toBe(1)
+    expect(sessionSurfaceReferenceCount('profile-b', 'stored-same')).toBe(1)
+
+    releaseSessionSurfaceReference('profile-a', 'stored-same')
+    releaseSessionSurfaceReference('profile-b', 'stored-same')
+  })
+
+  it('keeps a settled session an embedded surface references from eviction, and evicts on release', () => {
+    retainSessionSurfaceReference('profile-a', 'stored-a')
+    bindSessionSurfaceRuntime('profile-a', 'stored-a', 'rt-a')
+
+    publishSessionState('rt-a', state('stored-a', { busy: true }))
+    publishSessionState('rt-a', state('stored-a', { busy: false }))
+    // A surface still references the runtime: the settled transcript stays.
+    expect($sessionStates.get()['rt-a']).toBeDefined()
+
+    releaseSessionSurfaceReference('profile-a', 'stored-a')
+    // Released + settled -> the runtime is evicted, not parked forever.
+    expect($sessionStates.get()['rt-a']).toBeUndefined()
+  })
+
+  it('binding a new runtime supersedes and evicts the previous surface runtime', () => {
+    retainSessionSurfaceReference('profile-a', 'stored-a')
+    bindSessionSurfaceRuntime('profile-a', 'stored-a', 'rt-a')
+    publishSessionState('rt-a', state('stored-a', { busy: false }))
+    expect($sessionStates.get()['rt-a']).toBeDefined()
+
+    bindSessionSurfaceRuntime('profile-a', 'stored-a', 'rt-b')
+    // rt-a is no longer referenced by the surface -> evicted once settled.
+    expect($sessionStates.get()['rt-a']).toBeUndefined()
+
+    releaseSessionSurfaceReference('profile-a', 'stored-a')
+  })
+
+  it('an unreferenced settled session still releases its transcript at publish time', () => {
+    publishSessionState('rt-orphan', state('stored-orphan', { busy: true }))
+    publishSessionState('rt-orphan', state('stored-orphan', { busy: false }))
+
+    // No primary, tile, or surface reference -> transcript released, status kept.
+    expect($sessionStates.get()['rt-orphan']?.messages).toEqual([])
+    expect($sessionStates.get()['rt-orphan']).toMatchObject({ storedSessionId: 'stored-orphan', busy: false })
+  })
+})

--- a/apps/desktop/src/app/chat/session-surface.test.tsx
+++ b/apps/desktop/src/app/chat/session-surface.test.tsx
@@ -1,0 +1,393 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile } from '@/store/profile'
+import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
+import {
+  $sessionTiles,
+  releaseSessionSurfaceReference,
+  sessionSurfaceReferenceCount,
+  setSessionSurfaceDelegate
+} from '@/store/session-states'
+
+import { SessionSurface, SessionSurfaceCore } from './session-surface'
+
+const gatewaySubscriptions = vi.hoisted(() => ({
+  all: new Set<(profile: string) => void>(),
+  byProfile: new Map<string, Set<() => void>>(),
+  states: new Map<string, string>()
+}))
+
+vi.mock('@/store/gateway', () => ({
+  profileGatewayState: (profile: string) => ({ connectionState: gatewaySubscriptions.states.get(profile) ?? 'open' }),
+  subscribeProfileGateway: (profile: string, listener: () => void) => {
+    const listeners = gatewaySubscriptions.byProfile.get(profile) ?? new Set<() => void>()
+    listeners.add(listener)
+    gatewaySubscriptions.byProfile.set(profile, listeners)
+
+    return () => listeners.delete(listener)
+  },
+  subscribeProfileGateways: (listener: (profile: string) => void) => {
+    gatewaySubscriptions.all.add(listener)
+
+    return () => gatewaySubscriptions.all.delete(listener)
+  }
+}))
+
+function emitGatewayTransition(profile: string, state = 'open') {
+  gatewaySubscriptions.states.set(profile, state)
+  gatewaySubscriptions.all.forEach(listener => listener(profile))
+  gatewaySubscriptions.byProfile.get(profile)?.forEach(listener => listener())
+}
+
+vi.mock('./session-surface-chat', () => ({
+  SessionSurfaceChat: ({ runtimeSessionId }: { runtimeSessionId: string }) => (
+    <div data-testid="surface-chat">{runtimeSessionId}</div>
+  )
+}))
+
+const delegate = () => ({
+  adoptSurface: vi.fn(async (identity: { runtimeSessionId: string }) => identity.runtimeSessionId),
+  archiveSession: vi.fn(async () => undefined),
+  branchSession: vi.fn(async () => undefined),
+  deleteSession: vi.fn(async () => undefined),
+  executeSlash: vi.fn(async () => undefined),
+  interruptSession: vi.fn(async () => undefined),
+  resumeSurface: vi.fn(async (_identity: { profile: string; storedSessionId: string }) => 'runtime-resumed'),
+  resumeTile: vi.fn(async () => 'runtime-resumed'),
+  submitToSession: vi.fn(async () => undefined),
+  updateSession: vi.fn()
+})
+
+function deferred<T>() {
+  let reject!: (reason?: unknown) => void
+  let resolve!: (value: T | PromiseLike<T>) => void
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    reject = rejectPromise
+    resolve = resolvePromise
+  })
+
+  return { promise, reject, resolve }
+}
+
+function staleAdoptionError(message = 'Session surface identity mismatch') {
+  return Object.assign(new Error(message), { name: 'StaleSessionSurfaceRuntimeError' })
+}
+
+describe('SessionSurface', () => {
+  beforeEach(() => {
+    window.location.hash = '#/roadmaps'
+    $activeSessionId.set('runtime-primary')
+    $selectedStoredSessionId.set('stored-primary')
+    $activeGatewayProfile.set('default')
+    $sessionTiles.set([{ storedSessionId: 'tile-primary', runtimeId: 'runtime-tile' }])
+  })
+
+  afterEach(() => {
+    setSessionSurfaceDelegate(null)
+    gatewaySubscriptions.all.clear()
+    gatewaySubscriptions.byProfile.clear()
+    gatewaySubscriptions.states.clear()
+  })
+
+  it('adopts a fresh runtime hint without resume or foreground/layout navigation mutation', async () => {
+    const installed = delegate()
+    setSessionSurfaceDelegate(installed)
+    const beforeTiles = $sessionTiles.get()
+
+    render(<SessionSurface session={{ profile: 'work', runtimeSessionId: 'runtime-fresh', storedSessionId: 'stored-fresh' }} />)
+
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-fresh')
+    expect(installed.adoptSurface).toHaveBeenCalledWith({
+      profile: 'work',
+      runtimeSessionId: 'runtime-fresh',
+      storedSessionId: 'stored-fresh'
+    })
+    expect(installed.resumeSurface).not.toHaveBeenCalled()
+    expect(window.location.hash).toBe('#/roadmaps')
+    expect($activeSessionId.get()).toBe('runtime-primary')
+    expect($selectedStoredSessionId.get()).toBe('stored-primary')
+    expect($activeGatewayProfile.get()).toBe('default')
+    expect($sessionTiles.get()).toBe(beforeTiles)
+  })
+
+  it('falls back once to the durable identity when a runtime hint is stale', async () => {
+    const adoption = deferred<string>()
+    const resume = deferred<string>()
+    const installed = delegate()
+    installed.adoptSurface.mockImplementationOnce(() => adoption.promise)
+    installed.resumeSurface.mockImplementationOnce(() => resume.promise)
+    setSessionSurfaceDelegate(installed)
+
+    render(<SessionSurface session={{ profile: 'profile-b', runtimeSessionId: 'runtime-stale', storedSessionId: 'stored-b' }} />)
+    await waitFor(() => expect(installed.adoptSurface).toHaveBeenCalledTimes(1))
+
+    await act(async () => adoption.reject(staleAdoptionError()))
+    await waitFor(() =>
+      expect(installed.resumeSurface).toHaveBeenCalledWith({ profile: 'profile-b', storedSessionId: 'stored-b' })
+    )
+
+    act(() => emitGatewayTransition('profile-c', 'open'))
+    expect(installed.adoptSurface).toHaveBeenCalledTimes(1)
+    expect(installed.resumeSurface).toHaveBeenCalledTimes(1)
+
+    await act(async () => resume.resolve('runtime-recovered'))
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-recovered')
+  })
+
+  it('falls back durably when a previously adopted hint disappears after reconnect', async () => {
+    const installed = delegate()
+    installed.adoptSurface
+      .mockResolvedValueOnce('runtime-hint')
+      .mockRejectedValueOnce(staleAdoptionError('4007 Session not found'))
+    installed.resumeSurface.mockResolvedValueOnce('runtime-recovered')
+    setSessionSurfaceDelegate(installed)
+
+    render(<SessionSurface session={{ profile: 'profile-b', runtimeSessionId: 'runtime-hint', storedSessionId: 'stored-b' }} />)
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-hint')
+
+    act(() => {
+      emitGatewayTransition('profile-b', 'closed')
+      emitGatewayTransition('profile-b', 'open')
+    })
+
+    await waitFor(() => expect(installed.resumeSurface).toHaveBeenCalledTimes(1))
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-recovered')
+    expect(installed.adoptSurface).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries the durable recovery without adopting the known-stale hint forever', async () => {
+    const installed = delegate()
+    installed.adoptSurface.mockRejectedValueOnce(staleAdoptionError())
+    installed.resumeSurface.mockRejectedValueOnce(new Error('temporary timeout')).mockResolvedValueOnce('runtime-recovered')
+    setSessionSurfaceDelegate(installed)
+
+    render(<SessionSurface session={{ profile: 'profile-b', runtimeSessionId: 'runtime-stale', storedSessionId: 'stored-b' }} />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }))
+
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-recovered')
+    expect(installed.adoptSurface).toHaveBeenCalledTimes(1)
+    expect(installed.resumeSurface).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not turn transient or security adoption errors into a durable resume', async () => {
+    const installed = delegate()
+    installed.adoptSurface.mockRejectedValueOnce(new Error('403 forbidden'))
+    setSessionSurfaceDelegate(installed)
+
+    render(<SessionSurface session={{ profile: 'profile-b', runtimeSessionId: 'runtime-hint', storedSessionId: 'stored-b' }} />)
+
+    expect(await screen.findByRole('button', { name: 'Retry' })).toBeTruthy()
+    expect(installed.adoptSurface).toHaveBeenCalledTimes(1)
+    expect(installed.resumeSurface).not.toHaveBeenCalled()
+  })
+
+  it('discards a stale fallback completion after the durable identity changes', async () => {
+    const oldResume = deferred<string>()
+    const installed = delegate()
+    const onRuntimeSessionId = vi.fn()
+    installed.adoptSurface.mockRejectedValueOnce(staleAdoptionError())
+    installed.resumeSurface.mockImplementation(({ storedSessionId }: { storedSessionId: string }) =>
+      storedSessionId === 'stored-a' ? oldResume.promise : Promise.resolve('runtime-b')
+    )
+    setSessionSurfaceDelegate(installed)
+
+    const mounted = render(
+      <SessionSurfaceCore
+        onRuntimeSessionId={onRuntimeSessionId}
+        profile="profile-a"
+        runtimeSessionId="runtime-stale"
+        storedSessionId="stored-a"
+      />
+    )
+
+    await waitFor(() =>
+      expect(installed.resumeSurface).toHaveBeenCalledWith({ profile: 'profile-a', storedSessionId: 'stored-a' })
+    )
+
+    mounted.rerender(
+      <SessionSurfaceCore onRuntimeSessionId={onRuntimeSessionId} profile="profile-b" storedSessionId="stored-b" />
+    )
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-b')
+
+    await act(async () => oldResume.resolve('runtime-stale-completion'))
+    expect(screen.getByTestId('surface-chat').textContent).toBe('runtime-b')
+    expect(onRuntimeSessionId).toHaveBeenCalledTimes(1)
+    expect(onRuntimeSessionId).toHaveBeenCalledWith('runtime-b')
+  })
+
+  it('resumes durably with the explicit profile and hydrates without navigation', async () => {
+    const installed = delegate()
+    setSessionSurfaceDelegate(installed)
+
+    render(<SessionSurface session={{ profile: 'ai-engineer', storedSessionId: 'stored-existing' }} />)
+
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-resumed')
+    expect(installed.resumeSurface).toHaveBeenCalledWith({
+      profile: 'ai-engineer',
+      storedSessionId: 'stored-existing'
+    })
+    expect(installed.adoptSurface).not.toHaveBeenCalled()
+    expect(window.location.hash).toBe('#/roadmaps')
+    expect($activeGatewayProfile.get()).toBe('default')
+  })
+
+  it('releases only its local reference and remounts from the durable identity without interrupting', async () => {
+    const installed = delegate()
+    setSessionSurfaceDelegate(installed)
+
+    const first = render(
+      <SessionSurface session={{ profile: 'work', runtimeSessionId: 'runtime-fresh', storedSessionId: 'stored-fresh' }} />
+    )
+
+    await screen.findByTestId('surface-chat')
+    expect(sessionSurfaceReferenceCount('work', 'stored-fresh')).toBe(1)
+
+    act(() => first.unmount())
+    expect(sessionSurfaceReferenceCount('work', 'stored-fresh')).toBe(0)
+    expect(installed.interruptSession).not.toHaveBeenCalled()
+
+    render(<SessionSurface session={{ profile: 'work', storedSessionId: 'stored-fresh' }} />)
+    await waitFor(() => expect(installed.resumeSurface).toHaveBeenCalledWith({ profile: 'work', storedSessionId: 'stored-fresh' }))
+    expect(sessionSurfaceReferenceCount('work', 'stored-fresh')).toBe(1)
+
+    // Defensive cleanup in case a failed assertion leaves a retained token.
+    releaseSessionSurfaceReference('work', 'stored-fresh')
+  })
+
+  it('waits for a late delegate instead of latching unavailable at cold start', async () => {
+    render(<SessionSurface session={{ profile: 'work', storedSessionId: 'stored-late' }} />)
+    expect(screen.queryByText(/unavailable/i)).toBeNull()
+
+    const installed = delegate()
+    setSessionSurfaceDelegate(installed)
+
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-resumed')
+    expect(installed.resumeSurface).toHaveBeenCalledWith({ profile: 'work', storedSessionId: 'stored-late' })
+  })
+
+  it('starts only one resume while its profile opens and another profile transitions', async () => {
+    let resolveResume!: (runtimeSessionId: string) => void
+    const installed = delegate()
+    installed.resumeSurface.mockImplementationOnce(() => new Promise(resolve => (resolveResume = resolve)))
+    setSessionSurfaceDelegate(installed)
+
+    render(<SessionSurface session={{ profile: 'profile-b', storedSessionId: 'stored-b' }} />)
+    await waitFor(() => expect(installed.resumeSurface).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      emitGatewayTransition('profile-b')
+      emitGatewayTransition('profile-c')
+    })
+
+    expect(installed.resumeSurface).toHaveBeenCalledTimes(1)
+
+    resolveResume('runtime-b')
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-b')
+  })
+
+  it('discards an in-flight completion across connection loss and retries only after it settles', async () => {
+    let resolveFirst!: (runtimeSessionId: string) => void
+    let resolveSecond!: (runtimeSessionId: string) => void
+    const installed = delegate()
+    installed.resumeSurface
+      .mockImplementationOnce(() => new Promise(resolve => (resolveFirst = resolve)))
+      .mockImplementationOnce(() => new Promise(resolve => (resolveSecond = resolve)))
+    setSessionSurfaceDelegate(installed)
+
+    render(<SessionSurface session={{ profile: 'profile-b', storedSessionId: 'stored-b' }} />)
+    await waitFor(() => expect(installed.resumeSurface).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      emitGatewayTransition('profile-b', 'closed')
+      emitGatewayTransition('profile-b', 'open')
+    })
+    expect(installed.resumeSurface).toHaveBeenCalledTimes(1)
+
+    act(() => resolveFirst('runtime-stale'))
+    await waitFor(() => expect(installed.resumeSurface).toHaveBeenCalledTimes(2))
+    expect(screen.queryByText('runtime-stale')).toBeNull()
+
+    resolveSecond('runtime-fresh')
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-fresh')
+  })
+
+  it.each([
+    { profile: ' ', storedSessionId: 'stored', runtimeSessionId: undefined },
+    { profile: 'work\u0000evil', storedSessionId: 'stored', runtimeSessionId: undefined },
+    { profile: 'work', storedSessionId: '\n', runtimeSessionId: undefined },
+    { profile: 'work', storedSessionId: 'stored', runtimeSessionId: 'runtime\u0007evil' }
+  ])('rejects invalid public identities before retain or adoption: %o', async props => {
+    const installed = delegate()
+    setSessionSurfaceDelegate(installed)
+
+    render(<SessionSurface session={props} />)
+
+    expect(await screen.findByText("Couldn't open this session")).toBeTruthy()
+    expect(installed.adoptSurface).not.toHaveBeenCalled()
+    expect(installed.resumeSurface).not.toHaveBeenCalled()
+    expect(sessionSurfaceReferenceCount(props.profile, props.storedSessionId)).toBe(0)
+  })
+
+  it('redacts backend failures and retries when delegate readiness changes', async () => {
+    const failing = delegate()
+    failing.resumeSurface.mockRejectedValueOnce(new Error('/home/secret/state.db provider token=abc'))
+    setSessionSurfaceDelegate(failing)
+
+    render(<SessionSurface session={{ profile: 'work', storedSessionId: 'stored-retry' }} />)
+    expect(await screen.findByText("Couldn't open this session")).toBeTruthy()
+    expect(screen.queryByText(/secret|token=abc/)).toBeNull()
+
+    const recovered = delegate()
+    setSessionSurfaceDelegate(recovered)
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-resumed')
+  })
+
+  it('offers an explicit retry after a transient resume failure on the same delegate', async () => {
+    const installed = delegate()
+    installed.resumeSurface.mockRejectedValueOnce(new Error('temporary timeout'))
+    setSessionSurfaceDelegate(installed)
+
+    render(<SessionSurface session={{ profile: 'work', storedSessionId: 'stored-retry-button' }} />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }))
+
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-resumed')
+    expect(installed.resumeSurface).toHaveBeenCalledTimes(2)
+  })
+
+  it('never paints the previous transcript while its explicit durable identity changes', async () => {
+    const installed = delegate()
+    let resolveSecond!: (runtimeSessionId: string) => void
+
+    installed.resumeSurface
+      .mockResolvedValueOnce('runtime-one')
+      .mockImplementationOnce(() => new Promise(resolve => (resolveSecond = resolve)))
+    setSessionSurfaceDelegate(installed)
+
+    const mounted = render(<SessionSurface session={{ profile: 'work', storedSessionId: 'stored-one' }} />)
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-one')
+
+    mounted.rerender(<SessionSurface session={{ profile: 'other', storedSessionId: 'stored-two' }} />)
+    expect(screen.queryByTestId('surface-chat')).toBeNull()
+
+    resolveSecond('runtime-two')
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-two')
+  })
+
+  it('does not carry a prior profile connection loss into a new identity', async () => {
+    const installed = delegate()
+    installed.resumeSurface.mockResolvedValueOnce('runtime-a').mockResolvedValueOnce('runtime-b')
+    setSessionSurfaceDelegate(installed)
+
+    const mounted = render(<SessionSurface session={{ profile: 'profile-a', storedSessionId: 'stored-a' }} />)
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-a')
+    act(() => emitGatewayTransition('profile-a', 'closed'))
+
+    mounted.rerender(<SessionSurface session={{ profile: 'profile-b', storedSessionId: 'stored-b' }} />)
+    expect((await screen.findByTestId('surface-chat')).textContent).toBe('runtime-b')
+    act(() => emitGatewayTransition('profile-b', 'open'))
+
+    expect(installed.resumeSurface).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/app/chat/session-surface.tsx
+++ b/apps/desktop/src/app/chat/session-surface.tsx
@@ -1,0 +1,309 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { CenteredThreadSpinner } from '@/components/assistant-ui/thread/status'
+import { profileGatewayState, subscribeProfileGateway } from '@/store/gateway'
+import type { SessionSurfaceIdentity } from '@/store/session-states'
+import {
+  bindSessionSurfaceRuntime,
+  isStaleSessionSurfaceRuntimeError,
+  releaseSessionSurfaceReference,
+  retainSessionSurfaceReference,
+  sessionSurfaceDelegate,
+  subscribeSessionSurfaceDelegate
+} from '@/store/session-states'
+
+import { SessionSurfaceChat } from './session-surface-chat'
+
+export type { SessionSurfaceIdentity } from '@/store/session-states'
+
+export interface SessionSurfaceProps {
+  session: SessionSurfaceIdentity
+}
+
+export interface SessionSurfaceCoreProps extends SessionSurfaceIdentity {
+  /** Core-only lifecycle notification used by session tiles. */
+  onRuntimeSessionId?: (runtimeSessionId: string) => void
+}
+
+function validIdentityPart(value: unknown): value is string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return false
+  }
+
+  for (const character of value) {
+    const code = character.codePointAt(0)
+
+    if (code === undefined || code < 32 || code === 127) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export function SessionSurfaceCore({
+  onRuntimeSessionId,
+  profile,
+  runtimeSessionId,
+  storedSessionId
+}: SessionSurfaceCoreProps) {
+  const valid =
+    validIdentityPart(profile) &&
+    validIdentityPart(storedSessionId) &&
+    (runtimeSessionId == null || validIdentityPart(runtimeSessionId))
+
+  const identityKey = valid ? `${profile}\u0000${storedSessionId}` : ''
+  const [binding, setBinding] = useState<{ error?: boolean; identityKey?: string; runtimeSessionId?: string }>({})
+  const [readinessGeneration, setReadinessGeneration] = useState(0)
+  const [retryGeneration, setRetryGeneration] = useState(0)
+  const mountedRef = useRef(false)
+  const identityGenerationRef = useRef({ identityKey: '', value: 0 })
+
+  const attemptRef = useRef<{
+    generation: number
+    retryGeneration: number
+    status: 'failed' | 'in-flight' | 'succeeded'
+    transportGeneration: number
+  } | null>(null)
+
+  const connectionLostRef = useRef(false)
+  const staleRuntimeHintRef = useRef('')
+  const transportGenerationRef = useRef(0)
+  const bindingIdentityKey = valid ? `${identityKey}\u0000${runtimeSessionId ?? ''}` : ''
+
+  if (identityGenerationRef.current.identityKey !== bindingIdentityKey) {
+    identityGenerationRef.current = {
+      identityKey: bindingIdentityKey,
+      value: identityGenerationRef.current.value + 1
+    }
+    connectionLostRef.current = false
+    staleRuntimeHintRef.current = ''
+  }
+
+  // Lifecycle token, not a reactive-value mirror: async bindings must ignore unmount completion.
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    mountedRef.current = true
+
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  // Binding coordination is intentionally non-rendering hot state, not a mirrored atom.
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    const delegateChanged = () => {
+      if (attemptRef.current?.status !== 'in-flight') {
+        attemptRef.current = null
+        setReadinessGeneration(value => value + 1)
+      }
+    }
+
+    const gatewayChanged = () => {
+      const open = profileGatewayState(profile)?.connectionState === 'open'
+
+      if (!open) {
+        if (!connectionLostRef.current) {
+          transportGenerationRef.current += 1
+        }
+
+        connectionLostRef.current = true
+
+        return
+      }
+
+      if (connectionLostRef.current && attemptRef.current?.status !== 'in-flight') {
+        connectionLostRef.current = false
+        attemptRef.current = null
+        setReadinessGeneration(value => value + 1)
+      }
+    }
+
+    const offDelegate = subscribeSessionSurfaceDelegate(delegateChanged)
+    const offGateway = subscribeProfileGateway(profile, gatewayChanged)
+
+    return () => {
+      offDelegate()
+      offGateway()
+    }
+  }, [profile])
+
+  useEffect(() => {
+    if (!valid) {
+      return
+    }
+
+    retainSessionSurfaceReference(profile, storedSessionId)
+
+    return () => releaseSessionSurfaceReference(profile, storedSessionId)
+  }, [identityKey, profile, storedSessionId, valid])
+
+  // Attempt ownership is intentionally non-rendering hot state, not a mirrored atom.
+  // eslint-disable-next-line no-restricted-syntax
+  useEffect(() => {
+    if (!valid) {
+      setBinding({ error: true, identityKey })
+
+      return
+    }
+
+    const delegate = sessionSurfaceDelegate()
+
+    if (!delegate) {
+      setBinding({ identityKey })
+
+      return
+    }
+
+    const generation = identityGenerationRef.current.value
+    const currentAttempt = attemptRef.current
+
+    if (
+      currentAttempt?.generation === generation &&
+      currentAttempt.retryGeneration === retryGeneration &&
+      currentAttempt.status !== 'failed'
+    ) {
+      return
+    }
+
+    const transportGeneration = transportGenerationRef.current
+    attemptRef.current = { generation, retryGeneration, status: 'in-flight', transportGeneration }
+    setBinding({ identityKey })
+
+    const bind = async () => {
+      try {
+        let id: string
+
+        if (runtimeSessionId && staleRuntimeHintRef.current !== bindingIdentityKey) {
+          try {
+            id = await delegate.adoptSurface({ profile, runtimeSessionId, storedSessionId })
+          } catch (error) {
+            if (!isStaleSessionSurfaceRuntimeError(error)) {
+              throw error
+            }
+
+            // Do not start durable recovery for an adoption result that already
+            // belongs to an obsolete identity or transport generation.
+            if (
+              !mountedRef.current ||
+              identityGenerationRef.current.value !== generation ||
+              transportGenerationRef.current !== transportGeneration
+            ) {
+              throw error
+            }
+
+            // This hint is now known unusable for the current durable identity.
+            // Retry and reconnect attempts resume directly instead of looping
+            // through the same stale adoption forever.
+            staleRuntimeHintRef.current = bindingIdentityKey
+            id = await delegate.resumeSurface({ profile, storedSessionId })
+          }
+        } else {
+          id = await delegate.resumeSurface({ profile, storedSessionId })
+        }
+
+        if (mountedRef.current && identityGenerationRef.current.value === generation) {
+          if (transportGenerationRef.current !== transportGeneration) {
+            attemptRef.current = null
+
+            if (profileGatewayState(profile)?.connectionState === 'open') {
+              connectionLostRef.current = false
+              setReadinessGeneration(value => value + 1)
+            }
+
+            return
+          }
+
+          attemptRef.current = { generation, retryGeneration, status: 'succeeded', transportGeneration }
+          bindSessionSurfaceRuntime(profile, storedSessionId, id)
+          onRuntimeSessionId?.(id)
+          setBinding({ identityKey, runtimeSessionId: id })
+        }
+      } catch {
+        if (mountedRef.current && identityGenerationRef.current.value === generation) {
+          if (transportGenerationRef.current !== transportGeneration) {
+            attemptRef.current = null
+
+            if (profileGatewayState(profile)?.connectionState === 'open') {
+              connectionLostRef.current = false
+              setReadinessGeneration(value => value + 1)
+            }
+
+            return
+          }
+
+          attemptRef.current = { generation, retryGeneration, status: 'failed', transportGeneration }
+          setBinding({ error: true, identityKey })
+        }
+      }
+    }
+
+    void bind()
+  }, [
+    bindingIdentityKey,
+    identityKey,
+    onRuntimeSessionId,
+    profile,
+    readinessGeneration,
+    retryGeneration,
+    runtimeSessionId,
+    storedSessionId,
+    valid
+  ])
+
+  const currentBinding = binding.identityKey === identityKey ? binding : {}
+
+  if (!valid) {
+    return (
+      <div className="grid h-full place-items-center p-4">
+        <div className="max-w-[24rem] break-words text-center font-mono text-[11px] text-(--ui-text-quaternary)">
+          Couldn't open this session
+        </div>
+      </div>
+    )
+  }
+
+  if (currentBinding.error) {
+    return (
+      <div className="grid h-full place-items-center p-4">
+        <div className="flex max-w-[24rem] flex-col items-center gap-2 text-center font-mono text-[11px] text-(--ui-text-quaternary)">
+          <span>Couldn't open this session</span>
+          <button
+            className="rounded px-2 py-1 text-(--ui-text-secondary) hover:bg-(--ui-hover-bg)"
+            onClick={() => {
+              attemptRef.current = null
+              setBinding({ identityKey })
+              setRetryGeneration(value => value + 1)
+            }}
+            type="button"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!currentBinding.runtimeSessionId) {
+    return (
+      <div className="relative h-full">
+        <CenteredThreadSpinner />
+      </div>
+    )
+  }
+
+  return (
+    <SessionSurfaceChat
+      profile={profile}
+      runtimeSessionId={currentBinding.runtimeSessionId}
+      storedSessionId={storedSessionId}
+    />
+  )
+}
+
+/** Public plugin surface. Runtime correlation stays encapsulated; only core
+ * tile ownership code may observe the ephemeral runtime id. */
+export function SessionSurface({ session }: SessionSurfaceProps) {
+  return <SessionSurfaceCore {...session} />
+}

--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -36,6 +36,8 @@ function renderTileActions() {
 describe('useSessionTileActions sleep/wake session recovery', () => {
   beforeEach(() => {
     setSessionTileDelegate({
+      adoptSurface: vi.fn(async () => RUNTIME_SESSION_ID),
+      resumeSurface: vi.fn(async () => RUNTIME_SESSION_ID),
       archiveSession: vi.fn(async () => undefined),
       branchSession: vi.fn(async () => undefined),
       deleteSession: vi.fn(async () => undefined),

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -11,6 +11,7 @@
 import type { AppendMessage, ThreadMessage } from '@assistant-ui/react'
 import { useCallback, useMemo, useRef } from 'react'
 
+import type { GatewayRequester } from '@/app/contrib/types'
 import { useGatewayRequest } from '@/app/gateway/hooks/use-gateway-request'
 import type { ClientSessionState } from '@/app/types'
 import { useI18n } from '@/i18n'
@@ -20,7 +21,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { clearClarifyRequest } from '@/store/clarify'
 import type { ComposerAttachment } from '@/store/composer'
 import { resetSessionBackground } from '@/store/composer-status'
-import { notifyError } from '@/store/notifications'
+import { notifyError, profiledPresentationError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
 import { $connection, $sessions, sessionMatchesStoredId } from '@/store/session'
@@ -96,15 +97,59 @@ export function listTileSessionRow(deps: {
 }
 
 interface SessionTileActionsArgs {
+  /** Explicit owner profile; omitted is the primary chat's legacy routing. */
+  profile?: string
+  /**
+   * Surface-owned requester (non-activating, routed to the identity's owning
+   * profile backend). Supplied by the embedded SessionSurface; tiles omit it
+   * and fall back to the active gateway via useGatewayRequest.
+   */
+  requestGateway?: GatewayRequester
   runtimeId: string
   scope: ComposerScope
   storedSessionId: string
 }
 
-export function useSessionTileActions({ runtimeId, scope, storedSessionId }: SessionTileActionsArgs) {
+export function restoreErrorForSessionSurface(error: unknown, profile?: string): unknown {
+  return profiledPresentationError(error, 'Restore failed', profile)
+}
+
+export async function uploadSessionSurfaceAttachment(
+  attachment: ComposerAttachment,
+  opts: {
+    backendCwd?: null | string
+    onSessionRecovered?: (sessionId: string) => void
+    profile?: string
+    requestGateway: GatewayRequester
+    sessionId: string
+    storedSessionId?: null | string
+    terminalBackend?: string
+  }
+): Promise<ComposerAttachment> {
+  const connection = opts.profile
+    ? await window.hermesDesktop?.getConnection(opts.profile).catch(() => undefined)
+    : $connection.get()
+
+  return uploadComposerAttachment(attachment, {
+    backendCwd: opts.backendCwd,
+    // An explicitly-owned surface must fail safe when its descriptor is
+    // unavailable: byte upload cannot leak a host path to a remote backend.
+    remote: opts.profile ? connection?.mode !== 'local' : connection?.mode === 'remote',
+    requestGateway: opts.requestGateway,
+    sessionId: opts.sessionId,
+    storedSessionId: opts.storedSessionId,
+    onSessionRecovered: opts.onSessionRecovered,
+    terminalBackend: opts.terminalBackend
+  })
+}
+
+export function useSessionTileActions({ profile, requestGateway: surfaceRequestGateway, runtimeId, scope, storedSessionId }: SessionTileActionsArgs) {
+  const { requestGateway: activeGatewayRequest } = useGatewayRequest()
+  // A surface-owned requester (SessionSurface) routes to the identity's owning
+  // profile backend; tiles fall back to the active gateway.
+  const requestGateway = surfaceRequestGateway ?? activeGatewayRequest
   const { t } = useI18n()
   const copy = t.desktop
-  const { requestGateway } = useGatewayRequest()
 
   const runtimeIdRef = useRef(runtimeId)
   runtimeIdRef.current = runtimeId
@@ -137,8 +182,8 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
 
   const update = useCallback(
     (updater: (state: ClientSessionState) => ClientSessionState) =>
-      sessionTileDelegate()?.updateSession(runtimeIdRef.current, updater),
-    []
+      sessionTileDelegate()?.updateSession(runtimeIdRef.current, updater, profile),
+    [profile]
   )
 
   const readState = useCallback(() => $sessionStates.get()[runtimeIdRef.current], [])
@@ -169,12 +214,11 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       attachments: ComposerAttachment[],
       options: { updateComposerAttachments?: boolean } = {}
     ): Promise<{ attachments: ComposerAttachment[]; sessionId: string }> => {
-      const remote = $connection.get()?.mode === 'remote'
       let liveSessionId = sessionId
       const synced: ComposerAttachment[] = []
 
-      // A tile owns its own runtime binding, so a recovery here rebinds the
-      // tile's ref rather than the foreground session's.
+      // A surface owns its own runtime binding, so a recovery here rebinds the
+      // surface's ref rather than the foreground session's.
       const onSessionRecovered = (recoveredId: string) => {
         liveSessionId = recoveredId
         runtimeIdRef.current = recoveredId
@@ -188,9 +232,9 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
         }
 
         if (attachment.kind === 'image' || attachment.kind === 'file') {
-          const next = await uploadComposerAttachment(attachment, {
+          const next = await uploadSessionSurfaceAttachment(attachment, {
             backendCwd: readState()?.cwd,
-            remote,
+            profile,
             requestGateway,
             sessionId: liveSessionId,
             storedSessionId: storedIdRef.current,
@@ -224,7 +268,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
 
       return { attachments: synced, sessionId: liveSessionId }
     },
-    [requestGateway, scope.attachments]
+    [profile, readState, requestGateway, scope.attachments]
   )
 
   // The REAL submit pipeline with tile seams: session always exists, and the
@@ -246,7 +290,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
     resumeStoredSession: () => undefined,
     selectedStoredSessionIdRef: storedIdRef,
     syncAttachmentsForSubmit,
-    updateSessionState: (sessionId, updater) => sessionTileDelegate()!.updateSession(sessionId, updater),
+    updateSessionState: (sessionId, updater) => sessionTileDelegate()!.updateSession(sessionId, updater, profile),
     scope: {
       removeAttachments: attachments => scope.attachments.removeOccurrences(attachments),
       readAttachments: () => scope.attachments.$attachments.get(),
@@ -314,9 +358,9 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
         }
       )
     } catch (err) {
-      notifyError(err, copy.stopFailed)
+      notifyError(profile ? new Error(copy.stopFailed) : err, copy.stopFailed)
     }
-  }, [copy.stopFailed, requestGateway, update])
+  }, [copy.stopFailed, profile, requestGateway, update])
 
   const steerPrompt = useCallback(
     async (rawText: string): Promise<boolean> => {
@@ -330,7 +374,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       const messageId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
       const mutate = (updater: (state: ClientSessionState) => ClientSessionState) =>
-        sessionTileDelegate()?.updateSession(sessionId, updater)
+        sessionTileDelegate()?.updateSession(sessionId, updater, profile)
 
       // Match the primary composer: record the correction in arrival order —
       // sealed already-streamed output above, correction below, post-redirect
@@ -398,7 +442,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
 
       return false
     },
-    [requestGateway]
+    [profile, requestGateway]
   )
 
   // Rewind primitive (interrupt-first for live turns, busy-retry) — shared with
@@ -479,10 +523,10 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
         )
       } catch (err) {
         update(current => ({ ...current, busy: false, awaitingResponse: false, turnLive: false, turnStartedAt: null }))
-        notifyError(err, copy.regenerateFailed)
+        notifyError(profile ? new Error(copy.regenerateFailed) : err, copy.regenerateFailed)
       }
     },
-    [applySurvivorRowIds, copy.regenerateFailed, readState, submitRewind, update]
+    [applySurvivorRowIds, copy.regenerateFailed, profile, readState, submitRewind, update]
   )
 
   const restoreToMessage = useCallback(
@@ -522,10 +566,10 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
           turnStartedAt: null,
           messages
         }))
-        throw err
+        throw restoreErrorForSessionSurface(err, profile)
       }
     },
-    [applySurvivorRowIds, readMessages, readState, submitRewind, update]
+    [applySurvivorRowIds, profile, readMessages, readState, submitRewind, update]
   )
 
   const editMessage = useCallback(
@@ -570,10 +614,10 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
           turnStartedAt: null,
           messages
         }))
-        notifyError(err, copy.editFailed)
+        notifyError(profile ? new Error(copy.editFailed) : err, copy.editFailed)
       }
     },
-    [applySurvivorRowIds, copy.editFailed, readMessages, readState, submitRewind, update]
+    [applySurvivorRowIds, copy.editFailed, profile, readMessages, readState, submitRewind, update]
   )
 
   // Branch-visibility sync (assistant-ui hides non-active branches).

--- a/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
+++ b/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
@@ -95,11 +95,13 @@ function installDelegate(): void {
   }
 
   setSessionTileDelegate({
+    adoptSurface: vi.fn(async () => RUNTIME_ID),
     archiveSession: vi.fn(async () => undefined),
     branchSession: vi.fn(async () => undefined),
     deleteSession: vi.fn(async () => undefined),
     executeSlash: vi.fn(async () => undefined),
     interruptSession: vi.fn(async () => undefined),
+    resumeSurface: vi.fn(async () => RUNTIME_ID),
     resumeTile: vi.fn(async () => RUNTIME_ID),
     submitToSession: vi.fn(async () => undefined),
     updateSession
@@ -160,7 +162,7 @@ describe('session tile attachment occurrence ownership', () => {
     scope.attachments.add(original)
 
     const { result } = renderHook(() =>
-      useSessionTileActions({ runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
+      useSessionTileActions({ requestGateway, runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
     )
 
     let submitted!: Promise<boolean>
@@ -206,7 +208,7 @@ describe('session tile attachment occurrence ownership', () => {
     scope.attachments.add(original)
 
     const { result } = renderHook(() =>
-      useSessionTileActions({ runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
+      useSessionTileActions({ requestGateway, runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
     )
 
     let submitted!: Promise<boolean>
@@ -244,7 +246,7 @@ describe('session tile attachment occurrence ownership', () => {
     scope.attachments.add(original)
 
     const { result } = renderHook(() =>
-      useSessionTileActions({ runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
+      useSessionTileActions({ requestGateway, runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
     )
 
     let submitted!: Promise<boolean>
@@ -281,7 +283,7 @@ describe('session tile attachment occurrence ownership', () => {
     scope.attachments.add(original)
 
     const { result } = renderHook(() =>
-      useSessionTileActions({ runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
+      useSessionTileActions({ requestGateway, runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
     )
 
     let submitted!: Promise<boolean>
@@ -322,7 +324,7 @@ describe('session tile attachment occurrence ownership', () => {
     scope.attachments.add(original)
 
     const { result } = renderHook(() =>
-      useSessionTileActions({ runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
+      useSessionTileActions({ requestGateway, runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
     )
 
     await act(async () => {

--- a/apps/desktop/src/app/chat/session-tile-surface.test.tsx
+++ b/apps/desktop/src/app/chat/session-tile-surface.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile } from '@/store/profile'
+import { $sessions } from '@/store/session'
+import { $sessionTiles } from '@/store/session-states'
+
+import { SessionTilePane } from './session-tile'
+
+vi.mock('./session-surface', () => ({
+  SessionSurfaceCore: (props: { profile: string; runtimeSessionId?: null | string; storedSessionId: string }) => (
+    <div data-profile={props.profile} data-runtime={props.runtimeSessionId} data-testid="shared-session-surface">
+      {props.storedSessionId}
+    </div>
+  )
+}))
+
+vi.mock('./sidebar/session-actions-menu', () => ({
+  SessionContextMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+describe('SessionTilePane shared surface', () => {
+  beforeEach(() => {
+    $activeGatewayProfile.set('work')
+    $sessions.set([{ id: 'stored-tile', profile: 'vision' } as never])
+    $sessionTiles.set([{ runtimeId: 'runtime-tile', storedSessionId: 'stored-tile' }])
+  })
+
+  it('renders the same SessionSurface exported to plugins (no in-tile chat path)', () => {
+    render(<SessionTilePane storedSessionId="stored-tile" />)
+
+    const surface = screen.getByTestId('shared-session-surface')
+    expect(surface.textContent).toBe('stored-tile')
+    expect(surface.dataset.profile).toBe('vision')
+    expect(surface.dataset.runtime).toBe('runtime-tile')
+  })
+
+  it('keeps the tile owner profile when the foreground gateway profile changes', () => {
+    render(<SessionTilePane storedSessionId="stored-tile" />)
+
+    $activeGatewayProfile.set('personal')
+
+    expect(screen.getByTestId('shared-session-surface').dataset.profile).toBe('vision')
+  })
+
+  it('patches the live runtime id back onto the tile as the surface binds', () => {
+    render(<SessionTilePane storedSessionId="stored-tile" />)
+
+    // The surface owns the binding; the tile already mirrors the runtime id it
+    // was seeded with so tab chrome (status dot, close gate) stays live.
+    expect(screen.getByTestId('shared-session-surface').dataset.runtime).toBe('runtime-tile')
+  })
+})

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -15,42 +15,23 @@
  */
 
 import { useStore } from '@nanostores/react'
-import { useQueryClient } from '@tanstack/react-query'
-import { atom, computed } from 'nanostores'
-import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
+import { atom } from 'nanostores'
+import { useCallback, useRef, useSyncExternalStore } from 'react'
 
-import { useGatewayRequest } from '@/app/gateway/hooks/use-gateway-request'
-import { useModelControls } from '@/app/session/hooks/use-model-controls'
-import { blobToDataUrl } from '@/app/session/hooks/use-prompt-actions/utils'
-import { resolveStoredSession } from '@/app/session/hooks/use-session-actions/utils'
-import { ModelMenuPanel } from '@/app/shell/model-menu-panel'
-import { formatRefValue } from '@/components/assistant-ui/directive-text'
-import { CenteredThreadSpinner } from '@/components/assistant-ui/thread/status'
 import { findGroupOfPane } from '@/components/pane-shell/tree/model'
 import { $layoutTree, closeTreePane, moveTreePane, setTreeGroupHeaderHidden } from '@/components/pane-shell/tree/store'
-import { Button } from '@/components/ui/button'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
-import { transcribeAudio } from '@/hermes'
 import { useI18n } from '@/i18n'
-import type { ChatMessage } from '@/lib/chat-messages'
 import { NEW_SESSION_TITLE, sessionTitle } from '@/lib/chat-runtime'
-import { createComposerAttachmentScope, draftTitleFor } from '@/store/composer'
+import { draftTitleFor } from '@/store/composer'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $projectTree } from '@/store/projects'
-import { sessionAwaitingInput } from '@/store/prompts'
-import {
-  $gatewayState,
-  $selectedStoredSessionId,
-  $sessions,
-  sessionMatchesStoredId,
-  sessionPinId
-} from '@/store/session'
+import { $selectedStoredSessionId, $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
 import {
   $sessionStates,
   $sessionTiles,
   closeSessionTile,
-  discardSessionTile,
   patchSessionTile,
   type SessionTile,
   sessionTileDelegate
@@ -58,308 +39,52 @@ import {
 import type { SessionInfo } from '@/types/hermes'
 
 import type { SessionDragPayload } from './composer/inline-refs'
-import { type ComposerScope, ComposerScopeProvider } from './composer/scope'
-import { useComposerActions } from './hooks/use-composer-actions'
 import { paneMirror } from './pane-mirror'
 import { SessionDraftTitle } from './session-draft-title'
 import { startSessionDrag } from './session-drag'
 import { SessionStatusDot } from './session-status-dot'
-import { useSessionTileActions } from './session-tile-actions'
-import { type SessionView, SessionViewProvider } from './session-view'
+import { SessionSurfaceCore } from './session-surface'
 import { SessionContextMenu } from './sidebar/session-actions-menu'
-import { lastVisibleMessageIsUser } from './thread-loading'
 
-import { ChatView } from '.'
+/** Resolve a tile's owning profile for the embedded surface: the stored row's
+ * owner when listed, else the active gateway profile (a fresh ⌘T tab's session
+ * was created there). Empty only before either resolves. */
+function useTileProfile(storedSessionId: string): string {
+  const subscribe = useCallback((onChange: () => void) => {
+    const offSessions = $sessions.listen(onChange)
+    const offTree = $projectTree.listen(onChange)
+    const offProfile = $activeGatewayProfile.listen(onChange)
 
-const NO_MESSAGES: ChatMessage[] = []
-
-/** The tile's SessionView: the same atom shape the primary chat renders
- *  from, computed from this session's slice of `$sessionStates`. */
-function buildTileView(storedSessionId: string): SessionView {
-  const $runtimeId = computed(
-    $sessionTiles,
-    tiles => tiles.find(t => t.storedSessionId === storedSessionId)?.runtimeId ?? null
-  )
-
-  const $state = computed([$runtimeId, $sessionStates], (runtimeId, states) =>
-    runtimeId ? states[runtimeId] : undefined
-  )
-
-  const $messages = computed($state, state => state?.messages ?? NO_MESSAGES)
-
-  return {
-    kind: 'tile',
-    $awaitingResponse: computed($state, state => Boolean(state?.awaitingResponse)),
-    $busy: computed($state, state => Boolean(state?.busy)),
-    $cwd: computed($state, state => state?.cwd ?? ''),
-    $fast: computed($state, state => Boolean(state?.fast)),
-    $lastVisibleIsUser: computed($messages, lastVisibleMessageIsUser),
-    $messages,
-    $messagesEmpty: computed($messages, messages => messages.length === 0),
-    $model: computed($state, state => state?.model ?? ''),
-    $provider: computed($state, state => state?.provider ?? ''),
-    $reasoningEffort: computed($state, state => state?.reasoningEffort ?? ''),
-    $runtimeId,
-    // Constant for the tile's lifetime — a plain atom, not a computed.
-    $storedId: atom(storedSessionId),
-    $turnStartedAt: computed($state, state => state?.turnStartedAt ?? null)
-  }
-}
-
-// Module-level constants so these ChatView props are referentially stable —
-// tiles have no pin/delete affordance, and transcription needs no per-tile state.
-const noop = () => undefined
-
-const tileTranscribeAudio = async (audio: Blob) =>
-  (await transcribeAudio(await blobToDataUrl(audio), audio.type)).transcript
-
-function TileChat({
-  runtimeId,
-  storedSessionId,
-  view
-}: {
-  runtimeId: string
-  storedSessionId: string
-  view: SessionView
-}) {
-  const { gateway, requestGateway } = useGatewayRequest()
-  const queryClient = useQueryClient()
-  const { selectModel } = useModelControls({ queryClient, requestGateway })
-  const activeGatewayProfile = useStore($activeGatewayProfile)
-  const cwd = useStore(view.$cwd)
-  const gatewayOpen = useStore($gatewayState) === 'open'
-
-  // One attachment set + focus key per tile, stable for the tile's lifetime.
-  const attachments = useRef(createComposerAttachmentScope()).current
-
-  const scope = useMemo<ComposerScope>(
-    () => ({
-      $awaitingInput: sessionAwaitingInput(runtimeId),
-      $messages: view.$messages,
-      attachments,
-      target: `tile:${storedSessionId}`
-    }),
-    [attachments, runtimeId, storedSessionId, view.$messages]
-  )
-
-  const actions = useSessionTileActions({ runtimeId, scope, storedSessionId })
-
-  // The same attach/pick/paste/drop pipeline the primary composer uses,
-  // pointed at this tile's chips + session.
-  const composer = useComposerActions({
-    activeSessionId: runtimeId,
-    currentCwd: cwd,
-    requestGateway,
-    scope: {
-      add: attachments.add,
-      remove: attachments.remove,
-      target: scope.target,
-      update: attachments.update,
-      updateIfCurrent: attachments.updateIfCurrent
+    return () => {
+      offSessions()
+      offTree()
+      offProfile()
     }
-  })
+  }, [])
 
-  // ChatView is memo()d — every callback prop must be referentially stable or
-  // the memo never holds and each tile-level render (idle ticks, unrelated
-  // store updates) re-renders the whole chat shell. The individual composer
-  // functions are useCallback'd inside useComposerActions, so hoisting these
-  // wrappers onto them keeps identity stable across renders.
-  const { addContextRefAttachment, pasteClipboardImage, pickContextPaths, pickImages, removeAttachment } = composer
-
-  const onAddUrl = useCallback(
-    (url: string) => addContextRefAttachment(`@url:${formatRefValue(url)}`, url),
-    [addContextRefAttachment]
-  )
-
-  const onPasteClipboardImage = useCallback(
-    (opts?: { silent?: boolean }) => pasteClipboardImage(opts),
-    [pasteClipboardImage]
-  )
-
-  const onPickFiles = useCallback(() => void pickContextPaths('file'), [pickContextPaths])
-  const onPickFolders = useCallback(() => void pickContextPaths('folder'), [pickContextPaths])
-  const onPickImages = useCallback(() => void pickImages(), [pickImages])
-  const onRemoveAttachment = useCallback((id: string) => void removeAttachment(id), [removeAttachment])
-  const onRetryResume = useCallback(() => patchSessionTile(storedSessionId, { error: undefined }), [storedSessionId])
-
-  // Per-tile model menu — rendered under this tile's SessionView so the pill
-  // + switch target THIS runtime, not the primary (which may be mid-turn).
-  const modelMenuContent = useMemo(
-    () =>
-      gatewayOpen ? (
-        <ModelMenuPanel
-          gateway={gateway || undefined}
-          onSelectModel={selectModel}
-          profile={activeGatewayProfile}
-          requestGateway={requestGateway}
-        />
-      ) : null,
-    [activeGatewayProfile, gateway, gatewayOpen, requestGateway, selectModel]
-  )
-
-  return (
-    <SessionViewProvider value={view}>
-      <ComposerScopeProvider value={scope}>
-        <ChatView
-          gateway={gateway}
-          modelMenuContent={modelMenuContent}
-          onAddContextRef={addContextRefAttachment}
-          onAddUrl={onAddUrl}
-          onAttachDroppedItems={composer.attachDroppedItems}
-          onAttachImageBlob={composer.attachImageBlob}
-          onAttachPrCommentUrl={composer.attachPrCommentUrl}
-          onCancel={actions.cancelRun}
-          onDeleteSelectedSession={noop}
-          onDismissError={actions.dismissError}
-          onEdit={actions.editMessage}
-          onPasteClipboardImage={onPasteClipboardImage}
-          onPickFiles={onPickFiles}
-          onPickFolders={onPickFolders}
-          onPickImages={onPickImages}
-          onReload={actions.reloadFromMessage}
-          onRemoveAttachment={onRemoveAttachment}
-          onRestoreToMessage={actions.restoreToMessage}
-          onRetryResume={onRetryResume}
-          onSteer={actions.steerPrompt}
-          onSubmit={actions.submitText}
-          onThreadMessagesChange={actions.handleThreadMessagesChange}
-          onToggleSelectedPin={noop}
-          onTranscribeAudio={tileTranscribeAudio}
-        />
-      </ComposerScopeProvider>
-    </SessionViewProvider>
-  )
+  return useSyncExternalStore(subscribe, () => tileStoredRow(storedSessionId)?.profile ?? $activeGatewayProfile.get())
 }
 
 export function SessionTilePane({ storedSessionId }: { storedSessionId: string }) {
   const tiles = useStore($sessionTiles)
   const tile = tiles.find(t => t.storedSessionId === storedSessionId)
-  const runtimeId = tile?.runtimeId ?? null
-  const gatewayOpen = useStore($gatewayState) === 'open'
-  const resumingRef = useRef(false)
-  const view = useMemo(() => buildTileView(storedSessionId), [storedSessionId])
+  const profile = useTileProfile(storedSessionId)
 
-  // A tab-strip "+"/⌘T tab is created UNLISTED — its session stays out of
-  // $sessions (no sidebar clutter) until it's actually used, so the tab shows
-  // "New session". The moment this tile has a message, pull its row into
-  // $sessions via the lightweight by-id lookup so the tab (and a sidebar row)
-  // resolve the real title. `resolveStoredSession` no-ops when it's already
-  // listed, and 404s harmlessly for an in-memory draft that hasn't persisted a
-  // turn yet — so we retry across that brief persist lag and stop as soon as it
-  // lands (a global turn-complete refresh may beat us to it).
-  const hasMessages = useStore(view.$messagesEmpty) === false
+  // The surface owns the runtime binding; the tile only mirrors the live id so
+  // the tab's status dot, close-gate, and focus derivations keep reading it.
+  const onRuntimeSessionId = useCallback(
+    (runtimeId: string) => patchSessionTile(storedSessionId, { runtimeId }),
+    [storedSessionId]
+  )
 
-  useEffect(() => {
-    const alreadyListed = () => $sessions.get().some(s => sessionMatchesStoredId(s, storedSessionId))
-
-    if (!runtimeId || !hasMessages || alreadyListed()) {
-      return
-    }
-
-    let cancelled = false
-    let timer: number | undefined
-
-    const attempt = (remaining: number) => {
-      if (cancelled || alreadyListed()) {
-        return
-      }
-
-      void resolveStoredSession(storedSessionId)
-        .then(resolved => {
-          if (cancelled || resolved || remaining <= 0) {
-            return
-          }
-
-          timer = window.setTimeout(() => attempt(remaining - 1), 500)
-        })
-        .catch(() => undefined)
-    }
-
-    attempt(6)
-
-    return () => {
-      cancelled = true
-
-      if (timer !== undefined) {
-        window.clearTimeout(timer)
-      }
-    }
-  }, [hasMessages, runtimeId, storedSessionId])
-
-  // Same gating as the primary's route resume (use-route-resume): never fire
-  // session.resume before the gateway is OPEN. Persisted tiles mount at boot
-  // while it's still connecting — an ungated resume rejected there and
-  // latched every restored tile into the error card.
-  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
-  useEffect(() => {
-    if (!gatewayOpen || runtimeId || tile?.error || resumingRef.current) {
-      return
-    }
-
-    const delegate = sessionTileDelegate()
-
-    if (!delegate) {
-      return
-    }
-
-    resumingRef.current = true
-
-    delegate
-      .resumeTile(storedSessionId)
-      .then(id => patchSessionTile(storedSessionId, { error: undefined, runtimeId: id }))
-      .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err)
-
-        // A gone session (404 / "Session not found") is terminal — a stale or
-        // cross-profile persisted tile. Discard it instead of latching an error
-        // that re-retries on every reconnect (the "Session not found" spam).
-        if (/session not found|\b404\b/i.test(message)) {
-          discardSessionTile(storedSessionId)
-        } else {
-          patchSessionTile(storedSessionId, { error: message })
-        }
-      })
-      .finally(() => {
-        resumingRef.current = false
-      })
-  }, [gatewayOpen, runtimeId, storedSessionId, tile?.error])
-
-  // The gateway (re)opening invalidates any latched error — it likely came
-  // from a not-yet-open gateway or the previous connection. Clearing it
-  // retriggers the resume effect: one bounded auto-retry per (re)connect,
-  // mirroring the primary path's became-open resync.
-  useEffect(() => {
-    if (gatewayOpen && tile?.error) {
-      patchSessionTile(storedSessionId, { error: undefined })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gatewayOpen, storedSessionId])
-
-  if (tile?.error) {
-    return (
-      <div className="grid h-full place-items-center p-4">
-        <div className="max-w-[24rem] space-y-2 text-center font-mono text-[11px]">
-          <div className="text-(--ui-danger,#f87171)">Couldn't open this session</div>
-          <div className="break-words text-(--ui-text-quaternary)">{tile.error}</div>
-          <Button onClick={() => patchSessionTile(storedSessionId, { error: undefined })} size="sm" variant="outline">
-            Retry
-          </Button>
-        </div>
-      </div>
-    )
-  }
-
-  if (!runtimeId) {
-    // The SAME session loader the primary thread shows (Thread's
-    // loading === 'session' branch) — one loading language everywhere.
-    return (
-      <div className="relative h-full">
-        <CenteredThreadSpinner />
-      </div>
-    )
-  }
-
-  return <TileChat runtimeId={runtimeId} storedSessionId={storedSessionId} view={view} />
+  return (
+    <SessionSurfaceCore
+      onRuntimeSessionId={onRuntimeSessionId}
+      profile={profile}
+      runtimeSessionId={tile?.runtimeId}
+      storedSessionId={storedSessionId}
+    />
+  )
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -60,6 +60,7 @@ describe('useDesktopIntegrations', () => {
 
   beforeEach(() => {
     window.localStorage.clear()
+    window.sessionStorage.clear()
     _resetLegacyDiscardForTests()
     vi.mocked(requestMcpInstallFromDeepLink).mockClear()
     navigate = vi.fn()
@@ -160,6 +161,20 @@ describe('useDesktopIntegrations', () => {
       render({ profileReady: true, sessions })
 
       expect(navigate).toHaveBeenCalledWith('/remembered-session', { replace: true })
+    })
+
+    it('does not restore again when the hook remounts after a reconnect', () => {
+      window.localStorage.setItem('hermes.desktop.lastRoute.profile.default', '/embedded-session')
+      const sessions = [session({ id: 'embedded-session', profile: 'default' })]
+
+      const first = render({ profileReady: true, sessions })
+      expect(navigate).toHaveBeenCalledTimes(1)
+
+      first.unmount()
+      navigate.mockClear()
+      render({ profileReady: true, sessions })
+
+      expect(navigate).not.toHaveBeenCalled()
     })
 
     it('restores remembered session id when no remembered route exists', () => {

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -90,21 +90,39 @@ export function useDesktopIntegrations({
   }, [])
 
   const restoredRef = useRef(false)
+  const rememberedRestoreKey = `hermes.desktop.remembered-route-restored.${activeProfile}`
 
   // Wait until boot has adopted the primary profile, then restore that profile's
   // navigation exactly once. The same effect owns subsequent writes so the
   // initial `/` cannot overwrite remembered history before it is read.
   // This ref is a one-time lifecycle latch, not a mirror of reactive atom state.
-  // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
     if (!profileReady || isHudWindow()) {
       return
     }
 
+    const rememberedRestoreAlreadyDone = () => {
+      try {
+        return window.sessionStorage.getItem(rememberedRestoreKey) === '1'
+      } catch {
+        return false
+      }
+    }
+
+    const markRememberedRestoreDone = () => {
+      try {
+        window.sessionStorage.setItem(rememberedRestoreKey, '1')
+      } catch {
+        // Storage can be unavailable in restricted/browser test contexts.
+      }
+    }
+
     if (!restoredRef.current) {
-      // Only cold-start navigation at the default route is replaceable; a deep
-      // link or hidden-then-shown window keeps its explicit destination.
-      if (locationPathname === NEW_CHAT_ROUTE) {
+      if (rememberedRestoreAlreadyDone()) {
+        restoredRef.current = true
+      } else if (locationPathname === NEW_CHAT_ROUTE) {
+        // Only cold-start navigation at the default route is replaceable; a deep
+        // link or hidden-then-shown window keeps its explicit destination.
         const route = getRememberedRoute(activeProfile)
         const routeSession = route ? routeSessionId(route) : null
         const last = getRememberedSessionId(activeProfile)
@@ -121,6 +139,7 @@ export function useDesktopIntegrations({
         }
 
         restoredRef.current = true
+        markRememberedRestoreDone()
 
         if (
           route &&
@@ -150,6 +169,7 @@ export function useDesktopIntegrations({
         }
       } else {
         restoredRef.current = true
+        markRememberedRestoreDone()
       }
     }
 
@@ -163,7 +183,7 @@ export function useDesktopIntegrations({
     } else if (!routedSessionId && !isOverlayView(appViewForPath(locationPathname))) {
       setRememberedRoute(locationPathname, activeProfile)
     }
-  }, [activeProfile, locationPathname, navigate, profileReady, routedSessionId, sessions])
+  }, [activeProfile, locationPathname, navigate, profileReady, rememberedRestoreKey, routedSessionId, sessions])
 
   useEffect(() => {
     if (!profileReady || !resumeExhaustedSessionId) {

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -96,6 +96,7 @@ export function useDesktopIntegrations({
   // navigation exactly once. The same effect owns subsequent writes so the
   // initial `/` cannot overwrite remembered history before it is read.
   // This ref is a one-time lifecycle latch, not a mirror of reactive atom state.
+  // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
     if (!profileReady || isHudWindow()) {
       return

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -2,8 +2,9 @@ import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as HermesModule from '@/hermes'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { setSessions } from '@/store/session'
-import { sessionTileDelegate } from '@/store/session-states'
+import { sessionRuntimeStateKey, sessionTileDelegate } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
 import { useSessionTileDelegate } from './use-session-tile-delegate'
@@ -12,8 +13,12 @@ vi.mock('@/hermes', async importActual => ({
   ...(await importActual<typeof HermesModule>()),
   getLatestSessionMessages: vi.fn(async () => ({ messages: [], session_id: '' }))
 }))
+vi.mock('@/store/gateway', () => ({
+  requestGatewayForProfile: vi.fn()
+}))
 
 const { getLatestSessionMessages } = await import('@/hermes')
+const { requestGatewayForProfile } = await import('@/store/gateway')
 
 const row = (over: Partial<SessionInfo>): SessionInfo =>
   ({
@@ -169,6 +174,178 @@ describe('useSessionTileDelegate resumeTile', () => {
   })
 })
 
+describe('useSessionTileDelegate SessionSurface isolation', () => {
+  beforeEach(() => {
+    vi.mocked(requestGatewayForProfile).mockReset()
+  })
+
+  it('validates a runtime hint on its owner socket before adopting it', async () => {
+    vi.mocked(requestGatewayForProfile).mockResolvedValue({ output: 'Hermes TUI Status\n\nSession ID: stored-safe' })
+    const requestGateway = vi.fn()
+    renderTile(requestGateway)
+
+    await expect(
+      sessionTileDelegate()!.adoptSurface({
+        profile: 'work',
+        runtimeSessionId: 'runtime-safe',
+        storedSessionId: 'stored-safe'
+      })
+    ).resolves.toBe('runtime-safe')
+
+    expect(requestGatewayForProfile).toHaveBeenCalledWith('work', 'session.status', {
+      session_id: 'runtime-safe'
+    })
+    expect(requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('rejects a stale or cross-profile runtime hint before exposing it', async () => {
+    vi.mocked(requestGatewayForProfile).mockResolvedValue({ output: 'Hermes TUI Status\n\nSession ID: stored-other' })
+    renderTile(vi.fn())
+
+    await expect(
+      sessionTileDelegate()!.adoptSurface({
+        profile: 'work',
+        runtimeSessionId: 'runtime-collision',
+        storedSessionId: 'stored-safe'
+      })
+    ).rejects.toThrow('Session surface identity mismatch')
+  })
+
+  it('classifies a missing hinted runtime as stale for bounded durable recovery', async () => {
+    vi.mocked(requestGatewayForProfile).mockRejectedValue(new Error('4007 Session not found'))
+    renderTile(vi.fn())
+
+    await expect(
+      sessionTileDelegate()!.adoptSurface({
+        profile: 'work',
+        runtimeSessionId: 'runtime-gone',
+        storedSessionId: 'stored-safe'
+      })
+    ).rejects.toMatchObject({ name: 'StaleSessionSurfaceRuntimeError' })
+  })
+
+  it('drops a previously adopted cache entry before durable recovery', async () => {
+    const sessionStateByRuntimeIdRef = { current: new Map<string, ReturnType<typeof createClientSessionState>>() }
+    let statusAttempts = 0
+
+    vi.mocked(requestGatewayForProfile).mockImplementation(async (_profile, method) => {
+      if (method === 'session.status') {
+        statusAttempts += 1
+
+        if (statusAttempts === 1) {
+          return { output: 'Hermes TUI Status\n\nSession ID: stored-work' } as never
+        }
+
+        throw new Error('4007 Session not found')
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: 'runtime-fresh' } as never
+      }
+
+      return {} as never
+    })
+
+    renderHook(() =>
+      useSessionTileDelegate({
+        archiveSession: vi.fn(async () => undefined),
+        branchStoredSession: vi.fn(async () => undefined),
+        executeSlashCommand: vi.fn(async () => undefined) as never,
+        removeSession: vi.fn(async () => undefined),
+        requestGateway: vi.fn() as never,
+        runtimeIdByStoredSessionIdRef: { current: new Map() },
+        sessionStateByRuntimeIdRef: sessionStateByRuntimeIdRef as never,
+        updateSessionState: ((runtimeId: string, updater: (state: ReturnType<typeof createClientSessionState>) => ReturnType<typeof createClientSessionState>, storedSessionId?: string, profile?: string) => {
+          const key = sessionRuntimeStateKey(profile, runtimeId)
+          const next = updater(sessionStateByRuntimeIdRef.current.get(key) ?? createClientSessionState())
+          sessionStateByRuntimeIdRef.current.set(key, { ...next, storedSessionId: storedSessionId ?? null })
+
+          return next
+        }) as never
+      })
+    )
+
+    const identity = { profile: 'work', runtimeSessionId: 'runtime-old', storedSessionId: 'stored-work' }
+    await expect(sessionTileDelegate()!.adoptSurface(identity)).resolves.toBe('runtime-old')
+    await expect(sessionTileDelegate()!.adoptSurface(identity)).rejects.toMatchObject({
+      name: 'StaleSessionSurfaceRuntimeError'
+    })
+
+    await expect(sessionTileDelegate()!.resumeSurface(identity)).resolves.toBe('runtime-fresh')
+    expect(requestGatewayForProfile).toHaveBeenCalledWith('work', 'session.resume', expect.any(Object))
+  })
+
+  it('does not classify an authorization failure as a stale hinted runtime', async () => {
+    vi.mocked(requestGatewayForProfile).mockRejectedValue(new Error('403 forbidden'))
+    renderTile(vi.fn())
+
+    await expect(
+      sessionTileDelegate()!.adoptSurface({
+        profile: 'work',
+        runtimeSessionId: 'runtime-private',
+        storedSessionId: 'stored-safe'
+      })
+    ).rejects.not.toMatchObject({ name: 'StaleSessionSurfaceRuntimeError' })
+  })
+
+  it('resumes through the profile-bound requester rather than the foreground requester', async () => {
+    vi.mocked(requestGatewayForProfile).mockResolvedValue({ session_id: 'runtime-work' })
+    const requestGateway = vi.fn()
+    renderTile(requestGateway)
+
+    await expect(
+      sessionTileDelegate()!.resumeSurface({ profile: 'work', storedSessionId: 'stored-work' })
+    ).resolves.toBe('runtime-work')
+
+    expect(requestGatewayForProfile).toHaveBeenCalledWith('work', 'session.resume', {
+      session_id: 'stored-work',
+      cols: 96,
+      omit_messages: true,
+      profile: 'work'
+    })
+    expect(requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('purges the durable surface binding after archive so reopening cannot republish discarded runtime state', async () => {
+    const stateByRuntime = { current: new Map<string, ReturnType<typeof createClientSessionState>>() }
+    const archiveSession = vi.fn(async () => undefined)
+    const resumed = ['runtime-archived', 'runtime-fresh']
+
+    vi.mocked(requestGatewayForProfile).mockImplementation(async (_profile, method) =>
+      method === 'session.resume' ? ({ session_id: resumed.shift() } as never) : ({} as never)
+    )
+    renderHook(() =>
+      useSessionTileDelegate({
+        archiveSession,
+        branchStoredSession: vi.fn(async () => undefined),
+        executeSlashCommand: vi.fn(async () => undefined) as never,
+        removeSession: vi.fn(async () => undefined),
+        requestGateway: vi.fn() as never,
+        runtimeIdByStoredSessionIdRef: { current: new Map() },
+        sessionStateByRuntimeIdRef: stateByRuntime as never,
+        updateSessionState: ((runtimeId: string, updater: (state: ReturnType<typeof createClientSessionState>) => ReturnType<typeof createClientSessionState>, storedSessionId?: string, profile?: string) => {
+          const key = sessionRuntimeStateKey(profile, runtimeId)
+          const next = { ...updater(stateByRuntime.current.get(key) ?? createClientSessionState()), storedSessionId: storedSessionId ?? null }
+          stateByRuntime.current.set(key, next)
+
+          return next
+        }) as never
+      })
+    )
+
+    await expect(sessionTileDelegate()!.resumeSurface({ profile: 'work', storedSessionId: 'stored-work' })).resolves.toBe(
+      'runtime-archived'
+    )
+    await sessionTileDelegate()!.archiveSession('stored-work', 'work')
+    await expect(sessionTileDelegate()!.resumeSurface({ profile: 'work', storedSessionId: 'stored-work' })).resolves.toBe(
+      'runtime-fresh'
+    )
+
+    expect(archiveSession).toHaveBeenCalledWith('stored-work')
+    expect(requestGatewayForProfile).toHaveBeenCalledTimes(2)
+  })
+})
+
 describe('useSessionTileDelegate interruptSession', () => {
   beforeEach(() => {
     setSessions([])
@@ -189,8 +366,6 @@ describe('useSessionTileDelegate interruptSession', () => {
     await sessionTileDelegate()!.interruptSession('runtime-tile-1')
 
     expect(requestGateway).toHaveBeenCalledWith('session.interrupt', { session_id: 'runtime-tile-1' })
-    // Same 3s cooldown the primary chat's Stop sets: busy reads false while the
-    // gateway winds down, so the rewind path must still interrupt-first.
     expect(isSessionRecentlyInterrupted('runtime-tile-1')).toBe(true)
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -2,11 +2,20 @@ import { useEffect } from 'react'
 
 import { getLatestSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { toChatMessages } from '@/lib/chat-messages'
-import { publishSessionState, setSessionTileDelegate } from '@/store/session-states'
+import { requestGatewayForProfile } from '@/store/gateway'
+import { normalizeProfileKey } from '@/store/profile'
+import {
+  publishSessionState,
+  sessionRuntimeStateKey,
+  type SessionSurfaceIdentity,
+  type SessionSurfaceRuntimeIdentity,
+  setSessionTileDelegate,
+  StaleSessionSurfaceRuntimeError
+} from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
 
 import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
-import { markSessionRecentlyInterrupted, withSessionNotFoundResume } from '../../session/hooks/use-prompt-actions/utils'
+import { isSessionNotFoundError, markSessionRecentlyInterrupted, withSessionNotFoundResume } from '../../session/hooks/use-prompt-actions/utils'
 import { resolveSessionProfile } from '../../session/hooks/use-session-actions/utils'
 import type { useSessionStateCache } from '../../session/hooks/use-session-state-cache'
 import type { GatewayRequester } from '../types'
@@ -25,11 +34,13 @@ interface SessionTileDelegateParams {
 }
 
 /**
- * Publishes the session-tile delegate: resume / submit / interrupt / slash for
- * tiled sessions WITHOUT touching the primary view ($activeSessionId /
- * $messages stay the main thread's). Resume reuses a live runtime binding when
- * one exists (incl. the main thread's own session); a cold tile binds +
- * hydrates the cache, which publishSessionState mirrors to the tile.
+ * Publishes the session-tile delegate: resume / adopt / submit / interrupt /
+ * slash for tiled AND embedded surfaces WITHOUT touching the primary view
+ * ($activeSessionId / $messages stay the main thread's). Surface resume and
+ * adopt route through the identity's OWNING profile gateway
+ * (requestGatewayForProfile) so a background-profile surface never detours the
+ * foreground; a cold surface binds + hydrates the cache, which
+ * publishSessionState mirrors to the surface.
  */
 export function useSessionTileDelegate({
   archiveSession,
@@ -42,6 +53,36 @@ export function useSessionTileDelegate({
   updateSessionState
 }: SessionTileDelegateParams): void {
   useEffect(() => {
+    // Durable surface bindings keyed by profile-qualified stored identity. A
+    // runtime id is a cache warm-path hint, never the identity itself.
+    const surfaceRuntimeByIdentity = new Map<string, string>()
+
+    const surfaceKey = ({ profile, storedSessionId }: SessionSurfaceIdentity) =>
+      `${normalizeProfileKey(profile)}\u0000${storedSessionId}`
+
+    const discardSurface = ({ profile, storedSessionId }: SessionSurfaceIdentity): string[] => {
+      const ownerProfile = normalizeProfileKey(profile)
+      const identityKey = surfaceKey({ profile: ownerProfile, storedSessionId })
+      const runtimeId = surfaceRuntimeByIdentity.get(identityKey)
+
+      surfaceRuntimeByIdentity.delete(identityKey)
+      runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+
+      if (runtimeId) {
+        sessionStateByRuntimeIdRef.current.delete(sessionRuntimeStateKey(ownerProfile, runtimeId))
+      }
+
+      return runtimeId ? [runtimeId] : []
+    }
+
+    const discardStaleSurfaceRuntime = (identity: SessionSurfaceRuntimeIdentity) => {
+      const key = surfaceKey(identity)
+
+      if (surfaceRuntimeByIdentity.get(key) === identity.runtimeSessionId) {
+        surfaceRuntimeByIdentity.delete(key)
+      }
+    }
+
     // A tile's runtime binding can die the same way the foreground's does
     // (sleep/wake, backend restart). The cache maps stored -> runtime, so walk
     // it backwards to find the durable id this runtime belongs to.
@@ -71,15 +112,118 @@ export function useSessionTileDelegate({
       }
     }
 
+    const resumeSurface = async ({ profile, storedSessionId }: SessionSurfaceIdentity) => {
+      if (!profile.trim()) {
+        throw new Error('SessionSurface requires an explicit profile')
+      }
+
+      const surfaceRuntime = surfaceRuntimeByIdentity.get(surfaceKey({ profile, storedSessionId }))
+
+      const cached = surfaceRuntime
+        ? sessionStateByRuntimeIdRef.current.get(sessionRuntimeStateKey(profile, surfaceRuntime))
+        : undefined
+
+      if (surfaceRuntime && cached?.storedSessionId === storedSessionId) {
+        publishSessionState(surfaceRuntime, cached)
+
+        return surfaceRuntime
+      }
+
+      const [prefetch, resumed] = await Promise.all([
+        getLatestSessionMessages(storedSessionId, profile).catch(() => null),
+        requestGatewayForProfile<SessionResumeResponse>(profile, 'session.resume', {
+          session_id: storedSessionId,
+          cols: 96,
+          omit_messages: true,
+          profile
+        })
+      ])
+
+      const runtimeId = resumed?.session_id
+
+      if (!runtimeId) {
+        throw new Error('resume returned no session id')
+      }
+
+      surfaceRuntimeByIdentity.set(surfaceKey({ profile, storedSessionId }), runtimeId)
+      updateSessionState(
+        runtimeId,
+        state => ({
+          ...state,
+          busy: Boolean(resumed?.info?.running),
+          messages: state.messages.length > 0 ? state.messages : toChatMessages(prefetch?.messages ?? resumed?.messages ?? [])
+        }),
+        storedSessionId
+      )
+
+      return runtimeId
+    }
+
     setSessionTileDelegate({
-      archiveSession: async storedSessionId => {
-        await archiveSession(storedSessionId)
+      adoptSurface: async (identity: SessionSurfaceRuntimeIdentity) => {
+        if (!identity.profile.trim()) {
+          throw new Error('SessionSurface requires an explicit profile')
+        }
+
+        let status: { output?: string }
+
+        try {
+          status = await requestGatewayForProfile<{ output?: string }>(identity.profile, 'session.status', {
+            session_id: identity.runtimeSessionId
+          })
+        } catch (error) {
+          if (isSessionNotFoundError(error)) {
+            discardStaleSurfaceRuntime(identity)
+            throw new StaleSessionSurfaceRuntimeError('Session surface runtime hint was not found')
+          }
+
+          throw error
+        }
+
+        const authoritativeStoredId = status.output
+          ?.split('\n')
+          .find(line => line.startsWith('Session ID: '))
+          ?.slice('Session ID: '.length)
+          .trim()
+
+        if (authoritativeStoredId !== identity.storedSessionId) {
+          discardStaleSurfaceRuntime(identity)
+          throw new StaleSessionSurfaceRuntimeError('Session surface identity mismatch')
+        }
+
+        surfaceRuntimeByIdentity.set(surfaceKey(identity), identity.runtimeSessionId)
+
+        const cached = sessionStateByRuntimeIdRef.current.get(
+          sessionRuntimeStateKey(identity.profile, identity.runtimeSessionId)
+        )
+
+        updateSessionState(
+          identity.runtimeSessionId,
+          state =>
+            cached?.storedSessionId === identity.storedSessionId
+              ? { ...state }
+              : { ...state, messages: [], streamId: null, busy: false, awaitingResponse: false },
+          identity.storedSessionId
+        )
+
+        return identity.runtimeSessionId
       },
-      branchSession: async storedSessionId => {
+      archiveSession: async (storedSessionId, profile) => {
+        await archiveSession(storedSessionId)
+
+        if (profile) {
+          discardSurface({ profile, storedSessionId })
+        }
+      },
+      branchSession: async (storedSessionId) => {
         await branchStoredSession(storedSessionId)
       },
-      deleteSession: async storedSessionId => {
+      deleteSession: async (storedSessionId, profile) => {
         await removeSession(storedSessionId)
+
+        if (profile) {
+          discardSurface({ profile, storedSessionId })
+        }
       },
       executeSlash: async (rawCommand, sessionId) => {
         await executeSlashCommand(rawCommand, { sessionId })
@@ -112,6 +256,7 @@ export function useSessionTileDelegate({
           }
         )
       },
+      resumeSurface,
       resumeTile: async storedSessionId => {
         const existing = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
         const cached = existing ? sessionStateByRuntimeIdRef.current.get(existing) : undefined
@@ -135,13 +280,17 @@ export function useSessionTileDelegate({
         // the same cross-profile bleed the recovery resumes had (#67603).
         const profile = await resolveSessionProfile(storedSessionId)
 
+        if (!profile) {
+          throw new Error('Session surface profile unavailable')
+        }
+
         const [prefetch, resumed] = await Promise.all([
           getLatestSessionMessages(storedSessionId, profile).catch(() => null),
           requestGateway<SessionResumeResponse>('session.resume', {
             session_id: storedSessionId,
             cols: 96,
             omit_messages: true,
-            ...(profile ? { profile } : {})
+            profile
           })
         ])
 
@@ -156,8 +305,7 @@ export function useSessionTileDelegate({
           state => ({
             ...state,
             busy: Boolean(resumed?.info?.running),
-            messages:
-              state.messages.length > 0 ? state.messages : toChatMessages(prefetch?.messages ?? resumed?.messages ?? [])
+            messages: state.messages.length > 0 ? state.messages : toChatMessages(prefetch?.messages ?? resumed?.messages ?? [])
           }),
           storedSessionId
         )

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -19,15 +19,17 @@ import {
   setCurrentModelSource,
   setCurrentProvider
 } from '@/store/session'
-import { $sessionStates, sessionTileDelegate } from '@/store/session-states'
+import { $sessionStates, sessionRuntimeState, sessionTileDelegate } from '@/store/session-states'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
 interface ModelControlsOptions {
   queryClient: QueryClient
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  /** Explicit owner for an embedded surface; omitted is the primary chat. */
+  profile?: string
 }
 
-export function useModelControls({ queryClient, requestGateway }: ModelControlsOptions) {
+export function useModelControls({ profile, queryClient, requestGateway }: ModelControlsOptions) {
   const { t } = useI18n()
   const copy = t.desktop
   const profileRefreshEpochRef = useRef(0)
@@ -179,28 +181,33 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
     async (selection: ModelSelection): Promise<boolean> => {
       const primaryRuntimeId = $activeSessionId.get()
       const liveSessionId = 'sessionId' in selection ? (selection.sessionId ?? null) : primaryRuntimeId
-      const touchesPrimary = !liveSessionId || liveSessionId === primaryRuntimeId
+      // An explicitly-profiled caller is an embedded owner even when its runtime
+      // id collides with the foreground's — its switch must never touch the
+      // primary globals or persist a profile default.
+      const touchesPrimary = profile == null && (!liveSessionId || liveSessionId === primaryRuntimeId)
 
-      const prevModel = touchesPrimary ? $currentModel.get() : ($sessionStates.get()[liveSessionId!]?.model ?? '')
+      const prevModel = touchesPrimary
+        ? $currentModel.get()
+        : (sessionRuntimeState($sessionStates.get(), profile, liveSessionId!)?.model ?? '')
 
       const prevProvider = touchesPrimary
         ? $currentProvider.get()
-        : ($sessionStates.get()[liveSessionId!]?.provider ?? '')
+        : (sessionRuntimeState($sessionStates.get(), profile, liveSessionId!)?.provider ?? '')
 
       const prevSource = getCurrentModelSource()
-      const liveGatewayProfile = $activeGatewayProfile.get()
+      const liveGatewayProfile = profile ?? $activeGatewayProfile.get()
 
       if (touchesPrimary) {
         setCurrentModel(selection.model)
         setCurrentProvider(selection.provider)
         markComposerSelectionManual()
       } else if (liveSessionId) {
-        // Optimistic tile paint — session.info will confirm; rollback on error.
+        // Optimistic surface paint — session.info will confirm; rollback on error.
         sessionTileDelegate()?.updateSession(liveSessionId, state => ({
           ...state,
           model: selection.model,
           provider: selection.provider
-        }))
+        }), profile)
       }
 
       updateModelOptionsCache(
@@ -270,7 +277,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
             ...state,
             model: prevModel,
             provider: prevProvider
-          }))
+          }), profile)
         }
 
         updateModelOptionsCache(
@@ -280,12 +287,12 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
           touchesPrimary && !liveSessionId,
           liveGatewayProfile
         )
-        notifyError(err, copy.modelSwitchFailed)
+        notifyError(profile ? new Error(copy.modelSwitchFailed) : err, copy.modelSwitchFailed)
 
         return false
       }
     },
-    [copy.modelSwitchFailed, queryClient, requestGateway, updateModelOptionsCache]
+    [copy.modelSwitchFailed, profile, queryClient, requestGateway, updateModelOptionsCache]
   )
 
   return { applySavedMainModel, refreshCurrentModel, selectModel }

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -743,6 +743,11 @@ export {
   type ComposerAttachmentProvider,
   type ComposerMiddleware
 } from '@/app/chat/composer/contrib'
+/** THE embedded session surface — a native transcript + composer for an
+ *  explicitly-owned session (profile + stored id, never implicit). Plugin
+ *  panes mount this to render a full chat without foregrounding the session;
+ *  the profile always routes the resume/adopt to its owning backend. */
+export { SessionSurface, type SessionSurfaceIdentity, type SessionSurfaceProps } from '@/app/chat/session-surface'
 
 // -- ui: the design language --------------------------------------------------
 

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -22,16 +22,23 @@ vi.mock('@/store/session', async () => {
 
   return {
     $activeSessionId: atom(null),
+    $busy: atom(false),
     $connection: atom(null),
+    $cronSessions: atom([]),
     $currentCwd: atom(''),
     $currentModel: atom(''),
     $gatewayState: atom('open'),
     $messages: atom([]),
+    $messagingSessions: atom([]),
     $selectedStoredSessionId: atom(null),
     $sessions: atom([]),
+    $workspaceCwdOwner: atom(null),
     rememberedSessionProfile: (_sessions: unknown, _sessionId: null | string, activeProfile: null | string) =>
       (activeProfile ?? '').trim() || 'default',
     requestSessionResume: vi.fn(),
+    setAwaitingResponse: vi.fn(),
+    setBusy: vi.fn(),
+    setMessages: vi.fn(),
     setResumeExhaustedSessionId: vi.fn()
   }
 })
@@ -64,6 +71,7 @@ vi.mock('@/store/profile', async () => {
     $activeGatewayProfile: atom('remote-worker'),
     $gatewaySwapTarget: atom(null),
     $profiles: profiles,
+    $showAllProfiles: atom(false),
     ensureGatewayAgent: vi.fn(),
     ensureGatewayProfile: vi.fn(),
     newSessionInProfile: vi.fn(),
@@ -79,6 +87,7 @@ vi.mock('@/store/gateway', async () => {
 
   return {
     $gateway: atom(null),
+    activeGateway: vi.fn(() => null),
     ensureGatewayForAgent: vi.fn(),
     openGatewayForAgent: vi.fn(),
     openGatewayForProfile: vi.fn(),

--- a/apps/desktop/src/sdk/session-surface-export.test.ts
+++ b/apps/desktop/src/sdk/session-surface-export.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SessionSurfaceCore } from '@/app/chat/session-surface'
+
+import { installPluginSdk, sdkImportMap } from './runtime'
+
+import { SessionSurface, type SessionSurfaceProps } from './index'
+
+const sources: string[] = []
+
+beforeEach(() => {
+  sources.length = 0
+  vi.spyOn(URL, 'createObjectURL').mockImplementation(blob => {
+    void (blob as Blob).text().then((source: string) => sources.push(source))
+
+    return `blob:test-${sources.length}`
+  })
+})
+
+describe('runtime plugin SDK SessionSurface export', () => {
+  it('keeps the public component separate from the core lifecycle surface', () => {
+    const props: SessionSurfaceProps = { session: { profile: 'work', storedSessionId: 'stored' } }
+
+    expect(props).toEqual({ session: { profile: 'work', storedSessionId: 'stored' } })
+    expect(typeof SessionSurfaceCore).toBe('function')
+    expect(SessionSurface).not.toBe(SessionSurfaceCore)
+  })
+
+  it('installs and automatically includes SessionSurface in the generated SDK shim', async () => {
+    installPluginSdk()
+
+    const sdk = (globalThis as typeof globalThis & { __HERMES_PLUGIN_SDK__: Record<string, unknown> })
+      .__HERMES_PLUGIN_SDK__
+
+    expect(typeof sdk.SessionSurface).toBe('function')
+    expect(sdkImportMap()['@hermes/plugin-sdk']).toMatch(/^blob:test-/)
+    await vi.waitFor(() => expect(sources.some(source => source.includes('SessionSurface'))).toBe(true))
+  })
+
+  it('never leaks the internal surface internals through the SDK namespace', () => {
+    const sdk = (globalThis as typeof globalThis & { __HERMES_PLUGIN_SDK__: Record<string, unknown> })
+      .__HERMES_PLUGIN_SDK__
+
+    expect(sdk.SessionSurfaceChat).toBeUndefined()
+    expect(sdk.SessionSurfaceCore).toBeUndefined()
+    expect(sdk.$sessionStates).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -96,6 +96,10 @@ interface GatewayRegistryState {
   secondaries: Map<string, Secondary>
   $gateway: ReturnType<typeof atom<HermesGateway | null>>
   $activeProfile: ReturnType<typeof atom<string>>
+  // Transport install/reconnect observers keyed by PROFILE name (session
+  // ownership). Surfaces that render a background profile subscribe here to
+  // learn when its socket is ready WITHOUT observing the foreground `activeKey`.
+  profileListeners: Set<(profile: string) => void>
 }
 
 const STATE_KEY = Symbol.for('hermes.desktop.gatewayRegistryState')
@@ -118,7 +122,8 @@ function createRegistryState(): GatewayRegistryState {
     // the split-brain where an eviction re-pointed activeKey at the primary
     // while the profile atom kept naming the evicted bot routed every
     // "loki" session.resume to the default backend (#89206 wake failures).
-    $activeProfile: atom<string>('default')
+    $activeProfile: atom<string>('default'),
+    profileListeners: new Set()
   }
 }
 
@@ -176,8 +181,14 @@ export function emitLocalGatewayEvent(event: GatewayEvent): void {
 }
 
 export function setPrimaryGateway(gateway: HermesGateway | null, profile = 'default'): void {
+  const previousProfile = g.primaryProfile
   g.primaryGateway = gateway
   g.primaryProfile = normKey(profile)
+  g.profileListeners.forEach(listener => listener(previousProfile))
+
+  if (g.primaryProfile !== previousProfile) {
+    g.profileListeners.forEach(listener => listener(g.primaryProfile))
+  }
 }
 
 export function isActivePrimary(): boolean {
@@ -236,6 +247,7 @@ function reportGatewayState(profile: string, state: ConnectionState): void {
 
 export function reportPrimaryGatewayState(state: ConnectionState): void {
   reportGatewayState(g.primaryProfile, state)
+  g.profileListeners.forEach(listener => listener(g.primaryProfile))
 }
 
 function setActive(profile: string): void {
@@ -465,9 +477,12 @@ function createSecondary(profile: string, connectionId: null | string = null): S
     } else if ((state === 'closed' || state === 'error') && entry.wantOpen) {
       scheduleReconnect(entry)
     }
+
+    g.profileListeners.forEach(listener => listener(profile))
   })
 
   g.secondaries.set(scope, entry)
+  g.profileListeners.forEach(listener => listener(profile))
 
   return entry
 }
@@ -654,6 +669,38 @@ export async function requestGatewayForAgent<T>(
 // and error UX. An already-open (or primary) profile is a no-op.
 export async function openGatewayForProfile(profile: string): Promise<void> {
   await gatewayForProfile(profile)
+}
+
+/** Read a profile's transport connection state WITHOUT changing the foreground
+ * route or opening a socket. Returns the live gateway (primary or pooled
+ * secondary) when dialed, else null. The embedded SessionSurface uses this to
+ * decide adopt-vs-resume without activating the profile. */
+export function profileGatewayState(profile: string): HermesGateway | null {
+  const key = normKey(profile)
+
+  if (key === g.primaryProfile) {
+    return g.primaryGateway
+  }
+
+  return g.secondaries.get(key)?.gateway ?? null
+}
+
+/** Observe profile transport install/reconnect without observing activeKey. */
+export function subscribeProfileGateways(listener: (profile: string) => void): () => void {
+  g.profileListeners.add(listener)
+
+  return () => g.profileListeners.delete(listener)
+}
+
+/** Observe only one profile's transport install/connection changes. */
+export function subscribeProfileGateway(profile: string, listener: () => void): () => void {
+  const key = normKey(profile)
+
+  return subscribeProfileGateways(changedProfile => {
+    if (normKey(changedProfile) === key) {
+      listener()
+    }
+  })
 }
 
 // ── Connection-scoped agents (multi-source roster) ─────────────────────────
@@ -869,6 +916,7 @@ function disposeSecondary(entry: Secondary): void {
   entry.offEvent()
   entry.offState()
   entry.gateway.close()
+  g.profileListeners.forEach(listener => listener(entry.profile))
 }
 
 // Invariant restore for every eviction path: if the active key names a

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -200,6 +200,12 @@ export function notifyError(error: unknown, fallback: string): string {
   })
 }
 
+/** Keep raw legacy-primary detail, but replace profile-owned backend failures
+ * before they cross into any user-facing surface. */
+export function profiledPresentationError(error: unknown, fallback: string, ownerProfile?: null | string): unknown {
+  return ownerProfile ? new Error(fallback) : error
+}
+
 export function dismissNotification(id: string) {
   window.clearTimeout(timers.get(id))
   timers.delete(id)

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -95,6 +95,111 @@ export function liveSessionScopes(): Set<string> {
   return scopes
 }
 
+/** Runtime ids are process-scoped and unique per window; the reactive mirror
+ * stays keyed by the bare runtime id (matching the primary/tile cache). The
+ * profile is threaded for API symmetry with the durable surface identity but
+ * does not qualify the key — two profile gateways never mint the same runtime
+ * id in this process. Omitted profile preserves the legacy primary-chat key. */
+export function sessionRuntimeStateKey(profile: null | string | undefined, runtimeSessionId: string): string {
+  return runtimeSessionId
+}
+
+/** Read one session's live slice by runtime id. Profile is accepted for the
+ * durable-identity contract; the underlying key is the bare runtime id. */
+export function sessionRuntimeState(
+  states: Record<string, ClientSessionState>,
+  profile: null | string | undefined,
+  runtimeSessionId: string
+): ClientSessionState | undefined {
+  return states[sessionRuntimeStateKey(profile, runtimeSessionId)]
+}
+
+// ---------------------------------------------------------------------------
+// Embedded surface references — renderer-local, deliberately transient.
+// ---------------------------------------------------------------------------
+
+interface SessionSurfaceReference {
+  count: number
+  runtimeKeys: Set<string>
+}
+
+const sessionSurfaceReferences = new Map<string, SessionSurfaceReference>()
+
+const sessionSurfaceKey = (profile: string, storedSessionId: string) =>
+  `${normalizeProfileKey(profile)}\u0000${storedSessionId}`
+
+/** Profiles currently holding an embedded surface reference (for eviction /
+ * pruning awareness). */
+export const $sessionSurfaceProfiles = atom<string[]>([])
+
+function publishSessionSurfaceProfiles(): void {
+  $sessionSurfaceProfiles.set(
+    [...new Set([...sessionSurfaceReferences.keys()].map(key => normalizeProfileKey(key.split('\u0000', 1)[0])))].sort()
+  )
+}
+
+/** Retain an embedded conversation without making it a layout tile or the
+ * foreground chat. References are renderer-local and deliberately transient. */
+export function retainSessionSurfaceReference(profile: string, storedSessionId: string): void {
+  const key = sessionSurfaceKey(profile, storedSessionId)
+  const current = sessionSurfaceReferences.get(key)
+
+  if (current) {
+    current.count += 1
+  } else {
+    sessionSurfaceReferences.set(key, { count: 1, runtimeKeys: new Set() })
+  }
+
+  publishSessionSurfaceProfiles()
+}
+
+export function bindSessionSurfaceRuntime(profile: string, storedSessionId: string, runtimeSessionId: string): void {
+  const reference = sessionSurfaceReferences.get(sessionSurfaceKey(profile, storedSessionId))
+
+  if (!reference) {
+    return
+  }
+
+  const supersededRuntimeKeys = [...reference.runtimeKeys].filter(key => key !== runtimeSessionId)
+
+  reference.runtimeKeys.clear()
+  reference.runtimeKeys.add(runtimeSessionId)
+
+  for (const supersededKey of supersededRuntimeKeys) {
+    evictUnreferencedSurfaceRuntime(supersededKey)
+  }
+}
+
+export function releaseSessionSurfaceReference(profile: string, storedSessionId: string): void {
+  const key = sessionSurfaceKey(profile, storedSessionId)
+  const current = sessionSurfaceReferences.get(key)
+
+  if (!current) {
+    return
+  }
+
+  current.count -= 1
+
+  if (current.count > 0) {
+    publishSessionSurfaceProfiles()
+
+    return
+  }
+
+  const releasedRuntimeKeys = [...current.runtimeKeys]
+  current.runtimeKeys.clear()
+  sessionSurfaceReferences.delete(key)
+  publishSessionSurfaceProfiles()
+
+  for (const runtimeKey of releasedRuntimeKeys) {
+    evictUnreferencedSurfaceRuntime(runtimeKey)
+  }
+}
+
+export function sessionSurfaceReferenceCount(profile: string, storedSessionId: string): number {
+  return sessionSurfaceReferences.get(sessionSurfaceKey(profile, storedSessionId))?.count ?? 0
+}
+
 // Stored session ids whose authoritative state is still busy, but whose
 // runtime has produced no state publish for the watchdog window. Silence is
 // not completion: long tool calls can legitimately stay quiet, so this is a
@@ -249,11 +354,16 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
   }
 }
 
-/** Is any surface on THIS window still holding the runtime — the primary view
- *  or an open tile? (A tile mid-resume references by stored id only; its
- *  runtime binding is patched in after `resumeTile` returns.) */
+/** Is any surface on THIS window still holding the runtime — the primary view,
+ *  an open tile, or an embedded surface reference? (A tile mid-resume
+ *  references by stored id only; its runtime binding is patched in after
+ *  `resumeTile` returns.) */
 function runtimeReferenced(runtimeId: string, storedSessionId: null | string): boolean {
   if (runtimeId === $activeSessionId.get()) {
+    return true
+  }
+
+  if ([...sessionSurfaceReferences.values()].some(reference => reference.runtimeKeys.has(runtimeId))) {
     return true
   }
 
@@ -263,12 +373,24 @@ function runtimeReferenced(runtimeId: string, storedSessionId: null | string): b
 }
 
 /** A state no surface needs anymore: its turn is over (not busy, not waiting
- *  on the user) and neither the primary view nor any tile holds the runtime.
- *  `needsInput` states stay — the sidebar's attention dot reads them. */
+ *  on the user) and neither the primary view nor any tile/surface holds the
+ *  runtime. `needsInput` states stay — the sidebar's attention dot reads them. */
 function evictable(runtimeId: string, state: ClientSessionState): boolean {
   return (
     !state.busy && !state.needsInput && !state.awaitingResponse && !runtimeReferenced(runtimeId, state.storedSessionId)
   )
+}
+
+function evictUnreferencedSurfaceRuntime(runtimeKey: string): void {
+  const state = $sessionStates.get()[runtimeKey]
+
+  if (!state) {
+    return
+  }
+
+  if (evictable(runtimeKey, state)) {
+    dropSessionState(runtimeKey)
+  }
 }
 
 /** Publish one session's state. Automatically fires transition side-effects
@@ -650,13 +772,43 @@ export function unbindTileRuntime(runtimeId: string) {
 // store's pane closers.
 // ---------------------------------------------------------------------------
 
+export interface SessionSurfaceIdentity {
+  profile: string
+  runtimeSessionId?: string
+  storedSessionId: string
+}
+
+export interface SessionSurfaceRuntimeIdentity extends SessionSurfaceIdentity {
+  runtimeSessionId: string
+}
+
+/** Explicitly marks an ephemeral runtime hint that is no longer usable for its
+ * durable identity. Only this error enables SessionSurface's bounded resume
+ * fallback; transport, authorization, and other adoption failures stay visible. */
+export class StaleSessionSurfaceRuntimeError extends Error {
+  constructor(message = 'Session surface runtime hint is stale') {
+    super(message)
+    this.name = 'StaleSessionSurfaceRuntimeError'
+  }
+}
+
+export function isStaleSessionSurfaceRuntimeError(error: unknown): boolean {
+  return (
+    error instanceof StaleSessionSurfaceRuntimeError ||
+    (error instanceof Error && error.name === 'StaleSessionSurfaceRuntimeError')
+  )
+}
+
 export interface SessionTileDelegate {
+  /** Adopt a runtime returned by session.create. This path must not resume: a
+   *  fresh seeded session has no durable row until its first prompt. */
+  adoptSurface(identity: SessionSurfaceRuntimeIdentity): Promise<string>
   /** Archive a stored session (the sidebar's archive, incl. tile cleanup). */
-  archiveSession(storedSessionId: string): Promise<void>
+  archiveSession(storedSessionId: string, profile?: string): Promise<void>
   /** Branch a stored session into a new chat (the sidebar's branch). */
-  branchSession(storedSessionId: string): Promise<void>
+  branchSession(storedSessionId: string, profile?: string): Promise<void>
   /** Delete a stored session (the sidebar's delete, incl. tile cleanup). */
-  deleteSession(storedSessionId: string): Promise<void>
+  deleteSession(storedSessionId: string, profile?: string): Promise<void>
   /** Run a slash command against a tile's session (app-level effects — e.g.
    *  branch/handoff — act on the main surface, as they should). */
   executeSlash(rawCommand: string, sessionId: string): Promise<void>
@@ -671,17 +823,39 @@ export interface SessionTileDelegate {
   /** Bind a live runtime id for a stored session (resume without touching
    *  the main view). Returns the runtime id, or throws. */
   resumeTile(storedSessionId: string): Promise<string>
+  /** Bind a live runtime id for a stored session WITHOUT touching the main
+   *  view (resume against the identity's OWNING profile gateway). Returns the
+   *  runtime id, or throws. Used by the embedded SessionSurface. */
+  resumeSurface(identity: SessionSurfaceIdentity): Promise<string>
   /** Submit a prompt to a tile's live session. */
   submitToSession(runtimeId: string, text: string): Promise<void>
   /** THE session-state write path — routes through the wiring cache so the
    *  cache, the primary view (when active), and every tile mirror agree. */
-  updateSession(runtimeId: string, updater: (state: ClientSessionState) => ClientSessionState): ClientSessionState
+  updateSession(
+    runtimeId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    profile?: string
+  ): ClientSessionState
 }
 
 let delegate: SessionTileDelegate | null = null
+const delegateListeners = new Set<() => void>()
 
-export function setSessionTileDelegate(next: SessionTileDelegate) {
+export function setSessionSurfaceDelegate(next: SessionTileDelegate | null) {
   delegate = next
+  delegateListeners.forEach(listener => listener())
+}
+
+export function subscribeSessionSurfaceDelegate(listener: () => void): () => void {
+  delegateListeners.add(listener)
+
+  return () => delegateListeners.delete(listener)
+}
+
+export const setSessionTileDelegate = setSessionSurfaceDelegate
+
+export function sessionSurfaceDelegate(): SessionTileDelegate | null {
+  return delegate
 }
 
 export function sessionTileDelegate(): SessionTileDelegate | null {


### PR DESCRIPTION
Draft — re-open of #87795. Branch rebased onto origin/main (b007b80cb7); session-states.ts conflict resolved additively (both the event-source scopes block from 9caff74408 and the surface-identity block coexist). Re-validated: typecheck 3 configs, eslint on session-states.ts, SessionSurface 28/28, full UI suite 489 files / 4540 tests green.