### PR TITLE
fix(update): purge stale modules before dashboard cleanup on the ZIP path

### DIFF
--- a/hermes_cli/update_cmd_zip.py
+++ b/hermes_cli/update_cmd_zip.py
@@ -360,9 +360,9 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
     drivers causing 'Invalid argument'). Returns ``False`` when a Desktop rebuild ran and failed."""
     from hermes_cli.update_cmd import (
         _finish_dashboard_update_cleanup, _m, _print_bundled_skills_sync_report, _print_curator_first_run_notice,
-        _print_curator_recent_run_notice, _print_update_summary, _read_project_version, _rebuild_desktop_after_update,
-        _sweep_bytecode_after_update, _update_node_dependencies, _validate_critical_modules_import,
-        _verify_and_restore_state_dbs_post_update,
+        _print_curator_recent_run_notice, _print_update_summary, _purge_stale_hermes_modules, _read_project_version,
+        _rebuild_desktop_after_update, _sweep_bytecode_after_update, _update_node_dependencies,
+        _validate_critical_modules_import, _verify_and_restore_state_dbs_post_update,
     )
     active_tool_dependencies = _m()._capture_active_tool_dependencies()
     pre_update_version = _read_project_version()  # snapshot before files are replaced, for the completion line
@@ -425,6 +425,11 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
         _print_curator_first_run_notice()
     with _best_effort('Curator recent-run notice failed: %s'):
         _print_curator_recent_run_notice()
+    # Purge stale cached Hermes modules before the cleanup imports gateway source into this
+    # PRE-update interpreter: a cached OLD module missing a symbol the new source expects would
+    # ImportError the cleanup after the update already succeeded (#88371). The git path guards
+    # the same way ahead of its fleet restart; the ZIP fallback lacked the guard.
+    _purge_stale_hermes_modules()
     # Don't stop a working dashboard when the Node refresh failed — see the git-update path for rationale.
     # See #30271.
     _finish_dashboard_update_cleanup(node_failures)

--- a/tests/hermes_cli/test_update_zip_cleanup_purge.py
+++ b/tests/hermes_cli/test_update_zip_cleanup_purge.py
@@ -1,0 +1,36 @@
+"""The ZIP fallback's dashboard cleanup must run behind the stale-module purge (#88371).
+
+``hermes update`` runs in the pre-update interpreter, so after the ZIP swap ``sys.modules``
+still holds the OLD tree. ``_finish_dashboard_update_cleanup`` then imports ``gateway.status``
+lazily (``dashboard_procs``'s ``_pid_exists``), and a cached OLD module missing a symbol the
+new source expects crashes the cleanup with ``ImportError`` *after* the update already
+succeeded — the exact crash reported in #88371. The git path purges ahead of its fleet
+restart; these guards keep the ZIP fallback (Windows installs with broken git file I/O) from
+silently losing the same protection.
+"""
+import inspect
+
+from hermes_cli import update_cmd_zip
+
+
+def test_zip_cleanup_runs_behind_stale_module_purge():
+    """``_update_via_zip`` purges stale Hermes modules BEFORE the dashboard cleanup.
+
+    Structural guard: the crash would only reappear on the next cross-revision update, far
+    from any refactor that drops the call, so the ordering is pinned in source.
+    """
+    src = inspect.getsource(update_cmd_zip._update_via_zip)
+    purge_at = src.index("_purge_stale_hermes_modules()")
+    cleanup_at = src.index("_finish_dashboard_update_cleanup(")
+    assert purge_at < cleanup_at
+
+
+def test_purge_symbol_reachable_from_update_cmd_reexport():
+    """The ZIP path resolves the purge through the ``update_cmd`` re-export the fleet path uses.
+
+    The call would become a ``NameError`` at cleanup time if a future split of
+    ``update_cmd.py`` drops the re-export, so the import chain is asserted directly.
+    """
+    from hermes_cli.update_cmd import _purge_stale_hermes_modules
+
+    assert callable(_purge_stale_hermes_modules)


### PR DESCRIPTION
## What does this PR do?

`hermes update` runs in the pre-update interpreter, so after the working-tree swap `sys.modules` still holds the OLD tree. Any post-swap step that lazily imports a chain not fully loaded before the swap can mix the two revisions and die with `ImportError` after the update already succeeded (#88371's `gateway.status` → `gateway/__init__` → … → `hermes_cli.config` crash right after `✓ Update complete!`).

The git path now guards this with `_purge_stale_hermes_modules()` ahead of its fleet restart (044acf2bf7: evict every cached Hermes module so later imports rebuild a self-consistent graph from the updated checkout). The **Windows ZIP fallback** (`_update_via_zip`, used when git file I/O is broken) had no such guard: it calls `_finish_dashboard_update_cleanup` straight from the pre-update interpreter, and the entry-point reload added for #87134 only refreshes the process-scan pair (`_subprocess_compat`, `dashboard_procs`) — not the `gateway.status` chain that crashed in #88371.

This PR purges stale Hermes modules immediately before the ZIP path's dashboard cleanup, mirroring the git path's fleet-restart guard one-for-one (same helper, same "best-effort, never raises" semantics, already covered by `test_update_stale_module_purge.py`).

> Note: this replaces the original preload-based approach on this branch. The upstream fleet-restart purge (044acf2bf7) landed three days after this PR opened and explicitly moved away from per-symptom fixes ("Class fix replacing the per-symptom _UPDATE_RUNTIME_RELOAD_MODULES approach"), so aligning the ZIP path onto the same class fix is the consistent direction; it also keeps working for chains the cleanup grows later, where a hardcoded preload list would rot.

## Related Issue

Fixes #88371

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd_zip.py`: `_update_via_zip` now calls `_purge_stale_hermes_modules()` (imported through the same `update_cmd` re-export the fleet path uses) immediately before `_finish_dashboard_update_cleanup`, with a rationale comment referencing #88371 and the git-path precedent
- `tests/hermes_cli/test_update_zip_cleanup_purge.py`: structural regression guards — the purge must precede the cleanup call in `_update_via_zip` source (the crash would only reappear on the next cross-revision update, far from any refactor that drops it), and the purge symbol must stay reachable through the `update_cmd` re-export (otherwise the call becomes a `NameError` at cleanup time)

## How to Test

1. `python -m pytest tests/hermes_cli/test_update_zip_cleanup_purge.py -q` — Observed result: 2 passed.
2. `python -m pytest tests/hermes_cli/test_update_zip_atomic_replace.py tests/hermes_cli/test_update_zip_fallback_guards.py tests/hermes_cli/test_update_zip_release_preserve.py tests/hermes_cli/test_update_zip_symlink_reject.py tests/hermes_cli/test_update_zip_two_phase.py tests/hermes_cli/test_update_stale_module_purge.py tests/hermes_cli/test_update_fleet_restart_pending.py tests/hermes_cli/test_update_autostash.py -q` — Observed result: 90 passed, 11 failed; all 11 failures (9× autostash orphan-rescue family, 2× fleet-restart pending) reproduce identically on a clean `upstream/main` checkout with this change stashed (macOS 15 arm64, local-environment baseline; the ZIP-path and purge suites are fully green).
3. Manual review anchor: `hermes_cli/update_cmd_fleet.py`'s restart phase purges right before importing new gateway source — the ZIP-path call added here is the same one-line guard in the same relative position.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (all suites touched by this change pass; unrelated pre-existing local baseline failures are itemized in How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed; the call site carries a rationale comment referencing #88371 and the git-path precedent

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/hermes_cli/test_update_zip_cleanup_purge.py -q
2 passed in 0.41s
$ python -m pytest tests/hermes_cli/ -k "update or zip" -q
918 passed, 14 skipped, 69 failed  # 69 = pre-existing upstream/main baseline failures on this machine
                                   # (autostash 9 + fleet_restart_pending 2 verified identical with the change stashed;
                                   #  cmd_update 8 + yes_flag 3 match the known local baseline; launchd/web_server are
                                   #  macOS service/environment domains untouched by this diff)
```
