### PR TITLE
fix(tools): interpret lethal signal exits in background-process notifications

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1117,6 +1117,74 @@ class TestProcessToolHandler:
 from tools.process_registry import format_process_notification
 
 
+class TestBackgroundExitSignalNote:
+    """Background-process completion notifications must explain lethal
+    signal exits (SIGKILL/OOM, SIGSEGV, SIGBUS, ...), not just SIGTERM.
+
+    204302bd64 added terminal_tool._interpret_signal_exit() and wired it
+    into the FOREGROUND terminal_tool exit-code report, but
+    format_process_notification -- the shared formatter for background/
+    detached process completions -- kept its own, much older check that
+    only recognized SIGTERM (-15 / 143). A background process killed by
+    the OOM killer (137/-9) or crashing with SIGSEGV (139/-11) reached the
+    model as a bare "(exit code 137)" with no explanation.
+    """
+
+    def _evt(self, exit_code):
+        return {
+            "type": "completion",
+            "session_id": "proc_test",
+            "command": "some-command",
+            "exit_code": exit_code,
+            "output": "",
+        }
+
+    def test_sigkill_oom_int_exit_code_gets_note(self):
+        text = format_process_notification(self._evt(-9))
+        assert "(exit code -9)." in text
+        assert "SIGKILL" in text
+        assert "OOM" in text
+
+    def test_sigkill_shell_convention_137_gets_note(self):
+        text = format_process_notification(self._evt(137))
+        assert "(exit code 137)." in text
+        assert "SIGKILL" in text
+
+    def test_sigsegv_string_exit_code_gets_note(self):
+        """exit_code can arrive as a numeric string depending on the producer."""
+        text = format_process_notification(self._evt("-11"))
+        assert "(exit code -11)." in text
+        assert "SIGSEGV" in text
+
+    def test_sigterm_still_recognized(self):
+        """Regression guard: SIGTERM (the one signal the old check covered)
+        must not be lost in the rewrite."""
+        text = format_process_notification(self._evt(-15))
+        assert "SIGTERM" in text
+
+    def test_clean_exit_gets_no_signal_note(self):
+        text = format_process_notification(self._evt(0))
+        assert "SIGTERM" not in text
+        assert "SIGKILL" not in text
+        assert "completed normally" in text
+
+    def test_ordinary_nonzero_exit_gets_no_signal_note(self):
+        """exit_code=1 (e.g. grep 'no matches') is not a signal death."""
+        text = format_process_notification(self._evt(1))
+        assert "SIGTERM" not in text
+        assert "SIGKILL" not in text
+
+    def test_unknown_placeholder_exit_code_gets_no_signal_note(self):
+        evt = {
+            "type": "completion", "session_id": "proc_test",
+            "command": "cmd", "exit_code": "?", "output": "",
+        }
+        text = format_process_notification(evt)
+        assert "(exit code ?)." in text
+        assert "SIGTERM" not in text
+        assert "SIGKILL" not in text
+
+
 def test_drain_notifications_completion_callback_exception_fails_closed(registry):
     event = {
         "type": "completion",

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2872,6 +2872,28 @@ def _format_async_delegation(evt: dict) -> str:
     return "\n".join(lines)
 
 
+def _background_exit_signal_note(exit_code: "int | str") -> "str | None":
+    """Resolve a background process's exit code through terminal_tool's
+    signal-death table (OOM/SIGKILL, SIGSEGV, SIGBUS, ...).
+
+    ``exit_code`` arrives from the completion-queue event as either an int
+    or a numeric string depending on the producer; anything else (the "?"
+    placeholder, non-numeric) resolves to no note. Lazy import avoids a
+    circular dependency -- terminal_tool imports this module too, for
+    background-process registration/polling.
+    """
+    if isinstance(exit_code, bool):
+        return None
+    if isinstance(exit_code, int):
+        code = exit_code
+    elif isinstance(exit_code, str) and exit_code.lstrip("-").isdigit():
+        code = int(exit_code)
+    else:
+        return None
+    from tools.terminal_tool import _interpret_signal_exit
+    return _interpret_signal_exit(code)
+
+
 def format_process_notification(evt: dict) -> "str | None":
     """Format a process notification event into a [IMPORTANT: ...] message.
 
@@ -2913,9 +2935,7 @@ def format_process_notification(evt: dict) -> "str | None":
     _out = evt.get("output", "")
     _reason = evt.get("completion_reason") or "exited"
     _source = evt.get("termination_source") or ""
-    _signal = ""
-    if _exit in {-15, 143, "-15", "143"}:
-        _signal = ", SIGTERM"
+    _signal_note = _background_exit_signal_note(_exit)
     if _reason == "killed":
         _status = f"terminated by {_source or 'Hermes'}"
     elif _reason == "lost":
@@ -2926,9 +2946,11 @@ def format_process_notification(evt: dict) -> "str | None":
         _status = "completed normally"
     else:
         _status = "exited"
+    _note_line = f"{_signal_note}\n" if _signal_note else ""
     return (
         f"[IMPORTANT: Background process {_sid} {_status} "
-        f"(exit code {_exit}{_signal}).\n"
+        f"(exit code {_exit}).\n"
+        f"{_note_line}"
         f"Command: {_cmd}\n"
         f"Output:\n{_out}]"
     )


### PR DESCRIPTION
## Summary
204302bd64 added `terminal_tool._interpret_signal_exit()` (11 curated signals: SIGKILL/SIGSEGV/SIGBUS/SIGFPE/etc.) and wired it into the *foreground* terminal_tool exit-code report via `_interpret_exit_code()`. It never touched `format_process_notification()` — the shared formatter for *background/detached* process completions, called from `process_registry.py` itself, `tui_gateway/server.py` (x2), and `gateway/run.py`'s async-delegation path. That formatter kept its own, much older check that recognizes only SIGTERM:

```python
if _exit in {-15, 143, "-15", "143"}:
    _signal = ", SIGTERM"
```

A background process killed by the OOM killer (exit 137/-9 — "the big one" per 204302bd64's own commit message) or crashing with SIGSEGV (139/-11) reached the model as a bare `(exit code 137)` with zero explanation — exactly the failure mode 204302bd64 set out to fix, just on a different surface.

## Changes
- `tools/process_registry.py`: new `_background_exit_signal_note()` resolves `exit_code` (int or the numeric-string shape some producers use) through `terminal_tool._interpret_signal_exit()` via a lazy import — mirroring the existing established pattern in this pair of modules (`process_registry.py` already lazy-imports `terminal_tool._rewrite_compound_background` for the same reason: a circular top-level import). The note is surfaced as its own line rather than crammed into the exit-code parenthetical, matching how the foreground path surfaces it as its own `exit_code_meaning` field rather than a compact suffix.
- `tests/tools/test_process_registry.py`: 7 new tests (`TestBackgroundExitSignalNote`).

No test previously asserted on the exact SIGTERM-suffix string, so the format change (moving the note out of the parenthetical) does not touch any covered contract — grepped `test_watch_patterns.py`, `test_async_delegation.py`, and `test_context_compressor_zero_user_provenance.py`'s `format_process_notification` usages: all exercise other branches (watch_overflow, async_delegation, or only the `"[IMPORTANT: Background process"` prefix), none reach this code path.

## Test plan
- [x] New tests reproduce the gap against pre-fix code and pass after the fix
- [x] Mutation-verified: reverting the fix makes 3 of the 7 new tests fail against pre-fix code (SIGKILL as int, SIGKILL via the 128+signum shell convention, SIGSEGV as a numeric string); the other 4 (SIGTERM still recognized, clean exit, ordinary non-zero exit, unknown `"?"` placeholder) correctly pass either way since they were never exposed to the bug
- [x] Broader neighbor suite (160 tests: `test_process_registry.py`, `test_watch_patterns.py`, `test_async_delegation.py`, `test_context_compressor_zero_user_provenance.py`, `test_terminal_tool.py`) and the dedicated `test_terminal_signal_exit.py` (27 tests) pass unchanged
- [x] `ruff check` clean on both changed files

## Competing PR check
- My own open #86261 touches `format_process_notification`'s neighborhood (redaction for `watch_match`/`watch_disabled`/`watch_overflow_*`) but in `gateway/run.py`'s separate `_format_gateway_process_notification` — confirmed that function has no completion/exit-code branch of its own (`evt_type == "completion"` falls through to `return None`; the actual exit-code text is generated exclusively by `process_registry.py::format_process_notification`, which all 5 call sites — including the 2 in `tui_gateway/server.py` — delegate to directly). No overlap.
- #49809 ("neutral signal-kill rendering") touches `tools/process_registry.py` and `tests/tools/test_process_registry.py`, but its diff adds `remove()`/`clear_finished()` registry methods and extends the `process` tool's action schema/dispatch — it never touches `format_process_notification()`'s body. No overlap.