### PR TITLE
fix(desktop): route remote sub-profiles through the primary's remote gateway

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -346,6 +346,30 @@ const ROUTES = [
     profile: 'coder',
     opts: { primaryProfile: 'default', globalRemote: false, profileRemoteOverride: false },
     expected: { backend: 'pool', descriptorProfile: null, scopePath: false }
+  },
+  {
+    name: 'a remote sub-profile without a local entry routes through the primary remote gateway',
+    profile: 'pm',
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      primaryRemoteActive: true,
+      ownEntry: false
+    },
+    expected: { backend: 'primary', descriptorProfile: 'pm', scopePath: true }
+  },
+  {
+    name: 'a sub-profile with its own local entry still pools locally under a remote primary',
+    profile: 'pm',
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      primaryRemoteActive: true,
+      ownEntry: true
+    },
+    expected: { backend: 'pool', descriptorProfile: null, scopePath: false }
   }
 ]
 

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -481,6 +481,10 @@ export interface ProfileRouteOptions {
   globalRemote?: boolean
   primaryProfile?: null | string
   profileRemoteOverride?: boolean
+  /** The primary profile's own backend resolves to a remote host. */
+  primaryRemoteActive?: boolean
+  /** A stored per-profile entry exists for this profile (local or remote). */
+  ownEntry?: boolean
 }
 
 export interface ProfileBackendRoute {
@@ -525,6 +529,14 @@ function resolveProfileBackendRoute(profile, opts: ProfileRouteOptions = {}): Pr
   }
 
   if (opts.globalRemote) {
+    return { backend: 'primary', descriptorProfile: scopedProfile, scopePath: true }
+  }
+
+  if (opts.primaryRemoteActive && !opts.ownEntry) {
+    // The primary profile's own backend is a remote gateway (per-profile
+    // override or env) and this sub-profile has no stored entry of its own.
+    // Route through that gateway with profile scoping instead of spawning a
+    // fresh local backend that shares nothing but the name (#88296).
     return { backend: 'primary', descriptorProfile: scopedProfile, scopePath: true }
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9482,6 +9482,7 @@ function primaryProfileKey() {
 function profileRouteOptions(profile) {
   const config = readDesktopConnectionConfig()
   const sshOverride = profileSshOverride(config, profile)
+  const key = connectionScopeKey(profile) || primaryProfileKey()
 
   return {
     // A desktop profile can be only a client-side routing alias. Keep backend
@@ -9489,7 +9490,14 @@ function profileRouteOptions(profile) {
     backendProfile: sshOverride?.remoteProfile,
     globalRemote: globalRemoteActive(),
     primaryProfile: primaryProfileKey(),
-    profileRemoteOverride: Boolean(profileRemoteOverride(config, profile) || sshOverride)
+    profileRemoteOverride: Boolean(profileRemoteOverride(config, profile) || sshOverride),
+    // The primary profile's own backend resolves to a remote host (its
+    // per-profile override, env, or global). Unknown sub-profiles on that
+    // gateway must route THROUGH it, not spawn local backends (#88296).
+    primaryRemoteActive: primaryBackendIsRemote(),
+    // A stored per-profile entry (local or remote) — pins this profile to
+    // its own backend; absent entries inherit the primary's remote.
+    ownEntry: Boolean((readDesktopConnectionConfig().profiles || {})[key])
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #88296: with a URL-remote desktop whose primary profile carries a per-profile remote override, the Bots pane lists the gateway's sub-profiles — but clicking one fell through `resolveProfileBackendRoute`'s last case and spawned a fresh local backend that shares nothing but the name with the remote bot.

## Fix

- `profileRouteOptions` now passes `primaryRemoteActive` (the existing `primaryBackendIsRemote()` predicate: per-profile override → env → global) and `ownEntry` (a stored per-profile connection entry exists).
- `resolveProfileBackendRoute`: when the primary's own backend is remote and the sub-profile has **no entry of its own**, route `{ backend: 'primary', descriptorProfile, scopePath: true }` — the same shared-primary-with-profile-scoping flow global remote uses, so the renderer scopes WebSocket/FS/cache requests via `?profile=`.
- Profiles with their own local entries keep pooling locally; own remote overrides are unchanged.

## Validation

- Two new routing-table cases; **91 electron test files, 1152 tests passed** (1 skipped).
- Atomic commits: routing fix → tests.
