### PR TITLE
fix(whatsapp): preserve nested emphasis delimiters

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -458,15 +458,53 @@ class WhatsAppBehaviorMixin:
         result = re.sub(r"`[^`\n]+`", _save_code, result)
 
         # --- 3. Convert markdown formatting to WhatsApp syntax ---
-        # Italic: standard Markdown *text* → WhatsApp _text_.  Do this before
-        # bold conversion so **bold** does not become italic by accident.  The
-        # lookarounds avoid list bullets and bold delimiters.
+        # Protect combined emphasis before the single-star pass. Otherwise
+        # ``***text***`` loses one delimiter and renders as bold with literal
+        # asterisks instead of balanced bold+italic.
+        _EMPH_PH = "\x00EMPH"
+        combined_emphasis: list[str] = []
+
+        def _save_combined_emphasis(m: re.Match) -> str:
+            combined_emphasis.append(f"_*{m.group(1)}*_")
+            return f"{_EMPH_PH}{len(combined_emphasis) - 1}\x00"
+
         result = re.sub(
-            r"(?<!\*)\*(?!\s|\*)([^*\n]*?\S[^*\n]*?)\*(?!\*)",
-            r"_\1_",
+            r"(?<!\*)\*\*\*(?=\S)([^*\n]+?)(?<=\S)\*\*\*(?!\*)",
+            _save_combined_emphasis,
             result,
         )
-        # Bold: **text** or __text__ → *text*
+
+        # Italic: standard Markdown *text* → WhatsApp _text_. Treat an inner
+        # **bold** span as one atom so the outer italic delimiters cannot consume
+        # one of its stars. Convert that inner span while replacing the outer.
+        def _italic_to_whatsapp(m: re.Match) -> str:
+            inner = re.sub(r"\*\*(.+?)\*\*", r"*\1*", m.group(1))
+            return f"_{inner}_"
+
+        result = re.sub(
+            r"(?<!\*)\*(?!\s)(?=(?:[^*\n]|\*\*[^*\n]))"
+            r"((?:[^*\n]|\*\*[^*\n]+?\*\*)*?)(?<!\s)\*(?!\*)",
+            _italic_to_whatsapp,
+            result,
+        )
+
+        # Bold: **text** → *text*. Treat an inner *italic* span as one atom for
+        # the same reason, including when it touches either outer delimiter.
+        def _bold_to_whatsapp(m: re.Match) -> str:
+            inner = re.sub(
+                r"(?<!\*)\*(?!\s)([^*\n]*?\S[^*\n]*?)\*(?!\*)",
+                r"_\1_",
+                m.group(1),
+            )
+            return f"*{inner}*"
+
+        result = re.sub(
+            r"(?<!\*)\*\*(?!\s)(?=(?:[^*\n]|\*[^*\n]))"
+            r"((?:[^*\n]|\*[^*\n]+?\*)*?)(?<!\s)\*\*(?!\*)",
+            _bold_to_whatsapp,
+            result,
+        )
+        # Preserve the existing conversion for other double-star shapes.
         result = re.sub(r"\*\*(.+?)\*\*", r"*\1*", result)
         result = re.sub(r"__(.+?)__", r"*\1*", result)
         # Strikethrough: ~~text~~ → ~text~
@@ -491,6 +529,8 @@ class WhatsAppBehaviorMixin:
         result = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1 (\2)", result)
 
         # --- 6. Restore protected sections ---
+        for i, emphasis in enumerate(combined_emphasis):
+            result = result.replace(f"{_EMPH_PH}{i}\x00", emphasis)
         for i, fence in enumerate(fences):
             result = result.replace(f"{_FENCE_PH}{i}\x00", fence)
         for i, code in enumerate(codes):

--- a/tests/conformance/vectors/whatsapp.json
+++ b/tests/conformance/vectors/whatsapp.json
@@ -2,7 +2,7 @@
   "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_conformance_vectors.py; the native renderers are the oracle (executable spec).",
   "oracle": {
     "repo": "NousResearch/hermes-agent",
-    "commit": "40eebc7d70f3d8e95c429c8aa482f31ba6c867f6",
+    "commit": "5f08b2d6c1ec772834f6602f8457c1f01034cee2",
     "generator": "scripts/generate_conformance_vectors.py",
     "generator_version": 1
   },
@@ -288,7 +288,7 @@
       "category": "adversarial",
       "expect": "parity",
       "input": "***what is this*** and ____that____",
-      "native_output": "**what is this** and *__that*__"
+      "native_output": "_*what is this*_ and *__that*__"
     },
     {
       "id": "empty-string",

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -110,6 +110,53 @@ class TestFormatMessage:
         # Already-WhatsApp _italic_ passes through unchanged
         assert adapter.format_message("_italic_") == "_italic_"
 
+    @pytest.mark.parametrize(
+        ("markdown", "wire_text"),
+        [
+            ("***bold italic***", "_*bold italic*_"),
+            (
+                "*Italic containing **bold text** inside it*",
+                "_Italic containing *bold text* inside it_",
+            ),
+            (
+                "***Bold text** inside italic*",
+                "_*Bold text* inside italic_",
+            ),
+            (
+                "*Italic containing **bold text***",
+                "_Italic containing *bold text*_",
+            ),
+            (
+                "**Bold containing *italic text* inside it**",
+                "*Bold containing _italic text_ inside it*",
+            ),
+            (
+                "***Italic text* inside bold**",
+                "*_Italic text_ inside bold*",
+            ),
+            (
+                "**Bold containing *italic text***",
+                "*Bold containing _italic text_*",
+            ),
+        ],
+    )
+    def test_nested_emphasis_has_balanced_whatsapp_delimiters(
+        self, markdown, wire_text
+    ):
+        adapter = _make_adapter()
+        assert adapter.format_message(markdown) == wire_text
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "`***bold italic***`",
+            "```markdown\n***bold italic***\n```",
+        ],
+    )
+    def test_nested_emphasis_inside_code_is_unchanged(self, code):
+        adapter = _make_adapter()
+        assert adapter.format_message(code) == code
+
 
 # ---------------------------------------------------------------------------
 # MAX_MESSAGE_LENGTH tests


### PR DESCRIPTION
## What does this PR do?

Fixes WhatsApp Markdown conversion for combined and nested emphasis. Exact triple-star spans are protected before the single-star pass, and nested bold/italic spans are converted as units so their delimiters stay balanced when the inner span touches either outer edge.

The formatter keeps fenced and inline code unchanged and preserves the existing fallback for other double-star shapes.

## Related Issue

Fixes #88316

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style / refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test improvement

## Changes Made

- Protect exact `***text***` spans before single-star conversion.
- Convert nested bold and italic spans as units, including start- and end-adjacent delimiters.
- Add wire-output fixtures for combined and nested emphasis.
- Regenerate the WhatsApp conformance vector for the corrected combined-emphasis output.
- Verify fenced and inline code remain untouched.

## How to Test

1. Run `scripts/run_tests.sh tests/conformance/test_vector_generator.py tests/gateway/test_*whatsapp*.py -q`.
2. Run `uvx --from ruff==0.15.10 ruff check gateway/platforms/whatsapp_common.py tests/gateway/test_whatsapp_formatting.py`.
3. Run `python -m py_compile gateway/platforms/whatsapp_common.py tests/gateway/test_whatsapp_formatting.py`.

Expected result: the conformance and WhatsApp suites pass 134 tests with three platform-specific skips and no failures; Ruff and `py_compile` pass.

## Screenshots / Logs

```text
=== Summary: 19 files, 134 tests passed, 0 failed, 3 skipped
All checks passed!
ruff=passed py_compile=passed
```

Full-suite verification ran in the fork's Ubuntu CI on a fork-only trigger commit with the same Git tree as this PR (`e2d6e4d840c3d3176ece77c9afdfd891cb74683a`). All 12 Python test slices, the macOS and Windows marked-test lanes, and e2e passed: [CI run](https://github.com/alexskatell/hermes-agent/actions/runs/32029822277).

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have searched existing PRs to avoid duplicates
- [x] This PR contains only changes related to the issue
- [x] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on macOS 26.6

## Documentation

- [x] I have updated relevant documentation (N/A: no user-facing setup or API changed)
- [x] I have updated example scripts if needed (N/A)
- [x] I have updated AGENTS.md if needed (N/A)
- [x] I have updated `tests/MANUAL_TEST_PLAN.md` if needed (N/A)

## Security

- [x] I have reviewed the [Security Policy](../SECURITY.md) if my change touches security-sensitive code (N/A)
- [x] No credentials, API keys, or secrets are included in this PR
- [x] I have not weakened authentication or authorization checks
