### PR TITLE
fix(install): stop silencing npm, and name TLS-trust failures

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -972,6 +972,33 @@ npm_supports_npmrc() {
     return 0
 }
 
+# Inspect npm output for a TLS-trust failure and, if found, print actionable
+# remediation. npm/Node surface corporate MITM proxies and missing root CAs as
+# "unable to get local issuer certificate" / "self-signed certificate in
+# certificate chain" / UNABLE_TO_VERIFY_LEAF_SIGNATURE, which reads as a
+# generic install failure and gets reported as one (issue #38016). install.ps1
+# already routes its npm stages through Show-NpmCertHint; this is the POSIX
+# half, which was never written. Returns 0 when a cert error was detected.
+npm_cert_hint() {
+    local log_file="$1"
+    [ -s "$log_file" ] || return 1
+    grep -qiE 'unable to get local issuer certificate|self[- ]signed certificate|UNABLE_TO_GET_ISSUER_CERT_LOCALLY|UNABLE_TO_VERIFY_LEAF_SIGNATURE|SELF_SIGNED_CERT_IN_CHAIN|CERT_HAS_EXPIRED' \
+        "$log_file" || return 1
+    log_warn "This looks like a TLS certificate-trust failure, not a network or permissions problem."
+    log_info "  A corporate proxy or antivirus is likely intercepting HTTPS and presenting a"
+    log_info "  certificate Node.js doesn't trust. Node ignores SSL_CERT_FILE and CURL_CA_BUNDLE,"
+    log_info "  so pointing curl at the CA is not enough — Node needs telling separately."
+    log_info "  If the CA is already in your OS trust store (usual on a managed machine):"
+    log_info "    export NODE_OPTIONS=--use-system-ca"
+    log_info "  Otherwise point Node at the certificate directly:"
+    log_info "    1. Get your organization's root CA as a .pem/.crt from your IT team."
+    log_info "    2. export NODE_EXTRA_CA_CERTS=/path/to/corp-ca.pem"
+    log_info "  Then re-run the installer in that shell (add it to your shell profile to persist)."
+    log_info "  Quick (less secure) alternative — disable TLS verification just for the install:"
+    log_info "    npm config set strict-ssl false   (re-enable afterwards: npm config set strict-ssl true)"
+    return 0
+}
+
 check_node() {
     log_info "Checking Node.js (for browser tools)..."
 
@@ -2670,19 +2697,24 @@ install_node_deps() {
         # A failed npm install used to still print "✓ Node.js dependencies
         # installed", hiding the degradation from the user (#77003). Now it
         # fails the install outright instead of burying the warning (#85297).
-        # Capture npm output so failures are diagnosable (#87340).
+        # Capture npm output so failures are diagnosable (#87340). NOT --silent:
+        # that suppresses npm's own error reporting, so the capture above it
+        # recorded an empty log and printed a bare "npm output:" with nothing
+        # behind it. Output is only ever shown on failure, so the verbosity
+        # costs nothing on the happy path.
         # Scoped to the workspaces a CLI install needs so apps/desktop's
         # node-pty is never built here — see node_deps_workspace_args().
         node_deps_workspace_args "$INSTALL_DIR"
         local npm_log
         npm_log="$(mktemp)"
-        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install "${NODE_DEPS_WORKSPACE_ARGS[@]}" --silent \
+        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install "${NODE_DEPS_WORKSPACE_ARGS[@]}" \
                 >"$npm_log" 2>&1; then
             log_error "npm install failed or timed out; Node.js dependencies were not installed"
             if [ -s "$npm_log" ]; then
                 log_error "npm output:"
                 cat "$npm_log" >&2
             fi
+            npm_cert_hint "$npm_log" || true
             rm -f "$npm_log"
             restore_dirty_lockfiles "$INSTALL_DIR"
             return 1
@@ -2789,16 +2821,18 @@ install_node_deps() {
         # Time-boxed: a stalled registry fetch would otherwise hang here (#39219).
         # Report success only on actual success, same as node-deps above
         # (#77003) — and fail the install outright (#85297).
-        # Capture npm output so failures are diagnosable (#87340).
+        # Capture npm output so failures are diagnosable (#87340). NOT --silent
+        # — see the node-deps site above.
         local tui_npm_log
         tui_npm_log="$(mktemp)"
-        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent \
+        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install \
                 >"$tui_npm_log" 2>&1; then
             log_error "TUI npm install failed or timed out; TUI dependencies were not installed"
             if [ -s "$tui_npm_log" ]; then
                 log_error "npm output:"
                 cat "$tui_npm_log" >&2
             fi
+            npm_cert_hint "$tui_npm_log" || true
             rm -f "$tui_npm_log"
             restore_dirty_lockfiles "$INSTALL_DIR"
             return 1

--- a/tests/test_install_sh_npm_diagnostics.py
+++ b/tests/test_install_sh_npm_diagnostics.py
@@ -1,0 +1,106 @@
+"""Regression tests for install.sh npm failure diagnostics (#87340, #38016).
+
+Both install-blocking `npm install` calls captured output for diagnosis while
+still passing --silent, which suppresses npm's own error reporting. The capture
+recorded an empty log, so a failed install printed "npm output:" with nothing
+behind it. Node also reads neither SSL_CERT_FILE nor CURL_CA_BUNDLE, so a
+corporate MITM proxy surfaces as an opaque failure on POSIX; install.ps1 has
+had a hint for this since #38016 and install.sh had none.
+"""
+
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+# A real npm failure through an intercepting proxy, trimmed to the error lines.
+CERT_FAILURE = """\
+npm warn Unknown env config "nodedir".
+npm error code UNABLE_TO_VERIFY_LEAF_SIGNATURE
+npm error errno UNABLE_TO_VERIFY_LEAF_SIGNATURE
+npm error request to https://registry.npmjs.org/undici/-/undici-6.28.0.tgz \
+failed, reason: unable to verify the first certificate
+"""
+
+UNRELATED_FAILURE = """\
+npm error code E404
+npm error 404 Not Found - GET https://registry.npmjs.org/does-not-exist
+"""
+
+
+def _install_blocking_npm_calls() -> list[str]:
+    """The `npm install` invocations whose failure aborts the install."""
+    return re.findall(
+        r"run_with_timeout \"\$NODE_DEPS_TIMEOUT\" npm install[^\n]*",
+        INSTALL_SH.read_text(),
+    )
+
+
+def test_install_blocking_npm_calls_are_not_silenced() -> None:
+    """--silent defeats the output capture it sits next to (#87340)."""
+    calls = _install_blocking_npm_calls()
+    assert calls, "expected to find the install-blocking npm install calls"
+    offenders = [call for call in calls if "--silent" in call]
+    assert not offenders, (
+        "`npm install --silent` suppresses npm's error output, so the capture "
+        "records an empty log and the installer prints a bare 'npm output:'. "
+        "Offending calls: " + repr(offenders)
+    )
+
+
+def test_cert_hint_is_wired_into_both_failure_paths() -> None:
+    """Every install-blocking npm failure path must offer the hint."""
+    text = INSTALL_SH.read_text()
+    assert text.count("npm_cert_hint ") >= 2, (
+        "both the node-deps and TUI npm failure branches should call "
+        "npm_cert_hint"
+    )
+
+
+def _run_hint(tmp_path: Path, npm_output: str) -> subprocess.CompletedProcess:
+    """Execute npm_cert_hint against a captured npm log."""
+    body = re.search(
+        r"^npm_cert_hint\(\) \{.*?^\}", INSTALL_SH.read_text(), re.S | re.M
+    )
+    assert body, "npm_cert_hint not found in install.sh"
+
+    log = tmp_path / "npm.log"
+    log.write_text(npm_output)
+    script = tmp_path / "harness.sh"
+    script.write_text(
+        textwrap.dedent(
+            """\
+            log_warn() { echo "warn: $*"; }
+            log_info() { echo "info: $*"; }
+            """
+        )
+        + body.group(0)
+        + f'\nnpm_cert_hint "{log}"\n'
+    )
+    return subprocess.run(
+        ["bash", str(script)], capture_output=True, text=True
+    )
+
+
+def test_hint_fires_on_a_real_tls_failure(tmp_path: Path) -> None:
+    result = _run_hint(tmp_path, CERT_FAILURE)
+    assert result.returncode == 0
+    assert "TLS certificate-trust failure" in result.stdout
+    # Node needs its own variable; pointing curl at the CA is not enough.
+    assert "NODE_EXTRA_CA_CERTS" in result.stdout
+    assert "--use-system-ca" in result.stdout
+
+
+def test_hint_stays_quiet_on_unrelated_failures(tmp_path: Path) -> None:
+    result = _run_hint(tmp_path, UNRELATED_FAILURE)
+    assert result.returncode == 1
+    assert result.stdout == ""
+
+
+def test_hint_stays_quiet_on_empty_output(tmp_path: Path) -> None:
+    result = _run_hint(tmp_path, "")
+    assert result.returncode == 1
+    assert result.stdout == ""


### PR DESCRIPTION
## What does this PR do?

Two install-blocking `npm install` calls pass `--silent` while capturing output for diagnosis (#87340). `--silent` suppresses npm's own error reporting, so the capture records an effectively empty log and a failed install prints:

```
✗ npm install failed or timed out; Node.js dependencies were not installed
✗ npm output:
```

…with nothing behind it. The capture could never have worked. This drops `--silent` at both sites — output is only ever printed on failure, so the verbosity costs nothing on the happy path.

With real output available, it then ports the TLS-trust hint `install.ps1` has had since #38016. A corporate proxy or antivirus intercepting HTTPS surfaces as `UNABLE_TO_VERIFY_LEAF_SIGNATURE` / "unable to get local issuer certificate", which reads as a generic install failure and gets reported as one. `install.ps1` routes every npm stage through `Show-NpmCertHint`; the POSIX half was never written. Since 6a198f8 made a failed npm install fatal, affected users now get a hard abort with no explanation instead of a degraded install.

The hint also names the trap that makes this confusing: **Node reads neither `SSL_CERT_FILE` nor `CURL_CA_BUNDLE`**, so someone who has already pointed curl at their corporate CA still has a broken npm and no clue why.

## Related Issue

Refs #87340, #38016

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh` — drop `--silent` from both install-blocking `npm install` calls
- `scripts/install.sh` — add `npm_cert_hint()`, the POSIX counterpart to `Show-NpmCertHint`, called from both npm failure branches
- `tests/test_install_sh_npm_diagnostics.py` — new

Two deliberate details:

- The detector also matches `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, which `Show-NpmCertHint` does **not** currently cover. Worth adding there separately.
- It offers `NODE_OPTIONS=--use-system-ca` first, since on a managed machine the CA is usually already in the OS trust store, making that the zero-setup path. That flag needs Node >= 22.15.0 and `engines.node` here is `>= 22.22.0`, so every supported Node has it.

## How to Test

Reproducing needs an intercepting proxy. `scripts/dev-sandbox.sh` is one, and it currently trips this exact failure, so an unmodified installer leg reproduces it:

```
tests/install/install-update-e2e.sh --route installer --install-ref v2026.5.28
```

Before — the entire diagnostic output on failure:

```
✗ npm install failed or timed out; Node.js dependencies were not installed
✗ npm output:
```

After, same failure, same sandbox:

```
✗ npm install failed or timed out; Node.js dependencies were not installed
✗ npm output:
npm error code UNABLE_TO_VERIFY_LEAF_SIGNATURE
npm error request to https://registry.npmjs.org/undici/-/undici-6.28.0.tgz failed,
    reason: unable to verify the first certificate; if the root CA is installed
    locally, try running Node.js with --use-system-ca
⚠ This looks like a TLS certificate-trust failure, not a network or permissions problem.
→   A corporate proxy or antivirus is likely intercepting HTTPS and presenting a
→   certificate Node.js doesn't trust. Node ignores SSL_CERT_FILE and CURL_CA_BUNDLE,
→   so pointing curl at the CA is not enough — Node needs telling separately.
→   If the CA is already in your OS trust store (usual on a managed machine):
→     export NODE_OPTIONS=--use-system-ca
→   Otherwise point Node at the certificate directly:
→     1. Get your organization's root CA as a .pem/.crt from your IT team.
→     2. export NODE_EXTRA_CA_CERTS=/path/to/corp-ca.pem
```

Unit tests: `pytest tests/test_install_sh_npm_diagnostics.py -q` — 5 passed here, and all 5 fail against `main`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **ran only `tests/test_install_sh_npm_diagnostics.py` (5 passed); the full suite needs the app's dev deps, which I did not install**
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — this is the POSIX half of behaviour `install.ps1` already has; no Windows change
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

The before/after above is real output from the same E2E leg on Ubuntu 24.04, not a mock-up.
