### PR TITLE
fix(dev-sandbox): trust the sandbox CA in Node, not the real one

### DIFF
--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -216,7 +216,7 @@ exec bwrap \
   --setenv CURL_CA_BUNDLE /work/certs/ca.pem \
   --setenv SSL_CERT_FILE /work/certs/ca.pem \
   --setenv GIT_SSL_CAINFO /work/certs/ca.pem \
-  --setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem \
+  --setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \
   --setenv OPENSSL_CONF /work/certs/openssl.cnf \
   --setenv HTTP_PROXY http://127.0.0.1:8080 \
   --setenv HTTPS_PROXY http://127.0.0.1:8080 \


### PR DESCRIPTION
## What does this PR do?

`scripts/sandbox/stage2-run.sh` points `NODE_EXTRA_CA_CERTS` at the real CA bundle instead of the sandbox's own MITM CA. One line:

```diff
   --setenv CURL_CA_BUNDLE /work/certs/ca.pem \
   --setenv SSL_CERT_FILE /work/certs/ca.pem \
   --setenv GIT_SSL_CAINFO /work/certs/ca.pem \
-  --setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem \
+  --setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \
```

The sandbox intercepts HTTPS with a throwaway CA at `/work/certs/ca.pem` and exports it for curl, OpenSSL and git. Node reads none of those — it uses its bundled store plus `NODE_EXTRA_CA_CERTS`, which pointed at the *real* bundle. Node therefore could not verify the certificates the proxy mints, and every npm request failed:

```
http fetch GET https://registry.npmjs.org/zod/-/zod-4.4.3.tgz attempt 3 failed with UNABLE_TO_VERIFY_LEAF_SIGNATURE
error Exit handler never called!
```

npm hanging up on a certificate it rejects is what `proxy.log` records as the repeated `SSLEOFError`. That reads like a proxy fault, but the proxy is fine — `curl` reaches `registry.npmjs.org` with a 200 from inside the sandbox, because curl honors `CURL_CA_BUNDLE`.

`NODE_EXTRA_CA_CERTS` *appends* to Node's built-in store rather than replacing it, so this loses no trust. The old value was redundant with what Node already trusted, which is why it looked harmless.

### Why every installer leg has been failing

Wrong since `stage2-run.sh` was introduced in 84874c58 — `git log -S NODE_EXTRA_CA_CERTS -- scripts/sandbox/stage2-run.sh` returns that commit and nothing else. **npm has never succeeded inside this sandbox.** It stayed invisible while a failed `npm install` only logged a warning; the green runs before 2026-08-13 log the same failures:

```
⚠ npm install failed (browser tools may not work)
⚠ npm install failed or timed out (browser tools may not work)
```

6a198f8 correctly made that fatal, and every installer leg has failed since. The regression is not 6a198f8 — it stopped hiding this. Reverting it would restore a green graph and restore the blind spot with it.

## Related Issue

No existing issue — surfaced by investigating the Install & Update E2E failures since 2026-08-13.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/sandbox/stage2-run.sh` — `NODE_EXTRA_CA_CERTS` now points at `/work/certs/ca.pem`, matching its three sibling CA variables

## How to Test

```
tests/install/install-update-e2e.sh --route installer --install-ref v2026.5.28
```

Same leg, same commit otherwise, before vs after:

| | before | after |
|---|---|---|
| phase 1 npm | `⚠ npm install failed` | `✓ Node.js dependencies installed` |
| phase 2 npm | `✗ npm install failed or timed out` (exit 1) | `✓ Node.js dependencies installed` |
| leg | `✗ installer re-run failed (exit 1)` | `✓ install/update E2E passed` |

The run also reports `✓ hermes runs after installer re-run`, so the install is functional rather than merely past the npm step.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run; this changes only the sandbox harness, and it is verified by the E2E leg above. The full suite needs the app's dev deps, which I did not install**
- [ ] I've added tests for my changes — **the Install & Update E2E is the test; it fails on `main` and passes with this change**
- [x] I've tested on my platform: Ubuntu 24.04, x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the dev sandbox is Linux-only (bubblewrap + slirp4netns)
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Finding the npm error at all took some digging, because both install-blocking `npm install` call sites still pass `--silent` — so the capture added in #87340 records an empty log and prints a bare `✗ npm output:`. #88383 fixes that separately, and is worth landing alongside this: without it, the next harness failure is just as opaque as this one was.
