### PR TITLE
fix(install): don't set variables through a PATH-resolved env

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -746,8 +746,13 @@ attempt_install_git() {
             case "$DISTRO" in
                 ubuntu|debian)
                     log_info "Installing Git via apt..."
-                    $sudo_cmd env DEBIAN_FRONTEND=noninteractive apt-get update -qq >/dev/null 2>&1 || true
-                    $sudo_cmd env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git >/dev/null 2>&1 || true
+                    # `sh -c` rather than `env VAR=…`: when this runs as root
+                    # $sudo_cmd is empty, so a shadowed `env` on PATH (see
+                    # install_browser_use_cli) would swallow the apt-get call
+                    # entirely. Under sudo it resolved correctly via secure_path,
+                    # which is why this only ever broke root installs.
+                    $sudo_cmd sh -c 'DEBIAN_FRONTEND=noninteractive apt-get update -qq' >/dev/null 2>&1 || true
+                    $sudo_cmd sh -c 'DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git' >/dev/null 2>&1 || true
                     ;;
                 fedora)
                     log_info "Installing Git via dnf..."
@@ -883,8 +888,9 @@ check_cxx_compiler() {
             case "$DISTRO" in
                 ubuntu|debian)
                     log_info "Installing build-essential via apt..."
-                    $sudo_cmd env DEBIAN_FRONTEND=noninteractive apt-get update -qq >/dev/null 2>&1 || true
-                    $sudo_cmd env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential >/dev/null 2>&1 || true
+                    # `sh -c` rather than `env VAR=…` — see the Git apt site above.
+                    $sudo_cmd sh -c 'DEBIAN_FRONTEND=noninteractive apt-get update -qq' >/dev/null 2>&1 || true
+                    $sudo_cmd sh -c 'DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential' >/dev/null 2>&1 || true
                     ;;
                 fedora)
                     log_info "Installing gcc-c++ via dnf..."
@@ -1118,7 +1124,8 @@ install_node_line() {
             if [ "$(id -u 2>/dev/null || echo 1000)" -ne 0 ]; then
                 command -v sudo >/dev/null 2>&1 && sudo_cmd="sudo"
             fi
-            $sudo_cmd env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libatomic1 >/dev/null 2>&1 || true
+            # `sh -c` rather than `env VAR=…` — see the Git apt site above.
+            $sudo_cmd sh -c 'DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libatomic1' >/dev/null 2>&1 || true
         fi
     fi
 
@@ -2839,8 +2846,17 @@ install_browser_use_cli() {
     log_info "Installing Browser Use CLI (default browser backend)..."
     # UV_TOOL_BIN_DIR keeps the binary inside Hermes' managed bin dir, where
     # the browser tool resolves it — no reliance on the user's PATH.
-    if run_with_timeout 600 env UV_NO_CONFIG=1 UV_TOOL_BIN_DIR="$HERMES_HOME/bin" \
-        "$UV_CMD" tool install browser-use >/dev/null 2>&1; then
+    #
+    # Export in a subshell rather than prefixing with `env`. uv's own installer
+    # writes ~/.local/bin/env — a PATH helper meant to be sourced, which ignores
+    # its arguments and exits 0. Anyone with ~/.local/bin ahead of /usr/bin (uv
+    # puts it there, and this installer installs uv) resolves `env` to that
+    # script, so `env VAR=… uv tool install` ran nothing, returned 0, and this
+    # branch logged "Browser Use CLI installed" for an install that never
+    # happened. Hardcoding /usr/bin/env is not an option either — Termux has no
+    # such path — so avoid `env` altogether.
+    if ( export UV_NO_CONFIG=1 UV_TOOL_BIN_DIR="$HERMES_HOME/bin"
+         run_with_timeout 600 "$UV_CMD" tool install browser-use >/dev/null 2>&1 ); then
         log_success "Browser Use CLI installed"
     else
         log_warn "Browser Use CLI install failed — browser automation falls back to built-in tools."

--- a/tests/test_install_sh_env_shadowing.py
+++ b/tests/test_install_sh_env_shadowing.py
@@ -1,0 +1,91 @@
+"""Regression tests for install.sh not depending on a PATH-resolved `env`.
+
+uv's installer writes ``~/.local/bin/env`` -- a PATH helper meant to be
+*sourced*, which ignores its arguments and exits 0 -- and puts
+``~/.local/bin`` ahead of ``/usr/bin``. Since install.sh installs uv, any
+``env VAR=… cmd`` prefix in it can resolve to that script, run nothing, and
+return success. install_browser_use_cli used the result of exactly such a
+call as its success condition, so the installer logged "Browser Use CLI
+installed" for an install that never happened.
+"""
+
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+# `env FOO=bar cmd` where env is resolved through PATH. Excludes /usr/bin/env
+# and similar absolute or relative paths, which are not PATH-resolved.
+BARE_ENV_PREFIX = re.compile(r"(?:^|[^./\w-])env\s+[A-Z_]+=")
+# Comments discuss this pattern by name, so strip them before matching.
+COMMENT = re.compile(r"(?:^|\s)#.*$")
+
+
+def test_no_path_resolved_env_prefix() -> None:
+    """No install.sh line may set variables via a PATH-resolved `env`."""
+    offenders = [
+        (number, line.rstrip())
+        for number, line in enumerate(INSTALL_SH.read_text().splitlines(), 1)
+        if BARE_ENV_PREFIX.search(COMMENT.sub("", line))
+    ]
+    assert not offenders, (
+        "install.sh must not prefix commands with a PATH-resolved `env` -- a "
+        "shadowing ~/.local/bin/env (written by uv, which this installer "
+        "installs) swallows the command and returns 0. Use a subshell export "
+        "or `sh -c` instead. Offending lines: " + repr(offenders)
+    )
+
+
+def test_browser_use_install_uses_subshell_export() -> None:
+    """The Browser Use CLI install must not gate success on an `env` call."""
+    text = INSTALL_SH.read_text()
+    assert "export UV_NO_CONFIG=1 UV_TOOL_BIN_DIR=" in text
+    assert "run_with_timeout 600 env UV_NO_CONFIG=1" not in text
+
+
+def _write_env_shim(directory: Path) -> None:
+    """Drop in a no-op `env` matching the one uv installs."""
+    shim = directory / "env"
+    shim.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            # add binaries to PATH if they aren't added yet
+            case ":${PATH}:" in
+                *:"$HOME/.local/bin":*) ;;
+                *) export PATH="$HOME/.local/bin:$PATH" ;;
+            esac
+            """
+        )
+    )
+    shim.chmod(0o755)
+
+
+def test_env_shim_hides_failure_but_subshell_export_does_not(tmp_path: Path) -> None:
+    """Behavioural proof of the bug and of the fix.
+
+    With a shadowing `env` first on PATH, the old construct reports success
+    for a command that never ran. The subshell-export form still propagates
+    the real exit status, and still delivers the variables.
+    """
+    _write_env_shim(tmp_path)
+    path = f"{tmp_path}:/usr/bin:/bin"
+
+    def run(script: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", "-c", script],
+            env={"PATH": path, "HOME": str(tmp_path)},
+            capture_output=True,
+            text=True,
+        )
+
+    # The old shape: `false` never runs, yet the caller sees success.
+    assert run("env FOO=bar false").returncode == 0
+
+    # The new shape: failure is reported, and the variable is exported.
+    assert run("( export FOO=bar; false )").returncode != 0
+    delivered = run('( export FOO=bar; printf "%s" "$FOO" )')
+    assert delivered.stdout == "bar"


### PR DESCRIPTION
## What does this PR do?

`install.sh` sets environment variables by prefixing commands with `env VAR=…`, which resolves `env` through `PATH`. uv's installer writes `~/.local/bin/env` — a PATH helper meant to be **sourced**, which ignores its arguments, adjusts `PATH` and exits 0 — and puts `~/.local/bin` ahead of `/usr/bin`. `install.sh` installs uv, so it can create the very shim that breaks it; anyone who installed uv standalone beforehand is already exposed.

`install_browser_use_cli` used the result of such a call as its success condition:

```bash
if run_with_timeout 600 env UV_NO_CONFIG=1 UV_TOOL_BIN_DIR="$HERMES_HOME/bin" \
    "$UV_CMD" tool install browser-use >/dev/null 2>&1; then
    log_success "Browser Use CLI installed"
```

`run_with_timeout` sees `env` is not a shell function and execs it through `timeout`, so with the shim on `PATH` the uv command never runs, the shim returns 0, and the installer reports **`✓ Browser Use CLI installed`** for an install that never happened. Browser automation then silently falls back to the built-in tools with no indication why.

Demonstrated directly:

```
$ PATH="$HOME/.local/bin:/usr/bin:/bin"
$ command -v env
/home/user/.local/bin/env
$ if env FOO=1 /bin/false; then echo "success branch taken"; fi
success branch taken
```

## Related Issue

No existing issue — found while investigating installer failure reporting.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh` — `install_browser_use_cli` exports in a subshell instead of prefixing with `env`
- `scripts/install.sh` — the apt Git install uses `sh -c` instead of `env VAR=…`
- `scripts/install.sh` — same conversion for the two apt sites that landed on `main` after this branch was opened: the build-essential install in `check_cxx_compiler` and the libatomic1 preinstall for the managed Node (both were flagged by the new scanner test on rebase)
- `tests/test_install_sh_env_shadowing.py` — new

Two notes on approach:

- **Not `/usr/bin/env`.** Termux has no such path and this installer supports Termux, so the fix avoids `env` altogether rather than hardcoding a location.
- **The apt path only ever broke root installs.** There, `$sudo_cmd` is empty so bare `env` is hit; under `sudo` it resolved correctly via `secure_path`. Both calls are `|| true`, so the failure mode was silently skipping `apt-get update` / `apt-get install git` rather than a false success.

## How to Test

```
pytest tests/test_install_sh_env_shadowing.py -q
```

3 passed here; 2 of the 3 fail against `main`. The third is behavioural — it reconstructs uv's shim in a tmpdir, then shows the old shape reporting success for a command that never ran while the subshell form propagates the real exit status and still delivers the variable.

To see the original bug on a real machine, install uv via its standalone installer (which creates `~/.local/bin/env`), ensure `~/.local/bin` precedes `/usr/bin` on `PATH` — uv's installer arranges this — and run `install.sh` on `main`. It prints `✓ Browser Use CLI installed`; `ls $HERMES_HOME/bin/browser-use` shows nothing was installed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **ran only `tests/test_install_sh_env_shadowing.py` (3 passed); the full suite needs the app's dev deps, which I did not install**
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — avoids `/usr/bin/env` for Termux; `install.ps1` is unaffected
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

The regression test includes the shim reproduction, so the failure mode is reproducible in CI rather than only on an affected machine.

