### PR TITLE
fix(gateway): fence multiplex profile attribution in session lookup and inheritance

### DIFF
--- a/contributors/emails/lucasxavier926@gmail.com
+++ b/contributors/emails/lucasxavier926@gmail.com
@@ -1,0 +1,2 @@
+69k4xmdfm2-blip
+# multiplex profile fence

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4657,11 +4657,39 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                                              WHERE p.id = sessions.parent_session_id)),
                            git_branch = COALESCE(sessions.git_branch,
                                         (SELECT p.git_branch FROM sessions p
-                                          WHERE p.id = sessions.parent_session_id)),
-                           profile_name = COALESCE(sessions.profile_name,
+                                          WHERE p.id = sessions.parent_session_id))
+                     WHERE id = ? AND parent_session_id IS NOT NULL""",
+                    (session_id,),
+                )
+                # ``profile_name`` inherits under the SAME namespace fence as
+                # the routing columns below (upstream #74285, patched locally
+                # 2026-08-17). A gateway reset whose peer-fallback adopted a
+                # sibling profile's row links a default child (session_key
+                # ``agent:main:...``, profile_name NULL) to a non-default
+                # parent; the blind COALESCE then stamped the child with the
+                # PARENT's profile, mislabelling a default session as the
+                # sibling profile's for the rest of its lineage. Inherit only
+                # when the two rows agree on the ``agent:<ns>:`` namespace, or
+                # when either row is keyless (CLI/subagent lineage, where the
+                # parent's profile is the only signal available).
+                conn.execute(
+                    """UPDATE sessions
+                       SET profile_name = COALESCE(sessions.profile_name,
                                           (SELECT p.profile_name FROM sessions p
                                             WHERE p.id = sessions.parent_session_id))
-                     WHERE id = ? AND parent_session_id IS NOT NULL""",
+                     WHERE id = ? AND parent_session_id IS NOT NULL
+                       AND EXISTS (
+                           SELECT 1 FROM sessions p
+                           WHERE p.id = sessions.parent_session_id
+                             AND (
+                                 p.session_key IS NULL
+                                 OR sessions.session_key IS NULL
+                                 OR substr(p.session_key, 1,
+                                     instr(substr(p.session_key, 7), ':') + 6)
+                                    = substr(sessions.session_key, 1,
+                                        instr(substr(sessions.session_key, 7), ':') + 6)
+                             )
+                       )""",
                     (session_id,),
                 )
                 # Belt-and-suspenders for gateway routing metadata (#59527):
@@ -5225,8 +5253,24 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # Conservative fallback for rows created by current code but with a
             # temporarily-missing exact key: still require the complete peer
             # tuple so we never cross chats/threads/users.
+            #
+            # Profile fence (upstream #74285, patched locally 2026-08-17): for a
+            # Telegram DM ``chat_id == user_id`` and ``thread_id IS NULL`` for
+            # EVERY bot, so the peer tuple above is byte-identical across the
+            # profiles of a multiplexed gateway and this fallback would happily
+            # adopt a sibling profile's row — executing the wrong persona,
+            # credentials and filesystem scope. ``session_key`` already carries
+            # the namespace (``agent:main:...`` for default, ``agent:<p>:...``
+            # otherwise), so require the candidate to belong to the SAME
+            # namespace; a keyless candidate must agree on ``profile_name``
+            # instead ('' == default). Fail closed: no match mints a fresh
+            # session, which is strictly safer than borrowing another profile's.
             if chat_id is None or chat_type is None:
                 return None
+            _key_parts = str(session_key).split(":")
+            _req_ns = _key_parts[1] if len(_key_parts) >= 2 and _key_parts[0] == "agent" else ""
+            _ns_prefix = f"agent:{_req_ns}:%" if _req_ns else None
+            _req_profile = "" if _req_ns in ("", "main") else _req_ns
             row = self._conn.execute(
                 f"""
                 SELECT s.*,
@@ -5242,6 +5286,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                   AND COALESCE(s.chat_id, '') = COALESCE(?, '')
                   AND COALESCE(s.chat_type, '') = COALESCE(?, '')
                   AND COALESCE(s.thread_id, '') = COALESCE(?, '')
+                  AND (
+                      CASE
+                          WHEN ? IS NULL THEN 1
+                          WHEN s.session_key IS NOT NULL THEN s.session_key LIKE ?
+                          ELSE COALESCE(s.profile_name, '') = ?
+                      END
+                  )
                   AND (s.ended_at IS NULL OR s.end_reason IN ('agent_close', 'ws_orphan_reap'))
                   AND (COALESCE(s.message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = s.id LIMIT 1
@@ -5261,7 +5312,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ORDER BY COALESCE(s.last_activity_at, s.started_at) DESC
                 LIMIT 1
                 """,
-                (source, user_id, chat_id, chat_type, thread_id),
+                (
+                    source, user_id, chat_id, chat_type, thread_id,
+                    _ns_prefix, _ns_prefix, _req_profile,
+                ),
             ).fetchone()
         return self._session_row_dict(row) if row else None
 

--- a/tests/gateway/test_multiplex_peer_fallback_profile_fence.py
+++ b/tests/gateway/test_multiplex_peer_fallback_profile_fence.py
@@ -1,0 +1,168 @@
+"""Regression tests: multiplexed peer-fallback must not cross profiles (#74285).
+
+Incident shape (Aug 2026, local install, two Telegram bots on one multiplexed
+gateway): a Telegram private chat reports the *user's own id* as ``chat.id``, so
+for every bot in the multiplexer the peer tuple
+``(source, user_id, chat_id, chat_type, thread_id)`` is byte-identical. The
+conservative fallback inside ``find_latest_gateway_session_for_peer`` matched on
+that tuple alone and therefore returned a SIBLING PROFILE's row — executing the
+wrong persona, credentials and filesystem scope.
+
+Two fixes under test:
+  1. ``find_latest_gateway_session_for_peer`` fences the fallback by the
+     ``agent:<ns>:`` namespace carried in ``session_key`` (keyless candidates
+     must agree on ``profile_name`` instead), failing closed to ``None``.
+  2. ``create_session`` inherits ``profile_name`` from a parent only when the
+     two rows share that namespace, so a reset lineage that had already
+     borrowed a sibling row cannot mislabel a default session as the sibling
+     profile's forever after.
+"""
+
+import uuid
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    yield d
+    try:
+        d.close()
+    except Exception:
+        pass
+
+
+UID = "8693894969"
+# Telegram DM: chat_id == user_id, thread_id NULL — identical for every bot.
+PEER_TUPLE = dict(source="telegram", user_id=UID, chat_id=UID, chat_type="dm", thread_id=None)
+KEY_DEFAULT = f"agent:main:telegram:dm:{UID}"
+KEY_MEDICINA = f"agent:medicina:telegram:dm:{UID}"
+
+
+def _mk(db, sid, *, key=None, profile=None, msgs=1, parent=None):
+    kwargs = dict(user_id=UID, chat_id=UID, chat_type="dm")
+    if key:
+        kwargs["session_key"] = key
+    if profile:
+        kwargs["profile_name"] = profile
+    if parent:
+        kwargs["parent_session_id"] = parent
+    db.create_session(sid, "telegram", **kwargs)
+    for i in range(msgs):
+        db.append_message(sid, "user" if i % 2 == 0 else "assistant", f"m{i}")
+    return sid
+
+
+class TestPeerFallbackProfileFence:
+    def test_fallback_ignores_sibling_profile_row(self, db):
+        """The bug: only the sibling's row exists, keyed for another profile.
+
+        Its peer tuple matches exactly, so the unfenced fallback returned it.
+        The fence must return None (mint a fresh session) instead of handing
+        the default profile a medicina session.
+        """
+        _mk(db, "sib_medicina", key=KEY_MEDICINA, profile="medicina")
+        found = db.find_latest_gateway_session_for_peer(
+            session_key=KEY_DEFAULT, **PEER_TUPLE
+        )
+        assert found is None, (
+            "peer fallback adopted a sibling profile's session: "
+            f"{found and found.get('id')}"
+        )
+
+    def test_fallback_ignores_sibling_keyless_row_by_profile_name(self, db):
+        """Keyless candidate (identity write lost the key) must still be
+        fenced — by profile_name, the only signal left."""
+        _mk(db, "keyless_medicina", key=None, profile="medicina")
+        found = db.find_latest_gateway_session_for_peer(
+            session_key=KEY_DEFAULT, **PEER_TUPLE
+        )
+        assert found is None
+
+    def test_fallback_still_recovers_own_keyless_row(self, db):
+        """The fence must not break the case the fallback exists for: a row
+        for THIS profile whose session_key write was lost."""
+        _mk(db, "mine_keyless", key=None, profile=None)
+        found = db.find_latest_gateway_session_for_peer(
+            session_key=KEY_DEFAULT, **PEER_TUPLE
+        )
+        assert found is not None and found["id"] == "mine_keyless"
+
+    def test_fallback_recovers_own_profile_keyless_row(self, db):
+        """Same, from the non-default side: medicina recovers its own row."""
+        _mk(db, "medicina_keyless", key=None, profile="medicina")
+        found = db.find_latest_gateway_session_for_peer(
+            session_key=KEY_MEDICINA, **PEER_TUPLE
+        )
+        assert found is not None and found["id"] == "medicina_keyless"
+
+    def test_exact_key_match_unaffected(self, db):
+        """Primary (exact session_key) path keeps working with both rows
+        present — each profile resolves to its own session."""
+        _mk(db, "row_default", key=KEY_DEFAULT, profile=None)
+        _mk(db, "row_medicina", key=KEY_MEDICINA, profile="medicina")
+        got_default = db.find_latest_gateway_session_for_peer(
+            session_key=KEY_DEFAULT, **PEER_TUPLE
+        )
+        got_medicina = db.find_latest_gateway_session_for_peer(
+            session_key=KEY_MEDICINA, **PEER_TUPLE
+        )
+        assert got_default["id"] == "row_default"
+        assert got_medicina["id"] == "row_medicina"
+
+    def test_newest_sibling_does_not_outrank_own_row(self, db):
+        """Ordering is by recency; a NEWER sibling row must not win over this
+        profile's older-but-correct row."""
+        _mk(db, "mine_old", key=KEY_DEFAULT, profile=None)
+        _mk(db, "sibling_new", key=KEY_MEDICINA, profile="medicina")
+        with db._lock:
+            db._conn.execute(
+                "UPDATE sessions SET last_activity_at=? WHERE id=?", (1000.0, "mine_old")
+            )
+            db._conn.execute(
+                "UPDATE sessions SET last_activity_at=?, session_key=NULL WHERE id=?",
+                (9999.0, "sibling_new"),
+            )
+            db._conn.commit()
+        found = db.find_latest_gateway_session_for_peer(
+            session_key=KEY_DEFAULT, **PEER_TUPLE
+        )
+        assert found is not None and found["id"] == "mine_old"
+
+
+class TestProfileInheritanceFence:
+    def test_child_does_not_inherit_sibling_profile_across_namespaces(self, db):
+        """A reset lineage that crossed profiles must not stamp the child.
+
+        Real row observed locally: child key ``agent:main:...`` (default)
+        pointing at a parent keyed ``agent:medicina:...``. The blind COALESCE
+        stamped the default child ``profile_name='medicina'``.
+        """
+        _mk(db, "parent_medicina", key=KEY_MEDICINA, profile="medicina")
+        _mk(db, "child_default", key=KEY_DEFAULT, profile=None, parent="parent_medicina")
+        row = db.get_session("child_default")
+        assert row["profile_name"] is None, (
+            f"default child inherited sibling profile: {row['profile_name']!r}"
+        )
+
+    def test_child_inherits_within_same_namespace(self, db):
+        """Legitimate case must keep working: same-profile rotation."""
+        _mk(db, "parent_med2", key=KEY_MEDICINA, profile="medicina")
+        _mk(db, "child_med2", key=KEY_MEDICINA, profile=None, parent="parent_med2")
+        assert db.get_session("child_med2")["profile_name"] == "medicina"
+
+    def test_keyless_child_still_inherits(self, db):
+        """CLI/subagent children have no session_key — the parent's profile is
+        the only signal, so inheritance must remain unconditional there."""
+        _mk(db, "parent_med3", key=KEY_MEDICINA, profile="medicina")
+        sid = "sub_" + uuid.uuid4().hex[:6]
+        db.create_session(sid, "subagent", parent_session_id="parent_med3")
+        assert db.get_session(sid)["profile_name"] == "medicina"
+
+    def test_explicit_child_profile_never_overwritten(self, db):
+        _mk(db, "parent_med4", key=KEY_MEDICINA, profile="medicina")
+        _mk(db, "child_expl", key=KEY_MEDICINA, profile="other", parent="parent_med4")
+        assert db.get_session("child_expl")["profile_name"] == "other"


### PR DESCRIPTION
## What

Two profile fences in `hermes_state.py` so a multiplexed gateway can never attribute a session to
the wrong profile.

Fixes the durable-mislabel half of #88381; hardens the lookup half of #74285.

## Why

A Telegram **private chat reports the user's own id as `chat.id`**, so for every bot in a
multiplexed gateway the peer tuple `(source, user_id, chat_id, chat_type, thread_id)` is
byte-identical. Two places trusted that tuple:

**1. `find_latest_gateway_session_for_peer` — the conservative fallback (#74285).** With the
tuple alone it happily returns a *sibling profile's* row, so a DM to bot A can be answered by
profile B, with B's persona, credentials and filesystem scope.

**2. `create_session` — parent inheritance (#88381, this PR's new finding).** Once (1) has
crossed profiles, the reset records the adopted row as `parent_session_id`, and the unconditional

```sql
profile_name = COALESCE(sessions.profile_name,
               (SELECT p.profile_name FROM sessions p WHERE p.id = sessions.parent_session_id))
```

stamps the child with the parent's profile. Because `"default"` persists as `NULL`
(`run_agent.py::_ensure_db_session`, `conversation_compression.py`), a default child is *always*
`NULL` at insert and therefore always eligible — inheritance can only flow default → named
profile, never back. Every subsequent daily/idle reset copies the wrong name forward again, so
one crossing mislabels the lineage permanently while `session_key` stays correct. The two
disagree, and `profile_name` is the one that session lists, per-profile aggregation and the
desktop sidebar read.

Real rows from my install (`default` + `medicina`, two bot tokens, one gateway):

```
id                        session_key                        profile_name
20260816_122957_0d860ebc  agent:medicina:telegram:dm:<uid>    medicina   <- genuine
20260816_224836_5f838b2f  agent:main:telegram:dm:<uid>        medicina   <- WRONG (default session)
20260817_082108_0a750a44  agent:main:telegram:dm:<uid>        medicina   <- WRONG (inherited again)
```

The four open PRs for #74285 (#75043, #74153, #85205, #74593) all fence the lookup; none touches
the inheritance write, so already-crossed lineages stay mislabelled after any of them lands. This
PR is deliberately scoped to be compatible with whichever one you take: the lookup fence here is
a namespace comparison in the same predicate position, so it rebases cleanly or drops out
entirely if you prefer their shape.

## How

`session_key` already carries the truth (`agent:main:…` for default, `agent:<profile>:…`
otherwise), so both fences derive from it — no new column, no migration.

- **Lookup:** the fallback requires the candidate to share the requesting key's `agent:<ns>:`
  prefix. A keyless candidate (identity write lost the key — the case the fallback exists for) is
  compared on `profile_name` instead, `''` == default. No match now returns `None`, which mints a
  fresh session: strictly safer than borrowing a sibling's.
- **Inheritance:** `profile_name` moves out of the shared parent-backfill `UPDATE` into its own
  statement, gated on both rows sharing that namespace. `cwd` / `git_repo_root` / `git_branch`
  keep inheriting unconditionally (harmless across profiles; gating them would regress #64709).
  Keyless lineage — CLI, subagents, delegation — still inherits unconditionally, since there the
  parent's profile is the only signal available. Namespace extraction uses `substr`/`instr` so no
  UDF is needed.

Both fences fail closed and are no-ops on a single-profile gateway (`agent:main:` on both sides).

## Testing

New: `tests/gateway/test_multiplex_peer_fallback_profile_fence.py` — 10 cases.

```
tests/gateway/test_multiplex_peer_fallback_profile_fence.py .......... 10 passed
+ tests/gateway/test_session_continuity_82616.py                      21 passed (combined)
```

RED verified against a pristine `hermes_state.py` (same tests, module shadowed via `PYTHONPATH`):
3 fail without the patch —
`test_fallback_ignores_sibling_profile_row`,
`test_fallback_ignores_sibling_keyless_row_by_profile_name`,
`test_child_does_not_inherit_sibling_profile_across_namespaces`
(`AssertionError: default child inherited sibling profile: 'medicina'`).

Coverage includes the negative cases that keep the fences honest: own keyless row still recovers
(both from `default` and from a named profile), exact-key matching unaffected with both rows
present, a *newer* sibling row does not outrank this profile's older correct row, same-namespace
rotation still inherits, keyless subagent lineage still inherits, and an explicit child
`profile_name` is never overwritten.

Neighbouring suites (`test_session_continuity_82616`, `test_branch_routing_columns`,
`test_hermes_state.py`, `test_session.py`, `test_multiplex_profile_authz`,
`test_profile_resolution`, `test_profile_routing`, `test_multiplex_phase0`) show no new failures:
the handful that fail here reproduce identically against a pristine `hermes_state.py` on this
machine, so they are pre-existing and unrelated to this change.

**Platform:** Windows 11, Python 3.11 (venv) — verified end-to-end on a live 2-profile ×
2-Telegram-bot multiplexed gateway, which is where the mislabelled rows above came from.

## Existing data

Deployments that already crossed can be repaired offline, since `session_key` is authoritative:

```sql
UPDATE sessions SET profile_name = NULL
 WHERE session_key LIKE 'agent:main:%' AND profile_name IS NOT NULL;
```

plus clearing the cross-namespace `parent_session_id` links that caused them. I did not add that
to `hermes sessions repair-routing` in this PR to keep the diff reviewable — happy to follow up
if you want it there.
