### PR TITLE
fix(agent): run Phase-1 tool-result prune before insufficient-messages no-op

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -6950,6 +6950,28 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Only need head + 3 tail messages minimum (token budget decides the real tail size)
         _min_for_compress = self._protect_head_size(messages) + 3 + 1
         if n_messages <= _min_for_compress:
+            # A transcript this short can still be enormous when a handful of
+            # tool results are huge (e.g. a 7-message session sitting 46K+
+            # tokens over threshold). Try the cheap Phase-1 prune — including
+            # its protected-region pressure pass (#61932) — before conceding
+            # the no-op: it needs no LLM call and can shrink the transcript
+            # even when there aren't enough messages for a real compaction.
+            pruned_messages, pruned_count = self._prune_old_tool_results(
+                messages, protect_tail_count=self.protect_last_n,
+                protect_tail_tokens=self.tail_token_budget,
+            )
+            if pruned_messages != messages:
+                self._last_compression_made_progress = True
+                telemetry["failure_class"] = None
+                telemetry["chunk_count"] = 0
+                if not self.quiet_mode:
+                    logger.info(
+                        "Compression (small transcript): pruned %d tool "
+                        "result(s) across %d messages without summarization",
+                        pruned_count, n_messages,
+                    )
+                return pruned_messages
+
             # Record the no-op, exactly as the sibling "no compressable window"
             # branch below does (#40803). Returning without touching the
             # anti-thrashing counter leaves should_compress() saying True on a

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1913,6 +1913,63 @@ class TestTokenBudgetTailProtection:
 
 
 
+class TestInsufficientMessagesStillPrunesToolResults:
+    """Regression: a transcript far over the compaction threshold with only
+    a handful of messages must still get the cheap Phase-1 tool-result prune
+    (including the #61932 protected-region pressure pass) before falling
+    back to a no-op.
+
+    Live trigger: a 7-message session sitting 46K+ tokens over threshold —
+    every compaction returned unchanged as "insufficient_messages" because
+    the early return fired before Phase 1 ever ran, and the transcript rode
+    the context window into model degeneracy.
+    """
+
+    def test_huge_tool_results_pruned_below_message_floor(self, compressor):
+        c = compressor  # protect_first_n=2, protect_last_n=2 -> _min_for_compress=7
+        # Distinct (non-duplicate) content so the dedup pass can't explain
+        # any shrinkage on its own — this is exercising the protected-region
+        # pressure pass (#61932), not byte-identical back-referencing.
+        big_a = "read of file a: " + "a" * 58_000
+        big_b = "read of file b: " + "b" * 58_000
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "do the two big things"},
+            {
+                "role": "assistant",
+                "content": "on it",
+                "tool_calls": [
+                    {"id": "call-1", "function": {"name": "read_file", "arguments": '{"path":"a.txt"}'}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": big_a},
+            {
+                "role": "assistant",
+                "content": "and the second one",
+                "tool_calls": [
+                    {"id": "call-2", "function": {"name": "read_file", "arguments": '{"path":"b.txt"}'}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-2", "content": big_b},
+            {"role": "assistant", "content": "both done"},
+        ]
+        assert len(messages) == 7  # == _min_for_compress: exercises the early-return branch
+
+        before_count = c._ineffective_compression_count
+        total_before = sum(len(str(m.get("content", ""))) for m in messages)
+        result = c.compress(messages, current_tokens=90_000)
+        total_after = sum(len(str(m.get("content", ""))) for m in result)
+
+        assert result != messages
+        # One of the two ~58K-char tool bodies gets demoted to a one-line
+        # summary by the pressure pass; a short recent floor stays verbatim.
+        # Materially smaller (well over half) without requiring the exact
+        # ratio, which is sensitive to the token estimator's internals.
+        assert total_after < total_before * 0.6
+        # The prune-and-return path must not be scored as an ineffective
+        # compaction — it made real progress, unlike the old no-op.
+        assert c._ineffective_compression_count == before_count
+        assert c._last_compression_made_progress is True
 
 
 class TestUpdateModelBudgets:


### PR DESCRIPTION
## User-visible failure

A short transcript can sit far above the compaction threshold when just a
couple of tool results are enormous. Concretely: a 7-message session at
46K+ tokens over threshold, observed with a local quantized model acting as
an outage-bridge primary. Every compaction attempt on that session returned
the transcript completely unchanged, tagged `insufficient_messages`, and
the turn kept riding the oversized context window straight into model
degeneracy — worse completions, dropped instructions, garbled output —
because the context never actually shrank.

## Root cause

`ContextCompressor.compress()` has an early-exit guard:

```python
if n_messages <= _min_for_compress:
    ...
    telemetry["failure_class"] = "insufficient_messages"
    ...
    return messages
```

`_min_for_compress` is a *message-count* floor (roughly
`protect_first_n + 3 + 1`), sized for the LLM-summarization path, which
genuinely needs enough messages to have something to summarize. But the
cheap, no-LLM Phase-1 pass (`_prune_old_tool_results`, including the
protected-region pressure demotion from #61932) has no such requirement —
it can shrink a transcript of any length by replacing huge tool result
bodies with one-line summaries. That pass sits *after* this guard in
`compress()`, so on a message-count-starved-but-token-heavy transcript it
never runs at all. The session is stuck: `should_compress()` keeps saying
yes, `compress()` keeps saying no-op, and the only two ways out are `/new`
or letting the context run over the model's real limit.

## Fix

Before recording the no-op, run the Phase-1 prune inside the
`insufficient_messages` branch. If it actually changes the message list,
return the pruned result and record real progress (clearing
`failure_class`, marking `_last_compression_made_progress`) instead of
bumping the ineffective-compression counter. If pruning doesn't change
anything (e.g. a transcript that's short on both messages *and* tool-result
bulk), fall through to the existing no-op path unchanged — this only adds a
new recovery path, it doesn't touch the old one's semantics.

## Verification

Added `TestInsufficientMessagesStillPrunesToolResults` in
`tests/agent/test_context_compressor.py`: a synthetic 7-message transcript
(system, user, two assistant/tool_call → tool pairs with distinct ~58K-char
tool bodies, final assistant) sitting above threshold. Before the fix,
`compress()` returned it byte-for-byte unchanged and counted it as an
ineffective compaction. After the fix, the protected-region pressure pass
(#61932) engages, one of the two huge tool bodies is demoted to a one-line
summary, the returned list is materially smaller, and the
ineffective-compression counter does not move.

Ran the compressor/compression test selection locally
(`pytest -k "compressor or compression"`): 688 passed.

## Related

This is a companion recovery path to #87992 (fallback-chain consultation
when continuation attempts are exhausted) — that PR keeps a stuck turn
moving to a different model; this one keeps a stuck *transcript* from
staying oversized in the first place. Independent fixes, same failure
family (a turn or session that can't make forward progress under context
pressure).
