### PR TITLE
fix(xiaomi): remove deprecated MiMo V2 models from provider

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -571,11 +571,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     "moonshotai/Kimi-K2-Thinking": 262144,
     "MiniMaxAI/MiniMax-M2.5": 204800,
     "XiaomiMiMo/MiMo-V2-Flash": 262144,
-    "mimo-v2-pro": 1048576,
     "mimo-v2.5-pro": 1048576,
     "mimo-v2.5": 1048576,
-    "mimo-v2-omni": 262144,
-    "mimo-v2-flash": 262144,
     "zai-org/GLM-5": 202752,
 }
 

--- a/plugins/model-providers/xiaomi/__init__.py
+++ b/plugins/model-providers/xiaomi/__init__.py
@@ -9,7 +9,7 @@ xiaomi = ProviderProfile(
     env_vars=("XIAOMI_API_KEY",),
     base_url="https://api.xiaomimimo.com/v1",
     supports_health_check=False,  # /v1/models returns 401 even with valid key
-    supports_vision=True,  # mimo-v2-omni is vision-capable
+    supports_vision=True,  # mimo-v2.5 is vision-capable (native omni-modal)
     supports_vision_tool_messages=False,  # rejects list-type tool content (400 "text is not set")
 )
 


### PR DESCRIPTION
## Summary

Removes the deprecated MiMo-V2 model entries (`mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2-flash`) from the xiaomi provider.

**Why:** The MiMo-V2 series was fully deprecated on 2026-06-30. The API now returns `400 Unsupported model` for these names, so listing them in the model picker is misleading — users who select them will get errors.

## Changes

- **`agent/model_metadata.py`**: Removed 3 deprecated V2 entries (`mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2-flash`), keeping only `mimo-v2.5` and `mimo-v2.5-pro`
- **`plugins/model-providers/xiaomi/__init__.py`**: Updated comment from `mimo-v2-omni` → `mimo-v2.5` (the actual vision-capable model)

## Verification

Tested live API calls:
- `mimo-v2-pro` → HTTP 400 `"Unsupported model mimo-v2-pro"`
- `mimo-v2.5` → HTTP 200, valid response ✓
- `mimo-v2.5-pro` → HTTP 200, valid response ✓

## Notes

`XiaomiMiMo/MiMo-V2-Flash` (HuggingFace model ID) was left untouched as it's a separate HF identifier, not an API model name.