### PR TITLE
fix: stop auxiliary auth retry reusing revoked credential

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4749,8 +4749,18 @@ async def _retry_same_provider_async(
     )
 
 
-def _refresh_provider_credentials(provider: str) -> bool:
-    """Refresh short-lived credentials for OAuth-backed auxiliary providers."""
+def _refresh_provider_credentials(
+    provider: str, *, failed_api_key: Optional[str] = None
+) -> bool:
+    """Refresh short-lived credentials for OAuth-backed auxiliary providers.
+
+    ``failed_api_key`` is the token the rejected client actually used. This is
+    essential for long-running gateways: another process (CLI, sibling
+    profile, credential-sync job) may already have rotated the credential file
+    while the cached auxiliary client still holds the revoked token. In that
+    case the current on-disk token is already the recovery — use it rather than
+    rotating the refresh token again and invalidating sibling profiles.
+    """
     normalized = _normalize_aux_provider(provider)
     try:
         if normalized == "copilot":
@@ -4788,10 +4798,32 @@ def _refresh_provider_credentials(provider: str) -> bool:
             _evict_cached_clients(normalized)
             return True
         if normalized == "anthropic":
-            from agent.anthropic_adapter import read_claude_code_credentials, _refresh_oauth_token, resolve_anthropic_token
+            from agent.anthropic_adapter import (
+                _refresh_oauth_token,
+                read_claude_code_credentials,
+                resolve_anthropic_token,
+            )
 
             creds = read_claude_code_credentials()
-            token = _refresh_oauth_token(creds) if isinstance(creds, dict) and creds.get("refreshToken") else None
+            current_token = (
+                str(creds.get("accessToken", "") or "").strip()
+                if isinstance(creds, dict) else ""
+            )
+            failed_token = str(failed_api_key or "").strip()
+
+            # The client is stale but the shared credential file is already
+            # newer (typically another process refreshed it). Do NOT rotate
+            # the refresh token again: that would revoke the token a sibling
+            # profile has just copied. Evict and rebuild from disk instead.
+            if current_token and failed_token and current_token != failed_token:
+                _evict_cached_clients(normalized)
+                return True
+
+            token = (
+                _refresh_oauth_token(creds)
+                if isinstance(creds, dict) and creds.get("refreshToken")
+                else None
+            )
             if not str(token or "").strip():
                 token = resolve_anthropic_token()
             if not str(token or "").strip():
@@ -9627,7 +9659,10 @@ def _call_llm_impl(
         if (_is_auth_error(first_err)
                 and auth_refresh_provider not in {"auto", "", None}
                 and not client_is_nous):
-            if _refresh_provider_credentials(auth_refresh_provider):
+            failed_api_key = str(getattr(client, "api_key", "") or "")
+            if _refresh_provider_credentials(
+                auth_refresh_provider, failed_api_key=failed_api_key
+            ):
                 if auth_refresh_provider != _normalize_aux_provider(resolved_provider):
                     # The stale client is cached under the route label
                     # (e.g. "auto"), not the concrete backend we refreshed.
@@ -9641,7 +9676,11 @@ def _call_llm_impl(
                     resolved_provider=auth_refresh_provider,
                     resolved_model=resolved_model or final_model,
                     resolved_base_url=resolved_base_url,
-                    resolved_api_key=resolved_api_key,
+                    # Never feed the rejected credential back into the rebuilt
+                    # client. The refresh path evicts the cache and updates the
+                    # provider's credential source; passing resolved_api_key
+                    # here would override both and reproduce the same 401.
+                    resolved_api_key=None,
                     resolved_api_mode=resolved_api_mode,
                     main_runtime=main_runtime,
                     final_model=final_model,
@@ -10336,7 +10375,10 @@ async def _async_call_llm_impl(
         if (_is_auth_error(first_err)
                 and auth_refresh_provider not in {"auto", "", None}
                 and not client_is_nous):
-            if _refresh_provider_credentials(auth_refresh_provider):
+            failed_api_key = str(getattr(client, "api_key", "") or "")
+            if _refresh_provider_credentials(
+                auth_refresh_provider, failed_api_key=failed_api_key
+            ):
                 if auth_refresh_provider != _normalize_aux_provider(resolved_provider):
                     # The stale client is cached under the route label
                     # (e.g. "auto"), not the concrete backend we refreshed.
@@ -10350,7 +10392,11 @@ async def _async_call_llm_impl(
                     resolved_provider=auth_refresh_provider,
                     resolved_model=resolved_model or final_model,
                     resolved_base_url=resolved_base_url,
-                    resolved_api_key=resolved_api_key,
+                    # Never feed the rejected credential back into the rebuilt
+                    # client. The refresh path evicts the cache and updates the
+                    # provider's credential source; passing resolved_api_key
+                    # here would override both and reproduce the same 401.
+                    resolved_api_key=None,
                     resolved_api_mode=resolved_api_mode,
                     final_model=final_model,
                     messages=messages,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2498,6 +2498,7 @@ class TestAuxiliaryAuthRefreshRetry:
     def test_call_llm_refreshes_codex_on_401_for_vision(self):
         failing_client = MagicMock()
         failing_client.base_url = "https://chatgpt.com/backend-api/codex"
+        failing_client.api_key = "stale-codex-token"
         failing_client.chat.completions = _FailingThenSuccessCompletions()
 
         fresh_client = MagicMock()
@@ -2508,7 +2509,7 @@ class TestAuxiliaryAuthRefreshRetry:
             patch(
                 "agent.auxiliary_client.resolve_vision_provider_client",
                 side_effect=[("openai-codex", failing_client, "gpt-5.4"), ("openai-codex", fresh_client, "gpt-5.4")],
-            ),
+            ) as resolve_mock,
             patch("agent.auxiliary_client._refresh_provider_credentials", return_value=True) as mock_refresh,
         ):
             resp = call_llm(
@@ -2519,7 +2520,53 @@ class TestAuxiliaryAuthRefreshRetry:
             )
 
         assert resp.choices[0].message.content == "fresh-sync"
-        mock_refresh.assert_called_once_with("openai-codex")
+        mock_refresh.assert_called_once_with(
+            "openai-codex", failed_api_key="stale-codex-token"
+        )
+        # Regression: the retry must resolve from the refreshed credential
+        # source. Passing the rejected explicit key overrides the refreshed
+        # cache and deterministically reproduces the same 401.
+        assert resolve_mock.call_args_list[1].kwargs.get("api_key") is None
+
+    @pytest.mark.asyncio
+    async def test_async_auth_refresh_drops_rejected_key_on_retry(self):
+        """The async recovery path must obey the same credential invariant."""
+        failing_client = MagicMock()
+        failing_client.base_url = "https://chatgpt.com/backend-api/codex"
+        failing_client.api_key = "stale-async-token"
+        failing_client.chat.completions = _AsyncFailingThenSuccessCompletions()
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://chatgpt.com/backend-api/codex"
+        fresh_client.chat.completions.create = AsyncMock(
+            return_value=_DummyResponse("fresh-async")
+        )
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                side_effect=[
+                    ("openai-codex", failing_client, "gpt-5.4"),
+                    ("openai-codex", fresh_client, "gpt-5.4"),
+                ],
+            ) as resolve_mock,
+            patch(
+                "agent.auxiliary_client._refresh_provider_credentials",
+                return_value=True,
+            ) as mock_refresh,
+        ):
+            resp = await async_call_llm(
+                task="vision",
+                provider="openai-codex",
+                model="gpt-5.4",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert resp.choices[0].message.content == "fresh-async"
+        mock_refresh.assert_called_once_with(
+            "openai-codex", failed_api_key="stale-async-token"
+        )
+        assert resolve_mock.call_args_list[1].kwargs.get("api_key") is None
 
 
 
@@ -2555,6 +2602,67 @@ class TestAuxiliaryAuthRefreshRetry:
         mock_refresh_oauth.assert_called_once_with("refresh-token", use_json=False)
         mock_write.assert_called_once_with("fresh-token", "refresh-token-2", 9999999999999)
         stale_client.close.assert_called_once()
+
+    def test_anthropic_uses_newer_disk_token_without_rotating_again(self, monkeypatch):
+        """A long-running client may lag behind a credential rotated elsewhere.
+
+        Refreshing again is actively harmful: Anthropic rotates refresh tokens,
+        so it revokes the just-written token that a sibling profile may already
+        have copied. The current on-disk access token is the recovery; evict the
+        stale client and rebuild from disk.
+        """
+        stale_client = MagicMock()
+        cache_key = ("anthropic", False, None, None, None)
+
+        with (
+            patch(
+                "agent.auxiliary_client._client_cache",
+                {cache_key: (stale_client, "claude-sonnet-5", None)},
+            ),
+            patch(
+                "agent.anthropic_adapter.read_claude_code_credentials",
+                return_value={
+                    "accessToken": "new-token-already-on-disk",
+                    "refreshToken": "current-refresh-token",
+                    "expiresAt": 9999999999999,
+                },
+            ),
+            patch("agent.anthropic_adapter._refresh_oauth_token") as force_refresh,
+        ):
+            from agent.auxiliary_client import _refresh_provider_credentials
+
+            assert _refresh_provider_credentials(
+                "anthropic", failed_api_key="revoked-token-in-cached-client"
+            ) is True
+
+        force_refresh.assert_not_called()
+        stale_client.close.assert_called_once()
+
+    def test_anthropic_same_failed_token_forces_refresh(self):
+        """If disk still contains the rejected token, a real refresh is needed."""
+        with (
+            patch(
+                "agent.anthropic_adapter.read_claude_code_credentials",
+                return_value={
+                    "accessToken": "same-revoked-token",
+                    "refreshToken": "refresh-token",
+                    "expiresAt": 9999999999999,
+                },
+            ),
+            patch(
+                "agent.anthropic_adapter._refresh_oauth_token",
+                return_value="fresh-token",
+            ) as force_refresh,
+            patch("agent.auxiliary_client._evict_cached_clients") as evict,
+        ):
+            from agent.auxiliary_client import _refresh_provider_credentials
+
+            assert _refresh_provider_credentials(
+                "anthropic", failed_api_key="same-revoked-token"
+            ) is True
+
+        force_refresh.assert_called_once()
+        evict.assert_called_once_with("anthropic")
 
     def test_refresh_provider_credentials_remints_vertex_token_and_evicts_cache(self):
         """Vertex tokens live ~1h; on a long-running gateway the cached


### PR DESCRIPTION
## Problem

Long-running gateways cache auxiliary provider clients. If another process (CLI, sibling profile, credential sync) refreshes OAuth, the cached client keeps the revoked token while the credential file is already healthy.

Observed in production on an Anthropic-routed compression task:

```
Context compression aborted ... 401 authentication_error:
OAuth access token has been revoked
```

The same gateway failed compression repeatedly while a fresh `hermes -z ... --provider anthropic` call succeeded with the on-disk credential.

The recovery path had **two coupled bugs**:

1. Anthropic recovery always rotated the refresh token again, even when disk already contained a different token than the rejected client. Anthropic rotates refresh tokens, so this revokes the just-issued credential a sibling profile may already have copied.
2. After refresh and cache eviction, both sync and async retries passed the original `resolved_api_key` back into client construction. That explicit stale key overrides the refreshed credential source, deterministically reproducing the same 401. Compression aborts until gateway restart.

## Fix

- Pass the actual failed client key to `_refresh_provider_credentials`.
- Anthropic: if the current on-disk access token differs from the failed token, treat disk as the recovery — evict and rebuild, **do not rotate again**.
- Only force OAuth refresh when disk still contains the rejected token.
- After any successful auth refresh, retry with `resolved_api_key=None`, forcing provider resolution to read the refreshed source instead of overriding it with the rejected key.
- Apply the invariant to both sync and async paths.

## Tests

- RED on unmodified `main`: 3 focused failures (including stale retry-key behaviour).
- GREEN: 8 focused auth-refresh tests.
- Regression: **202 passed** across auxiliary client, Anthropic pool fallback, transient retry, xAI OAuth recovery and explicit Anthropic base-route suites.
- Added tests for:
  - newer on-disk Anthropic token avoids a second rotation
  - same rejected token forces a real refresh
  - sync retry drops the stale explicit key
  - async retry drops the stale explicit key
