### PR TITLE
fix(desktop): clarify Bot Mode session creation

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3268,7 +3268,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
                 host.newChat(bot.name)
               }
             },
-            children: 'New chat with this agent'
+            children: 'New session with this agent'
           }),
           bot.is_default ? null : jsx(ContextMenuSeparator, {}),
           bot.is_default

--- a/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
@@ -142,3 +142,9 @@ test('source contract: session controls expose filter and selection state to ass
   assert.match(pluginSource, /'aria-current': active \? 'page' : undefined/)
 })
 
+test('source contract: a fresh agent session is labelled separately from canonical Bot Chat', () => {
+  assert.match(pluginSource, /host\.newChat\(bot\.name\)/)
+  assert.match(pluginSource, /children: 'New session with this agent'/)
+  assert.doesNotMatch(pluginSource, /children: 'New chat with this agent'/)
+})
+


### PR DESCRIPTION
## What does this PR do?

Clarifies the distinction between a bot's canonical `Bot Chat` and a separate session created from the bot context menu.

The current action is labelled `New chat with this agent`, but it calls the generic fresh-session route and does not change the bot's canonical `meta.chat` pin. Users can therefore create a new session, switch away, click the bot again, and be returned to the older canonical chat. The behaviour is internally consistent, but the label makes the navigation feel broken and hides the session model.

This patch labels the action `New session with this agent`, preserving the existing safe routing semantics.

## Related Issues

Related to #88146 and #88200.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`
  - Rename the context-menu action to `New session with this agent`.
- `apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs`
  - Add a source-contract regression test for the separate-session wording and existing fresh-session route.

## How to Test

1. Run `node --test src/plugins/hermes-bots/tests/*.test.mjs` from `apps/desktop`.
2. Open the Desktop Bots pane and open an agent context menu.
3. Confirm the action reads `New session with this agent`.
4. Confirm the existing primary bot click still opens the pinned canonical `Bot Chat`, while separate sessions remain available from `Sessions`.

Focused Bot Mode suite: 150 tests passed.

## Checklist

- [x] Commit message follows Conventional Commits.
- [x] Existing related issues were searched before opening this PR.
- [x] PR contains only changes related to this fix.
- [x] Added regression coverage for the changed UI contract.
- [x] Cross-platform impact considered: this is Desktop renderer/plugin text and does not change platform-specific routing.
- [x] Full Python suite not run: no Python/backend code changed.

## Screenshots / Logs

Not included. The change is a single context-menu label plus a source-contract test.