### PR TITLE
fix(install): let the locked uv sync see the project's [tool.uv] config

### DIFF
--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -251,7 +251,18 @@ else
         # at first use.
         # Also: stream stderr through directly so the user sees uv's
         # progress UI instead of staring at a frozen prompt.
-        if UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" $UV_CMD sync --extra all --locked; then
+        #
+        # env -u UV_NO_CONFIG (exported above for the sudo -u case, #21269):
+        # a locked sync MUST see the project's [tool.uv] exclude-newer in
+        # pyproject.toml. With UV_NO_CONFIG set, uv 0.12+ cannot see it,
+        # considers the lockfile's recorded settings stale ("removal of
+        # global exclude newer") and refuses --locked — silently downgrading
+        # every fresh install to the non-hash-verified PyPI fallback
+        # (#88361). The runtime refresh path already pops UV_NO_CONFIG for
+        # exactly this reason (hermes_cli/managed_uv.py, "uv 0.12+ refuses
+        # --locked"). cwd is $SCRIPT_DIR (the checkout root), so the only
+        # pyproject uv can discover here is the project's own.
+        if UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" env -u UV_NO_CONFIG $UV_CMD sync --extra all --locked; then
             echo -e "${GREEN}✓${NC} Dependencies installed (hash-verified via uv.lock)"
         else
             echo -e "${YELLOW}⚠${NC} Lockfile sync failed (see uv output above)."


### PR DESCRIPTION
## What does this PR do?

Fresh installs via the setup script fail the hash-verified install tier and silently downgrade to the non-hash-verified PyPI fallback (#88361). Root cause, confirmed by the reporter's install log line `Resolving despite existing lockfile due to removal of global exclude newer` and reproduced locally:

- The setup script exports `UV_NO_CONFIG=1` early so uv cannot discover config files from the wrong user's home under `sudo -u <user>` (#21269).
- The hash-verified step `uv sync --extra all --locked` inherits that variable. With config discovery disabled, uv 0.12+ cannot see the project's `[tool.uv] exclude-newer` in `pyproject.toml`, compares it against the settings recorded in `uv.lock`, decides the lockfile is stale ("removal of global exclude newer"), and refuses `--locked`.
- The runtime refresh path already hit and fixed this exact interaction in `managed_uv.py` ("Locked sync must see project [tool.uv] exclude-newer; --no-config / UV_NO_CONFIG drops it and uv 0.12+ refuses --locked" — it pops `UV_NO_CONFIG` for the sync). The first-install path never got the same treatment.

The fix drops `UV_NO_CONFIG` for that single command via `env -u` (identical semantics to the runtime path's env pop). The script has already `cd`'d to the checkout root, so the only `pyproject.toml` uv can discover there is the project's own; every other uv call in the script keeps the #21269 protection.

## Related Issue

Fixes #88361

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `setup-hermes.sh`: the locked sync now runs with `env -u UV_NO_CONFIG` so uv 0.12+ can read the project's `[tool.uv]` settings and accept `--locked`; comment documents the hazard and the managed_uv.py precedent

## How to Test

1. Reproduce the bug (before this change), on any checkout of main with uv 0.12.5:
   `UV_PROJECT_ENVIRONMENT=/tmp/tv uvx uv@0.12.5 sync --extra all --locked --dry-run --no-config`
   Observed result: `error: The lockfile at 'uv.lock' needs to be updated, but '--locked' was provided.` — identical to the reporter's install log.
2. Verify the fix semantics — same command with the variable dropped, exactly what the patched script line now runs:
   `UV_NO_CONFIG=1; UV_PROJECT_ENVIRONMENT=/tmp/tv env -u UV_NO_CONFIG uvx uv@0.12.5 sync --extra all --locked --dry-run`
   Observed result: resolves cleanly, no lockfile complaint.
3. `bash -n setup-hermes.sh` — Observed result: syntax OK.
4. End-to-end on a Linux host with the installer-managed uv (0.12.5): a fresh install now prints `✓ Dependencies installed (hash-verified via uv.lock)` instead of `⚠ Lockfile sync failed ... Falling back to PyPI resolve`.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `bash -n` on the changed script and reproduced/fixed the uv behavior with uv 0.12.5 directly (no Python test surface exists for the installer shell script)
- [x] I have added tests for my changes — N/A: installer shell script, no test harness; verification commands above reproduce before/after behavior deterministically
- [x] I have tested on my platform: macOS 15 (arm64) with `uvx uv@0.12.5`; reporter's environment is Ubuntu 24.04 (x86_64) with installer-managed uv 0.12.5

### Documentation & Housekeeping

- [x] N/A — no config keys or docs changed; the inline comment in the script documents the hazard, the #21269 interaction, and the managed_uv.py precedent

## For New Skills

N/A

## Screenshots / Logs

```
# Before (reproduces the reporter's error):
$ UV_PROJECT_ENVIRONMENT=/tmp/tv uvx uv@0.12.5 sync --extra all --locked --dry-run --no-config
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
hint: To update the lockfile, run `uv lock`.

# After (the exact env shape the patched line runs):
$ UV_NO_CONFIG=1 UV_PROJECT_ENVIRONMENT=/tmp/tv env -u UV_NO_CONFIG uvx uv@0.12.5 sync --extra all --locked --dry-run
 + ... (resolves cleanly, exit 0)
```
