### PR TITLE
fix(desktop): pause inactive diffusion rendering

### DIFF
--- a/apps/desktop/src/components/chat/image-generation-placeholder.test.tsx
+++ b/apps/desktop/src/components/chat/image-generation-placeholder.test.tsx
@@ -1,0 +1,119 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DiffusionCanvas } from './image-generation-placeholder'
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+let windowStateCallback: ((payload: { isMinimized?: boolean; isVisible?: boolean }) => void) | null = null
+
+function render() {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+
+  act(() => {
+    root!.render(<DiffusionCanvas />)
+  })
+}
+
+function cleanup() {
+  if (root) {
+    act(() => {
+      root!.unmount()
+    })
+  }
+
+  container?.remove()
+  root = null
+  container = null
+}
+
+function installRaf() {
+  let nextId = 1
+  const frames = new Map<number, FrameRequestCallback>()
+
+  const request = vi.fn((callback: FrameRequestCallback) => {
+    const id = nextId++
+    frames.set(id, callback)
+
+    return id
+  })
+
+  const cancel = vi.fn((id: number) => {
+    frames.delete(id)
+  })
+
+  Object.defineProperty(window, 'requestAnimationFrame', { configurable: true, value: request })
+  Object.defineProperty(window, 'cancelAnimationFrame', { configurable: true, value: cancel })
+
+  return {
+    pending: () => frames.size,
+    request
+  }
+}
+
+function installWindowStateBridge() {
+  windowStateCallback = null
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: {
+      onWindowStateChanged: vi.fn((callback: typeof windowStateCallback) => {
+        windowStateCallback = callback
+
+        return () => {
+          if (windowStateCallback === callback) {
+            windowStateCallback = null
+          }
+        }
+      })
+    }
+  })
+}
+
+describe('DiffusionCanvas scheduling', () => {
+  beforeEach(() => {
+    ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    installWindowStateBridge()
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      setTransform: vi.fn()
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  it('cancels its loop while inactive and resumes only when the window is observable', () => {
+    const raf = installRaf()
+
+    render()
+    expect(raf.request).toHaveBeenCalledTimes(1)
+    expect(raf.pending()).toBe(1)
+
+    act(() => {
+      window.dispatchEvent(new Event('blur'))
+    })
+    expect(raf.pending()).toBe(0)
+
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+    })
+    expect(raf.pending()).toBe(1)
+
+    act(() => {
+      windowStateCallback?.({ isMinimized: true, isVisible: false })
+    })
+    expect(raf.pending()).toBe(0)
+
+    cleanup()
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+    })
+    expect(raf.pending()).toBe(0)
+  })
+})

--- a/apps/desktop/src/components/chat/image-generation-placeholder.tsx
+++ b/apps/desktop/src/components/chat/image-generation-placeholder.tsx
@@ -2,6 +2,7 @@ import { type FC, useCallback, useEffect, useRef } from 'react'
 
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { onThemeRepaint } from '@/hooks/use-theme-epoch'
+import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
 
 type Rgb = { r: number; g: number; b: number }
 
@@ -299,15 +300,50 @@ export const DiffusionCanvas: FC = () => {
 
     sizeRef.current = fitCanvas(canvas, ctx)
 
-    let frame = requestAnimationFrame(function draw(now) {
+    let frame = 0
+    let stopped = false
+    let pauseController: ReturnType<typeof createRendererLoopPauseController> | null = null
+
+    const cancelFrame = () => {
+      if (frame !== 0) {
+        window.cancelAnimationFrame(frame)
+        frame = 0
+      }
+    }
+
+    const scheduleFrame = () => {
+      if (stopped || pauseController?.isPaused() || frame !== 0) {
+        return
+      }
+
+      frame = window.requestAnimationFrame(draw)
+    }
+
+    const draw = (now: number) => {
+      frame = 0
+
+      if (stopped || pauseController?.isPaused()) {
+        return
+      }
+
       const { width, height } = sizeRef.current
       ctx.clearRect(0, 0, width, height)
       drawAsciiDiffusion(ctx, themeRef.current, width, height, now / 1000)
-      frame = requestAnimationFrame(draw)
-    })
+      scheduleFrame()
+    }
+
+    const handleVisibilityChange = () => {
+      cancelFrame()
+      scheduleFrame()
+    }
+
+    pauseController = createRendererLoopPauseController(handleVisibilityChange)
+    scheduleFrame()
 
     return () => {
-      cancelAnimationFrame(frame)
+      stopped = true
+      cancelFrame()
+      pauseController.dispose()
     }
   }, [])
 


### PR DESCRIPTION
## What does this PR do?

Makes the image-generation `DiffusionCanvas` follow the shared Desktop renderer pause policy. It still draws every frame while the main window is observable, but cancels its pending `requestAnimationFrame` when the window is hidden, minimized, or unfocused and schedules one resume frame when it becomes observable again.

## Related Issue

Fixes #88396

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/components/chat/image-generation-placeholder.tsx`: wire the animation loop to `createRendererLoopPauseController` with explicit cancel/resume lifecycle handling.
- `apps/desktop/src/components/chat/image-generation-placeholder.test.tsx`: cover blur, focus, Electron minimized state, and unmount cleanup.

## How to Test

1. Run `NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-vitest-localstorage.json' npm --workspace apps/desktop exec -- vitest run --environment jsdom src/components/chat/image-generation-placeholder.test.tsx`.
2. Run `npm --workspace apps/desktop run typecheck`.
3. Run `npm --workspace apps/desktop run build`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: this is an isolated Desktop TypeScript renderer change; focused Vitest, typecheck, ESLint, and production build were run instead.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: CachyOS Linux via focused jsdom Vitest and a production Desktop build.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A: no user-facing behavior or configuration changed.
- [x] I've updated `cli-config.yaml.example` — N/A.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A.
- [x] I've considered cross-platform impact — browser standard timer/RAF APIs only; no platform-specific code.
- [x] I've updated tool descriptions/schemas — N/A.

## Screenshots / Logs

Focused test: 1 passed. Desktop typecheck and production build passed. Changed-file ESLint exited successfully with only the repository's existing test-style `no-restricted-globals` warnings for `document`.
