### PR TITLE
feat(api): durable idempotency for POST /v1/runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -814,6 +814,134 @@ def check_api_server_requirements() -> bool:
     return AIOHTTP_AVAILABLE
 
 
+class RunIdempotencyStore:
+    """Durable, tenant-scoped reservations for ``POST /v1/runs``.
+
+    A unique ``(scope, key)`` row is inserted inside ``BEGIN IMMEDIATE`` so
+    separate gateway workers/processes cannot both admit the same request.
+    Only request fingerprints and public run status are stored; request bodies
+    and credentials are deliberately excluded.
+    """
+
+    RETENTION_SECONDS = 24 * 60 * 60
+
+    def __init__(self, db_path: str = None):
+        if db_path is None:
+            try:
+                from hermes_cli.config import get_hermes_home
+
+                db_path = str(get_hermes_home() / "runs_idempotency.db")
+            except Exception:
+                db_path = ":memory:"
+        self._db_path = None if db_path == ":memory:" else db_path
+        try:
+            self._conn = sqlite3.connect(db_path, check_same_thread=False, timeout=30)
+        except Exception:
+            self._conn = sqlite3.connect(":memory:", check_same_thread=False)
+            self._db_path = None
+        from hermes_state import apply_wal_with_fallback
+
+        apply_wal_with_fallback(self._conn, db_label="runs_idempotency.db")
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS run_idempotency (
+                scope TEXT NOT NULL,
+                idempotency_key TEXT NOT NULL,
+                fingerprint TEXT NOT NULL,
+                run_id TEXT NOT NULL,
+                status_json TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                PRIMARY KEY (scope, idempotency_key)
+            )"""
+        )
+        self._conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS run_idempotency_run_id ON run_idempotency(run_id)"
+        )
+        self._conn.commit()
+        self._lock = threading.Lock()
+        self._tighten_permissions()
+
+    def _tighten_permissions(self) -> None:
+        if not self._db_path:
+            return
+        for candidate in (
+            Path(self._db_path),
+            Path(self._db_path + "-wal"),
+            Path(self._db_path + "-shm"),
+        ):
+            try:
+                if candidate.exists():
+                    candidate.chmod(0o600)
+            except OSError:
+                logger.debug(
+                    "Failed to restrict run idempotency store permissions",
+                    exc_info=True,
+                )
+
+    def reserve(
+        self,
+        scope: str,
+        key: str,
+        fingerprint: str,
+        run_id: str,
+        status: Dict[str, Any],
+    ):
+        """Atomically reserve a key; return ``(outcome, stored_record)``."""
+        now = time.time()
+        encoded = json.dumps(status, sort_keys=True, separators=(",", ":"))
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._conn.execute(
+                    "DELETE FROM run_idempotency WHERE updated_at < ?",
+                    (now - self.RETENTION_SECONDS,),
+                )
+                row = self._conn.execute(
+                    "SELECT fingerprint, run_id, status_json FROM run_idempotency WHERE scope=? AND idempotency_key=?",
+                    (scope, key),
+                ).fetchone()
+                if row is not None:
+                    self._conn.commit()
+                    outcome = (
+                        "reused"
+                        if hmac.compare_digest(row[0], fingerprint)
+                        else "conflict"
+                    )
+                    return outcome, {"run_id": row[1], "status": json.loads(row[2])}
+                self._conn.execute(
+                    "INSERT INTO run_idempotency(scope,idempotency_key,fingerprint,run_id,status_json,created_at,updated_at) VALUES(?,?,?,?,?,?,?)",
+                    (scope, key, fingerprint, run_id, encoded, now, now),
+                )
+                self._conn.commit()
+                return "created", {"run_id": run_id, "status": status}
+            except Exception:
+                self._conn.rollback()
+                raise
+
+    def owns_run(self, scope: str, run_id: str) -> bool:
+        with self._lock:
+            return (
+                self._conn.execute(
+                    "SELECT 1 FROM run_idempotency WHERE scope=? AND run_id=?",
+                    (scope, run_id),
+                ).fetchone()
+                is not None
+            )
+
+    def update_status(self, run_id: str, status: Dict[str, Any]) -> None:
+        encoded = json.dumps(status, sort_keys=True, separators=(",", ":"))
+        with self._lock:
+            self._conn.execute(
+                "UPDATE run_idempotency SET status_json=?, updated_at=? WHERE run_id=?",
+                (encoded, time.time(), run_id),
+            )
+            self._conn.commit()
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+
 class ResponseStore:
     """
     SQLite-backed LRU store for Responses API state.
@@ -1419,6 +1547,9 @@ class APIServerAdapter(BasePlatformAdapter):
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
+        self._run_idempotency_store = RunIdempotencyStore()
+        self._run_idempotency_ids: set[str] = set()
+        self._run_owners: Dict[str, str] = {}
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
         # Creation timestamps for orphaned-run TTL sweep
@@ -4385,23 +4516,41 @@ class APIServerAdapter(BasePlatformAdapter):
         if idempotency_key:
             fp = _make_request_fingerprint(
                 body,
-                keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
+                keys=[
+                    "model",
+                    "provider",
+                    "model_options",
+                    "messages",
+                    "tools",
+                    "tool_choice",
+                    "stream",
+                ],
             )
             try:
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
+                result, usage = await _idem_cache.get_or_set(
+                    idempotency_key, fp, _compute_completion
+                )
             except Exception as e:
-                logger.error("Error running agent for chat completions: %s", e, exc_info=True)
+                logger.error(
+                    "Error running agent for chat completions: %s", e, exc_info=True
+                )
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error(
+                        f"Internal server error: {e}", err_type="server_error"
+                    ),
                     status=500,
                 )
         else:
             try:
                 result, usage = await _compute_completion()
             except Exception as e:
-                logger.error("Error running agent for chat completions: %s", e, exc_info=True)
+                logger.error(
+                    "Error running agent for chat completions: %s", e, exc_info=True
+                )
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error(
+                        f"Internal server error: {e}", err_type="server_error"
+                    ),
                     status=500,
                 )
 
@@ -5522,11 +5671,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 ],
             )
             try:
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
+                result, usage = await _idem_cache.get_or_set(
+                    idempotency_key, fp, _compute_response
+                )
             except Exception as e:
                 logger.error("Error running agent for responses: %s", e, exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error(
+                        f"Internal server error: {e}", err_type="server_error"
+                    ),
                     status=500,
                 )
         else:
@@ -6538,10 +6691,18 @@ class APIServerAdapter(BasePlatformAdapter):
         current.setdefault("created_at", fields.pop("created_at", now))
         current.update(fields)
         self._run_statuses[run_id] = current
+        if run_id in self._run_idempotency_ids:
+            try:
+                self._run_idempotency_store.update_status(run_id, current)
+            except Exception:
+                logger.exception(
+                    "[api_server] failed to persist idempotent run status %s", run_id
+                )
         return current
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
+
         def _push(event: Dict[str, Any]) -> None:
             self._set_run_status(
                 run_id,
@@ -6633,6 +6794,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return _callback
 
+    def _run_idempotency_scope(self, request: "web.Request") -> str:
+        """Opaque auth/profile namespace; never persist bearer credentials."""
+        profile = _api_request_profile.get() or "default"
+        expected_key = self._expected_api_key()
+        identity = expected_key or "unauthenticated-test-listener"
+        return hashlib.sha256(f"{profile}\0{identity}".encode()).hexdigest()
+
     @_admit_api_agent_request
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
@@ -6652,13 +6820,46 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
+        idempotency_key = request.headers.get("Idempotency-Key", "").strip()
+        if idempotency_key and (
+            len(idempotency_key) > 255
+            or any(ord(ch) < 33 or ord(ch) > 126 for ch in idempotency_key)
+        ):
+            return web.json_response(
+                _openai_error(
+                    "Idempotency-Key must be 1-255 visible ASCII characters",
+                    code="invalid_idempotency_key",
+                ),
+                status=400,
+            )
+        idempotency_scope = (
+            self._run_idempotency_scope(request) if idempotency_key else ""
+        )
+        idempotency_fingerprint = (
+            hashlib.sha256(
+                json.dumps(
+                    body, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+                ).encode()
+            ).hexdigest()
+            if idempotency_key
+            else ""
+        )
+
         raw_input = body.get("input")
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
+        user_message = (
+            raw_input
+            if isinstance(raw_input, str)
+            else (
+                raw_input[-1].get("content", "") if isinstance(raw_input, list) else ""
+            )
+        )
         if not user_message:
-            return web.json_response(_openai_error("No user message found in input"), status=400)
+            return web.json_response(
+                _openai_error("No user message found in input"), status=400
+            )
 
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
@@ -6721,6 +6922,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error(selection_error), status=400)
 
         run_id = f"run_{uuid.uuid4().hex}"
+        self._run_owners[run_id] = self._run_idempotency_scope(request)
         session_id = session_id or run_id
         # Approval queues gate host-side tool execution and must be isolated
         # per API run.  Client-provided session IDs and memory session keys are
@@ -6759,13 +6961,40 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
-        self._set_run_status(
+        initial_status = self._set_run_status(
             run_id,
             "queued",
             created_at=created_at,
             session_id=session_id,
             model=body.get("model", self._model_name),
         )
+        if idempotency_key:
+            outcome, record = self._run_idempotency_store.reserve(
+                idempotency_scope, idempotency_key, idempotency_fingerprint, run_id, initial_status
+            )
+            if outcome != "created":
+                self._run_streams.pop(run_id, None)
+                self._run_streams_created.pop(run_id, None)
+                self._run_approval_sessions.pop(run_id, None)
+                self._run_statuses.pop(run_id, None)
+                self._run_owners.pop(run_id, None)
+                if outcome == "conflict":
+                    return web.json_response(
+                        _openai_error(
+                            "Idempotency-Key was already used with a different request payload",
+                            code="idempotency_key_conflict",
+                        ), status=409,
+                    )
+                original_id = record["run_id"]
+                self._run_statuses.setdefault(original_id, record["status"])
+                self._run_idempotency_ids.add(original_id)
+                self._run_owners[original_id] = idempotency_scope
+                return web.json_response(
+                    {"run_id": original_id, "status": "started"},
+                    status=202,
+                    headers={"Idempotency-Replayed": "true"},
+                )
+            self._run_idempotency_ids.add(run_id)
 
         # Background task outlives the HTTP response (and thus the middleware
         # profile scope). Capture now and re-enter inside the task/executor.
@@ -7049,6 +7278,17 @@ class APIServerAdapter(BasePlatformAdapter):
             headers=response_headers,
         )
 
+    def _request_owns_run(self, request: "web.Request", run_id: str) -> bool:
+        scope = self._run_idempotency_scope(request)
+        owner = self._run_owners.get(run_id)
+        if owner is None and run_id in self._run_statuses:
+            # Backward compatibility for statuses created by older/in-process
+            # integrations before ownership tracking was introduced.
+            return True
+        return owner == scope or (
+            owner is None and self._run_idempotency_store.owns_run(scope, run_id)
+        )
+
     async def _handle_get_run(self, request: "web.Request") -> "web.Response":
         """GET /v1/runs/{run_id} — return pollable run status for external UIs."""
         auth_err = self._check_auth(request)
@@ -7056,6 +7296,11 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        if not self._request_owns_run(request, run_id):
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
         status = self._run_statuses.get(run_id)
         if status is None:
             return web.json_response(
@@ -7071,6 +7316,11 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        if not self._request_owns_run(request, run_id):
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
 
         # Allow subscribing slightly before the run is registered (race condition window)
         for _ in range(20):
@@ -7123,6 +7373,11 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        if not self._request_owns_run(request, run_id):
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
         status = self._run_statuses.get(run_id)
         if status is None:
             return web.json_response(
@@ -7211,9 +7466,17 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        if not self._request_owns_run(request, run_id):
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
         status = self._run_statuses.get(run_id)
         if status is None:
-            return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
         # Only genuinely running runs are steerable.  /stop retains agent/task
         # refs during cooperative shutdown, so the status gate (not the mere
         # presence of an agent ref) is what rejects stop-then-steer.
@@ -7271,11 +7534,19 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        if not self._request_owns_run(request, run_id):
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
         agent = self._active_run_agents.get(run_id)
         task = self._active_run_tasks.get(run_id)
 
         if agent is None and task is None:
-            return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
 
         self._set_run_status(run_id, "stopping", last_event="run.stopping")
         self._stopping_run_ids.add(run_id)
@@ -7566,6 +7837,13 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 logger.debug(
                     "Failed to close response store for %s", self.name, exc_info=True,
+                )
+        if self._run_idempotency_store is not None:
+            try:
+                self._run_idempotency_store.close()
+            except Exception:
+                logger.debug(
+                    "Failed to close run idempotency store for %s", self.name, exc_info=True,
                 )
         try:
             if self._site:

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -798,5 +798,172 @@ class TestRunsProviderAuthFailure:
                     await asyncio.sleep(0.05)
 
                 assert status["status"] == "failed"
-                assert status["error"] == "⚠️ Provider authentication failed: No credentials found for provider 'nous'"
+                assert (
+                    status["error"]
+                    == "⚠️ Provider authentication failed: No credentials found for provider 'nous'"
+                )
                 assert status["last_event"] == "run.failed"
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/runs idempotency
+# ---------------------------------------------------------------------------
+
+
+def _use_idempotency_db(adapter, path):
+    from gateway.platforms.api_server import RunIdempotencyStore
+
+    adapter._run_idempotency_store.close()
+    adapter._run_idempotency_store = RunIdempotencyStore(str(path))
+
+
+class TestRunIdempotency:
+    @pytest.mark.asyncio
+    async def test_sequential_duplicate_reuses_original(self, adapter, tmp_path):
+        _use_idempotency_db(adapter, tmp_path / "idem.db")
+        app = _create_runs_app(adapter)
+        calls = 0
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as create:
+                agent = MagicMock()
+
+                def run(**kwargs):
+                    nonlocal calls
+                    calls += 1
+                    return {"final_response": "done"}
+
+                agent.run_conversation.side_effect = run
+                agent.session_prompt_tokens = agent.session_completion_tokens = (
+                    agent.session_total_tokens
+                ) = 0
+                create.return_value = agent
+                headers = {"Idempotency-Key": "retry-1"}
+                first = await cli.post(
+                    "/v1/runs", json={"input": "hello"}, headers=headers
+                )
+                second = await cli.post(
+                    "/v1/runs", json={"input": "hello"}, headers=headers
+                )
+                assert first.status == second.status == 202
+                assert (await first.json())["run_id"] == (await second.json())["run_id"]
+                assert second.headers["Idempotency-Replayed"] == "true"
+                await asyncio.sleep(0.1)
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_changed_payload_conflicts(self, adapter, tmp_path):
+        _use_idempotency_db(adapter, tmp_path / "idem.db")
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as create:
+                agent = MagicMock()
+                agent.run_conversation.return_value = {"final_response": "done"}
+                agent.session_prompt_tokens = agent.session_completion_tokens = (
+                    agent.session_total_tokens
+                ) = 0
+                create.return_value = agent
+                headers = {"Idempotency-Key": "same-key"}
+                assert (
+                    await cli.post("/v1/runs", json={"input": "one"}, headers=headers)
+                ).status == 202
+                conflict = await cli.post(
+                    "/v1/runs", json={"input": "two"}, headers=headers
+                )
+                assert conflict.status == 409
+                assert (await conflict.json())["error"][
+                    "code"
+                ] == "idempotency_key_conflict"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_duplicate_starts_once(self, adapter, tmp_path):
+        _use_idempotency_db(adapter, tmp_path / "idem.db")
+        app = _create_runs_app(adapter)
+        calls = 0
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as create:
+                agent = MagicMock()
+
+                def run(**kwargs):
+                    nonlocal calls
+                    calls += 1
+                    time.sleep(0.05)
+                    return {"final_response": "done"}
+
+                agent.run_conversation.side_effect = run
+                agent.session_prompt_tokens = agent.session_completion_tokens = (
+                    agent.session_total_tokens
+                ) = 0
+                create.return_value = agent
+
+                async def post():
+                    response = await cli.post(
+                        "/v1/runs",
+                        json={"input": "race"},
+                        headers={"Idempotency-Key": "race-key"},
+                    )
+                    return response.status, await response.json()
+
+                results = await asyncio.gather(*[post() for _ in range(8)])
+                assert {status for status, _ in results} == {202}
+                assert len({body["run_id"] for _, body in results}) == 1
+                await asyncio.sleep(0.15)
+        assert calls == 1
+
+    def test_restart_durability_and_terminal_semantics(self, tmp_path):
+        from gateway.platforms.api_server import RunIdempotencyStore
+
+        path = tmp_path / "idem.db"
+        for terminal in ("completed", "failed", "cancelled"):
+            first = RunIdempotencyStore(str(path))
+            run_id = f"run_{terminal}"
+            assert (
+                first.reserve(
+                    "tenant",
+                    terminal,
+                    "fp",
+                    run_id,
+                    {"run_id": run_id, "status": terminal},
+                )[0]
+                == "created"
+            )
+            first.close()
+            restarted = RunIdempotencyStore(str(path))
+            outcome, record = restarted.reserve(
+                "tenant", terminal, "fp", "run_new", {"status": "queued"}
+            )
+            assert outcome == "reused"
+            assert record["run_id"] == run_id
+            assert record["status"]["status"] == terminal
+            restarted.close()
+
+    def test_tenant_isolation_and_retention(self, tmp_path):
+        from gateway.platforms.api_server import RunIdempotencyStore
+
+        store = RunIdempotencyStore(str(tmp_path / "idem.db"))
+        assert (
+            store.reserve("tenant-a", "key", "fp-a", "run_a", {"status": "queued"})[0]
+            == "created"
+        )
+        assert (
+            store.reserve("tenant-b", "key", "fp-b", "run_b", {"status": "queued"})[0]
+            == "created"
+        )
+        store.close()
+
+    @pytest.mark.asyncio
+    async def test_missing_key_preserves_legacy_new_run_behavior(
+        self, adapter, tmp_path
+    ):
+        _use_idempotency_db(adapter, tmp_path / "idem.db")
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as create:
+                agent = MagicMock()
+                agent.run_conversation.return_value = {"final_response": "done"}
+                agent.session_prompt_tokens = agent.session_completion_tokens = (
+                    agent.session_total_tokens
+                ) = 0
+                create.return_value = agent
+                first = await cli.post("/v1/runs", json={"input": "hello"})
+                second = await cli.post("/v1/runs", json={"input": "hello"})
+                assert (await first.json())["run_id"] != (await second.json())["run_id"]

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -355,6 +355,8 @@ Create a new agent run. Returns a `run_id` that can be used to subscribe to prog
 
 Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, or `previous_response_id`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs.
 
+For safely retryable creation, send an `Idempotency-Key` header (1–255 visible ASCII characters). Hermes durably reserves the key before starting work. An identical retry returns the original `run_id` with HTTP 202 and `Idempotency-Replayed: true`, including after a gateway restart and after the run has completed, failed, or been cancelled. Reusing the same key with a different JSON payload returns HTTP 409 with code `idempotency_key_conflict`. Keys are isolated by authenticated API profile/credential and retained for 24 hours after their last status update; clients should use unique, unguessable keys and must not reuse them for unrelated operations. Requests without the header retain the legacy behavior and always create a new run.
+
 ### GET /v1/runs/\{run_id\}
 
 Poll the current run state. This is useful for dashboards that need status without holding an SSE connection open, or for UIs that reconnect after navigation.


### PR DESCRIPTION
## Summary
- add atomic SQLite-backed `Idempotency-Key` reservations for `POST /v1/runs`
- replay the original run for identical retries across races, terminal states, and gateway restarts
- reject key reuse with changed payloads using `409 idempotency_key_conflict`
- scope records and run access to the authenticated profile/credential, retain records for 24 hours, and keep keyless behavior unchanged
- document the API contract and retention policy

## Tests
- `uv run --extra dev --extra messaging pytest -q tests/gateway/test_api_server_runs.py --disable-warnings --maxfail=1` (29 passed)
- `uv run --extra dev ruff check gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py`
- `git diff --check`

Closes #88400

## Compatibility
The header is optional. Existing clients without `Idempotency-Key` continue to create a fresh run per request. Durable state is stored in owner-only `runs_idempotency.db`; only fingerprints, opaque auth/profile scopes, run IDs, and public statuses are persisted (not payloads or credentials).

## Related Relay fix
The branch is based on current `main`, which already contains both `9a9b670e29f592fdf50bcca1e3e777150522b6b5` and merge commit `42708f8bb39c9c2fc19146956699699bc3ea2da5`; they were not duplicated.
