### PR TITLE
fix(buzz): preserve long gateway deliveries

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -63,6 +63,8 @@ from agent.delegation_context import (
 
 logger = logging.getLogger(__name__)
 
+_LIVE_ADAPTER_SEND_TIMEOUT_SECONDS = 60
+
 
 def _close_late_session_db_result(future: "concurrent.futures.Future") -> None:
     """Done-callback: close a SessionDB whose constructor finished after run_job's timeout.
@@ -2643,6 +2645,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             and getattr(loop, "is_running", lambda: False)()
         )
         delivered = False
+        partial_delivery = False
         target_errors = []
 
         # Continuable cron surface (D1/D2/D6): resolve the delivery surface for
@@ -2833,12 +2836,30 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     # detection when "thread_id"/"message_thread_id" are absent
                     # from metadata, deriving the routing from target.thread_id
                     # or the explicit direct_messages_topic_id above.
-                    future = safe_schedule_threadsafe(
-                        router._deliver_to_platform(
+                    # Coordinate timeout cancellation with coroutine startup.
+                    # concurrent.futures.Future.cancel() may return True even
+                    # after an asyncio task has started, so its return value
+                    # cannot tell us whether a send already produced visible
+                    # side effects.  The lock makes the two safe outcomes
+                    # mutually exclusive: either cron aborts before adapter
+                    # entry and may use standalone fallback, or adapter entry
+                    # wins and timeout must be assume-delivered.
+                    dispatch_lock = threading.Lock()
+                    dispatch_state = {"started": False, "abort": False}
+
+                    async def _deliver_after_dispatch_handshake():
+                        with dispatch_lock:
+                            if dispatch_state["abort"]:
+                                return None
+                            dispatch_state["started"] = True
+                        return await router._deliver_to_platform(
                             route_target,
                             text_to_send,
                             route_metadata,
-                        ),
+                        )
+
+                    future = safe_schedule_threadsafe(
+                        _deliver_after_dispatch_handshake(),
                         loop,
                     )
                     if future is None:
@@ -2848,27 +2869,22 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         send_result = None
                         timeout_handled = False
                         try:
-                            send_result = future.result(timeout=60)
+                            send_result = future.result(
+                                timeout=_LIVE_ADAPTER_SEND_TIMEOUT_SECONDS
+                            )
                         except TimeoutError:
-                            # #38922: a slow confirmation does NOT necessarily
-                            # mean the send failed — but we must distinguish two
-                            # cases via future.cancel()'s return value:
-                            #
-                            #   cancel() == False -> the coroutine was already
-                            #     running on the gateway loop when the timeout
-                            #     fired; the request is in flight on the wire and
-                            #     cannot be un-sent.  Re-sending via standalone
-                            #     would be a guaranteed DUPLICATE, so treat it as
-                            #     delivered (assume-delivered).
-                            #
-                            #   cancel() == True -> the scheduled callback never
-                            #     started executing (loop wedged/backlogged for
-                            #     the full 60s), so nothing was sent.  We MUST
-                            #     fall through to the standalone path or the
-                            #     message is silently dropped (worse than a
-                            #     duplicate).
-                            cancelled = future.cancel()
-                            if cancelled:
+                            # #38922: a slow confirmation does not prove failure.
+                            # Atomically stop a not-yet-started coroutine before
+                            # allowing standalone fallback.  If adapter execution
+                            # already began, it may have published one or more
+                            # Buzz chunks, so any full resend could duplicate the
+                            # visible prefix regardless of cancel()'s return value.
+                            with dispatch_lock:
+                                already_started = dispatch_state["started"]
+                                if not already_started:
+                                    dispatch_state["abort"] = True
+                            future.cancel()
+                            if not already_started:
                                 msg = (
                                     f"live adapter send to {platform_name}:{chat_id} "
                                     "timed out before the coroutine was dispatched"
@@ -2885,10 +2901,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 timeout_handled = True
                                 logger.warning(
                                     "Job '%s': live adapter send to %s:%s timed out "
-                                    "after 60s; already dispatched (in flight), "
+                                    "after %ss; already dispatched (in flight), "
                                     "assuming delivered (skipping standalone fallback "
                                     "to avoid duplicate)",
                                     job["id"], platform_name, chat_id,
+                                    _LIVE_ADAPTER_SEND_TIMEOUT_SECONDS,
                                 )
                         except Exception as ex:
                             # A real send error (not a slow confirmation) — fall
@@ -3020,18 +3037,29 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         enabled=mirror_this_target and not thread_seeded and not inchannel_seeded,
                     )
             except Exception as e:
+                partial_delivery = getattr(e, "partial_delivery", False) is True
                 err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
                 if not any(err_msg in err for err in target_errors):
                     target_errors.append(err_msg)
                 if transport is not None and transport.is_relay:
                     logger.warning("Job '%s': %s", job["id"], err_msg)
                 else:
-                    logger.warning(
-                        "Job '%s': %s, falling back to standalone",
-                        job["id"], err_msg,
-                    )
+                    if partial_delivery:
+                        logger.warning(
+                            "Job '%s': %s; visible partial delivery prevents "
+                            "standalone fallback",
+                            job["id"], err_msg,
+                        )
+                    else:
+                        logger.warning(
+                            "Job '%s': %s, falling back to standalone",
+                            job["id"], err_msg,
+                        )
 
         if not delivered:
+            if partial_delivery:
+                delivery_errors.extend(target_errors)
+                continue
             if transport is not None and transport.is_relay:
                 # Relay owns the logical destination and its connector owns the
                 # platform credential. A native retry could duplicate delivery

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -28,6 +28,16 @@ logger = logging.getLogger(__name__)
 # preserved.
 MAX_PLATFORM_OUTPUT = 4000
 
+
+class PartialDeliveryError(RuntimeError):
+    """A failed delivery that already produced visible, non-reversible output."""
+
+    partial_delivery = True
+
+    def __init__(self, message: str, result: Any):
+        super().__init__(message)
+        self.result = result
+
 # Matches strings that are *only* a "silence" narration with optional markdown
 # wrappers. Covers: *(silent)*, _silent_, `silent`, ~silent~, (silent), silent,
 # 🔇, a bare ".", "…", and the whitespace/marker-padded variants seen in the
@@ -169,6 +179,17 @@ def _send_result_error(result: Any) -> Optional[str]:
     else:
         error = getattr(result, "error", None)
     return str(error) if error else None
+
+
+def _send_result_is_partial(result: Any) -> bool:
+    if isinstance(result, dict):
+        raw_response = result.get("raw_response")
+    else:
+        raw_response = getattr(result, "raw_response", None)
+    return (
+        isinstance(raw_response, dict)
+        and raw_response.get("partial_delivery") is True
+    )
 
 
 def _is_thread_not_found_delivery_error(result: Any) -> bool:
@@ -638,9 +659,11 @@ class DeliveryRouter:
                     metadata=send_metadata or None,
                 )
             if _send_result_failed(result):
-                raise RuntimeError(_send_result_error(result) or f"{target.platform.value} delivery failed")
+                error = _send_result_error(result) or f"{target.platform.value} delivery failed"
+                if _send_result_is_partial(result):
+                    raise PartialDeliveryError(error, result)
+                raise RuntimeError(error)
         return result
-
 
 
 

--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -14,7 +14,8 @@ bounded retention). The gateway writes three checkpoints around the send:
     record_obligation()   state='pending'     before any send attempt
     mark_attempting()     state='attempting'  immediately before the await
     mark_delivered() /    state='delivered'   only on SendResult.success
-    mark_failed()         state='failed'      on a definitive rejection
+    mark_failed() /       state='failed'      on a definitive rejection
+    mark_partial()        content=unsent tail when a visible prefix landed
 
 On startup, ``sweep_recoverable()`` claims rows whose owning process is
 dead and hands them to the gateway for redelivery. Crash semantics are
@@ -237,6 +238,26 @@ def mark_delivered(obligation_id: str) -> None:
 
 def mark_failed(obligation_id: str, error: str = "") -> None:
     _update_state(obligation_id, "failed", error=error)
+
+
+def mark_partial(
+    obligation_id: str,
+    remaining_content: str,
+    error: str = "",
+) -> None:
+    """Persist only the unsent tail so recovery cannot replay a visible prefix."""
+    with _DB_LOCK, _transaction() as conn:
+        conn.execute(
+            """UPDATE delivery_obligations
+               SET state='failed', content=?, updated_at=?, last_error=?
+               WHERE obligation_id=?""",
+            (
+                remaining_content,
+                time.time(),
+                error[:500] if error else None,
+                obligation_id,
+            ),
+        )
 
 
 def _update_state(obligation_id: str, state: str, error: str = "") -> None:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2475,7 +2475,10 @@ class SendResult:
     # raw_response["partial_overflow"] with delivered_chunks, total_chunks,
     # last_message_id, delivered_prefix, and continuation_message_ids so the
     # stream consumer can send the missing tail instead of marking a clipped
-    # response complete.
+    # response complete.  Chunking adapters may also set
+    # raw_response["partial_delivery"] when a failed send has already produced
+    # visible side effects; _send_with_retry() must then return the failure
+    # unchanged instead of retrying or sending a plain-text fallback.
     retryable: bool = False  # True for transient connection errors — base will retry automatically
     # Server-requested retry delay in seconds (e.g. Telegram FloodWait retry_after).
     # When present, _send_with_retry() honors this instead of its default backoff.
@@ -5416,6 +5419,15 @@ class BasePlatformAdapter(ABC):
         lowered = error.lower()
         return "timed out" in lowered or "readtimeout" in lowered or "writetimeout" in lowered
 
+    @staticmethod
+    def _is_partial_delivery_result(result: "SendResult") -> bool:
+        """Whether retry or fallback would duplicate an already-visible effect."""
+        raw_response = result.raw_response
+        return (
+            isinstance(raw_response, dict)
+            and raw_response.get("partial_delivery") is True
+        )
+
     def _unwrap_ephemeral(self, response: Any) -> Tuple[Optional[str], int]:
         """Unwrap a handler response into (text, ttl_seconds).
 
@@ -5494,6 +5506,15 @@ class BasePlatformAdapter(ABC):
         if result.success:
             return result
 
+        if self._is_partial_delivery_result(result):
+            logger.error(
+                "[%s] Partial delivery already produced visible messages; "
+                "automatic retry and fallback are unsafe: %s",
+                self.name,
+                result.error or "unknown send failure",
+            )
+            return result
+
         error_str = result.error or ""
         is_network = result.retryable or self._is_retryable_error(error_str)
 
@@ -5526,6 +5547,14 @@ class BasePlatformAdapter(ABC):
                 )
                 if result.success:
                     logger.info("[%s] Send succeeded on retry %d", self.name, attempt)
+                    return result
+                if self._is_partial_delivery_result(result):
+                    logger.error(
+                        "[%s] Retry partially delivered visible messages; "
+                        "further retry and fallback are unsafe: %s",
+                        self.name,
+                        result.error or "unknown send failure",
+                    )
                     return result
                 error_str = result.error or ""
                 if result.retry_after is not None:
@@ -6558,10 +6587,28 @@ class BasePlatformAdapter(ABC):
                             from gateway.delivery_ledger import (
                                 mark_delivered,
                                 mark_failed,
+                                mark_partial,
                             )
 
                             if getattr(result, "success", False):
                                 await asyncio.to_thread(mark_delivered, _obligation_id)
+                            elif self._is_partial_delivery_result(result):
+                                remaining_content = result.raw_response.get(
+                                    "remaining_content"
+                                )
+                                if isinstance(remaining_content, str):
+                                    await asyncio.to_thread(
+                                        mark_partial,
+                                        _obligation_id,
+                                        remaining_content,
+                                        str(getattr(result, "error", "") or ""),
+                                    )
+                                else:
+                                    await asyncio.to_thread(
+                                        mark_failed,
+                                        _obligation_id,
+                                        str(getattr(result, "error", "") or ""),
+                                    )
                             else:
                                 await asyncio.to_thread(
                                     mark_failed,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11605,6 +11605,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ledger_enabled,
                 mark_delivered,
                 mark_failed,
+                mark_partial,
                 sweep_recoverable,
             )
 
@@ -11669,11 +11670,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         row["obligation_id"], row["attempts"],
                     )
                 else:
-                    await asyncio.to_thread(
-                        mark_failed,
-                        row["obligation_id"],
-                        str(getattr(result, "error", "") or "send failed"),
+                    raw_response = getattr(result, "raw_response", None)
+                    remaining_content = (
+                        raw_response.get("remaining_content")
+                        if isinstance(raw_response, dict)
+                        and raw_response.get("partial_delivery") is True
+                        else None
                     )
+                    if isinstance(remaining_content, str):
+                        await asyncio.to_thread(
+                            mark_partial,
+                            row["obligation_id"],
+                            remaining_content,
+                            str(getattr(result, "error", "") or "send failed"),
+                        )
+                    else:
+                        await asyncio.to_thread(
+                            mark_failed,
+                            row["obligation_id"],
+                            str(getattr(result, "error", "") or "send failed"),
+                        )
             except Exception:
                 logger.debug("delivery ledger update failed", exc_info=True)
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -100,6 +100,12 @@ _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
 
+# ``buzz messages send`` accepts at most 65,536 UTF-8 bytes.  Use Buzz's own
+# conservative 60 KiB diff ceiling for message parts, leaving 4 KiB below the
+# hard limit plus a fixed allowance for the visible part label.
+_BUZZ_MESSAGE_MAX_BYTES = 61_440
+_BUZZ_CHUNK_LABEL_RESERVE_BYTES = 64
+
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
 _WS_AUTH_TIMEOUT = 20.0
@@ -110,6 +116,53 @@ _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
 # BUZZ_PRIVATE_KEY is not set.  Module-level so tests can point it at a tmpdir.
 _DEFAULT_CREDENTIALS_DIR = Path("~/.config/buzz").expanduser()
+
+
+def _utf8_prefix_length(text: str, byte_limit: int) -> int:
+    """Largest codepoint offset whose UTF-8 encoding fits ``byte_limit``."""
+    low, high = 0, len(text)
+    while low < high:
+        mid = (low + high + 1) // 2
+        if len(text[:mid].encode("utf-8")) <= byte_limit:
+            low = mid
+        else:
+            high = mid - 1
+    return low
+
+
+def _split_buzz_message(content: str) -> List[str]:
+    """Split oversized content without losing Unicode or boundary whitespace."""
+    if len(content.encode("utf-8")) <= _BUZZ_MESSAGE_MAX_BYTES:
+        return [content]
+
+    body_limit = _BUZZ_MESSAGE_MAX_BYTES - _BUZZ_CHUNK_LABEL_RESERVE_BYTES
+    bodies: List[str] = []
+    remaining = content
+    while remaining:
+        codepoint_limit = _utf8_prefix_length(remaining, body_limit)
+        if codepoint_limit >= len(remaining):
+            split_at = len(remaining)
+        else:
+            region = remaining[:codepoint_limit]
+            # Prefer a paragraph boundary in the latter half of the available
+            # region, then a newline, then the exact UTF-8-safe byte boundary.
+            split_at = region.rfind("\n\n")
+            if split_at >= codepoint_limit // 2:
+                split_at += 2
+            else:
+                split_at = region.rfind("\n")
+                if split_at >= codepoint_limit // 2:
+                    split_at += 1
+                else:
+                    split_at = codepoint_limit
+        bodies.append(remaining[:split_at])
+        remaining = remaining[split_at:]
+
+    total = len(bodies)
+    parts = [f"[Part {index}/{total}]\n\n{body}" for index, body in enumerate(bodies, 1)]
+    if any(len(part.encode("utf-8")) > _BUZZ_MESSAGE_MAX_BYTES for part in parts):
+        raise ValueError("Buzz chunk label exceeded reserved byte allowance")
+    return parts
 
 
 def _load_nostr_auth():
@@ -353,6 +406,8 @@ class BuzzAdapter(BasePlatformAdapter):
 
     Instantiated by the adapter_factory passed to register_platform().
     """
+
+    splits_long_messages = True
 
     def __init__(self, config, **kwargs):
         platform = Platform("buzz")
@@ -608,30 +663,95 @@ class BuzzAdapter(BasePlatformAdapter):
     ) -> SendResult:
         if not content:
             return SendResult(success=False, error="Empty message")
-        args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
         reply_target = reply_to or (metadata or {}).get("thread_id")
-        if reply_target:
-            args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_cli(args, input_text=content)
-        if code != 0:
-            return SendResult(
-                success=False,
-                error=_cli_error_message(err, code),
-                retryable=code == 2,
+        chunks = _split_buzz_message(content)
+        total = len(chunks)
+        message_ids: List[str] = []
+        delivered_bodies: List[str] = []
+        data: Dict[str, Any] = {}
+
+        for part_number, chunk in enumerate(chunks, 1):
+            args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
+            # Every part stays attached to the original parent. Buzz derives
+            # the thread root from that immediate parent via the relay.
+            if reply_target:
+                args += ["--reply-to", str(reply_target)]
+            code, out, err = await self._run_cli(args, input_text=chunk)
+            if code != 0:
+                error = _cli_error_message(err, code)
+                delivered_prefix = "".join(delivered_bodies)
+                if total > 1:
+                    delivered = part_number - 1
+                    noun = "part" if delivered == 1 else "parts"
+                    error = (
+                        f"Buzz delivery failed at part {part_number}/{total} after "
+                        f"{delivered} {noun} delivered: {error}"
+                    )
+                return SendResult(
+                    success=False,
+                    error=error,
+                    raw_response={
+                        "partial_delivery": part_number > 1,
+                        "delivered_message_ids": message_ids,
+                        "delivered_parts": part_number - 1,
+                        "delivered_prefix": delivered_prefix,
+                        "remaining_content": content[len(delivered_prefix):],
+                        "failed_part": part_number,
+                        "total_parts": total,
+                    },
+                    # Retrying the whole send after any successful part would
+                    # duplicate the already-published prefix.
+                    retryable=code == 2 and part_number == 1,
+                )
+            try:
+                parsed = json.loads(out or "{}")
+                data = parsed if isinstance(parsed, dict) else {}
+            except ValueError:
+                data = {}
+            if data.get("accepted", True) is False:
+                error = str(data.get("message") or data.get("error") or "Buzz rejected message")
+                delivered_prefix = "".join(delivered_bodies)
+                if total > 1:
+                    delivered = part_number - 1
+                    noun = "part" if delivered == 1 else "parts"
+                    error = (
+                        f"Buzz delivery failed at part {part_number}/{total} after "
+                        f"{delivered} {noun} delivered: {error}"
+                    )
+                    data = {
+                        **data,
+                        "partial_delivery": delivered > 0,
+                        "delivered_message_ids": message_ids,
+                        "delivered_parts": delivered,
+                        "delivered_prefix": delivered_prefix,
+                        "remaining_content": content[len(delivered_prefix):],
+                        "failed_part": part_number,
+                        "total_parts": total,
+                    }
+                return SendResult(success=False, error=error, raw_response=data)
+            event_id = data.get("event_id")
+            if event_id:
+                event_id = str(event_id)
+                message_ids.append(event_id)
+                # Belt-and-braces echo suppression: the poll loop already skips
+                # our own pubkey, but marking each id seen makes de-dupe explicit.
+                self._mark_seen(str(chat_id), event_id)
+            delivered_bodies.append(
+                chunk if total == 1 else chunk.split("\n\n", 1)[1]
             )
-        try:
-            data = json.loads(out or "{}")
-        except ValueError:
-            data = {}
-        event_id = data.get("event_id")
-        if event_id:
-            # Belt-and-braces echo suppression: the poll loop already skips
-            # our own pubkey, but marking the id seen makes de-dupe explicit.
-            self._mark_seen(str(chat_id), str(event_id))
+
+        raw_response: Any = data
+        if total > 1:
+            raw_response = {
+                "parts": total,
+                "message_ids": message_ids,
+                "last_response": data,
+            }
         return SendResult(
-            success=bool(data.get("accepted", True)),
-            message_id=str(event_id) if event_id else None,
-            raw_response=data,
+            success=True,
+            message_id=message_ids[-1] if message_ids else None,
+            raw_response=raw_response,
+            continuation_message_ids=tuple(message_ids[:-1]),
         )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
@@ -1385,26 +1505,68 @@ async def _standalone_send(
     if not target:
         return {"error": "Buzz standalone send: no target channel (set BUZZ_HOME_CHANNEL)"}
 
-    args = ["messages", "send", "--channel", target, "--content", "-"]
-    if thread_id:
-        args += ["--reply-to", str(thread_id)]
-    for path in media_files or []:
-        args += ["--file", str(path)]
-    try:
-        code, out, err = await _exec_buzz(
-            cli_path, args, relay_url=relay, private_key=private_key, input_text=message
-        )
-    except asyncio.CancelledError:
-        raise
-    except OSError as e:
-        return {"error": f"Buzz standalone send failed to launch CLI: {e}"}
-    if code != 0:
-        return {"error": f"Buzz standalone send failed: {_cli_error_message(err, code)}"}
-    try:
-        data = json.loads(out or "{}")
-    except ValueError:
-        data = {}
-    return {"success": True, "message_id": str(data.get("event_id") or "")}
+    chunks = _split_buzz_message(message)
+    total = len(chunks)
+    message_ids: List[str] = []
+    for part_number, chunk in enumerate(chunks, 1):
+        args = ["messages", "send", "--channel", target, "--content", "-"]
+        if thread_id:
+            args += ["--reply-to", str(thread_id)]
+        # Files are a single delivery side effect; repeating them on every text
+        # continuation would duplicate attachments.
+        if part_number == 1:
+            for path in media_files or []:
+                args += ["--file", str(path)]
+        try:
+            code, out, err = await _exec_buzz(
+                cli_path,
+                args,
+                relay_url=relay,
+                private_key=private_key,
+                input_text=chunk,
+            )
+        except asyncio.CancelledError:
+            raise
+        except OSError as e:
+            return {
+                "error": f"Buzz standalone send failed to launch CLI: {e}",
+                "partial_delivery": part_number > 1,
+                "delivered_message_ids": message_ids,
+            }
+        if code != 0:
+            return {
+                "error": f"Buzz standalone send failed: {_cli_error_message(err, code)}",
+                "partial_delivery": part_number > 1,
+                "delivered_message_ids": message_ids,
+                "delivered_parts": part_number - 1,
+                "failed_part": part_number,
+                "total_parts": total,
+            }
+        try:
+            data = json.loads(out or "{}")
+        except ValueError:
+            data = {}
+        if data.get("accepted", True) is False:
+            return {
+                "error": str(data.get("message") or data.get("error") or "Buzz rejected message"),
+                "partial_delivery": part_number > 1,
+                "delivered_message_ids": message_ids,
+                "delivered_parts": part_number - 1,
+                "failed_part": part_number,
+                "total_parts": total,
+            }
+        event_id = str(data.get("event_id") or "")
+        if event_id:
+            message_ids.append(event_id)
+
+    if total == 1:
+        return {"success": True, "message_id": message_ids[-1] if message_ids else ""}
+    return {
+        "success": True,
+        "message_id": message_ids[-1] if message_ids else "",
+        "message_ids": message_ids,
+        "parts": total,
+    }
 
 
 def interactive_setup() -> None:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1,10 +1,12 @@
 """Tests for cron/scheduler.py — origin resolution, delivery routing, and error logging."""
 
+import asyncio
 import contextlib
 import itertools
 import json
 import logging
 import os
+import threading
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
@@ -1920,20 +1922,15 @@ class TestParallelTick:
 
 
 class TestDeliverResultTimeoutCancelsFuture:
-    """When future.result(timeout=60) raises TimeoutError in the live adapter
-    delivery path, the outcome depends on whether the coroutine was already
-    running.  future.cancel() returning False means it is in flight on the wire
-    (cannot be un-sent) → treat as DELIVERED and skip the standalone fallback to
-    avoid a duplicate (#38922).  future.cancel() returning True means it never
-    started (wedged loop) → nothing was sent, so fall through to standalone or
-    the message is silently dropped.  Regression for #38922.
+    """Timeout fallback depends on an atomic adapter-entry handshake.
+
+    ``run_coroutine_threadsafe`` futures can report successful cancellation
+    after their asyncio task has started.  Cancellation status therefore cannot
+    safely decide whether standalone delivery would duplicate visible effects.
     """
 
-    def test_live_adapter_timeout_assumes_delivered_no_duplicate(self):
-        """End-to-end: live adapter confirmation times out past the 60s budget.
-        The fix (#38922) treats the send as already-dispatched/delivered and
-        does NOT run the standalone fallback — otherwise the message is sent
-        twice."""
+    def test_never_started_coroutine_uses_standalone_fallback(self):
+        """A coroutine aborted before adapter entry has no visible effects."""
         from gateway.config import Platform
         from concurrent.futures import Future
 
@@ -1949,11 +1946,9 @@ class TestDeliverResultTimeoutCancelsFuture:
         loop = MagicMock()
         loop.is_running.return_value = True
 
-        # A real concurrent.futures.Future, but we override .result() to raise
-        # TimeoutError exactly like the 60s wait firing in production.  We make
-        # .cancel() return False to simulate the coroutine being ALREADY RUNNING
-        # on the gateway loop (in flight on the wire) — the case where the send
-        # cannot be un-sent and a standalone resend would be a duplicate.
+        # The scheduled wrapper is closed without running, so its atomic
+        # dispatch state remains "not started". cancel() deliberately returns
+        # False to prove cancellation status is not the delivery oracle.
         captured_future = Future()
         cancel_calls = []
 
@@ -1987,12 +1982,80 @@ class TestDeliverResultTimeoutCancelsFuture:
                 loop=loop,
             )
 
-        # 1. cancel() was attempted (returned False = in flight).
+        # 1. Cancellation is still attempted to clean up the future.
         assert cancel_calls == [True], "future.cancel() should be attempted on TimeoutError"
-        # 2. Delivery is reported successful (no error string returned).
+        # 2. Standalone delivery succeeds, so the target succeeds overall.
         assert result is None, f"expected successful delivery, got error: {result!r}"
-        # 3. The standalone fallback must NOT run — that is the #38922 fix:
-        #    an in-flight confirmation timeout is assume-delivered, not a resend.
+        # 3. Adapter entry never occurred, so standalone fallback is safe.
+        standalone_send.assert_awaited_once()
+
+    def test_running_coroutine_cancel_true_does_not_resend_visible_prefix(
+        self, monkeypatch
+    ):
+        """A real loop may cancel a running send and return True.
+
+        Model the dangerous Buzz sequence: an adapter makes its first chunk
+        visible, stalls on a later chunk, and is cancelled by cron's timeout.
+        The original payload must not be handed to standalone delivery.
+        """
+        from gateway.config import Platform
+
+        buzz = Platform("buzz")
+        first_chunk_visible = threading.Event()
+        task_cancelled = threading.Event()
+
+        class StalledAfterVisibleChunkAdapter:
+            async def send(self, _target, _content, metadata=None):
+                first_chunk_visible.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    task_cancelled.set()
+                    raise
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {buzz: pconfig}
+        adapter = StalledAfterVisibleChunkAdapter()
+        standalone_send = AsyncMock(return_value={"success": True})
+        loop = asyncio.new_event_loop()
+        loop_thread = threading.Thread(target=loop.run_forever)
+        loop_thread.start()
+
+        job = {
+            "id": "buzz-timeout-after-visible-chunk",
+            "deliver": "origin",
+            "origin": {"platform": "buzz", "chat_id": "123"},
+        }
+
+        monkeypatch.setattr(
+            "cron.scheduler._LIVE_ADAPTER_SEND_TIMEOUT_SECONDS", 0.05
+        )
+        try:
+            with patch(
+                "gateway.config.load_gateway_config", return_value=mock_cfg
+            ), patch(
+                "cron.scheduler.load_config",
+                return_value={"cron": {"wrap_response": False}},
+            ), patch(
+                "tools.send_message_tool._send_to_platform", new=standalone_send
+            ):
+                result = _deliver_result(
+                    job,
+                    "x" * 70_000,
+                    adapters={buzz: adapter},
+                    loop=loop,
+                )
+                cancel_observed = task_cancelled.wait(timeout=1)
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            loop_thread.join(timeout=2)
+            loop.close()
+
+        assert first_chunk_visible.is_set()
+        assert cancel_observed
+        assert result is None
         standalone_send.assert_not_awaited()
 
 
@@ -2057,6 +2120,67 @@ class TestDeliverResultLiveAdapterUnconfirmed:
         result, standalone_send = self._run(None)
         assert result is None, f"standalone should have delivered, got: {result!r}"
         standalone_send.assert_awaited_once()
+
+
+class TestDeliverResultPartialDelivery:
+    def test_partial_live_delivery_does_not_fall_back_to_standalone(self):
+        from concurrent.futures import Future
+
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+
+        adapter = AsyncMock()
+        adapter.send.return_value = SendResult(
+            success=False,
+            error="part 2/2 failed after 1 part delivered",
+            raw_response={
+                "partial_delivery": True,
+                "delivered_parts": 1,
+                "failed_part": 2,
+            },
+        )
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        buzz_platform = Platform("buzz")
+        mock_cfg.platforms = {buzz_platform: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            import asyncio as _asyncio
+
+            future = Future()
+            try:
+                future.set_result(_asyncio.run(coro))
+            except BaseException as exc:  # noqa: BLE001
+                future.set_exception(exc)
+            return future
+
+        job = {
+            "id": "partial-buzz-job",
+            "deliver": "origin",
+            "origin": {"platform": "buzz", "chat_id": "channel-1"},
+        }
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=mock_cfg),
+            patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+            patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro),
+            patch("tools.send_message_tool._send_to_platform", new=standalone_send),
+        ):
+            result = _deliver_result(
+                job,
+                "x" * 70_000,
+                adapters={buzz_platform: adapter},
+                loop=loop,
+            )
+
+        assert "part 2/2 failed after 1 part delivered" in result
+        standalone_send.assert_not_awaited()
 
 
 class TestDeliverOriginUnresolvableIsLocal:

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -6,6 +6,8 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
+from gateway.config import GatewayConfig, Platform
+from gateway.delivery import DeliveryRouter, DeliveryTarget
 from tests.gateway._plugin_adapter_loader import load_plugin_adapter
 
 # Load plugins/platforms/buzz/adapter.py under a unique module name
@@ -24,6 +26,7 @@ validate_config = _buzz_mod.validate_config
 register = _buzz_mod.register
 _env_enablement = _buzz_mod._env_enablement
 _standalone_send = _buzz_mod._standalone_send
+_split_buzz_message = _buzz_mod._split_buzz_message
 
 # Real key pair (Chip's public identity — public information, not a secret)
 SELF_PUBKEY = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
@@ -386,6 +389,26 @@ class TestDmClassification:
 
 class TestBuzzAdapterSend:
 
+    @pytest.mark.parametrize(
+        ("content", "expected_parts"),
+        [
+            ("x" * 61_439, 1),
+            ("x" * 61_440, 1),
+            ("x" * 61_441, 2),
+            ("🎉" * 15_360, 1),
+            ("🎉" * 15_361, 2),
+        ],
+    )
+    def test_split_uses_utf8_byte_threshold(self, content, expected_parts):
+        parts = _split_buzz_message(content)
+
+        assert len(parts) == expected_parts
+        assert all(len(part.encode("utf-8")) <= 61_440 for part in parts)
+        if expected_parts == 1:
+            assert parts == [content]
+        else:
+            assert "".join(part.split("\n\n", 1)[1] for part in parts) == content
+
     @pytest.mark.asyncio
     async def test_send_success_via_stdin(self):
         adapter = _make_adapter()
@@ -406,6 +429,146 @@ class TestBuzzAdapterSend:
         assert stdin_text == "hello **markdown**"
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
+
+    @pytest.mark.asyncio
+    async def test_router_preserves_output_above_gateway_cap(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt124"})
+        adapter._run_cli = cli
+        router = DeliveryRouter(GatewayConfig(), adapters={Platform.BUZZ: adapter})
+        content = "x" * 5_000
+
+        result = await router._deliver_to_platform(
+            DeliveryTarget.parse(f"buzz:{CHANNEL}"),
+            content,
+            metadata={"job_id": "long-buzz"},
+        )
+
+        assert result.success is True
+        assert [stdin_text for _args, stdin_text in cli.calls] == [content]
+
+    @pytest.mark.asyncio
+    async def test_send_splits_utf8_payloads_with_order_and_reply_anchor(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        for event_id in ("evt-a", "evt-b", "evt-c"):
+            cli.script(
+                "messages", "send", {"accepted": True, "event_id": event_id}
+            )
+        adapter._run_cli = cli
+        content = (("paragraph one 🎉\n\n" + ("数据" * 5_000) + "\n\n") * 4)
+
+        result = await adapter.send(CHANNEL, content, reply_to="a" * 64)
+
+        assert result.success is True
+        assert len(cli.calls) > 1
+        payloads = [stdin_text for _args, stdin_text in cli.calls]
+        assert all(len(payload.encode("utf-8")) <= 61_440 for payload in payloads)
+        assert all(
+            args[args.index("--reply-to") + 1] == "a" * 64
+            for args, _stdin_text in cli.calls
+        )
+        bodies = [payload.split("\n\n", 1)[1] for payload in payloads]
+        assert "".join(bodies) == content
+
+    @pytest.mark.asyncio
+    async def test_send_stops_and_reports_partial_chunk_failure(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-a"})
+        cli.script("messages", "send", "", code=2, stderr="relay unavailable")
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-c"})
+        adapter._run_cli = cli
+
+        content = "x" * 130_000
+        result = await adapter.send(CHANNEL, content)
+
+        assert result.success is False
+        assert result.retryable is False
+        assert "part 2/3" in result.error
+        assert "1 part delivered" in result.error
+        assert (
+            result.raw_response["delivered_prefix"]
+            + result.raw_response["remaining_content"]
+            == content
+        )
+        assert len(cli.calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_send_with_retry_does_not_duplicate_partial_delivery(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-a"})
+        cli.script("messages", "send", "", code=2, stderr="network unreachable")
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-c"})
+        adapter._run_cli = cli
+
+        result = await adapter._send_with_retry(
+            CHANNEL,
+            "x" * 130_000,
+            max_retries=1,
+            base_delay=0,
+        )
+
+        assert result.success is False
+        assert result.retryable is False
+        assert result.raw_response["partial_delivery"] is True
+        assert len(cli.calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_send_with_retry_does_not_fallback_after_partial_rejection(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-a"})
+        cli.script("messages", "send", {"accepted": False, "error": "rejected"})
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-c"})
+        adapter._run_cli = cli
+
+        result = await adapter._send_with_retry(CHANNEL, "x" * 130_000)
+
+        assert result.success is False
+        assert result.raw_response["partial_delivery"] is True
+        assert result.raw_response["delivered_message_ids"] == ["evt-a"]
+        assert len(cli.calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_stops_when_later_attempt_partially_delivers(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", "", code=2, stderr="network unreachable")
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-a"})
+        cli.script("messages", "send", "", code=2, stderr="network unreachable")
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-c"})
+        adapter._run_cli = cli
+
+        result = await adapter._send_with_retry(
+            CHANNEL,
+            "x" * 130_000,
+            max_retries=1,
+            base_delay=0,
+        )
+
+        assert result.success is False
+        assert result.raw_response["partial_delivery"] is True
+        assert result.raw_response["delivered_message_ids"] == ["evt-a"]
+        assert len(cli.calls) == 3
+
+    @pytest.mark.asyncio
+    async def test_send_keeps_first_chunk_failure_retryable(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", "", code=2, stderr="relay unavailable")
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "x" * 130_000)
+
+        assert result.success is False
+        assert result.retryable is True
+        assert "part 1/3" in result.error
+        assert "0 parts delivered" in result.error
+        assert len(cli.calls) == 1
 
 
     @pytest.mark.asyncio
@@ -537,4 +700,39 @@ class TestStandaloneSend:
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
+    @pytest.mark.asyncio
+    async def test_standalone_send_splits_long_utf8_payload_without_duplicate_files(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.config import PlatformConfig
 
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        calls = []
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
+            calls.append((args, input_text))
+            return 0, json.dumps({"accepted": True, "event_id": f"evt-{len(calls)}"}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        content = ("report 🎉\n\n" + ("数据" * 8_000)) * 3
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            CHANNEL,
+            content,
+            thread_id="a" * 64,
+            media_files=["/tmp/report.pdf"],
+        )
+
+        assert result["success"] is True
+        assert result["parts"] == len(calls)
+        assert len(calls) > 1
+        assert all(len(payload.encode("utf-8")) <= 61_440 for _args, payload in calls)
+        assert "--file" in calls[0][0]
+        assert all("--file" not in args for args, _payload in calls[1:])
+        assert all(args[args.index("--reply-to") + 1] == "a" * 64 for args, _ in calls)
+        assert "".join(payload.split("\n\n", 1)[1] for _args, payload in calls) == content

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -111,6 +111,17 @@ class TestSweep:
         _record()  # owner = this (live) process
         assert dl.sweep_recoverable() == []
 
+    def test_partial_row_claims_only_unsent_tail(self):
+        _record(content="visible prefix plus unsent tail")
+        dl.mark_partial("ob-1", "unsent tail", "part 2 failed")
+        _orphan("ob-1")
+
+        claimed = dl.sweep_recoverable()
+
+        assert len(claimed) == 1
+        assert claimed[0]["content"] == "unsent tail"
+        assert claimed[0]["needs_marker"] is True
+
     def test_dead_owner_pending_claimed_without_marker(self):
         _record()
         _orphan("ob-1")
@@ -198,6 +209,46 @@ class TestGatewayRedeliverySweep:
         sent = adapter.send.call_args.kwargs
         assert sent["content"].startswith(dl.RECOVERED_MARKER)
         assert sent["content"].endswith("the final answer")
+
+    @pytest.mark.asyncio
+    async def test_partial_redelivery_sends_only_unsent_tail(self):
+        _record(content="visible prefix plus unsent tail")
+        dl.mark_partial("ob-1", "unsent tail", "part 2 failed")
+        _orphan("ob-1")
+        adapter = self._adapter()
+        runner = self._runner(adapter)
+
+        await runner._redeliver_pending_obligations()
+
+        sent = adapter.send.call_args.kwargs["content"]
+        assert sent == dl.RECOVERED_MARKER + "unsent tail"
+        assert "visible prefix" not in sent
+        assert _row("ob-1")["state"] == "delivered"
+
+    @pytest.mark.asyncio
+    async def test_repeated_partial_redelivery_advances_unsent_tail(self):
+        from gateway.platforms.base import SendResult
+
+        _record(content="first tail then second tail")
+        dl.mark_partial("ob-1", "first tail then second tail", "part 2 failed")
+        _orphan("ob-1")
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SendResult(
+                success=False,
+                error="recovery part failed",
+                raw_response={
+                    "partial_delivery": True,
+                    "remaining_content": "second tail",
+                },
+            )
+        )
+        runner = self._runner(adapter)
+
+        await runner._redeliver_pending_obligations()
+
+        assert _row("ob-1")["state"] == "failed"
+        assert _row("ob-1")["content"] == "second tail"
 
     @pytest.mark.parametrize(
         ("send_success", "ledger_method"),

--- a/tests/gateway/test_delivery_ledger_producer.py
+++ b/tests/gateway/test_delivery_ledger_producer.py
@@ -122,6 +122,72 @@ class TestProducerHook:
         assert len(rows) == 1
         assert rows[0][1] == "failed"
 
+    @pytest.mark.asyncio
+    async def test_partial_send_persists_only_unsent_tail(self):
+        adapter = _Adapter()
+        adapter.send = AsyncMock(
+            return_value=SendResult(
+                success=False,
+                error="part 2 failed after part 1 delivered",
+                raw_response={
+                    "partial_delivery": True,
+                    "delivered_prefix": "final ",
+                    "remaining_content": "answer",
+                },
+            )
+        )
+
+        await _run(adapter, _event())
+
+        rows = _rows()
+        assert len(rows) == 1
+        assert rows[0][1] == "failed"
+        assert rows[0][2] == "answer"
+
+    @pytest.mark.asyncio
+    async def test_partial_send_recovers_only_unsent_tail_after_restart(self):
+        from gateway.run import GatewayRunner
+
+        adapter = _Adapter()
+        adapter.send = AsyncMock(
+            return_value=SendResult(
+                success=False,
+                error="part 2 failed after part 1 delivered",
+                raw_response={
+                    "partial_delivery": True,
+                    "delivered_prefix": "final ",
+                    "remaining_content": "answer",
+                },
+            )
+        )
+        await _run(adapter, _event())
+
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET owner_pid=999999999, "
+                "owner_started_at=1"
+            )
+
+        recovery_adapter = MagicMock()
+        recovery_adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="recovered-1")
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = {Platform.SLACK: recovery_adapter}
+        store = MagicMock()
+        store.clear_resume_pending = AsyncMock()
+        store._store = None
+        runner.session_store = None
+        runner._async_session_store = store
+
+        recovered = await runner._redeliver_pending_obligations()
+
+        assert recovered == 1
+        resent = recovery_adapter.send.call_args.kwargs["content"]
+        assert resent == dl.RECOVERED_MARKER + "answer"
+        assert "final answer" not in resent
+        assert _rows()[0][1] == "delivered"
+
 
     @pytest.mark.asyncio
     async def test_slow_ledger_record_does_not_block_event_loop(self):


### PR DESCRIPTION
## Summary

- split oversized Buzz messages on UTF-8 byte boundaries below Buzz's diff ceiling while preserving order and reply anchors
- propagate visible partial-delivery state through adapter retries and cron routing so already-published chunks are not resent
- persist only the unsent tail in the delivery ledger, including repeated partial recovery after restart
- make cron timeout fallback depend on an atomic adapter-entry handshake instead of concurrent future cancellation status

## Testing

- 189 focused tests passed across Buzz adapter/websocket delivery, shared retry handling, cron routing, and delivery-ledger recovery
- real asyncio-loop regression covers a visible first Buzz chunk, stalled later chunk, successful cancellation, and no standalone resend
- exact ASCII and four-byte UTF-8 boundary cases cover 61,439 through 61,444 bytes
- Ruff passed on all changed implementation and test files

## Notes

- no live Buzz canary was run; this is intentionally a draft for maintainer review and CI
