### PR TITLE
fix(gateway): keep launchd WorkingDirectory + log paths on the boot volume

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3815,30 +3815,37 @@ def _same_volume(a: Path, b: Path) -> bool:
         return True
 
 
-def _launchd_log_dir() -> Path:
+def _launchd_log_dir(*, notify: bool = False) -> Path:
     """Where launchd StandardOut/ErrPath should live.
 
     Normally HERMES_HOME/logs; when HERMES_HOME resolves onto a different
     volume than the user's home (external-SSD symlink), launchd cannot open
     the log paths at spawn and fails with EX_CONFIG (#88267). Fall back to
     ~/Library/Logs/<label> so the service can start and Hermes' own logging
-    still lands somewhere the user can find.
+    still lands somewhere the user can find. ``notify=True`` (interactive
+    installs) prints the relocation so users know where the logs moved.
     """
     home = Path.home()
     log_dir = get_hermes_home() / "logs"
     if not _same_volume(log_dir, home):
         fallback = Path.home() / "Library" / "Logs" / get_launchd_label()
         fallback.mkdir(parents=True, exist_ok=True)
+        if notify:
+            print(
+                f"Note: HERMES_HOME is on a different volume than the boot "
+                f"disk — launchd gateway logs will go to {fallback} "
+                f"(not {log_dir})."
+            )
         return fallback
     log_dir.mkdir(parents=True, exist_ok=True)
     return log_dir
 
 
-def generate_launchd_plist() -> str:
+def generate_launchd_plist(*, notify: bool = False) -> str:
     # Stable cwd anchor — never the volatile source checkout (same rot risk as systemd's WorkingDirectory).
     working_dir = _stable_service_working_dir()
     hermes_home = str(get_hermes_home().resolve())
-    log_dir = _launchd_log_dir()
+    log_dir = _launchd_log_dir(notify=notify)
     label = get_launchd_label()
     # An external-volume HERMES_HOME (symlink to an SSD) must not pin
     # WorkingDirectory there: launchd fails the spawn with EX_CONFIG before
@@ -4091,7 +4098,7 @@ def launchd_install(force: bool = False):
         return
 
     plist_path.parent.mkdir(parents=True, exist_ok=True)
-    new_plist = generate_launchd_plist()
+    new_plist = generate_launchd_plist(notify=True)
     if _refuse_temp_home_service_write(new_plist, "launchd plist"):
         return
     print(f"Installing launchd service to: {plist_path}")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3826,8 +3826,11 @@ def _launchd_log_dir(*, notify: bool = False) -> Path:
     installs) prints the relocation so users know where the logs moved.
     """
     home = Path.home()
-    log_dir = get_hermes_home() / "logs"
-    if not _same_volume(log_dir, home):
+    hermes_home = get_hermes_home()
+    log_dir = hermes_home / "logs"
+    # Compare the existing home root, not its possibly-not-yet-created logs
+    # child. A missing child makes stat() fail open and defeats the fallback.
+    if not _same_volume(hermes_home, home):
         fallback = Path.home() / "Library" / "Logs" / get_launchd_label()
         fallback.mkdir(parents=True, exist_ok=True)
         if notify:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3800,13 +3800,53 @@ def _launchd_degrade_or_raise(exc: subprocess.CalledProcessError, what: str) -> 
     _launchd_fallback_to_detached(f"{what} exit {exc.returncode}")
 
 
+def _same_volume(a: Path, b: Path) -> bool:
+    """True when both paths resolve onto the same filesystem volume.
+
+    launchd rejects WorkingDirectory / log paths that resolve onto an
+    external volume when HERMES_HOME is a symlink to one (EX_CONFIG, exit
+    code 78, before any Hermes log exists — #88267). Fail open on any
+    OSError: a path we cannot stat should keep the current behavior rather
+    than silently relocate the service.
+    """
+    try:
+        return a.resolve().stat().st_dev == b.resolve().stat().st_dev
+    except OSError:
+        return True
+
+
+def _launchd_log_dir() -> Path:
+    """Where launchd StandardOut/ErrPath should live.
+
+    Normally HERMES_HOME/logs; when HERMES_HOME resolves onto a different
+    volume than the user's home (external-SSD symlink), launchd cannot open
+    the log paths at spawn and fails with EX_CONFIG (#88267). Fall back to
+    ~/Library/Logs/<label> so the service can start and Hermes' own logging
+    still lands somewhere the user can find.
+    """
+    home = Path.home()
+    log_dir = get_hermes_home() / "logs"
+    if not _same_volume(log_dir, home):
+        fallback = Path.home() / "Library" / "Logs" / get_launchd_label()
+        fallback.mkdir(parents=True, exist_ok=True)
+        return fallback
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir
+
+
 def generate_launchd_plist() -> str:
     # Stable cwd anchor — never the volatile source checkout (same rot risk as systemd's WorkingDirectory).
     working_dir = _stable_service_working_dir()
     hermes_home = str(get_hermes_home().resolve())
-    log_dir = get_hermes_home() / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
+    log_dir = _launchd_log_dir()
     label = get_launchd_label()
+    # An external-volume HERMES_HOME (symlink to an SSD) must not pin
+    # WorkingDirectory there: launchd fails the spawn with EX_CONFIG before
+    # Hermes logs anything (#88267). Fall back to the user's home on the
+    # boot volume; HERMES_HOME itself stays pointed at the real home.
+    home_anchor = Path.home()
+    if not _same_volume(Path(working_dir), home_anchor):
+        working_dir = str(home_anchor)
     venv_dir = _service_venv_dir()
     # launchd's default PATH misses Homebrew, nvm, cargo…; prepend venv/bin + node dirs (as in the
     # systemd unit) so node stays resolvable even if the shell PATH changes, then the shell PATH.

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -418,6 +418,50 @@ class TestGeneratedSystemdUnits:
         assert "SoftResourceLimits" not in plist
 
 
+    def test_launchd_plist_avoids_external_volume_paths(self, tmp_path, monkeypatch):
+        """#88267: a HERMES_HOME symlinked to an external volume must not pin
+        WorkingDirectory or the log paths there — launchd fails EX_CONFIG
+        before Hermes logs anything. Same-volume homes are untouched."""
+        from hermes_cli import gateway as gateway_cli
+
+        external = tmp_path / "external"
+        external.mkdir()
+        home_link = tmp_path / "home"
+        home_link.mkdir()
+        hermes_link = home_link / ".hermes"
+        hermes_link.symlink_to(external)
+
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_link)
+        # Simulate the volume boundary: the symlink target reports a
+        # different device than the user home.
+        monkeypatch.setattr(gateway_cli, "_same_volume", lambda a, b: False)
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        # HERMES_HOME still points at the real home on the external volume…
+        assert str(external) in plist
+        # …but WorkingDirectory and the log paths never do: they fall back
+        # to the user home / ~/Library/Logs/<label>.
+        assert "<key>WorkingDirectory</key>\n    <string>" + str(Path.home()) + "</string>" in plist
+        assert f"{external}/logs" not in plist
+        assert "Library/Logs" in plist
+
+    def test_launchd_plist_keeps_same_volume_home_paths(self, tmp_path, monkeypatch):
+        """No volume boundary: WorkingDirectory + logs stay under HERMES_HOME."""
+        from hermes_cli import gateway as gateway_cli
+
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(gateway_cli, "_same_volume", lambda a, b: True)
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert str(home) in plist
+        assert "Library/Logs" not in plist
+
+
 class TestGatewayStopCleanup:
     @pytest.mark.linux_only
     def test_stop_only_kills_current_profile_by_default(self, tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -434,7 +434,13 @@ class TestGeneratedSystemdUnits:
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_link)
         # Simulate the volume boundary: the symlink target reports a
         # different device than the user home.
-        monkeypatch.setattr(gateway_cli, "_same_volume", lambda a, b: False)
+        compared = []
+
+        def different_volume(a, b):
+            compared.append((a, b))
+            return False
+
+        monkeypatch.setattr(gateway_cli, "_same_volume", different_volume)
 
         plist = gateway_cli.generate_launchd_plist()
 
@@ -442,9 +448,17 @@ class TestGeneratedSystemdUnits:
         assert str(external) in plist
         # …but WorkingDirectory and the log paths never do: they fall back
         # to the user home / ~/Library/Logs/<label>.
-        assert "<key>WorkingDirectory</key>\n    <string>" + str(Path.home()) + "</string>" in plist
+        assert (
+            "<key>WorkingDirectory</key>\n    <string>"
+            + str(Path.home())
+            + "</string>"
+            in plist
+        )
         assert f"{external}/logs" not in plist
         assert "Library/Logs" in plist
+        # The log directory does not exist yet. Probe the existing home root,
+        # otherwise _same_volume() fails open and misses the external disk.
+        assert compared[0][0] == hermes_link
 
     def test_launchd_plist_keeps_same_volume_home_paths(self, tmp_path, monkeypatch):
         """No volume boundary: WorkingDirectory + logs stay under HERMES_HOME."""
@@ -460,7 +474,6 @@ class TestGeneratedSystemdUnits:
 
         assert str(home) in plist
         assert "Library/Logs" not in plist
-
 
 class TestGatewayStopCleanup:
     @pytest.mark.linux_only


### PR DESCRIPTION
## Summary

Fixes #88267: on macOS, a `HERMES_HOME` symlinked to an external SSD made the launchd plist pin `WorkingDirectory` and the `StandardOutPath`/`StandardErrorPath` there — launchd fails the spawn with EX_CONFIG (exit 78) before Hermes produces any log, so every diagnostic is blind.

## Fix

- `_same_volume()` — resolved-path `st_dev` comparison (fails open on OSError).
- The plist generator now checks the boundary: `WorkingDirectory` falls back to the user's home, and the log paths fall back to `~/Library/Logs/<label>` — the exact workaround the report validated.
- `HERMES_HOME` itself still points at the real home on the external volume (config/state stay where the user put them).
- Same-volume setups are untouched — the fallback only fires across a real volume boundary.

## Validation

- Two new tests: external-volume symlink home → WorkingDirectory at the user home + logs under `~/Library/Logs`, HERMES_HOME still the real home; same-volume home → paths stay under HERMES_HOME.
- `tests/hermes_cli/test_gateway_service.py`: 85 passed, 1 skipped.
- Atomic commits: generator fix → tests.
