### PR TITLE
fix(gui-uninstall): detect agent in shared home when profile redirects

### DIFF
--- a/hermes_cli/gui_uninstall.py
+++ b/hermes_cli/gui_uninstall.py
@@ -40,7 +40,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, _get_platform_default_hermes_home
 
 from hermes_cli.colors import Colors, color
 
@@ -170,6 +170,13 @@ def agent_is_installed(hermes_home: Path) -> bool:
         return True
     if (agent_root / "venv").is_dir() or (agent_root / ".venv").is_dir():
         return True
+    # Profile redirect: when the active profile points HERMES_HOME at a
+    # data-only profile dir (no agent code by design), fall back to the
+    # platform default home where the shared agent actually lives. Without
+    # this the desktop uninstall panel hides the remove-agent options.
+    default_root = _get_platform_default_hermes_home()
+    if hermes_home != default_root:
+        return agent_is_installed(default_root)
     return False
 
 


### PR DESCRIPTION
## Problem

The desktop uninstall probe (`agent_is_installed()` in `hermes_cli/gui_uninstall.py`) only checked the active profile's `HERMES_HOME`. In multi-profile setups the active profile redirects that env var to a data-only profile directory that intentionally contains no agent code. The probe then answered `agent_installed: false`, and the desktop app hid the "remove agent" options in **Settings → Danger zone**.

## Fix

When the active profile's `HERMES_HOME` differs from the platform default, fall back to `_get_platform_default_hermes_home()` and check that shared install location. The shared agent install is detected regardless of profile redirect.

## Verification

- Probe reports `agent_installed: true` for a profile-dir home that points at the shared agent.
- Existing checks for a source checkout / venv under the active home are unchanged.