### PR TITLE
fix(cli,tui): skip Kitty keyboard protocol push for Ghostty, use modifyOtherKeys only

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4095,6 +4095,13 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
     "\x1b[?25h"    # ensure cursor visible
 )
 _EXTENDED_ENTER_KEYS_SEQ = "\x1b[>1u\x1b[>4;2m"
+# Ghostty: push ONLY modifyOtherKeys, not the Kitty keyboard protocol.
+# Ghostty's Kitty disambiguate-mode implementation strips the Alt modifier
+# from the Backspace key — Option+Backspace arrives as bare \x7f instead of
+# the expected \x1b[27;3;127~, breaking backward-kill-word (#87630
+# regression).  modifyOtherKeys mode works correctly on Ghostty and covers
+# every modified key combo the alias table handles.
+_GHOSTTY_EXTENDED_ENTER_KEYS_SEQ = "\x1b[>4;2m"
 
 
 _BACKSLASH_LINE_CONTINUATION_RE = re.compile(r"\\[ \t]*$")
@@ -4148,20 +4155,37 @@ def _enable_extended_enter_keys(output=None, env: Optional[Mapping[str, str]] = 
     Ctrl+C, which is handled by prompt_toolkit's ``c-c`` binding (raw mode
     clears ISIG, so the kernel INTR path was never in play for the CLI).
 
+    Ghostty exception: Ghostty's Kitty disambiguate mode strips the Alt
+    modifier from the Backspace key, so Option+Backspace arrives as bare
+    \x7f instead of \x1b[27;3;127~, breaking backward-kill-word.  Ghostty
+    implements modifyOtherKeys correctly, so for Ghostty we push only
+    modifyOtherKeys and skip the Kitty protocol push.
+
     The exit reset sequence pops/resets both modes, so this is safe across
     normal exits, Ctrl+C, and SIGTERM cleanup.
     """
     if not _terminal_supports_extended_enter_keys(env):
         return False
     try:
+        # Ghostty: skip Kitty protocol, use only modifyOtherKeys.
+        if env is None:
+            env = os.environ
+        term_program = (env.get("TERM_PROGRAM") or "").strip()
+        term = (env.get("TERM") or "").strip().lower()
+        is_ghostty = (
+            term_program == "ghostty"
+            or term == "xterm-ghostty"
+        )
+        seq = _GHOSTTY_EXTENDED_ENTER_KEYS_SEQ if is_ghostty else _EXTENDED_ENTER_KEYS_SEQ
+
         target = output
         if target is not None and hasattr(target, "write_raw"):
-            target.write_raw(_EXTENDED_ENTER_KEYS_SEQ)
+            target.write_raw(seq)
             target.flush()
             return True
         stream = sys.stdout
         if stream is not None and stream.isatty():
-            stream.write(_EXTENDED_ENTER_KEYS_SEQ)
+            stream.write(seq)
             stream.flush()
             return True
     except Exception:

--- a/cli.py
+++ b/cli.py
@@ -4094,17 +4094,34 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
     "\x1b[0m"      # reset text attributes
     "\x1b[?25h"    # ensure cursor visible
 )
-_EXTENDED_ENTER_KEYS_SEQ = "\x1b[>1u\x1b[>4;2m"
-# Ghostty: push ONLY modifyOtherKeys, not the Kitty keyboard protocol.
-# Ghostty's Kitty disambiguate-mode implementation strips the Alt modifier
-# from the Backspace key — Option+Backspace arrives as bare \x7f instead of
-# the expected \x1b[27;3;127~, breaking backward-kill-word (#87630
-# regression).  modifyOtherKeys mode works correctly on Ghostty and covers
-# every modified key combo the alias table handles.
-_GHOSTTY_EXTENDED_ENTER_KEYS_SEQ = "\x1b[>4;2m"
+_KITTY_KEYBOARD_PUSH_SEQ = "\x1b[>1u"
+_MODIFY_OTHER_KEYS_SEQ = "\x1b[>4;2m"
+_EXTENDED_ENTER_KEYS_SEQ = _KITTY_KEYBOARD_PUSH_SEQ + _MODIFY_OTHER_KEYS_SEQ
 
 
 _BACKSLASH_LINE_CONTINUATION_RE = re.compile(r"\\[ \t]*$")
+
+
+def _is_ghostty_terminal(env: Optional[Mapping[str, str]] = None) -> bool:
+    """Whether the terminal is Ghostty (either detection path).
+
+    Ghostty must be pushed ONLY modifyOtherKeys, not the Kitty keyboard
+    protocol: its Kitty disambiguate-mode implementation strips the Alt
+    modifier from the Backspace key, so Option+Backspace arrives as bare
+    \\x7f instead of the CSI-u form ``\\x1b[127;3u`` the protocol calls for
+    (upstream Ghostty bug), breaking backward-kill-word (#87630
+    regression).  Ghostty implements modifyOtherKeys correctly (it then
+    emits ``\\x1b[27;3;127~``, which the alias table also maps).
+
+    Matches exactly the two conditions that admit Ghostty through
+    ``_terminal_supports_extended_enter_keys``.
+    """
+    if env is None:
+        env = os.environ
+    return (
+        (env.get("TERM_PROGRAM") or "").strip() == "ghostty"
+        or (env.get("TERM") or "").strip().lower() == "xterm-ghostty"
+    )
 
 
 def _terminal_supports_extended_enter_keys(env: Optional[Mapping[str, str]] = None) -> bool:
@@ -4138,7 +4155,9 @@ def _enable_extended_enter_keys(output=None, env: Optional[Mapping[str, str]] = 
 
     Writes the Kitty keyboard protocol push (CSI >1u, disambiguate mode) AND
     xterm modifyOtherKeys level 2 (CSI >4;2m), mirroring the Ink TUI —
-    terminals honor whichever protocol they implement.  Both are needed:
+    terminals honor whichever protocol they implement (except Ghostty, which
+    gets only modifyOtherKeys; see the Ghostty exception below).  Both are
+    needed:
     kitty-the-terminal removed modifyOtherKeys support entirely (it only
     speaks its own protocol), while tmux/VS Code only accept modifyOtherKeys.
 
@@ -4155,29 +4174,17 @@ def _enable_extended_enter_keys(output=None, env: Optional[Mapping[str, str]] = 
     Ctrl+C, which is handled by prompt_toolkit's ``c-c`` binding (raw mode
     clears ISIG, so the kernel INTR path was never in play for the CLI).
 
-    Ghostty exception: Ghostty's Kitty disambiguate mode strips the Alt
-    modifier from the Backspace key, so Option+Backspace arrives as bare
-    \x7f instead of \x1b[27;3;127~, breaking backward-kill-word.  Ghostty
-    implements modifyOtherKeys correctly, so for Ghostty we push only
-    modifyOtherKeys and skip the Kitty protocol push.
+    Ghostty exception: pushes only modifyOtherKeys — see
+    ``_is_ghostty_terminal`` for the full rationale (#87630).
 
     The exit reset sequence pops/resets both modes, so this is safe across
     normal exits, Ctrl+C, and SIGTERM cleanup.
     """
     if not _terminal_supports_extended_enter_keys(env):
         return False
+    # Ghostty exception: only modifyOtherKeys — see _is_ghostty_terminal.
+    seq = _MODIFY_OTHER_KEYS_SEQ if _is_ghostty_terminal(env) else _EXTENDED_ENTER_KEYS_SEQ
     try:
-        # Ghostty: skip Kitty protocol, use only modifyOtherKeys.
-        if env is None:
-            env = os.environ
-        term_program = (env.get("TERM_PROGRAM") or "").strip()
-        term = (env.get("TERM") or "").strip().lower()
-        is_ghostty = (
-            term_program == "ghostty"
-            or term == "xterm-ghostty"
-        )
-        seq = _GHOSTTY_EXTENDED_ENTER_KEYS_SEQ if is_ghostty else _EXTENDED_ENTER_KEYS_SEQ
-
         target = output
         if target is not None and hasattr(target, "write_raw"):
             target.write_raw(seq)

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -154,10 +154,8 @@ def test_unknown_terminal_does_not_enable_extended_enter_keys():
 
 
 # ---------------------------------------------------------------------------
-# Ghostty: must push ONLY modifyOtherKeys, not the Kitty keyboard protocol.
-# Ghostty's Kitty disambiguate mode strips the Alt modifier from Backspace,
-# so Option+Backspace arrives as bare \x7f instead of \x1b[27;3;127~,
-# breaking backward-kill-word.  modifyOtherKeys mode works correctly.
+# Ghostty: must push ONLY modifyOtherKeys, not the Kitty keyboard protocol —
+# see cli._is_ghostty_terminal for the full rationale (#87630).
 # ---------------------------------------------------------------------------
 class _FakeOutput:
     """Minimal output object with write_raw + flush for _enable_extended_enter_keys."""
@@ -237,3 +235,14 @@ def test_proc_version_microsoft_marker_preserves_newline():
 # ---------------------------------------------------------------------------
 # install_ctrl_enter_alias() — ANSI sequence mappings for enhanced terminals
 # ---------------------------------------------------------------------------
+
+
+def test_is_ghostty_terminal_detection_paths():
+    """_is_ghostty_terminal matches exactly the two allowlist conditions."""
+    import cli as cli_mod
+
+    assert cli_mod._is_ghostty_terminal({"TERM_PROGRAM": "ghostty"}) is True
+    assert cli_mod._is_ghostty_terminal({"TERM": "xterm-ghostty"}) is True
+    assert cli_mod._is_ghostty_terminal({"TERM": "XTERM-GHOSTTY"}) is True
+    assert cli_mod._is_ghostty_terminal({"TERM_PROGRAM": "iTerm.app"}) is False
+    assert cli_mod._is_ghostty_terminal({}) is False

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -153,6 +153,66 @@ def test_unknown_terminal_does_not_enable_extended_enter_keys():
     assert cli_mod._terminal_supports_extended_enter_keys({"TERM_PROGRAM": "unknown"}) is False
 
 
+# ---------------------------------------------------------------------------
+# Ghostty: must push ONLY modifyOtherKeys, not the Kitty keyboard protocol.
+# Ghostty's Kitty disambiguate mode strips the Alt modifier from Backspace,
+# so Option+Backspace arrives as bare \x7f instead of \x1b[27;3;127~,
+# breaking backward-kill-word.  modifyOtherKeys mode works correctly.
+# ---------------------------------------------------------------------------
+class _FakeOutput:
+    """Minimal output object with write_raw + flush for _enable_extended_enter_keys."""
+    def __init__(self):
+        self.written = b""
+    def write_raw(self, data):
+        self.written += data.encode() if isinstance(data, str) else data
+    def flush(self):
+        pass
+
+
+def test_ghostty_uses_modify_other_keys_only():
+    """Ghostty must NOT push the Kitty keyboard protocol (CSI >1u)."""
+    import cli as cli_mod
+
+    out = _FakeOutput()
+    result = cli_mod._enable_extended_enter_keys(
+        output=out,
+        env={"TERM_PROGRAM": "ghostty", "TERM": "xterm-ghostty"},
+    )
+    assert result is True
+    # Must contain modifyOtherKeys push ...
+    assert b"\x1b[>4;2m" in out.written
+    # ... but NOT the Kitty protocol push.
+    assert b"\x1b[>1u" not in out.written
+
+
+def test_ghostty_via_term_var_uses_modify_other_keys_only():
+    """xterm-ghostty TERM (without TERM_PROGRAM) also skips Kitty protocol."""
+    import cli as cli_mod
+
+    out = _FakeOutput()
+    result = cli_mod._enable_extended_enter_keys(
+        output=out,
+        env={"TERM": "xterm-ghostty"},
+    )
+    assert result is True
+    assert b"\x1b[>4;2m" in out.written
+    assert b"\x1b[>1u" not in out.written
+
+
+def test_non_ghostty_terminals_still_push_kitty_protocol():
+    """iTerm2 and others still get the full dual-protocol push."""
+    import cli as cli_mod
+
+    out = _FakeOutput()
+    result = cli_mod._enable_extended_enter_keys(
+        output=out,
+        env={"TERM_PROGRAM": "iTerm.app", "TERM": "xterm-256color"},
+    )
+    assert result is True
+    assert b"\x1b[>1u" in out.written
+    assert b"\x1b[>4;2m" in out.written
+
+
 @pytest.mark.linux_only
 def test_proc_version_microsoft_marker_preserves_newline():
     """WSL detection via /proc when env vars are scrubbed (sudo etc.).

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -28,6 +28,7 @@ import {
   setTerminalBackgroundHex,
   setTerminalForegroundHex,
   setXtversionName,
+  skipKittyKeyboardProtocol,
   supportsExtendedKeys
 } from '../terminal.js'
 import {
@@ -333,9 +334,13 @@ export default class App extends PureComponent<Props, State> {
         // distinguishable from ctrl+<letter>. We write both the kitty stack
         // push (CSI >1u) and xterm modifyOtherKeys level 2 (CSI >4;2m) —
         // terminals honor whichever they implement (tmux only accepts the
-        // latter).
+        // latter). Ghostty gets only modifyOtherKeys — its kitty
+        // disambiguate mode strips Alt from Backspace (see
+        // skipKittyKeyboardProtocol).
         if (supportsExtendedKeys()) {
-          this.props.stdout.write(ENABLE_KITTY_KEYBOARD)
+          if (!skipKittyKeyboardProtocol()) {
+            this.props.stdout.write(ENABLE_KITTY_KEYBOARD)
+          }
           this.props.stdout.write(ENABLE_MODIFY_OTHER_KEYS)
         }
 

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -77,6 +77,7 @@ import {
 } from './selection.js'
 import {
   needsAltScreenResizeScrollbackClear,
+  skipKittyKeyboardProtocol,
   supportsExtendedKeys,
   SYNC_OUTPUT_SUPPORTED,
   type Terminal,
@@ -733,7 +734,11 @@ export default class Ink {
     // without the pop we'd accumulate depth on each editor round-trip).
     this.options.stdout.write(
       '\x1b[?1004h' +
-        (supportsExtendedKeys() ? DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS : '')
+        (supportsExtendedKeys()
+          ? DISABLE_KITTY_KEYBOARD +
+            (skipKittyKeyboardProtocol() ? '' : ENABLE_KITTY_KEYBOARD) +
+            ENABLE_MODIFY_OTHER_KEYS
+          : '')
     )
   }
   onRender() {
@@ -1472,7 +1477,11 @@ export default class Ink {
     // Pop-before-push keeps Kitty stack depth at 1 instead of accumulating
     // on each call.
     if (supportsExtendedKeys()) {
-      this.options.stdout.write(DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS)
+      this.options.stdout.write(
+        DISABLE_KITTY_KEYBOARD +
+          (skipKittyKeyboardProtocol() ? '' : ENABLE_KITTY_KEYBOARD) +
+          ENABLE_MODIFY_OTHER_KEYS
+      )
     }
 
     if (!this.altScreenActive) {

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
@@ -74,3 +74,36 @@ describe('writeDiffToTerminal sync-marker gating (#66490 main-screen gap)', () =
     expect(out).toContain('frame')
   })
 })
+
+describe('skipKittyKeyboardProtocol', () => {
+  // Ghostty's kitty disambiguate mode strips the Alt modifier from
+  // Backspace (Option+Backspace arrives as bare \x7f instead of CSI-u
+  // \x1b[127;3u), so Ghostty must get only the modifyOtherKeys push.
+  // Mirrors cli.py's _GHOSTTY_EXTENDED_ENTER_KEYS_SEQ exception.
+  it('skips the kitty protocol push for ghostty', async () => {
+    const { env } = await import('../utils/env.js')
+    const { skipKittyKeyboardProtocol } = await import('./terminal.js')
+    const saved = env.terminal
+    try {
+      env.terminal = 'ghostty'
+      expect(skipKittyKeyboardProtocol()).toBe(true)
+    } finally {
+      env.terminal = saved
+    }
+  })
+
+  it.each(['iTerm.app', 'kitty', 'WezTerm', 'tmux', 'windows-terminal', 'vscode'])(
+    'keeps the dual push for %s',
+    async terminal => {
+      const { env } = await import('../utils/env.js')
+      const { skipKittyKeyboardProtocol } = await import('./terminal.js')
+      const saved = env.terminal
+      try {
+        env.terminal = terminal
+        expect(skipKittyKeyboardProtocol()).toBe(false)
+      } finally {
+        env.terminal = saved
+      }
+    }
+  )
+})

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.ts
@@ -326,6 +326,16 @@ export function supportsExtendedKeys(): boolean {
   return EXTENDED_KEYS_TERMINALS.includes(env.terminal ?? '')
 }
 
+/** True when the Kitty keyboard protocol push (CSI >1u) must be skipped for
+ *  this terminal even though extended keys are supported. Ghostty's Kitty
+ *  disambiguate-mode implementation strips the Alt modifier from Backspace —
+ *  Option+Backspace arrives as bare \x7f instead of CSI-u \x1b[127;3u —
+ *  breaking backward-kill-word. Ghostty implements modifyOtherKeys correctly,
+ *  so it gets only that push (mirrors cli.py's Ghostty exception). */
+export function skipKittyKeyboardProtocol(): boolean {
+  return env.terminal === 'ghostty'
+}
+
 /** True if the terminal scrolls the viewport when it receives cursor-up
  *  sequences that reach above the visible area. On Windows, conhost's
  *  SetConsoleCursorPosition follows the cursor into scrollback


### PR DESCRIPTION
## Summary

Option+Backspace (backward-kill-word) and other Alt-modified combos work again on Ghostty — in BOTH the classic CLI and the Ink TUI. Root cause: Ghostty's Kitty disambiguate-mode implementation strips the Alt modifier from Backspace (Option+Backspace arrives as bare `\x7f` instead of the CSI-u form `\x1b[127;3u` the protocol calls for — upstream Ghostty bug, see ghostty discussions #9560 / issue #9895). Ghostty implements modifyOtherKeys correctly, so for Ghostty we push only `ESC[>4;2m` and skip the `ESC[>1u` Kitty push; every other allowlisted terminal keeps the dual push.

## Changes

- `cli.py`: `_GHOSTTY_EXTENDED_ENTER_KEYS_SEQ` + Ghostty gate in `_enable_extended_enter_keys` (detection matches exactly the two conditions that admit Ghostty through `_terminal_supports_extended_enter_keys`)
- `ui-tui/.../terminal.ts`: new `skipKittyKeyboardProtocol()` helper — the Ink TUI had the identical bug at 3 write sites
- `ui-tui/.../components/App.tsx`, `ui-tui/.../ink.tsx`: gate the `ENABLE_KITTY_KEYBOARD` push at raw-mode entry, alt-screen exit re-enable, and the extended-keys re-assert path; the pop (`DISABLE_KITTY_KEYBOARD`) stays unconditional (popping an empty stack is a spec no-op)
- Tests: 3 pytest cases (Ghostty via TERM_PROGRAM, via TERM, non-Ghostty regression guard) + 7 vitest cases for the TUI helper

## Validation

| | Before | After |
|---|---|---|
| Ghostty CLI push | `ESC[>1u ESC[>4;2m` | `ESC[>4;2m` only |
| Ghostty TUI push (3 sites) | `ESC[>1u ESC[>4;2m` | `ESC[>4;2m` only |
| Option+Backspace on Ghostty | bare `\x7f` (plain backspace) | `ESC[27;3;127~` → backward-kill-word |
| iTerm2 / kitty / WezTerm / tmux | dual push | dual push (unchanged) |

- 7/7 deterministic real-import probes (Ghostty both detection paths, iTerm2/kitty dual push retained, unknown-terminal no-op, reset seq still pops kitty mode, env=None path)
- `tests/cli/test_ctrl_enter_newline.py`: 13 passed; TUI `terminal.test.ts`: 15 passed; `tsc -b` clean
- Kitty pop in `_TERMINAL_INPUT_MODE_RESET_SEQ` and the TUI disable paths kept unconditional — cleans leaked state, no-op otherwise
