### PR TITLE
feat(matrix): bound peer-agent room conversations

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -401,6 +401,13 @@ def build_session_context_prompt(context: SessionContext, *, redact_pii: bool = 
             "only. Do not assume unresolved references are about other Matrix rooms or projects "
             "unless the user explicitly says so."
         )
+        if src.chat_type != "dm":
+            lines.append(
+                "**Matrix shared-room participation:** You do not have to answer every "
+                "message. When there is nothing useful, warm, or interesting to add, "
+                "respond with exactly `NO_REPLY`; the gateway will preserve the turn in "
+                "context without sending the marker to the room."
+            )
 
     # Shared multi-user sessions: never pin one user name in the system prompt (changes per turn ->
     # busts the prompt cache); sender names are prefixed on each user message instead.

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -826,6 +826,25 @@ class MatrixAdapter(BasePlatformAdapter):
         self._choice_picker_prompts_by_event: Dict[str, _MatrixPickerPrompt] = {}
         self._allowed_user_ids: Set[str] = _csv_set(os.getenv("MATRIX_ALLOWED_USERS", ""))
         self._allowed_room_ids: Set[str] = set(self._allowed_rooms)
+        peer_agents_raw = config.extra.get("peer_agent_ids", [])
+        if isinstance(peer_agents_raw, list):
+            self._peer_agent_ids: Set[str] = {
+                str(user_id).strip()
+                for user_id in peer_agents_raw
+                if str(user_id).strip()
+            }
+        else:
+            self._peer_agent_ids = {
+                user_id.strip()
+                for user_id in str(peer_agents_raw or "").split(",")
+                if user_id.strip()
+            }
+        try:
+            peer_budget = int(config.extra.get("peer_reply_budget_per_human_message", 0))
+        except (TypeError, ValueError):
+            peer_budget = 0
+        self._peer_reply_budget_per_human_message = max(0, peer_budget)
+        self._peer_reply_budget_remaining: Dict[str, int] = {}
         self._ignored_user_patterns: list[re.Pattern[str]] = []
         for pattern in (p.strip() for p in os.getenv("MATRIX_IGNORE_USER_PATTERNS", "").split(",") if p.strip()):
             try:
@@ -1932,12 +1951,26 @@ class MatrixAdapter(BasePlatformAdapter):
         mentions_block = source_content.get("m.mentions") or {}  # MSC3952: authoritative signal
         mention_user_ids = mentions_block.get("user_ids") if isinstance(mentions_block, dict) else None
         is_mentioned = self._is_bot_mentioned(body, formatted_body, mention_user_ids)
+        is_peer_agent_message = sender in self._peer_agent_ids
         if not is_dm:
             # Whitelist first: non-listed rooms are dropped even when @mentioned (DMs exempt).
             if self._allowed_rooms and room_id not in self._allowed_rooms:
                 logger.debug(
                     "Matrix: ignoring message %s in %s — room not in MATRIX_ALLOWED_ROOMS whitelist", event_id, room_id)
                 return None
+            if self._peer_agent_ids:
+                if is_peer_agent_message:
+                    if not is_mentioned:
+                        logger.debug(
+                            "Matrix: ignoring peer-agent message %s from %s — no direct @mention",
+                            event_id, sender)
+                        return None
+                    remaining = self._peer_reply_budget_remaining.get(room_id, 0)
+                    if remaining <= 0:
+                        logger.info(
+                            "Matrix: ignoring peer-agent message %s from %s — reply budget exhausted",
+                            event_id, sender)
+                        return None
             is_free_room = room_id in self._free_rooms
             in_bot_thread = bool(thread_id and thread_id in self._threads)
             if self._require_mention and not is_free_room and not in_bot_thread:
@@ -1946,14 +1979,19 @@ class MatrixAdapter(BasePlatformAdapter):
                         "Matrix: ignoring message %s in %s — no @mention "
                         "(set MATRIX_REQUIRE_MENTION=false to disable)", event_id, room_id)
                     return None
-            # thread_require_mention: even inside a bot thread require @mention — prevents
-            # infinite reply loops when several bots share one thread.
+            # Thread-level @mention gating: even in a bot-participated thread.
             elif self._thread_require_mention and in_bot_thread and not is_free_room and not is_mentioned:
                 logger.debug(
                     "Matrix: ignoring message %s in thread %s — no @mention (thread_require_mention=true)",
                     event_id, thread_id)
                 return None
-        if is_mentioned and self._require_mention:
+            # Open or consume a peer round only after all ordinary room, mention, and thread gates.
+            if self._peer_agent_ids:
+                if is_peer_agent_message:
+                    self._peer_reply_budget_remaining[room_id] -= 1
+                elif self._is_authorized_user(sender):
+                    self._peer_reply_budget_remaining[room_id] = self._peer_reply_budget_per_human_message
+        if is_mentioned and (self._require_mention or is_peer_agent_message):
             body = self._strip_mention(body)
         # Real thread roots are preserved above; synthetic roots (this event) follow policy: DM
         # @mention threads / DM auto-thread, or room auto-thread unless session_scope pins the room.
@@ -2964,12 +3002,10 @@ _YAML_LIST_KEYS = (
 
 
 def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
-    """apply_yaml_config_fn: config.yaml matrix: keys → MATRIX_* env (env wins). Returns None. Lowercased
-    flags apply whenever the key is present (None still writes "none"); list-valued keys skip None.
+    """Translate config.yaml matrix: keys into runtime configuration.
 
-    Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy matrix_cfg block from
-    gateway/config.py::load_gateway_config(). Env vars take precedence over YAML. Returns None — everything
-    flows through env.
+    Env vars take precedence over YAML. Matrix-local peer settings without legacy
+    env vars are returned as PlatformConfig extras.
     """
     for key, env_name in _YAML_LOWER_KEYS:
         if key in matrix_cfg and not os.getenv(env_name):
@@ -2982,7 +3018,11 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
             os.environ[env_name] = str(value)
     if "max_message_length" in matrix_cfg and not os.getenv("MATRIX_MAX_MESSAGE_LENGTH"):
         os.environ["MATRIX_MAX_MESSAGE_LENGTH"] = str(matrix_cfg["max_message_length"])
-    return None
+    seeded = {}
+    for key in ("peer_agent_ids", "peer_reply_budget_per_human_message"):
+        if key in matrix_cfg:
+            seeded[key] = matrix_cfg[key]
+    return seeded or None
 
 
 def _is_connected(config) -> bool:

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -192,7 +192,13 @@ class TestPeerAgentBudgetGating:
     async def test_empty_allowlist_with_allow_all_resets_budget(self, monkeypatch):
         monkeypatch.setenv("MATRIX_ALLOWED_USERS", "")
         monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
-        adapter = self._adapter(monkeypatch)
+        monkeypatch.setenv("MATRIX_REQUIRE_MENTION", "false")
+        monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+        adapter = _make_adapter(extra={
+            "peer_agent_ids": ["@yomi:example.org"],
+            "peer_reply_budget_per_human_message": 2,
+        })
+        assert adapter._allowed_user_ids == set()
         adapter._peer_reply_budget_remaining["!room1:example.org"] = 0
 
         await adapter._on_room_message(

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -15,7 +15,7 @@ from gateway.config import PlatformConfig
 # needing real mautrix APIs mock them individually.
 
 
-def _make_adapter(tmp_path=None):
+def _make_adapter(tmp_path=None, extra=None):
     """Create a MatrixAdapter with mocked config."""
     from plugins.platforms.matrix.adapter import MatrixAdapter
 
@@ -25,6 +25,7 @@ def _make_adapter(tmp_path=None):
         extra={
             "homeserver": "https://matrix.example.org",
             "user_id": "@hermes:example.org",
+            **(extra or {}),
         },
     )
     adapter = MatrixAdapter(config)
@@ -108,6 +109,203 @@ class TestIsBotMentioned:
             "please reply",  # no @hermes anywhere in body
             mention_user_ids=["@hermes:example.org"],
         )
+
+
+class TestPeerAgentBudgetConfig:
+    def test_defaults_are_inert(self):
+        adapter = _make_adapter()
+
+        assert adapter._peer_agent_ids == set()
+        assert adapter._peer_reply_budget_per_human_message == 0
+        assert adapter._peer_reply_budget_remaining == {}
+
+    def test_parses_peer_ids_from_list(self):
+        adapter = _make_adapter(
+            extra={
+                "peer_agent_ids": ["@ran:example.org", " @yomi:example.org "],
+                "peer_reply_budget_per_human_message": 2,
+            }
+        )
+
+        assert adapter._peer_agent_ids == {
+            "@ran:example.org",
+            "@yomi:example.org",
+        }
+        assert adapter._peer_reply_budget_per_human_message == 2
+
+    def test_parses_peer_ids_from_comma_string(self):
+        adapter = _make_adapter(
+            extra={
+                "peer_agent_ids": "@ran:example.org, @yomi:example.org",
+                "peer_reply_budget_per_human_message": "3",
+            }
+        )
+
+        assert adapter._peer_agent_ids == {
+            "@ran:example.org",
+            "@yomi:example.org",
+        }
+        assert adapter._peer_reply_budget_per_human_message == 3
+
+    @pytest.mark.parametrize("value", [-1, "invalid", None])
+    def test_invalid_budget_fails_closed(self, value):
+        adapter = _make_adapter(
+            extra={
+                "peer_agent_ids": ["@yomi:example.org"],
+                "peer_reply_budget_per_human_message": value,
+            }
+        )
+
+        assert adapter._peer_reply_budget_per_human_message == 0
+
+
+class TestPeerAgentBudgetGating:
+    @staticmethod
+    def _adapter(monkeypatch, *, require_mention=False):
+        monkeypatch.setenv(
+            "MATRIX_ALLOWED_USERS",
+            "@alice:example.org,@hermes:example.org,@yomi:example.org",
+        )
+        monkeypatch.setenv(
+            "MATRIX_REQUIRE_MENTION", str(require_mention).lower()
+        )
+        monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+        return _make_adapter(
+            extra={
+                "peer_agent_ids": ["@yomi:example.org"],
+                "peer_reply_budget_per_human_message": 2,
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_authorized_human_untagged_message_resets_budget(self, monkeypatch):
+        adapter = self._adapter(monkeypatch)
+
+        await adapter._on_room_message(
+            _make_event("hello everyone", sender="@alice:example.org")
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        assert adapter._peer_reply_budget_remaining["!room1:example.org"] == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_allowlist_with_allow_all_resets_budget(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "")
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        adapter = self._adapter(monkeypatch)
+        adapter._peer_reply_budget_remaining["!room1:example.org"] = 0
+
+        await adapter._on_room_message(
+            _make_event("hello everyone", sender="@alice:example.org", event_id="$allow-all")
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        assert adapter._peer_reply_budget_remaining["!room1:example.org"] == 2
+
+    @pytest.mark.asyncio
+    async def test_rejected_untagged_human_does_not_reset_budget(self, monkeypatch):
+        adapter = self._adapter(monkeypatch, require_mention=True)
+        adapter._peer_reply_budget_remaining["!room1:example.org"] = 0
+
+        await adapter._on_room_message(
+            _make_event("hello everyone", sender="@alice:example.org")
+        )
+
+        adapter.handle_message.assert_not_awaited()
+        assert adapter._peer_reply_budget_remaining["!room1:example.org"] == 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_sender_does_not_reset_budget(self, monkeypatch):
+        adapter = self._adapter(monkeypatch)
+        adapter._peer_reply_budget_remaining["!room1:example.org"] = 0
+
+        await adapter._on_room_message(
+            _make_event("hello everyone", sender="@mallory:example.org")
+        )
+
+        assert adapter._peer_reply_budget_remaining["!room1:example.org"] == 0
+
+    @pytest.mark.asyncio
+    async def test_untagged_peer_is_dropped_without_consuming_budget(self, monkeypatch):
+        adapter = self._adapter(monkeypatch)
+        adapter._peer_reply_budget_remaining["!room1:example.org"] = 2
+
+        await adapter._on_room_message(
+            _make_event("hello sister", sender="@yomi:example.org")
+        )
+
+        adapter.handle_message.assert_not_awaited()
+        assert adapter._peer_reply_budget_remaining["!room1:example.org"] == 2
+
+    @pytest.mark.asyncio
+    async def test_tagged_peer_is_dropped_before_human_opens_round(self, monkeypatch):
+        adapter = self._adapter(monkeypatch)
+
+        await adapter._on_room_message(
+            _make_event(
+                "@hermes:example.org hello sister",
+                sender="@yomi:example.org",
+            )
+        )
+
+        adapter.handle_message.assert_not_awaited()
+        assert adapter._peer_reply_budget_remaining.get("!room1:example.org", 0) == 0
+
+    @pytest.mark.asyncio
+    async def test_two_tagged_peer_calls_are_allowed_then_third_is_dropped(
+        self, monkeypatch
+    ):
+        adapter = self._adapter(monkeypatch)
+        await adapter._on_room_message(
+            _make_event("hello everyone", sender="@alice:example.org", event_id="$human")
+        )
+        adapter.handle_message.reset_mock()
+
+        for index in range(3):
+            await adapter._on_room_message(
+                _make_event(
+                    "@hermes:example.org continue",
+                    sender="@yomi:example.org",
+                    event_id=f"$peer{index}",
+                )
+            )
+
+        assert adapter.handle_message.await_count == 2
+        assert adapter._peer_reply_budget_remaining["!room1:example.org"] == 0
+        first_message = adapter.handle_message.await_args_list[0].args[0]
+        assert first_message.text == "continue"
+
+    @pytest.mark.asyncio
+    async def test_next_authorized_human_message_reopens_round(self, monkeypatch):
+        adapter = self._adapter(monkeypatch)
+        adapter._peer_reply_budget_remaining["!room1:example.org"] = 0
+
+        await adapter._on_room_message(
+            _make_event("new subject", sender="@alice:example.org", event_id="$human2")
+        )
+        adapter.handle_message.reset_mock()
+        await adapter._on_room_message(
+            _make_event(
+                "@hermes:example.org your turn",
+                sender="@yomi:example.org",
+                event_id="$peer-next",
+            )
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        assert adapter._peer_reply_budget_remaining["!room1:example.org"] == 1
+
+    @pytest.mark.asyncio
+    async def test_peer_command_still_requires_mention_and_budget(self, monkeypatch):
+        adapter = self._adapter(monkeypatch)
+        adapter._peer_reply_budget_remaining["!room1:example.org"] = 2
+
+        await adapter._on_room_message(
+            _make_event("/status", sender="@yomi:example.org")
+        )
+
+        adapter.handle_message.assert_not_awaited()
+        assert adapter._peer_reply_budget_remaining["!room1:example.org"] == 2
 
 
 class TestStripMention:

--- a/tests/gateway/test_matrix_plugin_setup.py
+++ b/tests/gateway/test_matrix_plugin_setup.py
@@ -10,7 +10,8 @@ clear-on-blank behavior added in the follow-up to PR #58421.
 import hermes_cli.config as config_mod
 import hermes_cli.cli_output as cli_output_mod
 import tools.lazy_deps as lazy_deps_mod
-from plugins.platforms.matrix.adapter import interactive_setup
+from gateway.config import Platform
+from plugins.platforms.matrix.adapter import MatrixAdapter, interactive_setup
 
 
 def _patch_setup_io(monkeypatch, prompts, yes_no_responses, saved, removed, existing):
@@ -79,5 +80,29 @@ class TestMatrixHomeChannelClear:
         interactive_setup()
         assert "MATRIX_HOME_ROOM" in removed
         assert "MATRIX_HOME_ROOM" not in saved
+
+
+def test_matrix_peer_yaml_reaches_runtime_adapter(monkeypatch, tmp_path):
+    """Documented top-level matrix YAML must seed adapter runtime extras."""
+    (tmp_path / "config.yaml").write_text(
+        "matrix:\n"
+        "  peer_agent_ids:\n"
+        "    - '@ran:example.org'\n"
+        "    - '@yomi:example.org'\n"
+        "  peer_reply_budget_per_human_message: 2\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("gateway.config.get_hermes_home", lambda: tmp_path)
+
+    from gateway.config import load_gateway_config
+
+    config = load_gateway_config()
+    adapter = MatrixAdapter(config.platforms[Platform.MATRIX])
+
+    assert adapter._peer_agent_ids == {
+        "@ran:example.org",
+        "@yomi:example.org",
+    }
+    assert adapter._peer_reply_budget_per_human_message == 2
 
 

--- a/tests/gateway/test_matrix_project_context_isolation.py
+++ b/tests/gateway/test_matrix_project_context_isolation.py
@@ -113,6 +113,32 @@ def _context_for(source: SessionSource) -> SessionContext:
 
 
 @pytest.mark.asyncio
+async def test_matrix_shared_room_prompt_allows_intentional_no_reply():
+    adapter = _make_adapter()
+    adapter._get_room_member_count = AsyncMock(return_value=3)
+    source = await _source_for(adapter, PROJECT_B_ROOM_ID, "$message")
+
+    prompt = build_session_context_prompt(_context_for(source))
+
+    assert "NO_REPLY" in prompt
+    assert "nothing useful, warm, or interesting to add" in prompt
+
+
+def test_matrix_dm_prompt_does_not_include_shared_room_silence_guidance():
+    source = SessionSource(
+        platform=Platform.MATRIX,
+        chat_id="!dm:example.org",
+        chat_type="dm",
+        user_id="@alice:example.org",
+    )
+
+    prompt = build_session_context_prompt(_context_for(source))
+
+    assert "Matrix shared-room participation" not in prompt
+    assert "nothing useful, warm, or interesting to add" not in prompt
+
+
+@pytest.mark.asyncio
 async def test_matrix_session_scope_auto_and_thread_preserve_synthetic_threads():
     adapter = _make_adapter()
     # Override member_count to 3 so the named project room is NOT classified as

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -90,6 +90,9 @@ matrix:
     - "!abc123:matrix.org"
   free_response_rooms:            # Rooms exempt from mention requirement
     - "!abc123:matrix.org"
+  peer_agent_ids:                 # Peer bots that must mention this bot to wake it
+    - "@other-agent:matrix.org"
+  peer_reply_budget_per_human_message: 2  # Peer-triggered calls opened by each authorized human message
   ignore_user_patterns:           # Bridge/appservice ghost users to ignore
     - "^@telegram_"
     - "^@whatsapp_"
@@ -127,6 +130,43 @@ Hermes sends structured Matrix user mentions for explicit Matrix IDs such as `@a
 :::note
 If you are upgrading from a version that did not have `MATRIX_REQUIRE_MENTION`, the bot previously responded to all messages in rooms. To preserve that behavior, set `MATRIX_REQUIRE_MENTION=false`.
 :::
+
+### Bounded multi-agent rooms
+
+For a shared room where ordinary human messages should reach multiple agents,
+but agents should not wake one another indefinitely, configure each profile
+with the other agents as peers:
+
+```yaml
+matrix:
+  require_mention: false
+  allowed_users:
+    - "@alice:matrix.org"
+    - "@ran:matrix.org"
+    - "@yomi:matrix.org"
+  peer_agent_ids:
+    - "@yomi:matrix.org"  # Ran's profile; Yomi lists Ran instead
+  peer_reply_budget_per_human_message: 2
+```
+
+With peer-agent gating enabled:
+
+- authorized non-peer messages open a new per-room round and reset the peer-call
+  allowance;
+- peer messages require a direct mention of the current bot even though ordinary
+  human messages do not;
+- each accepted peer-triggered model call consumes one slot, including a call
+  that ends in `NO_REPLY` or an error;
+- untagged peer messages and tagged peer messages after exhaustion are ignored
+  before model invocation; and
+- a gateway restart begins with no peer allowance until an authorized human
+  sends a new message.
+
+Hermes tells agents in Matrix shared rooms that they may return exactly
+`NO_REPLY` when they have nothing useful, warm, or interesting to add. The
+gateway preserves that turn in context but sends no visible marker. With two
+profiles and a budget of `2` on each, one human message can cause at most two
+initial model calls plus four peer follow-up calls.
 
 ### Project Room Isolation
 


### PR DESCRIPTION
## Summary

Add an opt-in safety boundary for Matrix rooms containing multiple Hermes agent accounts:

- identify configured peer-agent Matrix IDs;
- require an explicit direct mention before a peer can wake this agent;
- strip that mention before model invocation;
- open a bounded, per-room peer-reply allowance only after an authorized human message;
- begin fail-closed after gateway restart; and
- document intentional `NO_REPLY` participation in shared Matrix rooms.

This is proposed as a **Draft PR** because the use case is real but specialized, and the configuration shape may benefit from maintainer direction before being considered ready to merge.

## Motivation

Hermes agents send ordinary `m.text` events. In a shared room, ignoring notices or requiring mentions only for thread participation does not prevent unthreaded agent-to-agent recursion when multiple profiles use `require_mention: false` so humans can address the room naturally.

Prompt-only restraint is insufficient because a peer message can already incur a model call before the model chooses silence. This patch enforces the peer boundary in the Matrix adapter before model invocation.

## Behavior

The feature defaults inert at the routing layer (`peer_agent_ids: []`, budget `0`). When configured:

- untagged authorized human messages continue through normal routing and reset that room's allowance;
- untagged peer-agent messages are ignored without consuming allowance;
- tagged peer-agent messages require remaining allowance and consume one slot;
- allowances are isolated per room;
- unknown senders cannot open a round;
- a restart begins with all allowances closed; and
- existing `process_notices`, `thread_require_mention`, authorization, and room/thread routing remain in force.

A shared Matrix room also tells the agent it may answer exactly `NO_REPLY` when it has nothing useful to add; Hermes's existing response filtering preserves context without emitting that marker visibly.

## Configuration

```yaml
matrix:
  require_mention: false
  allowed_users:
    - "@human:matrix.example"
    - "@this-agent:matrix.example"
    - "@peer-agent:matrix.example"
  peer_agent_ids:
    - "@peer-agent:matrix.example"
  peer_reply_budget_per_human_message: 2
```

## Scope and privacy

The branch contains only portable adapter behavior, focused tests, and public documentation. It contains no household Matrix IDs, room IDs, homeserver credentials, E2EE state, service configuration, or deployment paths.

## Verification

- Matrix config/routing/prompt regression scope: **42 passed**
- Combined ACP + timestamp + Matrix + current-upstream compression integration scope: **709 passed, 0 failed**
- Independent composed-stack review: no blocking findings
- Ruff: passed
- Python compilation: passed
- `git diff --check`: passed

Independent review originally found three blockers; all were fixed before publication:

- documented YAML keys now reach `PlatformConfig.extra` and the runtime adapter;
- peer budgets open or decrement only after ordinary room/mention/thread gates accept the event; and
- shared-room `NO_REPLY` guidance is excluded from Matrix DMs.

## Draft questions

- Is `peer_agent_ids` the right Matrix-local configuration boundary, or should peer identities become a shared gateway concept?
- Is a per-profile, per-human-message budget the preferred cost/loop bound?
- Should shared-room `NO_REPLY` guidance remain Matrix-specific or move behind a generic platform capability hook?


## Refresh verification — 2026-09-07

Rebased onto upstream `08b140d14e6c1d49f9b7ad02c9437fe940d54d65`; current head `d76da9d65979b8be0ba94e070f8c0d90cef80c85`. Preserved extracted Matrix/session structure. Addressed the empty-allowlist review concern by using the existing `_is_authorized_user(sender)` policy for human budget resets: explicitly enabled `GATEWAY_ALLOW_ALL_USERS=true` now works without relaxing the ordinary room/mention/thread gates. The regression constructs a genuinely empty allowlist and asserts that precondition.

Parent verification: `scripts/run_tests.sh tests/gateway/test_matrix_mention.py tests/gateway/test_matrix_plugin_setup.py tests/gateway/test_matrix_project_context_isolation.py -q` — **43 passed, 0 failed**. `git diff --check` passed. No live Matrix send was performed; PR remains draft.
