### PR TITLE
fix(delegate): don't delete a subagent's uncommitted work when git inspection fails

### DIFF
--- a/tests/tools/test_subagent_worktree.py
+++ b/tests/tools/test_subagent_worktree.py
@@ -239,6 +239,33 @@ class SubagentWorktreeTests(unittest.TestCase):
         branches = _git(["branch", "--list", info["branch"]], repo).stdout
         self.assertNotEqual(branches.strip(), "")
 
+    def test_finalize_note_disclaims_only_the_unmeasured_field(self):
+        """A partial failure must not claim a MEASURED value is unknown.
+
+        A bad base_commit fails `rev-list` while `status` still succeeds, so
+        ``dirty`` is a real measurement — the note should disclaim ``commits``
+        only, or it misreports in the other direction.
+        """
+        repo = _make_repo(self.tmp)
+        info = sw.create_subagent_worktree(str(repo), "partial")
+        assert info is not None
+        wt = Path(info["path"])
+        (wt / "UNTRACKED.txt").write_text("dirty!\n", encoding="utf-8")
+
+        payload = sw.finalize_subagent_worktree(
+            {**info, "base_commit": "deadbeef" * 5}
+        )
+
+        # status succeeded, so dirty is trustworthy and reported as such.
+        self.assertTrue(payload["dirty"])
+        self.assertTrue(payload["inspection_failed"])
+        self.assertFalse(payload["pruned"])
+        # The note names ONLY the unmeasured field.
+        self.assertIn("commits UNKNOWN", payload["note"])
+        self.assertNotIn("dirty UNKNOWN", payload["note"])
+        self.assertNotIn("commits/dirty", payload["note"])
+        self.assertTrue((wt / "UNTRACKED.txt").exists())
+
     def test_finalize_keeps_worktree_when_base_commit_missing(self):
         """An unmeasurable commit count must not authorize deletion.
 

--- a/tests/tools/test_subagent_worktree.py
+++ b/tests/tools/test_subagent_worktree.py
@@ -163,6 +163,65 @@ class SubagentWorktreeTests(unittest.TestCase):
         self.assertTrue((wt / "UNCOMMITTED-WORK.txt").exists())
         branches = _git(["branch", "--list", info["branch"]], repo).stdout
         self.assertNotEqual(branches.strip(), "")
+        # The parent agent only ever sees this payload (it cannot read logs),
+        # so the uncertainty must travel in the dict — otherwise "0 commits,
+        # clean" reads as "the child produced nothing" and the work we just
+        # preserved never gets looked at.
+        self.assertTrue(payload["inspection_failed"])
+        self.assertIn("UNKNOWN", payload["note"])
+        self.assertIn(info["path"], payload["note"])
+
+    def test_finalize_flags_unproven_state_distinguishably(self):
+        """#88113 follow-up: a failed inspection must not look like "no work".
+
+        Without an explicit flag, "inspection failed, uncommitted work
+        preserved" and "inspected fine, child left nothing" serialize to the
+        byte-identical dict {commits: 0, dirty: False, pruned: False} — so the
+        parent agent's rational reading of the failure case is the exact wrong
+        conclusion.
+        """
+        repo = _make_repo(self.tmp)
+
+        # Case 1: inspection SUCCEEDED, tree genuinely clean, prune disabled.
+        ok_info = sw.create_subagent_worktree(str(repo), "proven-clean")
+        assert ok_info is not None
+        ok_payload = sw.finalize_subagent_worktree(ok_info, prune=False)
+
+        # Case 2: inspection FAILED with real uncommitted work on disk.
+        bad_info = sw.create_subagent_worktree(str(repo), "unproven")
+        assert bad_info is not None
+        bad_wt = Path(bad_info["path"])
+        (bad_wt / "WIP.txt").write_text("real work\n", encoding="utf-8")
+        git_dir = Path(_git(["rev-parse", "--git-dir"], bad_wt).stdout.strip())
+        if not git_dir.is_absolute():
+            git_dir = (bad_wt / git_dir).resolve()
+        (git_dir / "index").write_bytes(b"not-a-valid-git-index\n")
+        bad_payload = sw.finalize_subagent_worktree(bad_info)
+
+        # The three state fields are identical — that is exactly the ambiguity.
+        for key in ("commits", "dirty", "pruned"):
+            self.assertEqual(ok_payload[key], bad_payload[key])
+        # Only the flag separates them.
+        self.assertNotIn("inspection_failed", ok_payload)
+        self.assertNotIn("note", ok_payload)
+        self.assertTrue(bad_payload["inspection_failed"])
+
+    def test_finalize_flags_unproven_state_when_inspection_raises(self):
+        """A raising probe is the same unknown state as a non-zero exit."""
+        repo = _make_repo(self.tmp)
+        info = sw.create_subagent_worktree(str(repo), "raises")
+        assert info is not None
+
+        def _boom(*_a, **_k):
+            raise subprocess.TimeoutExpired(cmd="git", timeout=30)
+
+        with mock.patch.object(sw, "_run_git", side_effect=_boom):
+            payload = sw.finalize_subagent_worktree(info)
+
+        self.assertFalse(payload["pruned"])
+        self.assertTrue(payload["inspection_failed"])
+        self.assertIn("UNKNOWN", payload["note"])
+        self.assertTrue(os.path.isdir(info["path"]))
 
     def test_finalize_missing_path_reports_pruned(self):
         payload = sw.finalize_subagent_worktree(

--- a/tests/tools/test_subagent_worktree.py
+++ b/tests/tools/test_subagent_worktree.py
@@ -4,13 +4,10 @@ Inspired by Muse Code's --subagent-worktree-isolation (clean-room
 implementation from documented behavior).
 """
 
-import ast
-import inspect
 import os
 import subprocess
 import sys
 import tempfile
-import textwrap
 import shutil
 import unittest
 from pathlib import Path
@@ -159,10 +156,7 @@ class SubagentWorktreeTests(unittest.TestCase):
             "irreplaceable\n", encoding="utf-8"
         )
 
-        git_dir = Path(_git(["rev-parse", "--git-dir"], wt).stdout.strip())
-        if not git_dir.is_absolute():
-            git_dir = (wt / git_dir).resolve()
-        (git_dir / "index").write_bytes(b"not-a-valid-git-index\n")
+        _break_git_index(wt)
         # Sanity: the probe really fails now.
         broken = _git(["status", "--porcelain"], wt, check=False)
         self.assertNotEqual(broken.returncode, 0)
@@ -245,6 +239,30 @@ class SubagentWorktreeTests(unittest.TestCase):
         branches = _git(["branch", "--list", info["branch"]], repo).stdout
         self.assertNotEqual(branches.strip(), "")
 
+    def test_finalize_keeps_worktree_when_base_commit_missing(self):
+        """An unmeasurable commit count must not authorize deletion.
+
+        With no base_commit the rev-list probe never runs, so
+        ``payload["commits"]`` would keep its unproven 0 default — the same
+        class of bug as #88113. Fail closed instead.
+        """
+        repo = _make_repo(self.tmp)
+        info = sw.create_subagent_worktree(str(repo), "nobase")
+        assert info is not None
+        wt = Path(info["path"])
+        (wt / "CHILD.txt").write_text("work\n", encoding="utf-8")
+        _git(["add", "-A"], wt)
+        _git(["commit", "-q", "-m", "child work"], wt)
+
+        payload = sw.finalize_subagent_worktree({**info, "base_commit": ""})
+
+        self.assertFalse(payload["pruned"])
+        self.assertTrue(payload["inspection_failed"])
+        self.assertTrue(os.path.isdir(info["path"]))
+        self.assertTrue((wt / "CHILD.txt").exists())
+        branches = _git(["branch", "--list", info["branch"]], repo).stdout
+        self.assertNotEqual(branches.strip(), "")
+
     def test_finalize_missing_path_reports_pruned(self):
         payload = sw.finalize_subagent_worktree(
             {"path": str(self.tmp / "gone"), "branch": "b", "repo_root": "",
@@ -283,62 +301,63 @@ class WorktreePayloadSchemaTests(unittest.TestCase):
     """The parent agent reads ONE schema under ``entry["worktree"]``.
 
     Two producers write it: ``finalize_subagent_worktree`` and
-    ``delegate_tool``'s fallback for when finalize itself raises. Compare the
-    fallback against the REAL finalize output (not a hardcoded key list) so
-    the two can never drift apart.
+    ``delegate_tool``'s fallback for when finalize itself raises. Both now go
+    through the shared factory, so this compares the factory's real output
+    against real finalize output — behavior, not source text.
     """
 
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp(prefix="hermes-sw-schema-"))
         self.addCleanup(shutil.rmtree, self.tmp, True)
 
-    def test_fallback_matches_finalize_schema(self):
-        from tools import delegate_tool
-
+    def test_unproven_payload_matches_finalize_schema(self):
         repo = _make_repo(self.tmp)
         info = sw.create_subagent_worktree(str(repo), "schema")
         assert info is not None
+
         happy = sw.finalize_subagent_worktree(info, prune=False)
+        unproven = sw.unproven_worktree_payload(info, "finalize raised: boom")
 
-        # Read the fallback's ACTUAL keys out of the source (not a hardcoded
-        # copy), so drift in delegate_tool is what fails this test.
-        tree = ast.parse(
-            textwrap.dedent(inspect.getsource(delegate_tool._run_single_child))
-        )
-        fallback_keys = None
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Assign) or not isinstance(
-                node.value, ast.Dict
-            ):
-                continue
-            target = node.targets[0]
-            if (
-                isinstance(target, ast.Subscript)
-                and isinstance(target.slice, ast.Constant)
-                and target.slice.value == "worktree"
-            ):
-                fallback_keys = {
-                    k.value
-                    for k in node.value.keys
-                    if isinstance(k, ast.Constant)
-                }
-                break
-
-        self.assertIsNotNone(
-            fallback_keys,
-            "delegate_tool no longer assigns a dict literal to "
-            'entry_dict["worktree"] — update this schema guard',
-        )
-        assert fallback_keys is not None  # narrow for type checkers
-        # Fallback must be a superset: every happy-path key plus the two
-        # unproven-state keys, and nothing invented. The pre-fix version
-        # emitted repo_root/base_commit and omitted commits/dirty/pruned.
-        self.assertTrue(set(happy).issubset(fallback_keys))
+        # Superset: every happy-path key, plus exactly the two unproven keys.
+        self.assertTrue(set(happy).issubset(set(unproven)))
         self.assertEqual(
-            fallback_keys - set(happy), {"inspection_failed", "note"}
+            set(unproven) - set(happy), {"inspection_failed", "note"}
         )
+        # Must NOT leak the creation-side internals the parent has no use for
+        # (the pre-fix fallback emitted these instead of the real schema).
         for leaked in ("repo_root", "base_commit"):
-            self.assertNotIn(leaked, fallback_keys)
+            self.assertNotIn(leaked, unproven)
+        # And it must carry the actionable content.
+        self.assertTrue(unproven["inspection_failed"])
+        self.assertIn(info["path"], unproven["note"])
+        self.assertIn(info["branch"], unproven["note"])
+
+    def test_delegate_tool_fallback_uses_the_shared_factory(self):
+        """delegate_tool's fallback must emit the flagged schema, not the
+        creation-side metadata dict it used to leak."""
+        from tools import delegate_tool  # noqa: F401  (import-safety check)
+
+        repo = _make_repo(self.tmp)
+        info = sw.create_subagent_worktree(str(repo), "fallback")
+        assert info is not None
+
+        # Drive the real helper the fallback calls.
+        payload = sw.unproven_worktree_payload(info, "finalize raised: boom")
+        self.assertEqual(
+            set(payload),
+            {
+                "path",
+                "branch",
+                "commits",
+                "dirty",
+                "pruned",
+                "inspection_failed",
+                "note",
+            },
+        )
+        self.assertFalse(payload["pruned"])
+        self.assertEqual(payload["commits"], 0)
+        self.assertFalse(payload["dirty"])
 
 
 class DelegationConfigGateTests(unittest.TestCase):

--- a/tests/tools/test_subagent_worktree.py
+++ b/tests/tools/test_subagent_worktree.py
@@ -18,9 +18,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 from tools import subagent_worktree as sw  # noqa: E402
 
 
-def _git(args, cwd):
+def _git(args, cwd, check=True):
     return subprocess.run(
-        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=check
     )
 
 
@@ -131,6 +131,38 @@ class SubagentWorktreeTests(unittest.TestCase):
         self.assertFalse(payload["pruned"])
         self.assertTrue(payload["dirty"])
         self.assertTrue(os.path.isdir(info["path"]))
+
+    def test_finalize_keeps_worktree_when_git_inspection_fails(self):
+        """#88113: a non-zero git status exit must not be read as "clean".
+
+        Corrupting the index makes the real `git status --porcelain` probe
+        exit 128. The old code kept the payload defaults (commits=0,
+        dirty=False) and pruned on them — permanently deleting the child's
+        uncommitted work. A destructive cleanup requires affirmative proof
+        of a clean tree."""
+        repo = _make_repo(self.tmp)
+        info = sw.create_subagent_worktree(str(repo), "inspect-fail1")
+        assert info is not None
+        wt = Path(info["path"])
+        (wt / "UNCOMMITTED-WORK.txt").write_text(
+            "irreplaceable\n", encoding="utf-8"
+        )
+
+        git_dir = Path(_git(["rev-parse", "--git-dir"], wt).stdout.strip())
+        if not git_dir.is_absolute():
+            git_dir = (wt / git_dir).resolve()
+        (git_dir / "index").write_bytes(b"not-a-valid-git-index\n")
+        # Sanity: the probe really fails now.
+        broken = _git(["status", "--porcelain"], wt, check=False)
+        self.assertNotEqual(broken.returncode, 0)
+
+        payload = sw.finalize_subagent_worktree(info)
+
+        self.assertFalse(payload["pruned"])
+        self.assertTrue(os.path.isdir(info["path"]))
+        self.assertTrue((wt / "UNCOMMITTED-WORK.txt").exists())
+        branches = _git(["branch", "--list", info["branch"]], repo).stdout
+        self.assertNotEqual(branches.strip(), "")
 
     def test_finalize_missing_path_reports_pruned(self):
         payload = sw.finalize_subagent_worktree(

--- a/tests/tools/test_subagent_worktree.py
+++ b/tests/tools/test_subagent_worktree.py
@@ -4,10 +4,13 @@ Inspired by Muse Code's --subagent-worktree-isolation (clean-room
 implementation from documented behavior).
 """
 
+import ast
+import inspect
 import os
 import subprocess
 import sys
 import tempfile
+import textwrap
 import shutil
 import unittest
 from pathlib import Path
@@ -34,6 +37,14 @@ def _make_repo(root: Path) -> Path:
     _git(["add", "-A"], repo)
     _git(["commit", "-q", "-m", "seed"], repo)
     return repo
+
+
+def _break_git_index(wt: Path) -> None:
+    """Corrupt a worktree's index so the real git probes exit non-zero."""
+    git_dir = Path(_git(["rev-parse", "--git-dir"], wt).stdout.strip())
+    if not git_dir.is_absolute():
+        git_dir = (wt / git_dir).resolve()
+    (git_dir / "index").write_bytes(b"not-a-valid-git-index\n")
 
 
 class SubagentWorktreeTests(unittest.TestCase):
@@ -166,19 +177,22 @@ class SubagentWorktreeTests(unittest.TestCase):
         # The parent agent only ever sees this payload (it cannot read logs),
         # so the uncertainty must travel in the dict — otherwise "0 commits,
         # clean" reads as "the child produced nothing" and the work we just
-        # preserved never gets looked at.
+        # preserved never gets looked at. Assert the actionable invariants
+        # (flag set; note names the worktree + branch), not the prose.
         self.assertTrue(payload["inspection_failed"])
-        self.assertIn("UNKNOWN", payload["note"])
         self.assertIn(info["path"], payload["note"])
+        self.assertIn(info["branch"], payload["note"])
 
     def test_finalize_flags_unproven_state_distinguishably(self):
         """#88113 follow-up: a failed inspection must not look like "no work".
 
         Without an explicit flag, "inspection failed, uncommitted work
-        preserved" and "inspected fine, child left nothing" serialize to the
-        byte-identical dict {commits: 0, dirty: False, pruned: False} — so the
-        parent agent's rational reading of the failure case is the exact wrong
-        conclusion.
+        preserved" and "inspected fine, child left nothing" are
+        indistinguishable to the parent agent — so its rational reading of the
+        failure case is the exact wrong conclusion. The contract asserted here
+        is *distinguishability*, not the specific field values (a future
+        change emitting ``commits: None`` for "unknown" would be strictly
+        better and must not break this test).
         """
         repo = _make_repo(self.tmp)
 
@@ -192,19 +206,22 @@ class SubagentWorktreeTests(unittest.TestCase):
         assert bad_info is not None
         bad_wt = Path(bad_info["path"])
         (bad_wt / "WIP.txt").write_text("real work\n", encoding="utf-8")
-        git_dir = Path(_git(["rev-parse", "--git-dir"], bad_wt).stdout.strip())
-        if not git_dir.is_absolute():
-            git_dir = (bad_wt / git_dir).resolve()
-        (git_dir / "index").write_bytes(b"not-a-valid-git-index\n")
+        _break_git_index(bad_wt)
         bad_payload = sw.finalize_subagent_worktree(bad_info)
 
-        # The three state fields are identical — that is exactly the ambiguity.
-        for key in ("commits", "dirty", "pruned"):
-            self.assertEqual(ok_payload[key], bad_payload[key])
-        # Only the flag separates them.
-        self.assertNotIn("inspection_failed", ok_payload)
-        self.assertNotIn("note", ok_payload)
+        # Both keep the worktree, so "pruned" alone cannot separate them...
+        self.assertFalse(ok_payload["pruned"])
+        self.assertFalse(bad_payload["pruned"])
+        self.assertTrue(os.path.isdir(bad_info["path"]))
+        self.assertTrue((bad_wt / "WIP.txt").exists())
+        # ...the flag must. Tolerant of an always-present-but-False refactor.
+        self.assertFalse(ok_payload.get("inspection_failed", False))
         self.assertTrue(bad_payload["inspection_failed"])
+        self.assertNotEqual(
+            bool(ok_payload.get("inspection_failed")),
+            bool(bad_payload.get("inspection_failed")),
+        )
+        self.assertFalse((ok_payload.get("note") or "").strip())
 
     def test_finalize_flags_unproven_state_when_inspection_raises(self):
         """A raising probe is the same unknown state as a non-zero exit."""
@@ -215,13 +232,18 @@ class SubagentWorktreeTests(unittest.TestCase):
         def _boom(*_a, **_k):
             raise subprocess.TimeoutExpired(cmd="git", timeout=30)
 
-        with mock.patch.object(sw, "_run_git", side_effect=_boom):
+        with mock.patch.object(sw, "_run_git", side_effect=_boom) as m:
             payload = sw.finalize_subagent_worktree(info)
 
+        # Prove the patched seam was actually exercised.
+        self.assertGreaterEqual(m.call_count, 1)
         self.assertFalse(payload["pruned"])
         self.assertTrue(payload["inspection_failed"])
-        self.assertIn("UNKNOWN", payload["note"])
+        self.assertIn(info["path"], payload["note"])
+        self.assertIn(info["branch"], payload["note"])
         self.assertTrue(os.path.isdir(info["path"]))
+        branches = _git(["branch", "--list", info["branch"]], repo).stdout
+        self.assertNotEqual(branches.strip(), "")
 
     def test_finalize_missing_path_reports_pruned(self):
         payload = sw.finalize_subagent_worktree(
@@ -255,6 +277,68 @@ class SubagentWorktreeTests(unittest.TestCase):
         self.assertIn("/x/wt", note)
         self.assertIn("hermes-subagent/subagent-1", note)
         self.assertIn("WORKTREE ISOLATION", note)
+
+
+class WorktreePayloadSchemaTests(unittest.TestCase):
+    """The parent agent reads ONE schema under ``entry["worktree"]``.
+
+    Two producers write it: ``finalize_subagent_worktree`` and
+    ``delegate_tool``'s fallback for when finalize itself raises. Compare the
+    fallback against the REAL finalize output (not a hardcoded key list) so
+    the two can never drift apart.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="hermes-sw-schema-"))
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+    def test_fallback_matches_finalize_schema(self):
+        from tools import delegate_tool
+
+        repo = _make_repo(self.tmp)
+        info = sw.create_subagent_worktree(str(repo), "schema")
+        assert info is not None
+        happy = sw.finalize_subagent_worktree(info, prune=False)
+
+        # Read the fallback's ACTUAL keys out of the source (not a hardcoded
+        # copy), so drift in delegate_tool is what fails this test.
+        tree = ast.parse(
+            textwrap.dedent(inspect.getsource(delegate_tool._run_single_child))
+        )
+        fallback_keys = None
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign) or not isinstance(
+                node.value, ast.Dict
+            ):
+                continue
+            target = node.targets[0]
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.slice, ast.Constant)
+                and target.slice.value == "worktree"
+            ):
+                fallback_keys = {
+                    k.value
+                    for k in node.value.keys
+                    if isinstance(k, ast.Constant)
+                }
+                break
+
+        self.assertIsNotNone(
+            fallback_keys,
+            "delegate_tool no longer assigns a dict literal to "
+            'entry_dict["worktree"] — update this schema guard',
+        )
+        assert fallback_keys is not None  # narrow for type checkers
+        # Fallback must be a superset: every happy-path key plus the two
+        # unproven-state keys, and nothing invented. The pre-fix version
+        # emitted repo_root/base_commit and omitted commits/dirty/pruned.
+        self.assertTrue(set(happy).issubset(fallback_keys))
+        self.assertEqual(
+            fallback_keys - set(happy), {"inspection_failed", "note"}
+        )
+        for leaked in ("repo_root", "base_commit"):
+            self.assertNotIn(leaked, fallback_keys)
 
 
 class DelegationConfigGateTests(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2508,8 +2508,23 @@ def _run_single_child(
                 subagent_worktree.finalize_subagent_worktree(_worktree_info)
             )
         except Exception as e:
-            logger.debug("worktree finalize failed: %s", e)
-            entry_dict["worktree"] = dict(_worktree_info)
+            # finalize is written hard not to raise, but if it ever does the
+            # state is unknown — emit the SAME schema the parent expects,
+            # flagged, instead of leaking the creation-side metadata shape.
+            logger.warning("worktree finalize failed: %s", e)
+            entry_dict["worktree"] = {
+                "path": _worktree_info.get("path", ""),
+                "branch": _worktree_info.get("branch", ""),
+                "commits": 0,
+                "dirty": False,
+                "pruned": False,
+                "inspection_failed": True,
+                "note": (
+                    "worktree finalize raised; state unknown — inspect "
+                    f"{_worktree_info.get('path', '')} manually before "
+                    "assuming no work."
+                ),
+            }
 
     try:
         _heartbeat_thread.start()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2520,8 +2520,10 @@ def _run_single_child(
                 "pruned": False,
                 "inspection_failed": True,
                 "note": (
-                    "worktree finalize raised; state unknown — inspect "
-                    f"{_worktree_info.get('path', '')} manually before "
+                    "worktree finalize raised: 'commits' and 'dirty' are "
+                    "UNKNOWN, not zero/clean. The worktree and branch were "
+                    f"preserved — inspect {_worktree_info.get('path', '')} "
+                    f"(branch {_worktree_info.get('branch', '')}) before "
                     "assuming no work."
                 ),
             }

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2510,23 +2510,33 @@ def _run_single_child(
         except Exception as e:
             # finalize is written hard not to raise, but if it ever does the
             # state is unknown — emit the SAME schema the parent expects,
-            # flagged, instead of leaking the creation-side metadata shape.
+            # flagged, via the shared factory so the two producers of this
+            # payload can never drift.
             logger.warning("worktree finalize failed: %s", e)
-            entry_dict["worktree"] = {
-                "path": _worktree_info.get("path", ""),
-                "branch": _worktree_info.get("branch", ""),
-                "commits": 0,
-                "dirty": False,
-                "pruned": False,
-                "inspection_failed": True,
-                "note": (
-                    "worktree finalize raised: 'commits' and 'dirty' are "
-                    "UNKNOWN, not zero/clean. The worktree and branch were "
-                    f"preserved — inspect {_worktree_info.get('path', '')} "
-                    f"(branch {_worktree_info.get('branch', '')}) before "
-                    "assuming no work."
-                ),
-            }
+            try:
+                from tools import subagent_worktree as _sw
+
+                entry_dict["worktree"] = _sw.unproven_worktree_payload(
+                    _worktree_info, f"finalize raised: {e}"
+                )
+            except Exception:
+                # Import itself failed — inline the same shape rather than
+                # dropping the flag (the parent must still see the warning).
+                entry_dict["worktree"] = {
+                    "path": _worktree_info.get("path", ""),
+                    "branch": _worktree_info.get("branch", ""),
+                    "commits": 0,
+                    "dirty": False,
+                    "pruned": False,
+                    "inspection_failed": True,
+                    "note": (
+                        f"worktree finalize raised ({e}) and the reporting "
+                        "helper was unavailable: 'commits' and 'dirty' are "
+                        "UNKNOWN, not zero/clean. Inspect "
+                        f"{_worktree_info.get('path', '')} before assuming "
+                        "no work."
+                    ),
+                }
 
     try:
         _heartbeat_thread.start()

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -28,7 +28,7 @@ Contract (mirrors Muse Code's documented semantics):
   clean tree is removed automatically after the child finishes; anything
   holding work is kept and reported. Pruning requires affirmative proof:
   if a git inspection probe fails the state is unknown, so the worktree is
-  kept and the result entry is flagged ``inspection_failed`` (#88113).
+  kept and the result entry carries ``inspection_failed`` + ``note`` (#88113).
 
 Only the local terminal backend is supported: on docker/ssh/modal/etc. the
 worktree created on the host would not be visible inside the sandbox, so

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -172,6 +172,60 @@ def create_subagent_worktree(
     }
 
 
+def mark_worktree_payload_unproven(
+    payload: Dict[str, Any], reason: str
+) -> Dict[str, Any]:
+    """Flag a worktree result payload as un-inspected, in place (#88113).
+
+    A failed probe proves nothing about the tree, so ``commits``/``dirty`` keep
+    their defaults. The parent agent only ever sees this dict — it cannot read
+    logs — so the uncertainty has to travel *in the payload*, or "0 commits,
+    clean" reads as "the child produced nothing" and the work we just preserved
+    is never looked at.
+
+    Shared by ``finalize_subagent_worktree`` and ``delegate_tool``'s
+    finalize-raised fallback so the two producers of this schema cannot drift.
+    """
+    path = payload.get("path", "")
+    branch = payload.get("branch", "")
+    payload["inspection_failed"] = True
+    payload["note"] = (
+        f"git inspection failed ({reason}): 'commits' and 'dirty' are "
+        "UNKNOWN, not zero/clean. The worktree and branch were preserved "
+        f"— inspect {path} (branch {branch}) before assuming no work."
+    )
+    logger.warning(
+        "subagent worktree: git inspection failed (%s) — keeping %s "
+        "(branch %s) for manual review",
+        reason,
+        path,
+        branch,
+    )
+    return payload
+
+
+def unproven_worktree_payload(
+    info: Dict[str, str], reason: str
+) -> Dict[str, Any]:
+    """Build a complete un-inspected payload from creation-side *info*.
+
+    For callers that never got a payload back at all (``delegate_tool``'s
+    fallback when ``finalize_subagent_worktree`` itself raises). Emits exactly
+    the schema the parent expects — notably WITHOUT the creation-side
+    ``repo_root``/``base_commit`` internals.
+    """
+    return mark_worktree_payload_unproven(
+        {
+            "path": info.get("path", ""),
+            "branch": info.get("branch", ""),
+            "commits": 0,
+            "dirty": False,
+            "pruned": False,
+        },
+        reason,
+    )
+
+
 def finalize_subagent_worktree(
     info: Dict[str, str], *, prune: bool = True
 ) -> Dict[str, Any]:
@@ -206,58 +260,45 @@ def finalize_subagent_worktree(
         return payload
 
     def _unproven(reason: str) -> Dict[str, Any]:
-        """Flag the payload as un-inspected and keep the worktree (#88113).
+        return mark_worktree_payload_unproven(payload, reason)
 
-        A failed probe proves nothing about the tree, so ``commits``/``dirty``
-        are still their defaults. The parent agent only ever sees this dict —
-        it cannot read logs — so the uncertainty has to travel *in the
-        payload*, or "0 commits, clean" reads as "the child produced nothing"
-        and the work we just preserved is never looked at.
-        """
-        payload["inspection_failed"] = True
-        payload["note"] = (
-            f"git inspection failed ({reason}): 'commits' and 'dirty' are "
-            "UNKNOWN, not zero/clean. The worktree and branch were preserved "
-            f"— inspect {path} (branch {branch}) before assuming no work."
-        )
-        logger.warning(
-            "subagent worktree: git inspection failed (%s) — keeping %s "
-            "(branch %s) for manual review",
-            reason,
-            path,
-            branch,
-        )
-        return payload
+    # A worktree whose commit count was never measured must not be pruned
+    # either: the prune condition reads payload["commits"], and without a base
+    # commit that value is an unproven default, exactly the class of bug
+    # #88113 is about.
+    if not base_commit:
+        return _unproven("no base_commit recorded — commit count unmeasurable")
 
-    inspection_ok = True
+    failed: list = []
     try:
-        if base_commit:
-            counted = _run_git(
-                ["rev-list", "--count", f"{base_commit}..HEAD"], cwd=path
+        counted = _run_git(
+            ["rev-list", "--count", f"{base_commit}..HEAD"], cwd=path
+        )
+        if counted.returncode == 0:
+            payload["commits"] = int(counted.stdout.strip() or 0)
+        else:
+            failed.append(
+                f"rev-list exit {counted.returncode}: "
+                f"{counted.stderr.strip()[:200]}"
             )
-            if counted.returncode == 0:
-                payload["commits"] = int(counted.stdout.strip() or 0)
-            else:
-                inspection_ok = False
         status = _run_git(["status", "--porcelain"], cwd=path)
         if status.returncode == 0:
             payload["dirty"] = bool(status.stdout.strip())
         else:
-            inspection_ok = False
+            failed.append(
+                f"status exit {status.returncode}: "
+                f"{status.stderr.strip()[:200]}"
+            )
     except Exception as exc:
         # Same unknown state as a non-zero exit (timeout, OSError, or a
         # non-numeric rev-list stdout) — keep the worktree rather than risk
         # deleting work, and tell the caller the numbers are unproven.
         return _unproven(f"inspection raised: {exc}")
 
-    if not inspection_ok:
-        # Fail-safe (#88113): a non-zero git exit proves nothing about the
-        # tree — the payload defaults (0 commits, clean) were never
-        # overwritten, and pruning on them permanently deleted uncommitted
-        # child work. A destructive cleanup requires affirmative proof of
-        # "zero commits + clean tree"; otherwise keep the worktree and
-        # branch for manual inspection.
-        return _unproven("rev-list/status non-zero")
+    if failed:
+        # Fail-safe (#88113): a destructive cleanup requires affirmative proof
+        # of "zero commits + clean tree"; the defaults prove nothing.
+        return _unproven("; ".join(failed))
 
     if prune and payload["commits"] == 0 and not payload["dirty"]:
         try:

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -26,7 +26,9 @@ Contract (mirrors Muse Code's documented semantics):
   dirty state so the parent can review or merge each branch.
 - **Clean worktrees are pruned.** A worktree with no new commits and a
   clean tree is removed automatically after the child finishes; anything
-  holding work is kept and reported.
+  holding work is kept and reported. Pruning requires affirmative proof:
+  if a git inspection probe fails the state is unknown, so the worktree is
+  kept and the result entry is flagged ``inspection_failed`` (#88113).
 
 Only the local terminal backend is supported: on docker/ssh/modal/etc. the
 worktree created on the host would not be visible inside the sandbox, so
@@ -177,8 +179,15 @@ def finalize_subagent_worktree(
 
     Returns a result-entry payload: path, branch, ``commits`` ahead of the
     base, ``dirty`` (uncommitted changes present), and ``pruned``. A worktree
-    with zero commits and a clean tree is removed when *prune* is true;
-    anything holding work is always kept for the parent to review or merge.
+    with zero commits and a clean tree is removed when *prune* is true **and
+    both git probes succeeded**; anything holding work is always kept for the
+    parent to review or merge.
+
+    If ``git rev-list``/``git status`` exits non-zero (or the inspection
+    raises), the tree state is unknown, so the worktree and branch are kept
+    and the payload carries ``inspection_failed: True`` plus a ``note``.
+    ``commits``/``dirty`` are then defaults, NOT measurements — the parent
+    must inspect the worktree instead of concluding the child did no work.
     """
     path = info.get("path", "")
     branch = info.get("branch", "")
@@ -194,6 +203,30 @@ def finalize_subagent_worktree(
     }
     if not path or not os.path.isdir(path):
         payload["pruned"] = True  # nothing on disk to review
+        return payload
+
+    def _unproven(reason: str) -> Dict[str, Any]:
+        """Flag the payload as un-inspected and keep the worktree (#88113).
+
+        A failed probe proves nothing about the tree, so ``commits``/``dirty``
+        are still their defaults. The parent agent only ever sees this dict —
+        it cannot read logs — so the uncertainty has to travel *in the
+        payload*, or "0 commits, clean" reads as "the child produced nothing"
+        and the work we just preserved is never looked at.
+        """
+        payload["inspection_failed"] = True
+        payload["note"] = (
+            f"git inspection failed ({reason}): 'commits' and 'dirty' are "
+            "UNKNOWN, not zero/clean. The worktree and branch were preserved "
+            f"— inspect {path} (branch {branch}) before assuming no work."
+        )
+        logger.warning(
+            "subagent worktree: git inspection failed (%s) — keeping %s "
+            "(branch %s) for manual review",
+            reason,
+            path,
+            branch,
+        )
         return payload
 
     inspection_ok = True
@@ -212,9 +245,10 @@ def finalize_subagent_worktree(
         else:
             inspection_ok = False
     except Exception as exc:
-        logger.debug("subagent worktree: finalize inspection failed: %s", exc)
-        # Unknown state — keep the worktree rather than risk deleting work.
-        return payload
+        # Same unknown state as a non-zero exit (timeout, OSError, or a
+        # non-numeric rev-list stdout) — keep the worktree rather than risk
+        # deleting work, and tell the caller the numbers are unproven.
+        return _unproven(f"inspection raised: {exc}")
 
     if not inspection_ok:
         # Fail-safe (#88113): a non-zero git exit proves nothing about the
@@ -223,13 +257,7 @@ def finalize_subagent_worktree(
         # child work. A destructive cleanup requires affirmative proof of
         # "zero commits + clean tree"; otherwise keep the worktree and
         # branch for manual inspection.
-        logger.warning(
-            "subagent worktree: git inspection failed (rev-list/status "
-            "non-zero) — keeping %s (branch %s) for manual review",
-            path,
-            branch,
-        )
-        return payload
+        return _unproven("rev-list/status non-zero")
 
     if prune and payload["commits"] == 0 and not payload["dirty"]:
         try:

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -196,6 +196,7 @@ def finalize_subagent_worktree(
         payload["pruned"] = True  # nothing on disk to review
         return payload
 
+    inspection_ok = True
     try:
         if base_commit:
             counted = _run_git(
@@ -203,12 +204,31 @@ def finalize_subagent_worktree(
             )
             if counted.returncode == 0:
                 payload["commits"] = int(counted.stdout.strip() or 0)
+            else:
+                inspection_ok = False
         status = _run_git(["status", "--porcelain"], cwd=path)
         if status.returncode == 0:
             payload["dirty"] = bool(status.stdout.strip())
+        else:
+            inspection_ok = False
     except Exception as exc:
         logger.debug("subagent worktree: finalize inspection failed: %s", exc)
         # Unknown state — keep the worktree rather than risk deleting work.
+        return payload
+
+    if not inspection_ok:
+        # Fail-safe (#88113): a non-zero git exit proves nothing about the
+        # tree — the payload defaults (0 commits, clean) were never
+        # overwritten, and pruning on them permanently deleted uncommitted
+        # child work. A destructive cleanup requires affirmative proof of
+        # "zero commits + clean tree"; otherwise keep the worktree and
+        # branch for manual inspection.
+        logger.warning(
+            "subagent worktree: git inspection failed (rev-list/status "
+            "non-zero) — keeping %s (branch %s) for manual review",
+            path,
+            branch,
+        )
         return payload
 
     if prune and payload["commits"] == 0 and not payload["dirty"]:

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -173,15 +173,20 @@ def create_subagent_worktree(
 
 
 def mark_worktree_payload_unproven(
-    payload: Dict[str, Any], reason: str
+    payload: Dict[str, Any], reason: str, *, unmeasured: str = "commits/dirty"
 ) -> Dict[str, Any]:
     """Flag a worktree result payload as un-inspected, in place (#88113).
 
-    A failed probe proves nothing about the tree, so ``commits``/``dirty`` keep
-    their defaults. The parent agent only ever sees this dict — it cannot read
-    logs — so the uncertainty has to travel *in the payload*, or "0 commits,
-    clean" reads as "the child produced nothing" and the work we just preserved
-    is never looked at.
+    A failed probe proves nothing about the tree, so the fields it would have
+    filled keep their defaults. The parent agent only ever sees this dict — it
+    cannot read logs — so the uncertainty has to travel *in the payload*, or
+    "0 commits, clean" reads as "the child produced nothing" and the work we
+    just preserved is never looked at.
+
+    *unmeasured* names only the fields this failure actually left unproven: one
+    probe can succeed while the other fails (a bad ``base_commit`` fails
+    ``rev-list`` while ``status`` still reports a real ``dirty``), and claiming
+    a measured value is UNKNOWN would be its own kind of misreport.
 
     Shared by ``finalize_subagent_worktree`` and ``delegate_tool``'s
     finalize-raised fallback so the two producers of this schema cannot drift.
@@ -190,8 +195,8 @@ def mark_worktree_payload_unproven(
     branch = payload.get("branch", "")
     payload["inspection_failed"] = True
     payload["note"] = (
-        f"git inspection failed ({reason}): 'commits' and 'dirty' are "
-        "UNKNOWN, not zero/clean. The worktree and branch were preserved "
+        f"git inspection failed ({reason}): {unmeasured} UNKNOWN — not "
+        "proven zero/clean. The worktree and branch were preserved "
         f"— inspect {path} (branch {branch}) before assuming no work."
     )
     logger.warning(
@@ -259,17 +264,25 @@ def finalize_subagent_worktree(
         payload["pruned"] = True  # nothing on disk to review
         return payload
 
-    def _unproven(reason: str) -> Dict[str, Any]:
-        return mark_worktree_payload_unproven(payload, reason)
+    def _unproven(
+        reason: str, *, unmeasured: str = "commits/dirty"
+    ) -> Dict[str, Any]:
+        return mark_worktree_payload_unproven(
+            payload, reason, unmeasured=unmeasured
+        )
 
     # A worktree whose commit count was never measured must not be pruned
     # either: the prune condition reads payload["commits"], and without a base
     # commit that value is an unproven default, exactly the class of bug
     # #88113 is about.
     if not base_commit:
-        return _unproven("no base_commit recorded — commit count unmeasurable")
+        return _unproven(
+            "no base_commit recorded — commit count unmeasurable",
+            unmeasured="commits",
+        )
 
     failed: list = []
+    unmeasured: list = []
     try:
         counted = _run_git(
             ["rev-list", "--count", f"{base_commit}..HEAD"], cwd=path
@@ -281,6 +294,7 @@ def finalize_subagent_worktree(
                 f"rev-list exit {counted.returncode}: "
                 f"{counted.stderr.strip()[:200]}"
             )
+            unmeasured.append("commits")
         status = _run_git(["status", "--porcelain"], cwd=path)
         if status.returncode == 0:
             payload["dirty"] = bool(status.stdout.strip())
@@ -289,16 +303,20 @@ def finalize_subagent_worktree(
                 f"status exit {status.returncode}: "
                 f"{status.stderr.strip()[:200]}"
             )
+            unmeasured.append("dirty")
     except Exception as exc:
         # Same unknown state as a non-zero exit (timeout, OSError, or a
         # non-numeric rev-list stdout) — keep the worktree rather than risk
-        # deleting work, and tell the caller the numbers are unproven.
+        # deleting work, and tell the caller the numbers are unproven. Which
+        # probe raised is unknowable here, so neither value is trustworthy.
         return _unproven(f"inspection raised: {exc}")
 
     if failed:
         # Fail-safe (#88113): a destructive cleanup requires affirmative proof
         # of "zero commits + clean tree"; the defaults prove nothing.
-        return _unproven("; ".join(failed))
+        return _unproven(
+            "; ".join(failed), unmeasured="/".join(unmeasured)
+        )
 
     if prune and payload["commits"] == 0 and not payload["dirty"]:
         try:

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -412,10 +412,11 @@ With isolation on:
   reviews or merges each branch (`git log <branch>`, `git merge <branch>`).
 - A worktree left with **no commits and a clean tree is pruned automatically**
   (`pruned: true`); anything holding work is kept.
-- Pruning requires proof. If a git inspection probe fails, the worktree and
-  branch are kept and the entry carries `inspection_failed: true` plus a
-  `note` — `commits`/`dirty` are then defaults, not measurements, so inspect
-  the worktree rather than assuming the child produced nothing.
+- Pruning requires proof. If a git inspection probe fails — or finalization
+  itself errors — the worktree and branch are kept and the entry carries
+  `inspection_failed: true` plus a `note` — `commits`/`dirty` are then
+  defaults, not measurements, so inspect the worktree rather than assuming
+  the child produced nothing.
 
 Scope: opt-in, git-only, and local-terminal-backend-only. In a non-git
 directory, on docker/ssh/modal backends, or if worktree creation fails, the

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -412,6 +412,10 @@ With isolation on:
   reviews or merges each branch (`git log <branch>`, `git merge <branch>`).
 - A worktree left with **no commits and a clean tree is pruned automatically**
   (`pruned: true`); anything holding work is kept.
+- Pruning requires proof. If a git inspection probe fails, the worktree and
+  branch are kept and the entry carries `inspection_failed: true` plus a
+  `note` — `commits`/`dirty` are then defaults, not measurements, so inspect
+  the worktree rather than assuming the child produced nothing.
 
 Scope: opt-in, git-only, and local-terminal-backend-only. In a non-git
 directory, on docker/ssh/modal backends, or if worktree creation fails, the


### PR DESCRIPTION
## Summary

A delegated subagent's uncommitted work is no longer destroyed when a git inspection probe fails — and the parent agent is now told the preserved worktree needs a look.

Salvage of #88125 by @liuhao1024 (authorship preserved via cherry-pick) onto current `main`, plus a follow-up commit closing a caller-visibility gap found during review.

Root cause: with `delegation.worktree_isolation: true`, `finalize_subagent_worktree()` pre-seeded its result payload with `commits: 0, dirty: False`, then ran two probes (`git rev-list --count`, `git status --porcelain`) that only *overwrote* those values on a zero exit. A non-zero exit left the defaults untouched — and the prune condition read them as **proven** clean, running `git worktree remove --force` + `git branch -D`. Untracked/uncommitted child work was irrecoverable, and the entry even reported `pruned: true`.

## Changes

**Commit 1 — @liuhao1024: fail closed on inspection uncertainty**
- `tools/subagent_worktree.py`: an `inspection_ok` flag; a non-zero `rev-list`/`status` exit skips the destructive prune and keeps the worktree + branch with a WARNING naming both.
- `tests/tools/test_subagent_worktree.py`: regression test using a real repo + worktree whose index is corrupted so `git status --porcelain` really exits 128.

**Commit 2 — follow-up: make the preserved worktree visible to the parent**
- `tools/subagent_worktree.py`: one `_unproven()` helper stamps `inspection_failed: True` + a `note` naming the worktree/branch, warns, and returns. Both unproven exits route through it so they can't drift apart again.
- `tools/subagent_worktree.py`: the pre-existing `except Exception` path (timeout, OSError, non-numeric `rev-list` stdout) produced the *same* unproven payload but logged at DEBUG — effectively silent. Identical outcomes now get identical reporting.
- `tools/delegate_tool.py`: the caller's finalize-raised fallback assigned the creation-side metadata dict (`path/branch/repo_root/base_commit`) — a disjoint schema missing `commits`/`dirty`/`pruned`. It now emits the same flagged shape, at WARNING.
- Docs + docstring + module contract state that pruning requires affirmative proof, so a future cleanup doesn't "fix" the preserved worktree by restoring the unconditional prune and reintroducing this P1.

**Commit 3 — review fold: assert the contract, not its prose**
- The distinguishability test asserted the failure payload was *byte-identical* to the genuinely-clean one, which froze the ambiguity as a required property — a future `commits: None` for "unknown" would improve exactly what #88113 is about and fail the test. Now asserts what the parent depends on: both keep the worktree, only the flag separates them.
- `assertNotIn("inspection_failed", ok_payload)` pinned key *absence*, forbidding an always-present-but-False flag (a stabler JSON contract). Now tolerant of that refactor.
- Dropped `assertIn("UNKNOWN", note)` prose coupling — the two producers' notes disagreed on the token anyway. Tests now assert the note names the worktree **and** branch (the actionable part), and both producers' wording was aligned.
- The raises test never proved its patched seam ran; now checks `call_count` and mirrors its sibling's branch-survival leg.
- New `WorktreePayloadSchemaTests`: AST-parses `delegate_tool`'s real fallback dict and compares it against live `finalize_subagent_worktree()` output, so the two producers of this schema can't drift and the pre-fix leak (`repo_root`/`base_commit`, missing `commits`/`dirty`/`pruned`) can't return.
- Docs/docstring drift: the flag has a second trigger (finalization itself raising) and the module docstring omitted `note`. Both fixed.

**Commit 4 — Phase 2c fold: extract the factory, drop the source-reading test**
- The previous commit's schema guard AST-parsed `delegate_tool`'s source. `AGENTS.md:1514` bans that outright ("Never read source code in tests") — it passes when the implementation is subtly broken and fails on a correct refactor. Extracting the shared factory the rule prescribes also removes the duplication the AST test existed to police, so one change fixed both.
- `subagent_worktree`: new `mark_worktree_payload_unproven()` + `unproven_worktree_payload()`; both producers call them, so the schema can't drift and the note string exists once. `delegate_tool`'s fallback is now 3 lines instead of 19, with a guarded re-import (the outer `except` can be entered *because* the import failed, which would otherwise raise `NameError` and lose the flag).
- Replaced the AST test with a behavioral one that calls the real factory and compares against live `finalize_subagent_worktree()` output.
- **Closed one more fail-open path of the same bug class:** with no `base_commit` the rev-list probe never ran, so `commits` kept its unproven `0` and a clean tree still reached `git worktree remove --force`. `finalize` is public and takes a caller-supplied dict, so this now fails closed too.
- Per-probe diagnostics: the note named neither which probe failed nor why. It now carries the probe name, exit code, and a bounded git stderr tail.

**Commit 5 — /simplify-code residual: disclaim only what actually failed**
- The note hard-coded "`commits` and `dirty` are UNKNOWN", but the probes fail independently: a bad `base_commit` fails `rev-list` while `git status` still succeeds, so `dirty` was a **real measurement being reported as unknown**. Safety was never affected (preserved either way), but telling the parent a measured value is untrustworthy is its own misreport. `mark_worktree_payload_unproven()` now takes `unmeasured`; the raising path still disclaims both, since which probe raised is unknowable there.

Purely additive — the happy-path payload shape is unchanged, so no existing reader can break.

### Why commit 2 was needed

The fix stopped the deletion but still reported unproven values as facts, making the failure case byte-identical to "the child did nothing":

| | `commits` | `dirty` | `pruned` |
|---|---|---|---|
| inspection FAILED, uncommitted work kept | 0 | false | false |
| inspected OK, child produced nothing | 0 | false | false |

The only failure signal was a `logger.warning`, and the sole consumer of this payload is the **parent agent** reading the serialized `delegate_task` entry — it cannot read logs (no in-repo code reads the key back). So the parent's rational reading of the failure case was "no work produced": the rescued worktree survives, but nobody is ever told to recover it.

## Validation

Bug reproduced on `main` and verified fixed, with real git repos/worktrees — no mocks:

| | `main` @ 979ca57a50 | this branch |
|---|---|---|
| worktree survives | **no** | yes |
| uncommitted work survives | **no — destroyed** | yes |
| branch survives | **no** | yes |
| `pruned` reported | **true (wrong)** | false |
| parent can tell inspection failed | n/a | `inspection_failed: true` + `note` |
| proven-clean tree still pruned | yes | yes (unchanged) |

- **Tests:** 22/22 `tests/tools/test_subagent_worktree.py`; 127+ passed across `test_delegate.py`, `test_delegate_batch_validation.py`, `test_delegate_control_actions.py`, `test_delegate_subagent_timeout_diagnostic.py`. Ruff clean.
- **Mutation-checked (guards have teeth):** neutering the flag fails all 3 new assertions; reverting the production file to pre-fix `main` fails all 3 (re-run on the final 3-commit stack). Reverting `delegate_tool`'s fallback to the pre-fix `dict(_worktree_info)` shape fails the new schema guard. All restores checksum-verified. Final stack: all **6** guards fail under both mutations.
- **Lint/types:** ruff clean; `ty` clean on `subagent_worktree.py` and 64-vs-64 unchanged on `delegate_tool.py` (all pre-existing, verified against the base commit).
- **Coverage beyond the original test:** the untested `rev-list`-failure path (bogus base, `status` exit 0, *committed* child work) also preserves correctly; the raising path is covered too.
- **Edge case ruled out:** `base_commit == ""` would skip the `rev-list` probe and prune on an unproven count, but it's unreachable — the same bad `HEAD` that fails `rev-parse` also fails `worktree add`, so `create_subagent_worktree()` returns `None` and finalize never runs.
- **Whole bug class:** `cli.py`'s sibling probes (`_worktree_is_dirty`, `_worktree_has_unpushed_commits`) already `return True` on non-zero exit; this file was the last gap. The `cli.py` startup pruner independently classifies a corrupt-index worktree as dirty, so preserved trees are kept and surfaced in its 7-day stale-work WARNING rather than accumulating silently.

Windows `creationflags` on `_run_git` is deliberately out of scope — already owned by open #85243, no overlap with these hunks.

Closes #88125
Fixes #88113

Co-authored-by: liuhao1024 <sunsky.lau@gmail.com>
