### PR TITLE
fix(sandbox): trust sandbox CA for npm and keep CONNECT tunnels alive

### DIFF
--- a/scripts/sandbox/proxy.py
+++ b/scripts/sandbox/proxy.py
@@ -41,6 +41,23 @@ def read_request(conn):
         if not part:
             return b""
         data += part
+    # Read the request body when a Content-Length is present, so a keep-alive
+    # loop can start cleanly at the next request rather than re-reading body
+    # bytes as a bogus request head.
+    headers, sep, body = data.partition(b"\r\n\r\n")
+    for header in headers.split(b"\r\n"):
+        if header.lower().startswith(b"content-length:"):
+            try:
+                length = int(header.split(b":", 1)[1].strip())
+            except ValueError:
+                break
+            while len(body) < length and len(data) < MAX_REQUEST_BYTES:
+                part = conn.recv(4096)
+                if not part:
+                    break
+                body += part
+                data += part
+            break
     return data
 
 
@@ -169,7 +186,12 @@ def forward_http(conn, host, port, request, target):
 
 
 def handle_connect(conn, target):
-    """Intercept a CONNECT tunnel, terminating TLS with a minted cert."""
+    """Intercept a CONNECT tunnel, terminating TLS with a minted cert.
+
+    Serves multiple nested requests on the same client connection
+    (HTTP keep-alive) so clients that reuse connections — npm in
+    particular — don't hit an EOF on their second request.
+    """
     host, _, port_text = target.rpartition(':')
     port = int(port_text or '443')
     conn.sendall(b'HTTP/1.1 200 Connection Established\r\n\r\n')
@@ -177,16 +199,17 @@ def handle_connect(conn, target):
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     context.load_cert_chain(cert, key)
     with context.wrap_socket(conn, server_side=True) as tls:
-        nested = read_request(tls)
-        if not nested:
-            return
-        line = nested.split(b'\r\n', 1)[0].decode('iso-8859-1')
-        nested_target = line.split(' ', 2)[1]
-        found = file_for(host, nested_target)
-        if found is not None:
-            respond_fixture(tls, found)
-        else:
-            forward_https(tls, host, port, nested)
+        while True:
+            nested = read_request(tls)
+            if not nested:
+                return
+            line = nested.split(b'\r\n', 1)[0].decode('iso-8859-1')
+            nested_target = line.split(' ', 2)[1]
+            found = file_for(host, nested_target)
+            if found is not None:
+                respond_fixture(tls, found)
+            else:
+                forward_https(tls, host, port, nested)
 
 
 def host_from_headers(request):

--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -216,7 +216,7 @@ exec bwrap \
   --setenv CURL_CA_BUNDLE /work/certs/ca.pem \
   --setenv SSL_CERT_FILE /work/certs/ca.pem \
   --setenv GIT_SSL_CAINFO /work/certs/ca.pem \
-  --setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem \
+  --setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \
   --setenv OPENSSL_CONF /work/certs/openssl.cnf \
   --setenv HTTP_PROXY http://127.0.0.1:8080 \
   --setenv HTTPS_PROXY http://127.0.0.1:8080 \


### PR DESCRIPTION
## Summary

The `Install & Update E2E` workflow (`install-e2e.yml`, added 8/4) has been red on **every** run since it was introduced — the Node/browser-tools install step inside the dev sandbox always fails. Two bugs in `scripts/sandbox/`:

### 1. npm is pointed at the wrong CA bundle (primary cause)

`scripts/sandbox/stage2-run.sh` sets `NODE_EXTRA_CA_CERTS=/work/certs/real-ca.pem`, but inside the sandbox npm talks to the **MITM proxy** (`proxy.py`), whose per-host certificates are minted by the **sandbox CA** (`ca.pem`). With the real CA bundle, npm rejects the proxy cert:

```
npm error code UNABLE_TO_VERIFY_LEAF_SIGNATURE
npm error request to https://registry.npmjs.org/is-number failed, reason: unable to verify the first certificate
```

Every other tool (curl, git, OpenSSL) already points at `ca.pem` — only Node was given the wrong bundle.

Fix: `NODE_EXTRA_CA_CERTS=/work/certs/ca.pem`.

### 2. CONNECT tunnels are closed after one request (secondary)

`handle_connect` in `scripts/sandbox/proxy.py` serves a single nested request and then closes the TLS connection. Keep-alive clients — npm's default agent — hit `SSLEOFError` on connection reuse. Fix: loop over nested requests on the same client TLS connection and consume `Content-Length` bodies so each iteration starts at the next request head.

## Repro / verification (local)

Real npm through the sandbox proxy, before fix:

```
npm error code UNABLE_TO_VERIFY_LEAF_SIGNATURE
proxy request failed: SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] ...')
```

After both fixes, real `npm install is-number` through the same proxy:

```
added 1 package in 3s
```

Keep-alive client pattern (2 sequential requests over one CONNECT tunnel):
before → second request `SSLEOFError`; after → both `HTTP/1.1 200 OK`.

## Scope of this PR

This PR fixes the **TLS/CA trust + proxy keep-alive** causes. On the E2E workflow, the `update` legs now pass **4/5** across fork runs (v2026.3.12 / 4.8 / 5.28 / 7.7), where every leg failed before.

The **remaining** `installer` leg failures are a **separate root cause**: `node-pty` native compilation fails with `/usr/local/common.gypi not found` — `NODE_DIR` is resolved on the host (`scripts/dev-sandbox.sh:482-484`) while the sandbox uses the installer-provisioned node, so node-gyp gets a mismatched `npm_config_nodedir`. Tracked in #88453, not addressed here.

## Impact

Unblocks most of the `Install & Update E2E` workflow (TLS/keep-alive failures) for upstream and forks; remaining installer legs tracked in #88453. No change to fixture serving or short-lived clients.
