### PR TITLE
fix(update): unshallow shallow clones so fetch crosses the boundary

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4217,10 +4217,45 @@ def _fetch_command(git_cmd: list, branch: str, repo_root) -> list:
     reported success. When ``.git/shallow`` is present, fetch with
     ``--unshallow`` so ``origin/<branch>`` reaches the real remote tip
     (one-time cost per checkout; afterwards the repo is no longer shallow).
+
+    The shallow marker lives in the git COMMON dir. For a primary checkout
+    that is ``<root>/.git/shallow``; for a linked worktree the ``.git`` entry
+    is a file pointing at a gitdir elsewhere, so we resolve the common dir
+    via ``git rev-parse --git-common-dir`` and test that before deciding
+    (worktree blind spot noted in automated review).
     """
-    if (Path(repo_root) / ".git" / "shallow").exists():
+    git_dir = _git_common_dir(git_cmd, repo_root)
+    if git_dir is not None and (git_dir / "shallow").exists():
         return git_cmd + ["fetch", "--unshallow", "origin", branch]
     return git_cmd + ["fetch", "origin", branch]
+
+
+def _git_common_dir(git_cmd: list, repo_root) -> Optional[Path]:
+    """Resolve the repo's git common dir, or None when git is unusable.
+
+    ``git rev-parse --git-common-dir`` returns the directory holding
+    ``HEAD``/``shallow`` — ``<root>/.git`` for a primary checkout, the
+    linked-worktree gitdir's common parent for a worktree. Falls back to
+    ``<root>/.git`` when the command fails (e.g. not yet a git repo) so the
+    shallow probe still works for the primary-checkout shape.
+    """
+    root = Path(repo_root)
+    try:
+        result = subprocess.run(
+            git_cmd + ["rev-parse", "--git-common-dir"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=15,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            common = Path(result.stdout.strip())
+            if common.is_absolute():
+                return common
+            return (root / common).resolve()
+    except Exception:
+        pass
+    return root / ".git"
 
 
 def _discard_lockfile_churn(git_cmd, repo_root):

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4207,6 +4207,22 @@ def _resume_windows_gateways_after_update(token: dict | None) -> None:
             f"  ✓ Restarting {unmapped_relaunched} unmapped Windows gateway process(es)"
         )
 
+def _fetch_command(git_cmd: list, branch: str, repo_root) -> list:
+    """Build the git fetch command, unshallowing shallow checkouts (#88175).
+
+    A shallow clone's ``git fetch origin <branch>`` returns success WITHOUT
+    crossing the shallow boundary, so ``origin/<branch>`` stays at a stale
+    commit; ``reset --hard`` then aligns the working tree to that stale
+    commit and the update badge never clears even though the updater
+    reported success. When ``.git/shallow`` is present, fetch with
+    ``--unshallow`` so ``origin/<branch>`` reaches the real remote tip
+    (one-time cost per checkout; afterwards the repo is no longer shallow).
+    """
+    if (Path(repo_root) / ".git" / "shallow").exists():
+        return git_cmd + ["fetch", "--unshallow", "origin", branch]
+    return git_cmd + ["fetch", "origin", branch]
+
+
 def _discard_lockfile_churn(git_cmd, repo_root):
     """Restore tracked ``package-lock.json`` files that npm dirtied locally.
 
@@ -4681,7 +4697,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         print("→ Fetching updates...")
         fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin", branch],
+            _fetch_command(git_cmd, branch, _m().PROJECT_ROOT),
             cwd=_m().PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1264,3 +1264,48 @@ class TestShallowCloneFetch:
         (tmp_path / ".git").mkdir(parents=True)
         cmd = update_cmd._fetch_command(["git"], "main", tmp_path)
         assert cmd == ["git", "fetch", "origin", "main"]
+
+    def test_linked_worktree_shallow_uses_unshallow(self, tmp_path):
+        """Linked worktrees have `.git` as a file pointing at a gitdir
+        elsewhere — the shallow marker lives in the common dir, so the probe
+        must resolve it via `git rev-parse --git-common-dir` (#88175 follow-up
+        from automated review).
+        """
+        from unittest.mock import patch
+
+        from hermes_cli import update_cmd
+
+        # Worktree: `.git` is a file, the common dir is elsewhere.
+        (tmp_path / ".git").write_text("gitdir: ../.realgit/worktrees/wt\n")
+        common_dir = tmp_path / ".realgit"
+        (common_dir / "shallow").mkdir(parents=True)
+
+        with patch(
+            "hermes_cli.update_cmd.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = str(common_dir) + "\n"
+            cmd = update_cmd._fetch_command(["git"], "main", tmp_path)
+
+        assert cmd == ["git", "fetch", "--unshallow", "origin", "main"]
+
+    def test_worktree_without_shallow_uses_plain_fetch(self, tmp_path):
+        """A linked worktree with no shallow marker must keep the plain fetch
+        (the common-dir resolution must not force --unshallow).
+        """
+        from unittest.mock import patch
+
+        from hermes_cli import update_cmd
+
+        (tmp_path / ".git").write_text("gitdir: ../.realgit/worktrees/wt\n")
+        common_dir = tmp_path / ".realgit"
+        common_dir.mkdir(parents=True)
+
+        with patch(
+            "hermes_cli.update_cmd.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = str(common_dir) + "\n"
+            cmd = update_cmd._fetch_command(["git"], "main", tmp_path)
+
+        assert cmd == ["git", "fetch", "origin", "main"]

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1236,3 +1236,31 @@ class TestUpdateNodeDependencies:
         assert cwd_calls, "expected at least one npm call"
         for cwd in cwd_calls:
             assert cwd == tmp_path, f"npm must run from PROJECT_ROOT; got cwd={cwd}"
+
+
+class TestShallowCloneFetch:
+    """A shallow clone's fetch must cross the shallow boundary (#88175)."""
+
+    def test_shallow_clone_uses_unshallow(self, tmp_path):
+        from hermes_cli import update_cmd
+
+        (tmp_path / ".git" / "shallow").mkdir(parents=True)
+        cmd = update_cmd._fetch_command(
+            ["git", "-c", "windows.appendAtomically=false"], "main", tmp_path
+        )
+        assert cmd == [
+            "git",
+            "-c",
+            "windows.appendAtomically=false",
+            "fetch",
+            "--unshallow",
+            "origin",
+            "main",
+        ]
+
+    def test_full_clone_uses_plain_fetch(self, tmp_path):
+        from hermes_cli import update_cmd
+
+        (tmp_path / ".git").mkdir(parents=True)
+        cmd = update_cmd._fetch_command(["git"], "main", tmp_path)
+        assert cmd == ["git", "fetch", "origin", "main"]


### PR DESCRIPTION
## Summary

Fixes #88175: on a shallow clone, `git fetch origin <branch>` returns success WITHOUT crossing the shallow boundary, so `origin/<branch>` stays at a stale commit and `reset --hard` aligns to it — the updater reports success while the repo is actually far behind the real remote tip, and the desktop update badge never clears.

## Approach

- New `_fetch_command(git_cmd, branch, repo_root)`: when `.git/shallow` is present, build `git fetch --unshallow origin <branch>` so origin/<branch> reaches the true tip (one-time cost; the checkout stops being shallow afterwards); otherwise the plain fetch command.
- The update flow now calls `_fetch_command` instead of building the fetch inline.

## Test Plan

- 2 new tests in `TestShallowCloneFetch`: shallow checkout → fetch includes `--unshallow`; full checkout → plain fetch.
- `ruff check` clean; `scripts/check-windows-footguns.py` clean.

## Risk / Exclusions

- Only the fetch command changes; reset/stash/branch logic untouched.
- `--unshallow` is only used when `.git/shallow` exists (no-op otherwise).

References #88175