### PR TITLE
fix(tui): dedupe adjacent user/assistant transcript rows

### DIFF
--- a/ui-tui/src/lib/messages.test.ts
+++ b/ui-tui/src/lib/messages.test.ts
@@ -26,4 +26,49 @@ describe('appendTranscriptMessage', () => {
       { kind: 'trail', role: 'system', text: '', thinking: 'plan', tools: ['Terminal("one") ✓', 'Terminal("two") ✓'] }
     ])
   })
+
+  it('skips an adjacent duplicate user message (#88362)', () => {
+    const first = { role: 'user' as const, text: 'hello' }
+    const out = appendTranscriptMessage([first], { role: 'user', text: 'hello' })
+
+    expect(out).toHaveLength(1)
+    expect(out[0]?.text).toBe('hello')
+  })
+
+  it('skips an adjacent duplicate assistant message (#88362)', () => {
+    const first = { role: 'assistant' as const, text: 'hi there' }
+    const out = appendTranscriptMessage([first], { role: 'assistant', text: 'hi there' })
+
+    expect(out).toHaveLength(1)
+  })
+
+  it('does not skip a duplicate that is not adjacent (#88362)', () => {
+    const out = appendTranscriptMessage(
+      [
+        { role: 'user' as const, text: 'hello' },
+        { role: 'assistant' as const, text: 'hi' }
+      ],
+      { role: 'user', text: 'hello' }
+    )
+
+    expect(out).toHaveLength(3)
+  })
+
+  it('does not skip different user content (#88362)', () => {
+    const out = appendTranscriptMessage([{ role: 'user' as const, text: 'first' }], {
+      role: 'user',
+      text: 'second'
+    })
+
+    expect(out).toHaveLength(2)
+  })
+
+  it('leaves tool rows to the shelf-merge logic (#88362)', () => {
+    const out = appendTranscriptMessage(
+      [{ kind: 'trail', role: 'system', text: '', tools: ['Terminal("one") ✓'] }],
+      { kind: 'trail', role: 'system', text: '', tools: ['Terminal("one") ✓'] }
+    )
+
+    expect(out).toHaveLength(1)
+  })
 })

--- a/ui-tui/src/lib/messages.ts
+++ b/ui-tui/src/lib/messages.ts
@@ -7,8 +7,27 @@ import { appendToolShelfMessage } from './liveProgress.js'
 // a message's authoring time is when it entered the transcript, not when it
 // happened to be persisted or re-rendered (#82840-class rule). Rehydrated
 // rows arrive with their persisted `createdAt` and keep it.
-export const appendTranscriptMessage = (prev: Msg[], msg: Msg): Msg[] =>
-  appendToolShelfMessage(prev, msg.createdAt === undefined ? { ...msg, createdAt: Date.now() / 1000 } : msg)
+export const appendTranscriptMessage = (prev: Msg[], msg: Msg): Msg[] => {
+  const stamped = msg.createdAt === undefined ? { ...msg, createdAt: Date.now() / 1000 } : msg
+  const last = prev.at(-1)
+
+  // A snapshot/live-tail race can append the same user or assistant row
+  // back-to-back (pairwise duplication, #88362): the persisted snapshot and
+  // the live tail both carry the same row. Skip an adjacent duplicate —
+  // same role and same text — so the transcript renders exactly one copy.
+  // Tool rows are deliberately untouched: their merge semantics live in
+  // appendToolShelfMessage and repeated tool output is legitimate.
+  if (
+    last &&
+    stamped.role === last.role &&
+    stamped.text === last.text &&
+    (stamped.role === 'user' || stamped.role === 'assistant')
+  ) {
+    return prev
+  }
+
+  return appendToolShelfMessage(prev, stamped)
+}
 
 export const capTranscriptHistory = (items: Msg[]): Msg[] => {
   if (items.length <= MAX_HISTORY) {


### PR DESCRIPTION
## Summary

Fixes #88362: in long sessions the TUI renders user and assistant messages duplicated pairwise (message N and N+1 identical). Root cause class: the persisted transcript snapshot and the live tail race — both carry the same row, and `appendTranscriptMessage` appends both copies.

## Approach

- `appendTranscriptMessage` now skips an adjacent duplicate — same role and same text — for **user/assistant rows only**.
- Tool rows are deliberately untouched: their merge semantics live in `appendToolShelfMessage` and repeated tool output is legitimate.

## Test Plan

- 5 new tests in `ui-tui/src/lib/messages.test.ts`: adjacent duplicate user skipped / adjacent duplicate assistant skipped / non-adjacent duplicate kept / different content kept / tool rows still route through the shelf merge.
- `vitest run src/lib/messages.test.ts`: 7/7 pass. `src/__tests__/messages.test.ts` fails only on a pre-existing env issue (hermes-ink dist not built: `Cannot find module './dist/entry-exports.js'`) — unrelated to this change.
- `eslint` clean; `tsc -p tsconfig.json --noEmit` clean.

## Risk / Exclusions

- Dedupe only fires on adjacent identical (role+text) user/assistant rows; no history, persistence, or tool-row behavior changes.

References #88362