### PR TITLE
fix(api-server): close one-off API agent sessions after the turn

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5467,6 +5467,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                close_session_on_finish=(stored_session_id is None and not bool(gateway_session_key)),
                 **agent_overrides,
                 route=route,
             ))
@@ -5502,6 +5503,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                close_session_on_finish=(stored_session_id is None and not bool(gateway_session_key)),
                 **agent_overrides,
                 route=route,
             )
@@ -6278,6 +6280,7 @@ class APIServerAdapter(BasePlatformAdapter):
         conversation_history: List[Dict[str, str]],
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
+        close_session_on_finish: bool = False,
         stream_delta_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
@@ -6509,6 +6512,15 @@ class APIServerAdapter(BasePlatformAdapter):
                         # shutdown.  pop() is a no-op when _create_agent
                         # succeeded but the turn never reached registration.
                         self._shutdown_interruptible_agents.pop(id(agent), None)
+                    if close_session_on_finish and agent is not None:
+                        try:
+                            agent.close()
+                        except Exception:
+                            logger.debug(
+                                "Failed to close one-off API session %s",
+                                session_id or "",
+                                exc_info=True,
+                            )
                     clear_session_vars(tokens)
 
         self._activate_admitted_request()
@@ -6708,6 +6720,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
         session_id = body.get("session_id") or stored_session_id
+        one_off_session = not bool(session_id)
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
         selection_error = self._request_route_conflict_error(
@@ -6878,6 +6891,15 @@ class APIServerAdapter(BasePlatformAdapter):
                             # run deliberately left running (same race-window
                             # guard as gateway/run.py and _run_agent above).
                             _clear_turn_process_ownership(agent)
+                            if one_off_session:
+                                try:
+                                    agent.close()
+                                except Exception:
+                                    logger.debug(
+                                        "Failed to close one-off API run session %s",
+                                        session_id or "",
+                                        exc_info=True,
+                                    )
                             try:
                                 unregister_gateway_notify(approval_session_key)
                             finally:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -393,6 +393,42 @@ class TestAgentExecution:
         )
 
     @pytest.mark.asyncio
+    async def test_run_agent_closes_explicit_one_off_session(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            await adapter._run_agent(
+                user_message="one off",
+                conversation_history=[],
+                session_id="run-one-off",
+                close_session_on_finish=True,
+            )
+
+        mock_agent.close.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_run_agent_keeps_persistent_session_open(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            await adapter._run_agent(
+                user_message="persistent",
+                conversation_history=[],
+                session_id="api-persistent",
+                close_session_on_finish=False,
+            )
+
+        mock_agent.close.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_run_agent_sets_and_clears_process_ownership_markers(self, adapter):
         """#76188 review: this surface runs its own agent lifecycle outside
         TurnRunner, so it needs its own baseline snapshot/clear — verify the


### PR DESCRIPTION
## Summary

API requests that carry no `session_id` (and no gateway session key) create an ephemeral agent whose `SessionDB` handle is never closed. Each such request leaks a SQLite connection for the lifetime of the gateway process. Under sustained API load this exhausts file descriptors (EMFILE).

This is the same failure class addressed in #83226 (`fix(state): close leaked SessionDB connections on exception paths`), which closed temporary/cross-profile handles across CLI, MCP, search, trace, reactions, insights and recovery paths — but did not cover the `api_server` one-off request path.

## Change

Close the agent from the existing `finally` block when the turn owns the session, on both paths:

- `_run_agent` (streaming) — via a new `close_session_on_finish` parameter, defaulting to `False` so no existing caller changes behaviour
- the non-streaming run path — via a locally derived `one_off_session`

Sessions that are explicitly addressed (`session_id` supplied) or gateway-routed are left untouched. The close is best-effort and logged at debug level, so a close failure cannot fail an otherwise successful turn.

## Tests

Two new tests assert both directions:

- `test_run_agent_closes_explicit_one_off_session` — one-off session is closed
- `test_run_agent_keeps_persistent_session_open` — persistent session is not

`pytest -q tests/gateway/test_api_server.py` → **101 passed**, against current `origin/main` (cf64ca20c5).

## Notes

Found while investigating repeated `state.db` corruption on a long-running six-gateway deployment. The leak is not the cause of that corruption — it is an independent resource leak noticed during the same investigation, and it has been running in production here since before the 0.20.2 update.

Searched open and closed issues/PRs for `api_server` one-off session close and SessionDB handle leaks before opening — no existing coverage found.