### PR TITLE
Fix: Render Markdown in Bot Mode group chat messages

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -16,6 +16,7 @@
  */
 
 import * as sdk from '@hermes/plugin-sdk'
+import { Streamdown } from 'streamdown'
 import {
   atom,
   Button,
@@ -6265,8 +6266,8 @@ function GroupChatWorkspace({ group, members }) {
                         ]
                       }),
                       jsx('div', {
-                        className: 'whitespace-pre-wrap text-xs text-(--ui-text-secondary)',
-                        children: entry.text
+    className: 'text-xs text-(--ui-text-secondary) [&_p]:mb-1 [&_p:last-child]:mb-0',
+    children: jsx(Streamdown, { children: entry.text })
                       })
                     ]
                   }, `${entry.at}:${index}`)


### PR DESCRIPTION
## Summary
Fixes #88391

`GroupChatWorkspace` in the Desktop Bot Mode group chat surface renders every message (`entry.text`) as plain text via `whitespace-pre-wrap`, so Markdown syntax (`**bold**`, headings, lists, fenced code) shows up as raw source instead of a rendered preview. The main 1:1 Desktop chat already renders Markdown; this surface was missed.

## Fix
Render `entry.text` through `Streamdown` (the same lightweight Markdown renderer already used elsewhere in the desktop app, e.g. `compact-markdown.tsx`) instead of printing it as a plain-text node.

## Testing
Verified the file has no new TypeScript/Problems-panel errors after the change.