### PR TITLE
fix(verify): take down the whole Windows process tree on teardown

### DIFF
--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -160,13 +161,31 @@ def _poll_readiness(url: str, timeout: float, interval: float = 1.0) -> tuple[bo
 
 
 def _terminate_process_group(proc: subprocess.Popen) -> None:
-    """Terminate the started app and its whole process group cleanly.
+    """Terminate the started app and its whole process tree cleanly.
 
     On POSIX the child is spawned with ``start_new_session=True`` so we can
-    signal the whole group; on Windows (no ``os.killpg``) we fall back to
-    terminating just the direct child.
+    signal the whole group. On Windows that flag is a no-op and
+    ``proc.terminate()`` (TerminateProcess) only hits the *direct* child —
+    with ``shell=True`` that is ``cmd.exe``, while the real app and its
+    workers (e.g. Django's auto-reloader child) survive as grandchildren.
+    They keep the stdout pipe's write end open, so the later
+    ``proc.stdout.read()`` never sees EOF and ``hermes verify`` hangs after
+    readiness with no final receipt and an orphaned listener (#88427).
+    ``taskkill /T`` takes down the whole tree, which also closes every pipe
+    writer.
     """
     if proc.poll() is not None:
+        return
+    if sys.platform == "win32":
+        subprocess.run(
+            ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+            capture_output=True,
+            check=False,
+        )
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pass
         return
     killpg = getattr(os, "killpg", None)
     getpgid = getattr(os, "getpgid", None)

--- a/tests/verify/test_environment_and_runner.py
+++ b/tests/verify/test_environment_and_runner.py
@@ -187,3 +187,61 @@ class TestReadiness:
         finally:
             server.shutdown()
             thread.join(timeout=5)
+
+
+class TestWindowsTeardown:
+    """#88427 — on Windows the teardown must take down the whole tree.
+
+    ``shell=True`` means the direct child is ``cmd.exe``; the real app and
+    its workers (Django's auto-reloader) are grandchildren that
+    ``TerminateProcess`` cannot reach. They keep the stdout pipe open, so
+    ``proc.stdout.read()`` blocks forever and the verify run never emits its
+    receipt. The Windows branch must therefore use ``taskkill /T``.
+    """
+
+    def test_windows_teardown_kills_process_tree_via_taskkill(self, monkeypatch):
+        import sys as _sys
+        from unittest.mock import MagicMock
+
+        import agent.verify.runner as runner_mod
+
+        monkeypatch.setattr(_sys, "platform", "win32")
+
+        proc = MagicMock()
+        proc.poll.return_value = None  # still running
+        proc.pid = 4242
+
+        taskkill_calls = []
+
+        def _fake_run(cmd, **kwargs):
+            taskkill_calls.append((list(cmd), kwargs))
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(runner_mod.subprocess, "run", _fake_run)
+
+        runner_mod._terminate_process_group(proc)
+
+        assert len(taskkill_calls) == 1
+        cmd, kwargs = taskkill_calls[0]
+        assert cmd == ["taskkill", "/PID", "4242", "/T", "/F"]
+        assert kwargs.get("check") is False
+        proc.wait.assert_called_once()
+
+    def test_windows_teardown_skips_already_exited_process(self, monkeypatch):
+        import sys as _sys
+        from unittest.mock import MagicMock
+
+        import agent.verify.runner as runner_mod
+
+        monkeypatch.setattr(_sys, "platform", "win32")
+
+        proc = MagicMock()
+        proc.poll.return_value = 0  # already exited
+
+        def _no_run(*_a, **_kw):
+            raise AssertionError("taskkill must not run for an exited process")
+
+        monkeypatch.setattr(runner_mod.subprocess, "run", _no_run)
+
+        runner_mod._terminate_process_group(proc)
+        proc.wait.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

On native Windows, `hermes verify --json` can reach a ready Django server but then hang forever — no final JSON receipt, no teardown, and an orphaned `python manage.py runserver` holding the port (#88427). Two stacked causes, both Windows-only:

1. `start_new_session=True` is a POSIX no-op on Windows, and `_terminate_process_group`'s Windows fallback (`proc.terminate()`, i.e. TerminateProcess) only kills the **direct** child. With `shell=True` that child is `cmd.exe`; the real app — and Django's auto-reloader child — survive as grandchildren and keep the port bound.
2. Those grandchildren inherited the stdout pipe's write end. The teardown is followed by `proc.stdout.read()`, which blocks until EOF — EOF requires **every** writer to exit. With the grandchildren alive, the read never returns, which is exactly the observed "ready but never finalizes" hang. POSIX never sees this because `killpg` takes down the whole session, closing all writers.

The fix gives `_terminate_process_group` an explicit Windows branch: `taskkill /PID <pid> /T /F` takes down the entire tree (grandchildren included), which both frees the port and closes every pipe writer so the subsequent `read()` sees EOF and the receipt is emitted. The POSIX branch is unchanged.

## Related Issue

Fixes #88427

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/verify/runner.py`: `_terminate_process_group` now branches on `sys.platform == "win32"` and tears the process tree down with `taskkill /T /F` before waiting for the direct child; docstring documents the cmd.exe/reloader-grandchild mechanism and the stdout-EOF hang
- `tests/verify/test_environment_and_runner.py`: new `TestWindowsTeardown` class

## How to Test

1. `python -m pytest tests/verify/ -q` — Observed result: 76 passed, 1 failed (`test_readiness_timeout_when_nothing_listens` — environment-dependent: this machine's local proxy answers HTTP 502 on the "free" port the test picks, and the runner deliberately counts any HTTP response as ready; it fails identically with this change stashed, i.e. pre-existing local noise, not a regression).
2. New tests pin: with `sys.platform` faked as `win32` and a live fake process, teardown issues exactly `["taskkill", "/PID", "<pid>", "/T", "/F"]` with `check=False` and then waits for the direct child; an already-exited process triggers no taskkill at all.
3. On the reporter's environment (Windows 10, Django project): `hermes verify --json` should now emit the final JSON receipt promptly after readiness, exit within the configured timeout, and leave no orphaned listener on the app port (the taskkill tree-kill replaces TerminateProcess-of-cmd.exe only).

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the verify test suite (76 passed; the single failure is documented local proxy noise, identical with the change stashed)
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64) — the Windows branch is exercised via the platform-faked unit tests; `taskkill /T /F` semantics are the documented Windows tree-kill

### Documentation & Housekeeping

- [x] N/A — no config keys or docs changed; the teardown docstring documents the full mechanism with its #88427 reference

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/verify/ -q
76 passed, 1 failed in 5.53s
(failure: test_readiness_timeout_when_nothing_listens — pre-existing local proxy noise, fails identically without this change)
```
