### PR TITLE
ci: skip install-e2e on forks, which have no release tags

### DIFF
--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -57,6 +57,12 @@ jobs:
   # Which released versions do we test updating FROM? Resolved once and shared
   # by both route matrices, so the two routes cover the same set.
   pick-releases:
+    # Only run on the upstream repository, not on forks. A fork has no release
+    # tags of its own, so pick-release-tags.sh exits 1 ("no release tags found")
+    # and every scheduled run is red. The script is right to be strict -- here,
+    # an empty tag list means the checkout lost its tags and the matrix would
+    # silently cover nothing -- so gate the workflow rather than soften it.
+    if: github.repository == 'NousResearch/hermes-agent'
     name: Pick release tags
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## What does this PR do?

Install & Update E2E can't pass on a fork. `pick-releases` runs `scripts/sandbox/pick-release-tags.sh` to choose which releases to update FROM, and a fork has no release tags of its own, so the script exits 1 and the scheduled run goes red. The cron is `20 7,19 * * *`, so that's twice a day on every fork.

This adds the guard four other workflows already use, on the one job the rest of the matrix hangs off.

## Related Issue

Fixes #88432

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `.github/workflows/install-e2e.yml`: guard `pick-releases` with `if: github.repository == 'NousResearch/hermes-agent'`, plus a comment on why the script is left strict. `update` and `installer` both `needs: pick-releases`, so they skip with it and don't need their own guard.

Two approaches I didn't take, in case either was the intent:

Loosening `pick-release-tags.sh` to emit an empty matrix on zero tags. Its strictness is the canary for a checkout that lost its tags, and on your repo that's the right call. From inside the script, though, a fork looks identical to that fault, so the distinction seemed to belong in the workflow.

`github.event.repository.fork == false`, which reads better and hardcodes no name, but leans on the event payload carrying a `repository` object. `github.repository` is populated on every event, and matching the existing four felt better than adding a second idiom for the same job.

## How to Test

1. On a fork, the scheduled run shows `pick-releases` skipped instead of failed, and `update` and `installer` skip with it.
2. On this repo the expression is true, so nothing changes: the matrix is still resolved from real release tags.
3. `yamllint .github/workflows/install-e2e.yml` reports the same five findings before and after, line numbers shifted by the six added.

I can only run this on a fork, so I haven't exercised 2 directly. That's the part worth a second pair of eyes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (GitHub-hosted runner)

Didn't run pytest: this touches one workflow condition and no Python. Say the word if you want it run anyway. No test added either, since an Actions job condition isn't reachable from the suite as far as I can see. Point me at a pattern if there is one.

### Documentation & Housekeeping

- [x] Documentation (README, `docs/`, docstrings): N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact: N/A, the condition is evaluated before any runner is picked
