### PR TITLE
fix(acp): guard None final_response on cancelled turns

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2002,7 +2002,7 @@ class HermesACPAgent(acp.Agent):
                     exc_info=True,
                 )
 
-        final_response = result.get("final_response", "")
+        final_response = result.get("final_response") or ""
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         interrupted = bool(result.get("interrupted")) or cancelled
         # Hermes' local "waiting for model response" interrupt status is metadata,


### PR DESCRIPTION
## Summary

Fixes a crash in the ACP adapter when a turn is cancelled while a tool call is still in flight.

When a turn is interrupted, `conversation_loop` can return a result dict where `final_response` is explicitly `None` (the key is present, value is `None`). In that case `result.get("final_response", "")` returns `None` (the default only applies to a *missing* key), and the interrupted-turn check two lines later crashes:

```
suppress_interrupt_response = interrupted and final_response.startswith(
    INTERRUPT_WAITING_FOR_MODEL_PREFIX
)
# AttributeError: 'NoneType' object has no attribute 'startswith'
```

The exception surfaces through ACP as a JSON-RPC `-32603` internal error and leaves queued prompts stuck behind the failed turn.

## Reproduction

1. Connect an ACP client (e.g. Paseo) to a `hermes acp` session.
2. Send a prompt that triggers a long-running tool call (e.g. `sleep 45` via the terminal tool).
3. Cancel the turn while the tool is still running.
4. The turn fails with `Internal error: 'NoneType' object has no attribute 'startswith'` (code `-32603`) instead of ending cleanly as cancelled.

Observed on daemonVersion 0.4.0 client side; server-side logs show `handleStreamEvent: turn_failed` with the AttributeError above.

## Fix

Coalesce `None` to `""` when reading the result:

```python
final_response = result.get("final_response") or ""
```

This also matches the existing pattern already used in `hermes_cli/oneshot.py:472` (`result.get("final_response") or ""`).

## Test plan

- `python -m py_compile acp_adapter/server.py` passes.
- Manual: with the patch applied, cancel an ACP turn mid-tool-call — the turn now ends as cancelled with no `-32603` error, and queued prompts are drained normally.
