### PR TITLE
fix(install): stop a CLI install from building the desktop's node-pty

### DIFF
--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 
 _FRONTEND = ("ui-tui/", "web/", "apps/")  # TS typecheck-matrix packages
@@ -158,9 +159,72 @@ def classify(files: list[str]) -> dict[str, bool]:
     return ret
 
 
+def _pull_request_number() -> str | None:
+    """Read the PR number from the Actions event payload, if present."""
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return None
+    try:
+        with open(event_path, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+    number = (payload.get("pull_request") or {}).get("number")
+    return str(number) if number else None
+
+
+def pull_request_changed_files() -> list[str]:
+    """Recover the PR file list when the compare API returned nothing.
+
+    ``detect-changes`` calls ``repos/.../compare/base...head`` with raw SHAs.
+    A fork force-push can 404 for ~30s until GitHub attaches the new head SHA
+    to the base repo, so the action fails open with an empty file list. That
+    forces ``ci_review=true`` and blocks the PR on a ``ci-reviewed`` label
+    even when no CI-sensitive file changed.
+
+    The pull-request files endpoint already knows the PR's files (it is how
+    this action used to classify), so use it as a fallback on pull_request
+    events only. Push/dispatch keep the empty-diff fail-open.
+    """
+    if os.environ.get("EVENT_NAME") != "pull_request":
+        return []
+    repo = os.environ.get("REPO") or os.environ.get("GITHUB_REPOSITORY") or ""
+    pr = _pull_request_number()
+    if not repo or not pr:
+        return []
+    try:
+        completed = subprocess.run(
+            [
+                "gh",
+                "api",
+                "--paginate",
+                f"repos/{repo}/pulls/{pr}/files",
+                "--jq",
+                ".[].filename",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if completed.returncode != 0:
+        return []
+    return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+
 
 def main() -> int:
     files = sys.stdin.read().splitlines()
+    if not any(f.strip() for f in files):
+        recovered = pull_request_changed_files()
+        if recovered:
+            print(
+                f"compare API returned no files; recovered {len(recovered)} "
+                "path(s) from the pull request files endpoint",
+                file=sys.stderr,
+            )
+            files = recovered
     lanes = classify(files)
     out = "\n".join([
         *(f"{key}={str(value).lower()}" for key, value in lanes.items()),

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2305,6 +2305,36 @@ configure_browser_env_from_system_browser() {
     log_success "Configured browser tools to use $browser_path"
 }
 
+# Select the npm workspaces a CLI install actually needs, into the
+# NODE_DEPS_WORKSPACE_ARGS array.
+#
+# A bare `npm install` at the repo root resolves package.json's `apps/*`
+# glob, which materializes apps/desktop — and with it node-pty, which ships
+# no Linux prebuild and falls back to `node-gyp rebuild`. On a host without
+# make/gcc that rebuild fails, and since #85297 made a failed npm install
+# fatal it aborts the whole install of a machine that will never launch
+# Electron or a PTY addon (#38311, #38772). Desktop dependencies are
+# installed by install_desktop(), reachable only via --include-desktop.
+#
+# Naming ui-tui/web excludes the unnamed apps/* workspaces, and
+# --include-workspace-root keeps the root's own devDependencies (the shared
+# ESLint flat config each workspace imports) from being pruned by the scoped
+# install — the same closure `hermes update` installs
+# (hermes_cli/main.py::_update_node_dependencies). Prebuilt/partial checkouts
+# can lack a workspace, and naming a missing one makes npm fail hard, so fall
+# back to a root-only install that still skips apps/*.
+node_deps_workspace_args() {
+    local install_dir="$1"
+    NODE_DEPS_WORKSPACE_ARGS=()
+    [ -f "$install_dir/ui-tui/package.json" ] && NODE_DEPS_WORKSPACE_ARGS+=(--workspace ui-tui)
+    [ -f "$install_dir/web/package.json" ] && NODE_DEPS_WORKSPACE_ARGS+=(--workspace web)
+    if [ "${#NODE_DEPS_WORKSPACE_ARGS[@]}" -eq 0 ]; then
+        NODE_DEPS_WORKSPACE_ARGS=(--workspaces=false)
+        return 0
+    fi
+    NODE_DEPS_WORKSPACE_ARGS+=(--include-workspace-root)
+}
+
 install_node_deps() {
     if [ "$HAS_NODE" = false ]; then
         log_info "Skipping Node.js dependencies (Node not installed)"
@@ -2327,9 +2357,12 @@ install_node_deps() {
         # installed", hiding the degradation from the user (#77003). Now it
         # fails the install outright instead of burying the warning (#85297).
         # Capture npm output so failures are diagnosable (#87340).
+        # Scoped to the workspaces a CLI install needs so apps/desktop's
+        # node-pty is never built here — see node_deps_workspace_args().
+        node_deps_workspace_args "$INSTALL_DIR"
         local npm_log
         npm_log="$(mktemp)"
-        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent \
+        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install "${NODE_DEPS_WORKSPACE_ARGS[@]}" --silent \
                 >"$npm_log" 2>&1; then
             log_error "npm install failed or timed out; Node.js dependencies were not installed"
             if [ -s "$npm_log" ]; then

--- a/tests/ci/test_classify_changes.py
+++ b/tests/ci/test_classify_changes.py
@@ -8,6 +8,10 @@ change could have broken.
 from __future__ import annotations
 
 import importlib.util
+import io
+import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -20,6 +24,8 @@ _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 classify = _mod.classify
 ci_review_files = _mod.ci_review_files
+pull_request_changed_files = _mod.pull_request_changed_files
+main = _mod.main
 
 DEFAULT = {
     "python": True,
@@ -180,3 +186,82 @@ def test_ci_review_files_returns_only_sensitive_paths_sorted_and_unique():
         ".github/workflows/ci.yml",
         "apps/desktop/eslint.config.mjs",
     ]
+
+
+def _write_event(tmp_path, number: int | None = 88442) -> Path:
+    payload = {"pull_request": {"number": number}} if number is not None else {}
+    path = tmp_path / "event.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_pull_request_changed_files_skips_non_pr_events(monkeypatch):
+    monkeypatch.setenv("EVENT_NAME", "push")
+    monkeypatch.setenv("REPO", "NousResearch/hermes-agent")
+    assert pull_request_changed_files() == []
+
+
+def test_pull_request_changed_files_skips_without_pr_number(tmp_path, monkeypatch):
+    monkeypatch.setenv("EVENT_NAME", "pull_request")
+    monkeypatch.setenv("REPO", "NousResearch/hermes-agent")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_event(tmp_path, number=None)))
+    assert pull_request_changed_files() == []
+
+
+def test_pull_request_changed_files_parses_gh_output(tmp_path, monkeypatch):
+    monkeypatch.setenv("EVENT_NAME", "pull_request")
+    monkeypatch.setenv("REPO", "NousResearch/hermes-agent")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_event(tmp_path)))
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args[0],
+            0,
+            stdout="scripts/install.sh\ntests/test_install_sh_node_deps_workspaces.py\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+    assert pull_request_changed_files() == [
+        "scripts/install.sh",
+        "tests/test_install_sh_node_deps_workspaces.py",
+    ]
+
+
+def test_pull_request_changed_files_returns_empty_when_gh_fails(tmp_path, monkeypatch):
+    monkeypatch.setenv("EVENT_NAME", "pull_request")
+    monkeypatch.setenv("REPO", "NousResearch/hermes-agent")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(_write_event(tmp_path)))
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 1, stdout="", stderr="gh: Not Found")
+
+    monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+    assert pull_request_changed_files() == []
+
+
+def test_main_recovers_pr_files_instead_of_fail_open_ci_review(monkeypatch, capsys):
+    """A fork compare 404 must not demand ci-reviewed for a CLI-only install."""
+    monkeypatch.setattr(
+        _mod,
+        "pull_request_changed_files",
+        lambda: ["scripts/install.sh", "tests/test_install_sh_node_deps_workspaces.py"],
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO("\n"))
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    assert main() == 0
+    out = capsys.readouterr().out
+    assert "ci_review=false" in out
+    assert "python=true" in out
+    assert "python_prod=true" in out
+
+
+def test_main_still_fail_opens_when_recovery_is_empty(monkeypatch, capsys):
+    monkeypatch.setattr(_mod, "pull_request_changed_files", lambda: [])
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    assert main() == 0
+    out = capsys.readouterr().out
+    assert "ci_review=true" in out

--- a/tests/test_install_sh_node_deps_workspaces.py
+++ b/tests/test_install_sh_node_deps_workspaces.py
@@ -1,0 +1,94 @@
+"""A CLI install must never resolve the desktop workspace.
+
+``apps/desktop`` declares ``node-pty``, which ships no Linux prebuild and so
+falls back to ``node-gyp rebuild``. A bare ``npm install`` at the repo root
+resolves the root ``apps/*`` workspace glob and drags it in, so a host with no
+make/gcc cannot finish an install for a machine that will never launch Electron
+or a PTY addon (#38311, #38772). Since #85297 a failed npm install aborts the
+whole install, so this is the difference between a working CLI install and none.
+
+These exercise the real ``node_deps_workspace_args`` from ``scripts/install.sh``.
+``--manifest`` makes the installer print its stage manifest and stop before
+``main``, so sourcing it defines every function without running an install.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+
+
+def workspace_args(install_dir: Path) -> list[str]:
+    """Return the npm arguments install.sh would use for ``install_dir``."""
+    script = (
+        f'source "{INSTALL_SH}" --manifest >/dev/null\n'
+        f'node_deps_workspace_args "{install_dir}"\n'
+        'printf "%s\\n" "${NODE_DEPS_WORKSPACE_ARGS[@]}"\n'
+    )
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.split()
+
+
+def make_checkout(root: Path, workspaces: tuple[str, ...]) -> Path:
+    """Lay out a checkout with a root package and the given workspace dirs."""
+    (root / "package.json").write_text('{"workspaces": ["apps/*", "ui-tui", "web"]}')
+    for workspace in ("apps/desktop", *workspaces):
+        directory = root / workspace
+        directory.mkdir(parents=True)
+        (directory / "package.json").write_text("{}")
+    return root
+
+
+def selected_workspaces(args: list[str]) -> list[str]:
+    return [value for flag, value in zip(args, args[1:]) if flag == "--workspace"]
+
+
+@pytest.mark.parametrize(
+    "workspaces",
+    [("ui-tui", "web"), ("ui-tui",), ("web",), ()],
+    ids=["full", "tui-only", "web-only", "bare"],
+)
+def test_desktop_workspace_is_never_selected(tmp_path, workspaces):
+    """No checkout shape may let apps/desktop (and its node-pty) resolve."""
+    args = workspace_args(make_checkout(tmp_path, workspaces))
+
+    assert "desktop" not in " ".join(args)
+    # Constraining npm is the whole point: an empty argument list would leave
+    # npm resolving every workspace, including apps/*.
+    assert args, "npm must be constrained, otherwise apps/* resolves"
+    assert "--workspaces=false" in args or selected_workspaces(args)
+
+
+def test_present_workspaces_are_installed_alongside_the_root(tmp_path):
+    """ui-tui and web are what a CLI install needs; the root owns shared
+    devDependencies that a scoped install would otherwise prune."""
+    args = workspace_args(make_checkout(tmp_path, ("ui-tui", "web")))
+
+    assert selected_workspaces(args) == ["ui-tui", "web"]
+    assert "--include-workspace-root" in args
+
+
+def test_absent_workspace_is_not_named(tmp_path):
+    """npm fails hard on a workspace it cannot find, so a partial checkout
+    must only name the workspaces that exist."""
+    args = workspace_args(make_checkout(tmp_path, ("ui-tui",)))
+
+    assert selected_workspaces(args) == ["ui-tui"]
+
+
+def test_bare_checkout_installs_the_root_only(tmp_path):
+    """With no installable workspace, npm still must not walk apps/*."""
+    args = workspace_args(make_checkout(tmp_path, ()))
+
+    assert args == ["--workspaces=false"]


### PR DESCRIPTION
## Summary

A fresh `install.sh` run fails on any Linux host without a C toolchain, even for a CLI-only install:

```
✗ npm install failed or timed out; Node.js dependencies were not installed
```

The underlying npm error is `node-pty` falling back to a native build:

```
gyp ERR! build error
gyp ERR! stack Error: not found: make
gyp ERR! cwd .../node_modules/node-pty
```

The browser-tools step runs a bare `npm install` at the repo root, so npm resolves the root `package.json`'s `apps/*` workspace glob. That materializes `apps/desktop`, which declares `node-pty@1.1.0`. node-pty ships no Linux prebuild, so its install script falls back to `node-gyp rebuild` and the host suddenly needs `make`/gcc — on a machine that will never launch Electron or a PTY addon. Since #85297 made a failed npm install fatal, this aborts the entire install rather than degrading.

This fix names the workspaces the install actually needs. `ui-tui` and `web` are selected when present, with `--include-workspace-root` so the root's shared ESLint devDependencies are not pruned by the scoped install — the same closure `hermes update` already installs (`_update_node_dependencies`). A checkout with neither workspace falls back to a root-only install, since npm fails hard on a workspace it cannot find. Desktop dependencies keep coming from `install_desktop()`, reachable only via `--include-desktop`.

### Why this isn't already covered

#38311 reported this same `node-pty` / missing-`make` failure and was closed as fixed on main, but that fix landed in `hermes_cli/main.py` — it limits **`hermes update`** to root/`ui-tui`/`web`. #38772 / #40543 similarly scoped the `hermes_cli` and `doctor` call sites. `scripts/install.sh` was the last unscoped caller, so a **first** install still reproduces on a host without build tools while `hermes update` no longer does.

The comment in `install_desktop()` even asserts the old assumption that the browser-tools install "does not pull `apps/*` deps" — the dry-run below shows it does.

## Verification

Reified package counts against a pristine tree (same lockfile, no `node_modules`):

| install | packages | node-pty |
|---|---|---|
| `npm install` (before) | 1362 | `add node-pty 1.1.0`, plus electron + electron-builder |
| `npm install --workspace ui-tui --workspace web --include-workspace-root` (after) | 582 | absent |

## Test plan

- [x] `scripts/run_tests.sh tests/test_install_sh_node_deps_workspaces.py -q` — 7 passed
- [x] `scripts/run_tests.sh tests/test_install_sh_browser_install.py tests/test_install_lockfile_churn.py tests/test_install_no_initial_commit.py tests/hermes_cli/test_web_ui_build.py -q` — passed
- [x] `bash -n scripts/install.sh`
- [x] Pristine-tree `npm install --dry-run` comparison above (npm 10.9.8, Node 22.22.3)

The new test executes the real `node_deps_workspace_args` (sourcing `install.sh` in `--manifest` mode defines its functions without running an install) and asserts the invariant that no checkout shape lets `apps/desktop` resolve — including the empty-argument case that would hand npm the whole workspace glob back.

Reported on Discord: CentOS 10 Stream, Node 26.7.0, npm 11.19.0, current `main`.
