### PR TITLE
fix(cron): stamp failed cron sessions with cron_failed end_reason

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5543,6 +5543,11 @@ def run_job(
     _cron_session_var = _VAR_MAP["HERMES_CRON_SESSION"]
     _cron_session_token = None
     _non_dispatcher_token = None
+    # Whether this run took the failure path. The finally block closes the
+    # cron session via end_session(); it must stamp a FAILED run with
+    # end_reason="cron_failed" instead of "cron_complete" so the session
+    # stays distinguishable from a completed run (#88443).
+    _cron_run_failed = False
     try:
         if not _cwd_lock_acquired:
             # Fail closed (#79768): running without the lock would let a
@@ -6371,6 +6376,11 @@ def run_job(
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
+        # Stamp this run as failed so the finally block closes the cron
+        # session with end_reason="cron_failed" instead of "cron_complete"
+        # (#88443). A failed run must not be indistinguishable from a
+        # completed one.
+        _cron_run_failed = True
         # Best-effort audit write on failure path. _audit_fire_id
         # may be unset if the exception fired before submit() — guard
         # with a None check so the audit write itself never raises.
@@ -6500,8 +6510,14 @@ def run_job(
                     except (Exception, KeyboardInterrupt):
                         continue
             try:
+                # Stamp the run's real outcome, not a blanket "complete".
+                # A failed run gets end_reason="cron_failed" so it stays
+                # distinguishable from a completed one (#88443). The first
+                # end_session wins (SessionDB UPDATE only fires when
+                # ended_at IS NULL), so this must be the correct reason here.
                 _session_db.end_session(
-                    _final_cron_session_id, "cron_complete"
+                    _final_cron_session_id,
+                    "cron_failed" if _cron_run_failed else "cron_complete",
                 )
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5543,11 +5543,22 @@ def run_job(
     _cron_session_var = _VAR_MAP["HERMES_CRON_SESSION"]
     _cron_session_token = None
     _non_dispatcher_token = None
-    # Whether this run took the failure path. The finally block closes the
-    # cron session via end_session(); it must stamp a FAILED run with
-    # end_reason="cron_failed" instead of "cron_complete" so the session
-    # stays distinguishable from a completed run (#88443).
-    _cron_run_failed = False
+    # Outcome of this run, threaded to the finally block so it closes the
+    # cron session with the correct end_reason. Values: "cron_failed" (any
+    # failure path) or "cron_complete" (success). A failed run must not be
+    # indistinguishable from a completed one (#88443). Held as the reason
+    # string directly (not a bool+map) so future reasons (e.g. "cron_cancelled",
+    # "cron_timeout") don't need another parallel mapping.
+    #
+    # Exits that determine the outcome, in control-flow order:
+    #   - lock fail-closed (raise before session creation) -> no session to
+    #     stamp, the finally's end_session guard no-ops
+    #   - result-shape failure (raise from the failed/completed check below)
+    #     -> "cron_failed"
+    #   - inactivity TimeoutError -> "cron_failed"
+    #   - any other exception -> "cron_failed"
+    #   - normal return -> "cron_complete" (the default, left untouched)
+    _cron_run_outcome = "cron_complete"
     try:
         if not _cwd_lock_acquired:
             # Fail closed (#79768): running without the lock would let a
@@ -6380,7 +6391,7 @@ def run_job(
         # session with end_reason="cron_failed" instead of "cron_complete"
         # (#88443). A failed run must not be indistinguishable from a
         # completed one.
-        _cron_run_failed = True
+        _cron_run_outcome = "cron_failed"
         # Best-effort audit write on failure path. _audit_fire_id
         # may be unset if the exception fired before submit() — guard
         # with a None check so the audit write itself never raises.
@@ -6517,7 +6528,7 @@ def run_job(
                 # ended_at IS NULL), so this must be the correct reason here.
                 _session_db.end_session(
                     _final_cron_session_id,
-                    "cron_failed" if _cron_run_failed else "cron_complete",
+                    _cron_run_outcome,
                 )
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)

--- a/tests/cron/test_cron_session_end_reason.py
+++ b/tests/cron/test_cron_session_end_reason.py
@@ -1,0 +1,132 @@
+"""Regression test for issue #88443: failed cron sessions must be stamped
+end_reason="cron_failed", not "cron_complete".
+
+run_job's finally block closes the cron session via end_session()
+unconditionally. Before the fix it always passed end_reason="cron_complete",
+so a FAILED cron run was stamped as if it had completed — masking the failure
+and leaving the session indistinguishable from a healthy one. These tests
+drive run_job down both the failure and success paths and assert the correct
+end_reason is recorded by the SessionDB.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import cron.scheduler as cron_scheduler
+
+
+class _RecordingSessionDB:
+    """Captures end_session calls so the test can assert the end_reason."""
+
+    def __init__(self):
+        self.ended = []
+
+    def set_session_title(self, *args, **kwargs):
+        pass
+
+    def end_session(self, session_id, end_reason):
+        self.ended.append((session_id, end_reason))
+
+    def close(self):
+        pass
+
+
+class _FailingCronAgent:
+    """Agent whose run_conversation raises to force run_job's failure path."""
+
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+
+    def run_conversation(self, prompt):
+        raise RuntimeError("Connection error")
+
+    def close(self):
+        pass
+
+
+class _SucceedingCronAgent:
+    """Agent that returns a normal result to force run_job's success path."""
+
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+
+    def run_conversation(self, prompt):
+        return {
+            "completed": True,
+            "failed": False,
+            "final_response": "ok",
+            "turn_exit_reason": "",
+        }
+
+    def close(self):
+        pass
+
+
+def _install_patch_set(monkeypatch, tmp_path, session_db, fake_agent_cls):
+    """Apply the exact patch set the isolation test uses to make run_job
+    execute cleanly down both the success and failure paths."""
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: session_db)
+    monkeypatch.setattr("run_agent.AIAgent", fake_agent_cls)
+    monkeypatch.setattr(
+        "hermes_constants.resolve_reasoning_config", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_k: {
+            "api_key": "test-key",
+            "base_url": None,
+            "provider": "test-provider",
+            "api_mode": None,
+            "command": None,
+            "args": None,
+        },
+    )
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: [])
+    monkeypatch.setattr(cron_scheduler, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(cron_scheduler, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr(
+        cron_scheduler, "_guard_job_credential_exfil", lambda _job: None
+    )
+
+
+_JOB = {
+    "id": "end-reason",
+    "name": "End Reason",
+    "prompt": "Run the job",
+    "schedule_display": "manual",
+}
+
+
+def test_run_job_failed_run_stamps_end_reason_cron_failed(monkeypatch, tmp_path):
+    """A failing cron run must close its session with end_reason='cron_failed'."""
+    session_db = _RecordingSessionDB()
+    _install_patch_set(monkeypatch, tmp_path, session_db, _FailingCronAgent)
+
+    success, _output, final_response, error = cron_scheduler.run_job(_JOB)
+
+    assert success is False
+    assert error == "RuntimeError: Connection error"
+    # The session must have been closed exactly once, with the failure reason.
+    assert len(session_db.ended) == 1
+    session_id, end_reason = session_db.ended[0]
+    assert end_reason == "cron_failed"
+    assert end_reason != "cron_complete"
+
+
+def test_run_job_successful_run_stamps_end_reason_cron_complete(
+    monkeypatch, tmp_path
+):
+    """A successful cron run must still close with end_reason='cron_complete'
+    (the fix must not regress the success path)."""
+    session_db = _RecordingSessionDB()
+    _install_patch_set(monkeypatch, tmp_path, session_db, _SucceedingCronAgent)
+
+    success, _output, final_response, error = cron_scheduler.run_job(_JOB)
+
+    assert success is True
+    assert error is None
+    assert final_response == "ok"
+    assert len(session_db.ended) == 1
+    session_id, end_reason = session_db.ended[0]
+    assert end_reason == "cron_complete"

--- a/tests/cron/test_cron_session_end_reason.py
+++ b/tests/cron/test_cron_session_end_reason.py
@@ -63,6 +63,34 @@ class _SucceedingCronAgent:
         pass
 
 
+class _DictFailCronAgent:
+    """Agent that returns a failed result dict WITHOUT raising.
+
+    The AI review on #88454 worried a `failed: True` / `completed: False`
+    result (provider 401s, protocol violations) might fall through to the
+    finally block with the flag still unset and get stamped "cron_complete".
+    run_job converts that result shape into a raise (the result-failure check
+    below), so it lands on the same except handler that sets the failure
+    outcome. This fixture pins that chain so a future refactor can't silently
+    reintroduce the gap.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+
+    def run_conversation(self, prompt):
+        return {
+            "completed": True,
+            "failed": True,
+            "final_response": "",
+            "turn_exit_reason": "",
+            "error": "provider 401 unauthorized",
+        }
+
+    def close(self):
+        pass
+
+
 def _install_patch_set(monkeypatch, tmp_path, session_db, fake_agent_cls):
     """Apply the exact patch set the isolation test uses to make run_job
     execute cleanly down both the success and failure paths."""
@@ -130,3 +158,27 @@ def test_run_job_successful_run_stamps_end_reason_cron_complete(
     assert len(session_db.ended) == 1
     session_id, end_reason = session_db.ended[0]
     assert end_reason == "cron_complete"
+
+
+def test_run_job_failed_result_dict_stamps_cron_failed(monkeypatch, tmp_path):
+    """A run that returns failed:True WITHOUT raising must still stamp
+    end_reason='cron_failed'.
+
+    The AI review on #88454 flagged that a non-raising failure (provider 401,
+    protocol violation, kanban fail-closed) might fall through to the finally
+    block unmarked and be stamped 'cron_complete'. run_job converts that
+    result shape into a raise (the result-failure check), which the except
+    handler catches and marks failed — so it must land 'cron_failed'. Pins the
+    raise→except→outcome chain.
+    """
+    session_db = _RecordingSessionDB()
+    _install_patch_set(monkeypatch, tmp_path, session_db, _DictFailCronAgent)
+
+    success, _output, final_response, error = cron_scheduler.run_job(_JOB)
+
+    assert success is False
+    assert error is not None
+    assert len(session_db.ended) == 1
+    session_id, end_reason = session_db.ended[0]
+    assert end_reason == "cron_failed"
+    assert end_reason != "cron_complete"


### PR DESCRIPTION
## Summary

A failed cron run's session was stamped `end_reason='cron_complete'`, making it indistinguishable from a completed run and masking the failure.

`run_job()` in `cron/scheduler.py` wraps the whole execution in a `try/except/finally`. The `finally` block called `end_session(_final_cron_session_id, "cron_complete")` unconditionally — even when the `except` path returned `success=False`. Per `SessionDB.end_session()`'s first-reason-wins semantics (`UPDATE ... WHERE ended_at IS NULL`), that `cron_complete` reason is the authoritative one, so the failure is never reflected on the session record.

## Changes

- **`cron/scheduler.py`**: thread the run's outcome into the `finally` block. A `_cron_run_failed` flag is set on the failure path (`except Exception`), and `end_session` now stamps the session `cron_failed` when the run failed, `cron_complete` otherwise. This covers the whole failure class (agent exception, `failed=True`, non-dict return, inactivity timeout) — not just the one site the reporter hit.

## Tests

- **`tests/cron/test_cron_session_end_reason.py`** (new): a `_RecordingSessionDB` captures `end_session(session_id, end_reason)`. Asserts a failing run (`_FailingCronAgent` raising `RuntimeError`) records `end_reason='cron_failed'`, and a successful run still records `end_reason='cron_complete'`.
- Focused: `test_cron_session_end_reason.py` + `test_scheduler_cron_session_isolation.py` → **3 passed**.
- Revert-to-buggy proof: restoring the unconditional `"cron_complete"` makes the failure test fail with `AssertionError: assert 'cron_complete' == 'cron_failed'`, confirming the test catches the bug.

Closes #88443
