### PR TITLE
fix(desktop): show legacy cronjobs in default bot

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5077,7 +5077,7 @@ function selectRoutineJobs(data, error, lastJobs, bot) {
   return {
     live,
     all,
-    jobs: all.filter(job => routineBot(job) === bot)
+    jobs: all.filter(job => (routineBot(job) || 'default') === bot)
   }
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-error.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-error.test.mjs
@@ -43,6 +43,14 @@ test('unit: a live list is filtered to the current bot', () => {
   assert.equal(shown[0].job_id, '1')
 })
 
+test('regression: untagged legacy cronjobs remain visible only on the default bot', () => {
+  const legacy = { name: 'Existing reminder', job_id: 'legacy' }
+  const api = load().__api
+
+  assert.deepEqual(api.selectRoutineJobs({ jobs: [legacy] }, null, [], 'default').jobs, [legacy])
+  assert.deepEqual(api.selectRoutineJobs({ jobs: [legacy] }, null, [], 'ops').jobs, [])
+})
+
 test('unit: a failed refresh keeps the last good list', () => {
   const view = load().__api.selectRoutineJobs(undefined, new Error('down'), jobs, 'ops')
   assert.equal(view.live, null)


### PR DESCRIPTION
## What does this PR do?

Restores pre-Bot-Mode cronjobs to the default Hermes bot routine list.

Bot Mode currently shows only jobs whose display names begin with `[bot:<profile>]`. Existing jobs created before Bot Mode have no tag, so they remain scheduled in the default profile cron store but disappear from the UI. The jobs are still standing in `jobs.json`; this change makes them visible again.

The compatibility rule is intentionally narrow:

- an explicit `[bot:<profile>]` tag remains authoritative;
- an untagged legacy job is displayed only for `default`;
- named bot panes do not claim untagged jobs;
- no jobs are migrated, renamed, rescheduled, or rewritten.

## Related Issue

Fixes #88263.

## Type of Change

- [x] Bug fix
- [x] Focused regression test

## How to Test

1. Keep an existing untagged cronjob in the default profile cron store.
2. Open Bot Mode and select the default Hermes bot.
3. Open Cronjobs and confirm the existing job appears.
4. Select a named bot and confirm it does not claim that untagged job.

## Verification

- `node --test apps/desktop/src/plugins/hermes-bots/tests/routines-error.test.mjs apps/desktop/src/plugins/hermes-bots/tests/routine*.test.mjs apps/desktop/src/plugins/hermes-bots/tests/routines*.test.mjs`: 22 passed, 0 failed.
- `node --test apps/desktop/src/plugins/*/tests/*.test.mjs`: 150 passed, 0 failed.
- `npm --prefix apps/desktop run typecheck`: passed.
- `npm --prefix apps/desktop run lint`: passed with 0 errors and 110 existing warnings outside this change.
- `git diff --check`: passed.

## Scope and compatibility

This changes only the Bot Mode display selector and one existing selector test file. Cron storage, execution, ownership metadata, scheduling, and gateway APIs are unchanged. Older gateways that ignore profile-scoped cron listing retain the existing safe fallback: untagged jobs appear only in the default bot.