### PR TITLE
fix(gateway): scope pairing allowlist mirrors

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import MutableMapping
 from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Dict, Mapping, Optional
@@ -85,6 +86,25 @@ def reset_secret_scope(token: Token) -> None:
 def current_secret_scope() -> Optional[Mapping[str, str]]:
     """Return the active secret mapping, or None when no scope is installed."""
     return _SECRET_SCOPE.get()
+
+
+def update_current_secret_scope(name: str, value: Optional[str]) -> bool:
+    """Update one value in the active mutable scope without touching environ.
+
+    A profile-scoped configuration write can take effect during the current
+    multiplexed turn only if its already-installed secret mapping is updated
+    too. ``build_profile_secret_scope`` returns a dict, but accept arbitrary
+    read-only mappings for callers that deliberately install one and report
+    ``False`` rather than weakening their isolation boundary.
+    """
+    scope = _SECRET_SCOPE.get()
+    if not isinstance(scope, MutableMapping):
+        return False
+    if value is None:
+        scope.pop(name, None)
+    else:
+        scope[name] = value
+    return True
 
 
 # ── genuinely-global env vars (NOT per-profile secrets) ──────────────────

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -155,10 +155,9 @@ def _read_allowlist_env(env_var: str) -> str:
     borrowing the process value.  Unscoped callers (single-profile CLI /
     admin endpoints) keep the legacy ``os.getenv`` read.
 
-    TODO(profile-secrets): the grant mirror below still WRITES through
-    ``hermes_cli.config.save_env_value`` / ``remove_env_value``, which target
-    the root ``.env`` — those writes need a profile-aware counterpart before
-    pairing grants can be mirrored correctly under multiplexing.
+    Pairing's mirror writes use the active profile's HERMES_HOME and suppress
+    the legacy process-global ``os.environ`` update when a multiplex scope is
+    installed, so sibling profiles cannot inherit a newly approved grant.
     """
     try:
         from agent.secret_scope import UnscopedSecretError, get_secret
@@ -170,6 +169,45 @@ def _read_allowlist_env(env_var: str) -> str:
     except Exception:
         pass
     return (os.getenv(env_var) or "").strip()
+
+
+def _is_profile_secret_scope_active() -> bool:
+    """Return True when writes are occurring under a per-profile secret scope."""
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return is_multiplex_active() and current_secret_scope() is not None
+    except Exception:
+        return False
+
+
+def _persist_allowlist_env(env_var: str, value: Optional[str]) -> bool:
+    """Mirror a grant into the active profile ``.env`` when configured.
+
+    ``get_env_path()`` already follows the runtime HERMES_HOME override.  The
+    only special case for a multiplexed scope is preventing config's legacy
+    process-global environment update, which would leak this profile's grant.
+    """
+    try:
+        from hermes_cli.config import remove_env_value, save_env_value
+
+        if value is None:
+            if _is_profile_secret_scope_active():
+                persisted = remove_env_value(env_var, update_environ=False)
+            else:
+                persisted = remove_env_value(env_var)
+        elif _is_profile_secret_scope_active():
+            persisted = save_env_value(env_var, value, update_environ=False)
+        else:
+            persisted = save_env_value(env_var, value)
+        if persisted and _is_profile_secret_scope_active():
+            from agent.secret_scope import update_current_secret_scope
+
+            update_current_secret_scope(env_var, value)
+        return bool(persisted)
+    except Exception:
+        # Best-effort: the pairing store remains the authoritative grant.
+        return False
 
 
 def _sync_allowlist_add(platform: str, user_id: str) -> None:
@@ -191,14 +229,8 @@ def _sync_allowlist_add(platform: str, user_id: str) -> None:
     if "*" in ids or str(user_id) in ids:
         return  # Already covered.
     ids.append(str(user_id))
-    try:
-        from hermes_cli.config import save_env_value
-
-        save_env_value(env_var, ",".join(ids))
-    except Exception:
-        # Best-effort: the pairing store grant still authorizes via the union,
-        # so a failure here degrades to "grant recorded but not mirrored".
-        pass
+    combined = ",".join(ids)
+    _persist_allowlist_env(env_var, combined)
 
 
 def _iter_live_gateway_adapters():
@@ -315,15 +347,7 @@ def _sync_allowlist_remove(platform: str, user_id: str) -> None:
     ]
     if len(remaining) == len(ids):
         return  # Not present.
-    try:
-        from hermes_cli.config import save_env_value, remove_env_value
-
-        if remaining:
-            save_env_value(env_var, ",".join(remaining))
-        else:
-            remove_env_value(env_var)
-    except Exception:
-        pass
+    _persist_allowlist_env(env_var, ",".join(remaining) if remaining else None)
     _sync_live_adapter_allowlist_remove(platform, user_id)
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4087,11 +4087,18 @@ def _env_line_defines_key(line: str, key: str) -> bool:
     return stripped.startswith(f"{key}=")
 
 
-def save_env_value(key: str, value: str):
-    """Save or update a value in ~/.hermes/.env."""
+def save_env_value(key: str, value: str, *, update_environ: bool = True):
+    """Save or update a value in ``.env`` under the active HERMES_HOME.
+
+    ``update_environ=False`` is for a multiplexed profile scope: the active
+    HERMES_HOME still selects that profile's ``.env``, but publishing the
+    value into process-global ``os.environ`` would contaminate sibling
+    profiles. Existing interactive/single-profile callers keep the legacy
+    update behavior.
+    """
     if is_managed():
         managed_error(f"set {key}")
-        return
+        return False
     # Managed scope guard: a managed env key can't be set by the user — the
     # managed .env wins at load anyway. Distinct from is_managed() above.
     from hermes_cli import managed_scope
@@ -4104,7 +4111,7 @@ def save_env_value(key: str, value: str):
             f"and cannot be changed.",
             file=sys.stderr,
         )
-        return
+        return False
     if not _ENV_VAR_NAME_RE.match(key):
         raise ValueError(f"Invalid environment variable name: {key!r}")
     _reject_denylisted_env_var(key)
@@ -4177,8 +4184,10 @@ def save_env_value(key: str, value: str):
             pass
         raise
 
-    os.environ[key] = value
+    if update_environ:
+        os.environ[key] = value
     invalidate_env_cache()
+    return True
 
 
 def custom_endpoint_key_env(identity: str) -> str:
@@ -4200,10 +4209,13 @@ def custom_endpoint_key_env(identity: str) -> str:
     return f"HERMES_CUSTOM_{slug}_API_KEY" if slug else "HERMES_CUSTOM_API_KEY"
 
 
-def remove_env_value(key: str) -> bool:
-    """Remove a key from ~/.hermes/.env and os.environ.
+def remove_env_value(key: str, *, update_environ: bool = True) -> bool:
+    """Remove a key from ``.env`` under the active HERMES_HOME.
 
-    Returns True if the key was found and removed, False otherwise.
+    When ``update_environ`` is true (the legacy default), also remove the
+    process-global environment value. Scoped multiplex writes disable that
+    publication to avoid contaminating sibling profiles. Returns True if the
+    key was found and removed, False otherwise.
     """
     if is_managed():
         managed_error(f"remove {key}")
@@ -4224,7 +4236,8 @@ def remove_env_value(key: str) -> bool:
         raise ValueError(f"Invalid environment variable name: {key!r}")
     env_path = get_env_path()
     if not env_path.exists():
-        os.environ.pop(key, None)
+        if update_environ:
+            os.environ.pop(key, None)
         return False
 
     read_kw = {"encoding": "utf-8-sig", "errors": "replace"}
@@ -4268,7 +4281,8 @@ def remove_env_value(key: str) -> bool:
                 pass
             raise
 
-    os.environ.pop(key, None)
+    if update_environ:
+        os.environ.pop(key, None)
     invalidate_env_cache()
     return found
 

--- a/tests/gateway/test_88441_pairing_secret_scope_profiles.py
+++ b/tests/gateway/test_88441_pairing_secret_scope_profiles.py
@@ -1,0 +1,57 @@
+"""Proof-of-concept for #88441: multiplexer pairing updates must remain profile-scoped."""
+
+import os
+
+from agent import secret_scope as ss
+
+
+def test_pairing_allowlist_updates_are_profile_scoped(tmp_path, monkeypatch):
+    from gateway.pairing import PairingStore, _read_allowlist_env
+    from gateway.run import _profile_runtime_scope
+
+    default_profile_home = tmp_path / "default-profile"
+    secondary_profile_home = tmp_path / "secondary-profile"
+    default_profile_home.mkdir()
+    secondary_profile_home.mkdir()
+
+    default_env = default_profile_home / ".env"
+    secondary_env = secondary_profile_home / ".env"
+    default_env.write_text("TELEGRAM_ALLOWED_USERS=default-owner\n", encoding="utf-8")
+    secondary_env.write_text(
+        "TELEGRAM_ALLOWED_USERS=secondary-owner\n", encoding="utf-8"
+    )
+
+    user_id = "user-42"
+    platform = "telegram"
+    process_token = "process-owner"
+    prior_multiplex = ss.is_multiplex_active()
+    ss.set_multiplex_active(True)
+    monkeypatch.setenv("HERMES_HOME", str(default_profile_home))
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", process_token)
+    baseline_default = default_env.read_text(encoding="utf-8")
+
+    try:
+        with _profile_runtime_scope(secondary_profile_home):
+            store = PairingStore()
+            code = store.generate_code(platform, user_id, "Second User")
+            assert code is not None
+            approval = store.approve_code(platform, code)
+            assert approval and approval["user_id"] == user_id
+            assert _read_allowlist_env("TELEGRAM_ALLOWED_USERS") == (
+                f"secondary-owner,{user_id}"
+            )
+            assert PairingStore().is_approved(platform, user_id) is True
+
+            assert store.revoke(platform, user_id) is True
+            assert _read_allowlist_env("TELEGRAM_ALLOWED_USERS") == "secondary-owner"
+
+        assert os.environ.get("TELEGRAM_ALLOWED_USERS") == process_token
+        with _profile_runtime_scope(default_profile_home):
+            assert _read_allowlist_env("TELEGRAM_ALLOWED_USERS") == "default-owner"
+            assert PairingStore().is_approved(platform, user_id) is False
+    finally:
+        ss.set_multiplex_active(prior_multiplex)
+
+    assert default_env.read_text(encoding="utf-8") == baseline_default
+    assert secondary_env.read_text(encoding="utf-8") == "TELEGRAM_ALLOWED_USERS=secondary-owner\n"
+    assert os.environ.get("TELEGRAM_ALLOWED_USERS") == process_token

--- a/tests/gateway/test_pairing_allowlist_bypass.py
+++ b/tests/gateway/test_pairing_allowlist_bypass.py
@@ -14,10 +14,12 @@ Design (union + option-i mirror):
 """
 
 import os
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from agent import secret_scope
 from gateway.session import Platform, SessionSource
 
 
@@ -59,6 +61,16 @@ def _make_source(user_id: str = "pairme", chat_type: str = "dm"):
     )
 
 
+def _pairing_store_for_home(home: Path, monkeypatch):
+    import importlib
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import gateway.pairing as pairing_mod
+
+    pairing_mod = importlib.reload(pairing_mod)
+    return pairing_mod, pairing_mod.PairingStore()
+
+
 def test_paired_user_authorized_even_when_not_in_allowlist(monkeypatch):
     """Union semantics: pairing is a grant, honored alongside the allowlist."""
     runner = _make_runner(paired=True)
@@ -72,6 +84,59 @@ def test_unpaired_user_in_allowlist_still_authorized(monkeypatch):
     monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner1")
 
     assert runner._is_user_authorized(_make_source("owner1")) is True
+
+
+def test_scoped_approval_adds_to_profile_env_not_parent_env(tmp_path, monkeypatch):
+    """Profile-scoped approvals mirror to the scoped .env, not process env."""
+    default_home = tmp_path / "default-home"
+    profile_home = tmp_path / "profiles" / "coder"
+    default_home.mkdir(parents=True)
+    profile_home.mkdir(parents=True)
+    (default_home / ".env").write_text("TELEGRAM_ALLOWED_USERS=parent-owner\n")
+    (profile_home / ".env").write_text("TELEGRAM_ALLOWED_USERS=owner1\n")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "parent-process-owner")
+    pairing_mod, store = _pairing_store_for_home(profile_home, monkeypatch)
+    prior_multiplex = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"TELEGRAM_ALLOWED_USERS": "owner1"})
+    try:
+        _approve_new_user(store, "telegram", "newuser99")
+        assert pairing_mod._read_allowlist_env("TELEGRAM_ALLOWED_USERS") == "owner1,newuser99"
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(prior_multiplex)
+    profile_env = profile_home / ".env"
+    default_env = default_home / ".env"
+    assert "TELEGRAM_ALLOWED_USERS=owner1,newuser99" in profile_env.read_text(encoding="utf-8")
+    assert "TELEGRAM_ALLOWED_USERS=parent-owner" in default_env.read_text(encoding="utf-8")
+    assert os.environ.get("TELEGRAM_ALLOWED_USERS") == "parent-process-owner"
+
+
+def test_scoped_revoke_removes_from_profile_env_not_parent_env(tmp_path, monkeypatch):
+    """Profile-scoped revokes should sync only the scoped allowlist mirror."""
+    default_home = tmp_path / "default-home"
+    profile_home = tmp_path / "profiles" / "coder"
+    default_home.mkdir(parents=True)
+    profile_home.mkdir(parents=True)
+    (default_home / ".env").write_text("TELEGRAM_ALLOWED_USERS=parent-owner\n")
+    (profile_home / ".env").write_text("TELEGRAM_ALLOWED_USERS=owner1,newuser99\n")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "parent-process-owner")
+    pairing_mod, store = _pairing_store_for_home(profile_home, monkeypatch)
+    prior_multiplex = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"TELEGRAM_ALLOWED_USERS": "owner1,newuser99"})
+    try:
+        store._approve_user("telegram", "newuser99", "")
+        assert store.revoke("telegram", "newuser99") is True
+        assert pairing_mod._read_allowlist_env("TELEGRAM_ALLOWED_USERS") == "owner1"
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(prior_multiplex)
+    profile_env = profile_home / ".env"
+    default_env = default_home / ".env"
+    assert "TELEGRAM_ALLOWED_USERS=owner1" in profile_env.read_text(encoding="utf-8")
+    assert "TELEGRAM_ALLOWED_USERS=parent-owner" in default_env.read_text(encoding="utf-8")
+    assert os.environ.get("TELEGRAM_ALLOWED_USERS") == "parent-process-owner"
 
 
 # --------------------------------------------------------------------------

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -247,6 +247,32 @@ class TestSaveAndLoadRoundtrip:
 
 
 class TestSaveEnvValueSecure:
+    def test_save_env_value_without_update_environ_leaves_os_environment_untouched(
+        self, tmp_path, monkeypatch
+    ):
+        env_path = tmp_path / ".env"
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "process-user")
+        result = save_env_value(
+            "GATEWAY_ALLOWED_USERS",
+            "scoped-user",
+            update_environ=False,
+        )
+
+        assert result is True
+        assert env_path.exists()
+        assert "GATEWAY_ALLOWED_USERS=scoped-user" in env_path.read_text(encoding="utf-8")
+        # The helper writes only .env with this mode.
+        assert os.environ.get("GATEWAY_ALLOWED_USERS") == "process-user"
+
+    def test_save_env_value_default_update_environ_updates_process(self, tmp_path):
+        env_path = tmp_path / ".env"
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path), "GATEWAY_ALLOWED_USERS": "process-user"}):
+            result = save_env_value("GATEWAY_ALLOWED_USERS", "scoped-user")
+            assert result is True
+            assert "GATEWAY_ALLOWED_USERS=scoped-user" in env_path.read_text(encoding="utf-8")
+            assert os.environ.get("GATEWAY_ALLOWED_USERS") == "scoped-user"
+            assert load_env()["GATEWAY_ALLOWED_USERS"] == "scoped-user"
 
     def test_secure_save_returns_metadata_only(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
@@ -324,6 +350,16 @@ class TestSaveEnvValueSecure:
 
 
 class TestRemoveEnvValue:
+    def test_remove_env_value_without_update_environ_leaves_os_environment_untouched(self, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_text("DROP_ME=to-remove\nKEEP=stay\n")
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path), "DROP_ME": "process-value"}):
+            result = remove_env_value("DROP_ME", update_environ=False)
+            assert result is True
+            content = env_path.read_text(encoding="utf-8")
+            assert "DROP_ME" not in content
+            assert os.environ.get("DROP_ME") == "process-value"
+
     def test_removes_key_from_env_file(self, tmp_path):
         env_path = tmp_path / ".env"
         env_path.write_text("KEY_A=value_a\nKEY_B=value_b\nKEY_C=value_c\n")


### PR DESCRIPTION
## Summary

Fixes #88441.

- Persist pairing approval/revoke allowlist mirrors under the active profile `HERMES_HOME` when multiplexing is active.
- Keep those scoped writes out of process-global `os.environ` and update the live secret scope immediately.
- Preserve existing single-profile and unscoped behavior.

## Validation

- `132 passed` — focused pairing, config, profile-scope, and WhatsApp multiplex coverage.
- `compileall` passed for the modified Python modules.
- Isolated two-profile integration test covers approve + revoke, default-profile isolation, process-env isolation, and immediate in-scope reads.
- `git diff --check HEAD^ HEAD` passed.

## Risk

The change is restricted to pairing allowlist mirroring while a multiplex profile scope is active; normal CLI/admin writes retain the legacy process-environment behavior.