### PR TITLE
fix(desktop): resolve git root for review pane file operations and diffs

### DIFF
--- a/apps/desktop/src/app/right-sidebar/review/file-tree.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { HermesReviewFile } from '@/global'
 import { I18nProvider } from '@/i18n'
 import { $sidebarWorkspaceNodeOpen } from '@/store/layout'
-import { $reviewFiles, $reviewOpen } from '@/store/review'
+import { $reviewFiles, $reviewGitRoot, $reviewOpen } from '@/store/review'
 
 import { ReviewFileTree } from './file-tree'
 
@@ -41,6 +41,7 @@ describe('ReviewFileTree', () => {
   beforeEach(() => {
     $reviewOpen.set(true)
     $reviewFiles.set([])
+    $reviewGitRoot.set(null)
     $sidebarWorkspaceNodeOpen.set({})
 
     // jsdom has no layout: report the real row height for virtualized rows and
@@ -126,5 +127,15 @@ describe('ReviewFileTree', () => {
     expect(screen.getByText('b.ts')).toBeTruthy()
     expect(screen.getByText('src')).toBeTruthy()
     expect(screen.getByText('c.ts')).toBeTruthy()
+  })
+
+  it('resolves drag and context menu absolute paths using $reviewGitRoot when available', () => {
+    $reviewGitRoot.set('/top-level-repo')
+    $reviewFiles.set([file('src/c.ts')])
+
+    const { container } = renderTree()
+    const row = container.querySelector('[draggable="true"]')
+    expect(row).toBeTruthy()
+    expect(row?.getAttribute('title')).toBe('/top-level-repo/src/c.ts')
   })
 })

--- a/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
@@ -33,6 +33,7 @@ import { notifyError } from '@/store/notifications'
 import { openPreview } from '@/store/preview'
 import {
   $reviewFiles,
+  $reviewGitRoot,
   $reviewLoading,
   $reviewOpen,
   $reviewScopeCwd,
@@ -78,9 +79,9 @@ function absolutePath(relative: string): string {
     return relative
   }
 
-  const cwd = reviewRepoCwd()?.replace(/[\\/]+$/, '')
+  const root = $reviewGitRoot.get()?.trim() || reviewRepoCwd()?.replace(/[\\/]+$/, '')
 
-  return cwd ? `${cwd}/${relative}` : relative
+  return root ? `${root}/${relative}` : relative
 }
 
 // Fast, layout-aware row: `layout` slides siblings when one is inserted/removed

--- a/apps/desktop/src/store/review.test.ts
+++ b/apps/desktop/src/store/review.test.ts
@@ -8,6 +8,7 @@ import {
   $reviewDiff,
   $reviewDiffLoading,
   $reviewFiles,
+  $reviewGitRoot,
   $reviewIsRepo,
   $reviewLoading,
   $reviewMaxChurn,
@@ -89,6 +90,7 @@ beforeEach(() => {
   // Reset stores touched across tests.
   $reviewOpen.set(false)
   $reviewFiles.set([])
+  $reviewGitRoot.set(null)
   $reviewLoading.set(false)
   $reviewIsRepo.set(true)
   $reviewDiff.set(null)
@@ -177,6 +179,32 @@ describe('refreshReview', () => {
     expect($reviewFiles.get()).toEqual([])
     expect($reviewIsRepo.get()).toBe(true)
     expect($reviewLoading.get()).toBe(false)
+  })
+
+  it('resolves git root and executes review list and diff using git root when cwd is subdirectory', async () => {
+    const review = stubReview({
+      diff: vi.fn(async () => 'subdir diff'),
+      list: vi.fn(async () => ({ files: [file('src/a.ts')] }))
+    })
+    const gitRoot = vi.fn(async () => '/top-level-repo')
+
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = {
+      gitRoot,
+      git: { review },
+      openExternal: vi.fn()
+    }
+
+    $currentCwd.set('/top-level-repo/workspaces/subdir')
+    $reviewOpen.set(true)
+
+    await refreshReview()
+
+    expect(gitRoot).toHaveBeenCalledWith('/top-level-repo/workspaces/subdir')
+    expect($reviewGitRoot.get()).toBe('/top-level-repo')
+    expect(review.list).toHaveBeenCalledWith('/top-level-repo', 'uncommitted', null)
+
+    await selectReviewFile(file('src/a.ts'))
+    expect(review.diff).toHaveBeenCalledWith('/top-level-repo', 'src/a.ts', 'uncommitted', null, false)
   })
 })
 

--- a/apps/desktop/src/store/review.ts
+++ b/apps/desktop/src/store/review.ts
@@ -5,6 +5,7 @@ import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
 import { isPaneVisible, revealTreePane } from '@/components/pane-shell/tree/store'
 import type { HermesReviewFile, HermesReviewShipInfo } from '@/global'
 import { matchesQuery } from '@/hooks/use-media-query'
+import { desktopGitRoot } from '@/lib/desktop-fs'
 import { desktopGit } from '@/lib/desktop-git'
 import { isExcludedPath } from '@/lib/excluded-paths'
 import { requestOneShot } from '@/lib/oneshot'
@@ -95,6 +96,11 @@ export const $reviewScopeCwd = atom<null | string>(null)
 // whose worktree the user is reviewing, not broadcast to every mounted tile.
 export const $reviewScopeTarget = atom('main')
 
+// The top-level Git repository root directory. When CWD is inside a subdirectory
+// of a Git repo, Git operations, diffs, and file open targets must resolve against
+// the top-level repository root.
+export const $reviewGitRoot = atom<null | string>(null)
+
 /** The repo the pane is reading right now: its pinned scope, else the active
  *  session's cwd. Exported for pane helpers that join repo-relative paths. */
 export const reviewRepoCwd = (): null | string => $reviewScopeCwd.get()?.trim() || $currentCwd.get()?.trim() || null
@@ -110,7 +116,7 @@ let shipInfoLastCheckedAt = 0
 // The two things every review op needs: the repo cwd + the IPC bridge. Null when
 // either is missing (no session, remote backend), so callers bail in one line.
 function reviewCtx(): { cwd: string; review: ReviewBridge } | null {
-  const cwd = repoCwd()
+  const cwd = $reviewGitRoot.get()?.trim() || repoCwd()
   const review = desktopGit()?.review
 
   return cwd && review ? { cwd, review } : null
@@ -119,8 +125,36 @@ function reviewCtx(): { cwd: string; review: ReviewBridge } | null {
 // ── Reads ────────────────────────────────────────────────────────────────────
 
 export async function refreshReview(): Promise<void> {
-  const ctx = reviewCtx()
+  const initialCwd = repoCwd()
+
+  if (!$reviewOpen.get() || !initialCwd) {
+    $reviewFiles.set([])
+    $reviewGitRoot.set(null)
+    $reviewIsRepo.set(Boolean(initialCwd && desktopGit()?.review))
+
+    // Critical: clear loading on the no-cwd / not-a-repo path too. It's set
+    // true (optimistically) before a refresh is scheduled, so skipping it here
+    // strands the pane on a forever-skeleton for a fresh, detached chat.
+    $reviewLoading.set(false)
+
+    return
+  }
+
   const seq = (reviewRefreshSeq += 1)
+
+  try {
+    const resolvedRoot = await desktopGitRoot(initialCwd).catch(() => null)
+
+    if (seq === reviewRefreshSeq && repoCwd() === initialCwd) {
+      $reviewGitRoot.set(resolvedRoot?.trim() || null)
+    }
+  } catch {
+    if (seq === reviewRefreshSeq && repoCwd() === initialCwd) {
+      $reviewGitRoot.set(null)
+    }
+  }
+
+  const ctx = reviewCtx()
 
   if (!$reviewOpen.get() || !ctx) {
     $reviewFiles.set([])
@@ -145,7 +179,7 @@ export async function refreshReview(): Promise<void> {
     const result = await review.list(cwd, 'uncommitted', null)
 
     // Ignore a result that resolved after the cwd moved on.
-    if (seq !== reviewRefreshSeq || repoCwd() !== cwd) {
+    if (seq !== reviewRefreshSeq || repoCwd() !== initialCwd) {
       return
     }
 
@@ -276,6 +310,7 @@ export function closeReview(): void {
   $reviewOpen.set(false)
   $reviewScopeCwd.set(null)
   $reviewScopeTarget.set('main')
+  $reviewGitRoot.set(null)
   clearReviewSelection()
 }
 
@@ -394,17 +429,20 @@ async function afterMutation(): Promise<void> {
 }
 
 export async function stageReviewFile(path: null | string): Promise<void> {
-  await desktopGit()?.review?.stage(repoCwd() ?? '', path)
+  const ctx = reviewCtx()
+  await ctx?.review?.stage(ctx.cwd, path)
   await afterMutation()
 }
 
 export async function unstageReviewFile(path: null | string): Promise<void> {
-  await desktopGit()?.review?.unstage(repoCwd() ?? '', path)
+  const ctx = reviewCtx()
+  await ctx?.review?.unstage(ctx.cwd, path)
   await afterMutation()
 }
 
 export async function revertReviewFile(path: null | string): Promise<void> {
-  await desktopGit()?.review?.revert(repoCwd() ?? '', path)
+  const ctx = reviewCtx()
+  await ctx?.review?.revert(ctx.cwd, path)
   await afterMutation()
 }
 
@@ -596,6 +634,7 @@ function onReviewRepoMoved(): void {
   if ($reviewOpen.get()) {
     clearReviewSelection()
     $reviewFiles.set([])
+    $reviewGitRoot.set(null)
     $reviewLoading.set(true)
     scheduleReviewRefresh()
     void refreshShipInfo()


### PR DESCRIPTION
### What changed?
When a session is opened inside a subdirectory of a Git repository (e.g. `$CWD = /repo/packages/subapp` inside `/repo`), interacting with the Review Pane failed because:
1. Double-clicking or selecting "Open File" joined repo-relative paths with `$currentCwd` instead of the Git top-level root, causing 404 errors on file preview.
2. Clicking a file to inspect its inline diff executed `git diff` inside the subdirectory CWD instead of the repository root, returning empty diffs.

This PR fixes both issues:
- Introduces `$reviewGitRoot` in `apps/desktop/src/store/review.ts` and resolves the repository root via `desktopGitRoot(cwd)` during `refreshReview()`.
- Updates `reviewCtx()` to use `$reviewGitRoot` as the primary execution directory for git diff, stage, unstage, and revert operations.
- Updates `absolutePath()` in `file-tree.tsx` to join relative paths against `$reviewGitRoot` when available.

### How to test?
1. Open a session in a subdirectory of a Git repository.
2. Make a change or stage a file located outside the subdirectory (or at the repo root).
3. Open the Review Pane:
   - Click the file: inline diff renders correctly.
   - Double-click or select "Open File": file preview opens without 404 error.
   - Stage/unstage buttons work cleanly.

### Tests
- `npm test -- src/store/review.test.ts src/app/right-sidebar/review/file-tree.test.tsx` (42 passed)
- `npm run typecheck` (0 errors)

### Platforms tested
- Linux / WSL2
- Windows (via remote gateway desktop client)