### PR TITLE
fix(config): decode JSON-string-typed providers at load time (#88451)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1846,9 +1846,52 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def _normalize_providers_string(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Decode a JSON-string-typed ``providers`` value into a dict.
+
+    ``providers`` is an open-dict top-level key (``_OPEN_DICT_TOP_LEVEL_KEYS``),
+    so config validation accepts *any* shape under it and never complains when a
+    serialization round-trip (e.g. a dashboard/config write-back through
+    ``json.dumps``) persists the whole section as a single JSON string scalar:
+
+        providers: '{"custom": {"base_url": "...", "models": {...}}}'
+
+    Every consumer guards with ``isinstance(providers, dict)`` and silently
+    degrades to "no custom providers configured" — per-model ``supports_vision``
+    overrides (``agent.image_routing``) and custom-provider identity lookups
+    (``hermes_cli.runtime_provider``) never resolve, with zero warnings. Decode
+    the string here, at the single normalization chokepoint shared by the user
+    and managed configs, so every downstream reader sees the dict shape it
+    expects. Runs before ``_expand_env_vars`` so ``${VAR}`` refs inside the
+    decoded block still expand normally. A non-dict or malformed payload falls
+    back to ``{}`` (with a one-time warning) rather than surviving as a string.
+    """
+    raw = config.get("providers")
+    if not isinstance(raw, str):
+        return config
+    config = dict(config)
+    try:
+        decoded = json.loads(raw)
+    except (ValueError, TypeError):
+        decoded = None
+    if isinstance(decoded, dict):
+        config["providers"] = decoded
+    else:
+        logger.warning(
+            "Ignoring malformed 'providers' config: expected a mapping but got "
+            "a %s-typed value; treating it as empty. Custom providers and "
+            "per-model overrides will not resolve until this is fixed.",
+            "JSON string decoding to non-dict" if decoded is not None else "string",
+        )
+        config["providers"] = {}
+    return config
+
+
 def _canonicalize_config(config: Dict[str, Any]) -> Dict[str, Any]:
-    """The load/save normalization pipeline: max_turns relocation, then model-section canon."""
-    return _normalize_root_model_keys(_normalize_max_turns_config(config))
+    """The load/save normalization pipeline: max_turns relocation, model-section canon, providers-string decode."""
+    return _normalize_providers_string(
+        _normalize_root_model_keys(_normalize_max_turns_config(config))
+    )
 
 
 # Sentinel for an unlimited turn budget. ``sys.maxsize`` survives the str->int round-trip through

--- a/tests/hermes_cli/test_config_providers_json_string.py
+++ b/tests/hermes_cli/test_config_providers_json_string.py
@@ -1,0 +1,110 @@
+"""Regression for #88451: a JSON-string-typed ``providers`` must be decoded.
+
+``providers`` is an open-dict top-level key, so config validation accepts any
+shape under it. A serialization round-trip (dashboard/config write-back through
+``json.dumps``) can persist the whole section as a single JSON-string scalar:
+
+    providers: '{"custom": {"models": {"M": {"supports_vision": true}}}}'
+
+Every consumer guards with ``isinstance(providers, dict)`` and silently
+degrades to "no custom providers configured" — per-model ``supports_vision``
+overrides and custom-provider identity lookups never resolve. ``load_config``
+now normalizes the string into a dict at the shared normalization chokepoint,
+so downstream readers see the shape they expect.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import patch
+
+from agent.image_routing import _supports_vision_override
+from hermes_cli.config import _normalize_providers_string, load_config
+
+
+class TestNormalizeProvidersString:
+    def test_decodes_json_string_to_dict(self):
+        raw = '{"custom": {"base_url": "http://x", "models": {"M": {"supports_vision": true}}}}'
+        out = _normalize_providers_string({"providers": raw})
+        assert out["providers"] == {
+            "custom": {"base_url": "http://x", "models": {"M": {"supports_vision": True}}}
+        }
+
+    def test_dict_passthrough_untouched(self):
+        cfg = {"providers": {"custom": {"models": {}}}}
+        out = _normalize_providers_string(cfg)
+        assert out["providers"] is cfg["providers"]
+
+    def test_absent_providers_is_noop(self):
+        cfg = {"model": {"default": "x"}}
+        assert _normalize_providers_string(cfg) is cfg
+
+    def test_json_string_decoding_to_non_dict_falls_back_to_empty(self, caplog):
+        # A JSON array is valid JSON but the wrong shape — must not survive.
+        out = _normalize_providers_string({"providers": "[1, 2, 3]"})
+        assert out["providers"] == {}
+
+    def test_malformed_json_string_falls_back_to_empty(self):
+        out = _normalize_providers_string({"providers": "{not json"})
+        assert out["providers"] == {}
+
+    def test_original_config_not_mutated(self):
+        cfg = {"providers": "{}"}
+        _normalize_providers_string(cfg)
+        assert cfg["providers"] == "{}"  # caller's dict untouched
+
+
+class TestLoadConfigDecodesProvidersString:
+    def test_load_config_decodes_and_vision_override_resolves(self, tmp_path):
+        """The reporter's end-to-end repro, driven through real ``load_config``."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            providers = {
+                "custom": {
+                    "base_url": "http://127.0.0.1:16520/v1",
+                    "api_key": "vllm-local",
+                    "models": {
+                        "Qwen3.8-27B": {
+                            "context_length": 126976,
+                            "supports_vision": True,
+                            "capabilities": ["text", "image", "tool_use"],
+                        }
+                    },
+                }
+            }
+            # Persisted as a single-quoted YAML scalar holding a JSON string.
+            (tmp_path / "config.yaml").write_text(
+                "providers: " + json.dumps(json.dumps(providers)) + "\n",
+                encoding="utf-8",
+            )
+
+            config = load_config()
+
+            assert isinstance(config["providers"], dict)
+            assert (
+                _supports_vision_override(config, "custom", "Qwen3.8-27B") is True
+            )
+
+    def test_env_refs_inside_decoded_providers_still_expand(self, tmp_path):
+        """Decoding runs before env-expansion, so ``${VAR}`` inside the JSON
+        string is expanded normally once it lands in the dict."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path), "VLLM_KEY": "secret-123"}):
+            providers = {"custom": {"api_key": "${VLLM_KEY}", "models": {}}}
+            (tmp_path / "config.yaml").write_text(
+                "providers: " + json.dumps(json.dumps(providers)) + "\n",
+                encoding="utf-8",
+            )
+
+            config = load_config()
+
+            assert config["providers"]["custom"]["api_key"] == "secret-123"
+
+    def test_malformed_providers_string_loads_as_empty(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            (tmp_path / "config.yaml").write_text(
+                "providers: '{not valid json'\n", encoding="utf-8"
+            )
+
+            config = load_config()
+
+            assert config["providers"] == {}


### PR DESCRIPTION
## Problem

`providers:` is an **open-dict top-level key** (`_OPEN_DICT_TOP_LEVEL_KEYS`), so
config validation intentionally accepts *any* shape under it and never
complains when a serialization round-trip (a dashboard/config write-back
through `json.dumps`, a setup flow) persists the whole section as a single
JSON-string YAML scalar:

```yaml
providers: '{"custom":{"base_url":"http://127.0.0.1:16520/v1","models":{"Qwen3.8-27B":{"supports_vision":true}}}}'
```

No load path ever decodes that string into a dict, and **every consumer guards
with `isinstance(providers, dict)` and silently degrades** to "no custom
providers configured at all" — with zero warnings or validation errors:

| Site | Effect when `providers` is a string |
|---|---|
| `agent/image_routing.py` `_supports_vision_override` | per-model `supports_vision` override never seen → falls through to models.dev → images not routed natively / `vision_analyze` times out |
| `hermes_cli/runtime_provider.py` (`find_custom_provider_identity{,_by_model}`) | custom-provider identity / URL reverse-lookup skipped → session rebuild loses provider identity, placeholder credentials |
| `hermes_cli/config.py` `providers_dict_to_custom_providers` | compat layer returns `[]` |

The only escape hatch is the top-level `model.supports_vision` shortcut, which
applies to the *active* model, not per-model.

## Fix

Normalize at the single normalization chokepoint in `_load_config_impl()`,
shared by the user and managed configs, via a new `_normalize_providers_string`
helper that mirrors the existing `_normalize_root_model_keys` /
`_normalize_max_turns_config` style. This fixes **all** consumer sites at once:

- Runs **before** `_expand_env_vars`, so `${VAR}` refs inside a decoded
  `providers` block still expand normally.
- A non-dict JSON payload (e.g. a list) or malformed JSON falls back to `{}`
  with a **one-time WARNING** rather than surviving as a string and degrading
  silently.
- A dict-typed `providers` is passed through untouched (identity-preserving).

## Tests

`tests/hermes_cli/test_config_providers_json_string.py`:
- Unit coverage of `_normalize_providers_string`: JSON-string→dict, dict
  passthrough, absent no-op, JSON-non-dict→`{}`, malformed→`{}`, caller dict
  not mutated.
- The reporter's end-to-end repro driven through real `load_config()`:
  a JSON-string `providers` is decoded and `_supports_vision_override(cfg,
  "custom", "Qwen3.8-27B")` resolves `True`.
- `${VAR}` inside the decoded block still expands.
- Malformed string loads as `{}`.

Preflight: windows-footguns / ruff / affected tests all green.

Fixes #88451
