### PR TITLE
fix(whatsapp): survive version-endpoint outages with an on-disk last-good version cache

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -396,7 +396,9 @@ function emitPairEvent(event) {
 }
 
 const scheduleReconnect = createReconnectScheduler(() => startSocket());
-const getWAVersion = createVersionResolver(fetchLatestBaileysVersion);
+const getWAVersion = createVersionResolver(fetchLatestBaileysVersion, {
+  cacheFile: path.join(SESSION_DIR, 'wa-version-cache.json'),
+});
 
 async function startSocket() {
   const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);

--- a/scripts/whatsapp-bridge/bridge.versioncache.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.versioncache.test.mjs
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for the on-disk WhatsApp version cache.
+ *
+ * Regression tests for the 2026-08-17 GitHub outage trap: with
+ * raw.githubusercontent.com unreachable, fetchLatestBaileysVersion() times
+ * out, the resolver hands back the Baileys library default, and WhatsApp
+ * rejects the handshake with stream error 405 in an endless reconnect loop.
+ * The in-memory fallback cannot help a bridge that restarted during the
+ * outage — it never had a successful fetch in this process. Persisting the
+ * last successfully fetched version gives a cold start a known-good tier.
+ *
+ * These tests avoid importing bridge.js because that file starts an HTTP
+ * server and Baileys socket at module load. Keep the helper module pure.
+ */
+
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const roots = [];
+function tempDir() {
+  const dir = mkdtempSync(path.join(tmpdir(), 'wa-version-cache-'));
+  roots.push(dir);
+  return dir;
+}
+
+import { createVersionResolver } from './bridge_helpers.js';
+
+// A successful fetch writes the version through to disk, so the NEXT process
+// to start has something better than the library default to fall back on.
+{
+  const cacheFile = path.join(tempDir(), 'wa-version-cache.json');
+  const resolveVersion = createVersionResolver(
+    async () => ({ version: [2, 3000, 1023223821] }),
+    { log: () => {}, cacheFile },
+  );
+
+  assert.deepEqual(await resolveVersion(), [2, 3000, 1023223821]);
+
+  const persisted = JSON.parse(readFileSync(cacheFile, 'utf8'));
+  assert.deepEqual(persisted.version, [2, 3000, 1023223821]);
+  assert.ok(!Number.isNaN(Date.parse(persisted.fetched_at)), 'fetched_at is an ISO timestamp');
+}
+
+// The outage scenario end to end: a fresh resolver (no in-memory version,
+// exactly like a bridge restarted mid-outage) reads the last known-good
+// version off disk instead of falling through to the library default.
+{
+  const cacheFile = path.join(tempDir(), 'wa-version-cache.json');
+  writeFileSync(cacheFile, JSON.stringify({
+    version: [2, 3000, 1023223821],
+    fetched_at: '2026-08-16T12:00:00.000Z',
+  }));
+
+  const logs = [];
+  const resolveVersion = createVersionResolver(
+    async () => { throw new Error('network down'); },
+    { log: line => logs.push(line), cacheFile },
+  );
+
+  assert.deepEqual(await resolveVersion(), [2, 3000, 1023223821]);
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /network down/);
+  assert.match(logs[0], /from disk/);
+  assert.match(logs[0], /2\.3000\.1023223821/);
+}
+
+// Once the disk tier has been used it is held in memory, so a second failing
+// call does not re-read the file — and a later success replaces both tiers.
+{
+  const cacheFile = path.join(tempDir(), 'wa-version-cache.json');
+  writeFileSync(cacheFile, JSON.stringify({ version: [2, 3000, 1], fetched_at: 'x' }));
+
+  let reads = 0;
+  const resolveVersion = createVersionResolver(
+    async () => { reads += 1; throw new Error('still down'); },
+    { log: () => {}, cacheFile },
+  );
+
+  assert.deepEqual(await resolveVersion(), [2, 3000, 1]);
+  // Overwrite the file: an in-memory hit must win, so this is never observed.
+  writeFileSync(cacheFile, JSON.stringify({ version: [9, 9, 9], fetched_at: 'x' }));
+  assert.deepEqual(await resolveVersion(), [2, 3000, 1]);
+  assert.equal(reads, 2);
+}
+
+// A fresh fetch outranks the disk cache and rewrites it.
+{
+  const cacheFile = path.join(tempDir(), 'wa-version-cache.json');
+  writeFileSync(cacheFile, JSON.stringify({ version: [2, 3000, 1], fetched_at: 'x' }));
+
+  const resolveVersion = createVersionResolver(
+    async () => ({ version: [2, 3000, 2] }),
+    { log: () => {}, cacheFile },
+  );
+
+  assert.deepEqual(await resolveVersion(), [2, 3000, 2]);
+  assert.deepEqual(JSON.parse(readFileSync(cacheFile, 'utf8')).version, [2, 3000, 2]);
+}
+
+// Garbage on disk is treated as absent, not trusted: unparseable JSON, a
+// missing/ill-typed version field, and out-of-range tuple lengths all fall
+// through to the library default rather than feeding junk to makeWASocket().
+{
+  const badPayloads = [
+    'not json at all',
+    '{}',
+    JSON.stringify({ version: '2.3000.1' }),
+    JSON.stringify({ version: [] }),
+    JSON.stringify({ version: [2] }),
+    JSON.stringify({ version: [2, 3000, 1, 4, 5] }),
+    JSON.stringify({ version: [2, '3000', 1] }),
+    JSON.stringify({ version: [2, 3000.5, 1] }),
+    JSON.stringify({ version: [2, null, 1] }),
+  ];
+
+  for (const payload of badPayloads) {
+    const cacheFile = path.join(tempDir(), 'wa-version-cache.json');
+    writeFileSync(cacheFile, payload);
+
+    const logs = [];
+    const resolveVersion = createVersionResolver(
+      async () => { throw new Error('network down'); },
+      { log: line => logs.push(line), cacheFile },
+    );
+
+    assert.equal(await resolveVersion(), null, `payload should be rejected: ${payload}`);
+    assert.match(logs[0], /library default/);
+  }
+}
+
+// A cacheFile that can never be created (its parent is a regular file) must
+// not break the connection path: the resolver still returns the fetched
+// version, and it complains at most once no matter how often it reconnects.
+{
+  const blocker = path.join(tempDir(), 'not-a-directory');
+  writeFileSync(blocker, 'i am a file');
+  const cacheFile = path.join(blocker, 'wa-version-cache.json');
+
+  const logs = [];
+  const resolveVersion = createVersionResolver(
+    async () => ({ version: [2, 3000, 7] }),
+    { log: line => logs.push(line), cacheFile },
+  );
+
+  assert.deepEqual(await resolveVersion(), [2, 3000, 7]);
+  assert.deepEqual(await resolveVersion(), [2, 3000, 7]);
+  assert.equal(logs.length, 1, 'the write failure is reported once, not per reconnect');
+  assert.match(logs[0], /persist/);
+}
+
+// An unreadable cache path on the failure side is equally inert.
+{
+  const blocker = path.join(tempDir(), 'not-a-directory');
+  writeFileSync(blocker, 'i am a file');
+  const cacheFile = path.join(blocker, 'wa-version-cache.json');
+
+  const logs = [];
+  const resolveVersion = createVersionResolver(
+    async () => { throw new Error('network down'); },
+    { log: line => logs.push(line), cacheFile },
+  );
+
+  assert.equal(await resolveVersion(), null);
+  assert.match(logs[0], /library default/);
+}
+
+// A missing cache file is the ordinary first-run case, not an error.
+{
+  const cacheFile = path.join(tempDir(), 'nested', 'wa-version-cache.json');
+  const logs = [];
+  const resolveVersion = createVersionResolver(
+    async () => { throw new Error('network down'); },
+    { log: line => logs.push(line), cacheFile },
+  );
+
+  assert.equal(await resolveVersion(), null);
+  assert.match(logs[0], /library default/);
+}
+
+// Without a cacheFile the resolver behaves exactly as it did before: memory
+// only, no disk access, library default before the first success.
+{
+  const logs = [];
+  let calls = 0;
+  const resolveVersion = createVersionResolver(
+    async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('network down');
+      return { version: [2, 3000, 3] };
+    },
+    { log: line => logs.push(line) },
+  );
+
+  assert.equal(await resolveVersion(), null);
+  assert.match(logs[0], /library default/);
+  assert.deepEqual(await resolveVersion(), [2, 3000, 3]);
+}
+
+// The parent directory of the cache file is created on demand, so a first
+// successful fetch on a brand-new session dir still persists.
+{
+  const cacheFile = path.join(tempDir(), 'session', 'nested', 'wa-version-cache.json');
+  const resolveVersion = createVersionResolver(
+    async () => ({ version: [2, 3000, 11] }),
+    { log: () => {}, cacheFile },
+  );
+
+  assert.deepEqual(await resolveVersion(), [2, 3000, 11]);
+  assert.deepEqual(JSON.parse(readFileSync(cacheFile, 'utf8')).version, [2, 3000, 11]);
+}
+
+// The timeout tier persists too: a hung fetch that loses the race still
+// leaves the previously persisted version in place for the next process.
+{
+  const dir = tempDir();
+  const cacheFile = path.join(dir, 'wa-version-cache.json');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(cacheFile, JSON.stringify({ version: [2, 3000, 5], fetched_at: 'x' }));
+
+  const logs = [];
+  const resolveVersion = createVersionResolver(
+    () => new Promise(() => {}),
+    { timeoutMs: 20, log: line => logs.push(line), cacheFile },
+  );
+
+  assert.deepEqual(await resolveVersion(), [2, 3000, 5]);
+  assert.match(logs[0], /timed out/);
+  assert.match(logs[0], /from disk/);
+  assert.deepEqual(JSON.parse(readFileSync(cacheFile, 'utf8')).version, [2, 3000, 5]);
+}
+
+for (const dir of roots) {
+  try { rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+console.log('bridge.versioncache.test.mjs: all assertions passed');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { mkdirSync, writeFileSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { randomBytes } from 'crypto';
 
 export const MIME_MAP = {
@@ -594,18 +594,65 @@ export function createReconnectScheduler(startFn, {
   return scheduleReconnect;
 }
 
+// A WhatsApp Web version is a short tuple of integers ([2, 3000, 1023223821]).
+// Anything else on disk is treated as absent rather than trusted.
+function isValidWAVersion(value) {
+  return Array.isArray(value)
+    && value.length >= 2
+    && value.length <= 4
+    && value.every(part => Number.isInteger(part));
+}
+
 /**
  * Version resolution guard. fetchLatestBaileysVersion() is a plain fetch to
  * raw.githubusercontent.com with no AbortSignal; a stalled connection can
  * pend forever and wedge the reconnect path (the scheduler above cannot
  * retry past an await that never settles). Bound the fetch and fall back to
  * the last known-good version, or the Baileys default before first success.
+ *
+ * The in-memory fallback dies with the process, which is exactly when it is
+ * needed most: during the GitHub outage of 2026-08-17 the fetch timed out,
+ * the resolver handed back the Baileys library default, and WhatsApp refused
+ * the handshake with stream error 405 on an endless reconnect loop. A bridge
+ * restart in that window had no memory of the version it had been happily
+ * connected with minutes earlier. `cacheFile` persists the last successfully
+ * fetched version so a cold start still has a known-good tier to fall back
+ * to while the version endpoint is unreachable.
  */
 export function createVersionResolver(fetchVersionFn, {
   timeoutMs = 15000,
   log = console.log,
+  cacheFile = null,
 } = {}) {
   let cachedVersion = null;
+  let warnedWriteFailure = false;
+
+  function persistVersion(version) {
+    if (!cacheFile) return;
+    try {
+      mkdirSync(path.dirname(cacheFile), { recursive: true });
+      writeFileSync(cacheFile, JSON.stringify({
+        version,
+        fetched_at: new Date().toISOString(),
+      }));
+    } catch (err) {
+      if (!warnedWriteFailure) {
+        warnedWriteFailure = true;
+        log(`⚠️  Could not persist the WhatsApp version cache to ${cacheFile} (${err?.message || err}); continuing without it.`);
+      }
+    }
+  }
+
+  function readPersistedVersion() {
+    if (!cacheFile) return null;
+    try {
+      const parsed = JSON.parse(readFileSync(cacheFile, 'utf8'));
+      return isValidWAVersion(parsed?.version) ? parsed.version : null;
+    } catch {
+      return null;
+    }
+  }
+
   return async function resolveVersion() {
     let timer = null;
     try {
@@ -616,8 +663,19 @@ export function createVersionResolver(fetchVersionFn, {
         }),
       ]);
       cachedVersion = version;
+      persistVersion(version);
     } catch (err) {
-      log(`⚠️  Baileys version fetch failed (${err?.message || err}); using ${cachedVersion ? 'cached version' : 'library default'}.`);
+      let tier = 'library default';
+      if (cachedVersion) {
+        tier = 'cached version';
+      } else {
+        const persisted = readPersistedVersion();
+        if (persisted) {
+          cachedVersion = persisted;
+          tier = `last known-good version from disk (${persisted.join('.')})`;
+        }
+      }
+      log(`⚠️  Baileys version fetch failed (${err?.message || err}); using ${tier}.`);
     } finally {
       if (timer) clearTimeout(timer);
     }


### PR DESCRIPTION
## The outage

`fetchLatestBaileysVersion()` reads the current WhatsApp Web version from `raw.githubusercontent.com`. During the GitHub incident on **2026-08-17** that fetch timed out, and the bridge went into an endless reconnect loop:

```
⚠️  Baileys version fetch failed (version fetch timed out); using library default.
⚠️  Connection closed (reason: 405). Reconnecting in 3s...
⚠️  Connection closed (reason: 405). Reconnecting in 3s...
```

`createVersionResolver()` already guards the fetch with a timeout and falls back to the last known-good version — but `cachedVersion` lives only in process memory. A bridge restarted during the outage has no memory of the version it was connected with minutes earlier, so it falls all the way through to the Baileys library default, which WhatsApp refuses with stream error 405. The fallback is missing exactly when it matters most.

Reproduced deterministically by blocking the version endpoint and restarting the bridge.

## The fix

Persist the last **successfully fetched** version to disk and use it as a tier between the in-memory cache and the library default. `createVersionResolver()` takes an optional `cacheFile`, and `bridge.js` points it at `<session dir>/wa-version-cache.json`.

Resolution order on a failed fetch:

1. in-memory `cachedVersion` (this process already fetched successfully)
2. on-disk cache (a previous process did — this is the new tier)
3. `null`, i.e. the Baileys library default (unchanged behaviour)

The log line names the tier actually used, so an operator reading the logs during an outage can tell a healthy degraded connect from the 405 case.

Safety properties:

- **Writes are best effort.** A failing write is logged at most once and never breaks the connection path; the fetched version is still returned and used.
- **Disk content is validated, not trusted.** Unparseable JSON, a missing `version`, or anything that is not a 2-to-4 element array of integers is treated as absent. Nothing junk reaches `makeWASocket()`.
- **No behaviour change without `cacheFile`.** Callers that do not pass it keep the exact memory-only semantics they had.
- The file sits in the session directory, which is already created by the bridge; `buildLidMap()` filters that directory by a strict `lid-mapping-<digits>.json` regex, so the new file is ignored there.

## Tests

New `scripts/whatsapp-bridge/bridge.versioncache.test.mjs`, matching the plain-assert style of the neighbouring `bridge.reconnect.test.mjs`:

- a successful fetch writes `version` + ISO `fetched_at` through to disk
- the outage case: a fresh resolver with no in-memory version reads the last known-good version off disk instead of using the library default
- the in-memory tier beats the disk tier on a second call (the file is not re-read)
- a fresh fetch outranks and rewrites the disk cache
- nine malformed payloads (bad JSON, missing/ill-typed `version`, tuples too short or too long, non-integer members) all fall through to the library default
- a cache path that can never be created returns the fetched version anyway and warns exactly once across repeated reconnects
- an unreadable path on the failure side, and a missing file on first run, are both inert
- the parent directory is created on demand
- the timeout path (not just an outright rejection) also reaches the disk tier

All seven bridge test files pass: `allowlist` 5, `outbound_ids` 6, `owner_message_gate` 8 (node:test), plus `bridge.native`, `bridge.reconnect`, `bridge.sendqueue`, and `bridge.versioncache` (plain assert scripts, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
