### PR TITLE
fix(deps): relax hindsight-client pin to >=0.6.1,<1.0

### DIFF
--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -106,7 +106,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client>=0.6.1,<1.0",),
     # Cloud memory SDKs MUST be allowlisted + ensure()'d at the import site, or they never
     # install on the sealed Docker image (durable-target only).
     "memory.supermemory": ("supermemory==3.50.0",),


### PR DESCRIPTION
## Problem

`tools/lazy_deps.py` pins the `memory.hindsight` feature to `hindsight-client==0.6.1`, but hindsight-api-slim is now at **0.9.1** (released 2026-08-14) and its matching client is 0.9.1.

When a user upgrades the client to 0.9.1, lazy_deps sees the installed version as not matching `==0.6.1`, marks the feature unavailable, and forces a reinstall of 0.6.1 via `uv pip install`. On hosts where PyPI is only reachable through a proxy that uv does not inherit, that install times out after 300s and the `hindsight_retain` / `hindsight_recall` tools stay broken.

## Root cause

`tools/lazy_deps.py` line 194 hard-pins a version that the published ecosystem has already moved past. The plugin's own minimum check (`plugins/memory/hindsight/__init__.py` `_MIN_CLIENT_VERSION = "0.6.1"`) already treats `>=0.6.1` as the contract.

## Fix

Relax the pin to `hindsight-client>=0.6.1,<1.0` (upper bound per the supply-chain policy).

## Verification (local, real environment)

- `hindsight-client 0.9.1` satisfies `>=0.6.1,<1.0` ✓
- `from hindsight_client import Hindsight` imports cleanly on 0.9.1 ✓
- After the fix + gateway restart: `hindsight_retain` → `Memory stored successfully`; `hindsight_recall` returns results ✓
- No client-version downgrade is attempted anymore (no forced install)