### PR TITLE
fix(contributors): repo cannot be cloned cleanly on Windows/macOS — two email mappings differ only in case

### DIFF
--- a/scripts/add_contributor.py
+++ b/scripts/add_contributor.py
@@ -55,6 +55,22 @@ def _legacy_login(email: str) -> str | None:
         return None
 
 
+def _case_collision(email: str) -> str | None:
+    """An existing mapping whose filename differs from `email` only in case.
+
+    Returns the colliding filename, or None. Exact matches are not collisions --
+    that is the ordinary "already mapped" path handled by the caller.
+    """
+    if not EMAILS_DIR.is_dir():
+        return None
+
+    folded = email.lower()
+    for entry in EMAILS_DIR.iterdir():
+        if entry.name != email and entry.name.lower() == folded:
+            return entry.name
+    return None
+
+
 def add_contributor(email: str, login: str, comment: str = "") -> int:
     email = email.strip()
     login = login.strip().lstrip("@")
@@ -67,6 +83,23 @@ def add_contributor(email: str, login: str, comment: str = "") -> int:
         return 2
 
     path = EMAILS_DIR / email
+
+    # One file per email means the FILENAME is the key, and on a
+    # case-insensitive filesystem (Windows, default macOS) two emails differing
+    # only in case are the same file. Creating both makes the repo impossible to
+    # check out cleanly there -- `git status` reports a phantom modification
+    # forever, because whichever file git wrote second wins on disk. Refuse for
+    # the same reason a conflicting login is refused: resolve it deliberately.
+    collision = _case_collision(email)
+    if collision is not None:
+        print(
+            f"error: {email} collides with existing mapping {collision} on "
+            "case-insensitive filesystems (Windows/macOS) — the two are the same "
+            "file there. Reuse that mapping, or resolve manually.",
+            file=sys.stderr,
+        )
+        return 1
+
     existing = read_mapping_file(path) if path.is_file() else None
     if existing is None:
         existing = _legacy_login(email)

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -116,3 +116,55 @@ def test_cli_entrypoint_end_to_end(tmp_path):
     assert proc.returncode == 0, proc.stderr
     out = (tmp_path / "contributors" / "emails" / "cli@example.com").read_text(encoding="utf-8")
     assert out.splitlines()[0] == "cliperson"
+
+
+# ── case-insensitive filename collisions ──────────────────────────────
+#
+# The mapping key IS the filename, so two emails differing only in case are the
+# same file on Windows and on default macOS. When both exist, git writes one and
+# then reports the other as modified in a FRESH clone, permanently: the repo can
+# never be checked out clean on those platforms.
+#
+# This pair is a real conflict in the tree today and needs a maintainer to say
+# which login is correct -- they point at different logins, so deleting either
+# silently reassigns commits. It is pinned here so the breakage is visible and,
+# more importantly, so it cannot spread.
+KNOWN_CASE_CONFLICTS = {
+    frozenset(
+        {
+            "agent@Agents-Mac-mini.local",
+            "agent@agents-Mac-mini.local",
+        }
+    )
+}
+
+EMAILS_DIR = REPO_ROOT / "contributors" / "emails"
+
+
+def test_no_new_case_insensitive_mapping_collisions():
+    groups: dict[str, set[str]] = {}
+    for entry in EMAILS_DIR.iterdir():
+        if entry.is_file():
+            groups.setdefault(entry.name.lower(), set()).add(entry.name)
+
+    collisions = {frozenset(names) for names in groups.values() if len(names) > 1}
+    unexpected = collisions - KNOWN_CASE_CONFLICTS
+
+    assert not unexpected, (
+        "contributor mappings differing only in case cannot coexist on "
+        "case-insensitive filesystems (Windows, default macOS) — a fresh clone "
+        f"there is permanently dirty: {sorted(sorted(c) for c in unexpected)}"
+    )
+
+
+def test_add_contributor_refuses_a_case_collision(tmp_path, monkeypatch):
+    d = tmp_path / "emails"
+    d.mkdir()
+    (d / "agent@Example-Host.local").write_text("someone\n")
+
+    import add_contributor as mod
+
+    monkeypatch.setattr(mod, "EMAILS_DIR", d)
+
+    assert mod.add_contributor("agent@example-host.local", "otherperson") == 1
+    assert not (d / "agent@example-host.local").exists()


### PR DESCRIPTION
## A fresh clone is permanently dirty on Windows and default macOS

```console
> git clone --depth 1 --branch main https://github.com/NousResearch/hermes-agent.git build
> cd build && git status --porcelain -uno
 M contributors/emails/agent@Agents-Mac-mini.local
```

Nothing local touched that file. It is modified *the instant the clone finishes*, and it stays modified forever.

## Cause

`contributors/emails/` uses the email as the **filename**, so the key is a path. The tree contains two mappings that differ only in case:

| file | login |
|---|---|
| `contributors/emails/agent@Agents-Mac-mini.local` | `skip-agent` |
| `contributors/emails/agent@agents-Mac-mini.local` | `momomojo` |

On a case-insensitive filesystem those are **one file**. git checks out both, the second write wins, and the first is then permanently reported as modified.

```console
> git ls-files contributors/emails | grep -i agents-mac-mini
contributors/emails/agent@Agents-Mac-mini.local
contributors/emails/agent@agents-Mac-mini.local
```

This is the only such pair in the repo — I checked every tracked path:

```console
> git ls-files | awk '{ k=tolower($0); c[k]++; p[k]=p[k]" | "$0 } END { for (i in c) if (c[i]>1) print c[i] p[i] }'
2 | contributors/emails/agent@Agents-Mac-mini.local | contributors/emails/agent@agents-Mac-mini.local
```

## Why it matters beyond cosmetics

Any tool that gates on a clean tree is dead on those platforms. Concretely, it breaks unattended Windows Desktop rebuilds from pristine upstream — the build refuses with `fresh clone is NOT clean` and never reaches the build step, so the machine silently stops receiving Desktop updates. Anything else that shells out to `git status --porcelain` as a safety check has the same problem.

It also silently corrupts the mapping itself: on Windows only one of the two mappings exists on disk, so `release.py` and `audit_pr_attribution.py` see a different attribution table than they do on Linux CI.

## What this PR changes

`add_contributor()` now refuses a mapping that case-collides with an existing one. That is the same posture the script already takes toward a conflicting login — it exists so a typo cannot silently reassign commits, and a collision does exactly that on half the platforms it lands on:

```console
> python3 scripts/add_contributor.py agent@AGENTS-Mac-mini.local someone
error: agent@AGENTS-Mac-mini.local collides with existing mapping
agent@agents-Mac-mini.local on case-insensitive filesystems (Windows/macOS) —
the two are the same file there. Reuse that mapping, or resolve manually.
```

Two tests: one for the guard, one directory-wide check that no **new** collision can land.

## The existing pair needs a maintainer decision — deliberately not made here

The two files name **different logins**, so deleting either one reassigns a contributor's commits. I am not going to pick that for you. `skip-agent` appears nowhere in the tooling as a sentinel — it is only in that one file, and `_LOGIN_RE` accepts it as an ordinary login — so I could not infer intent from the code either.

It is therefore pinned in `KNOWN_CASE_CONFLICTS` so CI stays green, the breakage stays visible, and it cannot spread. **Windows and macOS clones stay dirty until you resolve it.** Whichever way you go, one line in that set comes out with it.

If the intent behind `skip-agent` is "do not attribute this machine identity", that would be worth making a real sentinel the tooling understands, rather than a login-shaped string.

## Verification

- `pytest tests/scripts/test_contributor_map.py` — 9 passed
- Guard exercised against the real `contributors/emails/` directory: returns the collision for a cased variant, `None` for an unrelated new address
