### PR TITLE
fix(auxiliary): thread named-custom extra_headers to aux clients and probes

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6526,7 +6526,17 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
-                _headers2 = _apply_user_default_headers(_extra2.get("default_headers"))
+                # The entry's own ``extra_headers`` (auth/routing headers a
+                # gateway like Bifrost/LiteLLM requires — e.g. ``x-bf-vk``)
+                # are part of the endpoint's contract: without them every
+                # auxiliary call to a named custom provider 401s even though
+                # the main chat loop sends them (#88463). Seed the client's
+                # default_headers with them; user-level
+                # ``model.default_headers`` still merges on top.
+                _entry_headers = custom_entry.get("extra_headers")
+                _headers2 = _apply_user_default_headers(
+                    dict(_entry_headers) if isinstance(_entry_headers, dict) else None
+                )
                 if _headers2:
                     _extra2["default_headers"] = _headers2
                 logger.debug(
@@ -6547,11 +6557,14 @@ def resolve_provider_client(
                             provider,
                         )
                         # Fallback went OpenAI-wire after all — redo the query
-                        # extraction against the rewritten /v1 URL.
+                        # extraction against the rewritten /v1 URL. Keep the
+                        # entry's ``extra_headers`` on this client too (#88463).
                         _fallback_base = _to_openai_base_url(custom_base)
                         _fb_clean, _fb_dq = _extract_url_query_params(_fallback_base)
                         _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
-                        _fb_headers = _apply_user_default_headers(_fb_extra.get("default_headers"))
+                        _fb_headers = _apply_user_default_headers(
+                            dict(_entry_headers) if isinstance(_entry_headers, dict) else None
+                        )
                         if _fb_headers:
                             _fb_extra["default_headers"] = _fb_headers
                         client = _create_openai_client(api_key=custom_key, base_url=_fb_clean, **_fb_extra)

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1561,6 +1561,13 @@ def _model_flow_named_custom(config, provider_info):
         fetch_kwargs = {"timeout": 8.0}
         if api_mode:
             fetch_kwargs["api_mode"] = api_mode
+        # Gateways fronting named custom providers often REQUIRE the entry's
+        # ``extra_headers`` (e.g. Bifrost's ``x-bf-vk`` virtual key) even on
+        # the /models probe — without them the probe 401s and the picker
+        # collapses to manual entry while chat works fine (#88463).
+        _probe_headers = provider_info.get("extra_headers")
+        if isinstance(_probe_headers, dict) and _probe_headers:
+            fetch_kwargs["headers"] = {str(k): str(v) for k, v in _probe_headers.items()}
         live_models = fetch_api_models(api_key, base_url, **fetch_kwargs)
         # If the probe came back empty but the operator configured an explicit
         # list, fall back to it rather than forcing manual entry.

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -110,6 +110,44 @@ class TestResolveProviderClientNamedCustom:
         assert "beans.local" in str(client.base_url)
 
 
+    def test_named_custom_extra_headers_reach_the_client(self, tmp_path):
+        """#88463 — the entry's extra_headers are part of the endpoint contract.
+
+        Gateways like Bifrost require their virtual-key header on every
+        request; without it the main chat loop works (it threads the entry)
+        while every auxiliary call 401s.
+        """
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {
+                    "name": "bifrost",
+                    "base_url": "http://bifrost.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {"x-bf-vk": "vk-secret", "x-tenant": "acme"},
+                },
+            ],
+        })
+        from agent.auxiliary_client import resolve_provider_client
+        client, _model = resolve_provider_client("bifrost", "my-model")
+        assert client is not None
+        headers = getattr(client, "default_headers", {}) or {}
+        assert headers.get("x-bf-vk") == "vk-secret"
+        assert headers.get("x-tenant") == "acme"
+
+    def test_named_custom_without_extra_headers_unchanged(self, tmp_path):
+        """No extra_headers on the entry → client built exactly as before."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {"name": "plain", "base_url": "http://plain.local/v1", "api_key": "k"},
+            ],
+        })
+        from agent.auxiliary_client import resolve_provider_client
+        client, _model = resolve_provider_client("plain", "my-model")
+        assert client is not None
+        assert "plain.local" in str(client.base_url)
+
     def test_named_custom_no_api_key_uses_fallback(self, tmp_path):
         _write_config(tmp_path, {
             "model": {"default": "test"},

--- a/tests/hermes_cli/test_model_flow_named_custom_headers.py
+++ b/tests/hermes_cli/test_model_flow_named_custom_headers.py
@@ -1,0 +1,67 @@
+"""#88463 — the named-custom model flow must probe with the entry's extra_headers.
+
+Gateways fronting named custom providers (Bifrost, LiteLLM, …) often REQUIRE
+their auth/routing headers on the /models probe itself; without them the
+picker probe 401s and collapses to manual entry while chat works fine.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text("model:\n  default: m\n")
+
+
+def _provider_info(**extra):
+    info = {
+        "name": "bifrost",
+        "base_url": "http://bifrost.local/v1",
+        "api_key": "k",
+        "model": "",
+    }
+    info.update(extra)
+    return info
+
+
+def test_named_custom_probe_carries_extra_headers():
+    captured = {}
+
+    def _fake_fetch(api_key, base_url, **kwargs):
+        captured.update(kwargs)
+        return ["m1", "m2"]
+
+    with (
+        patch("hermes_cli.models.fetch_api_models", _fake_fetch),
+        patch("hermes_cli.curses_ui.curses_radiolist", return_value=-1),
+    ):
+        from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+        _model_flow_named_custom(
+            None, _provider_info(extra_headers={"x-bf-vk": "vk-1", "x-tenant": "acme"})
+        )
+
+    assert captured.get("headers") == {"x-bf-vk": "vk-1", "x-tenant": "acme"}
+
+
+def test_named_custom_probe_without_extra_headers_sends_none():
+    captured = {}
+
+    def _fake_fetch(api_key, base_url, **kwargs):
+        captured.update(kwargs)
+        return ["m1"]
+
+    with (
+        patch("hermes_cli.models.fetch_api_models", _fake_fetch),
+        patch("hermes_cli.curses_ui.curses_radiolist", return_value=-1),
+    ):
+        from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+        _model_flow_named_custom(None, _provider_info())
+
+    assert "headers" not in captured


### PR DESCRIPTION
## What does this PR do?

Named custom providers can declare `extra_headers` (auth/routing headers a gateway like Bifrost or LiteLLM requires on every request — e.g. `x-bf-vk`). The main chat loop threads them, but two downstream paths dropped them, so users got `HTTP 401: virtual key is required` from side systems while chat worked fine (#88463):

1. **Auxiliary auto-resolution**: `resolve_provider_client`'s named-custom branch built the client without ever reading `custom_entry["extra_headers"]` — so title generation, compression, vision, and embedding calls to the same endpoint all 401'd. The branch now seeds the client's `default_headers` from the entry (user-level `model.default_headers` still merge on top via the existing `_apply_user_default_headers`), and the `anthropic_messages` SDK-missing OpenAI-wire fallback gets the same seed.
2. **Interactive model discovery**: `_model_flow_named_custom`'s `/models` probe called `fetch_api_models` without headers — the picker probe 401'd and collapsed to manual entry. `fetch_api_models` already accepts a `headers` kwarg; the flow now passes the entry's `extra_headers` through.

## Related Issue

Fixes #88463

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: the named-custom branch (and its anthropic fallback) seeds client `default_headers` from `custom_entry["extra_headers"]`
- `hermes_cli/model_setup_flows.py`: `_model_flow_named_custom` passes the entry's `extra_headers` to the `/models` probe
- `tests/agent/test_auxiliary_named_custom_providers.py`: two regression tests (entry headers reach `client.default_headers`; no-entry-headers behavior unchanged)
- `tests/hermes_cli/test_model_flow_named_custom_headers.py`: two regression tests (probe receives the headers kwarg; absent when the entry has none)

## How to Test

1. `python -m pytest tests/agent/test_auxiliary_named_custom_providers.py -q` — Observed result: 21 passed.
2. `python -m pytest tests/hermes_cli/test_model_flow_named_custom_headers.py -q` — Observed result: 2 passed.
3. `python -m pytest tests/agent/test_auxiliary_named_custom_providers.py tests/hermes_cli/test_model_switch_custom_providers.py tests/agent/test_auxiliary_client_ssl_verify.py -q` — Observed result: 71 passed (no regressions in the adjacent custom-provider surfaces).
4. On the reporter's setup (Bifrost entry with `x-bf-vk`): automatic session title generation now succeeds, and `hermes model` on the named provider lists models instead of 401-ing.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the custom-provider and auxiliary-client test suites and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config keys or schemas changed (`extra_headers` on provider entries is already a documented, main-loop-supported key); comments at both sites explain the contract with the #88463 reference

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/agent/test_auxiliary_named_custom_providers.py tests/hermes_cli/test_model_flow_named_custom_headers.py -q
23 passed
$ python -m pytest tests/agent/test_auxiliary_named_custom_providers.py tests/hermes_cli/test_model_switch_custom_providers.py tests/agent/test_auxiliary_client_ssl_verify.py -q
71 passed in 168.28s
```