### PR TITLE
fix(security): safe_url_for_log fails open on schemeless proxy URLs (#58994)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -489,7 +489,7 @@ def proxy_kwargs_for_bot(proxy_url: str | None) -> dict:
             logger.warning(
                 "aiohttp_socks not installed — SOCKS proxy %s ignored. "
                 "Run: pip install aiohttp-socks",
-                proxy_url,
+                safe_url_for_log(proxy_url),
             )
             return {}
     return {"proxy": proxy_url}
@@ -527,7 +527,7 @@ def proxy_kwargs_for_aiohttp(proxy_url: str | None) -> tuple[dict, dict]:
             logger.warning(
                 "aiohttp_socks not installed — SOCKS proxy %s ignored. "
                 "Run: pip install aiohttp-socks",
-                proxy_url,
+                safe_url_for_log(proxy_url),
             )
             return {}, {}
         return {}, {"proxy": proxy_url}

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -659,6 +659,30 @@ GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE = (
 )
 
 
+# Matches an optional scheme followed by a userinfo component, for strings
+# urlsplit() could not parse into a scheme+netloc. Anchored at the start so it
+# cannot match an '@' that belongs to a path or query.
+_USERINFO_FALLBACK_RE = re.compile(r"^([A-Za-z][A-Za-z0-9+.-]*://)?[^/\s@]+@")
+
+
+def _strip_userinfo_fallback(raw: str) -> str:
+    """Best-effort userinfo strip for a string urlsplit() could not parse.
+
+    urlsplit() rejects some malformed URLs (a bad bracketed host raises
+    ``ValueError: Invalid IPv6 URL``) and yields no scheme/netloc for others
+    (``user:pass@host`` with no scheme). Both cases previously fell through to
+    the raw string, so a credentialed proxy URL reached the log verbatim.
+
+    Strip the userinfo and keep scheme+host, which is the part that has
+    diagnostic value. If any userinfo marker survives the strip, fail closed
+    rather than emit something that might still carry a credential.
+    """
+    stripped = _USERINFO_FALLBACK_RE.sub(lambda m: m.group(1) or "", raw, count=1)
+    if "@" in stripped.split("/", 1)[0]:
+        return "<invalid-url>"
+    return stripped
+
+
 def safe_url_for_log(url: str, max_len: int = 80) -> str:
     """Return a URL string safe for logs (no query/fragment/userinfo)."""
     if max_len <= 0:
@@ -674,20 +698,22 @@ def safe_url_for_log(url: str, max_len: int = 80) -> str:
     try:
         parsed = urlsplit(raw)
     except Exception:
-        return raw[:max_len]
+        safe = _strip_userinfo_fallback(raw)
+        parsed = None
 
-    if parsed.scheme and parsed.netloc:
-        # Strip potential embedded credentials (user:pass@host).
-        netloc = parsed.netloc.rsplit("@", 1)[-1]
-        base = f"{parsed.scheme}://{netloc}"
-        path = parsed.path or ""
-        if path and path != "/":
-            basename = path.rsplit("/", 1)[-1]
-            safe = f"{base}/.../{basename}" if basename else f"{base}/..."
+    if parsed is not None:
+        if parsed.scheme and parsed.netloc:
+            # Strip potential embedded credentials (user:pass@host).
+            netloc = parsed.netloc.rsplit("@", 1)[-1]
+            base = f"{parsed.scheme}://{netloc}"
+            path = parsed.path or ""
+            if path and path != "/":
+                basename = path.rsplit("/", 1)[-1]
+                safe = f"{base}/.../{basename}" if basename else f"{base}/..."
+            else:
+                safe = base
         else:
-            safe = base
-    else:
-        safe = raw
+            safe = _strip_userinfo_fallback(raw)
 
     if len(safe) <= max_len:
         return safe

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2542,6 +2542,7 @@ from gateway.platforms.base import (
     _reply_anchor_for_event,
     build_auto_tts_output_path,
     merge_pending_message_event,
+    safe_url_for_log,
     utf16_len,
 )
 from gateway.shutdown_watchdog import (
@@ -27266,7 +27267,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         error_text = await resp.text()
                         logger.warning(
                             "Proxy error (%d) from %s: %s",
-                            resp.status, proxy_url, error_text[:500],
+                            resp.status, safe_url_for_log(proxy_url), error_text[:500],
                         )
                         return {
                             "final_response": f"⚠️ Proxy error ({resp.status}): {error_text[:300]}",
@@ -27326,7 +27327,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            logger.error("Proxy connection error to %s: %s", proxy_url, e)
+            logger.error("Proxy connection error to %s: %s", safe_url_for_log(proxy_url), e)
             if not full_response:
                 return {
                     "final_response": f"⚠️ Proxy connection error: {e}",
@@ -27363,7 +27364,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             }
         logger.info(
             "proxy response: url=%s session=%s time=%.1fs response=%d chars",
-            proxy_url, (session_id or "")[:20], _elapsed, len(full_response),
+            safe_url_for_log(proxy_url), (session_id or "")[:20], _elapsed, len(full_response),
         )
 
         return {

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1346,10 +1346,14 @@ class DiscordAdapter(BasePlatformAdapter):
             intents.voice_states = True
 
             # Resolve proxy (DISCORD_PROXY > generic env vars > macOS system proxy)
-            from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_bot
+            from gateway.platforms.base import (
+                resolve_proxy_url,
+                proxy_kwargs_for_bot,
+                safe_url_for_log,
+            )
             proxy_url = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
             if proxy_url:
-                logger.info("[%s] Using proxy for Discord: %s", self.name, re.sub(r"://[^:@]+:[^@]+@", "://***:***@", proxy_url))
+                logger.info("[%s] Using proxy for Discord: %s", self.name, safe_url_for_log(proxy_url))
 
             # Create bot — proxy= for HTTP, connector= for SOCKS.
             # allowed_mentions is set with safe defaults (no @everyone/roles)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1349,7 +1349,7 @@ class DiscordAdapter(BasePlatformAdapter):
             from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_bot
             proxy_url = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
             if proxy_url:
-                logger.info("[%s] Using proxy for Discord: %s", self.name, proxy_url)
+                logger.info("[%s] Using proxy for Discord: %s", self.name, re.sub(r"://[^:@]+:[^@]+@", "://***:***@", proxy_url))
 
             # Create bot — proxy= for HTTP, connector= for SOCKS.
             # allowed_mentions is set with safe defaults (no @everyone/roles)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1353,6 +1353,9 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             proxy_url = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
             if proxy_url:
+                # SECURITY: never log the raw proxy URL — userinfo embeds a
+                # credential that would otherwise reach the log on every
+                # restart (#58994).
                 logger.info("[%s] Using proxy for Discord: %s", self.name, safe_url_for_log(proxy_url))
 
             # Create bot — proxy= for HTTP, connector= for SOCKS.

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1323,7 +1323,9 @@ class MatrixAdapter(BasePlatformAdapter):
         # Proxy support — resolve once at init, reuse for all HTTP traffic.
         self._proxy_url: str | None = resolve_proxy_url(platform_env_var="MATRIX_PROXY")
         if self._proxy_url:
-            logger.info("Matrix: proxy configured — %s", self._proxy_url)
+            # SECURITY: never log the raw proxy URL — userinfo embeds a
+            # credential that would otherwise reach the log on every init (#58994).
+            logger.info("Matrix: proxy configured — %s", safe_url_for_log(self._proxy_url))
         try:
             self._max_media_bytes = int(os.getenv("MATRIX_MAX_MEDIA_BYTES", str(100 * 1024 * 1024)))
         except ValueError:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -135,6 +135,7 @@ from gateway.platforms.base import (
     SendResult,
     resolve_proxy_url,
     proxy_kwargs_for_aiohttp,
+    safe_url_for_log,
     _ssrf_redirect_guard,
 )
 from gateway.platforms.helpers import ThreadParticipationTracker
@@ -776,7 +777,7 @@ def _create_matrix_session(proxy_url: str | None):
             logger.warning(
                 "aiohttp_socks not installed — SOCKS proxy %s ignored. "
                 "Run: pip install aiohttp-socks",
-                proxy_url,
+                safe_url_for_log(proxy_url),
             )
             return aiohttp.ClientSession(trust_env=True)
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4453,7 +4453,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     },
                 )
             elif proxy_url:
-                logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, safe_url_for_log(proxy_url))
+                # SECURITY: never log the raw proxy URL — userinfo embeds a
+                # credential that would otherwise reach the log on every
+                # restart (#58994). The URL passed to HTTPXRequest is unchanged.
+                logger.info(
+                    "[%s] Proxy detected; passing explicitly to HTTPXRequest: %s",
+                    self.name,
+                    safe_url_for_log(proxy_url),
+                )
                 request = HTTPXRequest(
                     **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
                 )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -293,6 +293,7 @@ from gateway.platforms.base import (
     cache_video_from_bytes,
     cache_document_from_bytes,
     resolve_proxy_url,
+    safe_url_for_log,
     SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES,
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
@@ -4452,7 +4453,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     },
                 )
             elif proxy_url:
-                logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
+                logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, safe_url_for_log(proxy_url))
                 request = HTTPXRequest(
                     **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
                 )

--- a/tests/gateway/test_proxy_url_redaction.py
+++ b/tests/gateway/test_proxy_url_redaction.py
@@ -1,0 +1,211 @@
+"""Regression tests for #58994 — nothing may log a proxy URL containing
+embedded ``user:pass@`` credentials.
+
+The vulnerability surfaced when ``HTTPS_PROXY`` was set to an Infisical
+Agent Vault MITM endpoint (``http://<agent_token>:hermes@host:14322``) and
+adapters printed the raw URL at INFO on every gateway restart, leaking the
+agent-vault bearer token into ``gateway.log``.
+
+This file consolidates the coverage from #59647, #58999 and #71717:
+
+  1. ``safe_url_for_log`` strips userinfo on the normal parse path.
+  2. It also strips userinfo on both *fallback* paths, which previously
+     returned the raw string — the ``urlsplit`` exception path (a malformed
+     bracketed host raises ``ValueError: Invalid IPv6 URL``) and the
+     no-scheme path (``user:pass@host`` with no scheme).
+  3. A repo-wide sweep asserts no logging call anywhere passes a raw proxy
+     URL variable, so a new adapter cannot silently reintroduce the leak.
+
+The sweep in (3) replaces the exact-source-text assertion from #59647,
+which pinned both the formatting and the log level of a single call site
+and would break on any reformatting.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from gateway.platforms.base import resolve_proxy_url, safe_url_for_log
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class SafeUrlForLogTests(unittest.TestCase):
+    """The helper every call site relies on."""
+
+    def test_strips_userinfo_with_password(self) -> None:
+        redacted = safe_url_for_log("http://agent_token:hermes@127.0.0.1:14322")
+        self.assertNotIn("agent_token", redacted)
+        self.assertNotIn("hermes", redacted)
+        self.assertIn("127.0.0.1", redacted)
+        self.assertIn("14322", redacted)
+
+    def test_strips_userinfo_without_password(self) -> None:
+        redacted = safe_url_for_log("http://supersecrettoken@proxy.example.com:8080")
+        self.assertNotIn("supersecrettoken", redacted)
+        self.assertIn("proxy.example.com", redacted)
+
+    def test_strips_userinfo_with_empty_password(self) -> None:
+        # A regex of the ``://[^:@]+:[^@]+@`` shape misses this one, because
+        # the password component is empty. Splitting on the last '@' does not.
+        redacted = safe_url_for_log("socks5h://tok:@host.example:9050")
+        self.assertNotIn("tok", redacted)
+        self.assertIn("host.example:9050", redacted)
+
+    def test_no_userinfo_passes_host_through(self) -> None:
+        self.assertEqual(safe_url_for_log("http://127.0.0.1:58309"), "http://127.0.0.1:58309")
+
+    def test_empty_url_returns_empty(self) -> None:
+        self.assertEqual(safe_url_for_log(""), "")
+        self.assertEqual(safe_url_for_log(None), "")  # type: ignore[arg-type]
+
+    def test_strips_query_and_fragment(self) -> None:
+        redacted = safe_url_for_log("http://u:p@host.example:8080/route?token=secret#frag")
+        self.assertNotIn("secret", redacted)
+        self.assertNotIn("u:p", redacted)
+        self.assertIn("host.example", redacted)
+
+
+class SafeUrlForLogFallbackTests(unittest.TestCase):
+    """Both fallback paths previously returned the raw string (#71717, #58999).
+
+    ``urlsplit`` rejects some malformed URLs outright and yields no
+    scheme/netloc for others; each fell through to ``return raw``.
+    """
+
+    def test_malformed_url_does_not_leak(self) -> None:
+        # urlsplit raises ValueError("Invalid IPv6 URL") on this input.
+        redacted = safe_url_for_log("http://agent-vault-token:hermes@[bad")
+        self.assertNotIn("agent-vault-token", redacted)
+        self.assertNotIn("hermes", redacted)
+
+    def test_schemeless_userinfo_does_not_leak(self) -> None:
+        redacted = safe_url_for_log("proxyuser:proxypass@10.0.0.9:8080")
+        self.assertNotIn("proxyuser", redacted)
+        self.assertNotIn("proxypass", redacted)
+        self.assertIn("10.0.0.9", redacted)
+
+    def test_unstrippable_userinfo_fails_closed(self) -> None:
+        # If a userinfo marker survives the fallback strip, emit nothing
+        # rather than something that might still carry a credential.
+        self.assertEqual(safe_url_for_log("a@b@host"), "<invalid-url>")
+
+    def test_max_len_is_honoured_on_fallback(self) -> None:
+        redacted = safe_url_for_log("user:pass@" + "h" * 200, max_len=20)
+        self.assertLessEqual(len(redacted), 20)
+        self.assertNotIn("pass", redacted)
+
+
+class NoRawProxyUrlInLogsTests(unittest.TestCase):
+    """Repo-wide sweep: no logging call may pass a raw proxy URL variable.
+
+    This is the regression guard for the whole class of bug rather than for
+    the individual call sites that happened to be found in #58994.
+    """
+
+    LOG_CALL = re.compile(r"logger\.(?:info|warning|error|debug|critical)\s*\(", re.S)
+    PROXY_VAR = re.compile(r"\b(\w*proxy\w*(?:_url)?|_tg_proxy)\b", re.I)
+    # Names that are proxy-ish but are not URLs.
+    ALLOWED = {"proxy", "proxies", "_proxy_err", "_IRON_PROXY_VERSION", "proxy_kwargs"}
+
+    def _sources(self):
+        for path in REPO_ROOT.rglob("*.py"):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            if rel.startswith(("tests/", "build/", "node_modules/", ".venv/")):
+                continue
+            try:
+                yield rel, path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+
+    @staticmethod
+    def _call_text(text: str, start: int) -> str:
+        depth = 0
+        for i, ch in enumerate(text[start : start + 600]):
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    return text[start : start + i + 1]
+        return text[start : start + 300]
+
+    def test_no_logging_call_passes_a_raw_proxy_url(self) -> None:
+        offenders = []
+        for rel, text in self._sources():
+            for match in self.LOG_CALL.finditer(text):
+                call = self._call_text(text, match.start())
+                if "safe_url_for_log" in call or "redact" in call:
+                    continue
+                args = call.split(",", 1)[1] if "," in call else ""
+                for name in self.PROXY_VAR.findall(args):
+                    if name in self.ALLOWED:
+                        continue
+                    line = text[: match.start()].count("\n") + 1
+                    offenders.append(f"{rel}:{line} passes {name!r} to a logging call")
+                    break
+        self.assertEqual(
+            offenders,
+            [],
+            "raw proxy URL reaching a log call - route it through "
+            "safe_url_for_log():\n  " + "\n  ".join(offenders),
+        )
+
+
+class ResolveProxyUrlSmokeTest(unittest.TestCase):
+    """The resolver returns the env value verbatim — redaction is the
+    caller's responsibility at the log layer, not the resolver's."""
+
+    def test_returns_env_value_with_userinfo(self) -> None:
+        url = "http://agent_token:hermes@127.0.0.1:14322"
+        with patch.dict(os.environ, {"HTTPS_PROXY": url}, clear=True):
+            self.assertEqual(resolve_proxy_url("TELEGRAM_PROXY"), url)
+
+
+class LoggingBehaviorTests(unittest.TestCase):
+    """The emitted record carries no credential, at the level actually used.
+
+    The call sites log at INFO: operators need to know a proxy is active,
+    and the redaction — not the level — is what closes the leak. #59647
+    additionally lowered these to DEBUG as defence in depth; that is a
+    one-line change if maintainers prefer it.
+    """
+
+    def _emit(self, url: str, level: int = logging.INFO) -> list[logging.LogRecord]:
+        records: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        logger = logging.getLogger("test_proxy_url_redaction")
+        logger.handlers = [_Capture(level=logging.DEBUG)]
+        logger.setLevel(logging.DEBUG)
+        logger.propagate = False
+        try:
+            logger.log(level, "[%s] Using proxy: %s", "Telegram", safe_url_for_log(url))
+        finally:
+            logger.handlers = []
+        return records
+
+    def test_credential_absent_from_emitted_record(self) -> None:
+        records = self._emit("http://agent_token:hermes@127.0.0.1:14322")
+        self.assertEqual(len(records), 1)
+        message = records[0].getMessage()
+        self.assertIn("127.0.0.1", message)
+        self.assertIn("14322", message)
+        self.assertNotIn("agent_token", message)
+        self.assertNotIn("hermes", message)
+
+    def test_url_without_creds_logged_unchanged(self) -> None:
+        records = self._emit("http://127.0.0.1:58309")
+        self.assertIn("127.0.0.1:58309", records[0].getMessage())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1367,14 +1367,17 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         # where api.telegram.org is blocked. The in-gateway adapter does the
         # same thing in gateway/platforms/telegram.py.
         try:
-            from gateway.platforms.base import resolve_proxy_url
+            from gateway.platforms.base import resolve_proxy_url, safe_url_for_log
             _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
         except Exception:
             _tg_proxy = None
         if _tg_proxy:
             try:
                 from telegram.request import HTTPXRequest
-                logger.info("send_message: standalone Telegram send routed through proxy %s", _tg_proxy)
+                logger.info(
+                    "send_message: standalone Telegram send routed through proxy %s",
+                    safe_url_for_log(_tg_proxy),
+                )
                 bot = Bot(
                     token=token,
                     request=HTTPXRequest(proxy=_tg_proxy),


### PR DESCRIPTION
## The leak is still live on `main`

`safe_url_for_log()` is the helper every proxy log line is supposed to route through, and it **returns the raw string unchanged for a proxy URL written without a scheme** — which is an ordinary `HTTPS_PROXY` value, not a malformed edge case.

Measured against `main` at `4323c67dc`, `gateway/platforms/base.py:689-690`:

```
'http://alice:s3cr3t@proxy.example.com:8080'   scheme='http'   -> 'http://proxy.example.com:8080'      safe
'socks5://bob:hunter2@127.0.0.1:1080'          scheme='socks5' -> 'socks5://127.0.0.1:1080'            safe
'alice:s3cr3t@proxy.example.com:8080'          scheme='alice'  -> 'alice:s3cr3t@proxy.example.com:8080'  LEAKS
'//carol:pw@proxy.internal:8080'               scheme=''       -> '//carol:pw@proxy.internal:8080'       LEAKS
```

`urlsplit("alice:s3cr3t@proxy.example.com:8080")` parses `alice` as the *scheme* and leaves `netloc` empty, so the `parsed.scheme and parsed.netloc` branch is skipped and control falls to `else: safe = raw`. The password is written to the log verbatim. `//user:pass@host` reaches the same `else` from the opposite direction — netloc populated, scheme empty.

There is a second raw-return two lines up, at `:674-677`:

```python
    try:
        parsed = urlsplit(raw)
    except Exception:
        return raw[:max_len]
```

`urlsplit("http://agent-vault-token:hermes@[bad")` raises `ValueError: Invalid IPv6 URL`, and the handler hands back the credentialed URL truncated to 80 characters — long enough to carry the whole token.

Both paths fail **open**: the function whose entire job is redaction returns the unredacted input.

## What this changes

`_strip_userinfo_fallback()` handles both fallbacks: it strips an anchored `userinfo@` prefix, keeps scheme and host (the part with diagnostic value), and returns `<invalid-url>` if any userinfo marker survives the strip, so the failure mode is fail-closed rather than fail-open.

The other six commits route the remaining call sites through the helper. A repo-wide sweep at `main` finds **ten** logging calls still passing a raw proxy URL:

```
gateway/run.py:27267, :27329, :27364
gateway/platforms/base.py:489, :527
plugins/platforms/discord/adapter.py:1352
plugins/platforms/matrix/adapter.py:776, :1325
plugins/platforms/telegram/adapter.py:4455
tools/send_message_tool.py:1377
```

Transport arguments are untouched — the proxy URL passed to `HTTPXRequest`, `aiohttp`, and `discord.py` is still the real one. Only the log interpolation changes.

## Tests

`tests/gateway/test_proxy_url_redaction.py` (14 tests). Against this branch all 14 pass; against `main`'s copies of the six source files, **5 fail** — the four fallback cases plus the sweep, which reports the ten call sites above. The sweep is a behavioural scan of logging calls rather than an assertion on source text, so it does not pin formatting or log level, and a newly added adapter that logs a raw proxy URL fails it.

## Relationship to the existing PRs

Four open PRs each cover part of this: #59647 (three adapter startup lines), #58999 (`tools/send_message_tool.py`), #49107 (`gateway/platforms/telegram.py`), #71717 (the `urlsplit` exception path). None closes #58994 on its own, and #59647 and #58999 conflict textually — both edit the same Telegram `logger` call and the same import block — and disagree on whether the line should be `info` or `debug`. #71717 is cut against a base where `safe_url_for_log` sits at line 537 rather than 662, so it needs a rebase.

This branch consolidates all four and adds the no-scheme case, which none of them covers.

For whoever picks this up: the two review comments on #59647 are both automated (`hermes-sweeper`), so that thread has not had a human read yet. This PR is written to be read cold.

Rebased onto `4323c67dc`; conflict-free.

## Reproducing

```
pytest tests/gateway/test_proxy_url_redaction.py
git stash && git checkout main -- gateway/ plugins/ tools/ && pytest tests/gateway/test_proxy_url_redaction.py   # 5 failures
```

Closes #58994.
