### PR TITLE
feat(api): add reversible session archive endpoints

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3560,6 +3560,12 @@ class APIServerAdapter(BasePlatformAdapter):
         if "pinned" in body:
             await asyncio.to_thread(db.set_session_pinned, session_id, body["pinned"])
         if "archived" in body:
+            # Generic field write for desktop UIs / clients already driving
+            # PATCH. The dedicated reversible archive surface is the
+            # POST /api/sessions/{id}/archive[/unarchive] pair — see
+            # _set_session_archived. Both funnel into the same
+            # db.set_session_archived, so invoking either keeps the flag
+            # consistent; build new integrations on the archive endpoints.
             await asyncio.to_thread(db.set_session_archived, session_id, body["archived"])
         if "hidden" in body:
             await asyncio.to_thread(db.set_session_hidden, session_id, body["hidden"])
@@ -3571,7 +3577,17 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response({"object": "hermes.session", "session": self._session_response(session)})
 
     async def _set_session_archived(self, request: "web.Request", archived: bool) -> "web.Response":
-        """Set the reversible archive flag for one API session."""
+        """Set the reversible archive flag for one API session.
+
+        Canonical archive surface: clients wanting to archive/unarchive a
+        session should use the dedicated
+        ``POST /api/sessions/{session_id}/archive`` and
+        ``.../unarchive`` routes, not the ``archived`` field on PATCH.
+        ``PATCH /api/sessions/{session_id}`` with ``{\"archived\": bool}``
+        remains supported as the generic flag write the desktop sidebar
+        drives, and the two paths share this core, so the flag can never
+        diverge no matter which one a client uses.
+        """
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -11,6 +11,7 @@ Exposes an HTTP server with endpoints:
 - GET  /api/sessions               — list client-visible Hermes sessions
 - POST /api/sessions               — create an empty Hermes session
 - GET/PATCH/DELETE /api/sessions/{session_id} — read/update/delete a session
+- POST /api/sessions/{session_id}/archive[/unarchive] — reversible soft-archive
 - GET  /api/sessions/{session_id}/messages — read session message history
 - POST /api/sessions/{session_id}/fork — branch a session using SessionDB lineage
 - POST /api/sessions/{session_id}/chat[/stream] — chat with a persisted session
@@ -2069,6 +2070,8 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/api/sessions", self._handle_create_session),
             ("GET", "/api/sessions/{session_id}", self._handle_get_session),
             ("PATCH", "/api/sessions/{session_id}", self._handle_patch_session),
+            ("POST", "/api/sessions/{session_id}/archive", self._handle_archive_session),
+            ("POST", "/api/sessions/{session_id}/unarchive", self._handle_unarchive_session),
             ("DELETE", "/api/sessions/{session_id}", self._handle_delete_session),
             ("GET", "/api/sessions/{session_id}/messages", self._handle_session_messages),
             ("POST", "/api/sessions/{session_id}/fork", self._handle_fork_session),
@@ -3187,6 +3190,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_create": {"method": "POST", "path": "/api/sessions"},
                 "session": {"method": "GET", "path": "/api/sessions/{session_id}"},
                 "session_update": {"method": "PATCH", "path": "/api/sessions/{session_id}"},
+                "session_archive": {"method": "POST", "path": "/api/sessions/{session_id}/archive"},
+                "session_unarchive": {"method": "POST", "path": "/api/sessions/{session_id}/unarchive"},
                 "session_delete": {"method": "DELETE", "path": "/api/sessions/{session_id}"},
                 "session_messages": {"method": "GET", "path": "/api/sessions/{session_id}/messages"},
                 "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
@@ -3564,6 +3569,33 @@ class APIServerAdapter(BasePlatformAdapter):
             await asyncio.to_thread(db.end_session, session_id, str(body["end_reason"]))
         session = await asyncio.to_thread(db.get_session, session_id) or session
         return web.json_response({"object": "hermes.session", "session": self._session_response(session)})
+
+    async def _set_session_archived(self, request: "web.Request", archived: bool) -> "web.Response":
+        """Set the reversible archive flag for one API session."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        session_id = request.match_info["session_id"]
+        session, err = await self._get_existing_session_or_404(session_id)
+        if err:
+            return err
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return web.json_response(
+                _openai_error("Session database unavailable", code="session_db_unavailable"),
+                status=503,
+            )
+        await asyncio.to_thread(db.set_session_archived, session_id, archived)
+        session = await asyncio.to_thread(db.get_session, session_id) or session
+        return web.json_response({"object": "hermes.session", "session": self._session_response(session)})
+
+    async def _handle_archive_session(self, request: "web.Request") -> "web.Response":
+        """POST /api/sessions/{session_id}/archive."""
+        return await self._set_session_archived(request, True)
+
+    async def _handle_unarchive_session(self, request: "web.Request") -> "web.Response":
+        """POST /api/sessions/{session_id}/unarchive."""
+        return await self._set_session_archived(request, False)
 
     async def _handle_delete_session(self, request: "web.Request") -> "web.Response":
         """DELETE /api/sessions/{session_id}."""

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -45,6 +45,8 @@ def _create_session_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/api/sessions", adapter._handle_create_session)
     app.router.add_get("/api/sessions/{session_id}", adapter._handle_get_session)
     app.router.add_patch("/api/sessions/{session_id}", adapter._handle_patch_session)
+    app.router.add_post("/api/sessions/{session_id}/archive", adapter._handle_archive_session)
+    app.router.add_post("/api/sessions/{session_id}/unarchive", adapter._handle_unarchive_session)
     app.router.add_delete("/api/sessions/{session_id}", adapter._handle_delete_session)
     app.router.add_get("/api/sessions/{session_id}/messages", adapter._handle_session_messages)
     app.router.add_post("/api/sessions/{session_id}/fork", adapter._handle_fork_session)
@@ -72,6 +74,14 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["skills_api"] is True
     assert features["realtime_voice"] is False
     assert data["endpoints"]["sessions"] == {"method": "GET", "path": "/api/sessions"}
+    assert data["endpoints"]["session_archive"] == {
+        "method": "POST",
+        "path": "/api/sessions/{session_id}/archive",
+    }
+    assert data["endpoints"]["session_unarchive"] == {
+        "method": "POST",
+        "path": "/api/sessions/{session_id}/unarchive",
+    }
     assert data["endpoints"]["session_chat_stream"] == {
         "method": "POST",
         "path": "/api/sessions/{session_id}/chat/stream",
@@ -811,6 +821,34 @@ async def test_patch_session_persists_pinned_and_archived(adapter, session_db):
         resp = await cli.patch(f"/api/sessions/{session_id}", json={"archived": True})
         assert (await resp.json())["session"]["archived"] is True
         assert bool(session_db.get_session(session_id)["archived"]) is True
+
+
+@pytest.mark.asyncio
+async def test_archive_session_endpoint_is_reversible(adapter, session_db):
+    session_id = session_db.create_session("archive-session", "api_server")
+    app = _create_session_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(f"/api/sessions/{session_id}/archive")
+        assert response.status == 200, await response.text()
+        payload = await response.json()
+        assert payload["session"]["archived"] is True
+        assert bool(session_db.get_session(session_id)["archived"]) is True
+
+        response = await cli.post(f"/api/sessions/{session_id}/unarchive")
+        assert response.status == 200, await response.text()
+        payload = await response.json()
+        assert payload["session"]["archived"] is False
+        assert bool(session_db.get_session(session_id)["archived"]) is False
+
+
+@pytest.mark.asyncio
+async def test_archive_session_endpoint_returns_404_for_unknown_session(adapter):
+    app = _create_session_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post("/api/sessions/missing/archive")
+        assert response.status == 404
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

Adds explicit archive and unarchive endpoints to the Hermes API server session resource API.

This exposes the existing reversible session archive state through dedicated, action-oriented endpoints instead of requiring clients to use the generic session metadata update endpoint.

### Endpoints

```http
POST /api/sessions/{session_id}/archive
POST /api/sessions/{session_id}/unarchive
```

Both endpoints:

- require the same authentication as the existing session endpoints
- return `404` when the session does not exist
- update the durable `archived` session flag
- return the complete updated session representation
- are idempotent

### API capabilities

The endpoints are advertised through `/v1/capabilities`:

```json
{
  "session_archive": {
    "method": "POST",
    "path": "/api/sessions/{session_id}/archive"
  },
  "session_unarchive": {
    "method": "POST",
    "path": "/api/sessions/{session_id}/unarchive"
  }
}
```

### Compatibility

The existing `PATCH /api/sessions/{session_id}` behavior remains unchanged. Clients can still update the `archived` field through the generic metadata endpoint.

### Tests

Added coverage for:

- archive → unarchive round-trip
- durable persistence of the archive flag
- missing-session `404` behavior
- capability endpoint advertisement
- existing session metadata update compatibility

Closes #88231
