### PR TITLE
fix(skills): stop inspect/install from mixing same-named hub skills

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -123,33 +123,39 @@ def _format_extra_metadata_lines(extra: Dict[str, Any]) -> list[str]:
 
 
 def _resolve_source_meta_and_bundle(identifier: str, sources):
-    """Resolve metadata and bundle for a specific identifier."""
-    meta = None
-    bundle = None
-    matched_source = None
+    """Resolve metadata and bundle from a single source adapter.
+
+    Meta and bundle must come from the same adapter. Keeping catalog
+    metadata from skills.sh while taking a ClawHub zip of a same-named
+    skill is how ``hermes skills inspect owner/repo/skills/foo`` showed
+    the requested identifier and the wrong SKILL.md.
+    """
+    first_meta = None
+    first_meta_source = None
 
     for src in sources:
-        if meta is None:
-            try:
-                meta = src.inspect(identifier)
-                if meta:
-                    matched_source = src
-            except Exception:
-                meta = None
+        meta = None
+        bundle = None
+        try:
+            meta = src.inspect(identifier)
+        except Exception:
+            meta = None
         try:
             bundle = src.fetch(identifier)
         except Exception:
             bundle = None
         if bundle:
-            matched_source = src
             if meta is None:
                 try:
                     meta = src.inspect(identifier)
                 except Exception:
                     meta = None
-            break
+            return meta, bundle, src
+        if first_meta is None and meta:
+            first_meta = meta
+            first_meta_source = src
 
-    return meta, bundle, matched_source
+    return first_meta, None, first_meta_source
 
 
 def _derive_category_from_install_path(install_path: str) -> str:

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -186,6 +186,101 @@ def test_check_for_skill_updates_does_not_fall_back_across_registries():
     assert "bundle" not in results[0], "must not carry a foreign registry's bundle"
 
 
+def test_resolve_does_not_pair_catalog_meta_with_foreign_same_name_bundle():
+    """Inspect metadata from one registry must not ship with another registry's files.
+
+    skills.sh can inspect ``owner/repo/skills/skillopt`` while ClawHub used to
+    fetch by last path segment ``skillopt`` and return a different author's
+    SKILL.md. The header then showed the requested identifier and the preview
+    showed the wrong skill.
+    """
+    from hermes_cli.skills_hub import _resolve_source_meta_and_bundle
+    from tools.skills_hub import SkillBundle, SkillMeta
+
+    class CatalogSource:
+        def inspect(self, identifier):
+            return SkillMeta(
+                name="skillopt",
+                description="kanban-based pipelines",
+                source="skills.sh",
+                identifier="skills-sh/latipun7/agent-skill-collections/skills/skillopt",
+                trust_level="community",
+            )
+
+        def fetch(self, identifier):
+            return None
+
+    class ForeignSlugSource:
+        def inspect(self, identifier):
+            return SkillMeta(
+                name="skillopt",
+                description="Train, evaluate, and improve Agent skill files",
+                source="clawhub",
+                identifier="skillopt",
+                trust_level="community",
+            )
+
+        def fetch(self, identifier):
+            return SkillBundle(
+                name="skillopt",
+                files={"SKILL.md": "# Train, evaluate, and improve Agent skill files\n"},
+                source="clawhub",
+                identifier="skillopt",
+                trust_level="community",
+            )
+
+    meta, bundle, matched = _resolve_source_meta_and_bundle(
+        "latipun7/agent-skill-collections/skills/skillopt",
+        [CatalogSource(), ForeignSlugSource()],
+    )
+
+    assert bundle is not None
+    assert bundle.source == "clawhub"
+    assert meta is not None
+    assert meta.source == "clawhub"
+    assert meta.identifier == "skillopt"
+    assert "kanban-based" not in (meta.description or "")
+    assert matched is not None
+    assert matched.__class__ is ForeignSlugSource
+
+
+def test_resolve_keeps_catalog_meta_when_later_sources_do_not_fetch():
+    from hermes_cli.skills_hub import _resolve_source_meta_and_bundle
+    from tools.skills_hub import SkillMeta
+
+    class CatalogSource:
+        def inspect(self, identifier):
+            return SkillMeta(
+                name="skillopt",
+                description="kanban-based pipelines",
+                source="skills.sh",
+                identifier="skills-sh/latipun7/agent-skill-collections/skills/skillopt",
+                trust_level="community",
+            )
+
+        def fetch(self, identifier):
+            return None
+
+    class QuietSource:
+        def inspect(self, identifier):
+            return None
+
+        def fetch(self, identifier):
+            return None
+
+    meta, bundle, matched = _resolve_source_meta_and_bundle(
+        "latipun7/agent-skill-collections/skills/skillopt",
+        [CatalogSource(), QuietSource()],
+    )
+
+    assert bundle is None
+    assert meta is not None
+    assert meta.source == "skills.sh"
+    assert meta.identifier.endswith("latipun7/agent-skill-collections/skills/skillopt")
+    assert matched is not None
+    assert matched.__class__ is CatalogSource
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skills_hub_clawhub.py
+++ b/tests/tools/test_skills_hub_clawhub.py
@@ -370,6 +370,62 @@ class TestClawHubSource(unittest.TestCase):
         self.assertEqual(results[0].identifier, "only-skill")
         mock_write_cache.assert_called_once()
 
+    def test_parse_identifier_accepts_clawhub_shapes(self):
+        self.assertEqual(ClawHubSource._parse_identifier("skillopt"), ("skillopt", None))
+        self.assertEqual(ClawHubSource._parse_identifier("clawhub/skillopt"), ("skillopt", None))
+        self.assertEqual(
+            ClawHubSource._parse_identifier("@harrylabsj/skillopt"),
+            ("skillopt", "harrylabsj"),
+        )
+        self.assertEqual(
+            ClawHubSource._parse_identifier("harrylabsj/skills/skillopt"),
+            ("skillopt", "harrylabsj"),
+        )
+
+    def test_parse_identifier_rejects_github_style_paths(self):
+        self.assertIsNone(
+            ClawHubSource._parse_identifier("latipun7/agent-skill-collections/skillopt")
+        )
+        self.assertIsNone(
+            ClawHubSource._parse_identifier(
+                "latipun7/agent-skill-collections/skills/skillopt"
+            )
+        )
+        self.assertIsNone(
+            ClawHubSource._parse_identifier(
+                "skills-sh/latipun7/agent-skill-collections/skills/skillopt"
+            )
+        )
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_inspect_does_not_claim_github_style_identifier(self, mock_get):
+        meta = self.src.inspect("latipun7/agent-skill-collections/skills/skillopt")
+        self.assertIsNone(meta)
+        mock_get.assert_not_called()
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_does_not_claim_github_style_identifier(self, mock_get):
+        bundle = self.src.fetch("latipun7/agent-skill-collections/skillopt")
+        self.assertIsNone(bundle)
+        mock_get.assert_not_called()
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_inspect_rejects_owner_mismatch_on_clawhub_url_path(self, mock_get):
+        mock_get.return_value = _MockResponse(
+            status_code=200,
+            json_data={
+                "slug": "skillopt",
+                "displayName": "SkillOpt",
+                "summary": "Train, evaluate, and improve Agent skill files",
+                "owner": {"handle": "harrylabsj"},
+            },
+        )
+
+        meta = self.src.inspect("latipun7/skills/skillopt")
+
+        self.assertIsNone(meta)
+        mock_get.assert_called_once()
+
 
 class TestClawHubCatalogWalkBounded(unittest.TestCase):
     """max_items bounds the walk so browse's cold-start fallback renders one

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2302,12 +2302,15 @@ class ClawHubSource(SkillSource):
         return deduped
 
     def _exact_slug_meta(self, query: str) -> Optional[SkillMeta]:
-        slug = query.strip().split("/")[-1]
+        query = query.strip()
+        parsed = self._parse_identifier(query)
         query_terms = self._query_terms(query)
         candidates: List[str] = []
 
-        if slug and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", slug):
-            candidates.append(slug)
+        if parsed:
+            candidates.append(parsed[0])
+        elif "/" not in query and self._SLUG_RE.fullmatch(query):
+            candidates.append(query)
 
         if query_terms:
             base_slug = "-".join(query_terms)
@@ -2443,11 +2446,73 @@ class ClawHubSource(SkillSource):
         _write_index_cache(cache_key, [_skill_meta_to_dict(s) for s in final_results])
         return final_results
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
-        slug = identifier.split("/")[-1]
+    _SLUG_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*$")
 
-        skill_data = self._get_json(f"{self.BASE_URL}/skills/{slug}")
+    @classmethod
+    def _parse_identifier(cls, identifier: str) -> Optional[Tuple[str, Optional[str]]]:
+        """Return ``(slug, expected_owner)`` for a ClawHub identifier.
+
+        Accepts a bare slug, ``clawhub/<slug>``, ``@owner/slug``, and the
+        clawhub.ai URL path ``owner/skills/slug``. GitHub-style
+        ``owner/repo/skill`` and ``owner/repo/skills/skill`` identifiers
+        are not ClawHub's — claiming them by last path segment installs
+        a same-named skill from a different author.
+        """
+        raw = (identifier or "").strip()
+        if not raw:
+            return None
+        had_at = raw.startswith("@")
+        ident = raw[1:] if had_at else raw
+        if ident.startswith("clawhub/"):
+            ident = ident[len("clawhub/"):]
+        parts = [part for part in ident.split("/") if part]
+        if len(parts) == 1:
+            slug = parts[0]
+            return (slug, None) if cls._SLUG_RE.fullmatch(slug) else None
+        if len(parts) == 2 and had_at:
+            owner, slug = parts
+            if cls._SLUG_RE.fullmatch(owner) and cls._SLUG_RE.fullmatch(slug):
+                return slug, owner
+            return None
+        if len(parts) == 3 and parts[1].lower() == "skills":
+            owner, _, slug = parts
+            if cls._SLUG_RE.fullmatch(owner) and cls._SLUG_RE.fullmatch(slug):
+                return slug, owner
+            return None
+        return None
+
+    @staticmethod
+    def _owner_from_payload(data: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not isinstance(data, dict):
+            return None
+        owner = data.get("owner")
+        if isinstance(owner, dict):
+            handle = owner.get("handle")
+            if isinstance(handle, str) and handle.strip():
+                return handle.strip()
+        if isinstance(owner, str) and owner.strip():
+            return owner.strip()
+        return None
+
+    @classmethod
+    def _owner_matches(cls, expected_owner: Optional[str], data: Optional[Dict[str, Any]]) -> bool:
+        if not expected_owner:
+            return True
+        actual = cls._owner_from_payload(data)
+        if not actual:
+            return True
+        return actual.lower() == expected_owner.lower()
+
+    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+        parsed = self._parse_identifier(identifier)
+        if parsed is None:
+            return None
+        slug, expected_owner = parsed
+
+        skill_data = self._coerce_skill_payload(self._get_json(f"{self.BASE_URL}/skills/{slug}"))
         if not isinstance(skill_data, dict):
+            return None
+        if not self._owner_matches(expected_owner, skill_data):
             return None
 
         latest_version = self._resolve_latest_version(slug, skill_data)
@@ -2486,21 +2551,22 @@ class ClawHubSource(SkillSource):
         )
 
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
-        slug = identifier.split("/")[-1]
+        parsed = self._parse_identifier(identifier)
+        if parsed is None:
+            return None
+        slug, expected_owner = parsed
         data = self._coerce_skill_payload(self._get_json(f"{self.BASE_URL}/skills/{slug}"))
         if not isinstance(data, dict):
+            return None
+        if not self._owner_matches(expected_owner, data):
             return None
 
         tags = self._normalize_tags(data.get("tags", []))
         extra: Dict[str, Any] = {}
         # The detail API returns owner info — capture it so callers can build
         # valid ClawHub URLs (https://clawhub.ai/{owner}/skills/{slug}).
-        owner = data.get("owner")
-        if isinstance(owner, dict):
-            handle = owner.get("handle")
-            if isinstance(handle, str) and handle:
-                extra["owner"] = handle
-        elif isinstance(owner, str) and owner:
+        owner = self._owner_from_payload(data)
+        if owner:
             extra["owner"] = owner
 
         return SkillMeta(


### PR DESCRIPTION
## Summary
- `hermes skills inspect/install owner/repo/skills/skillopt` could show the requested skills.sh identity while downloading a different author's same-named skill from ClawHub (last path segment used as a slug).
- Keep catalog metadata and files from the same source adapter, and only treat bare slugs / ClawHub URL shapes as ClawHub identifiers.
- Same-name skills from a GitHub tap or skills.sh path no longer silently install the ClawHub copy.

## Test plan
- [x] `scripts/run_tests.sh tests/tools/test_skills_hub_clawhub.py tests/hermes_cli/test_skills_hub.py -q`
- [ ] `hermes skills inspect latipun7/agent-skill-collections/skills/skillopt` — header and SKILL.md preview both belong to that tap (kanban SkillOpt), not `harrylabsj/skills/skillopt`
- [ ] `hermes skills inspect skillopt` still resolves the ClawHub slug when that is what was asked for
