### PR TITLE
fix(kanban): keep crash diagnostics scoped to the failed run

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7972,6 +7972,10 @@ DEFAULT_SPAWN_FAILURE_LIMIT = DEFAULT_FAILURE_LIMIT
 # and rotates on spawn if the file is larger than this at spawn time.
 DEFAULT_LOG_ROTATE_BYTES = 2 * 1024 * 1024   # 2 MiB
 DEFAULT_LOG_BACKUP_COUNT = 1
+# Crash events keep a bounded diagnostic excerpt. The run marker written by
+# the dispatcher is the ownership boundary: bytes before it belong to an
+# earlier attempt and must never be attached to the current run.
+WORKER_CRASH_LOG_TAIL_BYTES = 8 * 1024
 
 # Keep a little wall-clock budget for the worker to observe a terminal timeout
 # and call kanban_block/kanban_complete before max_runtime_seconds kills it.
@@ -8849,7 +8853,9 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(
+    conn: sqlite3.Connection, *, board: Optional[str] = None,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Appends a ``crashed`` event and restores the task's source phase.
@@ -8892,7 +8898,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     exited_hook_payloads: list[dict] = []
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at, assignee "
+            "SELECT id, worker_pid, claim_lock, started_at, assignee, "
+            "current_run_id "
             "FROM tasks "
             "WHERE status = 'running' AND worker_pid IS NOT NULL"
         ).fetchall()
@@ -8976,6 +8983,14 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 if code is not None and kind != "unknown":
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
+
+                # A task log is cumulative across retries. Read only bytes
+                # after this run's dispatcher-written marker; if the worker
+                # died before emitting output, preserve that fact as null
+                # instead of falling back to the previous attempt's tail.
+                event_payload["worker_log_tail"] = _read_worker_run_log_tail(
+                    row["id"], row["current_run_id"], board=board,
+                )
 
             retry_status = _retry_status_for_run(conn, row["id"])
             event_payload["retry_status"] = retry_status
@@ -9951,7 +9966,7 @@ def _dispatch_once_locked(
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
-    result.crashed = detect_crashed_workers(conn)
+    result.crashed = detect_crashed_workers(conn, board=board)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
     # DispatchResult here so telemetry / tests see the trip.
@@ -10896,6 +10911,9 @@ def _default_spawn(
 
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
+    if task.current_run_id is not None:
+        log_f.write(_worker_run_log_marker(task.current_run_id))
+        log_f.flush()
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
             cmd,
@@ -11918,6 +11936,50 @@ def worker_log_path(task_id: str, *, board: Optional[str] = None) -> Path:
     board explicitly to avoid any resolution ambiguity when multiple
     boards exist."""
     return worker_logs_dir(board=board) / f"{task_id}.log"
+
+
+def _worker_run_log_marker(run_id: int) -> bytes:
+    """Return the dispatcher-owned boundary written before a worker starts."""
+    return f"\n--- hermes kanban run {int(run_id)} ---\n".encode("ascii")
+
+
+def _read_worker_run_log_tail(
+    task_id: str,
+    run_id: Optional[int],
+    *,
+    tail_bytes: int = WORKER_CRASH_LOG_TAIL_BYTES,
+    board: Optional[str] = None,
+) -> Optional[str]:
+    """Read a tail belonging strictly to ``run_id`` from a cumulative log.
+
+    Missing markers are treated as unknown ownership, never as permission to
+    return the task-level tail. This keeps legacy/custom-spawn logs from being
+    misattributed to a run that did not write them.
+    """
+    if run_id is None:
+        return None
+    path = worker_log_path(task_id, board=board)
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+
+    marker = _worker_run_log_marker(run_id)
+    marker_at = data.find(marker)
+    if marker_at < 0:
+        return None
+    run_output = data[marker_at + len(marker):]
+    if not run_output:
+        return None
+
+    if len(run_output) > tail_bytes:
+        run_output = run_output[-tail_bytes:]
+        newline = run_output.find(b"\n")
+        if newline >= 0:
+            run_output = run_output[newline + 1:]
+    if not run_output:
+        return None
+    return run_output.decode("utf-8", errors="replace")
 
 
 def read_worker_log(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11956,24 +11956,37 @@ def _read_worker_run_log_tail(
     return the task-level tail. This keeps legacy/custom-spawn logs from being
     misattributed to a run that did not write them.
     """
-    if run_id is None:
+    if run_id is None or tail_bytes <= 0:
         return None
     path = worker_log_path(task_id, board=board)
+    marker = _worker_run_log_marker(run_id)
+    marker_overlap = b""
     try:
-        data = path.read_bytes()
+        with path.open("rb") as log_f:
+            while chunk := log_f.read(64 * 1024):
+                scan = marker_overlap + chunk
+                marker_at = scan.find(marker)
+                if marker_at >= 0:
+                    marker_end = (
+                        log_f.tell() - len(chunk) - len(marker_overlap)
+                        + marker_at + len(marker)
+                    )
+                    break
+                marker_overlap = scan[-(len(marker) - 1):]
+            else:
+                return None
+
+            log_f.seek(0, os.SEEK_END)
+            log_end = log_f.tell()
+            output_size = log_end - marker_end
+            if output_size <= 0:
+                return None
+            log_f.seek(max(marker_end, log_end - tail_bytes))
+            run_output = log_f.read(min(output_size, tail_bytes))
     except OSError:
         return None
 
-    marker = _worker_run_log_marker(run_id)
-    marker_at = data.find(marker)
-    if marker_at < 0:
-        return None
-    run_output = data[marker_at + len(marker):]
-    if not run_output:
-        return None
-
-    if len(run_output) > tail_bytes:
-        run_output = run_output[-tail_bytes:]
+    if output_size > tail_bytes:
         newline = run_output.find(b"\n")
         if newline >= 0:
             run_output = run_output[newline + 1:]

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -262,6 +262,73 @@ def _exited_status(code: int) -> int:
     return code << 8
 
 
+def _crash_worker_with_output(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    current_output: bytes,
+) -> dict:
+    """Spawn one attempt behind an existing task log, then crash it."""
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(kb, "_classify_worker_exit", lambda _pid: ("nonzero_exit", 1))
+
+    workspace = kanban_home / "workspace"
+    workspace.mkdir()
+    host = kb._claimer_id().split(":", 1)[0]
+    board = "crash-log-ownership"
+    kb.create_board(board)
+    with kb.connect(board=board) as conn:
+        task_id = kb.create_task(conn, title="run log ownership", assignee="worker")
+        claimed = kb.claim_task(conn, task_id, claimer=f"{host}:test")
+        assert claimed is not None and claimed.current_run_id is not None
+
+        log_path = kb.worker_log_path(task_id, board=board)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_bytes(b"previous-run output\n")
+
+        class FakeProc:
+            pid = 76543
+
+        def fake_popen(_cmd, *args, **kwargs):
+            output = kwargs["stdout"]
+            output.write(current_output)
+            output.flush()
+            return FakeProc()
+
+        monkeypatch.setattr("subprocess.Popen", fake_popen)
+        pid = kb._default_spawn(claimed, str(workspace), board=board)
+        assert pid == FakeProc.pid
+        kb._set_worker_pid(conn, task_id, pid)
+
+        assert kb.detect_crashed_workers(conn, board=board) == [task_id]
+        crash = next(ev for ev in reversed(kb.list_events(conn, task_id)) if ev.kind == "crashed")
+        assert crash.run_id == claimed.current_run_id
+        assert crash.payload is not None
+        assert "worker_log_tail" in crash.payload
+        return crash.payload
+
+
+def test_crash_log_tail_is_null_when_current_run_wrote_nothing(
+    kanban_home, monkeypatch,
+):
+    payload = _crash_worker_with_output(
+        kanban_home, monkeypatch, current_output=b"",
+    )
+
+    assert payload["worker_log_tail"] is None
+
+
+def test_crash_log_tail_excludes_previous_run_output(
+    kanban_home, monkeypatch,
+):
+    payload = _crash_worker_with_output(
+        kanban_home, monkeypatch, current_output=b"current-run failure\n",
+    )
+
+    assert payload["worker_log_tail"] == "current-run failure\n"
+
+
 
 
 def test_rate_limit_exit_requeues_without_counting_failure(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import io
 import os
 import sqlite3
 import subprocess
@@ -327,6 +328,30 @@ def test_crash_log_tail_excludes_previous_run_output(
     )
 
     assert payload["worker_log_tail"] == "current-run failure\n"
+
+
+def test_crash_log_tail_reads_incrementally_and_handles_split_marker(
+    kanban_home, monkeypatch,
+):
+    run_id = 42
+    marker = kb._worker_run_log_marker(run_id)
+    prior = b"p" * (64 * 1024 - len(marker) // 2)
+    current = b"x" * (64 * 1024) + b"\ncurrent failure\n"
+    log_bytes = prior + marker + current
+    read_sizes = []
+
+    class GuardedLog(io.BytesIO):
+        def read(self, size=-1):
+            read_sizes.append(size)
+            assert 0 < size <= 64 * 1024
+            return super().read(size)
+
+    monkeypatch.setattr(Path, "open", lambda *_args, **_kwargs: GuardedLog(log_bytes))
+
+    tail = kb._read_worker_run_log_tail("task", run_id, tail_bytes=64)
+
+    assert tail == "current failure\n"
+    assert len(read_sizes) >= 3
 
 
 


### PR DESCRIPTION
## What does this PR do?

Crash events now report log output from the failed worker run only. Previously, when a worker exited before writing output, the cumulative task log made `worker_log_tail` fall back to a previous successful run and sent operators toward the wrong profile and session.

### Symptom

A newly crashed Kanban worker can have a `worker_log_tail` containing the previous attempt's successful session summary. The event PID, run ID, profile, and timing therefore disagree with the diagnostic text.

### Impact

Operators can investigate the wrong worker profile and session because the first crash diagnostic is attributed to a run that did not produce it. The affected blast radius is limited to crash diagnostics for retried tasks whose logs contain earlier attempts.

### Bug Cause

**Trigger:** `hermes_cli/kanban_db.py:8856` / `detect_crashed_workers` when a current worker dies before producing output.

**Causal chain:**
1. `_default_spawn` appends every worker attempt to one cumulative task log.
2. The current attempt exits before adding bytes, leaving the prior attempt at the end of the file.
3. Crash diagnostics read that task-level tail and attach previous-run output to the current crash event.

**Why it is wrong:** The cumulative log had no durable run ownership boundary, so a tail could not distinguish current-run bytes from adjacent attempts.

**Working sibling / contrast:** Normal task-log browsing can remain cumulative because it is not attributed to one crash event. Crash diagnostics require stricter ownership.

**Ruled out:** Missing stderr capture is not the cause. Worker stdout and stderr already share the spawned log stream; the failure occurs when the current run writes no bytes at all.

### Fix

The dispatcher writes a run-ID marker before spawning each worker. Crash detection scans the cumulative log incrementally for that marker and returns only a bounded tail after it. If the marker is missing or the current run produced no output, `worker_log_tail` is explicitly `null` instead of using adjacent-run bytes.

## Related Issue

Closes #88456

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` - add per-run log ownership markers and bounded current-run crash-tail extraction.
- `tests/hermes_cli/test_kanban_db.py` - cover output-less crashes, current-run-only output, bounded incremental reads, and split markers.

## How to Test

1. On a named Kanban board, run one successful worker so the task log contains previous output.
2. Start a second attempt and make it exit before writing output; confirm the crash event has `worker_log_tail: null`.
3. Repeat with current-run failure output; confirm the event contains only the current attempt's bytes.
4. Run the focused automated tests (5 passed):

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_boards.py -k 'crash_log_tail or default_spawn'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the related tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior and helpers are documented in code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no workflow contract changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the implementation uses portable binary file I/O
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model-tool schema changes

## Screenshots / Logs

The named-board real-environment verification covered both output-less and output-producing worker crashes. The focused test run passed all 5 selected tests.
