### PR TITLE
fix(kanban): preserve stderr when workers crash during startup

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7972,6 +7972,8 @@ DEFAULT_SPAWN_FAILURE_LIMIT = DEFAULT_FAILURE_LIMIT
 # and rotates on spawn if the file is larger than this at spawn time.
 DEFAULT_LOG_ROTATE_BYTES = 2 * 1024 * 1024   # 2 MiB
 DEFAULT_LOG_BACKUP_COUNT = 1
+WORKER_DIAGNOSTIC_TAIL_BYTES = 16 * 1024
+_WORKER_RUN_MARKER_PREFIX = "=== HERMES KANBAN WORKER RUN "
 
 # Keep a little wall-clock budget for the worker to observe a terminal timeout
 # and call kanban_block/kanban_complete before max_runtime_seconds kills it.
@@ -8849,7 +8851,11 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(
+    conn: sqlite3.Connection,
+    *,
+    board: Optional[str] = None,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Appends a ``crashed`` event and restores the task's source phase.
@@ -8892,7 +8898,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     exited_hook_payloads: list[dict] = []
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at, assignee "
+            "SELECT id, worker_pid, claim_lock, started_at, assignee, current_run_id "
             "FROM tasks "
             "WHERE status = 'running' AND worker_pid IS NOT NULL"
         ).fetchall()
@@ -8976,6 +8982,9 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 if code is not None and kind != "unknown":
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
+                event_payload["worker_log_tail"] = _read_worker_run_log_tail(
+                    row["id"], row["current_run_id"], board=board,
+                )
 
             retry_status = _retry_status_for_run(conn, row["id"])
             event_payload["retry_status"] = retry_status
@@ -9267,6 +9276,7 @@ def _record_task_failure(
                         "effective_limit": effective_limit,
                         "limit_source": limit_source,
                         "retry_status": retry_status,
+                        **(event_payload_extra or {}),
                     },
                 )
             payload = {
@@ -9310,6 +9320,7 @@ def _record_task_failure(
                     metadata={
                         "failures": failures,
                         "retry_status": retry_status,
+                        **(event_payload_extra or {}),
                     },
                 )
                 _append_event(
@@ -9318,6 +9329,7 @@ def _record_task_failure(
                         "error": error[:500],
                         "failures": failures,
                         "retry_status": retry_status,
+                        **(event_payload_extra or {}),
                     },
                     run_id=run_id,
                 )
@@ -9333,13 +9345,23 @@ def _record_spawn_failure(
     error: str,
     *,
     failure_limit: int = None,
+    board: Optional[str] = None,
 ) -> bool:
+    row = conn.execute(
+        "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    run_id = row["current_run_id"] if row is not None else None
     return _record_task_failure(
         conn, task_id, error,
         outcome="spawn_failed",
         failure_limit=failure_limit,
         release_claim=True,
         end_run=True,
+        event_payload_extra={
+            "worker_log_tail": _read_worker_run_log_tail(
+                task_id, run_id, board=board,
+            ),
+        },
     )
 
 
@@ -9951,7 +9973,7 @@ def _dispatch_once_locked(
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
-    result.crashed = detect_crashed_workers(conn)
+    result.crashed = detect_crashed_workers(conn, board=board)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
     # DispatchResult here so telemetry / tests see the trip.
@@ -10240,6 +10262,7 @@ def _dispatch_once_locked(
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
                 failure_limit=failure_limit,
+                board=board,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
@@ -10292,6 +10315,7 @@ def _dispatch_once_locked(
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
                 failure_limit=failure_limit,
+                board=board,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
@@ -10367,6 +10391,7 @@ def _dispatch_once_locked(
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
                 failure_limit=failure_limit,
+                board=board,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
@@ -10412,6 +10437,7 @@ def _dispatch_once_locked(
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
                 failure_limit=failure_limit,
+                board=board,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
@@ -10498,6 +10524,70 @@ def _rotate_worker_log(
         log_path.rename(_rotated_log_path(log_path, 1))
     except OSError:
         pass
+
+
+def _worker_run_marker(run_id: int) -> bytes:
+    return f"\n{_WORKER_RUN_MARKER_PREFIX}{int(run_id)} ===\n".encode("ascii")
+
+
+def _append_worker_run_marker(log_path: Path, run_id: Optional[int]) -> None:
+    """Persist a boundary that ties subsequent log bytes to one run."""
+    if run_id is None:
+        return
+    with log_path.open("ab") as stream:
+        stream.write(_worker_run_marker(run_id))
+
+
+def _read_worker_run_log_tail(
+    task_id: str,
+    run_id: Optional[int],
+    *,
+    board: Optional[str] = None,
+    max_bytes: int = WORKER_DIAGNOSTIC_TAIL_BYTES,
+) -> Optional[str]:
+    """Return a redacted, bounded tail produced after this run's marker."""
+    if run_id is None or max_bytes <= 0:
+        return None
+    path = worker_logs_dir(board=board) / f"{task_id}.log"
+    marker = _worker_run_marker(run_id)
+    try:
+        with path.open("rb") as stream:
+            end = stream.seek(0, os.SEEK_END)
+            position = end
+            suffix = b""
+            marker_end = None
+            while position > 0:
+                start = max(0, position - 64 * 1024)
+                stream.seek(start)
+                chunk = stream.read(position - start)
+                combined = chunk + suffix
+                index = combined.rfind(marker)
+                if index >= 0:
+                    marker_end = start + index + len(marker)
+                    break
+                suffix = chunk[: max(0, len(marker) - 1)]
+                position = start
+            if marker_end is None or marker_end >= end:
+                return None
+            stream.seek(max(marker_end, end - max_bytes))
+            raw = stream.read(max_bytes)
+    except OSError:
+        return None
+
+    text = raw.decode("utf-8", errors="replace").strip()
+    if not text:
+        return None
+    from agent.redact import redact_sensitive_text
+
+    redacted = redact_sensitive_text(
+        text,
+        force=True,
+        redact_url_credentials=True,
+    )
+    encoded = redacted.encode("utf-8")
+    if len(encoded) > max_bytes:
+        redacted = encoded[-max_bytes:].decode("utf-8", errors="replace")
+    return redacted.strip() or None
 
 
 def _module_hermes_argv() -> list[str]:
@@ -10893,6 +10983,7 @@ def _default_spawn(
     log_path = log_dir / f"{task.id}.log"
     rotate_bytes, backup_count = worker_log_rotation_config()
     _rotate_worker_log(log_path, rotate_bytes, backup_count)
+    _append_worker_run_marker(log_path, task.current_run_id)
 
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10586,7 +10586,10 @@ def _read_worker_run_log_tail(
     )
     encoded = redacted.encode("utf-8")
     if len(encoded) > max_bytes:
-        redacted = encoded[-max_bytes:].decode("utf-8", errors="replace")
+        start = len(encoded) - max_bytes
+        while start < len(encoded) and encoded[start] & 0xC0 == 0x80:
+            start += 1
+        redacted = encoded[start:].decode("utf-8")
     return redacted.strip() or None
 
 

--- a/tests/hermes_cli/test_kanban_worker_crash_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_worker_crash_diagnostics.py
@@ -92,6 +92,22 @@ def test_spawn_failure_explicitly_reports_no_worker_output(kanban_home: Path) ->
     assert payload["worker_log_tail"] is None
 
 
+def test_worker_tail_remains_byte_bounded_for_invalid_utf8(kanban_home: Path) -> None:
+    task_id = "t_invalid_utf8"
+    run_id = 77
+    log_path = kb.worker_logs_dir() / f"{task_id}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_bytes(
+        kb._worker_run_marker(run_id)
+        + b"\x80" * kb.WORKER_DIAGNOSTIC_TAIL_BYTES
+    )
+
+    tail = kb._read_worker_run_log_tail(task_id, run_id)
+
+    assert tail is not None
+    assert len(tail.encode("utf-8")) <= kb.WORKER_DIAGNOSTIC_TAIL_BYTES
+
+
 def test_default_spawn_marks_log_with_current_run(
     kanban_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/hermes_cli/test_kanban_worker_crash_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_worker_crash_diagnostics.py
@@ -1,0 +1,128 @@
+"""Crash diagnostics for dispatcher-spawned Kanban workers."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _claim_with_dead_worker(conn, task_id: str, pid: int):
+    host = kb._claimer_id().split(":", 1)[0]
+    task = kb.claim_task(conn, task_id, claimer=f"{host}:worker")
+    assert task is not None and task.current_run_id is not None
+    kb._set_worker_pid(conn, task_id, pid)
+    conn.execute(
+        "UPDATE tasks SET started_at = ? WHERE id = ?",
+        (int(time.time()) - 60, task_id),
+    )
+    conn.commit()
+    return task
+
+
+def test_nonzero_exit_event_has_bounded_redacted_current_run_tail(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(kb, "_classify_worker_exit", lambda _pid: ("nonzero_exit", 1))
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="startup crash", assignee="worker")
+        task = _claim_with_dead_worker(conn, task_id, 43210)
+
+        log_path = kb.worker_logs_dir() / f"{task_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("previous successful run\n", encoding="utf-8")
+        kb._append_worker_run_marker(log_path, task.current_run_id)
+        secret = "ghp_abcdefghijklmnopqrstuvwxyz"
+        with log_path.open("a", encoding="utf-8") as stream:
+            stream.write("x" * (kb.WORKER_DIAGNOSTIC_TAIL_BYTES + 200))
+            stream.write(f"\nAuthorization: Bearer {secret}\nstartup exploded\n")
+
+        assert kb.detect_crashed_workers(conn) == [task_id]
+        event = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'crashed' ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        payload = json.loads(event["payload"])
+
+    tail = payload["worker_log_tail"]
+    assert tail.endswith("startup exploded")
+    assert "previous successful run" not in tail
+    assert secret not in tail
+    assert len(tail.encode("utf-8")) <= kb.WORKER_DIAGNOSTIC_TAIL_BYTES
+
+
+def test_spawn_failure_explicitly_reports_no_worker_output(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="cannot spawn", assignee="worker")
+        task = _claim_with_dead_worker(conn, task_id, 43211)
+        log_path = kb.worker_logs_dir() / f"{task_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("previous attempt output\n", encoding="utf-8")
+        kb._append_worker_run_marker(log_path, task.current_run_id)
+
+        assert not kb._record_spawn_failure(
+            conn, task_id, "executable missing", failure_limit=2,
+        )
+        event = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'spawn_failed' ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        payload = json.loads(event["payload"])
+
+    assert payload["error"] == "executable missing"
+    assert payload["worker_log_tail"] is None
+
+
+def test_default_spawn_marks_log_with_current_run(
+    kanban_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (kanban_home / "profiles" / "worker").mkdir(parents=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    class FakeProc:
+        pid = 43212
+
+    monkeypatch.setattr("subprocess.Popen", lambda *_args, **_kwargs: FakeProc())
+    monkeypatch.setattr(kb, "_retag_legacy_worker_sessions", lambda _root: None)
+    task = kb.Task(
+        id="t_marked",
+        title="marked",
+        body=None,
+        assignee="worker",
+        status="running",
+        priority=0,
+        created_by=None,
+        created_at=0,
+        started_at=0,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=str(workspace),
+        claim_lock="host:worker",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=77,
+    )
+
+    assert kb._default_spawn(task, str(workspace)) == FakeProc.pid
+    log = (kb.worker_logs_dir() / "t_marked.log").read_text(encoding="utf-8")
+    assert "HERMES KANBAN WORKER RUN 77" in log


### PR DESCRIPTION
## What does this PR do?

Kanban workers that exit before profile logging is ready now leave a durable, run-scoped diagnostic tail in the crash event instead of only an exit code. Without this change, operators cannot diagnose startup import or plugin failures even though the worker already wrote the cause to its task log.

### Symptom

A worker can exit nonzero during startup while its profile log ends mid-initialization. The kanban task records the PID and exit code, but the `crashed` event does not contain the traceback or startup error that the child wrote to stderr.

### Impact

Operators cannot determine why an early-startup worker failed from durable task history. The affected card can exhaust its retry limit and block with no actionable cause beyond `exit_code: 1`.

### Bug Cause

**Trigger:** `hermes_cli/kanban_db.py` / `_default_spawn`, `detect_crashed_workers`, and `_record_spawn_failure`

**Causal chain:**
1. `_default_spawn` redirects both stdout and stderr to an append-only per-task worker log.
2. The crash and spawn-failure paths persist exit metadata but do not read the current run's worker output.
3. A failure before profile logging initializes therefore leaves its only diagnostic in the log file, outside the durable task event and run metadata.

**Why it is wrong:** The dispatcher owns the child process and its output destination, so it is the only reliable layer that can preserve diagnostics emitted before worker logging starts. Reading the whole append-only file would also be incorrect because it can attribute output from an earlier attempt to the current run.

**Working sibling / contrast:** Workers that initialize profile logging successfully record later failures in profile logs. Early startup failures do not reach that path, even though their combined stdout/stderr is already present in the dispatcher-owned task log.

**Ruled out:** The child did produce startup output. Native Windows verification launched a real child that exited on an invalid CLI argument, and the current run's task log contained `Unknown option: -p`; the missing link was durable crash-event persistence, not output generation.

### Fix

The dispatcher now writes a run boundary before spawning, scans backward for that run's marker, and reads only a 16 KiB tail produced by the current attempt. The tail is force-redacted before it is attached to `crashed`, `spawn_failed`, and run metadata. Output-less failures store `worker_log_tail: null` explicitly, and UTF-8 replacement decoding cannot expand the persisted value past the byte limit.

## Related Issue

Closes #88457

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` - bind worker output to a run marker and persist a bounded, redacted diagnostic tail for crash and spawn-failure paths.
- `tests/hermes_cli/test_kanban_worker_crash_diagnostics.py` - cover current-run attribution, redaction, byte bounds, invalid UTF-8, and explicit no-output handling.

## How to Test

1. Create an isolated kanban board with a real worker profile and seed its task log with previous-attempt text.
2. Set `HERMES_BIN` to the active Python executable so the spawned child rejects Hermes CLI arguments and exits before profile logging initializes.
3. Dispatch and reap the child, then verify the durable `crashed` event contains the current startup error, excludes previous-attempt output, redacts a synthetic bearer token, and stays within 16 KiB.
4. Force a controlled `subprocess.Popen` failure and verify `spawn_failed` records `worker_log_tail: null`.
5. Run the related automated tests (31 passed locally):

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_worker_crash_diagnostics.py tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all related tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is N/A because this changes internal crash diagnostics without a user-facing configuration or API change
- [x] `cli-config.yaml.example` is N/A because no configuration keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow contract changed
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); log reads use binary mode and native Windows verification passed
- [x] Tool descriptions and schemas are N/A because no model tool behavior changed

## Screenshots / Logs

Native Windows verification persisted a 237-byte current-run diagnostic containing `Unknown option: -p`, excluded seeded prior-attempt output, redacted a synthetic bearer credential, and stored `worker_log_tail: null` for a controlled output-less spawn failure.
