### PR TITLE
fix(gateway): scope projects.* RPCs to the active profile

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -20,6 +20,7 @@ import {
   endSessionMutation,
   enterProject,
   exitProjectScope,
+  fetchProjectSessions,
   openProjectCreate,
   pickProjectFolder,
   projectIdForCwd,
@@ -418,6 +419,7 @@ describe('repository discovery policy', () => {
     expect(scanRepos).not.toHaveBeenCalled()
     expect(request).toHaveBeenCalledWith('projects.record_repos', {
       discovery_policy: { enabled: false, exclude_paths: [], roots: [] },
+      profile: 'default',
       repos: []
     })
   })
@@ -453,6 +455,7 @@ describe('repository discovery policy', () => {
         exclude_paths: ['/work/vendor'],
         roots: ['/work']
       },
+      profile: 'default',
       repos: [{ label: 'repo', root: '/work/repo' }]
     })
   })
@@ -505,6 +508,40 @@ describe('project tree profile isolation', () => {
     await pendingA
 
     expect($projectTree.get().map(project => project.id)).toEqual(['profile-b'])
+  })
+})
+
+describe('projects RPC profile stamping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    $activeGatewayProfile.set('ray')
+  })
+
+  it('stamps the active profile on projects.list', async () => {
+    const request = vi.fn().mockResolvedValue({ active_id: null, projects: [] })
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await refreshProjects()
+
+    expect(request).toHaveBeenCalledWith('projects.list', { profile: 'ray' })
+  })
+
+  it('stamps the active profile on projects.tree', async () => {
+    const request = vi.fn().mockResolvedValue({ active_id: null, projects: [], scoped_session_ids: [] })
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await refreshProjectTree()
+
+    expect(request).toHaveBeenCalledWith('projects.tree', { preview_limit: 3, profile: 'ray' })
+  })
+
+  it('stamps the active profile on projects.project_sessions', async () => {
+    const request = vi.fn().mockResolvedValue({ project: null })
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await fetchProjectSessions('p_123')
+
+    expect(request).toHaveBeenCalledWith('projects.project_sessions', { project_id: 'p_123', profile: 'ray' })
   })
 })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -16,7 +16,7 @@ import { persistentAtom } from '@/lib/persisted'
 import { $gateway, activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
 import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
-import { $activeGatewayProfile, $profileScope, ALL_PROFILES, requestFreshSession } from '@/store/profile'
+import { $activeGatewayProfile, $profileScope, ALL_PROFILES, normalizeProfileKey, requestFreshSession } from '@/store/profile'
 import {
   $selectedStoredSessionId,
   $sessions,
@@ -349,6 +349,34 @@ async function gatewayRequestOn<T>(
   return gateway.request<T>(method, params)
 }
 
+// The profile the live gateway is currently connected to. Projects are
+// per-profile (each profile owns its own projects.db), so every projects.* RPC
+// must carry it — in app-global remote mode one backend serves every profile,
+// and an omitted profile silently falls back to the launch (default) profile's
+// Projects, grouping Ray sessions under default Projects like RSS Dashboard /
+// Emma General. The backend no-ops the stamp for the launch profile.
+function projectRpcProfile(): string {
+  return normalizeProfileKey($activeGatewayProfile.get())
+}
+
+// Stamp the active profile onto a projects.* request. One chokepoint so no call
+// site can forget it (mirrors the pet RPCs' petRpc helper).
+function projectRpcParams(params: Record<string, unknown> = {}): Record<string, unknown> {
+  return { ...params, profile: projectRpcProfile() }
+}
+
+async function projectRpc<T>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+  return gatewayRequest<T>(method, projectRpcParams(params))
+}
+
+async function projectRpcOn<T>(
+  gateway: HermesGateway,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<T> {
+  return gatewayRequestOn<T>(gateway, method, projectRpcParams(params))
+}
+
 interface ActiveProjectsContext {
   gateway: HermesGateway
   profile: string
@@ -378,7 +406,7 @@ function applyPayload(payload: ProjectsPayload): void {
 // not up yet) leaves the cached atoms intact so the sidebar doesn't flicker.
 export async function refreshProjects(): Promise<void> {
   try {
-    applyPayload(await gatewayRequest<ProjectsPayload>('projects.list'))
+    applyPayload(await projectRpc<ProjectsPayload>('projects.list'))
     markProjectsRpcSuccess()
   } catch (err) {
     markProjectsRpcFailure(err)
@@ -427,7 +455,7 @@ async function refreshProjectTreeOn(gateway: HermesGateway): Promise<void> {
   }
 
   try {
-    const res = await gatewayRequestOn<ProjectTreePayload>(gateway, 'projects.tree', {
+    const res = await projectRpcOn<ProjectTreePayload>(gateway, 'projects.tree', {
       preview_limit: PROJECT_TREE_PREVIEW_LIMIT
     })
 
@@ -502,7 +530,7 @@ async function refreshProjectTreeAcrossProfiles(): Promise<void> {
 // membership match exactly.
 export async function fetchProjectSessions(projectId: string): Promise<SidebarProjectTree | null> {
   try {
-    const res = await gatewayRequest<{ project: SidebarProjectTree | null }>('projects.project_sessions', {
+    const res = await projectRpc<{ project: SidebarProjectTree | null }>('projects.project_sessions', {
       project_id: projectId
     })
 
@@ -534,7 +562,7 @@ export async function moveSessionToProject(
     throw new Error(translateNow('sidebar.projects.moveNoFolder'))
   }
 
-  const res = await gatewayRequest<WorkspaceMovePayload>('session.workspace.move', {
+  const res = await projectRpc<WorkspaceMovePayload>('session.workspace.move', {
     cwd,
     session_key: sessionId,
     ...(profile ? { profile } : {})
@@ -635,7 +663,7 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
     state.runningSignature = signature
 
     if (!policy.enabled) {
-      await gatewayRequestOn(context.gateway, 'projects.record_repos', {
+      await projectRpcOn(context.gateway, 'projects.record_repos', {
         discovery_policy: policy,
         repos: []
       })
@@ -652,7 +680,7 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
         return
       }
 
-      await gatewayRequestOn(context.gateway, 'projects.record_repos', {
+      await projectRpcOn(context.gateway, 'projects.record_repos', {
         discovery_policy: policy,
         repos
       })
@@ -794,7 +822,7 @@ export async function createProject(input: CreateProjectInput): Promise<ProjectI
   let res: { project: ProjectInfo | null }
 
   try {
-    res = await gatewayRequest<{ project: ProjectInfo | null }>('projects.create', {
+    res = await projectRpc<{ project: ProjectInfo | null }>('projects.create', {
       name: input.name,
       folders: input.folders ?? [],
       primary_path: input.primaryPath,
@@ -877,7 +905,7 @@ export async function updateProject(
   // Backend treats null/undefined as "leave unchanged"; "" clears (stores NULL).
   // Map explicit null → "" so "no color"/"no icon" actually clear.
   await persistOrRollback(snap, () =>
-    gatewayRequest('projects.update', {
+    projectRpc('projects.update', {
       id,
       ...patch,
       ...(patch.color === null && { color: '' }),
@@ -953,7 +981,7 @@ export async function addProjectFolder(
   }
 
   await persistOrRollback(snap, () =>
-    gatewayRequest('projects.add_folder', { id, path, label: opts.label, is_primary: opts.isPrimary ?? false })
+    projectRpc('projects.add_folder', { id, path, label: opts.label, is_primary: opts.isPrimary ?? false })
   )
   reconcileProjects()
 }
@@ -996,13 +1024,13 @@ export async function deleteProject(id: string): Promise<void> {
   }
 
   await persistOrRollback(snap, async () => {
-    applyPayload(await gatewayRequest<ProjectsPayload>('projects.delete', { id }))
+    applyPayload(await projectRpc<ProjectsPayload>('projects.delete', { id }))
   })
   void refreshProjectTree()
 }
 
 export async function setActiveProject(id: null | string): Promise<void> {
-  const res = await gatewayRequest<{ active_id: null | string }>('projects.set_active', { id })
+  const res = await projectRpc<{ active_id: null | string }>('projects.set_active', { id })
   $activeProjectId.set(res.active_id ?? null)
 }
 

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -214,6 +214,53 @@ def test_create_list_roundtrip(tmp_path):
     assert listing["active_id"] == created["project"]["id"]
 
 
+def test_projects_rpc_is_profile_scoped(monkeypatch, tmp_path):
+    """A named profile's projects.* RPC must read THAT profile's projects.db.
+
+    In app-global remote mode one backend serves every profile. Without the
+    ``profile`` stamp, a Ray request silently fell back to the launch (default)
+    profile's Projects — the desktop then grouped Ray sessions under default
+    Projects like RSS Dashboard / Emma General.
+    """
+    from hermes_cli import profiles as profiles_mod
+    from hermes_constants import get_default_hermes_root
+
+    default_home = tmp_path / "default"
+    default_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    # The named profile lives under <root>/profiles/<name>.
+    root = get_default_hermes_root()
+    ray_home = root / "profiles" / "ray"
+    ray_home.mkdir(parents=True)
+
+    # Seed a project in the RAY profile's projects.db.
+    from hermes_cli import projects_db as pdb
+
+    with pdb.connect_closing(db_path=ray_home / "projects.db") as conn:
+        pdb.create_project(conn, name="Ray Project", folders=[str(tmp_path / "ray-ws")])
+
+    # The launch (default) profile has no projects.
+    assert _call("projects.list")["projects"] == []
+
+    # A profile-scoped call sees only the ray profile's project.
+    listing = _call("projects.list", {"profile": "ray"})
+    assert [p["slug"] for p in listing["projects"]] == ["ray-project"]
+
+    # The launch profile is untouched by the scoped call.
+    assert _call("projects.list")["projects"] == []
+
+    # A scoped call never writes into the launch profile's DB: create with the
+    # ray stamp lands in ray's projects.db only.
+    created = _call("projects.create", {"name": "Ray Two", "folders": [str(tmp_path / "ray-ws-2")], "profile": "ray"})
+    assert created["project"]["slug"] == "ray-two"
+    assert _call("projects.list")["projects"] == []
+    assert [p["slug"] for p in _call("projects.list", {"profile": "ray"})["projects"]] == [
+        "ray-project",
+        "ray-two",
+    ]
+
+
 def test_add_folder_and_for_cwd(tmp_path):
     folder = tmp_path / "repo"
     folder.mkdir()

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -20,23 +20,26 @@ _profile_scoped = _registry.profile_scoped
 def _(rid, params: dict) -> dict:
     """Repos for the desktop overview: scanned-from-disk (cached) ∪ session-derived."""
     try:
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"repos": []})
         from hermes_cli import projects_db as pdb
 
-        policy = _repo_discovery_policy()
-        policy_key = _repo_discovery_policy_key(policy)
-        with pdb.connect_closing() as conn:
-            pdb.reconcile_discovered_repos_policy(
-                conn,
-                policy_key,
-                preserve_unversioned=_repo_discovery_policy_is_default(policy),
-            )
-            repos = _discover_repos_payload(
-                db, conn=conn, include_cached=policy["enabled"]
-            )
-        return _ok(rid, {"repos": repos, "discovery_policy": policy})
+        profile = (params.get("profile") or "").strip() or None
+        home = _profile_home(profile)
+        db_path = Path(home) / "projects.db" if home is not None else None
+        with _profile_db(params) as db:
+            if db is None:
+                return _ok(rid, {"repos": []})
+            policy = _repo_discovery_policy()
+            policy_key = _repo_discovery_policy_key(policy)
+            with pdb.connect_closing(db_path=db_path) as conn:
+                pdb.reconcile_discovered_repos_policy(
+                    conn,
+                    policy_key,
+                    preserve_unversioned=_repo_discovery_policy_is_default(policy),
+                )
+                repos = _discover_repos_payload(
+                    db, conn=conn, include_cached=policy["enabled"]
+                )
+            return _ok(rid, {"repos": repos, "discovery_policy": policy})
     except Exception as e:
         return _err(rid, 5061, str(e))
 
@@ -49,6 +52,9 @@ def _(rid, params: dict) -> dict:
     try:
         from hermes_cli import projects_db as pdb
 
+        profile = (params.get("profile") or "").strip() or None
+        home = _profile_home(profile)
+        db_path = Path(home) / "projects.db" if home is not None else None
         policy = _repo_discovery_policy()
         policy_key = _repo_discovery_policy_key(policy)
         incoming_raw = params.get("discovery_policy")
@@ -72,7 +78,7 @@ def _(rid, params: dict) -> dict:
             elif isinstance(item, dict) and item.get("root"):
                 pairs.append((str(item["root"]), item.get("label")))
 
-        with pdb.connect_closing() as conn:
+        with pdb.connect_closing(db_path=db_path) as conn:
             pdb.reconcile_discovered_repos_policy(
                 conn,
                 policy_key,
@@ -88,19 +94,19 @@ def _(rid, params: dict) -> dict:
             elif not policy["enabled"]:
                 pdb.clear_discovered_repos(conn, policy_key=policy_key)
 
-        db = _get_db()
-        return _ok(
-            rid,
-            {
-                "repos": _discover_repos_payload(
-                    db, include_cached=policy["enabled"]
-                )
-                if db is not None
-                else [],
-                "accepted": accepted,
-                "discovery_policy": policy,
-            },
-        )
+        with _profile_db(params) as db:
+            return _ok(
+                rid,
+                {
+                    "repos": _discover_repos_payload(
+                        db, include_cached=policy["enabled"]
+                    )
+                    if db is not None
+                    else [],
+                    "accepted": accepted,
+                    "discovery_policy": policy,
+                },
+            )
     except Exception as e:
         return _err(rid, 5061, str(e))
 
@@ -113,21 +119,21 @@ def _(rid, params: dict) -> dict:
     Lanes carry no session rows here; drill-in uses ``projects.project_sessions``.
     """
     try:
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
+        with _profile_db(params) as db:
+            if db is None:
+                return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
 
-        tree, active_id = _build_project_tree(
-            db,
-            preview_limit=int(params.get("preview_limit") or 3),
-            hydrate=False,
-            session_limit=int(params.get("session_limit") or 2000),
-            include_discovered=True,
-        )
-        return _ok(
-            rid,
-            {"projects": tree["projects"], "active_id": active_id, "scoped_session_ids": tree["scoped_session_ids"]},
-        )
+            tree, active_id = _build_project_tree(
+                db,
+                preview_limit=int(params.get("preview_limit") or 3),
+                hydrate=False,
+                session_limit=int(params.get("session_limit") or 2000),
+                include_discovered=True,
+            )
+            return _ok(
+                rid,
+                {"projects": tree["projects"], "active_id": active_id, "scoped_session_ids": tree["scoped_session_ids"]},
+            )
     except Exception as e:
         return _err(rid, 5061, str(e))
 
@@ -142,18 +148,18 @@ def _(rid, params: dict) -> dict:
         if not project_id:
             return _err(rid, 5063, "project_id required")
 
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"project": None})
+        with _profile_db(params) as db:
+            if db is None:
+                return _ok(rid, {"project": None})
 
-        # Drill-in only needs the entered project (which has sessions), so skip
-        # the zero-session discovery tier entirely.
-        tree, _active = _build_project_tree(
-            db, preview_limit=0, hydrate=True, session_limit=int(params.get("session_limit") or 5000),
-            include_discovered=False,
-        )
-        proj = next((p for p in tree["projects"] if p["id"] == project_id), None)
-        return _ok(rid, {"project": proj})
+            # Drill-in only needs the entered project (which has sessions), so skip
+            # the zero-session discovery tier entirely.
+            tree, _active = _build_project_tree(
+                db, preview_limit=0, hydrate=True, session_limit=int(params.get("session_limit") or 5000),
+                include_discovered=False,
+            )
+            proj = next((p for p in tree["projects"] if p["id"] == project_id), None)
+            return _ok(rid, {"project": proj})
     except Exception as e:
         return _err(rid, 5061, str(e))
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12374,6 +12374,13 @@ def _projects_method(name: str):
     Every project CRUD handler opened the per-profile DB, mapped a missing id to
     5062, bad args to 5063, and everything else to 5061. This collapses that
     boilerplate so each handler is just its one meaningful operation.
+
+    Profile-scoped: in app-global remote mode the desktop serves every profile
+    from one backend, so ``params['profile']`` must select the owning profile's
+    ``projects.db`` — otherwise a Ray request silently reads the launch
+    (default) profile's Projects and the sidebar groups Ray sessions under
+    default Projects (RSS Dashboard / Emma General). The launch/own profile
+    keeps the existing unscoped path (no override, same DB).
     """
 
     def decorator(fn):
@@ -12382,7 +12389,10 @@ def _projects_method(name: str):
             try:
                 from hermes_cli import projects_db as pdb
 
-                with pdb.connect_closing() as conn:
+                profile = (params.get("profile") or "").strip() or None
+                home = _profile_home(profile)
+                db_path = Path(home) / "projects.db" if home is not None else None
+                with pdb.connect_closing(db_path=db_path) as conn:
                     return fn(rid, params, pdb, conn)
             except _NoProject:
                 return _err(rid, _E_NO_PROJECT, "no such project")


### PR DESCRIPTION
## Problem

In **app-global remote mode**, one dashboard backend serves every Hermes profile over a single WebSocket. The `projects.*` JSON-RPC handlers ignored `params['profile']` entirely and always opened the **launch (default) profile's** `projects.db` / `state.db`.

The desktop then grouped every profile's sessions using the default profile's Projects. Symptom (reported by user): sessions in the **Ray** profile appeared under default-profile Projects like **RSS Dashboard** and **Emma General**, even though Ray's own `projects.db` was empty.

### Evidence

- `hermes --profile ray project list` → "No projects yet"
- Ray `state.db` → 54 sessions with `cwd = NULL` (should land in the Home bucket), 1 with `cwd = /home/tom/workspaces/emma`
- Default `projects.db` → `rss-dashboard` + `emma-general`
- Desktop Project RPCs (`projects.list`, `projects.tree`, `projects.project_sessions`, `projects.record_repos`) sent **no** `profile` param

## Fix

**Backend** (`tui_gateway/`):

- `_projects_method` (CRUD + `projects.list`) now resolves the owning profile's `projects.db` via `_profile_home(profile)` from `params['profile']`.
- `projects.tree`, `projects.project_sessions`, `projects.record_repos`, `projects.discover_repos` now read the profile's `state.db` through the existing `_profile_db(params)` context manager and open the profile's `projects.db` through the scoped path.
- Launch/own profile (or omitted `profile`) keeps the existing unscoped path — same DB, no override.

**Desktop** (`apps/desktop/src/store/projects.ts`):

- Every `projects.*` request now stamps the active gateway profile (`projectRpc` / `projectRpcOn` helpers), so the shared backend can route it. Mirrors the existing pet-RPC helper pattern. The launch-profile stamp is a no-op on the backend.

## Tests

- Backend: `test_projects_rpc_is_profile_scoped` — seeds a named profile's `projects.db`, asserts `projects.list` with `profile` reads only that profile, and that scoped writes never land in the launch profile.
- Desktop: `projects RPC profile stamping` suite — asserts `projects.list`, `projects.tree`, `projects.project_sessions` carry the active profile.

Verification: `pytest tests/tui_gateway/test_projects_rpc.py` (24 passed), `pytest tests/test_tui_gateway_server.py` (585 passed), `vitest run src/store/projects.test.ts` (31 passed), `tsc -p tsconfig.json --noEmit` clean.