### PR TITLE
fix(desktop): stop duplicating active-gateway bots in the multi-source roster

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12504,10 +12504,17 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
 }
 
 ipcMain.handle('hermes:agents:roster', async () => {
-  const enumerations = await enumerateRegistryAgentSources()
+  const registry = readDesktopConnectionsRegistry()
+  const enumerations = await enumerateRegistryAgentSources(registry)
 
   return {
     agents: buildAgentRoster(enumerations),
+    // The active gateway owns the renderer's profiles.list — union agents
+    // that report THIS connection are the same identities, not extra rows.
+    // Expose the primary id so the plugin merger can annotate them in place
+    // instead of appending duplicates (remote-only desktops doubled every
+    // bot otherwise; see #88344).
+    primaryConnectionId: registry.primary,
     sources: enumerations.map(({ connection, profiles, error }) => ({
       connectionId: connection.id,
       label: connection.label,

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2073,14 +2073,16 @@ function useRoster() {
 }
 
 /** Merge the union agent roster (host.agents) over the active gateway's
- *  profiles.list. Local-source rows are matched by profile name and only
- *  ANNOTATED (handle, connectionId) — their rich fields stay authoritative.
- *  Rows from other sources become new roster entries tagged with their
- *  source label so BotRow can badge them and route open/warm through
+ *  profiles.list. Rows from the ACTIVE gateway (union.primaryConnectionId)
+ *  are matched by profile name and only ANNOTATED (handle, connectionId) —
+ *  their rich fields stay authoritative and they are NOT duplicated. Rows
+ *  from other sources become new roster entries tagged with their source
+ *  label so BotRow can badge them and route open/warm through
  *  ensureAgent/warmAgent. Pure — exercised directly by the tests. */
 function mergeMultiSourceRoster(local, union) {
   const profiles = Array.isArray(local?.profiles) ? local.profiles.slice() : []
   const agents = Array.isArray(union?.agents) ? union.agents : []
+  const primaryId = String(union?.primaryConnectionId || '').trim()
 
   if (!agents.length) {
     return { ...local, profiles }
@@ -2089,8 +2091,16 @@ function mergeMultiSourceRoster(local, union) {
   const localByName = new Map(profiles.map(p => [p.name, p]))
 
   for (const agent of agents) {
-    const isLocalSource = agent.connectionKind === 'local'
-    const row = isLocalSource ? localByName.get(agent.profile) : null
+    // The union enumerates EVERY registered connection, including the active
+    // gateway that already answered profiles.list. Without this the active
+    // gateway's own agents (connectionKind 'remote' on a remote-primary
+    // desktop) would be appended as phantom duplicates — every bot listed
+    // twice. Older Electron builds predate primaryConnectionId; fall back to
+    // the legacy local-source rule so single-source behavior stays intact.
+    const isPrimarySource = primaryId
+      ? String(agent.connectionId || '').trim() === primaryId
+      : agent.connectionKind === 'local'
+    const row = isPrimarySource ? localByName.get(agent.profile) : null
 
     if (row) {
       // Annotate in place: the @name-device handle only differs from the
@@ -2100,9 +2110,9 @@ function mergeMultiSourceRoster(local, union) {
       continue
     }
 
-    if (isLocalSource) {
-      // Union saw a local profile profiles.list didn't return (older
-      // backend mid-refresh) — skip rather than invent a thin row.
+    if (isPrimarySource) {
+      // Union saw a primary-source profile profiles.list didn't return
+      // (older backend mid-refresh) — skip rather than invent a thin row.
       continue
     }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -126,3 +126,62 @@ test('filterBots: matches the source device name for remote rows', () => {
   // Bare profile search keeps matching both rows.
   assert.equal(filterBots(roster, {}, 'research').length, 2)
 })
+
+test('merge: active-gateway union agents annotate local rows, not duplicates (remote-primary desktop)', () => {
+  const { __mergeMultiSourceRoster: merge } = runtime()
+  const local = {
+    profiles: [
+      { name: 'default', last_session: { id: 's-default' } },
+      { name: 'dev', last_session: { id: 's-dev' } }
+    ]
+  }
+  const union = {
+    primaryConnectionId: '10-244-108-128-9119',
+    agents: [
+      // The ACTIVE remote gateway itself — same identities as local, must
+      // annotate in place rather than append phantom duplicates (#88344).
+      { connectionId: '10-244-108-128-9119', connectionKind: 'remote', connectionLabel: '10.244.108.128:9119', profile: 'default', handle: 'default-10-244-108-128-9119' },
+      { connectionId: '10-244-108-128-9119', connectionKind: 'remote', connectionLabel: '10.244.108.128:9119', profile: 'dev', handle: 'dev' },
+      // A genuinely separate source with a same-named profile keeps its own row.
+      { connectionId: 'local', connectionKind: 'local', connectionLabel: 'This device', profile: 'default', handle: 'default-this-device' },
+      { connectionId: 'local', connectionKind: 'local', connectionLabel: 'This device', profile: 'agent-mentor', handle: 'agent-mentor' }
+    ]
+  }
+
+  const out = merge(local, union)
+  // 2 annotated local rows + 2 other-source rows = 4, NOT 6 (no phantom copies).
+  assert.equal(out.profiles.length, 4)
+
+  const defaultRow = out.profiles.find(p => p.name === 'default' && !p.remoteSource)
+  // Annotated with the ACTIVE gateway's handle; rich fields survive.
+  assert.equal(defaultRow.last_session.id, 's-default')
+  assert.equal(defaultRow.handle, 'default-10-244-108-128-9119')
+
+  // The same-named profile on the local device stays a separate tagged row.
+  const localDefault = out.profiles.find(p => p.name === 'default' && p.remoteSource)
+  assert.equal(localDefault.handle, 'default-this-device')
+  assert.equal(localDefault.connectionId, 'local')
+
+  const mentor = out.profiles.find(p => p.name === 'agent-mentor')
+  assert.equal(mentor.remoteSource, true)
+
+  // Exactly the two other-source rows are tagged remote; none from the active gateway.
+  assert.equal(out.profiles.filter(p => p.remoteSource).length, 2)
+})
+
+test('merge: primary-local desktop keeps single-source behavior (no phantom rows)', () => {
+  const { __mergeMultiSourceRoster: merge } = runtime()
+  const local = { profiles: [{ name: 'default' }, { name: 'dev' }] }
+  const union = {
+    primaryConnectionId: 'local',
+    agents: [
+      { connectionId: 'local', connectionKind: 'local', connectionLabel: 'This device', profile: 'default', handle: 'default-this-device' },
+      { connectionId: 'local', connectionKind: 'local', connectionLabel: 'This device', profile: 'dev', handle: 'dev' }
+    ]
+  }
+
+  const out = merge(local, union)
+  assert.equal(out.profiles.length, 2)
+  assert.equal(out.profiles.filter(p => p.remoteSource).length, 0)
+  assert.equal(out.profiles[0].handle, 'default-this-device')
+})


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop **BOTS** pane listing every bot **twice** (and more on each refetch) when the desktop's only backend is a **remote gateway** (#88344).

### Root cause

`useRoster()` merges two sources of truth:
- `local` = the **active gateway's** `profiles.list` (rich rows: ui_meta, last_session)
- `union` = `host.agents()` → `buildAgentRoster()`, which enumerates **every registered connection**, *including the active gateway itself*

`mergeMultiSourceRoster()` matched "rows that belong to the active gateway" with `agent.connectionKind === 'local'`. On a remote-primary desktop the active gateway reports `connectionKind: 'remote'`, so its own agents fell into the "other source" branch and were **appended as phantom duplicates** — every bot ×2 at baseline, and the roster kept accumulating copies across refetch/repaint cycles.

### Fix

- `hermes:agents:roster` now returns `primaryConnectionId` (the registry's primary, i.e. the connection that owns the active gateway).
- `mergeMultiSourceRoster()` matches union agents to the active gateway by `connectionId === primaryConnectionId` and **annotates the local rows in place** instead of appending duplicates.
- Same-named profiles on genuinely separate sources (This device, other remotes) still get their own tagged rows — the `@name-device` disambiguation rule is preserved.
- When `primaryConnectionId` is absent (older Electron builds), it falls back to the legacy `connectionKind === 'local'` rule, so single-source behavior stays byte-identical.

## Related Issue

Fixes #88344

Complementary to #88341 (dedupes *within* the union and reuses canonical chats; this PR dedupes the active gateway *across* the local/union boundary).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Tests
- [ ] Refactoring only

## How to Test

1. `node --test src/plugins/hermes-bots/tests/multi-source-roster.test.mjs` — 7 passed
2. `npm run check:test:plugins` — 151 passed
3. `npx vitest run electron/connection-registry.test.ts` — 43 passed

Manual scenario: remote-only desktop (e.g. connect Desktop to a headless gateway, no local profiles). Open BOTS → every bot appears **once**; interacting with the app no longer multiplies rows. A local source with the same profile name still shows as a separate `@name-device` row.

## Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove the regression and expected behavior.
- [x] Type checking passes (project-wide typecheck not run; change is additive and type-local — `registry.primary` already exists on the registry type).
- [x] I searched existing GitHub issues before opening the focused issue above.
- [x] I kept the change scoped to the BOTS roster merge boundary.
- [ ] I manually exercised the packaged Desktop UI (automated coverage only).
