### PR TITLE
fix(installer): retry transient failures when downloading install scripts

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/install_script.rs
+++ b/apps/bootstrap-installer/src-tauri/src/install_script.rs
@@ -322,6 +322,14 @@ fn upgrade_cached_script(kind: ScriptKind, cached: &Path, emit_log: &impl Fn(&st
 /// black-holed connection (captive portal, hung proxy, silently dropped
 /// packets) never errors — the whole bootstrap would hang here instead of
 /// falling back to the cached script.
+/// Transient HTTP statuses worth retrying: CDN/gateway hiccups (5xx) and
+/// rate-limit backpressure (429). A single raw.githubusercontent 503 once
+/// landed users on the fatal "INSTALL DIDN'T FINISH" screen during the
+/// beta→stable transition while the URL served 200 from elsewhere (#88475).
+fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+    status.as_u16() == 429 || status.is_server_error()
+}
+
 async fn download(kind: ScriptKind, commit_or_ref: &str, dest_path: &Path) -> Result<()> {
     let url = format!(
         "https://raw.githubusercontent.com/NousResearch/hermes-agent/{}/scripts/{}",
@@ -343,25 +351,66 @@ async fn download(kind: ScriptKind, commit_or_ref: &str, dest_path: &Path) -> Re
         format!("{ext}.tmp")
     });
 
-    let response = reqwest::Client::builder()
+    // raw.githubusercontent hiccups (503/502/429) are transient, but a single
+    // one of them used to abort the whole bootstrap and land the user on the
+    // fatal "INSTALL DIDN'T FINISH" screen while the URL served 200 from
+    // elsewhere (#88475). Retry the transient class — gateway/rate-limit
+    // statuses and network-level errors (connect/timeout/reset) — with a
+    // short backoff. Exhausting the attempts still returns Err, so the
+    // stale-cache fallback in `resolve()` keeps firing exactly as before.
+    let client = reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(10))
         .timeout(std::time::Duration::from_secs(60))
         .build()
-        .context("building download client")?
-        .get(&url)
-        .header("User-Agent", "hermes-setup/0.0.1")
-        .send()
-        .await
-        .with_context(|| format!("GET {url}"))?;
+        .context("building download client")?;
 
-    if !response.status().is_success() {
-        return Err(anyhow!(
-            "Failed to download {}: HTTP {} from {}",
-            kind.filename(),
-            response.status(),
-            url
-        ));
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut response: Option<reqwest::Response> = None;
+    let mut last_err: Option<anyhow::Error> = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        match client
+            .get(&url)
+            .header("User-Agent", "hermes-setup/0.0.1")
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                response = Some(resp);
+                break;
+            }
+            Ok(resp) if is_retryable_status(resp.status()) => {
+                last_err = Some(anyhow!(
+                    "Failed to download {}: HTTP {} from {}",
+                    kind.filename(),
+                    resp.status(),
+                    url
+                ));
+            }
+            Ok(resp) => {
+                // Non-transient client error (404, 403, …): retrying cannot
+                // change the answer — surface it immediately.
+                return Err(anyhow!(
+                    "Failed to download {}: HTTP {} from {}",
+                    kind.filename(),
+                    resp.status(),
+                    url
+                ));
+            }
+            Err(err) => {
+                last_err = Some(anyhow!("GET {url}: {err}"));
+            }
+        }
+        if attempt < MAX_ATTEMPTS {
+            tokio::time::sleep(std::time::Duration::from_secs(u64::from(attempt) * 2)).await;
+        }
     }
+    let response = match response {
+        Some(resp) => resp,
+        None => {
+            return Err(last_err
+                .expect("retry loop always records the last transient error"))
+        }
+    };
 
     let bytes = response
         .bytes()
@@ -394,6 +443,23 @@ async fn download(kind: ScriptKind, commit_or_ref: &str, dest_path: &Path) -> Re
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retryable_statuses_cover_gateway_hiccups_and_rate_limits() {
+        // #88475: the 503 that aborted a beta→stable bootstrap is in the
+        // transient class; definitive client errors are not.
+        assert!(is_retryable_status(reqwest::StatusCode::BAD_GATEWAY));
+        assert!(is_retryable_status(reqwest::StatusCode::SERVICE_UNAVAILABLE));
+        assert!(is_retryable_status(reqwest::StatusCode::GATEWAY_TIMEOUT));
+        assert!(is_retryable_status(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        ));
+        assert!(is_retryable_status(reqwest::StatusCode::TOO_MANY_REQUESTS));
+        assert!(!is_retryable_status(reqwest::StatusCode::NOT_FOUND));
+        assert!(!is_retryable_status(reqwest::StatusCode::FORBIDDEN));
+        assert!(!is_retryable_status(reqwest::StatusCode::UNAUTHORIZED));
+        assert!(!is_retryable_status(reqwest::StatusCode::OK));
+    }
 
     #[test]
     fn is_valid_commit_accepts_short_and_full_shas() {


### PR DESCRIPTION
## What does this PR do?

The bootstrap installer's `download()` made exactly one attempt to fetch the install scripts from raw.githubusercontent. A single transient CDN hiccup — the reporter hit `HTTP 503 Service Unavailable` during the desktop beta→stable transition while the same URL served 200 from elsewhere — aborted the whole bootstrap and landed the user on the fatal "INSTALL DIDN'T FINISH" screen (#88475).

This PR adds a bounded retry for the transient failure class: 5xx gateway statuses, 429 rate limits, and network-level send errors (connect/timeout/reset) are retried up to 3 attempts with a short linear backoff (2s, 4s). Definitive client errors (404, 403, …) still fail immediately — retrying cannot change that answer — and exhausting the attempts returns `Err` exactly as before, so the stale-cache fallback in `resolve()` keeps firing unchanged for genuinely unreachable hosts.

## Related Issue

Fixes #88475

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/bootstrap-installer/src-tauri/src/install_script.rs`: added `is_retryable_status()` (5xx + 429) and converted `download()`'s single-shot GET into a 3-attempt retry loop with linear backoff; non-retryable statuses surface immediately; attempt exhaustion preserves the original error format so the `resolve()` stale-cache fallback is untouched
- `apps/bootstrap-installer/src-tauri/src/install_script.rs` (tests): `retryable_statuses_cover_gateway_hiccups_and_rate_limits` pins the retry/not-retry boundary

## How to Test

1. `cargo test --lib install_script` (in `apps/bootstrap-installer/src-tauri`) — Observed result: 10 passed (9 pre-existing + 1 new), 0 failed.
2. `cargo clippy --lib` — Observed result: builds clean; the 4 warnings shown (needless_return at install_script.rs:157 / update.rs:753, dead_code `Bundled`, redundant_pattern_matching) are all pre-existing on main, none introduced by this change.
3. New test pins: 500/502/503/504 and 429 are retryable; 404/403/401 and 200 are not.
4. On the reporter's scenario (raw.githubusercontent 503 during a transition): the installer now retries twice and proceeds instead of fatal-ing to "INSTALL DIDN'T FINISH"; a genuinely down host still falls back to the cached script exactly as before.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `cargo test --lib install_script` (10 passed) and `cargo clippy --lib` (no new warnings)
- [x] I have added tests for my changes — the retry boundary is unit-tested; the loop itself needs a live flaky host, covered by the preserved error-path contract
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config or schemas changed; `is_retryable_status` and the loop carry comments with the #88475 incident reference and the fallback-contract note

## For New Skills

N/A

## Screenshots / Logs

```
$ cargo test --lib install_script
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 45 filtered out
```
