### PR TITLE
fix(install): retry transient GitHub raw failures for install.sh

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/install_script.rs
+++ b/apps/bootstrap-installer/src-tauri/src/install_script.rs
@@ -93,6 +93,34 @@ pub(crate) fn cache_plan(immutable: bool, cached_exists: bool) -> CachePlan {
     }
 }
 
+/// One try plus two retries. First-run installs have no stale cache, so a
+/// single GitHub raw 503 used to abort the whole beta-to-stable setup (#88475).
+const MAX_DOWNLOAD_ATTEMPTS: u32 = 3;
+
+/// GitHub raw / CDN blips we should swallow. 404/401/403 stay fatal.
+pub(crate) fn is_transient_script_http_status(code: u16) -> bool {
+    matches!(code, 408 | 429 | 500 | 502 | 503 | 504)
+}
+
+pub(crate) fn should_retry_script_download(
+    http_status: Option<u16>,
+    transport_error: bool,
+    attempt: u32,
+) -> bool {
+    if attempt >= MAX_DOWNLOAD_ATTEMPTS {
+        return false;
+    }
+    if transport_error {
+        return true;
+    }
+    http_status.is_some_and(is_transient_script_http_status)
+}
+
+fn download_backoff(attempt: u32) -> std::time::Duration {
+    let shift = attempt.saturating_sub(1).min(3);
+    std::time::Duration::from_millis(200 * (1u64 << shift))
+}
+
 /// Resolves the install script to use for this run.
 ///
 /// `pin` is the commit-or-branch from either Hermes-Setup's build-time
@@ -104,7 +132,9 @@ pub async fn resolve(
 ) -> Result<ResolvedScript> {
     // 1. Dev shortcut.
     if let Ok(repo_root) = std::env::var("HERMES_SETUP_DEV_REPO_ROOT") {
-        let candidate = PathBuf::from(repo_root).join("scripts").join(kind.filename());
+        let candidate = PathBuf::from(repo_root)
+            .join("scripts")
+            .join(kind.filename());
         if candidate.exists() {
             emit_log(&format!(
                 "[bootstrap] dev mode — using local {} at {}",
@@ -165,11 +195,7 @@ pub async fn resolve(
             emit_log(&format!(
                 "[bootstrap] downloading {} for {} {} from GitHub",
                 kind.filename(),
-                if immutable {
-                    "commit"
-                } else {
-                    "mutable ref"
-                },
+                if immutable { "commit" } else { "mutable ref" },
                 truncate_ref(&commit_or_ref)
             ));
 
@@ -330,9 +356,8 @@ async fn download(kind: ScriptKind, commit_or_ref: &str, dest_path: &Path) -> Re
     );
 
     if let Some(parent) = dest_path.parent() {
-        std::fs::create_dir_all(parent).with_context(|| {
-            format!("creating bootstrap-cache parent dir {}", parent.display())
-        })?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating bootstrap-cache parent dir {}", parent.display()))?;
     }
 
     let tmp_path = dest_path.with_extension({
@@ -343,49 +368,113 @@ async fn download(kind: ScriptKind, commit_or_ref: &str, dest_path: &Path) -> Re
         format!("{ext}.tmp")
     });
 
-    let response = reqwest::Client::builder()
+    let client = reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(10))
         .timeout(std::time::Duration::from_secs(60))
         .build()
-        .context("building download client")?
-        .get(&url)
+        .context("building download client")?;
+
+    let mut last_err: Option<anyhow::Error> = None;
+    for attempt in 1..=MAX_DOWNLOAD_ATTEMPTS {
+        match download_once(&client, kind, &url, &tmp_path, dest_path).await {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                let retry = should_retry_script_download(err.http_status, err.transport, attempt);
+                last_err = Some(err.err);
+                let _ = tokio::fs::remove_file(&tmp_path).await;
+                if !retry {
+                    break;
+                }
+                tokio::time::sleep(download_backoff(attempt)).await;
+            }
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| anyhow!("download failed")))
+}
+
+struct DownloadAttemptErr {
+    err: anyhow::Error,
+    http_status: Option<u16>,
+    transport: bool,
+}
+
+async fn download_once(
+    client: &reqwest::Client,
+    kind: ScriptKind,
+    url: &str,
+    tmp_path: &Path,
+    dest_path: &Path,
+) -> Result<(), DownloadAttemptErr> {
+    let response = match client
+        .get(url)
         .header("User-Agent", "hermes-setup/0.0.1")
         .send()
         .await
-        .with_context(|| format!("GET {url}"))?;
+    {
+        Ok(response) => response,
+        Err(err) => {
+            let transport = err.is_timeout() || err.is_connect() || err.is_request();
+            return Err(DownloadAttemptErr {
+                err: anyhow!(err).context(format!("GET {url}")),
+                http_status: None,
+                transport,
+            });
+        }
+    };
 
     if !response.status().is_success() {
-        return Err(anyhow!(
-            "Failed to download {}: HTTP {} from {}",
-            kind.filename(),
-            response.status(),
-            url
-        ));
+        let http_status = response.status().as_u16();
+        return Err(DownloadAttemptErr {
+            err: anyhow!(
+                "Failed to download {}: HTTP {} from {}",
+                kind.filename(),
+                response.status(),
+                url
+            ),
+            http_status: Some(http_status),
+            transport: false,
+        });
     }
 
-    let bytes = response
-        .bytes()
-        .await
-        .with_context(|| format!("reading body of {url}"))?;
+    let bytes = response.bytes().await.map_err(|err| DownloadAttemptErr {
+        transport: err.is_timeout() || err.is_connect() || err.is_request(),
+        err: anyhow!(err).context(format!("reading body of {url}")),
+        http_status: None,
+    })?;
     let bytes = prepare_cached_script_bytes(kind, &bytes);
 
-    let mut file = tokio::fs::File::create(&tmp_path)
+    let mut file = tokio::fs::File::create(tmp_path)
         .await
-        .with_context(|| format!("creating temp file {}", tmp_path.display()))?;
+        .map_err(|err| DownloadAttemptErr {
+            err: anyhow!(err).context(format!("creating temp file {}", tmp_path.display())),
+            http_status: None,
+            transport: false,
+        })?;
     file.write_all(&bytes)
         .await
-        .with_context(|| format!("writing temp file {}", tmp_path.display()))?;
-    file.flush().await.context("flushing temp file")?;
+        .map_err(|err| DownloadAttemptErr {
+            err: anyhow!(err).context(format!("writing temp file {}", tmp_path.display())),
+            http_status: None,
+            transport: false,
+        })?;
+    file.flush().await.map_err(|err| DownloadAttemptErr {
+        err: anyhow!(err).context("flushing temp file"),
+        http_status: None,
+        transport: false,
+    })?;
     drop(file);
 
-    tokio::fs::rename(&tmp_path, dest_path)
+    tokio::fs::rename(tmp_path, dest_path)
         .await
-        .with_context(|| {
-            format!(
+        .map_err(|err| DownloadAttemptErr {
+            err: anyhow!(err).context(format!(
                 "renaming {} → {}",
                 tmp_path.display(),
                 dest_path.display()
-            )
+            )),
+            http_status: None,
+            transport: false,
         })?;
 
     Ok(())
@@ -414,7 +503,10 @@ mod tests {
     #[test]
     fn prepare_cached_ps1_prefixes_utf8_bom() {
         let out = prepare_cached_script_bytes(ScriptKind::Ps1, b"Write-Host hi\n");
-        assert!(out.starts_with(UTF8_BOM), "cached .ps1 must start with UTF-8 BOM");
+        assert!(
+            out.starts_with(UTF8_BOM),
+            "cached .ps1 must start with UTF-8 BOM"
+        );
         assert_eq!(&out[UTF8_BOM.len()..], b"Write-Host hi\n");
     }
 
@@ -463,6 +555,41 @@ mod tests {
             cache_plan(/*immutable=*/ true, /*cached_exists=*/ false),
             CachePlan::Fetch { stale_ok: false }
         );
+    }
+
+    #[test]
+    fn transient_script_http_statuses_are_the_cdn_blips() {
+        for code in [408, 429, 500, 502, 503, 504] {
+            assert!(is_transient_script_http_status(code), "{code} should retry");
+        }
+        for code in [200, 301, 400, 401, 403, 404, 410] {
+            assert!(
+                !is_transient_script_http_status(code),
+                "{code} must stay fatal"
+            );
+        }
+    }
+
+    #[test]
+    fn script_download_retries_are_bounded_and_skip_404() {
+        assert!(should_retry_script_download(Some(503), false, 1));
+        assert!(should_retry_script_download(Some(502), false, 2));
+        assert!(
+            !should_retry_script_download(Some(503), false, MAX_DOWNLOAD_ATTEMPTS),
+            "third failure is terminal"
+        );
+        assert!(
+            !should_retry_script_download(Some(404), false, 1),
+            "missing ref must not burn retries"
+        );
+        assert!(!should_retry_script_download(Some(401), false, 1));
+        assert!(should_retry_script_download(None, true, 1));
+        assert!(!should_retry_script_download(
+            None,
+            true,
+            MAX_DOWNLOAD_ATTEMPTS
+        ));
+        assert!(!should_retry_script_download(None, false, 1));
     }
 
     #[test]

--- a/apps/desktop/electron/bootstrap-runner.test.ts
+++ b/apps/desktop/electron/bootstrap-runner.test.ts
@@ -13,9 +13,11 @@ import {
   installedAgentInstallScript,
   installRefForStamp,
   isPinnedCommit,
+  isTransientInstallScriptHttpStatus,
   resolveInstallScript,
   resolveMarkerPinnedCommit,
-  runBootstrap
+  runBootstrap,
+  shouldRetryInstallScriptDownload
 } from './bootstrap-runner'
 
 const SCRIPT_NAME = process.platform === 'win32' ? 'install.ps1' : 'install.sh'
@@ -271,4 +273,28 @@ test('resolveInstallScript rethrows when the 404 fallback is unavailable', async
   } finally {
     fs.rmSync(home, { recursive: true, force: true })
   }
+})
+
+test('isTransientInstallScriptHttpStatus retries CDN blips only', () => {
+  for (const status of [408, 429, 500, 502, 503, 504]) {
+    assert.equal(isTransientInstallScriptHttpStatus(status), true, String(status))
+  }
+
+  for (const status of [200, 301, 400, 401, 403, 404, 410]) {
+    assert.equal(isTransientInstallScriptHttpStatus(status), false, String(status))
+  }
+})
+
+test('shouldRetryInstallScriptDownload is bounded and skips 404', () => {
+  assert.equal(shouldRetryInstallScriptDownload(new Error('Failed to download install.sh: HTTP 503 from url'), 1), true)
+  assert.equal(shouldRetryInstallScriptDownload(new Error('Failed to download install.sh: HTTP 502 from url'), 2), true)
+  assert.equal(shouldRetryInstallScriptDownload(new Error('Failed to download install.sh: HTTP 503 from url'), 3), false)
+  assert.equal(shouldRetryInstallScriptDownload(new Error('Failed to download install.sh: HTTP 404 from url'), 1), false)
+  assert.equal(shouldRetryInstallScriptDownload(new Error('Failed to download install.sh: HTTP 401 from url'), 1), false)
+
+  const reset = new Error('socket hang up')
+  reset.code = 'ECONNRESET'
+  assert.equal(shouldRetryInstallScriptDownload(reset, 1), true)
+  assert.equal(shouldRetryInstallScriptDownload(reset, 3), false)
+  assert.equal(shouldRetryInstallScriptDownload(new Error('disk full'), 1), false)
 })

--- a/apps/desktop/electron/bootstrap-runner.test.ts
+++ b/apps/desktop/electron/bootstrap-runner.test.ts
@@ -292,8 +292,7 @@ test('shouldRetryInstallScriptDownload is bounded and skips 404', () => {
   assert.equal(shouldRetryInstallScriptDownload(new Error('Failed to download install.sh: HTTP 404 from url'), 1), false)
   assert.equal(shouldRetryInstallScriptDownload(new Error('Failed to download install.sh: HTTP 401 from url'), 1), false)
 
-  const reset = new Error('socket hang up')
-  reset.code = 'ECONNRESET'
+  const reset = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })
   assert.equal(shouldRetryInstallScriptDownload(reset, 1), true)
   assert.equal(shouldRetryInstallScriptDownload(reset, 3), false)
   assert.equal(shouldRetryInstallScriptDownload(new Error('disk full'), 1), false)

--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -240,7 +240,7 @@ function httpStatusFromDownloadError(err) {
 }
 
 function isTransientInstallScriptTransport(err) {
-  const code = err && err.code
+  const code = err && typeof err === 'object' && 'code' in err ? err.code : undefined
 
   return (
     code === 'EAI_AGAIN' ||

--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -227,7 +227,73 @@ function cachedScriptPath(hermesHome, commit) {
   return path.join(bootstrapCacheDir(hermesHome), `install-${commit}.${process.platform === 'win32' ? 'ps1' : 'sh'}`)
 }
 
+const MAX_DOWNLOAD_ATTEMPTS = 3
+
+function isTransientInstallScriptHttpStatus(status) {
+  return status === 408 || status === 429 || status === 500 || status === 502 || status === 503 || status === 504
+}
+
+function httpStatusFromDownloadError(err) {
+  const match = /HTTP (\d{3})\b/.exec(String(err && err.message ? err.message : err))
+
+  return match ? Number(match[1]) : null
+}
+
+function isTransientInstallScriptTransport(err) {
+  const code = err && err.code
+
+  return (
+    code === 'EAI_AGAIN' ||
+    code === 'ECONNREFUSED' ||
+    code === 'ECONNRESET' ||
+    code === 'ENETUNREACH' ||
+    code === 'ENOTFOUND' ||
+    code === 'EPIPE' ||
+    code === 'ETIMEDOUT'
+  )
+}
+
+function shouldRetryInstallScriptDownload(err, attempt) {
+  if (attempt >= MAX_DOWNLOAD_ATTEMPTS) {
+    return false
+  }
+
+  const status = httpStatusFromDownloadError(err)
+
+  if (status !== null) {
+    return isTransientInstallScriptHttpStatus(status)
+  }
+
+  return isTransientInstallScriptTransport(err)
+}
+
+function downloadBackoffMs(attempt) {
+  return 200 * 2 ** Math.min(attempt - 1, 3)
+}
+
 function downloadInstallScript(ref, destPath) {
+  return (async () => {
+    let lastError
+
+    for (let attempt = 1; attempt <= MAX_DOWNLOAD_ATTEMPTS; attempt += 1) {
+      try {
+        return await downloadInstallScriptOnce(ref, destPath)
+      } catch (err) {
+        lastError = err
+
+        if (!shouldRetryInstallScriptDownload(err, attempt)) {
+          throw err
+        }
+
+        await new Promise(resolve => setTimeout(resolve, downloadBackoffMs(attempt)))
+      }
+    }
+
+    throw lastError
+  })()
+}
+
+function downloadInstallScriptOnce(ref, destPath) {
   // Fetch from GitHub raw at the install ref. Normal production builds pass a
   // pinned SHA (immutable). Non-git fallback builds pass an unpinned branch
   // ref so local builds can still bootstrap without pretending the all-zero
@@ -1027,11 +1093,13 @@ export {
   installedAgentInstallScript,
   installRefForStamp,
   isPinnedCommit,
+  isTransientInstallScriptHttpStatus,
   // Exposed for testability
   parseStageResult,
   resolveCheckoutHead,
   resolveInstallScript,
   resolveLocalInstallScript,
   resolveMarkerPinnedCommit,
-  runBootstrap
+  runBootstrap,
+  shouldRetryInstallScriptDownload
 }


### PR DESCRIPTION
## What does this PR do?

A transient GitHub raw 503 during beta-to-stable setup aborted the whole install
because both downloaders tried the script URL once. First-run installs have no
stale cache to fall back to, so the user landed on INSTALL DIDN'T FINISH.

Retry 503/502/429/408/5xx and transport resets up to three attempts in the
Tauri setup downloader and the desktop `bootstrap-runner` path it mirrors.
404/401/403 stay fatal so a bad pin still fails immediately. Mutable-ref
stale-cache fallback is unchanged: it still only runs after the download
returns `Err`.

## Related Issue

Fixes #88475

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/bootstrap-installer/src-tauri/src/install_script.rs`: bounded retry around `download()`, plus `is_transient_script_http_status` / `should_retry_script_download` tests
- `apps/desktop/electron/bootstrap-runner.ts`: same policy around `downloadInstallScript`
- `apps/desktop/electron/bootstrap-runner.test.ts`: CDN-blip vs 404/401 coverage

## How to Test

1. Predicate tests (local):

```text
cd apps/desktop
vitest run --project electron electron/bootstrap-runner.test.ts
# 13 passed (2 new)
```

2. Rust unit tests live in `install_script.rs` (`transient_script_http_statuses_are_the_cdn_blips`, `script_download_retries_are_bounded_and_skip_404`). I could not `cargo test` the Tauri crate here (missing `libdbus-1-dev`); CI should run them.

3. No live GitHub-raw 503 was injected against a real installer run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (electron vitest + rustc of the retry predicates)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
