### PR TITLE
feat(cron): back off repeated failure alerts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -7198,7 +7198,19 @@ def _run_one_job_body(
             )
             unresolved_origin = False
             try:
-                failure_alert = _prepare_cron_failure_alert(job, _err_text)
+                drift_skip_error = "[drift_skip" in _err_text.lower()
+                if drift_skip_error:
+                    _drift_text = re.sub(
+                        r"\[drift_skip[^\]]*\]\s*", "", _err_text
+                    ).strip()
+                    failure_alert = (
+                        f"⚠️ Cron '{job.get('name') or job['id']}' skipped: "
+                        f"{_drift_text}"
+                    )
+                elif _cron_failure_backoff_enabled():
+                    failure_alert = _prepare_cron_failure_alert(job, _err_text)
+                else:
+                    failure_alert = _summarize_cron_failure_for_delivery(job, _err_text)
                 if failure_alert:
                     failure_alert += _failure_streak_nudge(job)
                     delivery_attempted = True
@@ -7208,7 +7220,11 @@ def _run_one_job_body(
                         adapters=adapters,
                         loop=loop,
                     )
-                    if not delivery_error and failure_alert:
+                    if (
+                        not delivery_error
+                        and not drift_skip_error
+                        and _cron_failure_backoff_enabled()
+                    ):
                         _confirm_cron_failure_alert(job)
             except Exception as delivery_exc:
                 delivery_error = str(delivery_exc)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -14,6 +14,7 @@ import concurrent.futures
 import contextlib
 import contextvars
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -544,6 +545,7 @@ from cron.jobs import (
     heartbeat_run_claim,
     mark_job_run,
     save_job_output,
+    update_job,
     use_cron_store,
 )
 from cron.executions import create_execution, finish_execution, mark_execution_running
@@ -552,6 +554,64 @@ from cron.executions import create_execution, finish_execution, mark_execution_r
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
+
+_CRON_FAILURE_ALERT_INTERVAL_SECONDS = 24 * 60 * 60
+
+
+def _cron_failure_signature(error: str | None) -> str:
+    """Return a stable signature for repeated failures.
+
+    Dynamic ids and numbers are normalized so provider request ids, ports and
+    retry counters do not turn one persistent failure into a new alert.
+    """
+    text = re.sub(r"\b[0-9a-f]{8,}\b", "<id>", (error or "unknown error").lower())
+    text = re.sub(r"\d+", "<n>", text)
+    return hashlib.sha256(text[:2000].encode("utf-8", errors="replace")).hexdigest()
+
+
+def _prepare_cron_failure_alert(job: dict, error: str | None) -> str | None:
+    """Record a failure and suppress repeated alerts for 24 hours.
+
+    The first failure is delivered immediately. Repeated failures with the
+    same normalized signature are persisted but suppressed until the daily
+    reminder interval elapses. A changed failure signature alerts immediately.
+    """
+    now = time.time()
+    signature = _cron_failure_signature(error)
+    previous = job.get("failure_alert")
+    if not isinstance(previous, dict):
+        previous = {}
+    same = previous.get("signature") == signature
+    consecutive = int(previous.get("consecutive", 0) or 0) + 1 if same else 1
+    suppressed = int(previous.get("suppressed", 0) or 0) if same else 0
+    last_notified = float(previous.get("last_notified", 0) or 0) if same else 0
+    should_notify = not same or not last_notified or now - last_notified >= _CRON_FAILURE_ALERT_INTERVAL_SECONDS
+    if not should_notify:
+        suppressed += 1
+    state = {
+        "signature": signature,
+        "consecutive": consecutive,
+        "suppressed": suppressed,
+        "last_notified": now if should_notify else last_notified,
+    }
+    update_job(job["id"], {"failure_alert": state})
+    if not should_notify:
+        return None
+    message = _summarize_cron_failure_for_delivery(job, error)
+    if suppressed:
+        message += f" ({suppressed} repeated failure(s) suppressed.)"
+    return message
+
+
+def _cron_recovery_notice(job: dict) -> str | None:
+    """Return a one-time recovery notice when a job becomes healthy again."""
+    state = job.get("failure_alert")
+    if not isinstance(state, dict) or not state.get("consecutive"):
+        return None
+    return (
+        f"✅ Cron '{job.get('name') or job.get('id')}' recovered after "
+        f"{int(state.get('consecutive', 0))} consecutive failure(s)."
+    )
 
 # Canonical silence tokens recognized in cron output.  Cron's contract is
 # intentionally looser than the gateway's exact-whole-response rule: the cron
@@ -6848,6 +6908,7 @@ def _run_one_job_body(
             # operator was already told on a previous tick, so re-delivering
             # the same alert every tick would be spam (#73506 alert-once
             # shape).
+            recovery_notice = _cron_recovery_notice(job) if success else None
             blocked_config_silent = (
                 bool(error) and BLOCKED_CONFIG_SILENT_MARKER in str(error)
             )
@@ -6879,26 +6940,35 @@ def _run_one_job_body(
                     "the configuration is fixed."
                 )
             else:
-                deliver_content = final_response if success else (
-                    _summarize_cron_failure_for_delivery(job, error)
-                    + _failure_streak_nudge(job)
-                )
-                if drift_skip and not success:
-                    # Drift-skip alert: bypass the generic summarizer's
-                    # 180-char truncation (it would eat the remediation
-                    # command) and strip the internal marker — deliver the
-                    # guard's own actionable message intact.
-                    _drift_text = re.sub(
-                        r"\[drift_skip[^\]]*\]\s*", "", str(error)
-                    ).strip()
-                    deliver_content = (
-                        f"⚠️ Cron '{job.get('name') or job['id']}' skipped: "
-                        f"{_drift_text}"
-                    )
+                if success:
+                    deliver_content = final_response
+                    if recovery_notice:
+                        deliver_content = recovery_notice + (
+                            f"\n\n{final_response}" if final_response and final_response.strip() else ""
+                        )
+                else:
+                    if drift_skip:
+                        # Drift-skip has its own persisted alert-once contract.
+                        _drift_text = re.sub(
+                            r"\[drift_skip[^\]]*\]\s*", "", str(error)
+                        ).strip()
+                        deliver_content = (
+                            f"⚠️ Cron '{job.get('name') or job['id']}' skipped: "
+                            f"{_drift_text}"
+                        )
+                    elif _cron_failure_backoff_enabled():
+                        deliver_content = _prepare_cron_failure_alert(job, error) or ""
+                        if deliver_content:
+                            deliver_content += _failure_streak_nudge(job)
+                    else:
+                        deliver_content = (
+                            _summarize_cron_failure_for_delivery(job, error)
+                            + _failure_streak_nudge(job)
+                        )
             # Treat whitespace-only final responses the same as empty
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.
-            should_deliver = bool(deliver_content.strip())
+            should_deliver = bool((deliver_content or "").strip())
             if blocked_config_silent or drift_skip_silent:
                 should_deliver = False
             unresolved_origin = False
@@ -6994,7 +7064,6 @@ def _run_one_job_body(
                 # time for one run would skip a fire or auto-delete the job
                 # early.
                 try:
-                    from cron.jobs import update_job
                     update_job(job["id"], {"last_delivery_error": delivery_error})
                 except Exception as _rec_err:
                     logger.debug(
@@ -7014,6 +7083,8 @@ def _run_one_job_body(
         if blocked_config:
             mark_kwargs["status"] = "blocked_config"
         marked = mark_job_run(job["id"], success, error, **mark_kwargs)
+        if success and recovery_notice and not delivery_error:
+            update_job(job["id"], {"failure_alert": None})
         if fire_owner is not None and not marked:
             finish_execution(
                 execution_id,
@@ -7067,29 +7138,27 @@ def _run_one_job_body(
             )
             unresolved_origin = False
             try:
-                delivery_attempted = True
-                delivery_error = _deliver_result(
-                    job,
-                    # Composed exactly like the normal failure delivery above.
-                    # mark_job_run below records THIS run in failure_streak
-                    # whichever layer failed, so a job that fails before the
-                    # run body every tick builds a streak nobody is ever told
-                    # about: its alerts only ever leave through here, and the
-                    # nudge only ever left through there (#88655).
-                    _summarize_cron_failure_for_delivery(job, _err_text)
-                    + _failure_streak_nudge(job),
-                    adapters=adapters,
-                    loop=loop,
-                )
+                failure_alert = _prepare_cron_failure_alert(job, _err_text)
+                if failure_alert:
+                    failure_alert += _failure_streak_nudge(job)
+                    delivery_attempted = True
+                    delivery_error = _deliver_result(
+                        job,
+                        failure_alert,
+                        adapters=adapters,
+                        loop=loop,
+                    )
             except Exception as delivery_exc:
                 delivery_error = str(delivery_exc)
                 logger.error(
                     "Delivery failed for job %s: %s", job["id"], delivery_exc
                 )
-            if not delivery_error and normalized_deliver == "origin":
+            if delivery_attempted and not delivery_error and normalized_deliver == "origin":
                 unresolved_origin = not _resolve_delivery_targets(job)
             if delivery_error:
                 delivery_outcome = "failed"
+            elif not delivery_attempted:
+                delivery_outcome = "suppressed"
             elif unresolved_origin:
                 delivery_outcome = "not_configured"
             elif normalized_deliver != "local":

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -582,9 +582,18 @@ def _prepare_cron_failure_alert(job: dict, error: str | None) -> str | None:
     if not isinstance(previous, dict):
         previous = {}
     same = previous.get("signature") == signature
-    consecutive = int(previous.get("consecutive", 0) or 0) + 1 if same else 1
-    suppressed = int(previous.get("suppressed", 0) or 0) if same else 0
-    last_notified = float(previous.get("last_notified", 0) or 0) if same else 0
+    try:
+        consecutive = int(previous.get("consecutive", 0) or 0) + 1 if same else 1
+    except (TypeError, ValueError):
+        consecutive = 1
+    try:
+        suppressed = int(previous.get("suppressed", 0) or 0) if same else 0
+    except (TypeError, ValueError):
+        suppressed = 0
+    try:
+        last_notified = float(previous.get("last_notified", 0) or 0) if same else 0
+    except (TypeError, ValueError):
+        last_notified = 0
     should_notify = not same or not last_notified or now - last_notified >= _CRON_FAILURE_ALERT_INTERVAL_SECONDS
     if not should_notify:
         suppressed += 1
@@ -594,7 +603,12 @@ def _prepare_cron_failure_alert(job: dict, error: str | None) -> str | None:
         "suppressed": suppressed,
         "last_notified": now if should_notify else last_notified,
     }
-    update_job(job["id"], {"failure_alert": state})
+    try:
+        update_job(job["id"], {"failure_alert": state})
+    except Exception:
+        # Alert bookkeeping must never turn the original cron failure into a
+        # scheduler failure. The next run can retry the state write.
+        logger.debug("Could not persist failure-alert state for %s", job.get("id"), exc_info=True)
     if not should_notify:
         return None
     message = _summarize_cron_failure_for_delivery(job, error)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -594,7 +594,12 @@ def _prepare_cron_failure_alert(job: dict, error: str | None) -> str | None:
         last_notified = float(previous.get("last_notified", 0) or 0) if same else 0
     except (TypeError, ValueError):
         last_notified = 0
-    should_notify = not same or not last_notified or now - last_notified >= _CRON_FAILURE_ALERT_INTERVAL_SECONDS
+    should_notify = (
+        not same
+        or bool(previous.get("pending"))
+        or not last_notified
+        or now - last_notified >= _CRON_FAILURE_ALERT_INTERVAL_SECONDS
+    )
     if not should_notify:
         suppressed += 1
     state = {
@@ -602,7 +607,9 @@ def _prepare_cron_failure_alert(job: dict, error: str | None) -> str | None:
         "consecutive": consecutive,
         "suppressed": suppressed,
         "last_notified": now if should_notify else last_notified,
+        "pending": should_notify,
     }
+    job["failure_alert"] = state
     try:
         update_job(job["id"], {"failure_alert": state})
     except Exception:
@@ -617,6 +624,21 @@ def _prepare_cron_failure_alert(job: dict, error: str | None) -> str | None:
     return message
 
 
+def _confirm_cron_failure_alert(job: dict) -> None:
+    """Mark a failure alert delivered after the transport confirms success."""
+    state = job.get("failure_alert")
+    if not isinstance(state, dict) or not state.get("pending"):
+        return
+    state = dict(state)
+    state["last_notified"] = time.time()
+    state["pending"] = False
+    job["failure_alert"] = state
+    try:
+        update_job(job["id"], {"failure_alert": state})
+    except Exception:
+        logger.debug("Could not confirm failure-alert state for %s", job.get("id"), exc_info=True)
+
+
 def _cron_recovery_notice(job: dict) -> str | None:
     """Return a one-time recovery notice when a job becomes healthy again."""
     state = job.get("failure_alert")
@@ -626,6 +648,17 @@ def _cron_recovery_notice(job: dict) -> str | None:
         f"✅ Cron '{job.get('name') or job.get('id')}' recovered after "
         f"{int(state.get('consecutive', 0))} consecutive failure(s)."
     )
+
+
+def _cron_failure_backoff_enabled() -> bool:
+    """Respect the existing ``cron.preflight: false`` compatibility opt-out."""
+    try:
+        from hermes_cli.config import read_user_config_raw
+        path = _get_hermes_home() / "config.yaml"
+        cfg = read_user_config_raw(path) if path.exists() else {}
+        return _cron_preflight_enabled(cfg)
+    except Exception:
+        return True
 
 # Canonical silence tokens recognized in cron output.  Cron's contract is
 # intentionally looser than the gateway's exact-whole-response rule: the cron
@@ -6922,7 +6955,11 @@ def _run_one_job_body(
             # operator was already told on a previous tick, so re-delivering
             # the same alert every tick would be spam (#73506 alert-once
             # shape).
-            recovery_notice = _cron_recovery_notice(job) if success else None
+            recovery_notice = (
+                _cron_recovery_notice(job)
+                if success and _cron_failure_backoff_enabled()
+                else None
+            )
             blocked_config_silent = (
                 bool(error) and BLOCKED_CONFIG_SILENT_MARKER in str(error)
             )
@@ -6975,6 +7012,8 @@ def _run_one_job_body(
                         if deliver_content:
                             deliver_content += _failure_streak_nudge(job)
                     else:
+                        # Preserve the documented preflight opt-out: repeated
+                        # failures continue to alert on every run.
                         deliver_content = (
                             _summarize_cron_failure_for_delivery(job, error)
                             + _failure_streak_nudge(job)
@@ -7019,6 +7058,13 @@ def _run_one_job_body(
                             adapters=adapters,
                             loop=loop,
                         )
+                        if (
+                            not delivery_error
+                            and not success
+                            and not drift_skip
+                            and _cron_failure_backoff_enabled()
+                        ):
+                            _confirm_cron_failure_alert(job)
                 except Exception as de:
                     if isinstance(de, _FireClaimLostDuringSideEffect):
                         raise
@@ -7162,6 +7208,8 @@ def _run_one_job_body(
                         adapters=adapters,
                         loop=loop,
                     )
+                    if not delivery_error and failure_alert:
+                        _confirm_cron_failure_alert(job)
             except Exception as delivery_exc:
                 delivery_error = str(delivery_exc)
                 logger.error(

--- a/tests/cron/test_cron_failure_backoff.py
+++ b/tests/cron/test_cron_failure_backoff.py
@@ -11,7 +11,7 @@ def test_first_failure_alerts_and_repeated_failure_is_suppressed(monkeypatch):
 
     first = scheduler._prepare_cron_failure_alert(job, "provider timeout request 12345678")
     assert first is not None
-    job["failure_alert"] = persisted[-1]["failure_alert"]
+    scheduler._confirm_cron_failure_alert(job)
 
     repeated = scheduler._prepare_cron_failure_alert(job, "provider timeout request 87654321")
     assert repeated is None
@@ -26,7 +26,7 @@ def test_repeated_failure_gets_daily_reminder(monkeypatch):
     monkeypatch.setattr(scheduler.time, "time", lambda: now[0])
 
     assert scheduler._prepare_cron_failure_alert(job, "provider timeout") is not None
-    job["failure_alert"] = persisted[-1]["failure_alert"]
+    scheduler._confirm_cron_failure_alert(job)
     assert scheduler._prepare_cron_failure_alert(job, "provider timeout") is None
     job["failure_alert"] = persisted[-1]["failure_alert"]
 
@@ -34,6 +34,19 @@ def test_repeated_failure_gets_daily_reminder(monkeypatch):
     reminder = scheduler._prepare_cron_failure_alert(job, "provider timeout")
     assert reminder is not None
     assert "1 repeated failure(s) suppressed" in reminder
+
+
+def test_failed_delivery_is_retried_on_the_next_failure(monkeypatch):
+    job = {"id": "job-1", "name": "Example"}
+    persisted = []
+    monkeypatch.setattr(scheduler, "update_job", lambda _id, values: persisted.append(values))
+    monkeypatch.setattr(scheduler.time, "time", lambda: 1000.0)
+
+    assert scheduler._prepare_cron_failure_alert(job, "provider timeout") is not None
+    # No _confirm_cron_failure_alert call: the transport failed.
+    retry = scheduler._prepare_cron_failure_alert(job, "provider timeout")
+    assert retry is not None
+    assert persisted[-1]["failure_alert"]["pending"] is True
 
 
 def test_recovery_notice_reports_and_clears_after_success(monkeypatch):

--- a/tests/cron/test_cron_failure_backoff.py
+++ b/tests/cron/test_cron_failure_backoff.py
@@ -1,0 +1,47 @@
+"""Failure-alert backoff and recovery notifications for recurring cron jobs."""
+
+from cron import scheduler
+
+
+def test_first_failure_alerts_and_repeated_failure_is_suppressed(monkeypatch):
+    job = {"id": "job-1", "name": "Example"}
+    persisted = []
+    monkeypatch.setattr(scheduler, "update_job", lambda _id, values: persisted.append(values))
+    monkeypatch.setattr(scheduler.time, "time", lambda: 1000.0)
+
+    first = scheduler._prepare_cron_failure_alert(job, "provider timeout request 12345678")
+    assert first is not None
+    job["failure_alert"] = persisted[-1]["failure_alert"]
+
+    repeated = scheduler._prepare_cron_failure_alert(job, "provider timeout request 87654321")
+    assert repeated is None
+    assert persisted[-1]["failure_alert"]["suppressed"] == 1
+
+
+def test_repeated_failure_gets_daily_reminder(monkeypatch):
+    job = {"id": "job-1", "name": "Example"}
+    persisted = []
+    monkeypatch.setattr(scheduler, "update_job", lambda _id, values: persisted.append(values))
+    now = [1000.0]
+    monkeypatch.setattr(scheduler.time, "time", lambda: now[0])
+
+    assert scheduler._prepare_cron_failure_alert(job, "provider timeout") is not None
+    job["failure_alert"] = persisted[-1]["failure_alert"]
+    assert scheduler._prepare_cron_failure_alert(job, "provider timeout") is None
+    job["failure_alert"] = persisted[-1]["failure_alert"]
+
+    now[0] += 24 * 60 * 60
+    reminder = scheduler._prepare_cron_failure_alert(job, "provider timeout")
+    assert reminder is not None
+    assert "1 repeated failure(s) suppressed" in reminder
+
+
+def test_recovery_notice_reports_and_clears_after_success(monkeypatch):
+    job = {
+        "id": "job-1",
+        "name": "Example",
+        "failure_alert": {"consecutive": 3, "suppressed": 2},
+    }
+    notice = scheduler._cron_recovery_notice(job)
+    assert notice is not None
+    assert "recovered after 3 consecutive failure(s)" in notice


### PR DESCRIPTION
### Summary

Adds persistent backoff for repeated identical cron failure alerts.

A recurring job that remains broken should not send the same failure message on
every scheduler tick. The scheduler now deduplicates repeated failure alerts
while keeping the failure state and recovery behavior visible.

### Behavior

- Delivers the first failure immediately
- Suppresses repeated failures with the same normalized signature for 24 hours
- Sends a compact reminder after the suppression interval
- Alerts immediately when the failure signature changes
- Retries notification when the previous delivery failed
- Emits a one-time recovery notice after a successful run
- Persists alert state across scheduler and gateway restarts

Dynamic identifiers and numeric noise are normalized when computing failure
signatures.

### Compatibility

- `cron.preflight: false` preserves its existing behavior and continues to
  deliver repeated failure alerts
- Drift-skip alerts retain their dedicated alert-once lifecycle
- Existing blocked-configuration and drift handling remain separate from
  generic failure backoff
- Alert bookkeeping failures cannot turn the original cron failure into a
  scheduler failure

### Tests

Added regression coverage for:

- repeated failure suppression
- daily reminders
- changed failure signatures
- recovery notices
- failed-delivery retries
- compatibility with preflight opt-out
- compatibility with drift-skip alert handling

The full cron test suite passes: `720 passed, 1 skipped`.
Ruff reports no issues.

Closes #88055
