### PR TITLE
feat(mcp): add Browserless catalog integration

### DIFF
--- a/optional-mcps/browserless/manifest.yaml
+++ b/optional-mcps/browserless/manifest.yaml
@@ -1,0 +1,35 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: browserless
+description: Automate browsers, scrape, search, crawl, and export with Browserless.
+source: https://docs.browserless.io/mcp/browserless-mcp-server/setup
+
+# Browserless hosts a Streamable HTTP MCP server with native OAuth 2.1 and
+# Dynamic Client Registration. Hermes handles discovery, PKCE, token exchange,
+# refresh, and secure token storage; no local package or API token is required.
+transport:
+  type: http
+  url: https://mcp.browserless.io/mcp
+
+auth:
+  type: oauth
+
+# Browserless currently exposes a compact tool surface covering interactive
+# browser control, site recipes, scraping, search, crawl/map, export,
+# performance, custom functions, and authenticated profiles. Leave
+# default_enabled unset so the install-time checklist reflects the live server
+# and starts with every tool selected. Users can prune it at any time with
+# `hermes mcp configure browserless`.
+
+post_install: |
+  Complete Browserless sign-in with:
+    hermes mcp login browserless
+
+  Then verify the connection:
+    hermes mcp test browserless
+
+  Start a new Hermes session after authentication so the Browserless tools are
+  loaded. Re-run the tool checklist any time with:
+    hermes mcp configure browserless

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -52,6 +52,7 @@ If `web.backend` is not set, the backend is auto-detected from whichever API key
 
 Hermes includes full browser automation with multiple backend options for navigating websites, filling forms, and extracting information:
 
+- **[Browserless](/user-guide/features/mcp#browserless-browser-automation)** — Hosted browser automation, scraping, search, crawl, and export tools through the Browserless MCP server
 - **Browserbase** — Managed cloud browsers with anti-bot tooling, CAPTCHA solving, and residential proxies
 - **Browser Use** — Alternative cloud browser provider
 - **Local Chromium-family CDP** — Connect to your running Chrome, Brave, Chromium, or Edge browser using `/browser connect`

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -68,6 +68,7 @@ The picker shows each entry with its current status:
 ```
 n8n          available              Manage and inspect n8n workflows from Hermes
 linear       enabled                Linear issue/project management (remote OAuth)
+browserless  available              Browser automation, scraping, search, and crawl
 github       installed (disabled)   GitHub repo + PR tools
 ```
 
@@ -252,6 +253,33 @@ mcp_servers:
 
 Or: `hermes mcp install figma`, then `hermes mcp login figma`.
 :::
+
+#### Browserless browser automation
+
+[Browserless](https://www.browserless.io/) provides a
+[hosted MCP server](https://docs.browserless.io/mcp/browserless-mcp-server/setup)
+for interactive browser tasks, scraping, search, crawl and map operations,
+page exports, performance audits, custom browser functions, and authenticated
+profiles. Install the catalog entry and complete Browserless sign-in:
+
+```bash
+hermes mcp install browserless
+hermes mcp login browserless
+hermes mcp test browserless
+```
+
+The login command opens your browser for OAuth; no API token needs to be copied
+into Hermes. Start a new Hermes session after authentication so the Browserless
+tools are loaded. To reduce the tool surface later, run:
+
+```bash
+hermes mcp configure browserless
+```
+
+This integration uses Browserless's MCP tools rather than Hermes's built-in
+`browser_*` toolset, so it does not add a cloud provider to the `hermes tools`
+browser-provider picker. The two surfaces can coexist, and no
+`browser.cloud_provider` setting is required for Browserless MCP.
 
 ```yaml
 mcp_servers:

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -254,33 +254,6 @@ mcp_servers:
 Or: `hermes mcp install figma`, then `hermes mcp login figma`.
 :::
 
-#### Browserless browser automation
-
-[Browserless](https://www.browserless.io/) provides a
-[hosted MCP server](https://docs.browserless.io/mcp/browserless-mcp-server/setup)
-for interactive browser tasks, scraping, search, crawl and map operations,
-page exports, performance audits, custom browser functions, and authenticated
-profiles. Install the catalog entry and complete Browserless sign-in:
-
-```bash
-hermes mcp install browserless
-hermes mcp login browserless
-hermes mcp test browserless
-```
-
-The login command opens your browser for OAuth; no API token needs to be copied
-into Hermes. Start a new Hermes session after authentication so the Browserless
-tools are loaded. To reduce the tool surface later, run:
-
-```bash
-hermes mcp configure browserless
-```
-
-This integration uses Browserless's MCP tools rather than Hermes's built-in
-`browser_*` toolset, so it does not add a cloud provider to the `hermes tools`
-browser-provider picker. The two surfaces can coexist, and no
-`browser.cloud_provider` setting is required for Browserless MCP.
-
 ```yaml
 mcp_servers:
   linear:
@@ -327,6 +300,33 @@ mcp_servers:
 Then run `hermes mcp login googledrive` — with the pre-registered client, Hermes skips registration and runs the normal browser authorization flow.
 
 **Pitfall — config auto-reload race.** When you edit `~/.hermes/config.yaml` from inside a running Hermes session, the CLI auto-reloads MCP connections with a 30s timeout. That's not enough for an interactive OAuth flow. Add the entry, then run `hermes mcp login <server>` from a fresh terminal — it waits the full 5 minutes for you to complete auth.
+
+### Browserless browser automation
+
+[Browserless](https://www.browserless.io/) provides a
+[hosted MCP server](https://docs.browserless.io/mcp/browserless-mcp-server/setup)
+for interactive browser tasks, scraping, search, crawl and map operations,
+page exports, performance audits, custom browser functions, and authenticated
+profiles. Install the catalog entry and complete Browserless sign-in:
+
+```bash
+hermes mcp install browserless
+hermes mcp login browserless
+hermes mcp test browserless
+```
+
+The login command opens your browser for OAuth; no API token needs to be copied
+into Hermes. Start a new Hermes session after authentication so the Browserless
+tools are loaded. To reduce the tool surface later, run:
+
+```bash
+hermes mcp configure browserless
+```
+
+This integration uses Browserless's MCP tools rather than Hermes's built-in
+`browser_*` toolset, so it does not add a cloud provider to the `hermes tools`
+browser-provider picker. The two surfaces can coexist, and no
+`browser.cloud_provider` setting is required for Browserless MCP.
 
 ## mTLS / client certificates
 


### PR DESCRIPTION
## What does this PR do?

Adds Browserless to Hermes's approved optional MCP catalog and documents the setup beside the existing Browserbase integration.

The integration uses Browserless's hosted Streamable HTTP MCP endpoint (`https://mcp.browserless.io/mcp`) and native OAuth 2.1 with Dynamic Client Registration, so users do not need to install a local package or copy an API token. It deliberately stays in the MCP catalog instead of adding a third-party provider to Hermes core, consistent with the maintainer direction on #20077 and #25992.

**Supersedes #84039** — that PR is stuck in draft because its author no longer has access to flip it to ready. This PR carries the same two commits, cherry-picked with original authorship preserved (Sean Yang), and is submitted ready for review. I work at Browserless with the original author.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update

## Changes Made

- Add `optional-mcps/browserless/manifest.yaml` with the official hosted endpoint and OAuth authentication.
- List Browserless in the integrations directory next to Browserbase.
- Add install, login, connection-test, and tool-selection instructions to the MCP guide.
- Clarify that Browserless MCP tools complement, rather than replace, Hermes's built-in `browser_*` tools and do not require `browser.cloud_provider` configuration.

## How to Test

1. Run `hermes mcp install browserless`.
2. Run `hermes mcp login browserless` and complete Browserless OAuth in the browser.
3. Run `hermes mcp test browserless`, then start a new Hermes session and confirm the Browserless tools are available.

Validation on the original PR: MCP catalog tests pass (21/21), documentation diagram lint clean (400 files), optimized English docs build succeeds (only the two pre-existing `/docs/llms*.txt` warnings), and the live Browserless OAuth discovery metadata endpoints return valid responses (unauthenticated requests correctly receive 401).

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched for existing PRs — supersedes #84039; reviewed #20077 and #25992.
- [x] My PR contains only related changes.

### Documentation & Housekeeping

- [x] I've updated relevant documentation.
- [x] `cli-config.yaml.example` changes are N/A; this adds no config key.
- [x] Cross-platform impact considered; the manifest uses Hermes's existing HTTP/OAuth catalog path with no bootstrap commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)