### PR TITLE
fix(tui): recover stale busy state from live session status

### DIFF
--- a/ui-tui/src/app/staleBusyRecovery.test.ts
+++ b/ui-tui/src/app/staleBusyRecovery.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionActiveItem } from '../gatewayTypes.js'
+
+import { shouldRecoverStaleBusy } from './staleBusyRecovery.js'
+
+const session = (status: SessionActiveItem['status'], id = 'sid-1'): SessionActiveItem => ({
+  id,
+  status
+})
+
+const completion = (awaiting: boolean, epoch = 1) => ({
+  awaiting,
+  epoch
+})
+
+const shouldRecover = ({
+  busy = true,
+  currentCompletion = completion(true),
+  currentSessionId = 'sid-1',
+  requestedCompletion = completion(true),
+  requestedSessionId = 'sid-1',
+  sessions = [session('idle')]
+}: Partial<Parameters<typeof shouldRecoverStaleBusy>[0]> = {}) =>
+  shouldRecoverStaleBusy({
+    busy,
+    currentCompletion,
+    currentSessionId,
+    requestedCompletion,
+    requestedSessionId,
+    sessions
+  })
+
+describe('shouldRecoverStaleBusy', () => {
+  it('recovers when the same in-flight turn is busy locally but idle on the backend', () => {
+    expect(shouldRecover()).toBe(true)
+  })
+
+  it.each(['working', 'waiting', 'starting'] as const)('does not recover while the backend reports %s', status => {
+    expect(shouldRecover({ sessions: [session(status)] })).toBe(false)
+  })
+
+  it('does not recover when the frontend is already idle', () => {
+    expect(shouldRecover({ busy: false })).toBe(false)
+  })
+
+  it('does not recover when the current session is missing', () => {
+    expect(shouldRecover({ sessions: [session('idle', 'sid-2')] })).toBe(false)
+  })
+
+  it('does not recover without a current session id', () => {
+    expect(shouldRecover({ currentSessionId: null })).toBe(false)
+  })
+
+  it('ignores a stale current flag from an older active-list response', () => {
+    expect(
+      shouldRecover({
+        sessions: [
+          { current: true, id: 'sid-old', status: 'idle' },
+          { id: 'sid-1', status: 'working' }
+        ]
+      })
+    ).toBe(false)
+  })
+
+  it('does not recover busy states that were not waiting for message.complete', () => {
+    expect(
+      shouldRecover({
+        requestedCompletion: completion(false)
+      })
+    ).toBe(false)
+  })
+
+  it('does not recover after the turn has already stopped awaiting completion', () => {
+    expect(
+      shouldRecover({
+        currentCompletion: completion(false)
+      })
+    ).toBe(false)
+  })
+
+  it('ignores an active-list response requested for a different session', () => {
+    expect(
+      shouldRecover({
+        requestedSessionId: 'sid-old'
+      })
+    ).toBe(false)
+  })
+
+  it('ignores a response from an older turn in the same session', () => {
+    expect(
+      shouldRecover({
+        currentCompletion: completion(true, 2),
+        requestedCompletion: completion(true, 1)
+      })
+    ).toBe(false)
+  })
+})

--- a/ui-tui/src/app/staleBusyRecovery.ts
+++ b/ui-tui/src/app/staleBusyRecovery.ts
@@ -1,0 +1,37 @@
+import type { SessionActiveItem } from '../gatewayTypes.js'
+
+interface CompletionSnapshot {
+  awaiting: boolean
+  epoch: number
+}
+
+export const shouldRecoverStaleBusy = ({
+  busy,
+  currentCompletion,
+  currentSessionId,
+  requestedCompletion,
+  requestedSessionId,
+  sessions
+}: {
+  busy: boolean
+  currentCompletion: CompletionSnapshot
+  currentSessionId: null | string
+  requestedCompletion: CompletionSnapshot
+  requestedSessionId: null | string
+  sessions: SessionActiveItem[]
+}): boolean => {
+  if (
+    !busy ||
+    !currentSessionId ||
+    requestedSessionId !== currentSessionId ||
+    !requestedCompletion.awaiting ||
+    !currentCompletion.awaiting ||
+    requestedCompletion.epoch !== currentCompletion.epoch
+  ) {
+    return false
+  }
+
+  const current = sessions.find(session => session.id === currentSessionId)
+
+  return current?.status === 'idle'
+}

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -110,6 +110,8 @@ const clear = (t: Timer): null => {
 }
 
 class TurnController {
+  awaitingCompletion = false
+  completionEpoch = 0
   bufRef = ''
   interrupted = false
   lastStatusNote = ''
@@ -347,6 +349,7 @@ class TurnController {
       return
     }
 
+    this.awaitingCompletion = false
     patchUiState({ status: 'interrupted' })
 
     this.statusTimer = setTimeout(() => {
@@ -552,6 +555,7 @@ class TurnController {
   }
 
   recordError() {
+    this.awaitingCompletion = false
     this.idle()
     this.clearReasoning()
     this.clearStatusTimer()
@@ -671,6 +675,7 @@ class TurnController {
     // Real turn end: surface any notice held back while busy. Done after
     // idle() flips busy=false so applyNotice() reaches the visible slot.
     this.flushPendingNotice()
+    this.awaitingCompletion = false
 
     return { finalMessages, finalText, wasInterrupted }
   }
@@ -925,6 +930,8 @@ class TurnController {
   }
 
   reset() {
+    this.awaitingCompletion = false
+    this.completionEpoch += 1
     this.clearReasoning()
     this.clearStatusTimer()
     this.idle()
@@ -986,7 +993,16 @@ class TurnController {
     patchTurnState({ streaming: boundedLiveRenderText(visible) })
   }
 
+  completionSnapshot() {
+    return {
+      awaiting: this.awaitingCompletion,
+      epoch: this.completionEpoch
+    }
+  }
+
   startMessage() {
+    this.completionEpoch += 1
+    this.awaitingCompletion = true
     this.endReasoningPhase()
     this.clearReasoning()
     this.activeTools = []

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -48,6 +48,7 @@ import { type GatewayRpc, type StateSetter, type TranscriptRow } from './interfa
 import { $overlayState, patchOverlayState } from './overlayStore.js'
 import { $goodVibesTick } from './petFlashStore.js'
 import { scrollWithSelectionBy } from './scroll.js'
+import { shouldRecoverStaleBusy } from './staleBusyRecovery.js'
 import { turnController } from './turnController.js'
 import { patchTurnState, useTurnSelector } from './turnStore.js'
 import { $uiState, getUiState, patchUiState } from './uiStore.js'
@@ -584,7 +585,10 @@ export function useMainApp(gw: GatewayClient) {
     let stopped = false
 
     const refresh = () => {
-      gw.request<SessionActiveListResponse>('session.active_list', { current_session_id: getUiState().sid })
+      const requestedSessionId = getUiState().sid
+      const requestedCompletion = turnController.completionSnapshot()
+
+      gw.request<SessionActiveListResponse>('session.active_list', { current_session_id: requestedSessionId })
         .then(raw => {
           const result = asRpcResult<SessionActiveListResponse>(raw)
 
@@ -595,15 +599,41 @@ export function useMainApp(gw: GatewayClient) {
             // titlebar. The active_list poll already carries it, so no extra
             // round-trip is needed.
             const currentSid = getUiState().sid
+            const currentCompletion = turnController.completionSnapshot()
 
             const sessionTitle = result.sessions.find(s => s.current || s.id === currentSid)?.title?.trim() ?? ''
+
+            const prev = getUiState()
+
+            // message.complete normally clears busy before the gateway reports this
+            // session idle. If the backend is already idle while the frontend still
+            // believes the turn is live, the terminal frame was lost or skipped.
+            // Finalize from the buffered turn state so partial output survives instead
+            // of merely flipping busy=false and discarding it.
+            if (
+              shouldRecoverStaleBusy({
+                busy: prev.busy,
+                currentCompletion,
+                currentSessionId: currentSid,
+                requestedCompletion,
+                requestedSessionId,
+                sessions: result.sessions
+              })
+            ) {
+              const { finalMessages, wasInterrupted } = turnController.recordMessageComplete({})
+
+              if (!wasInterrupted) {
+                finalMessages.forEach(appendMessage)
+                sys('response ended without a completion event — input unlocked')
+              }
+
+              patchUiState({ status: 'ready' })
+            }
 
             // Only patch when something actually changed. patchUiState always
             // produces a new state object, which notifies every $uiState
             // subscriber; patching unconditionally on each 1.5s poll re-renders
             // the whole TUI and causes idle flicker.
-            const prev = getUiState()
-
             if (prev.liveSessionCount !== liveSessionCount || prev.sessionTitle !== sessionTitle) {
               patchUiState({ liveSessionCount, sessionTitle })
             }
@@ -619,7 +649,7 @@ export function useMainApp(gw: GatewayClient) {
       stopped = true
       clearInterval(timer)
     }
-  }, [gw, ui.sid])
+  }, [appendMessage, gw, sys, ui.sid])
 
   // Tab title: `⚠` waiting on approval/sudo/secret/clarify, `⏳` busy, `✓` idle.
   // Format: `<marker> <session name> · <model> · <cwd>` — name/cwd omitted when absent.


### PR DESCRIPTION
## What does this PR do?

Adds a renderer-side recovery path for the Ink TUI when a turn has started but its terminal `message.complete` event is lost or skipped.

The TUI already polls `session.active_list` every 1.5 seconds. This change reuses that authoritative backend state instead of adding a fixed inactivity timeout. Recovery happens only when:

- the frontend is still `busy`,
- the exact current session is reported `idle` by the backend,
- and the same frontend turn that existed when the poll was sent is still awaiting `message.complete`.

The TUI then finalizes the buffered turn through the normal `recordMessageComplete({})` path and unlocks input, preserving partial streamed output instead of merely flipping `busy = false`.

## Why not a fixed stall timeout?

#70871 suggested a ~45 second watchdog. A fixed inactivity timeout can incorrectly terminate legitimate long-running model, provider, reasoning, or tool activity where no frontend event arrives for an extended period.

`session.active_list` already exposes the backend lifecycle state, so recovery can be state-based instead of time-based.

## Race safety

`busy` alone is not sufficient because the TUI also uses it for work that is not an active agent turn.

The recovery therefore tracks:

- whether `message.start` actually opened a turn awaiting completion,
- a monotonic completion epoch,
- the session ID and epoch when `session.active_list` was requested,
- and the session ID and epoch again when its response arrives.

This prevents local non-turn busy states, delayed responses from a previous session, and delayed responses from an older turn in the same session from unlocking a newer turn. Matching uses the exact current session ID rather than the response's potentially stale `current` flag.

## Scope

This PR addresses the **stale TUI busy-state** part of #70871 only.

The live context-usage portion is being handled separately in #87978, so this PR intentionally does not change context-meter behavior.

Refs #70871

## Changes Made

- `ui-tui/src/app/turnController.ts`
  - track whether a real agent turn is awaiting completion
  - add a monotonic completion epoch
  - invalidate completion state on completion, error, interruption, and reset
- `ui-tui/src/app/staleBusyRecovery.ts`
  - add the state/race checks for deciding when recovery is safe
- `ui-tui/src/app/staleBusyRecovery.test.ts`
  - cover normal recovery plus working/waiting/starting, session changes, stale active-list responses, non-turn busy state, and same-session turn-generation races
- `ui-tui/src/app/useMainApp.ts`
  - reuse the existing `session.active_list` poll
  - finalize buffered output through `recordMessageComplete({})` when recovery is proven safe

## Verification

Focused turn/submission regression suite:

```text
6 test files passed
130 tests passed
```

New recovery tests:

```text
12/12 passed
```

Additional checks:

- `npm --prefix ui-tui run typecheck` — passed
- affected-file ESLint — passed
- `git diff --cached --check` — passed before commit
- full TUI suite: 1652 passed, 8 skipped

The full suite has 10 failures in 3 terminal/editor test files when run natively on Windows. They are platform-assumption failures in unrelated terminal/editor tests (for example Unix path/editor expectations resolving to Windows paths / `notepad.exe`); the focused suites covering the changed turn/submission paths pass.

## Platform

Windows 11
