### PR TITLE
fix(models): filter Cloudflare /compat catalog to canonical chat routes

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4630,6 +4630,104 @@ def github_model_reasoning_efforts(
     return _github_reasoning_efforts_for_model_id(str(model_id or normalized))
 
 
+_CLOUDFLARE_COMPAT_PROVIDER_PREFIXES: frozenset[str] = frozenset({
+    # Cloudflare's documented Unified API providers.
+    "anthropic",
+    "baseten",
+    "cerebras",
+    "cohere",
+    "deepseek",
+    "dynamic",
+    "google-ai-studio",
+    "google-vertex-ai",
+    "grok",
+    "groq",
+    "mistral",
+    "openai",
+    "parallel",
+    "perplexity-ai",
+    "workers-ai",
+    # Bedrock is documented separately as supporting Claude and Nova through
+    # the same /compat/chat/completions surface.
+    "aws-bedrock",
+})
+
+_CLOUDFLARE_COMPAT_NON_CHAT_RE = re.compile(
+    r"(?i)(?:embedding|embed|rerank|moderation|image|imagen|imagine|video|"
+    r"tts|stt|speech|transcrib|whisper|audio|realtime|voice)"
+)
+
+_MODEL_SNAPSHOT_SUFFIXES = (
+    re.compile(r"-20\d{6}$"),
+    re.compile(r"-20\d{2}-\d{2}-\d{2}$"),
+    re.compile(r"-\d{4}$"),
+)
+
+
+def _is_cloudflare_compat_base_url(base_url: str) -> bool:
+    parsed = urllib.parse.urlparse(str(base_url or ""))
+    return (
+        parsed.hostname == "gateway.ai.cloudflare.com"
+        and parsed.path.rstrip("/").endswith("/compat")
+    )
+
+
+def _normalize_discovered_model_ids(
+    base_url: str,
+    model_ids: list[str],
+) -> list[str]:
+    """Return endpoint-appropriate, stable model IDs for picker surfaces.
+
+    Cloudflare's ``/compat/models`` currently returns the union of several
+    internal/provider catalogs rather than only IDs accepted by
+    ``/compat/chat/completions``. That includes unsupported provider prefixes,
+    duplicated ``provider/provider/model`` IDs, batch/non-chat models, and
+    dated aliases whose canonical alias is the only accepted route. Filter that
+    one endpoint while leaving every other OpenAI-compatible catalog untouched.
+    """
+    deduped = list(dict.fromkeys(
+        str(model_id or "").strip()
+        for model_id in model_ids
+        if str(model_id or "").strip()
+    ))
+    if not _is_cloudflare_compat_base_url(base_url):
+        return deduped
+
+    compatible: list[str] = []
+    for model_id in deduped:
+        parts = model_id.split("/")
+        provider_prefix = parts[0].lower()
+        if provider_prefix not in _CLOUDFLARE_COMPAT_PROVIDER_PREFIXES:
+            continue
+        if provider_prefix == "aws-bedrock" and not any(
+            family in model_id.lower() for family in ("anthropic", "nova")
+        ):
+            # Cloudflare documents only Claude and Nova families on Bedrock's
+            # OpenAI-compatible surface; the raw catalog includes other
+            # Bedrock families that require the provider-native API.
+            continue
+        if len(parts) > 1 and parts[1].lower() == provider_prefix:
+            continue
+        if model_id.endswith(":batch"):
+            continue
+        if _CLOUDFLARE_COMPAT_NON_CHAT_RE.search(model_id):
+            continue
+        compatible.append(model_id)
+
+    compatible_set = set(compatible)
+    canonical: list[str] = []
+    for model_id in compatible:
+        snapshot_alias = False
+        for suffix in _MODEL_SNAPSHOT_SUFFIXES:
+            base_alias = suffix.sub("", model_id)
+            if base_alias != model_id and base_alias in compatible_set:
+                snapshot_alias = True
+                break
+        if not snapshot_alias:
+            canonical.append(model_id)
+    return canonical
+
+
 def probe_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
@@ -4705,8 +4803,12 @@ def probe_api_models(
         try:
             with _urlopen_model_catalog_request(req, **_open_kwargs) as resp:
                 data = json.loads(resp.read().decode())
+                models = _normalize_discovered_model_ids(
+                    candidate_base,
+                    [m.get("id", "") for m in data.get("data", [])],
+                )
                 return {
-                    "models": [m.get("id", "") for m in data.get("data", [])],
+                    "models": models,
                     "probed_url": url,
                     "resolved_base_url": candidate_base.rstrip("/"),
                     "suggested_base_url": alternate_base if alternate_base != candidate_base else normalized,
@@ -5084,6 +5186,11 @@ def cached_fetch_api_models(
     entry = cache.get(cache_key)
     now = time.time()
 
+    def _normalized_for_endpoint(models: list[str]) -> list[str]:
+        return _normalize_discovered_model_ids(
+            str(base_url or normalized_url), list(models)
+        )
+
     if cache_only:
         # Same trust window as the stale-while-revalidate tier below, minus
         # the revalidation: an entry this side of the bound is good enough to
@@ -5093,12 +5200,12 @@ def cached_fetch_api_models(
             return None
         if now - entry["at"] >= _PROVIDER_MODELS_STALE_SERVE_MAX:
             return None
-        return list(entry["models"])
+        return _normalized_for_endpoint(entry["models"])
 
     if not force_refresh and _cache_entry_valid(entry, fp):
         age = now - entry["at"]
         if age < ttl_seconds:
-            return list(entry["models"])
+            return _normalized_for_endpoint(entry["models"])
         if age < _PROVIDER_MODELS_STALE_SERVE_MAX:
             # Stale-while-revalidate: serve the expired entry immediately so
             # picker opens never block on a live /v1/models round-trip
@@ -5111,14 +5218,19 @@ def cached_fetch_api_models(
                 )
                 if not live:
                     return None
-                return {"fp": fp, "at": time.time(), "models": list(live)}
+                normalized_live = _normalized_for_endpoint(live)
+                if not normalized_live:
+                    return None
+                return {"fp": fp, "at": time.time(), "models": normalized_live}
 
             _spawn_swr_refresh(cache_key, _refresh_custom)
-            return list(entry["models"])
+            return _normalized_for_endpoint(entry["models"])
 
     live = fetch_api_models(
         api_key, base_url, timeout=timeout, api_mode=api_mode, headers=headers
     )
+    if live:
+        live = _normalized_for_endpoint(live)
     if live:
         cache[cache_key] = {"fp": fp, "at": now, "models": list(live)}
         _save_provider_models_cache(cache)
@@ -5127,7 +5239,7 @@ def cached_fetch_api_models(
     # Live fetch returned nothing (offline endpoint, timeout, auth hiccup).
     # A stale same-fingerprint entry beats an empty result.
     if _cache_entry_valid(entry, fp):
-        return list(entry["models"])
+        return _normalized_for_endpoint(entry["models"])
     return live
 
 

--- a/tests/hermes_cli/test_cached_fetch_api_models.py
+++ b/tests/hermes_cli/test_cached_fetch_api_models.py
@@ -52,6 +52,29 @@ class TestCachedFetchApiModels:
         assert out == ["m1"]
         live.assert_not_called()
 
+    def test_cloudflare_compat_filters_an_existing_raw_cache_entry(self):
+        import hermes_cli.models as mod
+
+        base_url = "https://gateway.ai.cloudflare.com/v1/account/gateway/compat"
+        cache = {
+            f"custom:{base_url}": self._entry(
+                [
+                    "grok/grok-4.6",
+                    "grok/grok-4.6-20260810",
+                    "openrouter/x-ai/grok-4.6",
+                    "xai/xai/grok-4.6",
+                ],
+                age_seconds=10,
+            )
+        }
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
+             patch.object(mod, "fetch_api_models") as live:
+            out = mod.cached_fetch_api_models("sk-key", base_url)
+
+        assert out == ["grok/grok-4.6"]
+        live.assert_not_called()
+
     def test_expired_entry_triggers_live_fetch_and_is_persisted(self):
         import hermes_cli.models as mod
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -1,5 +1,6 @@
 """Tests for provider-aware `/model` validation in hermes_cli.models."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 from hermes_cli.models import (
@@ -218,6 +219,69 @@ class TestFetchApiModels:
         assert probe["models"] == ["gpt-5.4", "claude-sonnet-4.6"]
         assert probe["resolved_base_url"] == "https://api.githubcopilot.com"
         assert probe["used_fallback"] is False
+
+    def test_probe_filters_cloudflare_compat_catalog_to_canonical_chat_routes(self):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps(
+                    {
+                        "data": [
+                            {"id": "grok/grok-4.6"},
+                            {"id": "grok/grok-4.6-20260810"},
+                            {"id": "openrouter/x-ai/grok-4.6"},
+                            {"id": "xai/xai/grok-4.6"},
+                            {"id": "grok/grok-imagine-image"},
+                            {"id": "openai/gpt-5.6-sol"},
+                            {"id": "openai/openai/gpt-5.6-sol"},
+                            {"id": "openai/gpt-5.6-sol:batch"},
+                            {"id": "aws-bedrock/amazon.nova-micro-v1:0"},
+                            {"id": "aws-bedrock/meta.llama3-70b-instruct-v1:0"},
+                        ]
+                    }
+                ).encode()
+
+        with patch(
+            "hermes_cli.models._urlopen_model_catalog_request",
+            return_value=_Resp(),
+        ):
+            probe = probe_api_models(
+                "key",
+                "https://gateway.ai.cloudflare.com/v1/account/gateway/compat",
+            )
+
+        assert probe["models"] == [
+            "grok/grok-4.6",
+            "openai/gpt-5.6-sol",
+            "aws-bedrock/amazon.nova-micro-v1:0",
+        ]
+
+    def test_probe_does_not_filter_other_openai_compatible_catalogs(self):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data": [{"id": "openrouter/x-ai/grok-4.6"}, {"id": "xai/xai/grok-4.6"}]}'
+
+        with patch(
+            "hermes_cli.models._urlopen_model_catalog_request",
+            return_value=_Resp(),
+        ):
+            probe = probe_api_models("key", "https://proxy.example/v1")
+
+        assert probe["models"] == [
+            "openrouter/x-ai/grok-4.6",
+            "xai/xai/grok-4.6",
+        ]
 
 
 class TestGithubReasoningEfforts:


### PR DESCRIPTION
## Bug Description

Cloudflare AI Gateway's `/compat/models` currently returns the union of several internal/provider catalogs, not only IDs accepted by `/compat/chat/completions`. The picker therefore surfaces unsupported prefixes, duplicated `provider/provider/model` IDs, batch/non-chat models, and dated snapshot aliases whose canonical route is the only accepted one.

## Root Cause

`probe_api_models()` / `cached_fetch_api_models()` treated every OpenAI-compatible `/models` payload as a chat catalog. That is correct for most custom endpoints, but wrong for Cloudflare's `/compat` surface.

## Fix

- Detect Cloudflare `/compat` base URLs only (`gateway.ai.cloudflare.com` + path ending in `/compat`).
- Keep documented Unified API provider prefixes (plus Bedrock Claude/Nova).
- Drop duplicated `provider/provider/...` IDs, `:batch` models, non-chat families, and dated aliases when the canonical ID is already present.
- Apply the same filter to stale cache hits so an older raw catalog is not served as-is.
- Leave every other OpenAI-compatible catalog untouched.

## How to Verify

1. Point a custom provider at `https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/compat`.
2. Open the model picker / run a catalog probe.
3. Confirm only canonical chat routes remain (e.g. `grok/grok-4.6`, not `grok/grok-4.6-20260810`, `openrouter/...`, or `xai/xai/...`).
4. Confirm a non-Cloudflare OpenAI-compatible endpoint is unchanged.

## Test Plan

- [x] Added `test_probe_filters_cloudflare_compat_catalog_to_canonical_chat_routes`
- [x] Added `test_probe_does_not_filter_other_openai_compatible_catalogs`
- [x] Added `test_cloudflare_compat_filters_an_existing_raw_cache_entry`
- [x] Focused local run: `tests/hermes_cli/test_cached_fetch_api_models.py` + `tests/hermes_cli/test_model_validation.py` — 55 passed

## Risk Assessment

Low — filter is gated to one Cloudflare hostname/path. Other catalogs take the existing dedupe-only path.
