### PR TITLE
fix(telegram): rebind TypeHandler after lazy PTB install

### DIFF
--- a/tests/gateway/test_telegram_connect.py
+++ b/tests/gateway/test_telegram_connect.py
@@ -54,3 +54,36 @@ class TestTelegramUnconfiguredNonRetryable:
         assert adapter.fatal_error_retryable is False
         assert adapter.fatal_error_code == "missing_dependency"
 
+
+def test_lazy_install_rebinds_type_handler(monkeypatch):
+    """After a first-import miss, TypeHandler must be rebound to the real PTB class.
+
+    check_telegram_requirements() used to rebind Update/Application/HTTPXRequest
+    but leave TypeHandler as typing.Any. connect() then crashed in
+    _register_handlers with ``Any cannot be instantiated`` — the live
+    telegram gateway failure after a lazy install.
+    """
+    from typing import Any as TypingAny
+
+    monkeypatch.setattr(telegram_mod, "TELEGRAM_AVAILABLE", False)
+    monkeypatch.setattr(telegram_mod, "TypeHandler", TypingAny)
+    monkeypatch.setattr(telegram_mod, "Update", TypingAny)
+
+    def _fake_ensure(name, prompt=False):
+        assert name == "platform.telegram"
+        return True
+
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        _fake_ensure,
+    )
+
+    assert telegram_mod.check_telegram_requirements() is True
+    assert telegram_mod.TELEGRAM_AVAILABLE is True
+    assert telegram_mod.TypeHandler is not TypingAny
+
+    handler = telegram_mod.TypeHandler(
+        telegram_mod.Update, lambda *_args, **_kwargs: None
+    )
+    assert handler is not None
+


### PR DESCRIPTION
## Bug Description

After a first-import miss of `python-telegram-bot`, a lazy install used to leave `TypeHandler` bound to `typing.Any`. `connect()` then crashed in `_register_handlers` with `Any cannot be instantiated`.

## Root Cause

`check_telegram_requirements()` rebound `Update` / `Application` / `HTTPXRequest` after lazy install but historically omitted `TypeHandler`. Current `main` already rebinds it; this PR pins the contract.

## Fix

Regression test only: after forcing `TELEGRAM_AVAILABLE=False` and `TypeHandler=typing.Any`, `check_telegram_requirements()` must rebind `TypeHandler` to a real instantiable PTB class.

## How to Verify

1. `scripts/run_tests.sh tests/gateway/test_telegram_connect.py`
2. Confirm `test_lazy_install_rebinds_type_handler` passes.

## Test Plan

- [x] Added `test_lazy_install_rebinds_type_handler`
- [x] Focused local run: `tests/gateway/test_telegram_connect.py` — 2 passed

## Risk Assessment

Low — test-only change against the existing rebind path on `main`.
