### PR TITLE
fix(desktop): align sidebar density row heights

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row-details.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-row-details.test.ts
@@ -29,15 +29,15 @@ const session = (overrides: Partial<SessionInfo> = {}): SessionInfo => ({
 describe('session row details', () => {
   it('provides density-aware virtual row estimates', () => {
     expect(sessionRowEstimate('compact')).toBe(28)
-    expect(sessionRowEstimate('comfortable')).toBe(45)
-    expect(sessionRowEstimate('detailed')).toBe(63)
+    expect(sessionRowEstimate('comfortable')).toBe(48)
+    expect(sessionRowEstimate('detailed')).toBe(64)
   })
 
   it('keeps the detailed estimate even when preview is omitted as a title duplicate', () => {
     const details = sessionRowDetails(session({ title: null }), en)
 
     expect(details.preview).toBeNull()
-    expect(sessionRowEstimate('detailed')).toBe(63)
+    expect(sessionRowEstimate('detailed')).toBe(64)
   })
 
   it('formats deterministic metadata without ambiguous call wording', () => {

--- a/apps/desktop/src/app/chat/sidebar/session-row-details.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-row-details.ts
@@ -14,8 +14,14 @@ export interface SessionRowFormatters {
 const modelLabel = (model: null | string) => model?.split('/').pop()?.trim() || null
 const oneLine = (value: null | string) => value?.replace(/\s+/g, ' ').trim() || null
 
-export const sessionRowEstimate = (density: SessionListDensity) =>
-  ({ compact: 28, comfortable: 45, detailed: 63 })[density]
+/** Shared contract for rendered minimum height and virtual-list placement. */
+export const SESSION_ROW_HEIGHT_PX: Record<SessionListDensity, number> = {
+  compact: 28,
+  comfortable: 48,
+  detailed: 64
+}
+
+export const sessionRowEstimate = (density: SessionListDensity) => SESSION_ROW_HEIGHT_PX[density]
 
 export function sessionRowDetails(session: SessionInfo, fmt: SessionRowFormatters): SessionRowDetails {
   const preview = oneLine(session.preview)

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -349,8 +349,8 @@ function SidebarSessionRowImpl({
           card && SIDEBAR_ROW_CARD_MIN_H,
           // Density-aware minimum heights for the inline (non-card) row: the
           // metadata / preview lines below need the extra rows (#68119).
-          !card && density !== 'compact' && 'min-h-[2.75rem]',
-          !card && density === 'detailed' && 'min-h-[3.875rem]',
+          !card && density === 'comfortable' && 'min-h-[3rem]',
+          !card && density === 'detailed' && 'min-h-[4rem]',
           isSelected && 'bg-(--ui-row-active-background)',
           liveTurn && 'text-foreground',
           // Opaque surface while lifted so the dragged row erases what's under


### PR DESCRIPTION
## Summary

- align the virtual session-list estimates with explicit rendered minimum heights for every density
- raise comfortable rows to 48px and detailed rows to 64px
- keep compact rows at their existing one-line 28px height
- centralize the virtualizer height contract in `SESSION_ROW_HEIGHT_PX`

Closes #88473

## Root cause

The virtualized sidebar positions rows absolutely from `sessionRowEstimate()`, while the rendered row used different Tailwind minimum heights. Comfortable rendered at 44px but was placed 45px apart; detailed rendered at 62px but was placed 63px apart. Browser text metrics and padding could make the content taller than either value, allowing adjacent rows and date dividers to overlap before or between measurement passes.

The renderer and virtualizer now use matching 48px/64px boundaries with enough room for their two- and three-line content. Compact remains a one-line 28px row.

## Verification

- `npm exec --workspace=apps/desktop vitest -- run --project ui src/app/chat/sidebar/session-row-details.test.ts src/app/chat/sidebar/virtual-session-list.test.tsx` — 10 passed
- `npm run typecheck --workspace=apps/desktop`
- `npm run lint --workspace=apps/desktop -- --quiet`
- `git diff --check`

## Scope

This does not change virtualization, scrolling, density selection, or session data. It only makes row placement and rendered geometry agree.
