### PR TITLE
fix(session-search): scope Telegram history to conversation

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3158,8 +3158,10 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
                     detail=next_args.get("detail", "adaptive"),
+                    profile=next_args.get("profile"),
+                    scope=next_args.get("scope"),
                     db=session_db,
-                    current_session_id=agent.session_id,
+                    **agent.session_search_scope_context(),
                 ),
                 next_args,
             )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1890,6 +1890,20 @@ def _append_cancelled_tool_results(messages: list, tool_calls, *, reason: str) -
         ))
 
 
+def _session_search_scope_context(agent) -> dict[str, Any]:
+    """Return public agent provenance used by Telegram session-search scoping."""
+    provider = getattr(agent, "session_search_scope_context", None)
+    if callable(provider):
+        context = provider()
+        if isinstance(context, dict):
+            return context
+    return {
+        "current_session_id": getattr(agent, "session_id", None),
+        "current_platform": getattr(agent, "platform", None),
+        "current_session_key": None,
+    }
+
+
 def execute_tool_calls_sequential(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools.
 
@@ -2058,8 +2072,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
                     detail=next_args.get("detail", "adaptive"),
+                    profile=next_args.get("profile"),
+                    scope=next_args.get("scope"),
                     db=session_db,
-                    current_session_id=agent.session_id,
+                    **_session_search_scope_context(agent),
                 )
             function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
                 agent,

--- a/run_agent.py
+++ b/run_agent.py
@@ -627,6 +627,14 @@ class AIAgent:
             logger.debug("SessionDB unavailable for recall", exc_info=True)
             return None
 
+    def session_search_scope_context(self) -> Dict[str, Optional[str]]:
+        """Public provenance contract for conversation-scoped history tools."""
+        return {
+            "current_session_id": self.session_id,
+            "current_platform": self.platform,
+            "current_session_key": self._gateway_session_key,
+        }
+
     def _ensure_db_session(self) -> None:
         """Create session DB row on first use. Disables _session_db on failure."""
         if getattr(self, "_persist_disabled", False):

--- a/tests/agent/test_session_search_scope_context.py
+++ b/tests/agent/test_session_search_scope_context.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from agent.tool_executor import _session_search_scope_context
+
+
+def test_session_search_scope_context_uses_public_agent_contract():
+    expected = {
+        "current_session_id": "session-1",
+        "current_platform": "telegram",
+        "current_session_key": "telegram:chat-1:topic-7",
+    }
+    agent = SimpleNamespace(
+        session_search_scope_context=lambda: expected,
+        _chat_id="private-chat-must-not-be-read",
+        _thread_id="private-thread-must-not-be-read",
+    )
+
+    assert _session_search_scope_context(agent) == expected
+
+
+def test_session_search_scope_context_has_safe_public_fallback():
+    agent = SimpleNamespace(session_id="session-1", platform="cli")
+
+    assert _session_search_scope_context(agent) == {
+        "current_session_id": "session-1",
+        "current_platform": "cli",
+        "current_session_key": None,
+    }

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -63,6 +63,42 @@ def _seed_modpack_sessions(db):
     db._conn.commit()
 
 
+def _tag_telegram_session(db, session_id, chat_id, thread_id):
+    db.record_gateway_session_peer(
+        session_id,
+        source="telegram",
+        user_id="user-1",
+        session_key=f"telegram:{chat_id}:{thread_id}",
+        chat_id=str(chat_id),
+        chat_type="group",
+        thread_id=None if thread_id is None else str(thread_id),
+        display_name="Scoped chat",
+        origin_json="{}",
+    )
+
+
+def _seed_telegram_scope_sessions(db):
+    for sid in ("s_current", "s_same", "s_other_thread", "s_other_chat"):
+        db.create_session(sid, source="telegram")
+    _tag_telegram_session(db, "s_current", "chat-1", "topic-7")
+    _tag_telegram_session(db, "s_same", "chat-1", "topic-7")
+    _tag_telegram_session(db, "s_other_thread", "chat-1", "topic-8")
+    _tag_telegram_session(db, "s_other_chat", "chat-2", "topic-7")
+    db.append_message("s_current", role="user", content="telegram scopeprobe current")
+    db.append_message("s_current", role="assistant", content="scope current")
+    db.append_message("s_same", role="user", content="telegram scopeprobe same")
+    db.append_message("s_same", role="assistant", content="scope same")
+    db.append_message("s_other_thread", role="user", content="telegram scopeprobe other-thread")
+    db.append_message(
+        "s_other_thread", role="assistant", content="scope other-thread"
+    )
+    db.append_message("s_other_chat", role="user", content="telegram scopeprobe other-chat")
+    db.append_message("s_other_chat", role="assistant", content="scope other-chat")
+    db.create_session("s_child", source="subagent", parent_session_id="s_current")
+    db.append_message("s_child", role="assistant", content="child scope reply")
+    db._conn.commit()
+
+
 # =========================================================================
 # Schema invariants
 # =========================================================================
@@ -99,7 +135,13 @@ class TestSchema:
             "sort",
             "profile",
         ]
-        assert parameters == [*historical_prefix, "detail"]
+        assert parameters == [
+            *historical_prefix,
+            "detail",
+            "scope",
+            "current_platform",
+            "current_session_key",
+        ]
 
 
 class TestFormatTimestamp:
@@ -309,8 +351,250 @@ class TestDiscoverySort:
         assert first["session_id"] == "s_oldest"
 
 
-# =========================================================================
-# Scroll shape (session_id + around_message_id)
+class TestTelegramConversationScope:
+    def test_discovery_and_browse_stay_in_current_topic(self, db):
+        _seed_telegram_scope_sessions(db)
+
+        discovered = json.loads(
+            session_search(
+                query="scopeprobe",
+                current_session_id="s_current",
+                db=db,
+                current_platform="telegram",
+            )
+        )
+        discovered_sids = {row["session_id"] for row in discovered["results"]}
+        assert "s_same" in discovered_sids
+        assert "s_other_thread" not in discovered_sids
+        assert "s_other_chat" not in discovered_sids
+
+        browsed = json.loads(
+            session_search(
+                db=db,
+                current_session_id="s_current",
+                current_platform="telegram",
+            )
+        )
+        browsed_sids = {row["session_id"] for row in browsed["results"]}
+        assert "s_same" in browsed_sids
+        assert "s_current" not in browsed_sids
+        assert "s_other_thread" not in browsed_sids
+        assert "s_other_chat" not in browsed_sids
+
+    def test_session_link_read_stays_in_scope(self, db):
+        _seed_telegram_scope_sessions(db)
+        discovered = json.loads(
+            session_search(
+                query="scopeprobe",
+                current_session_id="s_current",
+                db=db,
+                current_platform="telegram",
+            )
+        )
+        assert discovered["results"]
+        row = discovered["results"][0]
+        link_sid = row["session_id"]
+
+        read_result = json.loads(
+            session_search(
+                session_id=link_sid,
+                current_session_id="s_current",
+                db=db,
+                current_platform="telegram",
+            )
+        )
+        assert read_result["success"] is True
+        assert read_result["session_id"] == link_sid
+        assert read_result["mode"] == "read"
+
+    def test_read_and_scroll_reject_other_topic_session(self, db):
+        _seed_telegram_scope_sessions(db)
+        other_anchor = db.get_messages("s_other_thread")[0]["id"]
+
+        read_result = json.loads(
+            session_search(
+                session_id="s_other_thread",
+                current_session_id="s_current",
+                db=db,
+                current_platform="telegram",
+            )
+        )
+        assert read_result["success"] is False
+        assert "scope" in read_result["error"].lower()
+
+        scroll_result = json.loads(
+            session_search(
+                session_id="s_other_thread",
+                around_message_id=other_anchor,
+                current_session_id="s_current",
+                db=db,
+                current_platform="telegram",
+            )
+        )
+        assert scroll_result["success"] is False
+        assert "scope" in scroll_result["error"].lower()
+
+    def test_flat_chat_without_thread_is_scoped(self, db):
+        for sid in ("s_current", "s_same", "s_other"):
+            db.create_session(sid, source="telegram")
+        _tag_telegram_session(db, "s_current", "chat-flat", None)
+        _tag_telegram_session(db, "s_same", "chat-flat", None)
+        _tag_telegram_session(db, "s_other", "other-flat", None)
+        for sid in ("s_current", "s_same", "s_other"):
+            db.append_message(sid, role="user", content="flat Telegram history")
+        db._conn.commit()
+
+        discovered = json.loads(
+            session_search(
+                query="flat Telegram",
+                current_session_id="s_current",
+                current_platform="telegram",
+                db=db,
+            )
+        )
+        browsed = json.loads(
+            session_search(
+                current_session_id="s_current",
+                current_platform="telegram",
+                db=db,
+            )
+        )
+        anchor = db.get_messages("s_same")[0]["id"]
+        read_result = json.loads(
+            session_search(
+                session_id="s_same",
+                current_session_id="s_current",
+                current_platform="telegram",
+                db=db,
+            )
+        )
+        scroll_result = json.loads(
+            session_search(
+                session_id="s_same",
+                around_message_id=anchor,
+                current_session_id="s_current",
+                current_platform="telegram",
+                db=db,
+            )
+        )
+
+        assert {row["session_id"] for row in discovered["results"]} == {"s_same"}
+        assert {row["session_id"] for row in browsed["results"]} == {"s_same"}
+        assert read_result["success"] is True
+        assert scroll_result["success"] is True
+
+    def test_missing_session_key_fails_closed(self, db):
+        db.create_session("s_current", source="telegram")
+        db.create_session("s_other", source="telegram")
+        db.append_message("s_current", role="user", content="unknown Telegram lane")
+        db.append_message("s_other", role="user", content="unknown Telegram lane")
+        db._conn.commit()
+
+        discover_result = json.loads(
+            session_search(
+                query="unknown Telegram lane",
+                current_session_id="s_current",
+                db=db,
+                current_platform="telegram",
+            )
+        )
+        browse_result = json.loads(
+            session_search(
+                current_session_id="s_current",
+                db=db,
+                current_platform="telegram",
+            )
+        )
+        other_anchor = db.get_messages("s_other")[0]["id"]
+        read_result = json.loads(
+            session_search(
+                session_id="s_other",
+                current_session_id="s_current",
+                db=db,
+                current_platform="telegram",
+            )
+        )
+        scroll_result = json.loads(
+            session_search(
+                session_id="s_other",
+                around_message_id=other_anchor,
+                current_session_id="s_current",
+                db=db,
+                current_platform="telegram",
+            )
+        )
+
+        assert discover_result["success"] is True
+        assert discover_result["count"] == 0
+        assert browse_result["success"] is True
+        assert browse_result["count"] == 0
+        assert read_result["success"] is False
+        assert scroll_result["success"] is False
+
+    def test_explicit_all_scope_allows_global_history(self, db):
+        _seed_telegram_scope_sessions(db)
+
+        result = json.loads(
+            session_search(
+                query="scopeprobe",
+                current_session_id="s_current",
+                current_platform="telegram",
+                scope="all",
+                db=db,
+            )
+        )
+        sids = {row["session_id"] for row in result["results"]}
+        assert {"s_same", "s_other_thread", "s_other_chat"} <= sids
+
+    def test_incompatible_telegram_provenance_fails_closed(self, db):
+        db.create_session("s_current", source="cli")
+        db.create_session("s_other", source="telegram")
+        db.append_message("s_other", role="user", content="incompatible provenance")
+        db._conn.commit()
+
+        result = json.loads(
+            session_search(
+                query="incompatible",
+                current_session_id="s_current",
+                current_platform="telegram",
+                db=db,
+            )
+        )
+        assert result["success"] is False
+        assert "provenance" in result["error"].lower()
+
+    def test_missing_current_telegram_session_fails_closed(self, db):
+        db.create_session("s_other", source="telegram")
+        db.append_message("s_other", role="user", content="missing current session")
+        db._conn.commit()
+
+        result = json.loads(
+            session_search(
+                query="missing current",
+                current_session_id="not-persisted",
+                current_platform="telegram",
+                db=db,
+            )
+        )
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_cross_profile_requires_explicit_global_scope(self, db):
+        _seed_telegram_scope_sessions(db)
+
+        result = json.loads(
+            session_search(
+                session_id="s_same",
+                profile="work",
+                current_session_id="s_current",
+                current_platform="telegram",
+                db=db,
+            )
+        )
+        assert result["success"] is False
+        assert "scope='all'" in result["error"]
+
+
 # =========================================================================
 
 class TestScrollShape:
@@ -973,18 +1257,18 @@ class TestLegacyContinuationPlusDelegation:
 
 def _seed_gateway_new_reset_chain(db, *, needle="ibuprofen night-dose protocol"):
     """A → B → C gateway /new chain. C is the empty current session."""
-    db.create_session(
-        "s_aug12", source="telegram", session_key="tg:user:1",
-    )
+    db.create_session("s_aug12", source="telegram")
+    _tag_telegram_session(db, "s_aug12", "chat-1", "topic-7")
     db.append_message("s_aug12", role="user", content="older unrelated chat")
     db.end_session("s_aug12", "session_reset")
 
     db.create_session(
-        "s_night", source="telegram",
+        "s_night",
+        source="telegram",
         parent_session_id="s_aug12",
-        session_key="tg:user:1",
         model_config={"_reset_from": "s_aug12"},
     )
+    _tag_telegram_session(db, "s_night", "chat-1", "topic-7")
     db._conn.execute(
         "UPDATE sessions SET title = ? WHERE id = ?",
         ("Night ibuprofen plan", "s_night"),
@@ -996,11 +1280,12 @@ def _seed_gateway_new_reset_chain(db, *, needle="ibuprofen night-dose protocol")
     db.end_session("s_night", "session_reset")
 
     db.create_session(
-        "s_today", source="telegram",
+        "s_today",
+        source="telegram",
         parent_session_id="s_night",
-        session_key="tg:user:1",
         model_config={"_reset_from": "s_night"},
     )
+    _tag_telegram_session(db, "s_today", "chat-1", "topic-7")
     db._conn.commit()
     return needle
 
@@ -1143,4 +1428,3 @@ class TestNewResetLineageBrowse:
         result = json.loads(session_search(db=db, current_session_id="s_other"))
         sids = [r["session_id"] for r in result["results"]]
         assert "s_legacy_child" in sids
-

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -25,6 +25,8 @@ mode parameter):
 All four modes operate on the SQLite session DB via the FTS5 index and
 the get_anchored_view / get_messages_around primitives in hermes_state.
 No LLM calls anywhere — every shape returns actual messages from the DB.
+Telegram calls default to the current conversation; pass `scope=\"all\"` explicitly
+for global history.
 
 History: PR #20238 (JabberELF) seeded a fast/summary dual-mode split; the
 toolkit expansion in PR #26419 (yoniebans) added the anchored drill-down,
@@ -60,6 +62,10 @@ _DEMOTED_SESSION_SOURCES = ("cron",)
 # interactive matches buried under a wall of cron hits, so this is well above
 # the handful of distinct sessions a typical query returns.
 _DISCOVER_SCAN_LIMIT = 300
+
+# Telegram scope query guards.
+_TELEGRAM_SCOPE_MAX_SCAN_ROWS = 30_000
+_TELEGRAM_SCOPE_PAGE_LIMIT = 5_000
 
 # Raw FTS rows are only a discovery-plan input. The final response hydrates
 # its own anchored message window and bookends after lineage deduplication.
@@ -162,6 +168,107 @@ def _resolve_to_parent(db, session_id: str) -> tuple[str, bool]:
             logging.debug("Error resolving parent for %s: %s", cur, e, exc_info=True)
             break
     return cur, has_compression
+
+
+def _telegram_scope_error(message: str) -> str:
+    """Construct a narrow, user-visible scope-denial payload."""
+    return json.dumps({
+        "success": False,
+        "error": message,
+    }, ensure_ascii=False)
+
+
+def _normalize_scope_value(value: Any) -> Optional[str]:
+    if value is None or not str(value).strip():
+        return "current"
+    normalized = str(value).strip().lower()
+    return normalized if normalized in ("current", "all") else None
+
+
+def _resolve_telegram_scope(
+    db,
+    *,
+    scope: Any,
+    current_platform: Optional[str],
+    current_session_id: Optional[str],
+    current_session_key: Optional[str],
+) -> tuple[Optional[set[str]], Optional[str]]:
+    """Resolve one fail-closed Telegram conversation scope per tool call.
+
+    A stable gateway session key is the canonical Telegram conversation lane:
+    it represents either a flat chat or a chat-topic pair.  Legacy rows without
+    that key retain only their provable parent/child lineage and never broaden
+    to global history.
+    """
+    scope_value = _normalize_scope_value(scope)
+    if scope_value is None:
+        return None, "scope must be 'current' or 'all'"
+    if scope_value == "all" or str(current_platform or "").strip().lower() != "telegram":
+        return None, None
+    if not current_session_id:
+        return None, "Telegram session scope unavailable: current session is missing"
+
+    try:
+        current = db.get_session(current_session_id)
+    except Exception:
+        logging.debug("session lookup failed for Telegram scope", exc_info=True)
+        current = None
+    if not current:
+        return None, "Telegram session scope unavailable: current session was not found"
+    if str((current.get("source") or "")).lower() != "telegram":
+        return None, "Telegram session scope unavailable: current session provenance is incompatible"
+
+    durable_key = str(current.get("session_key") or "").strip() or None
+    supplied_key = str(current_session_key or "").strip() or None
+    if supplied_key and durable_key and supplied_key != durable_key:
+        return None, "Telegram session scope unavailable: session key does not match"
+    session_key = supplied_key or durable_key
+
+    try:
+        with db._lock:
+            rows = db._conn.execute(
+                """
+                WITH RECURSIVE
+                ancestors(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT s.parent_session_id
+                    FROM sessions s
+                    JOIN ancestors a ON s.id = a.id
+                    WHERE s.parent_session_id IS NOT NULL
+                ),
+                descendants(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT s.id
+                    FROM sessions s
+                    JOIN descendants d ON s.parent_session_id = d.id
+                )
+                SELECT id FROM ancestors
+                UNION
+                SELECT id FROM descendants
+                UNION
+                SELECT id FROM sessions
+                WHERE ? IS NOT NULL AND session_key = ?
+                """,
+                (current_session_id, current_session_id, session_key, session_key),
+            ).fetchall()
+    except Exception:
+        logging.error("Telegram session scope resolution failed", exc_info=True)
+        return None, "Telegram session scope unavailable: lineage resolution failed"
+
+    allowed = {str(row[0]) for row in rows if row and row[0]}
+    if current_session_id not in allowed:
+        return None, "Telegram session scope unavailable: current lineage is unresolved"
+    return allowed, None
+
+
+def _is_session_in_telegram_scope(
+    session_id: str,
+    telegram_scope: Optional[set[str]],
+) -> bool:
+    """Return whether this session is visible in current Telegram topic scope."""
+    return telegram_scope is None or bool(session_id and session_id in telegram_scope)
 
 
 def _resolve_lineage(db, session_id: str) -> str:
@@ -482,7 +589,13 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
     return json.dumps(response, ensure_ascii=False)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None) -> str:
+def _list_recent_sessions(
+    db,
+    limit: int,
+    current_session_id: str = None,
+    link_profile: str = None,
+    telegram_scope: Optional[set[str]] = None,
+) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
         # list_sessions_rich (include_children=False) already applies the
@@ -492,40 +605,55 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_p
         # children are hidden. Re-classifying rows here in Python duplicated
         # that predicate and re-hid legacy pre-marker reset children the SQL
         # deliberately admits — trust the query instead (#85756).
-        sessions = db.list_sessions_rich(
-            limit=limit + 15,
-            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
-            order_by_last_active=True,
-        )  # fetch extra so we can skip current / compression roots
-
+        page_limit = _TELEGRAM_SCOPE_PAGE_LIMIT if telegram_scope is not None else limit + 15
+        max_scan = _TELEGRAM_SCOPE_MAX_SCAN_ROWS if telegram_scope is not None else page_limit
+        offset = 0
+        results = []
         current_root, has_compression_hop = (
             _resolve_to_parent(db, current_session_id)
             if current_session_id else (None, False)
         )
 
-        results = []
-        for s in sessions:
-            sid = s.get("id", "")
-            if sid == current_session_id:
-                continue
-            # Compression continuation: the root's original turns were
-            # summarised into the live child, so hide the root. /new-reset
-            # children share a lineage root but carry no transcript — keep
-            # that root browsable.
-            if has_compression_hop and current_root and sid == current_root:
-                continue
-            results.append({
-                "session_id": sid,
-                "link": _session_link(sid, link_profile),
-                "title": s.get("title") or None,
-                "source": s.get("source", ""),
-                "started_at": s.get("started_at", ""),
-                "last_active": s.get("last_active", ""),
-                "message_count": s.get("message_count", 0),
-                "preview": s.get("preview", ""),
-            })
+        while len(results) < limit and offset < max_scan:
+            sessions = db.list_sessions_rich(
+                limit=page_limit,
+                offset=offset,
+                exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+                order_by_last_active=True,
+            )
+
+            if not sessions:
+                break
+
+            for s in sessions:
+                sid = s.get("id", "")
+                if sid == current_session_id:
+                    continue
+                # Compression continuation: the root's original turns were
+                # summarised into the live child, so hide the root. /new-reset
+                # children share a lineage root but carry no transcript — keep
+                # that root browsable.
+                if has_compression_hop and current_root and sid == current_root:
+                    continue
+                if not _is_session_in_telegram_scope(sid, telegram_scope):
+                    continue
+                results.append({
+                    "session_id": sid,
+                    "link": _session_link(sid, link_profile),
+                    "title": s.get("title") or None,
+                    "source": s.get("source", ""),
+                    "started_at": s.get("started_at", ""),
+                    "last_active": s.get("last_active", ""),
+                    "message_count": s.get("message_count", 0),
+                    "preview": s.get("preview", ""),
+                })
+                if len(results) >= limit:
+                    break
             if len(results) >= limit:
                 break
+            if len(sessions) < page_limit:
+                break
+            offset += len(sessions)
 
         return json.dumps({
             "success": True,
@@ -545,6 +673,7 @@ def _scroll(
     around_message_id: int,
     window: int = 5,
     current_session_id: str = None,
+    telegram_scope: Optional[set[str]] = None,
 ) -> str:
     """Scroll shape: return a window of messages centered on an anchor.
 
@@ -555,6 +684,11 @@ def _scroll(
     if not isinstance(session_id, str) or not session_id.strip():
         return tool_error("scroll requires session_id", success=False)
     session_id = session_id.strip()
+    if not _is_session_in_telegram_scope(session_id, telegram_scope):
+        return tool_error(
+            "session is outside the current Telegram conversation scope",
+            success=False,
+        )
 
     try:
         around_message_id = int(around_message_id)
@@ -685,6 +819,7 @@ def _title_match_result(
     db,
     query: str,
     current_lineage_root: Optional[str],
+    telegram_scope: Optional[set[str]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Return a discovery-shaped result when the query matches a session title."""
     title_query = _normalize_title_query(query)
@@ -692,7 +827,33 @@ def _title_match_result(
         return None
 
     try:
-        session_id = db.resolve_session_by_title(title_query)
+        if telegram_scope is None:
+            session_id = db.resolve_session_by_title(title_query)
+        else:
+            escaped_title = (
+                title_query.replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_")
+            )
+            with db._lock:
+                candidates = db._conn.execute(
+                    """
+                    SELECT id
+                    FROM sessions
+                    WHERE title = ? OR title LIKE ? ESCAPE '\\'
+                    ORDER BY CASE WHEN title = ? THEN 1 ELSE 0 END,
+                             started_at DESC
+                    """,
+                    (title_query, f"{escaped_title} #%%", title_query),
+                ).fetchall()
+            session_id = next(
+                (
+                    str(row[0])
+                    for row in candidates
+                    if _is_session_in_telegram_scope(str(row[0]), telegram_scope)
+                ),
+                None,
+            )
     except Exception:
         logging.debug("resolve_session_by_title failed for %r", title_query, exc_info=True)
         return None
@@ -761,24 +922,47 @@ def _discover(
     detail: str,
     current_session_id: str = None,
     link_profile: str = None,
+    telegram_scope: Optional[set[str]] = None,
 ) -> str:
     """Discovery shape: FTS5 plus adaptive or full result hydration."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
+    title_result = _title_match_result(
+        db,
+        query,
+        current_lineage_root,
+        telegram_scope=telegram_scope,
+    )
+
 
     try:
-        raw_results = db.search_messages(
-            query=query,
-            role_filter=role_list,
-            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
-            limit=_DISCOVER_SCAN_LIMIT,  # widen so dedup-by-lineage can find
-            # distinct sessions AND so interactive matches buried under a wall
-            # of cron rows are still in hand for the demotion pass below.
-            offset=0,
-            sort=sort,
-            fields=_DISCOVER_SEARCH_FIELDS,
+        raw_results = []
+        offset = 0
+        page_limit = (
+            _TELEGRAM_SCOPE_PAGE_LIMIT if telegram_scope is not None else _DISCOVER_SCAN_LIMIT
         )
+        while len(raw_results) < _DISCOVER_SCAN_LIMIT and offset < _TELEGRAM_SCOPE_MAX_SCAN_ROWS:
+            raw_page = db.search_messages(
+                query=query,
+                role_filter=role_list,
+                exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+                limit=page_limit,
+                # distinct sessions AND so interactive matches buried under a
+                # wall of cron rows are still in hand for the demotion pass.
+                offset=offset,
+                sort=sort,
+                fields=_DISCOVER_SEARCH_FIELDS,
+            )
+            if not raw_page:
+                break
+            raw_results.extend(
+                row
+                for row in raw_page
+                if _is_session_in_telegram_scope(row.get("session_id", ""), telegram_scope)
+            )
+            if telegram_scope is None or len(raw_page) < page_limit:
+                break
+            offset += len(raw_page)
     except Exception as e:
         logging.error("FTS5 search failed: %s", e, exc_info=True)
         return tool_error(f"Search failed: {e}", success=False)
@@ -818,6 +1002,8 @@ def _discover(
         if len(seen_sessions) >= limit:
             break
         raw_sid = r["session_id"]
+        if not _is_session_in_telegram_scope(raw_sid, telegram_scope):
+            continue
         resolved_sid, _ = _resolve_to_parent(db, raw_sid)
         # Skip the current session lineage — UNLESS the hit's transcript has
         # left live context. Three sub-cases:
@@ -949,6 +1135,9 @@ def _session_search_impl(
     profile: str = None,
     # Discovery result shaping (appended to preserve positional compatibility)
     detail: str = "adaptive",
+    scope: str = None,
+    current_platform: str = None,
+    current_session_key: str = None,
     *,
     _owned_dbs: Optional[List[Any]] = None,
 ) -> str:
@@ -975,9 +1164,22 @@ def _session_search_impl(
             if emb_profile and (profile is None or not str(profile).strip()):
                 profile = emb_profile
 
-    # Cross-profile read: swap in the named profile's DB (read-only) for every
-    # shape below. The current-session-lineage guards no longer apply across
-    # profiles, but they key off ids that won't collide, so they stay inert.
+    telegram_scope, scope_error = _resolve_telegram_scope(
+        db,
+        scope=scope,
+        current_platform=current_platform,
+        current_session_id=current_session_id,
+        current_session_key=current_session_key,
+    )
+    if scope_error:
+        return _telegram_scope_error(scope_error)
+    if telegram_scope is not None and profile is not None and str(profile).strip():
+        return _telegram_scope_error(
+            "cross-profile session access requires explicit scope='all' from Telegram"
+        )
+
+    # Cross-profile reads are global by definition, so Telegram callers must
+    # opt in with scope=all before the database is swapped.
     if profile is not None and str(profile).strip():
         try:
             profile_db = _resolve_profile_db(profile)
@@ -997,11 +1199,16 @@ def _session_search_impl(
             around_message_id=around_message_id,
             window=window,
             current_session_id=current_session_id,
+            telegram_scope=telegram_scope,
         )
 
     # Read shape: a session_id with no anchor → dump the whole session.
     if isinstance(session_id, str) and session_id.strip():
         sid = session_id.strip()
+        if not _is_session_in_telegram_scope(sid, telegram_scope):
+            return _telegram_scope_error(
+                "session is outside the current Telegram conversation scope"
+            )
         result = _read_session(db, sid, link_profile=profile)
         if json.loads(result).get("success"):
             return result
@@ -1030,7 +1237,13 @@ def _session_search_impl(
 
     # Browse shape: no query → recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id, link_profile=profile)
+        return _list_recent_sessions(
+            db,
+            limit,
+            current_session_id,
+            link_profile=profile,
+            telegram_scope=telegram_scope,
+        )
 
     # Parse role_filter
     role_list: Optional[List[str]] = None
@@ -1059,6 +1272,7 @@ def _session_search_impl(
         detail=detail_norm,
         current_session_id=current_session_id,
         link_profile=profile,
+        telegram_scope=telegram_scope,
     )
 
 
@@ -1078,6 +1292,9 @@ def session_search(
     profile: str = None,
     # Discovery result shaping (appended to preserve positional compatibility)
     detail: str = "adaptive",
+    scope: str = None,
+    current_platform: str = None,
+    current_session_key: str = None,
 ) -> str:
     """Run session search and close databases opened by this invocation."""
     owned_dbs: List[Any] = []
@@ -1106,6 +1323,9 @@ def session_search(
             sort=sort,
             profile=profile,
             detail=detail,
+            scope=scope,
+            current_platform=current_platform,
+            current_session_key=current_session_key,
             _owned_dbs=owned_dbs,
         )
     finally:
@@ -1290,6 +1510,16 @@ SESSION_SEARCH_SCHEMA = {
                     "Omit to use the current profile."
                 ),
             },
+            "scope": {
+                "type": "string",
+                "enum": ["current", "all"],
+                "description": (
+                    "Optional. Telegram defaults to 'current': only the current "
+                    "gateway conversation key and its session lineage are visible. "
+                    "Use 'all' explicitly for global history. Non-Telegram calls "
+                    "retain their existing global behavior."
+                ),
+            },
         },
         "required": [],
     },
@@ -1312,10 +1542,13 @@ registry.register(
         window=args.get("window", 5),
         sort=args.get("sort"),
         detail=args.get("detail", "adaptive"),
-        profile=args.get("profile"),
-        db=kw.get("db"),
-        current_session_id=kw.get("current_session_id"),
-    ),
+            profile=args.get("profile"),
+            scope=args.get("scope"),
+            db=kw.get("db"),
+            current_session_id=kw.get("current_session_id"),
+            current_platform=kw.get("current_platform"),
+            current_session_key=kw.get("current_session_key"),
+        ),
     check_fn=check_session_search_requirements,
     emoji="🔍",
 )


### PR DESCRIPTION
## Summary
- scope Telegram session history to the current gateway conversation key and its proven lineage
- fail closed when Telegram provenance is missing, stale, or incompatible
- require explicit `scope=all` for global history and Telegram cross-profile reads
- preserve valid flat Telegram chats without a thread ID

## Validation
- targeted session-search tests: 64 passed
- compileall on touched Python modules: passed
- git diff --check: passed
- independent review: no blockers (base 4323c67dcc; reviewed patch SHA-256 313b9878cc642fe14d333cdb890a9eee254d30d387a2e0db93733929bff81724)
