### PR TITLE
fix(desktop): paginate archived sessions

### DIFF
--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -71,7 +71,8 @@ export async function listAllProfileSessions(
   archived: 'exclude' | 'include' | 'only' = 'exclude',
   order: 'created' | 'recent' = 'recent',
   profile: 'all' | (string & {}) = 'all',
-  filter: SessionSourceFilter = {}
+  filter: SessionSourceFilter = {},
+  offset = 0
 ): Promise<PaginatedSessions> {
   const sourceParam = filter.source ? `&source=${encodeURIComponent(filter.source)}` : ''
 
@@ -81,7 +82,7 @@ export async function listAllProfileSessions(
 
   const result = await hermesApi<PaginatedSessions>({
     path:
-      `/api/profiles/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}` +
+      `/api/profiles/sessions?limit=${limit}&offset=${Math.max(0, offset)}&min_messages=${Math.max(0, minMessages)}` +
       `&archived=${archived}&order=${order}&profile=${encodeURIComponent(profile)}${sourceParam}${excludeParam}`,
     timeoutMs: SESSION_LIST_REQUEST_TIMEOUT_MS
   })
@@ -89,7 +90,7 @@ export async function listAllProfileSessions(
   return {
     ...result,
     sessions: pageWindow(result.sessions, limit),
-    offset: 0
+    offset: Math.max(0, offset)
   }
 }
 

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -6,7 +6,6 @@ import { Tip } from '@/components/ui/tooltip'
 import {
   deleteSession,
   getHermesConfigRecord,
-  listAllProfileSessions,
   saveHermesConfig,
   setSessionArchived
 } from '@/hermes'
@@ -20,14 +19,13 @@ import { notify, notifyError } from '@/store/notifications'
 import { untombstoneSessions } from '@/store/projects'
 import { applyConfiguredDefaultProjectDir, ensureDefaultWorkspaceCwd, setSessions } from '@/store/session'
 import { forgetSessionUnread } from '@/store/session-unread'
+import { listEveryArchivedSession } from '@/store/sidebar-archive'
 import type { HermesConfigRecord, SessionInfo } from '@/types/hermes'
 
 import { EmptyState, ListRow, SectionHeading, SettingsContent, SettingsSkeleton, ToggleRow } from './primitives'
 import { useDeepLinkHighlight } from './use-deep-link-highlight'
 
 const DEFAULT_AUTO_ARCHIVE_DAYS = 3
-
-const ARCHIVED_FETCH_LIMIT = 200
 
 export function SessionsSettings() {
   const { t } = useI18n()
@@ -40,8 +38,7 @@ export function SessionsSettings() {
     setLoading(true)
 
     try {
-      const result = await listAllProfileSessions(ARCHIVED_FETCH_LIMIT, 0, 'only')
-      setLocalSessions(result.sessions)
+      setLocalSessions(await listEveryArchivedSession())
     } catch (err) {
       notifyError(err, s.failedLoad)
     } finally {

--- a/apps/desktop/src/store/sidebar-archive.test.ts
+++ b/apps/desktop/src/store/sidebar-archive.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { listEveryArchivedSession } from './sidebar-archive'
+
+const listAllProfileSessions = vi.hoisted(() => vi.fn())
+
+vi.mock('@/hermes', () => ({
+  listAllProfileSessions
+}))
+
+const row = (id: string): SessionInfo =>
+  ({
+    id,
+    archived: true,
+    input_tokens: 0,
+    output_tokens: 0,
+    message_count: 1,
+    started_at: 1,
+    last_active: 1,
+    source: 'desktop',
+    tool_call_count: 0
+  }) as SessionInfo
+
+beforeEach(() => listAllProfileSessions.mockReset())
+
+describe('listEveryArchivedSession', () => {
+  it('paginates until the backend total is loaded', async () => {
+    listAllProfileSessions
+      .mockResolvedValueOnce({ sessions: [row('a'), row('b')], total: 3 })
+      .mockResolvedValueOnce({ sessions: [row('c')], total: 3 })
+
+    await expect(listEveryArchivedSession()).resolves.toEqual([row('a'), row('b'), row('c')])
+    expect(listAllProfileSessions).toHaveBeenNthCalledWith(1, 200, 0, 'only', 'recent', 'all', {}, 0)
+    expect(listAllProfileSessions).toHaveBeenNthCalledWith(2, 200, 0, 'only', 'recent', 'all', {}, 2)
+  })
+
+  it('stops on an empty page when profiles changed during pagination', async () => {
+    listAllProfileSessions
+      .mockResolvedValueOnce({ sessions: [row('a')], total: 2 })
+      .mockResolvedValueOnce({ sessions: [], total: 2 })
+
+    await expect(listEveryArchivedSession()).resolves.toEqual([row('a')])
+    expect(listAllProfileSessions).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/store/sidebar-archive.test.ts
+++ b/apps/desktop/src/store/sidebar-archive.test.ts
@@ -6,7 +6,7 @@ import { listEveryArchivedSession } from './sidebar-archive'
 
 const listAllProfileSessions = vi.hoisted(() => vi.fn())
 
-vi.mock('@/hermes', () => ({
+vi.mock('@/api/sessions', () => ({
   listAllProfileSessions
 }))
 

--- a/apps/desktop/src/store/sidebar-archive.ts
+++ b/apps/desktop/src/store/sidebar-archive.ts
@@ -4,9 +4,29 @@ import { listAllProfileSessions, type SessionInfo } from '@/hermes'
 
 import { $sessions } from './session'
 
-// Archived rows are excluded from the sessions query, so the Archived view has
-// to fetch its own set. Capped: it's a lookup surface, not a feed.
-const ARCHIVED_FETCH_LIMIT = 200
+const ARCHIVED_FETCH_PAGE_SIZE = 200
+
+export async function listEveryArchivedSession(): Promise<SessionInfo[]> {
+  const sessions: SessionInfo[] = []
+
+  while (true) {
+    const page = await listAllProfileSessions(
+      ARCHIVED_FETCH_PAGE_SIZE,
+      0,
+      'only',
+      'recent',
+      'all',
+      {},
+      sessions.length
+    )
+
+    sessions.push(...page.sessions)
+
+    if (page.sessions.length === 0 || sessions.length >= page.total) {
+      return sessions
+    }
+  }
+}
 
 export const $archivedSessions = atom<SessionInfo[]>([])
 export const $archivedSessionsLoading = atom(false)
@@ -19,9 +39,7 @@ export async function loadArchivedSessions(): Promise<void> {
   $archivedSessionsLoading.set(true)
 
   try {
-    const result = await listAllProfileSessions(ARCHIVED_FETCH_LIMIT, 0, 'only')
-
-    $archivedSessions.set(result.sessions)
+    $archivedSessions.set(await listEveryArchivedSession())
   } catch {
     $archivedSessions.set([])
   } finally {

--- a/apps/desktop/src/store/sidebar-archive.ts
+++ b/apps/desktop/src/store/sidebar-archive.ts
@@ -1,6 +1,7 @@
 import { atom, computed } from 'nanostores'
 
-import { listAllProfileSessions, type SessionInfo } from '@/hermes'
+import { listAllProfileSessions } from '@/api/sessions'
+import type { SessionInfo } from '@/types/hermes'
 
 import { $sessions } from './session'
 

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -279,8 +279,11 @@ def get_profiles_sessions(
     source_list = [s.strip() for s in (sources or "").split(",") if s.strip()]
     exclude_list = [s.strip() for s in (exclude_sources or "").split(",") if s.strip()]
     # Over-fetch per profile so the merged+sorted window is correct for the
-    # requested page. Capped so a huge profile can't blow up the response.
-    per_profile = min(max(limit + offset, limit), 500)
+    # requested page. ``limit`` is already bounded to 500 by FastAPI; the
+    # offset is caller-controlled pagination state, so include it instead of
+    # capping the source window at 500. Otherwise page 3 of a 577-row profile
+    # is permanently empty even though ``total`` reports the remaining rows.
+    per_profile = limit + offset
 
     merged: List[Dict[str, Any]] = []
     total = 0

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1927,6 +1927,30 @@ class TestWebServerEndpoints:
         assert payload["limit"] == 3
         assert len(payload["sessions"]) == 3
 
+    def test_profiles_sessions_pages_past_500_rows(self):
+        """The aggregate route must not strand rows after its old 500-row
+        per-profile source cap (issue #88438)."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            for i in range(501):
+                sid = f"archived-page-{i:03d}"
+                db.create_session(session_id=sid, source="cli")
+                db.append_message(session_id=sid, role="user", content="hi")
+                db.set_session_archived(sid, True)
+        finally:
+            db.close()
+
+        resp = self.client.get(
+            "/api/profiles/sessions?limit=1&offset=500&archived=only&profile=default"
+        )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["total"] == 501
+        assert len(payload["sessions"]) == 1
+        assert payload["offset"] == 500
+
     def test_get_session_messages_rejects_negative_limit(self):
         """limit=-1 previously bypassed the documented 500-row clamp because
         min(-1, 500) == -1, which SQLite treats as 'no limit'."""


### PR DESCRIPTION
## Summary

- paginate the all-profile archived-session query instead of stopping at 200 rows
- share the pagination helper between Settings → Archived Conversations and the sidebar Archived view
- expose the backend `offset` parameter through `listAllProfileSessions`
- allow aggregate pages to reach rows beyond the old 500-row per-profile source window

Closes #88438

## Root cause

Both archived-session surfaces called `listAllProfileSessions(200, ..., 'only')` once, so every row after the first 200 remained invisible.

The backend already reported the true `total` and accepted `offset`, but its aggregate query capped each profile's source window at 500 rows. That made a later request such as `offset=500` return an empty page even when the profile had 577 archived sessions.

`listEveryArchivedSession()` now requests 200-row pages until the accumulated rows reach the backend total. The aggregate route includes the requested offset in its per-profile source window, so later pages remain reachable. The client also stops on an empty page so profile changes during pagination cannot create an infinite loop.

## Verification

- `npm exec --workspace=apps/desktop vitest -- run --project ui src/store/sidebar-archive.test.ts src/hermes.test.ts` — 30 passed
- `.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py -q -k 'profiles_sessions_pages_past_500_rows or profiles_sessions_positive_limit_still_works or profiles_sessions_rejects_negative'` — 4 passed
- `npm run typecheck --workspace=apps/desktop`
- `npm run lint --workspace=apps/desktop -- --quiet`
- `git diff --check`

## Scope

The API's per-request response limit remains 500. Only the source window needed to produce an explicitly requested page can exceed 500. Recents and command-palette limits are unchanged.