### PR TITLE
fix(telegram): bound fallback connection pools

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -305,8 +305,10 @@ from plugins.platforms.telegram.telegram_ids import (
 from plugins.platforms.telegram.telegram_network import (
     SEED_FALLBACK_IPS,
     TelegramFallbackTransport,
+    cap_fallback_ips,
     discover_fallback_ips,
     parse_fallback_ip_env,
+    safe_fallback_pool_limits,
 )
 from utils import atomic_replace, env_float, env_int
 
@@ -4414,6 +4416,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         self.name,
                         ", ".join(fallback_ips),
                     )
+            fallback_ips = cap_fallback_ips(fallback_ips)
 
             proxy_targets = ["api.telegram.org", *fallback_ips]
             proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=proxy_targets)
@@ -4434,7 +4437,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 # route this through `_with_limits`, httpx would discard it.
                 _transport_kwargs: dict = {}
                 if _pool_limits is not None:
-                    _transport_kwargs["limits"] = _pool_limits
+                    _transport_kwargs["limits"] = safe_fallback_pool_limits(
+                        _pool_limits, len(fallback_ips)
+                    )
                 request = HTTPXRequest(
                     **request_kwargs,
                     httpx_kwargs={

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -44,6 +44,7 @@ _DOH_PROVIDERS: list[dict] = [
 # cannot pin initialize() (#87015).
 SEED_FALLBACK_IPS: list[str] = ["149.154.166.110", "149.154.167.220"]
 _UNSET = object()
+DEFAULT_MAX_FALLBACK_IPS = 3
 
 
 def _resolve_proxy_url(target_hosts=None) -> str | None:
@@ -62,17 +63,28 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
     is last resort for IPv6-only networks.
     """
 
-    # Bound every pool. httpx defaults to 100 connections per pool, so a wedged
-    # endpoint plus the seed IPs can outgrow the process file-descriptor limit
-    # on its own (#63311).
+    # Default connection budget for one transport. It is divided among the
+    # primary pool and every lazy fallback pool when the caller has not supplied
+    # explicit limits; this prevents the default from multiplying per IP.
     _POOL_LIMITS = httpx.Limits(max_connections=8, max_keepalive_connections=4)
 
     def __init__(self, fallback_ips: Iterable[str], **transport_kwargs):
-        self._fallback_ips = list(dict.fromkeys(_normalize_fallback_ips(fallback_ips)))
+        # Each literal can materialize a separate lazy httpx pool. Cap here as
+        # well as in the adapter so direct users of this public transport cannot
+        # bypass the finite fan-out guarantee.
+        normalized_ips = list(dict.fromkeys(_normalize_fallback_ips(fallback_ips)))
+        self._fallback_ips = cap_fallback_ips(normalized_ips)
         proxy_url = _resolve_proxy_url(target_hosts=[_TELEGRAM_API_HOST, *self._fallback_ips])
         if proxy_url and "proxy" not in transport_kwargs:
             transport_kwargs["proxy"] = proxy_url
-        transport_kwargs.setdefault("limits", self._POOL_LIMITS)
+        if "limits" not in transport_kwargs:
+            # The class default is a budget for this whole transport, not for
+            # each lazy fallback pool. Explicit caller limits still win.
+            transport_kwargs["limits"] = safe_fallback_pool_limits(
+                self._POOL_LIMITS,
+                len(self._fallback_ips),
+                num_ptb_clients=1,
+            )
         self._transport_kwargs = transport_kwargs
         self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
         self._primary_lock = asyncio.Lock()
@@ -233,6 +245,46 @@ def parse_fallback_ip_env(value: str | None) -> list[str]:
         return []
     parts = [part.strip() for part in value.split(",")]
     return _normalize_fallback_ips(parts)
+
+
+def cap_fallback_ips(
+    ips: list[str], max_ips: int = DEFAULT_MAX_FALLBACK_IPS
+) -> list[str]:
+    """Bound fallback-IP fan-out so client + fallback pool construction stays bounded."""
+    if len(ips) <= max_ips:
+        return ips
+    logger.warning(
+        "Telegram fallback IP count %d exceeds the safety cap of %d; using only the first %d",
+        len(ips),
+        max_ips,
+        max_ips,
+    )
+    return ips[:max_ips]
+
+
+def safe_fallback_pool_limits(
+    base_limits: httpx.Limits, fallback_ip_count: int, num_ptb_clients: int = 2
+) -> httpx.Limits:
+    """Divide a total connection/keepalive budget across all possible pools.
+
+    The fallback transport has one primary pool plus one lazy pool per allowed
+    IPv4 literal. Telegram's request and polling clients each build that
+    transport, so the per-pool limit must account for both clients. The caller
+    is responsible for capping ``fallback_ip_count`` before using a configured
+    budget too small to allocate one connection per possible pool.
+    """
+    if base_limits.max_connections is None:
+        return base_limits
+    num_pools = num_ptb_clients * (1 + fallback_ip_count)
+    max_connections = max(1, base_limits.max_connections // num_pools)
+    max_keepalive = base_limits.max_keepalive_connections
+    if max_keepalive is not None:
+        max_keepalive = max(1, min(max_connections, max_keepalive // num_pools))
+    return httpx.Limits(
+        max_connections=max_connections,
+        max_keepalive_connections=max_keepalive,
+        keepalive_expiry=base_limits.keepalive_expiry,
+    )
 
 
 def _resolve_system_dns() -> set[str]:

--- a/tests/gateway/test_telegram_closewait_limits_31599.py
+++ b/tests/gateway/test_telegram_closewait_limits_31599.py
@@ -174,6 +174,7 @@ def test_fallback_branch_forwards_tuned_limits_to_inner_transports(monkeypatch):
     )
 
     assert len(instances) >= 2
+    expected = int(512 / (2 * (1 + 1)))
     for instance in instances:
         transport = instance.kwargs["httpx_kwargs"]["transport"]
         assert isinstance(transport, tg_adapter.TelegramFallbackTransport)
@@ -181,7 +182,7 @@ def test_fallback_branch_forwards_tuned_limits_to_inner_transports(monkeypatch):
         assert isinstance(limits, httpx.Limits)
         assert limits.keepalive_expiry is not None
         assert limits.keepalive_expiry < 5.0
-        assert limits.max_connections == 512
+        assert limits.max_connections == expected
 
     for instance in instances:
         asyncio.run(instance.kwargs["httpx_kwargs"]["transport"].aclose())

--- a/tests/gateway/test_telegram_fallback_pool_release_71593.py
+++ b/tests/gateway/test_telegram_fallback_pool_release_71593.py
@@ -16,8 +16,9 @@ The fix (this PR):
   * on a retryable connect failure calls ``_reset_fallback`` which pops the
     poisoned pool out of ``self._fallbacks`` and ``aclose()``s it, so its dead
     sockets are released instead of accumulating;
-  * bounds every pool at ``Limits(max_connections=8)`` as a *default* via
-    ``setdefault`` — a caller-supplied ``limits`` kwarg still wins.
+  * treats ``Limits(max_connections=8, max_keepalive_connections=4)`` as a
+    transport-wide default budget and divides it among the primary and lazy
+    fallback pools; a caller-supplied ``limits`` kwarg still wins.
 
 Contract asserted here (mutation-survivable)
 ---------------------------------------------
@@ -28,6 +29,8 @@ Contract asserted here (mutation-survivable)
    fails (the pool is retained and never closed).
 2. A caller-supplied ``limits`` kwarg wins over the ``_POOL_LIMITS`` default.
 """
+
+import asyncio
 
 import httpx
 import pytest
@@ -181,9 +184,12 @@ def test_caller_limits_win_over_pool_default(monkeypatch):
     assert custom_limits is not tnet.TelegramFallbackTransport._POOL_LIMITS
 
 
-def test_pool_default_limits_applied_when_caller_omits(monkeypatch):
-    """When the caller supplies no ``limits``, the bounded ``_POOL_LIMITS``
-    default (max_connections=8) is applied via setdefault (#71593)."""
+def test_pool_default_limits_are_shared_across_default_pools(monkeypatch):
+    """Without explicit limits, ``_POOL_LIMITS`` is a transport-wide budget.
+
+    A primary plus one lazy fallback pool must split the default instead of each
+    getting the full eight-connection ceiling.
+    """
     kwargs_log: list = []
     for key in (
         "HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy",
@@ -195,7 +201,14 @@ def test_pool_default_limits_applied_when_caller_omits(monkeypatch):
     )
 
     transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+    asyncio.run(transport._get_fallback("149.154.167.220"))
+
+    assert len(kwargs_log) == 2
     limits = kwargs_log[0]["limits"]
     assert isinstance(limits, httpx.Limits)
-    assert limits.max_connections == 8
-    assert limits is transport._POOL_LIMITS
+    assert limits.max_connections == 4
+    assert limits.max_keepalive_connections == 2
+    assert all(kw["limits"] is limits for kw in kwargs_log)
+    assert limits.max_connections * len(kwargs_log) <= 8
+    assert limits.max_keepalive_connections * len(kwargs_log) <= 4
+    assert limits is not transport._POOL_LIMITS

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -95,6 +95,45 @@ class TestNormalizeFallbackIps:
         assert tnet._normalize_fallback_ips(raw) == ["149.154.167.220", "149.154.167.220"]
 
 
+class TestCapFallbackIps:
+    def test_under_cap_is_unchanged(self):
+        ips = ["149.154.167.220", "149.154.167.221"]
+        assert tnet.cap_fallback_ips(ips, max_ips=3) is ips
+
+    def test_over_cap_is_truncated_and_logged(self, caplog):
+        ips = ["1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4"]
+        capped = tnet.cap_fallback_ips(ips, max_ips=3)
+        assert capped == ["1.1.1.1", "2.2.2.2", "3.3.3.3"]
+        assert "exceeds the safety cap" in caplog.text
+
+
+class TestSafeFallbackPoolLimits:
+    def test_derates_by_total_pool_count(self):
+        """2 PTB clients * (1 primary + 2 fallback) = 6 pools."""
+        base = httpx.Limits(
+            max_connections=512,
+            max_keepalive_connections=100,
+            keepalive_expiry=20.0,
+        )
+        derated = tnet.safe_fallback_pool_limits(base, fallback_ip_count=2, num_ptb_clients=2)
+        assert derated.max_connections == 512 // 6
+        assert derated.max_connections * 6 <= 512
+        assert derated.max_keepalive_connections == 100 // 6
+        assert derated.max_keepalive_connections * 6 <= 100
+        assert derated.keepalive_expiry == 20.0
+
+    def test_never_derates_below_one_connection(self):
+        base = httpx.Limits(max_connections=4, max_keepalive_connections=4)
+        derated = tnet.safe_fallback_pool_limits(base, fallback_ip_count=10, num_ptb_clients=2)
+        assert derated.max_connections >= 1
+        assert derated.max_keepalive_connections >= 1
+
+    def test_no_fallback_still_accounts_for_both_ptb_clients(self):
+        base = httpx.Limits(max_connections=100, max_keepalive_connections=100)
+        derated = tnet.safe_fallback_pool_limits(base, fallback_ip_count=0, num_ptb_clients=2)
+        assert derated.max_connections == 50
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Request rewriting
 # ═══════════════════════════════════════════════════════════════════════════
@@ -354,6 +393,36 @@ class TestFallbackTransportInit:
             # Caller-supplied limits must win over the setdefault default.
             assert kw["limits"] is custom_limits
 
+    def test_default_budget_is_shared_by_all_direct_transport_pools(self, monkeypatch):
+        seen_kwargs = []
+
+        def factory(**kwargs):
+            seen_kwargs.append(kwargs.copy())
+            return FakeTransport([], {})
+
+        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", factory)
+        transport = tnet.TelegramFallbackTransport(
+            ["149.154.167.220", "149.154.167.221", "149.154.167.222", "149.154.167.223"]
+        )
+        assert transport._fallback_ips == [
+            "149.154.167.220",
+            "149.154.167.221",
+            "149.154.167.222",
+        ]
+
+        import asyncio
+
+        for ip in transport._fallback_ips:
+            asyncio.run(transport._get_fallback(ip))
+
+        # One primary + the capped three fallback pools use one default budget.
+        assert len(seen_kwargs) == 4
+        limits = [kwargs["limits"] for kwargs in seen_kwargs]
+        assert all(limit.max_connections == 2 for limit in limits)
+        assert sum(limit.max_connections for limit in limits) <= 8
+        assert all(limit.max_keepalive_connections == 1 for limit in limits)
+        assert sum(limit.max_keepalive_connections for limit in limits) <= 4
+
 
 class TestFallbackTransportClose:
     @pytest.mark.asyncio
@@ -566,4 +635,3 @@ class TestDiscoverFallbackIps:
 
         assert ips == ["149.154.167.220"]
         assert elapsed < 1.4, f"discovery gated on hung system DNS ({elapsed:.2f}s)"
-


### PR DESCRIPTION
## Summary
- cap Telegram fallback IPv4 targets so lazy fallback-pool fan-out is finite
- distribute the configured connection and keepalive budget across both PTB clients and every primary/fallback pool
- make direct transport defaults transport-wide rather than per-IP pool budgets
- preserve explicit caller limits and existing fallback cleanup/CLOSE_WAIT protections

## Validation
- focused Telegram network, fallback-pool-release, and CLOSE_WAIT tests: 36 passed
- compileall on touched Telegram modules: passed
- git diff --check: passed
- independent review: no blockers (base 4323c67dcc; reviewed patch SHA-256 ad521d60e3ee5db978dc8148eeae7ffb5c2f8abe7ca5931c06b2bee1f9245884)
