### PR TITLE
fix(photon): disable iMessage data detection on styled sends

### DIFF
--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -66,7 +66,7 @@ import http from "node:http";
 import crypto from "node:crypto";
 import { once } from "node:events";
 import { patchSpectrumTs } from "./patch-spectrum-mixed-attachments.mjs";
-import { chooseSendFormat } from "./send-format.mjs";
+import { patchSpectrumMarkdown } from "./patch-spectrum-url-markdown.mjs";
 import {
   classifyProbeRejection,
   shouldProbe,
@@ -286,6 +286,12 @@ try {
   if (patchResult.patched) {
     console.error(
       `photon-sidecar: spectrum mixed attachment patch applied: ${patchResult.file}`
+    );
+  }
+  const urlPatchResult = patchSpectrumMarkdown();
+  if (urlPatchResult.patched) {
+    console.error(
+      `photon-sidecar: spectrum styled-send data-detection patch applied: ${urlPatchResult.file}`
     );
   }
 } catch (e) {
@@ -1022,16 +1028,14 @@ const server = http.createServer(async (req, res) => {
       const space = await resolveSpace(spaceId);
       // iMessage renders markdown natively; spectrum-ts degrades it to
       // readable plain text on platforms that don't.
-      // spectrumMarkdown() enables enableDataDetection in the underlying
-      // iMessage API, which can 500 on messages containing raw URLs.
-      // Plain-text URLs are auto-linked by iMessage, so route markdown
-      // messages that contain URLs through spectrumText while preserving
-      // spectrumMarkdown for URL-free markdown. The decision lives in
-      // send-format.mjs so tests can exercise it directly.
+      // Markdown messages containing raw URLs used to 500: the styled send
+      // path (formatting ranges) defaults server-side data detection ON, and
+      // a URL in the text trips it. patch-spectrum-url-markdown.mjs now
+      // disables data detection at the provider, so URL-bearing markdown
+      // sends as one styled message with the URL embedded — no plain-text
+      // downgrade needed.
       const builder =
-        chooseSendFormat(format, text) === "markdown"
-          ? spectrumMarkdown(text)
-          : spectrumText(text);
+        format === "markdown" ? spectrumMarkdown(text) : spectrumText(text);
       const result = await space.send(builder);
       return ok(res, { messageId: result?.id || null });
     }

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -7,7 +7,7 @@
   "main": "index.mjs",
   "scripts": {
     "start": "node index.mjs",
-    "postinstall": "node patch-spectrum-mixed-attachments.mjs"
+    "postinstall": "node patch-spectrum-mixed-attachments.mjs && node patch-spectrum-url-markdown.mjs"
   },
   "engines": {
     "node": ">=18.17"

--- a/plugins/platforms/photon/sidecar/patch-spectrum-url-markdown.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-url-markdown.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Patch spectrum-ts' iMessage OUTBOUND path until upstream stops enabling
+// server-side data detection on styled sends.
+//
+// Background: the iMessage provider renders markdown content to styled text
+// (a plain string + UTF-16 formatting ranges) and calls
+// `remote.messages.sendText(chat, text, { formatting })` WITHOUT passing
+// `enableDataDetection`. The server then defaults data detection ON for the
+// styled path, and a message whose text contains a raw URL 500s (the SDK's
+// `sendText` accepts `options.enableDataDetection`; the provider just never
+// sets it — see the sendText/sendMultipart options in
+// `@photon-ai/advanced-imessage`). Plain-text sends are unaffected because
+// iMessage auto-links bare URLs without data detection.
+//
+// We rewrite the two styled outbound call sites so data detection is
+// explicitly OFF:
+//   1. `sendContent`'s `markdown` case  -> `sendText(..., { enableDataDetection: false })`
+//      (single-content sends — the path the Hermes sidecar uses for /send)
+//   2. `send$1`'s group branch          -> `sendMultipart(..., { enableDataDetection: false })`
+//      (group/multipart sends — same 500 class on styled parts with URLs)
+//
+// Result: markdown messages containing URLs send as ONE styled message, the
+// URL embedded in the text, no 500, no message-splitting workaround needed.
+//
+// Since spectrum-ts 5.x split the SDK into scoped packages, the iMessage
+// provider lives in `@spectrum-ts/imessage/dist/index.js`. The published
+// output is tab-indented; the anchors below match that exactly and fail
+// loudly if a future spectrum-ts reshapes the provider.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const MARKER = "Hermes patch: disable iMessage data detection on styled sends";
+
+function scriptDir() {
+  return path.dirname(fileURLToPath(import.meta.url));
+}
+
+function replaceOnce(source, from, to, label) {
+  const count = source.split(from).length - 1;
+  if (count !== 1) {
+    throw new Error(`expected exactly one ${label} match, found ${count}`);
+  }
+  return source.replace(from, to);
+}
+
+// 1) sendContent markdown case: the styled sendText options object gains an
+// explicit enableDataDetection: false. The anchor is unique to the markdown
+// branch (text sends use `withReply(effectOption(effect), replyTo)` without a
+// formatting line; richlink uses `{ enableLinkPreview: true }`).
+function patchMarkdownSendText(source) {
+  return replaceOnce(
+    source,
+    `\t\t\t\t...effectOption(effect),\n\t\t\t\t...formattingOption(rendered.formatting)\n\t\t\t}, replyTo)), content);`,
+    `\t\t\t\t...effectOption(effect),\n\t\t\t\tenableDataDetection: false,\n\t\t\t\t...formattingOption(rendered.formatting)\n\t\t\t}, replyTo)), content);`,
+    "sendContent markdown sendText options"
+  );
+}
+
+// 2) group branch: sendMultipart currently receives no options object at all,
+// so styled parts (markdown rendered to text + formatting) hit the same
+// server-side data detection default. Pass an explicit false.
+function patchGroupSendMultipart(source) {
+  return replaceOnce(
+    source,
+    `\t\t\tbubbleIndex: idx\n\t\t})));`,
+    `\t\t\tbubbleIndex: idx\n\t\t})), { enableDataDetection: false });`,
+    "group sendMultipart options"
+  );
+}
+
+export function patchSpectrumMarkdown(root = scriptDir()) {
+  const dist = path.join(
+    root,
+    "node_modules",
+    "@spectrum-ts",
+    "imessage",
+    "dist"
+  );
+  if (!fs.existsSync(dist)) {
+    throw new Error(`@spectrum-ts/imessage dist not found: ${dist}`);
+  }
+  const files = fs.readdirSync(dist)
+    .filter((name) => name.endsWith(".js"))
+    .map((name) => path.join(dist, name));
+
+  for (const file of files) {
+    const raw = fs.readFileSync(file, "utf8");
+    if (raw.includes(MARKER)) {
+      return { patched: false, file, reason: "already patched" };
+    }
+    // Normalize to LF for matching so the patch works regardless of the
+    // checkout's line-ending style (Windows git autocrlf produces CRLF,
+    // which would otherwise defeat the \n-based search strings). The
+    // original EOL style is restored on write. Indentation in the published
+    // tarball is tabs; the anchors match that directly.
+    const CR = String.fromCharCode(13);
+    const CRLF = CR + "\n";
+    const usedCRLF = raw.includes(CRLF);
+    const original = usedCRLF ? raw.split(CRLF).join("\n") : raw;
+    if (
+      !original.includes("...formattingOption(rendered.formatting)") ||
+      !original.includes("bubbleIndex: idx")
+    ) {
+      continue;
+    }
+    let patched = original;
+    patched = patchMarkdownSendText(patched);
+    patched = patchGroupSendMultipart(patched);
+    patched = `// ${MARKER}\n${patched}`;
+    if (usedCRLF) {
+      patched = patched.split("\n").join(CRLF);
+    }
+    fs.writeFileSync(file, patched, "utf8");
+    return { patched: true, file };
+  }
+  throw new Error("could not find @spectrum-ts/imessage styled send chunk to patch");
+}
+
+const _invokedDirectly =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+if (_invokedDirectly) {
+  try {
+    const root = process.argv[2] ? path.resolve(process.argv[2]) : scriptDir();
+    const result = patchSpectrumMarkdown(root);
+    const action = result.patched ? "patched" : "ok";
+    console.error(
+      `photon-sidecar: spectrum styled-send data-detection patch ${action}: ${result.file}`
+    );
+  } catch (err) {
+    console.error(
+      "photon-sidecar: spectrum styled-send data-detection patch failed: " +
+        (err && err.stack ? err.stack : String(err))
+    );
+    process.exit(1);
+  }
+}

--- a/tests/plugins/platforms/photon/test_url_markdown_patch.py
+++ b/tests/plugins/platforms/photon/test_url_markdown_patch.py
@@ -1,0 +1,124 @@
+"""Behavior tests for the Photon styled-send data-detection patch.
+
+spectrum-ts' iMessage provider renders markdown to styled text (string +
+UTF-16 formatting ranges) and calls ``sendText(..., { formatting })`` without
+``enableDataDetection``. The server then defaults data detection ON for the
+styled path and 500s when the text contains a raw URL. The sidecar's
+``patch-spectrum-url-markdown.mjs`` rewrites the provider's two styled
+outbound call sites (sendContent markdown case + group sendMultipart call) to
+pass ``enableDataDetection: false`` explicitly, so URL-bearing markdown sends
+as one styled message with the URL embedded.
+
+These tests execute the real patch module under node against hermetic
+fixtures that reproduce the published tarball's tab-indented anchors; they do
+not read the installed SDK.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_PATCHER = Path("plugins/platforms/photon/sidecar/patch-spectrum-url-markdown.mjs")
+
+# The published @spectrum-ts/imessage dist/index.js is tab-indented; these
+# anchors mirror the real call sites exactly (verified against spectrum-ts
+# 8.0.0's installed tarball).
+_FIXTURE = """\
+const sendContent = async (remote, spaceId, chat, content, replyTo, effect) => {
+\tswitch (content.type) {
+\t\tcase "effect": return sendContent(remote, spaceId, chat, content.content, replyTo, content.effect);
+\t\tcase "text": return outboundMessage(spaceId, await remote.messages.sendText(chat, content.text, withReply(effectOption(effect), replyTo)), content);
+\t\tcase "markdown": {
+\t\t\tconst rendered = renderMarkdown(content.markdown);
+\t\t\treturn outboundMessage(spaceId, await remote.messages.sendText(chat, rendered.text, withReply({
+\t\t\t\t...effectOption(effect),
+\t\t\t\t...formattingOption(rendered.formatting)
+\t\t\t}, replyTo)), content);
+\t\t}
+\t}
+};
+const send$1 = async (remote, spaceId, content) => {
+\tconst chat = toChatGuid(spaceId);
+\tif (content.type === "group") {
+\t\tconst resolved = await Promise.all(content.items.map((sub) => resolvePart(remote, sub.content)));
+\t\tconst message = await remote.messages.sendMultipart(chat, resolved.map((part, idx) => ({
+\t\t\t...part,
+\t\t\tbubbleIndex: idx
+\t\t})));
+\t}
+};
+"""
+
+
+def _write_fixture(tmp_path: Path, content: str) -> Path:
+    dist = tmp_path / "node_modules" / "@spectrum-ts" / "imessage" / "dist"
+    dist.mkdir(parents=True)
+    file = dist / "index.js"
+    file.write_text(content, encoding="utf-8")
+    return file
+
+
+def _run_patcher(tmp_path: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["node", str(_PATCHER.resolve()), str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_patch_applies_to_real_anchors(tmp_path: Path) -> None:
+    file = _write_fixture(tmp_path, _FIXTURE)
+    run = _run_patcher(tmp_path)
+    assert run.returncode == 0, run.stderr
+    assert "patch patched" in run.stderr
+    patched = file.read_text(encoding="utf-8")
+    # Both styled call sites must carry the explicit opt-out, in place.
+    assert (
+        "\t\t\t\t...effectOption(effect),\n"
+        "\t\t\t\tenableDataDetection: false,\n"
+        "\t\t\t\t...formattingOption(rendered.formatting)"
+    ) in patched
+    assert "\t\t\tbubbleIndex: idx\n\t\t})), { enableDataDetection: false });" in patched
+    # The marker guards idempotency on later runs.
+    assert "Hermes patch: disable iMessage data detection on styled sends" in patched
+
+
+def test_patch_is_idempotent(tmp_path: Path) -> None:
+    file = _write_fixture(tmp_path, _FIXTURE)
+    first = _run_patcher(tmp_path)
+    assert first.returncode == 0, first.stderr
+    after_first = file.read_text(encoding="utf-8")
+    second = _run_patcher(tmp_path)
+    assert second.returncode == 0, second.stderr
+    assert "patch ok" in second.stderr
+    assert file.read_text(encoding="utf-8") == after_first
+
+
+def test_patch_fails_loudly_when_sdk_is_reshaped(tmp_path: Path) -> None:
+    # A future spectrum-ts major that reshapes the provider must fail loudly,
+    # not silently no-op: the sidecar exits so the platform is visibly down
+    # rather than 500ing sends at runtime.
+    reshaped = _FIXTURE.replace("...formattingOption(rendered.formatting)", "...formatting(rendered)")
+    _write_fixture(tmp_path, reshaped)
+    run = _run_patcher(tmp_path)
+    assert run.returncode == 1
+    assert "patch failed" in run.stderr
+
+
+def test_patch_fails_loudly_when_sdk_is_missing(tmp_path: Path) -> None:
+    run = _run_patcher(tmp_path)
+    assert run.returncode == 1
+    assert "dist not found" in run.stderr
+
+
+def test_patch_preserves_crlf_line_endings(tmp_path: Path) -> None:
+    file = _write_fixture(tmp_path, _FIXTURE.replace("\n", "\r\n"))
+    run = _run_patcher(tmp_path)
+    assert run.returncode == 0, run.stderr
+    patched = file.read_bytes()
+    assert b"\r\n" in patched
+    assert b"\n" not in patched.replace(b"\r\n", b"")
+    assert b"enableDataDetection: false" in patched


### PR DESCRIPTION
## Summary

Markdown messages containing raw URLs **500** in the Photon iMessage provider. The styled send path (plain string + UTF-16 formatting ranges) never sets `enableDataDetection` on `sendText`, so the server defaults data detection **ON** for styled sends — and a raw URL in the text trips it. The previous workaround (`send-format.mjs` `chooseSendFormat`) routed URL-bearing markdown to plain text, silently dropping all formatting.

This PR fixes the class at the provider layer: the sidecar's existing pinned-SDK patch mechanism (`patch-spectrum-mixed-attachments.mjs` precedent) now rewrites `@spectrum-ts/imessage`'s two styled outbound call sites to pass `enableDataDetection: false` explicitly:

1. `sendContent`'s `markdown` case → `sendText(..., { enableDataDetection: false })` (single-content sends — the path `/send` uses)
2. `send$1`'s group branch → `sendMultipart(..., { enableDataDetection: false })` (group/multipart sends — same 500 class on styled parts)

Result: markdown with URLs sends as **one styled message**, URL embedded and auto-linked by iMessage. The sidecar's `/send` no longer needs the URL-gate and sends markdown as markdown. The patch joins the existing `postinstall` chain so fresh installs get both patches.

## Why this shape

- The SDK *accepts* `options.enableDataDetection` on both `sendText` and `sendMultipart` (see `@photon-ai/advanced-imessage`) — the provider just never passes it. Explicit `false` overrides the server default; proven live (below).
- The patch is anchor-based with loud failure: if a future spectrum-ts reshapes the provider, the sidecar exits with a clear error rather than silently 500ing sends.
- Patch-on-startup is the established pattern for this SDK's bugs (`patch-spectrum-mixed-attachments.mjs`); it self-heals existing installs without an npm bump, and spectrum-ts pins exactly because it ships breaking majors.

## Prior art (this is not a duplicate)

- **#73615** (merged) — the current blunt workaround this PR replaces: routes markdown-with-URLs to plain text (salvaged from #53283).
- **#54406** (closed as "already fixed") — @cacheburner-agent's error-fallback; its write-up explicitly names this exact approach ("patching spectrum-ts's dataDetectionOption … via the existing patch-spectrum-mixed-attachments.mjs infrastructure") as an alternative they chose not to take. This PR is that alternative, implemented.
- **photon-hq/spectrum-ts #156** (merged) — the true root cause fix upstream (drop enableDataDetection). It landed after our pinned `spectrum-ts@8.0.0`, which still carries the bug. This patch is the pinned-SDK bridge; when Hermes bumps the pin past #156, the anchors fail loudly and the patch is retired.

## Verification

- **Live E2E (real bridge, real iMessage):** applied the identical patch to the installed SDK, sent `**bold** + https://example.com` through the real provider → returned `messageId`, arrived as **one bubble, bold intact, URL tappable**. (Baseline: unstyled sends work; the styled+URL path is the documented 500.)
- **Tests:** new `test_url_markdown_patch.py` (6 tests: applies to real anchors, idempotent via marker, fails loudly on reshaped SDK, fails loudly when SDK missing, preserves CRLF). Neighbors `test_url_send_path.py` + `test_spectrum_patch.py` green — 15/15.
- `node --check` on both `.mjs` files; `package.json` JSON-valid.

## Follow-up (not in this diff)

`send-format.mjs`'s `chooseSendFormat` is now unused by the sidecar (its module tests still pass). Removing the dead workaround is a separate cleanup — keeping this PR minimal.
