### PR TITLE
feat(agent): optional session token budget fuse + /usage session diagnostics

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1871,6 +1871,18 @@ def init_agent(
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
+    # Session token fuse: hard ceiling on cumulative session tokens (cache
+    # reads included). 0 disables. Set well above legitimate heavy-task
+    # usage — the fuse stops runaway episodes, not work. Checked at the top
+    # of each conversation-loop iteration.
+    try:
+        agent.session_token_hard_stop = max(
+            0, int(_agent_section.get("session_token_hard_stop", 0) or 0)
+        )
+    except (TypeError, ValueError):
+        agent.session_token_hard_stop = 0
+    agent._session_token_fuse_warned = False
+
     # Empty-response retry guard config (NS-503): additive
     # ``agent.empty_response_guard`` subsection. Resolution is tolerant —
     # a malformed section falls back to the schema defaults (guard on,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1927,7 +1927,40 @@ def run_conversation(
             if not agent.quiet_mode:
                 agent._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
             break
-        
+
+        # Session token fuse (agent.session_token_hard_stop, 0 = disabled):
+        # hard ceiling on cumulative session tokens, cache reads included —
+        # a runaway episode's cost is context re-read, not fresh output.
+        # Deliberately NOT routed through the budget-exhausted summary
+        # fallback: that would spend one more full-context call on a session
+        # the fuse exists to stop. Warn once at 80%.
+        _token_fuse = getattr(agent, "session_token_hard_stop", 0) or 0
+        if _token_fuse > 0:
+            _fuse_used = getattr(agent, "session_total_tokens", 0) or 0
+            if _fuse_used >= _token_fuse:
+                _turn_exit_reason = f"session_token_fuse({_fuse_used}/{_token_fuse})"
+                agent._emit_status(
+                    f"🛑 Session token fuse: {_fuse_used:,} of {_token_fuse:,} "
+                    "tokens used — stopping this turn. Continue in a fresh "
+                    "session (/new)."
+                )
+                if not agent.quiet_mode:
+                    agent._safe_print(
+                        f"\n🛑 Session token fuse blown "
+                        f"({_fuse_used:,}/{_token_fuse:,} tokens); stopping turn."
+                    )
+                break
+            if (
+                _fuse_used >= 0.8 * _token_fuse
+                and not getattr(agent, "_session_token_fuse_warned", False)
+            ):
+                agent._session_token_fuse_warned = True
+                agent._emit_status(
+                    f"⚠️ Session tokens at {_fuse_used:,} of the "
+                    f"{_token_fuse:,} fuse — wrap up or move to a fresh "
+                    "session soon."
+                )
+
         api_call_count += 1
         agent._api_call_count = api_call_count
         agent._touch_activity(f"starting API call #{api_call_count}")

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -937,6 +937,15 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Session token fuse: hard ceiling on cumulative session tokens (cache
+  # reads included — long tool-heavy sessions re-read a large live context
+  # on every call, so cache reads dominate runaway cost). One warning at
+  # 80%; at the ceiling the turn stops cleanly with a start-a-fresh-session
+  # notice, without the budget-exhausted summary fallback. 0 = disabled.
+  # Set well above legitimate heavy-task usage; this is a runaway fuse,
+  # not a working limit.
+  # session_token_hard_stop: 0
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5369,6 +5369,26 @@ class GatewaySlashCommandsMixin:
                 lines.append("")
                 lines.extend(breakdown_lines)
 
+            # Messaging sessions can feel fresh while reusing a cached prompt
+            # and transcript. Surface those hidden dimensions directly so
+            # messaging token burn is no longer opaque.
+            try:
+                sys_prompt_chars = len(getattr(agent, "_cached_system_prompt", "") or "")
+                agent_messages = getattr(agent, "messages", None) or []
+                session_id = getattr(agent, "session_id", "") or ""
+                cache_read_tokens = getattr(agent, "session_cache_read_tokens", 0) or 0
+                lines.append("")
+                lines.append("🔎 **Session diagnostics**")
+                lines.append(f"Session ID: `{session_id}`" if session_id else "Session ID: unknown")
+                lines.append(f"Cached system prompt: {sys_prompt_chars:,} chars")
+                lines.append(f"Messages in agent context: {len(agent_messages):,}")
+                if sys_prompt_chars >= 100_000:
+                    lines.append("⚠ Cached prompt is large; use /new at a task boundary if usage feels abnormal.")
+                if input_tokens >= 100_000 or cache_read_tokens >= 100_000:
+                    lines.append("⚠ This session is already in high-token territory; consider /new after this task.")
+            except Exception:
+                pass
+
             if account_lines:
                 lines.append("")
                 lines.extend(account_lines)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -44,6 +44,14 @@ DEFAULT_CONFIG = {
     },
     "agent": {
         "max_turns": 500,
+        # Session token fuse: hard ceiling on cumulative session tokens
+        # (cache reads included — context re-read is what runaway episodes
+        # actually spend). 0 = disabled. When the ceiling is reached the
+        # conversation loop stops the turn with a clear "/new" notice and
+        # WITHOUT the budget-exhausted summary fallback (which would spend
+        # one more full-context call). Set well above legitimate heavy-task
+        # usage; this is a runaway fuse, not a working limit.
+        "session_token_hard_stop": 0,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/tests/agent/test_session_token_fuse.py
+++ b/tests/agent/test_session_token_fuse.py
@@ -1,0 +1,152 @@
+"""Session token fuse: cumulative-token hard stop in the conversation loop.
+
+End-to-end behavior tests running ``AIAgent.run_conversation`` against an
+in-process mock provider. The fuse (``agent.session_token_hard_stop``) must:
+
+* stop a turn BEFORE any API call when the session is already over the cap
+  (no summary-fallback call either — the fuse exists to stop spending);
+* leave turns untouched when disabled (0, the default);
+* warn once at 80% without blocking the turn.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+    captured_requests: list = []
+    response_queue: list = []
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", 0))
+        req = json.loads(self.rfile.read(length) or b"{}")
+        type(self).captured_requests.append(req)
+        if type(self).response_queue:
+            resp = type(self).response_queue.pop(0)
+        else:
+            resp = _text_resp("done")
+        msg = resp["choices"][0]["message"]
+        if req.get("stream") is True:
+            content = msg.get("content") or ""
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            chunks = [{"id": "m", "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}]}]
+            if content:
+                chunks.append({"id": "m", "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None}]})
+            chunks.append({"id": "m", "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]})
+            for c in chunks:
+                self.wfile.write(f"data: {json.dumps(c)}\n\n".encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+        else:
+            payload = json.dumps(resp).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+    def log_message(self, *args):  # silence request logging
+        pass
+
+
+def _text_resp(text: str) -> dict:
+    return {
+        "id": "m",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+    }
+
+
+@pytest.fixture()
+def agent_env():
+    _MockHandler.captured_requests = []
+    _MockHandler.response_queue = []
+    srv = HTTPServer(("127.0.0.1", 0), _MockHandler)
+    port = srv.server_address[1]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+
+    test_home = tempfile.mkdtemp(prefix="hermes_token_fuse_")
+    os.makedirs(os.path.join(test_home, ".hermes"))
+    prev_home = os.environ.get("HERMES_HOME")
+    os.environ["HERMES_HOME"] = os.path.join(test_home, ".hermes")
+
+    for mod in list(sys.modules):
+        if mod == "run_agent" or mod.startswith("agent.") or mod.startswith("tools.") or mod.startswith("hermes_"):
+            del sys.modules[mod]
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key", base_url=f"http://127.0.0.1:{port}/v1",
+        provider="openai-compat", model="test-model",
+        max_iterations=10, enabled_toolsets=[],
+        quiet_mode=True, skip_context_files=True, skip_memory=True,
+        save_trajectories=False, platform="cli",
+    )
+
+    try:
+        yield agent, _MockHandler
+    finally:
+        srv.shutdown()
+        shutil.rmtree(test_home, ignore_errors=True)
+        if prev_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = prev_home
+
+
+def test_blown_fuse_stops_turn_with_zero_api_calls(agent_env):
+    agent, handler = agent_env
+    agent.session_token_hard_stop = 1_000
+    agent.session_total_tokens = 1_500
+
+    result = agent.run_conversation("hello", conversation_history=[], task_id="t")
+
+    chat_requests = [r for r in handler.captured_requests if "messages" in r]
+    assert chat_requests == [], (
+        "a blown fuse must stop the turn before ANY provider call, "
+        "including the budget-exhausted summary fallback"
+    )
+    assert result["api_calls"] == 0
+    assert str(result["turn_exit_reason"]).startswith("session_token_fuse(")
+
+
+def test_disabled_fuse_leaves_turn_untouched(agent_env):
+    agent, handler = agent_env
+    assert agent.session_token_hard_stop == 0  # default: disabled
+    agent.session_total_tokens = 10_000_000
+    handler.response_queue = [_text_resp("all good")]
+
+    result = agent.run_conversation("hello", conversation_history=[], task_id="t")
+
+    chat_requests = [r for r in handler.captured_requests if "messages" in r]
+    assert len(chat_requests) == 1
+    assert result["final_response"] == "all good"
+
+
+def test_warn_threshold_emits_once_and_does_not_block(agent_env):
+    agent, handler = agent_env
+    agent.session_token_hard_stop = 1_000
+    agent.session_total_tokens = 900  # >= 80%
+    handler.response_queue = [_text_resp("still working")]
+
+    statuses = []
+    agent._emit_status = statuses.append
+
+    result = agent.run_conversation("hello", conversation_history=[], task_id="t")
+
+    chat_requests = [r for r in handler.captured_requests if "messages" in r]
+    assert len(chat_requests) == 1
+    assert result["final_response"] == "still working"
+    warn_msgs = [s for s in statuses if "fuse" in s]
+    assert len(warn_msgs) == 1
+    assert agent._session_token_fuse_warned is True

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -22,6 +22,9 @@ def _make_mock_agent(**overrides):
         "session_output_tokens": 10_000,
         "session_cache_read_tokens": 5_000,
         "session_cache_write_tokens": 2_000,
+        "_cached_system_prompt": "system" * 100,
+        "session_id": "sess-usage-1",
+        "messages": [{"role": "user", "content": "hi"}],
     }
     defaults.update(overrides)
     for k, v in defaults.items():
@@ -91,6 +94,9 @@ class TestUsageCachedAgent:
         assert "Cache read" not in result
         assert "Cache write" not in result
         assert "Cost" not in result
+        assert "Session diagnostics" in result
+        assert "Cached system prompt: 600 chars" in result
+        assert "Messages in agent context: 1" in result
 
     @pytest.mark.asyncio
     async def test_running_agent_preferred_over_cache(self):


### PR DESCRIPTION
## What does this PR do?

Adds `agent.session_token_hard_stop` (default `0` = disabled, fully opt-in): a provider-independent hard ceiling on a session's **cumulative** token usage, enforced at the top of each conversation-loop iteration.

Motivation: long tool-heavy sessions accumulate a large live context that gets re-read on every API call, so cache reads come to dominate cost — a session can quietly reach hundreds of calls at 100K+ tokens of context each. Per-turn iteration caps (`max_turns`) don't bound this, and lowering them strands legitimate work. A cumulative-token fuse bounds the runaway case without reducing capability:

- warns once (via `_emit_status`) at 80% of the ceiling;
- at the ceiling, ends the turn **before** the next API call with a clear "continue in a fresh session (/new)" notice;
- deliberately does **not** route through the budget-exhausted summary fallback — that would spend one more full-context call on exactly the session the fuse exists to stop;
- applies uniformly to every surface that runs the conversation loop (gateway platforms, CLI, cron, delegation), and counts cache reads, since those are what runaway sessions actually spend.

Also adds a small session-diagnostics block to `/usage` (session id, cached system prompt size, message count in context, high-usage hints) so messaging-session token burn isn't opaque to users.

## Related Issue

No existing issue; this came out of a real-world incident on a long-running deployment where marathon sessions reached 40–80M cumulative tokens (>90% cache reads) with no mechanism able to bound them. Happy to open an issue for discussion if preferred.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/conversation_loop.py` — fuse check at the top of the iteration loop (before `api_call_count += 1`): warn-once at 80%, clean break with `session_token_fuse(<used>/<cap>)` exit reason at the ceiling
- `agent/agent_init.py` — read `agent.session_token_hard_stop` from config onto the agent (tolerant parsing, 0/invalid = disabled)
- `hermes_cli/config_defaults.py` — schema default + rationale comment
- `cli-config.yaml.example` — documented commented-out key
- `gateway/slash_commands.py` — `/usage` session-diagnostics block (best-effort, wrapped in try/except)
- `tests/agent/test_session_token_fuse.py` — new: blown fuse stops the turn with **zero** provider calls; disabled fuse leaves turns untouched; warn threshold emits once and doesn't block
- `tests/gateway/test_usage_command.py` — extended for the `/usage` diagnostics

## How to Test

1. `pytest tests/agent/test_session_token_fuse.py tests/gateway/test_usage_command.py -q` (9 tests)
2. Manual: set `agent.session_token_hard_stop: 1000` in config, run any turn — it stops before the first API call with the fuse notice; set `0` and behavior is byte-identical to before.
3. Default-off safety: with the key absent, `session_token_hard_stop` resolves to 0 and the new branch is never taken.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs for duplicates
- [x] My PR contains **only** changes related to this feature
- [ ] Full `pytest tests/ -q` — ran the targeted suites above plus `tests/agent/test_empty_tool_name_loop_dampening.py` and `tests/agent/test_turn_finalizer_iteration_limit_exit.py` (all green); deferring the full ~14K-test sweep to CI
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu Linux (x86_64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (config comments + example) — docstrings inline
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — pure-Python counter check, no platform-specific code
- [x] Tool descriptions/schemas — N/A (no tool behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)