### PR TITLE
test(tui): stabilize profile-local MCP discovery probe

### DIFF
--- a/tests/tui_gateway/test_slash_worker_mcp_discovery.py
+++ b/tests/tui_gateway/test_slash_worker_mcp_discovery.py
@@ -51,6 +51,10 @@ def test_profile_local_mcp_tool_is_visible_in_slash_worker(tmp_path):
     (profile_home / "config.yaml").write_text(
         yaml.safe_dump(
             {
+                # This test verifies profile-local discovery, not the
+                # production startup-latency bound. Give the real MCP
+                # subprocess enough time under loaded CI runners.
+                "mcp_discovery_timeout": 10.0,
                 "mcp_servers": {
                     "profileprobe": {
                         "enabled": True,
@@ -99,9 +103,9 @@ def test_profile_local_mcp_tool_is_visible_in_slash_worker(tmp_path):
         proc.stdin.write(json.dumps({"id": 1, "command": "/tools"}) + "\n")
         proc.stdin.flush()
         try:
-            line = output.get(timeout=10)
+            line = output.get(timeout=20)
         except queue.Empty:
-            pytest.fail("slash worker produced no /tools response within 10 seconds")
+            pytest.fail("slash worker produced no /tools response within 20 seconds")
         response = json.loads(line)
         assert response["ok"] is True
         assert "mcp__profileprobe__hermes_61922_profile_probe" in response["output"]


### PR DESCRIPTION
## Summary

Stabilize the real-process profile-local MCP discovery integration test without changing Hermes's production startup behavior.

- Give this test profile an explicit `mcp_discovery_timeout: 10.0`.
- Extend the test harness response deadline to 20 seconds.
- Keep the production interactive discovery default at 1.5 seconds.

## Root cause

`test_profile_local_mcp_tool_is_visible_in_slash_worker` is intended to verify that a slash-worker subprocess reads MCP configuration from its profile-local `HERMES_HOME` and exposes the discovered tool.

The fixture currently also depends on its real MCP subprocess completing within the production 1.5-second interactive startup bound. Under loaded GitHub runners, the subprocess sometimes misses that bound, `HermesCLI` snapshots the built-in tools, and the test fails at the missing `mcp__profileprobe__hermes_61922_profile_probe` assertion. This happened twice on the same exact upstream head:

- https://github.com/SnowfallHD/hermes-agent/actions/runs/32042254067/job/95423606368
- https://github.com/SnowfallHD/hermes-agent/actions/runs/32042254067/job/95424447081

The production bound is intentional: persistent interactive surfaces stay responsive and use late MCP refresh. The integration fixture should isolate profile propagation from that latency policy, so this change raises the bound only inside the temporary test profile.

## Verification

### Regression proof

A temporary 8-second startup delay was added to the generated MCP probe:

- Before the fixture timeout: failed at the expected missing-tool assertion.
- With `mcp_discovery_timeout: 10.0`: passed.
- The artificial delay was removed from the final diff.

### Final checks

- Integration test repeated 10 times: `10 passed`
- Adjacent MCP startup/discovery timing tests: `19 passed`
- Ruff: passed
- `git diff --check`: passed

## Scope

Test-only change. No production timeout, discovery, refresh, configuration default, or tool behavior changes.

Duplicate searches covered open PRs for the exact test name, slash-worker MCP timeout, and profile-local MCP discovery flakiness; no existing fix was found.
