### PR TITLE
feat(cron): out-of-band paging allowlist for chat deliveries

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1896,3 +1896,18 @@ updates:
 #   # This runs ONCE per process at startup, so it cannot replace a credential
 #   # that expires mid-session. For a single provider whose token needs
 #   # re-minting during a session, use `providers.<name>.key_cmd` instead.
+
+# ----------------------------------------------------------------------
+# Cron paging allowlist (optional)
+# ----------------------------------------------------------------------
+# Cron jobs do not own the paging decision. When enabled, chat deliveries
+# (telegram, discord, slack, ...) are suppressed at send time unless the
+# job name or id is listed in the allowlist file (one entry per line, "#"
+# comments allowed). Suppressed deliveries are audited and the withheld
+# payload is saved under output_root for review.
+# cron:
+#   paging:
+#     enabled: false
+#     allowlist_path: ~/.hermes/cron/page-allowlist.txt
+#     audit_log_path: ~/.hermes/cron/alerts/delivery-gate.log
+#     output_root: ~/.hermes/cron/output

--- a/cron/delivery_gate.py
+++ b/cron/delivery_gate.py
@@ -1,0 +1,130 @@
+"""Send-time paging allowlist for cron chat deliveries.
+
+Cron jobs do not own the paging decision: a job record can be hand-edited or
+misconfigured to deliver into a chat, and a recurring job can flood a chat
+with notifications the user never asked for. This module enforces an
+out-of-band allowlist (a plain text file, independent of job records) at
+send time: chat delivery is suppressed unless the job name or id is on the
+allowlist, and every suppression is audited to a log plus the withheld
+payload saved to disk.
+
+The gate is config-gated via ``cron.paging`` (default disabled): when
+disabled it is a no-op and delivery behavior is unchanged. The allowlist file
+is re-read on every check so an out-of-band edit takes effect immediately and
+jobs cannot cache paging permission.
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+import os
+import re
+
+# Chat transports are the paging surfaces this gate controls. Unknown or
+# non-chat transports are never suppressed, so the gate cannot change
+# delivery behavior for file/webhook-only adapters.
+CHAT_PLATFORMS = {
+    "telegram", "discord", "whatsapp", "whatsapp_cloud", "slack", "signal",
+    "mattermost", "matrix", "dingtalk", "feishu", "wecom", "weixin",
+    "bluebubbles", "qqbot", "yuanbao", "relay", "irc",
+}
+
+
+def _default_settings() -> dict:
+    # Default paths live under HERMES_HOME so a fresh install has a sensible,
+    # writable location without any configuration.
+    hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    return {
+        "enabled": False,
+        "allowlist_path": str(hermes_home / "cron" / "page-allowlist.txt"),
+        "audit_log_path": str(hermes_home / "cron" / "alerts" / "delivery-gate.log"),
+        "output_root": str(hermes_home / "cron" / "output"),
+    }
+
+
+def _load_settings() -> dict:
+    # Read cron.paging from config.yaml on every call so a running scheduler
+    # picks up out-of-band changes without a restart (same immediacy contract
+    # as the allowlist file itself).
+    settings = _default_settings()
+    try:
+        from hermes_cli.config import load_config
+
+        paging = (load_config().get("cron") or {}).get("paging") or {}
+        settings.update({k: v for k, v in paging.items() if v is not None})
+    except Exception:
+        pass  # Defaults are safe (disabled); never let a config error page.
+    return settings
+
+
+def _utc_timestamp() -> str:
+    # UTC with an explicit offset keeps audit records timezone-safe.
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _load_allowlist(path: str) -> set:
+    # A missing or unreadable control file fails CLOSED for chat paging so a
+    # deployment mistake cannot silently re-enable notification floods.
+    try:
+        lines = Path(path).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return set()
+    return {
+        line.strip()
+        for line in lines
+        if line.strip() and not line.strip().startswith("#")
+    }
+
+
+def _is_chat_target(target: dict) -> bool:
+    return str(target.get("platform", "")).strip().lower() in CHAT_PLATFORMS
+
+
+def delivery_gate_check(job, targets, settings=None) -> tuple:
+    """Return (allowed, reason). Suppresses only chat deliveries for jobs
+    not present in the out-of-band allowlist."""
+    settings = settings if settings is not None else _load_settings()
+    if not settings.get("enabled", False):
+        return True, "gate disabled"
+    if not targets or not any(_is_chat_target(target) for target in targets):
+        return True, "no chat target"
+    allowlist = _load_allowlist(str(settings["allowlist_path"]))
+    job_name = str(job.get("name", ""))
+    job_id = str(job.get("id", ""))
+    if job_name in allowlist or job_id in allowlist:
+        return True, "allowlisted"
+    return False, "not in page-allowlist"
+
+
+def suppress_and_audit(job, targets, content, settings=None) -> None:
+    """Audit a suppressed delivery: one log line plus the withheld payload
+    saved under output_root, so operators can inspect what was held back."""
+    settings = settings if settings is not None else _load_settings()
+    _, reason = delivery_gate_check(job, targets, settings)
+    timestamp = _utc_timestamp()
+    job_id = str(job.get("id", "unknown"))
+    job_name = str(job.get("name", ""))
+    deliver = str(job.get("deliver", "local"))
+    # One audit line per suppressed delivery result, not one per target.
+    target_text = ",".join(
+        f"{target.get('platform', '')}:{target.get('chat_id', '')}"
+        for target in targets
+        if _is_chat_target(target)
+    )
+    audit_path = Path(str(settings["audit_log_path"]))
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    # Append rather than overwrite so suppression evidence is durable.
+    with audit_path.open("a", encoding="utf-8") as audit_file:
+        audit_file.write(
+            f"SUPPRESS {timestamp} job={job_id} name={job_name} deliver={deliver} "
+            f"target={target_text} reason={reason}\n"
+        )
+    # Restrict the directory component to a safe filename while retaining the
+    # job id for normal ids, preventing a job record from escaping the root.
+    safe_job_id = re.sub(r"[^A-Za-z0-9._-]", "_", job_id) or "unknown"
+    if safe_job_id in (".", ".."):
+        # Dot-only ids would resolve to the output root itself or its parent;
+        # prefix them so the payload stays inside output_root.
+        safe_job_id = "_" + safe_job_id
+    output_dir = Path(str(settings["output_root"])) / safe_job_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / f"{timestamp}.md").write_text(str(content), encoding="utf-8")

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -60,6 +60,8 @@ from agent.delegation_context import (
     enter_non_dispatcher_owned_context,
     exit_non_dispatcher_owned_context,
 )
+# Import the independent send-time control so every delivery path shares it.
+from cron.delivery_gate import delivery_gate_check, suppress_and_audit
 
 logger = logging.getLogger(__name__)
 
@@ -2535,6 +2537,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     from gateway.platforms.base import BasePlatformAdapter
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+
+    # Enforce paging at send time so hand-edited records and scheduler errors
+    # cannot bypass the out-of-band control and flood chat notifications.
+    allowed, reason = delivery_gate_check(job, targets)
+    if not allowed:
+        suppress_and_audit(job, targets, delivery_content)
+        logger.warning("Job '%s': delivery suppressed by gate (%s)", job["id"], reason)
+        return None
 
     # Resolve the delivery-mirror gate ONCE (default off). When on, each
     # successful delivery is also appended to the target chat's gateway session

--- a/tests/cron/test_delivery_gate.py
+++ b/tests/cron/test_delivery_gate.py
@@ -1,0 +1,146 @@
+"""Tests for the cron paging allowlist (cron/delivery_gate.py).
+
+Behavior contracts: the gate must never suppress non-chat targets, must fail
+closed when the allowlist file is missing, and must reload the allowlist on
+every check so out-of-band edits take effect without a restart.
+"""
+
+import pytest
+
+from cron.delivery_gate import (
+    _default_settings,
+    delivery_gate_check,
+    suppress_and_audit,
+)
+
+
+def _settings(tmp_path, enabled=True, **overrides):
+    base = {
+        "enabled": enabled,
+        "allowlist_path": str(tmp_path / "page-allowlist.txt"),
+        "audit_log_path": str(tmp_path / "alerts" / "delivery-gate.log"),
+        "output_root": str(tmp_path / "output"),
+    }
+    base.update(overrides)
+    return base
+
+
+def _job(name="nightly-summary", job_id="job-1"):
+    return {"name": name, "id": job_id, "deliver": "origin"}
+
+
+def _chat_targets():
+    return [{"platform": "telegram", "chat_id": "123"}]
+
+
+def test_disabled_gate_never_suppresses(tmp_path):
+    settings = _settings(tmp_path, enabled=False)
+    allowed, reason = delivery_gate_check(_job(), _chat_targets(), settings)
+    assert allowed is True
+    assert reason == "gate disabled"
+
+
+def test_allowlisted_name_passes(tmp_path):
+    settings = _settings(tmp_path)
+    (tmp_path / "page-allowlist.txt").write_text("nightly-summary\n", encoding="utf-8")
+    allowed, _ = delivery_gate_check(_job(), _chat_targets(), settings)
+    assert allowed is True
+
+
+def test_allowlisted_id_passes(tmp_path):
+    settings = _settings(tmp_path)
+    (tmp_path / "page-allowlist.txt").write_text("job-1\n", encoding="utf-8")
+    allowed, _ = delivery_gate_check(_job(), _chat_targets(), settings)
+    assert allowed is True
+
+
+def test_unlisted_chat_job_is_suppressed(tmp_path):
+    settings = _settings(tmp_path)
+    (tmp_path / "page-allowlist.txt").write_text("other-job\n", encoding="utf-8")
+    allowed, reason = delivery_gate_check(_job(), _chat_targets(), settings)
+    assert allowed is False
+    assert reason == "not in page-allowlist"
+
+
+def test_non_chat_targets_are_never_suppressed(tmp_path):
+    settings = _settings(tmp_path)
+    (tmp_path / "page-allowlist.txt").write_text("other-job\n", encoding="utf-8")
+    targets = [{"platform": "local", "chat_id": ""}, {"platform": "", "chat_id": ""}]
+    allowed, reason = delivery_gate_check(_job(), targets, settings)
+    assert allowed is True
+    assert reason == "no chat target"
+
+
+def test_missing_allowlist_fails_closed(tmp_path):
+    settings = _settings(tmp_path)  # allowlist file was never created
+    allowed, reason = delivery_gate_check(_job(), _chat_targets(), settings)
+    assert allowed is False
+    assert reason == "not in page-allowlist"
+
+
+def test_allowlist_ignores_comments_and_blanks(tmp_path):
+    settings = _settings(tmp_path)
+    (tmp_path / "page-allowlist.txt").write_text(
+        "# paging allowlist\n\nnightly-summary\n", encoding="utf-8"
+    )
+    allowed, _ = delivery_gate_check(_job(), _chat_targets(), settings)
+    assert allowed is True
+
+
+def test_allowlist_reloaded_on_every_check(tmp_path):
+    settings = _settings(tmp_path)
+    (tmp_path / "page-allowlist.txt").write_text("", encoding="utf-8")
+    allowed, _ = delivery_gate_check(_job(), _chat_targets(), settings)
+    assert allowed is False
+    # Out-of-band edit takes effect without a restart.
+    (tmp_path / "page-allowlist.txt").write_text("nightly-summary\n", encoding="utf-8")
+    allowed, _ = delivery_gate_check(_job(), _chat_targets(), settings)
+    assert allowed is True
+
+
+def test_suppress_and_audit_writes_log_and_payload(tmp_path):
+    settings = _settings(tmp_path)
+    suppress_and_audit(_job(), _chat_targets(), "payload body", settings)
+    audit = (tmp_path / "alerts" / "delivery-gate.log").read_text(encoding="utf-8")
+    assert audit.startswith("SUPPRESS ")
+    assert "job=job-1" in audit
+    assert "name=nightly-summary" in audit
+    assert "target=telegram:123" in audit
+    saved = list((tmp_path / "output" / "job-1").glob("*.md"))
+    assert len(saved) == 1
+    assert "payload body" in saved[0].read_text(encoding="utf-8")
+
+
+def test_suppress_audit_sanitizes_job_id_for_path(tmp_path):
+    settings = _settings(tmp_path)
+    suppress_and_audit(_job(job_id="../evil"), _chat_targets(), "x", settings)
+    # Slashes become underscores; the result stays inside output_root.
+    assert (tmp_path / "output" / ".._evil").is_dir()
+    assert not (tmp_path / "evil").exists()
+
+
+def test_suppress_audit_dot_only_ids_stay_inside_root(tmp_path):
+    settings = _settings(tmp_path)
+    suppress_and_audit(_job(job_id=".."), _chat_targets(), "x", settings)
+    suppress_and_audit(_job(job_id="."), _chat_targets(), "x", settings)
+    assert (tmp_path / "output" / "_..").is_dir()
+    assert (tmp_path / "output" / "_.").is_dir()
+    # The payload never lands outside the output root.
+    assert not (tmp_path / ".." / "job-1").exists()
+
+
+def test_config_propagation_via_load_config(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    (tmp_path / "page-allowlist.txt").write_text("nightly-summary\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"cron": {"paging": settings}},
+    )
+    allowed, _ = delivery_gate_check(_job(), _chat_targets())
+    assert allowed is True
+
+
+def test_default_settings_are_disabled():
+    defaults = _default_settings()
+    assert defaults["enabled"] is False
+    assert "page-allowlist.txt" in defaults["allowlist_path"]


### PR DESCRIPTION
## What does this PR do?

Adds an optional, config-gated paging allowlist for cron deliveries. When
`cron.paging.enabled` is true, chat-platform deliveries (telegram, discord,
slack, and other chat adapters) are checked at send time against an
out-of-band allowlist file: the delivery is suppressed unless the job name or
job id is listed, and every suppression is audited (one log line plus the
withheld payload saved under `output_root`).

Why this exists: cron jobs do not own the paging decision. A job record can
be hand-edited or misconfigured to deliver into a chat, and a recurring job
can flood a chat with notifications the user never asked for. Keeping the
allowlist in a plain text file outside the job records means jobs cannot grant
themselves paging permission, and edits take effect immediately because the
file is re-read on every check.

The gate is fully backward compatible: when disabled (the default) it is a
no-op and delivery behavior is unchanged.

## Related Issue

No related issue (small config-gated feature, opened directly as a PR).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `cron/delivery_gate.py` (new): send-time gate with config-gated settings,
  fail-closed allowlist loading, chat-platform classification, audit log and
  withheld-payload output with path-sanitized job ids (dot-only ids prefixed
  so the payload cannot escape `output_root`).
- `cron/scheduler.py`: `_deliver_result` consults the gate after media
  extraction and before the existing delivery-mirror gate; suppression
  returns early and records an audit entry.
- `tests/cron/test_delivery_gate.py` (new): 13 behavior-contract tests
  (disabled no-op, allowlisted name/id, unlisted chat job suppressed,
  non-chat targets never suppressed, missing allowlist fails closed, comment
  handling, per-check reload, audit + payload output, path sanitization,
  config propagation via `load_config`).
- `cli-config.yaml.example`: documented `cron.paging` keys.

## How to Test

1. Create an allowlist file and enable the gate in config.yaml:
   ```yaml
   cron:
     paging:
       enabled: true
       allowlist_path: ~/.hermes/cron/page-allowlist.txt
       audit_log_path: ~/.hermes/cron/alerts/delivery-gate.log
       output_root: ~/.hermes/cron/output
   ```
2. Schedule a job with `deliver: origin` (or a chat target) whose name is not
   on the allowlist; its chat delivery is suppressed and the suppression is
   audited. Add the job name to the allowlist and the next run delivers.
3. With `enabled: false` (default), delivery behavior is unchanged.

Test run on this machine (Linux, Python 3.11.15):
```
$ PYTHONPATH=. python -m pytest tests/cron/test_delivery_gate.py -q
............. [100%]
13 passed in 0.40s
```

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (full suite not run on this box; targeted suite above: 13/13 pass)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu 24.04, Python 3.11.15)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings updated in the new module)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (stdlib-only module; path handling uses `pathlib`)

## Screenshots / Logs

Targeted test run (see How to Test).
