### PR TITLE
fix(gateway): discover secondary profiles' MCP servers in multiplex mode

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30180,6 +30180,49 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     except Exception as e:
         logger.debug("MCP tool discovery failed: %s", e)
 
+    # Multiplex gateways serve secondary profiles' turns under
+    # _profile_runtime_scope, but the discovery above runs unscoped, so it
+    # only ever connects the default profile's mcp_servers — a secondary
+    # profile's MCP tools never exist in gateway turns even though its
+    # config.yaml declares them and the CLI (HERMES_HOME=<profile>) connects
+    # them fine. Repeat discovery under each served profile's runtime scope
+    # so their servers connect at startup. Per-turn isolation is unaffected:
+    # _get_platform_tools() resolves enabled MCP server names from the
+    # active profile's config, so each profile still only sees its own
+    # servers even though the server registry is process-global.
+    # NOTE: gate on runner.config, not the ``config`` argument — under
+    # systemd this function runs with config=None and GatewayRunner loads
+    # the config itself.
+    try:
+        _pp_cfg = getattr(runner, "config", None) or config
+        if getattr(_pp_cfg, "multiplex_profiles", False):
+            from pathlib import Path as _ProfilePath
+            from tools.mcp_tool import discover_mcp_tools as _discover_mcp
+
+            def _discover_profile_mcp(profile_home):
+                with _profile_runtime_scope(_ProfilePath(profile_home)):
+                    _discover_mcp()
+
+            _pp_loop = asyncio.get_running_loop()
+            for _pname, _phome in _multiplex_profile_homes(_pp_cfg):
+                if _pname == "default":
+                    continue  # already discovered by the unscoped call above
+                try:
+                    await _pp_loop.run_in_executor(
+                        None, _discover_profile_mcp, _phome
+                    )
+                    logger.info(
+                        "Per-profile MCP discovery completed for '%s'", _pname
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Per-profile MCP discovery failed for '%s': %s",
+                        _pname,
+                        e,
+                    )
+    except Exception as e:
+        logger.warning("Per-profile MCP discovery skipped: %s", e)
+
     # Start the gateway
     try:
         success = await runner.start()


### PR DESCRIPTION
## Problem

In multiplex mode (`gateway.multiplex_profiles: true`), the gateway serves secondary profiles' turns under `_profile_runtime_scope`, which correctly redirects config, skills, memory, SOUL and secrets to the profile's `HERMES_HOME`. However, startup MCP discovery (`discover_mcp_tools()` in `start_gateway`) runs **unscoped**, so it only loads the default profile's `mcp_servers`. There is no other discovery path for secondary profiles in the gateway process.

The result: a secondary profile whose `config.yaml` declares an MCP server never gets its tools in any gateway turn. This is very hard to notice because everything *looks* correct:

- `HERMES_HOME=<profile> hermes mcp list` shows the server enabled,
- running the agent through the CLI connects the server and works fine,
- the gateway logs no error — the turn simply runs without the tools.

We hit this in production with a two-profile WhatsApp setup (default profile + a calendar-only secondary profile): the secondary profile's agent answered every scheduling request with its "I can't reach the calendar" fallback for two days, while the config, the CLI and an external calendar monitor all reported healthy.

## Fix

After the existing unscoped startup discovery, iterate the profiles returned by `_multiplex_profile_homes()` and repeat `discover_mcp_tools()` under each profile's `_profile_runtime_scope` (executed in the executor, like the original call; `default` is skipped since the unscoped call already covered it). Failures are logged per profile and never block startup.

Two details worth calling out:

- **Gate on `runner.config`, not the `config` argument.** Under systemd, `start_gateway()` runs with `config=None` and `GatewayRunner` loads the config internally, so gating on the argument silently skips the block.
- **Per-turn isolation is preserved.** The MCP server registry is process-global, but `_get_platform_tools()` already resolves enabled MCP server names from the *active profile's* config on every turn, so each profile still only sees the servers its own `config.yaml` declares.

## Verification

Verified on the production gateway described above (WhatsApp platform, `multiplex_profile_allowlist` with one secondary profile):

- Before: no MCP stdio watchdog child for the secondary profile's server under the gateway `MainPID`; the profile's turns had no MCP tools.
- After: the server spawns at startup as a child of the gateway (`mcp_stdio_watchdog.py --ppid <gateway-pid> -- npx -y <server>`), and the secondary profile's turns can use its tools. The default profile's five servers keep connecting exactly as before, and neither profile sees the other's tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQuvt6t29dE7cyWJSt3HzR
