### PR TITLE
fix(compression): disable Codex 85% autoraise above the verified window (#88511)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1979,10 +1979,31 @@ def init_agent(
             _is_codex_gpt54_or_gpt55 as _is_codex_gpt54_or_gpt55_fn,
             _is_codex_spark as _is_codex_spark_fn,
         )
+        # The Codex gpt-5.4/5.5/5.6 autoraise is premised on the old ~272K cap,
+        # so it must self-disable once the resolver verifies a larger window for
+        # the route (e.g. gpt-5.6 → 900K). Resolve the window here — only for
+        # that route, so no other model pays a lookup — and pass it through.
+        # get_model_context_length is cached and the compressor resolves the
+        # same value moments later, so this warms the cache rather than adding a
+        # probe. Best-effort: any failure leaves the window unknown, preserving
+        # the historical unconditional raise.
+        _codex_autoraise_ctx = None
+        if _is_codex_gpt54_or_gpt55_fn(agent.model, agent.provider):
+            try:
+                from agent.model_metadata import get_model_context_length
+                _codex_autoraise_ctx = get_model_context_length(
+                    agent.model,
+                    base_url=agent.base_url,
+                    api_key=getattr(agent, "api_key", ""),
+                    provider=agent.provider,
+                )
+            except Exception:
+                _codex_autoraise_ctx = None
         _model_cthresh = _cthresh_fn(
             agent.model,
             agent.provider,
             allow_codex_gpt55_autoraise=_codex_gpt55_autoraise,
+            resolved_context_length=_codex_autoraise_ctx,
         )
         # The Codex autoraises (gpt-5.4/5.5 272K family and gpt-5.3-codex-spark)
         # apply only when they RAISE (never lower a user's higher global

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -622,19 +622,31 @@ def _is_arcee_trinity_thinking(model: Optional[str]) -> bool:
     return bare == "trinity-large-thinking"
 
 
-# Context window enforced by ChatGPT's Codex OAuth backend for the
-# gpt-5.4 / gpt-5.5 / gpt-5.6 families. The raw OpenAI API and OpenRouter
-# expose 1.05M for the same slugs, but the Codex backend hard-caps at 272K
-# (verified live for 5.4/5.5: a ~330K-token request to
+# Context window historically enforced by ChatGPT's Codex OAuth backend for
+# the gpt-5.4 / gpt-5.5 / gpt-5.6 families. The raw OpenAI API and OpenRouter
+# expose 1.05M for the same slugs, but the Codex backend used to hard-cap at
+# 272K (verified live for 5.4/5.5: a ~330K-token request to
 # chatgpt.com/backend-api/codex/responses is rejected with
-# ``context_length_exceeded`` while ~250K succeeds; gpt-5.6 shares the same
-# 272K Codex cap — see _CODEX_OAUTH_CONTEXT_FALLBACK in model_metadata.py).
-# With a 272K ceiling the default 50% compaction trigger fires at ~136K —
-# wasteful, since the model can hold far more raw context before
-# summarization actually buys anything. We raise the trigger to 85% (~231K)
-# on this exact route so Codex gpt-5.4 / gpt-5.5 / gpt-5.6 sessions use the
-# window they actually have.
+# ``context_length_exceeded`` while ~250K succeeds). With a 272K ceiling the
+# default 50% compaction trigger fires at ~136K — wasteful, since the model
+# can hold far more raw context before summarization actually buys anything.
+# We raise the trigger to 85% (~231K) on this route so a genuinely 272K-capped
+# Codex session uses the window it actually has.
+#
+# The cap is NOT static, though: the resolver has since verified some of these
+# routes materially above 272K (e.g. gpt-5.6 sol/terra/luna resolve to 900K on
+# Codex — model_metadata._CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_*). When the
+# resolved window exceeds the old cap the 85% rationale is stale (0.85 * 900K =
+# 765K would defer compaction until hundreds of thousands of tokens accrue), so
+# the raise self-disables above _CODEX_AUTORAISE_MAX_CONTEXT and the session
+# keeps the user's global threshold. See _compression_threshold_for_model.
 _CODEX_GPT54_GPT55_COMPACTION_THRESHOLD = 0.85
+
+# Ceiling for the gpt-5.4/5.5/5.6 autoraise above. The raise only makes sense
+# while the resolved Codex window is still at/under the old ~272K cap; a small
+# margin over the 272K stale advertisement absorbs rounding in live catalog
+# values. Above this the override defers to the configured global threshold.
+_CODEX_AUTORAISE_MAX_CONTEXT = 276_000
 
 # gpt-5.3-codex-spark is Codex-OAuth-only (ChatGPT Pro entitlement) with a
 # native 128K context window.  The default 50% compaction trigger fires at
@@ -717,6 +729,7 @@ def _compression_threshold_for_model(
     provider: Optional[str] = None,
     *,
     allow_codex_gpt55_autoraise: bool = True,
+    resolved_context_length: Optional[int] = None,
 ) -> Optional[float]:
     """Return a context-compression threshold override for specific models.
 
@@ -727,16 +740,21 @@ def _compression_threshold_for_model(
     Per-model/route overrides:
       - Arcee Trinity Large Thinking → 0.75 (preserve reasoning context).
       - gpt-5.4 / gpt-5.5 / gpt-5.6 on the Codex OAuth route → 0.85, because
-        Codex caps all three families at 272K and the default 50% trigger
-        would compact at ~136K. Gated by ``allow_codex_gpt55_autoraise``
+        Codex historically caps these families at 272K and the default 50%
+        trigger would compact at ~136K. Gated by ``allow_codex_gpt55_autoraise``
         (historical config-key name kept for backward compatibility) so the
         user can opt back down to the global default (the caller passes the
-        config flag through here).
+        config flag through here). Also gated on ``resolved_context_length``:
+        the raise only applies while the resolved Codex window is still at/under
+        the old cap (``_CODEX_AUTORAISE_MAX_CONTEXT``). Once the resolver
+        verifies a larger window for the same route (e.g. gpt-5.6 → 900K on
+        Codex) the 85% rationale is stale, so the override defers to the user's
+        global threshold. ``None`` (window unknown) keeps historical behaviour.
       - gpt-5.3-codex-spark on the Codex OAuth route → 0.70, because the model
         has a native 128K window and the default 50% trigger would compact at
         ~64K — wasting half the usable context. Not gated by the gpt-5.5
-        opt-out flag: 128K is the model's native window, so the raise is
-        unambiguously correct.
+        opt-out flag or the window ceiling: 128K is the model's native window,
+        so the raise is unambiguously correct.
 
     Returns a float in (0, 1] to override the global ``compression.threshold``
     config value, or ``None`` to leave the user's config value unchanged.
@@ -744,7 +762,16 @@ def _compression_threshold_for_model(
     if _is_arcee_trinity_thinking(model):
         return 0.75
     if allow_codex_gpt55_autoraise and _is_codex_gpt54_or_gpt55(model, provider):
-        return _CODEX_GPT54_GPT55_COMPACTION_THRESHOLD
+        # The 0.85 raise exists only to avoid wasting the old 272K Codex cap.
+        # Above a verified-larger window it would delay compaction far past the
+        # user's intent, so fall back to the global threshold there. An unknown
+        # window (None) preserves the historical unconditional raise.
+        if (
+            resolved_context_length is None
+            or resolved_context_length <= _CODEX_AUTORAISE_MAX_CONTEXT
+        ):
+            return _CODEX_GPT54_GPT55_COMPACTION_THRESHOLD
+        return None
     if _is_codex_spark(model, provider):
         return _CODEX_SPARK_COMPACTION_THRESHOLD
     return None

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -89,6 +89,58 @@ def test_compression_threshold_for_codex_gpt55() -> None:
     assert _compression_threshold_for_model("gpt-5.5", "openai-codex") == 0.85
     assert _compression_threshold_for_model("gpt-5.5-pro", "openai-codex") == 0.85
     assert _compression_threshold_for_model("openai/gpt-5.5", "openai-codex") == 0.85
+    # gpt-5.6 family shares the route and, with no resolved window, keeps the
+    # historical unconditional raise.
+    assert _compression_threshold_for_model("gpt-5.6-luna", "openai-codex") == 0.85
+    assert _compression_threshold_for_model("gpt-5.6-sol", "openai-codex") == 0.85
+
+
+def test_codex_autoraise_disabled_above_verified_window() -> None:
+    """The 0.85 raise is premised on the ~272K cap: once the resolver verifies
+    a materially larger window for the same route (e.g. gpt-5.6 → 900K on
+    Codex), the override must defer to the user's global threshold instead of
+    compacting at 0.85 * 900K = 765K."""
+    # Above the cap → no override (keep global threshold).
+    assert (
+        _compression_threshold_for_model(
+            "gpt-5.6-luna", "openai-codex", resolved_context_length=900_000
+        )
+        is None
+    )
+    # At/under the old cap → the raise still applies.
+    assert (
+        _compression_threshold_for_model(
+            "gpt-5.5", "openai-codex", resolved_context_length=272_000
+        )
+        == 0.85
+    )
+    # Boundary: exactly the ceiling still raises; one token over defers.
+    assert (
+        _compression_threshold_for_model(
+            "gpt-5.6-sol", "openai-codex", resolved_context_length=276_000
+        )
+        == 0.85
+    )
+    assert (
+        _compression_threshold_for_model(
+            "gpt-5.6-sol", "openai-codex", resolved_context_length=276_001
+        )
+        is None
+    )
+    # Unknown window (None) preserves historical behaviour.
+    assert (
+        _compression_threshold_for_model(
+            "gpt-5.6-terra", "openai-codex", resolved_context_length=None
+        )
+        == 0.85
+    )
+    # A verified-large window does not affect spark (native 128K, ungated).
+    assert (
+        _compression_threshold_for_model(
+            "gpt-5.3-codex-spark", "openai-codex", resolved_context_length=900_000
+        )
+        == 0.70
+    )
 
 
 


### PR DESCRIPTION
## Summary

Fixes #88511. The Codex `gpt-5.4 / 5.5 / 5.6` compaction autoraise raised the compaction threshold to **85%** unconditionally on the `openai-codex` route. Its rationale (`agent/auxiliary_client.py`) is the old **272K** Codex cap: at 272K the default 50% trigger compacts at ~136K, so 85% (~231K) uses more of the window.

But the context resolver now **verifies some of those routes materially above 272K** — `gpt-5.6` sol/terra/luna resolve to **900K** on Codex (`model_metadata._CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES = {"gpt-5.6": 900_000}`, "all three verified live at 900K"). On a 900K window the fixed 85% override produces a **765K** effective threshold, exactly the symptom in the report:

> Resolved context length: `900000` … Codex gpt-5.6 autoraise: `0.85` … Effective compaction threshold: `765000` tokens.

That defers compaction until hundreds of thousands of tokens accrue, inflating prompt-replay cost and risking quota exhaustion on token-billed / limited upstreams.

## Fix

Gate the raise on the **resolved window** rather than on the model slug alone:

- `_compression_threshold_for_model()` gains a `resolved_context_length` parameter. The 0.85 override applies only while the window is still at/under the old cap — `_CODEX_AUTORAISE_MAX_CONTEXT = 276_000` (a small rounding margin over the 272K stale advertisement). Above it, the override returns `None` so the session keeps the user's configured global threshold (50% → 450K in the report's case, as the issue expects).
- `None` (window unknown) preserves the historical unconditional raise, so nothing regresses when the window can't be resolved.
- `gpt-5.3-codex-spark` (native 128K) stays ungated — its raise is unconditionally correct.
- `init_agent` resolves the window **only for the Codex route**, via the cached `get_model_context_length` the compressor resolves moments later in the same init — so this warms the cache rather than adding a probe, and is fully best-effort (any failure falls back to the prior behaviour).

This is a **dynamic** ceiling, not a hardcoded gpt-5.6 exclusion: if `gpt-5.5` is later verified above 272K, the raise self-disables for it too with no further code change — matching the issue's "a dynamic rule based on the resolved context length would also work."

The stale `# gpt-5.6 shares the same 272K Codex cap` comment is corrected to reflect the verified-above-cap tables and the self-disabling behaviour.

## Tests

Extended `tests/agent/test_arcee_trinity_overrides.py`:
- `gpt-5.6` family now covered for the base (window-unknown) case → 0.85.
- New `test_codex_autoraise_disabled_above_verified_window`: 900K → `None`; 272K → 0.85; boundary 276K → 0.85 and 276001 → `None`; `None` → 0.85; spark @ 900K → 0.70 (ungated).

All compression/codex/threshold tests pass locally (`tests/agent/`, plus `test_codex_gpt55_autoraise_notice.py`, `test_gpt56_registration.py`, `test_plugin_context_engine_init.py`). The 4 unrelated `test_auxiliary_*` failures in my local run are a missing optional `anthropic` package in this environment (client-transport selection, untouched by this change) and reproduce identically on clean `upstream/main`.

The arm64 fork-Docker build failure is the known fork-CI limitation, unrelated to this change.
