### PR TITLE
fix(kanban): honor auxiliary.kanban_decomposer.timeout and auxiliary.triage_specifier.timeout config

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -311,11 +311,20 @@ def decompose_task(
         default_assignee=default_assignee,
     )
 
+    # Resolve effective timeout: explicit arg > auxiliary.kanban_decomposer.timeout config > 180s legacy default
+    _aux_cfg = cfg.get("auxiliary", {}) if isinstance(cfg, dict) else {}
+    _decomp_cfg = _aux_cfg.get("kanban_decomposer", {}) if isinstance(_aux_cfg, dict) else {}
+    try:
+        _cfg_timeout = int(_decomp_cfg.get("timeout") or 0)
+    except (TypeError, ValueError):
+        _cfg_timeout = 0
+    effective_timeout = timeout or (_cfg_timeout if _cfg_timeout > 0 else 180)
+
     try:
         # Route through call_llm so auxiliary.kanban_decomposer.* config
         # (provider/model/base_url, extra_body, reasoning_effort, retries)
-        # all apply — the previous direct client.chat.completions.create()
-        # path dropped auxiliary.<task>.extra_body entirely (#35566).
+        # all apply — the previous direct client.chat.completions.create() path
+        # dropped auxiliary.<task>.extra_body entirely (#35566).
         resp = call_llm(
             task="kanban_decomposer",
             messages=[
@@ -324,7 +333,7 @@ def decompose_task(
             ],
             temperature=0.3,
             max_tokens=4000,
-            timeout=timeout or 180,
+            timeout=effective_timeout,
         )
     except Exception as exc:
         logger.info(

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -42,6 +42,15 @@ from hermes_cli import kanban_db as kb
 
 from utils import env_int
 
+
+def _load_config() -> dict:
+    try:
+        from hermes_cli.config import load_config
+        return load_config() or {}
+    except Exception:
+        return {}
+
+
 HERMES_KANBAN_SPECIFY_MAX_TOKENS = max(
     1500,
     env_int("HERMES_KANBAN_SPECIFY_MAX_TOKENS", 6000),
@@ -173,6 +182,16 @@ def specify_task(
         body=_truncate(task.body or "(no body)", 4000),
     )
 
+    # Resolve effective timeout: explicit arg > auxiliary.triage_specifier.timeout config > 120s legacy default
+    cfg = _load_config()
+    _aux_cfg = cfg.get("auxiliary", {}) if isinstance(cfg, dict) else {}
+    _spec_cfg = _aux_cfg.get("triage_specifier", {}) if isinstance(_aux_cfg, dict) else {}
+    try:
+        _cfg_timeout = int(_spec_cfg.get("timeout") or 0)
+    except (TypeError, ValueError):
+        _cfg_timeout = 0
+    effective_timeout = timeout or (_cfg_timeout if _cfg_timeout > 0 else 120)
+
     try:
         # Route through call_llm so auxiliary.triage_specifier.* config
         # (provider/model/base_url, extra_body, reasoning_effort, retries)
@@ -185,7 +204,7 @@ def specify_task(
             ],
             temperature=0.3,
             max_tokens=HERMES_KANBAN_SPECIFY_MAX_TOKENS,
-            timeout=timeout or 120,
+            timeout=effective_timeout,
         )
     except Exception as exc:
         logger.info(


### PR DESCRIPTION
## Summary

Fixes #88519 — Kanban auto-decompose ignores `auxiliary.kanban_decomposer.timeout` (hardcoded 180s) -> tasks stuck in triage on slow backends.

## Problem

Both `kanban_decompose.py` and `kanban_specify.py` hardcoded fallback timeouts (180s and 120s respectively) which shadowed the configurable `auxiliary.<task>.timeout` values. The gateway auto-decompose path calls `decompose_task()` with no `timeout` argument, so the effective deadline was always the hardcoded literal regardless of config.

On a slow backend (e.g. a local llama.cpp server at ~11 tok/s), decomposition of a normal-sized task generates for ~480s server-side and completes cleanly, but the client aborts at 180s and returns `APITimeoutError`. The task is stuck in `triage` forever: the 60s dispatch tick re-attempts and re-times-out every cycle, never fanning out to children.

## Solution

Both modules now resolve the timeout with precedence:
- explicit arg > `auxiliary.<task>.timeout` config > legacy default (180s/120s)

This allows users to configure longer timeouts for slow backends via `config.yaml`:

```yaml
auxiliary:
  kanban_decomposer:
    timeout: 1800
  triage_specifier:
    timeout: 600
```

## Changes

- `hermes_cli/kanban_decompose.py`: Added config resolution for `auxiliary.kanban_decomposer.timeout` with 180s legacy default
- `hermes_cli/kanban_specify.py`: Added `_load_config()` helper and config resolution for `auxiliary.triage_specifier.timeout` with 120s legacy default

## Testing

- All existing unit tests pass (`test_kanban_decompose.py`, `test_kanban_specify.py`)
- Related auxiliary client timeout tests pass