### PR TITLE
fix: warn about deprecated cwd env vars only when they are in .env

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2184,9 +2184,22 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
 
     These env vars are deprecated — the canonical setting is terminal.cwd
     in config.yaml.  Prints a migration hint to stderr.
+
+    Reads the on-disk .env rather than ``os.environ``: TERMINAL_CWD is also
+    set at runtime (config.yaml bridge, session-cwd restore, worktree switch,
+    kanban workspace pinning), and warning on the process env told users to
+    delete a line that was never in their .env.  ``hermes doctor`` already
+    reads the file for the same reason.
     """
-    messaging_cwd = os.environ.get("MESSAGING_CWD")
-    terminal_cwd_env = os.environ.get("TERMINAL_CWD")
+    try:
+        env_file = load_env()
+    except Exception:
+        return
+
+    messaging_cwd = env_file.get("MESSAGING_CWD")
+    terminal_cwd_env = env_file.get("TERMINAL_CWD")
+    if not messaging_cwd and not terminal_cwd_env:
+        return
 
     if config is None:
         try:

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -1,12 +1,28 @@
 """Tests for warn_deprecated_cwd_env_vars() migration warning."""
 
+import pytest
+
+
+@pytest.fixture
+def env_file(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a temp dir and return a writer for its .env."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import hermes_cli.config as hc_config
+
+    monkeypatch.setattr(hc_config, "_env_cache", None, raising=False)
+
+    def write(text: str) -> None:
+        (tmp_path / ".env").write_text(text, encoding="utf-8")
+        monkeypatch.setattr(hc_config, "_env_cache", None, raising=False)
+
+    return write
+
 
 class TestDeprecatedCwdWarning:
-    """Warn when MESSAGING_CWD or TERMINAL_CWD is set in .env."""
+    """Warn when MESSAGING_CWD or TERMINAL_CWD is set in the on-disk .env."""
 
-    def test_messaging_cwd_triggers_warning(self, monkeypatch, capsys):
-        monkeypatch.setenv("MESSAGING_CWD", "/some/path")
-        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    def test_messaging_cwd_triggers_warning(self, env_file, capsys):
+        env_file("MESSAGING_CWD=/some/path\n")
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
         warn_deprecated_cwd_env_vars(config={})
@@ -16,10 +32,8 @@ class TestDeprecatedCwdWarning:
         assert "deprecated" in captured.err.lower()
         assert "config.yaml" in captured.err
 
-
-    def test_both_deprecated_vars_warn(self, monkeypatch, capsys):
-        monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
-        monkeypatch.setenv("TERMINAL_CWD", "/term/path")
+    def test_both_deprecated_vars_warn(self, env_file, capsys):
+        env_file("MESSAGING_CWD=/msg/path\nTERMINAL_CWD=/term/path\n")
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
         warn_deprecated_cwd_env_vars(config={})
@@ -27,3 +41,19 @@ class TestDeprecatedCwdWarning:
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "TERMINAL_CWD" in captured.err
+
+    def test_runtime_terminal_cwd_does_not_warn(self, env_file, monkeypatch, capsys):
+        """TERMINAL_CWD bridged into the process env is not a .env entry.
+
+        The config.yaml bridge, session-cwd restore, worktree switch and kanban
+        workspace pinning all set os.environ["TERMINAL_CWD"]; none of them mean
+        the user has a stale .env line to delete.
+        """
+        env_file("SOME_API_KEY=abc\n")
+        monkeypatch.setenv("TERMINAL_CWD", "/runtime/path")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Problem

Every CLI/gateway startup on my machine printed:

```
⚠ Deprecated .env settings detected:
  ⚠ TERMINAL_CWD=/Users/jashlee found in .env — this is deprecated.
  Then remove the old entries from ~/.hermes/.env
```

My `~/.hermes/.env` has no `TERMINAL_CWD` line. The warning tells the user to delete something that isn't there, and there is no way to make it stop.

## Root cause

`warn_deprecated_cwd_env_vars()` (`hermes_cli/config.py`) reads `os.environ["TERMINAL_CWD"]` and reports it as "found in .env". It never opens `.env`. But `TERMINAL_CWD` is set at runtime by several unrelated paths:

- the `terminal.cwd` → `TERMINAL_CWD` config bridge (`TERMINAL_CONFIG_ENV_MAP`)
- session-cwd restore on resume (`cli.py:8378`)
- worktree switch (`cli_commands_mixin.py:1287`, `main.py:2738`)
- gateway placeholder resolution (`gateway/run.py:2492`)
- kanban workspace pinning (`kanban_db.py:10787`)
- cron per-job workdir (`cron/scheduler.py:4965`)

Any of those false-positives. `hermes doctor` already got this right — `doctor.py:1526` reads the on-disk `.env` with the comment *"Prefer the on-disk .env so bridged process env (e.g. TERMINAL_CWD from terminal.cwd) does not false-positive."* The startup warning just never got the same treatment.

## Fix

Read `load_env()` (the on-disk `.env` parser already used by doctor) instead of `os.environ`, and return early when neither key is present. The `config_has_explicit_cwd` suppression below it is left alone.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_deprecated_cwd_warning.py` → 3 passed.
- Teeth check: reverted `config.py` to the pre-fix version with the new tests in place → 3/3 fail, including the new `test_runtime_terminal_cwd_does_not_warn`. The test fails on known-bad.
- `ruff check` clean on both changed files.

The existing two tests set the vars via `monkeypatch.setenv`, which no longer describes the contract; they now write a real `.env` under a temp `HERMES_HOME`. Added `test_runtime_terminal_cwd_does_not_warn` as the regression case for the reported symptom.

## Known / out of scope

- `MESSAGING_CWD` is deliberately still warned about from the file — it has no config-bridge writer, so it can only come from `.env`; reading the file is correct for it too and keeps one code path.
- No UI/perf surface changed, so no screenshots or benchmarks apply.
