### PR TITLE
fix(auth): honour the shortest lifetime a key_cmd helper advertises

### DIFF
--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -24,8 +24,9 @@ fresh. It is cached until shortly before expiry, so the command runs about
 once per token lifetime rather than once per request.
 
 Output contract: print ONLY the token on stdout, either bare or as JSON with
-an ``access_token`` field (``expires_in`` is honoured when present) — the
-shape OAuth 2.0 token endpoints and the helpers above already emit.
+an ``access_token`` field — the shape OAuth 2.0 token endpoints and the helpers
+above already emit. A lifetime may arrive as a relative ``expires_in``, as an
+absolute ``expiry``/``expiresOn``, or both; the shortest one is honoured.
 
 Precedence: an explicit ``--api-key`` still wins (the one-off recovery escape
 hatch); otherwise ``key_cmd`` is preferred over a static ``api_key`` /
@@ -115,24 +116,26 @@ def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
                     f"key_cmd for provider {label!r} returned JSON without an "
                     "'access_token' field"
                 )
-            ttl = payload.get("expires_in")
-            if isinstance(ttl, (int, float)) and ttl > 0:
-                return token, float(ttl)
-            # A relative lifetime is the OAuth 2.0 field, but CLI token helpers
-            # commonly print an absolute ISO 8601 deadline instead. Treating
-            # that as "no TTL advertised" caches the token for the life of the
-            # process, so every request 401s once the deadline passes.
+            # Honour the SHORTEST advertised lifetime. A helper answering from
+            # its own credential cache reprints the original ``expires_in``
+            # while the absolute deadline keeps counting down, so reading only
+            # the relative field caches past the credential's real life.
+            #
             # Imported lazily: hermes_cli.auth imports from agent.* at module
             # level, so a top-level import here would risk a cycle.
             from hermes_cli.auth import _parse_iso_timestamp
 
+            lifetimes = []
+            relative = payload.get("expires_in")
+            if isinstance(relative, (int, float)):
+                lifetimes.append(float(relative))
             for field in ("expiry", "expiresOn"):
                 deadline = _parse_iso_timestamp(payload.get(field))
                 if deadline is not None:
-                    remaining = deadline - time.time()
-                    if remaining > 0:
-                        return token, remaining
-            return token, None
+                    lifetimes.append(deadline - time.time())
+
+            usable = [ttl for ttl in lifetimes if ttl > 0]
+            return token, (min(usable) if usable else None)
 
     # Bare token. The contract every comparable helper documents is "stdout
     # carries the token and nothing else" — extra output would be consumed as

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -258,11 +258,20 @@ class TestAbsoluteExpiry:
         _, ttl = _mint(f"printf '%s' '{{\"access_token\":\"t\",\"expiresOn\":\"{deadline}\"}}'", "p")
         assert ttl is not None and 1700 < ttl <= 1800
 
-    def test_expires_in_still_wins_when_both_present(self):
-        """The RFC 6749 field is authoritative where a helper sends both."""
-        deadline = self._iso(3600)
+    def test_the_shortest_advertised_lifetime_wins(self):
+        """Never cache past the soonest deadline the helper itself stated."""
+        # Absolute deadline sooner than the relative lifetime claims.
         _, ttl = _mint(
-            f"printf '%s' '{{\"access_token\":\"t\",\"expires_in\":120,\"expiry\":\"{deadline}\"}}'",
+            f"printf '%s' '{{\"access_token\":\"t\",\"expires_in\":3600,"
+            f"\"expiry\":\"{self._iso(600)}\"}}'",
+            "p",
+        )
+        assert ttl is not None and 500 < ttl <= 600
+
+        # Symmetric: relative lifetime is the shorter one.
+        _, ttl = _mint(
+            f"printf '%s' '{{\"access_token\":\"t\",\"expires_in\":120,"
+            f"\"expiry\":\"{self._iso(3600)}\"}}'",
             "p",
         )
         assert ttl == 120.0


### PR DESCRIPTION
## Summary

A `key_cmd` helper may report its token lifetime as a relative `expires_in`, as an absolute `expiry`/`expiresOn` deadline, or as both. `_mint` returned on `expires_in` as soon as it was present, so the absolute deadline was only read when the relative field was absent.

Those fields disagree whenever the helper answers from its own credential cache: it reprints the `expires_in` from when the token was first issued while the absolute deadline keeps counting down. The cache then outlives the credential by however long the token had already been alive, and because nothing in the request path re-mints on 401 (the SDKs retry 429/5xx only) every subsequent request fails until the process restarts.

Fixes #88535.

## Change

Collect the advertised lifetimes and cache on the shortest. A token is never usable for longer than the soonest deadline its own helper stated, so the minimum cannot over-cache regardless of which field a helper populates or which one is stale. Non-positive values are dropped, so an already-past deadline cannot become the minimum.

No behaviour change for a helper that reports one field, or two that agree.

## Evidence

`databricks auth token`, sampled twice ten minutes apart:

```
expires_in = 3600          (constant — reprinted from first issue)
expiry     = 14:13:12      (truthful)
actual remaining = 2950s   → 650s cached past the credential's life
```

`gcloud auth print-access-token`, `az account get-access-token`, `vault`, and OAuth brokers with a local token cache share the shape.

## Tests

`test_expires_in_still_wins_when_both_present` asserted the old precedence and becomes `test_the_shortest_advertised_lifetime_wins`, which asserts the rule in both directions — so it also fails on a naive inversion, not just on the old behaviour. It fails on `c86197e60` and passes with this change. No new test functions.

288 passed across `tests/agent/test_command_token_source.py` plus the two consumers of this module, `tests/agent/test_auxiliary_client.py` and `tests/hermes_cli/test_config.py`.

## CI

Green except `osv-scanner`, which died on GitHub's 503 outage while uploading its status report:

```
fail-on-vuln: false
Total 5 packages affected by 6 known vulnerabilities ... from 2 ecosystems.
##[error]No server is currently available to service your request.
CODEQL_ACTION_JOB_STATUS: JOB_STATUS_FAILURE
```

The scanner is configured `fail-on-vuln: false`, so the pre-existing advisories are not the failure. This diff touches no dependency manifest. All 12 test slices, `lint`, `contributor-check`, `history-check`, `supply-chain` and the OS-specific tests passed. Re-running failed jobs needs write access I do not have.

I also cannot self-apply labels. Titled `[Bug]:` on the issue per the convention on #84162; `type/bug` / `area/auth` / `comp/agent` look right.
