### PR TITLE
fix(desktop): run repo discovery server-side in remote mode so Projects sidebar surfaces disk-scanned repos

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -488,15 +488,35 @@ describe('repository discovery policy', () => {
     })
   })
 
-  it('does not scan the local filesystem for remote connections', async () => {
+  it('scans server-side for remote connections instead of the local filesystem', async () => {
+    const request = vi.fn(async (method: string) =>
+      method === 'projects.tree'
+        ? { active_id: null, projects: [], scoped_session_ids: [] }
+        : method === 'projects.scan_repos'
+          ? { accepted: true, repos: [{ label: 'repo', root: '/backend/repo' }] }
+          : { accepted: false, repos: [] }
+    )
+    gatewayWith(request)
+
     isDesktopFsRemoteMode.mockReturnValue(true)
     const scanRepos = vi.fn()
     desktopGit.mockReturnValue({ scanRepos } as never)
+    getHermesConfig.mockResolvedValue({
+      desktop: {
+        repo_scan_enabled: true,
+        repo_scan_exclude_paths: [],
+        repo_scan_roots: []
+      }
+    })
 
     await scanAndRecordRepos(true)
 
+    // The local Electron crawl must never run against the desktop host's fs.
     expect(scanRepos).not.toHaveBeenCalled()
-    expect(getHermesConfig).not.toHaveBeenCalled()
+    // Discovery is delegated to the backend, which walks ITS host's files.
+    expect(request).toHaveBeenCalledWith('projects.scan_repos', {
+      discovery_policy: { enabled: true, exclude_paths: [], roots: [] }
+    })
   })
 })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -601,9 +601,7 @@ function syncReposScanning(): void {
 $gateway.subscribe(syncReposScanning)
 
 export async function scanAndRecordRepos(force = false): Promise<void> {
-  if (isDesktopFsRemoteMode()) {
-    return
-  }
+  const remoteFs = isDesktopFsRemoteMode()
 
   let context: ActiveProjectsContext
 
@@ -613,9 +611,13 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
     return
   }
 
-  const scan = desktopGit()?.scanRepos
+  // The native crawl lives in the Electron host, so it can only see the
+  // filesystem of the machine running the desktop app. In remote mode that
+  // host is NOT the backend that holds the repos, so the scan must run
+  // server-side instead — the backend is co-located with the files.
+  const scan = remoteFs ? undefined : desktopGit()?.scanRepos
 
-  if (!scan) {
+  if (!remoteFs && !scan) {
     return
   }
 
@@ -639,11 +641,24 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
         discovery_policy: policy,
         repos: []
       })
+    } else if (remoteFs) {
+      scanningGatewayGenerations.set(context.gateway, generation)
+      syncReposScanning()
+
+      // Server-side discovery: the backend walks the policy roots on ITS host
+      // (where the repos live), records them, and returns the merged list.
+      await gatewayRequestOn(context.gateway, 'projects.scan_repos', {
+        discovery_policy: policy
+      })
+
+      if (state.generation !== generation) {
+        return
+      }
     } else {
       scanningGatewayGenerations.set(context.gateway, generation)
       syncReposScanning()
 
-      const repos = await scan(policy.roots, {
+      const repos = await scan!(policy.roots, {
         enabled: true,
         excludePaths: policy.exclude_paths
       })

--- a/tests/tui_gateway/test_repo_scan.py
+++ b/tests/tui_gateway/test_repo_scan.py
@@ -1,0 +1,97 @@
+"""Invariants for the server-side git repo scan (tui_gateway.repo_scan).
+
+The desktop's native Electron walk (apps/desktop/electron/git-repo-scan.ts)
+never runs in remote mode, so the backend — which is co-located with the
+actual files — needs its own bounded walk to populate discovered_repos. These
+assert the structural contract (repo detection, bounded depth, junk/hidden
+exclusion, home-dir default) without snapshotting exact results.
+"""
+
+from __future__ import annotations
+
+import os
+
+from tui_gateway import repo_scan
+
+
+def _make_git_repo(root: str, name: str) -> str:
+    repo = os.path.join(root, name)
+    os.makedirs(os.path.join(repo, ".git"))
+    with open(os.path.join(repo, ".git", "HEAD"), "w") as f:
+        f.write("ref: refs/heads/main\n")
+    return repo
+
+
+def _make_plain_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    os.makedirs(path)
+    return path
+
+
+def test_scans_nested_git_repos(tmp_path):
+    repo_a = _make_git_repo(str(tmp_path), "alpha")
+    repo_b = _make_git_repo(str(tmp_path), "beta")
+    _make_plain_dir(str(tmp_path), "not-a-repo")
+
+    found = repo_scan.scan_repos([str(tmp_path)])
+
+    roots = {f["root"] for f in found}
+    assert repo_a in roots
+    assert repo_b in roots
+
+
+def test_respects_max_depth(tmp_path):
+    _make_git_repo(str(tmp_path), "top")
+    deep = os.path.join(str(tmp_path), "one", "two", "three", "four")
+    deep_repo = _make_git_repo(deep, "nested")
+
+    shallow = repo_scan.scan_repos([str(tmp_path)], max_depth=2)
+    shallow_roots = {f["root"] for f in shallow}
+    assert deep_repo not in shallow_roots
+
+    deep_scan = repo_scan.scan_repos([str(tmp_path)], max_depth=6)
+    deep_roots = {f["root"] for f in deep_scan}
+    assert deep_repo in deep_roots
+
+
+def test_skips_junk_dirs(tmp_path):
+    _make_git_repo(str(tmp_path), "real")
+    # Junk and hidden dirs are never descended into, so a repo named as (or
+    # nested under) a junk dir is not discovered.
+    _make_git_repo(str(tmp_path), "node_modules")
+    _make_git_repo(os.path.join(str(tmp_path), "real", "node_modules"), "inner")
+
+    found = repo_scan.scan_repos([str(tmp_path)])
+
+    roots = {f["root"] for f in found}
+    assert os.path.join(str(tmp_path), "real") in roots
+    assert os.path.join(str(tmp_path), "node_modules") not in roots
+    assert os.path.join(str(tmp_path), "real", "node_modules", "inner") not in roots
+
+
+def test_skips_hidden_dirs(tmp_path):
+    _make_git_repo(str(tmp_path), "visible")
+    _make_git_repo(str(tmp_path), ".hidden")
+    _make_git_repo(os.path.join(str(tmp_path), "visible", ".config"), "inner")
+
+    found = repo_scan.scan_repos([str(tmp_path)])
+
+    roots = {f["root"] for f in found}
+    assert os.path.join(str(tmp_path), "visible") in roots
+    assert os.path.join(str(tmp_path), ".hidden") not in roots
+    assert os.path.join(str(tmp_path), "visible", ".config", "inner") not in roots
+
+
+def test_disabled_returns_empty(tmp_path):
+    found = repo_scan.scan_repos([str(tmp_path)], enabled=False)
+    assert found == []
+
+
+def test_does_not_require_real_git(tmp_path):
+    # A dir named .git without a readable HEAD is not a repo.
+    fake = _make_plain_dir(str(tmp_path), "fake")
+    os.makedirs(os.path.join(fake, ".git"))  # no HEAD file
+
+    found = repo_scan.scan_repos([str(tmp_path)])
+    roots = {f["root"] for f in found}
+    assert fake not in roots

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -105,6 +105,62 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5061, str(e))
 
 
+@method("projects.scan_repos")
+def _(rid, params: dict) -> dict:
+    """Server-side git repo discovery for remote-connected desktops.
+
+    The desktop's native crawl only sees the host that runs the Electron app.
+    When the desktop is remote (app host != backend files), that crawl never
+    reaches the repos the backend is co-located with. This method walks the
+    policy roots on the BACKEND instead, records the result into the same
+    ``discovered_repos`` cache, and returns the merged repo list — so remote
+    desktops get disk-scanned repos exactly like local ones.
+    """
+    try:
+        from hermes_cli import projects_db as pdb
+        from tui_gateway import repo_scan
+
+        policy = _repo_discovery_policy()
+        policy_key = _repo_discovery_policy_key(policy)
+
+        repos = repo_scan.scan_repos(
+            policy["roots"],
+            enabled=policy["enabled"],
+            exclude_paths=policy["exclude_paths"],
+        )
+
+        with pdb.connect_closing() as conn:
+            pdb.reconcile_discovered_repos_policy(
+                conn,
+                policy_key,
+                preserve_unversioned=_repo_discovery_policy_is_default(policy),
+            )
+            if policy["enabled"]:
+                pdb.record_discovered_repos(
+                    conn,
+                    [(r["root"], r["label"]) for r in repos],
+                    replace=True,
+                    policy_key=policy_key,
+                )
+            else:
+                pdb.clear_discovered_repos(conn, policy_key=policy_key)
+
+        db = _get_db()
+        return _ok(
+            rid,
+            {
+                "repos": _discover_repos_payload(
+                    db, include_cached=policy["enabled"]
+                )
+                if db is not None
+                else [],
+                "discovery_policy": policy,
+            },
+        )
+    except Exception as e:
+        return _err(rid, 5061, str(e))
+
+
 @method("projects.tree")
 def _(rid, params: dict) -> dict:
     """Authoritative project overview: project -> repo -> lane structure with

--- a/tui_gateway/repo_scan.py
+++ b/tui_gateway/repo_scan.py
@@ -1,0 +1,106 @@
+"""Server-side git repo discovery for the Desktop Projects sidebar.
+
+The desktop's native Electron walk (apps/desktop/electron/git-repo-scan.ts)
+runs on the machine that hosts the Electron app. In remote mode the app is on
+a different host than the backend files, so that walk never sees the repos the
+backend is co-located with. This module is the backend's own bounded walk so a
+remote-connected desktop still gets disk-scanned repos (populated into
+``discovered_repos`` via ``projects.scan_repos`` / ``projects.record_repos``).
+
+It mirrors the Electron walk's structural contract — repo detection by a
+``.git`` dir with a readable ``HEAD``, bounded depth, hidden + junk dir
+exclusion, empty-roots home-dir default — so local and remote discovery agree
+on the set of repos. Exact concurrency and ordering are not preserved (they
+never need to be).
+"""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_MAX_DEPTH = 3
+JUNK_DIRS = frozenset(
+    {"Applications", "Library", "node_modules", "site-packages", "vendor", "venv"}
+)
+
+
+def scan_repos(
+    roots: list[str],
+    *,
+    max_depth: int | None = None,
+    enabled: bool = True,
+    exclude_paths: list[str] | None = None,
+    home: str | None = None,
+) -> list[dict]:
+    """Walk ``roots`` for git repositories, bounded and junk-filtered.
+
+    Empty ``roots`` preserves the historical home-directory scan. Returns a
+    list of ``{"root": ..., "label": ...}`` (label = basename), deduplicated by
+    normalized root. ``enabled=False`` returns ``[]`` without touching disk.
+    """
+    if not enabled:
+        return []
+
+    home_dir = home or os.path.expanduser("~")
+    depth_cap = max_depth if isinstance(max_depth, int) and max_depth >= 0 else DEFAULT_MAX_DEPTH
+    search_roots = [os.path.normpath(r) for r in roots] if roots else [home_dir]
+    exclusions = [os.path.normpath(p) for p in (exclude_paths or []) if p]
+
+    found: dict[str, dict] = {}
+
+    def excluded(candidate: str) -> bool:
+        return any(_is_within(candidate, exc) for exc in exclusions)
+
+    def walk(dirpath: str, depth: int) -> None:
+        if depth > depth_cap or excluded(dirpath):
+            return
+
+        try:
+            entries = os.scandir(dirpath)
+        except OSError:
+            return
+
+        git_found = False
+        subdirs: list[str] = []
+
+        with entries:
+            for entry in entries:
+                try:
+                    is_dir = entry.is_dir()
+                except OSError:
+                    continue
+
+                name = entry.name
+                if is_dir and name == ".git":
+                    git_found = True
+                elif is_dir:
+                    if name.startswith(".") or name in JUNK_DIRS:
+                        continue
+                    subdirs.append(entry.path)
+
+        if git_found:
+            # Only a repo when HEAD is readable.
+            if os.access(os.path.join(dirpath, ".git", "HEAD"), os.R_OK):
+                norm = os.path.normpath(dirpath)
+                found.setdefault(
+                    norm,
+                    {"root": norm, "label": os.path.basename(norm) or norm},
+                )
+            return
+
+        for subdir in subdirs:
+            walk(subdir, depth + 1)
+
+    for root in search_roots:
+        walk(root, 0)
+
+    return list(found.values())
+
+
+def _is_within(candidate: str, parent: str) -> bool:
+    """True when ``candidate`` equals ``parent`` or is nested under it."""
+    try:
+        rel = os.path.relpath(candidate, parent)
+    except ValueError:  # different drive (Windows)
+        return False
+    return rel == "." or (rel != ".." and not rel.startswith(".." + os.sep) and not os.path.isabs(rel))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -270,6 +270,7 @@ _LONG_HANDLERS = frozenset(
         "image.generate",
         "projects.discover_repos",
         "projects.record_repos",
+        "projects.scan_repos",
         "projects.for_cwd",
         "projects.tree",
         "projects.project_sessions",


### PR DESCRIPTION
## Problem
The Projects sidebar's filesystem repo scan lives in the Electron host (`scanGitRepos`) and is skipped entirely when the desktop app connects in **remote mode** (`projects.ts` returned early on `isDesktopFsRemoteMode`). On a remote desktop the scan host is not the backend that holds the files, so `discovered_repos` stays empty and the tree only shows explicit projects plus session-derived repos. Zero-session repos vanish from the sidebar even though they exist on the backend host.

Reported in #88531 (this closes the Projects half of it).

## Fix
Move discovery to the **backend**, which is co-located with the files:

- **`tui_gateway/repo_scan.py`** (new): server-side bounded git walk mirroring the Electron scan contract (repo = `.git` dir with readable `HEAD`, bounded depth, hidden/junk dir exclusion, empty-roots -> home default).
- **`projects.scan_repos`** JSON-RPC (in `tui_gateway/methods_config.py` + registered in `server.py`): walks the policy roots on the backend host and records into the same `discovered_repos` cache.
- **`apps/desktop/src/store/projects.ts`**: in remote mode, `scanAndRecordRepos` calls `projects.scan_repos` on the backend instead of bailing. Local mode is unchanged (native Electron walk still wins).

## Tests
- New `tests/tui_gateway/test_repo_scan.py` (6 tests): nested repo detection, bounded depth, hidden/junk dir exclusion, disabled short-circuit, HEAD-readability.
- Updated desktop `projects.test.ts` remote-mode case: asserts `projects.scan_repos` is called and the local Electron scan is not.
- Backend server suite (585) and desktop projects suite (30) pass.

## Notes
- The related tab-bar half of #88531 is split into #88534 (separate defect).
- Verified the RPC registers on a live server instance.
