### PR TITLE
fix(copilot): route responses-only models across runtimes

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -810,6 +810,7 @@ def init_agent(
             or agent._provider_model_requires_responses_api(
                 agent.model,
                 provider=agent.provider,
+                api_key=api_key,
             )
         )
     ):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6813,6 +6813,21 @@ def resolve_provider_client(
         default_model = _get_aux_model_for_provider(provider)
         final_model = _normalize_resolved_model(model or default_model, provider)
 
+        # Resolve Copilot transport before building request headers. Catalog
+        # discovery issues its own Copilot request; doing it afterwards would
+        # interleave catalog headers with the actual auxiliary request headers.
+        copilot_needs_responses = False
+        if provider == "copilot" and final_model and not raw_codex:
+            try:
+                from hermes_cli.models import copilot_model_api_mode
+
+                copilot_needs_responses = (
+                    copilot_model_api_mode(final_model, api_key=api_key)
+                    == "codex_responses"
+                )
+            except ImportError:
+                pass
+
         if provider == "gemini":
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
@@ -6856,21 +6871,15 @@ def resolve_provider_client(
         client = _create_openai_client(api_key=api_key, base_url=base_url,
                         **({"default_headers": headers} if headers else {}))
 
-        # Copilot GPT-5+ models (except gpt-5-mini) require the Responses
-        # API — they are not accessible via /chat/completions.  Wrap the
-        # plain client in CodexAuxiliaryClient so call_llm() transparently
-        # routes through responses.stream().
-        if provider == "copilot" and final_model and not raw_codex:
-            try:
-                from hermes_cli.models import _should_use_copilot_responses_api
-                if _should_use_copilot_responses_api(final_model):
-                    logger.debug(
-                        "resolve_provider_client: copilot model %s needs "
-                        "Responses API — wrapping with CodexAuxiliaryClient",
-                        final_model)
-                    client = CodexAuxiliaryClient(client, final_model)
-            except ImportError:
-                pass
+        # Copilot models can advertise the Responses API independently of
+        # their vendor/name (for example Grok). Use the shared catalog-aware
+        # decision so auxiliary calls follow the same transport as main calls.
+        if copilot_needs_responses:
+            logger.debug(
+                "resolve_provider_client: copilot model %s needs "
+                "Responses API — wrapping with CodexAuxiliaryClient",
+                final_model)
+            client = CodexAuxiliaryClient(client, final_model)
 
         # Honor api_mode for any API-key provider (e.g. direct OpenAI with
         # codex-family models).  The copilot-specific wrapping above handles

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2629,6 +2629,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             elif agent._provider_model_requires_responses_api(
                 fb_model,
                 provider=fb_provider,
+                api_key=(
+                    fb_api_key_hint
+                    or getattr(fb_client, "api_key", None)
+                ),
             ):
                 # GPT-5.x models usually need Responses API, but keep
                 # provider-specific exceptions like Copilot gpt-5-mini on

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5218,16 +5218,19 @@ def copilot_model_api_mode(
         return "codex_responses"
 
     # Copilot Claude uses the provider's OpenAI-compatible chat transport,
-    # never Hermes' native Anthropic or Responses adapters. Keep that invariant
-    # ahead of generic catalog endpoint handling.
+    # never Hermes' native Anthropic or Responses adapters. The live catalog
+    # may advertise /v1/messages, but the Copilot token/header scheme is
+    # handled by the OpenAI client path; selecting anthropic_messages would
+    # send the wrong auth/wire shape. Keep that invariant ahead of generic
+    # catalog endpoint handling.
     if normalized.lower().startswith(("claude-", "anthropic/claude-")):
         return "chat_completions"
 
     # Catalog-driven fallback for models the pattern check does not cover.
     # Copilot advertises the accepted wire endpoint per model and rejects a
     # mismatch with ``unsupported_api_for_model``. Only upgrade a non-GPT
-    # model when it is explicitly Responses-only; Claude models remain on
-    # Copilot's OpenAI-compatible chat path even when /v1/messages is listed.
+    # model when it is explicitly Responses-only; dual-endpoint models stay
+    # on the existing chat_completions path.
     catalog_entry = next(
         (
             item
@@ -5247,11 +5250,7 @@ def copilot_model_api_mode(
             and "/chat/completions" not in supported_endpoints
         ):
             return "codex_responses"
-    # Copilot's Claude models are exposed through its OpenAI-compatible chat
-    # endpoint, not through Hermes' native Anthropic adapter. The live catalog may
-    # advertise /v1/messages, but the Copilot token/header scheme is handled by
-    # the OpenAI client path; selecting anthropic_messages would send the wrong
-    # auth/wire shape. Keep non-GPT Copilot slots on chat_completions.
+
     return "chat_completions"
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5217,6 +5217,36 @@ def copilot_model_api_mode(
     if _should_use_copilot_responses_api(normalized):
         return "codex_responses"
 
+    # Copilot Claude uses the provider's OpenAI-compatible chat transport,
+    # never Hermes' native Anthropic or Responses adapters. Keep that invariant
+    # ahead of generic catalog endpoint handling.
+    if normalized.lower().startswith(("claude-", "anthropic/claude-")):
+        return "chat_completions"
+
+    # Catalog-driven fallback for models the pattern check does not cover.
+    # Copilot advertises the accepted wire endpoint per model and rejects a
+    # mismatch with ``unsupported_api_for_model``. Only upgrade a non-GPT
+    # model when it is explicitly Responses-only; Claude models remain on
+    # Copilot's OpenAI-compatible chat path even when /v1/messages is listed.
+    catalog_entry = next(
+        (
+            item
+            for item in catalog or []
+            if isinstance(item, dict) and item.get("id") == normalized
+        ),
+        None,
+    )
+    if catalog_entry is not None:
+        supported_endpoints = {
+            str(endpoint).strip()
+            for endpoint in (catalog_entry.get("supported_endpoints") or [])
+            if str(endpoint).strip()
+        }
+        if (
+            "/responses" in supported_endpoints
+            and "/chat/completions" not in supported_endpoints
+        ):
+            return "codex_responses"
     # Copilot's Claude models are exposed through its OpenAI-compatible chat
     # endpoint, not through Hermes' native Anthropic adapter. The live catalog may
     # advertise /v1/messages, but the Copilot token/header scheme is handled by

--- a/run_agent.py
+++ b/run_agent.py
@@ -1648,6 +1648,7 @@ class AIAgent:
         model: str,
         *,
         provider: Optional[str] = None,
+        api_key: Optional[str] = None,
     ) -> bool:
         """Return True when this provider/model pair should use Responses API."""
         normalized_provider = (provider or "").strip().lower()
@@ -1662,8 +1663,11 @@ class AIAgent:
             return False
         if normalized_provider == "copilot":
             try:
-                from hermes_cli.models import _should_use_copilot_responses_api
-                return _should_use_copilot_responses_api(model)
+                from hermes_cli.models import copilot_model_api_mode
+                return (
+                    copilot_model_api_mode(model, api_key=api_key)
+                    == "codex_responses"
+                )
             except Exception:
                 # Fall back to the generic GPT-5 rule if Copilot-specific
                 # logic is unavailable for any reason.

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -482,6 +482,42 @@ class TestResolveVisionMainFirst:
         assert captured == {"is_agent_turn": True, "is_vision": False}
         assert "default_headers" not in mock_openai.call_args.kwargs
 
+    def test_responses_only_copilot_model_uses_responses_wrapper(self, monkeypatch):
+        """Auxiliary Copilot calls must honour catalog endpoint metadata."""
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "ghu_test-token")
+        catalog = [{
+            "id": "grok-4.6",
+            "supported_endpoints": ["/responses"],
+        }]
+
+        with patch(
+            "agent.auxiliary_client.OpenAI",
+        ) as mock_openai, patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={
+                "provider": "copilot",
+                "api_key": "copilot-api-token",
+                "base_url": "https://api.githubcopilot.com",
+            },
+        ), patch(
+            "hermes_cli.copilot_auth.copilot_request_headers",
+            return_value={},
+        ), patch(
+            "hermes_cli.models.fetch_github_model_catalog",
+            return_value=catalog,
+        ):
+            mock_openai.return_value = MagicMock()
+
+            from agent.auxiliary_client import (
+                CodexAuxiliaryClient,
+                resolve_provider_client,
+            )
+
+            client, model = resolve_provider_client("copilot", "grok-4.6")
+
+        assert isinstance(client, CodexAuxiliaryClient)
+        assert model == "grok-4.6"
+
 
 
 

--- a/tests/hermes_cli/test_copilot_model_api_mode.py
+++ b/tests/hermes_cli/test_copilot_model_api_mode.py
@@ -37,6 +37,20 @@ def test_copilot_responses_only_non_gpt_model_uses_responses_api():
     assert copilot_model_api_mode("grok-4.6", catalog=catalog) == "codex_responses"
 
 
+def test_copilot_dual_endpoint_non_gpt_model_stays_on_chat_completions():
+    """Both endpoints advertised: keep the cheaper existing chat path."""
+    from hermes_cli.models import copilot_model_api_mode
+
+    catalog = [
+        {
+            "id": "grok-4.6",
+            "supported_endpoints": ["/responses", "/chat/completions"],
+        }
+    ]
+
+    assert copilot_model_api_mode("grok-4.6", catalog=catalog) == "chat_completions"
+
+
 def test_copilot_claude_stays_on_chat_when_catalog_is_responses_only():
     """Copilot Claude always uses its OpenAI-compatible chat transport."""
     from hermes_cli.models import copilot_model_api_mode

--- a/tests/hermes_cli/test_copilot_model_api_mode.py
+++ b/tests/hermes_cli/test_copilot_model_api_mode.py
@@ -21,3 +21,31 @@ def test_copilot_gpt5_still_uses_responses_api():
 
     assert copilot_model_api_mode("gpt-5.5", catalog=[]) == "codex_responses"
     assert copilot_model_api_mode("gpt-5-mini", catalog=[]) == "chat_completions"
+
+
+def test_copilot_responses_only_non_gpt_model_uses_responses_api():
+    """The catalog, not the vendor prefix, owns endpoint selection."""
+    from hermes_cli.models import copilot_model_api_mode
+
+    catalog = [
+        {
+            "id": "grok-4.6",
+            "supported_endpoints": ["/responses"],
+        }
+    ]
+
+    assert copilot_model_api_mode("grok-4.6", catalog=catalog) == "codex_responses"
+
+
+def test_copilot_claude_stays_on_chat_when_catalog_is_responses_only():
+    """Copilot Claude always uses its OpenAI-compatible chat transport."""
+    from hermes_cli.models import copilot_model_api_mode
+
+    catalog = [
+        {
+            "id": "claude-opus-5",
+            "supported_endpoints": ["/responses", "/v1/messages"],
+        }
+    ]
+
+    assert copilot_model_api_mode("claude-opus-5", catalog=catalog) == "chat_completions"

--- a/tests/run_agent/test_fallback_api_mode_preservation.py
+++ b/tests/run_agent/test_fallback_api_mode_preservation.py
@@ -180,3 +180,29 @@ class TestPlainFallbackUnchanged:
         agent = _make_agent(fallback_model=fbs)
         _activate(agent, "https://api.anthropic.com/v1", "claude-opus-4-6")
         assert agent.api_mode == "anthropic_messages"
+
+
+class TestCopilotCatalogRouting:
+    def test_responses_only_non_gpt_fallback_uses_responses_api(self):
+        """Fallback activation must use the same catalog routing as primary."""
+        fbs = [{
+            "provider": "copilot",
+            "model": "grok-4.6",
+        }]
+        catalog = [{
+            "id": "grok-4.6",
+            "supported_endpoints": ["/responses"],
+        }]
+        agent = _make_agent(fallback_model=fbs)
+
+        with patch(
+            "hermes_cli.models.fetch_github_model_catalog",
+            return_value=catalog,
+        ):
+            _activate(
+                agent,
+                "https://api.githubcopilot.com",
+                "grok-4.6",
+            )
+
+        assert agent.api_mode == "codex_responses"


### PR DESCRIPTION
## Summary

- route Copilot models advertised as `/responses`-only through `codex_responses`, including Grok 4.6
- apply the same catalog-aware decision to primary agent initialisation, auxiliary clients, and fallback activation
- preserve Copilot Claude models on the OpenAI-compatible chat path

## Provenance and related work

This salvages the original implementation from #58835 by cherry-picking its commit, preserving Anatoly Svichkarev's authorship, then addresses the maintainer review on that PR: non-GPT Responses-only models also need catalog-aware routing in the auxiliary and fallback activation paths.

Related overlapping PRs: #74377, #85224, #86075. This branch differs by covering all three runtime paths with regression tests while retaining current-main Claude transport behaviour.

## Problem

Copilot's live model catalog advertises Grok 4.6 with:

```json
{"supported_endpoints": ["/responses"]}
```

Hermes classified Copilot transport primarily from the GPT-5 model-name heuristic. Non-GPT Responses-only models therefore used `/chat/completions` and failed with:

```text
HTTP 400: model "grok-4.6" is not accessible via the /chat/completions endpoint
```

The primary model helper, auxiliary client wrapper, and fallback activation each made that decision separately, so fixing only `copilot_model_api_mode()` left sibling paths broken.

## Approach

- make `copilot_model_api_mode()` honour `/responses` when `/chat/completions` is absent
- pass the active credential into the shared Copilot resolver during agent initialisation and fallback activation
- use the same resolver before auxiliary request headers are constructed, then wrap Responses-only models with `CodexAuxiliaryClient`
- keep GPT-5 heuristics and explicit API-mode overrides unchanged

## Verification

- regression tests were added before the fix and failed on current main in all three paths
- `scripts/run_tests.sh` across six affected test files: **182 passed, 0 failed**
- Ruff checks and `git diff --check`: passed
- a live end-to-end Copilot request could not be completed while GitHub Status reported a Copilot major outage and the token-exchange endpoint returned HTTP 503; the runtime failure itself is captured in existing Hermes logs and the regression tests use the catalog contract

## Risk

Low and provider-scoped. Catalog metadata only upgrades a model when `/responses` is explicitly present and `/chat/completions` is absent. Chat-capable Claude and Gemini models retain their current transport.
