### PR TITLE
fix(dashboard): bound uvicorn graceful shutdown timeout

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18831,6 +18831,13 @@ def start_server(
         ws_ping_interval=None if _is_loopback else 20.0,
         ws_ping_timeout=None if _is_loopback else 20.0,
         ws_max_size=_DESKTOP_ATTACHMENT_WS_MAX_BYTES,
+        # Bound graceful shutdown. On SIGINT (e.g. a systemd restart) uvicorn's
+        # shutdown() waits for open connections to finish, but a long-lived
+        # dashboard WebSocket never closes on its own, so with the default
+        # timeout_graceful_shutdown=None the wait is unbounded and the process
+        # hangs until the service manager's stop timeout fires SIGKILL. Cap the
+        # wait so uvicorn force-cancels the lingering ws task and exits cleanly.
+        timeout_graceful_shutdown=10,
     )
     server = uvicorn.Server(config)
 


### PR DESCRIPTION
## Problem

The dashboard's `uvicorn.Config` (`hermes_cli/web_server.py`) never sets `timeout_graceful_shutdown`, so it defaults to `None` — wait indefinitely.

On SIGINT (e.g. a `systemctl restart`), `uvicorn.Server.shutdown()` stops accepting, then waits for open connections to close. A long-lived dashboard WebSocket (e.g. `/api/console`) never closes on its own, so the wait is **unbounded**: the process hangs until the service/process manager force-kills it with SIGKILL after its stop timeout. Under systemd this shows up as a `status=9/KILL` on every restart.

## Fix

Set `timeout_graceful_shutdown=10` on the `uvicorn.Config`. Verified against the uvicorn source (0.41.0): once the graceful-shutdown timeout elapses, `Server.shutdown()` logs `Cancel N running task(s), timeout graceful shutdown exceeded` and `task.cancel()`s the remaining connections — so the process exits cleanly within the bound instead of hanging.

Shutdown-only change; runtime behavior is unaffected. One line (plus a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)