### PR TITLE
fix(codex): recover lingering token_expired after replay cache

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -106,6 +106,104 @@ logger = logging.getLogger(__name__)
 # in the api_messages loop. Module-level so both sites can never drift.
 _INTERRUPT_SCAFFOLD_MARKER = "[This response was interrupted by a user correction.]"
 
+# Providers whose 401 path already does a one-shot Codex/xAI OAuth refresh.
+# Lingering token_expired recovery must use the same set so a generic
+# Responses 401 does not strip replay.
+_CODEX_401_REPLAY_PROVIDERS = frozenset({"openai-codex", "xai-oauth"})
+
+
+def _messages_have_codex_reasoning_cache(messages: Any) -> bool:
+    if not isinstance(messages, list):
+        return False
+    return any(
+        isinstance(msg, dict)
+        and msg.get("role") == "assistant"
+        and isinstance(msg.get("codex_reasoning_items"), list)
+        and msg.get("codex_reasoning_items")
+        for msg in messages
+    )
+
+
+def _is_codex_token_expired_signature(error: BaseException | None) -> bool:
+    """True when the provider labeled this failure ``token_expired``."""
+    from agent.error_classifier import _extract_error_body, _extract_error_code
+
+    if error is None:
+        return False
+    body = _extract_error_body(error) if isinstance(error, Exception) else {}
+    code = (_extract_error_code(body) or "").lower()
+    if code == "token_expired":
+        return True
+    text = str(error).lower()
+    return "token_expired" in text or "authentication token is expired" in text
+
+
+def should_strip_codex_replay_after_lingering_401(
+    *,
+    api_mode: str = "",
+    provider: str = "",
+    status_code: Any = None,
+    error: BaseException | None = None,
+    auth_retry_attempted: bool = False,
+    replay_strip_attempted: bool = False,
+    replay_enabled: bool = True,
+    messages: Any = None,
+) -> bool:
+    """Return True only after Codex 401 refresh, when replay cache remains.
+
+    HTTP 401 stays ``FailoverReason.auth``. This predicate never reclassifies
+    the error; it only gates the existing strip+retry used for 400
+    ``invalid_encrypted_content``.
+    """
+    if (api_mode or "") != "codex_responses":
+        return False
+    if (provider or "") not in _CODEX_401_REPLAY_PROVIDERS:
+        return False
+    try:
+        status = int(status_code) if status_code is not None else None
+    except (TypeError, ValueError):
+        return False
+    if status != 401:
+        return False
+    if not auth_retry_attempted or replay_strip_attempted:
+        return False
+    if not replay_enabled:
+        return False
+    if not _is_codex_token_expired_signature(error):
+        return False
+    return _messages_have_codex_reasoning_cache(messages)
+
+
+def recover_codex_replay_after_lingering_401(
+    agent: Any,
+    retry: TurnRetryState,
+    messages: Any,
+    *,
+    status_code: Any,
+    error: BaseException | None,
+) -> bool:
+    """One-shot strip of cached Codex reasoning after a lingering 401.
+
+    Reuses ``invalid_encrypted_content_retry_attempted`` so a later 400
+    replay rejection in the same attempt cannot strip twice.
+    """
+    if not should_strip_codex_replay_after_lingering_401(
+        api_mode=getattr(agent, "api_mode", "") or "",
+        provider=getattr(agent, "provider", "") or "",
+        status_code=status_code,
+        error=error,
+        auth_retry_attempted=bool(getattr(retry, "codex_auth_retry_attempted", False)),
+        replay_strip_attempted=bool(
+            getattr(retry, "invalid_encrypted_content_retry_attempted", False)
+        ),
+        replay_enabled=bool(getattr(agent, "_codex_reasoning_replay_enabled", True)),
+        messages=messages,
+    ):
+        return False
+    retry.invalid_encrypted_content_retry_attempted = True
+    agent._disable_codex_reasoning_replay(messages)
+    return True
+
 
 def _restore_user_after_reference_handoff(
     messages: List[Dict[str, Any]], user_message: Any
@@ -4695,7 +4793,7 @@ def run_conversation(
 
                 if (
                     agent.api_mode == "codex_responses"
-                    and agent.provider in {"openai-codex", "xai-oauth"}
+                    and agent.provider in _CODEX_401_REPLAY_PROVIDERS
                     and status_code == 401
                     and not _retry.codex_auth_retry_attempted
                 ):
@@ -4704,6 +4802,28 @@ def run_conversation(
                         _label = "xAI OAuth" if agent.provider == "xai-oauth" else "Codex"
                         agent._buffer_vprint(f"🔐 {_label} auth refreshed after 401. Retrying request...")
                         continue
+                # After the one-shot Codex/xAI OAuth refresh, a persisted
+                # session can still 401 with token_expired while the same
+                # bearer works on a fresh transcript (#88510). Reuse the
+                # 400 invalid_encrypted_content strip — do not reclassify 401.
+                if recover_codex_replay_after_lingering_401(
+                    agent,
+                    _retry,
+                    messages,
+                    status_code=status_code,
+                    error=api_error,
+                ):
+                    agent._vprint(
+                        f"{agent.log_prefix}⚠️  Encrypted reasoning replay was rejected "
+                        f"as token_expired after auth refresh — disabled replay and retrying...",
+                        force=True,
+                    )
+                    logger.warning(
+                        "%sLingering Codex token_expired recovery: disabled "
+                        "encrypted reasoning replay after auth refresh",
+                        agent.log_prefix,
+                    )
+                    continue
                 if (
                     agent.api_mode == "chat_completions"
                     and agent.provider == "vertex"

--- a/tests/run_agent/test_codex_lingering_401_replay.py
+++ b/tests/run_agent/test_codex_lingering_401_replay.py
@@ -1,0 +1,183 @@
+"""Lingering Codex 401 token_expired after a live-token refresh (#88510).
+
+A persisted openai-codex session can keep returning HTTP 401
+``token_expired`` even though the same bearer works for a new session and
+for a minimal Responses request. Hermes already strips cached
+``codex_reasoning_items`` on HTTP 400 ``invalid_encrypted_content``.
+401 is classified as auth (and must stay that way) so the first pass
+still runs the Codex OAuth refresh. Only after that refresh has already
+been attempted, and only when the transcript still holds cached
+encrypted reasoning, do we reuse the existing one-shot strip+retry.
+
+These tests call the production helpers the conversation loop will use.
+They must fail on origin/main (helpers missing / recovery not wired).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.error_classifier import FailoverReason, classify_api_error
+from agent.turn_retry_state import TurnRetryState
+
+
+class _Fake401(Exception):
+    def __init__(self, message, status_code=401, body=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body or {}
+
+
+def _cached_messages():
+    return [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "ok",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "blob-1"},
+                {"type": "reasoning", "encrypted_content": "blob-2"},
+            ],
+        },
+    ]
+
+
+def _token_expired_error():
+    return _Fake401(
+        "HTTP 401: Provided authentication token is expired. "
+        "Please try signing in again. error code: token_expired",
+        status_code=401,
+        body={"error": {"code": "token_expired", "message": "Provided authentication token is expired. Please try signing in again."}},
+    )
+
+
+def test_token_expired_401_stays_auth_not_invalid_encrypted_content():
+    """Classifier must not treat 401 token_expired as replay rejection."""
+    result = classify_api_error(_token_expired_error(), provider="openai-codex", model="gpt-5.4")
+    assert result.reason == FailoverReason.auth
+    assert result.reason != FailoverReason.invalid_encrypted_content
+
+
+def test_invalid_encrypted_content_400_still_classifies_as_replay():
+    err = _Fake401(
+        "invalid_encrypted_content",
+        status_code=400,
+        body={"error": {"code": "invalid_encrypted_content", "message": "could not decrypt the provided encrypted_content"}},
+    )
+    result = classify_api_error(err, provider="openai-codex", model="gpt-5.4")
+    assert result.reason == FailoverReason.invalid_encrypted_content
+
+
+def test_should_not_strip_before_codex_auth_refresh():
+    from agent.conversation_loop import should_strip_codex_replay_after_lingering_401
+
+    assert (
+        should_strip_codex_replay_after_lingering_401(
+            api_mode="codex_responses",
+            provider="openai-codex",
+            status_code=401,
+            error=_token_expired_error(),
+            auth_retry_attempted=False,
+            replay_strip_attempted=False,
+            replay_enabled=True,
+            messages=_cached_messages(),
+        )
+        is False
+    )
+
+
+def test_should_not_strip_when_transcript_has_no_cached_reasoning():
+    from agent.conversation_loop import should_strip_codex_replay_after_lingering_401
+
+    assert (
+        should_strip_codex_replay_after_lingering_401(
+            api_mode="codex_responses",
+            provider="openai-codex",
+            status_code=401,
+            error=_token_expired_error(),
+            auth_retry_attempted=True,
+            replay_strip_attempted=False,
+            replay_enabled=True,
+            messages=[{"role": "user", "content": "hi"}, {"role": "assistant", "content": "ok"}],
+        )
+        is False
+    )
+
+
+def test_should_not_strip_generic_401_without_token_expired():
+    from agent.conversation_loop import should_strip_codex_replay_after_lingering_401
+
+    err = _Fake401(
+        "Incorrect API key provided",
+        status_code=401,
+        body={"error": {"code": "invalid_api_key", "message": "Incorrect API key provided"}},
+    )
+    assert (
+        should_strip_codex_replay_after_lingering_401(
+            api_mode="codex_responses",
+            provider="openai-codex",
+            status_code=401,
+            error=err,
+            auth_retry_attempted=True,
+            replay_strip_attempted=False,
+            replay_enabled=True,
+            messages=_cached_messages(),
+        )
+        is False
+    )
+
+
+def test_should_strip_after_auth_retry_when_cache_and_token_expired():
+    from agent.conversation_loop import should_strip_codex_replay_after_lingering_401
+
+    assert (
+        should_strip_codex_replay_after_lingering_401(
+            api_mode="codex_responses",
+            provider="openai-codex",
+            status_code=401,
+            error=_token_expired_error(),
+            auth_retry_attempted=True,
+            replay_strip_attempted=False,
+            replay_enabled=True,
+            messages=_cached_messages(),
+        )
+        is True
+    )
+
+
+def test_recover_strips_cache_once_and_reuses_400_oneshot():
+    from agent.conversation_loop import recover_codex_replay_after_lingering_401
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent.api_mode = "codex_responses"
+    agent.provider = "openai-codex"
+    agent._codex_reasoning_replay_enabled = True
+    retry = TurnRetryState()
+    retry.codex_auth_retry_attempted = True
+    messages = _cached_messages()
+
+    recovered = recover_codex_replay_after_lingering_401(
+        agent,
+        retry,
+        messages,
+        status_code=401,
+        error=_token_expired_error(),
+    )
+    assert recovered is True
+    assert agent._codex_reasoning_replay_enabled is False
+    assert "codex_reasoning_items" not in messages[1]
+    assert retry.invalid_encrypted_content_retry_attempted is True
+
+    # Second 401 in the same attempt must not fire again.
+    messages[1]["codex_reasoning_items"] = [{"encrypted_content": "again"}]
+    agent._codex_reasoning_replay_enabled = True
+    recovered_again = recover_codex_replay_after_lingering_401(
+        agent,
+        retry,
+        messages,
+        status_code=401,
+        error=_token_expired_error(),
+    )
+    assert recovered_again is False
+    assert messages[1]["codex_reasoning_items"] == [{"encrypted_content": "again"}]


### PR DESCRIPTION
## What does this PR do?

A persisted openai-codex session can keep failing with HTTP 401 `token_expired` even though the same access token works for a new session and for a minimal Codex Responses request. Hermes already recovers from rejected encrypted-reasoning replay on HTTP 400 `invalid_encrypted_content`. This change applies that same one-shot strip+retry after the existing Codex/xAI 401 OAuth refresh, and only when the transcript still holds cached `codex_reasoning_items`.

HTTP 401 stays classified as auth. Sessions without cached reasoning, and 401s that are not `token_expired`, still follow the normal credential path.

Residual: the strip is in-memory (same as the 400 path). A later resume of the same session rehydrates the blobs from SessionDB and pays one 401 → refresh → strip again. The Desktop session id does not change.

## Related Issue

Fixes #88510

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py` — after the openai-codex / xai-oauth 401 refresh, call `recover_codex_replay_after_lingering_401` (one-shot via `invalid_encrypted_content_retry_attempted`).
- `tests/run_agent/test_codex_lingering_401_replay.py` — 401 stays `FailoverReason.auth`; strip only after auth retry + cache + `token_expired`; recover is one-shot.

## How to Test

1. Classifier still treats HTTP 401 `token_expired` as auth, not `invalid_encrypted_content`.
2. After `codex_auth_retry_attempted`, a 401 `token_expired` with cached `codex_reasoning_items` disables replay and pops the sidecars.
3. The same 401 without cached reasoning, or a generic `invalid_api_key` 401, does not strip.
4. A second recover in the same attempt is a no-op.

```bash
scripts/run_tests.sh tests/run_agent/test_codex_lingering_401_replay.py \
  tests/agent/test_error_classifier.py tests/agent/test_turn_retry_state.py -q --tb=short
```

107 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
