### PR TITLE
fix(desktop): park the bot face clock when idle and tear it down on disable

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1110,24 +1110,68 @@ function startFaceClock() {
 
   window.__hbFaceClock = true
   const t0 = performance.now()
-  // The shadow-root walk over the whole document is the expensive part —
-  // do it at ~1Hz and paint the cached list per frame. Skip paints while
-  // the window is hidden; rAF is throttled there anyway, but be explicit.
+  // A large roster can mount hundreds of faces. Observe the cached nodes so
+  // off-screen cards do not consume a full animation frame by themselves.
   let faces = []
   let lastScan = -Infinity
+  let lastPaint = -Infinity
+  const visibleFaces = new Set()
+  const observedFaces = new Set()
+  const observer =
+    typeof IntersectionObserver === 'function'
+      ? new IntersectionObserver(entries => {
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              visibleFaces.add(entry.target)
+            } else {
+              visibleFaces.delete(entry.target)
+            }
+          }
+        })
+      : null
+
+  const scanFaces = () => {
+    faces = walkMathFaces(document, [])
+
+    if (!observer) {
+      return
+    }
+
+    const currentFaces = new Set(faces)
+
+    for (const svg of observedFaces) {
+      if (!currentFaces.has(svg)) {
+        observer.unobserve(svg)
+        observedFaces.delete(svg)
+        visibleFaces.delete(svg)
+      }
+    }
+
+    for (const svg of faces) {
+      if (!observedFaces.has(svg)) {
+        observedFaces.add(svg)
+        observer.observe(svg)
+      }
+    }
+  }
 
   const tick = now => {
-    if (!document.hidden) {
+    // 15fps is smooth at avatar scale and bounds SVG/DOM churn. The clock
+    // still uses rAF so Chromium can pause it when the window is occluded.
+    if (!document.hidden && now - lastPaint >= 1000 / 15) {
       if (now - lastScan > 1000) {
-        faces = walkMathFaces(document, [])
+        scanFaces()
         lastScan = now
       }
       const t = (now - t0) / 1000
-      for (const svg of faces) {
+      const facesToPaint = observer ? visibleFaces : faces
+
+      for (const svg of facesToPaint) {
         if (svg.isConnected) {
           paintMathFace(svg, t)
         }
       }
+      lastPaint = now
     }
     window.requestAnimationFrame(tick)
   }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1104,28 +1104,46 @@ function walkMathFaces(root, acc) {
 }
 
 function startFaceClock() {
-  if (typeof window === 'undefined' || window.__hbFaceClock) {
+  if (typeof window === 'undefined') {
     return
   }
 
-  window.__hbFaceClock = true
+  if (window.__hbFaceClock) {
+    // Already initialized (possibly parked) — make sure it's awake. BotFace
+    // renders route here, so a face mounting is what wakes a dormant clock.
+    window.__hbFaceClock.wake()
+
+    return
+  }
+
   const t0 = performance.now()
   // A large roster can mount hundreds of faces. Observe the cached nodes so
   // off-screen cards do not consume a full animation frame by themselves.
   let faces = []
   let lastScan = -Infinity
   let lastPaint = -Infinity
+  let rafId = 0
+  let dormant = false
+  let stopped = false
   const visibleFaces = new Set()
   const observedFaces = new Set()
   const observer =
     typeof IntersectionObserver === 'function'
       ? new IntersectionObserver(entries => {
+          let becameVisible = false
+
           for (const entry of entries) {
             if (entry.isIntersecting) {
               visibleFaces.add(entry.target)
+              becameVisible = true
             } else {
               visibleFaces.delete(entry.target)
             }
+          }
+
+          // A parked clock (no visible faces) resumes when one scrolls in.
+          if (becameVisible) {
+            wake()
           }
         })
       : null
@@ -1156,6 +1174,11 @@ function startFaceClock() {
   }
 
   const tick = now => {
+    if (stopped) {
+      return
+    }
+
+    rafId = 0
     // 15fps is smooth at avatar scale and bounds SVG/DOM churn. The clock
     // still uses rAF so Chromium can pause it when the window is occluded.
     if (!document.hidden && now - lastPaint >= 1000 / 15) {
@@ -1173,10 +1196,58 @@ function startFaceClock() {
       }
       lastPaint = now
     }
-    window.requestAnimationFrame(tick)
+
+    // Dormancy: no faces mounted (BotFace wakes us on the next mount), or
+    // none visible (the observer wakes us when one scrolls in). Park the
+    // clock instead of burning frames + 1Hz whole-document shadow walks.
+    if (faces.length === 0 || (observer && visibleFaces.size === 0)) {
+      dormant = true
+
+      return
+    }
+
+    rafId = window.requestAnimationFrame(tick)
   }
 
-  window.requestAnimationFrame(tick)
+  const wake = () => {
+    if (stopped || !dormant) {
+      return
+    }
+
+    dormant = false
+    // Faces may have mounted/unmounted while parked — rescan on first tick.
+    lastScan = -Infinity
+    rafId = window.requestAnimationFrame(tick)
+  }
+
+  const stop = () => {
+    stopped = true
+
+    if (rafId) {
+      window.cancelAnimationFrame(rafId)
+      rafId = 0
+    }
+
+    if (observer) {
+      observer.disconnect()
+    }
+
+    visibleFaces.clear()
+    observedFaces.clear()
+    faces = []
+    delete window.__hbFaceClock
+  }
+
+  window.__hbFaceClock = { stop, wake }
+  rafId = window.requestAnimationFrame(tick)
+}
+
+/** Tear the face clock down (plugin disable/reload) — cancels the animation
+ *  frame, disconnects the visibility observer, and drops all cached nodes. */
+function stopFaceClock() {
+  if (typeof window !== 'undefined' && window.__hbFaceClock) {
+    window.__hbFaceClock.stop()
+  }
 }
 
 /**
@@ -6777,6 +6848,11 @@ export default {
   register(ctx) {
     pluginCtx = ctx
     startFaceClock()
+    // Disabling the plugin (or a hot reload) must actually stop the clock —
+    // before this, the rAF loop + 1Hz document scan ran until app restart.
+    if (typeof ctx.onDispose === 'function') {
+      ctx.onDispose(stopFaceClock)
+    }
 
     // @-mention autocomplete: typing "@rese…" in ANY composer offers the
     // roster's handles (issue #88060). Reads the roster straight from the

--- a/apps/desktop/src/plugins/hermes-bots/tests/face-clock.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/face-clock.test.mjs
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+// Extract the clock functions only — the plugin is an ES module, so the whole
+// file can't be evaluated in a bare vm context. The slice is anchored on the
+// function declarations themselves.
+const start = pluginSource.indexOf('function startFaceClock()')
+const end = pluginSource.indexOf('/**\n * Live math face.')
+assert.ok(start > 0 && end > start, 'face clock functions present in plugin.js')
+const clockSource = pluginSource.slice(start, end)
+
+function load({ faces = [], intersectionObserver = true } = {}) {
+  const rafQueue = new Map()
+  let rafSeq = 0
+  let observerInstance = null
+
+  class FakeIntersectionObserver {
+    constructor(callback) {
+      this.callback = callback
+      this.observed = new Set()
+      this.disconnected = false
+      observerInstance = this
+    }
+
+    observe(el) {
+      this.observed.add(el)
+    }
+
+    unobserve(el) {
+      this.observed.delete(el)
+    }
+
+    disconnect() {
+      this.disconnected = true
+      this.observed.clear()
+    }
+
+    emit(entries) {
+      this.callback(entries)
+    }
+  }
+
+  const windowObj = {
+    requestAnimationFrame: cb => {
+      rafSeq += 1
+      rafQueue.set(rafSeq, cb)
+      return rafSeq
+    },
+    cancelAnimationFrame: id => {
+      rafQueue.delete(id)
+    }
+  }
+
+  const context = {
+    window: windowObj,
+    document: { hidden: false },
+    performance: { now: () => 0 },
+    IntersectionObserver: intersectionObserver ? FakeIntersectionObserver : undefined,
+    walkMathFaces: () => [...faces],
+    paintMathFace: () => undefined
+  }
+  vm.createContext(context)
+  vm.runInContext(`${clockSource}; __start = startFaceClock; __stop = stopFaceClock`, context)
+
+  let now = 0
+  const pump = (advance = 100) => {
+    now += advance
+    const pending = [...rafQueue.entries()]
+    rafQueue.clear()
+    for (const [, cb] of pending) {
+      cb(now)
+    }
+  }
+
+  return {
+    start: () => context.__start(),
+    stop: () => context.__stop(),
+    pump,
+    pending: () => rafQueue.size,
+    observer: () => observerInstance,
+    clock: () => context.window.__hbFaceClock,
+    setFaces: next => {
+      faces.length = 0
+      faces.push(...next)
+    }
+  }
+}
+
+test('unit: the clock parks itself when no faces are mounted', () => {
+  const h = load({ faces: [] })
+  h.start()
+  assert.equal(h.pending(), 1, 'clock schedules its first frame')
+  h.pump()
+  assert.equal(h.pending(), 0, 'no faces -> dormant, no further frames scheduled')
+})
+
+test('unit: a mounting face (startFaceClock re-entry) wakes a parked clock', () => {
+  const h = load({ faces: [] })
+  h.start()
+  h.pump()
+  assert.equal(h.pending(), 0, 'parked')
+
+  const face = { isConnected: true }
+  h.setFaces([face])
+  h.start() // BotFace render path
+  assert.equal(h.pending(), 1, 'wake scheduled a frame')
+})
+
+test('unit: the clock parks when all faces scroll out and the observer wakes it back', () => {
+  const face = { isConnected: true }
+  const h = load({ faces: [face] })
+  h.start()
+  h.pump()
+  // Face observed but not yet visible -> visibleFaces empty -> parked.
+  assert.equal(h.pending(), 0, 'no visible faces -> dormant')
+
+  h.observer().emit([{ target: face, isIntersecting: true }])
+  assert.equal(h.pending(), 1, 'visibility wakes the clock')
+  h.pump()
+  assert.equal(h.pending(), 1, 'visible face keeps the clock running')
+
+  h.observer().emit([{ target: face, isIntersecting: false }])
+  h.pump()
+  h.pump()
+  assert.equal(h.pending(), 0, 'all faces hidden -> parked again')
+})
+
+test('unit: stopFaceClock cancels the frame, disconnects the observer, and clears the handle', () => {
+  const face = { isConnected: true }
+  const h = load({ faces: [face] })
+  h.start()
+  h.observer().emit([{ target: face, isIntersecting: true }])
+  h.pump()
+  assert.equal(h.pending(), 1, 'running')
+
+  h.stop()
+  assert.equal(h.pending(), 0, 'pending frame cancelled')
+  assert.equal(h.observer().disconnected, true, 'observer disconnected')
+  assert.equal(h.clock(), undefined, 'window handle removed')
+
+  // A fresh start after teardown re-initializes rather than hitting a dead handle.
+  h.start()
+  assert.equal(h.pending(), 1, 'clock restarts cleanly after stop')
+})
+
+test('source: plugin registers face-clock teardown via ctx.onDispose', () => {
+  assert.match(pluginSource, /ctx\.onDispose\(stopFaceClock\)/)
+})


### PR DESCRIPTION
## Summary

The bundled Bots plugin's face-animation clock no longer burns CPU when idle and actually stops when the plugin is disabled. Salvages #88219 by @digitalbase (visible-faces-only painting via IntersectionObserver + 15 fps cap, authorship preserved) and completes it with dormancy and teardown.

Root cause of the field report (Desktop pinned at 100% CPU, persisting after disabling Bots): the clock started at plugin load, ran a `requestAnimationFrame` loop forever, rescanned the whole document — including every shadow root via `querySelectorAll('*')` — every second, and repainted all mounted faces at 60 fps. Disabling the plugin never tore any of it down.

## Changes

- `apps/desktop/src/plugins/hermes-bots/plugin.js`:
  - (salvaged #88219) observe faces, paint only viewport-visible ones, cap at 15 fps
  - dormancy: the loop parks (stops scheduling frames, no 1 Hz document scan) when no faces are mounted or none are visible; a mounting `BotFace` or a face scrolling into view wakes it
  - teardown: `register()` hooks `ctx.onDispose(stopFaceClock)` — disabling/reloading the plugin cancels the frame, disconnects the observer, drops cached nodes, clears `window.__hbFaceClock`
- `tests/face-clock.test.mjs`: behavioral park/wake/stop coverage via a vm-extracted clock harness (verified to fail against the pre-fix source)

## Validation

| | Before | After |
|---|---|---|
| No visible faces | 60 fps repaint + 1 Hz full-document shadow-root scan, forever | clock parked, zero frames scheduled |
| Plugin disabled | loop runs until app restart | rAF cancelled, observer disconnected, handle cleared |
| Plugin tests | 143 | 160, all pass (`node --test`) |

Field report: Discord (rahlquist) — Desktop at 100% CPU after this morning's update, unchanged by disabling Bots without a restart. Likely also issue #73082.

Credit: @digitalbase for the visibility/15 fps work in #88219, cherry-picked with authorship preserved. Diagnosis by @helix4u.

## Infographic

![Bot face clock idle CPU fix](https://v3b.fal.media/files/b/0aa6ba99/3cohoCLLXjFBZWkvKzOT2_vNjxDMLJ.png)
