### PR TITLE
test(agent): make text-only vision routing test hermetic

### DIFF
--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -180,8 +180,14 @@ model:
         monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
         _fresh_modules()
         text_only_caps = type("Caps", (), {"supports_vision": False})()
+        capability_lookups = []
+
+        def get_text_only_capabilities(*args, **kwargs):
+            capability_lookups.append((args, kwargs))
+            return text_only_caps
+
         monkeypatch.setattr(
-            "agent.models_dev.get_model_capabilities", lambda *a, **k: text_only_caps
+            "agent.models_dev.get_model_capabilities", get_text_only_capabilities
         )
 
         from agent.auxiliary_client import resolve_vision_provider_client
@@ -191,6 +197,7 @@ model:
             "no vision-capable aggregator is available, not return a client "
             "that will fail at API time"
         )
+        assert capability_lookups, "vision routing must consult model capabilities"
 
     def test_vision_capable_main_used(self, isolated_home, monkeypatch):
         """Vision-capable main provider should be returned by auto chain."""

--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -179,6 +179,10 @@ model:
 """)
         monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
         _fresh_modules()
+        text_only_caps = type("Caps", (), {"supports_vision": False})()
+        monkeypatch.setattr(
+            "agent.models_dev.get_model_capabilities", lambda *a, **k: text_only_caps
+        )
 
         from agent.auxiliary_client import resolve_vision_provider_client
         provider, client, _model = resolve_vision_provider_client(provider="auto")


### PR DESCRIPTION
## Summary

- stub the models.dev capability lookup in the text-only main-provider regression test
- keep the test focused on vision routing instead of live catalog reachability

Fixes #88392.

## Validation

- `.venv/bin/python -m pytest tests/agent/test_vision_routing_31179.py::TestTextOnlyMainSkippedForVision::test_text_only_main_skipped_when_no_aggregator -q`
- `.venv/bin/ruff check tests/agent/test_vision_routing_31179.py`
- `git diff --check`

The full test file currently has one unrelated failure in `test_vision_capable_main_used` because the clean test runner reports no Anthropic credentials; the changed test passes independently.

## Platform

- macOS arm64, Python 3.11
