### PR TITLE
fix(compression): make durable adoption proof-preserving across repair and restore

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2855,47 +2855,126 @@ def compress_context(
                 type(_lock_db), "get_messages_as_conversation", None
             )
             if callable(durable_loader):
-                durable_parent = durable_loader(_lock_db, _lock_sid)
-                if isinstance(durable_parent, list) and len(durable_parent) > len(messages):
-                    # The in-memory transcript carries the CURRENT turn's
-                    # un-persisted user tail (anchored by
-                    # _persist_user_message_idx) that the durable snapshot read
-                    # above does not contain yet. Flush that tail through the
-                    # normal rotation-boundary path (conversation_history = the
-                    # already-durable prefix, #68196 boundary) BEFORE adopting,
-                    # then re-read the durable parent so the adopted snapshot
-                    # includes the live input. If the flush fails (or the
-                    # anchor is unknown), skip adoption entirely: replacing
-                    # the in-memory transcript with a snapshot that lacks the
-                    # user's input would silently drop it from the summarized
-                    # and rotated history (#adopt-live-tail).
-                    _preflush_idx = getattr(agent, "_persist_user_message_idx", None)
-                    _preflush_ok = False
+                # CHANGE 1 — monotonic row-id watermark (replaces bare length).
+                # The DB orders rows by AUTOINCREMENT id (hermes_state.py
+                # L10105-10113), so insertion order is id-monotonic while
+                # active-row COUNT is not (rotation ends a parent and publishes
+                # a child with fewer but strictly NEWER rows). "Longer" is
+                # therefore not "newer": capture the highest durable row id the
+                # caller's snapshot has seen, and adopt only when the durable
+                # reload proves strictly newer rows exist.
+                _snap_max_id = max(
+                    (
+                        m.get("_row_id")
+                        for m in messages
+                        if isinstance(m, dict) and m.get("_row_id") is not None
+                    ),
+                    default=None,
+                )
+
+                def _is_pure_append(durable_parent: Any) -> bool:
+                    """Strictly-newer durable rows than the snapshot's
+                    watermark, i.e. the durable side is a pure APPEND of rows
+                    the snapshot has never seen. No length comparison: a
+                    rotated CHILD is shorter but strictly newer, and adopting
+                    it is exactly the re-anchor a crash-after-commit retry
+                    needs (the snapshot references already-rotated content).
+                    A missing snapshot watermark (no _row_id on any in-memory
+                    dict — CLI restore path) cannot prove freshness: fail
+                    closed, never adopt."""
+                    if not isinstance(durable_parent, list):
+                        return False
+                    if _snap_max_id is None:
+                        return False
+                    _durable_max_id = max(
+                        (
+                            m.get("_row_id")
+                            for m in durable_parent
+                            if isinstance(m, dict)
+                            and m.get("_row_id") is not None
+                        ),
+                        default=None,
+                    )
+                    return (
+                        _durable_max_id is not None
+                        and _durable_max_id > _snap_max_id
+                    )
+
+                durable_parent = durable_loader(
+                    _lock_db, _lock_sid, include_row_ids=True  # CHANGE 2
+                )
+                if _is_pure_append(durable_parent):
+                    # CHANGE 3 — liveness re-check (W1 class B): the L2709 gate
+                    # deflects only end_reason == 'compression'. Re-verify the
+                    # parent is NOT ended by ANY path in this lock window
+                    # before adopting or flushing; an ended session's rows are
+                    # frozen/orphaned and must never become the compress input.
+                    _session_getter = getattr(type(_lock_db), "get_session", None)
+                    _parent_row = (
+                        _session_getter(_lock_db, _lock_sid)
+                        if callable(_session_getter)
+                        else None
+                    )
                     if (
-                        isinstance(_preflush_idx, int)
-                        and 0 <= _preflush_idx < len(messages)
+                        _parent_row is not None
+                        and _parent_row.get("ended_at") is not None
                     ):
-                        try:
-                            _preflush_ok = agent._flush_messages_to_session_db(
-                                messages,
-                                conversation_history=messages[:_preflush_idx],
-                            )
-                        except Exception:
-                            _preflush_ok = False
+                        logger.info(
+                            "compression: session=%s ended (end_reason=%s) "
+                            "after lease acquisition; skipping durable-snapshot "
+                            "adoption so ended-session rows are never fed to "
+                            "the summarizer",
+                            _lock_sid,
+                            _parent_row.get("end_reason"),
+                        )
+                        _preflush_ok = False
                     else:
-                        # No known un-persisted tail (anchor unset or already
-                        # at the end of the snapshot): the in-memory transcript
-                        # is fully durable, so adopting the longer parent
-                        # cannot drop live input — keep the legacy
-                        # adopt-directly behavior for that shape
-                        # (test_compression_concurrent_fork).
-                        _preflush_ok = True
+                        # The in-memory transcript carries the CURRENT turn's
+                        # un-persisted user tail (anchored by
+                        # _persist_user_message_idx) that the durable snapshot
+                        # read above does not contain yet. Flush that tail
+                        # through the normal rotation-boundary path
+                        # (conversation_history = the already-durable prefix,
+                        # #68196 boundary) BEFORE adopting, then re-read the
+                        # durable parent so the adopted snapshot includes the
+                        # live input. If the flush fails (or the anchor is
+                        # unknown), skip adoption entirely: replacing the
+                        # in-memory transcript with a snapshot that lacks the
+                        # user's input would silently drop it from the
+                        # summarized and rotated history (#adopt-live-tail).
+                        _preflush_idx = getattr(
+                            agent, "_persist_user_message_idx", None
+                        )
+                        _preflush_ok = False
+                        if (
+                            isinstance(_preflush_idx, int)
+                            and 0 <= _preflush_idx < len(messages)
+                        ):
+                            try:
+                                _preflush_ok = agent._flush_messages_to_session_db(
+                                    messages,
+                                    conversation_history=messages[:_preflush_idx],
+                                )
+                            except Exception:
+                                _preflush_ok = False
+                        else:
+                            # CHANGE 4 — fail-closed unset anchor (W1 class C).
+                            # No anchor: adopt-directly is safe ONLY when every
+                            # message is already durable, i.e. every dict
+                            # carries a _row_id. Otherwise an un-persisted live
+                            # tail exists and adoption would drop it — skip.
+                            _snap_fully_durable = all(
+                                isinstance(m, dict) and m.get("_row_id") is not None
+                                for m in messages
+                            )
+                            _preflush_ok = _snap_fully_durable
                     if not _preflush_ok:
                         logger.warning(
                             "compression: session=%s grew before lease "
                             "(%d → %d msgs) but the pre-adoption flush of the "
-                            "live tail failed; skipping durable-snapshot "
-                            "adoption so un-persisted user input is kept",
+                            "live tail failed (or the session ended); skipping "
+                            "durable-snapshot adoption so un-persisted user "
+                            "input is kept",
                             _lock_sid,
                             len(messages),
                             len(durable_parent),
@@ -2903,11 +2982,13 @@ def compress_context(
                     else:
                         # Re-read after the flush so the adopted snapshot
                         # carries the just-persisted tail.
-                        durable_parent = durable_loader(_lock_db, _lock_sid)
+                        durable_parent = durable_loader(
+                            _lock_db, _lock_sid, include_row_ids=True  # CHANGE 2
+                        )
                     if (
                         _preflush_ok
                         and isinstance(durable_parent, list)
-                        and len(durable_parent) > len(messages)
+                        and _is_pure_append(durable_parent)  # CHANGE 5
                     ):
                         logger.info(
                             "compression: session=%s grew before lease "

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2915,7 +2915,20 @@ def compress_context(
                         if callable(_session_getter)
                         else None
                     )
-                    if (
+                    if _parent_row is None:
+                        # CHANGE 7 — fail closed on an unreadable session row.
+                        # If the getter is unavailable or returns no row, we
+                        # cannot prove the session is live; adopting rows whose
+                        # liveness is unknown risks feeding an ended session's
+                        # frozen/orphaned rows to the summarizer. Skip adoption.
+                        logger.warning(
+                            "compression: session=%s liveness unverifiable "
+                            "(get_session returned no row); skipping "
+                            "durable-snapshot adoption",
+                            _lock_sid,
+                        )
+                        _preflush_ok = False
+                    elif (
                         _parent_row is not None
                         and _parent_row.get("ended_at") is not None
                     ):
@@ -2985,6 +2998,42 @@ def compress_context(
                         durable_parent = durable_loader(
                             _lock_db, _lock_sid, include_row_ids=True  # CHANGE 2
                         )
+                    if (
+                        _preflush_ok
+                        and isinstance(durable_parent, list)
+                        and _is_pure_append(durable_parent)  # CHANGE 5
+                    ):
+                        # CHANGE 6 — re-verify liveness at the adopt decision.
+                        # The pre-flush ended_at check above ran before the
+                        # flush + re-read; end_session()/append_message() do
+                        # not take the compression lock, so a concurrent
+                        # gateway timeout/hygiene end can land between the
+                        # pre-flush check and here. Re-read the parent row in
+                        # this window and skip adoption if it ended — else an
+                        # ended session's rows (incl. the just-flushed tail)
+                        # would be fed to the summarizer.
+                        if callable(_session_getter):
+                            _parent_row_after = _session_getter(
+                                _lock_db, _lock_sid
+                            )
+                        else:
+                            _parent_row_after = None
+                        if (
+                            _parent_row_after is None
+                            or _parent_row_after.get("ended_at") is not None
+                        ):
+                            logger.info(
+                                "compression: session=%s ended or unreadable "
+                                "(end_reason=%s) after pre-adoption flush; "
+                                "skipping durable-snapshot adoption so "
+                                "ended-session rows are never fed to the "
+                                "summarizer",
+                                _lock_sid,
+                                _parent_row_after.get("end_reason")
+                                if _parent_row_after is not None
+                                else None,
+                            )
+                            _preflush_ok = False
                     if (
                         _preflush_ok
                         and isinstance(durable_parent, list)

--- a/contributors/emails/agent@Agents-Mac-mini.local
+++ b/contributors/emails/agent@Agents-Mac-mini.local
@@ -1,1 +1,0 @@
-skip-agent

--- a/contributors/emails/agent@agents-Mac-mini.local
+++ b/contributors/emails/agent@agents-Mac-mini.local
@@ -1,1 +1,0 @@
-momomojo

--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Compression stale-adoption class fix (#88197)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1296,6 +1296,14 @@ def _build_replay_entry(
     providers.
     """
     entry: Dict[str, Any] = {"role": role, "content": content}
+    # Carry the durable row id through replay: the preflight compression
+    # watermark needs _row_id on the in-memory snapshot to prove durable
+    # freshness (conversation_compression.py _snap_max_id). Without it the
+    # main-loop auto-compress surface stays watermark-dead for plain-text
+    # sessions. _row_id is underscore-prefixed and stripped by every
+    # transport before the wire, so this changes only in-process identity.
+    if "_row_id" in msg:
+        entry["_row_id"] = msg["_row_id"]
     # api_content sidecar (persist-what-you-send, prompt-cache stability):
     # forward the exact bytes previously sent to the API for this message so
     # the agent's api_messages build can substitute them and keep the request

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3990,8 +3990,18 @@ class SessionStore:
             # user;user wedge (e.g. a turn that persisted no assistant row)
             # would otherwise re-trigger the pre-request repair on every
             # request forever — heal it once at the restore boundary.
+            #
+            # include_row_ids: the transcript feeds compress_context's
+            # preflight durable-adoption watermark (_snap_max_id over
+            # _row_id, conversation_compression.py). Without row ids the
+            # watermark is unreachable and adoption is silently dead on
+            # every gateway surface that builds its history here
+            # (run_conversation, /compress msgs, hygiene _hyg_msgs) — the
+            # #14694 wedge shape. _row_id is underscore-prefixed and
+            # stripped by every transport before the wire, so this changes
+            # only in-process identity.
             return self._db.get_messages_as_conversation(
-                session_id, repair_alternation=True
+                session_id, repair_alternation=True, include_row_ids=True
             )
         except Exception as e:
             # A failed read must be distinguishable from an empty transcript:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8584,6 +8584,11 @@ class AIAgent:
                     conversation_history = _turn_db.get_messages_as_conversation(
                         self.session_id,
                         repair_alternation=True,
+                        # Row ids feed compress_context's preflight adoption
+                        # watermark (_snap_max_id); without them a lease-wait
+                        # reload can never prove durable freshness and the
+                        # crash-after-commit re-anchor (W1 class A) fails
+                        # closed on this surface.
                         include_row_ids=True,
                     )
 

--- a/tests/agent/test_compression_adoption_preserves_live_tail.py
+++ b/tests/agent/test_compression_adoption_preserves_live_tail.py
@@ -97,7 +97,7 @@ def _seed_drifted_session(db: SessionDB, session_id: str):
     db.append_message(session_id, "user", "persisted question")
     db.append_message(session_id, "assistant", "persisted answer")
 
-    loaded = db.get_messages_as_conversation(session_id)
+    loaded = db.get_messages_as_conversation(session_id, include_row_ids=True)
     messages = [*loaded, {"role": "user", "content": "LIVE USER INSTRUCTION"}]
 
     agent = _build_agent_with_db(db, session_id)

--- a/tests/agent/test_compression_adoption_watermark.py
+++ b/tests/agent/test_compression_adoption_watermark.py
@@ -1,0 +1,135 @@
+"""Regression: durable-parent adoption must be gated by a monotonic row-id
+watermark, not a bare length comparison.
+
+``compress_context`` re-reads the durable parent after acquiring the
+per-session compression lock and adopts it when it "grew" — historically
+``len(durable_parent) > len(messages)``. Length conflates count with
+freshness: active-row COUNT is not monotonic (rotation ends a parent and
+publishes a child whose rows are fewer but strictly NEWER — new
+AUTOINCREMENT ids), while row ID is. The bare length gate is therefore
+directionally blind:
+
+- W1 class A — an exception AFTER a committed rotation leaves the caller
+  holding the stale pre-rotation transcript while ``agent.session_id`` points
+  at the committed child; the length gate refuses to reconcile and the same
+  content is re-summarized into a second child.
+- W1 class B — a session ended by a NON-compression path (``/new``, gateway
+  hygiene, timeout) between the rotated-parent gate (compression-reason-only)
+  and the durable read is not deflected; its full transcript plus orphan
+  appends can be adopted.
+- W1 class C — with ``_persist_user_message_idx`` unset, the legacy path
+  ASSUMES full durability; an un-persisted live tail is silently dropped.
+
+The fix replaces the length comparison with a monotonic max-id watermark
+(adopt iff the durable reload's max row id strictly exceeds the snapshot's
+max known row id), guarded by a same-window liveness re-check and a
+fail-closed preflush.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hermes_state import SessionDB
+
+from tests.agent.test_compression_adoption_preserves_live_tail import (
+    _build_agent_with_db,
+)
+
+
+def test_retry_after_committed_rotation_adopts_child_not_stale_parent(tmp_path: Path) -> None:
+    """W1 class A: an exception AFTER a successful rotation commit leaves the
+    caller holding the pre-rotation transcript while agent.session_id points at
+    the committed child. The retry must be re-anchored to the child rows, not
+    re-summarize the same content into a second child."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "CRASH_AFTER_COMMIT_PARENT"
+    child_sid = "CRASH_AFTER_COMMIT_CHILD"
+    db.create_session(parent_sid, source="webui")
+    for i in range(100):
+        db.append_message(parent_sid, "user", f"p{i}")
+
+    # The rotation that already committed (mirrors L3488-3501): parent ended,
+    # child holds the 10-row compressed summary with strictly newer row ids.
+    child_rows = [
+        {"role": "user", "content": f"child summary {i}"} for i in range(10)
+    ]
+    db.publish_compression_child(
+        parent_session_id=parent_sid,
+        child_session_id=child_sid,
+        source="test",
+        messages=child_rows,
+        require_compression_lease=False,
+    )
+
+    # The caller kept its pre-compression list (L3071-3086 re-raises without
+    # restoring it); agent.session_id is already the child (L3502).
+    stale = db.get_messages_as_conversation(parent_sid, include_row_ids=True)
+    assert len(stale) == 100
+    agent = _build_agent_with_db(db, child_sid)
+
+    agent._compress_context(stale, "sys", approx_tokens=120_000)
+
+    compress_input = agent.context_compressor.compress.call_args.args[0]
+    assert [m["content"] for m in compress_input] == [
+        f"child summary {i}" for i in range(10)
+    ], (
+        "Retry after a committed rotation must compress the CHILD rows, not "
+        "re-summarize the stale parent transcript (W1 class A). "
+        f"Compress input: {[m.get('content') for m in compress_input]!r}"
+    )
+
+
+def test_ended_by_other_path_parent_not_adopted(tmp_path: Path) -> None:
+    """W1 class B: a session ended by a NON-compression path between the
+    rotated-parent gate (L2709, compression-reason-only) and the durable read
+    (L2834) is not deflected; its full transcript plus orphan appends must
+    never become the compress input."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "ENDED_BY_TIMEOUT"
+    db.create_session(parent_sid, source="webui")
+    db.append_message(parent_sid, "user", "persisted question")
+    db.append_message(parent_sid, "assistant", "persisted answer")
+
+    snapshot = db.get_messages_as_conversation(parent_sid, include_row_ids=True)
+    db.end_session(parent_sid, "timeout")          # non-compression end
+    db.append_message(parent_sid, "assistant", "orphan row 3")  # orphan append
+
+    agent = _build_agent_with_db(db, parent_sid)
+    agent._compress_context(snapshot, "sys", approx_tokens=120_000)
+
+    compress_input = agent.context_compressor.compress.call_args.args[0]
+    assert "orphan row 3" not in [m.get("content") for m in compress_input], (
+        "Adoption must not feed an ended session's rows (incl. orphan "
+        "appends) to the summarizer (W1 class B). "
+        f"Compress input: {[m.get('content') for m in compress_input]!r}"
+    )
+
+
+def test_unset_flush_anchor_fails_closed_keeps_live_tail(tmp_path: Path) -> None:
+    """W1 class C: with _persist_user_message_idx unset (cold-resumed preflight
+    agent), the in-memory list may still hold an un-persisted live tail. The
+    legacy adopt-directly assumption must fail closed so the live input is not
+    dropped from the compress input."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "UNSET_ANCHOR_TAIL"
+    db.create_session(session_id, source="desktop")
+    db.append_message(session_id, "user", "persisted question")
+    db.append_message(session_id, "assistant", "persisted answer")
+
+    snapshot = db.get_messages_as_conversation(session_id, include_row_ids=True)
+    messages = [*snapshot, {"role": "user", "content": "LIVE TAIL"}]  # no _row_id
+    # _persist_user_message_idx stays None (never anchored).
+
+    db.append_message(session_id, "assistant", "concurrent row 3")
+    db.append_message(session_id, "assistant", "concurrent row 4")
+
+    agent = _build_agent_with_db(db, session_id)
+    agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    compress_input = agent.context_compressor.compress.call_args.args[0]
+    assert "LIVE TAIL" in [m.get("content") for m in compress_input], (
+        "With an unset flush anchor and an un-persisted live tail, adoption "
+        "must be skipped so the live input reaches the summarizer (W1 class C). "
+        f"Compress input: {[m.get('content') for m in compress_input]!r}"
+    )

--- a/tests/agent/test_compression_adoption_watermark.py
+++ b/tests/agent/test_compression_adoption_watermark.py
@@ -133,3 +133,130 @@ def test_unset_flush_anchor_fails_closed_keeps_live_tail(tmp_path: Path) -> None
         "must be skipped so the live input reaches the summarizer (W1 class C). "
         f"Compress input: {[m.get('content') for m in compress_input]!r}"
     )
+
+
+def test_gateway_load_transcript_stamps_rows_for_adoption(tmp_path: Path) -> None:
+    """Review pass-B CRITICAL-1 (P4): the gateway production load path
+    (load_transcript) must now pass include_row_ids=True so the snapshot fed
+    to compress_context carries _row_id and genuine concurrent rows ARE
+    adopted. RED on the pre-fix commit (load_transcript returned unstamped
+    rows -> watermark _snap_max_id=None -> adoption silently dead), GREEN on
+    the fix."""
+    from gateway.session import GatewayConfig, SessionStore
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    if store._db is not None:
+        store._db.close()
+    store._db = db
+    session_id = "GATEWAY_STAMPED"
+    db.create_session(session_id, source="gateway")
+    db.append_message(session_id, "user", "persisted question")
+    db.append_message(session_id, "assistant", "persisted answer")
+
+    # Snapshot via the actual gateway load path (the fix point).
+    snapshot = store.load_transcript(session_id)
+
+    # Concurrent writer commits real NEW rows (higher ids) while session is live.
+    db.append_message(session_id, "assistant", "concurrent row 3")
+    db.append_message(session_id, "assistant", "concurrent row 4")
+
+    agent = _build_agent_with_db(db, session_id)
+    agent._compress_context(snapshot, "sys", approx_tokens=120_000)
+
+    compress_input = agent.context_compressor.compress.call_args.args[0]
+    assert "concurrent row 3" in [m.get("content") for m in compress_input], (
+        "The gateway load_transcript path must stamp _row_id so the watermark "
+        "is reachable in production and genuine concurrent rows are adopted. "
+        f"Compress input: {[m.get('content') for m in compress_input]!r}"
+    )
+
+
+def test_ended_during_flush_skips_adoption(tmp_path: Path, monkeypatch) -> None:
+    """Review pass-B IMPORTANT-2 (P2, TOCTOU): the session ends DURING the
+    pre-adoption flush (between the pre-flush liveness re-check and the
+    post-flush re-read / adopt decision). The fix re-verifies ended_at at the
+    adopt decision and skips. RED on pre-fix (adopts the ended session's rows),
+    GREEN on the fix."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "ENDED_MID_WINDOW"
+    db.create_session(session_id, source="desktop")
+    db.append_message(session_id, "user", "persisted question")
+    db.append_message(session_id, "assistant", "persisted answer")
+
+    snapshot = db.get_messages_as_conversation(session_id, include_row_ids=True)
+    messages = [*snapshot, {"role": "user", "content": "LIVE TAIL"}]
+
+    agent = _build_agent_with_db(db, session_id)
+    agent._persist_user_message_idx = 2  # anchor so flush path runs
+
+    # Concurrent writer commits a row.
+    db.append_message(session_id, "assistant", "concurrent row 3")
+
+    # Inject an end DURING the pre-adoption flush, i.e. after the pre-flush
+    # liveness re-check but before the post-flush re-read + adopt decision.
+    real_flush = agent._flush_messages_to_session_db
+
+    def _flush_ending_session(*args, **kwargs):
+        db.end_session(session_id, "timeout")
+        return real_flush(*args, **kwargs)
+
+    monkeypatch.setattr(agent, "_flush_messages_to_session_db", _flush_ending_session)
+
+    agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    compress_input = agent.context_compressor.compress.call_args.args[0]
+    assert "concurrent row 3" not in [m.get("content") for m in compress_input], (
+        "A session that ended during the pre-adoption flush must NOT have its "
+        "rows adopted — the adopt decision must re-verify ended_at (TOCTOU "
+        f"closed). Compress input: {[m.get('content') for m in compress_input]!r}"
+    )
+
+
+def test_duplicate_higher_id_rows_pinned_when_live(tmp_path: Path) -> None:
+    """Review pass-B IMPORTANT-3 (P1 shape, content-blindness): the watermark
+    proves only that some durable row has a strictly higher id — it is
+    content-blind. A concurrent writer that commits DUPLICATE content then
+    aborts WITHOUT ending the session leaves higher-id duplicate rows that ARE
+    adopted next cycle (session still live). This pins and documents that
+    semantic so it is a known, tested behavior rather than silent.
+
+    The snapshot is loaded through the GATEWAY production loader
+    (SessionStore.load_transcript): on the pre-fix commit the loader did not
+    pass include_row_ids, so this shape was watermark-dead (RED); on the fixed
+    tree the loader stamps rows and the content-blind watermark adopts the
+    duplicates (GREEN)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "DUPLICATE_HIGHER_ID"
+    db.create_session(session_id, source="desktop")
+    db.append_message(session_id, "user", "persisted question")
+    db.append_message(session_id, "assistant", "persisted answer")
+
+    # Gateway production load path (the fix point): snapshot via
+    # SessionStore.load_transcript, which on the fixed tree passes
+    # include_row_ids=True so the watermark is reachable.
+    from gateway.session import GatewayConfig, SessionStore
+
+    store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    if store._db is not None:
+        store._db.close()
+    store._db = db
+    snapshot = store.load_transcript(session_id)
+    messages = [*snapshot, {"role": "user", "content": "LIVE TAIL"}]
+    agent = _build_agent_with_db(db, session_id)
+    agent._persist_user_message_idx = 2
+
+    # Aborted writer committed exact-duplicate rows, session stays LIVE.
+    db.append_message(session_id, "user", "persisted question")
+    db.append_message(session_id, "assistant", "persisted answer")
+
+    agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    compress_input = agent.context_compressor.compress.call_args.args[0]
+    contents = [m.get("content") for m in compress_input]
+    assert contents.count("persisted question") >= 2, (
+        "Pinned semantic: on a LIVE session, aborted-but-committed higher-id "
+        "duplicate rows are adopted (watermark is content-blind by design) "
+        "via the gateway load path. "
+        f"Compress input: {contents!r}"
+    )

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -593,7 +593,7 @@ def test_durable_message_committed_before_lease_is_adopted(
 
     # Frontend takes its snapshot, then another producer commits before this
     # compressor acquires the lease.
-    stale_snapshot = [{"role": "user", "content": "old durable"}]
+    stale_snapshot = db.get_messages_as_conversation(parent_sid, include_row_ids=True)
     db.append_message(parent_sid, "assistant", "late committed before lease")
     agent = _build_agent_with_db(db, parent_sid)
 


### PR DESCRIPTION
## Current disposition

Exact head: `2345516d852de091d5ac845287add95c2f1a322d`.

Do **not** rebase or merge this branch as a standalone caller-only row-stamping change. Maintain it as one proof-preserving compression slice with #88740 and #88758.

Current topology: 3 commits ahead, 291 behind current main; merge base `e02d1e41...`; non-mergeable.

## Proof-preserving rebase contract

1. Rebase the existing durable-parent adoption gate onto current main, preserving merged #87150’s restore stamping.
2. Stamp only the three genuinely remaining restore boundaries from #88740.
3. Preserve exact surviving `_row_id` identity through repair/cleanup.
4. Stamp a separate projection-level **greatest raw durable row consumed** watermark from #88758 on every surviving projected message.
5. Compare both live and durable candidates only after the same repair/projection transform.
6. Carry only the internal row identity and consumed watermark through gateway/internal replay.
7. Strip both from provider/display serialization and do not persist inherited proof metadata as new row identity.
8. Keep missing, malformed, bool, zero, negative, forged, or unpersisted proof fail-closed.
9. Run real append, merge, orphan-tool, background-review, replay-tail, child adoption, ACP, CLI fallback, gateway, `/undo`, and lease-reload witnesses on the composed SHA.
10. Remove unrelated attribution housekeeping from this PR:
   - take current main’s canonical one-line `contributors/emails/andrexibiza@gmail.com` mapping instead of the branch’s comment-only variant;
   - drop the two hostname-derived contributor-file deletions from this compression PR and handle them separately if still needed.

A caller-only stamp can make a restore eligible while losing proof that cleanup consumed a higher durable row. That would re-adopt malformed or intentionally stripped content and reopen the amplification class under a more convincing watermark.

Repository ref/Contents writes currently fail because the connector has no installed GitHub App account/repository principal; no rebase is claimed.

## Original class closed by this branch

Follow-up to #88197: `compress_context` adopted a durable parent whenever `len(durable_parent) > len(messages)`. Active-row count is not monotonic. Rotation can end a parent and publish a newer child with fewer rows but strictly newer AUTOINCREMENT identities. The length gate could therefore re-adopt a stale-but-larger snapshot after an aborted rotation or concurrent flush, resummarize the same content, and amplify stored rows.

This branch replaces the direction-blind length gate with a monotonic row-identity adoption check:

- load the durable parent with row IDs;
- adopt only a strict durable append beyond the snapshot’s known durable row proof;
- recheck parent liveness in the same decision window;
- fail closed when the anchor/session proof is unavailable;
- preserve #14694’s no-wedge invariant by skipping adoption rather than aborting compression.

## Existing implementation

- `agent/conversation_compression.py`: max-row-id append gate and liveness recheck.
- `SessionStore.load_transcript`: production row-ID retrieval chokepoint.
- main-loop replay and lease-wait reload carry existing row proof.
- regression coverage for stale larger snapshots, genuine concurrent appends, liveness TOCTOU, missing anchors, and the known content-blind higher-ID behavior.

## Why #88740 and #88758 are prerequisites, not follow-ups

Repair transforms can merge or delete the message that carried the greatest raw `_row_id`:

- consecutive-user repair;
- orphan-tool cleanup;
- background-review stripping;
- replay-tail cleanup.

The repaired projection therefore needs two distinct facts:

```text
surviving message identity: _row_id
projection consumption proof: _row_id_watermark
```

Every survivor receives the greatest valid raw durable row consumed by that projection. Durable reload and live comparison use the same projected representation. Projection metadata is internal-only and is not written back as provider content.

## Prepared evidence

The stacked B2 patch/harness is useful design evidence only:

- patch `compression-restore-row-ids-b2-robust.patch`, SHA-256 `f6d6d4406e1ef69e4604bbd4271a7090bb4d4b10c2f3bc1060c82a2c9fbd3f6c`;
- 19 repository-integration regressions prepared;
- 26 dependency-free contract tests passed;
- structural apply/reverse-apply and diff checks passed against the frozen old head.

It was not rebased to current main, imported against a complete live repository, or run through Ruff/full CI. The newer packaged handoff is still a handoff, not a remote branch or commit.

## Historical verification

- focused adoption/fork/watermark suites: 52 passed;
- new regressions demonstrated RED on the pinned parent and GREEN on the fix;
- compilation, attribution audit, and `git diff --check`: clean;
- full historical CI matrix: green at the old exact head.

## Attribution and interlocks

- Fixes #88197 — reported by @mayqhw, including the 303→2,611 row amplification evidence.
- #88411 by @kshitijk4poor is the complementary merged flush guard and remains authoritative on its surface.
- #88227 by @jackulau is prior salvage/analysis provenance.
- #88740 — remaining restore-boundary stamping.
- #88758 — projection-level greatest-consumed watermark.
- #87150 — already merged restore stamping; do not duplicate.
- Composes with #14694, #60609, #80487, and #47202.
