### PR TITLE
fix(cli): suppress false-positive TERMINAL_CWD deprecation warning

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -702,6 +702,8 @@ def load_cli_config() -> Dict[str, Any]:
                     continue
                 # CLI: always export (overrides stale .env or inherited values)
                 os.environ[env_var] = str(terminal_config[config_key])
+                # Internal, not user-facing: set-time record of the launch cwd we just wrote to TERMINAL_CWD (mirrors the _HERMES_GATEWAY idiom) so warn_deprecated_cwd_env_vars() can distinguish a fresh bridge-written value from a stale .env one.
+                os.environ["_HERMES_TERMINAL_CWD_LAUNCHED"] = str(terminal_config[config_key])
                 continue
             if _file_has_terminal_config or env_var not in os.environ:
                 val = terminal_config[config_key]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2205,7 +2205,17 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
             f"  \033[33m⚠\033[0m MESSAGING_CWD={messaging_cwd} found in .env — "
             f"this is deprecated."
         )
-    if terminal_cwd_env and not config_has_explicit_cwd:
+    # Suppress the false positive: when TERMINAL_CWD equals the launch cwd that cli.py's
+    # bridge just wrote — recorded at set-time in the internal, non-user-facing
+    # _HERMES_TERMINAL_CWD_LAUNCHED sentinel (realpath-normalized) — it is a fresh
+    # bridge-written value, not a stale .env export. Missing sentinel or mismatch keeps it.
+    launched = os.environ.get("_HERMES_TERMINAL_CWD_LAUNCHED")
+    _is_fresh_bridge_cwd = (
+        terminal_cwd_env is not None
+        and bool(launched)
+        and os.path.realpath(terminal_cwd_env) == os.path.realpath(launched)
+    )
+    if terminal_cwd_env and not config_has_explicit_cwd and not _is_fresh_bridge_cwd:
         # TERMINAL_CWD in env but not from config bridge — likely from .env
         lines.append(
             f"  \033[33m⚠\033[0m TERMINAL_CWD={terminal_cwd_env} found in .env — "

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -18,6 +18,10 @@ class TestDeprecatedCwdWarning:
 
 
     def test_both_deprecated_vars_warn(self, monkeypatch, capsys):
+        # Guard against a launch sentinel leaked from a real bridge in the same
+        # process: this test asserts a stale TERMINAL_CWD still warns, which
+        # requires no matching _HERMES_TERMINAL_CWD_LAUNCHED to be present.
+        monkeypatch.delenv("_HERMES_TERMINAL_CWD_LAUNCHED", raising=False)
         monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
         monkeypatch.setenv("TERMINAL_CWD", "/term/path")
 
@@ -27,3 +31,94 @@ class TestDeprecatedCwdWarning:
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "TERMINAL_CWD" in captured.err
+
+    def test_fresh_bridge_cwd_no_warning(self, monkeypatch, capsys):
+        # cli.py's bridge writes TERMINAL_CWD AND the matching _HERMES_...LAUNCHED
+        # sentinel at set-time; the warn must treat this fresh value as bridge-written
+        # (not a stale .env export) and stay silent.
+        monkeypatch.setenv("TERMINAL_CWD", "/some/project")
+        monkeypatch.setenv("_HERMES_TERMINAL_CWD_LAUNCHED", "/some/project")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
+        assert "TERMINAL_CWD" not in captured.err
+        assert "deprecated" not in captured.err.lower()
+
+    def test_stale_terminal_cwd_no_sentinel_still_warns(self, monkeypatch, capsys):
+        # A genuine stale .env export has no matching bridge sentinel, so it must
+        # still warn — this is the "real .env, no bridge" case.
+        monkeypatch.setenv("TERMINAL_CWD", "/some/project")
+        monkeypatch.delenv("_HERMES_TERMINAL_CWD_LAUNCHED", raising=False)
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
+        assert "TERMINAL_CWD" in captured.err
+        assert "deprecated" in captured.err.lower()
+
+    def test_stale_mismatched_sentinel_still_warns(self, monkeypatch, capsys):
+        # A sentinel pointing at a different cwd is not a fresh bridge value, so a
+        # stale TERMINAL_CWD must still warn.
+        monkeypatch.setenv("TERMINAL_CWD", "/a/b")
+        monkeypatch.setenv("_HERMES_TERMINAL_CWD_LAUNCHED", "/c/d")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
+        assert "TERMINAL_CWD" in captured.err
+        assert "deprecated" in captured.err.lower()
+
+    def test_explicit_terminal_cwd_suppresses_even_with_env_set(self, monkeypatch, capsys):
+        # An explicit terminal.cwd in config.yaml suppresses the warning even when a
+        # matching sentinel is present — the config_has_explicit_cwd path, independent
+        # of the fresh-bridge fix.
+        monkeypatch.setenv("TERMINAL_CWD", "/some/project")
+        monkeypatch.setenv("_HERMES_TERMINAL_CWD_LAUNCHED", "/some/project")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={"terminal": {"cwd": "/explicit/path"}})
+
+        captured = capsys.readouterr()
+        assert "TERMINAL_CWD" not in captured.err
+        assert "deprecated" not in captured.err.lower()
+
+    def test_chdir_between_bridge_and_warn_no_false_positive(self, monkeypatch, capsys):
+        # The fix compares TERMINAL_CWD against the set-time sentinel, never a live
+        # os.getcwd(). A chdir between the bridge and the warn must not matter: even
+        # with getcwd() returning a different path, a fresh sentinel still suppresses.
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        monkeypatch.setattr("os.getcwd", lambda: "/some/other/cwd")
+        monkeypatch.setenv("TERMINAL_CWD", "/some/project")
+        monkeypatch.setenv("_HERMES_TERMINAL_CWD_LAUNCHED", "/some/project")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+
+        warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
+        assert "TERMINAL_CWD" not in captured.err
+        assert "deprecated" not in captured.err.lower()
+
+    def test_messaging_cwd_warning_unaffected_by_sentinel(self, monkeypatch, capsys):
+        # MESSAGING_CWD and the TERMINAL_CWD suppression are independent: a fresh
+        # bridge sentinel silences TERMINAL_CWD but must NOT silence MESSAGING_CWD.
+        monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
+        monkeypatch.setenv("TERMINAL_CWD", "/some/project")
+        monkeypatch.setenv("_HERMES_TERMINAL_CWD_LAUNCHED", "/some/project")
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
+        assert "MESSAGING_CWD" in captured.err
+        assert "deprecated" in captured.err.lower()
+        # Independence: the terminal line must be absent (suppressed) while the
+        # messaging line is still present.
+        assert "TERMINAL_CWD" not in captured.err


### PR DESCRIPTION
## Summary

- `cli.py`'s config bridge force-exports `TERMINAL_CWD` on every local launch (not just when it comes from `.env`), and `warn_deprecated_cwd_env_vars()` misread that fresh, bridge-written value as a stale `.env` export — printing a deprecation warning that fires on effectively every interactive launch when a messaging platform is enabled in `config.yaml`.
- Root cause traced to gateway-mode import order: `cli.py`'s module-level bridge exports `TERMINAL_CWD` *before* `gateway/run.py` sets its `_HERMES_GATEWAY` marker, so gating the warn on that marker doesn't work.
- Fix: record the launch cwd at set-time in an internal `_HERMES_TERMINAL_CWD_LAUNCHED` sentinel (mirrors the existing `_HERMES_GATEWAY` idiom) and compare against it (realpath-normalized) in the warn, instead of a live `os.getcwd()` or the `_HERMES_GATEWAY` marker. A genuinely stale `TERMINAL_CWD` (mismatched or missing sentinel) still warns as before.

## Test plan

- [x] New/updated unit tests in `tests/hermes_cli/test_deprecated_cwd_warning.py` (8 total): fresh bridge value suppressed, stale value with no sentinel still warns, mismatched sentinel still warns, explicit `terminal.cwd` still suppresses, chdir between bridge and warn doesn't cause a false positive, `MESSAGING_CWD` warning behavior unaffected.
- [x] Differential run (`-k "cwd or config or deprecat"`, 720 selected) against the unpatched baseline: exactly 3 fix-dependent tests flip from fail to pass; all other results (23 pre-existing, environment-dependent failures) identical in both runs.
- [x] Reproduced on a real CLI/TUI launch in two different directories after manually applying the same change to an installed Hermes runtime — the false-positive warning is gone.