### PR TITLE
fix(desktop): no phantom local default on remote-gateway desktops; main agent keeps its name

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -28,6 +28,7 @@ import {
   removeConnection,
   resolveRegistryLocalRoute,
   setPrimaryConnection,
+  shouldDeferLocalEnumeration,
   uniqueLabel,
   updateEligibility,
   upsertConnection
@@ -157,6 +158,28 @@ test('registry local route: a per-profile remote override also forces local', ()
   const route = resolveRegistryLocalRoute('research', { profileRemoteOverride: true })
 
   assert.deepEqual(route, { delegate: false, poolKey: 'conn:local::research' })
+})
+
+// --- shouldDeferLocalEnumeration (roster's connect-on-demand for 'local') ---
+
+test('local enumeration: delegate route (local-primary desktop) always enumerates', () => {
+  const route = resolveRegistryLocalRoute('default', {})
+
+  assert.equal(shouldDeferLocalEnumeration(route, []), false)
+  assert.equal(shouldDeferLocalEnumeration(route, ['conn:local::default']), false)
+})
+
+test('local enumeration: forced-local route defers until a local child exists (remote-primary desktop)', () => {
+  // Remote-gateway-only desktops: enumerating "This device" here would SPAWN
+  // a local backend the user never asked for — a phantom `default` agent
+  // that duplicates their real one and forces -device handles onto it.
+  const route = resolveRegistryLocalRoute('default', { globalRemote: true })
+
+  assert.equal(shouldDeferLocalEnumeration(route, []), true)
+  // The v1 remote descriptor cached at the BARE profile key is not a local child.
+  assert.equal(shouldDeferLocalEnumeration(route, ['default', 'research']), true)
+  // Once the user has genuinely opened a forced-local child, it enumerates.
+  assert.equal(shouldDeferLocalEnumeration(route, ['conn:local::default']), false)
 })
 
 // --- buildAgentRoster (union roster + @name-device rule) ---

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -211,6 +211,28 @@ export function resolveRegistryLocalRoute(
   return { delegate: true, poolKey: profileKey }
 }
 
+/**
+ * Whether the roster enumeration should SKIP the registry's local entry as
+ * connect-on-demand. True when the local source is the forced-local route
+ * (primary resolves remote — enumerating would spawn a local backend the
+ * user never asked for, minting a phantom `default` agent and forcing
+ * -device handles onto the real one) AND no forced-local child is already
+ * pooled. Pure — main.ts feeds it the live route + pool keys.
+ */
+export function shouldDeferLocalEnumeration(
+  route: RegistryLocalRoute,
+  poolKeys: Iterable<string>,
+  connectionId: string = LOCAL_CONNECTION_ID
+): boolean {
+  if (route.delegate) {
+    return false
+  }
+
+  const prefix = backendScopePrefix(connectionId)
+
+  return ![...poolKeys].some(key => String(key).startsWith(prefix))
+}
+
 // ── Union agent roster ──────────────────────────────────────────────────────
 
 export interface ConnectionAgents {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -103,6 +103,7 @@ import {
   removeConnection,
   resolveRegistryLocalRoute,
   setPrimaryConnection,
+  shouldDeferLocalEnumeration,
   updateEligibility,
   upsertConnection
 } from './connection-registry'
@@ -12488,6 +12489,25 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
           ![...sshConnections.keys()].some(scope => String(scope).startsWith(backendScopePrefix(connection.id)))
         ) {
           return { connection, profiles: null, error: 'connect-on-demand' }
+        }
+
+        // Same connect-on-demand courtesy for the forced-local path: when the
+        // primary route is remote, enumerating "This device" would SPAWN a
+        // local backend this user has never asked for — a phantom `default`
+        // agent that also forces -device handle disambiguation onto the real
+        // one (remote-gateway-only desktops showed their main agent twice,
+        // Aug 17 2026). Enumerate the local source only when it is the
+        // delegate route (local-primary desktops, unchanged behavior) or a
+        // forced-local child is ALREADY pooled (the user opened one).
+        if (connection.kind === 'local') {
+          const localRoute = resolveRegistryLocalRoute('default', {
+            globalRemote: globalRemoteActive(),
+            profileRemoteOverride: Boolean(profileHasRemoteOverride(primaryProfileKey()))
+          })
+
+          if (shouldDeferLocalEnumeration(localRoute, backendPool.keys(), connection.id)) {
+            return { connection, profiles: null, error: 'connect-on-demand' }
+          }
         }
 
         const descriptor: any = await ensureRegistryBackend(connection.id, null)

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2481,7 +2481,12 @@ async function prepareBotSource(bot, pinnedChat) {
 }
 
 function displayName(bot, meta) {
-  if (bot?.sourceScoped && (bot.name || '').trim().toLowerCase() === 'default' && bot.connectionLabel) {
+  // Only THIN rows from another source trade the friendly name for their
+  // connection label — the active gateway's own default must keep reading
+  // "Hermes". Annotated active rows carry sourceScoped too, and keying this
+  // off sourceScoped renamed the user's main agent to an IP-derived label
+  // (community report, Aug 17 2026).
+  if (bot?.remoteSource && (bot.name || '').trim().toLowerCase() === 'default' && bot.connectionLabel) {
     return bot.connectionLabel
   }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -240,8 +240,15 @@ test('default rows use source identity without borrowing another source title', 
 
   assert.equal(metaFor(remote, metadata), null)
   assert.equal(name(remote, metaFor(remote, metadata)), 'Personal')
-  assert.equal(name(active, metadata.default), 'Personal')
   assert.equal(key(remote), 'personal::default')
+
+  // The ACTIVE gateway's own default is the user's main agent — annotation
+  // (sourceScoped + connection fields) must NOT rename it to a connection
+  // label. Titled: the title wins. Untitled: it stays "Hermes". Regression:
+  // remote-gateway desktops showed the main agent as an IP-derived label
+  // with no shortname (Aug 17 2026 report).
+  assert.equal(name(active, metadata.default), 'Active workspace')
+  assert.equal(name(active, undefined), 'Hermes')
 })
 
 test('botHandle: precomputed multi-source handle wins; default stays hermes', () => {


### PR DESCRIPTION
## Summary

On remote-gateway-only desktops the Bots pane no longer shows a second phantom `default` agent, and the user's main agent reads "Hermes" (or their title) again instead of a bare handle/connection label. Follow-up to #88523/#88542 from a community report (diagnostics: main agent listed twice — `@default-<remote-slug>` + `@default-this-device` — neither with a friendly name).

Two distinct bugs, both specific to remote-primary desktops:

1. **Phantom "This device" default (electron).** Roster enumeration dialed `ensureRegistryBackend` for the registry's local entry unconditionally. On a remote-primary desktop that hits the forced-local branch — **spawning a local backend the user never asked for**, whose `default` profile then appears as a second agent and forces `-device` handle disambiguation onto the real one. New `shouldDeferLocalEnumeration()` extends the SSH connect-on-demand rule to the forced-local route: the local entry enumerates only when it's the delegate route (local-primary desktops — behavior unchanged) or a forced-local child is already pooled.
2. **Main agent renamed (plugin).** `displayName` keyed the show-connection-label rule for `default` rows off `sourceScoped`, which annotation also sets on ACTIVE-source rows — so the real agent rendered as an IP-derived label. Now keyed off `remoteSource`: only thin rows from another source trade the friendly name for their source label.

## Changes
- `electron/connection-registry.ts`: `shouldDeferLocalEnumeration()` (pure, tested)
- `electron/main.ts`: `enumerateRegistryAgentSources` defers the local entry via the new predicate
- `plugins/hermes-bots/plugin.js`: `displayName` label rule `sourceScoped` → `remoteSource`
- tests: route matrix for the deferral (delegate always enumerates; forced-local waits for a `conn:local::` child; a bare-key remote descriptor doesn't count) + displayName regression (active default stays Hermes/title, thin remote default keeps its source label)

## Validation

| | Result |
|---|---|
| Plugin tests | 165/165 |
| `electron/connection-registry.test.ts` | 46/46 |
| `npm run check:lint` (3 tsconfigs + eslint) | 0 errors |

## Infographic

![One Hermes, Not Two](https://v3b.fal.media/files/b/0aa6bb47/ScsQJFa3RK32QYzKtlJ_6_omsg2yvY.png)
