### PR TITLE
fix(approval): do not recover hardline payloads via bash <saved>

### DIFF
--- a/tests/tools/test_blocked_command_guidance.py
+++ b/tests/tools/test_blocked_command_guidance.py
@@ -49,6 +49,33 @@ class TestParserLimitRecovery:
         # And nothing was saved for a genuine hardline block.
         assert not (tmp_path / ".hermes" / "cache" / "blocked-scripts").exists()
 
+    def test_parser_limit_hardline_payload_is_not_handed_back(self, tmp_path, monkeypatch):
+        """A size-blocked hardline spelling must not be returned as bash <file>."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        cmd = "rm -rf / # " + ("A" * 5000)
+        r = _hardline_block_result(_PARSER_LIMIT_DESCRIPTION, cmd)
+        assert r["approved"] is False
+        assert "bash " not in r["message"]
+        assert "review only" in r["message"]
+        import re as _re
+        m = _re.search(r"saved to (\S+\.sh)", r["message"])
+        assert m, r["message"]
+        from pathlib import Path
+        saved = Path(m.group(1))
+        assert saved.exists()
+        assert "rm -rf /" in saved.read_text()
+
+    def test_bash_saved_hardline_payload_is_blocked(self, tmp_path, monkeypatch):
+        from tools.approval import check_all_command_guards
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        saved = tmp_path / "blocked.sh"
+        saved.write_text("#!/bin/bash\nrm -rf /\n")
+        r = check_all_command_guards(f'bash "{saved}"', "local")
+        assert r.get("approved") is False
+        assert r.get("hardline") is True
+
+
     def test_old_saved_payloads_cleaned(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
         import os

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -23,6 +23,7 @@ import threading
 import time
 import unicodedata
 import uuid
+from pathlib import Path
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -673,11 +674,11 @@ def _save_blocked_payload(command: str) -> Optional[str]:
     The parser-limit block fires on payload SIZE/shape, not on the
     operation — the command itself is usually a legitimate script the
     model inlined (heredoc, giant one-liner). Materialize it to a file so
-    the recovery is one turn (`bash <file>`) instead of two (re-author via
-    write_file, then run). Saving is strictly safer than the hint-only
-    path: the file goes through the same execution pipeline as any other
-    script (including the referenced-script content guard), and nothing
-    is executed here.
+    the recovery is one turn (`bash <file>`) instead of two — but only
+    when the saved text itself would not hit the hardline floor. A
+    payload that smuggled ``rm -rf /`` (or another hardline spelling)
+    behind the size limit is still saved for the operator to inspect;
+    the agent is not told to execute it.
 
     Returns the saved path, or None on any failure (the hint then falls
     back to the manual write_file recipe).
@@ -700,16 +701,67 @@ def _save_blocked_payload(command: str) -> Optional[str]:
         path.write_text(
             "#!/bin/bash\n"
             "# Auto-saved by Hermes: this command exceeded the inline command\n"
-            "# parser limit and was blocked from direct execution. Review it,\n"
-            "# then run it via: bash " + str(path) + "\n"
+            "# parser limit and was blocked from direct execution. Review it\n"
+            "# before running it yourself in a terminal outside the agent.\n"
             + command
             + ("\n" if not command.endswith("\n") else ""),
-            encoding="utf-8", errors="replace",
+            encoding="utf-8",
+            errors="replace",
         )
         return str(path)
     except Exception:
         logger.debug("failed to save blocked payload", exc_info=True)
         return None
+
+
+def _hardline_in_payload_text(text: str) -> tuple:
+    """Return whether *text* itself matches the hardline floor.
+
+    Parser-limit is a size/shape gate, not a verdict on the operation.
+    The saved body has to be inspected separately or a catastrophic
+    spelling padded past the limit would be handed back as ``bash <file>``.
+    """
+    if not text:
+        return (False, None)
+    candidates = [text]
+    try:
+        normalized = _normalize_command_for_detection(text)
+        if normalized and normalized != text:
+            candidates.append(normalized)
+    except Exception:
+        pass
+    for candidate in candidates:
+        lowered = candidate.lower()
+        for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
+            if pattern_re.search(lowered):
+                return (True, description)
+    return (False, None)
+
+
+def _script_path_from_interpreter_command(command: str) -> Optional[str]:
+    """Return the script path for ``bash file`` / ``sh file``, else None.
+
+    ``bash -c`` and similar inline forms are not a referenced file.
+    """
+    try:
+        argv = shlex.split(command, posix=True)
+    except ValueError:
+        return None
+    if not argv:
+        return None
+    exe = os.path.basename(argv[0]).lower()
+    if exe not in {"bash", "bash.exe", "sh", "sh.exe", "dash"}:
+        return None
+    i = 1
+    while i < len(argv) and argv[i].startswith("-") and argv[i] not in {"-", "--"}:
+        if argv[i] in {"-c", "-s"} or argv[i].startswith("-c") or argv[i].startswith("-s"):
+            return None
+        i += 1
+    if i < len(argv) and argv[i] == "--":
+        i += 1
+    if i >= len(argv):
+        return None
+    return argv[i]
 
 
 def _hardline_block_result(description: str, command: str = "") -> dict:
@@ -731,20 +783,29 @@ def _hardline_block_result(description: str, command: str = "") -> dict:
     if description in (_PARSER_LIMIT_DESCRIPTION, _MALFORMED_EXEC_DESCRIPTION):
         saved = _save_blocked_payload(command) if command else None
         if saved:
-            message += (
-                " RECOVERY: this block fires on oversized/unparseable inline "
-                "command payloads (heredocs, giant one-liners), not on the "
-                f"operation itself. Your command was saved to {saved} — "
-                f"review it, then run: terminal(command=\"bash {saved}\"). "
-                "Do not retry inline."
-            )
+            hits_floor, floor_desc = _hardline_in_payload_text(command)
+            if hits_floor:
+                message += (
+                    f" The oversized payload was saved to {saved} for operator "
+                    "review only. It matches the unconditional blocklist"
+                    + (f" ({floor_desc})" if floor_desc else "")
+                    + " and must not be executed via the agent. Do not retry inline."
+                )
+            else:
+                message += (
+                    " RECOVERY: this block fires on oversized/unparseable inline "
+                    "command payloads (heredocs, giant one-liners), not on the "
+                    f"operation itself. Your command was saved to {saved} — "
+                    f'review it, then run: terminal(command="bash {saved}"). '
+                    "Do not retry inline."
+                )
         else:
             message += (
                 " RECOVERY: this block fires on oversized/unparseable inline "
                 "command payloads (heredocs, giant one-liners), not on the "
                 "operation itself. Write the script to a file with write_file, "
-                "then run it: terminal(command=\"bash /path/script.sh\") or "
-                "\"python3 /path/script.py\". Do not retry inline."
+                'then run it: terminal(command="bash /path/script.sh") or '
+                '"python3 /path/script.py". Do not retry inline.'
             )
     return {
         "approved": False,
@@ -4357,6 +4418,22 @@ def check_all_command_guards(command: str, env_type: str,
     # once host paths are bind-mounted into the sandbox.
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
         return {"approved": True, "message": None}
+
+    script_path = _script_path_from_interpreter_command(command)
+    if script_path:
+        try:
+            body = Path(script_path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            body = ""
+        if body:
+            hits_floor, floor_desc = _hardline_in_payload_text(body)
+            if hits_floor:
+                logger.warning(
+                    "Hardline block via referenced script %s: %s",
+                    script_path,
+                    floor_desc,
+                )
+                return _hardline_block_result(floor_desc, body)
 
     # Hardline floor: unconditional block for catastrophic commands
     # (rm -rf /, mkfs, dd to raw device, shutdown/reboot, fork bomb,


### PR DESCRIPTION
## What does this PR do?

When the command parser hits its size/shape limit, Hermes saves the inline payload and tells the model to run `terminal(command="bash <saved>")`. That recovery is right for a legitimate oversized script. It is wrong when the oversized text is a hardline spelling padded past the limit (`rm -rf / #` + thousands of `A`s): the first turn is blocked on size, the saved file is written, and the follow-up `bash <file>` was approved because the interpreter line itself does not match the floor.

Two changes, both scoped to that hole:

1. If the saved payload itself matches the hardline floor, the block message still names the file for the operator but no longer emits a `bash <saved>` recovery recipe.
2. `check_all_command_guards` reads `bash`/`sh` script operands and runs the same hardline scan on the file body before approving.

Legitimate oversized scripts (the existing `python3 -c 'x = 1; ' * 900` case) still get the recovery recipe.

## Related Issue

#83146 fails closed on wrapper-parser depth limits; it does not change `_save_blocked_payload` or the `bash <saved>` recipe. No open PR covers "hardline text hidden behind the size gate, then re-executed". Filed as a PR directly.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/approval.py`: `_hardline_in_payload_text`, `_script_path_from_interpreter_command`; parser-limit recovery omits `bash <file>` when the body hits the floor; `check_all_command_guards` rescans referenced bash/sh scripts
- `tests/tools/test_blocked_command_guidance.py`: oversized `rm -rf /` is saved but not handed back; `bash <saved>` of a hardline script is blocked

## How to Test

1. `python -m pytest tests/tools/test_blocked_command_guidance.py -q` — 12 passed
2. `check_all_command_guards("rm -rf / # " + "A"*5000, "local")` — blocked, file saved, message has no `bash <path>` recipe
3. `check_all_command_guards('bash "<that-file>"', "local")` — `approved` is False, `hardline` is True
4. Existing recovery tests for a benign oversized `python3 -c` payload still expect `RECOVERY` + `bash <saved>`

Note: `tests/tools/test_approval.py::TestDetectDangerousRm` has two failures on this Windows tree that reproduce identically on unmodified upstream `main` (tempdir `/tmp` vs Windows). They are unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_blocked_command_guidance.py -q` (12 passed). Full `test_approval.py` has 2 pre-existing Windows failures identical on upstream; I did not run `pytest tests/ -q`.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.11)

### Documentation & Housekeeping

- [x] N/A — docstring on `_save_blocked_payload` updated in-code; no config / AGENTS.md / tool schema change

## For New Skills

N/A

## Screenshots / Logs

N/A

---

**AI assistance disclosure:** found during a code review of `tools/approval.py`; the fix, tests, and this description were prepared with AI assistance (Grok 4.6 via PokeAPI) and reviewed by the human submitter (FirmaSpring), who verified the reproduction and test results locally.
