### PR TITLE
fix(desktop): open WSL links via rundll32 instead of cmd start

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -372,6 +372,7 @@ import { installWindowsSystemCaTrust } from './windows-system-ca'
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
+import { openWslExternalUrl } from './wsl-open-url'
 import { resolvePickerDefaultPath } from './wsl-path-bridge'
 
 const USER_DATA_OVERRIDE = process.env.HERMES_DESKTOP_USER_DATA_DIR
@@ -1570,21 +1571,15 @@ function openExternalUrl(rawUrl) {
   const url = parsed.toString()
 
   if (IS_WSL) {
-    rememberLog(`[link] opening via WSL→Windows: ${url}`)
-
-    const proc = spawn('cmd.exe', ['/c', 'start', '""', url], {
-      detached: true,
-      stdio: 'ignore',
-      windowsHide: true
+    return openWslExternalUrl(url, {
+      spawn,
+      fallback: openedUrl => {
+        void shell.openExternal(openedUrl).catch(error => {
+          rememberLog(`[link] xdg-open failed: ${error.message}`)
+        })
+      },
+      log: rememberLog
     })
-
-    proc.on('error', error => {
-      rememberLog(`[link] cmd.exe start failed: ${error.message}; falling back to xdg-open`)
-      shell.openExternal(url).catch(fallback => rememberLog(`[link] xdg-open failed: ${fallback.message}`))
-    })
-    proc.unref()
-
-    return true
   }
 
   shell.openExternal(url).catch(error => rememberLog(`[link] openExternal failed: ${error.message}`))

--- a/apps/desktop/electron/wsl-open-url.test.ts
+++ b/apps/desktop/electron/wsl-open-url.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { test } from 'vitest'
+
+import { openWslExternalUrl, wslWindowsOpenUrlArgs } from './wsl-open-url'
+
+const SHELL_COMMANDS = new Set(['cmd.exe', 'cmd', 'command.com', 'powershell.exe', 'powershell', 'pwsh.exe', 'pwsh'])
+
+const HTTPS_META = 'https://example.com/?a=1&calc&z=2|x^y<z>w%20q'
+const MAILTO_META = 'mailto:user@example.com?subject=a&b|c^d<e>f%20g'
+
+type SpawnCall = {
+  command: string
+  args: string[]
+  options: { detached: boolean; stdio: 'ignore'; windowsHide: boolean }
+}
+
+function makeChild() {
+  const child = new EventEmitter() as EventEmitter & { unrefCalls: number; unref: () => void }
+  child.unrefCalls = 0
+  child.unref = () => {
+    child.unrefCalls += 1
+  }
+
+  return child
+}
+
+function launch(url: string) {
+  const calls: SpawnCall[] = []
+  const logs: string[] = []
+  const fallbacks: string[] = []
+  const child = makeChild()
+
+  const opened = openWslExternalUrl(url, {
+    spawn: (command, args, options) => {
+      calls.push({ command, args, options })
+
+      return child
+    },
+    fallback: openedUrl => {
+      fallbacks.push(openedUrl)
+    },
+    log: message => {
+      logs.push(message)
+    }
+  })
+
+  return { calls, child, fallbacks, logs, opened }
+}
+
+function assertSafeLaunch(call: SpawnCall, url: string) {
+  assert.equal(SHELL_COMMANDS.has(call.command.toLowerCase()), false)
+  assert.notEqual(call.command.toLowerCase(), 'cmd.exe')
+  assert.equal(call.args.includes('start'), false)
+  assert.equal(call.args.includes('/c'), false)
+  assert.equal(call.command, 'rundll32.exe')
+  assert.equal(call.args.length, 2)
+  assert.equal(call.args[0], 'url.dll,FileProtocolHandler')
+  assert.equal(call.args[1], url)
+  assert.deepEqual(call.options, { detached: true, stdio: 'ignore', windowsHide: true })
+}
+
+test('openWslExternalUrl launches rundll32 with the https URL as one argv element', () => {
+  const { calls, child, fallbacks, opened } = launch(HTTPS_META)
+
+  assert.equal(opened, true)
+  assert.equal(calls.length, 1)
+  assertSafeLaunch(calls[0], HTTPS_META)
+  assert.equal(calls[0].args[1], HTTPS_META)
+  assert.equal(child.unrefCalls, 1)
+  child.emit('exit', 0)
+  assert.deepEqual(fallbacks, [])
+})
+
+test('openWslExternalUrl keeps mailto metacharacters as one argv element', () => {
+  const { calls, fallbacks } = launch(MAILTO_META)
+
+  assert.equal(calls.length, 1)
+  assertSafeLaunch(calls[0], MAILTO_META)
+  assert.equal(calls[0].args[1], MAILTO_META)
+  assert.deepEqual(fallbacks, [])
+})
+
+test('openWslExternalUrl cannot select the old cmd.exe /c start route', () => {
+  const launched = wslWindowsOpenUrlArgs(HTTPS_META)
+  const { calls } = launch(HTTPS_META)
+
+  assert.notEqual(launched.command.toLowerCase(), 'cmd.exe')
+  assert.equal(
+    launched.args.some(arg => arg === '/c' || arg === 'start' || arg === '""' || arg === ''),
+    false
+  )
+  assert.notEqual(calls[0].command.toLowerCase(), 'cmd.exe')
+  assert.equal(calls[0].args.includes('start'), false)
+  assert.deepEqual(calls[0].args, launched.args)
+})
+
+test('spawn error falls back once', () => {
+  const { child, fallbacks, logs } = launch(HTTPS_META)
+
+  child.emit('error', new Error('ENOENT'))
+  child.emit('error', new Error('ENOENT again'))
+  assert.deepEqual(fallbacks, [HTTPS_META])
+  assert.equal(logs.some(line => line.includes('ENOENT')), true)
+})
+
+test('nonzero exit falls back once', () => {
+  const { child, fallbacks } = launch(HTTPS_META)
+
+  child.emit('exit', 1)
+  child.emit('close', 1)
+  assert.deepEqual(fallbacks, [HTTPS_META])
+})
+
+test('error followed by exit still falls back once', () => {
+  const { child, fallbacks } = launch(HTTPS_META)
+
+  child.emit('error', new Error('spawn failed'))
+  child.emit('exit', 1)
+  child.emit('close', 1)
+  assert.deepEqual(fallbacks, [HTTPS_META])
+})
+
+test('successful exit does not fall back', () => {
+  const { child, fallbacks } = launch(HTTPS_META)
+
+  child.emit('exit', 0)
+  child.emit('close', 0)
+  assert.deepEqual(fallbacks, [])
+})

--- a/apps/desktop/electron/wsl-open-url.ts
+++ b/apps/desktop/electron/wsl-open-url.ts
@@ -1,0 +1,100 @@
+/**
+ * Open an http(s)/mailto URL from WSL onto the Windows host without
+ * going through ``cmd.exe /c start``.
+ *
+ * ``cmd.exe /c start "" <url>`` is assembled unquoted by WSL binfmt
+ * interop when the URL has no spaces. ``&`` in a query string then
+ * becomes a command separator, so a chat link like
+ * ``https://example.com/?a=1&calc&z=2`` runs ``calc`` on the host.
+ *
+ * ``rundll32.exe url.dll,FileProtocolHandler`` takes the URL as a
+ * single argument and does not re-parse it as a cmd command line.
+ */
+
+export interface WslOpenUrlChild {
+  on(event: 'error', listener: (error: Error) => void): unknown
+  on(
+    event: 'exit' | 'close',
+    listener: (code: number | null, signal?: NodeJS.Signals | null) => void
+  ): unknown
+  unref?: () => void
+}
+
+export interface OpenWslExternalUrlDeps {
+  spawn: (
+    command: string,
+    args: string[],
+    options: { detached: boolean; stdio: 'ignore'; windowsHide: boolean }
+  ) => WslOpenUrlChild
+  fallback: (url: string) => void | Promise<void>
+  log: (message: string) => void
+}
+
+export function wslWindowsOpenUrlArgs(url: string): { command: string; args: string[] } {
+  return {
+    command: 'rundll32.exe',
+    args: ['url.dll,FileProtocolHandler', url]
+  }
+}
+
+function isFailedTermination(code: number | null | undefined, signal?: NodeJS.Signals | null): boolean {
+  if (signal) {
+    return true
+  }
+
+  return typeof code === 'number' && code !== 0
+}
+
+/**
+ * Production WSL launch seam. Callers inject spawn, fallback, and logging
+ * so the real argv + failure path can be exercised without Electron.
+ */
+export function openWslExternalUrl(url: string, deps: OpenWslExternalUrlDeps): boolean {
+  const launched = wslWindowsOpenUrlArgs(url)
+
+  deps.log(`[link] opening via WSL→Windows: ${url}`)
+
+  let fallbackUsed = false
+
+  const fallbackOnce = (reason: string) => {
+    if (fallbackUsed) {
+      return
+    }
+
+    fallbackUsed = true
+    deps.log(`[link] rundll32 FileProtocolHandler failed: ${reason}; falling back to xdg-open`)
+    void Promise.resolve(deps.fallback(url)).catch((fallbackError: Error) => {
+      deps.log(`[link] xdg-open failed: ${fallbackError.message}`)
+    })
+  }
+
+  let proc: WslOpenUrlChild
+
+  try {
+    proc = deps.spawn(launched.command, launched.args, {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true
+    })
+  } catch (error) {
+    const err = error as Error
+    fallbackOnce(err?.message || 'spawn threw')
+
+    return true
+  }
+
+  const onDone = (code: number | null, signal?: NodeJS.Signals | null) => {
+    if (isFailedTermination(code, signal)) {
+      fallbackOnce(signal ? `signal ${signal}` : `exited ${code}`)
+    }
+  }
+
+  proc.on('error', error => {
+    fallbackOnce(error.message)
+  })
+  proc.on('exit', onDone)
+  proc.on('close', onDone)
+  proc.unref?.()
+
+  return true
+}


### PR DESCRIPTION
## What does this PR do?

On WSL, `openExternalUrl` opened http(s)/mailto links with `cmd.exe /c start "" <url>`. WSL binfmt interop only quotes argv elements that contain spaces. A URL never does, so the URL is concatenated unquoted into the cmd command line. `&` in a query string is then a command separator: a chat/Markdown link such as `https://example.com/?a=1&calc&z=2` opens the first segment and runs `calc` on the Windows host.

The WSL branch now launches `rundll32.exe url.dll,FileProtocolHandler <url>`, which takes the URL as a single argument and does not re-parse it as a cmd line. Failure still falls back to `shell.openExternal`.

The argv helper lives in `electron/wsl-open-url.ts` so it can be unit-tested without booting Electron.

## Related Issue

No existing issue or PR covers this `cmd.exe /c start` URL path. Filed as a PR directly.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/wsl-open-url.ts`: `wslWindowsOpenUrlArgs()` returns rundll32 FileProtocolHandler
- `apps/desktop/electron/main.ts`: WSL `openExternalUrl` uses that helper
- `apps/desktop/electron/wsl-open-url.test.ts`: asserts the helper never returns `cmd.exe` / `start`

## How to Test

1. From `apps/desktop`: `npx vitest run --project electron electron/wsl-open-url.test.ts` (this worktree has no `node_modules`; the helper was checked by reading the source contract instead)
2. Manual on WSL Desktop: click `https://example.com/?a=1&calc&z=2` — Windows must not launch `calc`; the URL should open in the host browser as a single address
3. A normal `https://example.com/path` link still opens

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] Focused helper test is in-tree. I could not run vitest here (desktop `node_modules` not present in the worktree). Source contract checked: `main.ts` no longer contains `cmd.exe /c start` for this path.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (source-level). I do not have a WSL Desktop session in this environment for a live click test.

### Documentation & Housekeeping

- [x] N/A — no config keys, no architecture docs, no tool schemas

## For New Skills

N/A

## Screenshots / Logs

N/A

---

**AI assistance disclosure:** found during a code review of `apps/desktop/electron/main.ts`; the fix, tests, and this description were prepared with AI assistance (Grok 4.6 via PokeAPI) and reviewed by the human submitter (FirmaSpring). Live WSL click-through was not re-run in this environment; the argv change matches the rundll32 FileProtocolHandler approach described in the review notes.
