### PR TITLE
fix(gateway): read adapter allowlists through profile secret scope

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -576,7 +576,7 @@ class GatewayAuthorizationMixin:
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
-        if platform_allow_all_var and _auth_env(platform_allow_all_var).lower() in {"true", "1", "yes"}:
+        if platform_allow_all_var and _platform_gate_env(platform_allow_all_var).lower() in {"true", "1", "yes"}:
             return True
 
         # Adapter-verified role auth: the Discord adapter already confirmed the
@@ -610,13 +610,13 @@ class GatewayAuthorizationMixin:
             return True
 
         # Check platform-specific and global allowlists
-        platform_allowlist = _auth_env(platform_env_map.get(source.platform, ""))
+        platform_allowlist = _platform_gate_env(platform_env_map.get(source.platform, ""))
         group_user_allowlist = ""
         group_chat_allowlist = ""
         if source.chat_type in {"group", "forum"}:
-            group_user_allowlist = _auth_env(platform_group_user_env_map.get(source.platform, ""))
-            group_chat_allowlist = _auth_env(platform_group_chat_env_map.get(source.platform, ""))
-        global_allowlist = _auth_env("GATEWAY_ALLOWED_USERS")
+            group_user_allowlist = _platform_gate_env(platform_group_user_env_map.get(source.platform, ""))
+            group_chat_allowlist = _platform_gate_env(platform_group_chat_env_map.get(source.platform, ""))
+        global_allowlist = _platform_gate_env("GATEWAY_ALLOWED_USERS")
 
         if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
             # No env allowlist configured. Adapters that own their own
@@ -700,7 +700,7 @@ class GatewayAuthorizationMixin:
                     if user_id in allowed or "*" in allowed:
                         return True
             # No allowlists configured -- check global allow-all flag
-            return _auth_env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
+            return _platform_gate_env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
 
         # Telegram can optionally authorize group traffic by chat ID.
         # Keep this separate from TELEGRAM_GROUP_ALLOWED_USERS, which gates

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -3195,7 +3195,7 @@ class QQAdapter(BasePlatformAdapter):
         return stripped
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        if _resolve_qq_secret("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
         return _resolve_qq_secret("QQ_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -57,8 +57,18 @@ from gateway.platforms.signal_rate_limit import (
     _signal_send_timeout,
     get_scheduler,
 )
+from agent.secret_scope import UnscopedSecretError, get_secret
 
 logger = logging.getLogger(__name__)
+
+
+def _startup_env_secret(name: str, default: str = "") -> str:
+    """Scope-aware Signal gate read with the default-profile startup fallback."""
+    try:
+        val = get_secret(name, default)
+        return ("" if val is None else str(val)).strip()
+    except UnscopedSecretError:
+        return os.getenv(name, default).strip()
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -268,7 +278,7 @@ class SignalAdapter(BasePlatformAdapter):
         self.ignore_stories = extra.get("ignore_stories", True)
 
         # Parse allowlists — group policy is derived from presence of group allowlist
-        group_allowed_str = os.getenv("SIGNAL_GROUP_ALLOWED_USERS", "")
+        group_allowed_str = _startup_env_secret("SIGNAL_GROUP_ALLOWED_USERS", "")
         self.group_allow_from = set(_parse_comma_list(group_allowed_str))
 
         # Mention filter — only respond in groups when the bot account is @mentioned.
@@ -277,7 +287,7 @@ class SignalAdapter(BasePlatformAdapter):
         if _rm_cfg is not None:
             self.require_mention = bool(_rm_cfg)
         else:
-            self.require_mention = os.getenv("SIGNAL_REQUIRE_MENTION", "false").lower() in ("true", "1", "yes", "on")
+            self.require_mention = _startup_env_secret("SIGNAL_REQUIRE_MENTION", "false").lower() in ("true", "1", "yes", "on")
 
         # DM allowlist — mirrors SIGNAL_ALLOWED_USERS checked by run.py.
         # Stored here so the reaction hooks can skip unauthorized senders
@@ -285,7 +295,7 @@ class SignalAdapter(BasePlatformAdapter):
         # every inbound DM from any contact gets a 👀 reaction).
         # "*" means all users allowed (open mode); empty means no restriction
         # recorded at adapter level (run.py still enforces auth separately).
-        dm_allowed_str = os.getenv("SIGNAL_ALLOWED_USERS", "*")
+        dm_allowed_str = _startup_env_secret("SIGNAL_ALLOWED_USERS", "*")
         self.dm_allow_from = set(_parse_comma_list(dm_allowed_str))
 
         # HTTP client

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -291,12 +291,12 @@ class SignalAdapter(BasePlatformAdapter):
 
         # DM allowlist — mirrors SIGNAL_ALLOWED_USERS checked by run.py.
         # Stored here so the reaction hooks can skip unauthorized senders
-        # (reactions fire before run.py's auth gate, so without this check
-        # every inbound DM from any contact gets a 👀 reaction).
-        # "*" means all users allowed (open mode); empty means no restriction
-        # recorded at adapter level (run.py still enforces auth separately).
-        dm_allowed_str = _startup_env_secret("SIGNAL_ALLOWED_USERS", "*")
-        self.dm_allow_from = set(_parse_comma_list(dm_allowed_str))
+        # (reactions fire before run.py's auth gate). A scoped miss must
+        # stay empty — "*" is only an explicit open-access opt-in.
+        dm_allowed_raw = extra.get("allowed_users")
+        if dm_allowed_raw is None:
+            dm_allowed_raw = _startup_env_secret("SIGNAL_ALLOWED_USERS", "")
+        self.dm_allow_from = set(_parse_comma_list(str(dm_allowed_raw)))
 
         # HTTP client
         self.client: Optional[httpx.AsyncClient] = None
@@ -1645,16 +1645,17 @@ class SignalAdapter(BasePlatformAdapter):
 
         Two gates:
         1. SIGNAL_REACTIONS env var — set to false/0/no to disable globally.
-        2. DM allowlist — if SIGNAL_ALLOWED_USERS is set, only react to
-           messages from senders in that list.  This prevents unauthorized
-           contacts from seeing the 👀 reaction (which fires before run.py's
-           auth gate and would otherwise reveal that a bot is listening).
+        2. DM allowlist — react only to senders in SIGNAL_ALLOWED_USERS.
+           Empty (scoped miss / no allowlist) is closed: no pre-auth 👀.
+           Explicit "*" remains the open-access opt-in.
         """
-        if os.getenv("SIGNAL_REACTIONS", "true").lower() in {"false", "0", "no"}:
+        if _startup_env_secret("SIGNAL_REACTIONS", "true").lower() in {"false", "0", "no"}:
             return False
         if event is not None:
             sender = getattr(getattr(event, "source", None), "user_id", None)
-            if sender and "*" not in self.dm_allow_from and sender not in self.dm_allow_from:
+            if "*" in self.dm_allow_from:
+                return True
+            if not sender or sender not in self.dm_allow_from:
                 return False
         return True
 

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -291,11 +291,27 @@ class SignalAdapter(BasePlatformAdapter):
 
         # DM allowlist — mirrors SIGNAL_ALLOWED_USERS checked by run.py.
         # Stored here so the reaction hooks can skip unauthorized senders
-        # (reactions fire before run.py's auth gate). A scoped miss must
-        # stay empty — "*" is only an explicit open-access opt-in.
-        dm_allowed_raw = extra.get("allowed_users")
-        if dm_allowed_raw is None:
-            dm_allowed_raw = _startup_env_secret("SIGNAL_ALLOWED_USERS", "")
+        # (reactions fire before run.py's auth gate). Scoped secret >
+        # YAML extra > unscoped process env. A scoped miss stays empty;
+        # "*" is only an explicit open-access opt-in.
+        try:
+            from agent.secret_scope import current_secret_scope, is_multiplex_active
+            if is_multiplex_active() and current_secret_scope() is not None:
+                scope = current_secret_scope()
+                if "SIGNAL_ALLOWED_USERS" in scope:
+                    dm_allowed_raw = scope.get("SIGNAL_ALLOWED_USERS") or ""
+                elif extra.get("allowed_users") is not None:
+                    dm_allowed_raw = extra.get("allowed_users")
+                else:
+                    dm_allowed_raw = ""
+            else:
+                dm_allowed_raw = extra.get("allowed_users")
+                if dm_allowed_raw is None:
+                    dm_allowed_raw = _startup_env_secret("SIGNAL_ALLOWED_USERS", "")
+        except Exception:
+            dm_allowed_raw = extra.get("allowed_users")
+            if dm_allowed_raw is None:
+                dm_allowed_raw = _startup_env_secret("SIGNAL_ALLOWED_USERS", "")
         self.dm_allow_from = set(_parse_comma_list(str(dm_allowed_raw)))
 
         # HTTP client

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1537,9 +1537,9 @@ class WeixinAdapter(BasePlatformAdapter):
             await self.handle_message(event)
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        if _wx_secret("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("WEIXIN_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return (_wx_secret("WEIXIN_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         if self._dm_policy == "disabled":

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -208,7 +208,7 @@ class WhatsAppBehaviorMixin:
 
     # ------------------------------------------------------------------ gating
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        if (_get_wsecret("GATEWAY_ALLOW_ALL_USERS", default="") or "").lower() in {"true", "1", "yes"}:
             return True
         return (_get_wsecret("WHATSAPP_ALLOW_ALL_USERS", default="") or "").lower() in {"true", "1", "yes"}
 

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -97,8 +97,19 @@ from gateway.platforms.yuanbao_proto import (
     next_seq_no,
 )
 from gateway.session import build_session_key
+from agent.secret_scope import UnscopedSecretError, get_secret
 
 logger = logging.getLogger(__name__)
+
+
+def _yb_secret(name: str, default: str = "") -> str:
+    """Scope-aware YUANBAO_* / GATEWAY_* read with unscoped startup fallback."""
+    try:
+        val = get_secret(name, default)
+    except UnscopedSecretError:
+        val = os.getenv(name)
+    return ("" if val is None else str(val))
+
 
 # ---------------------------------------------------------------------------
 # Version / platform constants (used in AUTH_BIND and sign-token headers)
@@ -1282,9 +1293,9 @@ class AccessPolicy:
         self._group_allow_from = group_allow_from
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        if _yb_secret("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("YUANBAO_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return _yb_secret("YUANBAO_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 
     def is_dm_allowed(self, sender_id: str) -> bool:
         """Strict DM authorization — pairing does not imply access."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15423,10 +15423,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return _handler
 
     def _make_default_profile_message_handler(self):
-        """Scope a multiplexed default-profile message from ingress onward."""
-        profile_home = Path(get_hermes_home())
+        """Scope primary-transport messages to their routed multiplex profile."""
 
         async def _handler(event):
+            profile_home = self._resolve_profile_home_for_source(event.source)
             with _profile_runtime_scope(profile_home):
                 return await self._handle_message(event)
 

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -994,7 +994,7 @@ class EmailAdapter(BasePlatformAdapter):
         truthy = {"true", "1", "yes"}
         return (
             _get_secret("EMAIL_ALLOW_ALL_USERS", "").strip().lower() in truthy
-            or os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in truthy
+            or _get_secret("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in truthy
         )
 
     @staticmethod
@@ -1009,7 +1009,7 @@ class EmailAdapter(BasePlatformAdapter):
         """
         return bool(
             _get_secret("EMAIL_ALLOWED_USERS", "").strip()
-            or os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
+            or _get_secret("GATEWAY_ALLOWED_USERS", "").strip()
         )
 
     async def _dispatch_message(self, msg_data: Dict[str, Any]) -> None:
@@ -1033,7 +1033,7 @@ class EmailAdapter(BasePlatformAdapter):
         allowed_raw = _get_secret("EMAIL_ALLOWED_USERS", "").strip()
         if not allowed_raw:
             if _get_secret("EMAIL_ALLOW_ALL_USERS", "").strip().lower() not in {"true", "1", "yes"} and (
-                os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() not in {"true", "1", "yes"}
+                _get_secret("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() not in {"true", "1", "yes"}
             ):
                 logger.debug(
                     "[Email] Dropping sender at dispatch — EMAIL_ALLOWED_USERS is unset "

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4371,9 +4371,9 @@ class FeishuAdapter(BasePlatformAdapter):
                 return "bot_not_mentioned"
 
         if not is_group:
-            if os.getenv("FEISHU_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
+            if (_get_scoped_secret("FEISHU_ALLOW_ALL_USERS", "") or "").strip().lower() in {"true", "1", "yes"}:
                 return None
-            if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
+            if (_get_scoped_secret("GATEWAY_ALLOW_ALL_USERS", "") or "").strip().lower() in {"true", "1", "yes"}:
                 return None
             # Empty FEISHU_ALLOWED_USERS is the pairing-mode default from setup:
             # forward DMs to gateway intake so the pairing handshake can run.

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1288,9 +1288,9 @@ class MatrixAdapter(BasePlatformAdapter):
         # Mention/thread gating — parsed once from config.extra or env vars.
         self._require_mention: bool = self._parse_require_mention(config)
         self._thread_require_mention: bool = self._parse_thread_require_mention(config)
-        free_rooms_raw = config.extra.get("free_response_rooms")
-        if free_rooms_raw is None:
-            free_rooms_raw = os.getenv("MATRIX_FREE_RESPONSE_ROOMS", "")
+        free_rooms_raw = _resolve_allowlist(
+            "MATRIX_FREE_RESPONSE_ROOMS", config.extra.get("free_response_rooms")
+        )
         if isinstance(free_rooms_raw, list):
             self._free_rooms: Set[str] = {
                 str(r).strip() for r in free_rooms_raw if str(r).strip()
@@ -1403,7 +1403,9 @@ class MatrixAdapter(BasePlatformAdapter):
                 u.strip() for u in str(allowed_users_raw).split(",") if u.strip()
             }
         self._allowed_room_ids: Set[str] = set(self._allowed_rooms)
-        ignore_patterns_raw = os.getenv("MATRIX_IGNORE_USER_PATTERNS", "")
+        ignore_patterns_raw = _resolve_allowlist(
+            "MATRIX_IGNORE_USER_PATTERNS", config.extra.get("ignore_user_patterns")
+        )
         self._ignored_user_patterns: list[re.Pattern[str]] = []
         for pattern in (p.strip() for p in ignore_patterns_raw.split(",") if p.strip()):
             try:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1276,7 +1276,7 @@ class MatrixAdapter(BasePlatformAdapter):
         # If non-empty, bot ONLY responds in these rooms (whitelist); DMs exempt.
         allowed_rooms_raw = config.extra.get("allowed_rooms")
         if allowed_rooms_raw is None:
-            allowed_rooms_raw = os.getenv("MATRIX_ALLOWED_ROOMS", "")
+            allowed_rooms_raw = _startup_env_secret("MATRIX_ALLOWED_ROOMS")
         if isinstance(allowed_rooms_raw, list):
             self._allowed_rooms: Set[str] = {
                 str(r).strip() for r in allowed_rooms_raw if str(r).strip()
@@ -1363,7 +1363,7 @@ class MatrixAdapter(BasePlatformAdapter):
             self._approval_timeout_seconds = 300
         self._model_picker_prompts_by_event: Dict[str, _MatrixModelPickerPrompt] = {}
         self._choice_picker_prompts_by_event: Dict[str, _MatrixChoicePickerPrompt] = {}
-        allowed_users_raw = os.getenv("MATRIX_ALLOWED_USERS", "")
+        allowed_users_raw = _startup_env_secret("MATRIX_ALLOWED_USERS")
         self._allowed_user_ids: Set[str] = {
             u.strip() for u in allowed_users_raw.split(",") if u.strip()
         }

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1363,10 +1363,17 @@ class MatrixAdapter(BasePlatformAdapter):
             self._approval_timeout_seconds = 300
         self._model_picker_prompts_by_event: Dict[str, _MatrixModelPickerPrompt] = {}
         self._choice_picker_prompts_by_event: Dict[str, _MatrixChoicePickerPrompt] = {}
-        allowed_users_raw = _startup_env_secret("MATRIX_ALLOWED_USERS")
-        self._allowed_user_ids: Set[str] = {
-            u.strip() for u in allowed_users_raw.split(",") if u.strip()
-        }
+        allowed_users_raw = config.extra.get("allowed_users")
+        if allowed_users_raw is None:
+            allowed_users_raw = _startup_env_secret("MATRIX_ALLOWED_USERS")
+        if isinstance(allowed_users_raw, list):
+            self._allowed_user_ids: Set[str] = {
+                str(u).strip() for u in allowed_users_raw if str(u).strip()
+            }
+        else:
+            self._allowed_user_ids: Set[str] = {
+                u.strip() for u in str(allowed_users_raw).split(",") if u.strip()
+            }
         self._allowed_room_ids: Set[str] = set(self._allowed_rooms)
         ignore_patterns_raw = os.getenv("MATRIX_IGNORE_USER_PATTERNS", "")
         self._ignored_user_patterns: list[re.Pattern[str]] = []
@@ -5371,35 +5378,47 @@ def interactive_setup() -> None:
                 print_info("Home room cleared.")
 
 
-def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
-    """Translate config.yaml matrix: keys into MATRIX_* env vars.
+def _csv_or_raw(value):
+    if isinstance(value, list):
+        return ",".join(str(v) for v in value)
+    return str(value)
 
-    Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
-    matrix_cfg block from gateway/config.py::load_gateway_config(). Env vars
-    take precedence over YAML. Returns None — everything flows through env.
+
+def _profile_scoped_config_load() -> bool:
+    """True when this YAML load belongs to a multiplexed named profile."""
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
+def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
+    """Translate config.yaml matrix: keys into extra + optional MATRIX_* env.
+
+    Authorization keys are always seeded into PlatformConfig.extra so a
+    named profile's YAML allowlists survive a scoped secret miss. The
+    process-global env bridge stays first-writer-wins for single-profile
+    callers and is skipped under an active multiplex scope.
     """
+    _skip_env_bridge = _profile_scoped_config_load()
+    extras: dict = {}
+
+    def _bridge(env_name: str, extra_key: str, raw) -> None:
+        if raw is None:
+            return
+        value = _csv_or_raw(raw)
+        extras[extra_key] = value
+        if not _skip_env_bridge and not os.getenv(env_name):
+            os.environ[env_name] = value
+
     if "require_mention" in matrix_cfg and not os.getenv("MATRIX_REQUIRE_MENTION"):
         os.environ["MATRIX_REQUIRE_MENTION"] = str(matrix_cfg["require_mention"]).lower()
-    au = matrix_cfg.get("allowed_users")
-    if au is not None and not os.getenv("MATRIX_ALLOWED_USERS"):
-        if isinstance(au, list):
-            au = ",".join(str(v) for v in au)
-        os.environ["MATRIX_ALLOWED_USERS"] = str(au)
-    frc = matrix_cfg.get("free_response_rooms")
-    if frc is not None and not os.getenv("MATRIX_FREE_RESPONSE_ROOMS"):
-        if isinstance(frc, list):
-            frc = ",".join(str(v) for v in frc)
-        os.environ["MATRIX_FREE_RESPONSE_ROOMS"] = str(frc)
-    ar = matrix_cfg.get("allowed_rooms")
-    if ar is not None and not os.getenv("MATRIX_ALLOWED_ROOMS"):
-        if isinstance(ar, list):
-            ar = ",".join(str(v) for v in ar)
-        os.environ["MATRIX_ALLOWED_ROOMS"] = str(ar)
-    ignore_patterns = matrix_cfg.get("ignore_user_patterns")
-    if ignore_patterns is not None and not os.getenv("MATRIX_IGNORE_USER_PATTERNS"):
-        if isinstance(ignore_patterns, list):
-            ignore_patterns = ",".join(str(v) for v in ignore_patterns)
-        os.environ["MATRIX_IGNORE_USER_PATTERNS"] = str(ignore_patterns)
+    _bridge("MATRIX_ALLOWED_USERS", "allowed_users", matrix_cfg.get("allowed_users"))
+    _bridge("MATRIX_FREE_RESPONSE_ROOMS", "free_response_rooms", matrix_cfg.get("free_response_rooms"))
+    _bridge("MATRIX_ALLOWED_ROOMS", "allowed_rooms", matrix_cfg.get("allowed_rooms"))
+    _bridge("MATRIX_IGNORE_USER_PATTERNS", "ignore_user_patterns", matrix_cfg.get("ignore_user_patterns"))
     if "process_notices" in matrix_cfg and not os.getenv("MATRIX_PROCESS_NOTICES"):
         os.environ["MATRIX_PROCESS_NOTICES"] = str(matrix_cfg["process_notices"]).lower()
     if "session_scope" in matrix_cfg and not os.getenv("MATRIX_SESSION_SCOPE"):
@@ -5410,7 +5429,7 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
         os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
     if "max_message_length" in matrix_cfg and not os.getenv("MATRIX_MAX_MESSAGE_LENGTH"):
         os.environ["MATRIX_MAX_MESSAGE_LENGTH"] = str(matrix_cfg["max_message_length"])
-    return None
+    return extras or None
 
 
 def _is_connected(config) -> bool:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -991,6 +991,32 @@ def _startup_env_secret(name: str) -> str:
         return os.getenv(name, "").strip()
 
 
+def _resolve_allowlist(env_name: str, extra_value):
+    """Resolve a Matrix allowlist: scoped secret > YAML extra > unscoped env.
+
+    A named-profile secret scope is authoritative for that key. YAML
+    ``config.extra`` is next. The process environment is last and only
+    for default-profile / unscoped startup — never as a fallback that
+    lets another profile's bridged ``MATRIX_ALLOWED_*`` leak in.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        if is_multiplex_active():
+            scope = current_secret_scope()
+            if scope is not None:
+                if env_name in scope:
+                    return (scope.get(env_name) or "").strip()
+                if extra_value is not None:
+                    return extra_value
+                return ""
+    except Exception:
+        pass
+    if extra_value is not None:
+        return extra_value
+    return _startup_env_secret(env_name)
+
+
 def matrix_deps_present() -> bool:
     """PASSIVE probe: are the ``platform.matrix`` packages installed?
 
@@ -1274,9 +1300,10 @@ class MatrixAdapter(BasePlatformAdapter):
                 r.strip() for r in str(free_rooms_raw).split(",") if r.strip()
             }
         # If non-empty, bot ONLY responds in these rooms (whitelist); DMs exempt.
-        allowed_rooms_raw = config.extra.get("allowed_rooms")
-        if allowed_rooms_raw is None:
-            allowed_rooms_raw = _startup_env_secret("MATRIX_ALLOWED_ROOMS")
+        # Scoped secret > YAML extra > unscoped process env.
+        allowed_rooms_raw = _resolve_allowlist(
+            "MATRIX_ALLOWED_ROOMS", config.extra.get("allowed_rooms")
+        )
         if isinstance(allowed_rooms_raw, list):
             self._allowed_rooms: Set[str] = {
                 str(r).strip() for r in allowed_rooms_raw if str(r).strip()
@@ -1363,9 +1390,10 @@ class MatrixAdapter(BasePlatformAdapter):
             self._approval_timeout_seconds = 300
         self._model_picker_prompts_by_event: Dict[str, _MatrixModelPickerPrompt] = {}
         self._choice_picker_prompts_by_event: Dict[str, _MatrixChoicePickerPrompt] = {}
-        allowed_users_raw = config.extra.get("allowed_users")
-        if allowed_users_raw is None:
-            allowed_users_raw = _startup_env_secret("MATRIX_ALLOWED_USERS")
+        # Scoped secret > YAML extra > unscoped process env.
+        allowed_users_raw = _resolve_allowlist(
+            "MATRIX_ALLOWED_USERS", config.extra.get("allowed_users")
+        )
         if isinstance(allowed_users_raw, list):
             self._allowed_user_ids: Set[str] = {
                 str(u).strip() for u in allowed_users_raw if str(u).strip()

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3825,7 +3825,7 @@ class MatrixAdapter(BasePlatformAdapter):
         # federated Matrix user could invite the bot into arbitrary rooms,
         # exposing its presence and metadata. Mirrors the allow-list gate
         # used on the message/reaction paths.
-        allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {
+        allow_all = _startup_env_secret("GATEWAY_ALLOW_ALL_USERS").lower() in {
             "true",
             "1",
             "yes",
@@ -4196,7 +4196,7 @@ class MatrixAdapter(BasePlatformAdapter):
         prompt: Any,
         prompt_label: str,
     ) -> bool:
-        allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {
+        allow_all = _startup_env_secret("GATEWAY_ALLOW_ALL_USERS").lower() in {
             "true",
             "1",
             "yes",

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -893,9 +893,9 @@ class WeComAdapter(BasePlatformAdapter):
         return True
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        if (_get_scoped_secret("GATEWAY_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("WECOM_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return (_get_scoped_secret("WECOM_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         if self._dm_policy == "disabled":

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -11,6 +11,7 @@ this suite locks the complementary primary-path fixes:
 2. Primary startup skips token platforms that still have no credential under
    multiplex instead of connecting-and-failing forever.
 3. The reconnect watcher drops empty-token queued configs.
+4. Primary s...[truncated]
 """
 from __future__ import annotations
 
@@ -179,6 +180,88 @@ class TestPrimaryStartupSkipsEmptyTokenUnderMultiplex:
 
 class TestPrimaryMessageRuntimeScope:
     @pytest.mark.asyncio
+    async def test_shared_primary_route_uses_secondary_profile_allowlist(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope
+        from gateway import run as run_mod
+        from gateway.config import Platform
+        from gateway.platforms.base import BasePlatformAdapter
+        from gateway.profile_routing import ProfileRoute
+        from gateway.run import GatewayRunner
+
+        default_home = tmp_path / "default"
+        secondary_home = default_home / "profiles" / "work"
+        default_home.mkdir()
+        secondary_home.mkdir(parents=True)
+        (default_home / ".env").write_text(
+            "DISCORD_ALLOWED_USERS=default-only\n", encoding="utf-8"
+        )
+        (secondary_home / ".env").write_text(
+            "DISCORD_ALLOWED_USERS=work-only\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(run_mod, "get_hermes_home", lambda: default_home)
+        secret_scope.set_multiplex_active(True)
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            multiplex_profiles=True,
+            profile_routes=[
+                ProfileRoute(
+                    name="work-chat",
+                    platform="discord",
+                    profile="work",
+                    chat_id="work-channel",
+                )
+            ],
+        )
+        runner.adapters = {}
+        runner._profile_adapters = {}
+        runner.pairing_store = None
+        runner.pairing_stores = {}
+
+        class _SharedDiscordAdapter(BasePlatformAdapter):
+            pass
+
+        _SharedDiscordAdapter.__abstractmethods__ = frozenset()
+        adapter = _SharedDiscordAdapter.__new__(_SharedDiscordAdapter)
+        adapter.platform = Platform.DISCORD
+        adapter.gateway_runner = runner
+        runner.adapters[Platform.DISCORD] = adapter
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda **_: [("default", default_home), ("work", secondary_home)],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_profile_dir",
+            lambda name: secondary_home if name == "work" else default_home,
+        )
+        monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+        source = adapter.build_source(
+            chat_id="work-channel",
+            chat_type="group",
+            user_id="default-only",
+        )
+        allowed_source = adapter.build_source(
+            chat_id="work-channel",
+            chat_type="group",
+            user_id="work-only",
+        )
+
+        assert source.profile == "work"
+        assert allowed_source.profile == "work"
+
+        async def _handle_message(event):
+            return runner._is_user_authorized(event.source)
+
+        runner._handle_message = _handle_message  # type: ignore[method-assign]
+        handler = runner._primary_message_handler()
+
+        assert await handler(SimpleNamespace(source=source)) is False
+        assert await handler(SimpleNamespace(source=allowed_source)) is True
+
+    @pytest.mark.asyncio
     async def test_default_profile_prompt_gate_sees_its_scoped_token(
         self, tmp_path, monkeypatch
     ):
@@ -200,6 +283,7 @@ class TestPrimaryMessageRuntimeScope:
 
         runner = GatewayRunner.__new__(GatewayRunner)
         runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._resolve_profile_home_for_source = lambda _source: home
 
         async def _handle_message(_event):
             from gateway.session import _discord_tools_loaded

--- a/tests/gateway/test_adapter_allowlist_secret_scope.py
+++ b/tests/gateway/test_adapter_allowlist_secret_scope.py
@@ -107,6 +107,48 @@ class TestMatrixYamlAllowlistsSurviveScopedMiss:
         monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@default:example.org")
         assert matrix_secret("MATRIX_ALLOWED_USERS") == "@default:example.org"
 
+    def test_named_profile_yaml_survives_load_gateway_config(self, tmp_path, monkeypatch):
+        """YAML-only Matrix allowlists must reach MatrixAdapter via extra.
+
+        Reviewer asked for this exact path: a named profile configured only
+        in config.yaml, load_gateway_config() under that profile's runtime
+        scope, then construct MatrixAdapter and assert the effective
+        _allowed_rooms / _allowed_user_ids.
+        """
+        from gateway.config import Platform, load_gateway_config
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+        home = tmp_path / "profiles" / "operator"
+        home.mkdir(parents=True)
+        (home / "config.yaml").write_text(
+            "matrix:\n"
+            "  allowed_users:\n"
+            "    - \"@operator:example.org\"\n"
+            "  allowed_rooms:\n"
+            "    - \"!private:example.org\"\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@default:example.org")
+        monkeypatch.setenv("MATRIX_ALLOWED_ROOMS", "!default:example.org")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        home_token = set_hermes_home_override(str(home))
+        try:
+            cfg = load_gateway_config()
+            extra = cfg.platforms[Platform.MATRIX].extra
+            assert extra.get("allowed_users") == "@operator:example.org"
+            assert extra.get("allowed_rooms") == "!private:example.org"
+            import os
+            assert os.environ["MATRIX_ALLOWED_USERS"] == "@default:example.org"
+            assert os.environ["MATRIX_ALLOWED_ROOMS"] == "!default:example.org"
+            adapter = MatrixAdapter(cfg.platforms[Platform.MATRIX])
+            assert adapter._allowed_user_ids == {"@operator:example.org"}
+            assert adapter._allowed_rooms == {"!private:example.org"}
+        finally:
+            reset_hermes_home_override(home_token)
+            ss.reset_secret_scope(token)
+
 
 class TestSignalReactionsFailClosedOnScopedMiss:
     def test_helper_scoped_miss_is_empty_not_star(self, monkeypatch):

--- a/tests/gateway/test_adapter_allowlist_secret_scope.py
+++ b/tests/gateway/test_adapter_allowlist_secret_scope.py
@@ -381,3 +381,68 @@ class TestMatrixSiblingAllowAllIsScoped:
             assert scheduled == []
         finally:
             ss.reset_secret_scope(token)
+
+    def test_free_rooms_and_ignore_patterns_do_not_borrow_environ(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_FREE_RESPONSE_ROOMS", "!default:example.org")
+        monkeypatch.setenv("MATRIX_IGNORE_USER_PATTERNS", "@spam:example.org")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        try:
+            config = PlatformConfig(enabled=True)
+            config.extra = {"homeserver": "https://example.org"}
+            adapter = MatrixAdapter(config)
+            assert adapter._free_rooms == set()
+            assert adapter._ignored_user_patterns == []
+        finally:
+            ss.reset_secret_scope(token)
+
+
+class TestSiblingAllowAllDoesNotBorrowEnviron:
+    def test_weixin_open_dm_does_not_borrow_environ(self, monkeypatch):
+        from gateway.platforms.weixin import WeixinAdapter
+
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        try:
+            adapter = object.__new__(WeixinAdapter)
+            adapter._dm_policy = "open"
+            assert adapter._open_dm_opted_in() is False
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_wecom_open_dm_does_not_borrow_environ(self, monkeypatch):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        try:
+            adapter = object.__new__(WeComAdapter)
+            assert adapter._open_dm_opted_in() is False
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_qqbot_open_dm_does_not_borrow_environ(self, monkeypatch):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        try:
+            adapter = object.__new__(QQAdapter)
+            assert adapter._open_dm_opted_in() is False
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_yuanbao_open_dm_does_not_borrow_environ(self, monkeypatch):
+        from gateway.platforms.yuanbao import AccessPolicy
+
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        try:
+            policy = AccessPolicy("open", [], "open", [])
+            assert policy._open_dm_opted_in() is False
+        finally:
+            ss.reset_secret_scope(token)

--- a/tests/gateway/test_adapter_allowlist_secret_scope.py
+++ b/tests/gateway/test_adapter_allowlist_secret_scope.py
@@ -264,3 +264,120 @@ class TestEmailAndWhatsAppAdapterGates:
             assert _Host()._open_dm_opted_in() is False
         finally:
             ss.reset_secret_scope(token)
+
+
+class TestGatewayAuthorizationDoesNotBorrowEnviron:
+    def _runner(self):
+        from gateway.config import GatewayConfig, Platform
+        from gateway.run import GatewayRunner
+        from unittest.mock import AsyncMock, MagicMock
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(platforms={Platform.SIGNAL: PlatformConfig(enabled=True)})
+        runner.adapters = {
+            Platform.SIGNAL: SimpleNamespace(
+                send=AsyncMock(),
+                enforces_own_access_policy=False,
+                authorization_is_upstream=False,
+            )
+        }
+        runner.pairing_store = MagicMock()
+        runner.pairing_store.is_approved.return_value = False
+        runner.pairing_stores = {}
+        runner._profile_adapters = {}
+        return runner
+
+    def test_scoped_miss_does_not_borrow_process_allowlist(self, monkeypatch):
+        from gateway.config import Platform
+
+        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+155****0001")
+        monkeypatch.delenv("SIGNAL_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        try:
+            runner = self._runner()
+            source = SessionSource(
+                platform=Platform.SIGNAL,
+                chat_id="+155****0001",
+                user_id="+155****0001",
+                chat_type="dm",
+            )
+            assert runner._is_user_authorized(source) is False
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_scoped_profile_allowlist_authorizes_only_that_profile(self, monkeypatch):
+        from gateway.config import Platform
+
+        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+155****0001")
+        monkeypatch.delenv("SIGNAL_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SIGNAL_ALLOWED_USERS": "+155****0002"})
+        try:
+            runner = self._runner()
+            allowed = SessionSource(
+                platform=Platform.SIGNAL,
+                chat_id="+155****0002",
+                user_id="+155****0002",
+                chat_type="dm",
+            )
+            borrowed = SessionSource(
+                platform=Platform.SIGNAL,
+                chat_id="+155****0001",
+                user_id="+155****0001",
+                chat_type="dm",
+            )
+            assert runner._is_user_authorized(allowed) is True
+            assert runner._is_user_authorized(borrowed) is False
+        finally:
+            ss.reset_secret_scope(token)
+
+
+class TestSignalScopedSecretBeatsYamlExtra:
+    def test_scoped_env_wins_over_conflicting_extra(self, monkeypatch):
+        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+155****0001")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SIGNAL_ALLOWED_USERS": "+155****0002"})
+        try:
+            config = PlatformConfig(enabled=True)
+            config.extra = {
+                "http_url": "http://localhost:8080",
+                "account": "+155****4567",
+                "allowed_users": "+155****0003",
+            }
+            adapter = SignalAdapter(config)
+            assert adapter.dm_allow_from == {"+155****0002"}
+            assert adapter._reactions_enabled(_signal_event("+155****0002")) is True
+            assert adapter._reactions_enabled(_signal_event("+155****0003")) is False
+        finally:
+            ss.reset_secret_scope(token)
+
+
+class TestMatrixSiblingAllowAllIsScoped:
+    def test_invite_does_not_borrow_process_allow_all(self, monkeypatch):
+        import asyncio
+        from unittest.mock import MagicMock
+
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        try:
+            config = PlatformConfig(enabled=True)
+            config.extra = {"homeserver": "https://example.org"}
+            adapter = MatrixAdapter(config)
+            adapter._allowed_user_ids = set()
+            scheduled = []
+            adapter._schedule_invite_join = lambda *args, **kwargs: scheduled.append((args, kwargs))
+            event = SimpleNamespace(
+                room_id="!evil:example.org",
+                sender="@stranger:example.org",
+                content=SimpleNamespace(is_direct=True),
+            )
+            asyncio.run(adapter._on_invite(event))
+            assert scheduled == []
+        finally:
+            ss.reset_secret_scope(token)

--- a/tests/gateway/test_adapter_allowlist_secret_scope.py
+++ b/tests/gateway/test_adapter_allowlist_secret_scope.py
@@ -103,6 +103,44 @@ class TestMatrixYamlAllowlistsSurviveScopedMiss:
         finally:
             ss.reset_secret_scope(token)
 
+    def test_scoped_env_beats_yaml_extra(self, monkeypatch):
+        """Named-profile secret must outrank YAML extra and process env."""
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@default:example.org")
+        monkeypatch.setenv("MATRIX_ALLOWED_ROOMS", "!default:example.org")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope(
+            {
+                "MATRIX_ALLOWED_USERS": "@second:example.org",
+                "MATRIX_ALLOWED_ROOMS": "!second:example.org",
+            }
+        )
+        try:
+            config = PlatformConfig(enabled=True)
+            config.extra = {
+                "homeserver": "https://example.org",
+                "allowed_users": "@operator:example.org",
+                "allowed_rooms": "!private:example.org",
+            }
+            adapter = MatrixAdapter(config)
+            assert adapter._allowed_user_ids == {"@second:example.org"}
+            assert adapter._allowed_rooms == {"!second:example.org"}
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_yaml_extra_beats_unscoped_process_env(self, monkeypatch):
+        """Without a named-profile scope, YAML extra still beats process env."""
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@default:example.org")
+        monkeypatch.setenv("MATRIX_ALLOWED_ROOMS", "!default:example.org")
+        config = PlatformConfig(enabled=True)
+        config.extra = {
+            "homeserver": "https://example.org",
+            "allowed_users": "@operator:example.org",
+            "allowed_rooms": "!private:example.org",
+        }
+        adapter = MatrixAdapter(config)
+        assert adapter._allowed_user_ids == {"@operator:example.org"}
+        assert adapter._allowed_rooms == {"!private:example.org"}
+
     def test_unscoped_startup_still_reads_environ(self, monkeypatch):
         monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@default:example.org")
         assert matrix_secret("MATRIX_ALLOWED_USERS") == "@default:example.org"

--- a/tests/gateway/test_adapter_allowlist_secret_scope.py
+++ b/tests/gateway/test_adapter_allowlist_secret_scope.py
@@ -1,4 +1,4 @@
-"""Allowlist / gate env reads must honor the active profile secret scope.
+"""Allowlist / gate reads must honor the active profile secret scope.
 
 These adapter-level reads sit in front of gateway authz. A bare
 ``os.getenv`` under ``gateway.multiplex_profiles`` would borrow the
@@ -6,13 +6,23 @@ default profile's allowlist (or allow-all flag) for a secondary
 profile. Same shape as the Matrix recovery-key fix (#69090) and the
 Slack app-token pattern (#59739).
 """
+from types import SimpleNamespace
+
 import pytest
 
 from agent import secret_scope as ss
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.signal import SignalAdapter
+from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+from gateway.platforms.whatsapp_common import _get_wsecret as whatsapp_secret
+from gateway.session import SessionSource
+from plugins.platforms.email.adapter import EmailAdapter
+from plugins.platforms.email.adapter import _get_secret as email_secret
+from plugins.platforms.matrix.adapter import MatrixAdapter
+from plugins.platforms.matrix.adapter import _apply_yaml_config
 from plugins.platforms.matrix.adapter import _startup_env_secret as matrix_secret
 from gateway.platforms.signal import _startup_env_secret as signal_secret
-from plugins.platforms.email.adapter import _get_secret as email_secret
-from gateway.platforms.whatsapp_common import _get_wsecret as whatsapp_secret
 
 
 @pytest.fixture(autouse=True)
@@ -22,63 +32,155 @@ def _reset_multiplex():
     ss.set_multiplex_active(False)
 
 
-class TestMatrixAllowedUsersScope:
-    def test_scoped_secondary_uses_own_allowlist(self, monkeypatch):
+def _signal_event(sender: str) -> MessageEvent:
+    return MessageEvent(
+        text="hi",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=SimpleNamespace(value="signal"),
+            chat_id=sender,
+            user_id=sender,
+        ),
+    )
+
+
+class TestMatrixYamlAllowlistsSurviveScopedMiss:
+    def test_yaml_hook_seeds_extra_and_skips_env_under_multiplex(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@default:example.org")
+        monkeypatch.setenv("MATRIX_ALLOWED_ROOMS", "!default:example.org")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        try:
+            seeded = _apply_yaml_config(
+                {},
+                {
+                    "allowed_users": ["@operator:example.org"],
+                    "allowed_rooms": ["!private:example.org"],
+                },
+            )
+            assert seeded["allowed_users"] == "@operator:example.org"
+            assert seeded["allowed_rooms"] == "!private:example.org"
+            import os
+            assert os.environ["MATRIX_ALLOWED_USERS"] == "@default:example.org"
+            assert os.environ["MATRIX_ALLOWED_ROOMS"] == "!default:example.org"
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_adapter_uses_yaml_extra_not_default_profile_env(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@default:example.org")
+        monkeypatch.setenv("MATRIX_ALLOWED_ROOMS", "!default:example.org")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        try:
+            seeded = _apply_yaml_config(
+                {},
+                {
+                    "allowed_users": ["@operator:example.org"],
+                    "allowed_rooms": ["!private:example.org"],
+                },
+            )
+            config = PlatformConfig(enabled=True)
+            config.extra = {
+                "homeserver": "https://example.org",
+                **seeded,
+            }
+            adapter = MatrixAdapter(config)
+            assert adapter._allowed_user_ids == {"@operator:example.org"}
+            assert adapter._allowed_rooms == {"!private:example.org"}
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_scoped_env_value_wins_when_extra_absent(self, monkeypatch):
         monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@default:example.org")
         ss.set_multiplex_active(True)
         token = ss.set_secret_scope({"MATRIX_ALLOWED_USERS": "@second:example.org"})
         try:
             assert matrix_secret("MATRIX_ALLOWED_USERS") == "@second:example.org"
+            config = PlatformConfig(enabled=True)
+            config.extra = {"homeserver": "https://example.org"}
+            adapter = MatrixAdapter(config)
+            assert adapter._allowed_user_ids == {"@second:example.org"}
         finally:
             ss.reset_secret_scope(token)
 
-    def test_scoped_missing_does_not_borrow_environ(self, monkeypatch):
+    def test_unscoped_startup_still_reads_environ(self, monkeypatch):
         monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@default:example.org")
+        assert matrix_secret("MATRIX_ALLOWED_USERS") == "@default:example.org"
+
+
+class TestSignalReactionsFailClosedOnScopedMiss:
+    def test_helper_scoped_miss_is_empty_not_star(self, monkeypatch):
+        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+155****0001")
         ss.set_multiplex_active(True)
         token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
         try:
-            assert matrix_secret("MATRIX_ALLOWED_USERS") == ""
+            assert signal_secret("SIGNAL_ALLOWED_USERS", "") == ""
         finally:
             ss.reset_secret_scope(token)
 
-
-class TestSignalAllowedUsersScope:
-    def test_scoped_secondary_uses_own_allowlist(self, monkeypatch):
-        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+15550001")
-        ss.set_multiplex_active(True)
-        token = ss.set_secret_scope({"SIGNAL_ALLOWED_USERS": "+15550002"})
-        try:
-            assert signal_secret("SIGNAL_ALLOWED_USERS", "*") == "+15550002"
-        finally:
-            ss.reset_secret_scope(token)
-
-    def test_scoped_missing_does_not_borrow_environ(self, monkeypatch):
-        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+15550001")
+    def test_adapter_reactions_closed_when_profile_has_no_allowlist(self, monkeypatch):
+        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+155****0001")
         ss.set_multiplex_active(True)
         token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
         try:
-            assert signal_secret("SIGNAL_ALLOWED_USERS", "*") == "*"
+            config = PlatformConfig(enabled=True)
+            config.extra = {"http_url": "http://localhost:8080", "account": "+155****4567"}
+            adapter = SignalAdapter(config)
+            assert adapter.dm_allow_from == set()
+            event = _signal_event("+155****9999")
+            assert adapter._reactions_enabled(event) is False
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_explicit_star_still_opens_reactions(self, monkeypatch):
+        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "*")
+        config = PlatformConfig(enabled=True)
+        config.extra = {"http_url": "http://localhost:8080", "account": "+155****4567"}
+        adapter = SignalAdapter(config)
+        assert "*" in adapter.dm_allow_from
+        assert adapter._reactions_enabled(_signal_event("+155****9999")) is True
+
+    def test_scoped_profile_allowlist_is_used(self, monkeypatch):
+        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+155****0001")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SIGNAL_ALLOWED_USERS": "+155****0002"})
+        try:
+            config = PlatformConfig(enabled=True)
+            config.extra = {"http_url": "http://localhost:8080", "account": "+155****4567"}
+            adapter = SignalAdapter(config)
+            assert adapter.dm_allow_from == {"+155****0002"}
+            assert adapter._reactions_enabled(_signal_event("+155****0002")) is True
+            assert adapter._reactions_enabled(_signal_event("+155****0001")) is False
         finally:
             ss.reset_secret_scope(token)
 
 
-class TestEmailGatewayGatesScope:
-    def test_scoped_missing_allow_all_does_not_borrow_environ(self, monkeypatch):
+class TestEmailAndWhatsAppAdapterGates:
+    def test_email_allow_all_does_not_borrow_environ(self, monkeypatch):
         monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        monkeypatch.delenv("EMAIL_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("EMAIL_ALLOWED_USERS", raising=False)
         ss.set_multiplex_active(True)
         token = ss.set_secret_scope({"EMAIL_ADDRESS": "b@example.com"})
         try:
             assert email_secret("GATEWAY_ALLOW_ALL_USERS", "") == ""
+            config = PlatformConfig(enabled=True)
+            adapter = EmailAdapter(config)
+            assert adapter._allow_all_senders() is False
+            assert adapter._allowlist_in_effect() is False
         finally:
             ss.reset_secret_scope(token)
 
-
-class TestWhatsAppGatewayAllowAllScope:
-    def test_scoped_missing_does_not_borrow_environ(self, monkeypatch):
+    def test_whatsapp_open_dm_does_not_borrow_environ(self, monkeypatch):
         monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
         ss.set_multiplex_active(True)
         token = ss.set_secret_scope({"WHATSAPP_ALLOWED_USERS": "x"})
         try:
             assert (whatsapp_secret("GATEWAY_ALLOW_ALL_USERS", default="") or "") == ""
+
+            class _Host(WhatsAppBehaviorMixin):
+                name = "whatsapp"
+
+            assert _Host()._open_dm_opted_in() is False
         finally:
             ss.reset_secret_scope(token)

--- a/tests/gateway/test_adapter_allowlist_secret_scope.py
+++ b/tests/gateway/test_adapter_allowlist_secret_scope.py
@@ -1,0 +1,84 @@
+"""Allowlist / gate env reads must honor the active profile secret scope.
+
+These adapter-level reads sit in front of gateway authz. A bare
+``os.getenv`` under ``gateway.multiplex_profiles`` would borrow the
+default profile's allowlist (or allow-all flag) for a secondary
+profile. Same shape as the Matrix recovery-key fix (#69090) and the
+Slack app-token pattern (#59739).
+"""
+import pytest
+
+from agent import secret_scope as ss
+from plugins.platforms.matrix.adapter import _startup_env_secret as matrix_secret
+from gateway.platforms.signal import _startup_env_secret as signal_secret
+from plugins.platforms.email.adapter import _get_secret as email_secret
+from gateway.platforms.whatsapp_common import _get_wsecret as whatsapp_secret
+
+
+@pytest.fixture(autouse=True)
+def _reset_multiplex():
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+class TestMatrixAllowedUsersScope:
+    def test_scoped_secondary_uses_own_allowlist(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@default:example.org")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"MATRIX_ALLOWED_USERS": "@second:example.org"})
+        try:
+            assert matrix_secret("MATRIX_ALLOWED_USERS") == "@second:example.org"
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_scoped_missing_does_not_borrow_environ(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@default:example.org")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        try:
+            assert matrix_secret("MATRIX_ALLOWED_USERS") == ""
+        finally:
+            ss.reset_secret_scope(token)
+
+
+class TestSignalAllowedUsersScope:
+    def test_scoped_secondary_uses_own_allowlist(self, monkeypatch):
+        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+15550001")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SIGNAL_ALLOWED_USERS": "+15550002"})
+        try:
+            assert signal_secret("SIGNAL_ALLOWED_USERS", "*") == "+15550002"
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_scoped_missing_does_not_borrow_environ(self, monkeypatch):
+        monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+15550001")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        try:
+            assert signal_secret("SIGNAL_ALLOWED_USERS", "*") == "*"
+        finally:
+            ss.reset_secret_scope(token)
+
+
+class TestEmailGatewayGatesScope:
+    def test_scoped_missing_allow_all_does_not_borrow_environ(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"EMAIL_ADDRESS": "b@example.com"})
+        try:
+            assert email_secret("GATEWAY_ALLOW_ALL_USERS", "") == ""
+        finally:
+            ss.reset_secret_scope(token)
+
+
+class TestWhatsAppGatewayAllowAllScope:
+    def test_scoped_missing_does_not_borrow_environ(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"WHATSAPP_ALLOWED_USERS": "x"})
+        try:
+            assert (whatsapp_secret("GATEWAY_ALLOW_ALL_USERS", default="") or "") == ""
+        finally:
+            ss.reset_secret_scope(token)


### PR DESCRIPTION
## What does this PR do?

Several adapter-level allowlist / allow-all reads still used a bare `os.getenv` after sibling paths (Matrix recovery key, Feishu, Email `EMAIL_*`, WhatsApp `_get_wsecret`) had already moved to a scope-aware helper. Under `gateway.multiplex_profiles` the process environment can hold the default profile's bridged value, so a secondary profile would inherit that profile's `MATRIX_ALLOWED_USERS`, `SIGNAL_*` allowlists, or `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS`.

This is the same root cause as #69090 / #59739, at the remaining intake call sites. One PR, because the helper already exists and every site is the same "don't borrow another profile's env" change.

## Related Issue

Same class as #69090 (Matrix recovery key) and #87132 / #72657 (Telegram / Slack). Those PRs do not cover these call sites. WhatsApp `_live_dm_allow_from` was addressed in #87698; this PR only changes the leftover `GATEWAY_ALLOW_ALL_USERS` read in `_open_dm_opted_in`.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: `MATRIX_ALLOWED_USERS` / `MATRIX_ALLOWED_ROOMS` via existing `_startup_env_secret`
- `gateway/platforms/signal.py`: new `_startup_env_secret`; used for `SIGNAL_GROUP_ALLOWED_USERS`, `SIGNAL_REQUIRE_MENTION`, `SIGNAL_ALLOWED_USERS`
- `plugins/platforms/email/adapter.py`: `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` via existing `_get_secret`
- `gateway/platforms/whatsapp_common.py`: `GATEWAY_ALLOW_ALL_USERS` via existing `_get_wsecret`
- `tests/gateway/test_adapter_allowlist_secret_scope.py`: scoped secondary sees its own value; scoped miss does not fall through to the default profile's environ

## How to Test

1. `python -m pytest tests/gateway/test_adapter_allowlist_secret_scope.py tests/gateway/test_matrix_recovery_key_scope.py tests/gateway/test_email.py tests/gateway/test_signal.py tests/gateway/test_matrix_approval_reaction_fail_closed.py -q` — 104 passed
2. Multiplex on, scope without `MATRIX_ALLOWED_USERS`, process env set to `@default:example.org` → helper returns empty (no borrow)
3. Same with the key present in the scope → helper returns the scoped value

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused gateway tests listed above (104 passed). I did not run `pytest tests/ -q`.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.11)

### Documentation & Housekeeping

- [x] N/A — no config keys, no architecture docs, no tool schemas

## For New Skills

N/A

## Screenshots / Logs

N/A

---

**AI assistance disclosure:** found during a code review of adapter allowlist reads; the fix, tests, and this description were prepared with AI assistance (Grok 4.6 via PokeAPI) and reviewed by the human submitter (FirmaSpring), who verified the tests locally.
