### PR TITLE
fix(bot-mode): paginate pet gallery + explain hidden cronjobs in Routines pane

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1925,6 +1925,19 @@ function AvatarPicker({ shape, color, image, onShape, onColor, onImage, generate
 // so opening the tab doesn't fire dozens of 2MB fetches at once.
 const PET_FRAME_W = 192
 const PET_FRAME_H = 208
+const PET_PAGE_SIZE = 6
+
+function paginatePets(pets, page) {
+  const pageCount = Math.ceil(pets.length / PET_PAGE_SIZE)
+  const requestedPage = Number.isFinite(page) ? Math.trunc(page) : 0
+  const currentPage = Math.min(Math.max(requestedPage, 0), Math.max(0, pageCount - 1))
+  return {
+    pageCount,
+    currentPage,
+    visible: pets.slice(currentPage * PET_PAGE_SIZE, (currentPage + 1) * PET_PAGE_SIZE)
+  }
+}
+
 const petFrameCache = new Map()
 let petFetchActive = 0
 const petFetchQueue = []
@@ -2014,9 +2027,7 @@ function PetTab({ image, onImage }) {
     staleTime: 300000
   })
   const [query, setQuery] = useState('')
-  // Windowed rendering: the gallery is 4500+ pets — mounting an <img> per pet
-  // froze the dialog. Render `limit` at a time and grow on scroll-to-bottom.
-  const [limit, setLimit] = useState(24)
+  const [page, setPage] = useState(0)
   const pets = data?.pets ?? []
 
   if (isLoading) {
@@ -2042,15 +2053,7 @@ function PetTab({ image, onImage }) {
     const rank = pet => (pet.installed ? 0 : pet.curated ? 1 : 2)
     return rank(a) - rank(b)
   })
-  const visible = ranked.slice(0, limit)
-
-  const onScroll = event => {
-    const el = event.currentTarget
-
-    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 120 && limit < ranked.length) {
-      setLimit(prev => Math.min(prev + 24, ranked.length))
-    }
-  }
+  const { pageCount, currentPage, visible } = paginatePets(ranked, page)
 
   return jsxs('div', {
     className: 'grid w-full gap-2',
@@ -2065,7 +2068,7 @@ function PetTab({ image, onImage }) {
         value: query,
         onChange: event => {
           setQuery(event.target.value)
-          setLimit(24)
+          setPage(0)
         }
       }),
       image && selectedSlug
@@ -2087,14 +2090,16 @@ function PetTab({ image, onImage }) {
             children: 'No pets match.'
           })
         : jsxs('div', {
-            onScroll,
-            style: { maxHeight: 220, overflowY: 'auto' },
+            // Keep a small inset so the selected tile's focus ring is never
+            // clipped at the edge of the gallery or by the dialog viewport.
+            style: { padding: 2 },
             children: [
               jsx('div', {
                 style: {
                   display: 'grid',
                   gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-                  gap: '6px'
+                  gap: '6px',
+                  padding: 2
                 },
                 children: visible.map(pet =>
                   jsxs(
@@ -2131,10 +2136,33 @@ function PetTab({ image, onImage }) {
                   )
                 )
               }),
-              limit < ranked.length
-                ? jsx('div', {
-                    className: 'py-2 text-center text-[0.65rem] text-(--ui-text-quaternary)',
-                    children: `Scroll for more (${limit} of ${ranked.length})`
+              pageCount > 1
+                ? jsxs('div', {
+                    className: 'flex items-center justify-center gap-2 pt-1',
+                    children: [
+                      jsx(Button, {
+                        type: 'button',
+                        variant: 'ghost',
+                        size: 'xs',
+                        disabled: currentPage === 0,
+                        'aria-label': 'Previous pets',
+                        onClick: () => setPage(prev => Math.max(0, prev - 1)),
+                        children: 'Previous'
+                      }),
+                      jsx('span', {
+                        className: 'text-[0.65rem] text-(--ui-text-quaternary)',
+                        children: `${currentPage + 1} / ${pageCount}`
+                      }),
+                      jsx(Button, {
+                        type: 'button',
+                        variant: 'ghost',
+                        size: 'xs',
+                        disabled: currentPage === pageCount - 1,
+                        'aria-label': 'Next pets',
+                        onClick: () => setPage(prev => Math.min(pageCount - 1, prev + 1)),
+                        children: 'Next'
+                      })
+                    ]
                   })
                 : null
             ]
@@ -5307,6 +5335,23 @@ function selectRoutineJobs(data, error, lastJobs, bot) {
   }
 }
 
+/**
+ * Why the Routines pane can be empty while the bot's cron store has jobs.
+ *
+ * The pane only shows jobs namespaced `[bot:<name>]` for the active bot. When
+ * jobs exist in the store but none carry that tag, the user is left staring at
+ * the generic empty state with no hint that cronjobs are present but hidden.
+ * Return a short explanation string in that case, or null when the store is
+ * genuinely empty (or the active bot's tagged jobs are already shown).
+ */
+function routineFilterHint(all, jobs) {
+  if (jobs.length !== 0 || !Array.isArray(all) || all.length === 0) {
+    return null
+  }
+  return 'Cronjobs exist in this profile but none are tagged for this bot. ' +
+    'Name a job "[bot:<name>] …" to show it here, or see them in Cron below.'
+}
+
 function normalizedProfileName(profile) {
   return typeof profile === 'string' ? profile.trim().toLowerCase() : ''
 }
@@ -5852,6 +5897,7 @@ function RoutinesPane() {
   const staleNotice = error && !view.live && view.all.length
     ? 'Could not refresh cronjobs. Showing the last list we had.'
     : null
+  const filterHint = routineFilterHint(view.all, jobs)
 
   return jsxs('div', {
     className: 'flex h-full flex-col',
@@ -5932,13 +5978,15 @@ function RoutinesPane() {
                 jsx(Codicon, { name: 'calendar', className: 'text-[1.6rem] text-(--ui-text-quaternary)' }),
                 jsx('div', {
                   className: 'text-xs leading-5 text-(--ui-text-tertiary)',
-                  children: 'Cronjobs are recurring tasks this agent runs on a schedule.'
+                  children: filterHint
+                    ? filterHint
+                    : 'Cronjobs are recurring tasks this agent runs on a schedule.'
                 }),
                 jsx(Button, {
                   variant: 'secondary',
                   size: 'sm',
                   onClick: openCreate,
-                  children: 'Create Cronjob'
+                  children: filterHint ? 'Create a cronjob for this bot' : 'Create Cronjob'
                 })
               ]
             })

--- a/apps/desktop/src/plugins/hermes-bots/tests/pet-gallery-pagination.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/pet-gallery-pagination.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const context = {
+    atom: initial => ({ get: () => initial, set() {} }),
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    host: { state: { profile: { listen: () => undefined } } }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__api = { paginatePets };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context.__api
+}
+
+test('pet gallery paginates six pets per page and clamps page bounds', () => {
+  const { paginatePets } = load()
+  const pets = Array.from({ length: 13 }, (_, index) => index)
+  const normalize = result => ({
+    pageCount: result.pageCount,
+    currentPage: result.currentPage,
+    visible: Array.from(result.visible)
+  })
+
+  assert.deepEqual(normalize(paginatePets(pets, 0)), {
+    pageCount: 3,
+    currentPage: 0,
+    visible: [0, 1, 2, 3, 4, 5]
+  })
+  assert.deepEqual(normalize(paginatePets(pets, 1)), {
+    pageCount: 3,
+    currentPage: 1,
+    visible: [6, 7, 8, 9, 10, 11]
+  })
+  assert.deepEqual(normalize(paginatePets(pets, 99)), {
+    pageCount: 3,
+    currentPage: 2,
+    visible: [12]
+  })
+  assert.deepEqual(normalize(paginatePets(pets, -2.8)), {
+    pageCount: 3,
+    currentPage: 0,
+    visible: [0, 1, 2, 3, 4, 5]
+  })
+  assert.deepEqual(normalize(paginatePets(pets, Number.NaN)), {
+    pageCount: 3,
+    currentPage: 0,
+    visible: [0, 1, 2, 3, 4, 5]
+  })
+  assert.deepEqual(normalize(paginatePets([], 4)), {
+    pageCount: 0,
+    currentPage: 0,
+    visible: []
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-filter-hint.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-filter-hint.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// UX improvement: when a bot's cron store HAS jobs but none are namespaced
+// `[bot:<name>]` for the active bot, the Routines pane now explains why it's
+// empty instead of showing the generic empty state with no hint.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: { state: { profile: { listen: () => undefined } } }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__api = { routineFilterHint };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context
+}
+
+test('hint: null when the active bot already has tagged jobs', () => {
+  const all = [{ name: '[bot:ops] Morning', job_id: '1' }]
+  assert.equal(load().__api.routineFilterHint(all, all), null)
+})
+
+test('hint: null when the store is genuinely empty', () => {
+  assert.equal(load().__api.routineFilterHint([], []), null)
+  assert.equal(load().__api.routineFilterHint(undefined, []), null)
+})
+
+test('hint: explains hidden jobs when store has jobs but none match the bot', () => {
+  const all = [
+    { name: '[bot:research] Digest', job_id: '2' },
+    { name: 'untagged job', job_id: '3' }
+  ]
+  const hint = load().__api.routineFilterHint(all, [])
+  assert.ok(hint)
+  assert.match(hint, /tagged for this bot/)
+})


### PR DESCRIPTION
## Summary

Two UX fixes ported from the archived NousResearch/Hermes-Bot-Mode repo (that repo is frozen, so they land here):

1. **Pet gallery pagination** (port of NousResearch/Hermes-Bot-Mode#74): the 4500+ pet gallery used scroll-to-load in a 220px scroll window, so the selected tile's focus ring clipped at the edges. Now six-per-page with Previous/Next controls, a page indicator, and page reset on search change.

2. **Routines filter hint** (port of NousResearch/Hermes-Bot-Mode#95): when a bot's cron store has jobs but none carry the `[bot:<name>]` tag, the pane showed the generic empty state with no explanation. Now it states that cronjobs exist but are hidden by the tag filter, and tells the user how to name a job to surface it.

## Changes

- `apps/desktop/src/plugins/hermes-bots/plugin.js` —> `paginatePets()` helper + PetTab pagination UI; `routineFilterHint()` + RoutinesPane empty-state hint
- `tests/pet-gallery-pagination.test.mjs` —> new (page math, clamping, NaN/negative/empty-list bounds)
- `tests/routines-filter-hint.test.mjs` —> new (tagged jobs shown, empty store, hidden-jobs explanation)

## Verification

```
node --test tests/pet-gallery-pagination.test.mjs tests/routines-filter-hint.test.mjs
# tests 4, pass 4, fail 0
```

Run on the branch head (commit a5491d23c2) against current `main`.