### PR TITLE
fix(desktop): bound DiffusionCanvas — pause policy, 15fps budget, instance cap

### DIFF
--- a/apps/desktop/src/components/chat/image-generation-placeholder.test.tsx
+++ b/apps/desktop/src/components/chat/image-generation-placeholder.test.tsx
@@ -1,0 +1,119 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DiffusionCanvas } from './image-generation-placeholder'
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+let windowStateCallback: ((payload: { isMinimized?: boolean; isVisible?: boolean }) => void) | null = null
+
+function render() {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+
+  act(() => {
+    root!.render(<DiffusionCanvas />)
+  })
+}
+
+function cleanup() {
+  if (root) {
+    act(() => {
+      root!.unmount()
+    })
+  }
+
+  container?.remove()
+  root = null
+  container = null
+}
+
+function installRaf() {
+  let nextId = 1
+  const frames = new Map<number, FrameRequestCallback>()
+
+  const request = vi.fn((callback: FrameRequestCallback) => {
+    const id = nextId++
+    frames.set(id, callback)
+
+    return id
+  })
+
+  const cancel = vi.fn((id: number) => {
+    frames.delete(id)
+  })
+
+  Object.defineProperty(window, 'requestAnimationFrame', { configurable: true, value: request })
+  Object.defineProperty(window, 'cancelAnimationFrame', { configurable: true, value: cancel })
+
+  return {
+    pending: () => frames.size,
+    request
+  }
+}
+
+function installWindowStateBridge() {
+  windowStateCallback = null
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: {
+      onWindowStateChanged: vi.fn((callback: typeof windowStateCallback) => {
+        windowStateCallback = callback
+
+        return () => {
+          if (windowStateCallback === callback) {
+            windowStateCallback = null
+          }
+        }
+      })
+    }
+  })
+}
+
+describe('DiffusionCanvas scheduling', () => {
+  beforeEach(() => {
+    ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    installWindowStateBridge()
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      setTransform: vi.fn()
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  it('cancels its loop while inactive and resumes only when the window is observable', () => {
+    const raf = installRaf()
+
+    render()
+    expect(raf.request).toHaveBeenCalledTimes(1)
+    expect(raf.pending()).toBe(1)
+
+    act(() => {
+      window.dispatchEvent(new Event('blur'))
+    })
+    expect(raf.pending()).toBe(0)
+
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+    })
+    expect(raf.pending()).toBe(1)
+
+    act(() => {
+      windowStateCallback?.({ isMinimized: true, isVisible: false })
+    })
+    expect(raf.pending()).toBe(0)
+
+    cleanup()
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+    })
+    expect(raf.pending()).toBe(0)
+  })
+})

--- a/apps/desktop/src/components/chat/image-generation-placeholder.test.tsx
+++ b/apps/desktop/src/components/chat/image-generation-placeholder.test.tsx
@@ -50,7 +50,18 @@ function installRaf() {
 
   return {
     pending: () => frames.size,
-    request
+    request,
+    runNext: (now: number) => {
+      const next = frames.entries().next().value
+
+      if (!next) {
+        throw new Error('No pending RAF')
+      }
+
+      const [id, callback] = next
+      frames.delete(id)
+      callback(now)
+    }
   }
 }
 
@@ -115,5 +126,127 @@ describe('DiffusionCanvas scheduling', () => {
       window.dispatchEvent(new Event('focus'))
     })
     expect(raf.pending()).toBe(0)
+  })
+})
+
+/** 2D-context stand-in whose every method is a lazily-created spy — the draw
+ *  path touches gradients, transforms, and fills, and this keeps the mock
+ *  honest without enumerating the full CanvasRenderingContext2D surface. */
+function installDrawableContext() {
+  const clearRect = vi.fn()
+  const gradient = { addColorStop: vi.fn() }
+  const fns = new Map<PropertyKey, ReturnType<typeof vi.fn>>()
+  const ctx = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'clearRect') {
+          return clearRect
+        }
+
+        if (prop === 'createLinearGradient' || prop === 'createRadialGradient') {
+          return () => gradient
+        }
+
+        if (!fns.has(prop)) {
+          fns.set(prop, vi.fn())
+        }
+
+        return fns.get(prop)
+      },
+      set() {
+        return true
+      }
+    }
+  )
+
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(ctx as unknown as CanvasRenderingContext2D)
+
+  return { clearRect }
+}
+
+describe('DiffusionCanvas frame budget', () => {
+  beforeEach(() => {
+    ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    installWindowStateBridge()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  it('paints at most ~15fps: frames inside the interval reschedule without redrawing', () => {
+    const raf = installRaf()
+    const { clearRect } = installDrawableContext()
+
+    render()
+    expect(raf.pending()).toBe(1)
+
+    act(() => {
+      raf.runNext(1000) // first paint
+    })
+    const paintsAfterFirst = clearRect.mock.calls.length
+    expect(paintsAfterFirst).toBeGreaterThan(0)
+
+    act(() => {
+      raf.runNext(1010) // 10ms later — inside the 1000/15 ≈ 66.7ms budget
+    })
+    expect(clearRect.mock.calls.length).toBe(paintsAfterFirst)
+    expect(raf.pending()).toBe(1) // loop kept alive, just no repaint
+
+    act(() => {
+      raf.runNext(1080) // past the budget — repaints
+    })
+    expect(clearRect.mock.calls.length).toBeGreaterThan(paintsAfterFirst)
+  })
+
+  it('caps concurrent animated instances: extras draw one static frame and skip the loop', () => {
+    const raf = installRaf()
+    installDrawableContext()
+
+    const containers: HTMLDivElement[] = []
+    const roots: Root[] = []
+
+    act(() => {
+      for (let i = 0; i < 3; i++) {
+        const el = document.createElement('div')
+        document.body.append(el)
+        containers.push(el)
+        const r = createRoot(el)
+        roots.push(r)
+        r.render(<DiffusionCanvas />)
+      }
+    })
+
+    // Two animated loops pending; the third instance drew statically and
+    // scheduled nothing.
+    expect(raf.pending()).toBe(2)
+
+    act(() => {
+      for (const r of roots) {
+        r.unmount()
+      }
+    })
+    for (const el of containers) {
+      el.remove()
+    }
+
+    // Counter released on unmount — a fresh mount animates again.
+    const el = document.createElement('div')
+    document.body.append(el)
+    const r = createRoot(el)
+
+    act(() => {
+      r.render(<DiffusionCanvas />)
+    })
+    expect(raf.pending()).toBe(1)
+
+    act(() => {
+      r.unmount()
+    })
+    el.remove()
   })
 })

--- a/apps/desktop/src/components/chat/image-generation-placeholder.tsx
+++ b/apps/desktop/src/components/chat/image-generation-placeholder.tsx
@@ -2,6 +2,7 @@ import { type FC, useCallback, useEffect, useRef } from 'react'
 
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { onThemeRepaint } from '@/hooks/use-theme-epoch'
+import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
 
 type Rgb = { r: number; g: number; b: number }
 
@@ -299,15 +300,50 @@ export const DiffusionCanvas: FC = () => {
 
     sizeRef.current = fitCanvas(canvas, ctx)
 
-    let frame = requestAnimationFrame(function draw(now) {
+    let frame = 0
+    let stopped = false
+    let pauseController: ReturnType<typeof createRendererLoopPauseController> | null = null
+
+    const cancelFrame = () => {
+      if (frame !== 0) {
+        window.cancelAnimationFrame(frame)
+        frame = 0
+      }
+    }
+
+    const scheduleFrame = () => {
+      if (stopped || pauseController?.isPaused() || frame !== 0) {
+        return
+      }
+
+      frame = window.requestAnimationFrame(draw)
+    }
+
+    const draw = (now: number) => {
+      frame = 0
+
+      if (stopped || pauseController?.isPaused()) {
+        return
+      }
+
       const { width, height } = sizeRef.current
       ctx.clearRect(0, 0, width, height)
       drawAsciiDiffusion(ctx, themeRef.current, width, height, now / 1000)
-      frame = requestAnimationFrame(draw)
-    })
+      scheduleFrame()
+    }
+
+    const handleVisibilityChange = () => {
+      cancelFrame()
+      scheduleFrame()
+    }
+
+    pauseController = createRendererLoopPauseController(handleVisibilityChange)
+    scheduleFrame()
 
     return () => {
-      cancelAnimationFrame(frame)
+      stopped = true
+      cancelFrame()
+      pauseController.dispose()
     }
   }, [])
 

--- a/apps/desktop/src/components/chat/image-generation-placeholder.tsx
+++ b/apps/desktop/src/components/chat/image-generation-placeholder.tsx
@@ -249,6 +249,17 @@ const drawAsciiDiffusion = (
   ctx.fillRect(0, 0, width, height)
 }
 
+// Cap concurrent animated instances — each rAF loop redraws the full canvas
+// every frame, so N instances multiply the CPU/GPU cost linearly (#79077).
+// Beyond the cap the canvas still mounts (so layout/layout is unchanged) but
+// the animation loop is skipped, giving a zero-cost static placeholder.
+const MAX_ANIMATED_INSTANCES = 2
+let activeAnimatedCount = 0
+
+// ~15fps paint target for the animated shimmer — visually equivalent at
+// placeholder scale, 4x fewer full-canvas redraws than display cadence.
+const FRAME_INTERVAL = 1000 / 15
+
 export const DiffusionCanvas: FC = () => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const sizeRef = useRef({ width: 0, height: 0 })
@@ -300,7 +311,20 @@ export const DiffusionCanvas: FC = () => {
 
     sizeRef.current = fitCanvas(canvas, ctx)
 
+    // Over the concurrent cap — draw one static frame, skip the rAF loop so
+    // extra instances are zero-cost (#79077). Each animated instance redraws
+    // its full canvas per frame, so N instances multiply cost linearly.
+    if (activeAnimatedCount >= MAX_ANIMATED_INSTANCES) {
+      const { width, height } = sizeRef.current
+      drawAsciiDiffusion(ctx, themeRef.current, width, height, 0)
+
+      return
+    }
+
+    activeAnimatedCount++
+
     let frame = 0
+    let lastDraw = 0
     let stopped = false
     let pauseController: ReturnType<typeof createRendererLoopPauseController> | null = null
 
@@ -326,9 +350,15 @@ export const DiffusionCanvas: FC = () => {
         return
       }
 
-      const { width, height } = sizeRef.current
-      ctx.clearRect(0, 0, width, height)
-      drawAsciiDiffusion(ctx, themeRef.current, width, height, now / 1000)
+      // 15fps is visually equivalent for this placeholder shimmer and does
+      // 4x fewer full-canvas redraws than display cadence (#79077).
+      if (now - lastDraw >= FRAME_INTERVAL) {
+        const { width, height } = sizeRef.current
+        ctx.clearRect(0, 0, width, height)
+        drawAsciiDiffusion(ctx, themeRef.current, width, height, now / 1000)
+        lastDraw = now
+      }
+
       scheduleFrame()
     }
 
@@ -344,6 +374,7 @@ export const DiffusionCanvas: FC = () => {
       stopped = true
       cancelFrame()
       pauseController.dispose()
+      activeAnimatedCount--
     }
   }, [])
 


### PR DESCRIPTION
## Summary

The image-generation placeholder (`DiffusionCanvas`) no longer redraws its full canvas at display cadence, no longer multiplies that cost per concurrent instance, and pauses whenever the window is not observable. Composes the two competing fixes for this loop: #88407 by @frizikk (shared `createRendererLoopPauseController` wiring + scheduling tests) and #79327 by @Enough1122 (15 fps frame budget + concurrent-instance cap, submitted first), both cherry-picked with authorship preserved.

Root cause: the placeholder ran an uncapped `requestAnimationFrame` loop repainting the entire canvas every frame, ignored the shared renderer pause policy, and each concurrent instance (parallel `image_generate` calls, duplicate mounts) added another full 60 fps loop.

## Changes

- `apps/desktop/src/components/chat/image-generation-placeholder.tsx`:
  - (#88407) loop wired to `createRendererLoopPauseController` — cancels on hidden/minimized/unfocused, resumes when observable, disposes on unmount
  - (#79327) 15 fps paint budget inside the loop; instances beyond `MAX_ANIMATED_INSTANCES` (2) draw one static frame and skip the loop entirely, releasing their slot on unmount
- `image-generation-placeholder.test.tsx`: #88407's scheduling suite + new frame-budget and instance-cap coverage (verified to fail against the pause-controller-only version)

## Validation

| | Before | After |
|---|---|---|
| Visible, 1 instance | 60 fps full-canvas redraw | ~15 fps |
| N instances | N x 60 fps loops | max 2 animated, extras static |
| Hidden/minimized/unfocused | keeps drawing | loop cancelled, resumes on observable |
| Tests | — | 3/3 pass; `check:lint` 0 errors |

Fixes #88396. Addresses the DiffusionCanvas share of #79077.

Credit: @Enough1122 submitted the throttle + cap first (#79327); @frizikk's #88407 contributed the house pause-policy wiring and test harness. Both commits carry their authorship.

## Infographic

![Diffusion canvas bounded animation](https://v3b.fal.media/files/b/0aa6bb6e/dfUvEibMdNiXp4sjrTesy_RgBkDxXn.png)
