### PR TITLE
feat(providers): bundle Meta Model API (Muse Spark) as a built-in provider plugin

### DIFF
--- a/plugins/model-providers/meta-ai/__init__.py
+++ b/plugins/model-providers/meta-ai/__init__.py
@@ -1,11 +1,9 @@
 """Meta Model API (Muse Spark) provider plugin for Hermes Agent.
 
-Self-contained, out-of-tree provider profile for Meta Superintelligence Labs'
-Muse Spark family, served via the OpenAI-compatible Meta Model API at
-``https://api.meta.ai/v1``.
+Provider profile for Meta Superintelligence Labs' Muse Spark family, served
+via the OpenAI-compatible Meta Model API at ``https://api.meta.ai/v1``.
 
-Install by copying this directory to
-``$HERMES_HOME/plugins/model-providers/meta-ai/`` (see ``install.sh``). Hermes'
+Bundled from https://github.com/albertodepaola/hermes-meta-provider. Hermes'
 provider discovery (``providers/__init__.py``) imports it on first
 ``get_provider_profile()`` / ``list_providers()`` call, and the module-level
 ``register_provider()`` below wires it into the registry.

--- a/plugins/model-providers/meta-ai/__init__.py
+++ b/plugins/model-providers/meta-ai/__init__.py
@@ -1,0 +1,113 @@
+"""Meta Model API (Muse Spark) provider plugin for Hermes Agent.
+
+Self-contained, out-of-tree provider profile for Meta Superintelligence Labs'
+Muse Spark family, served via the OpenAI-compatible Meta Model API at
+``https://api.meta.ai/v1``.
+
+Install by copying this directory to
+``$HERMES_HOME/plugins/model-providers/meta-ai/`` (see ``install.sh``). Hermes'
+provider discovery (``providers/__init__.py``) imports it on first
+``get_provider_profile()`` / ``list_providers()`` call, and the module-level
+``register_provider()`` below wires it into the registry.
+
+Design notes
+------------
+* **Zero core edits.** Everything rides on ``ProviderProfile`` hooks. No changes
+  to hermes' ``model_metadata.py`` / ``models.py`` / ``run_agent.py`` are needed:
+  - Context window (1M), reasoning and vision capabilities already resolve from
+    models.dev for the muse-spark family, so no static ctx table entry is required.
+  - The reasoning dial is emitted as a **top-level ``reasoning_effort``** kwarg
+    (returned in the ``top_level`` slot of ``build_api_kwargs_extras``), which the
+    chat-completions transport merges unconditionally. This deliberately avoids
+    the ``extra_body.reasoning`` path, whose emission is gated by a hardcoded
+    host allowlist in core (``AIAgent._supports_reasoning_extra_body``) that a
+    third-party plugin must not edit.
+* **Meta 400 on ``reasoning_effort: "none"``.** Muse rejects ``none``; disabling
+  reasoning maps to ``"minimal"`` instead.
+* **``default_max_tokens=16384``.** Muse spends completion budget on hidden
+  reasoning tokens first; small caps can finish with empty content.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+def _resolve_effort(reasoning_config: dict | None) -> str:
+    """Map Hermes' reasoning_config to a Meta-safe ``reasoning_effort`` value.
+
+    - reasoning disabled / effort "none"  -> "minimal"  (Meta 400s on "none")
+    - low | medium | high                 -> passthrough
+    - max | xhigh | ultra                 -> "xhigh"
+    - unset / unknown                     -> "medium"
+    """
+    rc = reasoning_config or {}
+    if rc.get("enabled") is False:
+        return "minimal"
+    effort = str(rc.get("effort") or "").strip().lower()
+    if effort in {"", "none"}:
+        return "minimal" if effort == "none" else "medium"
+    if effort in {"low", "medium", "high"}:
+        return effort
+    if effort in {"max", "xhigh", "ultra"}:
+        return "xhigh"
+    return "medium"
+
+
+class MetaAIProfile(ProviderProfile):
+    """Meta Model API — top-level reasoning_effort, self-contained."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        supports_reasoning: bool = False,  # noqa: ARG002 — we self-gate below
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Emit ``reasoning_effort`` as a top-level api kwarg.
+
+        We ignore the core ``supports_reasoning`` gate on purpose: that flag is
+        driven by a host allowlist in core we cannot (and should not) edit from
+        an out-of-tree plugin. Muse Spark always accepts ``reasoning_effort``,
+        so we resolve it from ``reasoning_config`` directly.
+        """
+        return {}, {"reasoning_effort": _resolve_effort(reasoning_config)}
+
+
+def _base_url() -> str:
+    """Allow a base-URL override via ``META_BASE_URL`` without editing config."""
+    return os.getenv("META_BASE_URL", "").strip() or "https://api.meta.ai/v1"
+
+
+meta_ai = MetaAIProfile(
+    name="meta-ai",
+    aliases=("meta", "muse", "muse-spark", "model-api", "msl"),
+    display_name="Meta Model API",
+    description="Meta Muse Spark family (Meta Superintelligence Labs)",
+    signup_url="https://developer.meta.com/ai/",
+    # MODEL_API_KEY is Meta's documented env var; the aliases are conveniences.
+    env_vars=("MODEL_API_KEY", "META_API_KEY", "META_MODEL_API_KEY", "META_BASE_URL"),
+    base_url=_base_url(),
+    auth_type="api_key",
+    api_mode="chat_completions",
+    # Muse Spark is natively multimodal (image/video/pdf/audio in, text out).
+    supports_vision=True,
+    # Cheap contributor tier is a good default for auxiliary tasks
+    # (compaction, title generation, vision) when this is the main provider.
+    default_aux_model="muse-spark-1.2-contributor",
+    # Muse spends completion budget on hidden reasoning tokens first; a low cap
+    # can finish with empty content. 16k is a safe floor.
+    default_max_tokens=16384,
+    # Curated safety net shown in the picker when the live /v1/models fetch
+    # fails or no credentials are configured yet.
+    fallback_models=(
+        "muse-spark-1.2",
+        "muse-spark-1.2-contributor",
+    ),
+)
+
+register_provider(meta_ai)

--- a/plugins/model-providers/meta-ai/plugin.yaml
+++ b/plugins/model-providers/meta-ai/plugin.yaml
@@ -1,0 +1,6 @@
+name: meta-ai-provider
+kind: model-provider
+version: 1.0.0
+description: Meta Model API — Muse Spark family (Meta Superintelligence Labs)
+author: Beto de Paola
+homepage: https://github.com/albertodepaola/hermes-meta-provider

--- a/tests/providers/test_meta_ai_profile.py
+++ b/tests/providers/test_meta_ai_profile.py
@@ -1,0 +1,59 @@
+"""Tests for the bundled Meta Model API (Muse Spark) provider plugin.
+
+Adapted from the plugin's original suite at
+https://github.com/albertodepaola/hermes-meta-provider — the plugin is now
+bundled, so profiles resolve through normal registry discovery.
+"""
+
+import pytest
+
+from providers import get_provider_profile
+
+
+def _profile():
+    p = get_provider_profile("meta-ai")
+    assert p is not None
+    return p
+
+
+class TestMetaAIProfile:
+    def test_profile_registered(self):
+        p = _profile()
+        assert p.name == "meta-ai"
+        assert p.base_url == "https://api.meta.ai/v1"
+        assert p.auth_type == "api_key"
+        assert p.api_mode == "chat_completions"
+        assert "MODEL_API_KEY" in p.env_vars
+        assert p.supports_vision is True
+        assert p.default_aux_model == "muse-spark-1.2-contributor"
+        assert p.default_max_tokens == 16384
+        assert "muse-spark-1.2-contributor" in p.fallback_models
+        assert "muse-spark-1.2" in p.fallback_models
+
+    @pytest.mark.parametrize("alias", ["meta", "muse", "muse-spark", "model-api", "msl"])
+    def test_aliases_resolve(self, alias):
+        assert get_provider_profile(alias) is _profile()
+
+
+def _effort(cfg):
+    _eb, top = _profile().build_api_kwargs_extras(reasoning_config=cfg)
+    return top.get("reasoning_effort")
+
+
+class TestReasoningEffort:
+    def test_mapping(self):
+        assert _effort(None) == "medium"  # unset -> medium
+        assert _effort({"enabled": True, "effort": "high"}) == "high"
+        assert _effort({"enabled": True, "effort": "low"}) == "low"
+        assert _effort({"enabled": True, "effort": "max"}) == "xhigh"
+        assert _effort({"enabled": False}) == "minimal"  # disabled -> minimal
+        # Meta 400s on "none" — must map to "minimal"
+        assert _effort({"effort": "none"}) == "minimal"
+
+    def test_never_uses_extra_body(self):
+        """The dial must be top-level, not extra_body.reasoning (core-gated path)."""
+        eb, top = _profile().build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}
+        )
+        assert eb == {}
+        assert "reasoning_effort" in top

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -288,6 +288,10 @@ hermes chat --provider tencent-tokenhub --model hy3-preview
 hermes chat --provider arcee --model trinity-large-thinking
 # Requires: ARCEEAI_API_KEY in ~/.hermes/.env
 
+# Meta Model API (Muse Spark family)
+hermes chat --provider meta-ai --model muse-spark-1.2
+# Requires: MODEL_API_KEY in ~/.hermes/.env
+
 # GMI Cloud
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
@@ -303,7 +307,11 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `META_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+
+:::note Meta contributor tier
+`muse-spark-1.2-contributor` is Meta's discounted tier — Meta may train on your prompts and completions, so [interactive model selection asks for confirmation](../user-guide/configuring-models.md) before using it. Use `muse-spark-1.2` (standard pricing, no training) for confidential work.
+:::
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.


### PR DESCRIPTION
## Summary

The Meta Model API (Muse Spark family) is now a built-in provider — `--provider meta-ai` works out of the box, no plugin install needed.

Bundles the provider profile from [albertodepaola/hermes-meta-provider](https://github.com/albertodepaola/hermes-meta-provider) (follow-up to #81416/#81418) as `plugins/model-providers/meta-ai/`, with @albertodepaola's authorship preserved.

## Changes

- `plugins/model-providers/meta-ai/` — profile: `https://api.meta.ai/v1`, `MODEL_API_KEY` auth (+ `META_API_KEY`/`META_MODEL_API_KEY` aliases, `META_BASE_URL` override), OpenAI-compatible chat completions, vision, top-level `reasoning_effort` dial with the Meta `none → minimal` 400 guard, 16k default max_tokens, `muse-spark-1.2` / `muse-spark-1.2-contributor` fallback catalog
- `tests/providers/test_meta_ai_profile.py` — ported the plugin's suite into the repo (registry discovery, alias resolution, effort mapping, no-extra_body contract)
- `website/docs/integrations/providers.md` — meta-ai in the first-class API-key list, `META_BASE_URL` in the override list, contributor-tier data-training note

Existing infrastructure already covers the rest: the models.dev `meta-ai → meta` context mapping merged in #84679, and the `muse-spark-1.2-contributor` data-policy guard fires through the selection-guard registry (verified).

## Validation

| Check | Result |
|---|---|
| Registry + all 5 aliases resolve | ✓ real-import E2E |
| Auto-wire: auth `PROVIDER_REGISTRY`, `CANONICAL_PROVIDERS`, `OPTIONAL_ENV_VARS` (normal import order) | ✓ |
| `effort none → minimal`, top-level only | ✓ |
| data_policy guard on contributor tier via `selection_warnings()` | ✓ |
| `tests/providers/` + guard suites | 77 passed |

## Infographic

![Meta Model API — Built-in Provider](https://v3b.fal.media/files/b/0aa6bb8a/eJAqfF-4XNfQFVxIaDDHn_1BebYgtl.png)
