### PR TITLE
fix: align channel runtime status and bound local output

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2251,6 +2251,44 @@ def init_agent(
                     f"  Falling back to provider default.\n",
                     file=sys.stderr,
                 )
+
+    # Match gateway runtime resolution for OpenAI-compatible custom providers.
+    # A local provider's ``max_output_tokens`` is deliberately a fallback: an
+    # explicit caller value and the documented global ``model.max_tokens`` both
+    # take precedence.  Without this, foreground CLI sessions omit the cap and
+    # llama.cpp falls back to its server-side n_predict default (8192), which
+    # can monopolize a single slot long after a small answer is available.
+    if agent.max_tokens is None:
+        _providers_cfg = _agent_cfg.get("providers", {})
+        # The runtime router normalizes user-defined OpenAI-compatible
+        # providers to ``custom`` while retaining the configured key as
+        # ``requested_provider``.  Prefer that key so a ``llamacpp`` cap is
+        # not lost after normalization; native providers still use
+        # ``agent.provider``.
+        _configured_provider = str(
+            getattr(agent, "requested_provider", None) or agent.provider or ""
+        ).strip()
+        _provider_cfg = _providers_cfg.get(_configured_provider, {}) if isinstance(_providers_cfg, dict) else {}
+        _provider_max_tokens = (
+            _provider_cfg.get("max_output_tokens")
+            if isinstance(_provider_cfg, dict)
+            else None
+        )
+        if _provider_max_tokens is not None:
+            try:
+                if isinstance(_provider_max_tokens, bool):
+                    raise ValueError
+                _parsed_provider_max_tokens = int(_provider_max_tokens)
+                if _parsed_provider_max_tokens <= 0:
+                    raise ValueError
+                agent.max_tokens = _parsed_provider_max_tokens
+            except (TypeError, ValueError):
+                _ra().logger.warning(
+                    "Invalid providers.%s.max_output_tokens in config.yaml: %r — "
+                    "must be a positive integer; falling back to provider default.",
+                    _configured_provider,
+                    _provider_max_tokens,
+                )
     agent._session_init_model_config["max_tokens"] = agent.max_tokens
 
     # Read explicit context_length override from model config

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2743,11 +2743,18 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
+        _get_model_config,
     )
     try:
         runtime = resolve_runtime_provider(requested=provider)
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
+    model_cfg = _get_model_config()
+    max_tokens = model_cfg.get("max_tokens") if isinstance(model_cfg, dict) else None
+    if not isinstance(max_tokens, int) or max_tokens <= 0:
+        max_tokens = runtime.get("max_output_tokens")
+    if not isinstance(max_tokens, int) or max_tokens <= 0:
+        max_tokens = None
     return {
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
@@ -2757,6 +2764,7 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "max_tokens": max_tokens,
     }
 
 
@@ -20472,10 +20480,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
-                return self._format_session_info()
-        return self._format_session_info()
+                return self._format_session_info(source)
+        return self._format_session_info(source)
 
-    def _format_session_info(self) -> str:
+    def _format_session_info(self, source: Optional[SessionSource] = None) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
@@ -20519,9 +20527,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
-        # Resolve runtime credentials for probing
+        # Resolve the same route the next turn will use. A channel override
+        # must be reflected in /new before any agent has been constructed.
         try:
-            runtime = _resolve_runtime_agent_kwargs()
+            if source is not None:
+                model, runtime = self._resolve_session_agent_runtime(source=source)
+            else:
+                runtime = _resolve_runtime_agent_kwargs()
             provider = runtime.get("provider") or provider
             base_url = runtime.get("base_url") or base_url
             api_key = runtime.get("api_key")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2750,7 +2750,15 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
     model_cfg = _get_model_config()
-    max_tokens = model_cfg.get("max_tokens") if isinstance(model_cfg, dict) else None
+    max_tokens = None
+    _env_mt = os.environ.get("HERMES_MAX_TOKENS")
+    if _env_mt:
+        try:
+            max_tokens = int(_env_mt)
+        except (ValueError, TypeError):
+            max_tokens = None
+    elif isinstance(model_cfg, dict):
+        max_tokens = model_cfg.get("max_tokens")
     if not isinstance(max_tokens, int) or max_tokens <= 0:
         max_tokens = runtime.get("max_output_tokens")
     if not isinstance(max_tokens, int) or max_tokens <= 0:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -695,6 +695,18 @@ class GatewaySlashCommandsMixin:
                 user_config = _load_gateway_config()
             except Exception:
                 user_config = {}
+        if not route_resolved:
+            try:
+                model_name, runtime = self._resolve_session_agent_runtime(
+                    source=source,
+                    session_key=session_key,
+                    user_config=user_config,
+                )
+                provider_name = _clean_str(runtime.get("provider"))
+                base_url = _clean_str(runtime.get("base_url"))
+                route_resolved = bool(model_name and provider_name)
+            except Exception:
+                logger.debug("Status route resolution failed", exc_info=True)
         if not model_name:
             model_name = _resolve_gateway_model(user_config)
         if not provider_name:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1362,7 +1362,7 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "key_cmd",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "max_output_tokens", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
         "ssl_ca_cert", "ssl_verify",
@@ -1481,6 +1481,10 @@ def _normalize_custom_provider_entry(
     if isinstance(context_length, int) and context_length > 0:
         normalized["context_length"] = context_length
 
+    max_output_tokens = entry.get("max_output_tokens")
+    if isinstance(max_output_tokens, int) and not isinstance(max_output_tokens, bool) and max_output_tokens > 0:
+        normalized["max_output_tokens"] = max_output_tokens
+
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
@@ -1534,6 +1538,7 @@ def _custom_provider_entry_to_provider_config(
         "key_env",
         "models",
         "context_length",
+        "max_output_tokens",
         "rate_limit_delay",
         "discover_models",
         "extra_body",
@@ -1974,7 +1979,7 @@ _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay", "extra_body",
+    "context_length", "max_output_tokens", "rate_limit_delay", "extra_body",
     "ssl_ca_cert", "ssl_verify",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.

--- a/tests/gateway/test_max_tokens_propagation.py
+++ b/tests/gateway/test_max_tokens_propagation.py
@@ -95,3 +95,24 @@ def test_per_provider_max_output_tokens_fallback(isolated_home):
     assert kw["max_tokens"] == 12000
 
 
+def test_explicit_provider_keeps_its_output_cap(isolated_home):
+    """A channel override must pass its provider output cap to the agent."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(
+        """
+        model:
+          default: cloud-model
+          provider: openai-codex
+        providers:
+          llamacpp:
+            api: http://127.0.0.1:18080/v1
+            api_key: local
+            default_model: qwen3.8-27b-q4_k_m-128k
+            max_output_tokens: 12000
+        """
+    )
+    grun = fresh_gateway()
+    kw = grun._resolve_runtime_agent_kwargs_for_provider("llamacpp")
+    assert kw["max_tokens"] == 12000
+
+

--- a/tests/gateway/test_max_tokens_propagation.py
+++ b/tests/gateway/test_max_tokens_propagation.py
@@ -116,3 +116,28 @@ def test_explicit_provider_keeps_its_output_cap(isolated_home):
     assert kw["max_tokens"] == 12000
 
 
+def test_explicit_provider_honors_environment_output_cap(isolated_home, monkeypatch):
+    """A one-off cap must override channel-provider and global defaults."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(
+        """
+        model:
+          default: cloud-model
+          provider: openai-codex
+          max_tokens: 16000
+        providers:
+          llamacpp:
+            api: http://127.0.0.1:18080/v1
+            api_key: local
+            default_model: qwen3.8-27b-q4_k_m-128k
+            max_output_tokens: 12000
+        """
+    )
+    monkeypatch.setenv("HERMES_MAX_TOKENS", "8000")
+    grun = fresh_gateway()
+
+    kw = grun._resolve_runtime_agent_kwargs_for_provider("llamacpp")
+
+    assert kw["max_tokens"] == 8000
+
+

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -25,6 +25,30 @@ def _patch_info(tmp_path, config_yaml, model, runtime):
 
 
 class TestFormatSessionInfo:
+    def test_channel_runtime_is_shown_in_new_session_info(self, runner):
+        """A /new banner must show the channel override, not the global route."""
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+
+        source = SessionSource(platform=Platform.SLACK, chat_id="C0BQDHWP3M0", user_id="u1")
+        runtime = {
+            "provider": "llamacpp",
+            "base_url": "http://127.0.0.1:18080/v1",
+            "api_key": "local",
+        }
+        with patch.object(
+            runner,
+            "_resolve_session_agent_runtime",
+            return_value=("qwen3.8-27b-q4_k_m-128k", runtime),
+        ), patch("gateway.run._load_gateway_config", return_value={"model": {}}), patch(
+            "agent.model_metadata.get_model_context_length", return_value=131072
+        ):
+            info = runner._format_session_info(source)
+
+        assert "qwen3.8-27b-q4_k_m-128k" in info
+        assert "llamacpp" in info
+        assert "127.0.0.1:18080" in info
+
 
     def test_includes_model_name(self, runner, tmp_path):
         p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: anthropic/claude-opus-4.6\n  provider: openrouter\n",

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -67,4 +67,22 @@ class TestNormalizeCustomProviderEntry:
         assert result is not None
         assert result["base_url"] == "${PROVIDER_A_BASE_URL}"
 
+    def test_max_output_tokens_is_supported_and_normalized(self, caplog):
+        """A per-provider output cap must survive compatibility normalization.
+
+        The foreground CLI reads this cap to constrain a single-slot local
+        OpenAI-compatible server; treating it as unknown both emits a noisy
+        warning and drops the cap from legacy-compatible provider entries.
+        """
+        entry = {
+            "base_url": "http://127.0.0.1:18080/v1",
+            "max_output_tokens": 1024,
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="llamacpp")
+
+        assert result is not None
+        assert result["max_output_tokens"] == 1024
+        assert "unknown config keys" not in caplog.text
+
 


### PR DESCRIPTION
Summary: resolve channel-aware status metadata and output-cap precedence for the local provider. Verification: focused gateway/provider suite 20 passed; compileall and diff check passed; local llama.cpp completion returned stop with cap 12000. Hermes Kanban: t_c43c8d5a.