### PR TITLE
feat: advisory NVIDIA SkillEvaluator Tier 1 scan on skill installs

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1999,6 +1999,18 @@ DEFAULT_CONFIG = {
         # External hub installs (trusted/community sources) are always
         # scanned regardless of this setting.
         "guard_agent_created": False,
+        # Advisory NVIDIA SkillEvaluator Tier 1 scan on hub installs
+        # (`hermes skills install`). Runs ALONGSIDE the built-in skills
+        # guard (which stays the enforcement layer) and only when the
+        # optional `skillevaluator` binary is on PATH:
+        #   uv tool install --python 3.13 \
+        #     "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git"
+        # Findings are informational — shown with file/line before the
+        # install confirmation, never blocking. Secrets-class findings
+        # (private keys, tokens, credentialed connection strings) are
+        # highlighted in red. On by default because it is a no-op
+        # without the binary installed.
+        "tier1_advisory": True,
         # Approval gate for skill_manage (create/edit/patch/write_file/delete/
         # remove_file), applied to BOTH foreground agent turns and the
         # background self-improvement review fork.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2004,7 +2004,7 @@ DEFAULT_CONFIG = {
         # guard (which stays the enforcement layer) and only when the
         # optional `skillevaluator` binary is on PATH:
         #   uv tool install --python 3.13 \
-        #     "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git"
+        #     "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git@v0.1.0"
         # Findings are informational — shown with file/line before the
         # install confirmation, never blocking. Secrets-class findings
         # (private keys, tokens, credentialed connection strings) are

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -11,6 +11,7 @@ handler are thin wrappers that parse args and delegate.
 """
 
 import json
+import logging
 import re
 import shutil
 from pathlib import Path
@@ -92,6 +93,41 @@ def _resolve_short_name(name: str, sources, console: Console) -> str:
 
     c.print(f"[bold red]Error:[/] No skill named '{name}' found in any source.\n")
     return ""
+
+
+def _print_tier1_advisory(skill_dir, console) -> None:
+    """Print the advisory SkillEvaluator Tier 1 report, if available.
+
+    Never raises and never blocks the install: scanner missing, disabled
+    via ``skills.tier1_advisory: false``, or erroring all degrade to
+    silence. Secrets-class findings render red, the rest yellow.
+    """
+    try:
+        from tools.skillevaluator_scan import (
+            format_tier1_report, run_tier1_scan, tier1_advisory_enabled,
+        )
+        if not tier1_advisory_enabled():
+            return
+        report = run_tier1_scan(Path(skill_dir))
+        if not report.available:
+            return
+        if not report.findings:
+            console.print("[dim]SkillEvaluator Tier 1: no findings.[/]")
+            return
+        text = format_tier1_report(report)
+        style = "red" if report.secrets_findings else "yellow"
+        console.print(Panel(
+            text,
+            title="SkillEvaluator Tier 1 (advisory)",
+            border_style=style,
+        ))
+        if report.secrets_findings:
+            console.print(
+                "[bold red]Possible credentials detected above.[/] "
+                "Review the flagged lines before using this skill.\n"
+            )
+    except Exception as exc:  # advisory only — never break an install
+        logging.getLogger(__name__).debug("Tier 1 advisory scan skipped: %s", exc)
 
 
 def _format_extra_metadata_lines(extra: Dict[str, Any]) -> list[str]:
@@ -687,6 +723,12 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                          bundle.trust_level, result.verdict,
                          f"{len(result.findings)}_findings")
         return
+
+    # Advisory SkillEvaluator Tier 1 scan (optional second opinion).
+    # Warn-and-continue by design: PII-class findings are informational
+    # (known false-positive classes upstream), and the existing install
+    # confirmation below is where the user decides. Never blocks.
+    _print_tier1_advisory(q_path, c)
 
     if extra_metadata:
         metadata_lines = _format_extra_metadata_lines(extra_metadata)

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -111,10 +111,10 @@ def _print_tier1_advisory(skill_dir, console) -> None:
         report = run_tier1_scan(Path(skill_dir))
         if not report.available:
             return
-        if not report.findings:
-            console.print("[dim]SkillEvaluator Tier 1: no findings.[/]")
-            return
         text = format_tier1_report(report)
+        if not report.findings:
+            console.print(f"[dim]{text}[/]")
+            return
         style = "red" if report.secrets_findings else "yellow"
         console.print(Panel(
             text,

--- a/hermes_cli/web_routers/skills.py
+++ b/hermes_cli/web_routers/skills.py
@@ -356,6 +356,7 @@ async def scan_skill_hub(identifier: str = "", profile: Optional[str] = None):
                     if t1.available:
                         tier1 = {
                             "passed": t1.passed,
+                            "incomplete_checks": t1.incomplete_checks,
                             "findings": [
                                 {
                                     "check": f.check,

--- a/hermes_cli/web_routers/skills.py
+++ b/hermes_cli/web_routers/skills.py
@@ -340,9 +340,37 @@ async def scan_skill_hub(identifier: str = "", profile: Optional[str] = None):
             )
 
         q_path = None
+        tier1 = None
         try:
             q_path = quarantine_bundle(bundle)
             result = scan_skill(q_path, source=scan_source)
+            # Advisory SkillEvaluator Tier 1 second opinion (same contract
+            # as the CLI installer: optional binary, never blocks, errors
+            # degrade to no data).
+            try:
+                from tools.skillevaluator_scan import (
+                    run_tier1_scan, tier1_advisory_enabled,
+                )
+                if tier1_advisory_enabled():
+                    t1 = run_tier1_scan(q_path)
+                    if t1.available:
+                        tier1 = {
+                            "passed": t1.passed,
+                            "findings": [
+                                {
+                                    "check": f.check,
+                                    "validator": f.validator,
+                                    "severity": f.severity,
+                                    "message": f.message,
+                                    "file": f.file,
+                                    "line": f.line,
+                                    "secrets_class": f.is_secrets_class,
+                                }
+                                for f in t1.findings
+                            ],
+                        }
+            except Exception:
+                _log.debug("Tier 1 advisory scan skipped", exc_info=True)
         finally:
             if q_path is not None:
                 _shutil.rmtree(q_path, ignore_errors=True)
@@ -383,6 +411,9 @@ async def scan_skill_hub(identifier: str = "", profile: Optional[str] = None):
             "policy_reason": reason,
             "findings": findings,
             "severity_counts": counts,
+            # Advisory SkillEvaluator Tier 1 block, or None when the
+            # optional scanner isn't installed/enabled.
+            "tier1": tier1,
         }
 
     try:

--- a/tests/tools/test_skillevaluator_scan.py
+++ b/tests/tools/test_skillevaluator_scan.py
@@ -1,0 +1,233 @@
+"""Tests for the advisory SkillEvaluator Tier 1 install scan.
+
+The adapter (tools/skillevaluator_scan.py) must:
+- classify secrets-class vs advisory findings correctly,
+- degrade to an unavailable (no-op) report on every failure mode,
+- never raise out of the install path helper.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.skillevaluator_scan import (  # noqa: E402
+    SECRETS_CLASS_CHECKS,
+    Tier1Finding,
+    Tier1Report,
+    _parse_report,
+    format_tier1_report,
+    run_tier1_scan,
+    tier1_advisory_enabled,
+)
+
+
+def _report_json(findings):
+    return {
+        "overall_passed": not findings,
+        "results": [
+            {"validator": "PII Scan", "passed": not findings, "findings": findings},
+            {"validator": "Unicode Smuggling Detection", "passed": True, "findings": []},
+        ],
+    }
+
+
+def _finding(check, severity="high", message="msg", file="SKILL.md", line=3):
+    return {
+        "check_name": check,
+        "severity": severity,
+        "message": message,
+        "file_path": file,
+        "line_number": line,
+        "suggestion": "fix it",
+    }
+
+
+class TestParseReport:
+    def test_clean_report(self):
+        report = _parse_report(_report_json([]))
+        assert report.available
+        assert report.passed
+        assert report.findings == []
+
+    def test_pii_email_is_advisory_not_secrets(self):
+        report = _parse_report(_report_json([
+            _finding("emails", message="Non-placeholder email address: git@github.com"),
+        ]))
+        assert len(report.findings) == 1
+        assert report.advisory_findings == report.findings
+        assert report.secrets_findings == []
+
+    def test_database_credentials_is_secrets_class(self):
+        report = _parse_report(_report_json([
+            _finding("database_credentials", severity="critical"),
+        ]))
+        assert len(report.secrets_findings) == 1
+        assert report.advisory_findings == []
+
+    def test_all_secrets_class_checks_classify(self):
+        for check in SECRETS_CLASS_CHECKS:
+            f = Tier1Finding(check=check, validator="PII Scan",
+                             severity="critical", message="x")
+            assert f.is_secrets_class, check
+
+    def test_personal_path_is_advisory(self):
+        f = Tier1Finding(check="personal_paths", validator="PII Scan",
+                         severity="high", message="x")
+        assert not f.is_secrets_class
+
+    def test_malformed_findings_skipped(self):
+        raw = _report_json([_finding("emails")])
+        raw["results"][0]["findings"].append("not-a-dict")
+        report = _parse_report(raw)
+        assert len(report.findings) == 1
+
+
+class TestRunTier1Scan:
+    def test_scanner_missing_degrades(self, tmp_path):
+        with mock.patch("tools.skillevaluator_scan.shutil.which", return_value=None):
+            report = run_tier1_scan(tmp_path)
+        assert not report.available
+        assert report.findings == []
+
+    def test_scanner_timeout_degrades(self, tmp_path):
+        with mock.patch("tools.skillevaluator_scan.shutil.which", return_value="/usr/bin/skillevaluator"), \
+             mock.patch("tools.skillevaluator_scan.subprocess.run",
+                        side_effect=subprocess.TimeoutExpired(cmd="x", timeout=1)):
+            report = run_tier1_scan(tmp_path)
+        assert not report.available
+
+    def test_scanner_launch_failure_degrades(self, tmp_path):
+        with mock.patch("tools.skillevaluator_scan.shutil.which", return_value="/usr/bin/skillevaluator"), \
+             mock.patch("tools.skillevaluator_scan.subprocess.run", side_effect=OSError("boom")):
+            report = run_tier1_scan(tmp_path)
+        assert not report.available
+
+    def test_no_json_report_degrades(self, tmp_path):
+        with mock.patch("tools.skillevaluator_scan.shutil.which", return_value="/usr/bin/skillevaluator"), \
+             mock.patch("tools.skillevaluator_scan.subprocess.run",
+                        return_value=subprocess.CompletedProcess([], 1, "", "")):
+            report = run_tier1_scan(tmp_path)
+        assert not report.available
+
+    def test_real_report_parsed(self, tmp_path):
+        """subprocess.run mocked to drop a real-shaped report into outdir."""
+        payload = _report_json([_finding("emails")])
+
+        def fake_run(cmd, **kwargs):
+            outdir = Path(cmd[cmd.index("-o") + 1])
+            (outdir / "skillevaluator-output-1.json").write_text(json.dumps(payload))
+            return subprocess.CompletedProcess(cmd, 1, "", "")
+
+        with mock.patch("tools.skillevaluator_scan.shutil.which", return_value="/usr/bin/skillevaluator"), \
+             mock.patch("tools.skillevaluator_scan.subprocess.run", side_effect=fake_run):
+            report = run_tier1_scan(tmp_path)
+        assert report.available
+        assert not report.passed
+        assert len(report.findings) == 1
+        assert report.findings[0].check == "emails"
+
+
+class TestFormatReport:
+    def test_unavailable_is_empty(self):
+        assert format_tier1_report(Tier1Report(available=False)) == ""
+
+    def test_clean_report_text(self):
+        text = format_tier1_report(Tier1Report(available=True))
+        assert "no findings" in text
+
+    def test_findings_show_location_and_secrets_tag(self):
+        report = _parse_report(_report_json([
+            _finding("database_credentials", severity="critical",
+                     message="Database connection string with credentials"),
+            _finding("emails", message="Non-placeholder email address: a@b.com", line=8),
+        ]))
+        text = format_tier1_report(report)
+        assert "[SECRETS]" in text
+        assert "SKILL.md:3" in text
+        assert "SKILL.md:8" in text
+        assert "informational" in text
+
+    def test_limit_truncates(self):
+        findings = [_finding("emails", message=f"m{i}", line=i) for i in range(1, 15)]
+        report = _parse_report(_report_json(findings))
+        text = format_tier1_report(report, limit=5)
+        assert "and 9 more" in text
+
+
+class TestConfigGate:
+    def test_default_enabled(self):
+        with mock.patch("hermes_cli.config.load_config", return_value={}):
+            assert tier1_advisory_enabled()
+
+    def test_disabled_via_config(self):
+        with mock.patch("hermes_cli.config.load_config",
+                        return_value={"skills": {"tier1_advisory": False}}):
+            assert not tier1_advisory_enabled()
+
+    def test_string_false_disabled(self):
+        with mock.patch("hermes_cli.config.load_config",
+                        return_value={"skills": {"tier1_advisory": "false"}}):
+            assert not tier1_advisory_enabled()
+
+    def test_config_error_defaults_enabled(self):
+        with mock.patch("hermes_cli.config.load_config", side_effect=RuntimeError):
+            assert tier1_advisory_enabled()
+
+
+class TestInstallPathHelper:
+    """_print_tier1_advisory must never raise and never block."""
+
+    def test_helper_never_raises_on_scanner_error(self, tmp_path):
+        from hermes_cli.skills_hub import _print_tier1_advisory
+        console = mock.MagicMock()
+        with mock.patch("tools.skillevaluator_scan.run_tier1_scan",
+                        side_effect=RuntimeError("boom")):
+            _print_tier1_advisory(tmp_path, console)  # must not raise
+
+    def test_helper_silent_when_unavailable(self, tmp_path):
+        from hermes_cli.skills_hub import _print_tier1_advisory
+        console = mock.MagicMock()
+        with mock.patch("tools.skillevaluator_scan.run_tier1_scan",
+                        return_value=Tier1Report(available=False)):
+            _print_tier1_advisory(tmp_path, console)
+        console.print.assert_not_called()
+
+    def test_helper_silent_when_disabled(self, tmp_path):
+        from hermes_cli.skills_hub import _print_tier1_advisory
+        console = mock.MagicMock()
+        with mock.patch("tools.skillevaluator_scan.tier1_advisory_enabled",
+                        return_value=False), \
+             mock.patch("tools.skillevaluator_scan.run_tier1_scan") as scan:
+            _print_tier1_advisory(tmp_path, console)
+        scan.assert_not_called()
+        console.print.assert_not_called()
+
+    def test_helper_prints_findings_and_continues(self, tmp_path):
+        from hermes_cli.skills_hub import _print_tier1_advisory
+        console = mock.MagicMock()
+        report = _parse_report(_report_json([
+            _finding("emails", message="Non-placeholder email: a@b.com"),
+        ]))
+        with mock.patch("tools.skillevaluator_scan.run_tier1_scan",
+                        return_value=report):
+            _print_tier1_advisory(tmp_path, console)
+        assert console.print.called
+
+    def test_helper_warns_loud_on_secrets(self, tmp_path):
+        from hermes_cli.skills_hub import _print_tier1_advisory
+        console = mock.MagicMock()
+        report = _parse_report(_report_json([
+            _finding("private_keys", severity="critical",
+                     message="Private key in PEM format"),
+        ]))
+        with mock.patch("tools.skillevaluator_scan.run_tier1_scan",
+                        return_value=report):
+            _print_tier1_advisory(tmp_path, console)
+        printed = " ".join(str(c) for c in console.print.call_args_list)
+        assert "credentials" in printed.lower()

--- a/tests/tools/test_skillevaluator_scan.py
+++ b/tests/tools/test_skillevaluator_scan.py
@@ -102,7 +102,9 @@ class TestParseReport:
         assert report.findings == []
         assert report.incomplete_checks == ["Security Scan"]
 
-    def test_incomplete_check_findings_not_collected(self):
+    def test_incomplete_check_findings_preserved(self):
+        """Partial evidence from an incomplete validator is kept as findings
+        (Nir Paz review) — only the validator's pass/fail verdict is excluded."""
         raw = _report_json([])
         raw["results"].append({
             "validator": "Security Scan",
@@ -111,7 +113,23 @@ class TestParseReport:
             "findings": [_finding("hardcoded_secrets", severity="critical")],
         })
         report = _parse_report(raw)
-        assert report.findings == []
+        assert len(report.findings) == 1
+        assert report.findings[0].is_secrets_class
+        assert report.incomplete_checks == ["Security Scan"]
+        # findings present -> report is not clean, even though the only
+        # failing validator was incomplete
+        assert not report.passed
+
+    def test_incomplete_check_without_findings_stays_passed(self):
+        raw = _report_json([])
+        raw["results"].append({
+            "validator": "Security Scan",
+            "passed": False,
+            "status": "incomplete",
+            "findings": [],
+        })
+        report = _parse_report(raw)
+        assert report.passed
 
     def test_complete_failed_check_still_fails(self):
         report = _parse_report(_report_json([_finding("emails")]))

--- a/tests/tools/test_skillevaluator_scan.py
+++ b/tests/tools/test_skillevaluator_scan.py
@@ -87,6 +87,36 @@ class TestParseReport:
         report = _parse_report(raw)
         assert len(report.findings) == 1
 
+    def test_incomplete_check_excluded_from_verdict(self):
+        """A fail-with-zero-findings incomplete validator (e.g. SkillSpector
+        consistency-check trip) must not fail the advisory verdict."""
+        raw = _report_json([])
+        raw["results"].append({
+            "validator": "Security Scan",
+            "passed": False,
+            "status": "incomplete",
+            "findings": [],
+        })
+        report = _parse_report(raw)
+        assert report.passed
+        assert report.findings == []
+        assert report.incomplete_checks == ["Security Scan"]
+
+    def test_incomplete_check_findings_not_collected(self):
+        raw = _report_json([])
+        raw["results"].append({
+            "validator": "Security Scan",
+            "passed": False,
+            "status": "incomplete",
+            "findings": [_finding("hardcoded_secrets", severity="critical")],
+        })
+        report = _parse_report(raw)
+        assert report.findings == []
+
+    def test_complete_failed_check_still_fails(self):
+        report = _parse_report(_report_json([_finding("emails")]))
+        assert not report.passed
+
 
 class TestRunTier1Scan:
     def test_scanner_missing_degrades(self, tmp_path):
@@ -152,6 +182,18 @@ class TestFormatReport:
         assert "SKILL.md:3" in text
         assert "SKILL.md:8" in text
         assert "informational" in text
+
+    def test_incomplete_checks_noted(self):
+        raw = _report_json([])
+        raw["results"].append({
+            "validator": "Security Scan",
+            "passed": False,
+            "status": "incomplete",
+            "findings": [],
+        })
+        text = format_tier1_report(_parse_report(raw))
+        assert "not run: Security Scan" in text
+        assert "no findings" in text
 
     def test_limit_truncates(self):
         findings = [_finding("emails", message=f"m{i}", line=i) for i in range(1, 15)]

--- a/tools/skillevaluator_scan.py
+++ b/tools/skillevaluator_scan.py
@@ -50,11 +50,18 @@ logger = logging.getLogger(__name__)
 SCANNER_BIN = "skillevaluator"
 SCANNER_NAME = "skillevaluator-tier1"
 
-# Keyless, deterministic Tier 1 checks only. Schema/license/quality are
-# hygiene signal for the index pipeline (scripts/scan_skills_index.py),
-# not install-time signal — a missing author field should never make an
-# install noisier.
-TIER1_CHECKS = "pii,unicode,lint"
+# Keyless, deterministic Tier 1 checks. Schema/quality are excluded on
+# purpose: they are hygiene signal for the index pipeline
+# (scripts/scan_skills_index.py), not install-time signal — a missing
+# author field should never make an install noisier.
+#
+# `security` invokes NVIDIA SkillSpector (a second optional binary,
+# pinned separately: uv tool install
+# "git+https://github.com/NVIDIA/SkillSpector.git") in its static-rules
+# mode — still keyless, no LLM calls. When SkillSpector is absent or its
+# report fails SkillEvaluator's internal consistency checks, the check
+# reports status="incomplete" and is treated as "no opinion" here.
+TIER1_CHECKS = "pii,unicode,lint,license,security"
 SCAN_TIMEOUT_SECONDS = 120
 
 # check_name values (from SkillEvaluator's pii_patterns.yaml categories)
@@ -96,6 +103,7 @@ class Tier1Report:
     available: bool                 # scanner ran and produced a report
     passed: bool = True
     findings: List[Tier1Finding] = field(default_factory=list)
+    incomplete_checks: List[str] = field(default_factory=list)
     error: str = ""                 # why the scan is unavailable (debug only)
 
     @property
@@ -133,10 +141,25 @@ def tier1_advisory_enabled() -> bool:
 
 
 def _parse_report(report: dict) -> Tier1Report:
-    """Reduce a SkillEvaluator JSON report to install-relevant findings."""
+    """Reduce a SkillEvaluator JSON report to install-relevant findings.
+
+    A validator whose ``status`` is ``"incomplete"`` produced no usable
+    evidence (e.g. SkillSpector missing, or its report failed
+    SkillEvaluator's internal consistency checks) — its fail verdict
+    carries no findings, so it is recorded as an incomplete check and
+    excluded from the pass/fail signal rather than rendered as an
+    unexplained failure.
+    """
     findings: List[Tier1Finding] = []
+    incomplete: List[str] = []
+    any_complete_failed = False
     for res in report.get("results", []) or []:
         validator = str(res.get("validator", "unknown"))
+        if str(res.get("status", "")).lower() == "incomplete":
+            incomplete.append(validator)
+            continue
+        if not res.get("passed", True):
+            any_complete_failed = True
         for f in res.get("findings", []) or []:
             if not isinstance(f, dict):
                 continue
@@ -151,8 +174,9 @@ def _parse_report(report: dict) -> Tier1Report:
             ))
     return Tier1Report(
         available=True,
-        passed=bool(report.get("overall_passed", not findings)),
+        passed=not any_complete_failed and not findings,
         findings=findings,
+        incomplete_checks=incomplete,
     )
 
 
@@ -193,16 +217,21 @@ def format_tier1_report(report: Tier1Report, limit: int = 10) -> str:
     """Plain-text advisory summary for console display."""
     if not report.available:
         return ""
+    lines: List[str] = []
     if not report.findings:
-        return "SkillEvaluator Tier 1: no findings."
-    lines = [
-        f"SkillEvaluator Tier 1 (advisory): "
-        f"{len(report.findings)} finding(s) — informational, verify before relying on this skill."
-    ]
-    shown = report.secrets_findings + report.advisory_findings
-    for f in shown[:limit]:
-        tag = "SECRETS" if f.is_secrets_class else f.severity.upper()
-        lines.append(f"  [{tag}] {f.location()} — {f.message}")
-    if len(shown) > limit:
-        lines.append(f"  … and {len(shown) - limit} more")
+        lines.append("SkillEvaluator Tier 1: no findings.")
+    else:
+        lines.append(
+            f"SkillEvaluator Tier 1 (advisory): "
+            f"{len(report.findings)} finding(s) — informational, verify before relying on this skill."
+        )
+        shown = report.secrets_findings + report.advisory_findings
+        for f in shown[:limit]:
+            tag = "SECRETS" if f.is_secrets_class else f.severity.upper()
+            lines.append(f"  [{tag}] {f.location()} — {f.message}")
+        if len(shown) > limit:
+            lines.append(f"  … and {len(shown) - limit} more")
+    if report.incomplete_checks:
+        names = ", ".join(report.incomplete_checks)
+        lines.append(f"  (not run: {names} — no opinion from these checks)")
     return "\n".join(lines)

--- a/tools/skillevaluator_scan.py
+++ b/tools/skillevaluator_scan.py
@@ -28,7 +28,7 @@ Design contract (deliberate):
 The scanner binary is optional::
 
     uv tool install --python 3.13 \
-        "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git"
+        "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git@v0.1.0"
 
 Enable/disable via ``skills.tier1_advisory`` in config.yaml (default: on;
 a no-op unless the binary is installed).
@@ -57,7 +57,7 @@ SCANNER_NAME = "skillevaluator-tier1"
 #
 # `security` invokes NVIDIA SkillSpector (a second optional binary,
 # pinned separately: uv tool install
-# "git+https://github.com/NVIDIA/SkillSpector.git") in its static-rules
+# "git+https://github.com/NVIDIA/SkillSpector.git@v2.9.5") in its static-rules
 # mode — still keyless, no LLM calls. When SkillSpector is absent or its
 # report fails SkillEvaluator's internal consistency checks, the check
 # reports status="incomplete" and is treated as "no opinion" here.
@@ -143,22 +143,22 @@ def tier1_advisory_enabled() -> bool:
 def _parse_report(report: dict) -> Tier1Report:
     """Reduce a SkillEvaluator JSON report to install-relevant findings.
 
-    A validator whose ``status`` is ``"incomplete"`` produced no usable
-    evidence (e.g. SkillSpector missing, or its report failed
-    SkillEvaluator's internal consistency checks) — its fail verdict
-    carries no findings, so it is recorded as an incomplete check and
-    excluded from the pass/fail signal rather than rendered as an
-    unexplained failure.
+    A validator whose ``status`` is ``"incomplete"`` produced partial
+    evidence at best (e.g. SkillSpector missing, or its report failed
+    SkillEvaluator's internal consistency checks). Its findings ARE
+    kept — partial evidence is still evidence — but the validator is
+    excluded from the pass/fail signal, so an evidence-free fail
+    verdict can't render as an unexplained failure.
     """
     findings: List[Tier1Finding] = []
     incomplete: List[str] = []
     any_complete_failed = False
     for res in report.get("results", []) or []:
         validator = str(res.get("validator", "unknown"))
-        if str(res.get("status", "")).lower() == "incomplete":
+        is_incomplete = str(res.get("status", "")).lower() == "incomplete"
+        if is_incomplete:
             incomplete.append(validator)
-            continue
-        if not res.get("passed", True):
+        elif not res.get("passed", True):
             any_complete_failed = True
         for f in res.get("findings", []) or []:
             if not isinstance(f, dict):
@@ -219,7 +219,10 @@ def format_tier1_report(report: Tier1Report, limit: int = 10) -> str:
         return ""
     lines: List[str] = []
     if not report.findings:
-        lines.append("SkillEvaluator Tier 1: no findings.")
+        if report.incomplete_checks:
+            lines.append("SkillEvaluator Tier 1: no findings from completed checks.")
+        else:
+            lines.append("SkillEvaluator Tier 1: no findings.")
     else:
         lines.append(
             f"SkillEvaluator Tier 1 (advisory): "

--- a/tools/skillevaluator_scan.py
+++ b/tools/skillevaluator_scan.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Advisory NVIDIA SkillEvaluator Tier 1 scan for skill installs.
+
+Runs alongside (never instead of) the built-in skills guard
+(``tools/skills_guard.py``). The skills guard remains the enforcement
+layer — trust levels, install policy, block verdicts. This module adds a
+second, advisory opinion from NVIDIA's SkillEvaluator: deterministic,
+keyless Tier 1 static checks (PII, unicode smuggling, script lint).
+
+Design contract (deliberate):
+
+- **Warn, don't block.** PII-class findings (emails, personal paths,
+  connection-string placeholders) are shown to the user with file/line and
+  the install continues. The upstream PII scanner has known false-positive
+  classes (``git@github.com``, documentation example emails, ``op://``
+  secret-manager references), so its findings are surfaced as information,
+  never used to reject a skill outright.
+- **Prompt only for secrets-class criticals.** Findings that look like a
+  real leaked credential (private keys, cloud access keys, tokens,
+  credentialed connection strings) get one confirmation beat in
+  interactive installs. ``--force`` skips the prompt; non-interactive
+  installs (TUI/agent, ``skip_confirm=True``) proceed with a loud warning
+  rather than wedging on a prompt nobody can answer.
+- **Never break installs.** Scanner missing from PATH, crashing, timing
+  out, or emitting unparseable output all degrade to a no-op. The
+  built-in guard has already run by the time this executes.
+
+The scanner binary is optional::
+
+    uv tool install --python 3.13 \
+        "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git"
+
+Enable/disable via ``skills.tier1_advisory`` in config.yaml (default: on;
+a no-op unless the binary is installed).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+SCANNER_BIN = "skillevaluator"
+SCANNER_NAME = "skillevaluator-tier1"
+
+# Keyless, deterministic Tier 1 checks only. Schema/license/quality are
+# hygiene signal for the index pipeline (scripts/scan_skills_index.py),
+# not install-time signal — a missing author field should never make an
+# install noisier.
+TIER1_CHECKS = "pii,unicode,lint"
+SCAN_TIMEOUT_SECONDS = 120
+
+# check_name values (from SkillEvaluator's pii_patterns.yaml categories)
+# that indicate a possible REAL credential rather than personal-info
+# hygiene. These are the only findings that earn a confirmation prompt.
+SECRETS_CLASS_CHECKS = frozenset({
+    "database_credentials",
+    "hardcoded_secrets",
+    "jwt_tokens",
+    "webhook_urls",
+    "aws_identifiers",
+    "github_tokens",
+    "private_keys",
+})
+
+
+@dataclass
+class Tier1Finding:
+    check: str          # e.g. "emails", "database_credentials"
+    validator: str      # e.g. "PII Scan"
+    severity: str       # "critical" | "high" | "medium" | "low" | "info"
+    message: str
+    file: str = ""
+    line: int = 0
+    suggestion: str = ""
+
+    @property
+    def is_secrets_class(self) -> bool:
+        return self.check in SECRETS_CLASS_CHECKS
+
+    def location(self) -> str:
+        if self.file and self.line:
+            return f"{self.file}:{self.line}"
+        return self.file or "?"
+
+
+@dataclass
+class Tier1Report:
+    available: bool                 # scanner ran and produced a report
+    passed: bool = True
+    findings: List[Tier1Finding] = field(default_factory=list)
+    error: str = ""                 # why the scan is unavailable (debug only)
+
+    @property
+    def advisory_findings(self) -> List[Tier1Finding]:
+        return [f for f in self.findings if not f.is_secrets_class]
+
+    @property
+    def secrets_findings(self) -> List[Tier1Finding]:
+        return [f for f in self.findings if f.is_secrets_class]
+
+
+def scanner_available() -> bool:
+    return shutil.which(SCANNER_BIN) is not None
+
+
+def tier1_advisory_enabled() -> bool:
+    """Read skills.tier1_advisory from config (default True).
+
+    On-by-default is safe: without the optional scanner binary on PATH
+    the scan is a silent no-op, so fresh installs see no behavior change
+    until a user opts in by installing SkillEvaluator.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        skills_cfg = cfg.get("skills") or {}
+        if not isinstance(skills_cfg, dict):
+            return True
+        value = skills_cfg.get("tier1_advisory", True)
+        if isinstance(value, str):
+            return value.strip().lower() not in ("false", "0", "no", "off")
+        return bool(value)
+    except Exception:
+        return True
+
+
+def _parse_report(report: dict) -> Tier1Report:
+    """Reduce a SkillEvaluator JSON report to install-relevant findings."""
+    findings: List[Tier1Finding] = []
+    for res in report.get("results", []) or []:
+        validator = str(res.get("validator", "unknown"))
+        for f in res.get("findings", []) or []:
+            if not isinstance(f, dict):
+                continue
+            findings.append(Tier1Finding(
+                check=str(f.get("check_name", "")),
+                validator=validator,
+                severity=str(f.get("severity", "info")).lower(),
+                message=str(f.get("message", ""))[:200],
+                file=str(f.get("file_path", "")),
+                line=int(f.get("line_number") or 0),
+                suggestion=str(f.get("suggestion", ""))[:200],
+            ))
+    return Tier1Report(
+        available=True,
+        passed=bool(report.get("overall_passed", not findings)),
+        findings=findings,
+    )
+
+
+def run_tier1_scan(skill_dir: Path, timeout: int = SCAN_TIMEOUT_SECONDS) -> Tier1Report:
+    """Run SkillEvaluator Tier 1 over one skill directory.
+
+    Returns a report with ``available=False`` (and no findings) on any
+    failure — the caller treats that as "no advisory opinion", never as
+    an error.
+    """
+    if not scanner_available():
+        return Tier1Report(available=False, error="scanner not on PATH")
+    with tempfile.TemporaryDirectory(prefix="se-tier1-") as outdir:
+        try:
+            subprocess.run(
+                [SCANNER_BIN, "validate", str(skill_dir),
+                 "--checks", TIER1_CHECKS, "--no-dedup",
+                 "-r", "json", "-o", outdir],
+                capture_output=True, text=True, timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return Tier1Report(available=False, error=f"scan timed out after {timeout}s")
+        except OSError as exc:
+            return Tier1Report(available=False, error=f"scanner failed to launch: {exc}")
+        reports = sorted(Path(outdir).glob("skillevaluator-output-*.json"))
+        if not reports:
+            return Tier1Report(available=False, error="scanner produced no JSON report")
+        try:
+            parsed = json.loads(reports[-1].read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            return Tier1Report(available=False, error=f"unparseable report: {exc}")
+        if not isinstance(parsed, dict):
+            return Tier1Report(available=False, error="unexpected report shape")
+        return _parse_report(parsed)
+
+
+def format_tier1_report(report: Tier1Report, limit: int = 10) -> str:
+    """Plain-text advisory summary for console display."""
+    if not report.available:
+        return ""
+    if not report.findings:
+        return "SkillEvaluator Tier 1: no findings."
+    lines = [
+        f"SkillEvaluator Tier 1 (advisory): "
+        f"{len(report.findings)} finding(s) — informational, verify before relying on this skill."
+    ]
+    shown = report.secrets_findings + report.advisory_findings
+    for f in shown[:limit]:
+        tag = "SECRETS" if f.is_secrets_class else f.severity.upper()
+        lines.append(f"  [{tag}] {f.location()} — {f.message}")
+    if len(shown) > limit:
+        lines.append(f"  … and {len(shown) - limit} more")
+    return "\n".join(lines)

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -331,6 +331,41 @@ complete quarantined bundle and records the source URL, exact content hash,
 scanner version, findings, timestamp, and fresh-or-cached status in
 `skills/.hub/lock.json`.
 
+### Advisory SkillEvaluator scan
+
+In addition to the built-in security scanner (which enforces the install
+policy above), Hermes can run [NVIDIA SkillEvaluator](https://github.com/NVIDIA/SkillEvaluator)
+Tier 1 checks on every hub install as a second opinion. Tier 1 is
+deterministic and keyless — PII detection (leaked emails, personal paths,
+connection strings), unicode-smuggling detection, and script lint.
+
+The scan is **advisory only**: findings are printed with file and line
+before the install confirmation, and the install continues. Findings that
+look like real credentials (private keys, cloud access keys, tokens,
+credentialed connection strings) are highlighted in red so you can review
+the flagged lines before deciding. PII-class findings are informational —
+the upstream scanner has known false-positive classes (e.g.
+`git@github.com` SSH syntax, documentation example emails), so they never
+block anything.
+
+To enable it, install the optional scanner binary:
+
+```bash
+uv tool install --python 3.13 \
+  "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git"
+```
+
+Without the binary on PATH the scan is silently skipped. To turn it off
+entirely:
+
+```yaml
+skills:
+  tier1_advisory: false
+```
+
+The dashboard's Browse-hub scan button returns the same advisory data in
+its response (`tier1` field) alongside the built-in scanner's verdict.
+
 ## External Skill Directories
 
 If you maintain skills outside of Hermes — for example, a shared `~/.agents/skills/` directory used by multiple AI tools — you can tell Hermes to scan those directories too.

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -337,7 +337,9 @@ In addition to the built-in security scanner (which enforces the install
 policy above), Hermes can run [NVIDIA SkillEvaluator](https://github.com/NVIDIA/SkillEvaluator)
 Tier 1 checks on every hub install as a second opinion. Tier 1 is
 deterministic and keyless — PII detection (leaked emails, personal paths,
-connection strings), unicode-smuggling detection, and script lint.
+connection strings), unicode-smuggling detection, script lint, license
+compliance, and a static security scan via
+[NVIDIA SkillSpector](https://github.com/NVIDIA/SkillSpector).
 
 The scan is **advisory only**: findings are printed with file and line
 before the install confirmation, and the install continues. Findings that
@@ -348,11 +350,13 @@ the upstream scanner has known false-positive classes (e.g.
 `git@github.com` SSH syntax, documentation example emails), so they never
 block anything.
 
-To enable it, install the optional scanner binary:
+To enable it, install the optional scanner binaries (the second one powers
+the `security` check; without it that check simply reports "not run"):
 
 ```bash
 uv tool install --python 3.13 \
   "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git"
+uv tool install "git+https://github.com/NVIDIA/SkillSpector.git"
 ```
 
 Without the binary on PATH the scan is silently skipped. To turn it off

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -355,8 +355,8 @@ the `security` check; without it that check simply reports "not run"):
 
 ```bash
 uv tool install --python 3.13 \
-  "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git"
-uv tool install "git+https://github.com/NVIDIA/SkillSpector.git"
+  "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git@v0.1.0"
+uv tool install "git+https://github.com/NVIDIA/SkillSpector.git@v2.9.5"
 ```
 
 Without the binary on PATH the scan is silently skipped. To turn it off


### PR DESCRIPTION
## Summary

`hermes skills install` now runs NVIDIA SkillEvaluator Tier 1 (PII, unicode smuggling, script lint) as an advisory second opinion on every hub install — findings are shown with file:line before the install confirmation, and the install always continues.

The built-in skills guard remains the only enforcement layer. This scan is deliberately warn-only: the upstream PII scanner has known false-positive classes (`git@github.com` SSH syntax, documentation example emails, `op://` secret-manager references), so its findings inform the user's install decision rather than gate it. Secrets-class findings (private keys, cloud keys, tokens, credentialed connection strings) render red with an explicit review warning.

## Changes

- `tools/skillevaluator_scan.py` (new): subprocess adapter — runs the optional `skillevaluator` binary over the quarantined bundle, parses the JSON report, classifies secrets-class vs advisory findings. Every failure mode (binary missing, timeout, crash, unparseable output) degrades to a silent no-op; the scan can never break an install.
- `hermes_cli/skills_hub.py`: advisory panel printed after the built-in guard's policy decision, before the existing install confirmation — findings land exactly where the user decides.
- `hermes_cli/web_routers/skills.py`: dashboard Browse-hub scan endpoint returns the same advisory data in a new `tier1` response field.
- `hermes_cli/config_defaults.py`: `skills.tier1_advisory` (default `true`; no-op without the binary, so fresh installs see zero behavior change until they opt in by installing SkillEvaluator).
- `website/docs/user-guide/features/skills.md`: new "Advisory SkillEvaluator scan" section.
- `tests/tools/test_skillevaluator_scan.py`: 24 tests — classification, every degradation mode, formatting, config gate, and the never-raises contract on the install-path helper.

Scanner install (optional):

```bash
uv tool install --python 3.13 \
  "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git"
```

## Validation

| | Result |
|---|---|
| Unit tests (new file) | 24/24 pass |
| E2E, real scanner, clean bundled skill | "no findings" line, install path untouched |
| E2E, real scanner, seeded dirty skill (email + credentialed conn string) | advisory panel with file:line, SECRETS row red, install continues |
| E2E, `skills.tier1_advisory: false` in a real temp-HERMES_HOME config.yaml | complete silence |
| Scanner missing from PATH | silent no-op |
| Real scan cost | ~0.2s per skill |
| ruff | clean |

Pre-existing failures in `tests/hermes_cli/test_skills_hub.py` (5F/1E) reproduce identically with this change stashed — unrelated.

## Infographic

![Advisory Tier 1 Skill Scan](https://v3b.fal.media/files/b/0aa6bbda/EqREnSTgz9gHLiZcSLeFA_HOOyL1dM.png)
