### PR TITLE
feat(tools): honor delegation.enabled_toolsets for child agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1079,7 +1079,7 @@ Roles:
 Key config knobs (under `delegation:` in `config.yaml`):
 `max_concurrent_children`, `max_spawn_depth`, `child_timeout_seconds`,
 `orchestrator_enabled`, `subagent_auto_approve`, `inherit_mcp_toolsets`,
-`max_iterations`.
+`enabled_toolsets`, `max_iterations`.
 
 Durability rule: background `delegate_task` is detached from the current
 turn but still process-local. For work that must survive process restart, use

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1468,6 +1468,7 @@ delegation:
                                               # The parent TUI owns stdin, so blocking would deadlock; non-interactive resolution is required.
                                               # Both choices emit a logger.warning audit line. Flip to true only for cron/batch pipelines.
   # inherit_mcp_toolsets: true                # When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: true). Set false for strict intersection.
+  # enabled_toolsets: []                      # Default child toolsets when delegate_task does not pass an explicit list (default: [] = inherit parent). Example: [file, terminal]. Intersected with the parent; inherit_mcp_toolsets still applies.
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1837,6 +1837,12 @@ DEFAULT_CONFIG = {
         # extras" without silently stripping MCP tools the parent already has.
         # Set to false for strict intersection.
         "inherit_mcp_toolsets": True,
+        # Default child toolsets when the caller does not pass an explicit
+        # list (delegate_task never exposes toolsets to the model). Empty
+        # keeps current inherit-everything behavior. A non-empty list is
+        # treated as the child's requested toolsets: intersected with the
+        # parent, then inherit_mcp_toolsets is applied.
+        "enabled_toolsets": [],
         "max_iterations": 250,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
         # Subagent summaries return to the parent's context verbatim. A batch

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1037,6 +1037,163 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
         )
 
 
+class TestDefaultChildToolsets(unittest.TestCase):
+    """delegation.enabled_toolsets is the default requested child list."""
+
+    def _build(self, parent, toolsets=None):
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Default child toolsets",
+                context=None,
+                toolsets=toolsets,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+        return MockAgent.call_args[1]["enabled_toolsets"]
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_unset_config_inherits_parent_toolsets(self, _mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["web", "file", "terminal", "mcp-jcodemunch"]
+        self.assertEqual(
+            self._build(parent),
+            ["web", "file", "terminal", "mcp-jcodemunch"],
+        )
+
+    @patch("tools.delegate_tool._load_config", return_value={"enabled_toolsets": []})
+    def test_empty_list_inherits_parent_toolsets(self, _mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["web", "file", "terminal", "mcp-jcodemunch"]
+        self.assertEqual(
+            self._build(parent),
+            ["web", "file", "terminal", "mcp-jcodemunch"],
+        )
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "enabled_toolsets": ["file", "terminal"],
+            "inherit_mcp_toolsets": False,
+        },
+    )
+    def test_config_narrows_when_caller_omits_toolsets(self, _mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = [
+            "web",
+            "browser",
+            "file",
+            "terminal",
+            "mcp-jcodemunch",
+        ]
+        self.assertEqual(self._build(parent), ["file", "terminal"])
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "enabled_toolsets": ["file", "terminal"],
+            "inherit_mcp_toolsets": True,
+        },
+    )
+    def test_config_narrow_then_inherit_mcp_when_enabled(self, _mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["file", "terminal", "mcp-jcodemunch"]
+        self.assertEqual(
+            self._build(parent),
+            ["file", "terminal", "mcp-jcodemunch"],
+        )
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "enabled_toolsets": ["file", "terminal"],
+            "inherit_mcp_toolsets": False,
+        },
+    )
+    def test_explicit_toolsets_win_over_config(self, _mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["web", "file", "terminal"]
+        self.assertEqual(self._build(parent, toolsets=["web"]), ["web"])
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "enabled_toolsets": ["file", "terminal"],
+            "inherit_mcp_toolsets": False,
+        },
+    )
+    def test_config_cannot_grant_parent_missing_toolsets(self, _mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["terminal"]
+        self.assertEqual(self._build(parent), ["terminal"])
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "enabled_toolsets": ["file", "terminal"],
+            "inherit_mcp_toolsets": False,
+        },
+    )
+    def test_config_kept_when_parent_has_the_tools_under_other_names(self, _mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["desktop_ui", "jcodemunch"]
+        parent.valid_tool_names = {
+            "terminal",
+            "process",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
+        }
+        child_sets = self._build(parent)
+        self.assertIn("file", child_sets)
+        self.assertIn("terminal", child_sets)
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "enabled_toolsets": ["file", "terminal"],
+            "inherit_mcp_toolsets": False,
+        },
+    )
+    def test_restores_terminal_schema_if_child_init_drops_it(self, _mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["file", "terminal"]
+        parent.valid_tool_names = {"terminal", "process", "read_file"}
+        parent.tools = [
+            {"type": "function", "function": {"name": "terminal", "parameters": {}}},
+            {"type": "function", "function": {"name": "process", "parameters": {}}},
+            {"type": "function", "function": {"name": "read_file", "parameters": {}}},
+        ]
+
+        child = MagicMock()
+        child.valid_tool_names = {"process"}
+        child.tools = [
+            {"type": "function", "function": {"name": "process", "parameters": {}}},
+        ]
+
+        with patch("run_agent.AIAgent", return_value=child):
+            _build_child_agent(
+                task_index=0,
+                goal="Restore terminal",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertIn("terminal", child.valid_tool_names)
+        self.assertIn(
+            "terminal",
+            {t["function"]["name"] for t in child.tools},
+        )
+
+
 class TestChildCredentialLeasing(unittest.TestCase):
     def test_run_single_child_acquires_and_releases_lease(self):
         from tools.delegate_tool import _run_single_child

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -920,6 +920,102 @@ def _get_inherit_mcp_toolsets() -> bool:
     return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=True)
 
 
+def _get_default_child_toolsets() -> List[str]:
+    """Return ``delegation.enabled_toolsets`` when set, else ``[]``.
+
+    Empty means no default narrowing — children inherit the parent's full
+    enabled set. A non-empty list is the child's requested toolsets
+    (intersected with the parent, then ``inherit_mcp_toolsets``).
+    """
+    raw = _load_config().get("enabled_toolsets")
+    if isinstance(raw, str):
+        items = raw.split(",")
+    elif isinstance(raw, (list, tuple)):
+        items = raw
+    else:
+        return []
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _toolset_static_tools(name: str) -> List[str]:
+    """Return a toolset's static tool names (no registry overlays)."""
+    try:
+        from toolsets import resolve_toolset
+
+        return list(resolve_toolset(name, include_registry=False) or [])
+    except Exception:
+        ts_def = TOOLSETS.get(name) or {}
+        return list(ts_def.get("tools") or [])
+
+
+def _requested_toolsets_present_on_parent(
+    requested: List[str],
+    expanded_parent: set,
+    parent_valid_names,
+) -> List[str]:
+    """Keep requested toolsets the parent actually has.
+
+    Name intersection is the default. If the parent's enabled list uses
+    composites or raw tool names that ``_expand_parent_toolsets`` missed,
+    keep a requested toolset when any of its static tools appear in the
+    parent's already-resolved ``valid_tool_names``.
+    """
+    if isinstance(parent_valid_names, (set, frozenset, list, tuple)):
+        parent_valid = {str(name) for name in parent_valid_names}
+    else:
+        parent_valid = set()
+    kept: List[str] = []
+    for ts in requested:
+        if ts in expanded_parent:
+            kept.append(ts)
+            continue
+        tools = set(_toolset_static_tools(ts))
+        if tools and tools & parent_valid:
+            kept.append(ts)
+    return kept
+
+
+def _restore_requested_tools_from_parent(child, parent, requested_toolsets: List[str]) -> None:
+    """Copy requested tools from the parent if child init dropped them.
+
+    Desktop children have been observed to end up with only ``process``
+    even when ``terminal`` was requested and the parent still has it.
+    Re-attach the parent's already-validated schemas so the leaf can
+    actually run a shell.
+    """
+    if not requested_toolsets or child is None or parent is None:
+        return
+    wanted: set[str] = set()
+    for ts in requested_toolsets:
+        wanted.update(_toolset_static_tools(ts))
+    if not wanted:
+        return
+    parent_by_name = {}
+    for schema in getattr(parent, "tools", None) or []:
+        if not isinstance(schema, dict):
+            continue
+        name = (schema.get("function") or {}).get("name")
+        if name:
+            parent_by_name[str(name)] = schema
+    child_names = {str(n) for n in (getattr(child, "valid_tool_names", None) or [])}
+    missing = [name for name in wanted if name in parent_by_name and name not in child_names]
+    if not missing:
+        return
+    child.tools = list(getattr(child, "tools", None) or [])
+    valid = getattr(child, "valid_tool_names", None)
+    if not isinstance(valid, set):
+        valid = set(valid or [])
+        child.valid_tool_names = valid
+    for name in missing:
+        child.tools.append(parent_by_name[name])
+        valid.add(name)
+    logger.warning(
+        "Restored %s on delegated child from parent (requested toolsets %s)",
+        missing,
+        requested_toolsets,
+    )
+
+
 def _is_mcp_toolset_name(name: str) -> bool:
     """Return True for canonical MCP toolsets and their registered aliases."""
     if not name:
@@ -1540,12 +1636,19 @@ def _build_child_agent(
     else:
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
+    if not toolsets:
+        toolsets = _get_default_child_toolsets()
+
     if toolsets:
         # Intersect with parent — subagent must not gain tools the parent lacks.
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
+        child_toolsets = _requested_toolsets_present_on_parent(
+            toolsets,
+            expanded_parent,
+            getattr(parent_agent, "valid_tool_names", None),
+        )
         if _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
@@ -1873,6 +1976,7 @@ def _build_child_agent(
                 except Exception:
                     pass
             raise
+    _restore_requested_tools_from_parent(child, parent_agent, toolsets or [])
     child._print_fn = getattr(parent_agent, "_print_fn", None)
     # Ownership transfer for the dedicated handle: the child's close() must
     # release it (nothing else holds a reference), and no parent teardown can

--- a/website/docs/guides/delegation-patterns.md
+++ b/website/docs/guides/delegation-patterns.md
@@ -194,7 +194,7 @@ This is often the most efficient pattern: `execute_code` handles the 10+ sequent
 
 ## Inherited Tool Access
 
-Subagents inherit the parent's enabled toolsets. `delegate_task` does not accept a model-facing `toolsets` parameter, so delegated work cannot grant itself capabilities that the parent does not have. Configure the parent's tools before starting the conversation when a delegated task needs web, terminal, file, or other access. Hermes still strips child-blocked tools such as `clarify`, `memory`, and `send_message`; children keep `execute_code` for programmatic tool calling.
+Subagents inherit the parent's enabled toolsets. `delegate_task` does not accept a model-facing `toolsets` parameter, so delegated work cannot grant itself capabilities that the parent does not have. Configure the parent's tools before starting the conversation when a delegated task needs web, terminal, file, or other access. Operators can set `delegation.enabled_toolsets` to a default child subset (intersected with the parent; `inherit_mcp_toolsets` still applies). Hermes still strips child-blocked tools such as `clarify`, `memory`, and `send_message`; children keep `execute_code` for programmatic tool calling.
 
 ---
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -174,6 +174,14 @@ Note that the pin is global: `delegate_task` has no per-task model parameter, so
 
 `delegate_task` does not accept a model-facing `toolsets` parameter. Each subagent inherits the parent's enabled toolsets so the model cannot grant a child capabilities that the parent does not have. Configure the parent's tools before starting the conversation if delegated work needs additional capabilities.
 
+To give every child a narrower default than the parent (for example to drop large MCP schemas from a small local model), set `delegation.enabled_toolsets`. An empty list keeps inherit-everything. A non-empty list is intersected with the parent, then `inherit_mcp_toolsets` is applied — set that to `false` for a strict subset:
+
+```yaml
+delegation:
+  enabled_toolsets: [file, terminal]
+  inherit_mcp_toolsets: false
+```
+
 Certain tools are blocked for subagents even when the parent has them:
 - `delegate_task` — blocked for leaf subagents (the default). Retained for `role="orchestrator"` children, bounded by `max_spawn_depth` — see [Depth Limit and Nested Orchestration](#depth-limit-and-nested-orchestration) below.
 - `clarify` — subagents cannot interact with the user


### PR DESCRIPTION
## Summary

- Add `delegation.enabled_toolsets` as the default child toolset list for `delegate_task` (which has no model-facing `toolsets` argument).
- Empty / unset keeps inherit-everything. A non-empty list is intersected with the parent, then `inherit_mcp_toolsets` is applied.
- If child init still drops a requested tool the parent has (observed: only `process` remained, `terminal` was rejected), restore the parents already-validated schema.

## Motivation

Parent-spawned children inherited the full MCP catalog (~19k tokens) before any task work. `inherit_mcp_toolsets: false` only applied when child toolsets were already explicitly narrowed. There was no config default for that narrowing.

Live measurement on a 64k local subagent model:

- Before: first child prompt ~18930, full MCP catalog
- After: 4639 tokens, `terminal` + file tools; shell probe succeeded

## Changes

- `tools/delegate_tool.py`: `_get_default_child_toolsets()`, parent-valid-name intersection, `_restore_requested_tools_from_parent()`
- `hermes_cli/config_defaults.py`: `delegation.enabled_toolsets: []`
- Docs + example config
- Tests in `tests/tools/test_delegate.py` (`TestDefaultChildToolsets`)

`delegate_task` still does not expose `toolsets` to the model.

## Test Plan

- [x] `pytest tests/tools/test_delegate.py` on the implementation tree
- [x] Manual: `delegation.enabled_toolsets: [file, terminal]` + `inherit_mcp_toolsets: false` on a desktop parent with MCP servers
- [x] Child first prompt dropped from ~19k to ~4.6k
- [x] Child could call `terminal` (not just `process`)
- [ ] CI unit tests

## Notes for Reviewers

- Default is `[]` — no behavior change until the operator sets the list.
- Restore copies schemas from `parent.tools` onto the child list (child list is copied first so the shared tool-definition cache is not mutated).
- Does not add a model-facing `toolsets` argument.
