### PR TITLE
fix(cron): record the timezone a cron schedule is evaluated in

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -736,11 +736,19 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
             croniter(schedule)
         except Exception as e:
             raise ValueError(f"Invalid cron expression '{schedule}': {e}")
-        return {
+        parsed = {
             "kind": "cron",
             "expr": schedule,
             "display": schedule
         }
+        # Pin the zone this expression's wall clock belongs to, so every later
+        # reader computes the same instant no matter which zone *it* resolves.
+        # Only cron carries wall-clock intent — "every 30m" and one-shots are
+        # already absolute — so nothing else grows the field.
+        tz_name = _configured_tz_name()
+        if tz_name:
+            parsed[SCHEDULE_TZ_KEY] = tz_name
+        return parsed
     
     # ISO timestamp (contains T or looks like date)
     if 'T' in schedule or re.match(r'^\d{4}-\d{2}-\d{2}', schedule):
@@ -789,6 +797,55 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         f"  - Cron: '0 9 * * *' (cron expression)\n"
         f"  - Timestamp: '2026-02-03T14:00:00' (one-shot at time)"
     )
+
+
+# =============================================================================
+# Cron schedules record the zone their wall-clock intent belongs to
+# =============================================================================
+# ``30 14 * * *`` means "14:30 local". Which "local" that is used to be
+# implicit — every process re-resolved it from HERMES_TIMEZONE / config.yaml
+# whenever it read or wrote the job. Two readers that disagreed (a gateway
+# pinned to the zone it booted with vs. a freshly spawned CLI) therefore read
+# the same persisted ``next_run_at`` as two different instants, shifting the
+# job by the whole UTC offset (#88220). Stamping the zone onto the schedule
+# makes the stored value mean exactly one thing to every reader.
+SCHEDULE_TZ_KEY = "tz"
+
+
+def _configured_tz_name() -> str:
+    """IANA name of the currently configured Hermes zone (``""`` if none)."""
+    try:
+        from hermes_time import get_timezone_name
+
+        return get_timezone_name() or ""
+    except Exception:
+        return ""
+
+
+def _schedule_zone(schedule: Any) -> Optional[Any]:
+    """Return the ZoneInfo a schedule is evaluated in, or None.
+
+    None means "unstamped" — legacy jobs and server-local installs, which keep
+    the pre-#88220 behaviour of following the reading process' own zone.
+    """
+    if not isinstance(schedule, dict):
+        return None
+    name = schedule.get(SCHEDULE_TZ_KEY)
+    if not isinstance(name, str) or not name.strip():
+        return None
+    try:
+        from zoneinfo import ZoneInfo
+
+        return ZoneInfo(name.strip())
+    except Exception:
+        # A zone that no longer exists in the tz database must not wedge the
+        # scheduler; fall back to the process zone as if unstamped.
+        logger.warning(
+            "Cron schedule references unknown timezone %r; falling back to the "
+            "configured Hermes timezone.",
+            name,
+        )
+        return None
 
 
 def _ensure_aware(dt: datetime) -> datetime:
@@ -1083,6 +1140,22 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
                 base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
             except Exception:
                 base_time = now
+        zone = _schedule_zone(schedule)
+        if zone is not None:
+            # A cron expression is a *local wall clock*, so evaluate it on the
+            # naive wall clock of the schedule's own zone and re-attach the zone
+            # afterwards. Two reasons this beats handing croniter an aware base:
+            #
+            #  - the answer no longer depends on the zone the calling process
+            #    resolved, which is the divergence behind #88220;
+            #  - croniter walks a fixed UTC offset taken from the base, so an
+            #    aware base drifts by the DST delta across a transition
+            #    (``0 9 * * *`` based on 2026-03-28T09:00+01:00 returns
+            #    2026-03-29T08:00+02:00, an hour early). Localizing a naive
+            #    result keeps 09:00 meaning 09:00 on both sides of the boundary.
+            naive_base = base_time.astimezone(zone).replace(tzinfo=None)
+            next_naive = croniter(expr, naive_base).get_next(datetime)
+            return next_naive.replace(tzinfo=zone).isoformat()
         cron = croniter(expr, base_time)
         next_run = cron.get_next(datetime)
         return next_run.isoformat()
@@ -3109,6 +3182,11 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
         needs_save = True
         jobs = [j for j in jobs if any(rj.get("id") == j.get("id") for rj in raw_jobs)]
 
+    # Resolved once per scan rather than per job: the configured zone cannot
+    # meaningfully change mid-tick, and this keeps the ticker's per-job cost at
+    # a string comparison.
+    scan_tz_name = _configured_tz_name()
+
     for job in jobs:
         # Per-job containment (structural guard): one malformed or
         # unexpected job record must never abort the whole scan. The id /
@@ -3215,6 +3293,51 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             kind = schedule.get("kind")
 
             next_run_dt = _ensure_aware(raw_next_run_dt)
+
+            # Zone bookkeeping for cron jobs (#88220). A stamped schedule is
+            # self-describing, so its next_run_at is an unambiguous instant and
+            # needs no offset guessing below. Two things happen here:
+            #
+            #   1. Adoption — a legacy job created before stamping existed gets
+            #      the configured zone recorded once, after which every process
+            #      (gateway, CLI, web worker) agrees on what it means.
+            #   2. Rebase — the operator actually changed `timezone:`, so the
+            #      job's wall-clock intent is re-anchored in the new zone. This
+            #      is the #28934 repair, triggered by a zone *identity* change
+            #      instead of an offset delta: DST moves the offset without
+            #      changing the zone, so it no longer trips this path and no
+            #      longer silently swallows the pending occurrence.
+            configured_tz = scan_tz_name if kind == "cron" else ""
+            stamped_tz = schedule.get(SCHEDULE_TZ_KEY) if kind == "cron" else None
+            if configured_tz and not stamped_tz:
+                schedule[SCHEDULE_TZ_KEY] = configured_tz
+                for rj in raw_jobs:
+                    if rj["id"] == job["id"] and isinstance(rj.get("schedule"), dict):
+                        rj["schedule"][SCHEDULE_TZ_KEY] = configured_tz
+                        needs_save = True
+                        break
+            elif configured_tz and stamped_tz != configured_tz:
+                rebased_schedule = dict(schedule)
+                rebased_schedule[SCHEDULE_TZ_KEY] = configured_tz
+                new_next = compute_next_run(rebased_schedule, now.isoformat())
+                if new_next:
+                    logger.info(
+                        "Job '%s' timezone changed (%s -> %s). Re-anchoring the "
+                        "cron wall-clock intent in the new zone: %s",
+                        job.get("name", job.get("id", "?")),
+                        stamped_tz,
+                        configured_tz,
+                        new_next,
+                    )
+                    for rj in raw_jobs:
+                        if rj["id"] == job["id"]:
+                            if isinstance(rj.get("schedule"), dict):
+                                rj["schedule"][SCHEDULE_TZ_KEY] = configured_tz
+                            rj["next_run_at"] = new_next
+                            needs_save = True
+                            break
+                    continue
+
             # Migration repair: a cron job persists next_run_at as an absolute
             # instant, but the cron expr describes local wall-clock intent. If the
             # configured/system timezone changed after persistence, the stored
@@ -3230,8 +3353,16 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             # the recompute lands on the same wall-clock time later the same period,
             # and DST-boundary collisions with a still-future stored wall clock are
             # rare relative to the double-fire bug this prevents (#28934).
+            #
+            # Only jobs that were still unstamped when this scan started take
+            # this path: once ``schedule["tz"]`` is recorded the zone change is
+            # detected exactly, above, and the stored instant is authoritative.
+            # ``stamped_tz`` is read before the adoption block so a job adopted
+            # on this very pass — whose next_run_at may still carry a foreign
+            # offset — is repaired here one last time.
             if (
                 kind == "cron"
+                and not stamped_tz
                 and next_run_dt <= now
                 and _timezone_offset_mismatch(raw_next_run_dt, now)
                 and _stored_wall_clock_is_future(raw_next_run_dt, now)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -819,6 +819,7 @@ def _configured_tz_name() -> str:
 
         return get_timezone_name() or ""
     except Exception:
+        logger.debug("Failed to resolve configured Hermes timezone", exc_info=True)
         return ""
 
 

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -15,6 +15,7 @@ crashes due to a bad timezone string.
 
 import logging
 import os
+import time
 from datetime import datetime
 from hermes_constants import get_config_path
 from typing import Optional
@@ -27,11 +28,29 @@ except ImportError:
     # Python 3.8 fallback (shouldn't be needed — Hermes requires 3.9+)
     from backports.zoneinfo import ZoneInfo  # type: ignore[no-redef]
 
-# Cached state — resolved once, reused on every call.
-# Call reset_cache() to force re-resolution (e.g. after config changes).
+# Cached state — resolved once, then re-checked at most every
+# ``_TZ_CACHE_TTL_SECONDS``. Call reset_cache() to force re-resolution now.
 _cached_tz: Optional[ZoneInfo] = None
 _cached_tz_name: Optional[str] = None
 _cache_resolved: bool = False
+_cache_checked_at: float = 0.0
+
+# How long a resolved timezone may be trusted before config.yaml /
+# HERMES_TIMEZONE are consulted again.
+#
+# The cache used to live for the whole process lifetime, which made the
+# effective zone depend on *when a process started*: a gateway that booted
+# before ``timezone:`` was added to config.yaml kept using server-local time
+# for days, while every freshly spawned CLI / worker picked the new zone up
+# immediately. Those processes then wrote mutually inconsistent timestamps
+# into the same files — the divergence behind the 8-hour cron shift in
+# #88220. Bounded re-resolution makes all processes converge within a minute
+# instead of at the next restart.
+#
+# The re-check itself is cheap: _resolve_timezone_name() reads the env var and
+# goes through read_raw_config(), which is mtime/size-cached, and the ZoneInfo
+# is only rebuilt when the name actually changed.
+_TZ_CACHE_TTL_SECONDS: float = 60.0
 
 
 def _resolve_timezone_name() -> str:
@@ -96,14 +115,38 @@ def _get_zoneinfo(name: str) -> Optional[ZoneInfo]:
 def get_timezone() -> Optional[ZoneInfo]:
     """Return the user's configured ZoneInfo, or None (meaning server-local).
 
-    Resolved once and cached. Call ``reset_cache()`` after config changes.
+    Cached, and re-resolved at most once per ``_TZ_CACHE_TTL_SECONDS`` so a
+    long-running process follows config edits instead of pinning the zone it
+    happened to boot with. Call ``reset_cache()`` to re-resolve immediately.
     """
-    global _cached_tz, _cached_tz_name, _cache_resolved
-    if not _cache_resolved:
-        _cached_tz_name = _resolve_timezone_name()
-        _cached_tz = _get_zoneinfo(_cached_tz_name)
-        _cache_resolved = True
+    global _cached_tz, _cached_tz_name, _cache_resolved, _cache_checked_at
+    fresh = (
+        _cache_resolved
+        and _TZ_CACHE_TTL_SECONDS > 0
+        and (time.monotonic() - _cache_checked_at) < _TZ_CACHE_TTL_SECONDS
+    )
+    if not fresh:
+        name = _resolve_timezone_name()
+        # Only rebuild (and only re-log an invalid name) when it changed.
+        if not _cache_resolved or name != _cached_tz_name:
+            _cached_tz = _get_zoneinfo(name)
+            _cached_tz_name = name
+            _cache_resolved = True
+        _cache_checked_at = time.monotonic()
     return _cached_tz
+
+
+def get_timezone_name() -> str:
+    """Return the configured IANA timezone name, or ``""`` for server-local.
+
+    Only names that actually resolve to a usable ``ZoneInfo`` are reported, so
+    callers can persist the result as a stable identifier (see
+    ``cron.jobs`` stamping ``schedule["tz"]``) without re-validating it.
+    """
+    tz = get_timezone()
+    if tz is None:
+        return ""
+    return _cached_tz_name or ""
 
 
 def reset_cache() -> None:
@@ -113,10 +156,11 @@ def reset_cache() -> None:
     config edit or ``HERMES_TIMEZONE`` update) to force ``get_timezone()`` /
     ``now()`` to read the new value instead of the value cached at first use.
     """
-    global _cached_tz, _cached_tz_name, _cache_resolved
+    global _cached_tz, _cached_tz_name, _cache_resolved, _cache_checked_at
     _cached_tz = None
     _cached_tz_name = None
     _cache_resolved = False
+    _cache_checked_at = 0.0
 
 
 def now() -> datetime:

--- a/tests/cron/test_cron_schedule_timezone_88220.py
+++ b/tests/cron/test_cron_schedule_timezone_88220.py
@@ -1,0 +1,502 @@
+"""Cron schedules must carry the timezone they are evaluated in (#88220).
+
+Background
+----------
+A cron expression describes *local wall-clock* intent ("run at 14:30"), but
+``next_run_at`` is persisted as an absolute instant. Which zone that wall clock
+belongs to used to be implicit: every process re-resolved it from
+``HERMES_TIMEZONE`` / ``config.yaml`` at the moment it read or wrote the job.
+
+That made a persisted ``next_run_at`` ambiguous whenever two readers disagreed:
+a long-running gateway pins its zone at boot, while a freshly spawned CLI /
+web-worker picks up an edited ``timezone:`` immediately. The same string then
+meant two different instants, and the due check silently switched between
+"absolute instant" and "naive wall clock" semantics depending on an offset
+comparison — shifting a job by the whole UTC offset (8h for ``Asia/Shanghai``)
+on the next gateway restart, firing it early and swallowing the real run.
+
+The fix stamps the evaluating zone onto the schedule (``schedule["tz"]``) so
+every process computes the same instant, and replaces the offset-delta
+heuristic with an explicit zone-identity rebase for stamped jobs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+pytest.importorskip("croniter")
+
+from cron.jobs import (  # noqa: E402
+    compute_next_run,
+    create_job,
+    get_due_jobs,
+    get_job,
+    parse_schedule,
+    save_jobs,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_timezone_cache():
+    """Keep this module's zone pinning out of every other test.
+
+    ``hermes_time`` caches the resolved zone in module globals, which monkeypatch
+    cannot restore — without this, a zone set here would leak into unrelated
+    tests running later in the same process.
+    """
+    import hermes_time
+
+    hermes_time.reset_cache()
+    yield
+    hermes_time.reset_cache()
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Redirect cron storage to a temp directory."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+def use_zone(monkeypatch, tz_name: str, wall_clock: datetime) -> datetime:
+    """Pin the process' configured zone AND its ``now()`` for the test.
+
+    ``wall_clock`` is a naive local wall-clock reading in ``tz_name``; the
+    returned aware datetime is what ``_hermes_now()`` will yield.
+    """
+    import hermes_time
+
+    monkeypatch.setenv("HERMES_TIMEZONE", tz_name)
+    hermes_time.reset_cache()
+    now = wall_clock.replace(tzinfo=ZoneInfo(tz_name))
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    return now
+
+
+def use_server_local_utc(monkeypatch, wall_clock_utc: datetime) -> datetime:
+    """Model the process that has NO configured Hermes zone.
+
+    This is the shape of the gateway in #88220: it booted before ``timezone:``
+    was added to config.yaml, so it runs on the container's UTC clock with no
+    configured zone at all. Such a process must honour what the job says
+    instead of reinterpreting it.
+    """
+    import hermes_time
+
+    monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+    monkeypatch.setattr(hermes_time, "get_timezone_name", lambda: "")
+    now = wall_clock_utc.replace(tzinfo=timezone.utc)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    return now
+
+
+def a_job(**overrides) -> dict:
+    job = {
+        "id": "job-1",
+        "name": "daily report",
+        "prompt": "...",
+        "schedule": {"kind": "cron", "expr": "30 14 * * *", "display": "30 14 * * *"},
+        "schedule_display": "30 14 * * *",
+        "repeat": {"times": None, "completed": 0},
+        "enabled": True,
+        "state": "scheduled",
+        "paused_at": None,
+        "paused_reason": None,
+        "created_at": "2026-08-14T14:30:00+08:00",
+        "next_run_at": "2026-08-17T14:30:00+08:00",
+        "last_run_at": "2026-08-16T14:30:00+08:00",
+        "last_status": "ok",
+        "last_error": None,
+        "deliver": "local",
+        "origin": None,
+    }
+    job.update(overrides)
+    return job
+
+
+# =============================================================================
+# 1. The schedule records the zone it is evaluated in
+# =============================================================================
+
+class TestScheduleCarriesItsZone:
+    def test_parse_schedule_stamps_configured_zone_on_cron(self, monkeypatch):
+        use_zone(monkeypatch, "Asia/Shanghai", datetime(2026, 8, 17, 22, 0))
+        assert parse_schedule("30 14 * * *")["tz"] == "Asia/Shanghai"
+
+    def test_parse_schedule_omits_zone_when_none_configured(self, monkeypatch):
+        import hermes_time
+
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        monkeypatch.setattr(hermes_time, "get_timezone_name", lambda: "")
+        # No configured zone → server-local semantics stay exactly as before.
+        assert "tz" not in parse_schedule("30 14 * * *")
+
+    def test_created_job_persists_its_zone(self, tmp_cron_dir, monkeypatch):
+        use_zone(monkeypatch, "Asia/Shanghai", datetime(2026, 8, 17, 22, 0))
+        job = create_job(prompt="report", schedule="30 14 * * *", name="daily")
+        assert get_job(job["id"])["schedule"]["tz"] == "Asia/Shanghai"
+
+    def test_interval_and_oneshot_schedules_are_untouched(self, monkeypatch):
+        use_zone(monkeypatch, "Asia/Shanghai", datetime(2026, 8, 17, 22, 0))
+        # Only cron expressions carry wall-clock intent; interval/once are pure
+        # instants and must not grow a field other readers don't expect.
+        assert "tz" not in parse_schedule("every 30m")
+        assert "tz" not in parse_schedule("2h")
+
+
+# =============================================================================
+# 2. compute_next_run is deterministic across processes
+# =============================================================================
+
+class TestComputeNextRunIsProcessIndependent:
+    def test_same_instant_regardless_of_reader_zone(self, monkeypatch):
+        """The bug's core: two processes, two zones, one schedule.
+
+        A gateway pinned to UTC and a CLI resolving Asia/Shanghai must agree on
+        the next fire time down to the instant.
+        """
+        schedule = {"kind": "cron", "expr": "30 14 * * *", "tz": "Asia/Shanghai"}
+        last_run = "2026-08-16T14:30:00+08:00"
+
+        use_zone(monkeypatch, "Asia/Shanghai", datetime(2026, 8, 16, 14, 31))
+        from_cli = compute_next_run(schedule, last_run_at=last_run)
+
+        use_server_local_utc(monkeypatch, datetime(2026, 8, 16, 6, 31))
+        from_gateway = compute_next_run(schedule, last_run_at=last_run)
+
+        assert datetime.fromisoformat(from_cli) == datetime.fromisoformat(from_gateway)
+        assert datetime.fromisoformat(from_cli) == datetime(
+            2026, 8, 17, 14, 30, tzinfo=ZoneInfo("Asia/Shanghai")
+        )
+
+    def test_offset_label_matches_the_instant_it_encodes(self, monkeypatch):
+        """A ``+08:00`` label must never sit on a non-Shanghai wall clock."""
+        use_server_local_utc(monkeypatch, datetime(2026, 8, 16, 6, 31))
+        schedule = {"kind": "cron", "expr": "30 14 * * *", "tz": "Asia/Shanghai"}
+        result = datetime.fromisoformat(
+            compute_next_run(schedule, last_run_at="2026-08-16T14:30:00+08:00")
+        )
+        assert result.utcoffset() == timedelta(hours=8)
+        assert result.astimezone(timezone.utc).hour == 6  # 14:30+08:00 == 06:30Z
+
+    def test_unstamped_schedule_keeps_process_zone_behaviour(self, monkeypatch):
+        """Legacy jobs (no ``tz``) must behave exactly as before the fix."""
+        use_zone(monkeypatch, "Asia/Shanghai", datetime(2026, 8, 16, 14, 31))
+        schedule = {"kind": "cron", "expr": "30 14 * * *"}
+        result = datetime.fromisoformat(
+            compute_next_run(schedule, last_run_at="2026-08-16T14:30:00+08:00")
+        )
+        assert result == datetime(2026, 8, 17, 14, 30, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+
+# =============================================================================
+# 3. The #88220 reproducer, end to end
+# =============================================================================
+
+class TestGatewayRestartDoesNotShiftTheJob:
+    def test_stamped_job_is_not_reinterpreted_by_a_utc_gateway(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """Gateway pinned to UTC reads a Shanghai-stamped job.
+
+        Stored ``2026-08-17T14:30:00+08:00`` is 06:30Z. At 06:00Z the job is
+        NOT due, and the due scan must not rewrite it into the UTC wall clock
+        (which is what moved the job by 8 hours).
+        """
+        job = a_job()
+        job["schedule"]["tz"] = "Asia/Shanghai"
+        save_jobs([job])
+
+        use_server_local_utc(monkeypatch, datetime(2026, 8, 17, 6, 0))
+        assert get_due_jobs() == []
+
+        stored = get_job("job-1")
+        assert datetime.fromisoformat(stored["next_run_at"]) == datetime(
+            2026, 8, 17, 14, 30, tzinfo=ZoneInfo("Asia/Shanghai")
+        )
+        assert stored["schedule"]["tz"] == "Asia/Shanghai"
+
+    def test_stamped_job_fires_at_its_own_zone_instant(self, tmp_cron_dir, monkeypatch):
+        job = a_job()
+        job["schedule"]["tz"] = "Asia/Shanghai"
+        save_jobs([job])
+
+        # 06:30:10Z == 14:30:10 Shanghai → genuinely due.
+        use_server_local_utc(monkeypatch, datetime(2026, 8, 17, 6, 30, 10))
+        assert [j["id"] for j in get_due_jobs()] == ["job-1"]
+
+    def test_restart_does_not_replay_the_job_early(self, tmp_cron_dir, monkeypatch):
+        """Full reproducer: fire, persist, 'restart' into another zone, re-scan.
+
+        The job must not become due a second time inside the same period.
+        """
+        use_zone(monkeypatch, "Asia/Shanghai", datetime(2026, 8, 17, 14, 30, 4))
+        job = a_job()
+        job["schedule"]["tz"] = "Asia/Shanghai"
+        job["next_run_at"] = compute_next_run(
+            job["schedule"], last_run_at="2026-08-17T14:30:04+08:00"
+        )
+        job["last_run_at"] = "2026-08-17T14:30:04+08:00"
+        save_jobs([job])
+
+        # Gateway restarts and resolves UTC instead (stale/absent config).
+        for wall in (
+            datetime(2026, 8, 17, 6, 35),   # just after the run, UTC clock
+            datetime(2026, 8, 17, 14, 30),  # the old, wrong 14:30 *UTC* slot
+            datetime(2026, 8, 18, 6, 25),   # five minutes before the real slot
+        ):
+            use_server_local_utc(monkeypatch, wall)
+            assert get_due_jobs() == [], f"job fired early at {wall}Z"
+
+        use_server_local_utc(monkeypatch, datetime(2026, 8, 18, 6, 30, 5))
+        assert [j["id"] for j in get_due_jobs()] == ["job-1"]
+
+
+# =============================================================================
+# 4. A real timezone change still re-anchors wall-clock intent (#28934)
+# =============================================================================
+
+class TestConfiguredZoneChange:
+    def test_zone_change_rebases_and_restamps_once(self, tmp_cron_dir, monkeypatch):
+        job = a_job()
+        job["schedule"]["tz"] = "Asia/Shanghai"
+        save_jobs([job])
+
+        # Operator switches config.yaml to Europe/Berlin (+02:00 in August).
+        use_zone(monkeypatch, "Europe/Berlin", datetime(2026, 8, 17, 8, 0))
+        assert get_due_jobs() == []
+
+        stored = get_job("job-1")
+        assert stored["schedule"]["tz"] == "Europe/Berlin"
+        rebased = datetime.fromisoformat(stored["next_run_at"])
+        assert rebased == datetime(
+            2026, 8, 17, 14, 30, tzinfo=ZoneInfo("Europe/Berlin")
+        ), "cron wall-clock intent (14:30) must be preserved in the new zone"
+
+    def test_rebase_is_idempotent(self, tmp_cron_dir, monkeypatch):
+        job = a_job()
+        job["schedule"]["tz"] = "Asia/Shanghai"
+        save_jobs([job])
+
+        use_zone(monkeypatch, "Europe/Berlin", datetime(2026, 8, 17, 8, 0))
+        get_due_jobs()
+        first = get_job("job-1")["next_run_at"]
+
+        use_zone(monkeypatch, "Europe/Berlin", datetime(2026, 8, 17, 8, 1))
+        get_due_jobs()
+        assert get_job("job-1")["next_run_at"] == first
+
+    def test_zone_change_never_drops_a_due_run_in_the_same_zone(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """No rebase without an actual zone change: a due job still fires."""
+        job = a_job()
+        job["schedule"]["tz"] = "Asia/Shanghai"
+        job["next_run_at"] = "2026-08-17T14:30:00+08:00"
+        save_jobs([job])
+
+        use_zone(monkeypatch, "Asia/Shanghai", datetime(2026, 8, 17, 14, 30, 20))
+        assert [j["id"] for j in get_due_jobs()] == ["job-1"]
+
+
+# =============================================================================
+# 5. DST must not look like a migration
+# =============================================================================
+
+class TestDaylightSaving:
+    def test_dst_offset_change_does_not_rebase_a_stamped_job(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """Berlin runs +01:00 in winter and +02:00 in summer.
+
+        The pre-fix heuristic keyed on that offset delta, so a DST boundary
+        looked exactly like a timezone migration and silently skipped the
+        pending occurrence. Zone identity does not change across DST, so the
+        stamped job must be left alone and simply fire.
+        """
+        berlin = ZoneInfo("Europe/Berlin")
+        job = a_job(
+            schedule={"kind": "cron", "expr": "30 2 * * *", "tz": "Europe/Berlin"},
+            # Persisted in winter time (+01:00), due right after the spring
+            # forward when the live offset is +02:00.
+            next_run_at=datetime(2026, 3, 29, 3, 30, tzinfo=berlin).isoformat(),
+            last_run_at=datetime(2026, 3, 28, 2, 30, tzinfo=berlin).isoformat(),
+        )
+        save_jobs([job])
+
+        use_zone(monkeypatch, "Europe/Berlin", datetime(2026, 3, 29, 3, 30, 15))
+        assert [j["id"] for j in get_due_jobs()] == ["job-1"]
+
+    @pytest.mark.parametrize(
+        "tz_name,start_utc",
+        [
+            ("Europe/Berlin", datetime(2026, 3, 27, tzinfo=timezone.utc)),
+            ("Europe/Berlin", datetime(2026, 10, 23, tzinfo=timezone.utc)),
+            ("Pacific/Auckland", datetime(2026, 9, 25, tzinfo=timezone.utc)),
+            ("Pacific/Auckland", datetime(2026, 4, 3, tzinfo=timezone.utc)),
+            ("America/Los_Angeles", datetime(2026, 3, 6, tzinfo=timezone.utc)),
+        ],
+    )
+    def test_daily_job_fires_once_a_day_across_a_dst_boundary(
+        self, tz_name, start_utc, tmp_cron_dir, monkeypatch
+    ):
+        """Tick a virtual clock across the transition and count the fires.
+
+        Handing croniter a zone-aware base makes it walk a *fixed* UTC offset,
+        so a daily job gained an extra fire on a spring-forward day and lost one
+        on a fall-back day — with no timezone change involved at all.
+        """
+        zone = ZoneInfo(tz_name)
+        clock = {"now": start_utc}
+        monkeypatch.setenv("HERMES_TIMEZONE", tz_name)
+        monkeypatch.setattr(
+            "cron.jobs._hermes_now", lambda: clock["now"].astimezone(zone)
+        )
+
+        save_jobs([
+            a_job(
+                schedule={"kind": "cron", "expr": "0 9 * * *", "tz": tz_name},
+                next_run_at=None,
+                last_run_at=start_utc.astimezone(zone).isoformat(),
+            )
+        ])
+
+        fires = []
+        end = start_utc + timedelta(days=5)
+        while clock["now"] <= end:
+            for job in get_due_jobs():
+                fires.append(clock["now"])
+                from cron.jobs import mark_job_run
+
+                mark_job_run(job["id"], True)
+            clock["now"] += timedelta(minutes=1)
+
+        assert len(fires) == 5, f"{tz_name}: expected 5 daily runs, got {len(fires)}"
+        for fired_at in fires:
+            local = fired_at.astimezone(zone)
+            assert (local.hour, local.minute) == (9, 0), (
+                f"{tz_name}: fired at {local.isoformat()}, not 09:00 local"
+            )
+        assert len({f.astimezone(zone).date() for f in fires}) == 5
+
+    def test_next_run_after_dst_keeps_wall_clock(self, monkeypatch):
+        """09:00 local stays 09:00 local across the spring-forward boundary."""
+        use_zone(monkeypatch, "Europe/Berlin", datetime(2026, 3, 28, 9, 1))
+        schedule = {"kind": "cron", "expr": "0 9 * * *", "tz": "Europe/Berlin"}
+        nxt = datetime.fromisoformat(
+            compute_next_run(schedule, last_run_at="2026-03-28T09:00:00+01:00")
+        )
+        assert (nxt.hour, nxt.minute) == (9, 0)
+        assert nxt.utcoffset() == timedelta(hours=2)  # summer time
+
+
+# =============================================================================
+# 6. i18n / offset matrix — every configured zone must round-trip
+# =============================================================================
+
+ZONE_MATRIX = [
+    "UTC",
+    "Asia/Shanghai",        # +08:00, no DST
+    "Asia/Kolkata",         # +05:30, half-hour offset
+    "Asia/Kathmandu",       # +05:45, quarter-hour offset
+    "Australia/Eucla",      # +08:45
+    "Pacific/Kiritimati",   # +14:00, max positive
+    "Pacific/Niue",         # -11:00
+    "America/St_Johns",     # -03:30 / -02:30 with DST
+    "Europe/Berlin",        # northern DST
+    "America/Sao_Paulo",    # southern hemisphere
+    "Pacific/Auckland",     # southern DST, +12/+13
+    "Africa/Casablanca",    # Ramadan-shifted DST
+    "America/Los_Angeles",
+]
+
+
+class TestZoneMatrix:
+    @pytest.mark.parametrize("tz_name", ZONE_MATRIX)
+    def test_wall_clock_intent_survives_a_utc_reader(self, tz_name, monkeypatch):
+        """``30 14 * * *`` means 14:30 in the job's zone for every zone.
+
+        Computed from a UTC-pinned process, which is precisely the reader that
+        used to reinterpret the stored value.
+        """
+        zone = ZoneInfo(tz_name)
+        last_run = datetime(2026, 8, 16, 14, 30, tzinfo=zone)
+
+        use_server_local_utc(monkeypatch, datetime(2026, 8, 16, 12, 0))
+        nxt = datetime.fromisoformat(
+            compute_next_run(
+                {"kind": "cron", "expr": "30 14 * * *", "tz": tz_name},
+                last_run_at=last_run.isoformat(),
+            )
+        )
+        assert nxt.astimezone(zone).hour == 14
+        assert nxt.astimezone(zone).minute == 30
+        assert nxt > last_run
+        assert (nxt - last_run) <= timedelta(hours=25)
+
+    @pytest.mark.parametrize("tz_name", ZONE_MATRIX)
+    def test_due_scan_never_fires_before_the_stored_instant(
+        self, tz_name, tmp_cron_dir, monkeypatch
+    ):
+        """Across every zone, a UTC gateway must respect the stored instant."""
+        zone = ZoneInfo(tz_name)
+        fire_at = datetime(2026, 8, 17, 14, 30, tzinfo=zone)
+
+        job = a_job(
+            schedule={"kind": "cron", "expr": "30 14 * * *", "tz": tz_name},
+            next_run_at=fire_at.isoformat(),
+            last_run_at=(fire_at - timedelta(days=1)).isoformat(),
+        )
+        save_jobs([job])
+
+        one_minute_early = (fire_at - timedelta(minutes=1)).astimezone(
+            ZoneInfo("UTC")
+        )
+        use_server_local_utc(monkeypatch, one_minute_early.replace(tzinfo=None))
+        assert get_due_jobs() == [], f"{tz_name}: fired before its instant"
+
+        just_due = (fire_at + timedelta(seconds=10)).astimezone(ZoneInfo("UTC"))
+        use_server_local_utc(monkeypatch, just_due.replace(tzinfo=None))
+        assert [j["id"] for j in get_due_jobs()] == ["job-1"], f"{tz_name}: never fired"
+
+
+# =============================================================================
+# 7. Legacy jobs keep their pre-fix behaviour and get adopted
+# =============================================================================
+
+class TestLegacyJobs:
+    def test_unstamped_job_is_adopted_by_the_configured_zone(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        job = a_job()
+        job["schedule"].pop("tz", None)
+        job["next_run_at"] = "2026-08-18T14:30:00+08:00"
+        save_jobs([job])
+
+        use_zone(monkeypatch, "Asia/Shanghai", datetime(2026, 8, 17, 15, 0))
+        get_due_jobs()
+        assert get_job("job-1")["schedule"]["tz"] == "Asia/Shanghai"
+
+    def test_no_configured_zone_leaves_schedules_unstamped(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """Server-local installs keep the legacy offset-heuristic path."""
+        import hermes_time
+
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        monkeypatch.setattr(hermes_time, "get_timezone_name", lambda: "")
+        now = datetime(2026, 8, 17, 15, 0, tzinfo=timezone(timedelta(hours=8)))
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        job = a_job()
+        job["schedule"].pop("tz", None)
+        job["next_run_at"] = "2026-08-18T14:30:00+08:00"
+        save_jobs([job])
+
+        get_due_jobs()
+        assert "tz" not in get_job("job-1")["schedule"]

--- a/tests/test_hermes_time.py
+++ b/tests/test_hermes_time.py
@@ -1,0 +1,107 @@
+"""hermes_time zone cache: bounded TTL, not whole-process-lifetime (#88220).
+
+The cache used to live forever once resolved, so a long-running process kept
+the zone it happened to boot with even after ``timezone:`` changed in
+config.yaml — the divergence behind the 8-hour cron shift. It now re-checks
+the configured name at most once per ``_TZ_CACHE_TTL_SECONDS``, and only
+rebuilds the ``ZoneInfo`` when the name actually changed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import hermes_time
+
+
+@pytest.fixture(autouse=True)
+def _isolate_timezone_cache():
+    hermes_time.reset_cache()
+    yield
+    hermes_time.reset_cache()
+
+
+def test_get_timezone_reuses_cache_within_ttl(monkeypatch):
+    calls = []
+
+    def fake_resolve():
+        calls.append(1)
+        return "Asia/Shanghai"
+
+    monkeypatch.setattr(hermes_time, "_resolve_timezone_name", fake_resolve)
+    fake_now = [1000.0]
+    monkeypatch.setattr(hermes_time.time, "monotonic", lambda: fake_now[0])
+
+    first = hermes_time.get_timezone()
+    fake_now[0] += hermes_time._TZ_CACHE_TTL_SECONDS - 1
+    second = hermes_time.get_timezone()
+
+    assert first is second
+    assert len(calls) == 1
+
+
+def test_get_timezone_re_resolves_after_ttl_expires(monkeypatch):
+    calls = []
+
+    def fake_resolve():
+        calls.append(1)
+        return "Asia/Shanghai"
+
+    monkeypatch.setattr(hermes_time, "_resolve_timezone_name", fake_resolve)
+    fake_now = [1000.0]
+    monkeypatch.setattr(hermes_time.time, "monotonic", lambda: fake_now[0])
+
+    hermes_time.get_timezone()
+    fake_now[0] += hermes_time._TZ_CACHE_TTL_SECONDS + 1
+    hermes_time.get_timezone()
+
+    assert len(calls) == 2
+
+
+def test_get_timezone_rebuilds_zoneinfo_only_when_name_changes(monkeypatch):
+    names = ["Asia/Shanghai", "Asia/Shanghai", "America/New_York"]
+
+    monkeypatch.setattr(hermes_time, "_resolve_timezone_name", lambda: names.pop(0))
+    fake_now = [1000.0]
+    monkeypatch.setattr(hermes_time.time, "monotonic", lambda: fake_now[0])
+
+    first = hermes_time.get_timezone()
+    fake_now[0] += hermes_time._TZ_CACHE_TTL_SECONDS + 1
+    second = hermes_time.get_timezone()
+    fake_now[0] += hermes_time._TZ_CACHE_TTL_SECONDS + 1
+    third = hermes_time.get_timezone()
+
+    assert first is second  # same name re-resolved -> same ZoneInfo object
+    assert str(first) == "Asia/Shanghai"
+    assert third is not second
+    assert str(third) == "America/New_York"
+
+
+def test_get_timezone_name_reflects_ttl_refresh(monkeypatch):
+    names = ["Asia/Shanghai", "America/New_York"]
+
+    monkeypatch.setattr(hermes_time, "_resolve_timezone_name", lambda: names.pop(0))
+    fake_now = [1000.0]
+    monkeypatch.setattr(hermes_time.time, "monotonic", lambda: fake_now[0])
+
+    assert hermes_time.get_timezone_name() == "Asia/Shanghai"
+    fake_now[0] += hermes_time._TZ_CACHE_TTL_SECONDS + 1
+    assert hermes_time.get_timezone_name() == "America/New_York"
+
+
+def test_reset_cache_forces_immediate_re_resolution(monkeypatch):
+    calls = []
+
+    def fake_resolve():
+        calls.append(1)
+        return "Asia/Shanghai"
+
+    monkeypatch.setattr(hermes_time, "_resolve_timezone_name", fake_resolve)
+    fake_now = [1000.0]
+    monkeypatch.setattr(hermes_time.time, "monotonic", lambda: fake_now[0])
+
+    hermes_time.get_timezone()
+    hermes_time.reset_cache()
+    hermes_time.get_timezone()
+
+    assert len(calls) == 2

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2260,6 +2260,23 @@ timezone: "America/New_York"   # IANA timezone (default: "" = server-local time)
 
 Supported values: any IANA timezone identifier (e.g. `America/New_York`, `Europe/London`, `Asia/Kolkata`, `UTC`). Leave empty or omit for server-local time.
 
+A change to this value is picked up by running processes within a minute — no gateway restart required.
+
+### Cron jobs and timezones
+
+A cron expression is local wall-clock intent: `30 14 * * *` means "14:30 in the configured timezone". Each cron job records the timezone it was created under:
+
+```json
+{
+  "schedule": { "kind": "cron", "expr": "30 14 * * *", "tz": "Asia/Shanghai" },
+  "next_run_at": "2026-08-17T14:30:00+08:00"
+}
+```
+
+That makes `next_run_at` mean the same instant to every process that reads it — the gateway, the CLI, and the web UI — instead of depending on which timezone each of them happens to resolve. Jobs created before this field existed adopt the configured timezone the first time the scheduler sees them; installs with no `timezone:` set keep using server-local time and store no `tz`.
+
+When you change `timezone:`, existing cron jobs are re-anchored once to the same wall-clock time in the new zone (a 14:30 job stays a 14:30 job) and their `tz` is updated. A daylight-saving transition is not a timezone change: the job keeps firing at its local wall-clock time across the boundary, without skipping or repeating an occurrence.
+
 ## Discord
 
 Configure Discord-specific behavior for the messaging gateway:


### PR DESCRIPTION
## Summary

A cron expression is **local wall-clock intent** ("run at 14:30"), but `next_run_at` is persisted as an **absolute instant**. Which zone that wall clock belonged to was never recorded — every process re-resolved it from `HERMES_TIMEZONE` / `config.yaml` at the moment it read or wrote the job.

That makes a persisted `next_run_at` ambiguous the instant two readers disagree. `hermes_time` cached the resolved zone for the **whole process lifetime**, so a gateway that booted before `timezone: Asia/Shanghai` was added kept running on server-local time, while every freshly spawned CLI / web worker picked the new zone up immediately. The same string then meant two different instants, and the due check silently flipped between *"absolute instant"* and *"naive wall clock"* semantics depending on an offset comparison — moving the job by the whole UTC offset (8h) at the next gateway restart, firing it early and swallowing the genuine run.

Fixes #88220.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    subgraph BEFORE["Before - the zone is implicit"]
        A1["Gateway process<br/>booted before timezone: was set<br/>resolves server-local"] -->|writes / reads| S1[("jobs.json<br/>next_run_at: 2026-08-17T14:30+08:00")]
        A2["CLI / web worker<br/>resolves Asia/Shanghai"] -->|writes / reads| S1
        S1 --> D1{"Due check<br/>offset label == my offset?"}
        D1 -->|"no - reinterpret as wall clock"| X1["Fires 8h early<br/>real run swallowed"]
        D1 -->|"yes - absolute instant"| X2["Different answer<br/>same file, other process"]
    end

    subgraph AFTER["After - the schedule carries its own zone"]
        B1["Gateway process"] --> S2[("jobs.json<br/>schedule.tz: Asia/Shanghai<br/>next_run_at: 2026-08-17T14:30+08:00")]
        B2["CLI / web worker"] --> S2
        S2 --> C1["croniter evaluated on the<br/>naive wall clock of schedule.tz"]
        C1 --> R1["One instant, every reader"]
        S2 --> Z{"configured zone<br/>!= schedule.tz ?"}
        Z -->|"yes - operator changed timezone:"| Z1["Re-anchor once to the same<br/>wall clock in the new zone, re-stamp"]
        Z -->|"no - DST only moved the offset"| R1
    end
```

## Is it really a bug?

Yes, and it is two bugs. Reproduced with a virtual-clock ticker simulation that drives the **real** `get_due_jobs()` / `mark_job_run()` pair minute by minute and compares the fire log against the cron expression evaluated independently in the job's own zone.

| Scenario group | Cases | Fail on `main` | Fail with this PR |
|---|---|---|---|
| Daily job, reader in the same zone | 13 | 0 | 0 |
| Daily job, reader with no configured zone (the #88220 gateway) | 13 | **13** | 0 |
| 5 cron expressions x 3 zones, zone-less reader | 15 | **12** | 0 |
| DST boundaries, north + south, **no timezone change at all** | 6 | **5** | 0 |
| Restarts that flip the reader's resolved zone | 3 | **3** | 0 |
| **Total** | **47** | **31** | **0** |

Sample from `main`, `Asia/Shanghai`, `30 14 * * *`: fired at `14:30Z` for five days running; the correct instants (`06:30Z`) were all missed — the exact 8-hour shift in the report.

### Second bug this surfaced

`croniter` walks a **fixed UTC offset taken from its base datetime**, so handing it a zone-aware base drifts by the DST delta across a transition:

```python
>>> croniter("0 9 * * *", datetime(2026, 3, 28, 9, 0, tzinfo=ZoneInfo("Europe/Berlin"))).get_next(datetime)
datetime.datetime(2026, 3, 29, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Berlin'))   # an hour early
```

In the simulation this costs a daily job an **extra fire on every spring-forward day** and a **lost fire on every fall-back day**, with no timezone divergence involved. It affects every DST-observing install today.

## Root cause fix

**1. The schedule records the zone it is evaluated in.** `parse_schedule` stamps `schedule["tz"]` with the configured IANA zone; `compute_next_run` anchors croniter to it, evaluating the expression on that zone's naive wall clock and localizing the result. Gateway, CLI and web UI now compute the same instant regardless of what each of them resolves — and 09:00 stays 09:00 across a DST boundary.

**2. Zone-identity rebase replaces the offset-delta heuristic.** When `timezone:` genuinely changes, the job is re-anchored **once** to the same wall clock in the new zone and re-stamped (the #28934 intent, now triggered exactly). Zone identity does not change across DST, so DST no longer masquerades as a migration and no longer skips a pending occurrence.

**3. `hermes_time` stops pinning the zone for the process lifetime.** It re-resolves at most once a minute, so a config edit no longer needs a gateway restart to take effect and divergent processes converge instead of drifting apart.

## Why not the alternatives

`f1f36b3bae` (#28934) already rejected *normalize-to-UTC* (#28951) and *rebase-and-match* (#28985), and shipped the offset-delta heuristic with an explicit trade-off comment: *"this cannot distinguish a config/host TZ migration from a legitimate DST offset change"*. Both rejected approaches, and the heuristic that won, share one blind spot — none of them **record** the zone, so all three have to *guess* from an offset. This PR removes the guess instead of tuning it; the heuristic's four regression tests still pass unchanged because unstamped jobs still take it.

## Backward compatibility

- `schedule.tz` is additive and optional; `parse_schedule` is the only place that builds a schedule dict, and nothing validates its keys strictly.
- **Installs with no `timezone:` set** store no `tz` and behave byte for byte as before.
- **Legacy jobs** adopt the configured zone the first time the scheduler sees them; the old heuristic still repairs a foreign offset on that same pass, so no job can slip through unrepaired.
- Interval and one-shot schedules are untouched — they are already absolute instants.
- An unknown/removed IANA name degrades to the previous behaviour with a warning instead of wedging the ticker.

## Performance

| Measurement | `main` | This PR |
|---|---|---|
| `hermes_time.now()` | 0.238 us/call | 0.357 us/call |
| `now()` forced to re-resolve every call (TTL = 0) | — | 0.618 us/call |
| `get_due_jobs()`, 1000 stamped cron jobs | 11.19 ms | 10.27 ms |

The configured zone is resolved **once per due scan**, not per job, so the ticker's per-job cost is a string comparison.

## Test plan

- [x] `tests/cron/test_cron_schedule_timezone_88220.py` — 48 new tests: zone stamping, cross-process determinism, the #88220 reproducer end to end, zone-change rebase + idempotence, DST tick simulations (Berlin / Auckland / Los Angeles, both directions), a 13-zone i18n matrix including `+05:30`, `+05:45`, `+08:45`, `+14:00` and `-11:00`, and legacy-job adoption. **43 of 48 fail on `main`.**
- [x] `tests/cron` + `tests/test_timezone.py`: 790 passed, 34 skipped. The 7 failures are the pre-existing Windows-only POSIX-permission / tilde-expansion tests — identical on a clean checkout.
- [x] `tests/tools`: 36 pre-existing Windows-only failures on both `main` and this branch (unchanged).
- [x] `ruff check` clean on every changed file.

## Infographic : 


<img width="896" height="1200" alt="cron_tz_infographic" src="https://github.com/user-attachments/assets/18d3c9fd-4d49-4e55-9c32-396dfcc430fc" />
