### PR TITLE
fix(slack): render clarify choices as a numbered list with short buttons

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7098,25 +7098,45 @@ class SlackAdapter(BasePlatformAdapter):
 
             # Escape the Slack mrkdwn control chars (&, <, >) so a question
             # containing them renders literally instead of as markup/mentions.
-            # Section text caps at 3000 chars — budget the question so the
-            # wrapper never pushes the block over the limit (overflow →
-            # invalid_blocks → no buttons).
+            # Section text caps at 3000 chars — budget the numbered list so
+            # the block never overflows (overflow → invalid_blocks → no
+            # buttons). Each choice gets an equal share of the remaining
+            # budget and is truncated with an explicit ellipsis.
             q = (question or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-            body = f"❓ {q}"
+            choice_texts = [
+                str(c).strip() or f"Option {i + 1}"
+                for i, c in enumerate(choices)
+            ]
+            prefix = f"❓ {q}\n\n"
             budget = 3000 - len("...")
+            per_choice_cap = max(24, (budget - len(prefix)) // max(1, len(choice_texts)))
+
+            def _numbered_line(i: int, text: str) -> str:
+                if len(text) > per_choice_cap:
+                    text = text[: max(1, per_choice_cap - 1)] + "…"
+                return f"{i}. {text}"
+
+            body = prefix + "\n".join(
+                _numbered_line(i + 1, t) for i, t in enumerate(choice_texts)
+            )
             if len(body) > budget:
                 body = body[:budget] + "..."
 
-            # One button per choice + a free-text "Other" button.  Slack caps
-            # an actions block at 5 elements; the clarify tool caps choices at
-            # 4 (+ Other = 5) so this is normally one block, but chunk anyway
-            # so a larger choice list degrades gracefully instead of 400ing.
+            # One SHORT button per choice + a free-text "Other" button. The
+            # full choice text lives in the numbered section body above —
+            # Slack mobile ellipsizes button labels so aggressively that
+            # shared-prefix choices were indistinguishable when the label
+            # carried the whole option (#88579); a numeric label always fits.
+            # ``value`` keeps the ``clarify_id|idx`` contract, so selection
+            # semantics are unchanged.  Slack caps an actions block at 5
+            # elements; the clarify tool caps choices at 4 (+ Other = 5) so
+            # this is normally one block, but chunk anyway so a larger choice
+            # list degrades gracefully instead of 400ing.
             elements = []
             for idx, choice in enumerate(choices):
-                label = str(choice).strip() or f"Option {idx + 1}"
                 elements.append({
                     "type": "button",
-                    "text": {"type": "plain_text", "text": label[:75], "emoji": True},
+                    "text": {"type": "plain_text", "text": str(idx + 1), "emoji": True},
                     "action_id": f"hermes_clarify_choice_{idx}",
                     "value": f"{clarify_id}|{idx}",
                 })

--- a/tests/gateway/test_slack_clarify_buttons.py
+++ b/tests/gateway/test_slack_clarify_buttons.py
@@ -116,6 +116,10 @@ class TestSlackSendClarify:
         blocks = kwargs["blocks"]
         assert blocks[0]["type"] == "section"
         assert "Which environment?" in blocks[0]["text"]["text"]
+        # Full choice text lives in the numbered body (#88579) — mobile
+        # ellipsizes button labels, so the buttons carry only the number.
+        assert "1. staging" in blocks[0]["text"]["text"]
+        assert "2. production" in blocks[0]["text"]["text"]
         assert blocks[1]["type"] == "actions"
         elements = blocks[1]["elements"]
         # 2 choices + Other
@@ -124,7 +128,8 @@ class TestSlackSendClarify:
         assert elements[0]["value"] == "cid1|0"
         assert elements[1]["action_id"] == "hermes_clarify_choice_1"
         assert elements[1]["value"] == "cid1|1"
-        assert elements[0]["text"]["text"] == "staging"
+        assert elements[0]["text"]["text"] == "1"
+        assert elements[1]["text"]["text"] == "2"
         # Final button is the free-text "Other"
         assert elements[2]["action_id"] == "hermes_clarify_other"
         assert elements[2]["value"] == "cid1|other"
@@ -132,6 +137,68 @@ class TestSlackSendClarify:
             if block["type"] == "actions":
                 action_ids = [element["action_id"] for element in block["elements"]]
                 assert len(action_ids) == len(set(action_ids))
+
+    @pytest.mark.asyncio
+    async def test_long_shared_prefix_choices_readable_on_mobile(self):
+        """#88579 — long shared-prefix options must stay distinguishable.
+
+        Slack mobile truncates button labels early, so four options that all
+        start the same way rendered as four identical "prefix…" buttons. The
+        numbered body carries every complete choice; the buttons are short
+        numeric labels whose values still resolve to the right index.
+        """
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
+
+        shared = "Deploy the payment-service stack to"
+        choices = [
+            f"{shared} the staging environment with the canary config",
+            f"{shared} the staging environment with the full rollout config",
+            f"{shared} production behind the feature flag",
+            f"{shared} production with an immediate rollback plan",
+        ]
+        result = await adapter.send_clarify(
+            chat_id="C1",
+            question="Which deployment?",
+            choices=choices,
+            clarify_id="cid2",
+            session_key="sk1",
+        )
+        assert result.success is True
+
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        blocks = kwargs["blocks"]
+        body = blocks[0]["text"]["text"]
+        # Every complete choice is present, numbered.
+        for i, choice in enumerate(choices, start=1):
+            assert f"{i}. {choice}" in body
+        # Section stays within Slack's 3000-char block limit.
+        assert len(body) <= 3000
+        # Buttons are short numeric labels; values keep the idx contract.
+        elements = blocks[1]["elements"]
+        assert [e["text"]["text"] for e in elements[:4]] == ["1", "2", "3", "4"]
+        for idx in range(4):
+            assert elements[idx]["action_id"] == f"hermes_clarify_choice_{idx}"
+            assert elements[idx]["value"] == f"cid2|{idx}"
+
+    @pytest.mark.asyncio
+    async def test_huge_choices_are_truncated_within_block_budget(self):
+        """Explicit overflow behavior: each choice is truncated with an
+        ellipsis so the numbered body never exceeds the 3000-char cap."""
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
+
+        huge = ["x" * 2000, "y" * 2000, "z" * 2000]
+        result = await adapter.send_clarify(
+            chat_id="C1", question="Pick", choices=huge,
+            clarify_id="cid3", session_key="sk1",
+        )
+        assert result.success is True
+        body = mock_client.chat_postMessage.call_args[1]["blocks"][0]["text"]["text"]
+        assert len(body) <= 3000
+        assert body.endswith("…") or body.endswith("...")
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Slack mobile ellipsizes Block Kit button labels so aggressively that `clarify` choices sharing a prefix rendered as several indistinguishable `prefix…` buttons — the essential text was unreadable and the options effectively untappable (#88579).

This PR moves the full choice text into the message body as a numbered list (`1. <complete choice>` / `2. …`), and labels the buttons with just their number. Each choice gets an equal share of the section's 3000-char budget and is truncated with an explicit ellipsis on overflow, so the block can never exceed Slack's limit (which would kill the buttons entirely via `invalid_blocks`). Button `value`s keep the `clarify_id|idx` contract and `action_id`s are unchanged, so selection semantics, the double-click guard, and the "Other" text-capture flow behave exactly as before.

## Related Issue

Fixes #88579

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/adapter.py`: `send_clarify` now renders a numbered list of the complete choices in the section body (per-choice budget with ellipsis truncation + final 3000-char guard) and uses short numeric button labels; values/action-ids unchanged
- `tests/gateway/test_slack_clarify_buttons.py`: updated the render contract test (body carries `1. staging` / `2. production`, buttons are `1`/`2`) and added two regression tests per the issue's acceptance check

## How to Test

1. `python -m pytest tests/gateway/test_slack_clarify_buttons.py -q` — Observed result: 7 passed (4 pre-existing incl. the mrkdwn-escape and action-handler suites + 3 new/updated render tests).
2. `python -m pytest tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_plugin_action_handlers.py -q` — Observed result: 25 passed (adjacent Block Kit surfaces unaffected).
3. New tests pin the issue's acceptance criteria: four long shared-prefix choices all appear complete and numbered in the body; button labels are exactly `1`/`2`/`3`/`4`; values resolve to `clarify_id|idx`; and 3×2000-char choices keep the body within the 3000-char cap with an explicit trailing ellipsis.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the Slack clarify + approval + action-handler suites and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config keys or schemas changed; the render block carries comments explaining the mobile-truncation rationale (#88579) and the budget mechanics

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/gateway/test_slack_clarify_buttons.py -q
7 passed in 2.18s
$ python -m pytest tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_plugin_action_handlers.py -q
25 passed in 2.02s
```
