### PR TITLE
fix(skins): stop the CLI crashing on non-hex skins; support terminal-palette colors

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -59,8 +59,15 @@ def _diff_ansi() -> dict[str, str]:
         from hermes_cli.skin_engine import get_active_skin
         skin = get_active_skin()
 
+        from hermes_cli.skin_engine import to_sgr_fg as _skin_sgr_fg
+
         def _hex_fg(key: str, fallback_rgb: tuple[int, int, int]) -> str:
             h = skin.get_color(key, "")
+            # A terminal-native skin names a palette slot instead of a hex
+            # literal; without this branch it would fall to the hardcoded RGB
+            # below and force truecolor back onto a diff the user themed away.
+            if isinstance(h, str) and h.startswith("ansi:"):
+                return _skin_sgr_fg(h)
             if h and len(h) == 7 and h[0] == "#":
                 r, g, b = int(h[1:3], 16), int(h[3:5], 16), int(h[5:7], 16)
                 return f"\033[38;2;{r};{g};{b}m"

--- a/cli.py
+++ b/cli.py
@@ -2779,7 +2779,19 @@ def _hex_to_ansi(hex_color: str, *, bold: bool = False) -> str:
     Auto-remaps known dark-mode-tuned colors to readable light-mode
     equivalents when running on a light terminal (see
     _maybe_remap_for_light_mode + _LIGHT_MODE_REMAP).
+
+    A skin may also ask for one of the terminal's own palette slots
+    (``ansi:*``) or its default (``""``). Those are emitted as 30-37/90-97 /
+    39 — falling through to the hex parser would land on the gold truecolor
+    fallback below and quietly repaint a terminal-native skin.
     """
+    try:
+        from hermes_cli.skin_engine import is_terminal_palette_color, to_sgr_fg
+        if is_terminal_palette_color(hex_color):
+            return to_sgr_fg(hex_color, bold=bold)
+    except Exception:
+        pass  # never let color resolution break a print
+
     hex_color = _maybe_remap_for_light_mode(hex_color)
     try:
         r = int(hex_color[1:3], 16)
@@ -4515,15 +4527,15 @@ HERMES_CADUCEUS = """[#CD7F32]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⡀⠀⣀⣀�
 def _build_compact_banner() -> str:
     """Build a compact banner that fits the current terminal width."""
     try:
-        from hermes_cli.skin_engine import get_active_skin
+        from hermes_cli.skin_engine import get_active_skin, to_rich_color
         _skin = get_active_skin()
     except Exception:
         _skin = None
 
     skin_name = getattr(_skin, "name", "default") if _skin else "default"
-    border_color = _skin.get_color("banner_border", "#FFD700") if _skin else "#FFD700"
-    title_color = _skin.get_color("banner_title", "#FFBF00") if _skin else "#FFBF00"
-    dim_color = _skin.get_color("banner_dim", "#B8860B") if _skin else "#B8860B"
+    border_color = to_rich_color(_skin.get_color("banner_border", "#FFD700")) if _skin else "#FFD700"
+    title_color = to_rich_color(_skin.get_color("banner_title", "#FFBF00")) if _skin else "#FFBF00"
+    dim_color = to_rich_color(_skin.get_color("banner_dim", "#B8860B")) if _skin else "#B8860B"
 
     if skin_name == "default":
         line1 = "⚕ NOUS HERMES - AI Agent Framework"
@@ -7674,15 +7686,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             except Exception:
                 label = "⚕ Hermes"
                 _text_hex = "#FFF8DC"
-            # Build a true-color ANSI escape for the response text color
-            # so streamed content matches the Rich Panel appearance.
+            # Build an ANSI escape for the response text color so streamed
+            # content matches the Rich Panel appearance — truecolor for a hex
+            # skin, a 30-37/90-97 palette code for a terminal-native one.
             try:
-                _r = int(_text_hex[1:3], 16)
-                _g = int(_text_hex[3:5], 16)
-                _b = int(_text_hex[5:7], 16)
-                self._stream_text_ansi = f"\033[38;2;{_r};{_g};{_b}m"
-            except (ValueError, IndexError):
-                self._stream_text_ansi = ""
+                from hermes_cli.skin_engine import is_terminal_palette_color, to_sgr_fg
+                _is_palette = is_terminal_palette_color(_text_hex)
+            except Exception:
+                _is_palette = False
+            if _is_palette:
+                self._stream_text_ansi = to_sgr_fg(_text_hex)
+            else:
+                try:
+                    _r = int(_text_hex[1:3], 16)
+                    _g = int(_text_hex[3:5], 16)
+                    _b = int(_text_hex[5:7], 16)
+                    self._stream_text_ansi = f"\033[38;2;{_r};{_g};{_b}m"
+                except (ValueError, IndexError):
+                    self._stream_text_ansi = ""
             if self.show_timestamps:
                 label = f"{label} {datetime.now().strftime(getattr(self, 'timestamp_format', '%H:%M'))}"
             w = self._scrollback_box_width()
@@ -8911,11 +8932,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Build status line with proper markup — skin-aware colors
         try:
-            from hermes_cli.skin_engine import get_active_skin
+            from hermes_cli.skin_engine import get_active_skin, to_rich_color
             skin = get_active_skin()
-            separator_color = skin.get_color("banner_dim", "#B8860B")
-            accent_color = skin.get_color("ui_accent", "#FFBF00")
-            label_color = skin.get_color("ui_label", "#DAA520")
+            separator_color = to_rich_color(skin.get_color("banner_dim", "#B8860B"))
+            accent_color = to_rich_color(skin.get_color("ui_accent", "#FFBF00"))
+            label_color = to_rich_color(skin.get_color("ui_label", "#DAA520"))
         except Exception:
             separator_color, accent_color, label_color = "#B8860B", "#FFBF00", "cyan"
         toolsets_info = ""
@@ -11373,8 +11394,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     from hermes_cli.tips import get_random_tip
                     _tip = get_random_tip()
                     try:
-                        from hermes_cli.skin_engine import get_active_skin
-                        _tip_color = get_active_skin().get_color("banner_dim", "#B8860B")
+                        from hermes_cli.skin_engine import get_active_skin, to_rich_color
+                        _tip_color = to_rich_color(get_active_skin().get_color("banner_dim", "#B8860B"))
                     except Exception:
                         _tip_color = "#B8860B"
                     cc.print(f"[dim {_tip_color}]✦ Tip: {_tip}[/]")
@@ -11388,8 +11409,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     from hermes_cli.tips import get_random_tip
                     _tip = get_random_tip()
                     try:
-                        from hermes_cli.skin_engine import get_active_skin
-                        _tip_color = get_active_skin().get_color("banner_dim", "#B8860B")
+                        from hermes_cli.skin_engine import get_active_skin, to_rich_color
+                        _tip_color = to_rich_color(get_active_skin().get_color("banner_dim", "#B8860B"))
                     except Exception:
                         _tip_color = "#B8860B"
                     self._console_print(f"[dim {_tip_color}]✦ Tip: {_tip}[/]")
@@ -15996,11 +16017,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if response and not response_previewed:
                 # Use skin engine for label/color with fallback
                 try:
-                    from hermes_cli.skin_engine import get_active_skin
+                    from hermes_cli.skin_engine import get_active_skin, to_rich_color
                     _skin = get_active_skin()
                     label = _skin.get_branding("response_label", "⚕ Hermes")
-                    _resp_color = _maybe_remap_for_light_mode(_skin.get_color("response_border", "#CD7F32"))
-                    _resp_text = _maybe_remap_for_light_mode(_skin.get_color("banner_text", "#FFF8DC"))
+                    _resp_color = to_rich_color(_maybe_remap_for_light_mode(_skin.get_color("response_border", "#CD7F32")))
+                    _resp_text = to_rich_color(_maybe_remap_for_light_mode(_skin.get_color("banner_text", "#FFF8DC")))
                 except Exception:
                     label = "⚕ Hermes"
                     _resp_color = _maybe_remap_for_light_mode("#CD7F32")
@@ -16643,10 +16664,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 self._display_resumed_history()
 
         try:
-            from hermes_cli.skin_engine import get_active_skin
+            from hermes_cli.skin_engine import get_active_skin, to_rich_color
             _welcome_skin = get_active_skin()
             _welcome_text = _welcome_skin.get_branding("welcome", "Welcome to Hermes Agent! Type your message or /help for commands.")
-            _welcome_color = _welcome_skin.get_color("banner_text", "#FFF8DC")
+            _welcome_color = to_rich_color(_welcome_skin.get_color("banner_text", "#FFF8DC"))
         except Exception:
             _welcome_text = "Welcome to Hermes Agent! Type your message or /help for commands."
             _welcome_color = "#FFF8DC"
@@ -16715,7 +16736,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             )
             if not is_seen(self.config, OPENCLAW_RESIDUE_FLAG) and detect_openclaw_residue():
                 try:
-                    _resid_color = _welcome_skin.get_color("banner_dim", "#B8860B")
+                    from hermes_cli.skin_engine import to_rich_color as _to_rich
+                    _resid_color = _to_rich(_welcome_skin.get_color("banner_dim", "#B8860B"))
                 except Exception:
                     _resid_color = "#B8860B"
                 self._console_print(f"[{_resid_color}]{openclaw_residue_hint_cli()}[/]")
@@ -16731,7 +16753,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             from hermes_cli.tips import get_random_tip
             _tip = get_random_tip()
             try:
-                _tip_color = _welcome_skin.get_color("banner_dim", "#B8860B")
+                from hermes_cli.skin_engine import to_rich_color as _to_rich
+                _tip_color = _to_rich(_welcome_skin.get_color("banner_dim", "#B8860B"))
             except Exception:
                 _tip_color = "#B8860B"
             self._console_print(f"[dim {_tip_color}]✦ Tip: {_tip}[/]")

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -55,10 +55,15 @@ def cprint(text: str):
 # =========================================================================
 
 def _skin_color(key: str, fallback: str) -> str:
-    """Get a color from the active skin, or return fallback."""
+    """Get a color from the active skin, ready for rich, or return fallback.
+
+    Every consumer of this helper interpolates the result into rich markup, so
+    the skin's own vocabulary (``ansi:*`` palette slots, ``""`` for the
+    terminal default) is translated here — rich raises on both spellings.
+    """
     try:
-        from hermes_cli.skin_engine import get_active_skin
-        return get_active_skin().get_color(key, fallback)
+        from hermes_cli.skin_engine import get_active_skin, to_rich_color
+        return to_rich_color(get_active_skin().get_color(key, fallback))
     except Exception:
         return fallback
 # =========================================================================

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -875,12 +875,12 @@ class CLIAgentSetupMixin:
         from rich.text import Text
 
         try:
-            from hermes_cli.skin_engine import get_active_skin
+            from hermes_cli.skin_engine import get_active_skin, to_rich_color
             _skin = get_active_skin()
-            _history_text_c = _skin.get_color("banner_text", "#FFF8DC")
-            _session_label_c = _skin.get_color("session_label", "#DAA520")
-            _session_border_c = _skin.get_color("session_border", "#8B8682")
-            _assistant_label_c = _skin.get_color("ui_ok", "#8FBC8F")
+            _history_text_c = to_rich_color(_skin.get_color("banner_text", "#FFF8DC"))
+            _session_label_c = to_rich_color(_skin.get_color("session_label", "#DAA520"))
+            _session_border_c = to_rich_color(_skin.get_color("session_border", "#8B8682"))
+            _assistant_label_c = to_rich_color(_skin.get_color("ui_ok", "#8FBC8F"))
         except Exception:
             _history_text_c = "#FFF8DC"
             _session_label_c = "#DAA520"

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2210,11 +2210,11 @@ class CLICommandsMixin:
                 ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
                 if response:
                     try:
-                        from hermes_cli.skin_engine import get_active_skin
+                        from hermes_cli.skin_engine import get_active_skin, to_rich_color
                         _skin = get_active_skin()
                         label = _skin.get_branding("response_label", "⚕ Hermes")
-                        _resp_color = _maybe_remap_for_light_mode(_skin.get_color("response_border", "#CD7F32"))
-                        _resp_text = _maybe_remap_for_light_mode(_skin.get_color("banner_text", "#FFF8DC"))
+                        _resp_color = to_rich_color(_maybe_remap_for_light_mode(_skin.get_color("response_border", "#CD7F32")))
+                        _resp_text = to_rich_color(_maybe_remap_for_light_mode(_skin.get_color("banner_text", "#FFF8DC")))
                     except Exception:
                         label = "⚕ Hermes"
                         _resp_color = "#CD7F32"

--- a/hermes_cli/journey.py
+++ b/hermes_cli/journey.py
@@ -30,10 +30,14 @@ def _build_payload() -> dict[str, Any]:
 def _primary_hex() -> str:
     """The active skin's primary color (mirrors the TUI theme primary)."""
     try:
-        from hermes_cli.skin_engine import get_active_skin
+        from hermes_cli.skin_engine import get_active_skin, to_rich_color
 
         skin = get_active_skin()
-        return skin.get_color("ui_primary", "") or skin.get_color("banner_title", "#FFD700")
+        # The palette's `primary` reaches rich unfaded (``_fade`` short-circuits
+        # at alpha 1.0), so it has to be spelled the way rich expects.
+        return to_rich_color(
+            skin.get_color("ui_primary", "") or skin.get_color("banner_title", "#FFD700")
+        )
     except Exception:
         return "#FFD700"
 

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -152,6 +152,132 @@ logger = logging.getLogger(__name__)
 
 
 # =============================================================================
+# Terminal-palette color vocabulary
+# =============================================================================
+#
+# A skin value is normally a ``#rrggbb`` literal, but it may also name one of
+# the terminal's own 16 palette slots (``ansi:red``, ``ansi:blueBright``) or
+# ask for the terminal default (``""``). Those two forms are what let a skin
+# inherit the user's terminal theme instead of nailing colors to truecolor.
+#
+# Every rendering engine spells them differently, and none of them accepts the
+# skin's own spelling, so this table is the single source of truth and the
+# adapters below are the only translation layer. Getting it wrong is not
+# always loud: prompt_toolkit calls slot 7 ``ansigray`` and slot 15
+# ``ansiwhite`` — there is no ``ansibrightwhite`` — so a naive
+# ``"ansi" + name.lower()`` mapping raises on white and silently collapses the
+# base/bright pair everywhere else it guesses.
+
+_ANSI_PREFIX = "ansi:"
+
+
+@dataclass(frozen=True)
+class _AnsiSlot:
+    """One of the terminal's 16 palette slots, per rendering engine."""
+    rich: str
+    prompt_toolkit: str
+    sgr_fg: int
+    sgr_bg: int
+
+
+_ANSI_SLOTS: Dict[str, _AnsiSlot] = {
+    "black":         _AnsiSlot("black",          "ansiblack",         30, 40),
+    "red":           _AnsiSlot("red",            "ansired",           31, 41),
+    "green":         _AnsiSlot("green",          "ansigreen",         32, 42),
+    "yellow":        _AnsiSlot("yellow",         "ansiyellow",        33, 43),
+    "blue":          _AnsiSlot("blue",           "ansiblue",          34, 44),
+    "magenta":       _AnsiSlot("magenta",        "ansimagenta",       35, 45),
+    "cyan":          _AnsiSlot("cyan",           "ansicyan",          36, 46),
+    # prompt_toolkit names slot 7 "gray" and reserves "ansiwhite" for slot 15.
+    "white":         _AnsiSlot("white",          "ansigray",          37, 47),
+    "blackBright":   _AnsiSlot("bright_black",   "ansibrightblack",   90, 100),
+    "redBright":     _AnsiSlot("bright_red",     "ansibrightred",     91, 101),
+    "greenBright":   _AnsiSlot("bright_green",   "ansibrightgreen",   92, 102),
+    "yellowBright":  _AnsiSlot("bright_yellow",  "ansibrightyellow",  93, 103),
+    "blueBright":    _AnsiSlot("bright_blue",    "ansibrightblue",    94, 104),
+    "magentaBright": _AnsiSlot("bright_magenta", "ansibrightmagenta", 95, 105),
+    "cyanBright":    _AnsiSlot("bright_cyan",    "ansibrightcyan",    96, 106),
+    # ...and slot 15 is plain "ansiwhite", NOT "ansibrightwhite".
+    "whiteBright":   _AnsiSlot("bright_white",   "ansiwhite",         97, 107),
+}
+
+# SGR codes for "whatever the terminal's default fg/bg is".
+_SGR_DEFAULT_FG = 39
+_SGR_DEFAULT_BG = 49
+
+
+def _ansi_slot(value: Any) -> Optional[_AnsiSlot]:
+    """Resolve an ``ansi:<name>`` token to its slot, or None if it isn't one."""
+    if isinstance(value, str) and value.startswith(_ANSI_PREFIX):
+        return _ANSI_SLOTS.get(value[len(_ANSI_PREFIX):])
+    return None
+
+
+def is_terminal_palette_color(value: Any) -> bool:
+    """True when ``value`` asks for a terminal color rather than a literal one.
+
+    Both ``ansi:*`` (a palette slot) and ``""`` (the terminal default) belong to
+    this vocabulary — including malformed ``ansi:`` tokens, which degrade to the
+    default rather than falling through to a hex parser.
+    """
+    return isinstance(value, str) and (value == "" or value.startswith(_ANSI_PREFIX))
+
+
+def to_rich_color(value: Any) -> str:
+    """Translate a skin color into something ``rich`` can parse.
+
+    ``ansi:*`` becomes rich's palette name (``bright_blue``), ``""`` becomes
+    ``"default"`` (rich raises on the empty string), and everything else —
+    ``#rrggbb`` above all — passes through byte-identically. Unknown slots and
+    non-string junk degrade to the terminal default: a typo in a user's skin
+    must never crash the CLI.
+    """
+    slot = _ansi_slot(value)
+    if slot is not None:
+        return slot.rich
+    if not isinstance(value, str) or value == "" or value.startswith(_ANSI_PREFIX):
+        return "default"
+    return value
+
+
+def to_prompt_toolkit_color(value: Any) -> str:
+    """Translate a skin color into something ``prompt_toolkit`` can parse.
+
+    ``ansi:*`` becomes prompt_toolkit's palette name (``ansibrightblue``, and
+    the ``ansigray``/``ansiwhite`` pair for slots 7 and 15). ``""`` is left
+    exactly as ``""``: prompt_toolkit reads it as "inherit", which is the
+    deliberate default for the typed-input style — rewriting it to
+    ``ansidefault`` would change the cascade. Everything else passes through.
+    """
+    slot = _ansi_slot(value)
+    if slot is not None:
+        return slot.prompt_toolkit
+    if not isinstance(value, str) or value.startswith(_ANSI_PREFIX):
+        return ""
+    return value
+
+
+def to_sgr_fg(value: Any, *, bold: bool = False) -> str:
+    """Foreground SGR escape for a terminal-palette color (30-37 / 90-97).
+
+    Only meaningful for the ``ansi:*`` / ``""`` vocabulary; anything else
+    (including hex) resolves to the terminal default so callers can — and
+    should — check :func:`is_terminal_palette_color` first and keep their own
+    hex path intact.
+    """
+    slot = _ansi_slot(value)
+    code = slot.sgr_fg if slot is not None else _SGR_DEFAULT_FG
+    return f"\033[{'1;' if bold else ''}{code}m"
+
+
+def to_sgr_bg(value: Any) -> str:
+    """Background SGR escape for a terminal-palette color (40-47 / 100-107)."""
+    slot = _ansi_slot(value)
+    code = slot.sgr_bg if slot is not None else _SGR_DEFAULT_BG
+    return f"\033[{code}m"
+
+
+# =============================================================================
 # Skin data structure
 # =============================================================================
 
@@ -1021,6 +1147,26 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
     menu_current_bg = skin.get_color("completion_menu_current_bg", "#333355")
     menu_meta_bg = skin.get_color("completion_menu_meta_bg", menu_bg)
     menu_meta_current_bg = skin.get_color("completion_menu_meta_current_bg", menu_current_bg)
+
+    # Translate the resolved values into prompt_toolkit's color vocabulary
+    # ONCE, here, before they are interpolated into the rules below. Doing it
+    # on the variables rather than on the composed rules covers every rule —
+    # foregrounds and `bg:` fills alike — without teaching each rule about the
+    # `ansi:*` spelling, and keeps hex skins passing through untouched.
+    (
+        prompt, input_rule, title, text, dim, label, warn, error,
+        status_bg, status_text, status_strong, status_dim, status_good,
+        status_warn, status_bad, status_critical, voice_bg,
+        menu_bg, menu_current_bg, menu_meta_bg, menu_meta_current_bg,
+    ) = (
+        to_prompt_toolkit_color(value)
+        for value in (
+            prompt, input_rule, title, text, dim, label, warn, error,
+            status_bg, status_text, status_strong, status_dim, status_good,
+            status_warn, status_bad, status_critical, voice_bg,
+            menu_bg, menu_current_bg, menu_meta_bg, menu_meta_current_bg,
+        )
+    )
 
     return {
         # Typed input always uses terminal default fg/bg so it's

--- a/tests/hermes_cli/test_skin_ansi_colors.py
+++ b/tests/hermes_cli/test_skin_ansi_colors.py
@@ -1,0 +1,236 @@
+"""Contracts for the terminal-palette color adapters in ``skin_engine``.
+
+A skin may spell a color three ways: a ``#rrggbb`` literal, one of the
+terminal's 16 palette slots (``ansi:red``), or ``""`` for the terminal
+default. Rich, prompt_toolkit and raw SGR each name those slots differently
+and none of them accepts the skin's spelling, so these tests assert the
+adapters' *behavior* against the real engines — every produced value is fed
+to ``rich.color.Color.parse`` / ``prompt_toolkit.styles.Style.from_dict``
+rather than compared to a hardcoded string table (which would just restate
+the implementation).
+"""
+import pytest
+
+from hermes_cli.skin_engine import (
+    get_prompt_toolkit_style_overrides,
+    is_terminal_palette_color,
+    to_prompt_toolkit_color,
+    to_rich_color,
+    to_sgr_bg,
+    to_sgr_fg,
+)
+
+# The vocabulary a skin author may write. Kept here (not imported from the
+# implementation) because it IS the contract: these 16 names plus "" must work.
+ANSI_NAMES = [
+    "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
+    "blackBright", "redBright", "greenBright", "yellowBright",
+    "blueBright", "magentaBright", "cyanBright", "whiteBright",
+]
+ANSI_VALUES = [f"ansi:{name}" for name in ANSI_NAMES]
+GARBAGE = ["ansi:chartreuse", "ansi:", "lolnope", None, 123, [], "ANSI:RED"]
+
+
+def _rich_parse(value):
+    from rich.color import Color
+
+    return Color.parse(value)
+
+
+def _ptk_style(value):
+    from prompt_toolkit.styles import Style
+
+    # Both an fg rule and a bg fill: a value that parses as a foreground can
+    # still blow up behind `bg:`.
+    return Style.from_dict({"x": value, "y": f"bg:{value}"})
+
+
+# ---------------------------------------------------------------------------
+# T2 — every engine accepts every value in the vocabulary
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value", ANSI_VALUES + [""])
+def test_rich_accepts_every_terminal_palette_value(value):
+    _rich_parse(to_rich_color(value))
+
+
+@pytest.mark.parametrize("value", ANSI_VALUES + [""])
+def test_prompt_toolkit_accepts_every_terminal_palette_value(value):
+    _ptk_style(to_prompt_toolkit_color(value))
+
+
+@pytest.mark.parametrize("value", ANSI_VALUES + [""])
+def test_sgr_escapes_are_well_formed_palette_codes(value):
+    fg, bg = to_sgr_fg(value), to_sgr_bg(value)
+
+    assert fg.startswith("\033[") and fg.endswith("m")
+    assert bg.startswith("\033[") and bg.endswith("m")
+    fg_code, bg_code = int(fg[2:-1]), int(bg[2:-1])
+    # 30-37/90-97 fg and 40-47/100-107 bg, or the 39/49 defaults. Never a
+    # truecolor (38;2;…) or 256-color (38;5;…) sequence.
+    assert fg_code in {39} | set(range(30, 38)) | set(range(90, 98))
+    assert bg_code in {49} | set(range(40, 48)) | set(range(100, 108))
+
+
+def test_bold_sgr_keeps_the_palette_code():
+    plain, bold = to_sgr_fg("ansi:yellow"), to_sgr_fg("ansi:yellow", bold=True)
+
+    assert bold == plain.replace("\033[", "\033[1;")
+
+
+def test_style_overrides_still_cover_the_whole_prompt_toolkit_ui():
+    # Guards against "fixing" ansi support by deleting the rules that break.
+    assert len(get_prompt_toolkit_style_overrides()) >= 38
+
+
+def test_every_style_override_parses(monkeypatch):
+    from hermes_cli import skin_engine
+    from prompt_toolkit.styles import Style
+
+    # A skin whose every color is a palette slot — the shape D8 ships.
+    skin = skin_engine.load_skin("default")
+    skin.colors = {key: "ansi:cyan" for key in skin.colors}
+    monkeypatch.setattr(skin_engine, "get_active_skin", lambda: skin)
+
+    overrides = get_prompt_toolkit_style_overrides()
+
+    assert overrides  # the fixture actually took effect
+    Style.from_dict(overrides)
+    for rule in overrides.values():
+        assert "ansi:" not in rule
+
+
+# ---------------------------------------------------------------------------
+# T3 — base and bright stay distinct in every engine
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("base", ANSI_NAMES[:8])
+def test_base_and_bright_never_collapse(base):
+    dark, light = f"ansi:{base}", f"ansi:{base}Bright"
+
+    assert to_rich_color(dark) != to_rich_color(light)
+    assert to_prompt_toolkit_color(dark) != to_prompt_toolkit_color(light)
+    assert to_sgr_fg(dark) != to_sgr_fg(light)
+    assert to_sgr_bg(dark) != to_sgr_bg(light)
+
+
+@pytest.mark.parametrize("name", ANSI_NAMES)
+def test_each_slot_is_unique_per_engine(name):
+    # prompt_toolkit names slot 7 `ansigray` and slot 15 `ansiwhite`; a naive
+    # "ansi" + name mapping raises on one and aliases the other.
+    others = [n for n in ANSI_NAMES if n != name]
+
+    assert to_prompt_toolkit_color(f"ansi:{name}") not in {
+        to_prompt_toolkit_color(f"ansi:{o}") for o in others
+    }
+    assert to_rich_color(f"ansi:{name}") not in {to_rich_color(f"ansi:{o}") for o in others}
+
+
+# ---------------------------------------------------------------------------
+# Identity: a hex skin must come out byte-identical
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value", ["#FFD700", "#0e0e12", "#fff8dc", "cyan", "bright_white"])
+def test_non_palette_values_pass_through_unchanged(value):
+    assert to_rich_color(value) == value
+    assert to_prompt_toolkit_color(value) == value
+
+
+def test_empty_string_means_default_in_rich_and_inherit_in_prompt_toolkit():
+    # rich raises on ""; prompt_toolkit reads it as "inherit", which is the
+    # deliberate default for typed input — translating it would change the
+    # cascade.
+    assert to_rich_color("") == "default"
+    assert to_prompt_toolkit_color("") == ""
+    with pytest.raises(Exception):
+        _rich_parse("")
+
+
+# ---------------------------------------------------------------------------
+# T5 — a typo in a user's skin degrades, never raises
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value", GARBAGE)
+def test_adapters_never_raise_on_unknown_input(value):
+    to_rich_color(value)
+    to_prompt_toolkit_color(value)
+    to_sgr_fg(value)
+    to_sgr_bg(value)
+
+
+@pytest.mark.parametrize("value", ["ansi:chartreuse", "ansi:", None, 123, []])
+def test_malformed_palette_slots_still_produce_parseable_output(value):
+    # A typo inside the vocabulary this module owns must not reach an engine
+    # as garbage — it becomes the terminal default.
+    _rich_parse(to_rich_color(value))
+    _ptk_style(to_prompt_toolkit_color(value))
+
+
+@pytest.mark.parametrize("value", ["lolnope", "ANSI:RED"])
+def test_values_outside_the_vocabulary_are_left_verbatim(value):
+    # Not this module's vocabulary (the `ansi:` prefix is case-sensitive, like
+    # the TUI's), so it passes through for the engine to judge — exactly as it
+    # did before terminal colors existed. Rejecting it here would silently eat
+    # rich's own named colors.
+    assert to_rich_color(value) == value
+    assert to_prompt_toolkit_color(value) == value
+
+
+@pytest.mark.parametrize("value", ["ansi:chartreuse", "ansi:", None, 123])
+def test_unknown_palette_slots_degrade_to_the_terminal_default(value):
+    assert to_rich_color(value) == "default"
+    assert to_prompt_toolkit_color(value) == ""
+    assert to_sgr_fg(value) == "\033[39m"
+    assert to_sgr_bg(value) == "\033[49m"
+
+
+# ---------------------------------------------------------------------------
+# Classification: callers use this to decide whether to keep their hex path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value", ANSI_VALUES + ["", "ansi:chartreuse", "ansi:"])
+def test_terminal_palette_values_are_classified_as_such(value):
+    assert is_terminal_palette_color(value) is True
+
+
+@pytest.mark.parametrize("value", ["#FFD700", "cyan", "lolnope", None, 123])
+def test_literal_and_junk_values_are_left_to_the_caller(value):
+    assert is_terminal_palette_color(value) is False
+
+
+# ---------------------------------------------------------------------------
+# Downstream consumers: the CLI's own SGR/rich builders honor the vocabulary
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value", ANSI_VALUES + [""])
+def test_cli_hex_to_ansi_emits_palette_codes_not_truecolor(value):
+    from cli import _hex_to_ansi
+
+    assert "38;2;" not in _hex_to_ansi(value)
+    assert "38;5;" not in _hex_to_ansi(value)
+    assert _hex_to_ansi(value) == to_sgr_fg(value)
+    assert _hex_to_ansi(value, bold=True) == to_sgr_fg(value, bold=True)
+
+
+@pytest.mark.parametrize("value", ["#268bd2", "#FFD700"])
+def test_cli_hex_to_ansi_keeps_the_hex_path_intact(value):
+    from cli import _hex_to_ansi, _maybe_remap_for_light_mode
+
+    r, g, b = (int(_maybe_remap_for_light_mode(value)[i:i + 2], 16) for i in (1, 3, 5))
+    assert _hex_to_ansi(value) == f"\033[38;2;{r};{g};{b}m"
+    assert _hex_to_ansi(value, bold=True) == f"\033[1;38;2;{r};{g};{b}m"
+
+
+def test_diff_colors_follow_a_terminal_palette_skin(monkeypatch):
+    from agent import display
+    from hermes_cli import skin_engine
+
+    skin = skin_engine.load_skin("default")
+    skin.colors = dict(skin.colors, banner_dim="ansi:blackBright", session_label="ansi:blueBright")
+    monkeypatch.setattr(skin_engine, "get_active_skin", lambda: skin)
+    monkeypatch.setattr(display, "_diff_colors_cached", None, raising=False)
+
+    colors = display._diff_ansi()
+
+    assert colors["dim"] == to_sgr_fg("ansi:blackBright")
+    assert colors["file"] == to_sgr_fg("ansi:blueBright")

--- a/ui-tui/src/__tests__/bannerMarkup.test.ts
+++ b/ui-tui/src/__tests__/bannerMarkup.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseRichMarkup } from '../banner.js'
+
+// Banner art is authored once and parsed by TWO renderers: Rich (classic CLI)
+// and this one (TUI). The vocabulary is Rich's, so anything Rich accepts has to
+// survive here — a name this parser does not know is not "no color", it is the
+// whole line leaking its markup into the art.
+describe('parseRichMarkup', () => {
+  it('keeps hex colors untouched', () => {
+    expect(parseRichMarkup('[#B8860B]art[/]')).toEqual([['#B8860B', 'art']])
+  })
+
+  it('maps Rich palette names onto terminal-owned ansi specs', () => {
+    expect(parseRichMarkup('[bright_black]art[/]')).toEqual([['ansi:blackBright', 'art']])
+    expect(parseRichMarkup('[yellow]art[/]')).toEqual([['ansi:yellow', 'art']])
+    expect(parseRichMarkup('[bold yellow]art[/]')).toEqual([['ansi:yellow', 'art']])
+  })
+
+  it('never leaves a recognised tag in the rendered text', () => {
+    for (const tag of ['#B8860B', 'yellow', 'bold yellow', 'bright_cyan', 'dim white']) {
+      const [[, text]] = parseRichMarkup(`[${tag}]▀▀▀[/]`)
+
+      expect(text).toBe('▀▀▀')
+      expect(text).not.toContain('[')
+    }
+  })
+
+  it('distinguishes a base slot from its bright sibling', () => {
+    const [[base]] = parseRichMarkup('[white]a[/]')
+    const [[bright]] = parseRichMarkup('[bright_white]a[/]')
+
+    expect(base).not.toBe(bright)
+  })
+
+  it('falls back to the terminal foreground for an unknown name', () => {
+    // A typo must degrade to a readable line, not print the tag.
+    const [[color, text]] = parseRichMarkup('[chartreuse]art[/]')
+
+    expect(color).toBe('')
+    expect(text).toBe('art')
+  })
+
+  it('emits every art line for multi-line markup', () => {
+    const art = '[bright_black]one[/]\n[yellow]two[/]'
+
+    expect(parseRichMarkup(art)).toEqual([
+      ['ansi:blackBright', 'one'],
+      ['ansi:yellow', 'two']
+    ])
+  })
+})

--- a/ui-tui/src/banner.ts
+++ b/ui-tui/src/banner.ts
@@ -1,6 +1,37 @@
 import type { ThemeColors } from './theme.js'
 
-const RICH_RE = /\[(?:bold\s+)?(?:dim\s+)?(#(?:[0-9a-fA-F]{3,8}))\]([\s\S]*?)(\[\/\])/g
+// Banner art is ONE string consumed by two renderers: Rich (classic CLI) parses
+// it directly, and this parser feeds the TUI. So the tag vocabulary has to be
+// Rich's. A hex-only pattern silently failed the whole line — no match means the
+// line is emitted verbatim, tags and all — which is how a skin authored with
+// terminal-palette names ended up printing "[bright_black]" on screen.
+const RICH_COLOR_NAMES: Record<string, string> = {
+  black: 'ansi:black',
+  red: 'ansi:red',
+  green: 'ansi:green',
+  yellow: 'ansi:yellow',
+  blue: 'ansi:blue',
+  magenta: 'ansi:magenta',
+  cyan: 'ansi:cyan',
+  white: 'ansi:white',
+  bright_black: 'ansi:blackBright',
+  bright_red: 'ansi:redBright',
+  bright_green: 'ansi:greenBright',
+  bright_yellow: 'ansi:yellowBright',
+  bright_blue: 'ansi:blueBright',
+  bright_magenta: 'ansi:magentaBright',
+  bright_cyan: 'ansi:cyanBright',
+  bright_white: 'ansi:whiteBright'
+}
+
+const RICH_RE =
+  /\[(?:bold\s+)?(?:dim\s+)?(#(?:[0-9a-fA-F]{3,8})|[a-z_]+)\]([\s\S]*?)(\[\/\])/g
+
+/** Hex passes through; a Rich palette name becomes the ansi: spec the renderer
+ *  speaks. An unknown name yields '' — the terminal's own foreground — so a typo
+ *  degrades to a readable line instead of leaking the tag into the art. */
+const artColor = (token: string): string =>
+  token.startsWith('#') ? token : (RICH_COLOR_NAMES[token] ?? '')
 
 export function parseRichMarkup(markup: string): Line[] {
   const lines: Line[] = []
@@ -31,7 +62,7 @@ export function parseRichMarkup(markup: string): Line[] {
         lines.push(['', before])
       }
 
-      lines.push([m[1]!, m[2]!])
+      lines.push([artColor(m[1]!), m[2]!])
       cursor = m.index! + m[0].length
     }
 

--- a/ui-tui/src/components/__tests__/textInput.colorize.test.ts
+++ b/ui-tui/src/components/__tests__/textInput.colorize.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import { colorizeEcho, colorizeHint } from '../textInput.js'
+
+const ESC = '\x1b'
+
+// The skin vocabulary this file must understand, with the SGR foreground code
+// each slot maps to. Written out here because it IS the contract — the terminal
+// resolves these to the user's own theme, which is the whole point.
+const SLOTS: Array<[string, number]> = [
+  ['black', 30],
+  ['red', 31],
+  ['green', 32],
+  ['yellow', 33],
+  ['blue', 34],
+  ['magenta', 35],
+  ['cyan', 36],
+  ['white', 37],
+  ['blackBright', 90],
+  ['redBright', 91],
+  ['greenBright', 92],
+  ['yellowBright', 93],
+  ['blueBright', 94],
+  ['magentaBright', 95],
+  ['cyanBright', 96],
+  ['whiteBright', 97],
+]
+
+describe('colorizeHint', () => {
+  it('emits truecolor for a hex skin, byte for byte', () => {
+    expect(colorizeHint('hint', '#ff2d95')).toBe(`${ESC}[38;2;255;45;149mhint${ESC}[39m`)
+    expect(colorizeHint('hint', '#808080')).toBe(`${ESC}[38;2;128;128;128mhint${ESC}[39m`)
+  })
+
+  it('keeps the grey fallback when there is no usable color', () => {
+    const grey = `${ESC}[38;2;128;128;128mhint${ESC}[39m`
+
+    expect(colorizeHint('hint')).toBe(grey)
+    expect(colorizeHint('hint', 'lolnope')).toBe(grey)
+    expect(colorizeHint('hint', '#fff')).toBe(grey)
+    expect(colorizeHint('hint', 'ansi:chartreuse')).toBe(grey)
+  })
+
+  it.each(SLOTS)('maps ansi:%s to its palette code, not truecolor', (name, code) => {
+    const out = colorizeHint('hint', `ansi:${name}`)
+
+    expect(out).toBe(`${ESC}[${code}mhint${ESC}[39m`)
+    expect(out).not.toContain('38;2;')
+    expect(out).not.toContain('38;5;')
+  })
+
+  it('asks for the terminal default fg on an empty color', () => {
+    expect(colorizeHint('hint', '')).toBe(`${ESC}[39mhint${ESC}[39m`)
+  })
+
+  it('never emits a relative attribute (dim or inverse)', () => {
+    const outputs = [
+      colorizeHint('hint'),
+      colorizeHint('hint', ''),
+      colorizeHint('hint', '#808080'),
+      ...SLOTS.map(([name]) => colorizeHint('hint', `ansi:${name}`)),
+    ]
+
+    for (const out of outputs) {
+      expect(out).not.toContain(`${ESC}[2m`)
+      expect(out).not.toContain(`${ESC}[7m`)
+    }
+  })
+})
+
+describe('colorizeEcho', () => {
+  it('passes through when there is nothing explicit to paint with', () => {
+    expect(colorizeEcho('x')).toBe('x')
+    expect(colorizeEcho('x', undefined)).toBe('x')
+    expect(colorizeEcho('x', 'lolnope')).toBe('x')
+    expect(colorizeEcho('x', 'ansi:chartreuse')).toBe('x')
+    expect(colorizeEcho('x', '#fff')).toBe('x')
+  })
+
+  it('still carries the same explicit truecolor for hex skins', () => {
+    expect(colorizeEcho('x', '#ff2d95')).toBe(`${ESC}[38;2;255;45;149mx${ESC}[39m`)
+  })
+
+  it.each(SLOTS)('carries ansi:%s as a palette code', (name, code) => {
+    expect(colorizeEcho('x', `ansi:${name}`)).toBe(`${ESC}[${code}mx${ESC}[39m`)
+  })
+
+  it('agrees with colorizeHint on every color it paints', () => {
+    for (const value of ['#ff2d95', ...SLOTS.map(([name]) => `ansi:${name}`)]) {
+      expect(colorizeEcho('x', value)).toBe(colorizeHint('x', value))
+    }
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -40,11 +40,44 @@ type MinimalEnv = Record<string, string | undefined>
 
 const invert = (s: string) => INV + s + INV_OFF
 
-// Placeholder styling is EXPLICIT truecolor only — never SGR dim/inverse:
+// Placeholder styling is an EXPLICIT color only — never SGR dim/inverse:
 // both are terminal-interpreted relative to the default fg/bg, and on
 // transparent profiles (terminal.background #00000000) they composite
 // against a black RGB the user never sees — the hint rendered as a slab.
+// A palette slot (SGR 30-37/90-97) is explicit in exactly that sense — the
+// terminal looks it up in its own theme, it is not derived from whatever the
+// current cell happens to be — so the rule is "explicit color, never relative
+// attribute", not "truecolor at all costs".
 const HINT_FALLBACK = '#808080'
+
+const ANSI_PREFIX = 'ansi:'
+
+/** The terminal's 16 palette slots, keyed by the skin's `ansi:<name>`
+ *  vocabulary. `darkInk` marks the slots light enough to need black ink when
+ *  used as a chip background (the static stand-in for the hex path's
+ *  luminance test — the slot's real RGB lives in the user's terminal theme
+ *  and is unknowable from here). Mirrors skin_engine.py's table. */
+const ANSI_SLOTS: Record<string, { fg: number; bg: number; darkInk: boolean }> = {
+  black: { fg: 30, bg: 40, darkInk: false },
+  red: { fg: 31, bg: 41, darkInk: false },
+  green: { fg: 32, bg: 42, darkInk: false },
+  yellow: { fg: 33, bg: 43, darkInk: true },
+  blue: { fg: 34, bg: 44, darkInk: false },
+  magenta: { fg: 35, bg: 45, darkInk: false },
+  cyan: { fg: 36, bg: 46, darkInk: false },
+  white: { fg: 37, bg: 47, darkInk: true },
+  blackBright: { fg: 90, bg: 100, darkInk: false },
+  redBright: { fg: 91, bg: 101, darkInk: false },
+  greenBright: { fg: 92, bg: 102, darkInk: true },
+  yellowBright: { fg: 93, bg: 103, darkInk: true },
+  blueBright: { fg: 94, bg: 104, darkInk: false },
+  magentaBright: { fg: 95, bg: 105, darkInk: false },
+  cyanBright: { fg: 96, bg: 106, darkInk: true },
+  whiteBright: { fg: 97, bg: 107, darkInk: true },
+}
+
+const ansiSlot = (color?: string) =>
+  color?.startsWith(ANSI_PREFIX) ? ANSI_SLOTS[color.slice(ANSI_PREFIX.length)] : undefined
 
 const hintRgb = (hex?: string): [number, number, number] => {
   const n = parseInt((/^#([0-9a-f]{6})$/i.exec(hex ?? '')?.[1] ?? HINT_FALLBACK.slice(1)) as string, 16)
@@ -52,11 +85,24 @@ const hintRgb = (hex?: string): [number, number, number] => {
   return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff]
 }
 
-const colorizeHint = (s: string, hex?: string) => {
-  const [r, g, b] = hintRgb(hex)
+/** SGR foreground parameters for a skin color: truecolor for `#rrggbb`, a
+ *  palette code for `ansi:<name>`, 39 (terminal default) for `''`. Anything
+ *  unrecognized keeps today's grey fallback. */
+const hintFgSgr = (color?: string): string => {
+  if (color === '') {
+    return '39'
+  }
 
-  return `${ESC}[38;2;${r};${g};${b}m${s}${ESC}[39m`
+  const slot = ansiSlot(color)
+
+  if (slot) {
+    return String(slot.fg)
+  }
+
+  return `38;2;${hintRgb(color).join(';')}`
 }
+
+export const colorizeHint = (s: string, hex?: string) => `${ESC}[${hintFgSgr(hex)}m${s}${ESC}[39m`
 
 // Typed-text fast-echo must carry the SAME explicit fg the Ink render uses:
 // the bypass writes raw cells, and a default-fg glyph goes invisible the
@@ -64,11 +110,20 @@ const colorizeHint = (s: string, hex?: string) => {
 // skin on a light terminal ⇒ black-on-black). No color ⇒ passthrough, so
 // unthemed inputs keep the terminal default.
 export const colorizeEcho = (s: string, hex?: string) =>
-  /^#[0-9a-f]{6}$/i.test(hex ?? '') ? `${ESC}[38;2;${hintRgb(hex).join(';')}m${s}${ESC}[39m` : s
+  /^#[0-9a-f]{6}$/i.test(hex ?? '') || ansiSlot(hex) ? `${ESC}[${hintFgSgr(hex)}m${s}${ESC}[39m` : s
 
 /** Synthetic placeholder cursor: a hint-colored chip with luminance-picked
- *  ink, standing in for the hidden hardware cursor (bubbles pattern). */
+ *  ink, standing in for the hidden hardware cursor (bubbles pattern).
+ *  Palette slots use a static ink table instead — SGR 7 (inverse) would be
+ *  the obvious shortcut and is exactly the relative attribute this file
+ *  refuses to emit. */
 const hintCursorCell = (ch: string, hex?: string) => {
+  const slot = ansiSlot(hex)
+
+  if (slot) {
+    return `${ESC}[${slot.bg}m${ESC}[${slot.darkInk ? 30 : 97}m${ch}${ESC}[39m${ESC}[49m`
+  }
+
   const [r, g, b] = hintRgb(hex)
   const ink = 0.2126 * r + 0.7152 * g + 0.0722 * b > 140 ? '0;0;0' : '255;255;255'
 

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -46,7 +46,9 @@ display:
 
 ### Colors (`colors:`)
 
-Controls all color values throughout the CLI. Values are hex color strings.
+Controls all color values throughout the CLI. Values are hex color strings —
+or one of the terminal-palette values described in
+[Terminal colors](#terminal-colors-instead-of-hex) below.
 
 | Key | Description | Default (`default` skin) |
 |-----|-------------|--------------------------|
@@ -72,6 +74,48 @@ Controls all color values throughout the CLI. Values are hex color strings.
 | `completion_menu_current_bg` | Background color for the active completion row | `#333355` |
 | `completion_menu_meta_bg` | Background color for the completion meta column | `#1a1a2e` |
 | `completion_menu_meta_current_bg` | Background color for the active completion meta column | `#333355` |
+
+### Terminal colors instead of hex
+
+Any color key also accepts two non-hex values that hand the choice back to the
+terminal, so a skin can follow the user's own theme instead of pinning a
+literal RGB:
+
+| Value | Meaning |
+|-------|---------|
+| `ansi:<name>` | One of the terminal's 16 palette slots — whatever color the user's theme assigns it |
+| `""` (empty string) | The terminal's default foreground/background |
+
+The 16 slot names are `black`, `red`, `green`, `yellow`, `blue`, `magenta`,
+`cyan`, `white` and their bright variants `blackBright`, `redBright`,
+`greenBright`, `yellowBright`, `blueBright`, `magentaBright`, `cyanBright`,
+`whiteBright` (note the camelCase suffix — the names are case-sensitive).
+
+```yaml
+name: terminal
+description: Follows the terminal's own 16-color theme
+
+colors:
+  banner_border: "ansi:blue"
+  banner_title: "ansi:cyanBright"
+  banner_dim: "ansi:blackBright"
+  banner_text: ""            # whatever the terminal uses for normal text
+  ui_ok: "ansi:green"
+  ui_error: "ansi:red"
+```
+
+A skin like this looks correct on a light terminal and a dark one without
+maintaining two palettes, and it stays readable in a terminal profile with a
+transparent or custom background.
+
+**Mixing is fine.** Hex and `ansi:*` can coexist in one skin; each key is
+resolved independently, and hex values are passed through to the renderer
+untouched.
+
+**Typos degrade, they don't crash.** An unknown slot (`ansi:chartreuse`) or a
+malformed value falls back to the terminal's default color for that role. The
+CLI keeps running; you'll just see an unstyled element where you expected a
+colored one.
 
 ### Spinner (`spinner:`)
 


### PR DESCRIPTION
## The bug

A skin that uses anything other than `#rrggbb` **crashes the classic CLI on startup**:

```
rich.errors.MissingStyle: Failed to get style 'ansi:blackBright';
  unable to parse 'ansi:blackbright' as color
```

Raised from `hermes_cli/banner.py` → `console.print(outer_panel)`, reached via
`cli.py::show_banner()`. The TUI renderer has understood `ansi:<name>` since
`ui-tui/packages/hermes-ink/src/ink/colorize.ts`, and `skin_engine` passes values
through untouched, so the vocabulary already reaches Ink — it just kills the CLI.

## Why anyone would author a non-hex skin

To inherit the terminal's palette. A skin that pins hex cannot follow the emulator's
theme, so the agent looks foreign in any terminal the user themes themselves.

## Why it needs adapters and not one value

The three renderers Hermes paints with accept **mutually exclusive** vocabularies —
measured, not assumed:

| value | Rich | prompt_toolkit | chalk/Ink |
|---|---|---|---|
| `bright_black` | ok | **fails** | no color |
| `ansibrightblack` | **fails** | ok | no color |
| `ansi:blackBright` | **fails** | **fails** | **ok** |
| `""` | **fails** | ok | terminal default |

So the skin keeps one canonical vocabulary (`ansi:<name>[Bright]`, `""`) and each
engine gets a pure adapter at its boundary.

## What this changes

- `hermes_cli/skin_engine.py` — canonical slot table plus `to_rich_color`,
  `to_prompt_toolkit_color` and SGR helpers. The prompt_toolkit adapter is applied to
  the resolved variables **before** the rule dict is composed, so all 26 affected
  rules are covered without touching the dict's shape.
- `hermes_cli/banner.py::_skin_color` — one wrap covers the banner's six Rich consumers.
  This is the reported crash.
- `cli.py` — the remaining Rich call sites, plus `_hex_to_ansi`, whose `except` branch
  fell back to a hardcoded gold truecolor for **any** non-hex value.
- `agent/display.py::_hex_fg` — same hardcoded-fallback shape.
- `ui-tui/src/components/textInput.tsx` — the hint/cursor resolved an RGB triple behind a
  hex-only regex, silently pinning the placeholder to `#808080`. It now resolves an
  *escape*, which preserves the original intent stated in the comment there (explicit
  color, never `dim`/`inverse`, which composite wrongly on transparent profiles) while
  no longer forcing truecolor.
- `ui-tui/src/banner.ts` — `parseRichMarkup` matched hex only. Banner art is authored once
  and read by two renderers (Rich for the CLI, this parser for the TUI), so the tag
  vocabulary is Rich's. On a name it did not match, the line matched *nothing* and was
  emitted verbatim, printing `[bright_black]` as literal text across the banner.

## Compatibility

The adapters are the identity for anything that is not `ansi:*` or `""`, so hex skins are
byte-identical. No built-in skin and no palette test changed. Verified by dumping
`colors` + `branding` + `spinner` + `tool_prefix` + `get_prompt_toolkit_style_overrides()`
for all nine built-ins before and after: identical.

An unknown `ansi:*` never raises — it degrades to the terminal's own foreground.

## Tests

`tests/hermes_cli/test_skin_ansi_colors.py` asserts the 16 names + `""` parse in the real
Rich and prompt_toolkit parsers, that a base slot and its bright sibling never collapse
(prompt_toolkit calls slot 7 `ansigray` and slot 15 `ansiwhite`; there is no
`ansibrightwhite`, so a naive map fails silently), and that junk degrades without raising.
`bannerMarkup.test.ts` and `textInput.colorize.test.ts` cover the two renderers.

Beyond the suites, the CLI was launched under a temporary `HERMES_HOME` with an ANSI skin
in a real PTY: it starts, paints, and emits only SGR 30-37/90-97 — no `38;2;` truecolor and
no `38;5;N` with N>15.
