### PR TITLE
feat(tavily): update Tavily integration to support keyless access

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -4022,7 +4022,7 @@ OPTIONAL_ENV_VARS = {
         "advanced": True,
     },
     "TAVILY_API_KEY": {
-        "description": "Tavily API key for AI-native web search and extract",
+        "description": "Tavily API key for AI-native web search and extract (optional — keyless works without it)",
         "prompt": "Tavily API key",
         "url": "https://app.tavily.com/home",
         "tools": ["web_search", "web_extract"],

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -418,6 +418,7 @@ def get_nous_subscription_features(
     # Per-capability overrides: if set, they determine which backend is active for
     # search/extract independently of web.backend.
     web_search_backend = str(web_cfg.get("search_backend") or "").strip().lower()
+    web_extract_backend = str(web_cfg.get("extract_backend") or "").strip().lower()
     tts_provider = str(tts_cfg.get("provider") or "edge").strip().lower()
     # STT default is "local" (faster-whisper) per DEFAULT_CONFIG, which
     # requires `pip install faster-whisper`. For Nous subscribers we'd
@@ -451,6 +452,9 @@ def get_nous_subscription_features(
     direct_firecrawl = bool(get_env_value("FIRECRAWL_API_KEY") or get_env_value("FIRECRAWL_API_URL"))
     direct_parallel = bool(get_env_value("PARALLEL_API_KEY"))
     direct_tavily = bool(get_env_value("TAVILY_API_KEY"))
+    # Keyless Tavily is opt-in: selecting it in `hermes tools` / setup writes
+    # web.backend (or a per-capability override) without requiring a key.
+    tavily_selected = "tavily" in {web_backend, web_search_backend, web_extract_backend}
     direct_searxng = bool(get_env_value("SEARXNG_URL"))
     direct_fal = fal_key_is_configured()
     direct_fal_video = direct_fal  # same FAL_KEY; separate var so use_gateway is independent
@@ -483,6 +487,7 @@ def get_nous_subscription_features(
         direct_exa = False
         direct_parallel = False
         direct_tavily = False
+        tavily_selected = False
     if image_use_gateway:
         direct_fal = False
     if video_use_gateway:
@@ -549,6 +554,7 @@ def get_nous_subscription_features(
         managed_enabled=managed_tools_flag,
     )
 
+    tavily_ready = direct_tavily or tavily_selected
     web_managed = web_backend == "firecrawl" and managed_web_available and not direct_firecrawl
     web_active = bool(
         web_tool_enabled
@@ -557,7 +563,7 @@ def get_nous_subscription_features(
             or (web_backend == "exa" and direct_exa)
             or (web_backend == "firecrawl" and direct_firecrawl)
             or (web_backend == "parallel" and direct_parallel)
-            or (web_backend == "tavily" and direct_tavily)
+            or (web_backend == "tavily" and tavily_ready)
             or (web_backend == "searxng" and direct_searxng)
             # Per-capability overrides: search_backend or extract_backend may be set
             # without web.backend (using the new split config from #20061)
@@ -565,11 +571,17 @@ def get_nous_subscription_features(
             or (web_search_backend == "exa" and direct_exa)
             or (web_search_backend == "firecrawl" and direct_firecrawl)
             or (web_search_backend == "parallel" and direct_parallel)
-            or (web_search_backend == "tavily" and direct_tavily)
+            or (web_search_backend == "tavily" and tavily_ready)
+            or (web_extract_backend == "tavily" and tavily_ready)
         )
     )
     web_available = bool(
-        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_searxng
+        managed_web_available
+        or direct_exa
+        or direct_firecrawl
+        or direct_parallel
+        or tavily_ready
+        or direct_searxng
     )
 
     image_managed = image_tool_enabled and managed_image_available and not direct_fal
@@ -686,8 +698,8 @@ def get_nous_subscription_features(
             managed_by_nous=web_managed,
             direct_override=web_active and not web_managed,
             toolset_enabled=web_tool_enabled,
-            current_provider=web_backend or web_search_backend or "",
-            explicit_configured=bool(web_backend or web_search_backend),
+            current_provider=web_backend or web_search_backend or web_extract_backend or "",
+            explicit_configured=bool(web_backend or web_search_backend or web_extract_backend),
         ),
         "image_gen": NousFeatureState(
             key="image_gen",

--- a/plugins/web/tavily/plugin.yaml
+++ b/plugins/web/tavily/plugin.yaml
@@ -1,6 +1,6 @@
 name: web-tavily
 version: 1.0.0
-description: "Tavily web search + content extraction + crawl. Search + extract are mainstream; crawl is unique to Tavily among built-in providers. Requires TAVILY_API_KEY — sign up at https://app.tavily.com/home."
+description: "Tavily web search + content extraction. Works keyless (rate-limited); set TAVILY_API_KEY for higher limits — https://app.tavily.com/home."
 author: NousResearch
 kind: backend
 provides_web_providers:

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -227,7 +227,7 @@ class TavilyWebSearchProvider(WebSearchProvider):
     def get_setup_schema(self) -> Dict[str, Any]:
         return {
             "name": "Tavily",
-            "badge": "free | key optional",
+            "badge": "free · key optional",
             "tag": "Search + extract. Works keyless; set TAVILY_API_KEY for higher limits.",
             "env_vars": [
                 {

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -17,47 +17,62 @@ Config keys this provider responds to::
 
 Env vars::
 
-    TAVILY_API_KEY=...           # https://app.tavily.com/home (required)
+    TAVILY_API_KEY=...           # https://app.tavily.com/home (optional)
     TAVILY_BASE_URL=...          # optional override of https://api.tavily.com
+
+Auth is header-based. A key uses ``Authorization: Bearer``; without a key
+the request is keyless (``X-Tavily-Access-Mode: keyless``). Both paths
+send ``X-Client-Name: hermes-agent``.
 """
 
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any, Dict, List
+
+import httpx
 
 from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
 
+_CLIENT_NAME = "hermes-agent"
+
+
+def _tavily_headers(api_key: str) -> Dict[str, str]:
+    """Build Tavily request headers for keyed or keyless access."""
+    headers = {"X-Client-Name": _CLIENT_NAME}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    else:
+        headers["X-Tavily-Access-Mode"] = "keyless"
+    return headers
+
 
 def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     """POST to the Tavily API and return the parsed JSON response.
 
-    Mirrors :func:`tools.web_tools._tavily_request`. Raises ``ValueError``
-    when ``TAVILY_API_KEY`` is unset; the caller catches and surfaces as
-    a typed error response.
+    Keyed when ``TAVILY_API_KEY`` is set (Bearer auth); otherwise keyless.
+    Non-2xx responses raise ``ValueError`` with the response body so Tavily's
+    keyless rate-limit / upgrade text reaches the model.
     """
-    import httpx
-
     from agent.web_search_provider import get_provider_env
 
     api_key = get_provider_env("TAVILY_API_KEY")
-    if not api_key:
-        raise ValueError(
-            "TAVILY_API_KEY environment variable not set. "
-            "Get your API key at https://app.tavily.com/home"
-        )
-
     base_url = get_provider_env("TAVILY_BASE_URL") or "https://api.tavily.com"
-    payload = dict(payload)  # don't mutate caller's dict
-    payload["api_key"] = api_key
     url = f"{base_url}/{endpoint.lstrip('/')}"
     logger.info("Tavily %s request to %s", endpoint, url)
 
-    response = httpx.post(url, json=payload, timeout=60)
-    response.raise_for_status()
+    response = httpx.post(
+        url,
+        json=payload,
+        timeout=60,
+        headers=_tavily_headers(api_key),
+    )
+    if response.status_code >= 400:
+        body = (response.text or "").strip()
+        detail = body or f"HTTP {response.status_code}"
+        raise ValueError(detail)
     return response.json()
 
 
@@ -212,12 +227,12 @@ class TavilyWebSearchProvider(WebSearchProvider):
     def get_setup_schema(self) -> Dict[str, Any]:
         return {
             "name": "Tavily",
-            "badge": "paid",
-            "tag": "Search + extract in one provider.",
+            "badge": "free | key optional",
+            "tag": "Search + extract. Works keyless; set TAVILY_API_KEY for higher limits.",
             "env_vars": [
                 {
                     "key": "TAVILY_API_KEY",
-                    "prompt": "Tavily API key",
+                    "prompt": "Tavily API key (optional — keyless works without it)",
                     "url": "https://app.tavily.com/home",
                 },
             ],

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -58,8 +58,67 @@ def test_get_nous_subscription_features_recognizes_direct_exa_backend(monkeypatc
     assert features.web.current_provider == "exa"
 
 
+def test_get_nous_subscription_features_recognizes_keyless_tavily_backend(monkeypatch):
+    """Selecting Tavily in setup/tools counts as available with no API key.
+
+    Mirrors tools.web_tools._is_backend_available('tavily'): keyless is
+    opt-in via web.backend / search_backend / extract_backend, not a
+    silent empty-install default. The setup summary previously required
+    TAVILY_API_KEY and printed a false 'missing' after a skipped key prompt.
+    """
+    monkeypatch.setattr(ns, "get_env_value", lambda name: "")
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda: _account(logged_in=False)
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "web")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+
+    features = ns.get_nous_subscription_features({"web": {"backend": "tavily"}})
+
+    assert features.web.available is True
+    assert features.web.active is True
+    assert features.web.managed_by_nous is False
+    assert features.web.direct_override is True
+    assert features.web.current_provider == "tavily"
+    assert features.web.explicit_configured is True
 
 
+def test_keyless_tavily_search_backend_without_shared_backend(monkeypatch):
+    monkeypatch.setattr(ns, "get_env_value", lambda name: "")
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda: _account(logged_in=False)
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "web")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+
+    features = ns.get_nous_subscription_features(
+        {"web": {"search_backend": "tavily"}}
+    )
+
+    assert features.web.available is True
+    assert features.web.active is True
+    assert features.web.current_provider == "tavily"
+
+
+def test_unconfigured_web_without_keys_is_unavailable(monkeypatch):
+    monkeypatch.setattr(ns, "get_env_value", lambda name: "")
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda: _account(logged_in=False)
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "web")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+
+    features = ns.get_nous_subscription_features({})
+
+    assert features.web.available is False
+    assert features.web.active is False
+    assert features.web.explicit_configured is False
 def _stub_browser_probes(monkeypatch, *, has_agent_browser, chromium, lightpanda=False):
     """Common monkeypatches for local-browser readiness scenarios.
 

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -197,18 +197,37 @@ class TestUnconfiguredErrorEnvelopeParity:
         from tools import web_tools
 
         self._clear_web_creds(monkeypatch)
-        # Reset firecrawl client cache so the unconfigured state is re-evaluated
         monkeypatch.setattr(web_tools, "_firecrawl_client", None, raising=False)
         monkeypatch.setattr(web_tools, "_firecrawl_client_config", None, raising=False)
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
 
         result = json.loads(web_tools.web_search_tool("hello world", limit=3))
         assert "error" in result, f"expected top-level 'error' key, got {result}"
-        # ``Error searching web:`` prefix comes from web_tools' top-level except handler
         assert "Error searching web:" in result["error"]
         assert "FIRECRAWL_API_KEY" in result["error"]
-        # No per-result burying
+        assert "results" not in result
+
+
+    def test_explicit_firecrawl_unconfigured_emits_top_level_error(self, monkeypatch):
+        """``web.backend: firecrawl`` with no creds still uses the Firecrawl
+        error envelope — keyless Tavily must not silently take over.
+        """
+        from tools import web_tools
+
+        self._clear_web_creds(monkeypatch)
+        monkeypatch.setattr(web_tools, "_firecrawl_client", None, raising=False)
+        monkeypatch.setattr(web_tools, "_firecrawl_client_config", None, raising=False)
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "firecrawl"})
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+        monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: False)
+
+        result = json.loads(web_tools.web_search_tool("hello world", limit=3))
+        assert "error" in result, f"expected top-level 'error' key, got {result}"
+        assert "Error searching web:" in result["error"]
+        assert "FIRECRAWL_API_KEY" in result["error"]
         assert "results" not in result
 
 
@@ -311,6 +330,10 @@ class TestDispatchersTriggerPluginDiscovery:
                 web_tools, "_load_web_config",
                 lambda: {"extract_backend": "firecrawl"},
             )
+            monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+            async def _allow_ssrf(_url: str) -> bool:
+                return True
+            monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_ssrf)
             # Sanity: registry IS empty before the tool call.
             assert web_search_registry.get_provider("firecrawl") is None
 

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -219,7 +219,9 @@ class TestBackendSelection:
         """No keys, no config → 'firecrawl' (will fail at client init)."""
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch("tools.web_tools._ddgs_package_importable", return_value=False):
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=False), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False), \
+             patch("tools.web_tools._list_registered_web_providers", return_value=[]):
             assert _get_backend() == "firecrawl"
 
     def test_invalid_config_falls_through_to_fallback(self):
@@ -638,6 +640,28 @@ class TestSiblingProvidersEnvResolution:
                 f"{cls_name}.is_available() ignored {env_key} from the "
                 "config-aware env layer (get_env_value)"
             )
+
+    def test_tavily_request_reads_key_via_get_env_value(self, monkeypatch):
+        """Keyed Tavily must Bearer-auth with a key that lives only in .env."""
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": []}
+        mock_response.text = "{}"
+
+        with patch(
+            "hermes_cli.config.get_env_value",
+            side_effect=lambda k: "tvly-from-dotenv" if k == "TAVILY_API_KEY" else None,
+        ), patch(
+            "plugins.web.tavily.provider.httpx.post", return_value=mock_response
+        ) as mock_post:
+            from plugins.web.tavily.provider import _tavily_request
+
+            _tavily_request("search", {"query": "q"})
+            headers = mock_post.call_args.kwargs["headers"]
+            assert headers["Authorization"] == "Bearer tvly-from-dotenv"
+            assert headers["X-Client-Name"] == "hermes-agent"
+            assert "X-Tavily-Access-Mode" not in headers
 
 
     def test_get_provider_env_unset_returns_empty(self, monkeypatch):

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -1,10 +1,11 @@
 """Tests for Tavily web backend integration.
 
 Coverage:
-  _tavily_request() — API key handling, endpoint construction, error propagation.
+  _tavily_request() — keyed Bearer vs keyless header, attribution, error bodies.
   _normalize_tavily_search_results() — search response normalization.
   _normalize_tavily_documents() — extract response normalization, failed_results.
   web_search_tool / web_extract_tool — Tavily dispatch paths.
+  auto-detect ranking — keyed paid-band; keyless only when Tavily is selected.
 """
 
 import json
@@ -16,49 +17,72 @@ from unittest.mock import patch, MagicMock
 from tests.tools.conftest import register_all_web_providers
 
 
+def _ok_response(payload=None):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = payload if payload is not None else {"results": []}
+    mock_response.text = json.dumps(mock_response.json.return_value)
+    return mock_response
+
+
 # ─── _tavily_request ─────────────────────────────────────────────────────────
 
 class TestTavilyRequest:
     """Test suite for the _tavily_request helper."""
 
-    def test_raises_without_api_key(self):
-        """No TAVILY_API_KEY → ValueError with guidance."""
+    def test_keyless_when_no_api_key(self):
+        """No TAVILY_API_KEY → keyless header, no Authorization, no body key."""
+        mock_response = _ok_response()
+
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("TAVILY_API_KEY", None)
-            from tools.web_tools import _tavily_request
-            with pytest.raises(ValueError, match="TAVILY_API_KEY"):
+            with patch("plugins.web.tavily.provider.httpx.post", return_value=mock_response) as mock_post:
+                from plugins.web.tavily.provider import _tavily_request
                 _tavily_request("search", {"query": "test"})
 
-    def test_posts_with_api_key_in_body(self):
-        """api_key is injected into the JSON payload."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"results": []}
-        mock_response.raise_for_status = MagicMock()
+                mock_post.assert_called_once()
+                headers = mock_post.call_args.kwargs["headers"]
+                payload = mock_post.call_args.kwargs["json"]
+                assert headers["X-Client-Name"] == "hermes-agent"
+                assert headers["X-Tavily-Access-Mode"] == "keyless"
+                assert "Authorization" not in headers
+                assert "api_key" not in payload
+                assert payload["query"] == "test"
+                assert "api.tavily.com/search" in mock_post.call_args.args[0]
+
+    def test_keyed_uses_bearer_not_body(self):
+        """TAVILY_API_KEY → Bearer auth, attribution, no body api_key."""
+        mock_response = _ok_response()
 
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test-key"}):
-            with patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post:
-                from tools.web_tools import _tavily_request
-                result = _tavily_request("search", {"query": "hello"})
+            with patch("plugins.web.tavily.provider.httpx.post", return_value=mock_response) as mock_post:
+                from plugins.web.tavily.provider import _tavily_request
+                _tavily_request("search", {"query": "hello"})
 
                 mock_post.assert_called_once()
-                call_kwargs = mock_post.call_args
-                payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
-                assert payload["api_key"] == "tvly-test-key"
+                headers = mock_post.call_args.kwargs["headers"]
+                payload = mock_post.call_args.kwargs["json"]
+                assert headers == {
+                    "X-Client-Name": "hermes-agent",
+                    "Authorization": "Bearer tvly-test-key",
+                }
+                assert "X-Tavily-Access-Mode" not in headers
+                assert "api_key" not in payload
                 assert payload["query"] == "hello"
-                assert "api.tavily.com/search" in call_kwargs.args[0]
+                assert "api.tavily.com/search" in mock_post.call_args.args[0]
 
-    def test_raises_on_http_error(self):
-        """Non-2xx responses propagate as httpx.HTTPStatusError."""
-        import httpx as _httpx
+    def test_http_error_surfaces_response_body(self):
+        """Non-2xx responses raise ValueError with Tavily's response body."""
         mock_response = MagicMock()
-        mock_response.raise_for_status.side_effect = _httpx.HTTPStatusError(
-            "401 Unauthorized", request=MagicMock(), response=mock_response
-        )
+        mock_response.status_code = 429
+        mock_response.text = "Rate limit hit. Sign up for a free API key at https://app.tavily.com"
+        mock_response.json.return_value = {}
 
-        with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-bad-key"}):
-            with patch("tools.web_tools.httpx.post", return_value=mock_response):
-                from tools.web_tools import _tavily_request
-                with pytest.raises(_httpx.HTTPStatusError):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TAVILY_API_KEY", None)
+            with patch("plugins.web.tavily.provider.httpx.post", return_value=mock_response):
+                from plugins.web.tavily.provider import _tavily_request
+                with pytest.raises(ValueError, match="Rate limit hit"):
                     _tavily_request("search", {"query": "test"})
 
 
@@ -98,7 +122,7 @@ class TestNormalizeTavilySearchResults:
 # ─── _normalize_tavily_documents ──────────────────────────────────────────────
 
 class TestNormalizeTavilyDocuments:
-    """Test extract/crawl document normalization."""
+    """Test extract document normalization."""
 
     def test_basic_document(self):
         from tools.web_tools import _normalize_tavily_documents
@@ -125,6 +149,78 @@ class TestNormalizeTavilyDocuments:
         assert docs[0]["url"] == "https://fallback.com"
 
 
+# ─── availability / auto-detect ───────────────────────────────────────────────
+
+class TestTavilyAvailability:
+    """Keyed Tavily stays in the paid band; keyless only when selected."""
+
+    def test_is_available_without_key(self):
+        from plugins.web.tavily.provider import TavilyWebSearchProvider
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TAVILY_API_KEY", None)
+            assert TavilyWebSearchProvider().is_available() is False
+
+    def test_is_backend_available_without_key(self):
+        from tools.web_tools import _is_backend_available
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TAVILY_API_KEY", None)
+            assert _is_backend_available("tavily") is False
+
+    def test_is_backend_available_when_configured_without_key(self):
+        from tools.web_tools import _is_backend_available
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "tavily"}), \
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TAVILY_API_KEY", None)
+            assert _is_backend_available("tavily") is True
+
+    def test_keyless_does_not_preempt_managed_firecrawl(self):
+        """No TAVILY_API_KEY + Nous gateway ready → firecrawl, not keyless tavily."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=True), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False):
+            os.environ.pop("TAVILY_API_KEY", None)
+            assert _get_backend() == "firecrawl"
+
+    def test_keyless_does_not_preempt_ddgs(self):
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=False), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=True):
+            os.environ.pop("TAVILY_API_KEY", None)
+            assert _get_backend() == "ddgs"
+
+    def test_no_keys_defaults_to_firecrawl(self):
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=False), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False), \
+             patch("tools.web_tools._list_registered_web_providers", return_value=[]):
+            os.environ.pop("TAVILY_API_KEY", None)
+            assert _get_backend() == "firecrawl"
+
+    def test_explicit_search_backend_tavily_without_key(self):
+        """web.search_backend=tavily sticks even with no TAVILY_API_KEY."""
+        from tools.web_tools import _get_search_backend
+        with patch("tools.web_tools._load_web_config",
+                   return_value={"backend": "firecrawl", "search_backend": "tavily"}), \
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=True):
+            os.environ.pop("TAVILY_API_KEY", None)
+            assert _get_search_backend() == "tavily"
+
+    def test_check_web_api_key_when_tavily_configured_without_key(self):
+        from tools.web_tools import check_web_api_key
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "tavily"}), \
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=False), \
+             patch("tools.web_tools.check_firecrawl_api_key", return_value=False), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False), \
+             patch("agent.web_search_registry.get_active_search_provider", return_value=None), \
+             patch("agent.web_search_registry.get_active_extract_provider", return_value=None):
+            os.environ.pop("TAVILY_API_KEY", None)
+            assert check_web_api_key() is True
+
+
 # ─── web_search_tool (Tavily dispatch) ────────────────────────────────────────
 
 class TestWebSearchTavily:
@@ -140,21 +236,35 @@ class TestWebSearchTavily:
         _reset_for_tests()
 
     def test_search_dispatches_to_tavily(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
+        mock_response = _ok_response({
             "results": [{"title": "Result", "url": "https://r.com", "content": "desc", "score": 0.9}]
-        }
-        mock_response.raise_for_status = MagicMock()
+        })
 
         with patch("tools.web_tools._get_backend", return_value="tavily"), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
-             patch("tools.web_tools.httpx.post", return_value=mock_response), \
+             patch("plugins.web.tavily.provider.httpx.post", return_value=mock_response), \
              patch("tools.interrupt.is_interrupted", return_value=False):
             from tools.web_tools import web_search_tool
             result = json.loads(web_search_tool("test query", limit=3))
             assert result["success"] is True
             assert len(result["data"]["web"]) == 1
             assert result["data"]["web"][0]["title"] == "Result"
+
+    def test_search_keyless_dispatch(self):
+        mock_response = _ok_response({
+            "results": [{"title": "Result", "url": "https://r.com", "content": "desc"}]
+        })
+
+        with patch("tools.web_tools._get_backend", return_value="tavily"), \
+             patch("plugins.web.tavily.provider.httpx.post", return_value=mock_response) as mock_post, \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            os.environ.pop("TAVILY_API_KEY", None)
+            from tools.web_tools import web_search_tool
+            result = json.loads(web_search_tool("test query"))
+            assert result["success"] is True
+            headers = mock_post.call_args.kwargs["headers"]
+            assert headers["X-Tavily-Access-Mode"] == "keyless"
+            assert headers["X-Client-Name"] == "hermes-agent"
 
 
 # ─── web_extract_tool (Tavily dispatch) ───────────────────────────────────────
@@ -172,15 +282,17 @@ class TestWebExtractTavily:
         _reset_for_tests()
 
     def test_extract_dispatches_to_tavily(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
+        mock_response = _ok_response({
             "results": [{"url": "https://example.com", "raw_content": "Extracted content", "title": "Page"}]
-        }
-        mock_response.raise_for_status = MagicMock()
+        })
+
+        async def _allow_ssrf(_url: str) -> bool:
+            return True
 
         with patch("tools.web_tools._get_backend", return_value="tavily"), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
-             patch("tools.web_tools.httpx.post", return_value=mock_response):
+             patch("plugins.web.tavily.provider.httpx.post", return_value=mock_response), \
+             patch("tools.web_tools.async_is_safe_url", _allow_ssrf):
             from tools.web_tools import web_extract_tool
             result = json.loads(asyncio.get_event_loop().run_until_complete(
                 web_extract_tool(["https://example.com"])
@@ -189,4 +301,3 @@ class TestWebExtractTavily:
             assert len(result["results"]) == 1
             assert result["results"][0]["url"] == "https://example.com"
             assert "Extracted content" in result["results"][0]["content"]
-

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -308,6 +308,14 @@ def _get_capability_backend(capability: str) -> str:
     return _get_backend()
 
 
+def _tavily_explicitly_configured() -> bool:
+    cfg = _load_web_config()
+    return any(
+        (cfg.get(key) or "").lower().strip() == "tavily"
+        for key in ("backend", "search_backend", "extract_backend")
+    )
+
+
 def _is_backend_available(backend: str) -> bool:
     """Return True when the selected backend is currently usable.
 
@@ -332,7 +340,7 @@ def _is_backend_available(backend: str) -> bool:
     if backend == "firecrawl":
         return check_firecrawl_api_key()
     if backend == "tavily":
-        return _has_env("TAVILY_API_KEY")
+        return _has_env("TAVILY_API_KEY") or _tavily_explicitly_configured()
     if backend == "searxng":
         return _has_env("SEARXNG_URL")
     if backend == "brave-free":
@@ -1113,7 +1121,10 @@ if __name__ == "__main__":
         elif backend == "parallel":
             print("   Using Parallel API (https://parallel.ai)")
         elif backend == "tavily":
-            print("   Using Tavily API (https://tavily.com)")
+            if _has_env("TAVILY_API_KEY"):
+                print("   Using Tavily API (https://tavily.com)")
+            else:
+                print("   Using Tavily keyless (https://docs.tavily.com/documentation/keyless)")
         elif backend == "searxng":
             print(f"   Using SearXNG (search only): {_env_value('SEARXNG_URL')}")
         elif backend == "brave-free":

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -34,7 +34,7 @@ The `web_search` and `web_extract` tools support eight backend providers, config
 | **SearXNG** | `SEARXNG_URL` | ✔ | — | — |
 | **Brave** (free tier) | `BRAVE_SEARCH_API_KEY` | ✔ | — | — |
 | **DuckDuckGo** (ddgs) | _(none)_ | ✔ | — | — |
-| **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | ✔ |
+| **Tavily** | `TAVILY_API_KEY` (optional) | ✔ | ✔ | — |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | — |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — |
 | **xAI** | `XAI_API_KEY` | ✔ | — | — |
@@ -46,7 +46,7 @@ web:
   backend: firecrawl    # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai
 ```
 
-If `web.backend` is not set, the backend is auto-detected from whichever API key is available. Self-hosted Firecrawl is also supported via `FIRECRAWL_API_URL`.
+If `web.backend` is not set, the backend is auto-detected from whichever API key is available. Self-hosted Firecrawl is also supported via `FIRECRAWL_API_URL`. Selecting Tavily in `hermes tools` works without a key.
 
 ## Browser Automation
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -140,7 +140,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `PARALLEL_API_KEY` | AI-native web search ([parallel.ai](https://parallel.ai/)) |
 | `FIRECRAWL_API_KEY` | Web scraping and cloud browser ([firecrawl.dev](https://firecrawl.dev/)) |
 | `FIRECRAWL_API_URL` | Custom Firecrawl API endpoint for self-hosted instances (optional) |
-| `TAVILY_API_KEY` | Tavily API key for AI-native web search, extract, and crawl ([app.tavily.com](https://app.tavily.com/home)) |
+| `TAVILY_API_KEY` | Optional Tavily API key for higher search/extract limits. After selecting Tavily as the web backend, keyless access works without it ([app.tavily.com](https://app.tavily.com/home), [keyless docs](https://docs.tavily.com/documentation/keyless)) |
 | `SEARXNG_URL` | SearXNG instance URL for free self-hosted web search — no API key required ([searxng.github.io](https://searxng.github.io/searxng/)) |
 | `TAVILY_BASE_URL` | Override the Tavily API endpoint. Useful for corporate proxies and self-hosted Tavily-compatible search backends. Same pattern as `GROQ_BASE_URL`. |
 | `EXA_API_KEY` | Exa API key for AI-native web search and contents ([exa.ai](https://exa.ai/)) |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2203,10 +2203,10 @@ web:
 | **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ |
 | **SearXNG** | `SEARXNG_URL` | ✔ | — |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ |
-| **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ |
+| **Tavily** | `TAVILY_API_KEY` (optional) | ✔ | ✔ |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ |
 
-**Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys. If only `SEARXNG_URL` is set, SearXNG is used. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. Otherwise Firecrawl is the default.
+**Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys. If only `SEARXNG_URL` is set, SearXNG is used. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. Otherwise Firecrawl is the default. Selecting Tavily in `hermes tools` (or `web.backend: tavily`) works without a key.
 
 **SearXNG** is a free, self-hosted, privacy-respecting metasearch engine that queries 70+ search engines. No API key needed — just set `SEARXNG_URL` to your instance (e.g., `http://localhost:8080`). SearXNG is search-only; `web_extract` requires a separate extract provider (set `web.extract_backend`). See the [Web Search setup guide](/user-guide/features/web-search) for Docker setup instructions.
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -22,7 +22,7 @@ Both are configured through a single backend selection. Providers are chosen via
 | **SearXNG** | `SEARXNG_URL` | ✔ | — | ✔ Free (self-hosted) |
 | **Brave Search (free tier)** | `BRAVE_SEARCH_API_KEY` | ✔ | — | 2 000 queries/mo |
 | **DDGS (DuckDuckGo)** | — (no key) | ✔ | — | ✔ Free |
-| **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | 1 000 searches/mo |
+| **Tavily** | `TAVILY_API_KEY` (optional) | ✔ | ✔ | Keyless when selected, or 1 000 searches/mo with a free key |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | 1 000 searches/mo |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | Paid |
 | **xAI (Grok)** | `XAI_API_KEY` or `hermes auth add xai-oauth` | ✔ | — | Paid (SuperGrok or per-token) |
@@ -233,14 +233,17 @@ With this config, Hermes uses SearXNG for all search queries and Firecrawl for U
 
 ### Tavily
 
-AI-optimised search and extract with a generous free tier.
+AI-optimised search and extract. Select Tavily in `hermes tools` (or set `web.backend: tavily`) to use it **keyless** with no account (rate-limited). Set an API key when you want higher limits.
 
 ```bash
+# optional — skip this for keyless access after selecting Tavily
 # ~/.hermes/.env
 TAVILY_API_KEY=tvly-your-key-here
 ```
 
-Get a key at [app.tavily.com](https://app.tavily.com/home). The free tier includes 1 000 searches/month.
+Get a key at [app.tavily.com](https://app.tavily.com/home). See [Tavily keyless](https://docs.tavily.com/documentation/keyless).
+
+Empty installs keep Firecrawl as the named default. Keyless Tavily is not auto-selected.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Tavily Search and Extract now support **keyed and keyless** auth, with Hermes attribution on every request.

- **Keyed** (`TAVILY_API_KEY` set): `Authorization: Bearer …` + `X-Client-Name: hermes-agent`
- **Keyless** (no key): `X-Tavily-Access-Mode: keyless` + `X-Client-Name: hermes-agent`

Keyless is **opt-in**. It runs only when the user selected Tavily (`web.backend` / `search_backend` / `extract_backend: tavily`), including picking Tavily in `hermes tools` and skipping the key prompt. Empty installs stay on Firecrawl as the named default; `web_search` / `web_extract` stay gated until a real backend is configured. Keyed Tavily still ranks first in auto-detect.

Non-2xx Tavily responses surface the response body (rate-limit / upgrade text) instead of a bare HTTP status. The stale “crawl” claim is dropped from `plugin.yaml` — crawl was removed in #33824.

Supersedes #84561 (attribution header only).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/web/tavily/provider.py` — Bearer vs keyless headers; `X-Client-Name: hermes-agent`; error body on HTTP ≥400; optional-key setup schema
- `tools/web_tools.py` — keyed Tavily still paid-band; `_is_backend_available("tavily")` true with a key **or** explicit Tavily config; empty auto-detect still returns `firecrawl`
- `plugins/web/tavily/plugin.yaml` — drop crawl; key optional
- `hermes_cli/config_defaults.py` — `TAVILY_API_KEY` described as optional
- Docs: `website/docs/user-guide/features/web-search.md`, `configuration.md`, `integrations/index.md`, `reference/environment-variables.md`
- Tests: keyed/keyless request headers, empty-install Firecrawl default, explicit `web.search_backend: tavily` without a key

## How to Test

1. `scripts/run_tests.sh tests/tools/test_web_tools_tavily.py tests/tools/test_web_tools_config.py tests/tools/test_web_providers.py tests/tools/test_web_providers_searxng.py tests/plugins/web/test_web_search_provider_plugins.py`
2. Isolated keyless smoke (no `TAVILY_API_KEY` in env **or** `.env`)
3. Confirm empty install (no `web.backend`, no keys) does **not** call Tavily.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the touched test files
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A