### PR TITLE
feat(tui): render each tool's own icon instead of a generic bullet

### DIFF
--- a/tests/agent/test_display_emoji.py
+++ b/tests/agent/test_display_emoji.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch as mock_patch, MagicMock
 
+import pytest
+
 from agent.display import get_tool_emoji
 
 
@@ -11,6 +13,36 @@ class TestGetToolEmoji:
 
 
 
+
+    def test_unknown_tool_falls_back_to_the_bolt(self):
+        """A tool with no skin override and no registry emoji gets ⚡."""
+        with mock_patch("agent.display._get_skin", return_value=None):
+            mock_reg = MagicMock()
+            mock_reg.get_emoji.return_value = ""
+            import sys
+            mock_module = MagicMock()
+            mock_module.registry = mock_reg
+            with mock_patch.dict(sys.modules, {"tools.registry": mock_module}):
+                assert get_tool_emoji("no_such_tool_anywhere") == "⚡"
+
+    @pytest.mark.parametrize("bad_name", [None, ""])
+    def test_missing_tool_name_does_not_raise(self, bad_name):
+        """Resolution is presentation — a missing name degrades, never raises.
+
+        Both the skin lookup and the registry lookup must tolerate it, so this
+        exercises a skin that HAS overrides (dict.get with None) plus a
+        registry that rejects the key outright.
+        """
+        skin = MagicMock()
+        skin.tool_emojis = {"terminal": "⚔"}
+        mock_reg = MagicMock()
+        mock_reg.get_emoji.side_effect = TypeError("unhashable")
+        import sys
+        mock_module = MagicMock()
+        mock_module.registry = mock_reg
+        with mock_patch("agent.display._get_skin", return_value=skin), \
+             mock_patch.dict(sys.modules, {"tools.registry": mock_module}):
+            assert get_tool_emoji(bad_name) == "⚡"
 
     def test_custom_default(self):
         """Custom default is returned when nothing matches."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2642,6 +2642,134 @@ def test_tool_start_ships_full_args(monkeypatch):
     assert "args" not in events[1][2]
 
 
+def _capture_tool_events(monkeypatch, sid: str) -> list[tuple[str, str, dict]]:
+    events: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(
+        server, "_emit", lambda event_type, s, payload: events.append((event_type, s, payload))
+    )
+    monkeypatch.setitem(
+        server._sessions,
+        sid,
+        {"tool_progress_mode": "all", "tool_started_at": {}},
+    )
+    return events
+
+
+# Tools whose icon the classic CLI has always drawn, so the TUI must too. This
+# is a floor, not a catalog: it asserts these tools ship a REAL glyph rather
+# than the unknown-tool fallback. The glyphs themselves are never frozen here --
+# `tools/*.py` owns them, and an upstream release that adds a tool or retunes an
+# emoji must not turn into a red test for behaviour that is still correct.
+CORE_ICON_TOOLS = ("terminal", "read_file", "patch", "cronjob", "skill_view", "memory")
+
+TOOL_ICON_FALLBACK = "⚡"
+
+
+def _registered_tools_with_icons():
+    """Every registered tool that declares an emoji, straight from the registry."""
+    import model_tools  # noqa: F401  -- triggers tools/*.py auto-discovery
+    from tools.registry import registry
+
+    names = sorted(getattr(registry, "_tools", {}))
+
+    return [(n, registry.get_emoji(n, default="")) for n in names if registry.get_emoji(n, default="")]
+
+
+def test_tui_tool_start_ships_the_registry_icon_for_every_registered_tool(monkeypatch):
+    # The TUI used to draw a generic bullet for EVERY tool row. The icon is
+    # resolved once server-side (skin -> registry -> fallback) and shipped on the
+    # wire, so the renderer never needs a tool->icon table of its own.
+    #
+    # Sweeping the whole registry (not a hand-picked few) is the point: a tool
+    # added by a future release is covered the moment it declares an emoji, with
+    # no edit here. The assertion is the relationship registry->event, so it
+    # survives any glyph change upstream.
+    tools = _registered_tools_with_icons()
+
+    assert len(tools) > 20, "registry looks unpopulated; auto-discovery probably did not run"
+
+    events = _capture_tool_events(monkeypatch, "icon-start")
+
+    mismatched = []
+    for index, (tool_name, expected) in enumerate(tools):
+        events.clear()
+        server._on_tool_start("icon-start", f"tool-{index}", tool_name, {})
+        if not events or events[0][0] != "tool.start" or events[0][2].get("icon") != expected:
+            mismatched.append((tool_name, expected, events[0][2].get("icon") if events else None))
+
+    assert not mismatched, f"tool.start icon != registry emoji for: {mismatched}"
+
+
+@pytest.mark.parametrize("tool_name", CORE_ICON_TOOLS)
+def test_tui_core_tools_ship_a_real_icon_not_the_fallback(monkeypatch, tool_name):
+    # Guards the regression that started this work: a core tool rendering the
+    # generic marker instead of its own glyph. Checks identity with the CLI's
+    # helper rather than a frozen literal.
+    import model_tools  # noqa: F401
+    from agent.display import get_tool_emoji
+
+    events = _capture_tool_events(monkeypatch, "icon-core")
+
+    server._on_tool_start("icon-core", "tool-1", tool_name, {})
+
+    icon = events[0][2]["icon"]
+    assert icon == get_tool_emoji(tool_name)
+    assert icon != TOOL_ICON_FALLBACK, f"{tool_name} lost its icon and fell back to the bolt"
+
+
+def test_tui_tool_icon_matches_the_shared_display_helper(monkeypatch):
+    # Parity contract, independent of which glyphs are configured: whatever
+    # `get_tool_emoji` resolves (including a skin override) is exactly what the
+    # event carries. One source of truth, asserted as a relationship.
+    from agent import display
+
+    monkeypatch.setattr(display, "_get_skin", lambda: None)
+    monkeypatch.setattr(display, "get_tool_emoji", lambda name, default="⚡": f"<{name}>")
+
+    events = _capture_tool_events(monkeypatch, "icon-parity")
+
+    server._on_tool_start("icon-parity", "tool-1", "terminal", {})
+    server._on_tool_complete("icon-parity", "tool-1", "terminal", {}, "ok")
+
+    assert events[0][2]["icon"] == "<terminal>"
+    assert events[1][2]["icon"] == "<terminal>"
+
+
+def test_tui_tool_complete_repeats_the_icon_for_a_client_that_missed_the_start(monkeypatch):
+    # A client that attached mid-call never saw tool.start, so tool.complete
+    # has to carry the glyph too or the completed row degrades to the fallback
+    # while the live row showed the real icon.
+    import model_tools  # noqa: F401
+    from agent.display import get_tool_emoji
+
+    events = _capture_tool_events(monkeypatch, "icon-complete")
+
+    server._on_tool_complete("icon-complete", "tool-1", "read_file", {}, "contents")
+
+    assert events[0][0] == "tool.complete"
+    assert events[0][2]["icon"] == get_tool_emoji("read_file")
+    assert events[0][2]["icon"] != TOOL_ICON_FALLBACK
+
+
+def test_tui_tool_icon_falls_back_for_an_unregistered_tool():
+    # An MCP/plugin tool with no registry emoji still gets a glyph, never an
+    # empty string the renderer would have to special-case.
+    assert server._tool_icon("no_such_tool_anywhere") == "⚡"
+
+
+@pytest.mark.parametrize("bad_name", [None, ""])
+def test_tui_tool_icon_survives_a_missing_tool_name(bad_name):
+    # Icon resolution is presentation, never a reason to break a tool call.
+    assert server._tool_icon(bad_name) == "⚡"
+
+
+def test_tui_tool_icon_survives_an_unavailable_display_module(monkeypatch):
+    # Stripped-down embeddings may not import agent.display at all.
+    monkeypatch.setitem(sys.modules, "agent.display", None)
+
+    assert server._tool_icon("terminal") == "⚡"
+
+
 def test_tool_ctx_sends_an_arg_preview_not_a_phrased_label():
     # Clients phrase their own verb around this string: the TUI renders
     # `Terminal("<ctx>")` and the desktop prepends "Running"/"Ran". Sending a

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5806,6 +5806,24 @@ def _tool_summary(name: str, result: str, duration_s: float | None) -> str | Non
     return f"{text}{suffix}" if text else None
 
 
+def _tool_icon(name: str | None) -> str:
+    """Canonical display icon for *name*, resolved by the ONE source of truth.
+
+    ``agent.display.get_tool_emoji`` already owns the skin ``tool_emojis`` →
+    registry ``emoji`` → ``⚡`` fallback chain that the classic CLI renders
+    with; the TUI must show the same glyph, so it ships the resolved icon on
+    the wire instead of letting the renderer keep its own tool→icon table.
+    Never raises: a missing name (or an import failure in a stripped-down
+    embedding) degrades to the same ``⚡`` the helper falls back to.
+    """
+    try:
+        from agent.display import get_tool_emoji
+
+        return get_tool_emoji(name or "")
+    except Exception:
+        return "⚡"
+
+
 def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
     session = _sessions.get(sid)
     if session is not None:
@@ -5823,6 +5841,7 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
             "tool_id": tool_call_id,
             "name": name,
             "context": _tool_ctx(name, args),
+            "icon": _tool_icon(name),
         }
         # The desktop renders the expanded tool row (the `$` transcript) from
         # the args of the part, and `context` is an 80-char display preview.
@@ -5841,7 +5860,16 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
 
 
 def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result: str):
-    payload = {"tool_id": tool_call_id, "name": name, "args": args}
+    # `icon` rides on BOTH lifecycle events on purpose: a client that attached
+    # mid-call (reconnect, `session.resume`) never saw tool.start, so without
+    # it the completed row would fall back to ⚡ while the live row two frames
+    # earlier showed the real glyph.
+    payload = {
+        "tool_id": tool_call_id,
+        "name": name,
+        "args": args,
+        "icon": _tool_icon(name),
+    }
     session = _sessions.get(sid)
     snapshot = None
     started_at = None
@@ -6019,6 +6047,8 @@ def _on_tool_progress(
             payload["output_tail"] = list(_kwargs["output_tail"])  # list of dicts
         if name:
             payload["tool_name"] = str(name)
+            if event_type == "subagent.tool":
+                payload["icon"] = _tool_icon(str(name))
         if preview:
             payload["text"] = str(preview)
         if _kwargs.get("status"):
@@ -6112,10 +6142,14 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
             if st["open_tool"]:
                 _emit("tool.complete", csid, st["open_tool"])
             st["seq"] += 1
+            mirrored_name = str(payload.get("tool_name") or "tool")
             tool = {
-                "name": str(payload.get("tool_name") or "tool"),
+                "name": mirrored_name,
                 "tool_id": f"submirror:{child_key}:{st['seq']}",
                 "args": {},
+                # Same payload is replayed as the mirror's tool.complete, so
+                # the child window's completed row keeps the glyph too.
+                "icon": str(payload.get("icon") or _tool_icon(mirrored_name)),
             }
             if preview := str(payload.get("tool_preview") or payload.get("text") or ""):
                 tool["preview"] = preview

--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -280,10 +280,10 @@ Primary event types the client handles today:
 | `status.update`            | `{ kind, text }`                                                            |
 | `notification.show`        | `{ id, key, kind, level, text, ttl_ms? }`                                   |
 | `notification.clear`       | `{ key }`                                                                   |
-| `tool.start`               | `{ tool_id, name, context?, args_text? }`                                   |
+| `tool.start`               | `{ tool_id, name, icon?, context?, args_text? }`                             |
 | `tool.generating`          | `{ name }`                                                                  |
 | `tool.progress`            | `{ name, preview }`                                                         |
-| `tool.complete`            | `{ tool_id, name, error?, summary?, duration_s?, inline_diff?, todos? }`    |
+| `tool.complete`            | `{ tool_id, name, icon?, error?, summary?, duration_s?, inline_diff?, todos? }` |
 | `clarify.request`          | `{ question, choices?, request_id }`                                        |
 | `approval.request`         | `{ command, description, allow_permanent? }`                                |
 | `sudo.request`             | `{ request_id }`                                                            |
@@ -299,13 +299,29 @@ Primary event types the client handles today:
 | `subagent.spawn_requested` | `{ subagent_id?, task_index, goal?, depth?, parent_id? }`                   |
 | `subagent.start`           | `{ subagent_id?, task_index, goal?, depth?, parent_id? }`                   |
 | `subagent.thinking`        | `{ text }`                                                                  |
-| `subagent.tool`            | `{ tool_name?, tool_preview?, text? }`                                      |
+| `subagent.tool`            | `{ tool_name?, icon?, tool_preview?, text? }`                                |
 | `subagent.progress`        | `{ text }`                                                                  |
 | `subagent.complete`        | `{ status, summary?, text?, duration_seconds? }`                            |
 | `error`                    | `{ message }`                                                               |
 | `gateway.stderr`           | synthesized from child stderr                                               |
 | `gateway.protocol_error`   | synthesized from malformed stdout                                           |
 | `gateway.start_timeout`    | `{ cwd?, python?, stderr_tail? }`                                           |
+
+### Tool icons
+
+`icon` carries the canonical per-tool glyph (`terminal` → 💻, `read_file` → 📖,
+`patch` → 🔧, …). The gateway resolves it once with `agent.display.get_tool_emoji`
+— the same skin `tool_emojis` → registry → `⚡` chain the classic CLI printer
+uses — so the two frontends can never disagree. **The client never maps a tool
+name to a glyph**; there is no tool→icon table in TypeScript.
+
+It rides on `tool.start`, `tool.complete` and `subagent.tool`. Shipping it on
+`tool.complete` too is what keeps a *completed* row's icon correct for a client
+that attached mid-call and never saw the matching `tool.start`.
+
+The field is optional in both directions: an older gateway simply omits it and
+the renderer falls back to `⚡` (`TOOL_ICON_FALLBACK` in `lib/text.ts`), and an
+older client ignores it. A tool row is never drawn with a generic bullet.
 
 ## Theme model
 

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -3,10 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
 import { getOverlayState, patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import { turnController } from '../app/turnController.js'
-import { getTurnState, resetTurnState } from '../app/turnStore.js'
+import { getTurnState, resetTurnState, resolveToolIcon } from '../app/turnStore.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import { ZERO } from '../domain/usage.js'
-import { estimateTokensRough } from '../lib/text.js'
+import { estimateTokensRough, toolTrailBaseLabel } from '../lib/text.js'
 import type { Msg } from '../types.js'
 
 // Mock the external-URL opener so the billing.step_up.verification test can
@@ -1297,6 +1297,121 @@ describe('createGatewayEventHandler', () => {
     const hints = getTurnState().activity.filter(a => a.text.includes('/agents'))
     expect(hints).toHaveLength(1)
     expect(hints[0]).toMatchObject({ tone: 'info' })
+  })
+
+  describe('tool icons ride the wire and survive completion', () => {
+    const startTerminal = (onEvent: (ev: any) => void, icon?: string) =>
+      onEvent({
+        payload: { context: 'ls -la', name: 'terminal', tool_id: 'tool-1', ...(icon ? { icon } : {}) },
+        type: 'tool.start'
+      } as any)
+
+    it('propagates the icon from tool.start onto the live row', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      startTerminal(onEvent, '💻')
+
+      expect(getTurnState().tools[0]?.icon).toBe('💻')
+    })
+
+    it('keeps the icon on the completed row after tool.complete', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      startTerminal(onEvent, '💻')
+      onEvent({
+        payload: { icon: '💻', name: 'terminal', summary: 'ok', tool_id: 'tool-1' },
+        type: 'tool.complete'
+      } as any)
+
+      // The completed row is a formatted string by now; the trail label is the
+      // key that recovers the same glyph the live row drew.
+      const completedRow = getTurnState().streamPendingTools.find(line => line.startsWith('Terminal('))
+
+      expect(getTurnState().tools).toHaveLength(0)
+      expect(completedRow).toBeDefined()
+      expect(resolveToolIcon(toolTrailBaseLabel(completedRow!))).toBe('💻')
+    })
+
+    it('accepts the icon from tool.complete alone (client attached mid-call)', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      // No tool.start was ever seen for this id.
+      onEvent({
+        payload: { icon: '📖', name: 'read_file', summary: 'ok', tool_id: 'tool-9' },
+        type: 'tool.complete'
+      } as any)
+
+      expect(resolveToolIcon('Read File')).toBe('📖')
+    })
+
+    it('falls back to ⚡ when the gateway sends no icon', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      startTerminal(onEvent)
+
+      expect(getTurnState().tools[0]?.icon).toBeUndefined()
+      expect(resolveToolIcon('Terminal')).toBe('⚡')
+    })
+
+    it('keeps subagent tool icons index-aligned with the tool lines', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+
+      onEvent({
+        payload: { goal: 'child', subagent_id: 'sa-icons', task_index: 0 },
+        type: 'subagent.start'
+      } as any)
+      onEvent({
+        payload: { icon: '💻', subagent_id: 'sa-icons', task_index: 0, tool_name: 'terminal', tool_preview: 'ls' },
+        type: 'subagent.tool'
+      } as any)
+      onEvent({
+        payload: {
+          icon: '📖',
+          subagent_id: 'sa-icons',
+          task_index: 0,
+          tool_name: 'read_file',
+          tool_preview: 'app.ts'
+        },
+        type: 'subagent.tool'
+      } as any)
+
+      const sub = getTurnState().subagents.find(s => s.id === 'sa-icons')
+
+      expect(sub?.tools).toHaveLength(2)
+      expect(sub?.toolIcons).toEqual(['💻', '📖'])
+    })
+
+    it('pads a subagent frame that arrived without an icon so later rows stay aligned', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+
+      onEvent({
+        payload: { goal: 'child', subagent_id: 'sa-mixed', task_index: 0 },
+        type: 'subagent.start'
+      } as any)
+      onEvent({
+        payload: { subagent_id: 'sa-mixed', task_index: 0, tool_name: 'terminal', tool_preview: 'ls' },
+        type: 'subagent.tool'
+      } as any)
+      onEvent({
+        payload: {
+          icon: '📖',
+          subagent_id: 'sa-mixed',
+          task_index: 0,
+          tool_name: 'read_file',
+          tool_preview: 'app.ts'
+        },
+        type: 'subagent.tool'
+      } as any)
+
+      const sub = getTurnState().subagents.find(s => s.id === 'sa-mixed')
+
+      expect(sub?.toolIcons).toHaveLength(sub?.tools.length ?? 0)
+      expect(sub?.toolIcons?.[1]).toBe('📖')
+    })
   })
 
   it('nudges toward /agents on subagent.start (spawn_requested dropped in CLI path)', () => {

--- a/ui-tui/src/__tests__/toolRowIcons.test.tsx
+++ b/ui-tui/src/__tests__/toolRowIcons.test.tsx
@@ -1,0 +1,175 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { turnController } from '../app/turnController.js'
+import { rememberToolIcon, resetTurnState } from '../app/turnStore.js'
+import { ToolTrail } from '../components/thinking.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+import type { ActiveTool, SubagentProgress } from '../types.js'
+
+const flushEffects = async () => {
+  for (let i = 0; i < 10; i++) {
+    await new Promise(resolve => setTimeout(resolve, 5))
+  }
+}
+
+const mount = async (props: Record<string, unknown>) => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 30 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(<ToolTrail t={DEFAULT_THEME} {...(props as any)} />, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  await flushEffects()
+
+  instance.unmount()
+  instance.cleanup()
+
+  return stripAnsi(output)
+}
+
+const activeTool = (over: Partial<ActiveTool> = {}): ActiveTool => ({
+  context: 'ls -la',
+  id: 'tool-1',
+  name: 'terminal',
+  startedAt: Date.now(),
+  ...over
+})
+
+describe('tool rows render the canonical tool icon, never a generic bullet', () => {
+  beforeEach(() => {
+    resetTurnState()
+    turnController.fullReset()
+  })
+
+  it('draws the gateway-sent icon on the ACTIVE row', async () => {
+    const out = await mount({
+      busy: true,
+      sections: { tools: 'expanded' },
+      tools: [activeTool({ icon: '💻' })]
+    })
+
+    expect(out).toContain('💻')
+    expect(out).toContain('Terminal')
+    expect(out).not.toContain('●')
+  })
+
+  it('draws the same icon on the COMPLETED row after the tool finishes', async () => {
+    // What tool.start filed under the trail label is what the completed row —
+    // by then only a formatted string — resolves back out.
+    rememberToolIcon('Terminal', '💻')
+
+    const out = await mount({
+      sections: { tools: 'expanded' },
+      trail: ['Terminal("ls -la") (0.4s) ✓']
+    })
+
+    expect(out).toContain('💻')
+    expect(out).toContain('Terminal')
+    expect(out).not.toContain('●')
+  })
+
+  it('keeps distinct icons for distinct tools in the same trail', async () => {
+    rememberToolIcon('Terminal', '💻')
+    rememberToolIcon('Read File', '📖')
+
+    const out = await mount({
+      sections: { tools: 'expanded' },
+      trail: ['Terminal("ls") ✓', 'Read File("app.ts") ✓']
+    })
+
+    expect(out).toContain('💻')
+    expect(out).toContain('📖')
+    expect(out).not.toContain('●')
+  })
+
+  it('falls back to ⚡ when no icon ever arrived for that tool', async () => {
+    const out = await mount({
+      sections: { tools: 'expanded' },
+      trail: ['Mystery Tool("x") ✓']
+    })
+
+    expect(out).toContain('⚡')
+    expect(out).not.toContain('●')
+  })
+
+  it('falls back to ⚡ on an ACTIVE row from a gateway that sent no icon', async () => {
+    const out = await mount({
+      busy: true,
+      sections: { tools: 'expanded' },
+      tools: [activeTool({ icon: undefined })]
+    })
+
+    expect(out).toContain('⚡')
+    expect(out).not.toContain('●')
+  })
+
+  it('draws per-row icons inside the subagent tool list', async () => {
+    const subagent: SubagentProgress = {
+      depth: 0,
+      goal: 'inspect the repo',
+      id: 'sub-1',
+      index: 0,
+      notes: [],
+      parentId: null,
+      status: 'running',
+      taskCount: 1,
+      thinking: [],
+      toolCount: 2,
+      toolIcons: ['💻', '📖'],
+      tools: ['Terminal("ls")', 'Read File("app.ts")']
+    }
+
+    const out = await mount({
+      busy: true,
+      sections: { subagents: 'expanded', tools: 'expanded' },
+      subagents: [subagent]
+    })
+
+    expect(out).toContain('💻')
+    expect(out).toContain('📖')
+    expect(out).not.toContain('●')
+  })
+
+  it('falls back to ⚡ for a subagent frame that predates the icon contract', async () => {
+    const subagent: SubagentProgress = {
+      depth: 0,
+      goal: 'inspect the repo',
+      id: 'sub-1',
+      index: 0,
+      notes: [],
+      parentId: null,
+      status: 'running',
+      taskCount: 1,
+      thinking: [],
+      toolCount: 1,
+      tools: ['Terminal("ls")']
+    }
+
+    const out = await mount({
+      busy: true,
+      sections: { subagents: 'expanded', tools: 'expanded' },
+      subagents: [subagent]
+    })
+
+    expect(out).toContain('⚡')
+    expect(out).not.toContain('●')
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -20,7 +20,7 @@ import { openExternalUrl } from '../lib/openExternalUrl.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
 import { isPaintableHex, setTerminalBackground, setTerminalForeground } from '../lib/terminalModes.js'
-import { formatAbandonedClarify, formatToolCall, stripAnsi } from '../lib/text.js'
+import { formatAbandonedClarify, formatToolCall, stripAnsi, TOOL_ICON_FALLBACK } from '../lib/text.js'
 import { bootSeededPin, invalidateBootBackground, writeBootTheme } from '../lib/themeBoot.js'
 import { defaultThemeForCurrentBackground, fromSkin, skinIsLight, type Theme, themeToneHex } from '../theme.js'
 import type { Msg, SubagentProgress, SubagentStatus, Usage } from '../types.js'
@@ -394,6 +394,25 @@ const pushUnique =
 const pushThinking = pushUnique(6)
 const pushNote = pushUnique(6)
 const pushTool = pushUnique(8)
+
+// Keep a subagent's icon list index-aligned with its tool list across
+// pushTool's dedupe-and-cap, padding any earlier frame that arrived without an
+// icon so row N always reads the glyph that came with tool line N.
+const alignToolIcons = (
+  prevTools: string[],
+  nextTools: string[],
+  prevIcons: string[] | undefined,
+  icon: string
+): string[] | undefined => {
+  if (nextTools === prevTools) {
+    return prevIcons
+  }
+
+  const kept = prevTools.length ? (prevIcons ?? []).slice(-prevTools.length) : []
+  const pad = new Array(Math.max(0, prevTools.length - kept.length)).fill(TOOL_ICON_FALLBACK) as string[]
+
+  return [...pad, ...kept, icon].slice(-nextTools.length)
+}
 
 const KNOWN_SUBAGENT_STATUSES = new Set<SubagentStatus>([
   'completed',
@@ -1171,7 +1190,11 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           ev.payload.tool_id,
           ev.payload.name ?? 'tool',
           ev.payload.context ?? '',
-          ev.payload.args_text ? stripAnsi(String(ev.payload.args_text)) : undefined
+          ev.payload.args_text ? stripAnsi(String(ev.payload.args_text)) : undefined,
+          // Forwarded verbatim — the client never derives a glyph from the
+          // tool name. Absent (older gateway) leaves it undefined so the
+          // renderer applies TOOL_ICON_FALLBACK.
+          ev.payload.icon ? String(ev.payload.icon) : undefined
         )
 
         return
@@ -1188,6 +1211,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           ev.payload.inline_diff && getUiState().inlineDiffs ? stripAnsi(String(ev.payload.inline_diff)).trim() : ''
 
         const resultText = ev.payload.result_text ? stripAnsi(String(ev.payload.result_text)) : undefined
+        const icon = ev.payload.icon ? String(ev.payload.icon) : undefined
 
         if (inlineDiffText) {
           turnController.recordInlineDiffToolComplete(
@@ -1196,7 +1220,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
             ev.payload.name,
             ev.payload.error,
             ev.payload.duration_s,
-            resultText
+            resultText,
+            icon
           )
         } else {
           turnController.recordToolComplete(
@@ -1206,7 +1231,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
             ev.payload.summary,
             ev.payload.duration_s,
             ev.payload.todos,
-            resultText
+            resultText,
+            icon
           )
         }
 
@@ -1338,12 +1364,19 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           ev.payload.tool_preview ?? ev.payload.text ?? ''
         )
 
+        const icon = ev.payload.icon ? String(ev.payload.icon) : TOOL_ICON_FALLBACK
+
         turnController.upsertSubagent(
           ev.payload,
-          c => ({
-            status: keepTerminalElseRunning(c.status),
-            tools: pushTool(c.tools, line)
-          }),
+          c => {
+            const tools = pushTool(c.tools, line)
+
+            return {
+              status: keepTerminalElseRunning(c.status),
+              toolIcons: alignToolIcons(c.tools, tools, c.toolIcons, icon),
+              tools
+            }
+          },
           { createIfMissing: false }
         )
 

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -22,7 +22,7 @@ import type { ActiveTool, ActivityItem, Msg, SubagentProgress, TodoItem } from '
 import type { Notice } from './interfaces.js'
 import { resetFlowOverlays } from './overlayStore.js'
 import { pushSnapshot } from './spawnHistoryStore.js'
-import { archiveDoneTodos, getTurnState, patchTurnState, resetTurnState } from './turnStore.js'
+import { archiveDoneTodos, getTurnState, patchTurnState, rememberToolIcon, resetTurnState } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
 const INTERRUPT_COOLDOWN_MS = 1500
@@ -800,14 +800,15 @@ class TurnController {
     summary?: string,
     duration?: number,
     todos?: unknown,
-    resultText?: string
+    resultText?: string,
+    icon?: string
   ) {
     if (this.interrupted) {
       return
     }
 
     this.recordTodos(todos)
-    const line = this.completeTool(toolId, fallbackName, error, summary, duration, resultText)
+    const line = this.completeTool(toolId, fallbackName, error, summary, duration, resultText, icon)
 
     this.pendingSegmentTools = [...this.pendingSegmentTools, line]
     this.flushPendingToolsIntoLastSegment()
@@ -820,14 +821,17 @@ class TurnController {
     fallbackName?: string,
     error?: string,
     duration?: number,
-    resultText?: string
+    resultText?: string,
+    icon?: string
   ) {
     if (this.interrupted) {
       return
     }
 
     this.flushStreamingSegment()
-    this.pushInlineDiffSegment(diffText, [this.completeTool(toolId, fallbackName, error, '', duration, resultText)])
+    this.pushInlineDiffSegment(diffText, [
+      this.completeTool(toolId, fallbackName, error, '', duration, resultText, icon)
+    ])
     this.publishToolState()
   }
 
@@ -837,11 +841,18 @@ class TurnController {
     error?: string,
     summary?: string,
     duration?: number,
-    resultText?: string
+    resultText?: string,
+    icon?: string
   ) {
     const done = this.activeTools.find(tool => tool.id === toolId)
     const name = done?.name ?? fallbackName ?? 'tool'
     const label = toolTrailLabel(name)
+
+    // Re-file on completion as well. The live row's icon came from tool.start,
+    // but a client that attached mid-call never saw it — tool.complete carries
+    // the same glyph so the completed row still matches the CLI. The active
+    // tool's own icon wins when present (it is the frame that opened this row).
+    rememberToolIcon(label, done?.icon ?? icon)
     const fallbackDuration = done?.startedAt ? (Date.now() - done.startedAt) / 1000 : undefined
 
     const line =
@@ -906,10 +917,15 @@ class TurnController {
     }, STREAM_BATCH_MS)
   }
 
-  recordToolStart(toolId: string, name: string, context: string, verboseArgs?: string) {
+  recordToolStart(toolId: string, name: string, context: string, verboseArgs?: string, icon?: string) {
     if (this.interrupted) {
       return
     }
+
+    // File the glyph under the trail label too: once this tool completes, its
+    // row is only a formatted string and the label is the only key left to
+    // recover the icon by.
+    rememberToolIcon(toolTrailLabel(name), icon)
 
     this.flushStreamingSegment()
     this.closeReasoningSegment()
@@ -919,7 +935,7 @@ class TurnController {
     const sample = `${name} ${context}`.trim()
 
     this.toolTokenAcc += sample ? estimateTokensRough(sample) : 0
-    this.activeTools = [...this.activeTools, { context, id: toolId, name, startedAt: Date.now(), verboseArgs }]
+    this.activeTools = [...this.activeTools, { context, icon, id: toolId, name, startedAt: Date.now(), verboseArgs }]
 
     patchTurnState({ toolTokens: this.toolTokenAcc, tools: this.activeTools })
   }

--- a/ui-tui/src/app/turnStore.ts
+++ b/ui-tui/src/app/turnStore.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 import { useSyncExternalStore } from 'react'
 
 import { isTodoDone } from '../lib/liveProgress.js'
+import { TOOL_ICON_FALLBACK } from '../lib/text.js'
 import type { ActiveTool, ActivityItem, Msg, SubagentProgress, TodoItem } from '../types.js'
 
 const buildTurnState = (): TurnState => ({
@@ -64,7 +65,39 @@ export const archiveTodosAtTurnEnd = () => {
   return [msg]
 }
 
-export const resetTurnState = () => $turnState.set(buildTurnState())
+// ── Tool icon registry ───────────────────────────────────────────────
+//
+// NOT a tool→icon table: it holds nothing but glyphs the gateway already
+// resolved through `agent.display.get_tool_emoji` and shipped on the
+// tool.start / tool.complete frames. It exists because the completed trail is
+// persisted as plain strings (`Msg.tools`, `TurnState.turnTrail`) — there is
+// nowhere on a `string` to hang the icon, and widening that type would ripple
+// through every segment-merge path.
+//
+// Deliberately NOT reactive: a nanostore here would re-subscribe every
+// memoised history row to the turn atom and re-render the whole transcript on
+// each streamed token. Reads are safe without a subscription because
+// tool.start always lands (and files the icon) before the row it feeds can
+// exist, and the state patch that creates the row is what triggers the paint.
+const toolIcons = new Map<string, string>()
+
+/** File the server-resolved glyph under a `toolTrailLabel` key. */
+export const rememberToolIcon = (label: string, icon?: string) => {
+  if (label && icon) {
+    toolIcons.set(label, icon)
+  }
+}
+
+/** Look a glyph up, or fall back to the same default the backend uses. */
+export const resolveToolIcon = (label: string, fallback = TOOL_ICON_FALLBACK) =>
+  toolIcons.get(label) ?? fallback
+
+export const resetTurnState = () => {
+  // Session boundary (fullReset only, never a per-turn reset): the next
+  // session replays its own tool.start frames.
+  toolIcons.clear()
+  $turnState.set(buildTurnState())
+}
 
 export interface TurnState {
   activity: ActivityItem[]

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -2,6 +2,7 @@ import { Box, NoSelect, Text } from '@hermes/ink'
 import { memo, type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import spinners, { type BrailleSpinnerName } from 'unicode-animations'
 
+import { resolveToolIcon } from '../app/turnStore.js'
 import { THINKING_COT_MAX } from '../config/limits.js'
 import { sectionMode } from '../domain/details.js'
 import {
@@ -24,6 +25,8 @@ import {
   pick,
   splitToolDuration,
   thinkingPreview,
+  TOOL_ICON_FALLBACK,
+  toolTrailBaseLabel,
   toolTrailLabel
 } from '../lib/text.js'
 import type { Theme } from '../theme.js'
@@ -454,7 +457,9 @@ function SubagentAccordion({
               color={t.color.text}
               content={
                 <>
-                  <Text color={t.color.tool}>● </Text>
+                  {/* Index-aligned with `tools` by alignToolIcons; a frame
+                      that predates the icon contract falls back to ⚡. */}
+                  <Text color={t.color.tool}>{item.toolIcons?.[index] || TOOL_ICON_FALLBACK} </Text>
                   {line}
                 </>
               }
@@ -669,6 +674,11 @@ interface Group {
   color: string
   content: ReactNode
   details: DetailRow[]
+  // Canonical glyph for this tool row, always populated — the gateway-sent
+  // icon for live rows, the registry lookup for completed trail rows, and
+  // TOOL_ICON_FALLBACK when neither is available. Never a generic bullet:
+  // the TUI must render the same icon the classic CLI printer does.
+  icon: string
   key: string
   label: string
 }
@@ -830,6 +840,9 @@ export const ToolTrail = memo(function ToolTrail({
         color: parsed.mark === '✗' ? t.color.error : t.color.text,
         content: parsed.call,
         details: [],
+        // A completed row is only a formatted string by now, so recover the
+        // glyph the gateway sent at tool.start via the trail label.
+        icon: resolveToolIcon(toolTrailBaseLabel(parsed.call)),
         key: `tr-${i}`,
         label: parsed.call
       })
@@ -853,6 +866,7 @@ export const ToolTrail = memo(function ToolTrail({
         color: t.color.text,
         content: label,
         details: [{ color: t.color.muted, content: 'drafting...', dimColor: true, key: `tr-${i}-d` }],
+        icon: resolveToolIcon(label),
         key: `tr-${i}`,
         label
       })
@@ -885,6 +899,8 @@ export const ToolTrail = memo(function ToolTrail({
 
     groups.push({
       color: t.color.text,
+      // Live row: the glyph rode in on this tool's own tool.start frame.
+      icon: tool.icon || TOOL_ICON_FALLBACK,
       key: tool.id,
       label,
       details: tool.verboseArgs
@@ -1117,7 +1133,7 @@ export const ToolTrail = memo(function ToolTrail({
                   color={group.color}
                   content={
                     <>
-                      <Text color={t.color.tool}>● </Text>
+                      <Text color={t.color.tool}>{group.icon} </Text>
                       {toolLabel(group)}
                       {isDelegateGroup ? (
                         <Text color={t.color.statusFg} dim>

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -541,6 +541,8 @@ export interface SubagentEventPayload {
   files_read?: string[]
   files_written?: string[]
   goal: string
+  // Set on `subagent.tool` only — same server-resolved glyph as tool.start.
+  icon?: string
   input_tokens?: number
   iteration?: number
   model?: string
@@ -684,7 +686,18 @@ export type GatewayEvent =
   | { payload: { name?: string; preview?: string }; session_id?: string; type: 'tool.progress' }
   | { payload: { name?: string }; session_id?: string; type: 'tool.generating' }
   | {
-      payload: { args_text?: string; context?: string; name?: string; tool_id: string; todos?: unknown[] }
+      payload: {
+        args_text?: string
+        context?: string
+        // Canonical per-tool glyph resolved server-side by
+        // `agent.display.get_tool_emoji` (skin → registry → ⚡).  Optional so
+        // an older gateway (or a mirror frame) still parses; renderers fall
+        // back to ⚡ rather than deriving an icon from the tool name.
+        icon?: string
+        name?: string
+        tool_id: string
+        todos?: unknown[]
+      }
       session_id?: string
       type: 'tool.start'
     }
@@ -692,6 +705,7 @@ export type GatewayEvent =
       payload: {
         duration_s?: number
         error?: string
+        icon?: string
         inline_diff?: string
         name?: string
         result_text?: string

--- a/ui-tui/src/lib/text.test.ts
+++ b/ui-tui/src/lib/text.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatAbandonedClarify, stripTrailingPasteNewlines } from './text.js'
+import {
+  formatAbandonedClarify,
+  formatToolCall,
+  stripTrailingPasteNewlines,
+  TOOL_ICON_FALLBACK,
+  toolTrailBaseLabel,
+  toolTrailLabel
+} from './text.js'
 
 describe('stripTrailingPasteNewlines', () => {
   it('removes trailing newline runs from pasted text', () => {
@@ -49,5 +56,36 @@ describe('formatAbandonedClarify', () => {
 
     expect(out).toContain('  1. first')
     expect(out).not.toContain('  0.')
+  })
+})
+
+describe('toolTrailBaseLabel', () => {
+  // The completed trail row is a string; this is the inverse that recovers the
+  // key its icon was filed under at tool.start. Asserted as a round trip so it
+  // can never drift from formatToolCall's own shape.
+  it('round-trips every formatToolCall shape back to the trail label', () => {
+    for (const name of ['terminal', 'read_file', 'skill_view']) {
+      const label = toolTrailLabel(name)
+
+      expect(toolTrailBaseLabel(formatToolCall(name))).toBe(label)
+      expect(toolTrailBaseLabel(formatToolCall(name, 'some argument'))).toBe(label)
+    }
+  })
+
+  it('strips the duration the trail line appends', () => {
+    expect(toolTrailBaseLabel('Terminal("ls -la") (0.4s)')).toBe('Terminal')
+    expect(toolTrailBaseLabel('Read File (12.5s)')).toBe('Read File')
+  })
+
+  it('is not confused by parentheses inside the preview', () => {
+    expect(toolTrailBaseLabel(formatToolCall('terminal', 'echo ("hi") && ls'))).toBe('Terminal')
+  })
+})
+
+describe('TOOL_ICON_FALLBACK', () => {
+  it('matches the default agent.display.get_tool_emoji falls back to', () => {
+    // Both halves of the wire contract must degrade to the same glyph — a tool
+    // row is never drawn with a generic bullet on either side.
+    expect(TOOL_ICON_FALLBACK).toBe('⚡')
   })
 })

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -211,6 +211,23 @@ export const formatToolCall = (name: string, context = '') => {
   return preview ? `${label}("${preview}")` : label
 }
 
+// Glyph rendered for a tool row whose frame carried no `icon` — an older
+// gateway, a replayed transcript, or a mirror frame. Matches the `⚡` default
+// that `agent.display.get_tool_emoji` falls back to server-side, so the two
+// halves of the contract agree instead of drifting.
+export const TOOL_ICON_FALLBACK = '⚡'
+
+// Invert `formatToolCall` (plus any ` (1.2s)` the trail line appended) back to
+// the bare `toolTrailLabel` key, so a completed trail row can look its icon up
+// by the same key `recordToolStart` filed it under. Tool names never contain
+// `(`, so the first `("` is unambiguously the preview boundary.
+export const toolTrailBaseLabel = (call: string) => {
+  const { label } = splitToolDuration(call)
+  const paren = label.indexOf('("')
+
+  return (paren >= 0 ? label.slice(0, paren) : label).trim()
+}
+
 export const buildToolTrailLine = (
   name: string,
   context: string,

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -1,5 +1,8 @@
 export interface ActiveTool {
   context?: string
+  // Server-resolved glyph from the tool.start payload. Absent on frames from
+  // an older gateway; renderers fall back to TOOL_ICON_FALLBACK.
+  icon?: string
   id: string
   name: string
   verboseArgs?: string
@@ -45,6 +48,8 @@ export interface SubagentProgress {
   thinking: string[]
   toolCount: number
   tools: string[]
+  // Parallel to `tools`: the icon that came with each subagent.tool frame.
+  toolIcons?: string[]
   toolsets?: string[]
 }
 


### PR DESCRIPTION
## The gap

The classic CLI prints a per-tool glyph for every tool call — `terminal` gets 💻,
`read_file` 📖, `patch` 🔧, `cronjob` ⏰ — while the TUI drew a hardcoded `●` for
every row, in both places it renders one (`thinking.tsx`, two sites). The two
surfaces disagreed on every call, and 93 of the 99 registered tools already declare
an `emoji=` that the TUI never showed.

## Approach

The icon is resolved **server-side** by the helper that already owns this mapping,
`agent/display.py::get_tool_emoji()` (skin `tool_emojis` override → tool registry →
`⚡` fallback), and shipped on the wire. There is deliberately **no tool→icon table in
TypeScript**: the renderer prints what it receives, so a tool added by a future release
shows its icon with no client change, and a skin override keeps working on both surfaces.

`tool.complete` repeats the glyph. A client that attached mid-call never saw
`tool.start`, and without it the completed row would degrade to the fallback while the
live row showed the real icon.

## Changes

- `tui_gateway/server.py` — `icon` on `tool.start`, `tool.complete`, `subagent.tool`
  and the child-session mirror.
- `ui-tui/src/gatewayTypes.ts`, `types.ts`, `app/createGatewayEventHandler.ts`,
  `app/turnController.ts`, `app/turnStore.ts`, `lib/text.ts` — transport and retention.
  The trail is persisted as `string[]`, so the glyph is archived under the trail label
  rather than widening that type through every segment merge. The registry is
  deliberately non-reactive: a store there would resubscribe every memoised history row
  to the turn atom and repaint the transcript per token.
- `ui-tui/src/components/thinking.tsx` — both `●` sites now render the group's icon,
  with a defensive `⚡` for payloads that predate the field.
- `ui-tui/README.md` — event contract.

The field is optional, so old and new payloads interoperate in both directions.

## Tests

The gateway test sweeps **every registered tool that declares an emoji** and asserts the
registry→event relationship rather than freezing the glyphs, so adding a tool or retuning
an emoji upstream cannot turn into a false failure here. A separate test monkeypatches
`get_tool_emoji` and asserts the event carries its return value, which pins the delegation
itself. Core tools are additionally asserted not to fall back to `⚡`.

TS side covers propagation with and without the field, and the rendered active row and
completed trail.
