### PR TITLE
fix(tools): give the xAI video tools a real emoji

### DIFF
--- a/tests/agent/test_display_emoji.py
+++ b/tests/agent/test_display_emoji.py
@@ -58,3 +58,29 @@ class TestSkinConfigToolEmojis:
         skin = _build_skin_config(data)
         assert skin.tool_emojis == {"terminal": "🗡️", "patch": "⚒️"}
 
+
+
+class TestRegistryEmojiValues:
+    """Every declared tool emoji must actually be a glyph.
+
+    The TUI prints ``registry.get_emoji()`` verbatim into the tool row, so a
+    plain word slipped into ``emoji=`` renders as that word next to real icons.
+    This stayed invisible while the TUI drew a generic bullet for every tool.
+    The assertion is an invariant over whatever the registry holds, not a
+    snapshot of it: tools added later are covered with no edit here.
+    """
+
+    def test_every_registered_tool_emoji_is_a_glyph(self):
+        import model_tools  # noqa: F401  -- triggers tools/*.py auto-discovery
+        from tools.registry import registry
+
+        offenders = []
+        for name in sorted(getattr(registry, "_tools", {})):
+            emoji = registry.get_emoji(name, default="")
+            if emoji and not any(ord(ch) > 0x2000 for ch in emoji):
+                offenders.append((name, emoji))
+
+        assert not offenders, (
+            "these tools declare a non-glyph emoji= value, which the TUI would "
+            f"print literally into the tool row: {offenders}"
+        )

--- a/tools/xai_video_tools.py
+++ b/tools/xai_video_tools.py
@@ -194,7 +194,7 @@ registry.register(
     check_fn=_check_xai_video_requirements,
     requires_env=[],
     is_async=False,
-    emoji="video",
+    emoji="🎬",
 )
 
 registry.register(
@@ -205,5 +205,5 @@ registry.register(
     check_fn=_check_xai_video_requirements,
     requires_env=[],
     is_async=False,
-    emoji="video",
+    emoji="🎬",
 )


### PR DESCRIPTION
## The bug

`xai_video_edit` and `xai_video_extend` register with `emoji="video"` — the literal
word, not a glyph:

```python
# tools/xai_video_tools.py:197, :208
emoji="video",
```

`registry.get_emoji()` is printed verbatim into the tool row, so those two rows render
the text `video` next to real icons. Every sibling video tool (`video_generate`,
`video_analyze`, `bfl_flux3_text_to_video`) uses the clapper board.

This was invisible while the TUI drew a generic bullet for every tool; it surfaces as
soon as any surface prints the registry value.

## Fix

`emoji="🎬"` on both, matching the siblings.

## Test

`test_every_registered_tool_emoji_is_a_glyph` asserts the invariant over whatever the
registry holds rather than a fixed list, so tools added later are covered without
touching it. A sweep of the whole registry found these two and no others.
