### PR TITLE
fix(tui): avoid destructive redraw on focus regain

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink-focus-redraw.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-focus-redraw.test.ts
@@ -1,0 +1,62 @@
+import { EventEmitter } from 'events'
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import Text from './components/Text.js'
+import Ink from './ink.js'
+import { ERASE_SCREEN } from './termio/csi.js'
+import { DISABLE_MOUSE_TRACKING } from './termio/dec.js'
+
+class FakeTty extends EventEmitter {
+  chunks: string[] = []
+  columns = 40
+  rows = 8
+  isTTY = true
+
+  write(chunk: string | Uint8Array, cb?: (err?: Error | null) => void): boolean {
+    this.chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'))
+    cb?.()
+
+    return true
+  }
+}
+
+type InkPrivate = {
+  handleTerminalFocusChange: (isFocused: boolean) => void
+}
+
+const peek = (ink: Ink): InkPrivate => ink as unknown as InkPrivate
+const tick = () => new Promise<void>(resolve => queueMicrotask(resolve))
+
+describe('Ink focus recovery', () => {
+  it('repaints without clearing the screen or re-asserting terminal modes', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+
+    const ink = new Ink({
+      exitOnCtrlC: false,
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    ink.setAltScreenActive(true, 'all')
+    ink.render(React.createElement(Text, null, 'hello'))
+    ink.onRender()
+    await tick()
+    stdout.chunks = []
+
+    peek(ink).handleTerminalFocusChange(true)
+    await tick()
+
+    const output = stdout.chunks.join('')
+    expect(output).toContain('hello')
+    expect(output).not.toContain(ERASE_SCREEN)
+    expect(output).not.toContain(DISABLE_MOUSE_TRACKING)
+
+    ink.unmount()
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -610,14 +610,23 @@ export default class Ink {
     // if we continue with the pre-blur virtual cursor/backbuffer, only the
     // next small dirty region may repaint and stale status/progress rows can
     // remain visible. Defer one tick so TerminalFocusProvider subscribers
-    // observe the new focus state first, then do the same recovery as /redraw.
+    // observe the new focus state first, then repaint from a blank virtual
+    // frame. Do not clear the physical screen or re-assert terminal modes:
+    // focus reporting is already active, and those writes cause visible
+    // flicker while resending unnecessary DECRESET sequences.
     queueMicrotask(() => {
       if (this.isUnmounted || this.isPaused || !this.options.stdout.isTTY || this.currentNode === null) {
         return
       }
 
-      this.reassertTerminalModes(false)
-      this.forceRedraw()
+      if (this.altScreenActive) {
+        this.resetFramesForAltScreen()
+      } else {
+        this.repaint()
+        this.invalidatePrevFrame()
+      }
+
+      this.onRender()
     })
   }
 


### PR DESCRIPTION
## What does this PR do?

Makes terminal focus recovery repaint from blank virtual frame buffers without clearing the physical screen or re-asserting terminal modes.

The focus-regain handler previously reused the destructive `/redraw` path. Every focus change sent `ERASE_SCREEN`, resent mouse-tracking DECRESET sequences, and then rebuilt the frame. That caused a visible full-screen redraw and introduced unnecessary terminal-mode output on ordinary tab or pane changes.

The replacement keeps the stale-row recovery: it resets the virtual buffers and renders a complete replacement frame. The existing screen remains visible until that frame is ready, and focus regain sends neither the clear-screen sequence nor mouse-mode resets.

## Related Issue

Discord support report: https://discord.com/channels/1053877538025386074/1538966610776301719

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replace focus-in's `reassertTerminalModes()` plus `forceRedraw()` calls with a virtual frame reset and direct repaint.
- Add a behavioral regression test proving focus recovery repaints content without emitting `ERASE_SCREEN` or `DISABLE_MOUSE_TRACKING`.

## How to Test

1. Run `npm test -- packages/hermes-ink/src/ink/ink-focus-redraw.test.ts` from `ui-tui`.
2. Run `npm run typecheck` from `ui-tui`.
3. Switch focus away from and back to an active TUI tab or pane and confirm the current content repaints without a visible clear-screen cycle or an inserted lowercase `l`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused Vitest regression, TUI TypeScript check, and targeted ESLint all pass locally. Python tests were not run because this is a TypeScript-only change.
