### PR TITLE
fix(desktop): keep SSH Bot Mode agents visible across local clicks

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -42,6 +42,7 @@ import {
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
   resolveProfileBackendRoute,
+  resolveRemoteSshDashboardProfile,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,
@@ -56,6 +57,17 @@ test('connectionScopeKey trims to a name or null for the global scope', () => {
   assert.equal(connectionScopeKey(''), null)
   assert.equal(connectionScopeKey(null), null)
   assert.equal(connectionScopeKey(undefined), null)
+})
+
+test('resolveRemoteSshDashboardProfile never sends a conn: pool key to the remote', () => {
+  // Clicking Mac Mini / Spark default used `remoteProfile || poolKey`, which
+  // spawned a dashboard for the fictional profile "conn:mac-mini::default".
+  assert.equal(resolveRemoteSshDashboardProfile('', 'conn:mac-mini::default'), '')
+  assert.equal(resolveRemoteSshDashboardProfile(undefined, 'conn:spark::default'), '')
+  assert.equal(resolveRemoteSshDashboardProfile('', 'conn:mac-mini::dixie'), 'dixie')
+  assert.equal(resolveRemoteSshDashboardProfile('', 'bob'), 'bob')
+  assert.equal(resolveRemoteSshDashboardProfile('', 'default'), '')
+  assert.equal(resolveRemoteSshDashboardProfile('writer', 'conn:mac-mini::default'), 'writer')
 })
 
 test('normAuthMode coerces to token unless explicitly oauth', () => {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -214,6 +214,27 @@ function connectionScopeKey(profile) {
   return String(profile ?? '').trim() || null
 }
 
+/** Which Hermes profile the remote SSH dashboard should actually run as.
+ *  Registry pool keys (`conn:mac-mini::default`) are desktop routing labels —
+ *  they must never be sent to the remote as a profile name. `default` and
+ *  empty mean the remote root home. */
+function resolveRemoteSshDashboardProfile(configuredRemoteProfile, poolOrProfileKey) {
+  const configured = String(configuredRemoteProfile || '').trim()
+
+  if (configured && configured !== 'default') {
+    return configured
+  }
+
+  const key = String(poolOrProfileKey || '').trim()
+  const requested = key.startsWith('conn:') ? key.split('::').pop() || '' : key
+
+  if (!requested || requested === 'default') {
+    return ''
+  }
+
+  return requested
+}
+
 // Coerce a remote auth mode to one of the two supported values ('token' default).
 function normAuthMode(mode) {
   return mode === 'oauth' ? 'oauth' : 'token'
@@ -802,6 +823,7 @@ export {
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
   resolveProfileBackendRoute,
+  resolveRemoteSshDashboardProfile,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -28,6 +28,7 @@ import {
   REGISTRY_VERSION,
   rememberSshEnumeration,
   removeConnection,
+  shouldRetrySshInventory,
   resolveRegistryLocalRoute,
   setPrimaryConnection,
   uniqueLabel,
@@ -199,6 +200,13 @@ test('rememberSshEnumeration: live list wins, cache then seed default', () => {
     profiles: null,
     error: 'connect-on-demand'
   })
+})
+
+test('shouldRetrySshInventory: first try, cooldown, then retry; cache never retries', () => {
+  assert.equal(shouldRetrySshInventory(false, null, 1_000), true)
+  assert.equal(shouldRetrySshInventory(false, 1_000, 30_000, 60_000), false)
+  assert.equal(shouldRetrySshInventory(false, 1_000, 61_000, 60_000), true)
+  assert.equal(shouldRetrySshInventory(true, 1_000, 120_000, 60_000), false)
 })
 
 test('parseRemoteProfileListing: Mini/Spark dirs become roster names and drop rollbacks', () => {

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -24,7 +24,9 @@ import {
   migrateV1ToRegistry,
   normalizeConnectionInput,
   normalizeRegistry,
+  parseRemoteProfileListing,
   REGISTRY_VERSION,
+  rememberSshEnumeration,
   removeConnection,
   resolveRegistryLocalRoute,
   setPrimaryConnection,
@@ -179,6 +181,36 @@ test('roster: unique profiles keep bare handles; duplicates get @name-device', (
   assert.equal(byKey.get('local/default'), 'default')
   assert.equal(byKey.get('homelab/coder'), 'coder')
   assert.equal(roster.length, 4)
+})
+
+test('rememberSshEnumeration: live list wins, cache then seed default', () => {
+  assert.deepEqual(rememberSshEnumeration({ profiles: ['bob', 'kai'] }, ['stale'], 'ssh'), {
+    profiles: ['bob', 'kai']
+  })
+  assert.deepEqual(
+    rememberSshEnumeration({ profiles: null, error: 'connect-on-demand' }, ['bob', 'kai', 'rook'], 'ssh'),
+    { profiles: ['bob', 'kai', 'rook'], error: 'connect-on-demand' }
+  )
+  assert.deepEqual(rememberSshEnumeration({ profiles: null, error: 'connect-on-demand' }, null, 'ssh'), {
+    profiles: ['default'],
+    error: 'connect-on-demand'
+  })
+  assert.deepEqual(rememberSshEnumeration({ profiles: null, error: 'connect-on-demand' }, null, 'remote'), {
+    profiles: null,
+    error: 'connect-on-demand'
+  })
+})
+
+test('parseRemoteProfileListing: Mini/Spark dirs become roster names and drop rollbacks', () => {
+  const listed = parseRemoteProfileListing(
+    ['bob', 'dixie', 'goose', 'rambo', 'bob.rollback-old', '.hidden', '', 'not a name'].join('\n')
+  )
+
+  assert.deepEqual(listed, ['default', 'bob', 'dixie', 'goose', 'rambo'])
+})
+
+test('parseRemoteProfileListing: empty listing is still the default agent', () => {
+  assert.deepEqual(parseRemoteProfileListing(''), ['default'])
 })
 
 test('roster: unreachable sources contribute no rows and cannot fake duplicates', () => {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -262,6 +262,26 @@ export function rememberSshEnumeration(
   return enumeration
 }
 
+/** Whether an undialed SSH source should be inventoried again. Cached
+ *  successes never retry. Failures retry after `retryAfterMs` so a cold box
+ *  does not stay seeded as `default` until the user hits Test. */
+export function shouldRetrySshInventory(
+  hasCache: boolean,
+  lastAttemptMs: null | number | undefined,
+  nowMs: number,
+  retryAfterMs = 60_000
+): boolean {
+  if (hasCache) {
+    return false
+  }
+
+  if (lastAttemptMs == null) {
+    return true
+  }
+
+  return nowMs - lastAttemptMs >= retryAfterMs
+}
+
 const PROFILE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
 
 /** Turn `ls ~/.hermes/profiles` output into roster names. Always includes

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -233,6 +233,60 @@ export interface RosterAgent {
 }
 
 /**
+ * SSH roster enumeration skips undialed sources (connect-on-demand). Reuse the
+ * last successful profile list so Bot Mode does not go empty the moment the
+ * window switches back to local. Never-seen SSH sources still get a `default`
+ * seed so the device is clickable.
+ */
+export function rememberSshEnumeration(
+  enumeration: Pick<ConnectionAgents, 'error' | 'profiles'>,
+  cached: null | string[] | undefined,
+  kind: ConnectionKind
+): Pick<ConnectionAgents, 'error' | 'profiles'> {
+  if (enumeration.profiles && enumeration.profiles.length > 0) {
+    return enumeration
+  }
+
+  if (kind !== 'ssh') {
+    return enumeration
+  }
+
+  if (cached && cached.length > 0) {
+    return { profiles: cached, error: enumeration.error }
+  }
+
+  if (enumeration.error === 'connect-on-demand') {
+    return { profiles: ['default'], error: 'connect-on-demand' }
+  }
+
+  return enumeration
+}
+
+const PROFILE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
+
+/** Turn `ls ~/.hermes/profiles` output into roster names. Always includes
+ *  `default`. Drops rollback snapshots and junk lines. */
+export function parseRemoteProfileListing(text: string): string[] {
+  const names = new Set<string>(['default'])
+
+  for (const raw of String(text || '').split(/\r?\n/)) {
+    const name = raw.trim()
+
+    if (!name || name.startsWith('.') || name.endsWith('.rollback-old')) {
+      continue
+    }
+
+    if (!PROFILE_NAME_RE.test(name)) {
+      continue
+    }
+
+    names.add(name)
+  }
+
+  return ['default', ...[...names].filter(name => name !== 'default').sort()]
+}
+
+/**
  * Flatten per-connection profile enumerations into the union roster, applying
  * the duplicate-handle rule ONCE across all sources. Pure so the disambiguation
  * policy is testable without IPC; main.ts feeds it live enumerations.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -104,6 +104,7 @@ import {
   removeConnection,
   resolveRegistryLocalRoute,
   setPrimaryConnection,
+  shouldRetrySshInventory,
   updateEligibility,
   upsertConnection
 } from './connection-registry'
@@ -12418,7 +12419,7 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
     })
 
     if (result?.reachable) {
-      sshInventoryAttempted.delete(entry.id)
+      sshInventoryAttemptedAt.delete(entry.id)
       sshRosterCache.delete(entry.id)
       await probeSshProfileInventory(entry)
     }
@@ -12490,14 +12491,22 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
 // descriptor serves the enumeration like any remote. Last-known SSH profile
 // lists are reused so switching the window back to local does not empty Bot Mode.
 const sshRosterCache = new Map<string, string[]>()
-const sshInventoryAttempted = new Set<string>()
+const sshInventoryAttemptedAt = new Map<string, number>()
+const SSH_INVENTORY_RETRY_MS = 60_000
 
 async function probeSshProfileInventory(connection) {
-  if (sshRosterCache.has(connection.id) || sshInventoryAttempted.has(connection.id)) {
+  if (
+    !shouldRetrySshInventory(
+      sshRosterCache.has(connection.id),
+      sshInventoryAttemptedAt.get(connection.id),
+      Date.now(),
+      SSH_INVENTORY_RETRY_MS
+    )
+  ) {
     return
   }
 
-  sshInventoryAttempted.add(connection.id)
+  sshInventoryAttemptedAt.set(connection.id, Date.now())
 
   const sshConfig = normalizeSshConfig({
     mode: 'ssh',

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -86,6 +86,7 @@ import {
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
   resolveProfileBackendRoute,
+  resolveRemoteSshDashboardProfile,
   resolveTestWsUrl,
   savedProfileSsh,
   tokenPreview,
@@ -8845,7 +8846,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     const lifecycle = platform.os === 'Windows' ? connectWindowsRemote : remoteLifecycle.connect
     result = await lifecycle({
       ssh,
-      profile: sshConfig.remoteProfile || connectionScopeKey(profile) || '',
+      profile: resolveRemoteSshDashboardProfile(sshConfig.remoteProfile, profile),
       remoteHermesPath: sshConfig.remoteHermesPath || '',
       ownershipId: sshOwnershipKey(profile),
       reuseToken: reuseToken || '',

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12550,10 +12550,11 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
       let raw: { connection: typeof connection; error?: string; profiles: null | string[] }
 
       try {
-        if (
-          connection.kind === 'ssh' &&
-          ![...sshConnections.keys()].some(scope => String(scope).startsWith(backendScopePrefix(connection.id)))
-        ) {
+        // SSH roster listing must never spawn a dashboard. A stale
+        // sshConnections key used to fall into ensureRegistryBackend and
+        // respawn Spark/Mini every Bot Mode poll (~5s), then the mux died
+        // (ECONNRESET / liveness probe drop).
+        if (connection.kind === 'ssh') {
           await probeSshProfileInventory(connection)
           raw = { connection, profiles: null, error: 'connect-on-demand' }
         } else {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -100,6 +100,7 @@ import {
   migrateV1ToRegistry,
   normalizeConnectionInput,
   normalizeRegistry,
+  rememberSshEnumeration,
   removeConnection,
   resolveRegistryLocalRoute,
   setPrimaryConnection,
@@ -12407,7 +12408,7 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
   // The ssh probe path in testDesktopConnectionConfig never consults v1
   // connection state, so mapping the entry onto it is safe.
   if (entry.kind === 'ssh') {
-    return testDesktopConnectionConfig({
+    const result = await testDesktopConnectionConfig({
       mode: 'ssh',
       sshHost: entry.host,
       sshUser: entry.user,
@@ -12415,6 +12416,14 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
       sshKeyPath: entry.keyPath,
       sshRemoteHermesPath: entry.remoteHermesPath
     })
+
+    if (result?.reachable) {
+      sshInventoryAttempted.delete(entry.id)
+      sshRosterCache.delete(entry.id)
+      await probeSshProfileInventory(entry)
+    }
+
+    return result
   }
 
   // Remote/cloud/local probe built DIRECTLY from the registry entry. Routing
@@ -12478,35 +12487,92 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
 // instead of failing the whole roster. ssh sources that have never been dialed
 // are SKIPPED (connect-on-demand — dialing every ssh box just to list agents
 // would spawn tunnels the user never asked for); once dialed, their pooled
-// descriptor serves the enumeration like any remote.
+// descriptor serves the enumeration like any remote. Last-known SSH profile
+// lists are reused so switching the window back to local does not empty Bot Mode.
+const sshRosterCache = new Map<string, string[]>()
+const sshInventoryAttempted = new Set<string>()
+
+async function probeSshProfileInventory(connection) {
+  if (sshRosterCache.has(connection.id) || sshInventoryAttempted.has(connection.id)) {
+    return
+  }
+
+  sshInventoryAttempted.add(connection.id)
+
+  const sshConfig = normalizeSshConfig({
+    mode: 'ssh',
+    host: connection.host,
+    user: connection.user,
+    port: connection.port,
+    keyPath: connection.keyPath,
+    remoteHermesPath: connection.remoteHermesPath
+  })
+
+  if (!sshConfig) {
+    return
+  }
+
+  const ssh = createSshProbeConnection(
+    { host: sshConfig.host, user: sshConfig.user, port: sshConfig.port, keyPath: sshConfig.keyPath },
+    { rememberLog: sshRememberLog }
+  )
+
+  try {
+    await ssh.open()
+    const profiles = await remoteLifecycle.listRemoteHermesProfiles(ssh)
+
+    if (profiles.length > 0) {
+      sshRosterCache.set(connection.id, profiles)
+    }
+  } catch (error: any) {
+    sshRememberLog(`[ssh] profile inventory failed for ${connection.id}: ${error?.message || error}`)
+  } finally {
+    try {
+      await ssh.close()
+    } catch {
+      void 0
+    }
+  }
+}
+
 async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRegistry()) {
   return Promise.all(
     registry.connections.map(async connection => {
+      let raw: { connection: typeof connection; error?: string; profiles: null | string[] }
+
       try {
         if (
           connection.kind === 'ssh' &&
           ![...sshConnections.keys()].some(scope => String(scope).startsWith(backendScopePrefix(connection.id)))
         ) {
-          return { connection, profiles: null, error: 'connect-on-demand' }
+          await probeSshProfileInventory(connection)
+          raw = { connection, profiles: null, error: 'connect-on-demand' }
+        } else {
+          const descriptor: any = await ensureRegistryBackend(connection.id, null)
+          const body: any = await getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 })
+
+          const profiles = Array.isArray(body?.profiles)
+            ? body.profiles.map(p => String(p?.name || '').trim()).filter(Boolean)
+            : []
+
+          // The root HERMES_HOME is an agent too; enumerations that omit it
+          // (older backends list only named profiles) still get a default row.
+          if (!profiles.includes('default')) {
+            profiles.unshift('default')
+          }
+
+          raw = { connection, profiles }
         }
-
-        const descriptor: any = await ensureRegistryBackend(connection.id, null)
-        const body: any = await getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 })
-
-        const profiles = Array.isArray(body?.profiles)
-          ? body.profiles.map(p => String(p?.name || '').trim()).filter(Boolean)
-          : []
-
-        // The root HERMES_HOME is an agent too; enumerations that omit it
-        // (older backends list only named profiles) still get a default row.
-        if (!profiles.includes('default')) {
-          profiles.unshift('default')
-        }
-
-        return { connection, profiles }
       } catch (error: any) {
-        return { connection, profiles: null, error: String(error?.message || error) }
+        raw = { connection, profiles: null, error: String(error?.message || error) }
       }
+
+      if (raw.profiles && raw.profiles.length > 0) {
+        sshRosterCache.set(connection.id, raw.profiles)
+      }
+
+      const remembered = rememberSshEnumeration(raw, sshRosterCache.get(connection.id), connection.kind)
+      return { connection, ...remembered }
     })
   )
 }

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -10,6 +10,7 @@ import {
   expandRemotePath,
   fingerprintToken,
   isForwardBindCollision,
+  listRemoteHermesProfiles,
   locateHermes,
   LOCKFILE_SCHEMA_VERSION,
   lockfilePath,
@@ -78,6 +79,32 @@ function fakeSsh(rules: any[] = []) {
     }
   }
 }
+
+test('listRemoteHermesProfiles inventories Mini-style profile dirs without spawning a dashboard', async () => {
+  const ssh = fakeSsh([
+    [/HERMES_HOME/, '/Users/zillajr/.hermes\n'],
+    [/ls -1/, 'bob\ndixie\ngoose\nrambo\nbob.rollback-old\n']
+  ])
+
+  assert.deepEqual(await listRemoteHermesProfiles(ssh), ['default', 'bob', 'dixie', 'goose', 'rambo'])
+  assert.equal(
+    ssh.calls.some(cmd => cmd.includes('serve') || cmd.includes('dashboard')),
+    false
+  )
+})
+
+test('listRemoteHermesProfiles rejects a hostile HERMES_HOME', async () => {
+  const ssh = fakeSsh([[/HERMES_HOME/, '/tmp/x; echo pwned\n']])
+
+  await assert.rejects(() => listRemoteHermesProfiles(ssh), (err: any) => {
+    assert.equal(err.kind, 'unsafe-path')
+    return true
+  })
+  assert.equal(
+    ssh.calls.some(cmd => cmd.includes('ls -1')),
+    false
+  )
+})
 
 test('locateHermes prefers the explicit profile path when executable', async () => {
   const ssh = fakeSsh([[/\[ -x .*\/opt\/hermes/, 'OK']])

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -27,6 +27,8 @@
 
 import crypto from 'node:crypto'
 
+import { parseRemoteProfileListing } from './connection-registry'
+
 const LOCKFILE_SCHEMA_VERSION = 2
 // Bumped when the desktop<->dashboard reuse contract changes in a way that makes
 // an old running dashboard unsafe to reattach to (token handling, readiness/spawn
@@ -252,6 +254,35 @@ async function probeRemoteHermesHome(ssh) {
     error.cause = cause
     throw error
   }
+}
+
+async function listRemoteHermesProfiles(ssh) {
+  const home = assertSafeRemoteHome(await probeRemoteHermesHome(ssh))
+  const dir = expandRemotePath(`${home}/profiles`)
+  let listing = ''
+
+  try {
+    listing = await ssh.exec(`if [ -d ${dir} ]; then ls -1 ${dir}; fi`)
+  } catch (cause) {
+    const error: any = new Error('Could not list remote Hermes profiles.')
+    error.kind = 'transient-transport-error'
+    error.cause = cause
+    throw error
+  }
+
+  return parseRemoteProfileListing(listing)
+}
+
+function assertSafeRemoteHome(home) {
+  const value = String(home || '').trim()
+
+  if (!/^(\/|~\/)[A-Za-z0-9._/+-]+$/.test(value) || value.includes('..')) {
+    const error: any = new Error('Unsafe remote Hermes home.')
+    error.kind = 'unsafe-path'
+    throw error
+  }
+
+  return value.replace(/\/+$/, '')
 }
 
 async function readLockfile(ssh, ownershipId) {
@@ -882,6 +913,7 @@ export {
   locateHermes,
   LOCKFILE_SCHEMA_VERSION,
   lockfilePath,
+  listRemoteHermesProfiles,
   mintToken,
   openForward,
   ownershipDirectory,

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2203,10 +2203,11 @@ function mergeMultiSourceRoster(local, union, activeConnectionId, previous = [])
   const localProfiles = Array.isArray(local?.profiles) ? local.profiles : []
   const agents = Array.isArray(union?.agents) ? union.agents : []
   // A live id of null/'' means the window is on the unscoped local backend
-  // (host.state.connectionId is null for mode:'local'). Do NOT fall back to
-  // registry primary in that case — primary can still say "spark" after the
-  // user clicked a local bot, which skipped every Spark row as "active" and
-  // invented a This-device shadow of default.
+  // (legacy hosts reported null for mode:'local'; the SDK now reports
+  // 'local'). Do NOT fall back to registry primary when the third argument
+  // was passed — primary can still say "spark" after the user clicked a
+  // local bot, which skipped every Spark row as "active" and invented a
+  // This-device shadow of default.
   const liveProvided = arguments.length >= 3
   const liveId = String(activeConnectionId || '').trim()
   const activeId = liveId || (liveProvided ? '' : String(union?.primaryConnectionId || '').trim())
@@ -2300,12 +2301,22 @@ function mergeMultiSourceRoster(local, union, activeConnectionId, previous = [])
         .filter(Boolean)
     )
 
+    const registered = new Set(
+      (Array.isArray(union?.sources) ? union.sources : [])
+        .map(source => String(source?.connectionId || '').trim())
+        .filter(Boolean)
+    )
+
     for (const row of previous) {
       const connectionId = String(row?.connectionId || '').trim()
       const name = String(row?.name || '').trim()
       const key = `${connectionId}::${name || 'default'}`
 
       if (!row?.remoteSource || !connectionId || !name || present.has(key)) {
+        continue
+      }
+
+      if (registered.size > 0 && !registered.has(connectionId)) {
         continue
       }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2343,6 +2343,134 @@ function botHandle(name, bot) {
   return (name || '').trim().toLowerCase() === 'default' ? 'hermes' : name
 }
 
+function isActiveRosterBot(bot, active) {
+  const activeName = String(active?.name || 'default').trim() || 'default'
+  const activeId = String(active?.connectionId || '').trim()
+  const botId = String(bot?.connectionId || '').trim()
+  const botName = String(bot?.name || '').trim() || 'default'
+
+  if (bot?.remoteSource) {
+    return Boolean(activeId) && activeId === botId && botName === activeName
+  }
+
+  if (activeId && activeId !== 'local' && botId && activeId !== botId) {
+    return false
+  }
+
+  return botName === activeName
+}
+
+/** Resolve @handles in prose against the Bot Mode roster (local + Connections).
+ *  Skips the bot already speaking in this chat. Unique bare names match;
+ *  duplicate names require the @name-device handle. */
+function resolveRosterMentions(text, roster, active = {}) {
+  const members = Array.isArray(roster) ? roster : []
+  const prose = String(text || '').replace(/```[\s\S]*?```/g, ' ').replace(/`[^`\n]*`/g, ' ')
+  const byForm = new Map()
+
+  for (const bot of members) {
+    if (!bot?.name || isActiveRosterBot(bot, active)) {
+      continue
+    }
+
+    const handle = String(botHandle(bot.name, bot) || '').toLowerCase()
+    const name = String(bot.name || '').toLowerCase()
+    const forms = new Set([handle, name])
+
+    if (bot.handle) {
+      forms.add(String(bot.handle).toLowerCase())
+    }
+
+    for (const form of forms) {
+      if (!form) {
+        continue
+      }
+
+      const existing = byForm.get(form)
+
+      if (existing && existing !== bot) {
+        byForm.set(form, null)
+        continue
+      }
+
+      if (!existing) {
+        byForm.set(form, bot)
+      }
+    }
+  }
+
+  const mentioned = []
+  const seen = new Set()
+
+  for (const match of prose.matchAll(/(^|\s)@([a-z0-9][a-z0-9_-]*)/gi)) {
+    let token = match[2].toLowerCase()
+
+    if (token === 'hermes') {
+      token = byForm.has('hermes') ? 'hermes' : token
+    }
+
+    const bot = byForm.get(token)
+
+    if (!bot) {
+      continue
+    }
+
+    const key = botRosterKey(bot)
+
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    mentioned.push(bot)
+  }
+
+  return mentioned
+}
+
+async function deliverRemoteRosterMentions(bots, userText) {
+  const text = String(userText || '').trim()
+
+  if (!text || typeof host.requestProfile !== 'function') {
+    return
+  }
+
+  for (const bot of bots) {
+    const connectionId = String(bot?.connectionId || '').trim()
+    const profile = String(bot?.name || '').trim() || 'default'
+
+    if (!connectionId || connectionId === 'local') {
+      continue
+    }
+
+    try {
+      const created = await host.requestProfile(
+        { connectionId, profile, mode: 'remote', targetProfile: profile },
+        'session.create',
+        { profile, title: 'Bot Chat', hidden: true }
+      )
+      const sessionId = created?.session_id
+
+      if (!sessionId) {
+        throw new Error('No remote session')
+      }
+
+      await host.requestProfile(
+        { connectionId, profile, mode: 'remote', targetProfile: profile },
+        'prompt.submit',
+        { session_id: sessionId, text }
+      )
+      host.notify?.({
+        kind: 'info',
+        title: displayName(bot),
+        message: `Messaged @${botHandle(profile, bot)} on ${bot.connectionLabel || connectionId} from this chat.`
+      })
+    } catch (error) {
+      host.notifyError?.(error, `Could not reach ${bot.connectionLabel || profile}`)
+    }
+  }
+}
+
 /** Source-qualified identity for a roster row — the React list key AND the
  *  cross-surface roster identity. Names alone are NOT unique in a
  *  multi-source roster (two connections can both expose 'default');
@@ -3369,6 +3497,17 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
   const open = async () => {
     haptic('tap')
     $selectedBot.set(bot.name)
+
+    if (bot.remoteSource) {
+      const handle = botHandle(bot.name, bot)
+      host.notify?.({
+        kind: 'info',
+        title: displayName(bot),
+        message: `Stay in this chat and @${handle} to message them. Gateway stays on this device.`
+      })
+      return
+    }
+
     let pinnedChat = meta?.chat
 
     if (!bot.remoteSource && $botUnread.get()[bot.name]) {
@@ -6755,6 +6894,16 @@ function BotsPane() {
           haptic('tap')
           $selectedBot.set(bot.name)
 
+          if (bot.remoteSource) {
+            const handle = botHandle(bot.name, bot)
+            host.notify?.({
+              kind: 'info',
+              title: displayName(bot),
+              message: `Stay in this chat and @${handle} to message them. Gateway stays on this device.`
+            })
+            return
+          }
+
           if ($botUnread.get()[bot.name]) {
             const next = { ...$botUnread.get() }
             delete next[bot.name]
@@ -6997,9 +7146,13 @@ export default {
           const active = (host.state.profile.get() || 'default').trim() || 'default'
           const q = (query || '').toLowerCase()
           const items = []
+          const live = {
+            name: active,
+            connectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
+          }
 
           for (const profile of profiles) {
-            if (!profile?.name || profile.name === active) {
+            if (!profile?.name || isActiveRosterBot(profile, live)) {
               continue
             }
 
@@ -7199,52 +7352,73 @@ export default {
             return draft
           }
 
-          let names = []
-          try {
-            const res = await host.request('profiles.list', { include_sessions: false })
-            names = (res?.profiles ?? []).map(p => p.name)
-          } catch {
+          const live = {
+            name: (host.state.profile.get() || 'default').trim() || 'default',
+            connectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
+          }
+          const cached = typeof queryClient !== 'undefined' && queryClient && typeof queryClient.getQueryData === 'function'
+            ? queryClient.getQueryData(ROSTER_KEY)
+            : null
+          const roster = Array.isArray(cached?.profiles) ? cached.profiles : null
+          let mentionedBots = roster ? resolveRosterMentions(text, roster, live) : []
+
+          if (!roster) {
+            let names = []
+            try {
+              const res = await host.request('profiles.list', { include_sessions: false })
+              names = (res?.profiles ?? []).map(p => p.name)
+            } catch {
+              return draft
+            }
+
+            const prose = text.replace(/```[\s\S]*?```/g, ' ').replace(/`[^`\n]*`/g, ' ')
+            const mentioned = []
+
+            for (const match of prose.matchAll(/(^|\s)@([a-z0-9][a-z0-9_-]*)/gi)) {
+              let name = match[2].toLowerCase()
+
+              if (name === 'hermes' && !names.includes('hermes') && names.includes('default')) {
+                name = 'default'
+              }
+
+              if (names.includes(name) && name !== live.name && !mentioned.includes(name)) {
+                mentioned.push(name)
+              }
+            }
+
+            mentionedBots = mentioned.map(name => ({ name }))
+          }
+
+          if (!mentionedBots.length) {
             return draft
           }
 
-          // Mentions in code are code, not handoffs (#20).
-          const prose = text.replace(/```[\s\S]*?```/g, ' ').replace(/`[^`\n]*`/g, ' ')
-          const active = (host.state.profile.get() || 'default').trim() || 'default'
-          const mentioned = []
+          const localMentions = mentionedBots.filter(bot => !bot.remoteSource)
+          const remoteMentions = mentionedBots.filter(bot => bot.remoteSource)
 
-          for (const match of prose.matchAll(/(^|\s)@([a-z0-9][a-z0-9_-]*)/gi)) {
-            let name = match[2].toLowerCase()
-
-            if (name === 'hermes' && !names.includes('hermes') && names.includes('default')) {
-              name = 'default'
-            }
-
-            if (names.includes(name) && name !== active && !mentioned.includes(name)) {
-              mentioned.push(name)
-            }
+          if (remoteMentions.length && typeof host.requestProfile === 'function') {
+            void deliverRemoteRosterMentions(remoteMentions, text)
           }
 
-          if (!mentioned.length) {
-            return draft
+          const activeMeta = $botMeta.get()[live.name]
+          const senderName = displayName({ name: live.name, title: activeMeta?.title }, activeMeta)
+          let note = ''
+
+          if (localMentions.length) {
+            note +=
+              '\n\n[@mention handoff — for each mentioned agent (' + localMentions.map(bot => botHandle(bot.name, bot)).join(', ') + '): ' +
+              'COMPOSE a message from you (' + senderName + ') to that agent conveying what the user wants — do not forward this text verbatim (avoid double quotes in your composed message). Send it with exactly one terminal call, run with background=true AND notify_on_complete=true (the recipient may take minutes; the user must not be blocked):\n' +
+              localMentions.map(bot => '`hermes -p ' + shellQuote(bot.name) + ' chat --in ~ -c "Bot Chat" --create-if-missing -Q -q "Message from 🤖 ' + shellDoubleQuote(senderName) + ' (@' + shellDoubleQuote(botHandle(live.name)) + '): <your composed message>"`').join('\n') +
+              '\nAfter dispatching, tell the user the message was sent and END YOUR TURN — do not wait or poll; when the background process completes, its notification carries the reply — relay it then, attributed to that agent. ' +
+              'Relay the reply back to the user, attributed to that agent.]'
           }
 
-          // The ACTIVE BOT composes the message — it understands intent; a
-          // text pipe never can. Delivery is the one blessed command into the
-          // recipient's canonical Bot Chat, so their side reads as a normal
-          // DM (message bubble + their reply), and the reply prints on
-          // stdout for the sender to relay.
-          const activeMeta = $botMeta.get()[active]
-          const senderName = displayName({ name: active, title: activeMeta?.title }, activeMeta)
-          // The command below runs verbatim in the active agent's terminal:
-          // sender titles are free text (and sync from ui_meta), and profile
-          // names come from the gateway — every interpolated value must stay
-          // shell-literal, same class as the routine-prompt fix (#21).
-          const note =
-            '\n\n[@mention handoff — for each mentioned agent (' + mentioned.map(botHandle).join(', ') + '): ' +
-            'COMPOSE a message from you (' + senderName + ') to that agent conveying what the user wants — do not forward this text verbatim (avoid double quotes in your composed message). Send it with exactly one terminal call, run with background=true AND notify_on_complete=true (the recipient may take minutes; the user must not be blocked):\n' +
-            mentioned.map(n => '`hermes -p ' + shellQuote(n) + ' chat --in ~ -c "Bot Chat" --create-if-missing -Q -q "Message from \uD83E\uDD16 ' + shellDoubleQuote(senderName) + ' (@' + shellDoubleQuote(botHandle(active)) + '): <your composed message>"`').join('\n') +
-            '\nAfter dispatching, tell the user the message was sent and END YOUR TURN — do not wait or poll; when the background process completes, its notification carries the reply — relay it then, attributed to that agent. ' +
-            'Relay the reply back to the user, attributed to that agent.]'
+          if (remoteMentions.length) {
+            const labels = remoteMentions.map(bot => `@${botHandle(bot.name, bot)} (${bot.connectionLabel || bot.connectionId})`).join(', ')
+            note +=
+              '\n\n[@mention — stay on this device. Desktop is delivering to ' + labels +
+              ' over Connections in the background. Do not run hermes -p for them and do not switch Gateway. Tell the user they were messaged here; when a reply lands, relay it attributed to that agent.]'
+          }
 
           return { ...draft, text: text + note }
         }      }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2173,7 +2173,7 @@ function useRoster() {
       if (typeof host.agents === 'function') {
         try {
           const union = await host.agents()
-          return mergeMultiSourceRoster(local, union, activeConnectionId)
+          return mergeMultiSourceRoster(local, union, activeConnectionId, $lastRoster.get())
         } catch {
           /* older build or roster failure — single-source list stands */
         }
@@ -2199,10 +2199,17 @@ function useRoster() {
  *  Rows from other sources become new roster entries tagged with their
  *  source label so BotRow can badge them and route open/warm through
  *  ensureAgent/warmAgent. Pure — exercised directly by the tests. */
-function mergeMultiSourceRoster(local, union, activeConnectionId = null) {
+function mergeMultiSourceRoster(local, union, activeConnectionId, previous = []) {
   const localProfiles = Array.isArray(local?.profiles) ? local.profiles : []
   const agents = Array.isArray(union?.agents) ? union.agents : []
-  const activeId = String(activeConnectionId || union?.primaryConnectionId || '').trim()
+  // A live id of null/'' means the window is on the unscoped local backend
+  // (host.state.connectionId is null for mode:'local'). Do NOT fall back to
+  // registry primary in that case — primary can still say "spark" after the
+  // user clicked a local bot, which skipped every Spark row as "active" and
+  // invented a This-device shadow of default.
+  const liveProvided = arguments.length >= 3
+  const liveId = String(activeConnectionId || '').trim()
+  const activeId = liveId || (liveProvided ? '' : String(union?.primaryConnectionId || '').trim())
   const activeByName = new Map()
 
   // Treat the rich list as one row per active-source profile. Clone every
@@ -2226,10 +2233,6 @@ function mergeMultiSourceRoster(local, union, activeConnectionId = null) {
   }
 
   const profiles = [...activeByName.values()]
-
-  if (!agents.length) {
-    return { ...local, profiles }
-  }
 
   // host.agents is an Electron/main-process capability. Defend the plugin
   // boundary too: older shells or reconnect races can still hand us repeated
@@ -2282,6 +2285,35 @@ function mergeMultiSourceRoster(local, union, activeConnectionId = null) {
       remoteSource: true,
       sourceScoped: true
     })
+  }
+
+  // SSH sources drop to connect-on-demand the moment their tunnel is not
+  // the live gateway. Keep previously painted remote rows so clicking the
+  // local agent does not empty Bot Mode.
+  if (Array.isArray(previous) && previous.length > 0) {
+    const present = new Set(profiles.map(row => `${row.connectionId || ''}::${row.name}`))
+    const unionSourceIds = new Set(agents.map(agent => String(agent?.connectionId || '').trim()).filter(Boolean))
+    const omitted = new Set(
+      (Array.isArray(union?.sources) ? union.sources : [])
+        .filter(source => source?.error === 'connect-on-demand' || source?.reachable === false)
+        .map(source => String(source.connectionId || '').trim())
+        .filter(Boolean)
+    )
+
+    for (const row of previous) {
+      const connectionId = String(row?.connectionId || '').trim()
+      const name = String(row?.name || '').trim()
+      const key = `${connectionId}::${name || 'default'}`
+
+      if (!row?.remoteSource || !connectionId || !name || present.has(key)) {
+        continue
+      }
+
+      if (omitted.has(connectionId) || !unionSourceIds.has(connectionId)) {
+        profiles.push({ ...row, remoteSource: true, sourceScoped: true })
+        present.add(key)
+      }
+    }
   }
 
   return { ...local, profiles }
@@ -2482,7 +2514,16 @@ async function prepareBotSource(bot, pinnedChat) {
 }
 
 function displayName(bot, meta) {
-  if (bot?.sourceScoped && (bot.name || '').trim().toLowerCase() === 'default' && bot.connectionLabel) {
+  const isLocalSource = bot?.connectionKind === 'local' || bot?.connectionId === 'local'
+
+  // Remote/SSH default is the device itself. Local default is Hermes —
+  // naming it "This device" created the shadow agent next to this chat.
+  if (
+    bot?.sourceScoped &&
+    (bot.name || '').trim().toLowerCase() === 'default' &&
+    bot.connectionLabel &&
+    !isLocalSource
+  ) {
     return bot.connectionLabel
   }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2510,6 +2510,13 @@ async function prepareBotSource(bot, pinnedChat) {
     return pinnedChat
   }
 
+  const liveId = String(typeof host.activeConnectionId === 'function' ? host.activeConnectionId() || '' : '').trim()
+  const targetId = String(bot.connectionId || '').trim()
+
+  if (targetId && targetId !== 'local' && liveId !== targetId) {
+    throw new Error(`Still on ${liveId || 'this device'}, not ${bot.connectionLabel || targetId}`)
+  }
+
   // Thin rows deliberately omit metadata from the active source. Once their
   // owner is active, recover that source's canonical-chat pointer so
   // same-named agents never reuse or overwrite each other's pin.

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
@@ -110,3 +110,66 @@ test('regression: the handoff command quotes the recipient argument', async () =
   const result = await handler({ text: 'ping @ops please' })
   assert.match(result.text, /`hermes -p 'ops' chat --in ~/)
 })
+
+test('behavior: @dixie on a Connections bot stays in this chat and does not hermes -p', async () => {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const delivered = []
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    queryClient: {
+      getQueryData: () => ({
+        profiles: [
+          { name: 'default', connectionId: 'local' },
+          {
+            name: 'dixie',
+            connectionId: 'mac-mini',
+            connectionLabel: 'Mac Mini',
+            handle: 'dixie',
+            remoteSource: true
+          }
+        ]
+      })
+    },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      request: async () => ({ profiles: [{ name: 'default' }] }),
+      requestProfile: async (route, method) => {
+        delivered.push([route.connectionId, route.profile, method])
+        return { session_id: 'remote-1' }
+      },
+      state: {
+        profile: { get: () => 'default', listen: () => undefined },
+        connectionId: { get: () => 'local', listen: () => undefined },
+        gateway: { listen: () => undefined }
+      }
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__mention = { $botMeta };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  context.__mention.$botMeta.set({})
+
+  const registered = []
+  context.plugin.register({ storage: { get: () => null }, register: entry => registered.push(entry) })
+  const middleware = registered.find(entry => entry.id === 'mention-middleware')
+  const result = await middleware.data.handler({ text: '@dixie what is the disk space?' })
+
+  assert.match(result.text, /stay on this device/i)
+  assert.doesNotMatch(result.text, /hermes -p 'dixie'/)
+  await new Promise(resolve => setTimeout(resolve, 0))
+  assert.equal(delivered[0][0], 'mac-mini')
+  assert.equal(delivered[0][1], 'dixie')
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -336,6 +336,110 @@ test('merge: primary-local desktop keeps single-source behavior (no phantom rows
 // source's agent, profiles.list answers from THAT source — the merge must
 // classify against the live id, not the registry primary, or the active
 // source's agents duplicate all over again.
+test('merge: live-null local window does not treat registry primary as active', () => {
+  const { __mergeMultiSourceRoster: merge } = runtime()
+  const local = { profiles: [{ name: 'default', last_session: { id: 'this-chat' } }] }
+  const union = {
+    primaryConnectionId: 'spark',
+    agents: [
+      {
+        connectionId: 'local',
+        connectionKind: 'local',
+        connectionLabel: 'This device',
+        profile: 'default',
+        handle: 'default-this-device'
+      },
+      { connectionId: 'spark', connectionKind: 'ssh', connectionLabel: 'Spark', profile: 'bob', handle: 'bob' },
+      { connectionId: 'spark', connectionKind: 'ssh', connectionLabel: 'Spark', profile: 'kai', handle: 'kai' },
+      { connectionId: 'spark', connectionKind: 'ssh', connectionLabel: 'Spark', profile: 'rook', handle: 'rook' }
+    ]
+  }
+
+  // Clicking the local agent leaves host.state.connectionId null while the
+  // registry primary stays on Spark. That must not skip Spark bots or invent
+  // a second "This device" shadow of default.
+  const out = merge(local, union, null)
+
+  assert.equal(out.profiles.filter(p => p.name === 'default').length, 1)
+  assert.equal(out.profiles.find(p => p.name === 'default').last_session.id, 'this-chat')
+  assert.equal(out.profiles.filter(p => p.remoteSource && p.connectionId === 'local').length, 0)
+  assert.equal(
+    out.profiles
+      .filter(p => p.remoteSource)
+      .map(p => p.name)
+      .sort()
+      .join(','),
+    'bob,kai,rook'
+  )
+})
+
+test('merge: previously seen remotes survive a connect-on-demand empty union', () => {
+  const { __mergeMultiSourceRoster: merge } = runtime()
+  const previous = [
+    { name: 'default', last_session: { id: 'this-chat' } },
+    {
+      name: 'bob',
+      remoteSource: true,
+      sourceScoped: true,
+      connectionId: 'spark',
+      connectionKind: 'ssh',
+      connectionLabel: 'Spark',
+      handle: 'bob'
+    }
+  ]
+  const local = { profiles: [{ name: 'default', last_session: { id: 'this-chat' } }] }
+  const union = {
+    primaryConnectionId: 'local',
+    agents: [
+      {
+        connectionId: 'local',
+        connectionKind: 'local',
+        connectionLabel: 'This device',
+        profile: 'default',
+        handle: 'default'
+      }
+    ],
+    sources: [{ connectionId: 'spark', kind: 'ssh', error: 'connect-on-demand' }]
+  }
+
+  const out = merge(local, union, 'local', previous)
+  const bob = out.profiles.find(p => p.name === 'bob' && p.connectionId === 'spark')
+
+  assert.ok(bob)
+  assert.equal(bob.remoteSource, true)
+  assert.equal(out.profiles.filter(p => p.name === 'default').length, 1)
+})
+
+test('displayName: local default stays Hermes; remote default uses the device label', () => {
+  const { __displayName: name } = runtime()
+
+  assert.equal(
+    name(
+      {
+        name: 'default',
+        sourceScoped: true,
+        connectionKind: 'local',
+        connectionLabel: 'This device'
+      },
+      null
+    ),
+    'Hermes'
+  )
+  assert.equal(
+    name(
+      {
+        name: 'default',
+        sourceScoped: true,
+        remoteSource: true,
+        connectionKind: 'ssh',
+        connectionLabel: 'Spark'
+      },
+      null
+    ),
+    'Spark'
+  )
+})
+
 test('merge: live active id beats primaryConnectionId for active-source matching', () => {
   const { __mergeMultiSourceRoster: merge } = runtime()
   const local = { profiles: [{ name: 'default', last_session: { id: 's1' } }] }

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -32,7 +32,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;'
+      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;'
     )
   vm.runInNewContext(code, context)
   return context
@@ -506,4 +506,73 @@ test('botRosterKey: same name on two sources yields distinct React keys', () => 
   assert.notEqual(activeRow, remoteRow)
   // Single-source desktops (no connection ids anywhere) keep a stable key.
   assert.equal(legacyRow, 'legacy::default')
+})
+
+test('resolveRosterMentions: @dixie and @bob-mac-mini hit Connections bots, not this chat', () => {
+  const { __resolveRosterMentions: resolve } = runtime()
+  const roster = [
+    { name: 'default', connectionId: 'local', connectionKind: 'local', handle: 'default-this-device' },
+    {
+      name: 'dixie',
+      connectionId: 'mac-mini',
+      connectionKind: 'ssh',
+      connectionLabel: 'Mac Mini',
+      handle: 'dixie',
+      remoteSource: true,
+      sourceScoped: true
+    },
+    {
+      name: 'bob',
+      connectionId: 'mac-mini',
+      connectionKind: 'ssh',
+      connectionLabel: 'Mac Mini',
+      handle: 'bob-mac-mini',
+      remoteSource: true,
+      sourceScoped: true
+    },
+    {
+      name: 'bob',
+      connectionId: 'spark',
+      connectionKind: 'ssh',
+      connectionLabel: 'Spark',
+      handle: 'bob-spark',
+      remoteSource: true,
+      sourceScoped: true
+    }
+  ]
+
+  const hits = resolve('hey @dixie and @bob-spark, ping @bob-mac-mini', roster, {
+    name: 'default',
+    connectionId: 'local'
+  })
+
+  assert.equal(
+    hits
+      .map(bot => `${bot.connectionId}::${bot.name}`)
+      .sort()
+      .join(','),
+    'mac-mini::bob,mac-mini::dixie,spark::bob'
+  )
+})
+
+test('resolveRosterMentions: @hermes in this chat is not a handoff to yourself', () => {
+  const { __resolveRosterMentions: resolve } = runtime()
+  const roster = [
+    { name: 'default', connectionId: 'local', handle: 'hermes' },
+    {
+      name: 'default',
+      connectionId: 'mac-mini',
+      connectionLabel: 'Mac Mini',
+      handle: 'default-mac-mini',
+      remoteSource: true
+    }
+  ]
+
+  const hits = resolve('ask @hermes and @default-mac-mini', roster, {
+    name: 'default',
+    connectionId: 'local'
+  })
+
+  assert.equal(hits.length, 1)
+  assert.equal(hits[0].connectionId, 'mac-mini')
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -410,6 +410,39 @@ test('merge: previously seen remotes survive a connect-on-demand empty union', (
   assert.equal(out.profiles.filter(p => p.name === 'default').length, 1)
 })
 
+test('merge: previous remotes from a removed connection do not resurrect', () => {
+  const { __mergeMultiSourceRoster: merge } = runtime()
+  const previous = [
+    { name: 'default', last_session: { id: 'this-chat' } },
+    {
+      name: 'bob',
+      remoteSource: true,
+      sourceScoped: true,
+      connectionId: 'gone',
+      connectionKind: 'ssh',
+      connectionLabel: 'Gone',
+      handle: 'bob'
+    }
+  ]
+  const local = { profiles: [{ name: 'default', last_session: { id: 'this-chat' } }] }
+  const union = {
+    primaryConnectionId: 'local',
+    agents: [
+      {
+        connectionId: 'local',
+        connectionKind: 'local',
+        connectionLabel: 'This device',
+        profile: 'default',
+        handle: 'default'
+      }
+    ],
+    sources: [{ connectionId: 'local', kind: 'local' }]
+  }
+
+  const out = merge(local, union, 'local', previous)
+  assert.equal(out.profiles.find(p => p.connectionId === 'gone'), undefined)
+})
+
 test('displayName: local default stays Hermes; remote default uses the device label', () => {
   const { __displayName: name } = runtime()
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -23,6 +23,7 @@ function renderBotRow(input = 'alpha') {
   const ensured = []
   const opened = []
   const warmed = []
+  let liveConnectionId = 'local'
   const atom = value => ({
     get: () => value,
     set: next => {
@@ -63,7 +64,11 @@ function renderBotRow(input = 'alpha') {
     useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
     host: {
       state: { gateway: atom('open'), profile: atom('default') },
-      ensureAgent: async (connectionId, profile) => ensured.push([connectionId, profile]),
+      ensureAgent: async (connectionId, profile) => {
+        ensured.push([connectionId, profile])
+        liveConnectionId = connectionId
+      },
+      activeConnectionId: () => liveConnectionId,
       warmAgent: (connectionId, profile) => warmed.push([connectionId, profile]),
       warmProfile: profile => warmed.push(profile),
       request: async method =>
@@ -128,4 +133,84 @@ test('behavior: a thin source row activates its owner and uses that owner\'s cha
   await row.props.onClick()
   assert.deepEqual(ensured, [['work', 'research']])
   assert.deepEqual(opened, [['research', 'owner-chat']])
+})
+
+test('behavior: remote default does not open this-device chat when the source did not activate', async () => {
+  const bot = {
+    connectionId: 'mac-mini',
+    connectionLabel: 'Mac Mini',
+    name: 'default',
+    remoteSource: true,
+    sourceScoped: true
+  }
+  const prepareSource = sourceBetween('async function prepareBotSource(', 'function displayName(')
+  const botRowSource = sourceBetween('function BotRow(', '// ── model picker')
+  const ensured = []
+  const opened = []
+  const errors = []
+  const atom = value => ({
+    get: () => value,
+    set: next => {
+      value = next
+    }
+  })
+  const node = (type, props = {}) => ({ type, props })
+  const context = {
+    BotFace: 'BotFace',
+    ContextMenu: 'ContextMenu',
+    ContextMenuContent: 'ContextMenuContent',
+    ContextMenuItem: 'ContextMenuItem',
+    ContextMenuSeparator: 'ContextMenuSeparator',
+    ContextMenuTrigger: 'ContextMenuTrigger',
+    ROSTER_KEY: ['hermes-bots', 'roster'],
+    $botMeta: atom({ default: { chat: 'this-device-chat' } }),
+    $botUnread: atom({}),
+    $lastRoster: atom([]),
+    $selectedBot: atom('default'),
+    botAppearance: () => ({ shape: 'round', color: '#000', image: null }),
+    botHandle: value => value,
+    botRosterMeta: () => null,
+    cn: (...values) => values.filter(Boolean).join(' '),
+    createCanonicalChat: async () => null,
+    displayName: bot => bot.connectionLabel || bot.name,
+    duplicateBot: async () => 'copy',
+    haptic: () => undefined,
+    previewKind: () => ({ fromBot: false, sender: null }),
+    generatedSessionTitle: () => null,
+    openBotCanonicalChat: async (...args) => {
+      opened.push(args)
+      return 'this-device-chat'
+    },
+    ACTIVE_WINDOW_S: 90,
+    A2A_PREFIX_RE: /^$/,
+    useEffect: () => undefined,
+    useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
+    host: {
+      state: { gateway: atom('open'), profile: atom('default') },
+      ensureAgent: async (connectionId, profile) => ensured.push([connectionId, profile]),
+      activeConnectionId: () => 'local',
+      warmAgent: () => undefined,
+      warmProfile: () => undefined,
+      request: async () => ({ profiles: [{ name: 'default', ui_meta: { 'hermes-bots': { chat: 'this-device-chat' } } }] }),
+      notify: () => undefined,
+      notifyError: (_err, msg) => errors.push(msg)
+    },
+    jsx: node,
+    jsxs: node,
+    onEdit: () => undefined,
+    queryClient: { invalidateQueries: () => undefined },
+    relativeTime: () => 'now',
+    saveBotMeta: () => undefined,
+    showsHandle: () => false,
+    useValue: store => store.get()
+  }
+
+  vm.runInNewContext(`${prepareSource}\n${botRowSource}\nglobalThis.BotRow = BotRow`, context)
+  const tree = context.BotRow({ bot, onEdit: context.onEdit })
+  const row = tree.type === 'button' ? tree : tree.props.children[0].props.children
+
+  await row.props.onClick()
+  assert.deepEqual(ensured, [['mac-mini', 'default']])
+  assert.deepEqual(opened, [])
+  assert.match(String(errors[0] || ''), /Mac Mini/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -118,7 +118,7 @@ test('behavior: pointer entry prewarms only the hovered bot', () => {
   assert.deepEqual(warmed, ['alpha'])
 })
 
-test('behavior: a thin source row activates its owner and uses that owner\'s chat pin', async () => {
+test('behavior: a remote Connections row stays in this chat instead of hopping SSH', async () => {
   const { ensured, opened, row, warmed } = renderBotRow({
     connectionId: 'work',
     connectionLabel: 'Work',
@@ -131,8 +131,8 @@ test('behavior: a thin source row activates its owner and uses that owner\'s cha
   assert.deepEqual(warmed, [['work', 'research']])
 
   await row.props.onClick()
-  assert.deepEqual(ensured, [['work', 'research']])
-  assert.deepEqual(opened, [['research', 'owner-chat']])
+  assert.deepEqual(ensured, [])
+  assert.deepEqual(opened, [])
 })
 
 test('behavior: remote default does not open this-device chat when the source did not activate', async () => {
@@ -210,7 +210,7 @@ test('behavior: remote default does not open this-device chat when the source di
   const row = tree.type === 'button' ? tree : tree.props.children[0].props.children
 
   await row.props.onClick()
-  assert.deepEqual(ensured, [['mac-mini', 'default']])
+  assert.deepEqual(ensured, [])
   assert.deepEqual(opened, [])
-  assert.match(String(errors[0] || ''), /Mac Mini/)
+  assert.equal(errors.length, 0)
 })

--- a/apps/desktop/src/sdk/host-state.test.ts
+++ b/apps/desktop/src/sdk/host-state.test.ts
@@ -65,7 +65,7 @@ describe('host.state focused-session atoms', () => {
     expect(host.state.connectionId.get()).toBe('work')
 
     session.setConnection({ mode: 'local' } as never)
-    expect(host.state.connectionId.get()).toBeNull()
+    expect(host.state.connectionId.get()).toBe('local')
     session.setConnection(null)
   })
 

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -169,7 +169,20 @@ if (typeof window !== 'undefined') {
 /** Live usage of the FOCUSED session, projected out of the streamed session
  *  state — the same readout the core statusbar's context chip paints. */
 const $focusedUsage = computed($focusedSessionState, state => state?.usage ?? null)
-const $activeConnectionId = computed($connection, connection => connection?.connectionId ?? null)
+const $activeConnectionId = computed($connection, connection => {
+  if (!connection) {
+    return null
+  }
+
+  if (connection.connectionId) {
+    return connection.connectionId
+  }
+
+  // mode:'local' used to report null, which made Bot Mode fall back to the
+  // registry primary (often an SSH box) and treat Spark as the active source
+  // while this window was actually local.
+  return connection.mode === 'local' ? 'local' : null
+})
 
 export const host = {
   state: {


### PR DESCRIPTION
## Bug Description

With more than one SSH connection registered (e.g. Spark + Mac Mini), Bot Mode showed the live machine's agents and then **emptied the rest** when you clicked the local agent (this chat). A phantom **This device** row appeared next to Hermes. The other machines' bots were still in the profile rail above; clicking those brought them back.

`Test` on a connection was not enough: it is a throwaway probe that closes the tunnel, and undialed SSH sources were skipped as `connect-on-demand` with no profile list.

## Root Cause

1. Clicking the local bot left `host.state.connectionId` as `null` (`mode: 'local'`). Merge fell back to the registry **primary** (often an SSH box). Spark rows were classified as "active source missing from `profiles.list`" and dropped. Local `default` was also appended as a thin remote row named after the connection label (**This device**).
2. Roster enumeration never listed undialed SSH profiles (no dashboard spawn by design), so Mini's `bob` / `dixie` / `goose` / `rambo` never appeared unless the whole window switched onto that box.

## Fix

- Treat a live `null` connection id as the unscoped local backend. Do **not** inherit registry primary in that case.
- Report `connectionId: 'local'` for `mode: 'local'`.
- Keep local `default` named **Hermes**; remote/SSH default still uses the device label.
- Remember previously painted remote rows across connect-on-demand refreshes.
- Inventory undialed SSH sources with a cached `ls ~/.hermes/profiles` (no dashboard). One probe per connection; **Test** refreshes the cache. Hostile `HERMES_HOME` values are rejected before the listing command.

## How to Verify

1. Register two SSH connections (do not make the window live on both).
2. Open Bot Mode — both machines' named profiles should appear (Mini + Spark in the reporter's setup).
3. Click the local Hermes row — the remote bots must stay. No second **This device** shadow.
4. Click a Mini bot — Desktop dials that host and opens that profile's chat.

## Test Plan

- [x] Added regression tests for the live-null merge, shadow display name, remembered remotes, profile-dir parser, Mini-style inventory, and hostile `HERMES_HOME`
- [x] Existing desktop tests still pass (`vitest` 122 + Bot Mode plugin 16)
- [ ] Manual verification on a rebuilt Desktop (bundled plugin; this window was not rebuilt)

## Risk Assessment

Medium — touches Bot Mode merge (cached prefix of every roster refresh) and Electron SSH inventory. Scoped to SSH `connect-on-demand` + local `connectionId` null. Remote-primary desktops that omit the third merge argument still use the previous primary fallback. Inventory is cache-once so the 5s poll does not re-SSH.

## Disclosures

- First-run of the new merge tests failed the real symptom (`2 !== 1` default rows; Spark bots missing).
- Mutation: restore old primary fallback → live-null test red again; naive parser → Mini names missing.
- Packaged Desktop will not pick this up until rebuild; in-tree Bot Mode is bundled and wins over `~/.hermes/desktop-plugins`.
