### PR TITLE
feat(models): add Meta Muse Spark 1.2 to OpenRouter curated picker (salvages #80406)

### DIFF
--- a/contributors/emails/eleanor@intellectronica.net
+++ b/contributors/emails/eleanor@intellectronica.net
@@ -1,0 +1,1 @@
+intellectronica

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -125,6 +125,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("stepfun/step-3.7-flash",                 ""),
     # NVIDIA
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
+    # Meta
+    ("meta/muse-spark-1.2",                    ""),
     # Sakana
     ("sakana/fugu-ultra",                      ""),
     # OpenRouter routers

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-14T17:59:48Z",
+  "updated_at": "2026-08-17T19:11:38Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -139,6 +139,10 @@
         },
         {
           "id": "nvidia/nemotron-3-super-120b-a12b",
+          "description": ""
+        },
+        {
+          "id": "meta/muse-spark-1.2",
           "description": ""
         },
         {


### PR DESCRIPTION
## Summary

`meta/muse-spark-1.2` now appears in the OpenRouter curated model picker — CLI `hermes model`, desktop picker, and gateway `/model`.

Salvages #80406 by @intellectronica onto current main (authorship preserved). Muse Spark 1.2 has been live on OpenRouter since Aug 5 but was missing from the curated shortlist, so picker users couldn't select it without local catalog overrides.

## Changes

- `hermes_cli/models.py`: `meta/muse-spark-1.2` under a Meta section in `OPENROUTER_MODELS`
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py` (conflict with post-PR catalog updates resolved by regeneration, not hand-editing)

## Validation

| Check | Result |
|---|---|
| `tests/hermes_cli/test_models.py` | 30 passed |
| catalog JSON parses | ✓ |
| attribution audit | ✓ mapped |

## Infographic

![Muse Spark 1.2 in the OpenRouter Picker](https://v3b.fal.media/files/b/0aa6bc99/kXwQJCi0FH2DyREd75Xd2_EvqG7l6E.png)
