### PR TITLE
feat(providers): route api.meta.ai through the Responses API for prompt caching (salvages #83201)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -711,6 +711,12 @@ def init_agent(
         # rewrites (e.g. api.anthropic.com → provider="anthropic", #63425)
         # always run first. Covers api.meta.ai → codex_responses for prompt
         # caching (0% on chat vs 93-99% on responses) and future mandates.
+        # Note: provider="meta" without an api.meta.ai base_url (or with a non-api.meta.ai
+        # base_url) intentionally falls through to chat_completions here. The wire
+        # protocol for Meta is URL-driven BY DESIGN, not provider-name-driven, because
+        # user config `providers.meta` may point at any OpenAI-compatible endpoint, and
+        # forcing `codex_responses` on the provider name alone would break custom endpoints
+        # named "meta" that do not host the Responses API.
         try:
             from hermes_cli.providers import host_mandated_api_mode as _host_mandated_api_mode
 

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -671,43 +671,55 @@ def init_agent(
     agent.acp_args = list(acp_args or args or [])
     if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
         agent.api_mode = api_mode
-    elif agent.provider == "openai-codex":
-        agent.api_mode = "codex_responses"
-    elif agent.provider in {"xai", "xai-oauth"}:
-        agent.api_mode = "codex_responses"
-    elif (provider_name is None) and (
-        agent._base_url_hostname == "chatgpt.com"
-        and "/backend-api/codex" in agent._base_url_lower
-    ):
-        agent.api_mode = "codex_responses"
-        agent.provider = "openai-codex"
-    elif (provider_name is None) and agent._base_url_hostname == "api.x.ai":
-        agent.api_mode = "codex_responses"
-        agent.provider = "xai"
-    elif agent.provider == "anthropic" or (provider_name is None and agent._base_url_hostname == "api.anthropic.com"):
-        agent.api_mode = "anthropic_messages"
-        agent.provider = "anthropic"
-    elif agent._base_url_lower.rstrip("/").endswith("/anthropic"):
-        # Third-party Anthropic-compatible endpoints (e.g. MiniMax, DashScope)
-        # use a URL convention ending in /anthropic. Auto-detect these so the
-        # Anthropic Messages API adapter is used instead of chat completions.
-        agent.api_mode = "anthropic_messages"
-    elif agent.provider == "bedrock" or (
-        agent._base_url_hostname.startswith("bedrock-runtime.")
-        and base_url_host_matches(agent._base_url_lower, "amazonaws.com")
-    ):
-        # AWS Bedrock — auto-detect from provider name or base URL
-        # (bedrock-runtime.<region>.amazonaws.com).
-        agent.api_mode = "bedrock_converse"
-    elif agent.provider in {"nous", "nous-portal", "nousresearch"}:
-        # Portal is dual-wire: anthropic/* → Messages, everything else →
-        # chat_completions. Callers that already pass api_mode win above;
-        # this covers direct AIAgent construction without a resolved runtime.
-        from hermes_cli.providers import nous_api_mode
-
-        agent.api_mode = nous_api_mode(agent.model)
     else:
-        agent.api_mode = "chat_completions"
+        # Host-mandated wire check (single source of truth via providers.host_mandated_api_mode).
+        # Covers api.meta.ai → codex_responses for prompt caching (0% on chat vs 93-99% on responses)
+        # and any future host mandates. Lazy import to avoid circular imports.
+        try:
+            from hermes_cli.providers import host_mandated_api_mode as _host_mandated_api_mode
+
+            _mandated = _host_mandated_api_mode(base_url or "")
+        except Exception:
+            _mandated = None
+        if _mandated is not None:
+            agent.api_mode = _mandated
+        elif agent.provider == "openai-codex":
+            agent.api_mode = "codex_responses"
+        elif agent.provider in {"xai", "xai-oauth"}:
+            agent.api_mode = "codex_responses"
+        elif (provider_name is None) and (
+            agent._base_url_hostname == "chatgpt.com"
+            and "/backend-api/codex" in agent._base_url_lower
+        ):
+            agent.api_mode = "codex_responses"
+            agent.provider = "openai-codex"
+        elif (provider_name is None) and agent._base_url_hostname == "api.x.ai":
+            agent.api_mode = "codex_responses"
+            agent.provider = "xai"
+        elif agent.provider == "anthropic" or (provider_name is None and agent._base_url_hostname == "api.anthropic.com"):
+            agent.api_mode = "anthropic_messages"
+            agent.provider = "anthropic"
+        elif agent._base_url_lower.rstrip("/").endswith("/anthropic"):
+            # Third-party Anthropic-compatible endpoints (e.g. MiniMax, DashScope)
+            # use a URL convention ending in /anthropic. Auto-detect these so the
+            # Anthropic Messages API adapter is used instead of chat completions.
+            agent.api_mode = "anthropic_messages"
+        elif agent.provider == "bedrock" or (
+            agent._base_url_hostname.startswith("bedrock-runtime.")
+            and base_url_host_matches(agent._base_url_lower, "amazonaws.com")
+        ):
+            # AWS Bedrock — auto-detect from provider name or base URL
+            # (bedrock-runtime.<region>.amazonaws.com).
+            agent.api_mode = "bedrock_converse"
+        elif agent.provider in {"nous", "nous-portal", "nousresearch"}:
+            # Portal is dual-wire: anthropic/* → Messages, everything else →
+            # chat_completions. Callers that already pass api_mode win above;
+            # this covers direct AIAgent construction without a resolved runtime.
+            from hermes_cli.providers import nous_api_mode
+
+            agent.api_mode = nous_api_mode(agent.model)
+        else:
+            agent.api_mode = "chat_completions"
 
     # Credential-pool validation runs AFTER provider auto-detection so
     # a pool scoped to e.g. "anthropic" is not rejected when the agent

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -671,10 +671,46 @@ def init_agent(
     agent.acp_args = list(acp_args or args or [])
     if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
         agent.api_mode = api_mode
+    elif agent.provider == "openai-codex":
+        agent.api_mode = "codex_responses"
+    elif agent.provider in {"xai", "xai-oauth"}:
+        agent.api_mode = "codex_responses"
+    elif (provider_name is None) and (
+        agent._base_url_hostname == "chatgpt.com"
+        and "/backend-api/codex" in agent._base_url_lower
+    ):
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+    elif (provider_name is None) and agent._base_url_hostname == "api.x.ai":
+        agent.api_mode = "codex_responses"
+        agent.provider = "xai"
+    elif agent.provider == "anthropic" or (provider_name is None and agent._base_url_hostname == "api.anthropic.com"):
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"
+    elif agent._base_url_lower.rstrip("/").endswith("/anthropic"):
+        # Third-party Anthropic-compatible endpoints (e.g. MiniMax, DashScope)
+        # use a URL convention ending in /anthropic. Auto-detect these so the
+        # Anthropic Messages API adapter is used instead of chat completions.
+        agent.api_mode = "anthropic_messages"
+    elif agent.provider == "bedrock" or (
+        agent._base_url_hostname.startswith("bedrock-runtime.")
+        and base_url_host_matches(agent._base_url_lower, "amazonaws.com")
+    ):
+        # AWS Bedrock — auto-detect from provider name or base URL
+        # (bedrock-runtime.<region>.amazonaws.com).
+        agent.api_mode = "bedrock_converse"
+    elif agent.provider in {"nous", "nous-portal", "nousresearch"}:
+        # Portal is dual-wire: anthropic/* → Messages, everything else →
+        # chat_completions. Callers that already pass api_mode win above;
+        # this covers direct AIAgent construction without a resolved runtime.
+        from hermes_cli.providers import nous_api_mode
+
+        agent.api_mode = nous_api_mode(agent.model)
     else:
-        # Host-mandated wire check (single source of truth via providers.host_mandated_api_mode).
-        # Covers api.meta.ai → codex_responses for prompt caching (0% on chat vs 93-99% on responses)
-        # and any future host mandates. Lazy import to avoid circular imports.
+        # Host-mandated wire check — LAST, so the elif chain's provider-slug
+        # rewrites (e.g. api.anthropic.com → provider="anthropic", #63425)
+        # always run first. Covers api.meta.ai → codex_responses for prompt
+        # caching (0% on chat vs 93-99% on responses) and future mandates.
         try:
             from hermes_cli.providers import host_mandated_api_mode as _host_mandated_api_mode
 
@@ -683,41 +719,6 @@ def init_agent(
             _mandated = None
         if _mandated is not None:
             agent.api_mode = _mandated
-        elif agent.provider == "openai-codex":
-            agent.api_mode = "codex_responses"
-        elif agent.provider in {"xai", "xai-oauth"}:
-            agent.api_mode = "codex_responses"
-        elif (provider_name is None) and (
-            agent._base_url_hostname == "chatgpt.com"
-            and "/backend-api/codex" in agent._base_url_lower
-        ):
-            agent.api_mode = "codex_responses"
-            agent.provider = "openai-codex"
-        elif (provider_name is None) and agent._base_url_hostname == "api.x.ai":
-            agent.api_mode = "codex_responses"
-            agent.provider = "xai"
-        elif agent.provider == "anthropic" or (provider_name is None and agent._base_url_hostname == "api.anthropic.com"):
-            agent.api_mode = "anthropic_messages"
-            agent.provider = "anthropic"
-        elif agent._base_url_lower.rstrip("/").endswith("/anthropic"):
-            # Third-party Anthropic-compatible endpoints (e.g. MiniMax, DashScope)
-            # use a URL convention ending in /anthropic. Auto-detect these so the
-            # Anthropic Messages API adapter is used instead of chat completions.
-            agent.api_mode = "anthropic_messages"
-        elif agent.provider == "bedrock" or (
-            agent._base_url_hostname.startswith("bedrock-runtime.")
-            and base_url_host_matches(agent._base_url_lower, "amazonaws.com")
-        ):
-            # AWS Bedrock — auto-detect from provider name or base URL
-            # (bedrock-runtime.<region>.amazonaws.com).
-            agent.api_mode = "bedrock_converse"
-        elif agent.provider in {"nous", "nous-portal", "nousresearch"}:
-            # Portal is dual-wire: anthropic/* → Messages, everything else →
-            # chat_completions. Callers that already pass api_mode win above;
-            # this covers direct AIAgent construction without a resolved runtime.
-            from hermes_cli.providers import nous_api_mode
-
-            agent.api_mode = nous_api_mode(agent.model)
         else:
             agent.api_mode = "chat_completions"
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -115,10 +115,16 @@ def _default_prompt_cache_retention_for_request(
     model: str,
     base_url: Any,
 ) -> Optional[str]:
-    """Return ``24h`` for supported models on Amazon Bedrock Mantle."""
+    """Return ``24h`` for supported hosts/models (Bedrock Mantle, Meta)."""
     from utils import base_url_hostname
 
-    hostname_parts = base_url_hostname(str(base_url or "")).split(".")
+    hostname = base_url_hostname(str(base_url or "")).lower()
+    # Meta Model API: prompt caching is opt-in via prompt_cache_retention.
+    # Measured 0% hits on /chat/completions vs 93-99% on /responses with 24h.
+    if hostname == "api.meta.ai":
+        return "24h"
+
+    hostname_parts = hostname.split(".")
     is_bedrock_mantle = (
         len(hostname_parts) == 4
         and hostname_parts[0] == "bedrock-mantle"

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -135,8 +135,10 @@ model:
 # providers:
 #   meta:
 #     base_url: https://api.meta.ai/v1
-#     api_key: ${META_API_KEY}
+#     api_key: ${MODEL_API_KEY}
 #     # api_mode auto-detected as codex_responses for api.meta.ai; no need to set
+#     # (the bundled meta-ai provider covers this — a named custom provider is
+#     # only needed for a non-default Meta-compatible endpoint)
 
 
 # Command-minted credentials (optional): key_cmd

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -132,6 +132,12 @@ model:
   #       CF-Access-Client-Id: "xxxx.access"
   #       CF-Access-Client-Secret: "${CF_ACCESS_SECRET}"
   #       X-Client-Name: "hermes-agent"
+# providers:
+#   meta:
+#     base_url: https://api.meta.ai/v1
+#     api_key: ${META_API_KEY}
+#     # api_mode auto-detected as codex_responses for api.meta.ai; no need to set
+
 
 # Command-minted credentials (optional): key_cmd
 # ------------------------------------------------------------------

--- a/contributors/emails/lavie@local
+++ b/contributors/emails/lavie@local
@@ -1,0 +1,1 @@
+laviesony

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -617,6 +617,9 @@ def host_mandated_api_mode(base_url: str = "") -> Optional[str]:
     Some hosts only accept one API mode and reject the others outright:
       - api.openai.com only accepts the Responses API for its (reasoning)
         models when tools + reasoning are in play (chat/completions 400s).
+      - api.meta.ai only achieves KV-cache hits on /v1/responses with
+        prompt_cache_retention; /v1/chat/completions returns 0 cached
+        tokens (measured 0% vs 93-99% on /responses with retention).
       - api.anthropic.com / ``…/anthropic`` suffixes speak native Messages.
       - Kimi's ``/coding`` endpoint speaks native Messages.
       - AWS Bedrock runtime hosts speak Converse.
@@ -643,6 +646,11 @@ def host_mandated_api_mode(base_url: str = "") -> Optional[str]:
     # models with tools. Shared predicate keeps this lane in lockstep with
     # catalog filtering and listing authority.
     if is_official_openai_host(base_url):
+        return "codex_responses"
+    # Meta Model API (api.meta.ai) only achieves prompt-cache hits on the
+    # Responses API with prompt_cache_retention; chat/completions stays
+    # cache-cold (0% vs 93-99% measured). Exact-hostname match per #32243.
+    if hostname == "api.meta.ai":
         return "codex_responses"
     if hostname.startswith("bedrock-runtime.") and base_url_host_matches(base_url, "amazonaws.com"):
         return "bedrock_converse"

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -190,6 +190,7 @@ def _resolve_plain_custom_api_mode(model_cfg: Dict[str, Any], base_url: str) -> 
     Responses path after upgrades or /reset.
     """
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+    # Note: api.meta.ai is handled by _detect_api_mode_for_url (returns codex_responses), so the suppression guard below does not fire for Meta.
     detected_mode = _detect_api_mode_for_url(base_url)
 
     if configured_mode == "codex_responses" and detected_mode != "codex_responses":

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -134,6 +134,11 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     # providers.is_official_openai_host for the spoof-rejection contract.
     if is_official_openai_host(base_url):
         return "codex_responses"
+    # Meta Model API: prompt caching only on Responses API (0% on
+    # chat/completions vs 93-99% on /responses with retention). Exact
+    # hostname per #32243.
+    if hostname == "api.meta.ai":
+        return "codex_responses"
     if hostname == "api.actual.inc":
         return "codex_responses"
     # Direct native Anthropic host: realign with providers.determine_api_mode,

--- a/plugins/model-providers/meta-ai/__init__.py
+++ b/plugins/model-providers/meta-ai/__init__.py
@@ -91,7 +91,14 @@ meta_ai = MetaAIProfile(
     env_vars=("MODEL_API_KEY", "META_API_KEY", "META_MODEL_API_KEY", "META_BASE_URL"),
     base_url=_base_url(),
     auth_type="api_key",
-    api_mode="chat_completions",
+    # Responses API is the wire that engages Muse prompt caching: measured
+    # 0 cached tokens on /v1/chat/completions vs 93-99% cache hits on
+    # /v1/responses with prompt_cache_retention (see host_mandated_api_mode
+    # in hermes_cli/providers.py and the retention hint in
+    # agent/transports/codex.py). The MetaAIProfile chat-completions hook
+    # above still covers custom OpenAI-compatible endpoints configured with
+    # a non-api.meta.ai base URL, which fall through to chat_completions.
+    api_mode="codex_responses",
     # Muse Spark is natively multimodal (image/video/pdf/audio in, text out).
     supports_vision=True,
     # Cheap contributor tier is a good default for auxiliary tasks

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2939,6 +2939,14 @@ class TestCodexAdapterPromptCacheKey:
         ])
         assert captured["prompt_cache_retention"] == "24h"
 
+    def test_meta_endpoint_includes_prompt_cache_retention(self):
+        adapter, captured = self._build_adapter(base_url="https://api.meta.ai/v1", model="muse-spark-1.2")
+        adapter.create(messages=[
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hi"},
+        ])
+        assert captured["prompt_cache_retention"] == "24h"
+
     def test_prompt_cache_retention_skipped_for_codex_backend(self):
         adapter, captured = self._build_adapter()
         adapter.create(messages=[

--- a/tests/agent/test_meta_agent_init.py
+++ b/tests/agent/test_meta_agent_init.py
@@ -160,3 +160,41 @@ def test_agent_init_meta_url_without_provider_implies_codex_responses():
     )
     assert agent.api_mode == "codex_responses"
 
+
+def test_agent_init_meta_provider_without_meta_url_falls_through_to_chat_completions(monkeypatch):
+    """`provider="meta"` without an api.meta.ai base_url falls through to chat_completions.
+
+    The Meta wire protocol is URL-driven by design so custom OpenAI-compatible
+    endpoints configured under `providers.meta` are not broken by forcing Responses API.
+    """
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("META_API_KEY", "sk-test-meta")
+
+    agent_empty = AIAgent(
+        provider="meta",
+        base_url="",
+        api_key="sk-test-meta",
+        model="muse-spark-1.2",
+        api_mode=None,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent_empty.api_mode == "chat_completions"
+    assert agent_empty.provider == "meta"
+
+    agent_custom = AIAgent(
+        provider="meta",
+        base_url="https://custom.meta.endpoint.internal/v1",
+        api_key="sk-test-meta",
+        model="muse-spark-1.2",
+        api_mode=None,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent_custom.api_mode == "chat_completions"
+    assert agent_custom.provider == "meta"
+
+

--- a/tests/agent/test_meta_agent_init.py
+++ b/tests/agent/test_meta_agent_init.py
@@ -81,3 +81,82 @@ def test_agent_init_meta_url_case_insensitive():
         skip_memory=True,
     )
     assert agent.api_mode == "codex_responses"
+
+
+def test_agent_init_anthropic_url_implies_provider_and_api_mode():
+    """Regression for host-mandated api_mode shadowing provider-slug rewrite (#63425).
+
+    When provider=None and base_url is api.anthropic.com, the elif chain must
+    still rewrite provider to "anthropic" before the credential-pool check.
+    The host-mandated fallback moved to the bottom of the cascade (fix/meta-prompt-caching)
+    ensures this; the old top-position mandated branch set api_mode without the slug rewrite
+    and caused credential-pool validation to discard anthropic-scoped pools.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from run_agent import AIAgent
+
+    with patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()), patch(
+        "agent.anthropic_adapter._is_oauth_token", return_value=False
+    ):
+        agent = AIAgent(
+            provider=None,
+            base_url="https://api.anthropic.com/v1",
+            api_key="sk-test-anthropic",
+            model="claude-sonnet-4-5",
+            api_mode=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    assert agent.provider == "anthropic"
+    assert agent.api_mode == "anthropic_messages"
+
+
+def test_agent_init_anthropic_url_preserves_credential_pool():
+    """Anthropic-scoped credential pool must survive provider auto-detection.
+
+    Mirrors tests/run_agent/test_63425_credential_pool_auto_detect.py at the
+    public AIAgent surface (provider=None URL detection).
+    """
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock, patch
+
+    from run_agent import AIAgent
+
+    pool = SimpleNamespace(provider="anthropic")
+
+    with patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()), patch(
+        "agent.anthropic_adapter._is_oauth_token", return_value=False
+    ):
+        agent = AIAgent(
+            provider=None,
+            base_url="https://api.anthropic.com/v1",
+            api_key="sk-test-anthropic",
+            model="claude-sonnet-4-5",
+            api_mode=None,
+            credential_pool=pool,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    assert agent.provider == "anthropic"
+    assert agent.api_mode == "anthropic_messages"
+    assert agent._credential_pool is pool
+
+
+def test_agent_init_meta_url_without_provider_implies_codex_responses():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        provider=None,
+        base_url="https://api.meta.ai/v1",
+        api_key="sk-test-meta",
+        model="muse-spark-1.2",
+        api_mode=None,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.api_mode == "codex_responses"
+

--- a/tests/agent/test_meta_agent_init.py
+++ b/tests/agent/test_meta_agent_init.py
@@ -1,0 +1,83 @@
+"""Tests for AIAgent provider=meta host-mandated api_mode."""
+
+import pytest
+
+
+def test_agent_init_meta_base_url_implies_codex_responses():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        provider="meta",
+        base_url="https://api.meta.ai/v1",
+        api_key="sk-test-meta",
+        model="muse-spark-1.2",
+        api_mode=None,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.api_mode == "codex_responses"
+    assert agent.provider == "meta"
+
+
+def test_agent_init_explicit_chat_wins_over_mandate():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        provider="meta",
+        base_url="https://api.meta.ai/v1",
+        api_key="sk-test-meta",
+        model="muse-spark-1.2",
+        api_mode="chat_completions",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.api_mode == "chat_completions"
+    assert agent.provider == "meta"
+
+
+def test_agent_init_meta_provider_stays_meta():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        provider="meta",
+        base_url="https://api.meta.ai/v1",
+        api_key="sk-test-meta",
+        model="muse-spark-1.2",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.provider == "meta"
+    assert agent.provider != "custom"
+
+
+def test_agent_init_custom_with_meta_url_also_mandates():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        provider="custom",
+        base_url="https://api.meta.ai/v1",
+        api_key="sk-test-meta",
+        model="muse-spark-1.2",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.api_mode == "codex_responses"
+
+
+def test_agent_init_meta_url_case_insensitive():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        provider="meta",
+        base_url="https://API.META.AI/v1",
+        api_key="sk-test-meta",
+        model="muse-spark-1.2",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.api_mode == "codex_responses"

--- a/tests/agent/test_meta_usage_cache_reporting.py
+++ b/tests/agent/test_meta_usage_cache_reporting.py
@@ -1,0 +1,46 @@
+"""Usage cache reporting for Meta Responses path."""
+
+from types import SimpleNamespace
+
+from agent.usage_pricing import normalize_usage
+
+
+def test_meta_cached_tokens_flows_to_cache_read():
+    usage = SimpleNamespace(
+        input_tokens=4000,
+        output_tokens=100,
+        input_tokens_details=SimpleNamespace(cached_tokens=3920, cache_creation_tokens=0),
+        output_tokens_details=None,
+        prompt_tokens=None,
+        completion_tokens=None,
+    )
+    cu = normalize_usage(usage, api_mode="codex_responses")
+    assert cu.cache_read_tokens == 3920
+    assert cu.input_tokens == 80  # 4000 - 3920
+    # rendered cache line would be cache=3920/4000 (98%)
+    total = cu.prompt_tokens
+    assert total == 4000
+    pct = (cu.cache_read_tokens / total * 100) if total else 0
+    assert 97 <= pct <= 99
+    rendered = f"cache={cu.cache_read_tokens}/{total} ({pct:.0f}%)"
+    assert rendered == "cache=3920/4000 (98%)"
+
+
+def test_meta_cache_write_tokens():
+    first = SimpleNamespace(
+        input_tokens=4000,
+        output_tokens=100,
+        input_tokens_details=SimpleNamespace(cached_tokens=0, cache_creation_tokens=4000),
+    )
+    cu1 = normalize_usage(first, api_mode="codex_responses")
+    assert cu1.cache_write_tokens == 4000
+    assert cu1.cache_read_tokens == 0
+
+    second = SimpleNamespace(
+        input_tokens=4000,
+        output_tokens=100,
+        input_tokens_details=SimpleNamespace(cached_tokens=3920, cache_creation_tokens=0),
+    )
+    cu2 = normalize_usage(second, api_mode="codex_responses")
+    assert cu2.cache_read_tokens == 3920
+    assert cu2.cache_write_tokens == 0

--- a/tests/agent/transports/test_meta_codex_cache.py
+++ b/tests/agent/transports/test_meta_codex_cache.py
@@ -1,0 +1,114 @@
+"""Tests for Meta api.meta.ai prompt_cache_retention and transport plumbing."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.transports import get_transport
+from agent.transports.codex import _default_prompt_cache_retention_for_request
+
+
+@pytest.fixture
+def transport():
+    import agent.transports.codex  # noqa: F401
+    return get_transport("codex_responses")
+
+
+class TestMetaRetention:
+    def test_meta_retention_24h(self, transport):
+        kw = transport.build_kwargs(
+            model="muse-spark-1.2",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.meta.ai/v1",
+            session_id="test-session",
+        )
+        assert kw.get("prompt_cache_retention") == "24h"
+
+    def test_meta_retention_also_for_generic_model_name(self, transport):
+        for model in ["muse-spark", "meta/muse-spark-1.2-2026-04-01", "gpt-5.4", ""]:
+            kw = transport.build_kwargs(
+                model=model,
+                messages=[{"role": "user", "content": "Hi"}],
+                tools=[],
+                base_url="https://api.meta.ai/v1",
+                session_id="sid",
+            )
+            assert kw.get("prompt_cache_retention") == "24h", f"model={model!r}"
+
+    def test_meta_retention_helper_direct(self):
+        assert _default_prompt_cache_retention_for_request("muse-spark-1.2", "https://api.meta.ai/v1") == "24h"
+        assert _default_prompt_cache_retention_for_request("muse-spark-1.2", "https://API.META.AI/v1") == "24h"
+        assert _default_prompt_cache_retention_for_request("muse-spark-1.2", "https://api.meta.ai:443/v1") == "24h"
+
+    def test_meta_retention_not_sent_when_overridden(self, transport):
+        kw = transport.build_kwargs(
+            model="muse-spark-1.2",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.meta.ai/v1",
+            session_id="sid",
+            request_overrides={"prompt_cache_retention": "in_memory"},
+        )
+        assert kw.get("prompt_cache_retention") == "in_memory"
+
+    def test_non_meta_no_retention(self, transport):
+        kw = transport.build_kwargs(
+            model="muse-spark-1.2",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://generic.example.com/v1",
+            session_id="sid",
+        )
+        assert "prompt_cache_retention" not in kw
+
+    def test_non_meta_no_retention_helper(self):
+        assert _default_prompt_cache_retention_for_request("muse-spark-1.2", "https://generic.example.com/v1") is None
+
+    def test_meta_prompt_cache_key_is_content_addressed(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="muse-spark-1.2",
+            messages=messages,
+            tools=[],
+            base_url="https://api.meta.ai/v1",
+            session_id="cron_job_xxx_20260624_143000",
+        )
+        pck = kw.get("prompt_cache_key", "")
+        assert pck.startswith("pck_")
+        # stable across different cron fire timestamps (same scope)
+        kw2 = transport.build_kwargs(
+            model="muse-spark-1.2",
+            messages=messages,
+            tools=[],
+            base_url="https://api.meta.ai/v1",
+            session_id="cron_job_xxx_20260624_143500",
+        )
+        assert kw["prompt_cache_key"] == kw2["prompt_cache_key"]
+
+    def test_meta_reasoning_effort_passthrough(self, transport):
+        kw = transport.build_kwargs(
+            model="muse-spark-1.2",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.meta.ai/v1",
+            session_id="sid",
+            reasoning_config={"effort": "high", "enabled": True},
+        )
+        assert kw.get("reasoning") == {"effort": "high", "summary": "auto"}
+
+    def test_meta_request_hits_responses_plan(self, transport):
+        # Transport api_mode must be codex_responses so conversation_loop hits /v1/responses
+        assert transport.api_mode == "codex_responses"
+        kw = transport.build_kwargs(
+            model="muse-spark-1.2",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[{"type": "function", "function": {"name": "terminal", "description": "x", "parameters": {"type": "object", "properties": {"command": {"type": "string"}}}}}],
+            base_url="https://api.meta.ai/v1",
+            session_id="sid",
+        )
+        # Ensure instructions/input/tools and retention present - i.e., responses shape
+        assert "instructions" in kw or "input" in kw
+        assert kw.get("prompt_cache_retention") == "24h"
+        assert "prompt_cache_key" in kw

--- a/tests/agent/transports/test_meta_codex_cache.py
+++ b/tests/agent/transports/test_meta_codex_cache.py
@@ -42,7 +42,7 @@ class TestMetaRetention:
         assert _default_prompt_cache_retention_for_request("muse-spark-1.2", "https://API.META.AI/v1") == "24h"
         assert _default_prompt_cache_retention_for_request("muse-spark-1.2", "https://api.meta.ai:443/v1") == "24h"
 
-    def test_meta_retention_not_sent_when_overridden(self, transport):
+    def test_meta_retention_override_wins(self, transport):
         kw = transport.build_kwargs(
             model="muse-spark-1.2",
             messages=[{"role": "user", "content": "Hi"}],

--- a/tests/hermes_cli/test_meta_prompt_cache.py
+++ b/tests/hermes_cli/test_meta_prompt_cache.py
@@ -1,0 +1,102 @@
+"""Behavior contracts for Meta Muse prompt-caching host mandate."""
+
+import pytest
+
+from hermes_cli.providers import determine_api_mode, host_mandated_api_mode
+from hermes_cli import runtime_provider as rp
+
+
+class TestHostMandatedMetaResponses:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://api.meta.ai/v1",
+            "https://api.meta.ai/v1/",
+            "https://api.meta.ai/v1/chat/completions",
+            "https://API.META.AI/v1",
+            "https://api.meta.ai",
+            "https://api.meta.ai:443/v1",
+            "https://api.meta.ai./v1",
+            "https://attacker.test@api.meta.ai/v1",
+        ],
+    )
+    def test_host_mandated_meta_returns_codex_responses(self, url):
+        assert host_mandated_api_mode(url) == "codex_responses"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://api.meta.ai.attacker.test/v1",
+            "https://proxy.test/api.meta.ai/v1",
+            "https://api.meta.ai.evil/v1",
+            "https://meta.ai/v1",
+            "https://www.meta.ai/v1",
+            "https://api.meta.com/v1",
+            "https://[::1]/v1",
+            "https://generic.example.com/v1",
+            "",
+        ],
+    )
+    def test_host_mandated_meta_rejects_spoofs(self, url):
+        assert host_mandated_api_mode(url) != "codex_responses"
+        # Must be None for generic/unrelated hosts (contract: no clobber)
+        if url in (
+            "https://generic.example.com/v1",
+            "https://[::1]/v1",
+            "",
+            "https://meta.ai/v1",
+            "https://api.meta.ai.attacker.test/v1",
+            "https://proxy.test/api.meta.ai/v1",
+        ):
+            assert host_mandated_api_mode(url) is None
+
+    def test_determine_api_mode_meta_via_named_custom(self):
+        assert determine_api_mode("meta", "https://api.meta.ai/v1") == "codex_responses"
+        assert determine_api_mode("custom", "https://api.meta.ai/v1") == "codex_responses"
+        assert determine_api_mode("generic", "https://generic.example.com/v1") == "chat_completions"
+
+    def test_determine_api_mode_meta_with_trailing_slash(self):
+        assert determine_api_mode("meta", "https://api.meta.ai/v1/") == "codex_responses"
+
+    def test_runtime_detect_meta(self):
+        assert rp._detect_api_mode_for_url("https://api.meta.ai/v1") == "codex_responses"
+        assert rp._detect_api_mode_for_url("https://api.meta.ai/v1/chat/completions") == "codex_responses"
+        assert rp._detect_api_mode_for_url("https://API.META.AI/v1") == "codex_responses"
+
+    def test_runtime_detect_meta_rejects_spoofs(self):
+        assert rp._detect_api_mode_for_url("https://api.meta.ai.attacker.test/v1") is None
+        assert rp._detect_api_mode_for_url("https://proxy.test/api.meta.ai/v1") is None
+        assert rp._detect_api_mode_for_url("https://meta.ai/v1") is None
+        assert rp._detect_api_mode_for_url("https://generic.example.com/v1") is None
+
+    def test_fallback_api_mode_meta(self):
+        assert rp._fallback_api_mode("meta", "https://api.meta.ai/v1", "muse-spark-1.2") == "codex_responses"
+        assert rp._fallback_api_mode("custom", "https://api.meta.ai/v1", "muse-spark-1.2") == "codex_responses"
+        # generic still chat
+        assert rp._fallback_api_mode("custom", "https://generic.example.com/v1", "muse-spark-1.2") == "chat_completions"
+
+
+class TestMetaConfigRoundtrip:
+    def test_providers_meta_api_mode_roundtrip(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+
+        entry = {"name": "Meta", "base_url": "https://api.meta.ai/v1", "api_mode": "codex_responses"}
+        normalized = _normalize_custom_provider_entry(entry)
+        assert normalized.get("api_mode") == "codex_responses"
+
+        entry2 = {"name": "Meta", "base_url": "https://api.meta.ai/v1", "transport": "codex_responses"}
+        normalized2 = _normalize_custom_provider_entry(entry2)
+        # transport is lifted to api_mode via _normalize path or at least preserved
+        assert normalized2.get("api_mode") == "codex_responses" or normalized2.get("transport") == "codex_responses"
+
+    def test_providers_dict_to_custom_providers_preserves_meta_without_explicit_mode(self):
+        # Without explicit api_mode, host mandate resolves via providers.determine_api_mode
+        # This test ensures the providers entry survives normalization and the host still mandates
+        from hermes_cli.providers import host_mandated_api_mode
+
+        assert host_mandated_api_mode("https://api.meta.ai/v1") == "codex_responses"
+        # Simulate providers dict path: providers.meta.base_url stored, no api_mode field
+        # The resolution layer (determine_api_mode / runtime_provider) must mandate.
+        from hermes_cli.providers import determine_api_mode
+
+        assert determine_api_mode("meta", "https://api.meta.ai/v1", "muse-spark-1.2") == "codex_responses"

--- a/tests/hermes_cli/test_model_switch_openai_api_mode.py
+++ b/tests/hermes_cli/test_model_switch_openai_api_mode.py
@@ -18,6 +18,7 @@ reasoning_effort into a live one that OpenAI 400s on the chat_completions path.
 from unittest.mock import patch
 
 from hermes_cli.model_switch import switch_model
+from hermes_cli.providers import host_mandated_api_mode
 
 _MOCK_VALIDATION = {
     "accepted": True,
@@ -91,8 +92,6 @@ def test_generic_endpoint_keeps_explicit_api_mode():
     generic OpenAI-compatible relay returns None from host_mandated_api_mode,
     so the switch path leaves the resolver's api_mode untouched.
     """
-    from hermes_cli.providers import host_mandated_api_mode
-
     assert host_mandated_api_mode("https://generic.example.com/v1") is None
     # Lookalike / path-spoof hosts must also NOT be treated as mandated (#32243).
     assert host_mandated_api_mode("https://api.openai.com.attacker.test/v1") is None
@@ -123,9 +122,7 @@ def test_stale_chat_overridden_on_meta_direct():
 
 def test_generic_relay_not_clobbered_on_meta_switch():
     """Generic relay does not pick up Meta mandate."""
-    assert __import__("hermes_cli.providers", fromlist=["host_mandated_api_mode"]).host_mandated_api_mode(
-        "https://generic.example.com/v1"
-    ) is None
+    assert host_mandated_api_mode("https://generic.example.com/v1") is None
     result = _run_openai_switch(
         raw_input="some-model",
         current_provider="meta",

--- a/tests/hermes_cli/test_model_switch_openai_api_mode.py
+++ b/tests/hermes_cli/test_model_switch_openai_api_mode.py
@@ -100,3 +100,41 @@ def test_generic_endpoint_keeps_explicit_api_mode():
     # The real endpoints are mandated.
     assert host_mandated_api_mode("https://api.openai.com/v1") == "codex_responses"
     assert host_mandated_api_mode("https://api.anthropic.com") == "anthropic_messages"
+
+def test_stale_chat_overridden_on_meta_direct():
+    """Stale chat_completions on api.meta.ai → codex_responses (like openai direct).
+
+    Switching from openrouter/chat_completions to muse-spark on meta's
+    endpoint must flip to Responses API for caching (0% vs 93-99%).
+    """
+    result = _run_openai_switch(
+        raw_input="muse-spark-1.2",
+        current_provider="openrouter",
+        current_model="anthropic/claude-opus-4.8",
+        explicit_provider="meta",
+        runtime_api_mode="chat_completions",  # stale
+        runtime_base_url="https://api.meta.ai/v1",
+    )
+    assert result.success, f"switch_model failed: {result.error_message}"
+    assert result.target_provider == "meta"
+    assert result.new_model == "muse-spark-1.2"
+    assert result.api_mode == "codex_responses"
+
+
+def test_generic_relay_not_clobbered_on_meta_switch():
+    """Generic relay does not pick up Meta mandate."""
+    assert __import__("hermes_cli.providers", fromlist=["host_mandated_api_mode"]).host_mandated_api_mode(
+        "https://generic.example.com/v1"
+    ) is None
+    result = _run_openai_switch(
+        raw_input="some-model",
+        current_provider="meta",
+        current_model="muse-spark-1.2",
+        explicit_provider="openrouter",
+        runtime_api_mode="chat_completions",
+        runtime_base_url="https://generic.example.com/v1",
+    )
+    # For generic endpoint, resolver api_mode is chat_completions and host_mandated is None,
+    # so it stays chat_completions (not forced to codex_responses).
+    assert result.success
+    assert result.api_mode == "chat_completions"

--- a/tests/providers/test_meta_ai_profile.py
+++ b/tests/providers/test_meta_ai_profile.py
@@ -22,7 +22,9 @@ class TestMetaAIProfile:
         assert p.name == "meta-ai"
         assert p.base_url == "https://api.meta.ai/v1"
         assert p.auth_type == "api_key"
-        assert p.api_mode == "chat_completions"
+        # Responses API engages Muse prompt caching (0% on chat/completions
+        # vs 93-99% on /v1/responses with prompt_cache_retention).
+        assert p.api_mode == "codex_responses"
         assert "MODEL_API_KEY" in p.env_vars
         assert p.supports_vision is True
         assert p.default_aux_model == "muse-spark-1.2-contributor"

--- a/website/docs/developer-guide/adding-providers.md
+++ b/website/docs/developer-guide/adding-providers.md
@@ -34,7 +34,7 @@ A built-in provider has to line up across a few layers:
 The important abstraction is `api_mode`.
 
 - Most providers use `chat_completions`.
-- Codex uses `codex_responses`.
+- Codex and Meta Model API (`api.meta.ai` — Muse Spark) use `codex_responses` (auto-sends `prompt_cache_retention: 24h` for prompt caching; `api.meta.ai` achieves 93–99% cache hits only on `/v1/responses`).
 - Anthropic uses `anthropic_messages`.
 - A new non-OpenAI protocol usually means adding a new adapter and a new `api_mode` branch.
 
@@ -65,7 +65,7 @@ Use this when the provider does not behave like OpenAI chat completions.
 
 Examples in-tree today:
 
-- `codex_responses`
+- `codex_responses` (OpenAI Codex, xAI Grok, and Meta Muse Spark via `api.meta.ai` — the latter auto-sends `prompt_cache_retention: 24h`)
 - `anthropic_messages`
 
 This path includes everything from Path A plus:


### PR DESCRIPTION
## Summary

Muse Spark on `api.meta.ai` now rides the Responses API wire, turning prompt caching on — measured 0% cache hits on `/v1/chat/completions` vs 93–99% on `/v1/responses`, which on the contributor tier ($0.10/M input vs $0.002/M cached) is roughly a 13× cost difference on agentic workloads.

Salvages the transport half of #83201 by @laviesony onto current main (3 commits, authorship preserved), reconciled with the bundled `meta-ai` plugin from #88565. Also incorporates the earlier #80550/#83195 line of work that #83201 superseded.

## Changes

- `hermes_cli/providers.py` / `hermes_cli/runtime_provider.py`: `api.meta.ai` added to the host-mandated `codex_responses` set (exact-hostname match, spoof hosts rejected per #32243)
- `agent/transports/codex.py`: auto-send `prompt_cache_retention: 24h` for `api.meta.ai` (Meta's opt-in cache hint)
- `agent/agent_init.py`: host-mandate fallback runs at the bottom of the api_mode cascade so provider-slug rewrites (e.g. #63425 anthropic) still fire first; includes regression tests for that ordering
- `plugins/model-providers/meta-ai/__init__.py`: profile `api_mode` flipped to `codex_responses` (reconciliation commit, ours) — custom endpoints with non-`api.meta.ai` base URLs intentionally fall through to `chat_completions` (wire is URL-driven by design)
- `cli-config.yaml.example`: named-provider example uses `MODEL_API_KEY` and notes the bundled provider covers the default endpoint
- 5 new test files: host-mandate contracts + spoof rejection, transport retention/cache-key plumbing, agent-init cascade ordering, usage cache reporting, model-switch stale-mode flip
- `website/docs/developer-guide/adding-providers.md`: codex_responses examples updated

Dropped from the original PR: its duplicate `plugins/model-providers/meta/` profile (superseded by #88565's bundled meta-ai plugin).

## Validation

| Check | Result |
|---|---|
| targeted suites (providers, meta agent-init, transport cache, prompt-cache contracts, model-switch, data-policy guard) | 117 passed |
| real-import E2E: profile api_mode, host mandate, spoof rejection, retention hint, stable cron cache key | ✓ |
| disabled reasoning sends no `reasoning` key (Meta rejects `none`) | ✓ |
| attribution audit | ✓ mapped |

## Infographic

![Meta Muse Spark — Responses API Wire](https://v3b.fal.media/files/b/0aa6bca4/rV-0Z41zsz_xGIGt3zTEs_KKUOyizZ.png)
