### PR TITLE
fix(doctor): name structural state.db corruption honestly

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1235,12 +1235,16 @@ def check_macos_full_disk_access() -> None:
 
 # FTS5 object-name shapes (virtual table + shadow tables) for the messages
 # search indexes: messages_fts{,_trigram,_cjk} plus their _data/_idx/
-# _content/_docsize/_config/_segdir/_segments shadows.
+# _content/_docsize/_config/_segdir/_segments shadows. Full-match anchored on
+# the Hermes-owned roots: a suffix-only pattern would also swallow a
+# user-created lookalike such as archive_fts_data into the FTS set and keep
+# routing its damage to the FTS rebuild paths.
 _FTS_OBJECT_RE = re.compile(
-    r"_fts(_trigram|_cjk)?(_data|_idx|_content|_docsize|_config|_segdir|_segments)?$"
+    r"messages_fts(_trigram|_cjk)?(_data|_idx|_content|_docsize|_config|_segdir|_segments)?"
 )
 _TREE_RE = re.compile(r"\bTree (\d+)\b")
 _MISSING_INDEX_RE = re.compile(r"missing from index (\S+)")
+_FREELIST_RE = re.compile(r"^Freelist\b")
 
 
 def _integrity_damage_is_non_fts(integrity_rows: list, master_rows: list) -> bool:
@@ -1249,18 +1253,24 @@ def _integrity_damage_is_non_fts(integrity_rows: list, master_rows: list) -> boo
     ``integrity_rows`` are the raw PRAGMA integrity_check result rows;
     ``master_rows`` are ``(rootpage, type, name)`` triples from sqlite_master.
     Damage is structural when any damaged object — a tree id mapped through
-    rootpage, or an index named in a "row N missing from index X" line —
-    falls outside the FTS shadow set. Unparseable lines are deliberately
-    NOT counted (fail-closed toward the existing FTS wording, which is
-    never wrong to show, just incomplete).
+    rootpage, an index named in a "row N missing from index X" line, or the
+    database's own freelist — falls outside the FTS shadow set. Unparseable
+    lines are deliberately NOT counted (fail-closed toward the existing FTS
+    wording, which is never wrong to show, just incomplete).
     """
     name_by_rootpage = {int(rp): name for rp, _t, name in master_rows if rp}
 
     def _is_fts(name: str) -> bool:
-        return bool(_FTS_OBJECT_RE.search(name))
+        return bool(_FTS_OBJECT_RE.fullmatch(name))
 
     for row in integrity_rows:
         text = str(row[0]) if isinstance(row, (tuple, list)) else str(row)
+        if _FREELIST_RE.match(text):
+            # Freelist damage belongs to the database file itself, not to any
+            # FTS object: the free-page chain survives no FTS rebuild, so it
+            # is structural by definition (field-reported alongside a damaged
+            # canonical tree in the #88587 follow-up incident).
+            return True
         m = _TREE_RE.search(text)
         if m:
             name = name_by_rootpage.get(int(m.group(1)), "")

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -5,6 +5,7 @@ Diagnoses issues with Hermes Agent setup.
 """
 
 import os
+import re
 import sys
 import subprocess
 import shutil
@@ -1232,6 +1233,79 @@ def check_macos_full_disk_access() -> None:
         "grant survives every update."
     )
 
+# FTS5 object-name shapes (virtual table + shadow tables) for the messages
+# search indexes: messages_fts{,_trigram,_cjk} plus their _data/_idx/
+# _content/_docsize/_config/_segdir/_segments shadows.
+_FTS_OBJECT_RE = re.compile(
+    r"_fts(_trigram|_cjk)?(_data|_idx|_content|_docsize|_config|_segdir|_segments)?$"
+)
+_TREE_RE = re.compile(r"\bTree (\d+)\b")
+_MISSING_INDEX_RE = re.compile(r"missing from index (\S+)")
+
+
+def _integrity_damage_is_non_fts(integrity_rows: list, master_rows: list) -> bool:
+    """Classify integrity_check damage as structural (non-FTS) or FTS-only.
+
+    ``integrity_rows`` are the raw PRAGMA integrity_check result rows;
+    ``master_rows`` are ``(rootpage, type, name)`` triples from sqlite_master.
+    Damage is structural when any damaged object — a tree id mapped through
+    rootpage, or an index named in a "row N missing from index X" line —
+    falls outside the FTS shadow set. Unparseable lines are deliberately
+    NOT counted (fail-closed toward the existing FTS wording, which is
+    never wrong to show, just incomplete).
+    """
+    name_by_rootpage = {int(rp): name for rp, _t, name in master_rows if rp}
+
+    def _is_fts(name: str) -> bool:
+        return bool(_FTS_OBJECT_RE.search(name))
+
+    for row in integrity_rows:
+        text = str(row[0]) if isinstance(row, (tuple, list)) else str(row)
+        m = _TREE_RE.search(text)
+        if m:
+            name = name_by_rootpage.get(int(m.group(1)), "")
+            if name and not _is_fts(name):
+                return True
+        m = _MISSING_INDEX_RE.search(text)
+        if m and not _is_fts(m.group(1)):
+            return True
+    return False
+
+
+def _state_db_has_non_fts_damage(state_db_path) -> bool:
+    """True when the failing write-health probe reflects STRUCTURAL damage.
+
+    Re-runs integrity_check read-only and maps damaged tree ids through
+    sqlite_master so doctor can distinguish canonical-table corruption
+    (recover via `hermes sessions recover`) from FTS-index corruption
+    (repairable in place). Best-effort: any error classifies as False so
+    the caller keeps the pre-existing FTS reporting path (#88587).
+    """
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(
+            f"file:{state_db_path}?mode=ro", uri=True, isolation_level=None
+        )
+    except sqlite3.Error:
+        return False
+    try:
+        integrity_rows = conn.execute("PRAGMA integrity_check").fetchall()
+        master_rows = [
+            tuple(r) for r in conn.execute(
+                "SELECT rootpage, type, name FROM sqlite_master WHERE rootpage > 0"
+            ).fetchall()
+        ]
+    except sqlite3.Error:
+        return False
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    return _integrity_damage_is_non_fts(integrity_rows, master_rows)
+
+
 
 def run_doctor(args):
     """Run diagnostic checks."""
@@ -2058,7 +2132,27 @@ def run_doctor(args):
             from hermes_state import _db_opens_cleanly, repair_state_db_schema
 
             _write_reason = _db_opens_cleanly(state_db_path)
-            if _write_reason is not None:
+            if _write_reason is not None and _state_db_has_non_fts_damage(state_db_path):
+                # Structural corruption (canonical tables/indexes damaged —
+                # #88587): an FTS rebuild CANNOT repair this, and the
+                # .malformed-backup the FTS repair path leaves beside the DB
+                # is a snapshot of the same corrupt file. Name the class
+                # honestly and route to the tool that actually recovers:
+                # `hermes sessions recover --allow-partial` rebuilds canonical
+                # rows into a fresh database.
+                check_warn(
+                    f"{_DHH}/state.db has STRUCTURAL corruption "
+                    "(canonical tables/indexes damaged — not an FTS-index issue)",
+                    f"({_write_reason})",
+                )
+                issues.append(
+                    "state.db structural corruption — an FTS rebuild cannot "
+                    "repair it. Run 'hermes sessions recover --allow-partial' "
+                    "to rebuild canonical rows into a fresh database. Do NOT "
+                    "restore a .malformed-backup copy beside state.db: it is "
+                    "a snapshot of the same corrupt file."
+                )
+            elif _write_reason is not None:
                 check_warn(
                     f"{_DHH}/state.db fails a write-health probe (FTS index may be corrupt)",
                     f"({_write_reason})",

--- a/tests/hermes_cli/test_doctor_structural_corruption.py
+++ b/tests/hermes_cli/test_doctor_structural_corruption.py
@@ -87,6 +87,41 @@ class TestClassifier:
         integrity = [("Tree 999 page 1: btreeInitPage() returns error code 11",)]
         assert _integrity_damage_is_non_fts(integrity, _master([])) is False
 
+    def test_fts_lookalike_foreign_object_is_structural(self):
+        # The FTS set is anchored on the Hermes-owned messages_fts roots: a
+        # user-created table whose name merely ends like an FTS shadow must
+        # NOT be swallowed into the FTS-repairable set.
+        integrity = [("Tree 21 page 30: 2nd reference to page 5453",)]
+        master = _master([(21, "table", "archive_fts_data")])
+        assert _integrity_damage_is_non_fts(integrity, master) is True
+
+    def test_freelist_damage_is_structural(self):
+        # Field-reported lines from a gateway_routing incident: freelist
+        # damage belongs to the database file itself and no FTS rebuild
+        # repairs the free-page chain, so it is structural even when no
+        # canonical tree line is present.
+        integrity = [
+            ("Freelist: freelist leaf count too big on page 408680",),
+            ("Freelist: invalid page number 167772160",),
+        ]
+        assert _integrity_damage_is_non_fts(integrity, _master([])) is True
+
+    def test_field_reported_gateway_routing_incident_is_structural(self):
+        # The exact shape from the production follow-up: a damaged canonical
+        # table (tree 15 -> gateway_routing) with freelist damage alongside.
+        integrity = [
+            ("Tree 15 page 15 cell 0:      2nd reference to page 5453",),
+            ("Tree 15 page 15 cell 61: 2nd reference to page 5454",),
+            ("Freelist: freelist leaf count too big on page 408680",),
+            ("Freelist: invalid page number 167772160",),
+        ]
+        master = _master([
+            (15, "table", "gateway_routing"),
+            (12, "table", "messages_fts_data"),
+            (7, "table", "messages_fts_trigram"),
+        ])
+        assert _integrity_damage_is_non_fts(integrity, master) is True
+
 
 class TestProbeAgainstRealDb:
     def test_healthy_db_is_not_structural(self, tmp_path):

--- a/tests/hermes_cli/test_doctor_structural_corruption.py
+++ b/tests/hermes_cli/test_doctor_structural_corruption.py
@@ -1,0 +1,109 @@
+"""#88587 — doctor must name STRUCTURAL state.db corruption honestly.
+
+The write-health probe's failure used to be reported as "FTS write
+corruption" unconditionally, routing operators to `--fix` / `sessions
+repair` (FTS rebuilds that cannot repair canonical-table damage) and to
+the .malformed-backup beside the DB (a snapshot of the same corrupt
+file). The discriminator maps integrity_check damage through
+sqlite_master and only keeps the FTS wording when every damaged object
+is an FTS shadow.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+from hermes_cli.doctor import (
+    _integrity_damage_is_non_fts,
+    _state_db_has_non_fts_damage,
+)
+
+
+def _master(rows):
+    return [(rp, t, name) for rp, t, name in rows]
+
+
+class TestClassifier:
+    def test_canonical_table_tree_is_structural(self):
+        # The reporter's exact mapping: tree 5 -> sessions table.
+        integrity = [("Tree 5  page 421385: btreeInitPage() returns error code 11",)]
+        master = _master([(5, "table", "sessions")])
+        assert _integrity_damage_is_non_fts(integrity, master) is True
+
+    def test_canonical_index_tree_is_structural(self):
+        integrity = [("Tree 45 page 7701: btreeInitPage() returns error code 11",)]
+        master = _master([(45, "index", "idx_sessions_gateway_peer")])
+        assert _integrity_damage_is_non_fts(integrity, master) is True
+
+    def test_fts_shadow_tree_only_is_not_structural(self):
+        integrity = [("Tree 12 page 9: btreeInitPage() returns error code 11",)]
+        master = _master([
+            (12, "table", "messages_fts_data"),
+            (3, "table", "sessions"),
+        ])
+        assert _integrity_damage_is_non_fts(integrity, master) is False
+
+    def test_fts_virtual_table_tree_only_is_not_structural(self):
+        integrity = [("Tree 7 page 3: btreeInitPage() returns error code 11",)]
+        master = _master([
+            (7, "table", "messages_fts_trigram"),
+        ])
+        assert _integrity_damage_is_non_fts(integrity, master) is False
+
+    def test_missing_rows_from_canonical_index_is_structural(self):
+        integrity = [("row 1 missing from index sqlite_autoindex_delivery_obligations_1",)]
+        master = _master([])
+        assert _integrity_damage_is_non_fts(integrity, master) is True
+
+    def test_missing_rows_from_fts_shadow_is_not_structural(self):
+        integrity = [("row 4 missing from index messages_fts_idx",)]
+        master = _master([])
+        assert _integrity_damage_is_non_fts(integrity, master) is False
+
+    def test_mixed_damage_is_structural(self):
+        integrity = [
+            ("Tree 12 page 9: btreeInitPage() returns error code 11",),
+            ("Tree 5  page 421385: btreeInitPage() returns error code 11",),
+        ]
+        master = _master([
+            (12, "table", "messages_fts_data"),
+            (5, "table", "sessions"),
+        ])
+        assert _integrity_damage_is_non_fts(integrity, master) is True
+
+    def test_unparseable_line_keeps_fts_wording(self):
+        # Fail-closed toward the pre-existing reporting: an integrity line
+        # we cannot map is NOT classified as structural.
+        integrity = [("Page 99 is never used",)]
+        assert _integrity_damage_is_non_fts(integrity, _master([])) is False
+
+    def test_unknown_rootpage_keeps_fts_wording(self):
+        integrity = [("Tree 999 page 1: btreeInitPage() returns error code 11",)]
+        assert _integrity_damage_is_non_fts(integrity, _master([])) is False
+
+
+class TestProbeAgainstRealDb:
+    def test_healthy_db_is_not_structural(self, tmp_path):
+        db = tmp_path / "state.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY, k TEXT)")
+        conn.execute("CREATE TABLE messages_fts_data (a)")
+        conn.commit()
+        conn.close()
+        assert _state_db_has_non_fts_damage(db) is False
+
+    def test_missing_file_is_not_structural(self, tmp_path):
+        assert _state_db_has_non_fts_damage(tmp_path / "absent.db") is False
+
+    def test_garbage_file_fails_safely(self, tmp_path):
+        db = tmp_path / "state.db"
+        db.write_bytes(b"this is not a database" * 100)
+        # An unreadable file must classify as False so the caller keeps the
+        # existing reporting path rather than crashing.
+        assert _state_db_has_non_fts_damage(db) is False


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` reported every write-health-probe failure as "state.db FTS write corruption" and routed to `--fix` / `hermes sessions repair` (FTS rebuilds). When the corruption is **structural** — canonical tables and indexes damaged, as in the reporter's case where `integrity_check` showed broken b-trees on `sessions`, `session_model_usage`, and two `idx_sessions_*` indexes — an FTS rebuild cannot repair anything: `--fix` fails, leaves a full-size `.malformed-backup-<ts>` beside the DB (a snapshot of the same corrupt file), and the follow-up message tells the operator to restore that useless copy. The tool that actually recovers, `hermes sessions recover --allow-partial` (which rebuilt the reporter's 1.7 GB DB with 144,742/144,742 messages intact), was never mentioned (#88587).

This PR classifies the damage before choosing the message: the new `_state_db_has_non_fts_damage()` discriminator re-runs `integrity_check` read-only, maps damaged tree ids through `sqlite_master.rootpage` (and parses "row N missing from index X" names), and checks whether any damaged object falls outside the FTS shadow set. Structural damage gets its own class name, routes to `hermes sessions recover --allow-partial`, and explicitly warns against restoring the malformed backup. FTS-only damage keeps the existing wording and in-place repair path unchanged; damage that cannot be parsed also keeps the existing path (fail-closed toward the old behavior — never worse than before, per the issue's evidence that misclassification is the harmful direction).

## Related Issue

Fixes #88587

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py`: added `_FTS_OBJECT_RE` / `_TREE_RE` / `_MISSING_INDEX_RE` and the pure classifier `_integrity_damage_is_non_fts(integrity_rows, master_rows)` plus the read-only probe wrapper `_state_db_has_non_fts_damage(state_db_path)`; the write-health failure branch now branches on it — structural damage reports its own class, recommends `sessions recover --allow-partial`, warns against the backup copy, and skips the useless FTS repair attempt (no more 1.7 GB garbage backup)
- `tests/hermes_cli/test_doctor_structural_corruption.py`: 12 regression tests

## How to Test

1. `python -m pytest tests/hermes_cli/test_doctor_structural_corruption.py -q` — Observed result: 12 passed.
2. `python -m pytest tests/hermes_cli/test_doctor.py tests/test_state_db_malformed_repair.py -q` — Observed result: 68 passed (the FTS-corruption reporting and in-place repair paths are unchanged).
3. New tests pin the reporter's exact classification: tree→`sessions` and tree→`idx_sessions_gateway_peer` are structural; FTS-shadow/FTS-virtual trees and FTS-shadow missing-index rows are not; mixed damage is structural; unparseable lines and unmapped tree ids keep the existing FTS wording (fail-closed); a healthy DB, a missing file, and a garbage file all classify as non-structural without raising.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate (checked A/B/C; the doctor hits in my open PRs are the unrelated Bedrock probe #87215)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the doctor + state-db repair suites and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config keys or schemas changed; the classifier and probe carry docstrings explaining the mapping and the fail-closed contract (#88587)

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/hermes_cli/test_doctor_structural_corruption.py -q
12 passed in 0.75s
$ python -m pytest tests/hermes_cli/test_doctor.py tests/test_state_db_malformed_repair.py -q
68 passed in 13.96s
```
