### PR TITLE
fix(redact): add opt-in sensitive-data controls

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -12,6 +12,7 @@ import os
 import re
 import shlex
 import threading
+from collections.abc import Collection
 from urllib.parse import unquote_plus
 
 # Basenames treated as ``.env`` files by _command_reads_env_file. Imported
@@ -228,6 +229,19 @@ _YAML_ASSIGN_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+_CLI_SENSITIVE_SPACE_VALUE_RE = re.compile(
+    r"(?<![A-Za-z0-9_\-])"
+    r"(--(?:password|passwd|secret|token|api[-_]key|client-secret))"
+    r"([ \t]+)",
+    re.IGNORECASE,
+)
+_CLI_SENSITIVE_EQUALS_VALUE_RE = re.compile(
+    r"(?<![A-Za-z0-9_\-])"
+    r"(--(?:password|passwd|secret|token|api[-_]key|client-secret))"
+    r"(=)",
+    re.IGNORECASE,
+)
+
 # Word-boundary validation for the mixed/lowercase key patterns above
 # (_CFG_DOTTED_RE, _CFG_ANCHORED_RE, _YAML_ASSIGN_RE).
 #
@@ -314,6 +328,336 @@ def _key_has_secret_keyword(key: str) -> bool:
         if _is_word_start(key, m.start()) and _is_word_end(key, m.end()):
             return True
     return False
+
+
+def _normalize_sensitive_key(key: str) -> str:
+    """Canonicalize a caller-supplied exact sensitive key name."""
+    return key.strip().casefold().replace("-", "_")
+
+
+def _normalize_extra_sensitive_keys(
+    extra_sensitive_keys: Collection[str] | None,
+) -> frozenset[str]:
+    """Validate and normalize per-call exact sensitive keys.
+
+    Empty strings are ignored after ``strip()`` so an accidental blank entry
+    cannot create an empty-key pattern. ``str`` and ``bytes`` are rejected as
+    the top-level collection because they almost always mean the caller passed
+    one key directly instead of an iterable of keys.
+    """
+    if extra_sensitive_keys is None:
+        return frozenset()
+    if isinstance(extra_sensitive_keys, (str, bytes)):
+        raise TypeError("extra_sensitive_keys must be a collection of strings, not a string")
+    normalized: set[str] = set()
+    for key in extra_sensitive_keys:
+        if not isinstance(key, str):
+            raise TypeError("extra_sensitive_keys entries must be strings")
+        normalized_key = _normalize_sensitive_key(key)
+        if normalized_key:
+            normalized.add(normalized_key)
+    return frozenset(normalized)
+
+
+def _extra_key_matches(key: str, extra_sensitive_keys: frozenset[str]) -> bool:
+    """Return True only for an exact caller-supplied key match."""
+    return bool(extra_sensitive_keys) and _normalize_sensitive_key(key) in extra_sensitive_keys
+
+
+def _extra_sensitive_key_pattern(extra_sensitive_keys: frozenset[str]) -> str:
+    """Build a bounded regex alternation for exact per-call keys."""
+    variants = []
+    for key in sorted(extra_sensitive_keys, key=len, reverse=True):
+        parts = key.split("_")
+        variants.append(r"[-_]".join(re.escape(part) for part in parts))
+    return "(?:" + "|".join(variants) + ")"
+
+
+def _redact_extra_sensitive_key_values(text: str, extra_sensitive_keys: frozenset[str]) -> str:
+    """Redact KEY=value / JSON / YAML values for explicit per-call keys."""
+    if not extra_sensitive_keys or not text:
+        return text
+
+    key_pat = _extra_sensitive_key_pattern(extra_sensitive_keys)
+
+    def _mask_value(value: str) -> str:
+        # Explicitly selected values are fully replaced. Besides avoiding any
+        # sensitive suffix disclosure, the stable sentinel makes a second pass
+        # byte-identical to the first.
+        return "***" if value else value
+
+    def _line_end(source: str, start: int) -> int:
+        end = start
+        while end < len(source) and source[end] not in "\r\n":
+            end += 1
+        return end
+
+    def _yaml_single_quote_end(source: str, start: int) -> int | None:
+        cursor = start
+        while cursor < len(source):
+            char = source[cursor]
+            if char in "\r\n":
+                return None
+            if char == "'":
+                if cursor + 1 < len(source) and source[cursor + 1] == "'":
+                    cursor += 2
+                    continue
+                return cursor
+            cursor += 1
+        return None
+
+    def _rewrite_matches(source: str, pattern: re.Pattern, replacer) -> str:
+        chunks: list[str] = []
+        last_end = 0
+        for match in pattern.finditer(source):
+            if match.start() < last_end:
+                continue
+            replacement = replacer(source, match)
+            if replacement is None:
+                continue
+            replacement_text, value_end = replacement
+            if replacement_text == source[match.start():value_end]:
+                continue
+            chunks.append(source[last_end:match.start()])
+            chunks.append(replacement_text)
+            last_end = value_end
+        if not chunks:
+            return source
+        chunks.append(source[last_end:])
+        return "".join(chunks)
+
+    if "=" in text:
+        assign_re = re.compile(
+            rf"(^[ \t]*(?:export[ \t]+)?|(?<![A-Za-z0-9_.\-]))"
+            rf"({key_pat})([ \t]*=[ \t]*)",
+            re.IGNORECASE | re.MULTILINE,
+        )
+
+        def _redact_assignment(source: str, match: re.Match) -> tuple[str, int] | None:
+            if not _extra_key_matches(match.group(2), extra_sensitive_keys):
+                return None
+
+            value_start = match.end()
+            if value_start >= len(source) or source[value_start] in "&\r\n":
+                return None
+
+            prefix = f"{match.group(1)}{match.group(2)}{match.group(3)}"
+            quote = source[value_start]
+            if quote in {"'", '"'}:
+                content_start = value_start + 1
+                closing_quote = _find_unescaped_closing_quote(source, content_start, quote)
+                if closing_quote is None:
+                    value_end = _line_end(source, content_start)
+                    value = source[content_start:value_end]
+                    if not value:
+                        return None
+                    return f"{prefix}{quote}{_mask_value(value)}", value_end
+                value = source[content_start:closing_quote]
+                if not value:
+                    return None
+                return (
+                    f"{prefix}{quote}{_mask_value(value)}{quote}",
+                    closing_quote + 1,
+                )
+
+            value_end = value_start
+            while value_end < len(source) and source[value_end] not in "&\r\n":
+                value_end += 1
+            value = source[value_start:value_end]
+            if not value:
+                return None
+            return f"{prefix}{_mask_value(value)}", value_end
+
+        text = _rewrite_matches(text, assign_re, _redact_assignment)
+
+    if ":" in text:
+        json_re = re.compile(
+            rf'("({key_pat})"[ \t]*:[ \t]*")',
+            re.IGNORECASE,
+        )
+        yaml_re = re.compile(
+            rf"^([ \t]*)({key_pat})(:[ \t]*)",
+            re.IGNORECASE | re.MULTILINE,
+        )
+
+        def _redact_json(source: str, match: re.Match) -> tuple[str, int] | None:
+            if not _extra_key_matches(match.group(2), extra_sensitive_keys):
+                return None
+            value_start = match.end()
+            closing_quote = _find_unescaped_closing_quote(source, value_start, '"')
+            if closing_quote is None:
+                value_end = _line_end(source, value_start)
+                value = source[value_start:value_end]
+                if not value:
+                    return None
+                return f"{match.group(1)}{_mask_value(value)}", value_end
+            value = source[value_start:closing_quote]
+            if not value:
+                return None
+            return (
+                f'{match.group(1)}{_mask_value(value)}"',
+                closing_quote + 1,
+            )
+
+        def _redact_yaml(source: str, match: re.Match) -> tuple[str, int] | None:
+            if not _extra_key_matches(match.group(2), extra_sensitive_keys):
+                return None
+
+            prefix = f"{match.group(1)}{match.group(2)}{match.group(3)}"
+            value_start = match.end()
+            if value_start >= len(source) or source[value_start] in "\r\n":
+                return None
+
+            quote = source[value_start]
+            if quote in {"'", '"'}:
+                content_start = value_start + 1
+                if quote == "'":
+                    closing_quote = _yaml_single_quote_end(source, content_start)
+                else:
+                    closing_quote = _find_unescaped_closing_quote(
+                        source,
+                        content_start,
+                        quote,
+                    )
+                if closing_quote is None:
+                    value_end = _line_end(source, content_start)
+                    value = source[content_start:value_end]
+                    if not value:
+                        return None
+                    return f"{prefix}{quote}{_mask_value(value)}", value_end
+                value = source[content_start:closing_quote]
+                if not value:
+                    return None
+                return (
+                    f"{prefix}{quote}{_mask_value(value)}{quote}",
+                    closing_quote + 1,
+                )
+
+            line_end = _line_end(source, value_start)
+            value_end = line_end
+            for cursor in range(value_start, line_end):
+                if source[cursor] != "#" or source[cursor - 1] not in " \t":
+                    continue
+                value_end = cursor
+                while value_end > value_start and source[value_end - 1] in " \t":
+                    value_end -= 1
+                break
+            value = source[value_start:value_end]
+            if not value:
+                return None
+            return f"{prefix}{_mask_value(value)}", value_end
+
+        text = _rewrite_matches(text, json_re, _redact_json)
+        text = _rewrite_matches(text, yaml_re, _redact_yaml)
+
+    return text
+
+
+def _redact_cli_sensitive_space_values(text: str) -> str:
+    """Redact values passed with sensitive CLI flags."""
+    if "--" not in text:
+        return text
+
+    text = _redact_cli_sensitive_value_matches(
+        text,
+        _CLI_SENSITIVE_SPACE_VALUE_RE,
+        skip_next_flag=True,
+    )
+    return _redact_cli_sensitive_value_matches(
+        text,
+        _CLI_SENSITIVE_EQUALS_VALUE_RE,
+        skip_next_flag=False,
+    )
+
+
+def _count_preceding_backslashes(text: str, index: int) -> int:
+    """Count consecutive backslashes immediately before ``index``."""
+    count = 0
+    cursor = index - 1
+    while cursor >= 0 and text[cursor] == "\\":
+        count += 1
+        cursor -= 1
+    return count
+
+
+def _find_unescaped_closing_quote(text: str, start: int, quote: str) -> int | None:
+    """Find a same-type closing quote, respecting shell-style backslash parity."""
+    cursor = start
+    while cursor < len(text):
+        char = text[cursor]
+        if char in "\r\n":
+            return None
+        if char == quote and _count_preceding_backslashes(text, cursor) % 2 == 0:
+            return cursor
+        cursor += 1
+    return None
+
+
+def _redact_cli_sensitive_value_match(
+    text: str,
+    match: re.Match,
+    *,
+    skip_next_flag: bool,
+) -> tuple[str, int]:
+    """Return replacement text and original end offset for one CLI flag value."""
+    value_start = match.end()
+    if value_start >= len(text) or text[value_start] in "\r\n":
+        return match.group(0), match.end()
+
+    flag_and_separator = f"{match.group(1)}{match.group(2)}"
+    quote = text[value_start]
+    if quote in {"'", '"'}:
+        value_content_start = value_start + 1
+        closing_quote = _find_unescaped_closing_quote(text, value_content_start, quote)
+        if closing_quote is None:
+            value_end = value_content_start
+            while value_end < len(text) and text[value_end] not in "\r\n":
+                value_end += 1
+            # Unterminated quoted CLI secrets are redacted through EOL so an
+            # escaped quote cannot expose the sensitive suffix that follows it.
+            return f"{flag_and_separator}{quote}***", value_end
+        if closing_quote == value_content_start:
+            return text[match.start():closing_quote + 1], closing_quote + 1
+        return f"{flag_and_separator}{quote}***{quote}", closing_quote + 1
+
+    if skip_next_flag and text.startswith("--", value_start):
+        return match.group(0), match.end()
+
+    value_end = value_start
+    while value_end < len(text) and text[value_end] not in "\r\n\t ' \"":
+        value_end += 1
+    if value_end == value_start:
+        return match.group(0), match.end()
+    return f"{flag_and_separator}***", value_end
+
+
+def _redact_cli_sensitive_value_matches(
+    text: str,
+    pattern: re.Pattern,
+    *,
+    skip_next_flag: bool,
+) -> str:
+    """Redact CLI sensitive values matched by a flag/separator pattern."""
+    chunks: list[str] = []
+    last_end = 0
+    changed = False
+    for match in pattern.finditer(text):
+        if match.start() < last_end:
+            continue
+        replacement, value_end = _redact_cli_sensitive_value_match(
+            text,
+            match,
+            skip_next_flag=skip_next_flag,
+        )
+        chunks.append(text[last_end:match.start()])
+        chunks.append(replacement)
+        last_end = value_end
+        changed = changed or replacement != text[match.start():value_end]
+    if not chunks:
+        return text
+    chunks.append(text[last_end:])
+    redacted = "".join(chunks)
+    return redacted if changed else text
 
 # JSON field patterns: "apiKey": "value", "token": "value", etc.
 _JSON_KEY_NAMES = r"(?:api_?[Kk]ey|token|secret|password|access_token|refresh_token|auth_token|bearer|secret_value|raw_secret|secret_input|key_material)"
@@ -670,7 +1014,7 @@ def _canonical_url_param_name(name: str) -> str:
     return decoded.casefold().replace("-", "_")
 
 
-def _redact_strict_url_credentials(text: str) -> str:
+def _redact_strict_url_credentials(text: str, *, redact_usernames: bool = False) -> str:
     """Redact credentials from absolute, relative, and network URL references.
 
     This is intentionally stricter than display/log redaction and is used only
@@ -687,7 +1031,11 @@ def _redact_strict_url_credentials(text: str) -> str:
         userinfo = match.group(2)
         if ":" in userinfo:
             username, _, _password = userinfo.partition(":")
+            if redact_usernames:
+                return f"{match.group(1)}***:***@"
             return f"{match.group(1)}{username}:***@"
+        if redact_usernames:
+            return f"{match.group(1)}***@"
         return f"{match.group(1)}***@"
 
     text = _STRICT_URL_PARAM_RE.sub(_redact_param, text)
@@ -778,6 +1126,8 @@ def redact_sensitive_text(
     code_file: bool = False,
     file_read: bool = False,
     redact_url_credentials: bool = False,
+    extra_sensitive_keys: Collection[str] | None = None,
+    redact_url_usernames: bool = False,
 ) -> str:
     """Apply all redaction patterns to a block of text.
 
@@ -790,6 +1140,14 @@ def redact_sensitive_text(
     additionally redact credential-named query parameters and ``user:pass@``
     URL userinfo. The default remains False because actionable OAuth callback,
     magic-link, and pre-signed URLs must survive ordinary tool flows unchanged.
+    Set redact_url_usernames=True with redact_url_credentials=True to also
+    hide usernames in URL userinfo; alone it has no effect.
+
+    Set extra_sensitive_keys={...} to add exact per-call key names to the
+    KEY=value / JSON / YAML redaction passes. Keys are stripped, casefolded,
+    and normalized so hyphens and underscores are equivalent. Empty keys are
+    ignored. This does not mutate global sensitive-key sets or persist between
+    calls.
 
     Set code_file=True to skip the ENV-assignment and JSON-field regex
     patterns when the text is known to be source code (e.g. MAX_TOKENS=***
@@ -829,6 +1187,14 @@ def redact_sensitive_text(
     # paths either (it's config/data, not log lines).
     if file_read:
         code_file = True
+
+    normalized_extra_sensitive_keys = _normalize_extra_sensitive_keys(extra_sensitive_keys)
+
+    if normalized_extra_sensitive_keys:
+        text = _redact_extra_sensitive_key_values(text, normalized_extra_sensitive_keys)
+
+    if "--" in text:
+        text = _redact_cli_sensitive_space_values(text)
 
     # Known prefixes (sk-, ghp_, etc.) — gate on substring presence
     if _has_known_prefix_substring(text):
@@ -991,7 +1357,7 @@ def redact_sensitive_text(
     # left to pass through per #34029.
 
     if redact_url_credentials:
-        text = _redact_strict_url_credentials(text)
+        text = _redact_strict_url_credentials(text, redact_usernames=redact_url_usernames)
 
     # Form-urlencoded bodies (only triggers on clean k=v&k=v inputs).
     if "&" in text and "=" in text:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1,5 +1,6 @@
 """Tests for agent.redact -- secret masking in logs and output."""
 
+import inspect
 import logging
 
 import pytest
@@ -1031,6 +1032,441 @@ class TestKeywordWordBoundary:
         text = "secrets: hunter2hunter2hunter2hh"
         result = redact_sensitive_text(text)
         assert "hunter2hunter2hunter2hh" not in result
+
+
+class TestRedactSensitiveTextApiCompatibility:
+    def test_old_signature_prefix_still_valid_and_new_args_are_trailing_keyword_only(self):
+        sig = inspect.signature(redact_sensitive_text)
+        assert list(sig.parameters) == [
+            "text",
+            "force",
+            "code_file",
+            "file_read",
+            "redact_url_credentials",
+            "extra_sensitive_keys",
+            "redact_url_usernames",
+        ]
+        assert sig.parameters["force"].default is False
+        assert sig.parameters["code_file"].default is False
+        assert sig.parameters["file_read"].default is False
+        assert sig.parameters["redact_url_credentials"].default is False
+        assert sig.parameters["extra_sensitive_keys"].default is None
+        assert sig.parameters["redact_url_usernames"].default is False
+        assert redact_sensitive_text(
+            "normal",
+            force=True,
+            code_file=True,
+            file_read=False,
+            redact_url_credentials=False,
+        ) == "normal"
+
+
+class TestExtraSensitiveKeys:
+    def test_session_id_without_opt_in_is_unchanged(self):
+        text = "session_id=session-value"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def _assert_focused_repair(self, text, expected, *, secrets):
+        result = redact_sensitive_text(
+            text,
+            force=True,
+            extra_sensitive_keys={"session_id"},
+        )
+        assert result == expected
+        for secret in secrets:
+            assert secret not in result
+        assert redact_sensitive_text(
+            result,
+            force=True,
+            extra_sensitive_keys={"session_id"},
+        ) == result
+        return result
+
+    def test_focused_repair_nested_unquoted_yaml_preserves_indentation(self):
+        self._assert_focused_repair(
+            "parent:\n  session_id: secret",
+            "parent:\n  session_id: ***",
+            secrets=("secret",),
+        )
+
+    def test_focused_repair_nested_quoted_yaml_preserves_mapping(self):
+        import yaml
+
+        result = self._assert_focused_repair(
+            'parent:\n    session_id: "secret"',
+            'parent:\n    session_id: "***"',
+            secrets=("secret",),
+        )
+        assert yaml.safe_load(result) == {"parent": {"session_id": "***"}}
+
+    def test_focused_repair_yaml_preserves_mixed_indentation_bytes(self):
+        self._assert_focused_repair(
+            "parent:\n \t session_id: secret",
+            "parent:\n \t session_id: ***",
+            secrets=("secret",),
+        )
+
+    def test_focused_repair_unquoted_yaml_redacts_complete_multiword_value(self):
+        self._assert_focused_repair(
+            "session_id: my secret value",
+            "session_id: ***",
+            secrets=("my", "secret", "value"),
+        )
+
+    def test_focused_repair_assignment_redacts_complete_multiword_value(self):
+        self._assert_focused_repair(
+            "session_id = my secret value",
+            "session_id = ***",
+            secrets=("my", "secret", "value"),
+        )
+
+    def test_focused_repair_yaml_preserves_separated_trailing_comment(self):
+        self._assert_focused_repair(
+            "session_id: my secret value # trailing comment",
+            "session_id: *** # trailing comment",
+            secrets=("my", "secret", "value"),
+        )
+
+    def test_focused_repair_yaml_unspaced_hash_remains_in_sensitive_value(self):
+        self._assert_focused_repair(
+            "session_id: my#secret # public",
+            "session_id: *** # public",
+            secrets=("my", "secret"),
+        )
+
+    def test_focused_repair_double_quoted_yaml_uses_true_closing_quote(self):
+        self._assert_focused_repair(
+            'session_id: "my \\" secret" # public',
+            'session_id: "***" # public',
+            secrets=("my", "secret"),
+        )
+
+    def test_focused_repair_json_uses_true_closing_quote(self):
+        self._assert_focused_repair(
+            '{"session_id": "my \\" secret", "public": "ok"}',
+            '{"session_id": "***", "public": "ok"}',
+            secrets=("my", "secret"),
+        )
+
+    def test_focused_repair_single_quoted_yaml_honors_doubled_quotes(self):
+        self._assert_focused_repair(
+            "session_id: 'my ''secret''' # public",
+            "session_id: '***' # public",
+            secrets=("my", "secret"),
+        )
+
+    def test_focused_repair_quoted_assignment_preserves_public_suffix(self):
+        self._assert_focused_repair(
+            'session_id = "my secret" public-content',
+            'session_id = "***" public-content',
+            secrets=("my", "secret"),
+        )
+
+    def test_focused_repair_assignment_preserves_following_ampersand_pair(self):
+        self._assert_focused_repair(
+            "session_id=my secret&next=value",
+            "session_id=***&next=value",
+            secrets=("my", "secret"),
+        )
+
+    @pytest.mark.parametrize("line_ending", ["\r", "\n", "\r\n"], ids=["cr", "lf", "crlf"])
+    def test_focused_repair_assignment_does_not_cross_line_endings(self, line_ending):
+        self._assert_focused_repair(
+            f"session_id=my secret{line_ending}public=value",
+            f"session_id=***{line_ending}public=value",
+            secrets=("my", "secret"),
+        )
+
+    @pytest.mark.parametrize(
+        "text,key,secret",
+        [
+            ("session_id=session-value", "session_id", "session-value"),
+            ("session-id=session-value", "session_id", "session-value"),
+            ("SESSION_ID=session-value", "session_id", "session-value"),
+            ('"session_id": "session-value"', "session_id", "session-value"),
+            ("session_id: session-value", "session_id", "session-value"),
+            ("session_id='session-value'", "session_id", "session-value"),
+            ('session_id="session-value"', "session_id", "session-value"),
+            ("  session_id: 'session-value'", "session_id", "session-value"),
+        ],
+    )
+    def test_explicit_key_redacts_supported_textual_forms(self, text, key, secret):
+        result = redact_sensitive_text(text, force=True, extra_sensitive_keys={key})
+        assert secret not in result
+        assert "***" in result
+
+    def test_hyphen_key_opt_in_matches_underscore(self):
+        result = redact_sensitive_text(
+            "session_id=session-value",
+            force=True,
+            extra_sensitive_keys={"session-id"},
+        )
+        assert "session-value" not in result
+
+    def test_unrelated_similar_keys_remain_unchanged(self):
+        text = "session_name=session-value token_count=12345678901234567890"
+        assert redact_sensitive_text(text, force=True, extra_sensitive_keys={"session_id"}) == text
+
+    @pytest.mark.parametrize("bad", ["session_id", b"session_id"])
+    def test_top_level_string_collections_rejected(self, bad):
+        with pytest.raises(TypeError):
+            redact_sensitive_text("session_id=session-value", force=True, extra_sensitive_keys=bad)
+
+    def test_non_string_entry_rejected(self):
+        with pytest.raises(TypeError):
+            redact_sensitive_text(
+                "session_id=session-value",
+                force=True,
+                extra_sensitive_keys={object()},  # type: ignore[arg-type]
+            )
+
+    def test_empty_collection_does_not_change_behavior(self):
+        text = "session_id=session-value"
+        assert redact_sensitive_text(text, force=True, extra_sensitive_keys=set()) == text
+
+    def test_empty_keys_are_ignored(self):
+        text = "session_id=session-value"
+        assert redact_sensitive_text(text, force=True, extra_sensitive_keys={"", "   "}) == text
+
+    def test_does_not_persist_between_calls(self):
+        first = redact_sensitive_text(
+            "session_id=session-value",
+            force=True,
+            extra_sensitive_keys={"session_id"},
+        )
+        second = redact_sensitive_text("session_id=session-value", force=True)
+        assert "session-value" not in first
+        assert second == "session_id=session-value"
+
+    def test_code_file_explicit_key_still_redacts(self):
+        text = "SESSION_ID=session-value"
+        result = redact_sensitive_text(
+            text,
+            force=True,
+            code_file=True,
+            extra_sensitive_keys={"session_id"},
+        )
+        assert "session-value" not in result
+
+    def test_file_read_explicit_key_redacts_and_preserves_prefix_sentinel(self):
+        prefixed = "sk-" + "a" * 30
+        text = f"session_id=session-value\nOPENAI_API_KEY={prefixed}"
+        result = redact_sensitive_text(
+            text,
+            force=True,
+            file_read=True,
+            extra_sensitive_keys={"session_id"},
+        )
+        assert "session-value" not in result
+        assert "«redacted:sk-…»" in result
+
+
+class TestCliSensitiveSeparateValues:
+    def _assert_secret_redacted(
+        self,
+        text,
+        *,
+        secrets,
+        preserved=(),
+        expected=None,
+    ):
+        result = redact_sensitive_text(text, force=True)
+        assert "***" in result
+        for secret in secrets:
+            assert secret not in result
+        for external in preserved:
+            assert external in result
+        if expected is not None:
+            assert result == expected
+        assert redact_sensitive_text(result, force=True) == result
+
+    @pytest.mark.parametrize(
+        "text,secret,expected",
+        [
+            ("cmd --password secret-value", "secret-value", "cmd --password ***"),
+            ('cmd --password "secret-value"', "secret-value", 'cmd --password "***"'),
+            ("cmd --password 'secret-value'", "secret-value", "cmd --password '***'"),
+            ("cmd --passwd secret-value", "secret-value", "cmd --passwd ***"),
+            ("cmd --secret secret-value", "secret-value", "cmd --secret ***"),
+            ("cmd --token secret-value", "secret-value", "cmd --token ***"),
+            ("cmd --api-key secret-value", "secret-value", "cmd --api-key ***"),
+            ("cmd --api_key secret-value", "secret-value", "cmd --api_key ***"),
+            ("cmd --client-secret secret-value", "secret-value", "cmd --client-secret ***"),
+            ("cmd --password   secret-value", "secret-value", "cmd --password   ***"),
+        ],
+    )
+    def test_space_separated_sensitive_flag_values(self, text, secret, expected):
+        result = redact_sensitive_text(text, force=True)
+        assert secret not in result
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "cmd --password=secret-value",
+            "cmd --token=secret-value",
+            "cmd --api-key=secret-value",
+        ],
+    )
+    def test_equals_form_still_redacts(self, text):
+        result = redact_sensitive_text(text, force=True)
+        assert "secret-value" not in result
+
+    def test_multiple_sensitive_flags_one_line(self):
+        result = redact_sensitive_text("cmd --password one --token two", force=True)
+        assert "one" not in result
+        assert "two" not in result
+        assert result == "cmd --password *** --token ***"
+
+    def test_flag_at_end_stable(self):
+        assert redact_sensitive_text("cmd --password", force=True) == "cmd --password"
+
+    def test_next_flag_not_consumed(self):
+        assert redact_sensitive_text("cmd --password --verbose", force=True) == "cmd --password --verbose"
+
+    def test_quoted_empty_not_changed(self):
+        assert redact_sensitive_text('cmd --password ""', force=True) == 'cmd --password ""'
+        assert redact_sensitive_text('cmd --password=""', force=True) == 'cmd --password=""'
+
+    def test_does_not_cross_newline(self):
+        text = "cmd --password\nsecret-value"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_positional_ordinary_unchanged(self):
+        text = "cmd positional secret-value"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_similar_prefix_flag_unchanged(self):
+        text = "cmd --password-file path"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_space_quoted_value_with_escaped_quote_redacts_full_value(self):
+        text = 'cmd --secret "prefix ' + '\\"' + ' sensitive-suffix" --next'
+        self._assert_secret_redacted(
+            text,
+            secrets=(r'prefix \" sensitive-suffix', "sensitive-suffix"),
+            preserved=("cmd ", " --next"),
+            expected='cmd --secret "***" --next',
+        )
+
+    def test_equals_quoted_value_with_escaped_quote_redacts_full_value(self):
+        text = 'cmd --secret="prefix ' + '\\"' + ' sensitive-suffix" --next'
+        self._assert_secret_redacted(
+            text,
+            secrets=(r'prefix \" sensitive-suffix', "sensitive-suffix"),
+            preserved=("cmd ", " --next"),
+            expected='cmd --secret="***" --next',
+        )
+
+    def test_multiple_escaped_quotes_stay_inside_space_value(self):
+        text = 'cmd --secret "a ' + '\\"' + ' b ' + '\\"' + ' final-sensitive" tail'
+        self._assert_secret_redacted(
+            text,
+            secrets=(r'a \" b \" final-sensitive', "final-sensitive"),
+            preserved=("cmd ", " tail"),
+            expected='cmd --secret "***" tail',
+        )
+
+    def test_even_backslash_parity_closes_quote(self):
+        text = 'cmd --secret "prefix ' + ("\\" * 2) + '" outside-suffix --next'
+        result = redact_sensitive_text(text, force=True)
+        assert result == 'cmd --secret "***" outside-suffix --next'
+        assert "prefix" not in result
+        assert "outside-suffix --next" in result
+        assert redact_sensitive_text(result, force=True) == result
+
+    def test_odd_backslash_parity_above_one_keeps_quote_inside_value(self):
+        text = 'cmd --secret "prefix ' + ("\\" * 3) + '" final-sensitive" --next'
+        self._assert_secret_redacted(
+            text,
+            secrets=(r'prefix \\\" final-sensitive', "final-sensitive"),
+            preserved=("cmd ", " --next"),
+            expected='cmd --secret "***" --next',
+        )
+
+    def test_next_flag_preserved_after_escaped_quote_value(self):
+        text = 'cmd --token "hidden ' + '\\"' + ' sensitive-tail" --verbose'
+        self._assert_secret_redacted(
+            text,
+            secrets=("hidden", "sensitive-tail"),
+            preserved=("cmd ", " --verbose"),
+            expected='cmd --token "***" --verbose',
+        )
+
+    def test_equals_simple_quoted_value_redacts_and_preserves_tail(self):
+        text = 'cmd --api-key="secret-value" tail'
+        self._assert_secret_redacted(
+            text,
+            secrets=("secret-value",),
+            preserved=("cmd ", " tail"),
+            expected='cmd --api-key="***" tail',
+        )
+
+    def test_unterminated_escaped_quote_redacts_through_eol_only(self):
+        text = 'cmd --secret "prefix ' + '\\"' + ' sensitive-suffix --next' + "\nvisible-next-line"
+        result = redact_sensitive_text(text, force=True)
+        assert result == 'cmd --secret "***\nvisible-next-line'
+        assert "prefix" not in result
+        assert "sensitive-suffix" not in result
+        assert "--next" not in result
+        assert "visible-next-line" in result
+        assert redact_sensitive_text(result, force=True) == result
+
+    def test_non_sensitive_equivalent_quoting_remains_exact(self):
+        text = 'cmd --public "prefix ' + '\\"' + ' sensitive-suffix" --next'
+        assert redact_sensitive_text(text, force=True) == text
+
+
+class TestUrlUsernameOptIn:
+    def test_default_without_strict_mode_unchanged(self):
+        text = "https://user:password@example.invalid/"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_strict_without_username_opt_in_preserves_username(self):
+        text = "https://user:password@example.invalid/"
+        result = redact_sensitive_text(text, force=True, redact_url_credentials=True)
+        assert result == "https://user:***@example.invalid/"
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("http://user:password@example.invalid/", "http://***:***@example.invalid/"),
+            ("https://user:password@example.invalid/", "https://***:***@example.invalid/"),
+            ("//user:password@example.invalid/", "//***:***@example.invalid/"),
+            ("ws://user:password@example.invalid/", "ws://***:***@example.invalid/"),
+            ("wss://user:password@example.invalid/", "wss://***:***@example.invalid/"),
+            ("https://user@example.invalid/", "https://***@example.invalid/"),
+            ("https://user%40name:p%40ss@example.invalid/", "https://***:***@example.invalid/"),
+            ("https://δοκιμή:κωδικός@example.invalid/", "https://***:***@example.invalid/"),
+            (
+                "https://user:password@example.invalid/?token=query-secret",
+                "https://***:***@example.invalid/?token=***",
+            ),
+        ],
+    )
+    def test_strict_with_username_opt_in_masks_userinfo(self, text, expected):
+        assert redact_sensitive_text(
+            text,
+            force=True,
+            redact_url_credentials=True,
+            redact_url_usernames=True,
+        ) == expected
+
+    def test_username_opt_in_without_strict_mode_does_not_change_url(self):
+        text = "https://user:password@example.invalid/"
+        assert redact_sensitive_text(text, force=True, redact_url_usernames=True) == text
+
+
+class TestPrivateKeyBlocks:
+    def test_private_key_block_redacted_with_sentinel(self):
+        begin = "-----BEGIN " + "PRIVATE KEY-----"
+        end = "-----END " + "PRIVATE KEY-----"
+        payload = "synthetic-private-key-payload"
+        text = f"before\n{begin}\n{payload}\n{end}\nafter"
+        result = redact_sensitive_text(text, force=True)
+        assert payload not in result
+        assert "[REDACTED PRIVATE KEY]" in result
+        assert result == "before\n[REDACTED PRIVATE KEY]\nafter"
 
 
 class TestMaskSecretControlStripping:


### PR DESCRIPTION
## Summary

- add central redaction for values passed after sensitive CLI flags
- support both `--flag value` and `--flag=value` forms
- preserve flag spelling, separators, outer quotes and following arguments
- handle escaped quotes and unterminated quoted values conservatively
- keep redaction idempotent and limited to existing sensitive CLI flags

## Scope

Exactly two files:

- `agent/redact.py`
- `tests/agent/test_redact.py`

## Validation

The validated feature blobs are byte-identical to the previously tested candidate:

- focused `TestCliSensitiveSeparateValues`: PASS
- complete `tests/agent/test_redact.py`: PASS
- Python structural validation: PASS
- `git diff --check`: PASS
- current-main overlap: 0 paths

## Replacement packaging

This is the clean single-parent replacement for #74685.

#74685 accumulated historical DAG/base metadata that caused GitHub to present
hundreds of unrelated files in its review surface even though its effective
tree versus current `main` changed only the two files above.

This replacement starts directly from current `main` and contains one focal
commit so the review surface matches the actual change.
