### PR TITLE
fix(langfuse): fully redact secrets and emails before cloud upload

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -315,6 +315,38 @@ def _key_has_secret_keyword(key: str) -> bool:
             return True
     return False
 
+
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]")
+_SENSITIVE_BODY_KEYS_NORMALIZED = frozenset(
+    _NON_ALNUM_RE.sub("", k.lower()) for k in _SENSITIVE_BODY_KEYS
+)
+
+
+def is_sensitive_key(name: str) -> bool:
+    """True if a dict/JSON key named ``name`` should be treated as a secret.
+
+    For callers walking an already-parsed structure (a tool result, a
+    request body, a config object) where the value has been separated from
+    its key -- the value alone may not look like any known credential
+    shape (an opaque token, a plain password), so the regex-based passes
+    in :func:`redact_sensitive_text` can't catch it. The key still tells
+    you it's sensitive; this is the check for that.
+
+    Deliberately NOT built on ``_key_has_secret_keyword``: that matcher
+    treats a trailing ``s`` as the same keyword ("secrets" == "secret"),
+    which is correct for prose/config *text* but wrong here -- it would
+    flag ``token_count``, ``approx_input_tokens``, and ``total_tokens`` as
+    secret-valued fields, destroying legitimate usage/count metadata that
+    routinely flows through tool results. Instead this does an exact match
+    against ``_SENSITIVE_BODY_KEYS`` (deliberately includes ``authorization``,
+    which the word-boundary matcher excludes for its own text-scanning
+    reasons) after normalizing away separators and case, so
+    ``client_secret`` / ``clientSecret`` / ``Client-Secret`` all match the
+    same set entry without the substring risk.
+    """
+    return _NON_ALNUM_RE.sub("", name.strip().lower()) in _SENSITIVE_BODY_KEYS_NORMALIZED
+
+
 # JSON field patterns: "apiKey": "value", "token": "value", etc.
 _JSON_KEY_NAMES = r"(?:api_?[Kk]ey|token|secret|password|access_token|refresh_token|auth_token|bearer|secret_value|raw_secret|secret_input|key_material)"
 _JSON_FIELD_RE = re.compile(
@@ -778,6 +810,7 @@ def redact_sensitive_text(
     code_file: bool = False,
     file_read: bool = False,
     redact_url_credentials: bool = False,
+    full_mask: bool = False,
 ) -> str:
     """Apply all redaction patterns to a block of text.
 
@@ -807,6 +840,16 @@ def redact_sensitive_text(
     usable key or written back as one. Implies code_file=True (config/data
     files shouldn't trigger the source-code ENV/JSON false-positive paths).
 
+    Set full_mask=True at external-egress boundaries (data leaving the
+    machine entirely -- a third-party cloud upload, not a local log or a
+    value the agent might read back) where even a head/tail-preserving
+    preview is too much exposure. Every masked span -- prefix-matched
+    tokens, Authorization/API-key headers of any scheme, ENV/JSON/YAML
+    assignments, JWTs -- uses the same non-reusable sentinel as
+    file_read instead of ``mask_secret``'s partial reveal. Independent of
+    file_read: pass both if the text is also being read back into an
+    agent workflow.
+
     Performance: each regex pattern is gated behind a cheap substring
     pre-check (e.g. ``"=" in text`` for ENV assignments, ``"://" in text``
     for URLs, ``"eyJ" in text`` for JWTs). On a typical hermes log line
@@ -830,9 +873,16 @@ def redact_sensitive_text(
     if file_read:
         code_file = True
 
+    # Masking function for every span below: full_mask and file_read both
+    # want the non-reusable sentinel instead of mask_secret's head/tail
+    # preview -- file_read so a truncated-looking value can't be written
+    # back as a corrupted credential, full_mask because a preview is still
+    # too much to hand to a third-party egress boundary.
+    _mask_fn = _mask_token_nonreusable if (file_read or full_mask) else _mask_token
+
     # Known prefixes (sk-, ghp_, etc.) — gate on substring presence
     if _has_known_prefix_substring(text):
-        _prefix_sub = _mask_token_nonreusable if file_read else _mask_token
+        _prefix_sub = _mask_fn
         # Control/zero-width chars (\\n, \\r, ESC, U+200B, …) split a token
         # body so _PREFIX_RE cannot match across them — a secret smuggled as
         # ``sk-abc\\x1bdef…`` leaks verbatim (issue #77484). Mask such runs by
@@ -859,7 +909,7 @@ def redact_sensitive_text(
                 # embedded matching inside the helper.
                 if not _key_has_secret_keyword(name):
                     return m.group(0)
-                return f"{name}={quote}{_mask_token(value)}{quote}"
+                return f"{name}={quote}{_mask_fn(value)}{quote}"
             text = _ENV_ASSIGN_RE.sub(_redact_env, text)
             # Lowercase env names (``openai_key=…``). Skip URLs — the query
             # string may contain ``token=``/``key=`` params that are
@@ -894,7 +944,7 @@ def redact_sensitive_text(
                 # not a leaked secret value.
                 if _ENV_LOOKUP_VALUE_RE.match(value):
                     return m.group(0)
-                return f'{key}: "{_mask_token(value)}"'
+                return f'{key}: "{_mask_fn(value)}"'
             text = _JSON_FIELD_RE.sub(_redact_json, text)
 
         # Unquoted YAML / colon config: password: ***  (after JSON so quoted
@@ -913,7 +963,7 @@ def redact_sensitive_text(
                 # document text, not credentials (nearai/ironclaw#6129).
                 if not _key_has_secret_keyword(key):
                     return m.group(0)
-                return f"{key}{sep}{_mask_token(value)}"
+                return f"{key}{sep}{_mask_fn(value)}"
             text = _YAML_ASSIGN_RE.sub(_redact_yaml, text)
 
     # Authorization headers — _AUTH_HEADER_RE matches any scheme after
@@ -921,7 +971,7 @@ def redact_sensitive_text(
     # cheapest substring gate that covers every casing without a casefold().
     if "uthorization" in text or "UTHORIZATION" in text:
         text = _AUTH_HEADER_RE.sub(
-            lambda m: m.group(1) + (m.group(2) or "") + _mask_token(m.group(3)),
+            lambda m: m.group(1) + (m.group(2) or "") + _mask_fn(m.group(3)),
             text,
         )
 
@@ -929,7 +979,7 @@ def redact_sensitive_text(
     # colon-separated, so gate on ":" — the regex itself is the precise filter.
     if ":" in text:
         text = _SECRET_HEADER_RE.sub(
-            lambda m: m.group(1) + _mask_token(m.group(2)),
+            lambda m: m.group(1) + _mask_fn(m.group(2)),
             text,
         )
 
@@ -968,13 +1018,13 @@ def redact_sensitive_text(
         # query-string tokens are left to pass through (see the web-URL note
         # below). See _URL_BARE_TOKEN_RE for the false-positive guards.
         text = _URL_BARE_TOKEN_RE.sub(
-            lambda m: f"{m.group(1)}{_mask_token(m.group(2))}{m.group(3)}",
+            lambda m: f"{m.group(1)}{_mask_fn(m.group(2))}{m.group(3)}",
             text,
         )
 
     # JWT tokens (eyJ... — base64-encoded JSON headers)
     if "eyJ" in text:
-        text = _JWT_RE.sub(lambda m: _mask_token(m.group(0)), text)
+        text = _JWT_RE.sub(lambda m: _mask_fn(m.group(0)), text)
 
     # NOTE: Web-URL redaction (query params + userinfo + HTTP access-log
     # request targets) is intentionally OFF. Many legitimate workflows pass

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -151,63 +151,87 @@ def _capture_mode() -> str:
     return _DEFAULT_CAPTURE_MODE
 
 
-# Secret redaction in ``sanitized`` mode first reuses the project-wide
-# ``agent.redact.redact_sensitive_text(force=True)`` — which covers 50+ credential
-# patterns, private keys, JWTs, auth headers, DB connection strings, and env
-# assignments with pre-check-gated regex. The ``force=True`` flag ensures
-# redaction runs even if the user has ``security.redact_secrets: false`` set —
-# appropriate for an observability plugin exporting to an external service.
-#
-# That shared redactor is scoped to *local* logs/tool output (its own
-# docstring: "Longer tokens preserve the first 6 and last 4 characters for
-# debuggability") — a reasonable tradeoff when only the operator ever reads
-# the log, but not once the text is about to leave the machine for a
-# third-party cloud service. This plugin is the one call site where that
-# distinction matters, so a second, stricter pass runs on top: full
-# redaction (no partial reveal) of the same credential shapes, plus email
-# addresses, which the shared redactor doesn't attempt at all (it targets
-# credentials, not general PII). Upstreamed as a PR to
-# NousResearch/hermes-agent rather than kept as a silent local patch —
-# delete this second pass once that lands.
+# Secret redaction in ``sanitized`` mode delegates entirely to the
+# project-wide ``agent.redact.redact_sensitive_text`` — 50+ credential
+# patterns, private keys, JWTs, auth headers (any scheme), DB connection
+# strings, and env/JSON/YAML assignments, all with pre-check-gated regex and
+# false-positive guards (word-boundary key matching, env-lookup exceptions)
+# already fought out and tested there. Three flags tune it for this
+# call site specifically:
+#   force=True                 -- run even if the user set
+#                                  security.redact_secrets: false; this is a
+#                                  third-party cloud upload, not a local log.
+#   full_mask=True              -- the shared redactor's default preserves a
+#                                  head/tail preview for local-log
+#                                  debuggability; that is too much exposure
+#                                  once the text is leaving the machine.
+#   redact_url_credentials=True -- also strip credential-named query params
+#                                  and user:pass@ URL userinfo, which the
+#                                  shared redactor otherwise leaves alone for
+#                                  ordinary tool-flow URLs (OAuth callbacks,
+#                                  magic links).
+# Email addresses are PII, not credentials, so the shared redactor
+# deliberately doesn't touch them -- that pass runs here as a second, plugin-
+# local step.
 _REDACTED = "[REDACTED]"
-_UPLOAD_MASK_PATTERNS: list[tuple[re.Pattern[str], str]] = [
-    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), _REDACTED),
-    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"), _REDACTED),
-    (re.compile(r"\bghp_[A-Za-z0-9]{20,}\b"), _REDACTED),
-    (re.compile(r"\bsk-or-v1-[A-Za-z0-9]{16,}\b"), _REDACTED),
-    (re.compile(r"\b[sp]k-lf-[A-Za-z0-9\-]{8,}\b"), _REDACTED),
-    (re.compile(r"\b[sp]k-[A-Za-z0-9_\-]{16,}\b"), _REDACTED),
-    (re.compile(r"\bBearer\s+[A-Za-z0-9._\-~+/=]{8,}"), f"Bearer {_REDACTED}"),
-    (re.compile(r"\bAuthorization\s*[:=]\s*\S+", re.IGNORECASE), f"Authorization: {_REDACTED}"),
-    (
-        re.compile(
-            r"\b([A-Za-z0-9_.\-]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PWD))"
-            r"(\s*[:=]\s*)(\"[^\"]*\"|'[^']*'|\S+)",
-            re.IGNORECASE,
-        ),
-        rf"\1\2{_REDACTED}",
-    ),
-    (re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"), _REDACTED),
-]
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b")
+_REDACTION_FAILED = "[content omitted: redaction failed]"
 
 
 def _redact_secrets(value: str) -> str:
-    # Order matters: the stricter, fully-redacting patterns must run BEFORE
-    # the shared redactor, which partially reveals long tokens
-    # ("sk-abc...2345") for local-log debuggability. Once that partial
-    # reveal has happened, the full-secret shape no longer matches these
-    # patterns and can't be tightened further.
-    try:
-        for pattern, replacement in _UPLOAD_MASK_PATTERNS:
-            value = pattern.sub(replacement, value)
-    except Exception:
-        pass
+    """Fully redact secrets and emails from ``value`` before it leaves the
+    machine. Fails CLOSED: any error here omits the content rather than
+    risk shipping it raw to a third-party service.
+    """
     try:
         from agent.redact import redact_sensitive_text
-        value = redact_sensitive_text(value, force=True)
+        value = redact_sensitive_text(
+            value, force=True, full_mask=True, redact_url_credentials=True,
+        )
+        return _EMAIL_RE.sub(_REDACTED, value)
     except Exception:
-        pass
-    return value
+        logger.warning("langfuse: redaction failed, omitting content from upload", exc_info=True)
+        return _REDACTION_FAILED
+
+
+def _is_sensitive_key(name: str) -> bool:
+    """True if a dict key names a field whose value is a credential.
+
+    Lets sanitization catch opaque secrets (a bare password, an unrecognized
+    token format) that don't match any of ``_redact_secrets``' shape-based
+    patterns once the value has been separated from its key by JSON
+    parsing -- the key itself is still the signal.
+    """
+    try:
+        from agent.redact import is_sensitive_key
+        return is_sensitive_key(name)
+    except Exception:
+        return False
+
+
+def _redact_metadata_url(value: str) -> str:
+    """Sanitize a URL going into trace *metadata* (not message content).
+
+    ``_capture_content``/``_safe_value`` intentionally never see metadata
+    fields (provider, model, IDs) -- those pass through unredacted by
+    design, they're not conversation content. ``base_url`` is the one
+    metadata field that can carry a credential: a self-hosted or proxied
+    LLM endpoint may embed an API key in the query string or basic-auth
+    userinfo. Only URL-shaped credentials are stripped (query params,
+    userinfo) -- this is not the general secret/email pass, and it only
+    runs in ``sanitized`` mode, matching every other redaction boundary
+    in this plugin.
+    """
+    if not value or _capture_mode() != "sanitized":
+        return value
+    try:
+        from agent.redact import redact_sensitive_text
+        return redact_sensitive_text(
+            value, force=True, full_mask=True, redact_url_credentials=True,
+        )
+    except Exception:
+        logger.warning("langfuse: base_url redaction failed, omitting from metadata", exc_info=True)
+        return _REDACTION_FAILED
 
 
 def _describe_content(value: Any, *, depth: int = 0) -> Any:
@@ -624,7 +648,7 @@ def _normalize_payload(value: Any, *, tool_name: str = "", args: Any = None) -> 
 
 
 def _safe_value(value: Any, *, max_chars: Optional[int] = None, depth: int = 0,
-                parse_json_strings: bool = False) -> Any:
+                parse_json_strings: bool = False, key_hint: Optional[str] = None) -> Any:
     max_chars = max_chars if max_chars is not None else int(_env("HERMES_LANGFUSE_MAX_CHARS", "12000") or "12000")
     if depth > 4:
         return "<max-depth>"
@@ -633,6 +657,14 @@ def _safe_value(value: Any, *, max_chars: Optional[int] = None, depth: int = 0,
     if isinstance(value, bytes):
         return {"type": "bytes", "len": len(value)}
     if isinstance(value, str):
+        # Key-aware override: once JSON has been parsed, the key is the only
+        # signal left that a bare scalar ("hunter2", an opaque token with no
+        # recognized vendor prefix) is a credential -- _redact_secrets' shape
+        # patterns can't catch it from the value alone. Checked before
+        # JSON-string parsing so a stringified secret payload doesn't get
+        # structurally exposed by descending into it.
+        if value and key_hint and _capture_mode() == "sanitized" and _is_sensitive_key(key_hint):
+            return _REDACTED
         if parse_json_strings:
             parsed = _maybe_parse_json_string(value)
             if parsed is not value:
@@ -643,7 +675,7 @@ def _safe_value(value: Any, *, max_chars: Optional[int] = None, depth: int = 0,
         if normalized is not value:
             return _safe_value(normalized, max_chars=max_chars, depth=depth, parse_json_strings=parse_json_strings)
         return {
-            str(k): _safe_value(v, max_chars=max_chars, depth=depth + 1, parse_json_strings=parse_json_strings)
+            str(k): _safe_value(v, max_chars=max_chars, depth=depth + 1, parse_json_strings=parse_json_strings, key_hint=str(k))
             for k, v in list(value.items())[:50]
         }
     if isinstance(value, (list, tuple, set)):
@@ -1399,7 +1431,7 @@ def on_pre_llm_request(
             "provider": provider,
             "platform": platform,
             "api_mode": api_mode,
-            "base_url": base_url,
+            "base_url": _redact_metadata_url(base_url),
             "message_count": message_count,
             "approx_input_tokens": approx_input_tokens,
         }

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -151,20 +151,63 @@ def _capture_mode() -> str:
     return _DEFAULT_CAPTURE_MODE
 
 
-# Secret redaction in ``sanitized`` mode reuses the project-wide
+# Secret redaction in ``sanitized`` mode first reuses the project-wide
 # ``agent.redact.redact_sensitive_text(force=True)`` — which covers 50+ credential
 # patterns, private keys, JWTs, auth headers, DB connection strings, and env
 # assignments with pre-check-gated regex. The ``force=True`` flag ensures
 # redaction runs even if the user has ``security.redact_secrets: false`` set —
 # appropriate for an observability plugin exporting to an external service.
+#
+# That shared redactor is scoped to *local* logs/tool output (its own
+# docstring: "Longer tokens preserve the first 6 and last 4 characters for
+# debuggability") — a reasonable tradeoff when only the operator ever reads
+# the log, but not once the text is about to leave the machine for a
+# third-party cloud service. This plugin is the one call site where that
+# distinction matters, so a second, stricter pass runs on top: full
+# redaction (no partial reveal) of the same credential shapes, plus email
+# addresses, which the shared redactor doesn't attempt at all (it targets
+# credentials, not general PII). Upstreamed as a PR to
+# NousResearch/hermes-agent rather than kept as a silent local patch —
+# delete this second pass once that lands.
+_REDACTED = "[REDACTED]"
+_UPLOAD_MASK_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), _REDACTED),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"), _REDACTED),
+    (re.compile(r"\bghp_[A-Za-z0-9]{20,}\b"), _REDACTED),
+    (re.compile(r"\bsk-or-v1-[A-Za-z0-9]{16,}\b"), _REDACTED),
+    (re.compile(r"\b[sp]k-lf-[A-Za-z0-9\-]{8,}\b"), _REDACTED),
+    (re.compile(r"\b[sp]k-[A-Za-z0-9_\-]{16,}\b"), _REDACTED),
+    (re.compile(r"\bBearer\s+[A-Za-z0-9._\-~+/=]{8,}"), f"Bearer {_REDACTED}"),
+    (re.compile(r"\bAuthorization\s*[:=]\s*\S+", re.IGNORECASE), f"Authorization: {_REDACTED}"),
+    (
+        re.compile(
+            r"\b([A-Za-z0-9_.\-]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PWD))"
+            r"(\s*[:=]\s*)(\"[^\"]*\"|'[^']*'|\S+)",
+            re.IGNORECASE,
+        ),
+        rf"\1\2{_REDACTED}",
+    ),
+    (re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"), _REDACTED),
+]
 
 
 def _redact_secrets(value: str) -> str:
+    # Order matters: the stricter, fully-redacting patterns must run BEFORE
+    # the shared redactor, which partially reveals long tokens
+    # ("sk-abc...2345") for local-log debuggability. Once that partial
+    # reveal has happened, the full-secret shape no longer matches these
+    # patterns and can't be tightened further.
+    try:
+        for pattern, replacement in _UPLOAD_MASK_PATTERNS:
+            value = pattern.sub(replacement, value)
+    except Exception:
+        pass
     try:
         from agent.redact import redact_sensitive_text
-        return redact_sensitive_text(value, force=True)
+        value = redact_sensitive_text(value, force=True)
     except Exception:
-        return value
+        pass
+    return value
 
 
 def _describe_content(value: Any, *, depth: int = 0) -> Any:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -4,7 +4,13 @@ import logging
 
 import pytest
 
-from agent.redact import mask_secret, redact_cdp_url, redact_sensitive_text, RedactingFormatter
+from agent.redact import (
+    is_sensitive_key,
+    mask_secret,
+    redact_cdp_url,
+    redact_sensitive_text,
+    RedactingFormatter,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -942,6 +948,76 @@ class TestFileReadNonReusableRedaction:
 
 
 
+
+
+class TestFullMaskExternalEgress:
+    """full_mask=True: every masked span uses the non-reusable sentinel
+    (no head/tail preview) for external-egress boundaries like a
+    third-party cloud upload -- see the Langfuse plugin's _redact_secrets."""
+
+    def test_prefix_token_no_partial_reveal(self):
+        key = "sk-abcdefghijklmnopqrstuvwxyz012345"
+        out = redact_sensitive_text(f"key: {key}", force=True, full_mask=True)
+        assert key not in out
+        assert key[:8] not in out
+        assert key[-4:] not in out
+
+    @pytest.mark.parametrize("header,credential", [
+        ("Authorization: Basic dXNlcjpwYXNzd29yZA==", "dXNlcjpwYXNzd29yZA=="),
+        ("Authorization: Digest abcdef0123456789abcdef0123456789", "abcdef0123456789abcdef0123456789"),
+        ("Authorization: Token abcdef0123456789abcdef0123456789", "abcdef0123456789abcdef0123456789"),
+        ("authorization: bearer abcdef0123456789abcdef0123456789", "abcdef0123456789abcdef0123456789"),
+        ("Proxy-Authorization: Basic cHJveHl1c2VyOnByb3h5cGFzcw==", "cHJveHl1c2VyOnByb3h5cGFzcw=="),
+    ])
+    def test_authorization_any_scheme_no_partial_reveal(self, header, credential):
+        out = redact_sensitive_text(header, force=True, full_mask=True)
+        assert credential not in out
+        assert credential[:8] not in out
+
+    def test_jwt_no_partial_reveal(self):
+        jwt = "eyJhbGciOiJIUzI1NiJ9." + "A" * 40 + "." + "B" * 20
+        out = redact_sensitive_text(f"token={jwt}", force=True, full_mask=True)
+        assert jwt not in out
+        assert jwt[:10] not in out
+
+    def test_ordinary_prose_unaffected(self):
+        prose = "monkey hockey donkey key.getenv('X')"
+        assert redact_sensitive_text(prose, force=True, full_mask=True) == prose
+
+    def test_independent_of_file_read(self):
+        # full_mask and file_read both select the non-reusable sentinel but
+        # are independent flags -- file_read's existing contract (implies
+        # code_file=True) must not change when full_mask alone is set.
+        text = 'MAX_TOKENS=100\n"apiKey": "test"'
+        assert redact_sensitive_text(text, force=True, full_mask=True, code_file=True) == text
+
+
+class TestIsSensitiveKey:
+    """is_sensitive_key: dict-key-aware check for structured-payload
+    sanitizers (e.g. the Langfuse plugin) walking already-parsed JSON,
+    where the value alone may not match any credential shape."""
+
+    @pytest.mark.parametrize("key", [
+        "password", "client_secret", "clientSecret", "authorization",
+        "access_token", "api_key", "apiKey", "secret", "token",
+    ])
+    def test_known_sensitive_keys(self, key):
+        assert is_sensitive_key(key) is True
+
+    @pytest.mark.parametrize("key", [
+        "monkey", "hockey", "donkey", "username", "session_id",
+        "token_count", "secretary", "tokenizer",
+        # Plural/compound false positives _key_has_secret_keyword would flag
+        # (trailing "s" counts as the same keyword there) but that are
+        # common, legitimate usage-metadata field names -- not secrets.
+        "approx_input_tokens", "total_tokens", "prompt_tokens",
+    ])
+    def test_false_positive_keys_rejected(self, key):
+        assert is_sensitive_key(key) is False
+
+    @pytest.mark.parametrize("key", ["clientSecret", "Client-Secret", "APIKEY", "Authorization"])
+    def test_case_and_separator_variants_still_match(self, key):
+        assert is_sensitive_key(key) is True
 
 
 class TestFireworksToken:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -982,6 +982,96 @@ class TestUploadRedaction:
         ):
             assert mod._redact_secrets(prose) == prose, f"false positive on: {prose!r}"
 
+    @pytest.mark.parametrize("header,credential", [
+        ("Authorization: Basic dXNlcjpwYXNzd29yZA==", "dXNlcjpwYXNzd29yZA=="),
+        ("Authorization: Digest abcdef0123456789abcdef0123456789", "abcdef0123456789abcdef0123456789"),
+        ("Authorization: Token abcdef0123456789abcdef0123456789", "abcdef0123456789abcdef0123456789"),
+        ("authorization: bearer abcdef0123456789abcdef0123456789", "abcdef0123456789abcdef0123456789"),
+        ("Proxy-Authorization: Basic cHJveHl1c2VyOnByb3h5cGFzcw==", "cHJveHl1c2VyOnByb3h5cGFzcw=="),
+    ])
+    def test_authorization_header_any_scheme_fully_redacted(self, header, credential):
+        # Regression for the plugin-local Authorization regex (`\S+` stops at
+        # the scheme word) that redacted only the scheme and left the actual
+        # credential bytes -- Basic/Digest/Token/Proxy -- in the clear. Each
+        # case here is the single-opaque-token shape _AUTH_HEADER_RE targets;
+        # RFC 7616 Digest's multi-field `key="value", ...` list is a separate,
+        # out-of-scope shape (no single credential token to mask).
+        mod = self._fresh_plugin()
+        redacted = mod._redact_secrets(header)
+        assert credential not in redacted, f"credential leaked from: {header!r} -> {redacted!r}"
+        assert credential[:8] not in redacted, f"partial reveal from: {header!r} -> {redacted!r}"
+
+    def test_structured_dict_sensitive_keys_fully_redacted_regardless_of_shape(self):
+        # Regression: once a payload is parsed into a dict, _safe_value walked
+        # bare scalar values with no key context, so opaque secrets that don't
+        # match any shape pattern (a plain password, a raw client secret)
+        # reached Langfuse untouched. Key-aware redaction catches these via
+        # the key name alone.
+        mod = self._fresh_plugin()
+        payload = {
+            "password": "hunter2",
+            "client_secret": "not-a-recognized-shape-at-all",
+            "authorization": "some opaque bearer-less value",
+            "access_token": "opaque-token-no-vendor-prefix",
+            "username": "alice",
+            "note": "this mentions a password in prose but is not one",
+        }
+        safe = mod._safe_value(payload)
+        assert safe["password"] == "[REDACTED]"
+        assert safe["client_secret"] == "[REDACTED]"
+        assert safe["authorization"] == "[REDACTED]"
+        assert safe["access_token"] == "[REDACTED]"
+        assert safe["username"] == "alice"
+        assert safe["note"] == payload["note"]
+
+    def test_structured_false_positives_not_redacted(self):
+        # Same word-boundary false-positive class as the deleted local regex
+        # (monkey/hockey/donkey embed "key") -- key-aware redaction must use
+        # the shared word-boundary matcher, not a bare substring check.
+        mod = self._fresh_plugin()
+        payload = {"monkey": "banana", "hockey": "score", "donkey": "kong"}
+        safe = mod._safe_value(payload)
+        assert safe == payload
+
+    def test_structured_usage_metadata_not_redacted(self):
+        # A tool result embedding an LLM API's usage block ({"usage": {...}})
+        # is common and not secret -- key-aware redaction must not treat
+        # "total_tokens" as a "tokens" secret via plural matching.
+        mod = self._fresh_plugin()
+        payload = {"usage": {"prompt_tokens": 50, "completion_tokens": 20, "total_tokens": 70}}
+        safe = mod._safe_value(payload)
+        assert safe == payload
+
+    def test_url_userinfo_and_query_credentials_redacted_public_params_kept(self):
+        mod = self._fresh_plugin()
+        redacted = mod._redact_secrets(
+            "https://user:s3cr3tpass@api.example.com/v1/x?api_key=abcdef123456&region=us-east-1"
+        )
+        assert "s3cr3tpass" not in redacted
+        assert "abcdef123456" not in redacted
+        assert "region=us-east-1" in redacted
+
+    def test_base_url_credentials_redacted_in_generation_metadata(self):
+        mod = self._fresh_plugin()
+        redacted = mod._redact_metadata_url("https://proxyuser:proxysecret@llm-gateway.internal:8443/v1")
+        assert "proxysecret" not in redacted
+
+    def test_redaction_failure_omits_content_never_returns_raw(self, monkeypatch):
+        # Fail-CLOSED regression: both sanitizer passes used to swallow every
+        # exception and return the raw, unredacted value. A sanitizer failure
+        # at a third-party export boundary must never transmit the original.
+        mod = self._fresh_plugin()
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated redaction failure")
+
+        import agent.redact
+        monkeypatch.setattr(agent.redact, "redact_sensitive_text", _boom)
+        secret = "sk-abcdefghijklmnopqrstuvwxyz012345"
+        result = mod._redact_secrets(f"here is {secret}")
+        assert secret not in result
+        assert result == mod._REDACTION_FAILED
+
 
 # ---------------------------------------------------------------------------
 # Model attribution: wire truth over stale agent attribute

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -937,6 +937,53 @@ class TestUsageFromSanitizedResponse:
 
 
 # ---------------------------------------------------------------------------
+# Redaction before cloud upload.
+# ---------------------------------------------------------------------------
+
+class TestUploadRedaction:
+    """_redact_secrets must fully redact (not partially reveal) before
+
+    anything reaches the Langfuse cloud. The shared agent.redact utility
+    deliberately keeps a 6/4-char preview for local-log debuggability
+    (see its docstring) -- correct there, wrong once data is about to
+    leave the machine. This plugin layers a stricter pass on top; these
+    tests cover that pass specifically.
+    """
+
+    def _fresh_plugin(self):
+        mod_name = "plugins.observability.langfuse"
+        sys.modules.pop(mod_name, None)
+        return importlib.import_module(mod_name)
+
+    @pytest.mark.parametrize("secret", [
+        "sk-abcdefghijklmnopqrstuvwxyz012345",
+        "sk-or-v1-0123456789abcdef0123456789abcdef",
+        "AKIAIOSFODNN7EXAMPLE",
+        "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+    ])
+    def test_secret_shapes_fully_redacted_not_partially_revealed(self, secret):
+        mod = self._fresh_plugin()
+        redacted = mod._redact_secrets(f"here is the key {secret} use it")
+        assert secret not in redacted
+        # No partial reveal (prefix/suffix) of the original secret either.
+        assert secret[:8] not in redacted
+        assert secret[-4:] not in redacted
+
+    def test_email_is_redacted(self):
+        mod = self._fresh_plugin()
+        redacted = mod._redact_secrets("contact person@example.com for access")
+        assert "person@example.com" not in redacted
+
+    def test_ordinary_prose_passes_through_unchanged(self):
+        mod = self._fresh_plugin()
+        for prose in (
+            "Refactor the trace helper so it stops leaking state between turns.",
+            "def add(a, b):\n    return a + b",
+        ):
+            assert mod._redact_secrets(prose) == prose, f"false positive on: {prose!r}"
+
+
+# ---------------------------------------------------------------------------
 # Model attribution: wire truth over stale agent attribute
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Security-relevant

Yes — this fixes a gap in what the Langfuse observability plugin uploads to a third-party cloud service.

## What & why

`_redact_secrets()` in `plugins/observability/langfuse/__init__.py` delegates entirely to `agent.redact.redact_sensitive_text()`, which is explicitly scoped to local logs/tool output (its own docstring: longer tokens keep a 6/4-character preview "for debuggability"). That's the right tradeoff when only the operator reads the log — it's the wrong tradeoff once the same text is about to leave the machine for Langfuse's cloud, which is exactly what this plugin does.

Concretely, in `sanitized` capture mode (the default):
- API-key-shaped secrets (`sk-...`, `AKIA...`, `ghp_...`, etc.) upload with their prefix and suffix still visible instead of being fully redacted.
- Email addresses aren't redacted at all — `redact_sensitive_text` targets credentials, not general PII, so there's no coverage for this anywhere in the pipeline before upload.

Confirmed live: a message containing a plain email address and a fake API key both reached a real Langfuse trace with meaningful portions intact.

## Fix

Adds a second, stricter redaction pass inside the plugin itself — the one call site where the local-log-vs-third-party-upload distinction actually matters — run **before** the shared redactor. Order matters: the shared redactor's partial-reveal formatting (`sk-abc...2345`) no longer matches a full-secret-shape pattern, so running it first would leave the stricter pass unable to tighten what's already been partially masked.

The added patterns are deliberately high-signal (known key shapes, auth headers, `KEY=VALUE` assignments, email addresses) rather than an attempt at exhaustive PII detection — same philosophy as the existing shared redactor, just with full replacement instead of a partial preview, and with email coverage added.

## How to test

```
pytest tests/plugins/test_langfuse_plugin.py -v
```

New `TestUploadRedaction` class covers: full redaction (no partial reveal) of API-key/AWS-key/GitHub-token shapes, email redaction, and a no-false-positives check against ordinary prose/code. All pre-existing tests in the file still pass (95 passed).

## Platforms tested

macOS. This is pure string/regex logic with no OS-specific behavior, so I'd expect it to be platform-independent, but flagging since I only tested on one platform.
