### PR TITLE
fix(desktop): keep variant tags in model display names

### DIFF
--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -5,10 +5,12 @@ import { reasoningEffortLabel } from './reasoning-effort'
 
 describe('model-status-label', () => {
   it('formats display names consistently', () => {
-    expect(displayModelName('anthropic/claude-opus-4.8-fast')).toBe('Opus 4.8')
-    expect(displayModelName('openai/gpt-5.5-fast')).toBe('GPT-5.5')
-    expect(displayModelName('deepseek/deepseek-v4-pro-thinking')).toBe('Deepseek V4 Pro')
+    expect(displayModelName('anthropic/claude-opus-4.8-fast')).toBe('Opus 4.8 Fast')
+    expect(displayModelName('openai/gpt-5.5-fast')).toBe('GPT-5.5 Fast')
+    expect(displayModelName('deepseek/deepseek-v4-pro-thinking')).toBe('Deepseek V4 Pro Thinking')
     expect(displayModelName('openai/gpt-5.5')).toBe('GPT-5.5')
+    // A base model and its variant must NEVER share a display label (#88597).
+    expect(displayModelName('claude-opus-5')).not.toBe(displayModelName('claude-opus-5-thinking'))
   })
 
   it('strips trailing date-pin snapshots from the display name', () => {
@@ -28,6 +30,18 @@ describe('model-status-label', () => {
     expect(formatModelStatusLabel('openai/gpt-5.5', { fastMode: true, reasoningEffort: 'high' })).toBe(
       'GPT-5.5 · Fast High'
     )
+  })
+
+  it('keeps variant tags disambiguating in the status label without doubling Fast (#88597)', () => {
+    // The reporter's exact case: base vs -thinking must differ in the pill.
+    expect(formatModelStatusLabel('claude-opus-5')).toBe('Opus 5 · Med')
+    expect(formatModelStatusLabel('claude-opus-5-thinking')).toBe('Opus 5 Thinking · Med')
+    // A -fast variant already says Fast in its name; the pill must not
+    // repeat it as a session-state part.
+    expect(formatModelStatusLabel('openai/gpt-5.5-fast')).toBe('GPT-5.5 Fast · Med')
+    // The param-driven fast flag still appends when the model id has no
+    // -fast suffix.
+    expect(formatModelStatusLabel('openai/gpt-5.5', { fastMode: true })).toBe('GPT-5.5 · Fast Med')
   })
 
   it('falls back to the profile default effort, then to medium', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -90,9 +90,12 @@ export function modelDisplayParts(model: string): { name: string; tag: string } 
   return { name: prettifyBase(base) || model.trim() || 'No model', tag }
 }
 
-/** Friendly one-line model name for menus and the status bar. */
+/** Friendly one-line model name for menus and the status bar.
+ *  The variant tag is part of the name: `…-4.8` vs `…-4.8-thinking` must
+ *  not collapse to the same label on any surface (#88597). */
 export function displayModelName(model: string): string {
-  return modelDisplayParts(model).name
+  const { name, tag } = modelDisplayParts(model)
+  return tag ? `${name} ${tag}` : name
 }
 
 /** Status bar trigger label — model name plus the live session state (effort/fast).
@@ -102,17 +105,20 @@ export function formatModelStatusLabel(
   model: string,
   options?: { defaultEffort?: string; fastMode?: boolean; reasoningEffort?: string }
 ): string {
-  const name = displayModelName(model)
+  const { name, tag } = modelDisplayParts(model)
+  const label = tag ? `${name} ${tag}` : name
 
   if (!model.trim()) {
-    return name
+    return label
   }
 
   const parts: string[] = []
 
   // Fast is shown when the speed=fast param is on (options.fastMode) OR the
-  // active model is a `…-fast` variant (fast via a separate model id).
-  if (options?.fastMode || /-fast$/i.test(modelBaseId(model))) {
+  // active model is a `…-fast` variant (fast via a separate model id). The
+  // variant's tag is already in the name above, so only the param-driven
+  // case pushes a second Fast — never both (#88597).
+  if (options?.fastMode || (/-fast$/i.test(modelBaseId(model)) && tag !== 'Fast')) {
     parts.push('Fast')
   }
 
@@ -120,5 +126,5 @@ export function formatModelStatusLabel(
   // glance, not just when non-default.
   parts.push(reasoningEffortLabel(options?.reasoningEffort || options?.defaultEffort || DEFAULT_REASONING_EFFORT))
 
-  return `${name} · ${parts.join(' ')}`
+  return `${label} · ${parts.join(' ')}`
 }


### PR DESCRIPTION
## What does this PR do?

`displayModelName()` stripped the `-thinking`/`-fast`/`-preview`/`-latest` tag that `modelDisplayParts()` had deliberately split out — the `VARIANT_TAGS` machinery exists precisely so two distinct ids never collapse to one label, but every `displayModelName` consumer (composer pill via `formatModelStatusLabel`, session rows, delegate rows, catalog/visibility dialogs) showed only the bare name. A provider serving both `claude-opus-5` and `claude-opus-5-thinking` rendered an identical `Opus 5 · Med` pill for both, so the user could not tell which model was active (#88597).

This PR applies the issue's Option A: `displayModelName()` appends the tag when present (`Opus 5` vs `Opus 5 Thinking`), which automatically disambiguates every consumer. One companion change in `formatModelStatusLabel()`: a `-fast` variant id already carries `Fast` in its name now, so the status pill no longer pushes a second `Fast` part for it — only the param-driven `fastMode` flag appends one (`GPT-5.5 Fast · Med` for the variant, `GPT-5.5 · Fast Med` for the flag).

## Related Issue

Fixes #88597

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/model-status-label.ts`: `displayModelName()` keeps the variant tag; `formatModelStatusLabel()` builds from `modelDisplayParts()` directly and only pushes the `Fast` session-state part when it is not already the name's tag
- `apps/desktop/src/lib/model-status-label.test.ts`: updated the display-name contract (tags now part of the name, with an explicit base-vs-variant inequality pin) and added a status-label test covering the reporter's exact case plus the no-doubled-Fast and flag-still-appends cases

## How to Test

1. `npx vitest run src/lib/model-status-label.test.ts` (in `apps/desktop`) — Observed result: 12 passed.
2. New pins: `claude-opus-5` → `Opus 5 · Med` while `claude-opus-5-thinking` → `Opus 5 Thinking · Med` (the reporter's exact collision, now distinct); `openai/gpt-5.5-fast` → `GPT-5.5 Fast · Med` (Fast once, in the name); `gpt-5.5` + `fastMode` → `GPT-5.5 · Fast Med` (the param flag still appends).
3. The other `src/lib` suites were run for regression: `model-status-label` and the clipboard/cron/keyboard suites pass; the remaining local failures (`session-refs`, `brand-icon` collection, etc.) reproduce identically with this change stashed — pre-existing local dependency-version noise from a symlinked node_modules, not regressions (CI runs hermetic).

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the model-status-label suite (12 passed) and the wider src/lib suites (environment-independent failures verified pre-existing via a stashed baseline)
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config keys or schemas changed; the two touched functions carry docstrings explaining the disambiguation contract (#88597)

## For New Skills

N/A

## Screenshots / Logs

```
$ cd apps/desktop && npx vitest run src/lib/model-status-label.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)
```
