### PR TITLE
fix(acp): extend approval timeout

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -287,10 +287,15 @@ def make_acp_edit_approval_requester(
     request_permission_fn: Callable,
     loop: asyncio.AbstractEventLoop,
     session_id: str,
-    timeout: float = 60.0,
+    timeout: float | None = None,
     auto_approve_getter: Callable[[], tuple[str, str | None]] | None = None,
 ) -> EditApprovalRequester:
     """Return a sync requester that bridges edit proposals to ACP permissions."""
+
+    if timeout is None:
+        from acp_adapter.permissions import DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS
+
+        timeout = DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS
 
     def _requester(proposal: EditProposal) -> bool:
         from acp.schema import PermissionOption

--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from concurrent.futures import TimeoutError as FutureTimeout
 from itertools import count
 from typing import Callable
@@ -14,6 +15,23 @@ from acp.schema import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Human-reviewed ACP prompts routinely stay open while the user reads a diff.
+# Keep the default aligned for terminal-command and file-edit approvals.
+DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS = 600.0
+
+
+def coerce_approval_timeout_seconds(value: object) -> float:
+    """Return a safe positive ACP approval timeout from user config."""
+    if isinstance(value, bool):
+        return DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS
+    if not math.isfinite(timeout) or timeout <= 0:
+        return DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS
+    return timeout
 
 # Maps ACP permission option ids to Hermes approval result strings.
 # Option ids are stable across both the ``allow_permanent=True`` and
@@ -111,7 +129,7 @@ def make_approval_callback(
     request_permission_fn: Callable,
     loop: asyncio.AbstractEventLoop,
     session_id: str,
-    timeout: float = 60.0,
+    timeout: float = DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS,
 ) -> Callable[..., str]:
     """
     Return a Hermes-compatible approval callback that bridges to ACP.

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -70,7 +70,11 @@ from acp_adapter.events import (
     make_thinking_cb,
     make_tool_progress_cb,
 )
-from acp_adapter.permissions import make_approval_callback
+from acp_adapter.permissions import (
+    DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS,
+    coerce_approval_timeout_seconds,
+    make_approval_callback,
+)
 from acp_adapter.provenance import session_provenance_meta
 from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
 from acp_adapter.tools import build_tool_complete, build_tool_start
@@ -85,6 +89,24 @@ from tools.approval import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _configured_approval_timeout_seconds() -> float:
+    """Load the shared ACP command/edit approval deadline from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        acp_config = config.get("acp") if isinstance(config, dict) else None
+        value = (
+            acp_config.get("approval_timeout_seconds")
+            if isinstance(acp_config, dict)
+            else DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS
+        )
+    except Exception:
+        logger.debug("Could not load ACP approval timeout", exc_info=True)
+        value = DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS
+    return coerce_approval_timeout_seconds(value)
 
 
 def _named_custom_provider_catalogs() -> list[tuple[str, str, list[tuple[str, str]]]]:
@@ -1801,7 +1823,13 @@ class HermesACPAgent(acp.Agent):
                     streamed_message = True
                 message_cb(text)
 
-            approval_cb = make_approval_callback(conn.request_permission, loop, session_id)
+            approval_timeout = _configured_approval_timeout_seconds()
+            approval_cb = make_approval_callback(
+                conn.request_permission,
+                loop,
+                session_id,
+                timeout=approval_timeout,
+            )
             try:
                 from acp_adapter.edit_approval import make_acp_edit_approval_requester
 
@@ -1809,6 +1837,7 @@ class HermesACPAgent(acp.Agent):
                     conn.request_permission,
                     loop,
                     session_id,
+                    timeout=approval_timeout,
                     auto_approve_getter=lambda: self._edit_approval_policy_for_state(state),
                 )
             except Exception:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -25,6 +25,13 @@ DEFAULT_CONFIG = {
     "runtime": {
         "nofile_soft_limit": 4096,
     },
+    # Agent Client Protocol host behavior (editors such as Zed/Neoscript).
+    "acp": {
+        # Maximum seconds Hermes waits for a human response to either a file
+        # edit or dangerous-command approval prompt. Invalid/non-positive
+        # values fall back to this default.
+        "approval_timeout_seconds": 600,
+    },
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -2,17 +2,23 @@
 
 from __future__ import annotations
 
+import asyncio
+from concurrent.futures import Future
 import json
-import tempfile
 from pathlib import Path
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from acp_adapter.edit_approval import (
     EditProposal,
     build_acp_edit_tool_call,
     clear_edit_approval_requester,
+    make_acp_edit_approval_requester,
     set_edit_approval_requester,
     should_auto_approve_edit,
 )
+from acp_adapter.permissions import DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS
 from model_tools import handle_function_call
 
 
@@ -39,6 +45,44 @@ def test_acp_permission_tool_call_uses_edit_kind_and_diff_content():
     assert diff.path == "demo.txt"
     assert diff.oldText == "old\n"
     assert diff.newText == "new\n"
+
+
+def test_edit_approval_default_timeout_leaves_time_for_human_review():
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    request_permission = AsyncMock(name="request_permission")
+    future = MagicMock(spec=Future)
+    future.result.return_value = SimpleNamespace(
+        outcome=SimpleNamespace(outcome="selected", option_id="allow_once")
+    )
+    scheduled = {}
+
+    def _schedule(coro, passed_loop):
+        scheduled["coro"] = coro
+        scheduled["loop"] = passed_loop
+        return future
+
+    proposal = EditProposal(
+        tool_name="write_file",
+        path="demo.txt",
+        old_text="old\n",
+        new_text="new\n",
+        arguments={"path": "demo.txt", "content": "new\n"},
+    )
+    with patch(
+        "agent.async_utils.asyncio.run_coroutine_threadsafe",
+        side_effect=_schedule,
+    ):
+        requester = make_acp_edit_approval_requester(
+            request_permission,
+            loop,
+            session_id="s1",
+        )
+        assert requester(proposal) is True
+
+    scheduled["coro"].close()
+    future.result.assert_called_once_with(
+        timeout=DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS
+    )
 
 
 

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -11,7 +11,10 @@ from acp.schema import (
     RequestPermissionResponse,
 )
 
-from acp_adapter.permissions import make_approval_callback
+from acp_adapter.permissions import (
+    DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS,
+    make_approval_callback,
+)
 from tools.approval import prompt_dangerous_approval
 
 
@@ -63,6 +66,34 @@ def _invoke_callback(
 
 
 class TestApprovalBridge:
+    def test_default_timeout_leaves_time_for_human_review(self):
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        request_permission = AsyncMock(name="request_permission")
+        future = MagicMock(spec=Future)
+        future.result.return_value = _make_response(
+            AllowedOutcome(option_id="allow_once", outcome="selected")
+        )
+
+        scheduled = {}
+
+        def _schedule(coro, passed_loop):
+            scheduled["coro"] = coro
+            scheduled["loop"] = passed_loop
+            return future
+
+        with patch(
+            "agent.async_utils.asyncio.run_coroutine_threadsafe",
+            side_effect=_schedule,
+        ):
+            cb = make_approval_callback(request_permission, loop, session_id="s1")
+            assert cb("rm -rf /", "dangerous command") == "once"
+
+        scheduled["coro"].close()
+        future.result.assert_called_once_with(
+            timeout=DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS
+        )
+        assert DEFAULT_ACP_APPROVAL_TIMEOUT_SECONDS == 600.0
+
     def test_bridge_schedules_request_on_the_given_loop(self):
         result, kwargs, scheduled, _, loop = _invoke_callback(
             AllowedOutcome(option_id="allow_once", outcome="selected"),

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -40,6 +40,7 @@ from acp_adapter.server import (
     ACP_MAX_MODELS_PER_PROVIDER,
     HermesACPAgent,
     HERMES_VERSION,
+    _configured_approval_timeout_seconds,
 )
 from acp_adapter.session import SessionManager
 from hermes_state import SessionDB
@@ -402,6 +403,68 @@ class TestSessionConfiguration:
 
 
 class TestPrompt:
+    def test_configured_approval_timeout_defaults_to_ten_minutes(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+        assert _configured_approval_timeout_seconds() == 600.0
+
+    def test_configured_approval_timeout_accepts_positive_seconds(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"acp": {"approval_timeout_seconds": 900}},
+        )
+        assert _configured_approval_timeout_seconds() == 900.0
+
+    @pytest.mark.parametrize("value", [None, True, 0, -1, "not-a-number"])
+    def test_invalid_configured_approval_timeout_uses_default(
+        self, monkeypatch, value
+    ):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"acp": {"approval_timeout_seconds": value}},
+        )
+        assert _configured_approval_timeout_seconds() == 600.0
+
+    @pytest.mark.asyncio
+    async def test_prompt_applies_configured_timeout_to_command_and_edit_approvals(
+        self, agent, mock_manager, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"acp": {"approval_timeout_seconds": 900}},
+        )
+        response = await agent.new_session(cwd=".")
+        state = mock_manager.get_session(response.session_id)
+        state.agent.run_conversation.return_value = {
+            "final_response": "ok",
+            "messages": [],
+        }
+        state.agent.model = "test-model"
+        state.agent.provider = "openrouter"
+
+        connection = MagicMock(spec=acp.Client)
+        connection.session_update = AsyncMock()
+        agent._conn = connection
+
+        command_factory = MagicMock(return_value=MagicMock())
+        edit_factory = MagicMock(return_value=MagicMock())
+        with (
+            patch(
+                "acp_adapter.server.make_approval_callback",
+                command_factory,
+            ),
+            patch(
+                "acp_adapter.edit_approval.make_acp_edit_approval_requester",
+                edit_factory,
+            ),
+        ):
+            await agent.prompt(
+                prompt=[TextContentBlock(type="text", text="hi")],
+                session_id=response.session_id,
+            )
+
+        assert command_factory.call_args.kwargs["timeout"] == 900.0
+        assert edit_factory.call_args.kwargs["timeout"] == 900.0
+
     @pytest.mark.asyncio
     async def test_prompt_returns_refusal_for_unknown_session(self, agent):
         prompt = [TextContentBlock(type="text", text="hello")]

--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -342,7 +342,17 @@ request programmatically instead of showing it to you, in which case these
 options exist on the wire but never reach a human. Buzz Desktop does this, so
 treat that path as unattended execution regardless of your `approvals` setting.
 
-On timeout or error, the approval bridge denies the request.
+Hermes waits 10 minutes for approval by default. You can change the shared
+file-edit and dangerous-command deadline in `~/.hermes/config.yaml`:
+
+```yaml
+acp:
+  approval_timeout_seconds: 900
+```
+
+The value is read at the start of each prompt, so the next prompt uses a saved
+change without requiring a Hermes restart. On timeout or error, the approval
+bridge denies the request.
 
 ### Session-scoped edit auto-approval
 


### PR DESCRIPTION
## Summary

- extend the default ACP approval window from 60 seconds to 10 minutes
- apply one configurable timeout to file-edit and dangerous-command approvals
- document `acp.approval_timeout_seconds` and validate malformed values safely

## Root cause

Hermes timed out ACP permission requests after 60 seconds. Editor clients could keep a diff visible longer than that, so a writer could accept a still-visible edit after Hermes had already treated the request as denied.

## Impact

People reviewing edits in ACP clients now have 10 minutes by default. They can tune the deadline in `config.yaml`, and Hermes reads the setting at the start of each prompt.

## Validation

- `scripts/run_tests.sh tests/acp/ tests/acp_adapter/ -q`
- 151 tests passed
- `screenwriter config get acp.approval_timeout_seconds` returns `600`
- `screenwriter acp --check`
