### PR TITLE
fix(bot-mode): show profile-owned cronjobs

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5306,10 +5306,11 @@ async function invalidateRoutineOwner(profile) {
 function selectRoutineJobs(data, error, lastJobs, bot) {
   const live = Array.isArray(data?.jobs) ? data.jobs : null
   const all = live ?? (error ? lastJobs : [])
+  const scopedToBot = normalizedProfileName(data?.scoped) === normalizedProfileName(bot)
   return {
     live,
     all,
-    jobs: all.filter(job => routineBot(job) === bot)
+    jobs: scopedToBot ? all : all.filter(job => routineBot(job) === bot)
   }
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-error.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-error.test.mjs
@@ -43,6 +43,45 @@ test('unit: a live list is filtered to the current bot', () => {
   assert.equal(shown[0].job_id, '1')
 })
 
+test('regression: a profile-scoped list shows every job owned by that bot profile', () => {
+  const profileJobs = [
+    { name: 'ordinary profile cronjob', job_id: 'legacy' },
+    { name: '[bot:ops] Bot Mode routine', job_id: 'routine' }
+  ]
+  const view = load().__api.selectRoutineJobs({ jobs: profileJobs, scoped: 'ops' }, null, [], 'ops')
+
+  assert.deepEqual(
+    Array.from(view.jobs, job => job.job_id),
+    ['legacy', 'routine']
+  )
+})
+
+test('compatibility: an unmarked list keeps tag filtering for older gateways', () => {
+  const profileJobs = [
+    { name: 'ordinary launch-profile cronjob', job_id: 'legacy' },
+    { name: '[bot:ops] Bot Mode routine', job_id: 'routine' }
+  ]
+  const view = load().__api.selectRoutineJobs({ jobs: profileJobs }, null, [], 'ops')
+
+  assert.deepEqual(
+    Array.from(view.jobs, job => job.job_id),
+    ['routine']
+  )
+})
+
+test('compatibility: a stale scope marker cannot leak another profile\'s jobs', () => {
+  const profileJobs = [
+    { name: 'ordinary research cronjob', job_id: 'research' },
+    { name: '[bot:ops] Bot Mode routine', job_id: 'routine' }
+  ]
+  const view = load().__api.selectRoutineJobs({ jobs: profileJobs, scoped: 'research' }, null, [], 'ops')
+
+  assert.deepEqual(
+    Array.from(view.jobs, job => job.job_id),
+    ['routine']
+  )
+})
+
 test('unit: a failed refresh keeps the last good list', () => {
   const view = load().__api.selectRoutineJobs(undefined, new Error('down'), jobs, 'ops')
   assert.equal(view.live, null)

--- a/tests/test_cron_manage_profile_scope.py
+++ b/tests/test_cron_manage_profile_scope.py
@@ -47,6 +47,7 @@ def test_cron_manage_profile_reads_that_profiles_store(tmp_path, monkeypatch):
     )
 
     assert "result" in resp, resp
+    assert resp["result"]["scoped"] == "botA"
     names = [j.get("name") for j in resp["result"]["jobs"]]
     assert "botA-only-job" in names
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1699,15 +1699,19 @@ def _(rid, params: dict) -> dict:
         if action == "list":
             # Paused jobs are excluded by default, which reads as deletion in
             # any UI with an enable/disable toggle — forward the flag.
-            return _ok(
-                rid,
-                json.loads(
-                    cronjob(
-                        action="list",
-                        include_disabled=is_truthy_value(params.get("include_disabled", False)),
-                    )
-                ),
+            result = json.loads(
+                cronjob(
+                    action="list",
+                    include_disabled=is_truthy_value(params.get("include_disabled", False)),
+                )
             )
+            # This marker proves the gateway honored the optional profile
+            # scope. New clients may therefore treat every returned job as
+            # owned by that profile; older gateways omit it, preserving the
+            # safe [bot:<name>] compatibility filter.
+            if profile:
+                result["scoped"] = profile
+            return _ok(rid, result)
         if action == "add":
             return _ok(
                 rid,


### PR DESCRIPTION
## Problem

The Bot Mode right-sidebar **Cronjobs** pane asks `cron.manage` for the selected profile's store, but then filters the response back down to jobs whose display names begin with `[bot:<profile>]`. Ordinary profile-owned jobs therefore disappear even though the profile-scoped backend returned them correctly. This reproduces with named profiles such as `trading`, not just the default profile.

Addresses #88445 and #88263.

## Fix

- When `cron.manage list` successfully honors an explicit profile scope, return a `scoped` ownership marker.
- When that marker matches the selected bot profile, render every returned job because the profile store is already the ownership boundary.
- If the marker is absent or stale/mismatched, retain the existing `[bot:<name>]` filter. This keeps older gateways from leaking the launch profile's jobs into another bot pane.

This differs from #88458/#88461: it does not infer ownership from an untagged job name or assign untagged jobs to `default`. It requires positive backend proof and therefore works safely for named profiles too.

## RED / GREEN

**RED**
- The selector regression test returned only the tagged routine and omitted the ordinary profile cronjob.
- The RPC regression test raised `KeyError: scoped`.

**GREEN**
- Scoped lists show both ordinary profile jobs and Bot Mode routines.
- Unmarked and mismatched lists keep the compatibility filter.
- The RPC marks only explicitly profile-scoped list responses.

## Verification

- `npm --prefix apps/desktop run check:test:plugins` — 167 passed
- `PYTHONPATH="$PWD" python3.11 -m pytest tests/test_cron_manage_profile_scope.py tests/tools/test_cronjob_tools.py -o "addopts=" -q` — 70 passed
- `npm --prefix apps/desktop run typecheck` — passed
- `npm --prefix apps/desktop run lint` — 0 errors (120 pre-existing warnings)
- `npm --prefix apps/desktop run build` — passed
- `uvx ruff check tui_gateway/methods_tools.py tests/test_cron_manage_profile_scope.py` — passed
- `git diff --check` — passed

## Risk

Low and fail-closed. A client only relaxes name-tag filtering when the backend confirms the exact selected profile. Older gateways omit the marker and keep current behavior. No cron records are renamed, migrated, rescheduled, or rewritten.