### PR TITLE
fix(desktop): mermaid zoom overlay renders blank

### DIFF
--- a/apps/desktop/src/components/ui/zoomable.tsx
+++ b/apps/desktop/src/components/ui/zoomable.tsx
@@ -80,7 +80,7 @@ function ZoomPanViewer({
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent
-        bodyClassName="flex min-h-0 flex-col gap-0 overflow-hidden p-0"
+        bodyClassName="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden p-0"
         className="h-[85vh] w-[90vw] max-w-[90vw]"
         showCloseButton={false}
       >


### PR DESCRIPTION
## Summary

The click-to-zoom overlay for mermaid diagrams opened **blank**. This fixes it with a one-line CSS change.

## Root cause

The zoom overlay is rendered by `ZoomPanViewer` in `apps/desktop/src/components/ui/zoomable.tsx`. Its `DialogContent` shell is a **fixed-height flex column** (`h-[85vh] flex flex-col`), but the body wrapper was passed:

```
bodyClassName="flex min-h-0 flex-col gap-0 overflow-hidden p-0"
```

With no `flex-1`, the body kept `flex-basis: auto`; since its flex content has no intrinsic height, the body **collapsed to height 0**. The pan/zoom stage inside it (`flex-1` + `overflow-hidden`) then also had 0 height and **clipped the injected SVG entirely** — so the overlay showed nothing. The SVG itself renders fine; it was just being clipped away.

## Fix

Add `flex-1` to the body so it fills the shell height:

```diff
- bodyClassName="flex min-h-0 flex-col gap-0 overflow-hidden p-0"
+ bodyClassName="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden p-0"
```

## Verification

Reproduced headlessly with a faithful copy of the overlay DOM chain and measured the layout boxes:

| Variant | body / stage height | Result |
|---|---|---|
| Before (no `flex-1`) | **0px** | blank overlay |
| After (`flex-1`) | **765px** | diagram fully visible |

`Zoomable` is only consumed by the mermaid embed (`components/assistant-ui/embeds/mermaid-embed.tsx`), so the blast radius is limited to this feature.

## Test plan

- [ ] Open the desktop app, render a mermaid diagram in chat, click it to zoom — the overlay shows the diagram (not blank) and pan/zoom works.
