### PR TITLE
fix(web_server): deliver WebSocket rejection close codes to the client

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5511,10 +5511,10 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
                chunked API — the client uses the POST endpoint instead.
     """
     if not _ws_auth_ok(ws):
-        await ws.close(code=4401)
+        await _ws_reject(ws, 4401)
         return
     if not _ws_request_is_allowed(ws):
-        await ws.close(code=4403)
+        await _ws_reject(ws, 4403)
         return
     await ws.accept()
 
@@ -16741,6 +16741,27 @@ def _ws_close_reason(text: str) -> str:
         return text
     return encoded[:120].decode("utf-8", "ignore") + "..."
 
+async def _ws_reject(ws: "WebSocket", code: int, reason: str = "") -> None:
+    """Application-level rejection that the client can actually observe.
+
+    A ``ws.close()`` issued *before* ``ws.accept()`` never reaches the peer as
+    a close frame: uvicorn answers the upgrade with a bare HTTP 403 instead
+    (websockets_impl / wsproto_impl / websockets_sansio_impl all do this), so
+    a browser sees ``close code=1006 reason=""`` and the app-level codes the
+    dashboard keys on (4401 auth, 4403 host/origin, 4404 chat disabled, ...)
+    are lost. Complete the handshake first, then close with the code — the
+    only frames on the wire are the handshake and the close.
+
+    Every caller must ``return`` right after this; nothing is registered,
+    subscribed, or read on a rejected socket. Peer-gone errors are expected
+    here and swallowed; anything else propagates.
+    """
+    try:
+        await ws.accept()
+        await ws.close(code=code, reason=reason)
+    except (WebSocketDisconnect, OSError):
+        return
+
 
 # ---------------------------------------------------------------------------
 # /api/console — safe Hermes Console command WebSocket.
@@ -16963,7 +16984,7 @@ async def console_ws(ws: WebSocket) -> None:
 
     if not _DASHBOARD_EMBEDDED_CHAT_ENABLED:
         _log.info("console refused: embedded chat disabled peer=%s", peer)
-        await ws.close(code=4404, reason="embedded chat disabled")
+        await _ws_reject(ws, 4404, reason="embedded chat disabled")
         return
 
     auth_reason, cred = _ws_auth_reason(ws)
@@ -16973,19 +16994,19 @@ async def console_ws(ws: WebSocket) -> None:
             "console auth rejected reason=%s mode=%s cred=%s peer=%s",
             auth_reason, mode, cred, peer,
         )
-        await ws.close(code=4401, reason=_ws_close_reason(f"auth: {auth_reason}"))
+        await _ws_reject(ws, 4401, reason=_ws_close_reason(f"auth: {auth_reason}"))
         return
 
     host_origin_reason = _ws_host_origin_reason(ws)
     if host_origin_reason is not None:
         _log.warning("console refused: %s peer=%s", host_origin_reason, peer)
-        await ws.close(code=4403, reason=_ws_close_reason(host_origin_reason))
+        await _ws_reject(ws, 4403, reason=_ws_close_reason(host_origin_reason))
         return
 
     client_reason = _ws_client_reason(ws)
     if client_reason is not None:
         _log.warning("console refused: %s", client_reason)
-        await ws.close(code=4408, reason=_ws_close_reason(client_reason))
+        await _ws_reject(ws, 4408, reason=_ws_close_reason(client_reason))
         return
 
     await ws.accept()
@@ -17313,11 +17334,11 @@ async def pty_ws(ws: WebSocket) -> None:
 
     if not _DASHBOARD_EMBEDDED_CHAT_ENABLED:
         _log.info("pty refused: embedded chat disabled peer=%s", peer)
-        await ws.close(code=4404, reason="embedded chat disabled")
+        await _ws_reject(ws, 4404, reason="embedded chat disabled")
         return
 
-    # --- auth + host/origin/peer check (before accept so we can close
-    #     cleanly AND tell the client WHY via the close code + reason).
+    # --- auth + host/origin/peer check. Rejections go through _ws_reject()
+    #     so the client actually receives the close code + reason.
     #     Each gate maps to a distinct close code so the log and the
     #     browser banner agree on the cause:
     #       4401 bad credential   4403 host/origin mismatch
@@ -17329,19 +17350,19 @@ async def pty_ws(ws: WebSocket) -> None:
             "pty auth rejected reason=%s mode=%s cred=%s peer=%s",
             auth_reason, mode, cred, peer,
         )
-        await ws.close(code=4401, reason=_ws_close_reason(f"auth: {auth_reason}"))
+        await _ws_reject(ws, 4401, reason=_ws_close_reason(f"auth: {auth_reason}"))
         return
 
     host_origin_reason = _ws_host_origin_reason(ws)
     if host_origin_reason is not None:
         _log.warning("pty refused: %s peer=%s", host_origin_reason, peer)
-        await ws.close(code=4403, reason=_ws_close_reason(host_origin_reason))
+        await _ws_reject(ws, 4403, reason=_ws_close_reason(host_origin_reason))
         return
 
     client_reason = _ws_client_reason(ws)
     if client_reason is not None:
         _log.warning("pty refused: %s", client_reason)
-        await ws.close(code=4408, reason=_ws_close_reason(client_reason))
+        await _ws_reject(ws, 4408, reason=_ws_close_reason(client_reason))
         return
 
     await ws.accept()
@@ -17499,6 +17520,13 @@ async def pty_ws(ws: WebSocket) -> None:
 
 @app.websocket("/api/ws")
 async def gateway_ws(ws: WebSocket) -> None:
+    # Deliberately still close-before-accept (HTTP 403 to the client, no
+    # close code): JsonRpcGatewayClient.connect() resolves on `open`, and the
+    # desktop boot path treats a resolved connect() as a usable gateway
+    # (use-gateway-boot.ts). Rejecting after accept here would let boot
+    # complete on a socket that is already closed. Switch this endpoint to
+    # _ws_reject() together with the client change that settles connect() on
+    # the first frame (gateway.ready) instead of `open`.
     if not _DASHBOARD_EMBEDDED_CHAT_ENABLED:
         await ws.close(code=4403)
         return
@@ -17539,20 +17567,20 @@ async def gateway_ws(ws: WebSocket) -> None:
 @app.websocket("/api/pub")
 async def pub_ws(ws: WebSocket) -> None:
     if not _DASHBOARD_EMBEDDED_CHAT_ENABLED:
-        await ws.close(code=4403)
+        await _ws_reject(ws, 4403)
         return
 
     if not _ws_auth_ok(ws):
-        await ws.close(code=4401)
+        await _ws_reject(ws, 4401)
         return
 
     if not _ws_request_is_allowed(ws):
-        await ws.close(code=4403)
+        await _ws_reject(ws, 4403)
         return
 
     channel = _channel_or_close_code(ws)
     if not channel:
-        await ws.close(code=4400)
+        await _ws_reject(ws, 4400)
         return
 
     await ws.accept()
@@ -17567,20 +17595,20 @@ async def pub_ws(ws: WebSocket) -> None:
 @app.websocket("/api/events")
 async def events_ws(ws: WebSocket) -> None:
     if not _DASHBOARD_EMBEDDED_CHAT_ENABLED:
-        await ws.close(code=4403)
+        await _ws_reject(ws, 4403)
         return
 
     if not _ws_auth_ok(ws):
-        await ws.close(code=4401)
+        await _ws_reject(ws, 4401)
         return
 
     if not _ws_request_is_allowed(ws):
-        await ws.close(code=4403)
+        await _ws_reject(ws, 4403)
         return
 
     channel = _channel_or_close_code(ws)
     if not channel:
-        await ws.close(code=4400)
+        await _ws_reject(ws, 4400)
         return
 
     await ws.accept()

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2898,7 +2898,16 @@ async def stream_events(ws: WebSocket):
     # Authorization on a WS upgrade, so the credential rides in the query
     # string — the browser SDK's buildWsUrl() assembles it.
     if not _ws_upgrade_authorized(ws):
-        await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
+        # Accept, then close: a close issued before accept() is answered by
+        # uvicorn with a bare HTTP 403 and no close frame, so the browser sees
+        # 1006 and the dashboard's "1008 → auth failed, reload" branch never
+        # runs (it just backs off and retries forever). Same rule as
+        # hermes_cli.web_server._ws_reject.
+        try:
+            await ws.accept()
+            await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
+        except (WebSocketDisconnect, OSError):
+            pass
         return
     await ws.accept()
 

--- a/tests/hermes_cli/test_web_server_console_ws.py
+++ b/tests/hermes_cli/test_web_server_console_ws.py
@@ -59,15 +59,20 @@ def _recv_until(conn, frame_type: str, *, status: str | None = None) -> dict:
 
 
 def test_console_ws_rejects_missing_or_bad_token(console_client):
+    # The rejection is delivered as a close frame AFTER the handshake (see
+    # web_server._ws_reject), so the context enters and the first receive
+    # observes the close code + reason.
     with pytest.raises(WebSocketDisconnect) as exc:
-        with console_client.websocket_connect("/api/console"):
-            pass
+        with console_client.websocket_connect("/api/console") as conn:
+            conn.receive_text()
     assert exc.value.code == 4401
+    assert exc.value.reason == "auth: no_credential"
 
     with pytest.raises(WebSocketDisconnect) as exc:
-        with console_client.websocket_connect(_url(token="wrong")):
-            pass
+        with console_client.websocket_connect(_url(token="wrong")) as conn:
+            conn.receive_text()
     assert exc.value.code == 4401
+    assert exc.value.reason == "auth: token_mismatch"
 
 
 def test_console_ws_cancel_returns_to_prompt(console_client, monkeypatch):

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -160,8 +160,10 @@ class TestWebSocketHostOriginGuard:
                     "Host": "evil.example",
                     "Origin": "http://evil.example",
                 },
-            ):
-                pass
+            ) as conn:
+                # Rejection arrives as a close frame after the handshake
+                # (web_server._ws_reject); the first receive observes it.
+                conn.receive_text()
 
         assert exc.value.code == 4403
 
@@ -237,7 +239,9 @@ class TestWebSocketHostOriginGuard:
                     "Host": "dashboard.example.test:9443",
                     "Origin": "https://evil.test",
                 },
-            ):
-                pass
+            ) as conn:
+                # Rejection arrives as a close frame after the handshake
+                # (web_server._ws_reject); the first receive observes it.
+                conn.receive_text()
 
         assert exc.value.code == 4403

--- a/tests/hermes_cli/test_web_server_ws_reject.py
+++ b/tests/hermes_cli/test_web_server_ws_reject.py
@@ -1,0 +1,188 @@
+"""WebSocket rejections must reach the client as close codes.
+
+``ws.close(code=44xx)`` issued *before* ``ws.accept()`` never arrives as a
+close frame: uvicorn answers the upgrade with a bare HTTP 403 and drops the
+ASGI code/reason, so a browser sees ``close code=1006 reason=""`` and the
+dashboard's 4401/4403/4404 handling never fires. Starlette's ``TestClient``
+does not emulate that (it surfaces the pre-accept close as
+``WebSocketDisconnect(44xx)``), which is why the existing TestClient tests
+stayed green while the codes were lost in production. Hence the real-uvicorn
+test below: it is the fail-before for ``web_server._ws_reject``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+import threading
+
+import pytest
+from starlette.websockets import WebSocketDisconnect
+
+from hermes_cli import web_server
+
+
+# ---------------------------------------------------------------------------
+# Unit: helper contract on a fake socket.
+# ---------------------------------------------------------------------------
+
+
+class _FakeWs:
+    def __init__(self, accept_error: Exception | None = None) -> None:
+        self.calls: list[tuple] = []
+        self._accept_error = accept_error
+
+    async def accept(self) -> None:
+        self.calls.append(("accept",))
+        if self._accept_error is not None:
+            raise self._accept_error
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.calls.append(("close", code, reason))
+
+
+def test_ws_reject_accepts_then_closes_with_code_and_reason():
+    ws = _FakeWs()
+    asyncio.run(web_server._ws_reject(ws, 4401, "auth: token_mismatch"))
+    assert ws.calls == [("accept",), ("close", 4401, "auth: token_mismatch")]
+
+
+@pytest.mark.parametrize(
+    "error", [WebSocketDisconnect(1006), OSError("peer gone")],
+)
+def test_ws_reject_swallows_peer_gone_on_accept(error):
+    ws = _FakeWs(accept_error=error)
+    asyncio.run(web_server._ws_reject(ws, 4403, "host"))
+    # Nothing after the failed accept: no close attempted, no raise.
+    assert ws.calls == [("accept",)]
+
+
+def test_ws_reject_propagates_programming_errors():
+    ws = _FakeWs(accept_error=RuntimeError("accepted twice"))
+    with pytest.raises(RuntimeError):
+        asyncio.run(web_server._ws_reject(ws, 4401))
+
+
+# /api/ws stays close-before-accept until JsonRpcGatewayClient.connect()
+# settles on the first frame instead of `open` (see the comment at the
+# endpoint); everything else must reject through _ws_reject.
+_PRE_ACCEPT_CLOSE_ALLOWED = {"/api/ws"}
+
+
+def test_no_pre_accept_close_remains_in_websocket_endpoints():
+    """Every ``ws.close(code=44xx)`` before the endpoint's ``accept()`` must go
+    through ``_ws_reject`` (structural guard, not a count freeze)."""
+    import inspect
+    import re
+
+    source = inspect.getsource(web_server).split("\n")
+    endpoints = [i for i, l in enumerate(source) if l.startswith("@app.websocket(")]
+    offenders = []
+    for start in endpoints:
+        route = re.search(r'@app\.websocket\("([^"]+)"', source[start])
+        if route and route.group(1) in _PRE_ACCEPT_CLOSE_ALLOWED:
+            continue
+        accept_at = next(
+            (
+                j
+                for j in range(start, len(source))
+                if "await ws.accept()" in source[j] or "handle_ws(ws)" in source[j]
+            ),
+            None,
+        )
+        for j in range(start, accept_at if accept_at is not None else len(source)):
+            if "await ws.close(code=44" in source[j]:
+                offenders.append(f"{j + 1}: {source[j].strip()}")
+    assert offenders == []
+
+
+# ---------------------------------------------------------------------------
+# E2E on a real uvicorn server: the code + reason must reach a real client.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _ws_reject_server(monkeypatch, _isolate_hermes_home):
+    uvicorn = pytest.importorskip("uvicorn")
+    pytest.importorskip("websockets")
+
+    previous = {
+        name: getattr(web_server.app.state, name, None)
+        for name in ("auth_required", "bound_host")
+    }
+    web_server.app.state.auth_required = False
+    web_server.app.state.bound_host = None
+    monkeypatch.setattr(web_server, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+
+    # Pre-bind so the port is known before the server thread starts.
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(64)
+    port = sock.getsockname()[1]
+
+    config = uvicorn.Config(
+        web_server.app, host="127.0.0.1", port=port, log_level="error",
+        ws_ping_interval=None, ws_ping_timeout=None,
+    )
+    server = uvicorn.Server(config)
+    thread = threading.Thread(
+        target=lambda: asyncio.run(server.serve(sockets=[sock])), daemon=True,
+    )
+    thread.start()
+    deadline = threading.Event()
+    for _ in range(200):
+        if server.started:
+            break
+        deadline.wait(0.05)
+    assert server.started, "uvicorn did not start"
+    try:
+        yield f"ws://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10)
+        with contextlib.suppress(OSError):
+            sock.close()
+        for name, value in previous.items():
+            if value is None:
+                if hasattr(web_server.app.state, name):
+                    delattr(web_server.app.state, name)
+            else:
+                setattr(web_server.app.state, name, value)
+
+
+def _connect_and_capture_close(url: str, **kwargs) -> tuple[int, str]:
+    """Return ``(close_code, reason)`` as observed by a real WebSocket client."""
+    import websockets
+
+    async def run() -> tuple[int, str]:
+        async with websockets.connect(url, open_timeout=5, **kwargs) as ws:
+            try:
+                await asyncio.wait_for(ws.recv(), timeout=5)
+            except websockets.ConnectionClosed as exc:
+                assert exc.rcvd is not None, "closed without a close frame"
+                return exc.rcvd.code, exc.rcvd.reason
+        raise AssertionError("server did not close the socket")
+
+    return asyncio.run(run())
+
+
+def test_real_server_delivers_4401_close_code_for_bad_token(_ws_reject_server):
+    code, reason = _connect_and_capture_close(
+        f"{_ws_reject_server}/api/console?token=wrong",
+    )
+    assert (code, reason) == (4401, "auth: token_mismatch")
+
+
+def test_real_server_delivers_4403_close_code_for_foreign_host(_ws_reject_server):
+    web_server.app.state.bound_host = "127.0.0.1"
+    token = web_server._SESSION_TOKEN
+    code, reason = _connect_and_capture_close(
+        f"{_ws_reject_server}/api/events?token={token}&channel=security-test",
+        additional_headers={
+            "Host": "evil.example",
+            "Origin": "http://evil.example",
+        },
+    )
+    assert code == 4403

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -566,17 +566,19 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
     app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
     c = TestClient(app)
 
-    # No token → policy violation close.
+    # No token → policy violation close. The rejection is delivered as a
+    # close frame AFTER the handshake (a pre-accept close would reach the
+    # browser as a bare 1006), so the first receive observes it.
     from starlette.websockets import WebSocketDisconnect
     with pytest.raises(WebSocketDisconnect) as exc:
-        with c.websocket_connect("/api/plugins/kanban/events"):
-            pass
+        with c.websocket_connect("/api/plugins/kanban/events") as conn:
+            conn.receive_text()
     assert exc.value.code == 1008
 
     # Wrong token → policy violation close.
     with pytest.raises(WebSocketDisconnect) as exc:
-        with c.websocket_connect("/api/plugins/kanban/events?token=nope"):
-            pass
+        with c.websocket_connect("/api/plugins/kanban/events?token=nope") as conn:
+            conn.receive_text()
     assert exc.value.code == 1008
 
     # Correct token → accepted (connect then close cleanly from our side).
@@ -589,6 +591,74 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
     # The bug symptom was a traceback; we don't assert on stderr because
     # capturing asyncio's internal "exception was never retrieved" logging
     # is flaky. The assertion that matters is: no CancelledError escaped.
+
+
+def test_ws_events_rejection_code_reaches_a_real_client(tmp_path, monkeypatch):
+    """The 1008 must arrive as a close frame on a real server. Starlette's
+    TestClient reports a pre-accept close as WebSocketDisconnect(1008), but
+    uvicorn answers a pre-accept close with HTTP 403 and no close frame, so
+    the dashboard's "1008 -> auth failed, reload" branch never ran and it
+    retried with backoff instead. Real uvicorn + real websockets client."""
+    uvicorn = pytest.importorskip("uvicorn")
+    websockets = pytest.importorskip("websockets")
+    import asyncio
+    import socket
+    import threading
+    import types
+
+    import hermes_cli
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    stub = types.SimpleNamespace(
+        _SESSION_TOKEN="secret-xyz",
+        _ws_auth_ok=lambda ws: ws.query_params.get("token", "") == "secret-xyz",
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.web_server", stub)
+    monkeypatch.setattr(hermes_cli, "web_server", stub, raising=False)
+
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(16)
+    port = sock.getsockname()[1]
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error"))
+    thread = threading.Thread(target=lambda: asyncio.run(server.serve(sockets=[sock])), daemon=True)
+    thread.start()
+    started = threading.Event()
+    for _ in range(200):
+        if server.started:
+            started.set()
+            break
+        started.wait(0.05)
+    assert server.started, "uvicorn did not start"
+
+    async def capture_close(url):
+        async with websockets.connect(url, open_timeout=5) as ws:
+            try:
+                await asyncio.wait_for(ws.recv(), timeout=5)
+            except websockets.ConnectionClosed as exc:
+                assert exc.rcvd is not None, "closed without a close frame"
+                return exc.rcvd.code
+        raise AssertionError("server did not close the socket")
+
+    try:
+        code = asyncio.run(capture_close(f"ws://127.0.0.1:{port}/api/plugins/kanban/events?token=nope"))
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10)
+        try:
+            sock.close()
+        except OSError:
+            pass
+    assert code == 1008
 
 
 # ---------------------------------------------------------------------------

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -43,8 +43,8 @@ import {
   eventsReconnectDelayMs,
   eventsReconnectingMessage,
   eventsRejectedMessage,
-  isEventsAuthRejection,
   isEventsFeedMessage,
+  isEventsRejection,
   shouldRetryEventsClose,
 } from "@/lib/events-reconnect";
 import { titleFromSessionInfoPayload } from "@/lib/chat-title";
@@ -382,7 +382,11 @@ export function ChatSidebar({
         if (maybeReloadForLoopbackWsAuthFailure(ev.code)) {
           return;
         }
-        if (isEventsAuthRejection(ev.code)) {
+        if (isEventsRejection(ev.code)) {
+          // 4401/4403 and the other 44xx policy codes: the server accepted
+          // the upgrade only to close with the reason; retrying the same
+          // request cannot succeed and would loop (the `open` above resets
+          // `attempt`), so stop here and tell the user.
           surface(eventsRejectedMessage(ev.code));
           return;
         }

--- a/web/src/lib/events-reconnect.test.ts
+++ b/web/src/lib/events-reconnect.test.ts
@@ -9,6 +9,7 @@ import {
   eventsReconnectingMessage,
   eventsRejectedMessage,
   isEventsAuthRejection,
+  isEventsRejection,
   isEventsFeedMessage,
   shouldRetryEventsClose,
   EVENTS_DISCONNECTED_MESSAGE,
@@ -65,6 +66,20 @@ describe("shouldRetryEventsClose", () => {
   it("does not retry auth rejections", () => {
     expect(shouldRetryEventsClose(4401)).toBe(false);
     expect(shouldRetryEventsClose(4403)).toBe(false);
+  });
+
+  it("does not retry the other server rejection codes either", () => {
+    // web_server.py accepts the upgrade and closes with 4400 (bad channel),
+    // 4404 (chat disabled) or 4408 (peer refused); the sidebar's `open`
+    // handler resets the attempt counter, so retrying these would loop
+    // forever at the base delay instead of giving up.
+    for (const code of [4400, 4404, 4408, 4499]) {
+      expect(shouldRetryEventsClose(code)).toBe(false);
+      expect(isEventsRejection(code)).toBe(true);
+    }
+    expect(isEventsRejection(4500)).toBe(false);
+    expect(isEventsRejection(1006)).toBe(false);
+    expect(isEventsRejection(undefined)).toBe(false);
   });
 
   it("retries when the code is missing", () => {

--- a/web/src/lib/events-reconnect.ts
+++ b/web/src/lib/events-reconnect.ts
@@ -16,6 +16,15 @@ export const EVENTS_CONNECT_TIMEOUT_MS = 15_000;
 const WS_CLOSE_NORMAL = 1000;
 /** Ticket rejected / forbidden: retrying just burns tickets, user must reload. */
 const WS_CLOSE_AUTH_CODES = new Set([4401, 4403]);
+/**
+ * 4400-4499 is the private-use range web_server.py answers rejections with
+ * (4400 bad channel, 4401 auth, 4403 host/origin, 4404 chat disabled, 4408
+ * peer). The server accepts the upgrade and closes with the code, so the
+ * browser sees `open` and then this close — reconnecting with the same
+ * request can only reproduce it.
+ */
+const WS_CLOSE_REJECTION_MIN = 4400;
+const WS_CLOSE_REJECTION_MAX = 4499;
 
 /**
  * Exponential backoff, 1s → 2s → 4s → … → 30s cap.
@@ -36,16 +45,26 @@ export function eventsReconnectDelayMs(attempt: number): number {
 /**
  * Whether a close code should trigger a retry.
  *
- * Auth rejections are terminal (the banner tells the user to reload) and a
- * normal 1000 close is intentional. Everything else — gateway restart,
- * network drop, 1005/1006, proxy timeout — is worth retrying.
+ * Server rejections (4400-4499, auth included) are terminal — the banner
+ * tells the user to reload — and a normal 1000 close is intentional.
+ * Everything else — gateway restart, network drop, 1005/1006, proxy
+ * timeout — is worth retrying.
  */
 export function shouldRetryEventsClose(code: number | undefined): boolean {
   if (code === undefined) {
     return true;
   }
 
-  return code !== WS_CLOSE_NORMAL && !WS_CLOSE_AUTH_CODES.has(code);
+  return code !== WS_CLOSE_NORMAL && !isEventsRejection(code);
+}
+
+/** Any app-level rejection the server closed the socket with (4400-4499). */
+export function isEventsRejection(code: number | undefined): boolean {
+  return (
+    code !== undefined &&
+    code >= WS_CLOSE_REJECTION_MIN &&
+    code <= WS_CLOSE_REJECTION_MAX
+  );
 }
 
 export function isEventsAuthRejection(code: number | undefined): boolean {


### PR DESCRIPTION
Fixes #88607.

## What does this PR do?

`hermes_cli/web_server.py` rejects WebSocket upgrades with `await ws.close(code=44xx, reason=...)` before `await ws.accept()` on all six endpoints. uvicorn answers a pre-accept close with a bare HTTP 403 and never sends the close frame (`uvicorn/protocols/websockets/websockets_impl.py:286-294`, same in the wsproto/sansio impls), so a browser sees `close code=1006 reason=""` and everything in `web/` that keys on 4401/4403/4404 (the ChatPage auth/refused banners, the one-shot loopback token reload, the events feed's "stop retrying on auth rejection") is dead code in production. Starlette's `TestClient` reports the pre-accept close as `WebSocketDisconnect(44xx)`, which is why the existing tests were green.

- Add `_ws_reject(ws, code, reason)` next to `_ws_close_reason`: accept, then close with the code. Peer-gone errors (`WebSocketDisconnect`, `OSError`; uvicorn's `ClientDisconnected` is one) are swallowed and anything else propagates. Every caller `return`s right after it, so nothing is registered, subscribed or read on a rejected socket.
- Route the pre-accept rejections of `/api/console`, `/api/pty`, `/api/pub`, `/api/events` and `/api/audio/speak-stream` through it (18 sites). Post-accept closes (e.g. the 4400 after `/api/console` accepted, the 4410 in the PTY session) are untouched. Fix the `/api/pty` comment that described the old behaviour.
- `/api/ws` deliberately keeps close-before-accept for now: its clients use `JsonRpcGatewayClient`, whose `connect()` resolves on `open`, and the desktop boot path (`use-gateway-boot.ts`) treats a resolved `connect()` as a usable gateway, so accept-then-close there would let boot complete on a socket that is already closed. It switches over together with the client change that settles `connect()` on the first frame (`gateway.ready`). A structural test pins that no other endpoint closes with 44xx before accept.
- Second commit: the same rule for the kanban dashboard's `/api/plugins/kanban/events` (`plugins/kanban/dashboard/plugin_api.py`), which closed with 1008 before `accept()`. Its client (`plugins/kanban/dashboard/dist/index.js`) stops retrying and shows "WebSocket auth failed — reload the page" only on `ev.code === 1008`, so a stale token meant silent backoff-and-retry instead. Same real-uvicorn test shape (old code: `InvalidStatus` 403; now: close 1008).
- `web/src/lib/events-reconnect.ts`: because the browser now observes `open` followed by the 44xx close, and `ChatSidebar`'s `open` handler resets the attempt counter, a 4400/4404/4408 close would have retried at the base delay forever. `shouldRetryEventsClose` now treats the whole 4400-4499 range as terminal and the sidebar shows the existing "events feed rejected (code)" banner for them. 4401/4403 keep the loopback auto-reload path.

Related: #19938 (2026-05-04) moves `ws.accept()` ahead of the early closes on `/api/pty`, `/api/ws`, `/api/pub`, `/api/events` and the kanban `/events` route for the same ordering reason (reported there as a FastAPI 0.136 handshake hang, #19914). It has been conflicting since its 2026-05-18 review and the sweeper's 2026-07-12 note lists what a salvage needs (`/api/console`, the `/api/pty` gates). This PR is an independent implementation on current main covering those points, and it leaves `/api/ws` alone for the client reason above.

## How was it tested?

- New `tests/hermes_cli/test_web_server_ws_reject.py`:
  - real-uvicorn E2E (server on a pre-bound loopback port in a thread, `websockets` client): `/api/console?token=wrong` → close `4401`, reason `auth: token_mismatch`; `/api/events` with foreign Host/Origin → `4403`. On main both fail with `InvalidStatus` (HTTP 403), which is the fail-before for this bug.
  - helper contract on a fake socket (accept → close order and arguments; peer-gone swallowed; `RuntimeError` propagates) and a structural guard that no `ws.close(code=44xx)` remains before an endpoint's `accept()` (allowlist: `/api/ws`).
- Existing TestClient tests (`test_web_server_console_ws.py`, `test_web_server_host_header.py`) now receive once so they observe the post-accept close. The console tests also assert the reason; the host-header test still asserts only the code.
- Local: the three touched Python test files pass (15 tests). 374 passed across `tests/hermes_cli/test_web_server*.py`, `tests/test_web_server.py`, `tests/test_tui_gateway_ws.py`, `tests/test_pty_session.py`, `tests/plugins/test_kanban_dashboard_plugin.py` (2 pre-existing Windows-only failures, same on main). `web/`: vitest 276/276, `tsc` clean.
- Manual: the probe from the issue prints `close code= 4401 reason= "auth: stale"` with accept-then-close, `1006 ""` without.

## Behaviour changes worth knowing

- Access logs show `101` + close for a rejection on these five endpoints instead of `403`. The per-site warning logs are unchanged.
- Clients of these endpoints now see `open` before the rejection close. Checked: ChatPage (`/api/pty`) returns on 4401/4403/4404/4408 before `scheduleReconnect` and reads the code, HermesConsoleModal (`/api/console`) has no retry and prints the code; ChatSidebar (`/api/events`) is covered by the 4400-4499 change; the desktop `voice-playback.ts` (`/api/audio/speak-stream`) already routes a close before its `start` frame to the fallback path, same as the old error+1006.

## Follow-ups (not in this PR)

- `/api/ws`: settle `JsonRpcGatewayClient.connect()` on the first frame (`gateway.ready`) instead of `open`, route a 4401 close to the desktop sign-in path, then move the `/api/ws` gates to `_ws_reject` and drop the allowlist entry.
