### PR TITLE
fix(cron): retry transient provider failures

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -15,6 +15,7 @@ import contextvars
 import json
 import logging
 import os
+import random
 import re
 import shutil
 import subprocess
@@ -46,6 +47,68 @@ from hermes_cli.fallback_config import get_fallback_chain
 from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_TRANSIENT_RETRY_DELAYS = (60.0, 180.0, 600.0)
+
+
+def _cron_transient_retry_delays() -> tuple[float, ...]:
+    """Return job-level retry delays for transient provider failures.
+
+    An explicit empty list disables job-level retries. Invalid values fall
+    back to the safe default instead of silently disabling resilience.
+    """
+    try:
+        cfg = load_config() or {}
+        cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+        raw = cron_cfg.get(
+            "transient_retry_delays_seconds",
+            _DEFAULT_TRANSIENT_RETRY_DELAYS,
+        )
+        if raw == [] or raw == ():
+            return ()
+        if not isinstance(raw, (list, tuple)) or len(raw) > 10:
+            raise ValueError("expected a list of at most 10 delays")
+        delays = tuple(float(value) for value in raw)
+        if any(value < 0 or value > 3600 for value in delays):
+            raise ValueError("delays must be between 0 and 3600 seconds")
+        return delays
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid cron.transient_retry_delays_seconds; using default %s",
+            list(_DEFAULT_TRANSIENT_RETRY_DELAYS),
+        )
+        return _DEFAULT_TRANSIENT_RETRY_DELAYS
+
+
+def _is_transient_cron_error(error: str | None) -> bool:
+    """Whether a failed cron attempt should be retried as a fresh job run."""
+    text = (error or "").lower()
+    if not text:
+        return False
+    if any(marker in text for marker in (
+        "overloaded",
+        "server_is_overloaded",
+        "service unavailable",
+        "service_unavailable",
+        "at capacity",
+        "rate limit",
+        "rate_limit",
+        "too many requests",
+    )):
+        return True
+    return bool(re.search(r"\b(429|500|502|503|504|529)\b", text))
+
+
+def _wait_for_cron_retry(job_id: str, delay: float) -> bool:
+    """Wait interruptibly. Return False if shutdown interrupted the job."""
+    deadline = time.monotonic() + delay
+    while True:
+        if _is_interrupted(job_id):
+            return False
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return True
+        time.sleep(min(1.0, remaining))
 
 
 def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
@@ -3445,18 +3508,48 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
         try:
-            success, output, final_response, error = run_job(
-                job, defer_agent_teardown=_deferred_agents
-            )
-        except BaseException:
-            # run_job's finally still hands back the agent when it raises; tear
-            # it down here so a failed run never leaks its async resources
-            # (#10200), then re-raise into the outer handler. BaseException
-            # (not just Exception) so a KeyboardInterrupt/SystemExit mid-run
-            # still triggers teardown before propagating.
-            for _deferred_agent in _deferred_agents:
-                _teardown_cron_agent(_deferred_agent, job["id"])
-            raise
+            retry_delays = _cron_transient_retry_delays()
+            retry_index = 0
+            while True:
+                attempt_agents: list = []
+                try:
+                    success, output, final_response, error = run_job(
+                        job, defer_agent_teardown=attempt_agents
+                    )
+                except BaseException:
+                    # run_job's finally still hands back the agent when it raises.
+                    for deferred_agent in attempt_agents:
+                        _teardown_cron_agent(deferred_agent, job["id"])
+                    raise
+
+                if (
+                    success
+                    or retry_index >= len(retry_delays)
+                    or not _is_transient_cron_error(error)
+                ):
+                    # Keep only the final attempt live until delivery. Failed
+                    # intermediate attempts are torn down before the backoff.
+                    _deferred_agents.extend(attempt_agents)
+                    break
+
+                for deferred_agent in attempt_agents:
+                    _teardown_cron_agent(deferred_agent, job["id"])
+
+                base_delay = retry_delays[retry_index]
+                retry_index += 1
+                delay = base_delay * random.uniform(0.8, 1.2)
+                logger.warning(
+                    "Job '%s': transient provider failure; retrying fresh job run "
+                    "in %.1fs (job retry %d/%d): %s",
+                    job.get("name", job["id"]),
+                    delay,
+                    retry_index,
+                    len(retry_delays),
+                    error,
+                )
+                if not _wait_for_cron_retry(job["id"], delay):
+                    error = "Interrupted during transient provider retry backoff."
+                    break
         finally:
             reset_secret_scope(_scope_token)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2690,6 +2690,10 @@ DEFAULT_CONFIG = {
         # 1 = serial (pre-v0.9 behaviour).
         # Also overridable via HERMES_CRON_MAX_PARALLEL env var.
         "max_parallel_jobs": None,
+        # Fresh job-level retries after the agent's normal per-request retries
+        # are exhausted by transient provider failures (429, overload, 5xx).
+        # Each delay gets ±20% jitter. Set [] to disable.
+        "transient_retry_delays_seconds": [60, 180, 600],
         # Per-job output-file retention: save_job_output keeps the N most
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -100,6 +100,128 @@ def test_run_one_job_failed_job_delivers_error(monkeypatch):
     assert mark == ("mark", "j5", False)
 
 
+def test_run_one_job_retries_transient_provider_failures_before_delivery(monkeypatch):
+    """A provider overload gets fresh job attempts with delayed backoff, while
+    only the final successful attempt is saved, delivered, and marked."""
+    calls = []
+    outcomes = iter([
+        (False, "failed-1", "", "Our servers are currently overloaded."),
+        (False, "failed-2", "", "HTTP 503 service unavailable"),
+        (True, "success-output", "final response", None),
+    ])
+
+    class FakeAgent:
+        def __init__(self, attempt):
+            self.attempt = attempt
+
+        def close(self):
+            calls.append(("close", self.attempt))
+
+    def fake_run_job(job, *, defer_agent_teardown=None):
+        attempt = 1 + len([c for c in calls if c[0] == "run_job"])
+        calls.append(("run_job", attempt))
+        assert defer_agent_teardown is not None
+        defer_agent_teardown.append(FakeAgent(attempt))
+        return next(outcomes)
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "_cron_transient_retry_delays", lambda: (60.0, 180.0, 600.0))
+    monkeypatch.setattr(s.random, "uniform", lambda low, high: 1.0)
+    monkeypatch.setattr(
+        s,
+        "_wait_for_cron_retry",
+        lambda job_id, delay: calls.append(("wait", delay)) or True,
+    )
+    monkeypatch.setattr(
+        s, "save_job_output",
+        lambda jid, output: calls.append(("save", output)) or f"/tmp/{jid}.txt",
+    )
+    monkeypatch.setattr(
+        s, "_deliver_result",
+        lambda job, content, adapters=None, loop=None: calls.append(("deliver", content)),
+    )
+    monkeypatch.setattr(
+        s, "mark_job_run",
+        lambda jid, ok, err=None, delivery_error=None: calls.append(("mark", ok)),
+    )
+    import agent.auxiliary_client as aux
+    monkeypatch.setattr(aux, "cleanup_stale_async_clients", lambda: None)
+
+    assert s.run_one_job({"id": "retry-job", "name": "retry job"}) is True
+
+    assert [c for c in calls if c[0] == "run_job"] == [
+        ("run_job", 1), ("run_job", 2), ("run_job", 3)
+    ]
+    assert [c for c in calls if c[0] == "wait"] == [
+        ("wait", 60.0), ("wait", 180.0)
+    ]
+    assert [c for c in calls if c[0] == "save"] == [("save", "success-output")]
+    assert [c for c in calls if c[0] == "deliver"] == [("deliver", "final response")]
+    assert [c for c in calls if c[0] == "mark"] == [("mark", True)]
+    assert [c for c in calls if c[0] == "close"] == [
+        ("close", 1), ("close", 2), ("close", 3)
+    ]
+
+
+def test_run_one_job_does_not_retry_permanent_failure(monkeypatch):
+    """Authentication and other permanent failures keep the existing immediate
+    failure behavior."""
+    calls = _patch_pipeline(
+        monkeypatch,
+        success=False,
+        final="",
+        error="HTTP 401 authentication failed",
+    )
+    monkeypatch.setattr(s, "_cron_transient_retry_delays", lambda: (60.0, 180.0, 600.0))
+    monkeypatch.setattr(
+        s,
+        "_wait_for_cron_retry",
+        lambda job_id, delay: calls.append(("wait", delay)) or True,
+    )
+
+    assert s.run_one_job({"id": "permanent-job", "name": "permanent"}) is True
+
+    assert [c for c in calls if c[0] == "run_job"] == [("run_job", "permanent-job")]
+    assert not [c for c in calls if c[0] == "wait"]
+    assert [c for c in calls if c[0] == "mark"] == [("mark", "permanent-job", False)]
+
+
+def test_transient_cron_error_classification():
+    transient = [
+        "Our servers are currently overloaded.",
+        "HTTP 429 too many requests",
+        "HTTP 500 internal server error",
+        "HTTP 502 bad gateway",
+        "HTTP 503 service unavailable",
+        "HTTP 504 gateway timeout",
+        "HTTP 529",
+    ]
+    permanent = [
+        "HTTP 401 authentication failed",
+        "HTTP 402 billing exhausted",
+        "HTTP 400 invalid request",
+        "tool call failed",
+        None,
+    ]
+
+    assert all(s._is_transient_cron_error(error) for error in transient)
+    assert not any(s._is_transient_cron_error(error) for error in permanent)
+
+
+def test_transient_retry_delays_are_configurable_and_disableable(monkeypatch):
+    monkeypatch.setattr(
+        s, "load_config",
+        lambda: {"cron": {"transient_retry_delays_seconds": [2, 5]}},
+    )
+    assert s._cron_transient_retry_delays() == (2.0, 5.0)
+
+    monkeypatch.setattr(
+        s, "load_config",
+        lambda: {"cron": {"transient_retry_delays_seconds": []}},
+    )
+    assert s._cron_transient_retry_delays() == ()
+
+
 def test_run_one_job_exception_marks_failure(monkeypatch):
     """If run_job raises, the helper marks the run failed and returns False
     rather than propagating."""

--- a/website/docs/guides/cron-troubleshooting.md
+++ b/website/docs/guides/cron-troubleshooting.md
@@ -159,6 +159,12 @@ Likely a delivery target issue (see Delivery Failures above), no output, or a re
 **Job hangs or times out**
 The scheduler uses an inactivity-based timeout (default 600s, configurable via `HERMES_CRON_TIMEOUT` env var, `0` for unlimited). The agent can run as long as it's actively calling tools — the timer only fires after sustained inactivity. Long-running jobs should use scripts to handle data collection and deliver only the result.
 
+**Provider overload, rate limit, or 5xx**
+After the agent's normal request retries are exhausted, cron starts fresh job
+attempts after 1, 3, and 10 minutes by default (with jitter). Configure the
+delays with `cron.transient_retry_delays_seconds`; set it to `[]` to disable.
+Only the final attempt is delivered and recorded as the run result.
+
 ### Check 3: Lock contention
 
 The scheduler uses file-based locking to prevent overlapping ticks. If two gateway instances are running (or a CLI session conflicts with a gateway), jobs may be delayed or skipped.

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -225,6 +225,23 @@ On each tick Hermes:
 
 A file lock at `~/.hermes/cron/.tick.lock` prevents overlapping scheduler ticks from double-running the same job batch.
 
+### Transient provider retries
+
+If the agent exhausts its normal request retries because the model provider is
+overloaded, rate-limited, or returning a 5xx response, cron retries the whole
+job in a fresh agent session. The default delays are 1, 3, and 10 minutes, each
+with ±20% jitter. Intermediate failures are not delivered or marked as the
+job's final result.
+
+```yaml
+# ~/.hermes/config.yaml
+cron:
+  transient_retry_delays_seconds: [60, 180, 600]
+```
+
+Set the list to `[]` to disable job-level retries. Authentication, billing,
+invalid-request, tool, and script failures are not retried by this mechanism.
+
 ## Delivery options
 
 When scheduling jobs, you specify where the output goes:


### PR DESCRIPTION
## Problem
Cron jobs only had per-request retries. If a provider stayed overloaded for those few seconds, the whole cron run failed and waited until the next scheduled interval.

## Change
- retry the whole cron job in a fresh agent session after transient 429, overload, and 5xx failures
- default backoff: 1m, 3m, 10m with ±20% jitter
- tear down intermediate agents, and only save/deliver/mark the final attempt
- make delays configurable with `cron.transient_retry_delays_seconds` (`[]` disables)
- leave permanent failures such as auth, billing, invalid requests, tools, and scripts unchanged

## Verification
- `python -m pytest tests/cron/ -q -o 'addopts='`\n- 677 passed