### PR TITLE
fix(tui-gateway): route /context to parent session

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16683,7 +16683,7 @@ def test_slash_exec_concurrent_first_use_spawns_single_worker(monkeypatch):
             {
                 "id": str(n),
                 "method": "slash.exec",
-                "params": {"command": "/context", "session_id": "race-spawn"},
+                "params": {"command": "/tools", "session_id": "race-spawn"},
             }
         )
         results.append(resp)
@@ -16702,6 +16702,50 @@ def test_slash_exec_concurrent_first_use_spawns_single_worker(monkeypatch):
         assert all("result" in r for r in results), results
     finally:
         server._sessions.pop("race-spawn", None)
+
+
+@pytest.mark.parametrize("command", ["/context", "/ctx"])
+def test_slash_exec_context_uses_parent_session_without_spawning_worker(monkeypatch, command):
+    """/context is a read-only parent-session command.
+
+    It must not be sent to the agent-less slash worker: resumed Desktop/TUI
+    sessions can have transcript history without a resident HermesCLI agent.
+    """
+    session = _session(
+        slash_worker=None,
+        session_key="context-session-key",
+        history=[
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ],
+    )
+    server._sessions["context-sid"] = session
+    spawned = []
+
+    class _UnexpectedWorker:
+        def __init__(self, *args, **kwargs):
+            spawned.append(True)
+
+    monkeypatch.setattr(server, "_SlashWorker", _UnexpectedWorker)
+    monkeypatch.setattr(
+        server,
+        "_format_live_context_output",
+        lambda live_session: "parent-session-context",
+    )
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "context-read",
+                "method": "slash.exec",
+                "params": {"command": command, "session_id": "context-sid"},
+            }
+        )
+        assert response["result"]["output"] == "parent-session-context"
+        assert spawned == []
+        assert session["slash_worker"] is None
+    finally:
+        server._sessions.pop("context-sid", None)
 
 
 def test_session_close_rpc_claims_then_tears_down(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13537,6 +13537,7 @@ _LIVE_SESSION_DIRECT_COMMANDS = frozenset(
     {
         "clear",
         "compress",
+        "context",
         "effort",
         "history",
         "models",
@@ -13547,7 +13548,7 @@ _LIVE_SESSION_DIRECT_COMMANDS = frozenset(
     }
 )
 
-_ISOLATED_SESSION_READ_COMMANDS = frozenset({"context", "tools", "help"})
+_ISOLATED_SESSION_READ_COMMANDS = frozenset({"tools", "help"})
 
 
 def _format_live_usage_output(session: dict) -> str:
@@ -13728,6 +13729,14 @@ def _format_live_model_output(session: dict) -> str:
 def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg: str) -> Optional[str]:
     name = (name or "").lstrip("/").lower()
     arg = arg or ""
+    try:
+        from hermes_cli.commands import resolve_command
+
+        resolved = resolve_command(name)
+        if resolved is not None:
+            name = resolved.name
+    except Exception:
+        pass
     if name == "model" and not arg.strip():
         return _format_live_model_output(session or {})
     if name not in _LIVE_SESSION_DIRECT_COMMANDS:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13736,6 +13736,9 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
         if resolved is not None:
             name = resolved.name
     except Exception:
+        logger.debug(
+            "slash-command alias resolution failed for %r", name, exc_info=True
+        )
         pass
     if name == "model" and not arg.strip():
         return _format_live_model_output(session or {})


### PR DESCRIPTION
## What does this PR do?

This fixes a regression in resumed Desktop/TUI sessions where `/context` and `/ctx` could be routed to the agent-less slash worker instead of the live parent session. The parent-session path has the transcript needed to render context output, while the isolated worker may not have a resident HermesCLI agent.

## Related Issue

No linked issue. This is a standalone bug fix; related context PRs were searched and none addresses this TUI session-routing failure.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`
  - Add `context` to the live parent-session direct-command set.
  - Remove `context` from the isolated-session read-command set.
  - Resolve slash-command aliases before dispatch so `/ctx` follows the same path as `/context`.
- `tests/test_tui_gateway_server.py`
  - Add parameterized regression coverage for `/context` and `/ctx`.
  - Assert that a resumed session with no slash worker returns parent-session context without spawning a worker.

## How to Test

1. Run the focused regression test:

   ```bash
   pytest tests/test_tui_gateway_server.py -k context_uses_parent_session_without_spawning_worker -q
   ```

2. Run the affected test file:

   ```bash
   pytest tests/test_tui_gateway_server.py -q
   ```

3. Verify the diff:

   ```bash
   git diff --check
   ```

Results on Windows 11:

- Focused test: 2 passed.
- Affected test file: 587 passed.
- `git diff --check`: passed.
- Full canonical suite (`scripts/run_tests.sh`): 3,033 files; 33,463 passed, 587 failed, 478 skipped; 207 files had test failures and 2 files had no tests run; exit code 1 after 1,144.0s with 40 workers.
- Scope check: `tests/test_tui_gateway_server.py` passed all 587 tests, and no failure was reported in either changed file (`tui_gateway/server.py` or `tests/test_tui_gateway_server.py`). The full-suite failures were in unrelated Windows path/permission, optional-dependency, external-service, and other subsystem tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass; the full suite was run, but it reported 33,463 passed, 587 failed, and 478 skipped across 3,033 files; failures were outside the two changed files
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows 11 tested; no platform-specific routing was introduced)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshot is applicable. The relevant test output is recorded above.


