### PR TITLE
fix(dashboard): escape hatch for the ws keepalive on 0.0.0.0 binds

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -529,6 +529,37 @@ _DASHBOARD_EMBEDDED_CHAT_ENABLED = True
 # overhead.
 _DESKTOP_ATTACHMENT_WS_MAX_BYTES = 384 * 1024 * 1024
 
+# ws keepalive for non-loopback binds (see _ws_keepalive_policy): short
+# enough to detect a half-open tunnel (Cloudflare ~100s idle) before it
+# drops the connection silently.
+_WS_KEEPALIVE_INTERVAL_S = 20.0
+_WS_KEEPALIVE_TIMEOUT_S = 20.0
+
+
+def _ws_keepalive_policy(host: str) -> "tuple[Optional[float], Optional[float]]":
+    """uvicorn ws ping (interval, timeout) for a dashboard bind host.
+
+    Loopback binds disable the protocol ping entirely (see the long comment
+    at the uvicorn.Config call site): the keepalive's only job is detecting
+    half-open network paths, which cannot happen locally, while a stalled
+    client/server event loop turns the 20s ping deadline into false
+    disconnects (#53773/#48445/#50005). Non-loopback binds keep the 20/20
+    ping for half-open detection behind tunnels and proxies.
+
+    HERMES_DASHBOARD_WS_PING_OFF=1 is the escape hatch for deployments that
+    must bind 0.0.0.0 (e.g. reachable through a docker bridge reverse
+    proxy) yet serve only local clients: same false-disconnect exposure as
+    loopback, same lack of a real tunnel to detect, so the ping is disabled
+    (#88617). Defaults to off — public-tunnel deployments keep 20/20.
+    """
+    from utils import env_var_enabled
+
+    if host in ("127.0.0.1", "localhost", "::1"):
+        return (None, None)
+    if env_var_enabled("HERMES_DASHBOARD_WS_PING_OFF"):
+        return (None, None)
+    return (_WS_KEEPALIVE_INTERVAL_S, _WS_KEEPALIVE_TIMEOUT_S)
+
 # Simple rate limiter for the reveal endpoint
 _reveal_timestamps: List[float] = []
 _REVEAL_MAX_PER_WINDOW = 5
@@ -18812,8 +18843,8 @@ def start_server(
     # disable it entirely. Non-loopback binds sit behind a Cloudflare Tunnel
     # (idle timeout ~100s) where half-open IS a real failure mode, so keep the
     # ping at 20/20 to detect it promptly and stay under the tunnel's idle
-    # window.
-    _is_loopback = host in ("127.0.0.1", "localhost", "::1")
+    # window. The loopback/env decision lives in _ws_keepalive_policy.
+    ws_keepalive = _ws_keepalive_policy(host)
     config = uvicorn.Config(
         app, host=host, port=port, log_level="warning",
         # proxy_headers defaults to False so _ws_client_is_allowed sees
@@ -18828,8 +18859,8 @@ def start_server(
         # disables the protocol ping (None) so an event-loop stall can never
         # trigger a false disconnect; a genuinely dead local client is still
         # reaped via the WebSocketDisconnect → disconnect/reap path.
-        ws_ping_interval=None if _is_loopback else 20.0,
-        ws_ping_timeout=None if _is_loopback else 20.0,
+        ws_ping_interval=ws_keepalive[0],
+        ws_ping_timeout=ws_keepalive[1],
         ws_max_size=_DESKTOP_ATTACHMENT_WS_MAX_BYTES,
     )
     server = uvicorn.Server(config)

--- a/tests/hermes_cli/test_ws_keepalive_policy.py
+++ b/tests/hermes_cli/test_ws_keepalive_policy.py
@@ -1,0 +1,48 @@
+"""#88617 — the ws keepalive must be escapable on 0.0.0.0 binds.
+
+The 20/20 uvicorn ws ping detects half-open tunnels on public binds, but a
+deployment that must bind 0.0.0.0 (docker-bridge reverse proxy) while
+serving only local clients gets the same hostile keepalive: a client event
+loop stalled >20s during heavy streaming is declared dead and dropped
+(1006). HERMES_DASHBOARD_WS_PING_OFF=1 disables the ping for that case;
+loopback keeps its unconditional ping-off; public-tunnel defaults keep 20/20.
+"""
+
+import sys
+from pathlib import Path
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+import pytest
+
+from hermes_cli.web_server import _ws_keepalive_policy
+
+
+class TestWsKeepalivePolicy:
+    def test_loopback_never_pings(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DASHBOARD_WS_PING_OFF", raising=False)
+        for host in ("127.0.0.1", "localhost", "::1"):
+            assert _ws_keepalive_policy(host) == (None, None)
+
+    def test_public_bind_defaults_to_2020(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DASHBOARD_WS_PING_OFF", raising=False)
+        assert _ws_keepalive_policy("0.0.0.0") == (20.0, 20.0)
+        assert _ws_keepalive_policy("example.com") == (20.0, 20.0)
+
+    def test_escape_hatch_disables_ping_on_non_loopback(self, monkeypatch):
+        # The reporter's deployment: bind 0.0.0.0 for the docker bridge,
+        # serve only local clients.
+        monkeypatch.setenv("HERMES_DASHBOARD_WS_PING_OFF", "1")
+        assert _ws_keepalive_policy("0.0.0.0") == (None, None)
+
+    def test_escape_hatch_truthy_set_matches_repo_convention(self, monkeypatch):
+        for value in ("1", "true", "yes", "on"):
+            monkeypatch.setenv("HERMES_DASHBOARD_WS_PING_OFF", value)
+            assert _ws_keepalive_policy("0.0.0.0") == (None, None), value
+
+    def test_escape_hatch_false_like_values_keep_the_ping(self, monkeypatch):
+        for value in ("0", "false", "no", "off", ""):
+            monkeypatch.setenv("HERMES_DASHBOARD_WS_PING_OFF", value)
+            assert _ws_keepalive_policy("0.0.0.0") == (20.0, 20.0), value


### PR DESCRIPTION
## What does this PR do?

The dashboard's uvicorn ws keepalive (20/20 ping/timeout) exists to detect half-open paths behind public tunnels, and loopback binds already disable it (the long comment at the `uvicorn.Config` call site documents why: a stalled event loop turns the 20s ping deadline into false disconnects, #53773/#48445/#50005). But a deployment that **must bind 0.0.0.0** — e.g. reachable through a docker-bridge reverse proxy — while serving only local clients gets the same hostile keepalive with no way out: the reporter's five incidents all show the TUI client's Node event loop stalling >20s during heavy streaming (pty buffer full while the dashboard's browser leg had detached), pongs stop, and uvicorn closes the otherwise-healthy connection with `1006`, then reaps the detached session (#88617).

This PR extracts the decision into `_ws_keepalive_policy(host)` and implements the issue's option 1 — an environment escape hatch, `HERMES_DASHBOARD_WS_PING_OFF=1` (the repo's `utils.env_var_enabled` truthy set: `1/true/yes/on`) — for exactly that deployment shape: no real tunnel to detect, the same false-disconnect exposure as loopback, so the ping is disabled. **Defaults are unchanged**: loopback stays ping-off, public binds keep 20/20 for half-open detection under Cloudflare's ~100s idle window. (Options 2 — per-peer ping decisions — and 3 — docs-only — are left for the maintainer; this is the strictly additive path that conflicts with no existing design rationale.)

## Related Issue

Fixes #88617

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: new `_ws_keepalive_policy(host)` pure function (loopback → ping off; `HERMES_DASHBOARD_WS_PING_OFF` truthy → ping off; otherwise 20/20 via named constants); the `uvicorn.Config` call now takes its ping values from the policy; the inline `_is_loopback` local is gone (the decision lives in one place)
- `tests/hermes_cli/test_ws_keepalive_policy.py`: 5 regression tests

## How to Test

1. `python -m pytest tests/hermes_cli/test_ws_keepalive_policy.py -q` — Observed result: 5 passed.
2. `python -m pytest tests/hermes_cli/test_web_server_boot_handshake.py tests/hermes_cli/test_web_server_console_ws.py -q` — Observed result: 10 passed (boot and console WS behavior unchanged).
3. New tests pin: all three loopback spellings never ping; `0.0.0.0`/public default to 20/20; the escape hatch disables the ping on non-loopback binds; the truthy set matches the repo convention and false-like values (`0/false/no/off/empty`) keep the ping.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the new policy tests (5 passed) and the boot/console WS suites (10 passed)
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — the env knob is documented in `_ws_keepalive_policy`'s docstring with the #88617 deployment rationale; no config-schema surface changes (env var, matching the module's existing env-knob pattern)

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/hermes_cli/test_ws_keepalive_policy.py -q
5 passed in 1.12s
$ python -m pytest tests/hermes_cli/test_web_server_boot_handshake.py tests/hermes_cli/test_web_server_console_ws.py -q
10 passed in 4.46s
```
