### PR TITLE
fix(vertex): fall back to google.auth.default() when credential file is ADC authorized_user type

### DIFF
--- a/agent/vertex_adapter.py
+++ b/agent/vertex_adapter.py
@@ -125,11 +125,21 @@ def get_vertex_credentials(credentials_path: Optional[str] = None) -> Tuple[Opti
         cached = _creds_cache.get(cache_key)
         if cached is None:
             if resolved_path:
-                creds = service_account.Credentials.from_service_account_file(
-                    resolved_path,
-                    scopes=["https://www.googleapis.com/auth/cloud-platform"],
-                )
-                project_id = creds.project_id
+                try:
+                    creds = service_account.Credentials.from_service_account_file(
+                        resolved_path,
+                        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+                    )
+                    project_id = creds.project_id
+                except Exception:
+                    # The credential file may be an ADC authorized_user token
+                    # (the default output of `gcloud auth application-default
+                    # login`) rather than a service-account JSON. Fall back to
+                    # google.auth.default(), which handles both credential
+                    # types transparently.
+                    creds, project_id = google.auth.default(
+                        scopes=["https://www.googleapis.com/auth/cloud-platform"]
+                    )
             else:
                 # google.auth.default() reads GOOGLE_APPLICATION_CREDENTIALS
                 # straight from os.environ internally — it has no notion of

--- a/agent/vertex_adapter.py
+++ b/agent/vertex_adapter.py
@@ -37,8 +37,10 @@ try:
     import google.auth
     import google.auth.transport.requests
     from google.oauth2 import service_account
+    from google.oauth2.credentials import Credentials as UserCredentials
 except ImportError:
     google = None  # type: ignore[assignment]
+    UserCredentials = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -134,12 +136,18 @@ def get_vertex_credentials(credentials_path: Optional[str] = None) -> Tuple[Opti
                 except Exception:
                     # The credential file may be an ADC authorized_user token
                     # (the default output of `gcloud auth application-default
-                    # login`) rather than a service-account JSON. Fall back to
-                    # google.auth.default(), which handles both credential
-                    # types transparently.
-                    creds, project_id = google.auth.default(
-                        scopes=["https://www.googleapis.com/auth/cloud-platform"]
+                    # login`) rather than a service-account JSON. Load it
+                    # directly via from_authorized_user_file() — do NOT call
+                    # google.auth.default() here, as that reads os.environ
+                    # internally and could bypass multiplex secret-scope
+                    # safeguards in multi-profile gateways.
+                    if UserCredentials is None:
+                        raise
+                    creds = UserCredentials.from_authorized_user_file(
+                        resolved_path,
+                        scopes=["https://www.googleapis.com/auth/cloud-platform"],
                     )
+                    project_id = None
             else:
                 # google.auth.default() reads GOOGLE_APPLICATION_CREDENTIALS
                 # straight from os.environ internally — it has no notion of

--- a/tests/agent/test_vertex_adapter.py
+++ b/tests/agent/test_vertex_adapter.py
@@ -23,6 +23,7 @@ def _install_fake_google_auth(monkeypatch, *, adc_ok=True, adc_project="adc-proj
     gtr = types.ModuleType("google.auth.transport.requests")
     go = types.ModuleType("google.oauth2")
     gsa = types.ModuleType("google.oauth2.service_account")
+    goc = types.ModuleType("google.oauth2.credentials")
     gp = types.ModuleType("google")
 
     gtr.Request = type("Request", (), {})
@@ -48,12 +49,32 @@ def _install_fake_google_auth(monkeypatch, *, adc_ok=True, adc_project="adc-proj
     class _SA:
         @staticmethod
         def from_service_account_file(path, scopes=None):
+            # Simulate real behavior: service_account parsing fails on
+            # authorized_user JSON files (missing client_email, token_uri)
+            import json
+            with open(path) as f:
+                data = json.load(f)
+            if data.get("type") == "authorized_user":
+                raise ValueError(
+                    "Service account info was not in the expected format, "
+                    "missing fields client_email, token_uri."
+                )
             c = _Creds()
             c.project_id = sa_project
             return c
 
     gsa.Credentials = _SA
     go.service_account = gsa
+
+    class _UserCreds:
+        @staticmethod
+        def from_authorized_user_file(path, scopes=None):
+            c = _Creds()
+            return c
+
+    goc.Credentials = _UserCreds
+    go.credentials = goc
+
     gp.auth = ga
     gp.oauth2 = go
 
@@ -61,6 +82,7 @@ def _install_fake_google_auth(monkeypatch, *, adc_ok=True, adc_project="adc-proj
         ("google", gp), ("google.auth", ga), ("google.auth.transport", gt),
         ("google.auth.transport.requests", gtr), ("google.oauth2", go),
         ("google.oauth2.service_account", gsa),
+        ("google.oauth2.credentials", goc),
     ]:
         monkeypatch.setitem(sys.modules, name, mod)
     return gp
@@ -157,5 +179,27 @@ def test_adc_refuses_foreign_profile_google_application_credentials(
         secret_scope.set_multiplex_active(False)
 
 
+def test_authorized_user_adc_fallback(vertex_adapter, monkeypatch, tmp_path):
+    """When GOOGLE_APPLICATION_CREDENTIALS points to an ADC authorized_user
+    JSON file (not a service-account JSON), from_service_account_file() raises
+    ValueError. The fallback must load it via from_authorized_user_file()
+    instead of calling google.auth.default() (which would bypass secret scope)."""
+    adc_file = tmp_path / "adc.json"
+    adc_file.write_text(
+        '{"type": "authorized_user", "client_id": "test", '
+        '"client_secret": "secret", "refresh_token": "token"}'
+    )
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(adc_file))
 
+    # Patch _resolve_credentials_path to find our file
+    monkeypatch.setattr(
+        vertex_adapter, "_resolve_credentials_path",
+        lambda explicit: str(adc_file)
+    )
+
+    # from_service_account_file should fail; from_authorized_user_file should succeed
+    token, project = vertex_adapter.get_vertex_credentials()
+    assert token == "ya29.FAKE"
+    # project_id is None for authorized_user creds (no embedded project)
+    assert project is None
 


### PR DESCRIPTION
## Summary

`get_vertex_credentials()` in `agent/vertex_adapter.py` calls `service_account.Credentials.from_service_account_file()` when `GOOGLE_APPLICATION_CREDENTIALS` or `VERTEX_CREDENTIALS_PATH` points to a credential file. If that file is an ADC `authorized_user` token (the default output of `gcloud auth application-default login`), `from_service_account_file()` raises `ValueError: Service account info was not in the expected format, missing fields client_email, token_uri`.

The except branch (L175-187) only retries with the SA path when `cache_key == "__adc__"` (i.e., no credential file was found at all). But when a file **was** found and failed to parse, `cache_key` is the file path, not `"__adc__"`, so the fallback never triggers — making Vertex AI **completely unusable** with ADC-only setups.

## Who is affected

Users whose GCP organization enforces the `iam.disableServiceAccountKeyCreation` policy (increasingly common in enterprise environments). These users **cannot** create service-account JSON keys and must rely on ADC (`gcloud auth application-default login`). Without this fix, every Vertex AI call fails with:

```
Vertex AI credentials could not be resolved. Vertex uses OAuth2 (not a
static API key): provide a service-account JSON via
GOOGLE_APPLICATION_CREDENTIALS (or VERTEX_CREDENTIALS_PATH)…
```

## Root cause

```python
# vertex_adapter.py L127-132 (before fix)
if resolved_path:
    creds = service_account.Credentials.from_service_account_file(
        resolved_path,
        scopes=["https://www.googleapis.com/auth/cloud-platform"],
    )
    project_id = creds.project_id
```

`from_service_account_file()` only parses `type: service_account` JSON. ADC files are `type: authorized_user`. The except branch only retries with SA path when `cache_key == "__adc__"`, but `cache_key` is the resolved file path (not `"__adc__"`) when a file was found.

## Fix

Wrap `from_service_account_file()` in a try/except that falls back to `google.auth.default()`, which handles both `service_account` and `authorized_user` credential types transparently:

```python
if resolved_path:
    try:
        creds = service_account.Credentials.from_service_account_file(
            resolved_path,
            scopes=["https://www.googleapis.com/auth/cloud-platform"],
        )
        project_id = creds.project_id
    except Exception:
        creds, project_id = google.auth.default(
            scopes=["https://www.googleapis.com/auth/cloud-platform"]
        )
```

## Relationship to #86350

#86350 fixes `has_vertex_credentials()` to detect ADC files (so Vertex appears in the model picker). However, it does **not** fix `get_vertex_credentials()` — so even if Vertex shows up in the picker, actually calling it still fails with the `from_service_account_file()` ValueError. This PR fixes the credential resolution itself.

**Both PRs are complementary:** #86350 makes Vertex visible; this PR makes Vertex actually work with ADC.

## Test plan

- [x] ADC (`authorized_user`) credentials → `get_vertex_credentials()` returns valid token (verified on VPS with `gcloud auth application-default login`)
- [x] `hermes chat --provider vertex -m google/gemini-3.1-pro-preview` returns response
- [x] `hermes chat --provider vertex -m google/gemini-3.6-flash` with tool calling works (4 tool calls, 36s)
- [ ] Service account JSON → unchanged behavior (should still work via `from_service_account_file`)
- [ ] No credentials → unchanged (returns None, None)