### PR TITLE
fix(cli): list the background_review slot in the aux-model picker

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4025,6 +4025,11 @@ _AUX_TASKS: list[tuple[str, str, str]] = [
     ("kanban_decomposer", "Kanban decomposer", "task decomposition"),
     ("profile_describer", "Profile describer", "auto profile descriptions"),
     ("curator", "Curator", "skill-usage review pass"),
+    # The post-turn memory/skill review fork: agent/background_review.py
+    # reads auxiliary.background_review.{provider,model} and the slot ships
+    # in DEFAULT_CONFIG, but it was missing here so the picker — and "Reset
+    # all to auto" — never surfaced it (#88618).
+    ("background_review", "Background review", "post-turn memory/skill review"),
 ]
 
 # Special non-auxiliary task surfaced in the same picker: subagent delegation.

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -46,6 +46,38 @@ def test_title_generation_present_in_default_config():
     assert tg["extra_body"] == {}
 
 
+def test_every_default_aux_slot_is_pickable():
+    """Every DEFAULT_CONFIG["auxiliary"] routing slot must appear in _AUX_TASKS.
+
+    #88618: background_review ships in DEFAULT_CONFIG and is read by
+    agent/background_review.py, but was missing from _AUX_TASKS — the
+    interactive picker never surfaced it and "Reset all to auto" skipped it.
+    A slot that exists in config but not in the picker is undiscoverable.
+    """
+    # Keys that are settings or internal-only tasks with no picker entry by
+    # design (pre-existing state, not part of #88618): tuning knobs like
+    # free_only/stream_only_base_urls/transient_retries/openrouter_model,
+    # and internal call_llm tasks surfaced elsewhere.
+    _NON_TASK_KEYS = {
+        "defaults",
+        "free_only",
+        "goal_judge",
+        "moa_aggregator",
+        "moa_reference",
+        "monitor",
+        "openrouter_model",
+        "stream_only_base_urls",
+        "transient_retries",
+    }
+    missing = [
+        key
+        for key in DEFAULT_CONFIG["auxiliary"]
+        if key not in _NON_TASK_KEYS
+        and not any(task_key == key for task_key, _n, _d in _AUX_TASKS)
+    ]
+    assert not missing, f"aux slots invisible in the picker: {missing}"
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

`hermes model` → "Configure auxiliary models" lists 13 tasks but not `background_review` — even though the slot ships in `DEFAULT_CONFIG["auxiliary"]`, is documented ("running the review on a cheaper model", memory.md), and is read at runtime by `agent/background_review.py` from `auxiliary.background_review.{provider,model}`. The slot was configurable only by hand-editing `config.yaml` or `hermes config set`: invisible in the interactive picker, undiscoverable, and skipped by "Reset all to auto" (#88618).

This PR adds the entry to `_AUX_TASKS`. The picker, `_save_aux_choice` persistence, `_reset_aux_to_auto`, and display-name plumbing are all generic over that list, so the one-line registration is the entire fix.

## Related Issue

Fixes #88618

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: `("background_review", "Background review", "post-turn memory/skill review")` added to `_AUX_TASKS` with a comment explaining the gap (#88618)
- `tests/hermes_cli/test_aux_config.py`: new sync test — every `DEFAULT_CONFIG["auxiliary"]` routing slot must appear in `_AUX_TASKS` (with the pre-existing non-picker keys exempted and documented), so the next slot that ships in config but not the picker fails CI instead of hiding

## How to Test

1. `python -m pytest tests/hermes_cli/test_aux_config.py tests/hermes_cli/test_plugin_auxiliary_tasks.py -q` — Observed result: 11 passed.
2. The new sync test fails on the pre-change `_AUX_TASKS` (reports `background_review` as invisible) and passes after.
3. Manual: `hermes model` → "Configure auxiliary models" now shows "Background review" between the other tasks; picking a provider/model writes `auxiliary.background_review.{provider,model}`; "Reset all to auto" clears it.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate (#84411 covers the dashboard surface, not this CLI picker)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the aux-config and plugin-auxiliary suites and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config keys changed (the slot already ships); the registration comment documents the #88618 gap

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/hermes_cli/test_aux_config.py tests/hermes_cli/test_plugin_auxiliary_tasks.py -q
11 passed in 0.60s
```
