### PR TITLE
fix(acp): expose model picker through Zed config options

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -46,6 +46,7 @@ from acp.schema import (
     SetSessionModeResponse,
     ResourceContentBlock,
     SessionCapabilities,
+    SessionConfigOptionSelect,
     SessionForkCapabilities,
     SessionInfoUpdate,
     SessionListCapabilities,
@@ -821,6 +822,51 @@ class HermesACPAgent(acp.Agent):
         )
 
     @staticmethod
+    def _build_model_config_option(
+        model_state: SessionModelState | None,
+    ) -> list[SessionConfigOptionSelect] | None:
+        """Expose the model catalog through ACP config options for Zed.
+
+        Zed's ACP client currently renders ``session/new.configOptions`` and
+        sends ``session/set_config_option`` for external-agent model pickers.
+        The newer ``models``/``session/set_model`` fields are still returned
+        for clients that support them, but are not enough for Zed's selector.
+        """
+        if model_state is None or not model_state.available_models:
+            return None
+
+        return [
+            SessionConfigOptionSelect.model_validate(
+                {
+                    "id": "model",
+                    "name": "Model",
+                    "type": "select",
+                    "category": "model",
+                    "description": "Model and provider used for this Hermes session.",
+                    "currentValue": model_state.current_model_id,
+                    "options": [
+                        {
+                            "name": model.name,
+                            "value": model.model_id,
+                            "description": model.description,
+                        }
+                        for model in model_state.available_models
+                    ],
+                }
+            )
+        ]
+
+    @staticmethod
+    def _model_response_fields(
+        model_state: SessionModelState | None,
+    ) -> dict[str, Any]:
+        """Build the model fields shared by ACP session responses."""
+        return {
+            "models": model_state,
+            "config_options": HermesACPAgent._build_model_config_option(model_state),
+        }
+
+    @staticmethod
     def _resolve_model_selection(raw_model: str, current_provider: str) -> tuple[str, str]:
         """Resolve ``provider:model`` input into the provider and normalized model id."""
         target_provider = current_provider
@@ -1444,9 +1490,10 @@ class HermesACPAgent(acp.Agent):
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
         self._schedule_available_commands_update(state.session_id)
         self._schedule_usage_update(state)
+        model_state = self._build_model_state(state)
         return NewSessionResponse(
             session_id=state.session_id,
-            models=self._build_model_state(state),
+            **self._model_response_fields(model_state),
             modes=self._session_modes(state),
             field_meta=self._provenance_meta(
                 state.session_id, getattr(state.agent, "session_id", state.session_id)
@@ -1493,8 +1540,9 @@ class HermesACPAgent(acp.Agent):
             )
         self._schedule_available_commands_update(session_id)
         self._schedule_usage_update(state)
+        model_state = self._build_model_state(state)
         return LoadSessionResponse(
-            models=self._build_model_state(state),
+            **self._model_response_fields(model_state),
             modes=self._session_modes(state),
             field_meta=self._provenance_meta(
                 session_id, getattr(state.agent, "session_id", session_id)
@@ -1529,8 +1577,9 @@ class HermesACPAgent(acp.Agent):
             )
         self._schedule_available_commands_update(state.session_id)
         self._schedule_usage_update(state)
+        model_state = self._build_model_state(state)
         return ResumeSessionResponse(
-            models=self._build_model_state(state),
+            **self._model_response_fields(model_state),
             modes=self._session_modes(state),
             field_meta=self._provenance_meta(
                 state.session_id, getattr(state.agent, "session_id", state.session_id)
@@ -1572,9 +1621,10 @@ class HermesACPAgent(acp.Agent):
         logger.info("Forked session %s -> %s", session_id, new_id)
         if new_id:
             self._schedule_available_commands_update(new_id)
+        model_state = self._build_model_state(state) if state is not None else None
         return ForkSessionResponse(
             session_id=new_id,
-            models=self._build_model_state(state) if state is not None else None,
+            **self._model_response_fields(model_state),
             modes=self._session_modes(state) if state is not None else None,
         )
 
@@ -2469,6 +2519,14 @@ class HermesACPAgent(acp.Agent):
         if state is None:
             logger.warning("Session %s: config update requested for missing session", session_id)
             return None
+
+        if str(config_id) == "model":
+            await self.set_session_model(str(value), session_id)
+            model_state = self._build_model_state(state)
+            model_options = self._build_model_config_option(model_state)
+            return SetSessionConfigOptionResponse(
+                config_options=list(model_options) if model_options is not None else []
+            )
 
         if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
             mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(str(value), self._MODE_DEFAULT)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -29,6 +29,7 @@ from acp.schema import (
     SetSessionModeResponse,
     SessionInfo,
     SessionInfoUpdate,
+    ModelInfo,
     TextContentBlock,
     ToolCallProgress,
     ToolCallStart,
@@ -58,16 +59,53 @@ def agent(mock_manager):
 
 
 @pytest.mark.asyncio
-async def test_new_session_exposes_edit_approvals_as_modes_not_config_options(agent):
+async def test_new_session_exposes_edit_approvals_as_modes_and_model_config(agent):
     resp = await agent.new_session(cwd="/tmp")
 
-    assert resp.config_options is None
+    assert resp.config_options is not None
+    assert [option.id for option in resp.config_options] == ["model"]
     assert isinstance(resp.modes, SessionModeState)
     assert resp.modes.current_mode_id == "default"
     assert [(mode.id, mode.name) for mode in resp.modes.available_modes] == [
         ("default", "Default"),
         ("accept_edits", "Accept Edits"),
         ("dont_ask", "Don't Ask"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_new_session_exposes_model_picker_as_select_config_option(agent, monkeypatch):
+    monkeypatch.setattr(
+        "acp_adapter.server.HermesACPAgent._build_model_state",
+        lambda self, state: SessionModelState(
+            available_models=[
+                ModelInfo(
+                    model_id="openrouter:model-a",
+                    name="OpenRouter · model-a",
+                    description="Provider: OpenRouter",
+                ),
+                ModelInfo(
+                    model_id="nous:model-b",
+                    name="Nous · model-b",
+                    description="Provider: Nous",
+                ),
+            ],
+            current_model_id="openrouter:model-a",
+        ),
+    )
+
+    response = await agent.new_session(cwd="/tmp")
+
+    assert response.config_options is not None
+    assert len(response.config_options) == 1
+    option = response.config_options[0].model_dump(by_alias=True, exclude_none=True)
+    assert option["id"] == "model"
+    assert option["name"] == "Model"
+    assert option["type"] == "select"
+    assert option["currentValue"] == "openrouter:model-a"
+    assert [entry["value"] for entry in option["options"]] == [
+        "openrouter:model-a",
+        "nous:model-b",
     ]
 
 
@@ -84,6 +122,32 @@ async def test_set_config_option_persists_edit_approval_policy_without_advertisi
     assert isinstance(update, SetSessionConfigOptionResponse)
     assert update.config_options == []
     assert getattr(state, "mode", None) == "accept_edits"
+
+
+@pytest.mark.asyncio
+async def test_set_model_config_option_delegates_to_session_model_switch(agent, monkeypatch):
+    response = await agent.new_session(cwd="/tmp")
+    calls = []
+
+    async def fake_set_session_model(model_id, session_id, **kwargs):
+        calls.append((model_id, session_id))
+        return SetSessionModelResponse()
+
+    monkeypatch.setattr(agent, "set_session_model", fake_set_session_model)
+    monkeypatch.setattr(
+        "acp_adapter.server.HermesACPAgent._build_model_state",
+        lambda self, state: SessionModelState(
+            available_models=[
+                ModelInfo(model_id="nous:model-b", name="Nous · model-b"),
+            ],
+            current_model_id="nous:model-b",
+        ),
+    )
+
+    update = await agent.set_config_option("model", response.session_id, "nous:model-b")
+
+    assert calls == [("nous:model-b", response.session_id)]
+    assert update.config_options[0].model_dump(by_alias=True)["currentValue"] == "nous:model-b"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Expose Hermes' model catalog through ACP `session/new.configOptions` so Zed renders the model selector for Hermes external-agent threads.

## Root cause

Hermes already returned the newer ACP `models`/`session/set_model` fields, but Zed's ACP client currently reads `session/new.configOptions` and sends `session/set_config_option` for external-agent selectors. The model catalog was therefore present on the wire but ignored by Zed.

## Changes

- add a `model` select config option containing Hermes' provider-aware model catalog
- return it from new/load/resume/fork session responses
- route Zed's `session/set_config_option` model changes through the existing model-switch implementation
- keep the existing ACP model fields for clients that support them

## Validation

- targeted red test reproduced the missing `configOptions`
- `scripts/run_tests.sh tests/acp/` in a clean worktree: **132 passed**
- live ACP smoke test through the installed launcher: `configOptions[0].id=model`, current model returned, 350 model options
- live `session/set_config_option` switched the session model and returned the updated selector state
