### PR TITLE
fix(gateway): resolve the session DB inside the active profile scope

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1235,6 +1235,13 @@ class AsyncSessionStore:
         return _offloaded
 
 
+# Sentinel for "no explicit SessionDB has been pinned on this store", so the
+# ``_db`` property can distinguish "resolve from the active profile scope"
+# from a deliberate ``store._db = None`` (which disables the DB and selects
+# the JSONL fallback).  A plain ``None`` cannot express both.
+_DB_UNPINNED = object()
+
+
 class SessionStore:
     """
     Manages session storage and retrieval.
@@ -1285,21 +1292,91 @@ class SessionStore:
             getattr(config, "write_sessions_json", True)
         )
         
-        # Initialize SQLite session database
-        self._db = None
-        try:
-            from hermes_state import SessionDB
-            self._db = SessionDB()
-        except RuntimeError as e:
-            if "live-system guard" in str(e):
-                # Test-isolation guard fired: a pytest-context process
-                # resolved the developer's production state.db. Never
-                # swallow this into the JSONL fallback — the whole point
-                # is a loud, hard failure.
-                raise
-            print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
-        except Exception as e:
-            print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+        # Initialize SQLite session database.
+        #
+        # Handles are cached per resolved path and looked up through the
+        # ``_db`` property instead of being bound to one handle here.  A
+        # multiplexed gateway serves every profile from a SINGLE process, so
+        # a handle bound during __init__ is frozen to the process's own root
+        # home; every profile's rows then land in the root state.db even
+        # though ``_profile_runtime_scope`` has already redirected
+        # ``get_hermes_home()`` for the turn (its docstring lists "sessions"
+        # among what it scopes).  The row still carries the right
+        # ``profile_name``, so the damage is invisible in the data and shows
+        # up only as the desktop listing a profile's session under the
+        # default bot -- ``_open_session_db_for_profile`` reads
+        # ``profiles/<name>/state.db``, which never received the write.
+        # See #88532.
+        #
+        # Priming the handle for the current scope here keeps the startup
+        # diagnostics exactly where they were: the live-DB isolation guard
+        # still raises during construction, and the JSONL-fallback warning
+        # is still printed once at startup rather than on first use.
+        self._db_pinned = _DB_UNPINNED
+        self._db_handles: Dict[Path, Any] = {}
+        self._db_handles_lock = threading.Lock()
+        self._open_session_db_for_active_scope()
+
+    def _open_session_db_for_active_scope(self):
+        """Return the SessionDB for the profile scope active on this task.
+
+        ``SessionDB(db_path=None)`` resolves ``_default_db_path()`` at call
+        time, and that helper follows the context-local HERMES_HOME override
+        installed by ``_profile_runtime_scope``.  Resolving here rather than
+        once in ``__init__`` is the whole fix for #88532: it lets the
+        scoping that the multiplexed inbound path already performs actually
+        reach session storage.
+
+        Handles are cached per resolved path, so a hot inbound path opens
+        SQLite once per profile rather than once per message, and two
+        profiles never share a handle.  Construction is done under the lock
+        so a concurrent first message on the same profile cannot open (and
+        then leak) a second handle for the same path.
+
+        A construction failure is cached as ``None`` for that path, matching
+        the previous behavior where a failed startup left ``_db`` None for
+        the life of the store and callers fell back to JSONL.
+        """
+        from hermes_state import SessionDB, _default_db_path
+
+        path = Path(_default_db_path())
+        with self._db_handles_lock:
+            if path in self._db_handles:
+                return self._db_handles[path]
+            db = None
+            try:
+                db = SessionDB()
+            except RuntimeError as e:
+                if "live-system guard" in str(e):
+                    # Test-isolation guard fired: a pytest-context process
+                    # resolved the developer's production state.db. Never
+                    # swallow this into the JSONL fallback — the whole point
+                    # is a loud, hard failure.  Deliberately not cached: the
+                    # guard must fire again on the next attempt.
+                    raise
+                print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+            except Exception as e:
+                print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+            self._db_handles[path] = db
+            return db
+
+    @property
+    def _db(self):
+        """The SessionDB for the active profile scope, or a pinned override.
+
+        Assigning ``store._db`` pins that value for every subsequent read,
+        which is what tests rely on to install a fake or to disable the DB
+        with ``store._db = None``.  Unpinned (the production path), each read
+        resolves the scope so a multiplexed profile's writes reach its own
+        store.
+        """
+        if self._db_pinned is not _DB_UNPINNED:
+            return self._db_pinned
+        return self._open_session_db_for_active_scope()
+
+    @_db.setter
+    def _db(self, value) -> None:
+        self._db_pinned = value
 
     def _has_active_processes_safe(self, session_key: str, *, context: str) -> bool:
         """Return whether a session has active work, failing closed on registry errors."""

--- a/tests/gateway/test_multiplex_session_db_profile_scope.py
+++ b/tests/gateway/test_multiplex_session_db_profile_scope.py
@@ -1,0 +1,172 @@
+"""Regression coverage for #88532.
+
+A multiplexed gateway serves every profile from one process.  ``SessionStore``
+used to bind a single ``SessionDB`` during ``__init__``, freezing it to the
+process's own root home, so a named profile's sessions were physically written
+to the root ``state.db`` even though ``_profile_runtime_scope`` had already
+redirected ``get_hermes_home()`` for that turn.  The rows carried the correct
+``profile_name``, which is why the only visible symptom was the desktop listing
+a profile's session under the default bot: the desktop reads
+``profiles/<name>/state.db``, which never received the write.
+
+These tests pin the handle to the *active* scope rather than to construction
+time.  ``test_write_under_profile_scope_lands_in_profile_store`` is the one
+that reproduces the report; it fails against the pre-fix code with the session
+row sitting in the root store.
+"""
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig
+from gateway.session import SessionStore
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture
+def multiplex_homes(tmp_path, monkeypatch):
+    """A root home plus a named profile home, with HERMES_HOME on the root.
+
+    Mirrors the reported layout: one gateway process launched under the root
+    home, serving a ``fitness`` profile whose store lives under
+    ``profiles/fitness``.
+    """
+    import hermes_state
+
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "fitness"
+    root.mkdir(parents=True)
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    # The suite-wide fixture in conftest re-points ``hermes_state.DEFAULT_DB_PATH``
+    # at a fake home, which trips the deliberate escape hatch in
+    # ``_default_db_path()``: a re-pointed constant wins over everything,
+    # including the context-local override.  That is correct for tests that
+    # want one fixed DB, but it would pin every lookup here to a single path
+    # and make these assertions vacuous.  Restore the import-time snapshot so
+    # the hatch is closed and resolution goes through ``get_hermes_home()``,
+    # which is what production does.  ``HERMES_HOME`` above still keeps that
+    # resolution inside ``tmp_path``, so no real store is ever opened.
+    monkeypatch.setattr(
+        hermes_state, "DEFAULT_DB_PATH", hermes_state._IMPORT_DEFAULT_DB_PATH
+    )
+    return root, profile
+
+
+def _make_store(root: Path) -> SessionStore:
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        store = SessionStore(sessions_dir=root / "sessions", config=GatewayConfig())
+    store._loaded = True
+    return store
+
+
+def _session_ids(db_path: Path) -> set:
+    """Read session ids straight out of a state.db, or empty if absent."""
+    if not db_path.exists():
+        return set()
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute("SELECT id FROM sessions").fetchall()
+    except sqlite3.OperationalError:
+        # No sessions table: nothing was ever written here.
+        return set()
+    finally:
+        conn.close()
+    return {r[0] for r in rows}
+
+
+def test_store_uses_root_db_when_no_profile_scope_is_active(multiplex_homes):
+    """Single-profile gateways are unaffected: no scope, same path as before."""
+    root, _profile = multiplex_homes
+    store = _make_store(root)
+
+    assert Path(store._db.db_path) == root / "state.db"
+
+
+def test_db_handle_follows_the_active_profile_scope(multiplex_homes):
+    """The handle is resolved per access, not frozen at construction."""
+    root, profile = multiplex_homes
+    store = _make_store(root)
+
+    # Constructed outside any scope, exactly as the gateway constructs it.
+    assert Path(store._db.db_path) == root / "state.db"
+
+    token = set_hermes_home_override(str(profile))
+    try:
+        assert Path(store._db.db_path) == profile / "state.db"
+    finally:
+        reset_hermes_home_override(token)
+
+    # And the scope is restored once the turn's scope exits.
+    assert Path(store._db.db_path) == root / "state.db"
+
+
+def test_write_under_profile_scope_lands_in_profile_store(multiplex_homes):
+    """The reported bug: the row must be in the profile's own file.
+
+    This is the assertion the issue makes by hand with ``sqlite3``: the
+    session for profile ``fitness`` belongs in ``profiles/fitness/state.db``
+    and must NOT be in the root store.
+    """
+    root, profile = multiplex_homes
+    store = _make_store(root)
+
+    token = set_hermes_home_override(str(profile))
+    try:
+        store._db.create_session("20260817_233028_542fda58", "feishu")
+    finally:
+        reset_hermes_home_override(token)
+
+    assert _session_ids(profile / "state.db") == {"20260817_233028_542fda58"}
+    assert _session_ids(root / "state.db") == set()
+
+
+def test_handles_are_cached_per_path(multiplex_homes):
+    """One handle per profile: no reopen per message, no sharing across profiles."""
+    root, profile = multiplex_homes
+    store = _make_store(root)
+
+    root_first = store._db
+    root_second = store._db
+    assert root_first is root_second
+
+    token = set_hermes_home_override(str(profile))
+    try:
+        profile_first = store._db
+        profile_second = store._db
+    finally:
+        reset_hermes_home_override(token)
+
+    assert profile_first is profile_second
+    assert profile_first is not root_first
+
+
+def test_explicitly_pinned_handle_still_wins(multiplex_homes):
+    """``store._db = ...`` remains authoritative for every subsequent read.
+
+    Guardrail rather than a bug reproduction: a large number of existing
+    tests install a fake handle or disable the DB this way, and the property
+    must not quietly resolve past a deliberate assignment.
+    """
+    root, profile = multiplex_homes
+    store = _make_store(root)
+
+    sentinel = object()
+    store._db = sentinel
+    token = set_hermes_home_override(str(profile))
+    try:
+        assert store._db is sentinel
+    finally:
+        reset_hermes_home_override(token)
+
+    # Disabling the DB (the JSONL-fallback path) must survive scope changes.
+    store._db = None
+    token = set_hermes_home_override(str(profile))
+    try:
+        assert store._db is None
+    finally:
+        reset_hermes_home_override(token)


### PR DESCRIPTION
## What does this PR do?

A multiplexed gateway serves every profile from **one process**, but `SessionStore` bound a single `SessionDB` during `__init__`:

```python
# gateway/session.py
self._db = SessionDB()
```

`SessionDB(db_path=None)` falls back to `_default_db_path()`, which resolves `get_hermes_home()` **at call time** and correctly follows the context-local override installed by `set_hermes_home_override`. So the path machinery was already right. The bug is *when* it ran: at construction, on the process's own root home, long before any inbound event enters a profile scope.

The per-profile scoping on the inbound path is also already correct:

```python
# gateway/run.py — _make_profile_message_handler
with _profile_runtime_scope(profile_home):
    return await self._handle_message(event)
```

and `_profile_runtime_scope` documents itself as redirecting `get_hermes_home()` for "config, skills, memory, SOUL, **sessions**". Sessions were meant to follow the profile. The frozen handle is what prevented it: nothing re-resolved the DB at that point, so the write went through the handle pinned to the root home at startup.

Because `profile_name` is stamped from `source.profile` by that same handler, **the row is correct in every column and simply lands in the wrong file**. That is why the only visible symptom is a display one: the desktop reads per profile,

```python
# hermes_cli/web_server.py
def _open_session_db_for_profile(profile, *, read_only):
    if profile:
        _name, home = _cron_profile_home(profile)
        db_path = Path(home) / "state.db"
```

so `/api/sessions?profile=fitness` opens `profiles/fitness/state.db`, legitimately does not find the session, and the row shows up under the default/hermes bot instead.

**The fix** looks the handle up through a property that resolves the active scope per access, caching one handle per resolved path. The scoping the inbound path already performs then does the routing on its own.

### Why this approach

Per-profile physical stores plus read-only cross-profile aggregation already look like the intended architecture rather than something invented here: `_open_session_db_for_profile` opens other profiles' stores directly, and `SessionDB(read_only=True)` documents itself as the non-contending attach for exactly that aggregation. On that reading the writer was the side out of line, so this moves the writer into the existing design rather than adding a new mechanism.

Two details worth calling out:

- **Caching is per resolved path**, so a hot inbound path opens SQLite once per profile rather than once per message, and two profiles never share a handle. Construction happens under the cache lock so a concurrent first message on the same profile cannot open (and then leak) a second handle for the same path.
- **Assignment is preserved as an explicit pin.** A large number of existing suites install a fake handle or disable the DB with `store._db = None`, and `None` alone cannot express "unpinned" versus "deliberately disabled", so an `_DB_UNPINNED` sentinel distinguishes them. A pin keeps winning across scope changes.

### Scope and limits (please confirm these are the calls you want)

- **Inert without an active profile scope.** Single-profile gateways resolve exactly the path they did before; there is a test pinning that.
- **Forward-only.** Rows already written into the root store are *not* migrated and will keep displaying under the default bot until moved. I did not want to write a data migration unasked; happy to add one, or to leave it for a follow-up.
- **This changes where a multiplexed gateway physically writes**, which is a policy call. If you would rather keep one shared store and fix the display side instead, this is the wrong patch and I will close it. Both options are allowed by the issue text and they are mutually exclusive.
- `#76584` frames `default` being a hardcoded alias for the root home as the underlying design problem. This is deliberately the narrow writer fix, not that decoupling.
- I deliberately did **not** touch the attribution paths already covered by open work on the neighbouring seam (`#88437` adapter-derived session keys, `#88387` profile fences in lookup/inheritance, `#75198` peer fallback scoping). All three are about which profile a row is *labeled* with; this report confirms the label was already correct, so there is no overlap in behavior or in files beyond `gateway/session.py` being untouched by the first and third.

## Related Issue

Fixes #88532

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/session.py`
  - `SessionStore.__init__` no longer binds `self._db`. It primes the handle for the current scope instead, which keeps startup diagnostics exactly where they were: the live-DB isolation guard still raises during construction, and the JSONL-fallback warning is still printed once at startup rather than on first use.
  - New `SessionStore._open_session_db_for_active_scope()` resolves `_default_db_path()` per call and caches one `SessionDB` per resolved path under a lock. A construction failure is cached as `None` for that path, matching the previous behavior where a failed startup left `_db` `None` for the life of the store and callers fell back to JSONL. The live-guard `RuntimeError` is deliberately re-raised and **not** cached, so it fires again on the next attempt.
  - `SessionStore._db` is now a property with a setter; the setter pins the value.
  - Module-level `_DB_UNPINNED` sentinel.
- `tests/gateway/test_multiplex_session_db_profile_scope.py` (new, 5 tests).

## How to Test

```
pytest tests/gateway/test_multiplex_session_db_profile_scope.py -q
```

**Proof the tests encode the bug.** Reverting only `gateway/session.py` to `main` and re-running fails 3 of the 5, including the one that reproduces the report by hand exactly as the issue does with `sqlite3`:

```
>       assert _session_ids(profile / "state.db") == {"20260817_233028_542fda58"}
E       AssertionError: assert set() == {'20260817_233028_542fda58'}
E         Extra items in the right set:
E         '20260817_233028_542fda58'

3 failed, 2 passed
```

The row is in the root store and the profile store is empty, which is the reported condition. With the fix, 5 passed.

The other two are guardrails, not reproductions, and pass either way by design: one pins that no-scope resolution is unchanged (single-profile gateways), the other that an explicit `store._db = ...` still wins across scope changes.

**Note for anyone writing tests near this.** The suite-wide conftest fixture re-points `hermes_state.DEFAULT_DB_PATH`, which trips the deliberate escape hatch in `_default_db_path()` (a re-pointed constant beats everything, including the context-local override). Under that fixture every lookup is pinned to one path and scope assertions become vacuous. The fixture here restores the import-time snapshot to close the hatch, while `HERMES_HOME` keeps resolution inside `tmp_path`, so no real store is ever opened.

**Regression sweep.** All 45 test files mentioning `SessionStore`:

```
436 passed, 1 failed in 105.53s
```

The one failure is `tests/gateway/test_session_store_prune.py::test_session_store_default_db_uses_runtime_hermes_home` and it is **pre-existing and unrelated to this PR**. It passes in isolation both with and without the change, and fails identically in the combined run with `gateway/session.py` reverted to `main` (`1 failed, 431 passed`), so it is a cross-file fixture-ordering interaction that already exists on `main`. Flagging it only so a CI run does not get misread as a regression here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.12
- [ ] I've run `pytest tests/ -q` and all tests pass — **not claimed.** I ran the 45 `SessionStore` suites (436 passed, 1 pre-existing failure documented above) plus the new file, not the full tree. Leaving this unchecked rather than overstating it; CI covers the rest.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the reasoning lives in the docstrings and comments on the new resolver and property, since that is where the next reader will look
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code; paths go through `pathlib` and the existing `get_hermes_home()`, which already resolves `%LOCALAPPDATA%` on Windows. Developed and tested on Windows 11.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
