### PR TITLE
fix(gateway): bind multiplex sessions to routed profile cwd

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2480,45 +2480,59 @@ def build_context_files_prompt(
     When *skip_soul* is True, SOUL.md is not included here (it was already
     loaded via ``load_soul_md()`` for the identity slot).
     """
+    cwd_is_masked = False
     if cwd is None:
-        cwd = os.getcwd()
-        cwd_is_fallback = True
+        from agent.runtime_cwd import context_cwd_is_masked
+
+        cwd_is_masked = context_cwd_is_masked()
+        if cwd_is_masked:
+            logger.debug(
+                "skipping project-context discovery: session cwd is explicitly masked"
+            )
+            cwd_is_fallback = False
+        else:
+            cwd = os.getcwd()
+            cwd_is_fallback = True
     else:
         cwd_is_fallback = False
 
-    cwd_path = Path(cwd).resolve()
     sections = []
 
-    # Never let a FALLBACK-picked directory inside the Hermes install/source
-    # tree gain system-prompt authority. A backend that self-spawns into that
-    # tree (the desktop app default) would otherwise load this repo's
-    # contributor AGENTS.md as authoritative project context (#64590). An
-    # explicitly configured cwd is honored verbatim — the Hermes tree is a
-    # legitimate workspace when the user deliberately points a session at it —
-    # and CLI-style surfaces pass allow_install_tree_fallback=True because
-    # their launch dir IS the user's shell cwd (developing Hermes in-tree).
-    from agent.runtime_cwd import _is_install_tree
-
-    if (
-        cwd_is_fallback
-        and not allow_install_tree_fallback
-        and _is_install_tree(cwd_path)
-    ):
-        logger.warning(
-            "skipping project-context discovery: working-directory resolution "
-            "fell back to the Hermes install tree (%s) — set terminal.cwd to "
-            "your project directory",
-            cwd_path,
-        )
+    if cwd_is_masked:
         project_context = ""
     else:
-        # Priority-based project context: first match wins
-        project_context = (
-            _load_hermes_md(cwd_path, context_length)
-            or _load_agents_md(cwd_path, context_length)
-            or _load_claude_md(cwd_path, context_length)
-            or _load_cursorrules(cwd_path, context_length)
-        )
+        cwd_path = Path(cwd).resolve()
+
+        # Never let a FALLBACK-picked directory inside the Hermes install/source
+        # tree gain system-prompt authority. A backend that self-spawns into that
+        # tree (the desktop app default) would otherwise load this repo's
+        # contributor AGENTS.md as authoritative project context (#64590). An
+        # explicitly configured cwd is honored verbatim — the Hermes tree is a
+        # legitimate workspace when the user deliberately points a session at it —
+        # and CLI-style surfaces pass allow_install_tree_fallback=True because
+        # their launch dir IS the user's shell cwd (developing Hermes in-tree).
+        from agent.runtime_cwd import _is_install_tree
+
+        if (
+            cwd_is_fallback
+            and not allow_install_tree_fallback
+            and _is_install_tree(cwd_path)
+        ):
+            logger.warning(
+                "skipping project-context discovery: working-directory resolution "
+                "fell back to the Hermes install tree (%s) — set terminal.cwd to "
+                "your project directory",
+                cwd_path,
+            )
+            project_context = ""
+        else:
+            # Priority-based project context: first match wins
+            project_context = (
+                _load_hermes_md(cwd_path, context_length)
+                or _load_agents_md(cwd_path, context_length)
+                or _load_claude_md(cwd_path, context_length)
+                or _load_cursorrules(cwd_path, context_length)
+            )
     if project_context:
         sections.append(project_context)
 

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -19,6 +19,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _UNSET: Any = object()
+_MASK_PROCESS_CWD: Any = object()
 
 _SESSION_CWD: ContextVar = ContextVar("HERMES_SESSION_CWD", default=_UNSET)
 
@@ -43,27 +44,31 @@ def _is_install_tree(p: Path) -> bool:
 
 def set_session_cwd(cwd: str | None) -> Token:
     """Pin the logical cwd for the current context."""
-    return _SESSION_CWD.set((cwd or "").strip())
+    return _SESSION_CWD.set(_MASK_PROCESS_CWD if cwd is None else cwd.strip())
 
 
 def clear_session_cwd() -> None:
     _SESSION_CWD.set("")
 
 
-def _session_cwd_override() -> str:
+def _session_cwd_override() -> tuple[bool, str]:
     value = _SESSION_CWD.get()
-    if value is _UNSET:
-        return ""
-    return str(value).strip()
+    if value is _MASK_PROCESS_CWD:
+        return True, ""
+    if value is _UNSET or not str(value).strip():
+        return False, ""
+    return True, str(value).strip()
 
 
 def resolve_agent_cwd() -> Path:
-    override = _session_cwd_override()
-    if override:
-        p = Path(override).expanduser()
-        if p.is_dir():
-            return p
-        logger.warning("configured working directory does not exist: %s", override)
+    pinned, override = _session_cwd_override()
+    if pinned:
+        if override:
+            p = Path(override).expanduser()
+            if p.is_dir():
+                return p
+            logger.warning("configured working directory does not exist: %s", override)
+        return Path(os.getcwd())
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         p = Path(raw).expanduser()
@@ -82,13 +87,14 @@ def resolve_context_cwd() -> Path | None:
     # source tree itself, which is a legitimate workspace when the user is
     # developing Hermes (per-surface policy for fallback-picked directories
     # lives in build_context_files_prompt; see #64590).
-    override = _session_cwd_override()
-    if override:
-        p = Path(override).expanduser()
-        if not p.is_dir():
-            logger.warning("configured working directory does not exist: %s", override)
-        else:
-            return p
+    pinned, override = _session_cwd_override()
+    if pinned:
+        if override:
+            p = Path(override).expanduser()
+            if not p.is_dir():
+                logger.warning("configured working directory does not exist: %s", override)
+            else:
+                return p
         return None
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -60,6 +60,18 @@ def _session_cwd_override() -> tuple[bool, str]:
     return True, str(value).strip()
 
 
+def context_cwd_is_masked() -> bool:
+    """Return whether context discovery must not use the process cwd.
+
+    A multiplexed profile with no configured workspace intentionally resolves
+    to ``None`` for compatibility with callers that expect an optional Path.
+    This separate predicate preserves the distinction between that explicit
+    mask and the ordinary unset state used by local CLI fallback.
+    """
+    pinned, override = _session_cwd_override()
+    return pinned and not override
+
+
 def resolve_agent_cwd() -> Path:
     pinned, override = _session_cwd_override()
     if pinned:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24076,13 +24076,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
-        _session_cwd = ""
+        _session_cwd: str | None = ""
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             # The caller has already entered _profile_runtime_scope for the
             # routed profile. Read terminal.cwd from that scoped config and pin
             # it in the task-local session context. Without this, secondary
             # profiles inherit the launch profile's process-wide TERMINAL_CWD,
             # so context discovery can load another profile's AGENTS.md.
+            _session_cwd = None
             try:
                 from hermes_cli.config import (
                     apply_terminal_config_to_env,
@@ -24095,11 +24096,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     config=load_config_readonly(),
                     override=True,
                 )
-                _session_cwd = _cwd_env.get("TERMINAL_CWD", "")
+                _session_cwd = _cwd_env.get("TERMINAL_CWD")
             except Exception:
                 logger.warning(
                     "Could not resolve routed profile terminal.cwd; "
-                    "session context will continue without a cwd override",
+                    "session context will mask the process default cwd",
                     exc_info=True,
                 )
         return set_session_vars(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24076,6 +24076,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        _session_cwd = ""
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            # The caller has already entered _profile_runtime_scope for the
+            # routed profile. Read terminal.cwd from that scoped config and pin
+            # it in the task-local session context. Without this, secondary
+            # profiles inherit the launch profile's process-wide TERMINAL_CWD,
+            # so context discovery can load another profile's AGENTS.md.
+            try:
+                from hermes_cli.config import (
+                    apply_terminal_config_to_env,
+                    load_config_readonly,
+                )
+
+                _cwd_env: Dict[str, str] = {}
+                apply_terminal_config_to_env(
+                    env=_cwd_env,
+                    config=load_config_readonly(),
+                    override=True,
+                )
+                _session_cwd = _cwd_env.get("TERMINAL_CWD", "")
+            except Exception:
+                logger.warning(
+                    "Could not resolve routed profile terminal.cwd; "
+                    "session context will continue without a cwd override",
+                    exc_info=True,
+                )
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -24091,6 +24117,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
+            cwd=_session_cwd,
             async_delivery=_async_delivery,
             cron_session="",
         )

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -228,7 +228,7 @@ def set_session_vars(
     session_id: str = "",
     message_id: str = "",
     profile: str = "",
-    cwd: str = "",
+    cwd: str | None = "",
     async_delivery: bool = True,
     ui_session_id: str = "",
     cron_session: Any = _UNSET,
@@ -241,7 +241,9 @@ def set_session_vars(
     helpers are not nestable/stack-safe, and the returned tokens are accepted
     only for API compatibility.
 
-    ``cwd`` pins the logical working directory for this context.
+    ``cwd`` pins the logical working directory for this context. ``None``
+    explicitly masks a process-global ``TERMINAL_CWD`` for a routed profile
+    that has not configured its own workspace.
 
     ``async_delivery`` declares whether this session's channel can route a
     background completion back to the agent after the turn ends (see

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -552,6 +552,21 @@ class TestBuildContextFilesPrompt:
         assert "Never give up" not in result
         assert result == ""
 
+    def test_masked_session_cwd_never_falls_back_to_process_agents(self, monkeypatch, tmp_path):
+        import agent.runtime_cwd as rt
+        from agent.runtime_cwd import set_session_cwd
+
+        (tmp_path / "AGENTS.md").write_text(
+            "Process cwd must not become profile context.", encoding="utf-8"
+        )
+        monkeypatch.chdir(tmp_path)
+        token = set_session_cwd(None)
+        try:
+            result = build_context_files_prompt(cwd=None, skip_soul=True)
+        finally:
+            rt._SESSION_CWD.reset(token)
+        assert result == ""
+
 
 
 
@@ -1011,5 +1026,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -8,6 +8,7 @@ import pytest
 import agent.runtime_cwd as rt
 from agent.runtime_cwd import (
     clear_session_cwd,
+    context_cwd_is_masked,
     resolve_agent_cwd,
     resolve_context_cwd,
     set_session_cwd,
@@ -79,3 +80,10 @@ class TestSessionCwdOverride:
         finally:
             rt._SESSION_CWD.reset(token)
 
+    def test_missing_session_cwd_is_explicitly_masked(self):
+        token = set_session_cwd(None)
+        try:
+            assert resolve_context_cwd() is None
+            assert context_cwd_is_masked() is True
+        finally:
+            rt._SESSION_CWD.reset(token)

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -145,6 +145,40 @@ def test_multiplex_session_env_pins_routed_profile_cwd(monkeypatch, tmp_path):
     ]
 
 
+def test_multiplex_profile_without_config_masks_process_default_cwd(monkeypatch, tmp_path):
+    """A fresh routed profile must not inherit the launch profile workspace."""
+    from agent.runtime_cwd import resolve_context_cwd
+    from agent.prompt_builder import build_context_files_prompt
+
+    stale = tmp_path / "default-workspace"
+    stale.mkdir()
+    (stale / "AGENTS.md").write_text("# wrong default profile\n", encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_CWD", str(stale))
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(multiplex_profiles=True)
+    runner.adapters = {}
+    home = tmp_path / "fresh-profile" / "home"
+    home.mkdir(parents=True)
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="fresh",
+        chat_type="channel",
+        user_id="fresh-user",
+        profile="fresh",
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    with _profile_runtime_scope(home):
+        tokens = runner._set_session_env(context)
+        try:
+            assert resolve_context_cwd() is None
+            assert "wrong default profile" not in build_context_files_prompt(
+                cwd=resolve_context_cwd(), skip_soul=True
+            )
+        finally:
+            runner._clear_session_env(tokens)
+
+
 def test_clear_session_env_restores_previous_state(monkeypatch):
     """_clear_session_env should restore contextvars to their pre-handler values."""
     runner = object.__new__(GatewayRunner)

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -1,10 +1,12 @@
 import asyncio
 import os
+from types import SimpleNamespace
 
 import pytest
 
 from gateway.config import Platform
 from gateway.run import GatewayRunner
+from gateway.run import _profile_runtime_scope
 from gateway.session import SessionContext, SessionSource
 from gateway.session_context import (
     get_session_env,
@@ -74,6 +76,73 @@ def test_set_session_env_sets_contextvars(monkeypatch):
 
     # Clean up
     runner._clear_session_env(tokens)
+
+
+def test_multiplex_session_env_pins_routed_profile_cwd(monkeypatch, tmp_path):
+    """Concurrent profiles must not discover one another's AGENTS workspace."""
+    from agent.runtime_cwd import resolve_context_cwd
+    from agent.prompt_builder import build_context_files_prompt
+
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path / "stale-default"))
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(multiplex_profiles=True)
+    runner.adapters = {}
+
+    homes = []
+    for profile in ("eve", "grace"):
+        home = tmp_path / profile / "home"
+        workspace = tmp_path / profile / "workspace"
+        home.mkdir(parents=True)
+        workspace.mkdir(parents=True)
+        (workspace / "AGENTS.md").write_text(
+            f"# {profile} operating manual\n", encoding="utf-8"
+        )
+        (home / "config.yaml").write_text(
+            f"terminal:\n  cwd: {workspace}\n", encoding="utf-8"
+        )
+        homes.append((profile, home, workspace))
+
+    async def bind(profile, home, workspace):
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id=profile,
+            chat_type="channel",
+            user_id=f"{profile}-user",
+            profile=profile,
+        )
+        context = SessionContext(source=source, connected_platforms=[], home_channels={})
+        with _profile_runtime_scope(home):
+            tokens = runner._set_session_env(context)
+            try:
+                await asyncio.sleep(0)
+                cwd = resolve_context_cwd()
+                return (
+                    cwd,
+                    get_session_env("HERMES_SESSION_PROFILE"),
+                    build_context_files_prompt(cwd=cwd, skip_soul=True),
+                )
+            finally:
+                runner._clear_session_env(tokens)
+
+    async def run():
+        return await asyncio.gather(*(bind(*item) for item in homes))
+
+    assert asyncio.run(run()) == [
+        (
+            homes[0][2],
+            "eve",
+            "# Project Context\n\nThe following project context files have "
+            "been loaded and should be followed:\n\n## AGENTS.md\n\n"
+            "# eve operating manual",
+        ),
+        (
+            homes[1][2],
+            "grace",
+            "# Project Context\n\nThe following project context files have "
+            "been loaded and should be followed:\n\n## AGENTS.md\n\n"
+            "# grace operating manual",
+        ),
+    ]
 
 
 def test_clear_session_env_restores_previous_state(monkeypatch):
@@ -272,4 +341,3 @@ def test_cron_session_set_clear_and_reset_tristate(monkeypatch):
 
     reset_session_vars()
     assert get_session_env("HERMES_CRON_SESSION") == "1"
-


### PR DESCRIPTION
## Summary

- resolve terminal.cwd while already inside the routed multiplex profile scope
- pin that cwd in the task-local session context
- mask process-global cwd inheritance when a fresh routed profile has no cwd
- prevent prompt-context discovery from falling back to the launch process cwd when that mask is active
- preserve legacy single-profile, configured-cwd, and explicit-clear behavior

## Why

Multiplex profile routing already scopes config, credentials, memory, and SOUL to the routed profile. The session context did not receive that profile’s configured cwd, so context-file discovery could inherit the launch profile’s process-wide TERMINAL_CWD or os.getcwd() and load the wrong workspace instructions.

## Tests

- exact source head: 36baf8b1c4ea8d51c9bdb3b29944589bc7918d2c
- exact CI retry head: 0fb3761d71ec8d48e7ff1743a0e5a8d82160d999; its only delta is an empty CI retry commit
- focused session/cwd/prompt suite: 82 passed, 1 platform skip
- final thin-r22 acceptance review: PASS 98
- final thin-r22 adversarial review: PASS 98; the process-cwd AGENTS crossover no longer reproduces
- exact-head upstream CI: pending on the retry head

The previous source-head CI workflow failed before creating any job and could not be retried without upstream admin rights. This empty commit triggers the same unchanged source through CI again. No CI claim is made until that run is terminal.

Source/test proof only; no release or customer-runtime claim.

## Reported by a user

#84517 reports this exact symptom from a real deployment — five profiles behind one multiplexed gateway with per-profile Discord bots, where every routed profile inherits the first-configured profile's `terminal.cwd`. Their diagnosis matches this implementation (bridge the routed profile's cwd into the existing session-local cwd context, and don't put cwd in the session key). Note #79117 covers the related half where `TERMINAL_ENV`/`TERMINAL_CWD` are still read from the process environment; #84584 is another open PR targeting the same issue via `gateway/run.py`.
