### PR TITLE
feat(code-execution): persist Python state per conversation

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3255,6 +3255,11 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             dispatch_kwargs = dict(
                 tool_call_id=tool_call_id,
                 session_id=agent.session_id or "",
+                code_execution_session_id=(
+                    agent._code_execution_scope_id()
+                    if function_name == "execute_code"
+                    else None
+                ),
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2353,6 +2353,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             effective_task_id,
                             tool_call_id=tool_call.id,
                             session_id=agent.session_id or "",
+                            code_execution_session_id=(
+                                agent._code_execution_scope_id()
+                                if function_name == "execute_code"
+                                else None
+                            ),
                             turn_id=getattr(agent, "_current_turn_id", "") or "",
                             api_request_id=getattr(agent, "_current_api_request_id", "")
                             or "",
@@ -2435,6 +2440,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             effective_task_id,
                             tool_call_id=tool_call.id,
                             session_id=agent.session_id or "",
+                            code_execution_session_id=(
+                                agent._code_execution_scope_id()
+                                if function_name == "execute_code"
+                                else None
+                            ),
                             turn_id=getattr(agent, "_current_turn_id", "") or "",
                             api_request_id=getattr(agent, "_current_api_request_id", "")
                             or "",

--- a/cli.py
+++ b/cli.py
@@ -521,6 +521,9 @@ def load_cli_config() -> Dict[str, Any]:
         "code_execution": {
             "timeout": 300,    # Max seconds a sandbox script can run before being killed (5 min)
             "max_tool_calls": 50,  # Max RPC tool calls per execution
+            "kernel_mode": "session",
+            "kernel_idle_seconds": 1800,
+            "max_live_kernels": 16,
         },
         "auxiliary": {
             "vision": {
@@ -9430,6 +9433,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     def new_session(self, silent=False, title=None):
         """Start a fresh session with a new session ID and cleared agent state."""
         old_session_id = self.session_id
+        if self.agent:
+            try:
+                from tools.code_execution_kernel import kernel_registry
+                kernel_registry.dispose_scope(self.agent._code_execution_scope_id())
+            except Exception:
+                pass
         _boundary_snapshot = None
         if self.agent and self.conversation_history:
             # Deliver the context-engine boundary synchronously and get back

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2604,6 +2604,14 @@ DEFAULT_CONFIG = {
         # Env scrubbing (strips *_API_KEY, *_TOKEN, *_SECRET, ...) and the
         # tool whitelist apply identically in both modes.
         "mode": "project",
+        # Local Python state lifetime. Remote backends remain per-call.
+        "kernel_mode": "session",
+        # Reap inactive local kernels so gateways cannot retain them forever.
+        "kernel_idle_seconds": 1800,
+        # Process-wide LRU bound across profiles and conversations.
+        "max_live_kernels": 16,
+        "timeout": 300,
+        "max_tool_calls": 50,
     },
 
     # Tool Search (progressive disclosure for large tool surfaces).

--- a/model_tools.py
+++ b/model_tools.py
@@ -1205,6 +1205,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    code_execution_session_id: Optional[str] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1334,6 +1335,7 @@ def handle_function_call(
                 task_id=task_id,
                 tool_call_id=tool_call_id,
                 session_id=session_id,
+                code_execution_session_id=code_execution_session_id,
                 turn_id=turn_id,
                 api_request_id=api_request_id,
                 user_task=user_task,
@@ -1499,6 +1501,7 @@ def handle_function_call(
                         function_name, next_args,
                         task_id=task_id,
                         session_id=session_id,
+                        code_execution_session_id=code_execution_session_id,
                         enabled_tools=sandbox_enabled,
                     )
             else:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4488,6 +4488,12 @@ class AIAgent:
 
         task_id = getattr(self, "session_id", None) or ""
 
+        try:
+            from tools.code_execution_kernel import kernel_registry
+            kernel_registry.dispose_scope(self._code_execution_scope_id())
+        except Exception:
+            pass
+
         # 1. Kill background processes for this task
         try:
             from tools.process_registry import process_registry
@@ -8333,6 +8339,14 @@ class AIAgent:
             except Exception:
                 logger.debug("Conversation root lineage walk failed", exc_info=True)
         return start
+
+    def _code_execution_scope_id(self) -> str:
+        """Return the stable, isolated owner for a local Python kernel."""
+        session_id = getattr(self, "session_id", None) or ""
+        if getattr(self, "platform", None) == "subagent":
+            return f"subagent:{session_id}"
+        root_id = self._conversation_root_id() or session_id
+        return f"conversation:{root_id}" if root_id else ""
 
     def run_conversation(
         self,

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -74,6 +74,9 @@ class _FakeAgent:
             self.context_compressor.compression_count = 0
             self.context_compressor._context_probed = False
 
+    def _code_execution_scope_id(self):
+        return f"conversation:{self.session_id}"
+
 
 def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
     """Create a HermesCLI instance with minimal mocking."""
@@ -173,6 +176,18 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
     assert cli.session_start > old_session_start
     assert cli.agent.session_start == cli.session_start
     cli.agent._invalidate_system_prompt.assert_called_once()
+
+
+def test_new_session_disposes_the_previous_python_kernel(tmp_path):
+    cli = _prepare_cli_with_active_session(tmp_path)
+    old_scope = cli.agent._code_execution_scope_id()
+
+    with patch(
+        "tools.code_execution_kernel.kernel_registry.dispose_scope"
+    ) as dispose_scope:
+        cli.new_session(silent=True)
+
+    dispose_scope.assert_called_once_with(old_scope)
 
 
 
@@ -295,5 +310,4 @@ def test_new_session_with_title(capsys):
 
     captured = capsys.readouterr()
     assert "My Test Session" in captured.out
-
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1971,6 +1971,7 @@ class TestConcurrentToolExecution:
                 "web_search", {"q": "test"}, "task-1",
                 tool_call_id=None,
                 session_id=agent.session_id,
+                code_execution_session_id=None,
                 turn_id="",
                 api_request_id="",
                 enabled_tools=list(agent.valid_tool_names),
@@ -1981,6 +1982,31 @@ class TestConcurrentToolExecution:
                 tool_request_middleware_trace=[],
             )
             assert result == "result"
+
+    def test_invoke_tool_forwards_stable_code_execution_scope(self, agent):
+        with patch("run_agent.handle_function_call", return_value="result") as mock_hfc:
+            agent._invoke_tool("execute_code", {"code": "42"}, "task-1")
+
+        assert mock_hfc.call_args.kwargs["code_execution_session_id"] == (
+            agent._code_execution_scope_id()
+        )
+
+    @pytest.mark.parametrize("quiet_mode", [True, False])
+    def test_sequential_execute_code_forwards_stable_scope(self, agent, quiet_mode):
+        agent.quiet_mode = quiet_mode
+        tool_call = _mock_tool_call(
+            name="execute_code",
+            arguments='{"code":"42"}',
+            call_id="c1",
+        )
+        message = _mock_assistant_msg(content="", tool_calls=[tool_call])
+
+        with patch("run_agent.handle_function_call", return_value='{"status":"success"}') as mock_hfc:
+            agent._execute_tool_calls_sequential(message, [], "task-1")
+
+        assert mock_hfc.call_args.kwargs["code_execution_session_id"] == (
+            agent._code_execution_scope_id()
+        )
 
     def test_sequential_tool_callbacks_fire_in_order(self, agent):
         tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -30,6 +30,21 @@ class TestHandleFunctionCall:
         assert "error" in result
         assert "totally_fake_tool_xyz" in result["error"]
 
+    def test_code_execution_scope_reaches_registry_dispatch(self):
+        with patch(
+            "model_tools.registry.dispatch", return_value='{"status":"success"}'
+        ) as dispatch:
+            handle_function_call(
+                "execute_code",
+                {"code": "42"},
+                session_id="segment",
+                code_execution_session_id="conversation:root",
+            )
+
+        assert dispatch.call_args.kwargs["code_execution_session_id"] == (
+            "conversation:root"
+        )
+
 
 
     def test_post_tool_call_receives_non_negative_integer_duration_ms(self):

--- a/tests/tools/test_code_execution_persistent.py
+++ b/tests/tools/test_code_execution_persistent.py
@@ -1,0 +1,787 @@
+import contextvars
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tools.code_execution_kernel import (
+    KernelDiedError,
+    KernelRegistry,
+    KernelStartupTimeout,
+    PersistentPythonKernel,
+    kernel_registry,
+)
+from tools.code_execution_tool import (
+    _execute_code_handler,
+    build_execute_code_schema,
+    dispose_code_execution_sessions,
+    execute_code,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_kernels(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    kernel_registry.close_all()
+    yield
+    kernel_registry.close_all()
+
+
+@pytest.fixture
+def config():
+    return {
+        "mode": "project",
+        "kernel_mode": "session",
+        "timeout": 10,
+        "max_tool_calls": 10,
+        "kernel_idle_seconds": 60,
+        "max_live_kernels": 8,
+    }
+
+
+def _run(code, scope, config, **kwargs):
+    with patch("tools.code_execution_tool._load_config", return_value=config), patch(
+        "tools.approval.check_execute_code_guard", return_value={"approved": True}
+    ):
+        return json.loads(
+            execute_code(
+                code,
+                task_id=f"task-{scope}",
+                enabled_tools=[],
+                execution_session_id=scope,
+                **kwargs,
+            )
+        )
+
+
+def test_state_and_last_expression_persist(config):
+    first = _run("value = 41", "conversation-a", config)
+    second = _run("value + 1", "conversation-a", config)
+
+    assert first["status"] == "success"
+    assert first["kernel_reused"] is False
+    assert second["status"] == "success"
+    assert second["output"].strip() == "42"
+    assert second["kernel_reused"] is True
+    assert second["persistent"] is True
+
+
+def test_schema_exposes_reset_and_describes_configured_lifetime():
+    persistent = build_execute_code_schema(mode="project", kernel_mode="session")
+    per_call = build_execute_code_schema(mode="project", kernel_mode="per_call")
+
+    assert persistent["parameters"]["properties"]["reset"]["type"] == "boolean"
+    assert "persist" in persistent["description"].lower()
+    assert "fresh Python process" in per_call["description"]
+
+
+def test_registry_handler_forwards_session_scope_and_reset():
+    with patch("tools.code_execution_tool.execute_code", return_value="{}") as mocked:
+        result = _execute_code_handler(
+            {"code": "1 + 1", "reset": True},
+            task_id="task",
+            session_id="segment",
+            code_execution_session_id="conversation:root",
+            enabled_tools=["read_file"],
+        )
+
+    assert result == "{}"
+    assert mocked.call_args.kwargs["execution_session_id"] == "conversation:root"
+    assert mocked.call_args.kwargs["reset"] is True
+
+
+def test_agent_scope_survives_compression_but_isolates_subagents():
+    from run_agent import AIAgent
+
+    parent = SimpleNamespace(
+        session_id="compressed-segment",
+        platform="cli",
+        _conversation_root_id=lambda: "conversation-root",
+    )
+    child = SimpleNamespace(
+        session_id="child-session",
+        platform="subagent",
+        _conversation_root_id=lambda: "conversation-root",
+    )
+
+    assert AIAgent._code_execution_scope_id(parent) == "conversation:conversation-root"
+    assert AIAgent._code_execution_scope_id(child) == "subagent:child-session"
+
+
+def test_sessions_are_isolated_and_reset_is_scoped(config):
+    _run("value = 'alpha'", "conversation-a", config)
+    isolated = _run("'value' in globals()", "conversation-b", config)
+    reset = _run("'value' in globals()", "conversation-a", config, reset=True)
+
+    assert isolated["output"].strip() == "False"
+    assert reset["output"].strip() == "False"
+    assert reset["kernel_reused"] is False
+
+
+def test_exception_does_not_destroy_kernel_state(config):
+    failed = _run(
+        "items = [1]; items.append(2); raise ValueError('bad')",
+        "errors",
+        config,
+    )
+    recovered = _run("items", "errors", config)
+
+    assert failed["status"] == "error"
+    assert "ValueError: bad" in failed["error"]
+    assert recovered["status"] == "success"
+    assert recovered["output"].strip() == "[1, 2]"
+    assert recovered["kernel_reused"] is True
+
+
+def test_user_tracebacks_hide_runner_frames(config):
+    result = _run(
+        "def fail():\n    raise ValueError('boom')\nfail()",
+        "traceback",
+        config,
+    )
+
+    assert result["status"] == "error"
+    assert "ValueError: boom" in result["error"]
+    assert 'File "<cell>"' in result["error"]
+    assert "code_execution_kernel.py" not in result["error"]
+    assert "_runner_eval" not in result["error"]
+
+
+def test_syntax_errors_point_to_the_cell_without_runner_frames(config):
+    result = _run("if True print('no')", "syntax", config)
+
+    assert result["status"] == "error"
+    assert "SyntaxError" in result["error"]
+    assert 'File "<cell>"' in result["error"]
+    assert "code_execution_kernel.py" not in result["error"]
+    assert "_runner_eval" not in result["error"]
+
+
+def test_input_fails_immediately_without_destroying_state(config):
+    started = time.monotonic()
+    result = _run("value = 41\ninput('prompt: ')", "input", config)
+    recovered = _run("value + 1", "input", config)
+
+    assert time.monotonic() - started < 2
+    assert result["status"] == "error"
+    assert "input() is unavailable" in result["error"]
+    assert recovered["output"].strip() == "42"
+    assert recovered["kernel_reused"] is True
+
+
+def test_top_level_await_and_imports_persist(config):
+    _run(
+        "import asyncio\nasync def answer():\n    await asyncio.sleep(0)\n    return 9",
+        "await",
+        config,
+    )
+    result = _run("await answer()", "await", config)
+
+    assert result["status"] == "success"
+    assert result["output"].strip() == "9"
+
+
+def test_project_cwd_changes_without_resetting_state(config, tmp_path):
+    first_cwd = tmp_path / "first"
+    second_cwd = tmp_path / "second"
+    first_cwd.mkdir()
+    second_cwd.mkdir()
+    with patch.dict("os.environ", {"TERMINAL_CWD": str(first_cwd)}):
+        _run("value = 42", "moving-cwd", config)
+    with patch.dict("os.environ", {"TERMINAL_CWD": str(second_cwd)}):
+        result = _run("import os; (os.getcwd(), value)", "moving-cwd", config)
+
+    assert str(second_cwd) in result["output"]
+    assert "42" in result["output"]
+    assert result["kernel_reused"] is True
+
+
+def test_project_cwd_modules_are_importable(config, tmp_path):
+    (tmp_path / "project_module.py").write_text("VALUE = 42\n", encoding="utf-8")
+    with patch.dict("os.environ", {"TERMINAL_CWD": str(tmp_path)}):
+        result = _run(
+            "import project_module\nproject_module.VALUE",
+            "project-import",
+            config,
+        )
+
+    assert result["status"] == "success"
+    assert result["output"].strip() == "42"
+
+
+def test_per_call_mode_preserves_legacy_fresh_process_behavior(config):
+    per_call = {**config, "kernel_mode": "per_call"}
+    _run("value = 41", "per-call", per_call)
+    result = _run("print('value' in globals())", "per-call", per_call)
+
+    assert result["status"] == "success"
+    assert result["output"].strip() == "False"
+    assert result["persistent"] is False
+
+
+def test_cached_hermes_tools_reconnects_with_fresh_turn_context(config):
+    turn_value = contextvars.ContextVar("turn_value", default="missing")
+
+    def dispatch(_name, _args, task_id=None):
+        return json.dumps({"content": turn_value.get()})
+
+    code = "from hermes_tools import read_file\nprint(read_file('x')['content'])"
+    with patch("model_tools.handle_function_call", side_effect=dispatch):
+        token = turn_value.set("first-turn")
+        try:
+            first = _run(code, "rpc", config)
+        finally:
+            turn_value.reset(token)
+        token = turn_value.set("second-turn")
+        try:
+            second = _run(code, "rpc", config)
+        finally:
+            turn_value.reset(token)
+
+    assert first["output"].strip() == "first-turn"
+    assert second["output"].strip() == "second-turn"
+    assert first["tool_calls_made"] == 1
+    assert second["tool_calls_made"] == 1
+
+
+def test_kernel_crash_is_discarded_and_next_call_recovers(config):
+    crashed = _run("import os; os._exit(7)", "crash", config)
+    recovered = _run("6 * 7", "crash", config)
+
+    assert crashed["status"] == "error"
+    assert "kernel stopped unexpectedly" in crashed["error"].lower()
+    assert recovered["status"] == "success"
+    assert recovered["output"].strip() == "42"
+    assert recovered["kernel_reused"] is False
+
+
+def test_persistent_kernel_captures_subprocess_stdout(config):
+    result = _run(
+        "import subprocess, sys\n"
+        "subprocess.run([sys.executable, '-c', \"print('child-output')\"])",
+        "subprocess-output",
+        config,
+    )
+
+    assert result["status"] == "success"
+    assert "child-output" in result["output"]
+
+
+def test_persistent_output_keeps_head_tail_and_metadata(config):
+    result = _run("print('x' * 60000)\n'final-value'", "large-output", config)
+
+    assert result["status"] == "success"
+    assert result["stdout_truncated"] is True
+    assert result["stdout_bytes_total"] > result["stdout_bytes_captured"]
+    assert "final-value" in result["output"]
+
+
+def test_persistent_output_sanitizes_ansi_and_carriage_returns(config):
+    result = _run(
+        "print('\\x1b[31mred\\x1b[0m\\rreplacement')",
+        "sanitized-output",
+        config,
+    )
+
+    assert result["status"] == "success"
+    assert "\x1b" not in result["output"]
+    assert "\r" not in result["output"]
+    assert result["output"].splitlines() == ["red", "replacement"]
+
+
+def test_timeout_resets_kernel(config):
+    timed = {**config, "timeout": 2}
+    _run("value = 41", "timeout", timed)
+    result = _run("while True:\n    pass", "timeout", timed)
+    recovered = _run("'value' in globals()", "timeout", timed)
+
+    assert result["status"] == "timeout"
+    assert "kernel was reset" in result["error"]
+    assert recovered["output"].strip() == "False"
+    assert recovered["kernel_reused"] is False
+
+
+def test_interrupt_resets_kernel(config, tmp_path):
+    from tools.interrupt import set_interrupt
+
+    marker = tmp_path / "started"
+    result = {}
+
+    def run_cell():
+        result.update(
+            _run(
+                f"import pathlib, time\npathlib.Path({str(marker)!r}).touch()\n"
+                "value = 41\ntime.sleep(30)",
+                "interrupt",
+                {**config, "timeout": 60},
+            )
+        )
+
+    thread = threading.Thread(target=run_cell)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while not marker.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert marker.exists()
+
+    set_interrupt(True, thread.ident)
+    thread.join(timeout=3)
+    set_interrupt(False, thread.ident)
+    recovered = _run("'value' in globals()", "interrupt", config)
+
+    assert thread.is_alive() is False
+    assert result["status"] == "interrupted"
+    assert "kernel reset" in result["output"]
+    assert recovered["output"].strip() == "False"
+    assert recovered["kernel_reused"] is False
+
+
+def test_queued_interrupt_does_not_kill_the_running_cell(config, tmp_path):
+    from tools.interrupt import set_interrupt
+
+    marker = tmp_path / "running"
+    first = {}
+    second = {}
+
+    def run_first():
+        first.update(
+            _run(
+                f"import pathlib, time\npathlib.Path({str(marker)!r}).touch()\n"
+                "shared = 42\ntime.sleep(1)",
+                "queued-interrupt",
+                config,
+            )
+        )
+
+    def run_second():
+        second.update(_run("shared + 1", "queued-interrupt", config))
+
+    first_thread = threading.Thread(target=run_first)
+    first_thread.start()
+    deadline = time.monotonic() + 5
+    while not marker.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert marker.exists()
+    second_thread = threading.Thread(target=run_second)
+    second_thread.start()
+    time.sleep(0.1)
+    set_interrupt(True, second_thread.ident)
+    second_thread.join(timeout=2)
+    set_interrupt(False, second_thread.ident)
+
+    assert second_thread.is_alive() is False
+    assert second["status"] == "interrupted"
+    assert "kernel reset" not in second["output"]
+
+    first_thread.join(timeout=3)
+    recovered = _run("shared", "queued-interrupt", config)
+    assert first["status"] == "success"
+    assert recovered["output"].strip() == "42"
+    assert recovered["kernel_reused"] is True
+
+
+def test_profile_context_is_part_of_kernel_identity(config, tmp_path):
+    home_a = tmp_path / "a"
+    home_b = tmp_path / "b"
+    token = set_hermes_home_override(home_a)
+    try:
+        _run("value = 'profile-a'", "same-conversation", config)
+    finally:
+        reset_hermes_home_override(token)
+    token = set_hermes_home_override(home_b)
+    try:
+        profile_b = _run("'value' in globals()", "same-conversation", config)
+    finally:
+        reset_hermes_home_override(token)
+    token = set_hermes_home_override(home_a)
+    try:
+        profile_a = _run("value", "same-conversation", config)
+    finally:
+        reset_hermes_home_override(token)
+
+    assert profile_b["output"].strip() == "False"
+    assert profile_a["output"].strip() == "'profile-a'"
+
+
+def test_explicit_disposal_closes_session_kernel(config):
+    _run("value = 1", "dispose", config)
+    assert kernel_registry.size() == 1
+
+    dispose_code_execution_sessions("dispose")
+
+    assert kernel_registry.size() == 0
+
+
+def test_agent_hard_close_disposes_owned_kernel(config):
+    from run_agent import AIAgent
+
+    _run("value = 1", "conversation:hard-close", config)
+    agent = object.__new__(AIAgent)
+    agent.session_id = "hard-close"
+    agent.platform = "cli"
+    agent._session_db = None
+    agent._active_children_lock = threading.Lock()
+    agent._active_children = set()
+
+    agent.close()
+    agent.close()
+
+    assert kernel_registry.size() == 0
+
+
+def test_agent_close_does_not_dispose_another_session(config):
+    from run_agent import AIAgent
+
+    _run("value = 'first'", "conversation:first", config)
+    _run("value = 'second'", "conversation:second", config)
+    agent = object.__new__(AIAgent)
+    agent.session_id = "first"
+    agent.platform = "cli"
+    agent._session_db = None
+    agent._active_children_lock = threading.Lock()
+    agent._active_children = set()
+
+    agent.close()
+    first = _run("'value' in globals()", "conversation:first", config)
+    second = _run("value", "conversation:second", config)
+
+    assert first["output"].strip() == "False"
+    assert first["kernel_reused"] is False
+    assert second["output"].strip() == "'second'"
+    assert second["kernel_reused"] is True
+
+
+def test_reset_racing_active_execution_does_not_discard_new_kernel(config, tmp_path):
+    marker = tmp_path / "old-running"
+    old = {}
+
+    def run_old():
+        old.update(
+            _run(
+                f"import pathlib, time\npathlib.Path({str(marker)!r}).touch()\n"
+                "old_value = 1\ntime.sleep(30)",
+                "reset-race",
+                {**config, "timeout": 60},
+            )
+        )
+
+    thread = threading.Thread(target=run_old)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while not marker.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert marker.exists()
+
+    reset = _run("new_value = 42", "reset-race", config, reset=True)
+    thread.join(timeout=3)
+    recovered = _run("new_value", "reset-race", config)
+
+    assert thread.is_alive() is False
+    assert old["status"] == "error"
+    assert reset["status"] == "success"
+    assert recovered["output"].strip() == "42"
+    assert recovered["kernel_reused"] is True
+
+
+def test_disposal_stops_an_active_cell_without_waiting_for_its_timeout(config):
+    result = {}
+
+    def run_cell():
+        result.update(_run("import time; time.sleep(30)", "active-close", config))
+
+    thread = threading.Thread(target=run_cell)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while kernel_registry.size() == 0 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert kernel_registry.size() == 1
+
+    dispose_code_execution_sessions("active-close")
+    thread.join(timeout=3)
+
+    assert thread.is_alive() is False
+    assert result["status"] == "error"
+    assert kernel_registry.size() == 0
+
+
+def test_disposal_kills_subprocesses_started_by_the_kernel(config):
+    import psutil
+
+    result = _run(
+        "import subprocess, sys\n"
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])\n"
+        "child.pid",
+        "child-process",
+        config,
+    )
+    child_pid = int(result["output"].strip())
+    assert psutil.pid_exists(child_pid)
+
+    dispose_code_execution_sessions("child-process")
+    deadline = time.monotonic() + 3
+    while psutil.pid_exists(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert psutil.pid_exists(child_pid) is False
+
+
+@pytest.mark.linux_only
+def test_kernel_crash_kills_its_existing_process_group(config, tmp_path):
+    import psutil
+
+    pid_file = tmp_path / "child.pid"
+    code = (
+        "import os, pathlib, subprocess, sys\n"
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])\n"
+        f"pathlib.Path({str(pid_file)!r}).write_text(str(child.pid))\n"
+        "os._exit(9)"
+    )
+    result = _run(code, "crash-child", config)
+    child_pid = int(pid_file.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 3
+    while psutil.pid_exists(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert result["status"] == "error"
+    assert psutil.pid_exists(child_pid) is False
+
+
+class _FakeKernel:
+    def __init__(self):
+        self.alive = True
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+        self.alive = False
+
+
+def test_registry_coalesces_concurrent_startup():
+    registry = KernelRegistry()
+    created = []
+    factory_started = threading.Event()
+    allow_factory = threading.Event()
+    results = []
+
+    def factory():
+        kernel = _FakeKernel()
+        created.append(kernel)
+        factory_started.set()
+        assert allow_factory.wait(timeout=3)
+        return kernel
+
+    def acquire():
+        results.append(
+            registry.acquire(
+                ("shared",),
+                scope_id="shared",
+                profile_key="profile",
+                factory=factory,
+                max_live=8,
+                idle_seconds=60,
+                deadline=time.monotonic() + 5,
+            )
+        )
+
+    first = threading.Thread(target=acquire)
+    second = threading.Thread(target=acquire)
+    first.start()
+    assert factory_started.wait(timeout=2)
+    second.start()
+    allow_factory.set()
+    first.join(timeout=3)
+    second.join(timeout=3)
+
+    assert first.is_alive() is False
+    assert second.is_alive() is False
+    assert len(created) == 1
+    assert len(results) == 2
+    assert sorted(reused for _, reused in results) == [False, True]
+    registry.close_all()
+
+
+def test_registry_startup_does_not_block_other_scopes():
+    registry = KernelRegistry()
+    first_started = threading.Event()
+    release_first = threading.Event()
+    second_finished = threading.Event()
+
+    def first_factory():
+        first_started.set()
+        assert release_first.wait(timeout=3)
+        return _FakeKernel()
+
+    def acquire_first():
+        registry.acquire(
+            ("first",),
+            scope_id="first",
+            profile_key="profile",
+            factory=first_factory,
+            max_live=8,
+            idle_seconds=60,
+        )
+
+    def acquire_second():
+        registry.acquire(
+            ("second",),
+            scope_id="second",
+            profile_key="profile",
+            factory=_FakeKernel,
+            max_live=8,
+            idle_seconds=60,
+        )
+        second_finished.set()
+
+    first = threading.Thread(target=acquire_first)
+    second = threading.Thread(target=acquire_second)
+    first.start()
+    assert first_started.wait(timeout=2)
+    second.start()
+    assert second_finished.wait(timeout=1)
+    release_first.set()
+    first.join(timeout=3)
+    second.join(timeout=3)
+    registry.close_all()
+
+
+def test_dispose_invalidates_inflight_startup():
+    registry = KernelRegistry()
+    factory_started = threading.Event()
+    allow_factory = threading.Event()
+    created = _FakeKernel()
+    error = []
+
+    def factory():
+        factory_started.set()
+        assert allow_factory.wait(timeout=3)
+        return created
+
+    def acquire():
+        try:
+            registry.acquire(
+                ("pending",),
+                scope_id="pending",
+                profile_key="profile",
+                factory=factory,
+                max_live=8,
+                idle_seconds=60,
+            )
+        except BaseException as exc:
+            error.append(exc)
+
+    thread = threading.Thread(target=acquire)
+    thread.start()
+    assert factory_started.wait(timeout=2)
+    registry.dispose_scope("pending", "profile")
+    allow_factory.set()
+    thread.join(timeout=3)
+
+    assert thread.is_alive() is False
+    assert len(error) == 1
+    assert isinstance(error[0], KernelDiedError)
+    assert created.closed is True
+    assert registry.size() == 0
+
+
+def test_startup_timeout_is_structured_and_leaves_no_registry_entry(config):
+    class SlowKernel:
+        def __init__(self, *_args, deadline, **_kwargs):
+            time.sleep(max(0, deadline - time.monotonic()) + 0.01)
+            raise KernelStartupTimeout("slow startup")
+
+    started = time.monotonic()
+    with patch("tools.code_execution_kernel.PersistentPythonKernel", SlowKernel):
+        result = _run(
+            "42",
+            "startup-timeout",
+            {**config, "timeout": 0.2},
+        )
+    elapsed = time.monotonic() - started
+    recovered = _run("42", "startup-timeout", config)
+
+    assert elapsed < 1
+    assert result["status"] == "timeout"
+    assert "did not start within" in result["error"]
+    assert recovered["status"] == "success"
+    assert recovered["output"].strip() == "42"
+    assert recovered["kernel_reused"] is False
+
+
+def test_failed_startup_terminates_process_and_removes_staging_dir(tmp_path):
+    real_popen = subprocess.Popen
+    real_mkdtemp = tempfile.mkdtemp
+    processes = []
+    staging_dirs = []
+
+    def tracked_popen(*args, **kwargs):
+        process = real_popen(*args, **kwargs)
+        processes.append(process)
+        return process
+
+    def tracked_mkdtemp(*, prefix):
+        path = real_mkdtemp(prefix=prefix, dir=tmp_path)
+        staging_dirs.append(path)
+        return path
+
+    with patch(
+        "tools.code_execution_kernel.subprocess.Popen",
+        side_effect=tracked_popen,
+    ), patch(
+        "tools.code_execution_kernel.tempfile.mkdtemp",
+        side_effect=tracked_mkdtemp,
+    ), patch.object(
+        PersistentPythonKernel,
+        "_wait_until_ready",
+        side_effect=KernelStartupTimeout("forced timeout"),
+    ):
+        with pytest.raises(KernelStartupTimeout):
+            PersistentPythonKernel(
+                sys.executable,
+                str(tmp_path),
+                os.environ.copy(),
+                "",
+                deadline=time.monotonic() + 1,
+            )
+
+    assert len(processes) == 1
+    assert processes[0].poll() is not None
+    assert len(staging_dirs) == 1
+    assert os.path.exists(staging_dirs[0]) is False
+
+
+def test_registry_lru_bound_and_idle_reaping():
+    registry = KernelRegistry()
+    first = _FakeKernel()
+    second = _FakeKernel()
+    registry.acquire(
+        ("first",),
+        scope_id="a",
+        profile_key="p",
+        factory=lambda: first,
+        max_live=1,
+        idle_seconds=1,
+    )
+    registry.release(("first",))
+    registry.acquire(
+        ("second",),
+        scope_id="b",
+        profile_key="p",
+        factory=lambda: second,
+        max_live=1,
+        idle_seconds=1,
+    )
+    registry.release(("second",))
+
+    assert first.closed is True
+    assert registry.size() == 1
+    assert registry.reap_idle(now=time.monotonic() + 2) == 1
+    assert second.closed is True
+    assert registry.size() == 0

--- a/tests/tools/test_code_execution_persistent.py
+++ b/tests/tools/test_code_execution_persistent.py
@@ -78,9 +78,21 @@ def test_schema_exposes_reset_and_describes_configured_lifetime():
     persistent = build_execute_code_schema(mode="project", kernel_mode="session")
     per_call = build_execute_code_schema(mode="project", kernel_mode="per_call")
 
+    persistent_description = persistent["description"]
+    persistent_code = persistent["parameters"]["properties"]["code"]["description"]
+    per_call_description = per_call["description"]
+    per_call_code = per_call["parameters"]["properties"]["code"]["description"]
+
     assert persistent["parameters"]["properties"]["reset"]["type"] == "boolean"
-    assert "persist" in persistent["description"].lower()
-    assert "fresh Python process" in per_call["description"]
+    assert persistent_description.startswith("Run one Python cell")
+    assert "conversation-scoped persistent kernel" in persistent_description
+    assert "Work incrementally" in persistent_description
+    assert "reuse prior names" in persistent_description
+    assert "fix and rerun only the failing step" in persistent_description
+    assert "Prior top-level names" in persistent_code
+    assert "fresh process" in per_call_description
+    assert "no prior Python state" in per_call_description
+    assert "Prior top-level names" not in per_call_code
 
 
 def test_registry_handler_forwards_session_scope_and_reset():

--- a/tests/tools/test_code_execution_persistent_platforms.py
+++ b/tests/tools/test_code_execution_persistent_platforms.py
@@ -1,0 +1,56 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tools.code_execution_kernel import kernel_registry
+from tools.code_execution_tool import execute_code
+
+
+def _run_persistent_smoke():
+    config = {
+        "mode": "project",
+        "kernel_mode": "session",
+        "timeout": 10,
+        "max_tool_calls": 10,
+        "kernel_idle_seconds": 60,
+        "max_live_kernels": 8,
+    }
+    with patch("tools.code_execution_tool._load_config", return_value=config), patch(
+        "tools.approval.check_execute_code_guard", return_value={"approved": True}
+    ):
+        first = json.loads(
+            execute_code("value = 41", execution_session_id="platform-smoke")
+        )
+        second = json.loads(
+            execute_code("value + 1", execution_session_id="platform-smoke")
+        )
+    return first, second
+
+
+@pytest.fixture(autouse=True)
+def _clean_kernels(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    kernel_registry.close_all()
+    yield
+    kernel_registry.close_all()
+
+
+@pytest.mark.windows_only
+def test_persistent_kernel_smoke_on_windows():
+    first, second = _run_persistent_smoke()
+
+    assert first["status"] == "success"
+    assert second["status"] == "success"
+    assert second["output"].strip() == "42"
+    assert second["kernel_reused"] is True
+
+
+@pytest.mark.macos_only
+def test_persistent_kernel_smoke_on_macos():
+    first, second = _run_persistent_smoke()
+
+    assert first["status"] == "success"
+    assert second["status"] == "success"
+    assert second["output"].strip() == "42"
+    assert second["kernel_reused"] is True

--- a/tools/code_execution_kernel.py
+++ b/tools/code_execution_kernel.py
@@ -1,0 +1,779 @@
+"""Persistent local Python kernels used by ``execute_code``."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import atexit
+import base64
+import builtins
+import inspect
+import json
+import os
+import queue
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import traceback
+import uuid
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+
+_FRAME_PREFIX = b"\x1ehermes-python\t"
+
+
+class KernelDiedError(RuntimeError):
+    pass
+
+
+class KernelStartupTimeout(KernelDiedError):
+    pass
+
+
+class KernelStartupInterrupted(KernelDiedError):
+    pass
+
+
+class _CapturedOutput:
+    def __init__(self, limit: int):
+        self._head_limit = int(limit * 0.4)
+        self._tail_limit = limit - self._head_limit
+        self._head = bytearray()
+        self._tail: deque[bytes] = deque()
+        self._tail_size = 0
+        self.total = 0
+
+    def append(self, data: bytes) -> None:
+        self.total += len(data)
+        if len(self._head) < self._head_limit:
+            keep = min(len(data), self._head_limit - len(self._head))
+            self._head.extend(data[:keep])
+            data = data[keep:]
+        if not data:
+            return
+        self._tail.append(data)
+        self._tail_size += len(data)
+        while self._tail_size > self._tail_limit and self._tail:
+            overflow = self._tail_size - self._tail_limit
+            first = self._tail[0]
+            if len(first) <= overflow:
+                self._tail.popleft()
+                self._tail_size -= len(first)
+            else:
+                self._tail[0] = first[overflow:]
+                self._tail_size -= overflow
+
+    @property
+    def head(self) -> bytes:
+        return bytes(self._head)
+
+    @property
+    def tail(self) -> bytes:
+        return b"".join(self._tail)
+
+
+@dataclass
+class KernelExecutionResult:
+    status: str
+    stdout_head: bytes
+    stdout_tail: bytes
+    stdout_total: int
+    stderr: bytes
+    error: str
+    invalidate_kernel: bool
+
+
+class PersistentPythonKernel:
+    def __init__(
+        self,
+        python: str,
+        cwd: str,
+        env: dict[str, str],
+        tools_source: str,
+        *,
+        deadline: Optional[float] = None,
+        interrupted: Optional[Callable[[], bool]] = None,
+    ):
+        self.python = python
+        self.staging_dir = tempfile.mkdtemp(prefix="hermes_kernel_")
+        self.cwd = cwd or self.staging_dir
+        self.env = dict(env)
+        existing_path = self.env.get("PYTHONPATH", "")
+        self.env["PYTHONPATH"] = os.pathsep.join(
+            part for part in (self.staging_dir, existing_path) if part
+        )
+        self._lock = threading.Lock()
+        self._frames: queue.Queue[dict] = queue.Queue()
+        self._infra_stderr = bytearray()
+        self._closed = False
+        Path(self.staging_dir, "hermes_tools.py").write_text(
+            tools_source, encoding="utf-8"
+        )
+        self._proc = subprocess.Popen(
+            [python, str(Path(__file__).resolve()), "--runner"],
+            cwd=self.cwd,
+            env=self.env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+            creationflags=(
+                subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0
+            ),
+        )
+        self._stdout_thread = threading.Thread(
+            target=self._read_frames, daemon=True
+        )
+        self._stderr_thread = threading.Thread(
+            target=self._read_infra_stderr, daemon=True
+        )
+        self._stdout_thread.start()
+        self._stderr_thread.start()
+        try:
+            self._wait_until_ready(
+                deadline=deadline,
+                interrupted=interrupted or (lambda: False),
+            )
+        except Exception:
+            self.close()
+            raise
+
+    @property
+    def pid(self) -> int:
+        return self._proc.pid
+
+    @property
+    def alive(self) -> bool:
+        return not self._closed and self._proc.poll() is None
+
+    def execute(
+        self,
+        code: str,
+        *,
+        cwd: str,
+        env: dict[str, str],
+        python_paths: list[str],
+        deadline: float,
+        interrupted: Callable[[], bool],
+        stdout_limit: int,
+        stderr_limit: int,
+        activity: Optional[Callable[[], None]] = None,
+    ) -> KernelExecutionResult:
+        while True:
+            if interrupted():
+                return KernelExecutionResult(
+                    status="interrupted",
+                    stdout_head=b"",
+                    stdout_tail=b"",
+                    stdout_total=0,
+                    stderr=b"",
+                    error="",
+                    invalidate_kernel=False,
+                )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return KernelExecutionResult(
+                    status="timeout",
+                    stdout_head=b"",
+                    stdout_tail=b"",
+                    stdout_total=0,
+                    stderr=b"",
+                    error="",
+                    invalidate_kernel=False,
+                )
+            if self._lock.acquire(timeout=min(0.1, remaining)):
+                break
+        try:
+            if not self.alive:
+                raise KernelDiedError(self._death_message())
+            request_id = uuid.uuid4().hex
+            payload = {
+                "type": "execute",
+                "id": request_id,
+                "code": code,
+                "cwd": cwd,
+                "env": env,
+                "python_paths": python_paths,
+            }
+            assert self._proc.stdin is not None
+            try:
+                self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+                self._proc.stdin.flush()
+            except (BrokenPipeError, OSError) as exc:
+                raise KernelDiedError(self._death_message()) from exc
+
+            stdout = _CapturedOutput(stdout_limit)
+            stderr = _CapturedOutput(stderr_limit)
+            status = "success"
+            error = ""
+            invalidate_kernel = False
+            while True:
+                if interrupted():
+                    status = "interrupted"
+                    invalidate_kernel = True
+                    self._interrupt_then_stop()
+                    break
+                if time.monotonic() >= deadline:
+                    status = "timeout"
+                    invalidate_kernel = True
+                    self._interrupt_then_stop()
+                    break
+                if activity is not None:
+                    activity()
+                try:
+                    frame = self._frames.get(timeout=0.1)
+                except queue.Empty:
+                    if self._proc.poll() is not None:
+                        raise KernelDiedError(self._death_message())
+                    continue
+                if frame.get("type") == "eof":
+                    raise KernelDiedError(self._death_message())
+                if frame.get("id") not in (None, request_id):
+                    continue
+                kind = frame.get("type")
+                if kind == "stdout":
+                    stdout.append(base64.b64decode(frame.get("data", "")))
+                elif kind == "stderr":
+                    stderr.append(base64.b64decode(frame.get("data", "")))
+                elif kind == "error":
+                    status = "error"
+                    error = str(frame.get("error") or "Python execution failed")
+                elif kind == "done":
+                    break
+
+            return KernelExecutionResult(
+                status=status,
+                stdout_head=stdout.head,
+                stdout_tail=stdout.tail,
+                stdout_total=stdout.total,
+                stderr=stderr.head + stderr.tail,
+                error=error,
+                invalidate_kernel=invalidate_kernel,
+            )
+        finally:
+            self._lock.release()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._terminate()
+        shutil.rmtree(self.staging_dir, ignore_errors=True)
+
+    def _wait_until_ready(
+        self,
+        *,
+        deadline: Optional[float],
+        interrupted: Callable[[], bool],
+    ) -> None:
+        deadline = deadline if deadline is not None else time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if interrupted():
+                self._terminate()
+                raise KernelStartupInterrupted("Python kernel startup was interrupted")
+            try:
+                frame = self._frames.get(
+                    timeout=min(0.1, max(0.001, deadline - time.monotonic()))
+                )
+            except queue.Empty:
+                if self._proc.poll() is not None:
+                    break
+                continue
+            if frame.get("type") == "ready":
+                return
+            if frame.get("type") == "eof":
+                break
+        self._terminate()
+        if time.monotonic() >= deadline:
+            raise KernelStartupTimeout("Python kernel did not start before the deadline")
+        raise KernelDiedError(self._death_message() or "Python kernel did not start")
+
+    def _read_frames(self) -> None:
+        assert self._proc.stdout is not None
+        try:
+            for line in iter(self._proc.stdout.readline, b""):
+                if not line.startswith(_FRAME_PREFIX):
+                    continue
+                try:
+                    self._frames.put(json.loads(line[len(_FRAME_PREFIX):]))
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    continue
+        finally:
+            self._frames.put({"type": "eof"})
+
+    def _read_infra_stderr(self) -> None:
+        assert self._proc.stderr is not None
+        try:
+            while len(self._infra_stderr) < 10_000:
+                chunk = self._proc.stderr.read(4096)
+                if not chunk:
+                    break
+                self._infra_stderr.extend(chunk[: 10_000 - len(self._infra_stderr)])
+        except (OSError, ValueError):
+            pass
+
+    def _interrupt_then_stop(self) -> None:
+        try:
+            if os.name == "nt":
+                self._proc.send_signal(signal.CTRL_BREAK_EVENT)
+            else:
+                os.killpg(self._proc.pid, signal.SIGINT)  # windows-footgun: ok
+            self._proc.wait(timeout=1)
+        except Exception:
+            pass
+        self._terminate()
+
+    def _terminate(self) -> None:
+        if os.name != "nt":
+            try:
+                os.killpg(self._proc.pid, signal.SIGTERM)  # windows-footgun: ok
+            except ProcessLookupError:
+                return
+            try:
+                self._proc.wait(timeout=0.5)
+            except subprocess.TimeoutExpired:
+                pass
+            time.sleep(0.05)
+            try:
+                os.killpg(self._proc.pid, 0)  # windows-footgun: ok
+            except ProcessLookupError:
+                pass
+            else:
+                try:
+                    os.killpg(self._proc.pid, signal.SIGKILL)  # windows-footgun: ok
+                except ProcessLookupError:
+                    pass
+            return
+        if self._proc.poll() is not None:
+            return
+        try:
+            import psutil
+
+            parent = psutil.Process(self._proc.pid)
+            processes = parent.children(recursive=True)
+            processes.append(parent)
+            for process in processes:
+                try:
+                    process.terminate()
+                except psutil.NoSuchProcess:
+                    pass
+            _, alive = psutil.wait_procs(processes, timeout=1)
+            for process in alive:
+                try:
+                    process.kill()
+                except psutil.NoSuchProcess:
+                    pass
+            self._proc.wait(timeout=1)
+        except Exception:
+            try:
+                self._proc.kill()
+            except Exception:
+                pass
+
+    def _death_message(self) -> str:
+        detail = bytes(self._infra_stderr).decode("utf-8", errors="replace").strip()
+        if detail:
+            return detail
+        return f"Python kernel exited with code {self._proc.poll()}"
+
+
+@dataclass
+class _KernelEntry:
+    kernel: PersistentPythonKernel
+    scope_id: str
+    profile_key: str
+    last_used: float
+    idle_seconds: float
+    active: int = 0
+
+
+@dataclass
+class _PendingKernel:
+    scope_id: str
+    profile_key: str
+    generation: int
+    event: threading.Event
+    error: Optional[BaseException] = None
+    invalidated: bool = False
+
+
+class KernelRegistry:
+    def __init__(self):
+        self._entries: dict[tuple, _KernelEntry] = {}
+        self._pending: dict[tuple, _PendingKernel] = {}
+        self._scope_generations: dict[tuple[str, str], int] = {}
+        self._lock = threading.RLock()
+        self._reaper_started = False
+        self._idle_seconds = 1800.0
+
+    def acquire(
+        self,
+        key: tuple,
+        *,
+        scope_id: str,
+        profile_key: str,
+        factory: Callable[[], PersistentPythonKernel],
+        max_live: int,
+        idle_seconds: float,
+        deadline: Optional[float] = None,
+        interrupted: Optional[Callable[[], bool]] = None,
+    ) -> tuple[PersistentPythonKernel, bool]:
+        interrupted = interrupted or (lambda: False)
+        scope_key = (scope_id, profile_key)
+        while True:
+            victim = None
+            starter = False
+            with self._lock:
+                entry_idle_seconds = max(1.0, float(idle_seconds))
+                self._idle_seconds = min(self._idle_seconds, entry_idle_seconds)
+                self._start_reaper_locked()
+                entry = self._entries.get(key)
+                if entry is not None and entry.kernel.alive:
+                    entry.active += 1
+                    entry.last_used = time.monotonic()
+                    return entry.kernel, True
+                if entry is not None:
+                    victim = entry.kernel
+                    self._entries.pop(key, None)
+                pending = self._pending.get(key)
+                if pending is None:
+                    pending = _PendingKernel(
+                        scope_id=scope_id,
+                        profile_key=profile_key,
+                        generation=self._scope_generations.get(scope_key, 0),
+                        event=threading.Event(),
+                    )
+                    self._pending[key] = pending
+                    starter = True
+            if victim is not None:
+                victim.close()
+            if starter:
+                break
+            while not pending.event.wait(timeout=0.05):
+                if interrupted():
+                    raise KernelStartupInterrupted(
+                        "Python kernel startup was interrupted"
+                    )
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise KernelStartupTimeout(
+                        "Python kernel did not start before the deadline"
+                    )
+            if pending.error is not None:
+                raise pending.error
+            if pending.invalidated:
+                raise KernelDiedError("Python kernel startup was invalidated")
+
+        kernel = None
+        victims: list[PersistentPythonKernel] = []
+        try:
+            if interrupted():
+                raise KernelStartupInterrupted("Python kernel startup was interrupted")
+            if deadline is not None and time.monotonic() >= deadline:
+                raise KernelStartupTimeout(
+                    "Python kernel did not start before the deadline"
+                )
+            kernel = factory()
+            with self._lock:
+                current = self._pending.get(key)
+                generation = self._scope_generations.get(scope_key, 0)
+                if current is not pending or pending.invalidated or generation != pending.generation:
+                    raise KernelDiedError("Python kernel startup was invalidated")
+                self._entries[key] = _KernelEntry(
+                    kernel=kernel,
+                    scope_id=scope_id,
+                    profile_key=profile_key,
+                    last_used=time.monotonic(),
+                    idle_seconds=entry_idle_seconds,
+                    active=1,
+                )
+                self._pending.pop(key, None)
+                victims.extend(self._evict_lru_locked(max_live, preserve=key))
+                pending.event.set()
+            for victim in victims:
+                victim.close()
+            return kernel, False
+        except BaseException as exc:
+            if kernel is not None:
+                kernel.close()
+            with self._lock:
+                if self._pending.get(key) is pending:
+                    self._pending.pop(key, None)
+                pending.error = exc
+                pending.event.set()
+            raise
+
+    def release(self, key: tuple, kernel: Optional[PersistentPythonKernel] = None) -> None:
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is not None and (kernel is None or entry.kernel is kernel):
+                entry.active = max(0, entry.active - 1)
+                entry.last_used = time.monotonic()
+
+    def discard(
+        self,
+        key: tuple,
+        expected_kernel: Optional[PersistentPythonKernel] = None,
+    ) -> None:
+        with self._lock:
+            entry = self._entries.pop(key, None)
+            if entry is not None and (
+                expected_kernel is None or entry.kernel is expected_kernel
+            ):
+                removed = entry.kernel
+            elif entry is not None:
+                self._entries[key] = entry
+                removed = None
+            else:
+                removed = None
+        if removed is not None:
+            removed.close()
+
+    def dispose_scope(self, scope_id: str, profile_key: Optional[str] = None) -> None:
+        victims = []
+        with self._lock:
+            profiles = {entry.profile_key for entry in self._entries.values() if entry.scope_id == scope_id}
+            profiles.update(
+                pending.profile_key
+                for pending in self._pending.values()
+                if pending.scope_id == scope_id
+            )
+            if profile_key is not None:
+                profiles.add(profile_key)
+            for profile in profiles:
+                if profile_key is None or profile == profile_key:
+                    scope_key = (scope_id, profile)
+                    self._scope_generations[scope_key] = self._scope_generations.get(scope_key, 0) + 1
+            for key, entry in list(self._entries.items()):
+                if entry.scope_id != scope_id:
+                    continue
+                if profile_key is not None and entry.profile_key != profile_key:
+                    continue
+                victims.append(entry.kernel)
+                self._entries.pop(key, None)
+            for key, pending in list(self._pending.items()):
+                if pending.scope_id != scope_id:
+                    continue
+                if profile_key is not None and pending.profile_key != profile_key:
+                    continue
+                pending.invalidated = True
+                pending.event.set()
+                self._pending.pop(key, None)
+        for victim in victims:
+            victim.close()
+
+    def close_all(self) -> None:
+        with self._lock:
+            victims = [entry.kernel for entry in self._entries.values()]
+            self._entries.clear()
+            for pending in self._pending.values():
+                pending.invalidated = True
+                pending.event.set()
+            self._pending.clear()
+            self._scope_generations = {
+                scope: generation + 1
+                for scope, generation in self._scope_generations.items()
+            }
+        for victim in victims:
+            victim.close()
+
+    def size(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+    def reap_idle(self, now: Optional[float] = None) -> int:
+        current = time.monotonic() if now is None else now
+        victims = []
+        with self._lock:
+            for key, entry in list(self._entries.items()):
+                if (
+                    entry.active == 0
+                    and current - entry.last_used > entry.idle_seconds
+                ):
+                    victims.append(entry.kernel)
+                    self._entries.pop(key, None)
+        for victim in victims:
+            victim.close()
+        return len(victims)
+
+    def _evict_lru_locked(self, max_live: int, preserve: tuple) -> list[PersistentPythonKernel]:
+        victims = []
+        limit = max(1, int(max_live))
+        while len(self._entries) > limit:
+            candidates = [
+                (key, entry) for key, entry in self._entries.items()
+                if key != preserve and entry.active == 0
+            ]
+            if not candidates:
+                break
+            key, entry = min(candidates, key=lambda item: item[1].last_used)
+            self._entries.pop(key, None)
+            victims.append(entry.kernel)
+        return victims
+
+    def _start_reaper_locked(self) -> None:
+        if self._reaper_started:
+            return
+        self._reaper_started = True
+        threading.Thread(target=self._reaper_loop, daemon=True).start()
+
+    def _reaper_loop(self) -> None:
+        while True:
+            time.sleep(min(60.0, max(1.0, self._idle_seconds / 2)))
+            self.reap_idle()
+
+
+kernel_registry = KernelRegistry()
+atexit.register(kernel_registry.close_all)
+
+
+def _runner_send(protocol, frame: dict, lock: threading.Lock) -> None:
+    data = _FRAME_PREFIX + json.dumps(frame, ensure_ascii=False).encode("utf-8") + b"\n"
+    with lock:
+        protocol.write(data)
+        protocol.flush()
+
+
+def _runner_output_drain(pipe, stream_name: str, current_id, protocol, lock) -> None:
+    while True:
+        data = os.read(pipe, 4096)
+        if not data:
+            return
+        request_id = current_id[0]
+        if request_id:
+            _runner_send(
+                protocol,
+                {
+                    "type": stream_name,
+                    "id": request_id,
+                    "data": base64.b64encode(data).decode("ascii"),
+                },
+                lock,
+            )
+
+
+def _runner_eval(code: str, namespace: dict) -> None:
+    tree = ast.parse(code, filename="<cell>", mode="exec")
+    body = list(tree.body)
+    last_expr = body.pop() if body and isinstance(body[-1], ast.Expr) else None
+    flags = ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
+    if body:
+        prefix = ast.Module(body=body, type_ignores=[])
+        ast.fix_missing_locations(prefix)
+        value = eval(compile(prefix, "<cell>", "exec", flags=flags), namespace)
+        if inspect.isawaitable(value):
+            asyncio.run(value)
+    if last_expr is not None:
+        expression = ast.Expression(last_expr.value)
+        ast.fix_missing_locations(expression)
+        value = eval(compile(expression, "<cell>", "eval", flags=flags), namespace)
+        if inspect.isawaitable(value):
+            value = asyncio.run(value)
+        namespace["_"] = value
+        if value is not None:
+            print(repr(value))
+
+
+def _format_runner_exception(exc: BaseException) -> str:
+    formatted = traceback.TracebackException.from_exception(exc)
+    runner_path = os.path.realpath(__file__)
+    formatted.stack = traceback.StackSummary.from_list(
+        frame
+        for frame in formatted.stack
+        if os.path.realpath(frame.filename) != runner_path
+    )
+    return "".join(formatted.format())
+
+
+def run_kernel() -> None:
+    protocol = os.fdopen(os.dup(1), "wb", buffering=0)  # windows-footgun: ok
+    send_lock = threading.Lock()
+    current_id = [None]
+    stdout_read, stdout_write = os.pipe()
+    stderr_read, stderr_write = os.pipe()
+    os.dup2(stdout_write, 1)
+    os.dup2(stderr_write, 2)
+    os.close(stdout_write)
+    os.close(stderr_write)
+    sys.stdout = os.fdopen(os.dup(1), "w", encoding="utf-8", buffering=1)
+    sys.stderr = os.fdopen(os.dup(2), "w", encoding="utf-8", buffering=1)
+    threading.Thread(
+        target=_runner_output_drain,
+        args=(stdout_read, "stdout", current_id, protocol, send_lock),
+        daemon=True,
+    ).start()
+    threading.Thread(
+        target=_runner_output_drain,
+        args=(stderr_read, "stderr", current_id, protocol, send_lock),
+        daemon=True,
+    ).start()
+
+    def _no_input(*_args, **_kwargs):
+        raise RuntimeError("input() is unavailable inside execute_code")
+
+    namespace = {
+        "__name__": "__main__",
+        "__builtins__": dict(vars(builtins), input=_no_input),
+    }
+    managed_env: set[str] = set()
+    managed_paths: list[str] = []
+    _runner_send(protocol, {"type": "ready"}, send_lock)
+    for raw in sys.stdin.buffer:
+        try:
+            request = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if request.get("type") == "shutdown":
+            return
+        if request.get("type") != "execute":
+            continue
+        request_id = str(request.get("id") or "")
+        current_id[0] = request_id
+        try:
+            requested_env = request.get("env") or {}
+            for key in managed_env - set(requested_env):
+                os.environ.pop(key, None)
+            for key, value in requested_env.items():
+                os.environ[str(key)] = str(value)
+            managed_env = set(requested_env)
+            requested_paths = [str(p) for p in request.get("python_paths") or [] if p]
+            for path in managed_paths:
+                while path in sys.path:
+                    sys.path.remove(path)
+            for path in reversed(requested_paths):
+                if path not in sys.path:
+                    sys.path.insert(0, path)
+            managed_paths = requested_paths
+            os.chdir(str(request.get("cwd") or os.getcwd()))
+            _runner_eval(str(request.get("code") or ""), namespace)
+        except BaseException as exc:
+            error = _format_runner_exception(exc)
+            print(error, file=sys.stderr, end="")
+            _runner_send(
+                protocol,
+                {"type": "error", "id": request_id, "error": error},
+                send_lock,
+            )
+        finally:
+            try:
+                sys.stdout.flush()
+                sys.stderr.flush()
+            except Exception:
+                pass
+            time.sleep(0.01)
+            os.environ.pop("HERMES_RPC_SOCKET", None)
+            os.environ.pop("HERMES_RPC_TOKEN", None)
+            managed_env.discard("HERMES_RPC_SOCKET")
+            managed_env.discard("HERMES_RPC_TOKEN")
+            _runner_send(protocol, {"type": "done", "id": request_id}, send_lock)
+            current_id[0] = None
+
+
+if __name__ == "__main__" and "--runner" in sys.argv:
+    run_kernel()

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -8,10 +8,10 @@ collapsing multi-step tool chains into a single inference turn.
 Architecture (two transports):
 
   **Local backend (UDS):**
-  1. Parent generates a `hermes_tools.py` stub module with UDS RPC functions
-  2. Parent opens a Unix domain socket and starts an RPC listener thread
-  3. Parent spawns a child process that runs the LLM's script
-  4. Tool calls travel over the UDS back to the parent for dispatch
+  1. Parent creates one Python kernel per conversation
+  2. Each cell gets a fresh authenticated UDS/TCP RPC listener
+  3. Variables and imports remain in the child process between cells
+  4. Tool calls travel over RPC back to the parent for dispatch
 
   **Remote backends (file-based RPC):**
   1. Parent generates `hermes_tools.py` with file-based RPC stubs
@@ -24,7 +24,7 @@ Architecture (two transports):
 In both cases, only the script's stdout is returned to the LLM; intermediate
 tool results never enter the context window.
 
-Platform: Linux / macOS only (Unix domain sockets for local). Disabled on Windows.
+Platform: Linux, macOS, and Windows (loopback TCP is used on Windows).
 Remote execution additionally requires Python 3 in the terminal backend.
 """
 
@@ -513,6 +513,8 @@ _UDS_TRANSPORT_HEADER = '''\
 import json, os, socket, shlex, threading, time
 
 _sock = None
+_sock_endpoint = None
+_sock_token = None
 # The RPC server handles a single client connection serially and has no
 # request-id in the protocol, so concurrent _call() invocations from multiple
 # threads (e.g. ThreadPoolExecutor) would race on the shared socket and get
@@ -529,9 +531,16 @@ def _connect():
       - a string of the form ``tcp://127.0.0.1:<port>`` (Windows, where
         AF_UNIX is unreliable — the parent falls back to loopback TCP)
     """
-    global _sock
+    global _sock, _sock_endpoint, _sock_token
+    endpoint = os.environ["HERMES_RPC_SOCKET"]
+    token = os.environ.get("HERMES_RPC_TOKEN", "")
+    if _sock is not None and (endpoint != _sock_endpoint or token != _sock_token):
+        try:
+            _sock.close()
+        except OSError:
+            pass
+        _sock = None
     if _sock is None:
-        endpoint = os.environ["HERMES_RPC_SOCKET"]
         if endpoint.startswith("tcp://"):
             # tcp://host:port  (host is always 127.0.0.1 in practice — we
             # only bind loopback server-side)
@@ -543,6 +552,8 @@ def _connect():
             _sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             _sock.connect(endpoint)
         _sock.settimeout(300)
+        _sock_endpoint = endpoint
+        _sock_token = token
     return _sock
 
 def _call(tool_name, args):
@@ -676,14 +687,16 @@ def _rpc_server_loop(
                 continue
         if conn is None:
             return
-        conn.settimeout(300)
+        conn.settimeout(0.1)
 
         buf = b""
         while True:
             try:
                 chunk = conn.recv(65536)
             except socket.timeout:
-                break
+                if stop_event.is_set():
+                    break
+                continue
             if not chunk:
                 break
             buf += chunk
@@ -1252,7 +1265,7 @@ def _execute_remote(
 # Main entry point
 # ---------------------------------------------------------------------------
 
-def execute_code(
+def _execute_code_per_call(
     code: str,
     task_id: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
@@ -1744,6 +1757,358 @@ def execute_code(
             pass  # already cleaned up or never created
 
 
+def _persistent_child_environment(child_python: str) -> tuple[dict, list[str]]:
+    child_env = _scrub_child_env(os.environ)
+    child_env["PYTHONDONTWRITEBYTECODE"] = "1"
+    child_env["PYTHONIOENCODING"] = "utf-8"
+    child_env["PYTHONUTF8"] = "1"
+    timezone = os.getenv("HERMES_TIMEZONE", "").strip()
+    if timezone:
+        child_env["TZ"] = timezone
+    child_env.pop("HERMES_TIMEZONE", None)
+
+    from hermes_constants import apply_subprocess_home_env
+    apply_subprocess_home_env(child_env)
+
+    from tools.environments.local import _strip_hermes_owned_pythonpath
+    _strip_hermes_owned_pythonpath(child_env)
+    python_paths = []
+    hermes_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if _uses_hermes_python_environment(child_python):
+        python_paths.append(hermes_root)
+    elif child_python not in _external_env_logged:
+        _external_env_logged.add(child_python)
+        logger.info(
+            "execute_code: child interpreter %s is outside the Hermes "
+            "environment; hermes root omitted from PYTHONPATH",
+            child_python,
+        )
+    existing = child_env.get("PYTHONPATH", "")
+    if existing:
+        python_paths.extend(part for part in existing.split(os.pathsep) if part)
+    child_env["PYTHONPATH"] = os.pathsep.join(python_paths)
+    return child_env, python_paths
+
+
+def _open_local_rpc_server():
+    sock_path = None
+    if _IS_WINDOWS:
+        server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server_sock.bind(("127.0.0.1", 0))
+        host, port = server_sock.getsockname()[:2]
+        endpoint = f"tcp://{host}:{port}"
+    else:
+        sock_dir = "/tmp" if sys.platform == "darwin" else tempfile.gettempdir()
+        sock_path = os.path.join(sock_dir, f"hermes_rpc_{uuid.uuid4().hex}.sock")
+        server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server_sock.bind(sock_path)
+        os.chmod(sock_path, 0o600)
+        endpoint = sock_path
+    server_sock.listen(1)
+    return server_sock, endpoint, sock_path
+
+
+def _execute_code_persistent(
+    code: str,
+    *,
+    task_id: Optional[str],
+    execution_session_id: str,
+    enabled_tools: Optional[List[str]],
+    reset: bool,
+) -> str:
+    from hermes_constants import hermes_home_key
+    from tools.code_execution_kernel import (
+        KernelDiedError,
+        KernelStartupInterrupted,
+        KernelStartupTimeout,
+        PersistentPythonKernel,
+        kernel_registry,
+    )
+    from tools.interrupt import is_interrupted
+
+    cfg = _load_config()
+    timeout = float(cfg.get("timeout", DEFAULT_TIMEOUT))
+    max_tool_calls = int(cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS))
+    idle_seconds = float(cfg.get("kernel_idle_seconds", DEFAULT_KERNEL_IDLE_SECONDS))
+    max_live = int(cfg.get("max_live_kernels", DEFAULT_MAX_LIVE_KERNELS))
+    mode = _get_execution_mode()
+    child_python = _resolve_child_python(mode)
+    placeholder = tempfile.gettempdir()
+    child_cwd = _resolve_child_cwd(mode, placeholder, task_id=task_id or "")
+    if mode == "strict":
+        child_cwd = ""
+
+    session_tools = set(enabled_tools) if enabled_tools else set()
+    sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
+    if not sandbox_tools:
+        sandbox_tools = SANDBOX_ALLOWED_TOOLS
+    tools_source = generate_hermes_tools_module(list(sandbox_tools))
+    child_env, python_paths = _persistent_child_environment(child_python)
+    profile_key = hermes_home_key()
+    key = (
+        profile_key,
+        execution_session_id,
+        mode,
+        os.path.realpath(child_python),
+        tuple(sorted(sandbox_tools)),
+    )
+    if reset:
+        kernel_registry.dispose_scope(execution_session_id, profile_key)
+
+    exec_start = time.monotonic()
+    deadline = exec_start + timeout
+
+    def create_kernel():
+        return PersistentPythonKernel(
+            child_python,
+            child_cwd,
+            child_env,
+            tools_source,
+            deadline=deadline,
+            interrupted=is_interrupted,
+        )
+
+    kernel = None
+    acquired = False
+    server_sock = None
+    sock_path = None
+    stop_event = threading.Event()
+    rpc_thread = None
+    tool_call_log: list = []
+    tool_call_counter = [0]
+    try:
+        kernel, reused = kernel_registry.acquire(
+            key,
+            scope_id=execution_session_id,
+            profile_key=profile_key,
+            factory=create_kernel,
+            max_live=max_live,
+            idle_seconds=idle_seconds,
+            deadline=deadline,
+            interrupted=is_interrupted,
+        )
+        acquired = True
+        server_sock, endpoint, sock_path = _open_local_rpc_server()
+        rpc_token = secrets.token_urlsafe(32)
+        rpc_thread = threading.Thread(
+            target=propagate_context_to_thread(_rpc_server_loop),
+            args=(
+                server_sock,
+                task_id,
+                tool_call_log,
+                tool_call_counter,
+                max_tool_calls,
+                sandbox_tools,
+                stop_event,
+                rpc_token,
+            ),
+            daemon=True,
+        )
+        rpc_thread.start()
+        cell_env = dict(child_env)
+        cell_env["HERMES_RPC_SOCKET"] = endpoint
+        cell_env["HERMES_RPC_TOKEN"] = rpc_token
+
+        activity_state = {"last_touch": time.monotonic(), "start": exec_start}
+        try:
+            from tools.environments.base import touch_activity_if_due
+        except Exception:
+            touch_activity_if_due = None
+
+        def touch_activity():
+            if touch_activity_if_due is not None:
+                try:
+                    touch_activity_if_due(activity_state, "execute_code running")
+                except Exception:
+                    pass
+
+        result = kernel.execute(
+            code,
+            cwd=child_cwd or kernel.staging_dir,
+            env=cell_env,
+            python_paths=[
+                kernel.staging_dir,
+                *([child_cwd] if child_cwd else []),
+                *python_paths,
+            ],
+            deadline=deadline,
+            interrupted=is_interrupted,
+            stdout_limit=MAX_STDOUT_BYTES,
+            stderr_limit=MAX_STDERR_BYTES,
+            activity=touch_activity,
+        )
+        stdout_text, stdout_metadata = _assemble_stdout_result(
+            result.stdout_head,
+            result.stdout_tail,
+            total_bytes=result.stdout_total,
+        )
+        stderr_text = result.stderr.decode("utf-8", errors="replace")
+        from tools.ansi_strip import sanitize_display_text
+        stdout_text = sanitize_display_text(stdout_text)
+        stderr_text = sanitize_display_text(stderr_text)
+        from agent.redact import redact_sensitive_text
+        stdout_text = redact_sensitive_text(stdout_text, code_file=True)
+        stderr_text = redact_sensitive_text(stderr_text, code_file=True)
+        duration = round(time.monotonic() - exec_start, 2)
+        response: Dict[str, Any] = {
+            "status": result.status,
+            "output": stdout_text,
+            "exit_code": 0 if result.status == "success" else 1,
+            "tool_calls_made": tool_call_counter[0],
+            "duration_seconds": duration,
+            "persistent": True,
+            "kernel_reused": reused,
+        }
+        response.update(stdout_metadata)
+        if result.status == "timeout":
+            suffix = (
+                " and the Python kernel was reset"
+                if result.invalidate_kernel
+                else " before execution started"
+            )
+            message = f"Script timed out after {timeout:g}s{suffix}."
+            response["error"] = message
+            response["output"] = (
+                f"{stdout_text}\n\n⏰ {message}" if stdout_text else f"⏰ {message}"
+            )
+            if result.invalidate_kernel:
+                kernel_registry.discard(key, kernel)
+        elif result.status == "interrupted":
+            suffix = " — Python kernel reset" if result.invalidate_kernel else ""
+            response["output"] = stdout_text + f"\n[execution interrupted{suffix}]"
+            if result.invalidate_kernel:
+                kernel_registry.discard(key, kernel)
+        elif result.status == "error":
+            error = result.error or stderr_text or "Python execution failed"
+            response["error"] = error
+            if stderr_text:
+                response["output"] = stdout_text + "\n--- stderr ---\n" + stderr_text
+            hint = _sandbox_failure_hint(stderr_text or error, enabled_tools=sandbox_tools)
+            if hint:
+                response["hint"] = hint
+        return json.dumps(response, ensure_ascii=False)
+    except KernelStartupTimeout:
+        return json.dumps({
+            "status": "timeout",
+            "error": f"Python kernel did not start within {timeout:g}s.",
+            "output": f"⏰ Python kernel did not start within {timeout:g}s.",
+            "exit_code": 1,
+            "tool_calls_made": tool_call_counter[0],
+            "duration_seconds": round(time.monotonic() - exec_start, 2),
+            "persistent": True,
+        }, ensure_ascii=False)
+    except KernelStartupInterrupted:
+        return json.dumps({
+            "status": "interrupted",
+            "output": "[execution interrupted during Python kernel startup]",
+            "exit_code": 1,
+            "tool_calls_made": tool_call_counter[0],
+            "duration_seconds": round(time.monotonic() - exec_start, 2),
+            "persistent": True,
+        }, ensure_ascii=False)
+    except KernelDiedError as exc:
+        if kernel is not None:
+            kernel_registry.discard(key, kernel)
+        return json.dumps({
+            "status": "error",
+            "error": f"Python kernel stopped unexpectedly: {exc}",
+            "tool_calls_made": tool_call_counter[0],
+            "duration_seconds": round(time.monotonic() - exec_start, 2),
+            "persistent": True,
+        }, ensure_ascii=False)
+    except Exception as exc:
+        logger.error("persistent execute_code failed: %s", exc, exc_info=True)
+        if kernel is not None and not kernel.alive:
+            kernel_registry.discard(key, kernel)
+        return json.dumps({
+            "status": "error",
+            "error": str(exc),
+            "tool_calls_made": tool_call_counter[0],
+            "duration_seconds": round(time.monotonic() - exec_start, 2),
+            "persistent": True,
+        }, ensure_ascii=False)
+    finally:
+        stop_event.set()
+        if server_sock is not None:
+            try:
+                server_sock.close()
+            except OSError:
+                pass
+        if rpc_thread is not None:
+            rpc_thread.join(timeout=3)
+        if sock_path:
+            try:
+                os.unlink(sock_path)
+            except OSError:
+                pass
+        if acquired:
+            kernel_registry.release(key, kernel)
+
+
+def execute_code(
+    code: str,
+    task_id: Optional[str] = None,
+    enabled_tools: Optional[List[str]] = None,
+    execution_session_id: Optional[str] = None,
+    reset: bool = False,
+) -> str:
+    """Execute Python, retaining local state when a session identity is available."""
+    from tools.terminal_tool import _get_env_config, _docker_has_host_access
+
+    cfg = _load_config()
+    kernel_mode = _get_kernel_mode(cfg)
+    env_config = _get_env_config()
+    if (
+        env_config["env_type"] != "local"
+        or kernel_mode == "per_call"
+        or not execution_session_id
+    ):
+        result = json.loads(_execute_code_per_call(code, task_id, enabled_tools))
+        result.setdefault("persistent", False)
+        return json.dumps(result, ensure_ascii=False)
+
+    if not SANDBOX_AVAILABLE:
+        return tool_error("execute_code is unavailable in this environment")
+    if not code or not code.strip():
+        return tool_error(
+            "No code provided. execute_code requires a non-empty 'code' parameter."
+        )
+    from tools.approval import check_execute_code_guard
+    guard = check_execute_code_guard(
+        code,
+        "local",
+        has_host_access=_docker_has_host_access(env_config),
+    )
+    if not guard.get("approved", False):
+        return json.dumps({
+            "status": "error",
+            "error": guard.get("message") or "execute_code blocked by approval guard.",
+            "tool_calls_made": 0,
+            "duration_seconds": 0,
+            "persistent": True,
+        }, ensure_ascii=False)
+    if guard.get("user_approved"):
+        from tools.interrupt import clear_current_thread_interrupt
+        clear_current_thread_interrupt()
+    return _execute_code_persistent(
+        code,
+        task_id=task_id,
+        execution_session_id=execution_session_id,
+        enabled_tools=enabled_tools,
+        reset=reset,
+    )
+
+
+def dispose_code_execution_sessions(
+    execution_session_id: str,
+    profile_key: Optional[str] = None,
+) -> None:
+    if not execution_session_id:
+        return
+    from tools.code_execution_kernel import kernel_registry
+    kernel_registry.dispose_scope(execution_session_id, profile_key)
+
+
 def _kill_process_group(proc, escalate: bool = False):
     """Kill the child and its entire process tree (cross-platform via psutil)."""
     import psutil
@@ -1821,6 +2186,28 @@ def _load_config() -> dict:
 # and the config layer can reference the canonical set.
 EXECUTION_MODES = ("project", "strict")
 DEFAULT_EXECUTION_MODE = "project"
+KERNEL_MODES = ("session", "per_call")
+DEFAULT_KERNEL_MODE = "session"
+DEFAULT_KERNEL_IDLE_SECONDS = 1800
+DEFAULT_MAX_LIVE_KERNELS = 16
+
+
+def _get_kernel_mode(cfg: Optional[dict] = None) -> str:
+    value = str(
+        (cfg if cfg is not None else _load_config()).get(
+            "kernel_mode", DEFAULT_KERNEL_MODE
+        )
+    ).strip().lower().replace("-", "_")
+    if value in KERNEL_MODES:
+        return value
+    logger.warning(
+        "Ignoring code_execution.kernel_mode=%r (expected one of %s), "
+        "falling back to %r",
+        value,
+        KERNEL_MODES,
+        DEFAULT_KERNEL_MODE,
+    )
+    return DEFAULT_KERNEL_MODE
 
 
 def _get_execution_mode() -> str:
@@ -2074,7 +2461,8 @@ _TOOL_DOC_LINES = [
 
 
 def build_execute_code_schema(enabled_sandbox_tools: set = None,
-                              mode: str = None) -> dict:
+                              mode: str = None,
+                              kernel_mode: str = None) -> dict:
     """Build the execute_code schema with description listing only enabled tools.
 
     When tools are disabled via ``hermes tools`` (e.g. web is turned off),
@@ -2091,6 +2479,8 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         enabled_sandbox_tools = SANDBOX_ALLOWED_TOOLS
     if mode is None:
         mode = _get_execution_mode()
+    if kernel_mode is None:
+        kernel_mode = _get_kernel_mode()
 
     # Build tool documentation lines for only the enabled tools
     tool_lines = "\n".join(
@@ -2119,6 +2509,13 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
             "Scripts run in the session's working directory with the active venv's python, "
             "so project deps (pandas, etc.) and relative paths work like in terminal()."
         )
+    if kernel_mode == "session":
+        lifetime_note = (
+            "On the local backend, variables, imports, and function definitions persist "
+            "across calls in this conversation. Set reset=true to start a fresh kernel."
+        )
+    else:
+        lifetime_note = "Each call starts a fresh Python process."
 
     description = (
         "Run a Python script that calls Hermes tools programmatically. "
@@ -2132,7 +2529,9 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "
         "terminal() is foreground-only (no background or pty).\n\n"
         f"{cwd_note}\n\n"
-        "Print your final result to stdout; stdlib (json, re, csv, datetime, ...) "
+        f"{lifetime_note}\n\n"
+        "Print your final result or leave it as the final expression; "
+        "stdlib (json, re, csv, datetime, ...) "
         "is available for processing.\n\n"
         "Built-in helpers (no import): json_parse(text) — tolerant json.loads for "
         "terminal() output; shell_quote(s) — shlex.quote for dynamic shell args; "
@@ -2150,8 +2549,16 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
                     "description": (
                         "Python code to execute. Import tools with "
                         f"`from hermes_tools import {import_str}` "
-                        "and print your final result to stdout."
+                        "and print your final result or leave it as the final expression."
                     ),
+                },
+                "reset": {
+                    "type": "boolean",
+                    "description": (
+                        "Reset this conversation's local Python kernel before "
+                        "running the code. Ignored on per-call and remote backends."
+                    ),
+                    "default": False,
                 },
             },
             "required": ["code"],
@@ -2196,10 +2603,20 @@ def _execute_code_handler(args: dict, **kwargs) -> str:
             "execute_code(code=\"...\")."
         )
 
+    reset = args.get("reset", False)
+    if not isinstance(reset, bool):
+        return tool_error(
+            "execute_code 'reset' must be true or false."
+        )
+
     return execute_code(
         code=code or "",
         task_id=kwargs.get("task_id"),
         enabled_tools=kwargs.get("enabled_tools"),
+        execution_session_id=(
+            kwargs.get("code_execution_session_id") or kwargs.get("session_id")
+        ),
+        reset=reset,
     )
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -2501,35 +2501,45 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
     # temp-dir staging and hermes-agent's own python.
     if mode == "strict":
         cwd_note = (
-            "Scripts run in their own temp dir, not the session's CWD — use absolute paths "
+            "Code runs in its own temp dir, not the session's CWD — use absolute paths "
             "(os.path.expanduser('~/.hermes/.env')) or terminal()/read_file() for user files."
         )
     else:
         cwd_note = (
-            "Scripts run in the session's working directory with the active venv's python, "
+            "Code runs in the session's working directory with the active venv's python, "
             "so project deps (pandas, etc.) and relative paths work like in terminal()."
         )
     if kernel_mode == "session":
-        lifetime_note = (
-            "On the local backend, variables, imports, and function definitions persist "
-            "across calls in this conversation. Set reset=true to start a fresh kernel."
+        execution_note = (
+            "Run one Python cell. On the local backend, it executes in a conversation-scoped "
+            "persistent kernel: variables, imports, functions, and in-memory objects survive "
+            "across calls. Work incrementally — import or load once, then define, test, and "
+            "reuse prior names in later calls. After an error, fix and rerun only the failing "
+            "step. Use reset=true only when a fresh kernel is required."
+        )
+        code_note = (
+            "One Python cell to execute. Prior top-level names from this conversation are "
+            "available. Import tools with "
         )
     else:
-        lifetime_note = "Each call starts a fresh Python process."
+        execution_note = (
+            "Run a Python script in a fresh process. Each call starts with no prior Python state."
+        )
+        code_note = "Python code to execute in a fresh process. Import tools with "
 
     description = (
-        "Run a Python script that calls Hermes tools programmatically. "
-        "Use when you need 3+ tool calls with logic between them: "
+        f"{execution_note}\n\n"
+        "Use this for incremental computation, or call Hermes tools programmatically when "
+        "you need 3+ tool calls with logic between them: "
         "filtering/reducing large outputs before they enter context, "
         "conditional branching, or loops (N pages/files, retry on failure). "
         "Use normal tool calls for single calls, results you must reason "
         "over in full, or anything needing user interaction.\n\n"
         f"Available via `from hermes_tools import ...`:\n\n"
         f"{tool_lines}\n\n"
-        "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "
+        "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per call. "
         "terminal() is foreground-only (no background or pty).\n\n"
         f"{cwd_note}\n\n"
-        f"{lifetime_note}\n\n"
         "Print your final result or leave it as the final expression; "
         "stdlib (json, re, csv, datetime, ...) "
         "is available for processing.\n\n"
@@ -2547,9 +2557,9 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
                 "code": {
                     "type": "string",
                     "description": (
-                        "Python code to execute. Import tools with "
-                        f"`from hermes_tools import {import_str}` "
-                        "and print your final result or leave it as the final expression."
+                        code_note
+                        + f"`from hermes_tools import {import_str}` "
+                        + "and print your final result or leave it as the final expression."
                     ),
                 },
                 "reset": {

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2174,14 +2174,24 @@ Configure the `execute_code` tool:
 ```yaml
 code_execution:
   mode: project                # project (default) | strict
-  timeout: 300                 # Max execution time in seconds
-  max_tool_calls: 50           # Max tool calls within code execution
+  kernel_mode: session         # session (default) | per_call
+  kernel_idle_seconds: 1800    # Reap inactive local kernels
+  max_live_kernels: 16         # Process-wide local-kernel bound
+  timeout: 300                 # Max execution time per call
+  max_tool_calls: 50           # Max tool calls per call
 ```
 
 **`mode`** controls the working directory and Python interpreter for scripts:
 
 - **`project`** (default) — scripts run in the session's working directory with the active virtualenv/conda env's python. Project deps (`pandas`, `torch`, project packages) and relative paths (`.env`, `./data.csv`) resolve naturally, matching what `terminal()` sees.
 - **`strict`** — scripts run in a temp staging directory with `sys.executable` (Hermes's own python). Maximum reproducibility, but project deps and relative paths won't resolve.
+
+**`kernel_mode`** controls local Python state:
+
+- **`session`** (default) — variables, imports, functions, and objects persist across `execute_code` calls in one conversation. A call with `reset: true`, `/new`, session teardown, timeout, interrupt, or kernel crash starts a fresh kernel.
+- **`per_call`** — every call starts a fresh Python process, matching the legacy behavior. Remote terminal backends always use this behavior.
+
+`kernel_idle_seconds` and `max_live_kernels` bound persistent processes in long-running gateways. Idle kernels are reaped after the configured interval, and the least-recently-used inactive kernel is closed when the process-wide cap is exceeded.
 
 Environment scrubbing (strips `*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, `*_CREDENTIAL`, `*_PASSWD`, `*_AUTH`) and the tool whitelist apply identically in both modes — switching mode does not change the security posture.
 

--- a/website/docs/user-guide/features/code-execution.md
+++ b/website/docs/user-guide/features/code-execution.md
@@ -6,15 +6,15 @@ description: "Programmatic Python execution with RPC tool access — collapse mu
 
 # Code Execution (Programmatic Tool Calling)
 
-The `execute_code` tool lets the agent write Python scripts that call Hermes tools programmatically, collapsing multi-step workflows into a single LLM turn. The script runs in a child process on the agent host, communicating with Hermes over a Unix domain socket RPC.
+The `execute_code` tool lets the agent write Python that calls Hermes tools programmatically, collapsing multi-step workflows into a single LLM turn. On the local backend, each conversation owns a persistent child Python process and each call uses a fresh authenticated RPC connection to Hermes.
 
 ## How It Works
 
 1. The agent writes a Python script using `from hermes_tools import ...`
 2. Hermes generates a `hermes_tools.py` stub module with RPC functions
-3. Hermes opens a Unix domain socket and starts an RPC listener thread
-4. The script runs in a child process — tool calls travel over the socket back to Hermes
-5. Only the script's `print()` output is returned to the LLM; intermediate tool results never enter the context window
+3. Hermes opens a fresh local RPC endpoint for the call
+4. The code runs in the conversation's Python process — tool calls travel over RPC back to Hermes
+5. Printed output and the final expression's representation are returned to the LLM; intermediate tool results never enter the context window
 
 ```python
 # The agent can write scripts like:
@@ -28,6 +28,25 @@ print(summary)
 ```
 
 **Available tools inside scripts:** `web_search`, `web_extract`, `read_file`, `write_file`, `search_files`, `patch`, `terminal` (foreground only).
+
+## Persistent Local State
+
+With the default `code_execution.kernel_mode: session`, local calls behave like a notebook or REPL: variables, imports, functions, and in-memory objects remain available to later `execute_code` calls in the same conversation.
+
+```python
+# First call
+import pandas as pd
+rows = pd.read_csv("data.csv")
+
+# Later call in the same conversation
+rows.groupby("category")["amount"].sum()
+```
+
+Set `reset: true` on a call to discard that conversation's kernel before running the new code. `/new`, session teardown, a timeout, an interrupt, or a kernel crash also discards it. Ordinary Python exceptions do not: definitions and mutations made before the exception remain available for diagnosis and recovery.
+
+Kernels are isolated by Hermes profile and conversation. Subagents receive separate kernels. Context compression keeps the parent conversation's kernel because it preserves the conversation lineage.
+
+Remote terminal backends continue to run one fresh process per call. To restore that behavior locally, set `code_execution.kernel_mode: per_call`.
 
 ## When the Agent Uses This
 
@@ -159,7 +178,7 @@ Switching mode changes where scripts run and which interpreter runs them, not wh
 
 | Resource | Limit | Notes |
 |----------|-------|-------|
-| **Timeout** | 5 minutes (300s) | Script is killed with SIGTERM, then SIGKILL after 5s grace |
+| **Timeout** | 5 minutes (300s) | The running call is stopped and its local kernel is reset |
 | **Stdout** | 50 KB | Output truncated with `[output truncated at 50KB]` notice |
 | **Stderr** | 10 KB | Included in output on non-zero exit for debugging |
 | **Tool calls** | 50 per execution | Error returned when limit reached |
@@ -169,16 +188,19 @@ All limits are configurable via `config.yaml`:
 ```yaml
 # In ~/.hermes/config.yaml
 code_execution:
-  mode: project      # project (default) | strict
-  timeout: 300       # Max seconds per script (default: 300)
-  max_tool_calls: 50 # Max tool calls per execution (default: 50)
+  mode: project               # project (default) | strict
+  kernel_mode: session        # session (default) | per_call
+  kernel_idle_seconds: 1800   # Reap an inactive local kernel after 30 minutes
+  max_live_kernels: 16        # Process-wide LRU bound
+  timeout: 300                # Max seconds per call (default: 300)
+  max_tool_calls: 50          # Max tool calls per call (default: 50)
 ```
 
 ## How Tool Calls Work Inside Scripts
 
 When your script calls a function like `web_search("query")`:
 
-1. The call is serialized to JSON and sent over a Unix domain socket to the parent process
+1. The call is serialized to JSON and sent over the current call's authenticated local RPC endpoint
 2. The parent dispatches through the standard `handle_function_call` handler
 3. The result is sent back over the socket
 4. The function returns the parsed result


### PR DESCRIPTION
## Summary

`execute_code` currently starts every local invocation in a fresh Python process. That works for self-contained scripts, but it prevents agents from working iteratively: imports, functions, loaded datasets, intermediate objects, and debugging state disappear after every call.

This PR gives each conversation an isolated persistent Python kernel. Local `execute_code` calls can now build on earlier work like a REPL or notebook, while retaining fresh per-call RPC authorization, existing environment scrubbing, tool restrictions, timeouts, and output limits.

```python
# First execute_code call
import pandas as pd
trades = pd.read_csv("trades.csv")

# Later call in the same conversation
trades.groupby("token").profit.sum()
```

This makes `execute_code` substantially more useful for iterative data analysis, debugging, and multi-step programmatic tool use. Agents no longer need to repeat initialization, spill intermediate state into temporary files, or route large working sets back through the model context.

## Behavior

- Preserves variables, imports, functions, and in-memory objects across local calls in one conversation.
- Displays the final expression's representation and supports top-level `await`.
- Keeps state after ordinary Python exceptions so the agent can inspect and recover.
- Adds `reset: true` for an explicit fresh kernel.
- Resets automatically on `/new`, session teardown, timeout, interrupt, kernel crash, or Hermes shutdown.
- Isolates kernels by profile and conversation; subagents receive separate kernels.
- Preserves the parent kernel across context compression because the conversation lineage is unchanged.
- Leaves remote terminal backends on the existing per-call execution path.
- Provides `code_execution.kernel_mode: per_call` as a compatibility opt-out.

## Safety and lifecycle

Persistence does not widen the execution sandbox:

- Every call receives a fresh authenticated RPC endpoint with the current turn, session, task, and enabled-tool context. A cached `hermes_tools` module reconnects rather than retaining stale authorization.
- Existing child-environment scrubbing and the `execute_code` tool whitelist apply unchanged.
- Timeouts and interrupts invalidate the affected kernel so partially running work cannot leak into the next call.
- Kernel startup is coalesced per scope without globally blocking unrelated conversations.
- Generation-aware reset and disposal prevent an old invocation from deleting or resurrecting a replacement kernel during races.
- Process-group cleanup terminates subprocesses started by a kernel.
- Idle reaping and a process-wide LRU cap bound resource use in long-running gateways.

This extends the existing `execute_code` capability rather than adding another core model tool, and it does not mutate the system prompt or toolset during a conversation.

## Configuration

```yaml
code_execution:
  kernel_mode: session       # session (default) | per_call
  kernel_idle_seconds: 1800  # reap inactive local kernels
  max_live_kernels: 16       # process-wide local-kernel bound
```

## Validation

- `scripts/run_tests.sh tests/tools/test_code_execution_persistent.py tests/tools/test_code_execution_persistent_platforms.py tests/cli/test_cli_new_session.py tests/run_agent/test_run_agent.py tests/test_model_tools.py -q`
  - 331 passed, 2 skipped on Linux; the native persistence smokes run on the macOS and Windows CI lanes.
- Ruff passes for all changed Python implementation and test files.
- `git diff origin/main...HEAD --check` passes.
- A broader local suite run completed with 34,542 passing tests. Five failures were outside the changed paths and host-sensitive: three updater cases passed when rerun independently, while the existing Doctor/Vercel and Termux/container cases reproduce independently.
