### PR TITLE
fix(desktop): stop deleted profiles reconnecting

### DIFF
--- a/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
@@ -1,6 +1,7 @@
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { deleteProfile } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { retireLocalProfileGateways } from '@/store/gateway'
 import { $activeGatewayProfile, normalizeProfileKey, selectProfile, setActiveProfile } from '@/store/profile'
 
 // Thin wrapper over ConfirmDialog: owns the deleteProfile call, inherits
@@ -48,6 +49,7 @@ export function DeleteProfileDialog({
         // onDeleted refresh so our reset is the last write — a refreshActiveProfile
         // racing the (still-dying) backend can't clobber the pill back to it.
         const wasActive = normalizeProfileKey(profile.name) === normalizeProfileKey($activeGatewayProfile.get())
+        retireLocalProfileGateways(profile.name)
         await deleteProfile(profile.name)
         await onDeleted?.()
 

--- a/apps/desktop/src/app/profiles/index.test.tsx
+++ b/apps/desktop/src/app/profiles/index.test.tsx
@@ -3,6 +3,7 @@ import type * as Nanostores from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { deleteProfile } from '@/hermes'
+import { retireLocalProfileGateways } from '@/store/gateway'
 import { refreshProfiles, selectProfile, setActiveProfile } from '@/store/profile'
 import type { ProfileInfo } from '@/types/hermes'
 
@@ -37,6 +38,10 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/store/notifications', () => ({
   notify: vi.fn(),
   notifyError: vi.fn()
+}))
+
+vi.mock('@/store/gateway', () => ({
+  retireLocalProfileGateways: vi.fn()
 }))
 
 const { $activeGatewayProfile: activeGateway, $profileColors } = vi.hoisted(() => {
@@ -126,6 +131,11 @@ describe('ProfilesView', () => {
   })
 
   it('re-homes to default when the active profile is deleted', async () => {
+    const deleteProfileMock = vi.mocked(deleteProfile)
+    const retireLocalProfileGatewaysMock = vi.mocked(retireLocalProfileGateways)
+
+    deleteProfileMock.mockClear()
+    retireLocalProfileGatewaysMock.mockClear()
     vi.mocked(refreshProfiles).mockResolvedValue([makeProfile('default', true), makeProfile(NAMED_PROFILE)])
     activeGateway.set(NAMED_PROFILE)
 
@@ -133,6 +143,10 @@ describe('ProfilesView', () => {
     await deleteTheNamedProfile()
 
     await waitFor(() => expect(deleteProfile).toHaveBeenCalledWith(NAMED_PROFILE))
+    expect(retireLocalProfileGateways).toHaveBeenCalledWith(NAMED_PROFILE)
+    expect(retireLocalProfileGatewaysMock.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteProfileMock.mock.invocationCallOrder[0]
+    )
     await waitFor(() => expect(selectProfile).toHaveBeenCalledWith('default'))
     expect(setActiveProfile).toHaveBeenCalledWith('default')
   })

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -32,7 +32,8 @@ import {
   openGatewayForAgent,
   openGatewayForProfile,
   requestGatewayForAgent,
-  requestGatewayForProfile
+  requestGatewayForProfile,
+  retireLocalProfileGateways
 } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import {
@@ -280,6 +281,10 @@ export const host = {
     // backend can't clobber the pill back to the deleted profile).
     const wasActive = normalizeProfileKey(name) === normalizeProfileKey($activeGatewayProfile.get())
 
+    // A hover-warmed Bot Mode row owns a retained renderer socket. Retire it
+    // before Electron stops the profile backend so the socket closure cannot
+    // schedule a reconnect that resurrects the deleted profile.
+    retireLocalProfileGateways(name)
     await deleteProfile(name)
 
     if (wasActive) {

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -87,12 +87,14 @@ vi.mock('@/store/gateway', async () => {
       method,
       params,
       profile
-    }))
+    })),
+    retireLocalProfileGateways: vi.fn()
   }
 })
 
 const { host } = await import('./index')
-const { requestGatewayForAgent, requestGatewayForProfile } = await import('@/store/gateway')
+const { deleteProfile } = await import('@/hermes')
+const { requestGatewayForAgent, requestGatewayForProfile, retireLocalProfileGateways } = await import('@/store/gateway')
 const { $profiles, refreshProfiles } = await import('@/store/profile')
 
 const profile = (name: string): ProfileInfo => ({
@@ -112,6 +114,24 @@ afterEach(() => {
 })
 
 describe('connection-aware plugin host APIs', () => {
+  it('retires a profile gateway before deleting it', async () => {
+    const order: string[] = []
+
+    vi.mocked(retireLocalProfileGateways).mockImplementationOnce(() => {
+      order.push('retire')
+    })
+    vi.mocked(deleteProfile).mockImplementationOnce(async () => {
+      order.push('delete')
+
+      return { ok: true, path: '/profiles/worker' }
+    })
+
+    await host.deleteProfile('worker')
+
+    expect(order).toEqual(['retire', 'delete'])
+    expect(retireLocalProfileGateways).toHaveBeenCalledWith('worker')
+  })
+
   it('refreshes the profile inventory before asking Electron for routes', async () => {
     const getProfileRoutes = vi.fn(async () => [
       { connectionId: 'connection-local', mode: 'local', profile: 'desktop-primary', targetProfile: 'desktop-primary' },

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -51,6 +51,9 @@ const {
   disposeSecondariesForConnection,
   ensureActiveGatewayOpen,
   ensureGatewayForAgent,
+  openGatewayForProfile,
+  reconnectSecondaryGateways,
+  retireLocalProfileGateways,
   setPrimaryGateway
 } = await import('./gateway')
 
@@ -142,6 +145,52 @@ describe('disposeSecondariesForConnection', () => {
     disposeSecondariesForConnection('ghost')
 
     expect(gatewayMocks.instances[0].close).not.toHaveBeenCalled()
+  })
+})
+
+describe('retireLocalProfileGateways', () => {
+  it('retires both local profile scopes without touching the same-named remote agent', async () => {
+    const getConnection = vi.fn(async (profile: string) => descriptorFor('legacy-local', profile))
+
+    const getConnectionFor = vi.fn(
+      async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+        descriptorFor(connectionId, profile)
+    )
+
+    installDesktop({ getConnection, getConnectionFor })
+
+    await openGatewayForProfile('selena')
+    await ensureGatewayForAgent('local', 'selena')
+    await ensureGatewayForAgent('homelab', 'selena')
+
+    expect(gatewayMocks.instances).toHaveLength(3)
+    const connectionCallsBeforeRetire = getConnection.mock.calls.length + getConnectionFor.mock.calls.length
+
+    retireLocalProfileGateways('selena')
+
+    expect(gatewayMocks.instances[0].close).toHaveBeenCalledOnce()
+    expect(gatewayMocks.instances[1].close).toHaveBeenCalledOnce()
+    expect(gatewayMocks.instances[2].close).not.toHaveBeenCalled()
+
+    // A wake/reconnect sweep cannot redial either retired local scope. The
+    // homelab entry remains open and therefore also needs no extra dial.
+    reconnectSecondaryGateways()
+    await Promise.resolve()
+    expect(getConnection.mock.calls.length + getConnectionFor.mock.calls.length).toBe(connectionCallsBeforeRetire)
+  })
+
+  it('allows an explicit later access to create a fresh profile secondary', async () => {
+    const getConnection = vi.fn(async (profile: string) => descriptorFor('legacy-local', profile))
+
+    installDesktop({ getConnection })
+
+    await openGatewayForProfile('selena')
+    retireLocalProfileGateways('selena')
+    await openGatewayForProfile('selena')
+
+    expect(gatewayMocks.instances).toHaveLength(2)
+    expect(gatewayMocks.instances[0].close).toHaveBeenCalledOnce()
+    expect(gatewayMocks.instances[1].close).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -806,6 +806,43 @@ export function closeSecondaryGateways(): void {
   restoreActiveToPrimaryIfEvicted()
 }
 
+// A local profile can have two renderer-owned sockets: the legacy bare
+// profile scope and the explicit `local` registry scope. Profile deletion
+// stops their Electron backend processes, but a retained Secondary otherwise
+// sees that shutdown as a transient disconnect and starts its reconnect loop,
+// resurrecting the backend that was just deleted. Retire both local scopes
+// before the DELETE request while preserving same-named agents on remote,
+// cloud, or SSH connections.
+export function retireLocalProfileGateways(profile: string): void {
+  const name = String(profile || '').trim()
+
+  if (!name) {
+    return
+  }
+
+  const key = normKey(name)
+  const scopes = new Set([key, registryBackendScopeKey('local', key)])
+  let activeInvalidated = false
+
+  for (const scope of scopes) {
+    const entry = g.secondaries.get(scope)
+
+    if (!entry) {
+      continue
+    }
+
+    activeInvalidated ||= scope === g.activeKey
+    disposeSecondary(entry)
+    g.secondaries.delete(scope)
+  }
+
+  restoreActiveToPrimaryIfEvicted()
+
+  if (activeInvalidated) {
+    g.config?.onActiveConnectionInvalidated?.(g.primaryProfile, gatewayActivationEpoch())
+  }
+}
+
 // Registry lifecycle: a connection was removed or materially edited. Dispose
 // every secondary scoped to it (a removed remote/cloud source has no local
 // process to die, so without this its WebSocket stays open streaming ghost


### PR DESCRIPTION
## What does this PR do?

Desktop could keep a renderer-owned secondary gateway alive after deleting a named local profile. When Electron stopped that profile backend, the retained socket treated the shutdown as transient and reconnected, which recreated the backend and made the deleted bot reappear.

This change retires both local renderer socket scopes before profile deletion:

- the legacy bare profile scope
- the explicit `local` connection-registry scope

It applies the same lifecycle rule to the SDK/Bot Mode delete path and the normal Desktop profile dialog. Same-named agents on remote, Cloud, or SSH connections are preserved.

## Related Issue

Follow-up to #52279 and #88120.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add `retireLocalProfileGateways()` in `apps/desktop/src/store/gateway.ts` to dispose and evict both local scopes without touching other connections.
- Retire local profile gateways before deletion in `apps/desktop/src/sdk/index.ts` and `apps/desktop/src/app/profiles/delete-profile-dialog.tsx`.
- Add regression coverage for reconnect suppression, later explicit reopening, SDK ordering, and the normal profile-dialog path.

## How to Test

1. Open or prewarm a named local profile through Desktop/Bot Mode so its renderer gateway is retained.
2. Delete that profile from Bot Mode or the Desktop profile dialog.
3. Confirm the deleted profile backend is not started again, while a same-named agent on another connection remains available.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, focused Desktop UI tests, renderer typecheck, and targeted lint

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Passed:

- `vitest run --project ui src/store/gateway-connection-lifecycle.test.ts src/sdk/profile-routing.test.ts src/app/profiles/index.test.tsx` - 3 files, 18 tests
- `tsc -p . --noEmit`
- targeted ESLint on all six changed files

The full Desktop `npm run typecheck` could not complete in this isolated worktree because the existing shared dependency installation does not contain the Electron package/types. The renderer typecheck passed; GitHub CI can run the complete dependency-backed check.