### PR TITLE
feat(desktop): warn in About when the app build is out of sync with the runtime

### DIFF
--- a/apps/desktop/electron/bundle-skew.test.ts
+++ b/apps/desktop/electron/bundle-skew.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectBundleSkew, isFallbackCommit, type RunGit } from './bundle-skew'
+
+const REPO = '/repo'
+const STAMP = { commit: 'a'.repeat(40), source: 'ci' }
+
+function gitReturning(stdout: string, code = 0): RunGit {
+  return async () => ({ code, stderr: '', stdout })
+}
+
+describe('isFallbackCommit', () => {
+  it('matches the all-zero placeholder at any stamp length', () => {
+    expect(isFallbackCommit('0'.repeat(40))).toBe(true)
+    expect(isFallbackCommit('0'.repeat(7))).toBe(true)
+    expect(isFallbackCommit('a'.repeat(40))).toBe(false)
+  })
+})
+
+describe('detectBundleSkew', () => {
+  it('reports stale when desktop commits landed after the stamp', async () => {
+    const result = await detectBundleSkew(STAMP, gitReturning('3\n'), REPO)
+
+    expect(result).toEqual({ desktopCommitsBehind: 3, outOfSync: true })
+  })
+
+  it('passes the stamp range scoped to apps/desktop', async () => {
+    let seen: string[] = []
+    const git: RunGit = async args => {
+      seen = args
+
+      return { code: 0, stderr: '', stdout: '0' }
+    }
+
+    await detectBundleSkew(STAMP, git, REPO)
+
+    expect(seen).toEqual(['rev-list', '--count', `${STAMP.commit}..HEAD`, '--', 'apps/desktop'])
+  })
+
+  it('is quiet when no desktop commits follow the stamp', async () => {
+    const result = await detectBundleSkew(STAMP, gitReturning('0\n'), REPO)
+
+    expect(result).toEqual({ desktopCommitsBehind: 0, outOfSync: false })
+  })
+
+  it('is quiet without a stamp (dev runs)', async () => {
+    expect(await detectBundleSkew(null, gitReturning('9'), REPO)).toEqual({
+      desktopCommitsBehind: null,
+      outOfSync: false
+    })
+  })
+
+  it('is quiet on a fallback stamp (non-git build)', async () => {
+    const fallback = { commit: '0'.repeat(40), source: 'fallback' }
+
+    expect(await detectBundleSkew(fallback, gitReturning('9'), REPO)).toEqual({
+      desktopCommitsBehind: null,
+      outOfSync: false
+    })
+  })
+
+  it('is quiet when git fails (unknown commit, shallow clone, no git)', async () => {
+    expect(await detectBundleSkew(STAMP, gitReturning('', 128), REPO)).toEqual({
+      desktopCommitsBehind: null,
+      outOfSync: false
+    })
+  })
+
+  it('is quiet when git throws', async () => {
+    const git: RunGit = async () => {
+      throw new Error('spawn ENOENT')
+    }
+
+    expect(await detectBundleSkew(STAMP, git, REPO)).toEqual({
+      desktopCommitsBehind: null,
+      outOfSync: false
+    })
+  })
+
+  it('is quiet on unparsable rev-list output', async () => {
+    expect(await detectBundleSkew(STAMP, gitReturning('fatal: bad object'), REPO)).toEqual({
+      desktopCommitsBehind: null,
+      outOfSync: false
+    })
+  })
+})

--- a/apps/desktop/electron/bundle-skew.ts
+++ b/apps/desktop/electron/bundle-skew.ts
@@ -1,0 +1,84 @@
+/**
+ * Renderer-bundle skew detection.
+ *
+ * The desktop UI (including bundled plugins like Bot Mode) is compiled into
+ * the app binary at build time, while `hermes update` only moves the source
+ * tree. A user who updates from the terminal — or whose in-app update failed
+ * on the bundle-swap leg — ends up running a NEW runtime under an OLD
+ * renderer: About proudly reports the new Hermes version while the sidebar
+ * is missing the features that version shipped (the "no Bots tab after the
+ * Bot Mode update" reports).
+ *
+ * Detection: the packaged build carries install-stamp.json with the commit
+ * it was built from. If commits touching `apps/desktop/` exist in the source
+ * tree AFTER that stamp commit, the running renderer is provably missing
+ * desktop changes the installed runtime has:
+ *
+ *   git rev-list --count <stampCommit>..HEAD -- apps/desktop
+ *
+ * Scoping to `apps/desktop/` keeps this quiet for the common case where the
+ * repo advances with agent-only changes — a shell built before those is not
+ * stale in any way the user can see.
+ *
+ * Fail-quiet by design: no stamp (dev runs), a fallback all-zero stamp
+ * (non-git build), an unknown commit (stamp predates a shallow clone's
+ * history), or any git failure all report "not stale". This warning must
+ * never false-positive — it tells users their install is torn.
+ *
+ * Pure + injectable so it is testable without booting Electron or git.
+ */
+
+export interface BundleSkewStamp {
+  commit: string
+  /** write-build-stamp.mjs source tag — 'fallback' means the commit is fake. */
+  source?: null | string
+}
+
+export interface BundleSkewResult {
+  /** Commits under apps/desktop/ between the build stamp and HEAD (null = unknowable). */
+  desktopCommitsBehind: null | number
+  /** True only on positive proof that the renderer predates desktop changes in the tree. */
+  outOfSync: boolean
+}
+
+export type RunGit = (
+  args: string[],
+  options: { cwd: string }
+) => Promise<{ code: number; stderr: string; stdout: string }>
+
+const NOT_STALE: BundleSkewResult = { desktopCommitsBehind: null, outOfSync: false }
+
+/** Matches write-build-stamp.mjs's all-zero placeholder for non-git builds. */
+export function isFallbackCommit(commit: string): boolean {
+  return /^0{7,40}$/.test(commit)
+}
+
+export async function detectBundleSkew(
+  stamp: BundleSkewStamp | null,
+  runGit: RunGit,
+  repoRoot: string
+): Promise<BundleSkewResult> {
+  if (!stamp?.commit || stamp.source === 'fallback' || isFallbackCommit(stamp.commit)) {
+    return NOT_STALE
+  }
+
+  try {
+    const result = await runGit(['rev-list', '--count', `${stamp.commit}..HEAD`, '--', 'apps/desktop'], {
+      cwd: repoRoot
+    })
+
+    if (result.code !== 0) {
+      return NOT_STALE
+    }
+
+    const count = Number.parseInt(result.stdout.trim(), 10)
+
+    if (!Number.isFinite(count) || count <= 0) {
+      return { desktopCommitsBehind: Number.isFinite(count) ? count : null, outOfSync: false }
+    }
+
+    return { desktopCommitsBehind: count, outOfSync: true }
+  } catch {
+    return NOT_STALE
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -58,6 +58,7 @@ import {
 } from './bootstrap-platform'
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
+import { detectBundleSkew } from './bundle-skew'
 import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
@@ -14403,26 +14404,49 @@ function resolveHermesVersion() {
   return app.getVersion()
 }
 
+// Renderer-bundle skew: `hermes update` moves the SOURCE TREE, but the UI
+// (including bundled plugins like Bot Mode) is compiled into this binary at
+// build time. A terminal-side update — or an in-app update whose bundle-swap
+// leg failed — leaves the new runtime running under an old renderer, so About
+// shows the new version while the sidebar is missing that version's desktop
+// features. Compare the build stamp's commit against the tree, scoped to
+// apps/desktop/, and warn when the running renderer is provably behind.
+// Fail-quiet: dev runs (no stamp), non-git builds, and shallow-clone gaps all
+// report in-sync rather than risk a false "your install is torn" warning.
+async function detectRendererSkew() {
+  return detectBundleSkew(INSTALL_STAMP, runGit, resolveUpdateRoot())
+}
+
 // Re-resolve the live Hermes version and push it into the native About panel
 // just before showing it, so an in-place `hermes update` is reflected without
 // an app restart. macOS only — `showAboutPanel()` is a no-op elsewhere, and the
 // other platforms don't use this menu item.
 function showAboutPanelFresh() {
-  app.setAboutPanelOptions({
-    applicationName: APP_NAME,
-    applicationVersion: resolveHermesVersion(),
-    copyright: 'Copyright © 2026 Nous Research'
+  void detectRendererSkew().then(skew => {
+    app.setAboutPanelOptions({
+      applicationName: APP_NAME,
+      applicationVersion: skew.outOfSync
+        ? `${resolveHermesVersion()} — app build out of date, update the desktop app`
+        : resolveHermesVersion(),
+      copyright: 'Copyright © 2026 Nous Research'
+    })
+    app.showAboutPanel()
   })
-  app.showAboutPanel()
 }
 
-ipcMain.handle('hermes:version', async () => ({
-  appVersion: resolveHermesVersion(),
-  electronVersion: process.versions.electron,
-  nodeVersion: process.versions.node,
-  platform: process.platform,
-  hermesRoot: resolveUpdateRoot()
-}))
+ipcMain.handle('hermes:version', async () => {
+  const skew = await detectRendererSkew()
+
+  return {
+    appVersion: resolveHermesVersion(),
+    electronVersion: process.versions.electron,
+    nodeVersion: process.versions.node,
+    platform: process.platform,
+    hermesRoot: resolveUpdateRoot(),
+    bundleOutOfSync: skew.outOfSync,
+    bundleCommitsBehind: skew.desktopCommitsBehind
+  }
+})
 
 // ===========================================================================
 // Uninstall — remove the Chat GUI (and optionally the agent / user data).

--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -5,7 +5,7 @@ import { BrandMark } from '@/components/brand-mark'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { type Translations, useI18n } from '@/i18n'
-import { CheckCircle2, ExternalLink, Loader2, RefreshCw } from '@/lib/icons'
+import { AlertTriangle, CheckCircle2, ExternalLink, Loader2, RefreshCw } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import {
   $desktopVersion,
@@ -106,6 +106,17 @@ export function AboutSettings() {
             {version?.appVersion ? a.version(version.appVersion) : a.versionUnavailable}
           </p>
         </div>
+        {version?.bundleOutOfSync && (
+          <div className="mx-auto w-full max-w-2xl rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-left text-sm">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+              <div className="min-w-0">
+                <p className="font-medium">{a.bundleOutOfSync}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{a.bundleOutOfSyncDesc}</p>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="mx-auto mt-4 w-full max-w-2xl">

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -450,6 +450,11 @@ export interface DesktopVersionInfo {
   nodeVersion: string
   platform: string
   hermesRoot: string
+  /** True when the running renderer bundle predates desktop changes in the
+   *  installed source tree (runtime updated, app binary not rebuilt/swapped). */
+  bundleOutOfSync?: boolean
+  /** Commits under apps/desktop/ the running bundle is missing (null unknown). */
+  bundleCommitsBehind?: null | number
 }
 
 export type DesktopUninstallMode = 'full' | 'gui' | 'lite'

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -604,6 +604,9 @@ export const ar = defineLocale({
       heading: 'حول Hermes',
       version: value => `الإصدار ${value}`,
       versionUnavailable: 'الإصدار غير متاح',
+      bundleOutOfSync: 'إصدار التطبيق قديم',
+      bundleOutOfSyncDesc:
+        'تم تحديث وقت تشغيل Hermes، لكن تطبيق سطح المكتب نفسه لا يزال إصدارًا قديمًا — لن تظهر ميزات الواجهة الجديدة (مثل Bot Mode) حتى يتم تحديث التطبيق. شغّل التحديث أدناه لإعادة بناء التطبيق.',
       updates: 'التحديثات',
       checkNow: 'التحقق الآن',
       checking: 'جار التحقق...',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -562,6 +562,9 @@ export const en: Translations = {
       heading: 'Hermes Desktop',
       version: value => `Version ${value}`,
       versionUnavailable: 'Version unavailable',
+      bundleOutOfSync: 'App build out of date',
+      bundleOutOfSyncDesc:
+        'The Hermes runtime was updated, but the desktop app itself is still an older build — new interface features (like Bot Mode) will be missing until it updates. Run the update below to rebuild the app.',
       updates: 'Updates',
       checkNow: 'Check now',
       checking: 'Checking…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -644,6 +644,9 @@ export const ja = defineLocale({
       heading: 'Hermes Desktop',
       version: value => `バージョン ${value}`,
       versionUnavailable: 'バージョンを取得できません',
+      bundleOutOfSync: 'アプリのビルドが古くなっています',
+      bundleOutOfSyncDesc:
+        'Hermes ランタイムは更新されましたが、デスクトップアプリ自体は古いビルドのままです。アプリを更新するまで、新しいインターフェース機能(Bot Mode など)は表示されません。下の更新を実行してアプリを再ビルドしてください。',
       updates: '更新',
       checkNow: '今すぐ確認',
       checking: '確認中…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -458,6 +458,8 @@ export interface Translations {
       heading: string
       version: (value: string) => string
       versionUnavailable: string
+      bundleOutOfSync: string
+      bundleOutOfSyncDesc: string
       updates: string
       checkNow: string
       checking: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -631,6 +631,9 @@ export const zhHant = defineLocale({
       heading: 'Hermes Desktop',
       version: value => `版本 ${value}`,
       versionUnavailable: '版本不可用',
+      bundleOutOfSync: '應用程式建置版本過舊',
+      bundleOutOfSyncDesc:
+        'Hermes 執行環境已更新,但桌面應用程式本身仍是舊建置——在應用程式更新之前,新的介面功能(如 Bot Mode)不會顯示。請執行下方的更新以重新建置應用程式。',
       updates: '更新',
       checkNow: '立即檢查',
       checking: '檢查中…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -771,6 +771,9 @@ export const zh: Translations = {
       heading: 'Hermes Desktop',
       version: value => `版本 ${value}`,
       versionUnavailable: '版本不可用',
+      bundleOutOfSync: '应用构建版本过旧',
+      bundleOutOfSyncDesc:
+        'Hermes 运行时已更新,但桌面应用本身仍是旧构建——在应用更新之前,新的界面功能(如 Bot Mode)不会显示。请运行下方的更新以重新构建应用。',
       updates: '更新',
       checkNow: '立即检查',
       checking: '检查中…',


### PR DESCRIPTION
## Summary

The desktop About surfaces now warn when the running app binary is older than the installed Hermes runtime — the "updated to get Bot Mode but there's no Bots tab" state, where `hermes update` moved the source tree but the renderer bundle (which carries bundled plugins like Bot Mode at build time) was never rebuilt or swapped.

Root cause of the reports: About shows the live repo version (`resolveHermesVersion()` reads `hermes_cli/__init__.py`), so a terminal-side `hermes update` — or an in-app update whose bundle-swap leg failed — displays the new version while the user is still running an old renderer with no Bot Mode compiled in.

## Changes

- `apps/desktop/electron/bundle-skew.ts` (new): pure, injectable skew detector — compares the packaged `install-stamp.json` commit against the tree with `git rev-list --count <stamp>..HEAD -- apps/desktop`, so agent-only repo advances stay quiet. Fail-quiet on missing/fallback stamps and any git failure: this warning must never false-positive.
- `apps/desktop/electron/main.ts`: `hermes:version` IPC gains `bundleOutOfSync` / `bundleCommitsBehind`; the macOS native About panel suffixes the version line with "app build out of date, update the desktop app" when skewed.
- `apps/desktop/src/app/settings/about-settings.tsx`: amber warning banner under the version heading, pointing at the updater right below it.
- i18n: `bundleOutOfSync` / `bundleOutOfSyncDesc` in all 5 locales (en, ja, zh, zh-hant, ar).
- `apps/desktop/electron/bundle-skew.test.ts`: 9 tests covering the stale path, the arg shape, and every quiet path (no stamp, fallback stamp, git failure, git throw, unparsable output).

## Validation

| | Before | After |
|---|---|---|
| Runtime updated, old app binary | About shows new version, silence | Banner in Settings → About + native About suffix |
| Dev run (no stamp) / non-git build | n/a | quiet (no false alarm) |
| `vitest run electron/bundle-skew.test.ts` | — | 9/9 pass |
| `tsc -p tsconfig.electron.json` | pre-existing electron-types noise only | no new errors |

## Infographic

![App build out of sync warning](https://v3b.fal.media/files/b/0aa6bebf/2uDMulmObzTWwPfZ_pywi_1Ow4finR.png)
