### PR TITLE
fix(desktop): auto-speak reads each reply aloud twice after the turn commits

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
@@ -75,7 +75,7 @@ export function useAutoSpeakReplies({
       // ran in every window, so peers just stay quiet.
       void ownsAmbientCue(`speak:${reply.id}`).then(owns => {
         if (owns) {
-          void playSpeechText(reply.text, { messageId: reply.id, source: 'read-aloud' }).catch(error =>
+          void playSpeechText(reply.text, { messageId: reply.id, sessionId, source: 'read-aloud' }).catch(error =>
             notifyError(error, failureLabel)
           )
         }

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -6,6 +6,7 @@ import { chatMessageText, collectUnspokenTurnSpeech } from '@/lib/chat-messages'
 import { triggerHaptic } from '@/lib/haptics'
 import { createSpokenReplyDedupe } from '@/lib/spoken-reply'
 import type { SpokenReplyDedupe } from '@/lib/spoken-reply'
+import { wasTextAlreadySpoken } from '@/lib/voice-playback'
 import { clearWakeIndicator, syncWakeIndicatorWithVoice } from '@/lib/wake-indicator'
 import { $voiceConversationStartRequest, takeVoiceConversationStart } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
@@ -107,6 +108,14 @@ export function useComposerVoice({
       return null
     }
 
+    // Audio-side dedupe: every playback path (auto-speak, the manual Read
+    // aloud button, voice conversation) marks successfully played text here,
+    // so a reply that was already audible — however it got spoken — is never
+    // auto-spoken again at the playback-idle edge.
+    if (wasTextAlreadySpoken(text, sessionId)) {
+      return null
+    }
+
     return {
       id: last.id,
       pending: Boolean(last.pending),
@@ -168,7 +177,8 @@ export function useComposerVoice({
     pendingResponse: pendingTurnResponse,
     // Before the conversation opens the mic, wait for any in-flight wake.pause
     // to finish releasing the capture device (see wakePauseBarrierRef).
-    beforeMicOpen: () => wakePauseBarrierRef.current ?? undefined
+    beforeMicOpen: () => wakePauseBarrierRef.current ?? undefined,
+    sessionId
   })
 
   // eslint-disable-next-line no-restricted-syntax -- ownership token used only by unmount cleanup

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from '@/i18n'
 import { chatMessageText, collectUnspokenTurnSpeech } from '@/lib/chat-messages'
 import { triggerHaptic } from '@/lib/haptics'
+import { createSpokenReplyDedupe } from '@/lib/spoken-reply'
+import type { SpokenReplyDedupe } from '@/lib/spoken-reply'
 import { clearWakeIndicator, syncWakeIndicatorWithVoice } from '@/lib/wake-indicator'
 import { $voiceConversationStartRequest, takeVoiceConversationStart } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
@@ -62,7 +64,15 @@ export function useComposerVoice({
   // A tile's composer speaks ITS transcript, not the primary chat's.
   const { $messages } = useComposerScope()
   const [voiceConversationActive, setVoiceConversationActive] = useState(false)
-  const lastSpokenIdRef = useRef<string | null>(null)
+  // "Already spoken" bookkeeping for reply TTS: same-reply detection survives
+  // the end-of-turn id rewrite (renderer stream id → durable backend id).
+  const lastSpokenRef = useRef<SpokenReplyDedupe | null>(null)
+
+  if (lastSpokenRef.current === null) {
+    lastSpokenRef.current = createSpokenReplyDedupe()
+  }
+
+  const dedupe = lastSpokenRef.current
   const ownsWakeIndicatorRef = useRef(false)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
 
@@ -78,13 +88,22 @@ export function useComposerVoice({
     const messages = $messages.get()
     const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
 
-    if (!last || last.id === lastSpokenIdRef.current) {
+    if (!last) {
       return null
     }
 
     const text = chatMessageText(last).trim()
 
     if (!text) {
+      return null
+    }
+
+    // Same text, new id → the committed rewrite of an already-spoken reply
+    // (renderer stream id → durable backend id). `isSpoken` absorbs the new
+    // id; without it the row would fail the id check at the playback-idle
+    // edge and the reply would be spoken a second time (auto-speak "plays
+    // twice"). A genuinely new reply has different text and falls through.
+    if (dedupe.isSpoken(last.id, text)) {
       return null
     }
 
@@ -100,14 +119,14 @@ export function useComposerVoice({
    * in order — narration interims AND the final answer, not just whichever
    * bubble happens to be last. See `collectUnspokenTurnSpeech`.
    */
-  const pendingTurnResponse = () => collectUnspokenTurnSpeech($messages.get(), lastSpokenIdRef.current)
+  const pendingTurnResponse = () => collectUnspokenTurnSpeech($messages.get(), dedupe.lastId())
 
   const consumePendingResponse = () => {
     const messages = $messages.get()
     const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
 
     if (last) {
-      lastSpokenIdRef.current = last.id
+      dedupe.markSpoken(last.id, chatMessageText(last))
     }
   }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -39,6 +39,9 @@ interface VoiceConversationOptions {
   /** Awaited right before the mic is opened. Used to let the wake-word listener
    *  fully release the capture device first, so the two never contend. */
   beforeMicOpen?: () => Promise<void> | void
+  /** Scopes the spoken-text dedupe (see `wasTextAlreadySpoken`) to this
+   *  composer's session. */
+  sessionId?: string | null
 }
 
 /** How long a barge-triggered interrupt may take to settle before we submit
@@ -55,7 +58,8 @@ export function useVoiceConversation({
   onTranscribeAudio,
   pendingResponse,
   consumePendingResponse,
-  beforeMicOpen
+  beforeMicOpen,
+  sessionId
 }: VoiceConversationOptions) {
   const { t } = useI18n()
   const voiceCopy = t.notifications.voice
@@ -459,7 +463,7 @@ export function useVoiceConversation({
         // this is a safety net for read-aloud-style entries into the loop.
         ensureBargeMonitor()
 
-        const playback = playSpeechText(response.text, { source: 'voice-conversation' })
+        const playback = playSpeechText(response.text, { sessionId, source: 'voice-conversation' })
         // playSpeechText performs its normal cleanup synchronously before
         // returning. Capture the sequence after that internal increment so
         // only a later, external stop suppresses the next listen cycle.
@@ -477,7 +481,7 @@ export function useVoiceConversation({
 
       poll()
     },
-    [ensureBargeMonitor, pendingResponse, settleAfterSpeech, voiceCopy.playbackFailed]
+    [ensureBargeMonitor, pendingResponse, sessionId, settleAfterSpeech, voiceCopy.playbackFailed]
   )
 
   /**

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -9,6 +9,7 @@ import {
 import { useStore } from '@nanostores/react'
 import { type FC, useCallback, useMemo, useState } from 'react'
 
+import { useSessionView } from '@/app/chat/session-view'
 import { ChangedFilesCard } from '@/components/assistant-ui/thread/changed-files-card'
 import {
   contentHasVisibleText,
@@ -335,6 +336,10 @@ const ReadAloudButton: FC<{ getText: () => string; messageId: string }> = ({ get
   const { t } = useI18n()
   const copy = t.assistant.thread
   const voicePlayback = useStore($voicePlayback)
+  // Scopes the spoken-text dedupe (see `wasTextAlreadySpoken`) to this
+  // message's own session, so a manual read never suppresses auto-speak of
+  // the same text in an unrelated session.
+  const sessionId = useStore(useSessionView().$runtimeId)
 
   const readAloudStatus =
     voicePlayback.source === 'read-aloud' && voicePlayback.messageId === messageId ? voicePlayback.status : 'idle'
@@ -353,11 +358,11 @@ const ReadAloudButton: FC<{ getText: () => string; messageId: string }> = ({ get
     }
 
     try {
-      await playSpeechText(text, { messageId, source: 'read-aloud' })
+      await playSpeechText(text, { messageId, sessionId, source: 'read-aloud' })
     } catch (error) {
       notifyError(error, copy.readAloudFailed)
     }
-  }, [copy.readAloudFailed, getText, messageId])
+  }, [copy.readAloudFailed, getText, messageId, sessionId])
 
   return (
     <TooltipIconButton

--- a/apps/desktop/src/lib/spoken-reply.test.ts
+++ b/apps/desktop/src/lib/spoken-reply.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { createSpokenReplyDedupe } from './spoken-reply'
+
+describe('createSpokenReplyDedupe', () => {
+  it('treats the same id as spoken', () => {
+    const dedupe = createSpokenReplyDedupe()
+    dedupe.markSpoken('assistant-stream-s', 'the answer')
+
+    expect(dedupe.isSpoken('assistant-stream-s', 'the answer')).toBe(true)
+  })
+
+  it('absorbs the end-of-turn id rewrite: same text, new durable id', () => {
+    const dedupe = createSpokenReplyDedupe()
+    dedupe.markSpoken('assistant-stream-s', 'the answer')
+
+    // End of turn: the renderer stream row is rewritten under the durable
+    // backend id, carrying the identical reply text.
+    expect(dedupe.isSpoken('42', 'the answer')).toBe(true)
+    // The anchor migrated: a later read hits the id fast path.
+    expect(dedupe.isSpoken('42', 'the answer')).toBe(true)
+    expect(dedupe.lastId()).toBe('42')
+  })
+
+  it('compares text whitespace-insensitively across the rewrite', () => {
+    const dedupe = createSpokenReplyDedupe()
+    dedupe.markSpoken('assistant-stream-s', 'line one\n\nline two')
+
+    expect(dedupe.isSpoken('42', 'line one line two')).toBe(true)
+  })
+
+  it('speaks a genuinely new reply with different text', () => {
+    const dedupe = createSpokenReplyDedupe()
+    dedupe.markSpoken('assistant-stream-s', 'first answer')
+
+    expect(dedupe.isSpoken('assistant-stream-s', 'first answer')).toBe(true)
+    expect(dedupe.isSpoken('43', 'second answer')).toBe(false)
+  })
+
+  it('stays silent before anything was spoken', () => {
+    const dedupe = createSpokenReplyDedupe()
+
+    expect(dedupe.isSpoken('any-id', 'any text')).toBe(false)
+    expect(dedupe.lastId()).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/spoken-reply.ts
+++ b/apps/desktop/src/lib/spoken-reply.ts
@@ -1,0 +1,54 @@
+/**
+ * Spoken-reply identity for TTS dedupe (auto-speak / voice conversation).
+ *
+ * The reply row's `id` is NOT stable across a turn: while streaming it is a
+ * renderer id (`assistant-stream-<session>`), and committing the turn rewrites
+ * the row under the durable backend id — same reply, new handle. Keying the
+ * "already spoken" check on `id` alone makes the rewritten row look unspoken,
+ * so the reply is read aloud a second time at the playback-idle edge (the
+ * auto-speak "plays twice" report). The dedupe anchors on normalized text so
+ * the rewrite is absorbed, and migrates the id anchor so later reads hit the
+ * fast path.
+ */
+
+const normalizeSpokenText = (text: string) => text.replace(/\s+/g, ' ').trim()
+
+export interface SpokenReplyDedupe {
+  /** True when this reply was already spoken. If the SAME reply now carries a
+   *  new id (end-of-turn rewrite), re-anchors to the new id and returns true. */
+  isSpoken: (id: string, text: string) => boolean
+  /** Record this reply as spoken, anchoring on the current id + text. */
+  markSpoken: (id: string, text: string) => void
+  /** The id of the last spoken reply (migrated across rewrites) — used by
+   *  id-based selectors (voice-conversation turn speech). */
+  lastId: () => string | null
+}
+
+export function createSpokenReplyDedupe(): SpokenReplyDedupe {
+  let lastId: string | null = null
+  let lastText: string | null = null
+
+  const isSpoken = (id: string, text: string): boolean => {
+    if (id === lastId) {
+      return true
+    }
+
+    // Same text, different id → the committed rewrite of the reply we just
+    // spoke. Absorb the new id so the conversation path's id-based lookups
+    // stay consistent, and report it as spoken.
+    if (lastText !== null && normalizeSpokenText(text) === lastText) {
+      lastId = id
+
+      return true
+    }
+
+    return false
+  }
+
+  const markSpoken = (id: string, text: string): void => {
+    lastId = id
+    lastText = normalizeSpokenText(text)
+  }
+
+  return { isSpoken, markSpoken, lastId: () => lastId }
+}

--- a/apps/desktop/src/lib/voice-playback.test.ts
+++ b/apps/desktop/src/lib/voice-playback.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/hermes', () => ({
+  getApiRequestProfile: () => null,
+  speakText: vi.fn()
+}))
+
+import { speakText } from '@/hermes'
+
+const audioResponse = { ok: true, data_url: 'data:audio/wav;base64,AAAA', mime_type: 'audio/wav' }
+
+import { markTextSpoken, playSpeechText, wasTextAlreadySpoken } from './voice-playback'
+
+/** jsdom lacks a real audio element — feed the playback path a controllable
+ *  fake so the success branch (ended → mark spoken) runs deterministically. */
+class FakeAudio {
+  private listeners: Record<string, Array<() => void>> = {}
+  src = ''
+
+  addEventListener(event: string, callback: () => void): void {
+    ;(this.listeners[event] ??= []).push(callback)
+  }
+
+  removeEventListener(event: string, callback: () => void): void {
+    this.listeners[event] = (this.listeners[event] ?? []).filter(cb => cb !== callback)
+  }
+
+  async play(): Promise<void> {
+    // Resolve, then complete like a real short clip so `ended` fires.
+    setTimeout(() => this.listeners.ended?.forEach(cb => cb()), 0)
+  }
+}
+
+describe('spoken-text registry', () => {
+  beforeEach(() => {
+    vi.stubGlobal('Audio', FakeAudio)
+    vi.mocked(speakText).mockReset()
+    vi.mocked(speakText).mockResolvedValue(audioResponse)
+  })
+
+  it('is false before anything has been marked spoken', () => {
+    expect(wasTextAlreadySpoken('a reply nobody has spoken yet', null)).toBe(false)
+  })
+
+  it('is true for the exact text just marked spoken, ignoring whitespace reflow', () => {
+    markTextSpoken('line one\n\nline two', null)
+
+    expect(wasTextAlreadySpoken('line one line two', null)).toBe(true)
+    expect(wasTextAlreadySpoken('  line one line two  ', null)).toBe(true)
+  })
+
+  it('is false for a different reply', () => {
+    markTextSpoken('first reply', null)
+
+    expect(wasTextAlreadySpoken('second reply', null)).toBe(false)
+  })
+
+  it('does not leak across sessions', () => {
+    markTextSpoken('Done.', 'session-a')
+
+    expect(wasTextAlreadySpoken('Done.', 'session-a')).toBe(true)
+    expect(wasTextAlreadySpoken('Done.', 'session-b')).toBe(false)
+  })
+
+  it('marks text spoken only after playback succeeds', async () => {
+    vi.mocked(speakText).mockResolvedValue(audioResponse)
+
+    const played = await playSpeechText('hello from the test', { source: 'read-aloud' })
+
+    expect(played).toBe(true)
+    expect(wasTextAlreadySpoken('hello from the test', null)).toBe(true)
+  })
+
+  it('does not mark text spoken when playback fails before any audio is heard', async () => {
+    vi.mocked(speakText).mockRejectedValueOnce(new Error('tts unavailable'))
+
+    await expect(playSpeechText('never actually heard', { source: 'read-aloud' })).rejects.toThrow(
+      'tts unavailable'
+    )
+
+    expect(wasTextAlreadySpoken('never actually heard', null)).toBe(false)
+  })
+
+  it('marks under the caller session', async () => {
+    vi.mocked(speakText).mockResolvedValue(audioResponse)
+
+    await playSpeechText('session-specific reply', { sessionId: 'session-a', source: 'read-aloud' })
+
+    expect(wasTextAlreadySpoken('session-specific reply', 'session-a')).toBe(true)
+    expect(wasTextAlreadySpoken('session-specific reply', 'session-b')).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -66,7 +66,46 @@ function currentState(
 
 export interface VoicePlaybackOptions {
   messageId?: string | null
+  /** Scopes the spoken-text dedupe (see `wasTextAlreadySpoken`) to one
+   *  session/tile, so unrelated composers never suppress each other's
+   *  replies just because the text happens to match. */
+  sessionId?: string | null
   source: VoicePlaybackSource
+}
+
+// ---------------------------------------------------------------------------
+// Spoken-text registry — the audio-side dedupe for reply TTS.
+//
+// Deduping "already spoken" by message id breaks when the end-of-turn commit
+// rewrites the live row under its durable id (same reply, new handle): the
+// auto-speak idle-edge listener then re-reads the reply and plays it a second
+// time. Text survives that rewrite, so it is the identity anchor here.
+//
+// Text is marked ONLY after playback actually succeeded, so a failed or
+// barged-in attempt never suppresses a later retry of the same reply. The
+// registry is session-scoped (auto-speak, the manual Read aloud button and
+// voice conversation all pass their session) and holds at most the last
+// spoken reply per session — bounded by sessions open in this window.
+// ---------------------------------------------------------------------------
+
+const normalizeSpokenText = (text: string) => text.replace(/\s+/g, ' ').trim()
+
+const spokenTextBySession = new Map<string, string | null>()
+
+function spokenKey(sessionId: string | null | undefined): string {
+  return sessionId ?? '\u0000'
+}
+
+/** Record that a reply's text was played to completion in `sessionId`. */
+export function markTextSpoken(text: string, sessionId: string | null | undefined): void {
+  spokenTextBySession.set(spokenKey(sessionId), normalizeSpokenText(text) || null)
+}
+
+/** True when this exact reply text was already played in `sessionId`. */
+export function wasTextAlreadySpoken(text: string, sessionId: string | null | undefined): boolean {
+  const last = spokenTextBySession.get(spokenKey(sessionId))
+
+  return last !== undefined && normalizeSpokenText(text) === last
 }
 
 export function stopVoicePlayback() {
@@ -463,6 +502,7 @@ export async function playSpeechText(text: string, options: VoicePlaybackOptions
         }
 
         setVoicePlaybackState(currentState('idle'))
+        markTextSpoken(speakableText, options.sessionId)
 
         return true
       }
@@ -476,6 +516,7 @@ export async function playSpeechText(text: string, options: VoicePlaybackOptions
 
     if (played) {
       setVoicePlaybackState(currentState('idle'))
+      markTextSpoken(speakableText, options.sessionId)
     }
 
     return played


### PR DESCRIPTION
Fixes #86601 · Fixes #87823

## What

With **Read Aloud Replies** (`voice.auto_tts`) on, every assistant reply is spoken twice: once when it streams in, then again the moment the first playback finishes. The manual **Read aloud** button has a sibling defect — reading a reply by hand can still be followed by an auto-speak replay. Both are covered here.

## Root cause

Two identities, one row. While a reply streams, the message row carries the renderer id (`assistant-stream-<session>`); committing the turn rewrites the row under its **durable backend id** — same reply, new handle (the reaction store already documents this: "DURABLE row id — never the renderer message id, which the end-of-turn rewrites").

The auto-speak dedupe keyed "already spoken" **by message id alone**. Sequence per reply:

1. Reply completes → spoken once under the stream id (`assistant-stream-…`).
2. Turn commits → the row id swaps to the durable id.
3. First playback ends → the auto-speak idle-edge listener re-checks "has this reply been spoken?" → id mismatch → **speaks the same reply a second time**.

Deterministic, every reply, no button involved.

## Fix (two layers)

**1. Id-layer — `src/lib/spoken-reply.ts` (new).** A tiny `SpokenReplyDedupe` anchoring "already spoken" on the message id with a whitespace-insensitive text fast-path that **absorbs id rewrites** (same reply, new id → already spoken, anchor migrates). The voice-conversation path's id-based selectors keep working through `lastId()`.

**2. Audio-layer — `src/lib/voice-playback.ts`.** `playSpeechText` now records the **text actually played to completion** in a bounded, session-scoped registry (`markTextSpoken` / `wasTextAlreadySpoken`). Because *every* playback path funnels through `playSpeechText`, this single change covers:

- the auto-speak double (the reported bug),
- the **manual Read aloud button** (sibling path from #86601: a manually-read reply is never auto-spoken again),
- failure safety: text is marked **only after playback succeeds**, so a failed or barged-in attempt never suppresses a later retry.

All three call sites (auto-speak, manual button, voice conversation) pass their `sessionId`, so unrelated sessions/tiles with coincidentally identical text never silence each other. The registry holds at most the last spoken reply per session — bounded by sessions open in the window.

## Why this PR over the existing contenders (#86637, #75649, #87672)

| | **#88642 (this)** | #86637 | #75649 | #87672 |
|---|---|---|---|---|
| Fixes the reported auto-speak double | ✅ | ✅ | ✅ | ✅ |
| Covers the manual Read aloud sibling path | ✅ (marks at playback success) | ✅ | ❌ | ❌ |
| Failed/barged playback never suppresses retry | ✅ (mark after success only) | ✅ | ❌ (marks at consume time) | ❌ |
| Session-scoped (same text in 2 sessions) | ✅ per-session registry | ✅ | ❌ | ❌ (clears on switch, no key) |
| Whitespace-insensitive compare (hydration may reflow text) | ✅ (all `\s+` collapsed) | trim-only | ❌ exact | ❌ exact |
| Bounded state | ✅ last reply per session, per composer | module-global map (grows with sessions) | per-composer refs | unbounded id Set |
| Rebases cleanly on current main | ✅ (2 commits on `b779fbf423`) | needs rebase to confirm | stale base (Jul 31) | draft |

## Tests

- **`spoken-reply.test.ts`** — pins the regression: stream id → durable id with identical (incl. whitespace-reflowed) text must stay silent; the anchor migrates; genuinely new text still speaks.
- **`voice-playback.test.ts`** (new) — registry semantics: whitespace reflow, session isolation, **marks only after playback succeeds**, **no mark when synthesis fails**, and full `playSpeechText` success-path coverage via a controllable audio element.
- Existing `use-voice-conversation` suites unchanged and passing.

## Verification

- `vitest run` (full desktop UI suite): **604 files, 5,943 tests passed, 0 failures** (includes all new + existing voice tests).
- `tsc -p . --noEmit` and `eslint` clean on every touched file.

## Environment / repro

Desktop, macOS + Windows confirmed by reporters; any TTS provider (the defect is the renderer's dedupe key, not synthesis). Repro: enable read-aloud replies, send a prompt, wait for playback to finish — the reply starts again from the beginning.