### PR TITLE
fix(desktop): omit invalid SSH --profile composite keys

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8845,7 +8845,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     const lifecycle = platform.os === 'Windows' ? connectWindowsRemote : remoteLifecycle.connect
     result = await lifecycle({
       ssh,
-      profile: sshConfig.remoteProfile || connectionScopeKey(profile) || '',
+      profile: remoteLifecycle.remoteCliProfile(sshConfig.remoteProfile || connectionScopeKey(profile) || ''),
       remoteHermesPath: sshConfig.remoteHermesPath || '',
       ownershipId: sshOwnershipKey(profile),
       reuseToken: reuseToken || '',

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -20,6 +20,7 @@ import {
   PROTOCOL_VERSION,
   readLockfile,
   READY_RE,
+  remoteCliProfile,
   remotePidAlive,
   remoteSupportsSshOwnership,
   scrapeReadyPort,
@@ -253,6 +254,25 @@ test('metadata and process proof transport failures remain indeterminate', async
   )
 })
 
+test('pidIsOurDashboard treats a dead pid as FOREIGN instead of a transport error', async () => {
+  if (process.platform === 'win32') {
+    return
+  }
+
+  const { execFileSync } = await import('node:child_process')
+
+  const ssh = {
+    calls: [] as string[],
+    async exec(cmd: string) {
+      this.calls.push(cmd)
+
+      return execFileSync('bash', ['-lc', cmd], { encoding: 'utf8' })
+    }
+  }
+
+  assert.equal(await pidIsOurDashboard(ssh, 2_147_483_647, SPAWN_NONCE, '/x/hermes'), false)
+})
+
 test('pidIsOurDashboard requires the exact serve ownership nonce', async () => {
   const ours = `/x/hermes serve --isolated --ssh-owner-nonce ${SPAWN_NONCE}`
   assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'OWNED\n']]), 5, SPAWN_NONCE, '/x/hermes'), true)
@@ -312,6 +332,31 @@ test('buildSpawnCommand always uses serve (legacy dashboard path removed)', () =
   assert.doesNotMatch(cmd, /dashboard/)
   assert.doesNotMatch(cmd, /--skip-build/)
   assert.match(cmd, /setsid/)
+})
+
+test('remoteCliProfile accepts Hermes profile ids and drops desktop composite keys', () => {
+  assert.equal(remoteCliProfile('writer_2'), 'writer_2')
+  assert.equal(remoteCliProfile('default'), 'default')
+  assert.equal(remoteCliProfile('  coder '), 'coder')
+  assert.equal(remoteCliProfile(''), '')
+  assert.equal(remoteCliProfile('conn:yun3d::default'), '')
+  assert.equal(remoteCliProfile('conn:homelab::research'), '')
+})
+
+test('buildSpawnCommand never passes a desktop composite scope as --profile', () => {
+  const cmd = buildSpawnCommand('/x/hermes', 'conn:yun3d::default', {
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+  })
+
+  assert.doesNotMatch(cmd, /--profile/)
+  assert.doesNotMatch(cmd, /conn:yun3d/)
+  assert.match(cmd, /serve --isolated/)
+})
+
+test('buildSpawnCommand still pins a valid remote profile name', () => {
+  const cmd = buildSpawnCommand('/x/hermes', 'writer_2', { logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE) })
+  assert.match(cmd, /--profile/)
+  assert.match(cmd, /writer_2/)
 })
 
 test('spawnRemoteDashboard returns exact ownership artifacts', async () => {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -362,6 +362,17 @@ async function remotePidAlive(ssh, pid) {
   }
 }
 
+// Mirrors hermes_cli.profiles._PROFILE_ID_RE / desktop PROFILE_NAME_RE.
+// Desktop routing keys (`conn:<id>::<profile>`) are valid pool/ownership ids
+// and invalid remote --profile values — omit the flag rather than spawn-fail.
+const REMOTE_CLI_PROFILE_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+function remoteCliProfile(profile) {
+  const value = String(profile ?? '').trim()
+
+  return REMOTE_CLI_PROFILE_RE.test(value) ? value : ''
+}
+
 // A pid is "provably ours" only if its remote cmdline carries our dashboard
 // args — never kill a pid we can't positively identify as our dashboard.
 async function pidIsOurDashboard(ssh, pid, spawnNonce, hermesPath = '') {
@@ -379,7 +390,11 @@ async function pidIsOurDashboard(ssh, pid, spawnNonce, hermesPath = '') {
       ' raw=open(f"/proc/{pid}/cmdline","rb").read()\n' +
       ' args=[x.decode("utf-8","surrogateescape") for x in raw.split(b"\\0") if x]\n' +
       'except OSError:\n' +
-      ' line=subprocess.check_output(["ps","-o","command=","-p",str(pid)],text=True).strip()\n' +
+      ' try:\n' +
+      '  line=subprocess.check_output(["ps","-o","command=","-p",str(pid)],text=True).strip()\n' +
+      ' except Exception:\n' +
+      '  print("FOREIGN")\n' +
+      '  raise SystemExit\n' +
       ' args=shlex.split(line)\n' +
       'ok=False\n' +
       'try:\n' +
@@ -441,7 +456,8 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
 // fd-detachment is already handled by </dev/null + redirect + &).
 function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
   const hermes = expandRemotePath(hermesPath)
-  const profileArgs = profile ? `--profile ${shq(profile)} ` : ''
+  const cliProfile = remoteCliProfile(profile)
+  const profileArgs = cliProfile ? `--profile ${shq(cliProfile)} ` : ''
   const logPath = expandRemotePath(opts.logPath)
   const tokenFilePath = opts.tokenFilePath
   const tokenArg = tokenFilePath ? ` --ssh-session-token-file ${expandRemotePath(tokenFilePath)}` : ''
@@ -893,6 +909,7 @@ export {
   readLockfile,
   READY_RE,
   REMOTE_LOCK_DIR,
+  remoteCliProfile,
   remotePidAlive,
   remoteSupportsSshOwnership,
   removeLockfile,

--- a/tests/test_ssh_remote_cli_profile.py
+++ b/tests/test_ssh_remote_cli_profile.py
@@ -1,0 +1,90 @@
+"""Class repro for #88625: desktop SSH must not pass conn:<id>::<profile> as --profile.
+
+Exercises the real buildSpawnCommand / ownership probe from apps/desktop
+(no MagicMock, no source-regex). After the desktop vitest lands, this file
+is the Gate-3 harness that run_tests_gated.sh can stamp.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+DESKTOP = REPO / "apps" / "desktop"
+OWNERSHIP_ID = "0123456789abcdef0123456789abcdef"
+SPAWN_NONCE = "0123456789abcdef"
+
+
+def _node_eval(script: str) -> subprocess.CompletedProcess[str]:
+    node = shutil.which("node")
+    assert node, "node is required to exercise desktop spawn helpers"
+    return subprocess.run(
+        [node, "--experimental-strip-types", "--input-type=module", "-e", script],
+        cwd=DESKTOP,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_build_spawn_command_omits_desktop_composite_scope_as_profile():
+    script = f"""
+import {{ buildSpawnCommand, spawnLogPath }} from './electron/remote-lifecycle.ts'
+const cmd = buildSpawnCommand('/x/hermes', 'conn:yun3d::default', {{
+  logPath: spawnLogPath({OWNERSHIP_ID!r}, {SPAWN_NONCE!r}),
+}})
+if (cmd.includes('--profile') || cmd.includes('conn:yun3d')) {{
+  console.error(cmd)
+  process.exit(2)
+}}
+if (!cmd.includes('serve --isolated')) {{
+  console.error(cmd)
+  process.exit(3)
+}}
+"""
+    result = _node_eval(script)
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_build_spawn_command_still_pins_a_valid_profile_name():
+    script = f"""
+import {{ buildSpawnCommand, spawnLogPath }} from './electron/remote-lifecycle.ts'
+const cmd = buildSpawnCommand('/x/hermes', 'writer_2', {{
+  logPath: spawnLogPath({OWNERSHIP_ID!r}, {SPAWN_NONCE!r}),
+}})
+if (!cmd.includes('--profile') || !cmd.includes('writer_2')) {{
+  console.error(cmd)
+  process.exit(2)
+}}
+"""
+    result = _node_eval(script)
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+@pytest.mark.linux_only
+def test_ownership_probe_dead_pid_is_foreign_not_a_crash():
+    """Dead PID must print FOREIGN (exit 0). CalledProcessError from ps is the bug."""
+    script = f"""
+import {{ pidIsOurDashboard }} from './electron/remote-lifecycle.ts'
+import {{ execFileSync }} from 'node:child_process'
+const ssh = {{
+  async exec(cmd) {{
+    try {{
+      return execFileSync('bash', ['-lc', cmd], {{ encoding: 'utf8' }})
+    }} catch (error) {{
+      throw error
+    }}
+  }},
+}}
+const owned = await pidIsOurDashboard(ssh, 2147483647, {SPAWN_NONCE!r}, '/x/hermes')
+if (owned !== false) {{
+  console.error('expected FOREIGN/false, got', owned)
+  process.exit(2)
+}}
+"""
+    result = _node_eval(script)
+    assert result.returncode == 0, result.stderr + result.stdout


### PR DESCRIPTION
## What does this PR do?

Desktop SSH registry dials were passing the internal pool key (`conn:<connectionId>::<profile>`) as remote `hermes --profile`. That string is not a valid Hermes profile name, so the remote CLI never started `serve` and the Bots roster stayed on `connect-on-demand`.

The remote `--profile` argument is now restricted to the same profile-id regex the CLI already uses. Composite routing keys stay as pool/SSH/ownership ids. When there is no valid remote profile, the flag is omitted (same as the existing empty-`remoteProfile` mapping for `default`).

A dead remote PID in the ownership probe is treated as FOREIGN instead of `Could not verify SSH backend process ownership.`

Residual: this does not change argparse's `invalid choice` wording if some other caller still leaves a bad `--profile` token on argv.

## Related Issue

Fixes #88625

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/remote-lifecycle.ts` — `remoteCliProfile()`; `buildSpawnCommand` only emits `--profile` for a valid name; ownership `ps` fallback prints FOREIGN on a missing PID
- `apps/desktop/electron/main.ts` — `bootstrapSshConnectionInner` sanitizes the lifecycle `profile` before Unix and Windows spawn
- `apps/desktop/electron/remote-lifecycle.test.ts` — composite key omitted; valid name still pinned; dead PID is FOREIGN
- `tests/test_ssh_remote_cli_profile.py` — hermetic runner over the same helpers

## How to Test

1. `scripts/run_tests.sh tests/test_ssh_remote_cli_profile.py -q --tb=line` — 3 passed
2. From `apps/desktop`: `npx vitest run electron/remote-lifecycle.test.ts` — 71 passed
3. Optional live: SSH connection without `remoteProfile`, dial `getGatewayWsUrlFor({ connectionId, profile: 'default' })`. Remote argv must not contain `--profile 'conn:…'`. Roster should list the remote bots after a successful dial.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu / Linux, Python 3.12.3, Node 22.22.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
