### PR TITLE
feat(desktop/bots): add disband (delete) for group chats

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2825,6 +2825,61 @@ function updateGroupChat(group, mutate) {
   return next
 }
 
+/** Soft-disband a group chat: clear every member's group assignment (the
+ *  grouping is bot-meta, so the disband syncs cross-machine via ui_meta),
+ *  drop the room log from the atom + plugin storage, and close the room view
+ *  if it's open. The members' per-group gateway sessions ("Group: <name>")
+ *  are intentionally KEPT — they stay reachable through each bot's session
+ *  browser. */
+async function disbandGroupChat(group, memberNames) {
+  // Invalidate any in-flight round-robin FIRST: bump the epoch so a running
+  // drive bails at its next member boundary instead of appending to a room
+  // the user just discarded.
+  const all = { ...$groupChats.get() }
+  const prior = all[group] || {}
+
+  delete all[group]
+  // Keep a runtime-only tombstone while a drive may still be mid-turn; it
+  // carries no log and is never persisted, so it can't rehydrate.
+  if (prior.running) {
+    all[group] = { log: [], watermarks: {}, sessions: {}, epoch: (prior.epoch || 0) + 1, running: false }
+  }
+
+  $groupChats.set(all)
+
+  if ($groupChatWorkspace.get() === group) {
+    $groupChatWorkspace.set(null)
+  }
+
+  const needs = { ...$groupNeedsYou.get() }
+
+  delete needs[group]
+  $groupNeedsYou.set(needs)
+
+  // Persist the room map WITHOUT the disbanded room so it can't come back
+  // on the next window load.
+  try {
+    const durable = {}
+
+    for (const [name, room] of Object.entries($groupChats.get())) {
+      if (name !== group && Array.isArray(room.log)) {
+        durable[name] = { log: room.log, watermarks: room.watermarks, sessions: room.sessions || {} }
+      }
+    }
+
+    await Promise.resolve(pluginCtx?.storage?.set?.('group-chats', durable))
+  } catch {
+    /* storage unavailable — the atom reset above still empties the room */
+  }
+
+  // Ungroup the members last. saveBotMeta never throws (local storage +
+  // best-effort profiles.configure per member), so a flaky gateway can't
+  // strand the disband halfway with the room log already gone.
+  for (const name of memberNames) {
+    await saveBotMeta(name, { group: null })
+  }
+}
+
 function appendGroupChatEntry(group, from, text) {
   const entry = { from, text: String(text).trim(), at: Date.now() }
 
@@ -6465,6 +6520,7 @@ function GroupChatWorkspace({ group, members }) {
   const allMeta = useValue($botMeta)
   const room = rooms[group] || { log: [], running: false }
   const [draft, setDraft] = useState('')
+  const [confirmDisband, setConfirmDisband] = useState(false)
 
   const header = jsxs('div', {
     className: 'flex items-center gap-2 px-2.5 pt-2.5 pb-2',
@@ -6482,6 +6538,14 @@ function GroupChatWorkspace({ group, members }) {
       jsx('span', {
         className: 'shrink-0 text-[0.65rem] text-(--ui-text-quaternary)',
         children: `${members.length} bots`
+      }),
+      jsx(Button, {
+        variant: 'ghost',
+        size: 'sm',
+        className: 'shrink-0 text-(--ui-text-tertiary) hover:text-destructive',
+        title: `Disband the ${group} group chat`,
+        onClick: () => setConfirmDisband(true),
+        children: jsx(Codicon, { name: 'trash' })
       })
     ]
   })
@@ -6574,6 +6638,30 @@ function GroupChatWorkspace({ group, members }) {
             jsx(Button, { type: 'submit', size: 'sm', disabled: !draft.trim(), children: 'Send' })
           ]
         })
+      }),
+      jsx(ConfirmDialog, {
+        open: confirmDisband,
+        title: 'Disband group chat?',
+        description: jsxs('span', {
+          children: [
+            'This removes the ',
+            jsx('span', { className: 'font-medium text-foreground', children: group }),
+            ' grouping from its ',
+            String(members.length),
+            ' bots and clears the shared room log. The bots themselves and their “Group: ',
+            group,
+            '” sessions are kept — you can still open those from each bot’s session browser.'
+          ]
+        }),
+        destructive: true,
+        confirmLabel: 'Disband',
+        busyLabel: 'Disbanding…',
+        doneLabel: 'Disbanded',
+        onClose: () => setConfirmDisband(false),
+        onConfirm: async () => {
+          await disbandGroupChat(group, members.map(bot => bot.name))
+          host.notify({ kind: 'success', message: `Disbanded “${group}”` })
+        }
       })
     ]
   })

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -62,11 +62,15 @@ function load(turnScript) {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, $groupChats, $groupNeedsYou, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
-  context.plugin.register({ storage: { get: () => null, set: () => undefined }, register: () => undefined })
-  return { ...context.__gc, calls }
+  const storageWrites = new Map()
+  context.plugin.register({
+    storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
+    register: () => undefined
+  })
+  return { ...context.__gc, calls, storageWrites }
 }
 
 const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }, { name: 'ops', title: 'The Ops' }]
@@ -242,4 +246,69 @@ test('source contract: workspace + header affordance + prompt rules are wired', 
   assert.match(pluginSource, /Open chat/)
   assert.match(pluginSource, /reply with exactly "\(pass\)"/i)
   assert.match(pluginSource, /\[Group chat: "\$\{groupName\}"\]/)
+})
+
+test('disband: clears grouping meta, room log, workspace, needs-you; keeps sessions in storage map only for other rooms', async () => {
+  const gc = load(() => '(pass)')
+
+  // Two rooms; disband one.
+  gc.sendToGroupChat('Keep', [{ name: 'research', title: '' }], 'hello keepers')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Keep || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  gc.sendToGroupChat('Gone', [{ name: 'builder', title: '' }], 'hello goners')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Gone || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  gc.$botMeta.set({ builder: { group: 'Gone' }, research: { group: 'Keep' } })
+  gc.$groupChatWorkspace.set('Gone')
+  gc.$groupNeedsYou.set({ Gone: true, Keep: true })
+
+  await gc.disbandGroupChat('Gone', ['builder'])
+
+  // Room state: gone from the atom (no running drive, so no tombstone).
+  assert.equal(gc.$groupChats.get().Gone, undefined)
+  assert.ok(gc.$groupChats.get().Keep, 'other rooms untouched')
+  // The open room view closed; needs-you cleared for the disbanded room only.
+  assert.equal(gc.$groupChatWorkspace.get(), null)
+  assert.equal(gc.$groupNeedsYou.get().Gone, undefined)
+  assert.equal(gc.$groupNeedsYou.get().Keep, true)
+  // Members ungrouped; other bots keep their group.
+  assert.equal(gc.$botMeta.get().builder.group, null)
+  assert.equal(gc.$botMeta.get().research.group, 'Keep')
+  // Persisted room map no longer carries the room.
+  const durable = gc.storageWrites.get('group-chats')
+  assert.ok(durable && !('Gone' in durable), 'disbanded room not persisted')
+  assert.ok('Keep' in durable, 'surviving room still persisted')
+})
+
+test('disband: a running room leaves an epoch-bumped empty tombstone so in-flight turns bail', async () => {
+  const gc = load(() => '(pass)')
+
+  gc.sendToGroupChat('Live', [{ name: 'research', title: '' }], 'kick off')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Live || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  // Simulate a drive still in flight at disband time.
+  const rooms = { ...gc.$groupChats.get() }
+  rooms.Live = { ...rooms.Live, running: true, epoch: 3 }
+  gc.$groupChats.set(rooms)
+
+  await gc.disbandGroupChat('Live', ['research'])
+
+  const tomb = gc.$groupChats.get().Live
+  assert.ok(tomb, 'tombstone present while a drive is mid-turn')
+  assert.equal(tomb.log.length, 0)
+  assert.equal(tomb.running, false)
+  assert.equal(tomb.epoch, 4, 'epoch bumped so the loop bails at its member boundary')
+  const durable = gc.storageWrites.get('group-chats')
+  assert.ok(!durable || !('Live' in (durable || {})), 'tombstone is never persisted')
+})
+
+test('source contract: workspace header offers disband behind a ConfirmDialog', () => {
+  assert.match(pluginSource, /function disbandGroupChat\(/)
+  assert.match(pluginSource, /Disband group chat\?/)
+  assert.match(pluginSource, /title: `Disband the \$\{group\} group chat`/)
 })


### PR DESCRIPTION
## Summary
Bot Mode group chats can now be disbanded — before this the desktop GUI could create a group chat but offered no way to delete it, leaving the grouping and the shared room log around forever.

## Changes
- `apps/desktop/src/plugins/hermes-bots/plugin.js`: new `disbandGroupChat()` — clears every member's `group` bot-meta (syncs cross-machine via ui_meta), drops the room from `$groupChats` and the persisted `group-chats` storage map, clears the needs-you badge, and closes the room view. A room with a drive still in flight leaves a runtime-only epoch-bumped tombstone so the round-robin loop bails at its next member boundary; the tombstone is never persisted.
- `GroupChatWorkspace` header: trash button behind a `ConfirmDialog` (destructive, "Disband") that spells out the semantics — bots and their per-group "Group: <name>" gateway sessions are kept and stay reachable from each bot's session browser.
- `tests/group-chat.test.mjs`: 2 behavioral tests (full disband effects incl. storage map + sibling-room isolation; running-room tombstone) + 1 source-contract test.

## Validation
| | Before | After |
|---|---|---|
| Group chat deletion | not possible from the GUI | header trash → confirm → disbanded |
| `node --test tests/*.test.mjs` | 166 pass | 169 pass, 0 fail |

## Infographic

![Disband group chats infographic](https://v3b.fal.media/files/b/0aa6bf76/WI-2GICbMDTUhujoKK_2Y_FmwmklWy.png)
