### PR TITLE
feat(desktop): cross-connection Bot Mode — Create-on picker, multi-machine group chats, SSH roster fixes (#88598 salvage)

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -42,6 +42,7 @@ import {
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
   resolveProfileBackendRoute,
+  resolveRemoteSshDashboardProfile,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,
@@ -56,6 +57,17 @@ test('connectionScopeKey trims to a name or null for the global scope', () => {
   assert.equal(connectionScopeKey(''), null)
   assert.equal(connectionScopeKey(null), null)
   assert.equal(connectionScopeKey(undefined), null)
+})
+
+test('resolveRemoteSshDashboardProfile never sends a conn: pool key to the remote', () => {
+  // Clicking Mac Mini / Spark default used `remoteProfile || poolKey`, which
+  // spawned a dashboard for the fictional profile "conn:mac-mini::default".
+  assert.equal(resolveRemoteSshDashboardProfile('', 'conn:mac-mini::default'), '')
+  assert.equal(resolveRemoteSshDashboardProfile(undefined, 'conn:spark::default'), '')
+  assert.equal(resolveRemoteSshDashboardProfile('', 'conn:mac-mini::dixie'), 'dixie')
+  assert.equal(resolveRemoteSshDashboardProfile('', 'bob'), 'bob')
+  assert.equal(resolveRemoteSshDashboardProfile('', 'default'), '')
+  assert.equal(resolveRemoteSshDashboardProfile('writer', 'conn:mac-mini::default'), 'writer')
 })
 
 test('normAuthMode coerces to token unless explicitly oauth', () => {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -214,6 +214,27 @@ function connectionScopeKey(profile) {
   return String(profile ?? '').trim() || null
 }
 
+/** Which Hermes profile the remote SSH dashboard should actually run as.
+ *  Registry pool keys (`conn:mac-mini::default`) are desktop routing labels —
+ *  they must never be sent to the remote as a profile name. `default` and
+ *  empty mean the remote root home. */
+function resolveRemoteSshDashboardProfile(configuredRemoteProfile, poolOrProfileKey) {
+  const configured = String(configuredRemoteProfile || '').trim()
+
+  if (configured && configured !== 'default') {
+    return configured
+  }
+
+  const key = String(poolOrProfileKey || '').trim()
+  const requested = key.startsWith('conn:') ? key.split('::').pop() || '' : key
+
+  if (!requested || requested === 'default') {
+    return ''
+  }
+
+  return requested
+}
+
 // Coerce a remote auth mode to one of the two supported values ('token' default).
 function normAuthMode(mode) {
   return mode === 'oauth' ? 'oauth' : 'token'
@@ -802,6 +823,7 @@ export {
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
   resolveProfileBackendRoute,
+  resolveRemoteSshDashboardProfile,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -28,10 +28,10 @@ import {
   REGISTRY_VERSION,
   rememberSshEnumeration,
   removeConnection,
-  shouldRetrySshInventory,
   resolveRegistryLocalRoute,
   setPrimaryConnection,
   shouldDeferLocalEnumeration,
+  shouldRetrySshInventory,
   uniqueLabel,
   updateEligibility,
   upsertConnection

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -24,7 +24,9 @@ import {
   migrateV1ToRegistry,
   normalizeConnectionInput,
   normalizeRegistry,
+  parseRemoteProfileListing,
   REGISTRY_VERSION,
+  rememberSshEnumeration,
   removeConnection,
   resolveRegistryLocalRoute,
   setPrimaryConnection,
@@ -202,6 +204,36 @@ test('roster: unique profiles keep bare handles; duplicates get @name-device', (
   assert.equal(byKey.get('local/default'), 'default')
   assert.equal(byKey.get('homelab/coder'), 'coder')
   assert.equal(roster.length, 4)
+})
+
+test('rememberSshEnumeration: live list wins, cache then seed default', () => {
+  assert.deepEqual(rememberSshEnumeration({ profiles: ['bob', 'kai'] }, ['stale'], 'ssh'), {
+    profiles: ['bob', 'kai']
+  })
+  assert.deepEqual(
+    rememberSshEnumeration({ profiles: null, error: 'connect-on-demand' }, ['bob', 'kai', 'rook'], 'ssh'),
+    { profiles: ['bob', 'kai', 'rook'], error: 'connect-on-demand' }
+  )
+  assert.deepEqual(rememberSshEnumeration({ profiles: null, error: 'connect-on-demand' }, null, 'ssh'), {
+    profiles: ['default'],
+    error: 'connect-on-demand'
+  })
+  assert.deepEqual(rememberSshEnumeration({ profiles: null, error: 'connect-on-demand' }, null, 'remote'), {
+    profiles: null,
+    error: 'connect-on-demand'
+  })
+})
+
+test('parseRemoteProfileListing: Mini/Spark dirs become roster names and drop rollbacks', () => {
+  const listed = parseRemoteProfileListing(
+    ['bob', 'dixie', 'goose', 'rambo', 'bob.rollback-old', '.hidden', '', 'not a name'].join('\n')
+  )
+
+  assert.deepEqual(listed, ['default', 'bob', 'dixie', 'goose', 'rambo'])
+})
+
+test('parseRemoteProfileListing: empty listing is still the default agent', () => {
+  assert.deepEqual(parseRemoteProfileListing(''), ['default'])
 })
 
 test('roster: unreachable sources contribute no rows and cannot fake duplicates', () => {

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -28,6 +28,7 @@ import {
   REGISTRY_VERSION,
   rememberSshEnumeration,
   removeConnection,
+  shouldRetrySshInventory,
   resolveRegistryLocalRoute,
   setPrimaryConnection,
   shouldDeferLocalEnumeration,
@@ -222,6 +223,13 @@ test('rememberSshEnumeration: live list wins, cache then seed default', () => {
     profiles: null,
     error: 'connect-on-demand'
   })
+})
+
+test('shouldRetrySshInventory: first try, cooldown, then retry; cache never retries', () => {
+  assert.equal(shouldRetrySshInventory(false, null, 1_000), true)
+  assert.equal(shouldRetrySshInventory(false, 1_000, 30_000, 60_000), false)
+  assert.equal(shouldRetrySshInventory(false, 1_000, 61_000, 60_000), true)
+  assert.equal(shouldRetrySshInventory(true, 1_000, 120_000, 60_000), false)
 })
 
 test('parseRemoteProfileListing: Mini/Spark dirs become roster names and drop rollbacks', () => {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -255,6 +255,60 @@ export interface RosterAgent {
 }
 
 /**
+ * SSH roster enumeration skips undialed sources (connect-on-demand). Reuse the
+ * last successful profile list so Bot Mode does not go empty the moment the
+ * window switches back to local. Never-seen SSH sources still get a `default`
+ * seed so the device is clickable.
+ */
+export function rememberSshEnumeration(
+  enumeration: Pick<ConnectionAgents, 'error' | 'profiles'>,
+  cached: null | string[] | undefined,
+  kind: ConnectionKind
+): Pick<ConnectionAgents, 'error' | 'profiles'> {
+  if (enumeration.profiles && enumeration.profiles.length > 0) {
+    return enumeration
+  }
+
+  if (kind !== 'ssh') {
+    return enumeration
+  }
+
+  if (cached && cached.length > 0) {
+    return { profiles: cached, error: enumeration.error }
+  }
+
+  if (enumeration.error === 'connect-on-demand') {
+    return { profiles: ['default'], error: 'connect-on-demand' }
+  }
+
+  return enumeration
+}
+
+const PROFILE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
+
+/** Turn `ls ~/.hermes/profiles` output into roster names. Always includes
+ *  `default`. Drops rollback snapshots and junk lines. */
+export function parseRemoteProfileListing(text: string): string[] {
+  const names = new Set<string>(['default'])
+
+  for (const raw of String(text || '').split(/\r?\n/)) {
+    const name = raw.trim()
+
+    if (!name || name.startsWith('.') || name.endsWith('.rollback-old')) {
+      continue
+    }
+
+    if (!PROFILE_NAME_RE.test(name)) {
+      continue
+    }
+
+    names.add(name)
+  }
+
+  return ['default', ...[...names].filter(name => name !== 'default').sort()]
+}
+
+/**
  * Flatten per-connection profile enumerations into the union roster, applying
  * the duplicate-handle rule ONCE across all sources. Pure so the disambiguation
  * policy is testable without IPC; main.ts feeds it live enumerations.

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -284,6 +284,26 @@ export function rememberSshEnumeration(
   return enumeration
 }
 
+/** Whether an undialed SSH source should be inventoried again. Cached
+ *  successes never retry. Failures retry after `retryAfterMs` so a cold box
+ *  does not stay seeded as `default` until the user hits Test. */
+export function shouldRetrySshInventory(
+  hasCache: boolean,
+  lastAttemptMs: null | number | undefined,
+  nowMs: number,
+  retryAfterMs = 60_000
+): boolean {
+  if (hasCache) {
+    return false
+  }
+
+  if (lastAttemptMs == null) {
+    return true
+  }
+
+  return nowMs - lastAttemptMs >= retryAfterMs
+}
+
 const PROFILE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
 
 /** Turn `ls ~/.hermes/profiles` output into roster names. Always includes

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12552,10 +12552,11 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
       let raw: { connection: typeof connection; error?: string; profiles: null | string[] }
 
       try {
-        if (
-          connection.kind === 'ssh' &&
-          ![...sshConnections.keys()].some(scope => String(scope).startsWith(backendScopePrefix(connection.id)))
-        ) {
+        // SSH roster listing must never spawn a dashboard. A stale
+        // sshConnections key used to fall into ensureRegistryBackend and
+        // respawn Spark/Mini every Bot Mode poll (~5s), then the mux died
+        // (ECONNRESET / liveness probe drop).
+        if (connection.kind === 'ssh') {
           await probeSshProfileInventory(connection)
           raw = { connection, profiles: null, error: 'connect-on-demand' }
         } else {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -101,6 +101,7 @@ import {
   migrateV1ToRegistry,
   normalizeConnectionInput,
   normalizeRegistry,
+  rememberSshEnumeration,
   removeConnection,
   resolveRegistryLocalRoute,
   setPrimaryConnection,
@@ -12409,7 +12410,7 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
   // The ssh probe path in testDesktopConnectionConfig never consults v1
   // connection state, so mapping the entry onto it is safe.
   if (entry.kind === 'ssh') {
-    return testDesktopConnectionConfig({
+    const result = await testDesktopConnectionConfig({
       mode: 'ssh',
       sshHost: entry.host,
       sshUser: entry.user,
@@ -12417,6 +12418,14 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
       sshKeyPath: entry.keyPath,
       sshRemoteHermesPath: entry.remoteHermesPath
     })
+
+    if (result?.reachable) {
+      sshInventoryAttempted.delete(entry.id)
+      sshRosterCache.delete(entry.id)
+      await probeSshProfileInventory(entry)
+    }
+
+    return result
   }
 
   // Remote/cloud/local probe built DIRECTLY from the registry entry. Routing
@@ -12480,54 +12489,113 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
 // instead of failing the whole roster. ssh sources that have never been dialed
 // are SKIPPED (connect-on-demand — dialing every ssh box just to list agents
 // would spawn tunnels the user never asked for); once dialed, their pooled
-// descriptor serves the enumeration like any remote.
+// descriptor serves the enumeration like any remote. Last-known SSH profile
+// lists are reused so switching the window back to local does not empty Bot Mode.
+const sshRosterCache = new Map<string, string[]>()
+const sshInventoryAttempted = new Set<string>()
+
+async function probeSshProfileInventory(connection) {
+  if (sshRosterCache.has(connection.id) || sshInventoryAttempted.has(connection.id)) {
+    return
+  }
+
+  sshInventoryAttempted.add(connection.id)
+
+  const sshConfig = normalizeSshConfig({
+    mode: 'ssh',
+    host: connection.host,
+    user: connection.user,
+    port: connection.port,
+    keyPath: connection.keyPath,
+    remoteHermesPath: connection.remoteHermesPath
+  })
+
+  if (!sshConfig) {
+    return
+  }
+
+  const ssh = createSshProbeConnection(
+    { host: sshConfig.host, user: sshConfig.user, port: sshConfig.port, keyPath: sshConfig.keyPath },
+    { rememberLog: sshRememberLog }
+  )
+
+  try {
+    await ssh.open()
+    const profiles = await remoteLifecycle.listRemoteHermesProfiles(ssh)
+
+    if (profiles.length > 0) {
+      sshRosterCache.set(connection.id, profiles)
+    }
+  } catch (error: any) {
+    sshRememberLog(`[ssh] profile inventory failed for ${connection.id}: ${error?.message || error}`)
+  } finally {
+    try {
+      await ssh.close()
+    } catch {
+      void 0
+    }
+  }
+}
+
 async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRegistry()) {
   return Promise.all(
     registry.connections.map(async connection => {
+      let raw: { connection: typeof connection; error?: string; profiles: null | string[] }
+
       try {
         if (
           connection.kind === 'ssh' &&
           ![...sshConnections.keys()].some(scope => String(scope).startsWith(backendScopePrefix(connection.id)))
         ) {
-          return { connection, profiles: null, error: 'connect-on-demand' }
-        }
+          await probeSshProfileInventory(connection)
+          raw = { connection, profiles: null, error: 'connect-on-demand' }
+        } else {
+          // Same connect-on-demand courtesy for the forced-local path: when
+          // the primary route is remote, enumerating "This device" would
+          // SPAWN a local backend this user has never asked for — a phantom
+          // `default` agent that also forces -device handle disambiguation
+          // onto the real one (remote-gateway-only desktops showed their main
+          // agent twice, Aug 17 2026). Enumerate the local source only when
+          // it is the delegate route (local-primary desktops, unchanged
+          // behavior) or a forced-local child is ALREADY pooled (the user
+          // opened one).
+          if (connection.kind === 'local') {
+            const localRoute = resolveRegistryLocalRoute('default', {
+              globalRemote: globalRemoteActive(),
+              profileRemoteOverride: Boolean(profileHasRemoteOverride(primaryProfileKey()))
+            })
 
-        // Same connect-on-demand courtesy for the forced-local path: when the
-        // primary route is remote, enumerating "This device" would SPAWN a
-        // local backend this user has never asked for — a phantom `default`
-        // agent that also forces -device handle disambiguation onto the real
-        // one (remote-gateway-only desktops showed their main agent twice,
-        // Aug 17 2026). Enumerate the local source only when it is the
-        // delegate route (local-primary desktops, unchanged behavior) or a
-        // forced-local child is ALREADY pooled (the user opened one).
-        if (connection.kind === 'local') {
-          const localRoute = resolveRegistryLocalRoute('default', {
-            globalRemote: globalRemoteActive(),
-            profileRemoteOverride: Boolean(profileHasRemoteOverride(primaryProfileKey()))
-          })
-
-          if (shouldDeferLocalEnumeration(localRoute, backendPool.keys(), connection.id)) {
-            return { connection, profiles: null, error: 'connect-on-demand' }
+            if (shouldDeferLocalEnumeration(localRoute, backendPool.keys(), connection.id)) {
+              return { connection, profiles: null, error: 'connect-on-demand' }
+            }
           }
+
+          const descriptor: any = await ensureRegistryBackend(connection.id, null)
+          const body: any = await getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 })
+
+          const profiles = Array.isArray(body?.profiles)
+            ? body.profiles.map(p => String(p?.name || '').trim()).filter(Boolean)
+            : []
+
+          // The root HERMES_HOME is an agent too; enumerations that omit it
+          // (older backends list only named profiles) still get a default row.
+          if (!profiles.includes('default')) {
+            profiles.unshift('default')
+          }
+
+          raw = { connection, profiles }
         }
 
-        const descriptor: any = await ensureRegistryBackend(connection.id, null)
-        const body: any = await getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 })
-
-        const profiles = Array.isArray(body?.profiles)
-          ? body.profiles.map(p => String(p?.name || '').trim()).filter(Boolean)
-          : []
-
-        // The root HERMES_HOME is an agent too; enumerations that omit it
-        // (older backends list only named profiles) still get a default row.
-        if (!profiles.includes('default')) {
-          profiles.unshift('default')
-        }
-
-        return { connection, profiles }
       } catch (error: any) {
-        return { connection, profiles: null, error: String(error?.message || error) }
+        raw = { connection, profiles: null, error: String(error?.message || error) }
       }
+
+      if (raw.profiles && raw.profiles.length > 0) {
+        sshRosterCache.set(connection.id, raw.profiles)
+      }
+
+      const remembered = rememberSshEnumeration(raw, sshRosterCache.get(connection.id), connection.kind)
+      return { connection, ...remembered }
     })
   )
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -87,6 +87,7 @@ import {
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
   resolveProfileBackendRoute,
+  resolveRemoteSshDashboardProfile,
   resolveTestWsUrl,
   savedProfileSsh,
   tokenPreview,
@@ -8847,7 +8848,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     const lifecycle = platform.os === 'Windows' ? connectWindowsRemote : remoteLifecycle.connect
     result = await lifecycle({
       ssh,
-      profile: sshConfig.remoteProfile || connectionScopeKey(profile) || '',
+      profile: resolveRemoteSshDashboardProfile(sshConfig.remoteProfile, profile),
       remoteHermesPath: sshConfig.remoteHermesPath || '',
       ownershipId: sshOwnershipKey(profile),
       reuseToken: reuseToken || '',

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -106,6 +106,7 @@ import {
   resolveRegistryLocalRoute,
   setPrimaryConnection,
   shouldDeferLocalEnumeration,
+  shouldRetrySshInventory,
   updateEligibility,
   upsertConnection
 } from './connection-registry'
@@ -12420,7 +12421,7 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
     })
 
     if (result?.reachable) {
-      sshInventoryAttempted.delete(entry.id)
+      sshInventoryAttemptedAt.delete(entry.id)
       sshRosterCache.delete(entry.id)
       await probeSshProfileInventory(entry)
     }
@@ -12492,14 +12493,22 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
 // descriptor serves the enumeration like any remote. Last-known SSH profile
 // lists are reused so switching the window back to local does not empty Bot Mode.
 const sshRosterCache = new Map<string, string[]>()
-const sshInventoryAttempted = new Set<string>()
+const sshInventoryAttemptedAt = new Map<string, number>()
+const SSH_INVENTORY_RETRY_MS = 60_000
 
 async function probeSshProfileInventory(connection) {
-  if (sshRosterCache.has(connection.id) || sshInventoryAttempted.has(connection.id)) {
+  if (
+    !shouldRetrySshInventory(
+      sshRosterCache.has(connection.id),
+      sshInventoryAttemptedAt.get(connection.id),
+      Date.now(),
+      SSH_INVENTORY_RETRY_MS
+    )
+  ) {
     return
   }
 
-  sshInventoryAttempted.add(connection.id)
+  sshInventoryAttemptedAt.set(connection.id, Date.now())
 
   const sshConfig = normalizeSshConfig({
     mode: 'ssh',

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -10,6 +10,7 @@ import {
   expandRemotePath,
   fingerprintToken,
   isForwardBindCollision,
+  listRemoteHermesProfiles,
   locateHermes,
   LOCKFILE_SCHEMA_VERSION,
   lockfilePath,
@@ -78,6 +79,32 @@ function fakeSsh(rules: any[] = []) {
     }
   }
 }
+
+test('listRemoteHermesProfiles inventories Mini-style profile dirs without spawning a dashboard', async () => {
+  const ssh = fakeSsh([
+    [/HERMES_HOME/, '/Users/zillajr/.hermes\n'],
+    [/ls -1/, 'bob\ndixie\ngoose\nrambo\nbob.rollback-old\n']
+  ])
+
+  assert.deepEqual(await listRemoteHermesProfiles(ssh), ['default', 'bob', 'dixie', 'goose', 'rambo'])
+  assert.equal(
+    ssh.calls.some(cmd => cmd.includes('serve') || cmd.includes('dashboard')),
+    false
+  )
+})
+
+test('listRemoteHermesProfiles rejects a hostile HERMES_HOME', async () => {
+  const ssh = fakeSsh([[/HERMES_HOME/, '/tmp/x; echo pwned\n']])
+
+  await assert.rejects(() => listRemoteHermesProfiles(ssh), (err: any) => {
+    assert.equal(err.kind, 'unsafe-path')
+    return true
+  })
+  assert.equal(
+    ssh.calls.some(cmd => cmd.includes('ls -1')),
+    false
+  )
+})
 
 test('locateHermes prefers the explicit profile path when executable', async () => {
   const ssh = fakeSsh([[/\[ -x .*\/opt\/hermes/, 'OK']])

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -27,6 +27,8 @@
 
 import crypto from 'node:crypto'
 
+import { parseRemoteProfileListing } from './connection-registry'
+
 const LOCKFILE_SCHEMA_VERSION = 2
 // Bumped when the desktop<->dashboard reuse contract changes in a way that makes
 // an old running dashboard unsafe to reattach to (token handling, readiness/spawn
@@ -252,6 +254,35 @@ async function probeRemoteHermesHome(ssh) {
     error.cause = cause
     throw error
   }
+}
+
+async function listRemoteHermesProfiles(ssh) {
+  const home = assertSafeRemoteHome(await probeRemoteHermesHome(ssh))
+  const dir = expandRemotePath(`${home}/profiles`)
+  let listing = ''
+
+  try {
+    listing = await ssh.exec(`if [ -d ${dir} ]; then ls -1 ${dir}; fi`)
+  } catch (cause) {
+    const error: any = new Error('Could not list remote Hermes profiles.')
+    error.kind = 'transient-transport-error'
+    error.cause = cause
+    throw error
+  }
+
+  return parseRemoteProfileListing(listing)
+}
+
+function assertSafeRemoteHome(home) {
+  const value = String(home || '').trim()
+
+  if (!/^(\/|~\/)[A-Za-z0-9._/+-]+$/.test(value) || value.includes('..')) {
+    const error: any = new Error('Unsafe remote Hermes home.')
+    error.kind = 'unsafe-path'
+    throw error
+  }
+
+  return value.replace(/\/+$/, '')
 }
 
 async function readLockfile(ssh, ownershipId) {
@@ -882,6 +913,7 @@ export {
   locateHermes,
   LOCKFILE_SCHEMA_VERSION,
   lockfilePath,
+  listRemoteHermesProfiles,
   mintToken,
   openForward,
   ownershipDirectory,

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -410,7 +410,11 @@ async function pidIsOurDashboard(ssh, pid, spawnNonce, hermesPath = '') {
       ' raw=open(f"/proc/{pid}/cmdline","rb").read()\n' +
       ' args=[x.decode("utf-8","surrogateescape") for x in raw.split(b"\\0") if x]\n' +
       'except OSError:\n' +
-      ' line=subprocess.check_output(["ps","-o","command=","-p",str(pid)],text=True).strip()\n' +
+      ' try:\n' +
+      '  line=subprocess.check_output(["ps","-o","command=","-p",str(pid)],text=True).strip()\n' +
+      ' except subprocess.CalledProcessError:\n' +
+      '  # pid already gone — a dead process is FOREIGN, not a transport error\n' +
+      '  print("FOREIGN");sys.exit(0)\n' +
       ' args=shlex.split(line)\n' +
       'ok=False\n' +
       'try:\n' +
@@ -910,10 +914,10 @@ export {
   expandRemotePath,
   fingerprintToken,
   isForwardBindCollision,
+  listRemoteHermesProfiles,
   locateHermes,
   LOCKFILE_SCHEMA_VERSION,
   lockfilePath,
-  listRemoteHermesProfiles,
   mintToken,
   openForward,
   ownershipDirectory,

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2211,7 +2211,7 @@ function useRoster() {
       if (typeof host.agents === 'function') {
         try {
           const union = await host.agents()
-          return mergeMultiSourceRoster(local, union, activeConnectionId)
+          return mergeMultiSourceRoster(local, union, activeConnectionId, $lastRoster.get())
         } catch {
           /* older build or roster failure — single-source list stands */
         }
@@ -2237,10 +2237,17 @@ function useRoster() {
  *  Rows from other sources become new roster entries tagged with their
  *  source label so BotRow can badge them and route open/warm through
  *  ensureAgent/warmAgent. Pure — exercised directly by the tests. */
-function mergeMultiSourceRoster(local, union, activeConnectionId = null) {
+function mergeMultiSourceRoster(local, union, activeConnectionId, previous = []) {
   const localProfiles = Array.isArray(local?.profiles) ? local.profiles : []
   const agents = Array.isArray(union?.agents) ? union.agents : []
-  const activeId = String(activeConnectionId || union?.primaryConnectionId || '').trim()
+  // A live id of null/'' means the window is on the unscoped local backend
+  // (host.state.connectionId is null for mode:'local'). Do NOT fall back to
+  // registry primary in that case — primary can still say "spark" after the
+  // user clicked a local bot, which skipped every Spark row as "active" and
+  // invented a This-device shadow of default.
+  const liveProvided = arguments.length >= 3
+  const liveId = String(activeConnectionId || '').trim()
+  const activeId = liveId || (liveProvided ? '' : String(union?.primaryConnectionId || '').trim())
   const activeByName = new Map()
 
   // Treat the rich list as one row per active-source profile. Clone every
@@ -2264,10 +2271,6 @@ function mergeMultiSourceRoster(local, union, activeConnectionId = null) {
   }
 
   const profiles = [...activeByName.values()]
-
-  if (!agents.length) {
-    return { ...local, profiles }
-  }
 
   // host.agents is an Electron/main-process capability. Defend the plugin
   // boundary too: older shells or reconnect races can still hand us repeated
@@ -2320,6 +2323,35 @@ function mergeMultiSourceRoster(local, union, activeConnectionId = null) {
       remoteSource: true,
       sourceScoped: true
     })
+  }
+
+  // SSH sources drop to connect-on-demand the moment their tunnel is not
+  // the live gateway. Keep previously painted remote rows so clicking the
+  // local agent does not empty Bot Mode.
+  if (Array.isArray(previous) && previous.length > 0) {
+    const present = new Set(profiles.map(row => `${row.connectionId || ''}::${row.name}`))
+    const unionSourceIds = new Set(agents.map(agent => String(agent?.connectionId || '').trim()).filter(Boolean))
+    const omitted = new Set(
+      (Array.isArray(union?.sources) ? union.sources : [])
+        .filter(source => source?.error === 'connect-on-demand' || source?.reachable === false)
+        .map(source => String(source.connectionId || '').trim())
+        .filter(Boolean)
+    )
+
+    for (const row of previous) {
+      const connectionId = String(row?.connectionId || '').trim()
+      const name = String(row?.name || '').trim()
+      const key = `${connectionId}::${name || 'default'}`
+
+      if (!row?.remoteSource || !connectionId || !name || present.has(key)) {
+        continue
+      }
+
+      if (omitted.has(connectionId) || !unionSourceIds.has(connectionId)) {
+        profiles.push({ ...row, remoteSource: true, sourceScoped: true })
+        present.add(key)
+      }
+    }
   }
 
   return { ...local, profiles }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2548,6 +2548,13 @@ async function prepareBotSource(bot, pinnedChat) {
     return pinnedChat
   }
 
+  const liveId = String(typeof host.activeConnectionId === 'function' ? host.activeConnectionId() || '' : '').trim()
+  const targetId = String(bot.connectionId || '').trim()
+
+  if (targetId && targetId !== 'local' && liveId !== targetId) {
+    throw new Error(`Still on ${liveId || 'this device'}, not ${bot.connectionLabel || targetId}`)
+  }
+
   // Thin rows deliberately omit metadata from the active source. Once their
   // owner is active, recover that source's canonical-chat pointer so
   // same-named agents never reuse or overwrite each other's pin.

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2241,10 +2241,11 @@ function mergeMultiSourceRoster(local, union, activeConnectionId, previous = [])
   const localProfiles = Array.isArray(local?.profiles) ? local.profiles : []
   const agents = Array.isArray(union?.agents) ? union.agents : []
   // A live id of null/'' means the window is on the unscoped local backend
-  // (host.state.connectionId is null for mode:'local'). Do NOT fall back to
-  // registry primary in that case — primary can still say "spark" after the
-  // user clicked a local bot, which skipped every Spark row as "active" and
-  // invented a This-device shadow of default.
+  // (legacy hosts reported null for mode:'local'; the SDK now reports
+  // 'local'). Do NOT fall back to registry primary when the third argument
+  // was passed — primary can still say "spark" after the user clicked a
+  // local bot, which skipped every Spark row as "active" and invented a
+  // This-device shadow of default.
   const liveProvided = arguments.length >= 3
   const liveId = String(activeConnectionId || '').trim()
   const activeId = liveId || (liveProvided ? '' : String(union?.primaryConnectionId || '').trim())
@@ -2338,12 +2339,22 @@ function mergeMultiSourceRoster(local, union, activeConnectionId, previous = [])
         .filter(Boolean)
     )
 
+    const registered = new Set(
+      (Array.isArray(union?.sources) ? union.sources : [])
+        .map(source => String(source?.connectionId || '').trim())
+        .filter(Boolean)
+    )
+
     for (const row of previous) {
       const connectionId = String(row?.connectionId || '').trim()
       const name = String(row?.name || '').trim()
       const key = `${connectionId}::${name || 'default'}`
 
       if (!row?.remoteSource || !connectionId || !name || present.has(key)) {
+        continue
+      }
+
+      if (registered.size > 0 && !registered.has(connectionId)) {
         continue
       }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2518,6 +2518,46 @@ function botRosterKey(bot) {
   return `${bot?.connectionId || 'legacy'}::${bot?.name || 'default'}`
 }
 
+// ── cross-connection routing ─────────────────────────────────────────────────
+// A bot from another registered connection (remoteSource rows) is reached
+// through host.requestProfile with a route descriptor; local bots keep the
+// active-gateway door. Feature-detected: older desktops without
+// requestProfile simply have no remote routes (callers fall back / disable).
+
+/** Route descriptor for a bot on another connection, or null for the local /
+ *  active source (or when the desktop can't route). */
+function botConnectionRoute(bot) {
+  const id = String(bot?.connectionId || '').trim()
+
+  if (!bot?.remoteSource || !id || id === 'local' || typeof host.requestProfile !== 'function') {
+    return null
+  }
+
+  const profile = String(bot?.name || '').trim() || 'default'
+
+  return { connectionId: id, mode: 'remote', profile, targetProfile: profile }
+}
+
+/** Gateway RPC on the bot's OWN source: requestProfile for remote rows,
+ *  the active gateway for local ones. Never activates/foregrounds. */
+async function requestForBot(bot, method, params = {}) {
+  const route = botConnectionRoute(bot)
+
+  if (route) {
+    return host.requestProfile(route, method, params)
+  }
+
+  return host.request(method, params)
+}
+
+/** Stable per-member identity inside a group room. Local members keep their
+ *  bare name (compat with rooms persisted before cross-connection groups);
+ *  remote members get the source-qualified key so `dixie` on the Mini and a
+ *  local `dixie` never share watermarks or sessions. */
+function groupMemberKey(member) {
+  return member?.remoteSource ? botRosterKey(member) : member?.name
+}
+
 // Bot metadata is scoped to the active gateway until the server exposes a
 // union of rich profile rows. Never paint that metadata onto a thin row from
 // another source: two `default` agents must not borrow each other's title,
@@ -2842,9 +2882,14 @@ function parseGroupChatMentions(text, members) {
 
   for (const member of members) {
     const title = String(member.title || '').trim()
+    // Cross-connection members are also addressable by their @name-device
+    // handle (the roster's disambiguated form) — same-named agents on two
+    // machines resolve to the right one.
+    const handle = String(member.handle || '').trim()
     const forms = new Set([
       member.name.toLowerCase(),
       member.name.toLowerCase().replace(/[\s_-]+/g, ''),
+      ...(handle ? [handle.toLowerCase(), handle.toLowerCase().replace(/[\s_-]+/g, '')] : []),
       ...(title
         ? [title.toLowerCase(), title.toLowerCase().replace(/[\s_-]+/g, ''), title.split(/\s+/)[0].toLowerCase()]
         : [])
@@ -2852,7 +2897,7 @@ function parseGroupChatMentions(text, members) {
 
     for (const form of forms) {
       if (form) {
-        handles.set(form, member.name)
+        handles.set(form, groupMemberKey(member))
       }
     }
   }
@@ -2912,7 +2957,7 @@ function resolveGroupResponders(log, members) {
     return members
   }
 
-  return members.filter(member => mentioned.has(member.name))
+  return members.filter(member => mentioned.has(groupMemberKey(member)))
 }
 
 /** Rotate the roster so a different member leads each round. */
@@ -2934,16 +2979,25 @@ function formatGroupChatLine(entry, viewerName) {
   }
 
   const suffix = entry.from.name === viewerName ? ' (you)' : ''
+  // Cross-connection speakers carry their device so same-named agents on
+  // two machines stay tellable apart in every member's transcript.
+  const source = entry.from.source ? ` [${entry.from.source}]` : ''
 
-  return `${entry.from.name}${suffix}: ${entry.text}`
+  return `${entry.from.name}${suffix}${source}: ${entry.text}`
 }
 
 /** The full per-turn payload for one member: participation rules + the room
  *  delta. Rules travel in the turn payload (not SOUL) so every existing bot
  *  can join a group chat without a profile migration. */
 function buildGroupChatTurnPrompt({ groupName, members, viewer, deltaLines }) {
-  const peers = members.filter(m => m.name !== viewer.name)
-  const peerNames = peers.map(m => (m.title ? `${m.title} (@${m.name})` : `@${m.name}`)).join(', ')
+  const viewerKey = groupMemberKey(viewer)
+  const peers = members.filter(m => groupMemberKey(m) !== viewerKey)
+  const peerNames = peers
+    .map(m => {
+      const handle = m.title ? `${m.title} (@${m.name})` : `@${m.name}`
+      return m.remoteSource ? `${handle} [on ${m.connectionLabel || m.connectionId}]` : handle
+    })
+    .join(', ')
 
   return [
     `[Group chat: "${groupName}"] You are @${viewer.name}, one participant in a group chat with ${peerNames || 'no one else yet'} and the user.`,
@@ -2992,7 +3046,14 @@ function updateGroupChat(group, mutate) {
     const durable = {}
 
     for (const [name, room] of Object.entries(all)) {
-      durable[name] = { log: room.log, watermarks: room.watermarks, sessions: room.sessions || {} }
+      durable[name] = {
+        log: room.log,
+        watermarks: room.watermarks,
+        sessions: room.sessions || {},
+        // Cross-connection member descriptors — remote bots can't ride
+        // bot-meta, so the room record carries who they are.
+        members: Array.isArray(room.members) ? room.members : []
+      }
     }
 
     Promise.resolve(pluginCtx?.storage?.set?.('group-chats', durable)).catch(() => undefined)
@@ -3023,11 +3084,13 @@ function appendGroupChatEntry(group, from, text) {
  *  session id for it. Gateway-native: session.create mints the session
  *  (lazy until its first message), session.resume by stored id — or by
  *  title, which also covers rehydrated rooms whose sid was lost — reopens
- *  it after restarts. */
-async function ensureGroupChatSession(group, memberName) {
+ *  it after restarts. Cross-connection members route to their OWN source
+ *  via requestForBot; the window's gateway never switches. */
+async function ensureGroupChatSession(group, member) {
   const title = `Group: ${group}`
   const room = $groupChats.get()[group] || {}
-  const known = room.sessions && room.sessions[memberName]
+  const key = groupMemberKey(member)
+  const known = room.sessions && room.sessions[key]
 
   // Try resuming what we know (stored sid first, then title lookup).
   for (const target of [known, title]) {
@@ -3036,9 +3099,9 @@ async function ensureGroupChatSession(group, memberName) {
     }
 
     try {
-      const res = await host.request('session.resume', {
+      const res = await requestForBot(member, 'session.resume', {
         session_id: target,
-        profile: memberName,
+        profile: member.name,
         omit_messages: true
       })
 
@@ -3050,8 +3113,8 @@ async function ensureGroupChatSession(group, memberName) {
     }
   }
 
-  const created = await host.request('session.create', {
-    profile: memberName,
+  const created = await requestForBot(member, 'session.create', {
+    profile: member.name,
     title,
     ...($hideBotChats.get() ? { hidden: true } : {})
   })
@@ -3059,7 +3122,7 @@ async function ensureGroupChatSession(group, memberName) {
 
   if (stored) {
     updateGroupChat(group, r => {
-      r.sessions = { ...(r.sessions || {}), [memberName]: stored }
+      r.sessions = { ...(r.sessions || {}), [key]: stored }
       return r
     })
   }
@@ -3074,7 +3137,7 @@ const GROUP_TURN_POLL_MS = 2000
  *  the member's per-group session, then poll the session until a NEW
  *  assistant message lands (or timeout → pass). No shell composition. */
 async function runGroupChatMemberTurn(group, member, prompt) {
-  const { runtime, stored } = await ensureGroupChatSession(group, member.name)
+  const { runtime, stored } = await ensureGroupChatSession(group, member)
 
   if (!runtime) {
     return null
@@ -3084,7 +3147,7 @@ async function runGroupChatMemberTurn(group, member, prompt) {
   let before = 0
 
   try {
-    const pre = await host.request('session.resume', {
+    const pre = await requestForBot(member, 'session.resume', {
       session_id: stored || runtime,
       profile: member.name
     })
@@ -3093,7 +3156,7 @@ async function runGroupChatMemberTurn(group, member, prompt) {
     /* lazy session — zero messages */
   }
 
-  await host.request('prompt.submit', { session_id: runtime, text: prompt })
+  await requestForBot(member, 'prompt.submit', { session_id: runtime, text: prompt })
 
   const deadline = Date.now() + GROUP_TURN_TIMEOUT_MS
 
@@ -3103,7 +3166,7 @@ async function runGroupChatMemberTurn(group, member, prompt) {
     let state = null
 
     try {
-      state = await host.request('session.resume', {
+      state = await requestForBot(member, 'session.resume', {
         session_id: stored || runtime,
         profile: member.name
       })
@@ -3156,7 +3219,8 @@ async function runGroupChatRounds(group, members) {
         }
 
         const room = $groupChats.get()[group] || { log: [], watermarks: {} }
-        const seen = room.watermarks[member.name] || 0
+        const memberKey = groupMemberKey(member)
+        const seen = room.watermarks[memberKey] || 0
         const delta = room.log.slice(seen)
 
         if (!delta.length) {
@@ -3180,15 +3244,19 @@ async function runGroupChatRounds(group, members) {
 
         // The member has now seen everything up to the pre-reply log length.
         updateGroupChat(group, r => {
-          r.watermarks[member.name] = r.log.length
+          r.watermarks[memberKey] = r.log.length
           return r
         })
 
         if (reply !== null && !isGroupPassText(reply)) {
-          appendGroupChatEntry(group, { kind: 'member', name: member.name }, reply)
+          appendGroupChatEntry(
+            group,
+            { kind: 'member', name: member.name, ...(member.remoteSource ? { source: member.connectionLabel || member.connectionId } : {}) },
+            reply
+          )
           // Its own message counts as seen too.
           updateGroupChat(group, r => {
-            r.watermarks[member.name] = r.log.length
+            r.watermarks[memberKey] = r.log.length
             return r
           })
           posted += 1
@@ -4777,6 +4845,43 @@ function CreateAgentDialog({ open, onClose, roster }) {
   const [noSkills, setNoSkills] = useState(false)
   const [shareAuth, setShareAuth] = useState(true)
   const [advTab, setAdvTab] = useState('general')
+  // Where the profile is created: '' = the active gateway (unchanged default),
+  // else a registry connection id — the profiles.create lands on THAT
+  // machine's backend via host.requestProfile, no gateway switch. Only
+  // rendered when the desktop has a multi-connection registry.
+  const [targetConnection, setTargetConnection] = useState('')
+  const [connections, setConnections] = useState(null)
+
+  useEffect(() => {
+    if (!open || connections !== null || typeof host.connections !== 'function' || typeof host.requestProfile !== 'function') {
+      return
+    }
+
+    host
+      .connections()
+      .then(value => setConnections(Array.isArray(value) ? value : []))
+      .catch(() => setConnections([]))
+  }, [open, connections])
+
+  const activeConnectionId = String(host.state?.connectionId?.get?.() || '').trim()
+  // Remote target = an explicitly picked registry connection that is not the
+  // one this window is already on.
+  const remoteTarget = Boolean(targetConnection) && targetConnection !== (activeConnectionId || 'local')
+  const targetLabel = remoteTarget
+    ? (connections || []).find(c => c.id === targetConnection)?.label || targetConnection
+    : ''
+
+  /** Gateway RPC on the create target: the picked connection's default
+   *  backend for remote targets, the active gateway otherwise. */
+  const requestForTarget = (method, params = {}) =>
+    remoteTarget
+      ? host.requestProfile(
+          { connectionId: targetConnection, mode: 'remote', profile: 'default', targetProfile: 'default' },
+          method,
+          params
+        )
+      : host.request(method, params)
+
   // Set once ensureAgentCreated() materializes the profile for the live
   // Capabilities tab (SkillsView needs a real backend to point at). State —
   // not just createdRef — because the render must flip when it lands.
@@ -4792,7 +4897,12 @@ function CreateAgentDialog({ open, onClose, roster }) {
   const valid = slug.length > 0 && NAME_RE.test(slug)
   // Once the draft profile is materialized (Capabilities tab / MCP setup) it
   // shows up in the roster — its OWN slug must not read as "taken".
-  const taken = roster.some(b => b.name === slug && b.name !== createdRef.current)
+  // A remote-target create is gated by the TARGET machine's roster: a local
+  // name clash is fine there, and the remote's own duplicate check rejects
+  // real collisions at profiles.create time.
+  const taken = remoteTarget
+    ? roster.some(b => b.remoteSource && b.connectionId === targetConnection && b.name === slug && b.name !== createdRef.current)
+    : roster.some(b => !b.remoteSource && b.name === slug && b.name !== createdRef.current)
 
   // Draft semantics for the lazily-created profile: opening the Capabilities
   // tab (or running MCP setup) materializes the profile so the LIVE config
@@ -4809,7 +4919,10 @@ function CreateAgentDialog({ open, onClose, roster }) {
 
     createdRef.current = null
     flightRef.current = null
-    void deleteBot({ name: draft })
+    const discard = remoteTarget
+      ? requestForTarget('cli.exec', { argv: ['profile', 'delete', draft, '--yes'] })
+      : deleteBot({ name: draft })
+    void Promise.resolve(discard)
       .then(() => host.notify({ kind: 'success', message: `Draft agent "${draft}" discarded` }))
       .catch(err => host.notifyError(err, `Could not clean up draft profile "${draft}"`))
   }
@@ -4837,6 +4950,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
     setCapsFailed(false)
     setDirtyCaps({ skills: false, toolsets: false, mcp: false })
     setCapFilter('')
+    setTargetConnection('')
     setBusy(false)
     setError(null)
     createdRef.current = null
@@ -4852,8 +4966,8 @@ function CreateAgentDialog({ open, onClose, roster }) {
     }
 
     Promise.all([
-      host.request('profiles.describe', { name: capSource }),
-      host.request('mcp.catalog', {}).catch(() => null)
+      requestForTarget('profiles.describe', { name: remoteTarget ? 'default' : capSource }),
+      requestForTarget('mcp.catalog', {}).catch(() => null)
     ])
       .then(([res, cat]) => {
         // Full MCP menu = the profile's configured servers + the bundled
@@ -4917,10 +5031,14 @@ function CreateAgentDialog({ open, onClose, roster }) {
 
       const descriptionText = [title, description].filter(Boolean).join(' — ')
 
-      await host.request('profiles.create', {
+      await requestForTarget('profiles.create', {
         name: slug,
         description: descriptionText,
-        clone_from: cloneFrom === '__none__' ? null : cloneFrom,
+        // Clone sources are profiles of the TARGET backend. The picker's
+        // roster is the local one, so a remote create always starts from the
+        // remote machine's default (or fresh) — never a local profile name
+        // the remote box doesn't have.
+        clone_from: cloneFrom === '__none__' ? null : remoteTarget ? 'default' : cloneFrom,
         no_skills: noSkills,
         // Shared (not copied) auth keeps ONE OAuth/token pool with the main
         // profile, so refreshes can't invalidate each other. Older gateways
@@ -4949,13 +5067,39 @@ function CreateAgentDialog({ open, onClose, roster }) {
           capPayload.enabled_mcp_servers = caps.mcp.filter(m => m.enabled).map(m => m.name)
         }
         if (Object.keys(capPayload).length) {
-          await host.request('profiles.configure', { name: slug, ...capPayload })
+          await requestForTarget('profiles.configure', { name: slug, ...capPayload })
         }
       } catch {
         /* capability application is best-effort */
       }
 
-      saveBotMeta(slug, { shape, color, image, imageKind: image ? 'photo' : 'shape', title: title.trim(), created: Date.now() })
+      if (remoteTarget) {
+        // The bot lives on ANOTHER machine — local bot-meta is scoped to the
+        // active gateway, so write appearance/title into the remote
+        // profile's ui_meta (and asset store) directly. Best-effort: the
+        // profile exists either way.
+        const { image: avatarImage, ...look } = {
+          shape,
+          color,
+          image,
+          imageKind: image ? 'photo' : 'shape',
+          title: title.trim(),
+          created: Date.now()
+        }
+
+        try {
+          void requestForTarget('profiles.configure', { name: slug, ui_meta: { 'hermes-bots': look } }).catch(() => undefined)
+
+          if (avatarImage) {
+            void requestForTarget('profiles.set_asset', { name: slug, asset: 'avatar', data: avatarImage }).catch(() => undefined)
+          }
+        } catch {
+          /* older remote gateway */
+        }
+      } else {
+        saveBotMeta(slug, { shape, color, image, imageKind: image ? 'photo' : 'shape', title: title.trim(), created: Date.now() })
+      }
+
       queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
       return slug
     })
@@ -4979,9 +5123,24 @@ function CreateAgentDialog({ open, onClose, roster }) {
         return
       }
 
-      host.notify({ kind: 'success', message: `Agent "${displayName({ name: slug, title })}" created` })
+      host.notify({
+        kind: 'success',
+        message: remoteTarget
+          ? `Agent "${displayName({ name: slug, title })}" created on ${targetLabel}`
+          : `Agent "${displayName({ name: slug, title })}" created`
+      })
+      const wasRemote = remoteTarget
       reset()
       onClose()
+
+      if (wasRemote) {
+        // The bot lives on another machine: it appears in the roster via the
+        // union enumeration; chat routes through its own source. No local
+        // canonical chat to birth here.
+        queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
+        return
+      }
+
       $selectedBot.set(slug)
 
       // Birth the bot's forever chat right away: it introduces itself as
@@ -5060,7 +5219,56 @@ function CreateAgentDialog({ open, onClose, roster }) {
             taken
               ? jsx('div', {
                   className: 'text-xs text-(--ui-accent)',
-                  children: `An agent named "${slug}" already exists.`
+                  children: remoteTarget
+                    ? `An agent named "${slug}" already exists on ${targetLabel}.`
+                    : `An agent named "${slug}" already exists.`
+                })
+              : null,
+            // Multi-connection desktops choose WHERE the agent lives. Hidden
+            // on single-connection setups — the active gateway is the only
+            // possible home, exactly the old behavior.
+            Array.isArray(connections) && connections.length > 1
+              ? labeled(
+                  'Create on',
+                  jsxs(Select, {
+                    value: targetConnection || activeConnectionId || 'local',
+                    onValueChange: value => {
+                      setTargetConnection(value === (activeConnectionId || 'local') ? '' : value)
+                      // The capability catalog and clone list belong to the
+                      // target backend — refetch for the new home. The live
+                      // Capabilities tab only exists for the active gateway.
+                      setCaps(null)
+                      setCapsFailed(false)
+                      setAdvTab('general')
+                    },
+                    children: [
+                      jsx(SelectTrigger, {
+                        className: 'h-8 rounded-md',
+                        children: jsx(SelectValue, {})
+                      }),
+                      jsx(SelectContent, {
+                        children: connections.map(connection =>
+                          jsx(
+                            SelectItem,
+                            {
+                              value: connection.id,
+                              children:
+                                connection.id === (activeConnectionId || 'local')
+                                  ? `${connection.label || connection.id} (current)`
+                                  : connection.label || connection.id
+                            },
+                            connection.id
+                          )
+                        )
+                      })
+                    ]
+                  })
+                )
+              : null,
+            remoteTarget
+              ? jsx('div', {
+                  className: 'text-[0.7rem] leading-5 text-(--ui-text-tertiary)',
+                  children: `The agent is created on ${targetLabel} and appears in the roster as a Connections bot. Chat routes to that machine.`
                 })
               : null,
             labeled(
@@ -5105,7 +5313,11 @@ function CreateAgentDialog({ open, onClose, roster }) {
                       className: 'flex gap-1',
                       // Newer desktops export the whole Capabilities surface —
                       // one live tab replaces the three staged checklists.
-                      children: (SkillsView
+                      // The live Capabilities surface (SkillsView) binds to
+                      // the ACTIVE gateway's backend — a remote-target draft
+                      // lives elsewhere, so it keeps the staged checklists
+                      // (their catalog reads already route to the target).
+                      children: (SkillsView && !remoteTarget
                         ? [
                             ['general', 'General'],
                             ['capabilities', 'Capabilities']
@@ -5152,9 +5364,10 @@ function CreateAgentDialog({ open, onClose, roster }) {
                           className: 'grid gap-3.5',
                           children: [
                             labeled(
-                              'Clone from profile',
+                              remoteTarget ? `Clone from profile (on ${targetLabel})` : 'Clone from profile',
                               jsxs(Select, {
-                                value: cloneFrom,
+                                disabled: remoteTarget,
+                                value: remoteTarget ? 'default' : cloneFrom,
                                 onValueChange: value => {
                                   setCloneFrom(value)
                                   setCaps(null)
@@ -6502,11 +6715,11 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
     }
   }, [open])
 
-  const selected = roster.filter(bot => checked[bot.name])
+  const selected = roster.filter(bot => checked[botRosterKey(bot)])
   const visible = filterBots(roster, allMeta, query)
   const atCap = selected.length >= GROUP_CHAT_MAX_MEMBERS
   const placeholder = selected.length
-    ? selected.map(bot => displayName(bot, allMeta[bot.name])).join(', ')
+    ? selected.map(bot => displayName(bot, botRosterMeta(bot, allMeta))).join(', ')
     : 'Group name'
   const canCreate = selected.length >= 2 && Boolean(name.trim() || selected.length)
 
@@ -6518,7 +6731,31 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
     }
 
     for (const bot of selected) {
-      void saveBotMeta(bot.name, { group: groupName })
+      if (!bot.remoteSource) {
+        void saveBotMeta(bot.name, { group: groupName })
+      }
+    }
+
+    // Members from OTHER connections can't ride bot-meta (it is scoped to
+    // the active gateway and name-keyed). Their descriptors live on the room
+    // record instead, so the roster merge can seat them every refresh.
+    const remoteMembers = selected
+      .filter(bot => bot.remoteSource)
+      .map(bot => ({
+        name: bot.name,
+        handle: bot.handle || bot.name,
+        connectionId: bot.connectionId,
+        connectionKind: bot.connectionKind,
+        connectionLabel: bot.connectionLabel,
+        remoteSource: true,
+        sourceScoped: true
+      }))
+
+    if (remoteMembers.length) {
+      updateGroupChat(groupName, room => {
+        room.members = remoteMembers
+        return room
+      })
     }
 
     host.notify({ kind: 'info', message: `“${groupName}” created with ${selected.length} bots` })
@@ -6562,8 +6799,8 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
                   className:
                     'flex items-center gap-1 rounded-full bg-(--chrome-action-hover) py-0.5 pl-2 pr-1.5 text-[0.6875rem] text-(--ui-text-secondary) transition-colors hover:text-foreground',
                   title: 'Remove from selection',
-                  onClick: () => setChecked(prev => ({ ...prev, [bot.name]: false })),
-                  children: [displayName(bot, allMeta[bot.name]), jsx(Codicon, { name: 'close', className: 'text-[0.6rem]' })]
+                  onClick: () => setChecked(prev => ({ ...prev, [botRosterKey(bot)]: false })),
+                  children: [displayName(bot, botRosterMeta(bot, allMeta)), jsx(Codicon, { name: 'close', className: 'text-[0.6rem]' })]
                 }, botRosterKey(bot))
               )
             })
@@ -6574,9 +6811,9 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
             className: 'grid gap-0.5 pr-2',
             children: visible.length
               ? visible.map(bot => {
-                  const meta = allMeta[bot.name]
+                  const meta = botRosterMeta(bot, allMeta)
                   const { shape, color, image } = botAppearance(bot.name, meta)
-                  const isChecked = Boolean(checked[bot.name])
+                  const isChecked = Boolean(checked[botRosterKey(bot)])
                   const disabled = !isChecked && atCap
                   const currentGroup = (meta?.group || '').trim()
 
@@ -6599,14 +6836,19 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
                           jsx('div', { className: 'truncate text-xs text-foreground', children: displayName(bot, meta) }),
                           jsx('div', {
                             className: 'truncate text-[0.625rem] text-(--ui-text-quaternary)',
-                            children: currentGroup ? `@${bot.name} · in “${currentGroup}”` : `@${bot.name}`
+                            children: [
+                              currentGroup
+                                ? `@${botHandle(bot.name, bot)} · in “${currentGroup}”`
+                                : `@${botHandle(bot.name, bot)}`,
+                              bot.remoteSource && bot.connectionLabel ? ` · ${bot.connectionLabel}` : ''
+                            ].join('')
                           })
                         ]
                       }),
                       jsx(Checkbox, {
                         checked: isChecked,
                         disabled,
-                        onCheckedChange: value => setChecked(prev => ({ ...prev, [bot.name]: Boolean(value) }))
+                        onCheckedChange: value => setChecked(prev => ({ ...prev, [botRosterKey(bot)]: Boolean(value) }))
                       })
                     ]
                   }, botRosterKey(bot))
@@ -6683,7 +6925,16 @@ function GroupChatWorkspace({ group, members }) {
     }
 
     setDraft('')
-    sendToGroupChat(group, members.map(b => ({ name: b.name, title: allMeta[b.name]?.title || '' })), text)
+    // Full descriptors ride into the turn loop: remote members keep their
+    // connection fields so their turns route to their own machines.
+    sendToGroupChat(
+      group,
+      members.map(b => ({
+        ...b,
+        title: (b.remoteSource ? '' : allMeta[b.name]?.title) || b.title || ''
+      })),
+      text
+    )
   }
 
   return jsxs('div', {
@@ -6698,12 +6949,13 @@ function GroupChatWorkspace({ group, members }) {
             ...(room.log.length
               ? room.log.map((entry, index) => {
                   const isUser = entry.from.kind === 'user'
-                  const meta = isUser ? null : allMeta[entry.from.name]
+                  const meta = isUser || entry.from.source ? null : allMeta[entry.from.name]
+                  const sourceBadge = !isUser && entry.from.source ? ` · ${entry.from.source}` : ''
                   const label = isUser
                     ? 'You'
                     : meta?.title
-                      ? `${meta.title} (@${entry.from.name})`
-                      : `@${entry.from.name}`
+                      ? `${meta.title} (@${entry.from.name})${sourceBadge}`
+                      : `@${entry.from.name}${sourceBadge}`
 
                   return jsxs('div', {
                     className: isUser ? 'rounded-md bg-(--chrome-action-hover) px-2 py-1.5' : 'px-2 py-1',
@@ -6844,7 +7096,30 @@ function BotsPane() {
   }
 
   const groupChatMembers = groupChatName
-    ? activeSourceRoster.filter(bot => (botRosterMeta(bot, allMeta)?.group || '').trim() === groupChatName)
+    ? (() => {
+        const local = activeSourceRoster.filter(
+          bot => (botRosterMeta(bot, allMeta)?.group || '').trim() === groupChatName
+        )
+        // Remote members live on the room record (they can't ride bot-meta).
+        // Prefer the LIVE roster row for each descriptor when present —
+        // fresher handle/label — else seat the stored descriptor itself.
+        const stored = ($groupChats.get()[groupChatName] || {}).members || []
+        const seated = new Set(local.map(botRosterKey))
+        const remote = []
+
+        for (const descriptor of stored) {
+          const key = botRosterKey(descriptor)
+
+          if (seated.has(key)) {
+            continue
+          }
+
+          seated.add(key)
+          remote.push(roster.find(bot => botRosterKey(bot) === key) || descriptor)
+        }
+
+        return [...local, ...remote]
+      })()
     : []
 
   if (groupChatName && groupChatMembers.length) {
@@ -7097,7 +7372,9 @@ function BotsPane() {
       }),
       jsx(CreateGroupChatDialog, {
         open: groupCreateOpen,
-        roster: activeSourceRoster,
+        // Full multi-source roster: group chats can seat bots from other
+        // registered connections — their turns route to their own machines.
+        roster,
         onClose: () => setGroupCreateOpen(false),
         onCreated: groupName => $groupChatWorkspace.set(groupName)
       }),
@@ -7280,6 +7557,7 @@ export default {
                   log: room.log,
                   watermarks: room.watermarks && typeof room.watermarks === 'object' ? room.watermarks : {},
                   sessions: room.sessions && typeof room.sessions === 'object' ? room.sessions : {},
+                  members: Array.isArray(room.members) ? room.members : [],
                   epoch: 0,
                   running: false
                 }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2381,6 +2381,134 @@ function botHandle(name, bot) {
   return (name || '').trim().toLowerCase() === 'default' ? 'hermes' : name
 }
 
+function isActiveRosterBot(bot, active) {
+  const activeName = String(active?.name || 'default').trim() || 'default'
+  const activeId = String(active?.connectionId || '').trim()
+  const botId = String(bot?.connectionId || '').trim()
+  const botName = String(bot?.name || '').trim() || 'default'
+
+  if (bot?.remoteSource) {
+    return Boolean(activeId) && activeId === botId && botName === activeName
+  }
+
+  if (activeId && activeId !== 'local' && botId && activeId !== botId) {
+    return false
+  }
+
+  return botName === activeName
+}
+
+/** Resolve @handles in prose against the Bot Mode roster (local + Connections).
+ *  Skips the bot already speaking in this chat. Unique bare names match;
+ *  duplicate names require the @name-device handle. */
+function resolveRosterMentions(text, roster, active = {}) {
+  const members = Array.isArray(roster) ? roster : []
+  const prose = String(text || '').replace(/```[\s\S]*?```/g, ' ').replace(/`[^`\n]*`/g, ' ')
+  const byForm = new Map()
+
+  for (const bot of members) {
+    if (!bot?.name || isActiveRosterBot(bot, active)) {
+      continue
+    }
+
+    const handle = String(botHandle(bot.name, bot) || '').toLowerCase()
+    const name = String(bot.name || '').toLowerCase()
+    const forms = new Set([handle, name])
+
+    if (bot.handle) {
+      forms.add(String(bot.handle).toLowerCase())
+    }
+
+    for (const form of forms) {
+      if (!form) {
+        continue
+      }
+
+      const existing = byForm.get(form)
+
+      if (existing && existing !== bot) {
+        byForm.set(form, null)
+        continue
+      }
+
+      if (!existing) {
+        byForm.set(form, bot)
+      }
+    }
+  }
+
+  const mentioned = []
+  const seen = new Set()
+
+  for (const match of prose.matchAll(/(^|\s)@([a-z0-9][a-z0-9_-]*)/gi)) {
+    let token = match[2].toLowerCase()
+
+    if (token === 'hermes') {
+      token = byForm.has('hermes') ? 'hermes' : token
+    }
+
+    const bot = byForm.get(token)
+
+    if (!bot) {
+      continue
+    }
+
+    const key = botRosterKey(bot)
+
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    mentioned.push(bot)
+  }
+
+  return mentioned
+}
+
+async function deliverRemoteRosterMentions(bots, userText) {
+  const text = String(userText || '').trim()
+
+  if (!text || typeof host.requestProfile !== 'function') {
+    return
+  }
+
+  for (const bot of bots) {
+    const connectionId = String(bot?.connectionId || '').trim()
+    const profile = String(bot?.name || '').trim() || 'default'
+
+    if (!connectionId || connectionId === 'local') {
+      continue
+    }
+
+    try {
+      const created = await host.requestProfile(
+        { connectionId, profile, mode: 'remote', targetProfile: profile },
+        'session.create',
+        { profile, title: 'Bot Chat', hidden: true }
+      )
+      const sessionId = created?.session_id
+
+      if (!sessionId) {
+        throw new Error('No remote session')
+      }
+
+      await host.requestProfile(
+        { connectionId, profile, mode: 'remote', targetProfile: profile },
+        'prompt.submit',
+        { session_id: sessionId, text }
+      )
+      host.notify?.({
+        kind: 'info',
+        title: displayName(bot),
+        message: `Messaged @${botHandle(profile, bot)} on ${bot.connectionLabel || connectionId} from this chat.`
+      })
+    } catch (error) {
+      host.notifyError?.(error, `Could not reach ${bot.connectionLabel || profile}`)
+    }
+  }
+}
+
 /** Source-qualified identity for a roster row — the React list key AND the
  *  cross-surface roster identity. Names alone are NOT unique in a
  *  multi-source roster (two connections can both expose 'default');
@@ -3403,6 +3531,17 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
   const open = async () => {
     haptic('tap')
     $selectedBot.set(bot.name)
+
+    if (bot.remoteSource) {
+      const handle = botHandle(bot.name, bot)
+      host.notify?.({
+        kind: 'info',
+        title: displayName(bot),
+        message: `Stay in this chat and @${handle} to message them. Gateway stays on this device.`
+      })
+      return
+    }
+
     let pinnedChat = meta?.chat
 
     if (!bot.remoteSource && $botUnread.get()[bot.name]) {
@@ -6789,6 +6928,16 @@ function BotsPane() {
           haptic('tap')
           $selectedBot.set(bot.name)
 
+          if (bot.remoteSource) {
+            const handle = botHandle(bot.name, bot)
+            host.notify?.({
+              kind: 'info',
+              title: displayName(bot),
+              message: `Stay in this chat and @${handle} to message them. Gateway stays on this device.`
+            })
+            return
+          }
+
           if ($botUnread.get()[bot.name]) {
             const next = { ...$botUnread.get() }
             delete next[bot.name]
@@ -7031,9 +7180,13 @@ export default {
           const active = (host.state.profile.get() || 'default').trim() || 'default'
           const q = (query || '').toLowerCase()
           const items = []
+          const live = {
+            name: active,
+            connectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
+          }
 
           for (const profile of profiles) {
-            if (!profile?.name || profile.name === active) {
+            if (!profile?.name || isActiveRosterBot(profile, live)) {
               continue
             }
 
@@ -7233,52 +7386,73 @@ export default {
             return draft
           }
 
-          let names = []
-          try {
-            const res = await host.request('profiles.list', { include_sessions: false })
-            names = (res?.profiles ?? []).map(p => p.name)
-          } catch {
+          const live = {
+            name: (host.state.profile.get() || 'default').trim() || 'default',
+            connectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
+          }
+          const cached = typeof queryClient !== 'undefined' && queryClient && typeof queryClient.getQueryData === 'function'
+            ? queryClient.getQueryData(ROSTER_KEY)
+            : null
+          const roster = Array.isArray(cached?.profiles) ? cached.profiles : null
+          let mentionedBots = roster ? resolveRosterMentions(text, roster, live) : []
+
+          if (!roster) {
+            let names = []
+            try {
+              const res = await host.request('profiles.list', { include_sessions: false })
+              names = (res?.profiles ?? []).map(p => p.name)
+            } catch {
+              return draft
+            }
+
+            const prose = text.replace(/```[\s\S]*?```/g, ' ').replace(/`[^`\n]*`/g, ' ')
+            const mentioned = []
+
+            for (const match of prose.matchAll(/(^|\s)@([a-z0-9][a-z0-9_-]*)/gi)) {
+              let name = match[2].toLowerCase()
+
+              if (name === 'hermes' && !names.includes('hermes') && names.includes('default')) {
+                name = 'default'
+              }
+
+              if (names.includes(name) && name !== live.name && !mentioned.includes(name)) {
+                mentioned.push(name)
+              }
+            }
+
+            mentionedBots = mentioned.map(name => ({ name }))
+          }
+
+          if (!mentionedBots.length) {
             return draft
           }
 
-          // Mentions in code are code, not handoffs (#20).
-          const prose = text.replace(/```[\s\S]*?```/g, ' ').replace(/`[^`\n]*`/g, ' ')
-          const active = (host.state.profile.get() || 'default').trim() || 'default'
-          const mentioned = []
+          const localMentions = mentionedBots.filter(bot => !bot.remoteSource)
+          const remoteMentions = mentionedBots.filter(bot => bot.remoteSource)
 
-          for (const match of prose.matchAll(/(^|\s)@([a-z0-9][a-z0-9_-]*)/gi)) {
-            let name = match[2].toLowerCase()
-
-            if (name === 'hermes' && !names.includes('hermes') && names.includes('default')) {
-              name = 'default'
-            }
-
-            if (names.includes(name) && name !== active && !mentioned.includes(name)) {
-              mentioned.push(name)
-            }
+          if (remoteMentions.length && typeof host.requestProfile === 'function') {
+            void deliverRemoteRosterMentions(remoteMentions, text)
           }
 
-          if (!mentioned.length) {
-            return draft
+          const activeMeta = $botMeta.get()[live.name]
+          const senderName = displayName({ name: live.name, title: activeMeta?.title }, activeMeta)
+          let note = ''
+
+          if (localMentions.length) {
+            note +=
+              '\n\n[@mention handoff — for each mentioned agent (' + localMentions.map(bot => botHandle(bot.name, bot)).join(', ') + '): ' +
+              'COMPOSE a message from you (' + senderName + ') to that agent conveying what the user wants — do not forward this text verbatim (avoid double quotes in your composed message). Send it with exactly one terminal call, run with background=true AND notify_on_complete=true (the recipient may take minutes; the user must not be blocked):\n' +
+              localMentions.map(bot => '`hermes -p ' + shellQuote(bot.name) + ' chat --in ~ -c "Bot Chat" --create-if-missing -Q -q "Message from 🤖 ' + shellDoubleQuote(senderName) + ' (@' + shellDoubleQuote(botHandle(live.name)) + '): <your composed message>"`').join('\n') +
+              '\nAfter dispatching, tell the user the message was sent and END YOUR TURN — do not wait or poll; when the background process completes, its notification carries the reply — relay it then, attributed to that agent. ' +
+              'Relay the reply back to the user, attributed to that agent.]'
           }
 
-          // The ACTIVE BOT composes the message — it understands intent; a
-          // text pipe never can. Delivery is the one blessed command into the
-          // recipient's canonical Bot Chat, so their side reads as a normal
-          // DM (message bubble + their reply), and the reply prints on
-          // stdout for the sender to relay.
-          const activeMeta = $botMeta.get()[active]
-          const senderName = displayName({ name: active, title: activeMeta?.title }, activeMeta)
-          // The command below runs verbatim in the active agent's terminal:
-          // sender titles are free text (and sync from ui_meta), and profile
-          // names come from the gateway — every interpolated value must stay
-          // shell-literal, same class as the routine-prompt fix (#21).
-          const note =
-            '\n\n[@mention handoff — for each mentioned agent (' + mentioned.map(botHandle).join(', ') + '): ' +
-            'COMPOSE a message from you (' + senderName + ') to that agent conveying what the user wants — do not forward this text verbatim (avoid double quotes in your composed message). Send it with exactly one terminal call, run with background=true AND notify_on_complete=true (the recipient may take minutes; the user must not be blocked):\n' +
-            mentioned.map(n => '`hermes -p ' + shellQuote(n) + ' chat --in ~ -c "Bot Chat" --create-if-missing -Q -q "Message from \uD83E\uDD16 ' + shellDoubleQuote(senderName) + ' (@' + shellDoubleQuote(botHandle(active)) + '): <your composed message>"`').join('\n') +
-            '\nAfter dispatching, tell the user the message was sent and END YOUR TURN — do not wait or poll; when the background process completes, its notification carries the reply — relay it then, attributed to that agent. ' +
-            'Relay the reply back to the user, attributed to that agent.]'
+          if (remoteMentions.length) {
+            const labels = remoteMentions.map(bot => `@${botHandle(bot.name, bot)} (${bot.connectionLabel || bot.connectionId})`).join(', ')
+            note +=
+              '\n\n[@mention — stay on this device. Desktop is delivering to ' + labels +
+              ' over Connections in the background. Do not run hermes -p for them and do not switch Gateway. Tell the user they were messaged here; when a reply lands, relay it attributed to that agent.]'
+          }
 
           return { ...draft, text: text + note }
         }      }

--- a/apps/desktop/src/plugins/hermes-bots/tests/create-group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/create-group-chat.test.mjs
@@ -30,5 +30,5 @@ test('source contract: create-group modal has search, checkboxes, name, create',
 })
 
 test('source contract: group name falls back to member names, Discord-style', () => {
-  assert.match(pluginSource, /selected\.map\(bot => displayName\(bot, allMeta\[bot\.name\]\)\)\.join\(', '\)/)
+  assert.match(pluginSource, /selected\.map\(bot => displayName\(bot, botRosterMeta\(bot, allMeta\)\)\)\.join\(', '\)/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// Cross-connection Bot Mode: the New Agent "Create on" picker targets another
+// registered connection's backend, and group chats seat members from other
+// machines by routing their turns through host.requestProfile route
+// descriptors instead of the active gateway.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function runtime() {
+  const context = {
+    console,
+    setTimeout,
+    clearTimeout,
+    Date,
+    URL,
+    atom: initial => {
+      const listeners = new Set()
+      let value = initial
+      return {
+        get: () => value,
+        set: next => {
+          value = next
+          listeners.forEach(fn => fn(next))
+        },
+        listen: fn => {
+          listeners.add(fn)
+          return () => listeners.delete(fn)
+        }
+      }
+    },
+    host: {
+      request: async () => ({}),
+      requestProfile: async () => ({}),
+      state: {
+        profile: { get: () => 'default', listen: () => undefined },
+        connectionId: { get: () => 'local', listen: () => undefined },
+        gateway: { listen: () => undefined }
+      }
+    },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } }
+  }
+  const code = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(
+      '\nglobalThis.__x = { botConnectionRoute, requestForBot, groupMemberKey, parseGroupChatMentions, resolveGroupResponders, formatGroupChatLine, buildGroupChatTurnPrompt };\n'
+    )
+  vm.runInNewContext(code, context, { filename: 'plugin.js' })
+  return context
+}
+
+test('botConnectionRoute: remote rows get a route descriptor, local rows do not', () => {
+  const ctx = runtime()
+  const { botConnectionRoute } = ctx.__x
+
+  assert.equal(botConnectionRoute({ name: 'writer', connectionId: 'local' }), null)
+  assert.equal(botConnectionRoute({ name: 'writer' }), null)
+  // remoteSource is required — an annotated ACTIVE row keeps the active door.
+  assert.equal(botConnectionRoute({ name: 'writer', connectionId: 'spark', sourceScoped: true }), null)
+
+  const route = botConnectionRoute({ name: 'dixie', connectionId: 'mac-mini', remoteSource: true })
+  assert.deepEqual(JSON.parse(JSON.stringify(route)), {
+    connectionId: 'mac-mini',
+    mode: 'remote',
+    profile: 'dixie',
+    targetProfile: 'dixie'
+  })
+})
+
+test('requestForBot: remote members go through requestProfile, local through host.request', async () => {
+  const ctx = runtime()
+  const calls = []
+  ctx.host.request = async (method, params) => {
+    calls.push(['active', method, params])
+    return {}
+  }
+  ctx.host.requestProfile = async (route, method, params) => {
+    calls.push(['routed', route.connectionId, method, params])
+    return {}
+  }
+
+  const { requestForBot } = ctx.__x
+
+  await requestForBot({ name: 'local-bot' }, 'session.create', { title: 'x' })
+  await requestForBot({ name: 'dixie', connectionId: 'mac-mini', remoteSource: true }, 'prompt.submit', { text: 'hi' })
+
+  assert.equal(calls[0][0], 'active')
+  assert.equal(calls[0][1], 'session.create')
+  assert.equal(calls[1][0], 'routed')
+  assert.equal(calls[1][1], 'mac-mini')
+  assert.equal(calls[1][2], 'prompt.submit')
+})
+
+test('groupMemberKey: local members keep bare names (persisted-room compat), remote members are source-qualified', () => {
+  const ctx = runtime()
+  const { groupMemberKey } = ctx.__x
+
+  assert.equal(groupMemberKey({ name: 'ops' }), 'ops')
+  assert.equal(groupMemberKey({ name: 'dixie', connectionId: 'mac-mini', remoteSource: true }), 'mac-mini::dixie')
+})
+
+test('mentions: @name-device handle resolves the remote member; same-named agents stay distinct', () => {
+  const ctx = runtime()
+  const { parseGroupChatMentions, resolveGroupResponders } = ctx.__x
+  const members = [
+    { name: 'dixie', title: '' },
+    { name: 'dixie', handle: 'dixie-mac-mini', connectionId: 'mac-mini', remoteSource: true }
+  ]
+
+  const parsed = parseGroupChatMentions('hey @dixie-mac-mini can you check disk space', members)
+  assert.deepEqual([...parsed.mentioned], ['mac-mini::dixie'])
+
+  const log = [{ from: { kind: 'user', name: 'You' }, text: '@dixie-mac-mini ping', at: 1 }]
+  const responders = resolveGroupResponders(log, members)
+  assert.equal(responders.length, 1)
+  assert.equal(responders[0].remoteSource, true)
+})
+
+test('room lines and turn prompts badge cross-connection speakers with their device', () => {
+  const ctx = runtime()
+  const { formatGroupChatLine, buildGroupChatTurnPrompt } = ctx.__x
+
+  const line = formatGroupChatLine(
+    { from: { kind: 'member', name: 'dixie', source: 'Mac Mini' }, text: 'done', at: 1 },
+    'ops'
+  )
+  assert.equal(line, 'dixie [Mac Mini]: done')
+
+  const prompt = buildGroupChatTurnPrompt({
+    groupName: 'infra',
+    members: [
+      { name: 'ops', title: '' },
+      { name: 'dixie', connectionId: 'mac-mini', connectionLabel: 'Mac Mini', remoteSource: true }
+    ],
+    viewer: { name: 'ops' },
+    deltaLines: ['You (user): hi']
+  })
+  assert.match(prompt, /@dixie \[on Mac Mini\]/)
+})
+
+test('source contract: New Agent has a Create on picker that routes creation to the target backend', () => {
+  assert.match(pluginSource, /'Create on'/)
+  assert.match(pluginSource, /const \[targetConnection, setTargetConnection\] = useState\(''\)/)
+  // Creation and configuration go through the target door, not bare host.request.
+  assert.match(pluginSource, /await requestForTarget\('profiles\.create', \{/)
+  assert.match(pluginSource, /await requestForTarget\('profiles\.configure', \{ name: slug/)
+  // The picker only renders on multi-connection registries.
+  assert.match(pluginSource, /connections\.length > 1/)
+})
+
+test('source contract: group chat turns route through requestForBot on the member source', () => {
+  assert.match(pluginSource, /await requestForBot\(member, 'prompt\.submit'/)
+  assert.match(pluginSource, /await requestForBot\(member, 'session\.create'/)
+  // Room records persist remote member descriptors.
+  assert.match(pluginSource, /members: Array\.isArray\(room\.members\) \? room\.members : \[\]/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/draft-agent-discard.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/draft-agent-discard.test.mjs
@@ -8,11 +8,11 @@ import test from 'node:test'
 
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-test('discardDraft deletes the materialized draft via deleteBot', () => {
+test('discardDraft deletes the materialized draft (deleteBot locally, remote CLI for other connections)', () => {
   assert.match(source, /const discardDraft = \(\) => \{/)
-  assert.match(source, /void deleteBot\(\{ name: draft \}\)/)
+  assert.match(source, /: deleteBot\(\{ name: draft \}\)/)
   // Ref cleared FIRST so a re-entrant cancel can't double-delete.
-  assert.match(source, /createdRef\.current = null\n\s*flightRef\.current = null\n\s*void deleteBot/)
+  assert.match(source, /createdRef\.current = null\n\s*flightRef\.current = null\n\s*const discard = remoteTarget/)
 })
 
 test('both cancel paths discard the draft (esc/overlay + Cancel button)', () => {
@@ -32,5 +32,10 @@ test('renaming after materialization discards the orphaned draft', () => {
 })
 
 test("the draft's own slug does not read as taken", () => {
-  assert.match(source, /roster\.some\(b => b\.name === slug && b\.name !== createdRef\.current\)/)
+  // Both branches of the target-scoped taken check exempt the draft's slug.
+  assert.match(source, /roster\.some\(b => !b\.remoteSource && b\.name === slug && b\.name !== createdRef\.current\)/)
+  assert.match(
+    source,
+    /roster\.some\(b => b\.remoteSource && b\.connectionId === targetConnection && b\.name === slug && b\.name !== createdRef\.current\)/
+  )
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
@@ -110,3 +110,66 @@ test('regression: the handoff command quotes the recipient argument', async () =
   const result = await handler({ text: 'ping @ops please' })
   assert.match(result.text, /`hermes -p 'ops' chat --in ~/)
 })
+
+test('behavior: @dixie on a Connections bot stays in this chat and does not hermes -p', async () => {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const delivered = []
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    queryClient: {
+      getQueryData: () => ({
+        profiles: [
+          { name: 'default', connectionId: 'local' },
+          {
+            name: 'dixie',
+            connectionId: 'mac-mini',
+            connectionLabel: 'Mac Mini',
+            handle: 'dixie',
+            remoteSource: true
+          }
+        ]
+      })
+    },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      request: async () => ({ profiles: [{ name: 'default' }] }),
+      requestProfile: async (route, method) => {
+        delivered.push([route.connectionId, route.profile, method])
+        return { session_id: 'remote-1' }
+      },
+      state: {
+        profile: { get: () => 'default', listen: () => undefined },
+        connectionId: { get: () => 'local', listen: () => undefined },
+        gateway: { listen: () => undefined }
+      }
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__mention = { $botMeta };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  context.__mention.$botMeta.set({})
+
+  const registered = []
+  context.plugin.register({ storage: { get: () => null }, register: entry => registered.push(entry) })
+  const middleware = registered.find(entry => entry.id === 'mention-middleware')
+  const result = await middleware.data.handler({ text: '@dixie what is the disk space?' })
+
+  assert.match(result.text, /stay on this device/i)
+  assert.doesNotMatch(result.text, /hermes -p 'dixie'/)
+  await new Promise(resolve => setTimeout(resolve, 0))
+  assert.equal(delivered[0][0], 'mac-mini')
+  assert.equal(delivered[0][1], 'dixie')
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -417,6 +417,39 @@ test('merge: previously seen remotes survive a connect-on-demand empty union', (
   assert.equal(out.profiles.filter(p => p.name === 'default').length, 1)
 })
 
+test('merge: previous remotes from a removed connection do not resurrect', () => {
+  const { __mergeMultiSourceRoster: merge } = runtime()
+  const previous = [
+    { name: 'default', last_session: { id: 'this-chat' } },
+    {
+      name: 'bob',
+      remoteSource: true,
+      sourceScoped: true,
+      connectionId: 'gone',
+      connectionKind: 'ssh',
+      connectionLabel: 'Gone',
+      handle: 'bob'
+    }
+  ]
+  const local = { profiles: [{ name: 'default', last_session: { id: 'this-chat' } }] }
+  const union = {
+    primaryConnectionId: 'local',
+    agents: [
+      {
+        connectionId: 'local',
+        connectionKind: 'local',
+        connectionLabel: 'This device',
+        profile: 'default',
+        handle: 'default'
+      }
+    ],
+    sources: [{ connectionId: 'local', kind: 'local' }]
+  }
+
+  const out = merge(local, union, 'local', previous)
+  assert.equal(out.profiles.find(p => p.connectionId === 'gone'), undefined)
+})
+
 test('displayName: local default stays Hermes; remote default uses the device label', () => {
   const { __displayName: name } = runtime()
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -32,7 +32,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;'
+      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;'
     )
   vm.runInNewContext(code, context)
   return context
@@ -513,4 +513,73 @@ test('botRosterKey: same name on two sources yields distinct React keys', () => 
   assert.notEqual(activeRow, remoteRow)
   // Single-source desktops (no connection ids anywhere) keep a stable key.
   assert.equal(legacyRow, 'legacy::default')
+})
+
+test('resolveRosterMentions: @dixie and @bob-mac-mini hit Connections bots, not this chat', () => {
+  const { __resolveRosterMentions: resolve } = runtime()
+  const roster = [
+    { name: 'default', connectionId: 'local', connectionKind: 'local', handle: 'default-this-device' },
+    {
+      name: 'dixie',
+      connectionId: 'mac-mini',
+      connectionKind: 'ssh',
+      connectionLabel: 'Mac Mini',
+      handle: 'dixie',
+      remoteSource: true,
+      sourceScoped: true
+    },
+    {
+      name: 'bob',
+      connectionId: 'mac-mini',
+      connectionKind: 'ssh',
+      connectionLabel: 'Mac Mini',
+      handle: 'bob-mac-mini',
+      remoteSource: true,
+      sourceScoped: true
+    },
+    {
+      name: 'bob',
+      connectionId: 'spark',
+      connectionKind: 'ssh',
+      connectionLabel: 'Spark',
+      handle: 'bob-spark',
+      remoteSource: true,
+      sourceScoped: true
+    }
+  ]
+
+  const hits = resolve('hey @dixie and @bob-spark, ping @bob-mac-mini', roster, {
+    name: 'default',
+    connectionId: 'local'
+  })
+
+  assert.equal(
+    hits
+      .map(bot => `${bot.connectionId}::${bot.name}`)
+      .sort()
+      .join(','),
+    'mac-mini::bob,mac-mini::dixie,spark::bob'
+  )
+})
+
+test('resolveRosterMentions: @hermes in this chat is not a handoff to yourself', () => {
+  const { __resolveRosterMentions: resolve } = runtime()
+  const roster = [
+    { name: 'default', connectionId: 'local', handle: 'hermes' },
+    {
+      name: 'default',
+      connectionId: 'mac-mini',
+      connectionLabel: 'Mac Mini',
+      handle: 'default-mac-mini',
+      remoteSource: true
+    }
+  ]
+
+  const hits = resolve('ask @hermes and @default-mac-mini', roster, {
+    name: 'default',
+    connectionId: 'local'
+  })
+
+  assert.equal(hits.length, 1)
+  assert.equal(hits[0].connectionId, 'mac-mini')
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -343,6 +343,110 @@ test('merge: primary-local desktop keeps single-source behavior (no phantom rows
 // source's agent, profiles.list answers from THAT source — the merge must
 // classify against the live id, not the registry primary, or the active
 // source's agents duplicate all over again.
+test('merge: live-null local window does not treat registry primary as active', () => {
+  const { __mergeMultiSourceRoster: merge } = runtime()
+  const local = { profiles: [{ name: 'default', last_session: { id: 'this-chat' } }] }
+  const union = {
+    primaryConnectionId: 'spark',
+    agents: [
+      {
+        connectionId: 'local',
+        connectionKind: 'local',
+        connectionLabel: 'This device',
+        profile: 'default',
+        handle: 'default-this-device'
+      },
+      { connectionId: 'spark', connectionKind: 'ssh', connectionLabel: 'Spark', profile: 'bob', handle: 'bob' },
+      { connectionId: 'spark', connectionKind: 'ssh', connectionLabel: 'Spark', profile: 'kai', handle: 'kai' },
+      { connectionId: 'spark', connectionKind: 'ssh', connectionLabel: 'Spark', profile: 'rook', handle: 'rook' }
+    ]
+  }
+
+  // Clicking the local agent leaves host.state.connectionId null while the
+  // registry primary stays on Spark. That must not skip Spark bots or invent
+  // a second "This device" shadow of default.
+  const out = merge(local, union, null)
+
+  assert.equal(out.profiles.filter(p => p.name === 'default').length, 1)
+  assert.equal(out.profiles.find(p => p.name === 'default').last_session.id, 'this-chat')
+  assert.equal(out.profiles.filter(p => p.remoteSource && p.connectionId === 'local').length, 0)
+  assert.equal(
+    out.profiles
+      .filter(p => p.remoteSource)
+      .map(p => p.name)
+      .sort()
+      .join(','),
+    'bob,kai,rook'
+  )
+})
+
+test('merge: previously seen remotes survive a connect-on-demand empty union', () => {
+  const { __mergeMultiSourceRoster: merge } = runtime()
+  const previous = [
+    { name: 'default', last_session: { id: 'this-chat' } },
+    {
+      name: 'bob',
+      remoteSource: true,
+      sourceScoped: true,
+      connectionId: 'spark',
+      connectionKind: 'ssh',
+      connectionLabel: 'Spark',
+      handle: 'bob'
+    }
+  ]
+  const local = { profiles: [{ name: 'default', last_session: { id: 'this-chat' } }] }
+  const union = {
+    primaryConnectionId: 'local',
+    agents: [
+      {
+        connectionId: 'local',
+        connectionKind: 'local',
+        connectionLabel: 'This device',
+        profile: 'default',
+        handle: 'default'
+      }
+    ],
+    sources: [{ connectionId: 'spark', kind: 'ssh', error: 'connect-on-demand' }]
+  }
+
+  const out = merge(local, union, 'local', previous)
+  const bob = out.profiles.find(p => p.name === 'bob' && p.connectionId === 'spark')
+
+  assert.ok(bob)
+  assert.equal(bob.remoteSource, true)
+  assert.equal(out.profiles.filter(p => p.name === 'default').length, 1)
+})
+
+test('displayName: local default stays Hermes; remote default uses the device label', () => {
+  const { __displayName: name } = runtime()
+
+  assert.equal(
+    name(
+      {
+        name: 'default',
+        sourceScoped: true,
+        connectionKind: 'local',
+        connectionLabel: 'This device'
+      },
+      null
+    ),
+    'Hermes'
+  )
+  assert.equal(
+    name(
+      {
+        name: 'default',
+        sourceScoped: true,
+        remoteSource: true,
+        connectionKind: 'ssh',
+        connectionLabel: 'Spark'
+      },
+      null
+    ),
+    'Spark'
+  )
+})
+
 test('merge: live active id beats primaryConnectionId for active-source matching', () => {
   const { __mergeMultiSourceRoster: merge } = runtime()
   const local = { profiles: [{ name: 'default', last_session: { id: 's1' } }] }

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -23,6 +23,7 @@ function renderBotRow(input = 'alpha') {
   const ensured = []
   const opened = []
   const warmed = []
+  let liveConnectionId = 'local'
   const atom = value => ({
     get: () => value,
     set: next => {
@@ -63,7 +64,11 @@ function renderBotRow(input = 'alpha') {
     useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
     host: {
       state: { gateway: atom('open'), profile: atom('default') },
-      ensureAgent: async (connectionId, profile) => ensured.push([connectionId, profile]),
+      ensureAgent: async (connectionId, profile) => {
+        ensured.push([connectionId, profile])
+        liveConnectionId = connectionId
+      },
+      activeConnectionId: () => liveConnectionId,
       warmAgent: (connectionId, profile) => warmed.push([connectionId, profile]),
       warmProfile: profile => warmed.push(profile),
       request: async method =>
@@ -128,4 +133,84 @@ test('behavior: a thin source row activates its owner and uses that owner\'s cha
   await row.props.onClick()
   assert.deepEqual(ensured, [['work', 'research']])
   assert.deepEqual(opened, [['research', 'owner-chat']])
+})
+
+test('behavior: remote default does not open this-device chat when the source did not activate', async () => {
+  const bot = {
+    connectionId: 'mac-mini',
+    connectionLabel: 'Mac Mini',
+    name: 'default',
+    remoteSource: true,
+    sourceScoped: true
+  }
+  const prepareSource = sourceBetween('async function prepareBotSource(', 'function displayName(')
+  const botRowSource = sourceBetween('function BotRow(', '// ── model picker')
+  const ensured = []
+  const opened = []
+  const errors = []
+  const atom = value => ({
+    get: () => value,
+    set: next => {
+      value = next
+    }
+  })
+  const node = (type, props = {}) => ({ type, props })
+  const context = {
+    BotFace: 'BotFace',
+    ContextMenu: 'ContextMenu',
+    ContextMenuContent: 'ContextMenuContent',
+    ContextMenuItem: 'ContextMenuItem',
+    ContextMenuSeparator: 'ContextMenuSeparator',
+    ContextMenuTrigger: 'ContextMenuTrigger',
+    ROSTER_KEY: ['hermes-bots', 'roster'],
+    $botMeta: atom({ default: { chat: 'this-device-chat' } }),
+    $botUnread: atom({}),
+    $lastRoster: atom([]),
+    $selectedBot: atom('default'),
+    botAppearance: () => ({ shape: 'round', color: '#000', image: null }),
+    botHandle: value => value,
+    botRosterMeta: () => null,
+    cn: (...values) => values.filter(Boolean).join(' '),
+    createCanonicalChat: async () => null,
+    displayName: bot => bot.connectionLabel || bot.name,
+    duplicateBot: async () => 'copy',
+    haptic: () => undefined,
+    previewKind: () => ({ fromBot: false, sender: null }),
+    generatedSessionTitle: () => null,
+    openBotCanonicalChat: async (...args) => {
+      opened.push(args)
+      return 'this-device-chat'
+    },
+    ACTIVE_WINDOW_S: 90,
+    A2A_PREFIX_RE: /^$/,
+    useEffect: () => undefined,
+    useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
+    host: {
+      state: { gateway: atom('open'), profile: atom('default') },
+      ensureAgent: async (connectionId, profile) => ensured.push([connectionId, profile]),
+      activeConnectionId: () => 'local',
+      warmAgent: () => undefined,
+      warmProfile: () => undefined,
+      request: async () => ({ profiles: [{ name: 'default', ui_meta: { 'hermes-bots': { chat: 'this-device-chat' } } }] }),
+      notify: () => undefined,
+      notifyError: (_err, msg) => errors.push(msg)
+    },
+    jsx: node,
+    jsxs: node,
+    onEdit: () => undefined,
+    queryClient: { invalidateQueries: () => undefined },
+    relativeTime: () => 'now',
+    saveBotMeta: () => undefined,
+    showsHandle: () => false,
+    useValue: store => store.get()
+  }
+
+  vm.runInNewContext(`${prepareSource}\n${botRowSource}\nglobalThis.BotRow = BotRow`, context)
+  const tree = context.BotRow({ bot, onEdit: context.onEdit })
+  const row = tree.type === 'button' ? tree : tree.props.children[0].props.children
+
+  await row.props.onClick()
+  assert.deepEqual(ensured, [['mac-mini', 'default']])
+  assert.deepEqual(opened, [])
+  assert.match(String(errors[0] || ''), /Mac Mini/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -118,7 +118,7 @@ test('behavior: pointer entry prewarms only the hovered bot', () => {
   assert.deepEqual(warmed, ['alpha'])
 })
 
-test('behavior: a thin source row activates its owner and uses that owner\'s chat pin', async () => {
+test('behavior: a remote Connections row stays in this chat instead of hopping SSH', async () => {
   const { ensured, opened, row, warmed } = renderBotRow({
     connectionId: 'work',
     connectionLabel: 'Work',
@@ -131,8 +131,8 @@ test('behavior: a thin source row activates its owner and uses that owner\'s cha
   assert.deepEqual(warmed, [['work', 'research']])
 
   await row.props.onClick()
-  assert.deepEqual(ensured, [['work', 'research']])
-  assert.deepEqual(opened, [['research', 'owner-chat']])
+  assert.deepEqual(ensured, [])
+  assert.deepEqual(opened, [])
 })
 
 test('behavior: remote default does not open this-device chat when the source did not activate', async () => {
@@ -210,7 +210,7 @@ test('behavior: remote default does not open this-device chat when the source di
   const row = tree.type === 'button' ? tree : tree.props.children[0].props.children
 
   await row.props.onClick()
-  assert.deepEqual(ensured, [['mac-mini', 'default']])
+  assert.deepEqual(ensured, [])
   assert.deepEqual(opened, [])
-  assert.match(String(errors[0] || ''), /Mac Mini/)
+  assert.equal(errors.length, 0)
 })

--- a/apps/desktop/src/sdk/host-state.test.ts
+++ b/apps/desktop/src/sdk/host-state.test.ts
@@ -65,7 +65,7 @@ describe('host.state focused-session atoms', () => {
     expect(host.state.connectionId.get()).toBe('work')
 
     session.setConnection({ mode: 'local' } as never)
-    expect(host.state.connectionId.get()).toBeNull()
+    expect(host.state.connectionId.get()).toBe('local')
     session.setConnection(null)
   })
 

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -169,7 +169,20 @@ if (typeof window !== 'undefined') {
 /** Live usage of the FOCUSED session, projected out of the streamed session
  *  state — the same readout the core statusbar's context chip paints. */
 const $focusedUsage = computed($focusedSessionState, state => state?.usage ?? null)
-const $activeConnectionId = computed($connection, connection => connection?.connectionId ?? null)
+const $activeConnectionId = computed($connection, connection => {
+  if (!connection) {
+    return null
+  }
+
+  if (connection.connectionId) {
+    return connection.connectionId
+  }
+
+  // mode:'local' used to report null, which made Bot Mode fall back to the
+  // registry primary (often an SSH box) and treat Spark as the active source
+  // while this window was actually local.
+  return connection.mode === 'local' ? 'local' : null
+})
 
 export const host = {
   state: {

--- a/contributors/emails/alzilla22@gmail.com
+++ b/contributors/emails/alzilla22@gmail.com
@@ -1,0 +1,1 @@
+AL-ZiLLA

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -39,6 +39,18 @@ An **Advanced** disclosure opens the full capabilities surface:
 - **Per-skill, per-toolset, and per-MCP-server enablement** — tick exactly the capabilities this specialist needs.
 - **Shared keys** — by default the new Bot shares one OAuth/token pool with the main profile, so credential refreshes cannot invalidate each other. (Older gateways copy credentials instead — still functional, just forked.)
 
+### Choosing which machine it lives on ("Create on")
+
+With more than one connection registered in [Settings → Connections](./multi-connection-desktop.md), the New Agent dialog grows a **Create on** picker. Pick a device and the profile is created on **that** machine's backend — your window never switches gateways. The new Bot then appears in the roster as a Connections Bot (with an `@name-device` handle when the name exists on several machines), and chatting with it routes to its own machine.
+
+With a single connection (the common case) the picker is hidden and the Bot is created on the machine you're connected to — exactly the old behavior.
+
+Remote-creation notes:
+
+- **Clone source** is a profile of the *target* machine (its `default`) — a remote box doesn't have your local profiles to clone.
+- The live Capabilities tab binds to your active gateway, so a remote-target draft uses the staged Skills/Tools/MCP checklists instead; both read the target machine's catalog.
+- Cancelling the dialog discards the draft profile on whichever machine it was created.
+
 **Edit Profile** (right-click a Bot) reopens the same surface on the live profile any time: avatar, title, description, model pin, skills, toolsets, MCP servers, and the full SOUL.md.
 
 **Duplicate** (right-click) makes a full clone of a Bot — config, skills, SOUL.md, memory, and its look. **Delete Profile** permanently removes one, behind the same destructive confirmation the desktop's profile menu uses; the default profile cannot be deleted.
@@ -70,12 +82,15 @@ Right-click a Bot → **Move to group** to organize the roster into labeled sect
 - Bots pull each other in with `@name`, and escalate real judgment calls to you with `@user` — the group header shows a **needs you** badge when that happens.
 - Hard caps (10 messages per send, 3 rounds) keep rooms from spinning.
 - Each member keeps its own persistent `Group: <name>` session, so room context survives like any other conversation.
+- **Not every Bot replies to every message.** Speaking is each member's own choice — a Bot replies only when it has something new to add and passes otherwise, and @-mentioning specific members scopes the round to them. Expect the members you addressed (or whoever has something to say) to speak, and the rest to stay quiet.
+- **Rooms can span machines.** The New Group Chat picker seats Bots from any registered connection; each member's turns run on its own machine, in its own `Group: <name>` session there. Cross-machine members carry a device badge (`dixie · Mac Mini`) in the room and in other members' transcripts, and the disambiguated `@name-device` handle works in room mentions — so same-named agents on two machines never blur together.
 
 ## Bot-to-bot messaging
 
 Bots message each other with attribution, and you can hand work off from any chat:
 
 - **@mentions** — type `@researcher have a look at this` in any chat and the active Bot hands the message off, waits for the reply, and reports back. Mention names are validated against the live roster, so an email address or an unknown `@` passes through untouched.
+- **@mentions across machines** — mentioning a Bot that lives on another registered connection (use its `@name-device` handle when names collide) delivers over the Connections registry in the background: the active Bot stays on this device, the desktop routes the message to the recipient's machine, and the reply is relayed back attributed to that agent. Your window's gateway never switches.
 - **Direct messages** — a Bot reaches a teammate's Bot Chat through the standard CLI: `hermes -p <bot> chat --in ~ -c "Bot Chat" --create-if-missing -Q -q "Message from 🤖 <sender> (@<sender>): ..."`. The receiving Bot sees the message the next time it runs and knows how to reply, because the messaging protocol is part of its Bot Chat system prompt.
 
 The backend teaches each Bot's canonical Bot Chat session the messaging protocol automatically at prompt-build time — including when a teammate opens it headlessly from the CLI. Only the canonical Bot Chat gets the protocol section; your regular sessions and your SOUL.md stay untouched. This is controlled by `agent.bot_mode_protocol` in `config.yaml` (default: on):
@@ -91,7 +106,9 @@ Bot-to-bot delivery is per-invocation: the receiving Bot picks the message up wh
 
 ## Bots across machines
 
-When you register several backends in **Settings → Connections** — the local runtime, remote gateways, SSH hosts, Hermes Cloud instances — the roster shows the Bots from **every** connected source. When the same profile name exists on several sources, handles disambiguate as `@name-device` (for example `@research-homelab`). Opening a Bot dials its own source: its chats, sessions, memory, and routines live on the machine that owns the profile.
+When you register several backends in **Settings → Connections** — the local runtime, remote gateways, SSH hosts, Hermes Cloud instances — the roster shows the Bots from **every** connected source, persistently: SSH sources are inventoried without spawning anything on the remote box, and machines that are momentarily unreachable keep their last-known rows instead of vanishing. When the same profile name exists on several sources, handles disambiguate as `@name-device` (for example `@research-homelab`). A Bot's chats, sessions, memory, and routines live on the machine that owns the profile.
+
+Clicking a Connections Bot does **not** hop your window onto that machine — stay in your chat and `@mention` it, seat it in a group chat, or create new agents on it directly with the **Create on** picker. Cloud and local agents share one roster this way: register your Hermes Cloud instance and your desktop (say, over Tailscale or SSH) and their Bots can message each other and sit in the same rooms, with each agent's work running on its own machine.
 
 See [Connecting Desktop to Many Hermes Instances](./multi-connection-desktop.md) for the full multi-connection guide.
 

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -185,6 +185,10 @@ sessions stay untouched.
 Don't want it? Flip it off in **Settings → Plugins → Bots** — the roster,
 routines pane, and composer middleware unregister live, no restart needed.
 
+Full guide — creating agents (including the multi-machine **Create on**
+picker), the roster across connections, bot-to-bot mentions, and how group
+chats decide who replies: [Bot Mode: A Roster of Agents](./bot-mode.md).
+
 ### Keyboard & navigation
 
 - **Command palette** — press **Cmd+K** or **Cmd+P** (Ctrl+K / Ctrl+P on Windows/Linux) to jump to actions and navigate the app from the keyboard: open any page or settings section, jump to a session by title or id, switch model/theme/color mode, spawn a terminal, restart the gateway, update Hermes, and more.

--- a/website/docs/user-guide/multi-connection-desktop.md
+++ b/website/docs/user-guide/multi-connection-desktop.md
@@ -116,8 +116,8 @@ machine keep working. If a migrated name collided, it was suffixed
 ## Agents across sources
 
 Every [profile](./profiles.md) on every registered connection is an *agent*.
-The union roster is what multi-source surfaces (and plugins like
-[Bot Mode](https://github.com/NousResearch/Hermes-Bot-Mode)) render:
+The union roster is what multi-source surfaces (and the built-in
+[Bot Mode](./bot-mode.md) roster) render:
 
 - When the same profile name exists on several sources, handles disambiguate
   as **`@name-device`** — `research` on your Homelab renders as


### PR DESCRIPTION
## Summary
Bot Mode now works fully across machines: the New Agent dialog can create a bot on any registered connection ("Create on" picker), group chats can seat bots from different machines with each member's turns running on its own backend, and @mentions of Connections bots deliver without switching your window's gateway. Salvages @AL-ZiLLA's #88598 multi-source roster fixes (6 commits, authorship preserved) onto current main and builds the cross-connection features on top.

## Changes
- **Salvaged #88598 (@AL-ZiLLA):** SSH Bot Mode agents stay visible across local clicks (live-null connection id no longer inherits registry primary), SSH inventory without spawning dashboards (`ls ~/.hermes/profiles` probe, cached, cooldown retry, hostile-HERMES_HOME guard), rows for removed SSH connections dropped, SSH default bots open on the remote root profile (fixes the `--profile conn:<id>::<profile>` spawn bug from #88625), Connections bots mentionable from the local chat.
- **New Agent "Create on" picker** (plugin): multi-connection registries get a device selector; `profiles.create`/`configure`/`describe`/`mcp.catalog` route to the picked backend via `host.requestProfile` route descriptors. Target-scoped taken-name check, remote draft discard, ui_meta/avatar writes on the remote profile, staged capability checklists for remote targets (live SkillsView stays active-gateway-bound).
- **Cross-machine group chats** (plugin): member turns (`session.create`/`resume`, `prompt.submit`, reply polling) route to each member's own source via the new `requestForBot` helper; remote member descriptors persist on the room record; watermarks/sessions keyed by source-qualified member keys; `@name-device` handles resolve in room mentions; device badges in room lines and turn prompts.
- **`pidIsOurDashboard`** (electron): a dead remote PID reads as FOREIGN instead of throwing the misleading "Could not verify SSH backend process ownership" (secondary bug from #88625).
- **Docs:** Bot Mode guide gains the Create-on picker, the "not every bot replies" group-chat explanation, cross-machine mentions, and the cloud+desktop recipe; desktop.md and multi-connection pages cross-link.

## Validation
| | Result |
|---|---|
| Bot Mode plugin tests (incl. new cross-connection-bots.test.mjs) | 181/181 |
| Desktop vitest (electron + sdk) | 1280 passed, 2 skipped |
| `npm run check:lint` (3 tsconfigs + eslint) | 0 errors |
| Attribution audit | all emails mapped (@AL-ZiLLA added) |

Closes #88598 (salvaged with authorship). Fixes the spawn half + error-classification half of #88625.

## Infographic

![Cross-connection Bot Mode](https://v3b.fal.media/files/b/0aa6bf99/X8gkoX2Tfs99e8ZNPYRph_O0c7hipA.png)
