### PR TITLE
fix(desktop): identify native About build

### DIFF
--- a/apps/desktop/electron/about-version.test.ts
+++ b/apps/desktop/electron/about-version.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+
+import { describe, it } from 'vitest'
+
+import { buildAboutPanelVersionOptions } from './about-version'
+
+describe('native About version', () => {
+  it('uses the Hermes version and immutable bundle commit', () => {
+    assert.deepEqual(
+      buildAboutPanelVersionOptions({
+        applicationVersion: '0.20.3',
+        installCommit: 'a'.repeat(40)
+      }),
+      {
+        applicationVersion: '0.20.3',
+        version: 'aaaaaaa'
+      }
+    )
+  })
+
+  it('keeps the bundle-skew warning in secondary text', () => {
+    assert.deepEqual(
+      buildAboutPanelVersionOptions({
+        applicationVersion: '0.20.3',
+        installCommit: 'b'.repeat(40),
+        bundleOutOfSync: true
+      }),
+      {
+        applicationVersion: '0.20.3',
+        credits: 'App build out of date. Update the desktop app.',
+        version: 'bbbbbbb'
+      }
+    )
+  })
+
+  it('omits missing, malformed, and fallback build stamps', () => {
+    for (const installCommit of [null, 'not-a-sha', '0'.repeat(40)]) {
+      assert.deepEqual(buildAboutPanelVersionOptions({ applicationVersion: '0.20.3', installCommit }), {
+        applicationVersion: '0.20.3'
+      })
+    }
+  })
+
+  it('marks locally modified builds', () => {
+    assert.equal(
+      buildAboutPanelVersionOptions({
+        applicationVersion: '0.20.3',
+        installCommit: 'c'.repeat(40),
+        installDirty: true
+      }).version,
+      'ccccccc-dirty'
+    )
+  })
+})

--- a/apps/desktop/electron/about-version.ts
+++ b/apps/desktop/electron/about-version.ts
@@ -1,0 +1,24 @@
+const FULL_GIT_SHA = /^[0-9a-f]{40}$/i
+
+export interface AboutPanelVersionInput {
+  applicationVersion: string
+  installCommit?: string | null
+  installDirty?: boolean
+  bundleOutOfSync?: boolean
+}
+
+export function buildAboutPanelVersionOptions({
+  applicationVersion,
+  installCommit,
+  installDirty = false,
+  bundleOutOfSync = false
+}: AboutPanelVersionInput) {
+  const validCommit = FULL_GIT_SHA.test(installCommit || '') && !/^0{40}$/.test(installCommit || '')
+  const buildVersion = validCommit ? `${installCommit!.slice(0, 7)}${installDirty ? '-dirty' : ''}` : null
+
+  return {
+    applicationVersion,
+    ...(buildVersion ? { version: buildVersion } : {}),
+    ...(bundleOutOfSync ? { credits: 'App build out of date. Update the desktop app.' } : {})
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -30,6 +30,7 @@ import {
   systemPreferences
 } from 'electron'
 
+import { buildAboutPanelVersionOptions } from './about-version'
 import { classifyActiveRuntime } from './active-runtime-state'
 import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } from './api-transport'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
@@ -1241,15 +1242,9 @@ if (IS_WINDOWS) {
   app.setAppUserModelId('com.nousresearch.hermes')
 }
 
-// Seed the native About panel with the live Hermes version. This is refreshed
-// on every open via the explicit "About" menu handler (refreshAboutPanel), so
-// an in-place `hermes update` mid-session is reflected without an app restart;
-// the seed here just covers the first open and any non-menu invocation path.
-app.setAboutPanelOptions({
-  applicationName: APP_NAME,
-  applicationVersion: resolveHermesVersion(),
-  copyright: 'Copyright © 2026 Nous Research'
-})
+// Seed the native About panel before app readiness. The menu handler refreshes
+// the live runtime version and renderer-skew warning before every open.
+app.setAboutPanelOptions(currentAboutPanelOptions())
 
 // Custom scheme for streaming audio/video into the renderer. Local paths read
 // from this machine; remote paths are proxied through the configured gateway
@@ -15027,19 +15022,24 @@ async function detectRendererSkew() {
   return detectBundleSkew(INSTALL_STAMP, runGit, resolveUpdateRoot())
 }
 
-// Re-resolve the live Hermes version and push it into the native About panel
-// just before showing it, so an in-place `hermes update` is reflected without
-// an app restart. macOS only — `showAboutPanel()` is a no-op elsewhere, and the
-// other platforms don't use this menu item.
+function currentAboutPanelOptions(bundleOutOfSync = false) {
+  return {
+    applicationName: APP_NAME,
+    ...buildAboutPanelVersionOptions({
+      applicationVersion: resolveHermesVersion(),
+      installCommit: INSTALL_STAMP?.commit,
+      installDirty: INSTALL_STAMP?.dirty,
+      bundleOutOfSync
+    }),
+    copyright: 'Copyright © 2026 Nous Research'
+  }
+}
+
+// Refresh the live Hermes version and renderer-skew warning before opening.
+// macOS only — `showAboutPanel()` is a no-op elsewhere.
 function showAboutPanelFresh() {
   void detectRendererSkew().then(skew => {
-    app.setAboutPanelOptions({
-      applicationName: APP_NAME,
-      applicationVersion: skew.outOfSync
-        ? `${resolveHermesVersion()} — app build out of date, update the desktop app`
-        : resolveHermesVersion(),
-      copyright: 'Copyright © 2026 Nous Research'
-    })
+    app.setAboutPanelOptions(currentAboutPanelOptions(skew.outOfSync))
     app.showAboutPanel()
   })
 }


### PR DESCRIPTION
## What does this PR do?

The native macOS About panel can currently render `Version 0.20.3 (0.17.0)`: the live Hermes version followed by stale Desktop package metadata. That makes a healthy build look like a runtime/client mismatch.

Use the validated `install-stamp.json` commit as the native build identity instead, so the panel reads `Version 0.20.3 (2bc80c7)`. Missing, malformed, dirty, and fallback stamps are handled explicitly. The bundle-skew warning from #88641 remains secondary text.

This is intentionally separate from #63167, which fixes the release pipeline that allowed Desktop package metadata to drift.

## Related work

- #88326 uses the same validated packaged commit for update status, behind-count, and changelog; this PR owns the native macOS About surface only.
- #91525 verifies that a package's renderer content matches the source that built it. That provenance hash is complementary to, not a replacement for, the packaged commit shown here.
- #88641 and #63167 cover bundle-skew detection and release metadata drift.
- #91277 is the fleet-update umbrella; this PR supplies one truthful client-build identity surface.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add a pure helper for native About version options.
- Show the canonical Hermes version plus the immutable packaged commit on macOS.
- Preserve the existing out-of-sync warning without changing native typography.

## How to Test

1. Package Hermes Desktop with a valid install stamp.
2. Open **Hermes → About Hermes** on macOS.
3. Confirm it shows `Version <Hermes version> (<short build commit>)` and does not show the stale package version.

## Validation

Validation on rebased head `5614cf61875` over frozen `main` `28b758d5caa`:

- Focused About-version suite: **4 passed**
- Full Electron/platform suite: **121 files passed, 1 skipped / 1,733 tests passed, 3 skipped**
- Desktop typecheck: passed
- ESLint on changed files: 0 errors
- `git diff --check` and contributor-attribution audit: passed
- The earlier packaged macOS About-panel UAT remains supplementary evidence; this history-only rebase preserved the exact virtual-merge tree.

## Checklist

- [x] I have read the contributing guide.
- [x] The commit follows Conventional Commits.
- [x] I searched open and merged PRs for duplicates.
- [x] The PR contains only this fix.
- [x] Tests cover the new behavior.
- [x] Documentation, config, architecture, and tool-schema updates are N/A.
- [x] Cross-platform impact considered: the native About menu is macOS-only; other About surfaces are unchanged.

## Screenshot

<img src="https://raw.githubusercontent.com/dokterdok/hermes-agent/pr-assets/.github/pr-assets/pr-88665/about-version-identity.jpg" alt="Native macOS About panel showing Hermes Version 0.20.3 with its packaged commit" width="284">
