### PR TITLE
fix(discord): avoid poisoning shared rate-limit buckets

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2419,17 +2419,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 return
             self._record_command_sync_attempt(app_id, fingerprint)
 
-            http = getattr(self._client, "http", None)
-            has_ratelimit_timeout = http is not None and hasattr(http, "max_ratelimit_timeout")
-            previous_ratelimit_timeout = getattr(http, "max_ratelimit_timeout", None) if has_ratelimit_timeout else None
-            if has_ratelimit_timeout:
-                http.max_ratelimit_timeout = _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS
-
             try:
-                # Discord's per-app command-management bucket is small, and
-                # discord.py can otherwise sit inside one long retry sleep
-                # before surfacing the 429. Keep the whole sync bounded and
-                # persist Discord's retry-after when it refuses the batch.
+                # Bound the whole sync without mutating the shared Discord HTTP
+                # client's rate-limit policy. Discord buckets snapshot that
+                # value when they are created, so a temporary global override
+                # can permanently leak into unrelated concurrent routes.
                 summary = await asyncio.wait_for(self._safe_sync_slash_commands(), timeout=600)
             except Exception as e:
                 if not self._is_discord_rate_limit(e):
@@ -2446,9 +2440,6 @@ class DiscordAdapter(BasePlatformAdapter):
                     retry_after,
                 )
                 return
-            finally:
-                if has_ratelimit_timeout:
-                    http.max_ratelimit_timeout = previous_ratelimit_timeout
 
             self._record_command_sync_success(app_id, fingerprint, summary)
             logger.info(

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -440,6 +440,43 @@ async def test_safe_sync_slash_commands_only_mutates_diffs():
 
 
 @pytest.mark.asyncio
+async def test_post_connect_sync_does_not_mutate_shared_http_rate_limit(monkeypatch):
+    """Command sync must not lower rate-limit waits for concurrent Discord calls."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    http = SimpleNamespace(max_ratelimit_timeout=None)
+    adapter._client = SimpleNamespace(
+        http=http,
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+    summary = {
+        "total": 0,
+        "unchanged": 0,
+        "updated": 0,
+        "recreated": 0,
+        "created": 0,
+        "deleted": 0,
+    }
+    observed_limits = []
+
+    async def sync():
+        observed_limits.append(http.max_ratelimit_timeout)
+        return summary
+
+    monkeypatch.setattr(adapter, "_get_discord_command_sync_policy", lambda: "safe")
+    monkeypatch.setattr(adapter, "_desired_command_sync_fingerprint", lambda: "fingerprint")
+    monkeypatch.setattr(adapter, "_command_sync_skip_reason", lambda *_args: None)
+    monkeypatch.setattr(adapter, "_record_command_sync_attempt", MagicMock())
+    monkeypatch.setattr(adapter, "_record_command_sync_success", MagicMock())
+    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
+
+    await adapter._run_post_connect_initialization()
+
+    assert observed_limits == [None]
+    assert http.max_ratelimit_timeout is None
+
+
+@pytest.mark.asyncio
 async def test_post_connect_initialization_retries_fingerprint_after_timeout(tmp_path, monkeypatch):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
     monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)


### PR DESCRIPTION
## What does this PR do?

Discord route buckets can inherit a temporary 30-second rate-limit ceiling during post-connect slash-command synchronization. A production thread request later received `retry_after=136.57`; discord.py raised `RateLimited` instead of waiting, and Hermes entered its seed-message fallback, posted two duplicate notices, then abandoned the request.

`HTTPClient.max_ratelimit_timeout` is shared mutable state. Discord.py copies it into each route bucket when the bucket is created, so restoring the client property does not repair a thread bucket created during the synchronization window.

This PR removes that shared mutation. Slash-command synchronization remains bounded by the existing 600-second `asyncio.wait_for()`, while unrelated Discord routes keep the client's normal rate-limit policy.

The tradeoff is that command synchronization can wait inside discord.py instead of surfacing and persisting an exact `retry_after` immediately. The existing operation timeout still caps the wait, and avoiding cross-route state corruption is the safer boundary.

## Related Issue

Fixes #88653

PR #76060 handles residual 429 responses inside auto-thread creation. It does not remove the slash-sync mutation that caused the observed thread bucket to retain a 30-second ceiling. This PR stays separate from that function so the two changes do not conflict.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/discord/adapter.py`
  - Stop changing the shared Discord HTTP client's `max_ratelimit_timeout` during post-connect command synchronization.
  - Keep the existing 600-second whole-operation timeout.
  - Document why a temporary client-level override leaks into unrelated route buckets.
- `tests/gateway/test_discord_connect.py`
  - Add a regression test that observes the shared limit while synchronization runs and proves it remains unchanged.

## How to Test

1. Run the new regression test on `origin/main`. It fails because synchronization exposes `30.0` instead of the configured `None`.
2. Run the same test on this branch: `1 passed`.
3. Run `scripts/run_tests.sh tests/gateway/test_discord*.py -q`: `251 passed, 1 skipped, 0 failed`.
4. Run Ruff 0.15.10 on the two changed files: clean.
5. Run `py_compile` on the two changed files and `git diff --check`: clean.
6. Run `scripts/run_tests.sh tests/ -q` with the exact CI dependency set: `34,352 passed, 343 skipped, 20 failed` across 15 unrelated files on macOS. Replaying those 15 files against parent `cf7b3d0c90` fails the same 15 files; neither changed file fails.
7. Run the exact candidate on Linux through the fork CI harness: 11 of 12 Python slices pass. Slice 3 fails only `tests/tui_gateway/test_slash_worker_mcp_discovery.py`; the single allowed rerun fails the same unrelated test. Windows, macOS-only, lint, security, and the other Linux slices pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): inline rationale updated; other docs N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): network-only behavior; N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A

## Screenshots / Logs

Production evidence:

```text
Discord requested retry_after=136.57 seconds.
The affected thread route bucket retained max_ratelimit_timeout=30.0.
Hermes posted two seed messages, then returned:
Hermes could not create a Discord thread for this message, so the request was not processed.
```
