### PR TITLE
fix(auth): keep callable api_key intact when resolving a custom provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6385,7 +6385,15 @@ def resolve_provider_client(
             if api_mode == "anthropic_messages":
                 wrap_base = (explicit_base_url or "").strip().rstrip("/")
             custom_key = (
-                (explicit_api_key or "").strip()
+                # ``explicit_api_key`` may be a callable token provider (a
+                # ``key_cmd``-backed source that mints a bearer token per
+                # request), so only string keys are normalized here; a callable
+                # is a valid credential and passes through untouched.
+                (
+                    explicit_api_key
+                    if callable(explicit_api_key)
+                    else (explicit_api_key or "").strip()
+                )
                 or _scoped_key_env("OPENAI_API_KEY")
                 or _read_main_api_key_if_same_host(custom_base)
                 or "no-key-required"  # local servers don't need auth

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3763,6 +3763,80 @@ def test_pool_runtime_base_url_uses_nous_env_override(monkeypatch):
     assert _pool_runtime_base_url(entry) == "https://ai.wildebeest-newton.ts.net/v1"
 
 
+class TestCustomProviderCallableApiKey:
+    """A callable api_key (key_cmd token provider) must survive resolution.
+
+    ``key_cmd`` providers supply ``explicit_api_key`` as a callable that mints a
+    bearer token per request rather than a string, so the custom-provider branch
+    must not assume ``str``. These assert the contract across all three key
+    shapes, not just the crash that motivated it.
+    """
+
+    def test_callable_api_key_is_passed_through_uncalled(self):
+        """A callable key reaches the client unchanged and is not invoked or stringified."""
+        calls = []
+
+        def token_provider():
+            calls.append(1)
+            return "minted-token"
+
+        mock_openai = MagicMock()
+        mock_openai.return_value = MagicMock(name="custom-client")
+
+        with patch("agent.auxiliary_client.OpenAI", mock_openai):
+            client, _model = resolve_provider_client(
+                provider="custom",
+                model="some-model",
+                explicit_base_url="https://example.invalid/gateway/openai/v1",
+                explicit_api_key=token_provider,
+            )
+
+        assert client is not None
+        mock_openai.assert_called_once()
+        assert mock_openai.call_args[1]["api_key"] is token_provider, (
+            "callable api_key must be handed to the client unchanged so it can "
+            "mint a fresh token per request"
+        )
+        assert calls == [], (
+            "resolution must not invoke the token provider — minting is deferred "
+            "to request time"
+        )
+
+    def test_string_api_key_is_still_stripped(self):
+        """String keys keep their existing normalization."""
+        mock_openai = MagicMock()
+        mock_openai.return_value = MagicMock(name="custom-client")
+
+        with patch("agent.auxiliary_client.OpenAI", mock_openai):
+            client, _model = resolve_provider_client(
+                provider="custom",
+                model="some-model",
+                explicit_base_url="https://example.invalid/gateway/openai/v1",
+                explicit_api_key="  spaced-key  ",
+            )
+
+        assert client is not None
+        assert mock_openai.call_args[1]["api_key"] == "spaced-key"
+
+    def test_blank_string_api_key_still_falls_through(self, monkeypatch):
+        """A whitespace-only key must not short-circuit the env fallback."""
+        monkeypatch.setenv("OPENAI_API_KEY", "env-fallback-key")
+
+        mock_openai = MagicMock()
+        mock_openai.return_value = MagicMock(name="custom-client")
+
+        with patch("agent.auxiliary_client.OpenAI", mock_openai):
+            client, _model = resolve_provider_client(
+                provider="custom",
+                model="some-model",
+                explicit_base_url="https://example.invalid/gateway/openai/v1",
+                explicit_api_key="   ",
+            )
+
+        assert client is not None
+        assert mock_openai.call_args[1]["api_key"] == "env-fallback-key"
+
+
 class TestAnthropicExplicitApiKey:
     """Test that explicit_api_key is correctly propagated to _try_anthropic().
 


### PR DESCRIPTION
Fixes #88667.

`resolve_provider_client()` normalized the custom-provider credential with `(explicit_api_key or "").strip()`, which assumes a string. Providers configured with `key_cmd` supply a callable token source instead, so resolution raised `AttributeError: 'CommandTokenSource' object has no attribute 'strip'` and no client was ever built.

## The change

Callables pass through untouched; string and empty-string keys keep their existing normalization and their position in the fallback chain (`_scoped_key_env` → `_read_main_api_key_if_same_host` → `"no-key-required"`).

This is the handling the file already uses where the runtime snapshot is built (~line 3413), where a callable `api_key` is preserved and only `str` values are stripped. The fix makes the custom-provider branch consistent with that established pattern rather than introducing a new one.

## Why it matters

`key_cmd` is a supported provider setting and `build_command_token_provider()` returns a `CommandTokenSource` by design, so a callable credential is expected input on this path.

Mixture of Agents is where it surfaces: presets resolve, the loop announces both reference slots, then every slot fails credential resolution and the run falls back to a single model. The fallback is silent, so the answer looks normal and the user cannot tell MoA did not run. On an install where every provider uses `key_cmd`, MoA is unusable.

## Tests

`TestCustomProviderCallableApiKey` in `tests/agent/test_auxiliary_client.py` pins the contract across all three key shapes rather than only the crash:

- a callable is handed to the client unchanged **and is not invoked during resolution** (minting stays deferred to request time)
- a string key is still stripped
- a whitespace-only key still falls through to the env fallback

Verified the tests fail without the source change — `test_callable_api_key_is_passed_through_uncalled` raises the original `AttributeError` at the patched line — and pass with it.

```
$ python -m pytest tests/agent/test_auxiliary_client.py -q
184 passed in 8.94s
```

## Scope

One source site and one test class. A sibling site at line 6664 has the identical defect and is **not** touched here to keep this reviewable; it is documented in #88667 with its reachability, and I am happy to fix it here or in a follow-up if maintainers prefer to close the class in one change.
