### PR TITLE
fix: preserve safe Hermes workspace cleanup and update notices

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -710,6 +710,21 @@ def _format_update_notice(behind: int) -> str:
     return line
 
 
+def _format_update_notice_plain(behind: int) -> str:
+    """Render the deferred interactive notice without Rich markup or ANSI."""
+    from hermes_cli.config import get_managed_update_command, recommended_update_command
+
+    if behind > 0:
+        commits_word = "commit" if behind == 1 else "commits"
+        return (
+            f"⚠ {behind} {commits_word} behind — run "
+            f"{recommended_update_command()} to update"
+        )
+
+    managed_cmd = get_managed_update_command()
+    return f"⚠ update available — run {managed_cmd}" if managed_cmd else "⚠ update available"
+
+
 _deferred_update_notice_started = False
 
 
@@ -731,7 +746,11 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
             behind = _update_result
             if behind is None or behind == 0:
                 return
-            console.print(_format_update_notice(behind))
+            # This path runs after startup from a background thread.  Passing
+            # Rich's ANSI output through prompt_toolkit's renderer can expose
+            # CSI sequences as literal ``?[...m`` text, so keep this late
+            # notice plain while the in-banner path retains its styling.
+            console.print(_format_update_notice_plain(behind))
         except Exception:
             pass  # never break the session over an update notice
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -3216,7 +3216,6 @@ def _cmd_decompose(args: argparse.Namespace) -> int:
 def _cmd_gc(args: argparse.Namespace) -> int:
     """Remove scratch workspaces of archived tasks, prune old events, and
     delete old worker logs."""
-    import shutil
     scratch_root = kb.workspaces_root()
     removed_ws = 0
     with kb.connect_closing() as conn:
@@ -3224,32 +3223,12 @@ def _cmd_gc(args: argparse.Namespace) -> int:
             "SELECT id, workspace_kind, workspace_path, branch_name FROM tasks "
             "WHERE status = 'archived'"
         ).fetchall()
-    for row in rows:
-        if row["workspace_kind"] == "worktree":
-            # Backstop for worktrees that escaped the completion/archive hook
-            # (e.g. tasks archived before that hook existed). Same safety
-            # predicate: only clean, fully-pushed worktrees are removed.
-            wt_path = row["workspace_path"]
-            if wt_path and Path(wt_path).is_dir():
-                kb._cleanup_worktree_workspace(row["id"], wt_path, row["branch_name"])
-                if not Path(wt_path).is_dir():
-                    removed_ws += 1
-            continue
-        if row["workspace_kind"] != "scratch":
-            continue
-        path = Path(row["workspace_path"] or (scratch_root / row["id"]))
-        try:
-            path = path.resolve()
-        except OSError:
-            continue
-        try:
-            path.relative_to(scratch_root.resolve())
-        except ValueError:
-            # Safety: never delete outside the scratch root.
-            continue
-        if path.exists() and path.is_dir():
-            shutil.rmtree(path, ignore_errors=True)
-            removed_ws += 1
+        for row in rows:
+            path = Path(row["workspace_path"] or (scratch_root / row["id"]))
+            existed = path.is_dir()
+            kb.cleanup_task_workspace(conn, row["id"])
+            if existed and not path.is_dir():
+                removed_ws += 1
 
     event_days = getattr(args, "event_retention_days", 30)
     log_days = getattr(args, "log_retention_days", 30)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5578,7 +5578,7 @@ def complete_task(
     # Recompute ready status for dependents (separate txn so children see done).
     recompute_ready(conn)
     # Clean up the scratch workspace and any stale tmux session for the worker.
-    _cleanup_workspace(conn, task_id)
+    cleanup_task_workspace(conn, task_id)
     _done_task = get_task(conn, task_id)
     if fire_lifecycle_hook:
         _fire_kanban_lifecycle_hook(
@@ -5893,6 +5893,11 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
             return
         kind: Optional[str] = row["workspace_kind"]
         path: Optional[str] = row["workspace_path"]
+        # Older cards may not have persisted the generated scratch path.
+        # Reconstruct only the managed default location; never infer a path
+        # for a user-supplied workspace.
+        if kind == "scratch" and not path:
+            path = str(workspaces_root() / task_id)
         if kind not in ("scratch", "worktree") or not path:
             # This task's own workspace isn't a removable scratch dir, but its
             # completion may still unblock a deferred parent scratch cleanup
@@ -5951,6 +5956,15 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
         _try_cleanup_parent_workspaces(conn, task_id)
     except Exception:
         pass  # best-effort — never block completion
+
+
+def cleanup_task_workspace(conn: sqlite3.Connection, task_id: str) -> None:
+    """Apply the task workspace cleanup policy once the card is terminal.
+
+    Completion, archive, and garbage collection all use this same entry point
+    so cleanup stays idempotent and ``dir:<path>`` workspaces remain protected.
+    """
+    _cleanup_workspace(conn, task_id)
 
 
 def _cleanup_worktree_workspace(
@@ -7535,7 +7549,7 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     recompute_ready(conn)
     # Reap the workspace on archive too — tasks archived without ever
     # completing previously kept their scratch dir / worktree forever.
-    _cleanup_workspace(conn, task_id)
+    cleanup_task_workspace(conn, task_id)
     return True
 
 

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -1,5 +1,7 @@
 """Tests for banner toolset name normalization and skin color usage."""
 
+import threading
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from rich.console import Console
@@ -17,6 +19,36 @@ def test_cprint_falls_back_to_plain_print_when_prompt_toolkit_has_no_console(cap
         banner.cprint("fallback text")
 
     assert capsys.readouterr().out == "fallback text\n"
+
+
+def test_deferred_update_notice_is_plain_text_for_interactive_console():
+    """Late startup notices must not send Rich markup through the ANSI bridge."""
+    notice = banner._format_update_notice_plain(31)
+
+    assert notice == "⚠ 31 commits behind — run hermes update to update"
+    assert "[" not in notice
+    assert "\x1b" not in notice
+
+
+def test_deferred_update_notice_sends_plain_text(monkeypatch):
+    printed = []
+    event = threading.Event()
+    event.set()
+    monkeypatch.setattr(banner, "_deferred_update_notice_started", False)
+    monkeypatch.setattr(banner, "_update_check_done", event)
+    monkeypatch.setattr(banner, "_update_result", 31)
+
+    class ImmediateThread:
+        def __init__(self, *, target, **_kwargs):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(banner.threading, "Thread", ImmediateThread)
+    banner._defer_update_notice(SimpleNamespace(print=printed.append))
+
+    assert printed == ["⚠ 31 commits behind — run hermes update to update"]
 
 
 

--- a/tests/hermes_cli/test_kanban_worktree_teardown.py
+++ b/tests/hermes_cli/test_kanban_worktree_teardown.py
@@ -128,6 +128,42 @@ def test_non_git_dir_preserved(tmp_path: Path) -> None:
     assert plain.is_dir()
 
 
+def test_terminal_cleanup_removes_generated_scratch_but_preserves_dir(
+    kanban_home: Path, tmp_path: Path
+) -> None:
+    """The shared cleanup policy removes generated work, never ``dir:`` data."""
+    generated = kb.workspaces_root() / "t_scratch1234"
+    generated.mkdir(parents=True)
+    source = tmp_path / "user-source"
+    source.mkdir()
+    (source / "keep.txt").write_text("keep\n", encoding="utf-8")
+
+    with kb.connect_closing() as conn:
+        scratch = kb.create_task(conn, title="generated", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET workspace_kind='scratch', workspace_path=? WHERE id=?",
+                (str(generated), scratch),
+            )
+        direct = kb.create_task(conn, title="source", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET workspace_kind='dir', workspace_path=? WHERE id=?",
+                (str(source), direct),
+            )
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (scratch,))
+        assert kb.claim_task(conn, scratch, claimer="worker") is not None
+        assert kb.complete_task(conn, scratch, summary="verified")
+        # A retry after completion is safe and must not affect other paths.
+        kb.cleanup_task_workspace(conn, scratch)
+        assert kb.archive_task(conn, direct)
+
+    assert not generated.exists()
+    assert source.is_dir()
+    assert (source / "keep.txt").read_text(encoding="utf-8") == "keep\n"
+
+
 def test_tree_dirtied_between_check_and_removal_preserved(
     repo: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Share the terminal workspace cleanup policy across completion, archive, and garbage collection.
- Keep generated scratch cleanup safe while preserving user-owned dir workspaces.
- Render deferred interactive update notices as plain text.
- Preserve the focused tests for both fixes.

## Test plan
- `uv run --with pytest python -m pytest -q tests/hermes_cli/test_banner.py tests/hermes_cli/test_kanban_worktree_teardown.py`
- Result: 17 passed

This branch is based directly on `origin/main` and carries the two local fixes as two commits.