### PR TITLE
fix(cli): map kitty CSI-u sequences with the num_lock modifier bit

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -12,6 +12,22 @@ can be unit-tested without importing the whole CLI runtime.
 from __future__ import annotations
 
 
+# Kitty's keyboard protocol encodes the modifier field as a bitmask + 1:
+# shift=1, alt=2, ctrl=4, super=8, hyper=16, meta=32, caps_lock=64,
+# num_lock=128. The lock bits are ORed into EVERY key event while the lock
+# is on, so a user with NumLock enabled sends ``ESC[99;133u`` (5 + 128) for
+# Ctrl+C and ``ESC[127;129u`` (1 + 128) for a plain Backspace. Every
+# fixed-modifier registration below therefore also installs its NumLock-on
+# twin, otherwise those events are absent from ``ANSI_SEQUENCES`` and leak
+# into the prompt as literal text (#88221).
+_NUM_LOCK = 128
+
+
+def _num_lock_variants(modifier: int) -> tuple[int, int]:
+    """Return ``(modifier, modifier | num_lock)`` for a kitty modifier value."""
+    return (modifier, modifier + _NUM_LOCK)
+
+
 def _clear_vt100_prefix_cache() -> None:
     """Drop prompt_toolkit's memoized "is this a prefix of a longer match?"
     answers after mutating ``ANSI_SEQUENCES``.
@@ -62,10 +78,11 @@ def install_shift_enter_alias() -> int:
 
     alt_enter = (Keys.Escape, Keys.ControlM)
     changed = 0
-    for seq in ("\x1b[13;2u", "\x1b[27;2;13~", "\x1b[27;2;13u"):
-        if ANSI_SEQUENCES.get(seq) != alt_enter:
-            ANSI_SEQUENCES[seq] = alt_enter
-            changed += 1
+    for mod in _num_lock_variants(2):
+        for seq in (f"\x1b[13;{mod}u", f"\x1b[27;{mod};13~", f"\x1b[27;{mod};13u"):
+            if ANSI_SEQUENCES.get(seq) != alt_enter:
+                ANSI_SEQUENCES[seq] = alt_enter
+                changed += 1
     if changed:
         _clear_vt100_prefix_cache()
     return changed
@@ -96,10 +113,11 @@ def install_ctrl_enter_alias() -> int:
 
     alt_enter = (Keys.Escape, Keys.ControlM)
     changed = 0
-    for seq in ("\x1b[13;5u", "\x1b[27;5;13~", "\x1b[27;5;13u"):
-        if ANSI_SEQUENCES.get(seq) != alt_enter:
-            ANSI_SEQUENCES[seq] = alt_enter
-            changed += 1
+    for mod in _num_lock_variants(5):
+        for seq in (f"\x1b[13;{mod}u", f"\x1b[27;{mod};13~", f"\x1b[27;{mod};13u"):
+            if ANSI_SEQUENCES.get(seq) != alt_enter:
+                ANSI_SEQUENCES[seq] = alt_enter
+                changed += 1
     if changed:
         _clear_vt100_prefix_cache()
     return changed
@@ -133,13 +151,12 @@ def install_cmd_backspace_alias() -> int:
     except Exception:
         return 0
 
-    aliases = {
-        "\x1b[127;9u": Keys.ControlU,
-        "\x1b[127;10u": Keys.ControlU,
-        "\x1b[27;9;127~": Keys.ControlU,
-        "\x1b[3;9~": Keys.ControlK,
-        "\x1b[3;10~": Keys.ControlK,
-    }
+    aliases: dict[str, object] = {}
+    for mod in _num_lock_variants(9) + _num_lock_variants(10):
+        aliases[f"\x1b[127;{mod}u"] = Keys.ControlU
+        aliases[f"\x1b[3;{mod}~"] = Keys.ControlK
+    for mod in _num_lock_variants(9):
+        aliases[f"\x1b[27;{mod};127~"] = Keys.ControlU
     changed = 0
     for seq, key in aliases.items():
         if ANSI_SEQUENCES.get(seq) != key:
@@ -200,6 +217,11 @@ def install_modify_other_keys_aliases() -> int:
     ``install_shift_enter_alias`` / ``install_ctrl_enter_alias``) are never
     overwritten — ``setdefault`` semantics.
 
+    Every modifier above is registered twice: once bare and once with
+    kitty's ``num_lock`` bit (128) ORed in, since kitty stamps that bit onto
+    the modifier field of *every* key event while NumLock is on — Ctrl+C
+    becomes ``ESC[99;133u`` and plain Backspace ``ESC[127;129u`` (#88221).
+
     Returns the number of sequences whose mapping was newly installed.
     """
     try:
@@ -246,16 +268,21 @@ def install_modify_other_keys_aliases() -> int:
 
     def _install_paired(modifier: int, mapping: dict) -> None:
         """Install both modifyOtherKeys (ESC[27;N;CP~) and CSI-u (ESC[CP;Nu)
-        mappings for the given modifier and codepoint→key mapping."""
+        mappings for the given modifier and codepoint→key mapping.
+
+        Each modifier is installed twice: once bare, once with kitty's
+        num_lock bit (128) ORed in, because kitty reports that bit on every
+        key event while NumLock is on (#88221)."""
         nonlocal changed
-        for codepoint, key_val in mapping.items():
-            for seq in (
-                f"\x1b[27;{modifier};{codepoint}~",
-                f"\x1b[{codepoint};{modifier}u",
-            ):
-                if seq not in ANSI_SEQUENCES:
-                    ANSI_SEQUENCES[seq] = key_val
-                    changed += 1
+        for mod in _num_lock_variants(modifier):
+            for codepoint, key_val in mapping.items():
+                for seq in (
+                    f"\x1b[27;{mod};{codepoint}~",
+                    f"\x1b[{codepoint};{mod}u",
+                ):
+                    if seq not in ANSI_SEQUENCES:
+                        ANSI_SEQUENCES[seq] = key_val
+                        changed += 1
 
     # Ctrl+letter / Ctrl+digit / Ctrl+symbol (modifier 5)
     _install_paired(5, ctrl_key_map)
@@ -321,7 +348,11 @@ def install_modify_other_keys_aliases() -> int:
     # (#56684 — previously leaked "[27u" as literal text into the prompt).
     # Modifiers run to 16 because kitty reports Cmd as the super bit
     # (mod 9+) — same reason install_cmd_backspace_alias maps 9/10.
-    for seq in ["\x1b[27u"] + [f"\x1b[27;{m}u" for m in range(2, 17)]:
+    for seq in ["\x1b[27u"] + [
+        f"\x1b[27;{m}u"
+        for base in range(2, 17)
+        for m in _num_lock_variants(base)
+    ]:
         if seq not in ANSI_SEQUENCES:
             ANSI_SEQUENCES[seq] = Keys.Escape
             changed += 1
@@ -343,6 +374,21 @@ def install_modify_other_keys_aliases() -> int:
         9: Keys.ControlI,                   # Ctrl+Tab — degrade to Tab
         127: (Keys.Escape, Keys.ControlH),  # Ctrl+Backspace — backward-kill-word,
                                             # matching Ink TUI + Desktop (#78285)
+    })
+
+    # -- Unmodified keys with a lock bit set (kitty modifier 1 = "none") ----
+    # With NumLock on, kitty stamps the num_lock bit onto keys pressed with
+    # NO real modifier too, so plain Backspace arrives as ESC[127;129u
+    # (1 + 128) rather than \x7f. _install_paired(1, ...) registers both the
+    # bare mod-1 spelling and its NumLock twin. Only keys kitty CSI-u-encodes
+    # on their own are listed; plain text characters are still delivered as
+    # UTF-8, lock bits or not.
+    _install_paired(1, {
+        9: Keys.ControlI,     # Tab
+        13: Keys.ControlM,    # Enter
+        27: Keys.Escape,      # Esc
+        32: " ",              # Space
+        127: Keys.ControlH,   # Backspace
     })
 
     # -- Kitty functional keys (Private Use Area codepoints) ----

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -433,3 +433,135 @@ def test_cmd_backspace_alias_not_clobbered():
     install_cmd_backspace_alias()
     install_modify_other_keys_aliases()
     assert _parse("\x1b[127;9u") == [Keys.ControlU]
+
+
+# ---------------------------------------------------------------------------
+# Kitty num_lock bit (128) ORed into the modifier field (#88221)
+#
+# The kitty keyboard protocol encodes the modifier field as bitmask+1
+# (shift=1, alt=2, ctrl=4, super=8, ..., num_lock=128). While NumLock is on
+# kitty sets that bit on EVERY key event, so Ctrl+C arrives as ESC[99;133u
+# (5 + 128) rather than ESC[99;5u. Each registration must therefore install
+# its num_lock twin, or the sequence leaks into the buffer as literal text.
+# ---------------------------------------------------------------------------
+
+NUM_LOCK = 128
+
+
+@pytest.mark.parametrize("letter", CTRL_LETTERS)
+def test_num_lock_ctrl_letter_matches_num_lock_off(letter):
+    """Ctrl+<letter> with NumLock on must parse exactly like NumLock off."""
+    cp = ord(letter)
+    expected = _parse(f"\x1b[{cp};5u")
+    assert expected == _parse(chr(cp & 0x1F))
+    assert _parse(f"\x1b[{cp};{5 + NUM_LOCK}u") == expected
+    assert _parse(f"\x1b[27;{5 + NUM_LOCK};{cp}~") == expected
+
+
+def test_num_lock_ctrl_c_is_control_c():
+    """The reported symptom: Ctrl+C under NumLock leaked as literal text."""
+    assert _parse("\x1b[99;133u") == [Keys.ControlC]
+    assert _parse("\x1b[27;133;99~") == [Keys.ControlC]
+
+
+@pytest.mark.parametrize("base_modifier", [2, 3, 4, 5, 6, 7, 8])
+def test_num_lock_variant_matches_base_modifier(base_modifier):
+    """For every letter modifier the module registers, the num_lock twin
+    must parse identically to the bare form."""
+    for cp in (ord("a"), ord("r")):
+        expected = _parse(f"\x1b[{cp};{base_modifier}u")
+        assert len(expected) >= 1
+        got = _parse(f"\x1b[{cp};{base_modifier + NUM_LOCK}u")
+        assert got == expected, (
+            f"CSI-u cp={cp} mod={base_modifier}+num_lock parsed as {got!r}, "
+            f"expected {expected!r}"
+        )
+        got_mok = _parse(f"\x1b[27;{base_modifier + NUM_LOCK};{cp}~")
+        assert got_mok == expected
+
+
+@pytest.mark.parametrize("base_modifier", [2, 3, 5])
+def test_num_lock_variant_matches_base_for_special_keys(base_modifier):
+    """Backspace and Space carry explicit per-modifier registrations; their
+    num_lock twins must match the bare form too."""
+    for cp in (127, 32):
+        expected = _parse(f"\x1b[{cp};{base_modifier}u")
+        assert len(expected) >= 1
+        assert _parse(f"\x1b[{cp};{base_modifier + NUM_LOCK}u") == expected
+        assert _parse(f"\x1b[27;{base_modifier + NUM_LOCK};{cp}~") == expected
+
+
+def test_num_lock_plain_backspace_is_backspace():
+    """Modifier 1 means 'no modifiers'; with NumLock on it becomes 129, and
+    kitty then sends plain Backspace as ESC[127;129u instead of \\x7f."""
+    assert _parse("\x1b[127;129u") == _parse("\x7f")
+
+
+@pytest.mark.parametrize(
+    "codepoint,raw",
+    [(9, "\t"), (13, "\r"), (32, " "), (127, "\x7f")],
+)
+def test_num_lock_unmodified_keys_match_raw_byte(codepoint, raw):
+    """Unmodified Tab/Enter/Space/Backspace under NumLock must behave like
+    the legacy raw byte, under both the bare mod-1 and mod-129 spellings."""
+    expected = _parse(raw)
+    assert _parse(f"\x1b[{codepoint};1u") == expected
+    assert _parse(f"\x1b[{codepoint};129u") == expected
+
+
+def test_num_lock_escape_key_is_escape():
+    """The Esc key with NumLock on (ESC[27;129u) must not leak."""
+    assert _parse("\x1b[27;129u") == [Keys.Escape]
+    assert _parse("\x1b[27;133u") == [Keys.Escape]
+
+
+def test_num_lock_alt_letter_matches_bare_escape_letter():
+    """Alt+a with NumLock on (mod 3+128) = bare ESC+a."""
+    bare = _parse("\x1ba")
+    assert _parse("\x1b[97;131u") == bare
+    assert _parse("\x1b[27;131;97~") == bare
+
+
+def test_num_lock_shift_letter_produces_uppercase():
+    assert _parse("\x1b[97;130u") == ["A"]
+
+
+def test_num_lock_shift_enter_alias_covered():
+    """install_shift_enter_alias must also cover the NumLock spelling."""
+    from hermes_cli.pt_input_extras import install_shift_enter_alias
+    install_shift_enter_alias()
+    assert _parse("\x1b[13;130u") == _parse("\x1b\r")
+
+
+def test_num_lock_ctrl_enter_alias_covered():
+    """install_ctrl_enter_alias must also cover the NumLock spelling."""
+    from hermes_cli.pt_input_extras import install_ctrl_enter_alias
+    install_ctrl_enter_alias()
+    assert _parse("\x1b[13;133u") == _parse("\x1b\r")
+
+
+def test_num_lock_cmd_backspace_alias_covered():
+    """install_cmd_backspace_alias must also cover the NumLock spellings."""
+    from hermes_cli.pt_input_extras import install_cmd_backspace_alias
+    install_cmd_backspace_alias()
+    assert _parse("\x1b[127;137u") == [Keys.ControlU]
+    assert _parse("\x1b[3;137~") == [Keys.ControlK]
+
+
+def test_num_lock_install_still_idempotent():
+    """The num_lock twins must be registered on the first pass, so a second
+    install still reports zero newly-installed sequences."""
+    install_modify_other_keys_aliases()
+    assert install_modify_other_keys_aliases() == 0
+    from hermes_cli.pt_input_extras import (
+        install_cmd_backspace_alias,
+        install_ctrl_enter_alias,
+        install_shift_enter_alias,
+    )
+    for fn in (
+        install_shift_enter_alias,
+        install_ctrl_enter_alias,
+        install_cmd_backspace_alias,
+    ):
+        fn()
+        assert fn() == 0


### PR DESCRIPTION
## Summary

With NumLock on in kitty, keys stopped working in the CLI — Backspace typed `[127;129u`, Ctrl+C typed `[99;133u`, and the raw escape codes landed in the input box as literal text. They now behave normally.

Root cause: kitty's keyboard protocol encodes the modifier field as a **bitmask + 1** (`shift=1, alt=2, ctrl=4, super=8, hyper=16, meta=32, caps_lock=64, num_lock=128`) and ORs the `num_lock` bit into **every** key event while the lock is on. `hermes_cli/pt_input_extras.py` registers CSI-u / modifyOtherKeys sequences as exact-string keys in prompt_toolkit's `ANSI_SEQUENCES`, and every registration site hardcoded a bare modifier number — `_install_paired(5, …)` for Ctrl, `\x1b[13;2u` for Shift+Enter, `\x1b[127;9u` for Ctrl+Backspace, and the `ESC[27;<m>u` loop for Esc. Kitty therefore emits `ESC[99;133u` (5 + 128) where the table only holds `ESC[99;5u`, no entry matches, and the VT100 parser falls through to literal text. Plain letters keep working because they arrive as UTF-8 rather than CSI-u.

Same failure class as [zellij-org/zellij#4178](https://github.com/zellij-org/zellij/issues/4178).

## Changes

- **`hermes_cli/pt_input_extras.py`** — one `_NUM_LOCK = 128` constant and a `_num_lock_variants(mod) -> (mod, mod + 128)` helper, applied at every fixed-modifier registration site so the whole bug class is covered rather than just the reported Ctrl+C:
  - `install_shift_enter_alias` — modifier 2, now also 130
  - `install_ctrl_enter_alias` — modifier 5, now also 133
  - `install_cmd_backspace_alias` — modifiers 9/10, now also 137/138
  - `_install_paired()` — one outer loop over the twins, so **all** its callers (modifiers 2–8) are covered at once
  - the `ESC[27;<m>u` Escape loop — modifiers 2–16, now also 130–144
  - a new `_install_paired(1, {Tab, Enter, Esc, Space, Backspace})`. Modifier 1 means "no modifiers"; with NumLock on that becomes 129, which is exactly the reported plain-Backspace case `ESC[127;129u`.

  Routing every site through one helper means a future lock-bit report (e.g. `caps_lock`) is a one-line widening rather than another sweep of the file.

- **`tests/cli/test_modify_other_keys_aliases.py`** — regression tests asserting the invariant that each NumLock-on sequence parses **identically to its NumLock-off twin**, across every affected installer, plus idempotency (a second install returns 0 and overwrites nothing).

### Deliberately not changed: `caps_lock` (bit 64)

The same mechanism applies — `ESC[99;69u` would leak identically. Left out on purpose: the issue reports NumLock only, NumLock is commonly left on permanently by keypad users while CapsLock is a transient state, and covering both would double the registrations again for a case with no reported user. `_num_lock_variants` is the single seam to widen if a report lands.

## How to test

1. Open kitty (`TERM=xterm-kitty`), turn NumLock **on**
2. Run `hermes`
3. Press Backspace and Ctrl+C in the input box — both act normally instead of inserting `[127;129u` / `[99;133u`

Deterministic without kitty by feeding the sequences directly:

```python
from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
from hermes_cli.pt_input_extras import install_modify_other_keys_aliases
install_modify_other_keys_aliases()
assert ANSI_SEQUENCES["\x1b[99;133u"]   # Ctrl+C,   NumLock on
assert ANSI_SEQUENCES["\x1b[127;129u"]  # Backspace, NumLock on
```

## Validation

| Check | Result |
|---|---|
| `pytest tests/cli/test_modify_other_keys_aliases.py` | **220 passed** |
| Mutation check (production revert, tests kept) | **48 failed, 172 passed** — every failure is a new num_lock test, no pre-existing test broke |
| Mutation check (restored) | **220 passed** |
| Reproduction before fix | 5/6 NumLock sequences unmapped |
| Reproduction after fix | 0/6 unmapped |
| `scripts/check-windows-footguns.py` | clean |
| `ANSI_SEQUENCES` growth | 242 → 1850 (+1608), ~one twin per existing fixed-modifier registration; installed once at startup |
| Rebased onto current `main` | yes, tests re-run green after rebase |

Behavior preserved: every site keeps its "only install when absent / when the value differs" guard, so earlier aliases are never overwritten, and the `changed` counter still reflects only newly-installed sequences.

Tested on **Linux only** (Ubuntu, Python 3.13). The change is pure table registration with no platform-specific code paths.

Closes #88221
