### PR TITLE
fix(install): fail the repository stage when the update fetch fails

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1242,6 +1242,18 @@ show_manual_install_hint() {
 # Installation
 # ============================================================================
 
+# Name work the update path stashed, when that update is about to abort. The
+# stash is taken several steps before the block that restores it; bailing out in
+# between leaves the working tree quietly clean, with nothing on screen saying
+# where the changes went. Silent on a checkout that had nothing to stash.
+log_autostash_recovery() {
+    local ref="$1"
+    local name="$2"
+    [ -n "$ref" ] || return 0
+    log_warn "Your local changes were stashed before the update: $name"
+    log_warn "Restore them with: git stash apply $ref"
+}
+
 clone_repo() {
     log_info "Installing to $INSTALL_DIR..."
 
@@ -1290,8 +1302,24 @@ clone_repo() {
             # branches — on a non-single-branch checkout that turns each update
             # into a multi-minute download that can stall the installer.
             git remote set-branches origin "$BRANCH" 2>/dev/null || true
-            git fetch origin "$BRANCH"
-            git checkout "$BRANCH"
+            # Both of these must be checked explicitly. `set -e` is not in force
+            # here: run_stage runs the stage body in a subshell that inherits
+            # its `set +e`, so an unguarded failure falls through to
+            # "Repository ready" and exit 0 -- reporting an update that never
+            # fetched anything, and handing the JSON contract {ok: true}.
+            # A github.com rate limit (HTTP 429) is the failure seen in practice.
+            if ! git fetch origin "$BRANCH"; then
+                log_error "Failed to fetch $BRANCH from origin."
+                log_info "This is usually transient — a network blip, or a rate limit"
+                log_info "from github.com (HTTP 429). Retrying shortly usually works."
+                log_autostash_recovery "$autostash_ref" "$stash_name"
+                exit 1
+            fi
+            if ! git checkout "$BRANCH"; then
+                log_error "Failed to check out $BRANCH."
+                log_autostash_recovery "$autostash_ref" "$stash_name"
+                exit 1
+            fi
             # Managed installs should follow origin/$BRANCH exactly. If the
             # checkout has diverged (or has local-only commits), ff-only pull
             # cannot succeed — mirror ``hermes update`` and reset to the

--- a/tests/test_install_update_fetch_failure.py
+++ b/tests/test_install_update_fetch_failure.py
@@ -1,0 +1,136 @@
+"""Regression: a failed update fetch must not be reported as a ready repository.
+
+The repository stage runs ``git fetch origin $BRANCH`` unguarded. The staged
+entry point runs the stage body inside a subshell that inherits ``set +e``
+(scripts/install.sh, run_stage), so the failure is ignored: the stage continues,
+prints "Repository ready" and exits 0. The checkout is left on whatever it
+already had, and callers consuming the JSON contract see {ok: true} for an
+update that fetched nothing.
+
+Any fetch failure triggers this. The one observed in the wild is HTTP 429 from
+github.com, which this repo's network is large enough to hit in bursts.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _managed_checkout(tmp_path: Path, *, local_changes: bool) -> Path:
+    """A managed checkout whose origin cannot be fetched.
+
+    Moving the bare remote aside after cloning makes ``git fetch origin main``
+    fail the way a transient network error or a rate limit does, without having
+    to reproduce one.
+    """
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _git(seed, "init")
+    (seed / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _git(seed, "add", "tracked.txt")
+    _git(seed, "commit", "-m", "base")
+    _git(seed, "branch", "-M", "main")
+
+    remote = tmp_path / "origin.git"
+    _git(tmp_path, "init", "--bare", str(remote))
+    _git(seed, "remote", "add", "origin", str(remote))
+    _git(seed, "push", "-u", "origin", "main")
+
+    managed = tmp_path / "hermes-agent"
+    _git(tmp_path, "clone", "--branch", "main", str(remote), str(managed))
+
+    if local_changes:
+        (managed / "tracked.txt").write_text("local edit\n", encoding="utf-8")
+
+    remote.rename(tmp_path / "origin.git.gone")
+    return managed
+
+
+def _run_repository_stage(tmp_path: Path, managed: Path) -> subprocess.CompletedProcess:
+    env = os.environ | {
+        "HERMES_HOME": str(tmp_path / "hermes-home"),
+        "HERMES_INSTALL_DIR": str(managed),
+    }
+    return subprocess.run(
+        ["bash", str(INSTALL_SH), "--stage", "repository", "--non-interactive"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+requires_shell = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="needs git and bash",
+)
+
+
+@pytest.mark.live_system_guard_bypass
+@requires_shell
+def test_failed_fetch_fails_the_stage(tmp_path: Path) -> None:
+    """The headline bug: an unreachable origin still reports a ready repository."""
+    managed = _managed_checkout(tmp_path, local_changes=False)
+
+    result = _run_repository_stage(tmp_path, managed)
+    output = result.stdout + result.stderr
+
+    assert "Repository ready" not in output, output
+    assert result.returncode != 0, output
+
+
+@pytest.mark.live_system_guard_bypass
+@requires_shell
+def test_failed_fetch_is_named_as_such(tmp_path: Path) -> None:
+    """The user is told what failed, not left with a bare git error."""
+    managed = _managed_checkout(tmp_path, local_changes=False)
+
+    result = _run_repository_stage(tmp_path, managed)
+    output = result.stdout + result.stderr
+
+    assert "Failed to fetch" in output, output
+
+
+@pytest.mark.live_system_guard_bypass
+@requires_shell
+def test_stashed_changes_are_pointed_at_on_failure(tmp_path: Path) -> None:
+    """Local work stashed before the fetch must not go unmentioned."""
+    managed = _managed_checkout(tmp_path, local_changes=True)
+
+    result = _run_repository_stage(tmp_path, managed)
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0, output
+    assert _git(managed, "stash", "list").stdout.strip(), "stash must survive"
+    assert "git stash apply" in output, output
+    assert "hermes-install-autostash-" in output, output
+
+
+@pytest.mark.live_system_guard_bypass
+@requires_shell
+def test_no_stash_hint_when_nothing_was_stashed(tmp_path: Path) -> None:
+    """The recovery hint must not misfire on a clean checkout."""
+    managed = _managed_checkout(tmp_path, local_changes=False)
+
+    result = _run_repository_stage(tmp_path, managed)
+    output = result.stdout + result.stderr
+
+    assert "git stash apply" not in output, output


### PR DESCRIPTION
## What does this PR do?

The update path in `clone_repo()` runs two git commands unguarded:

```bash
git fetch origin "$BRANCH"
git checkout "$BRANCH"
```

`set -e` does not cover them. `run_stage` executes the stage body as `( run_stage_body "$stage" )` **after** `set +e`, and the subshell inherits that — so a failed fetch is simply ignored. Execution falls through to `git pull --ff-only` (which also fails), then into the `git reset --hard "origin/$BRANCH"` recovery branch — which *succeeds*, against the stale local ref — and prints `✓ Repository ready` before exiting 0.

**An update that fetched nothing is reported as a success.** Callers consuming `--json` get `{ok: true}` for it.

Reproduced on current `main` with an unreachable origin:

```
→ Local changes detected, stashing before update...
Saved working directory and index state On main: hermes-install-autostash-20260817-211718
fatal: Could not read from remote repository.
✓ Repository ready                                       # exit 0
```

This PR checks both commands and aborts with a named error. Where the update had already autostashed local changes, it also names the stash and gives the restore command — the stash is taken well before the block that restores it, so bailing out in between leaves the working tree quietly clean with nothing on screen accounting for the user's work.

**On the trigger:** what I hit in the wild is HTTP 429 from github.com. This repository network is large enough (46,196 forks) that git draws rate limits in bursts — and they are not an anonymous-only problem: in one CI run I have `actions/checkout`, authenticated via `http.extraheader`, taking a 429 and recovering only because it retries internally with a 15s wait. A plain `git fetch` has no retry behind it. But the rate limit is only the trigger I can point at; any fetch failure reaches this path, which is why the fix and the tests are about the unguarded failure rather than about 429 specifically.

**Deliberately not fixed here:** the `set +e` inheritance itself. Every command in every stage has this same exposure, and making all stages fail-fast is a far larger blast radius than this change should carry. It's worth its own issue; I'd rather not smuggle it in.

**Related work:** #15338 (open, April) adds retries and stall detection to the *fresh HTTPS clone*. That is a different site and a different mechanism, and it does not touch the update path — this PR does not overlap or compete with it. I've left my findings there.

## Related Issue

None filed. Refs #15338 (adjacent, fresh-clone path).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh` — check `git fetch` and `git checkout` in the update path; abort with a named error instead of falling through to a false "Repository ready".
- `scripts/install.sh` — add `log_autostash_recovery()`, which names the pending autostash and its `git stash apply` command on an aborted update. Silent when nothing was stashed.
- `tests/test_install_update_fetch_failure.py` — new.

## How to Test

The test builds a managed checkout, then moves its bare origin aside so `git fetch origin main` fails the way a transient network error or a rate limit does — no real 429 required.

```bash
pytest tests/test_install_update_fetch_failure.py -q
```

**Patched: 4 passed. Unpatched: 3 failed, 1 passed.**

The three that flip are the bug:

| Test | Against `main` |
|---|---|
| `test_failed_fetch_fails_the_stage` | fails — prints `Repository ready`, exits 0 |
| `test_failed_fetch_is_named_as_such` | fails — no error names the fetch |
| `test_stashed_changes_are_pointed_at_on_failure` | fails — stash never mentioned |
| `test_no_stash_hint_when_nothing_was_stashed` | **passes** — control, must pass both before and after |

The fourth is deliberately a control: it would also pass against a fix that printed the stash hint unconditionally, which would be wrong.

No regressions in the neighbouring tests over this code path — all 21 non-PowerShell `tests/test_install*.py` files: **77 passed, 1 skipped**.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — searched `Failed to clone repository`, `clone retry`, `install.sh clone`, `retry git clone`, `update fetch retry`, `git fetch origin retry`, `update_cmd fetch`, `rate limit install.sh`. Found #15338 on the fresh-clone path (different site, different mechanism, commented there rather than competing); nothing covers the update path.
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run in full.** The full suite errors at collection in my environment on missing dev deps (`celery` and others), unrelated to this change. I ran every `tests/test_install*.py` except the PowerShell ones: 77 passed, 1 skipped.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, x86_64, git 2.43.0, bash 5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, rationale is a comment at the change site
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [ ] I've considered cross-platform impact — **partially.** `install.ps1` has the same shape (autostash, then fetch, then restore) and I have not audited whether it has the equivalent hole; I have no Windows machine to verify on. Flagging rather than ticking. This change is POSIX-only and does not alter Windows behaviour.
