### PR TITLE
fix(dev-sandbox): retry a rate-limited upstream fetch instead of failing the leg

### DIFF
--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -116,6 +116,12 @@ INSTALLER_PATH=""
 # expressible. --from-main is shorthand for refs/heads/main.
 INSTALL_REF=""
 UPSTREAM_URL="${HERMES_DEV_SANDBOX_UPSTREAM:-https://github.com/NousResearch/hermes-agent.git}"
+# How hard to try the upstream fetch when the remote fails transiently, and what
+# counts as transient. Overridable so the tests can drive the loop without
+# sleeping through it.
+FETCH_ATTEMPTS="${HERMES_DEV_SANDBOX_FETCH_ATTEMPTS:-3}"
+FETCH_RETRY_DELAY="${HERMES_DEV_SANDBOX_FETCH_DELAY:-15}"
+FETCH_TRANSIENT_RE="${HERMES_DEV_SANDBOX_FETCH_TRANSIENT_RE:-rate.?limit|error: *429|HTTP 429|could not resolve host|connection (timed out|reset|refused)|RPC failed|early EOF|the remote end hung up|operation timed out}"
 
 if [ "${1:-}" = install ]; then
   INSTALL_SHORTCUT=true
@@ -232,17 +238,42 @@ if [ -n "$INSTALL_REF" ]; then
   # Peel to ^{commit} in both cases: an annotated tag fetches as a tag OBJECT,
   # and using it directly fails later with "trying to write non-commit object
   # ... to branch 'refs/heads/main'".
-  if git -C "$UPSTREAM_REPO" fetch -q "$UPSTREAM_URL" "$INSTALL_REF" 2>/dev/null; then
-    UPSTREAM_COMMIT="$(git -C "$UPSTREAM_REPO" rev-parse "FETCH_HEAD^{commit}")"
-  elif git -C "$UPSTREAM_REPO" fetch -q "$UPSTREAM_URL" refs/heads/main \
-    && UPSTREAM_COMMIT="$(git -C "$UPSTREAM_REPO" rev-parse --verify -q "$INSTALL_REF^{commit}")"; then
-    :
-  else
+  #
+  # Both strategies can fail for a reason that has nothing to do with the ref:
+  # github.com rate-limits git, and this repository network is large enough that
+  # bursts reach CI (observed as HTTP 429 on some matrix legs and not others in
+  # the same run). Authenticating does not help -- actions/checkout draws 429s
+  # too and survives only because it retries -- so retry is the mitigation, and
+  # one 15s wait is what checkout needed to clear the same burst.
+  #
+  # Scoped to transient remote failures on purpose. Retrying every failure would
+  # sit here for 45s on a typo before printing the same "bad ref" message.
+  attempt=1
+  fetch_err=""
+  main_err=""
+  while :; do
+    fetch_err="$(git -C "$UPSTREAM_REPO" fetch -q "$UPSTREAM_URL" "$INSTALL_REF" 2>&1)" \
+      && UPSTREAM_COMMIT="$(git -C "$UPSTREAM_REPO" rev-parse "FETCH_HEAD^{commit}")" \
+      && break
+    main_err="$(git -C "$UPSTREAM_REPO" fetch -q "$UPSTREAM_URL" refs/heads/main 2>&1)" \
+      && UPSTREAM_COMMIT="$(git -C "$UPSTREAM_REPO" rev-parse --verify -q "$INSTALL_REF^{commit}")" \
+      && break
+    if [ "$attempt" -lt "$FETCH_ATTEMPTS" ] \
+      && printf '%s\n%s' "$fetch_err" "$main_err" | grep -qiE "$FETCH_TRANSIENT_RE"; then
+      delay=$(( attempt * FETCH_RETRY_DELAY ))
+      echo "[sandbox] upstream fetch hit a transient remote error (attempt $attempt/$FETCH_ATTEMPTS); retrying in ${delay}s" >&2
+      sleep "$delay"
+      attempt=$(( attempt + 1 ))
+      continue
+    fi
     rm -rf -- "$UPSTREAM_REPO"
     echo "error: could not resolve upstream ref: $INSTALL_REF" >&2
+    # Print what git actually said. Discarding it is why a rate-limited leg
+    # looked like a bad ref for as long as it did.
+    printf '%s\n%s\n' "$fetch_err" "$main_err" | grep -v '^$' | sed 's/^/       /' >&2
     echo '       Use a branch (main), a tag (v2026.7.7), or a SHA reachable from main.' >&2
     exit 1
-  fi
+  done
 fi
 if [ ! -e "$SANDBOX_ROOT/root/repo/.sandbox-source" ]; then
   mkdir -p "$SANDBOX_ROOT/root/repo"

--- a/tests/test_dev_sandbox_fetch_retry.py
+++ b/tests/test_dev_sandbox_fetch_retry.py
@@ -1,0 +1,210 @@
+"""dev-sandbox must retry a rate-limited upstream fetch, and only that.
+
+github.com rate-limits git, and this repository network is large enough that
+bursts reach CI: matrix legs draw HTTP 429 on the upstream fetch while sibling
+legs in the same run fetch fine. The fetch had no retry behind it, so a leg that
+drew one died at "could not resolve upstream ref" -- indistinguishable, in the
+log, from a genuinely bad ref.
+
+The retry is scoped to transient remote failures: a bad ref must still fail on
+the first attempt rather than after three backoffs.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEV_SANDBOX = REPO_ROOT / "scripts" / "dev-sandbox.sh"
+
+RATE_LIMITED = (
+    "remote: This request was rate-limited due to too many requests.\n"
+    "fatal: unable to access 'https://github.com/NousResearch/hermes-agent.git/': "
+    "The requested URL returned error: 429\n"
+)
+
+# A `git` that fails the first FAIL_COUNT fetches with a 429 and then delegates
+# to the real binary. Every non-fetch subcommand passes straight through, so the
+# script's `init` / `rev-parse` still behave.
+GIT_STUB = """#!/usr/bin/env bash
+real_git={real_git}
+counter="$STUB_COUNTER"
+
+is_fetch=false
+for arg in "$@"; do
+  case "$arg" in
+    fetch) is_fetch=true; break ;;
+  esac
+done
+
+if [ "$is_fetch" = true ]; then
+  n=0
+  [ -f "$counter" ] && n="$(cat "$counter")"
+  n=$(( n + 1 ))
+  printf '%s' "$n" > "$counter"
+  if [ "$n" -le "$STUB_FAIL_COUNT" ]; then
+    printf '%s' {rate_limited_q} >&2
+    exit 128
+  fi
+fi
+
+exec "$real_git" "$@"
+"""
+
+
+def _write_git_stub(tmp_path: Path) -> tuple[Path, Path]:
+    bindir = tmp_path / "stubbin"
+    bindir.mkdir()
+    counter = tmp_path / "fetch-count"
+    stub = bindir / "git"
+    stub.write_text(
+        GIT_STUB.format(
+            real_git=shutil.which("git"),
+            rate_limited_q=_shell_quote(RATE_LIMITED),
+        ),
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    return bindir, counter
+
+
+def _shell_quote(text: str) -> str:
+    return "'" + text.replace("'", "'\\''") + "'"
+
+
+def _run_sandbox(
+    tmp_path: Path,
+    bindir: Path,
+    counter: Path,
+    *,
+    fail_count: int,
+    install_ref: str = "v2026.7.20",
+) -> subprocess.CompletedProcess:
+    env = os.environ | {
+        "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+        "STUB_COUNTER": str(counter),
+        "STUB_FAIL_COUNT": str(fail_count),
+        # Drive the loop without sleeping through the real 15s/30s backoff.
+        "HERMES_DEV_SANDBOX_FETCH_DELAY": "0",
+        "HERMES_DEV_SANDBOX_FETCH_ATTEMPTS": "3",
+        # Never touch the real remote.
+        "HERMES_DEV_SANDBOX_UPSTREAM": str(tmp_path / "unused.git"),
+    }
+    return subprocess.run(
+        ["bash", str(DEV_SANDBOX), "install", "--install-ref", install_ref],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def _local_upstream(tmp_path: Path, ref: str) -> Path:
+    """A real bare repo carrying `ref`, so a post-retry fetch can succeed."""
+    seed = tmp_path / "up-seed"
+    seed.mkdir()
+    _git_real(seed, "init")
+    (seed / "f.txt").write_text("x\n", encoding="utf-8")
+    _git_real(seed, "add", "f.txt")
+    _git_real(seed, "commit", "-m", "c")
+    _git_real(seed, "branch", "-M", "main")
+    _git_real(seed, "tag", ref)
+    bare = tmp_path / "up.git"
+    _git_real(tmp_path, "init", "--bare", str(bare))
+    _git_real(seed, "remote", "add", "origin", str(bare))
+    _git_real(seed, "push", "-q", "origin", "main", "--tags")
+    return bare
+
+
+def _git_real(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd, check=True, capture_output=True, text=True,
+    )
+
+
+def _run_until_ref_resolved(env: dict, timeout: float = 45.0) -> str:
+    """Run the sandbox and stop once ref resolution is done.
+
+    A successful fetch falls through into building a real sandbox (certs, bwrap,
+    a network namespace), which is not what this test is about -- so it is
+    killed once it is past the part under test.
+    """
+    proc = subprocess.Popen(
+        ["bash", str(DEV_SANDBOX), "install", "--install-ref", "v2026.7.20"],
+        cwd=REPO_ROOT, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, start_new_session=True,
+    )
+    try:
+        return proc.communicate(timeout=timeout)[0]
+    except subprocess.TimeoutExpired:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        return proc.communicate()[0]
+
+
+requires_shell = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="needs git and bash",
+)
+
+
+@pytest.mark.live_system_guard_bypass
+@requires_shell
+def test_rate_limited_fetch_is_retried(tmp_path: Path) -> None:
+    """Two 429s then success: the ref resolves instead of aborting the run."""
+    bindir, counter = _write_git_stub(tmp_path)
+    upstream = _local_upstream(tmp_path, "v2026.7.20")
+    env = os.environ | {
+        "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+        "STUB_COUNTER": str(counter),
+        "STUB_FAIL_COUNT": "2",
+        "HERMES_DEV_SANDBOX_FETCH_DELAY": "0",
+        "HERMES_DEV_SANDBOX_FETCH_ATTEMPTS": "3",
+        "HERMES_DEV_SANDBOX_UPSTREAM": str(upstream),
+        "HERMES_SANDBOX_SOURCE_ROOT": str(tmp_path / "up-seed"),
+    }
+    output = _run_until_ref_resolved(env)
+
+    assert "retrying in" in output, output
+    assert "could not resolve upstream ref" not in output, output
+    assert int(counter.read_text()) > 2, "the fetch must have been retried"
+
+
+@pytest.mark.live_system_guard_bypass
+@requires_shell
+def test_retries_are_bounded_and_report_the_real_error(tmp_path: Path) -> None:
+    """A burst that outlasts the budget fails, saying 429 rather than 'bad ref'."""
+    bindir, counter = _write_git_stub(tmp_path)
+    result = _run_sandbox(tmp_path, bindir, counter, fail_count=99)
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0, output
+    assert "could not resolve upstream ref" in output, output
+    # The reason must survive into the message -- discarding it is what made a
+    # rate-limited leg look like a typo.
+    assert "429" in output, output
+    # Bounded: 3 attempts x 2 strategies, not an unbounded loop.
+    assert int(counter.read_text()) == 6, counter.read_text()
+
+
+@pytest.mark.live_system_guard_bypass
+@requires_shell
+def test_a_bad_ref_is_not_retried(tmp_path: Path) -> None:
+    """Scope check: a genuinely unresolvable ref fails on the first attempt."""
+    bindir, counter = _write_git_stub(tmp_path)
+    # fail_count=0 means the stub never injects 429; the fetch fails on its own
+    # merits because the upstream URL does not exist.
+    result = _run_sandbox(tmp_path, bindir, counter, fail_count=0)
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0, output
+    assert "could not resolve upstream ref" in output, output
+    assert "retrying in" not in output, output
+    assert int(counter.read_text()) == 2, "one attempt, both strategies"


### PR DESCRIPTION
## What does this PR do?

`scripts/dev-sandbox.sh` resolves `--install-ref` with a bare `git fetch` and nothing behind it, so one transient remote failure ends the run:

```
[sandbox] fetching upstream v2026.7.20 for installer/update test
remote: This request was rate-limited due to too many requests.
fatal: unable to access 'https://github.com/NousResearch/hermes-agent.git/':
       The requested URL returned error: 429
error: could not resolve upstream ref: v2026.7.20
✗ install of upstream v2026.7.20 failed (exit 1)
```

**This is not a rare-network story — it's a consequence of how big this repository network is.** 46,196 forks, and `Install & Update E2E` is fork-runnable on a 12-hour cron, so a lot of CI fetches the same network on a schedule. Measured over seven runs of this workflow on a fork, the 429s cluster **by run**, not by leg:

| Run (UTC) | Legs with a 429 |
|---|---|
| 08-13 20:00 | 0/10 |
| 08-14 08:39 | 0/10 |
| **08-14 19:57** | **2/10** |
| 08-15 19:38 | 0/10 |
| 08-16 19:37 | 0/10 |
| **08-17 08:02** | **5/10** |
| 08-17 19:23 | 0/10 |

All-or-nothing per run is the signature of a short, ecosystem-wide burst rather than per-machine bad luck. Inside one, legs that started within the same second disagree, and two different VMs took 429s one second apart.

### Why retry, and why 15s

**Authenticating does not avoid this.** In the failing run, `actions/checkout` — authenticated via `http.extraheader` — drew a 429 as well, including on a low-traffic fork repo. The limit follows the resource, not the caller. Checkout survives purely because it retries, and its recovery is where the timing comes from:

```
08:04:21  ##[error]error: RPC failed; HTTP 429 curl 22 The requested URL returned error: 429
08:04:21  Waiting 15 seconds before trying again
08:05:14  ✓ fetched
```

One 15s wait cleared the same burst that killed the sandbox fetch. Hence 3 attempts at 15s then 30s.

**Scoped to transient signatures, not to any failure.** The first strategy failing is *normal* for a raw SHA — the remote may not allow fetching it directly — so a blanket retry would sit here for 45s on a typo before printing the same "bad ref" message. This matches the narrow-retry style `install.sh` already uses for the Playwright platform override ("deliberately narrower than a retry-on-any-failure").

It also **stops discarding git's stderr on the failing path.** The first fetch ran under `2>/dev/null` because a SHA failing there is expected, but that swallowed the reason on genuine failures too — which is exactly why a rate-limited leg was indistinguishable from a bad ref in the log.

## Related Issue

None filed. Refs #87635 / #88420 (same workflow, unrelated mechanism — those are the npm/CA failure; this is the fetch that happens before it).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/dev-sandbox.sh` — retry the upstream ref resolution on transient remote failures (3 attempts, 15s/30s), scoped by pattern.
- `scripts/dev-sandbox.sh` — print git's actual error on the failing path instead of discarding it.
- `scripts/dev-sandbox.sh` — `HERMES_DEV_SANDBOX_FETCH_ATTEMPTS`, `_FETCH_DELAY`, `_FETCH_TRANSIENT_RE` overrides, so tests can drive the loop without sleeping through it.
- `tests/test_dev_sandbox_fetch_retry.py` — new.

## How to Test

```bash
pytest tests/test_dev_sandbox_fetch_retry.py -q
```

The tests put a stub `git` on `PATH` that injects the real 429 text for the first N fetches and then delegates to the real binary, so no rate limit has to be reproduced.

**Patched: 3 passed. Unpatched: 2 failed, 1 passed.**

| Test | Against `main` |
|---|---|
| `test_rate_limited_fetch_is_retried` | fails — no retry, run aborts |
| `test_retries_are_bounded_and_report_the_real_error` | fails — bounded at 6 fetches, and `429` must appear in the message |
| `test_a_bad_ref_is_not_retried` | **passes** — control; a bad ref must still fail on the first attempt |

The control is the one that keeps this honest: it would fail against a blanket retry-on-any-failure, which is the obvious wrong version of this change.

No regressions: all non-PowerShell `tests/test_install*.py` plus the new file — **76 passed, 1 skipped**.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — searched `dev-sandbox retry`, `dev-sandbox fetch`, `sandbox fetch upstream`, `could not resolve upstream ref`, `install-e2e flaky`, `429`, `rate-limited`. Nothing covers this site. #15338 adds retries to the installer's *clone* (different file, different path); I've noted the shared root cause there.
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run in full.** The full suite errors at collection in my environment on missing dev deps (`celery` and others), unrelated to this change. I ran the install + dev-sandbox tests: 76 passed, 1 skipped.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, x86_64, git 2.43.0, bash 5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the new env vars are documented as a comment at the definition site, alongside the existing `HERMES_DEV_SANDBOX_UPSTREAM`
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A, `dev-sandbox.sh` is Linux-only (bubblewrap, user namespaces)

## Screenshots / Logs

Every log line quoted above is from real runs, not constructed: the failing legs are in [run 32008508487](https://github.com/lxman/hermes-agent/actions/runs/32008508487), and the `actions/checkout` 429-and-recovery is from job `95322969999` in that same run.
