### PR TITLE
fix(memory): forward new_text from the agent loop to memory_tool

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3172,6 +3172,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 action=next_args.get("action"),
                 target=target,
                 content=next_args.get("content"),
+                new_text=next_args.get("new_text"),
                 old_text=next_args.get("old_text"),
                 operations=operations,
                 store=agent._memory_store,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2083,6 +2083,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     action=next_args.get("action"),
                     target=target,
                     content=next_args.get("content"),
+                    new_text=next_args.get("new_text"),
                     old_text=next_args.get("old_text"),
                     operations=operations,
                     store=agent._memory_store,

--- a/contributors/emails/debriann07@gmail.com
+++ b/contributors/emails/debriann07@gmail.com
@@ -1,0 +1,1 @@
+deBrian07

--- a/tests/run_agent/test_memory_new_text_dispatch.py
+++ b/tests/run_agent/test_memory_new_text_dispatch.py
@@ -1,0 +1,155 @@
+"""The agent loop must forward ``new_text`` to memory_tool.
+
+``new_text`` is an alias for ``content`` on the memory tool's single-op
+shape (see MEMORY_SCHEMA in tools/memory_tool.py). The alias is resolved
+inside ``memory_tool`` itself, so it only works if the caller actually
+passes the argument through.
+
+``memory`` never reaches the registry dispatcher — both agent loops
+special-case it and call ``memory_tool`` directly. That makes these call
+sites the only thing standing between the schema's promise and the tool,
+and unit tests that call ``memory_tool`` directly cannot see a break in
+them.
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import tools.memory_tool as memory_tool_module
+from agent.agent_runtime_helpers import invoke_tool
+from agent.tool_executor import execute_tool_calls_sequential
+from run_agent import AIAgent
+from tools.memory_tool import MemoryStore
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_tool_module, "get_memory_dir", lambda: tmp_path)
+    s = MemoryStore(memory_char_limit=5000, user_char_limit=5000)
+    s.load_from_disk()
+    return s
+
+
+def _memory_call(call_id: str, arguments: dict):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name="memory", arguments=json.dumps(arguments)),
+    )
+
+
+def _make_agent(tmp_path: Path, store: MemoryStore) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent._hermes_home", tmp_path),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._memory_store = store
+    agent._memory_manager = None
+    agent._flush_messages_to_session_db = MagicMock(return_value=True)
+    agent._append_guardrail_observation = MagicMock(
+        side_effect=lambda _name, _args, result, **_kwargs: result
+    )
+    agent._record_file_mutation_result = MagicMock()
+    agent._subdirectory_hints.check_tool_call = MagicMock(return_value="")
+    agent._tool_result_content_for_active_model = MagicMock(
+        side_effect=lambda _name, result: result
+    )
+    return agent
+
+
+class TestInvokeToolPath:
+    """agent/agent_runtime_helpers.py::invoke_tool — the concurrent path."""
+
+    def _invoke(self, store, args):
+        agent = SimpleNamespace(
+            _memory_store=store,
+            _memory_manager=None,
+            session_id="test-session",
+            _current_turn_id="turn-1",
+            _current_api_request_id="req-1",
+            _turns_since_memory=0,
+            _iters_since_skill=0,
+        )
+        return invoke_tool(
+            agent,
+            "memory",
+            args,
+            "task-1",
+            tool_call_id="call-1",
+            pre_tool_block_checked=True,
+            skip_tool_request_middleware=True,
+            skip_tool_execution_middleware=True,
+        )
+
+    def test_new_text_writes_the_entry(self, store):
+        result = json.loads(
+            self._invoke(
+                store,
+                {"action": "add", "target": "user", "new_text": "prefers metric units"},
+            )
+        )
+
+        assert result["success"] is True
+        assert "prefers metric units" in store.user_entries
+
+    def test_content_still_works(self, store):
+        result = json.loads(
+            self._invoke(
+                store,
+                {"action": "add", "target": "user", "content": "prefers dark mode"},
+            )
+        )
+
+        assert result["success"] is True
+        assert "prefers dark mode" in store.user_entries
+
+    def test_content_wins_when_both_are_set(self, store):
+        """MEMORY_SCHEMA documents this precedence; keep it pinned."""
+        self._invoke(
+            store,
+            {
+                "action": "add",
+                "target": "user",
+                "content": "from content",
+                "new_text": "from new_text",
+            },
+        )
+
+        assert "from content" in store.user_entries
+        assert "from new_text" not in store.user_entries
+
+
+class TestSequentialPath:
+    """agent/tool_executor.py::execute_tool_calls_sequential."""
+
+    def test_new_text_writes_the_entry(self, tmp_path, store):
+        agent = _make_agent(tmp_path, store)
+        assistant = SimpleNamespace(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                _memory_call(
+                    "call-1",
+                    {"action": "add", "target": "user", "new_text": "likes celsius"},
+                )
+            ],
+        )
+        messages = []
+
+        execute_tool_calls_sequential(agent, assistant, messages, "task-1", 0)
+
+        assert "likes celsius" in store.user_entries


### PR DESCRIPTION
## What does this PR do?

Calling `memory` with `new_text` always fails:

```
memory(action="add", target="user", new_text="prefers metric units")
-> Content is required for 'add' action.
```

Swap `new_text` for `content` and the same call works. The schema tells the model `new_text` is fine, but the value never reaches the tool.

#86642 added `new_text` as an alias for `content`. It changed two files: `tools/memory_tool.py` and its test. The schema now advertises the alias (`tools/memory_tool.py:1218`), and the tool knows what to do with it (`tools/memory_tool.py:1086`):

```python
if content is None and new_text is not None:
    content = new_text
```

The problem is that `memory` never goes through the registry. Both agent loops special-case it and call the function themselves, at `agent/tool_executor.py:2077` and `agent/agent_runtime_helpers.py:3166`. Neither one passed `new_text`, so `content` and `new_text` both arrived as `None`, the alias check did nothing, and line 1111 rejected the call.

`tools/registry.py` does forward `new_text` correctly, which is probably why this looked covered. The memory tool just never gets there.

This PR passes the argument through at both call sites.

## Related Issue

No existing issue — I searched open and closed issues and PRs for `memory new_text` and for the error string before filing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/tool_executor.py:2086` — pass `new_text=next_args.get("new_text")` into `memory_tool()`
- `agent/agent_runtime_helpers.py:3175` — same, in the second dispatch path
- `contributors/emails/debriann07@gmail.com` — contributor email mapping, required by the Contributor Attribution Check job

## How to Test

Before the patch:

1. Start a session with the memory toolset enabled.
2. Get the model to call `memory(action="add", target="user", new_text="prefers metric units")`.
3. It returns `Content is required for 'add' action.` and nothing is written to `USER.md`.

After the patch:

4. Same call now succeeds and the entry lands in `USER.md`.
5. `memory(action="add", target="user", content="...")` still works, unchanged.
6. If both are set, `content` still wins, which is what the schema documents.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] Ran the full suite via `scripts/run_tests.sh` (the wrapper AGENTS.md requires
      instead of bare pytest): 32,793 passed, 85 failed. All 85 are pre-existing and
      unrelated — missing optional extras (daytona, modal, parallel-web, tflite),
      macOS-incompatible WSL2 tests, and failures in video/image gen and cron.
      Verified by reverting this patch and re-running the failing files: identical
      failure count with and without the change. This PR's blast radius
      (tests/run_agent/ + memory tool tests) is 1731 passed, 0 failed.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A