### PR TITLE
fix(desktop): make Bot Chat visibility toggle effective

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -269,28 +269,159 @@ async function saveBotMeta(name, patch) {
 }
 
 /** Flip the "hide Bot Chats from the sidebar" pref, persist it, and reconcile
- *  every known canonical chat via the core session.set_hidden RPC so the change
- *  applies to already-created Bot Chats (not just future ones). Feature-detected:
- *  older gateways lack session.set_hidden and simply keep the chats visible. */
-async function setHideBotChats(hidden) {
-  $hideBotChats.set(hidden)
+ * every known canonical chat via the stored-session RPC. `$botMeta.chat` holds
+ * the durable stored ID, not a live runtime ID, so `session.set_hidden` is the
+ * wrong contract once a runtime has been reaped. */
+function isSessionNotFoundError(error) {
+  const code = error && typeof error === 'object' ? error.code : undefined
+  const message = error && typeof error === 'object' && 'message' in error ? String(error.message) : String(error || '')
+  return code === 4007 || /session not found/i.test(message)
+}
 
-  try {
-    Promise.resolve(pluginCtx?.storage?.set?.('hide-bot-chats', hidden)).catch(() => undefined)
-  } catch {
-    /* storage unavailable — pref holds for this window only */
+function isUnknownMethodError(error) {
+  const code = error && typeof error === 'object' ? error.code : undefined
+  const message = error && typeof error === 'object' && 'message' in error ? String(error.message) : String(error || '')
+  return code === -32601 || /unknown method/i.test(message)
+}
+
+async function setHideBotChats(hidden) {
+  const previous = $hideBotChats.get()
+  const persistPreference = value => {
+    try {
+      Promise.resolve(pluginCtx?.storage?.set?.('hide-bot-chats', value)).catch(() => undefined)
+    } catch {
+      /* storage unavailable — pref holds for this window only */
+    }
   }
 
-  const meta = $botMeta.get()
-  const ids = Object.values(meta)
-    .map(m => m && m.chat)
-    .filter(Boolean)
+  const chats = Object.entries($botMeta.get())
+    .map(([profile, meta]) => ({ profile, sessionId: meta && meta.chat }))
+    .filter(chat => Boolean(chat.sessionId))
 
-  await Promise.all(
-    ids.map(sid =>
-      Promise.resolve(host.request('session.set_hidden', { session_id: sid, hidden })).catch(() => undefined)
+  if (!chats.length) {
+    $hideBotChats.set(hidden)
+    persistPreference(hidden)
+    return
+  }
+
+  let profileRoutes = []
+  if (typeof host.profileRoutes === 'function' && typeof host.requestProfile === 'function') {
+    try {
+      const routes = await host.profileRoutes()
+      profileRoutes = Array.isArray(routes) ? routes : []
+    } catch {
+      // Older Desktop shells keep the active-gateway compatibility path below.
+    }
+  }
+
+  const routesFor = chat => profileRoutes.filter(route => route?.targetProfile === chat.profile)
+  const requestOnRoute = (route, chat, method, params) =>
+    route
+      ? host.requestProfile(route, method, params)
+      : host.request(method, { profile: chat.profile, ...params })
+
+  const writeOnRoute = async (route, chat, value) => {
+    try {
+      await requestOnRoute(route, chat, 'session.set_stored_hidden', {
+        session_id: chat.sessionId,
+        hidden: value
+      })
+      return { applied: true, compatibilityMiss: false, unavailable: false }
+    } catch (error) {
+      if (isSessionNotFoundError(error)) {
+        return { applied: false, compatibilityMiss: false, unavailable: true }
+      }
+      if (!isUnknownMethodError(error)) {
+        throw error
+      }
+    }
+
+    try {
+      await requestOnRoute(route, chat, 'session.set_hidden', {
+        session_id: chat.sessionId,
+        hidden: value
+      })
+      return { applied: true, compatibilityMiss: false, unavailable: false }
+    } catch (error) {
+      if (!isSessionNotFoundError(error) && !isUnknownMethodError(error)) {
+        throw error
+      }
+      return { applied: false, compatibilityMiss: true, unavailable: false }
+    }
+  }
+
+  const writeVisibility = async (chat, value) => {
+    const routes = routesFor(chat)
+    const destinations = routes.length ? routes : [null]
+    const routeOutcomes = await Promise.allSettled(
+      destinations.map(route => writeOnRoute(route, chat, value))
     )
+    const applied = routeOutcomes.find(outcome => outcome.status === 'fulfilled' && outcome.value.applied)
+
+    if (applied) {
+      return applied.value
+    }
+
+    const hardFailure = routeOutcomes.find(outcome => outcome.status === 'rejected')
+    if (hardFailure) {
+      throw hardFailure.reason
+    }
+
+    const compatibilityMiss = routeOutcomes.some(
+      outcome => outcome.status === 'fulfilled' && outcome.value.compatibilityMiss
+    )
+    return { applied: false, compatibilityMiss, unavailable: !compatibilityMiss }
+  }
+
+  const outcomes = await Promise.allSettled(chats.map(chat => writeVisibility(chat, hidden)))
+  const changedChats = chats.filter(
+    (_, index) => outcomes[index]?.status === 'fulfilled' && outcomes[index].value.applied
   )
+  const compatibilityMisses = outcomes.filter(
+    outcome => outcome.status === 'fulfilled' && outcome.value.compatibilityMiss
+  ).length
+  const unavailable = outcomes.filter(
+    outcome => outcome.status === 'fulfilled' && outcome.value.unavailable
+  ).length
+  const failed = outcomes.filter(outcome => outcome.status === 'rejected').length
+
+  if (failed) {
+    const rollback = await Promise.allSettled(changedChats.map(chat => writeVisibility(chat, previous)))
+    const rollbackFailed = rollback.filter(
+      outcome => outcome.status === 'rejected' || (outcome.status === 'fulfilled' && !outcome.value.applied)
+    ).length
+    $hideBotChats.set(previous)
+    persistPreference(previous)
+    host.notify({
+      kind: 'error',
+      message: `Could not ${hidden ? 'hide' : 'show'} ${failed} Bot Chat${failed === 1 ? '' : 's'}. Preference unchanged.${
+        rollbackFailed ? ` ${rollbackFailed} rollback${rollbackFailed === 1 ? '' : 's'} failed; refresh Sessions.` : ''
+      }`
+    })
+    return
+  }
+
+  $hideBotChats.set(hidden)
+  persistPreference(hidden)
+  if (hidden && changedChats.length && typeof host.hideSessionsFromRecents === 'function') {
+    host.hideSessionsFromRecents(changedChats)
+  }
+  if (compatibilityMisses) {
+    host.notify({
+      kind: 'warning',
+      message: `Preference saved. Update the Hermes backend to reconcile ${compatibilityMisses} existing Bot Chat${
+        compatibilityMisses === 1 ? '' : 's'
+      }.`
+    })
+  }
+  if (unavailable) {
+    host.notify({
+      kind: 'warning',
+      message: `Preference saved. ${unavailable} existing Bot Chat${
+        unavailable === 1 ? ' is' : 's are'
+      } unavailable on this connection. Activate the owning source to reconcile.`
+    })
+  }
 }
 
 /** Fetch server-side avatars for roster rows flagged has_avatar when the

--- a/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
@@ -6,7 +6,7 @@ import vm from 'node:vm'
 // #46: canonical "Bot Chat" sessions can be hidden from the global Sessions
 // sidebar via the core generic `hidden` session flag, while staying in the Bots
 // roster. The plugin passes hidden:true on session.create when the pref is on,
-// and setHideBotChats reconciles existing chats via session.set_hidden.
+// and reconciles the durable ids via session.set_stored_hidden.
 
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
@@ -49,11 +49,203 @@ test('createCanonicalChat omits hidden when the pref is off', async () => {
   assert.ok(!('hidden' in created[0]), 'hidden should be omitted, not false')
 })
 
-test('setHideBotChats persists the pref and reconciles known chats via session.set_hidden', () => {
-  // Source-level: the toggle calls session.set_hidden for each known canonical
-  // chat id and persists the pref to storage.
-  const fn = source.slice(source.indexOf('async function setHideBotChats('), source.indexOf('const avatarFetchInflight'))
-  assert.match(fn, /storage\?\.set\?\.\('hide-bot-chats', hidden\)/)
-  assert.match(fn, /session\.set_hidden.*session_id: sid, hidden/)
-  assert.match(fn, /\.map\(m => m && m\.chat\)/)
+function loadToggle({
+  failProfile = null,
+  previous = false,
+  storedUnsupported = false,
+  legacyFails = false,
+  legacyTransient = false,
+  staleProfile = null,
+  profileRoutes = null,
+  routeOwners = {}
+} = {}) {
+  const requests = []
+  const storage = []
+  const notifications = []
+  const hiddenFromRecents = []
+  const savedMeta = []
+  const state = []
+  const start = source.indexOf('function isSessionNotFoundError(')
+  const end = source.indexOf('const avatarFetchInflight', start)
+  const context = {
+    pluginCtx: { storage: { set: async (...args) => storage.push(args) } },
+    $hideBotChats: { get: () => previous, set: value => state.push(value) },
+    $botMeta: {
+      get: () => ({
+        default: { chat: 'stored-default' },
+        jarvis: { chat: 'stored-jarvis' }
+      })
+    },
+    saveBotMeta: (profile, patch) => savedMeta.push({ profile, patch }),
+    host: {
+      profileRoutes: profileRoutes ? async () => profileRoutes : undefined,
+      requestProfile: profileRoutes
+        ? async (route, method, params) => {
+            requests.push({ via: 'route', route, method, params })
+            if (routeOwners[params.session_id] !== route.connectionId) {
+              const error = new Error('session not found')
+              error.code = 4007
+              throw error
+            }
+            return { hidden: params.hidden, session_id: params.session_id }
+          }
+        : undefined,
+      request: async (method, params) => {
+        requests.push({ method, params })
+        if (method === 'session.set_stored_hidden' && params.profile === staleProfile) {
+          const error = new Error('session not found')
+          error.code = 4007
+          throw error
+        }
+        if (method === 'session.set_stored_hidden' && storedUnsupported) {
+          const error = new Error('unknown method: session.set_stored_hidden')
+          error.code = -32601
+          throw error
+        }
+        if (method === 'session.set_hidden' && legacyTransient) {
+          throw new Error('connection closed')
+        }
+        if (method === 'session.set_hidden' && legacyFails) {
+          throw new Error('session not found')
+        }
+        if (params.profile === failProfile) {
+          throw new Error('write failed')
+        }
+        return { hidden: params.hidden, session_id: params.session_id }
+      },
+      hideSessionsFromRecents: ids => hiddenFromRecents.push(ids),
+      notify: notification => notifications.push(notification)
+    }
+  }
+  const section = source.slice(start, end).concat('\nglobalThis.__toggle = setHideBotChats;\n')
+  vm.runInNewContext(section, context, { filename: 'toggle.js' })
+  return { toggle: context.__toggle, requests, storage, notifications, hiddenFromRecents, savedMeta, state }
+}
+
+test('setHideBotChats persists the pref and updates each durable session in its profile', async () => {
+  const fixture = loadToggle()
+  await fixture.toggle(true)
+
+  assert.deepEqual(fixture.storage, [['hide-bot-chats', true]])
+  assert.deepEqual(fixture.state, [true])
+  assert.deepEqual(JSON.parse(JSON.stringify(fixture.requests)), [
+    {
+      method: 'session.set_stored_hidden',
+      params: { profile: 'default', session_id: 'stored-default', hidden: true }
+    },
+    {
+      method: 'session.set_stored_hidden',
+      params: { profile: 'jarvis', session_id: 'stored-jarvis', hidden: true }
+    }
+  ])
+  assert.equal(fixture.notifications.length, 0)
+  assert.deepEqual(JSON.parse(JSON.stringify(fixture.hiddenFromRecents)), [
+    [
+      { profile: 'default', sessionId: 'stored-default' },
+      { profile: 'jarvis', sessionId: 'stored-jarvis' }
+    ]
+  ])
+  assert.equal(fixture.requests.some(request => request.method === 'session.set_hidden'), false)
+})
+
+test('setHideBotChats finds the owning connection without foregrounding it', async () => {
+  const routes = [
+    { connectionId: 'local', mode: 'local', profile: 'default', targetProfile: 'default' },
+    { connectionId: 'remote-a', mode: 'remote', profile: 'jarvis-a', targetProfile: 'jarvis' },
+    { connectionId: 'remote-b', mode: 'remote', profile: 'jarvis-b', targetProfile: 'jarvis' }
+  ]
+  const fixture = loadToggle({
+    profileRoutes: routes,
+    routeOwners: { 'stored-default': 'local', 'stored-jarvis': 'remote-b' }
+  })
+  await fixture.toggle(true)
+
+  assert.equal(fixture.requests.every(request => request.via === 'route'), true)
+  assert.equal(fixture.requests.filter(request => request.params.session_id === 'stored-jarvis').length, 2)
+  assert.deepEqual(fixture.storage, [['hide-bot-chats', true]])
+  assert.deepEqual(fixture.state, [true])
+  assert.deepEqual(JSON.parse(JSON.stringify(fixture.hiddenFromRecents)), [
+    [
+      { profile: 'default', sessionId: 'stored-default' },
+      { profile: 'jarvis', sessionId: 'stored-jarvis' }
+    ]
+  ])
+  assert.equal(fixture.notifications.length, 0)
+})
+
+test('setHideBotChats keeps an unavailable remote pointer without blocking valid chats', async () => {
+  const fixture = loadToggle({ staleProfile: 'jarvis' })
+  await fixture.toggle(true)
+
+  assert.deepEqual(fixture.savedMeta, [])
+  assert.deepEqual(fixture.storage, [['hide-bot-chats', true]])
+  assert.deepEqual(fixture.state, [true])
+  assert.deepEqual(JSON.parse(JSON.stringify(fixture.hiddenFromRecents)), [
+    [{ profile: 'default', sessionId: 'stored-default' }]
+  ])
+  assert.equal(fixture.notifications.length, 1)
+  assert.equal(fixture.notifications[0].kind, 'warning')
+  assert.match(fixture.notifications[0].message, /unavailable on this connection.*owning source/)
+})
+
+test('setHideBotChats uses the legacy live-session RPC on an older backend', async () => {
+  const fixture = loadToggle({ storedUnsupported: true })
+  await fixture.toggle(true)
+
+  assert.equal(fixture.requests.filter(request => request.method === 'session.set_stored_hidden').length, 2)
+  assert.equal(fixture.requests.filter(request => request.method === 'session.set_hidden').length, 2)
+  assert.deepEqual(fixture.storage, [['hide-bot-chats', true]])
+  assert.deepEqual(fixture.state, [true])
+  assert.equal(fixture.notifications.length, 0)
+  assert.equal(fixture.hiddenFromRecents.length, 1)
+})
+
+test('setHideBotChats saves the future preference when legacy reconciliation cannot apply', async () => {
+  const fixture = loadToggle({ storedUnsupported: true, legacyFails: true })
+  await fixture.toggle(true)
+
+  assert.deepEqual(fixture.storage, [['hide-bot-chats', true]])
+  assert.deepEqual(fixture.state, [true])
+  assert.equal(fixture.hiddenFromRecents.length, 0)
+  assert.equal(fixture.notifications.length, 1)
+  assert.equal(fixture.notifications[0].kind, 'warning')
+  assert.match(fixture.notifications[0].message, /Preference saved.*2 existing Bot Chats/)
+})
+
+test('setHideBotChats treats a transient legacy failure as a real write failure', async () => {
+  const fixture = loadToggle({ storedUnsupported: true, legacyTransient: true })
+  await fixture.toggle(true)
+
+  assert.deepEqual(fixture.storage, [['hide-bot-chats', false]])
+  assert.deepEqual(fixture.state, [false])
+  assert.equal(fixture.hiddenFromRecents.length, 0)
+  assert.equal(fixture.notifications.length, 1)
+  assert.equal(fixture.notifications[0].kind, 'error')
+  assert.match(fixture.notifications[0].message, /Could not hide 2 Bot Chats. Preference unchanged/)
+})
+
+test('setHideBotChats rolls back successful writes and preserves the preference on failure', async () => {
+  const fixture = loadToggle({ failProfile: 'jarvis', previous: true })
+  await fixture.toggle(false)
+
+  assert.deepEqual(JSON.parse(JSON.stringify(fixture.requests)), [
+    {
+      method: 'session.set_stored_hidden',
+      params: { profile: 'default', session_id: 'stored-default', hidden: false }
+    },
+    {
+      method: 'session.set_stored_hidden',
+      params: { profile: 'jarvis', session_id: 'stored-jarvis', hidden: false }
+    },
+    {
+      method: 'session.set_stored_hidden',
+      params: { profile: 'default', session_id: 'stored-default', hidden: true }
+    }
+  ])
+  assert.deepEqual(fixture.storage, [['hide-bot-chats', true]])
+  assert.deepEqual(fixture.state, [true])
+  assert.equal(fixture.hiddenFromRecents.length, 0)
+  assert.equal(fixture.notifications.length, 1)
+  assert.equal(fixture.notifications[0].kind, 'error')
+  assert.match(fixture.notifications[0].message, /Could not show 1 Bot Chat. Preference unchanged/)
 })

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { host } from '@/sdk'
-import { setActiveSessionId, setAwaitingResponse, setBusy } from '@/store/session'
+import { $sessions, setActiveSessionId, setAwaitingResponse, setBusy, setSessions } from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 
 describe('host.state turn flags', () => {
@@ -105,5 +105,37 @@ describe('host.state turn flags', () => {
     expect(host.state.awaitingResponse.get()).toBe(false)
 
     $sessionTiles.set([])
+  })
+})
+
+describe('host.hideSessionsFromRecents', () => {
+  afterEach(() => setSessions([]))
+
+  it('evicts matching durable ids and lineage roots within the owning profile', () => {
+    setSessions([
+      { id: 'visible', profile: 'default', title: 'Visible' },
+      { id: 'shared-id', profile: 'default', title: 'Keep same id in default' },
+      { id: 'shared-id', profile: 'jarvis', title: 'Bot Chat' },
+      { id: 'hidden-tip', _lineage_root_id: 'hidden-root', profile: 'sabiska', title: 'Bot Chat' }
+    ] as never)
+
+    host.hideSessionsFromRecents([
+      { profile: 'jarvis', sessionId: 'shared-id' },
+      { profile: 'sabiska', sessionId: 'hidden-root' }
+    ])
+
+    expect($sessions.get().map(session => [session.profile, session.id])).toEqual([
+      ['default', 'visible'],
+      ['default', 'shared-id']
+    ])
+  })
+
+  it('preserves the existing array when no id matches', () => {
+    const sessions = [{ id: 'visible', title: 'Visible' }] as never
+    setSessions(sessions)
+
+    host.hideSessionsFromRecents([{ profile: 'default', sessionId: 'missing' }])
+
+    expect($sessions.get()).toBe(sessions)
   })
 })

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -53,7 +53,8 @@ import {
   $currentCwd,
   $currentModel,
   $gatewayState,
-  $selectedStoredSessionId
+  $selectedStoredSessionId,
+  setSessions
 } from '@/store/session'
 import {
   $focusedRuntimeId,
@@ -433,6 +434,39 @@ export const host = {
     method: string,
     params: Record<string, unknown> = {}
   ): Promise<T> => requestPluginProfile<T>(route, method, params),
+
+  /** Remove backend-confirmed hidden stored sessions from the recents cache.
+   *  The ordinary refresh deliberately preserves the focused/working row when
+   *  it is absent from a page; a visibility mutation is an explicit tombstone,
+   *  not a paging or persistence race. Unhide is authoritative on the next
+   *  sessions.changed refresh, so this door is intentionally hide-only. */
+  hideSessionsFromRecents: (sessions: readonly { profile: string; sessionId: string }[]): void => {
+    const hiddenKeys = new Set(
+      sessions
+        .map(({ profile, sessionId }) => {
+          const id = sessionId.trim()
+
+          return id ? `${normalizeProfileKey(profile)}\u0000${id}` : ''
+        })
+        .filter(Boolean)
+    )
+
+    if (!hiddenKeys.size) {
+      return
+    }
+
+    setSessions(previous => {
+      const next = previous.filter(session => {
+        const profile = normalizeProfileKey(session.profile)
+        const idKey = `${profile}\u0000${session.id}`
+        const lineageKey = session._lineage_root_id ? `${profile}\u0000${session._lineage_root_id}` : ''
+
+        return !hiddenKeys.has(idKey) && (!lineageKey || !hiddenKeys.has(lineageKey))
+      })
+
+      return next.length === previous.length ? previous : next
+    })
+  },
 
   /** Gateway JSON-RPC — sessions, config, skills, cron, kanban, everything
    *  the app itself uses. Lazy: resolves the LIVE socket per call. */

--- a/tests/hermes_state/test_session_hidden.py
+++ b/tests/hermes_state/test_session_hidden.py
@@ -42,3 +42,13 @@ def test_hidden_excluded_by_default_included_on_request(db):
     assert db.get_session("secret")["hidden"] == 0
     unhidden_ids = {s["id"] for s in db.list_sessions_rich(min_message_count=1)}
     assert unhidden_ids == {"visible", "secret"}
+
+
+def test_hidden_setter_is_idempotent_and_distinguishes_missing(db):
+    db.create_session("existing", source="cli")
+
+    assert db.set_session_hidden("existing", True) is True
+    assert db.set_session_hidden("existing", True) is True
+    assert db.set_session_hidden("existing", False) is True
+    assert db.set_session_hidden("existing", False) is True
+    assert db.set_session_hidden("missing", True) is False

--- a/tests/tui_gateway/test_session_stored_hidden.py
+++ b/tests/tui_gateway/test_session_stored_hidden.py
@@ -20,6 +20,7 @@ class FakeSessionDB:
 def test_set_stored_hidden_targets_profile_scoped_db(monkeypatch):
     db = FakeSessionDB({"stored-bot-chat"})
     seen_params: list[dict] = []
+    events: list[tuple[str, dict]] = []
 
     @contextmanager
     def profile_db(params):
@@ -27,6 +28,7 @@ def test_set_stored_hidden_targets_profile_scoped_db(monkeypatch):
         yield db
 
     monkeypatch.setattr(server, "_profile_db", profile_db)
+    monkeypatch.setattr(server, "_broadcast_global_event", lambda event, payload: events.append((event, payload)))
 
     response = server._methods["session.set_stored_hidden"](
         1,
@@ -37,16 +39,19 @@ def test_set_stored_hidden_targets_profile_scoped_db(monkeypatch):
     assert response["result"] == {"hidden": True, "session_id": "stored-bot-chat"}
     assert db.calls == [("stored-bot-chat", True)]
     assert seen_params == [{"session_id": "stored-bot-chat", "profile": "researcher", "hidden": True}]
+    assert events == [("sessions.changed", {})]
 
 
 def test_set_stored_hidden_rejects_unknown_session(monkeypatch):
     db = FakeSessionDB(set())
+    events: list[tuple[str, dict]] = []
 
     @contextmanager
     def profile_db(_params):
         yield db
 
     monkeypatch.setattr(server, "_profile_db", profile_db)
+    monkeypatch.setattr(server, "_broadcast_global_event", lambda event, payload: events.append((event, payload)))
 
     response = server._methods["session.set_stored_hidden"](
         2,
@@ -55,3 +60,4 @@ def test_set_stored_hidden_rejects_unknown_session(monkeypatch):
 
     assert response["error"]["code"] == 4007
     assert db.calls == [("missing", False)]
+    assert events == []

--- a/tests/tui_gateway/test_session_stored_hidden.py
+++ b/tests/tui_gateway/test_session_stored_hidden.py
@@ -1,0 +1,57 @@
+"""Regression coverage for durable stored-session visibility changes."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from tui_gateway import server
+
+
+class FakeSessionDB:
+    def __init__(self, existing: set[str]):
+        self.existing = existing
+        self.calls: list[tuple[str, bool]] = []
+
+    def set_session_hidden(self, session_id: str, hidden: bool) -> bool:
+        self.calls.append((session_id, hidden))
+        return session_id in self.existing
+
+
+def test_set_stored_hidden_targets_profile_scoped_db(monkeypatch):
+    db = FakeSessionDB({"stored-bot-chat"})
+    seen_params: list[dict] = []
+
+    @contextmanager
+    def profile_db(params):
+        seen_params.append(params)
+        yield db
+
+    monkeypatch.setattr(server, "_profile_db", profile_db)
+
+    response = server._methods["session.set_stored_hidden"](
+        1,
+        {"session_id": "stored-bot-chat", "profile": "researcher", "hidden": True},
+    )
+
+    assert "error" not in response, response
+    assert response["result"] == {"hidden": True, "session_id": "stored-bot-chat"}
+    assert db.calls == [("stored-bot-chat", True)]
+    assert seen_params == [{"session_id": "stored-bot-chat", "profile": "researcher", "hidden": True}]
+
+
+def test_set_stored_hidden_rejects_unknown_session(monkeypatch):
+    db = FakeSessionDB(set())
+
+    @contextmanager
+    def profile_db(_params):
+        yield db
+
+    monkeypatch.setattr(server, "_profile_db", profile_db)
+
+    response = server._methods["session.set_stored_hidden"](
+        2,
+        {"session_id": "missing", "hidden": False},
+    )
+
+    assert response["error"]["code"] == 4007
+    assert db.calls == [("missing", False)]

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1211,6 +1211,34 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 5007, str(e))
 
 
+@method("session.set_stored_hidden")
+def _(rid, params: dict) -> dict:
+    """Set a stored session's durable ``hidden`` flag by its stable ID.
+
+    ``session.set_hidden`` deliberately addresses an in-memory runtime session
+    so a just-created draft can retain a deferred visibility intent. Desktop
+    plugins can retain the stored ID after that runtime session has been reaped,
+    so they need this profile-scoped database operation instead of targeting a
+    non-existent runtime ID.
+    """
+    target = str(params.get("session_id") or "").strip()
+    if not target:
+        return _err(rid, 4006, "session_id required")
+
+    hidden = is_truthy_value(params.get("hidden", True))
+    with _profile_db(params) as db:
+        if db is None:
+            return _db_unavailable_error(rid, code=5007)
+        try:
+            changed = db.set_session_hidden(target, hidden)
+        except Exception as e:
+            return _err(rid, 5007, str(e))
+
+    if not changed:
+        return _err(rid, 4007, "session not found")
+    return _ok(rid, {"hidden": hidden, "session_id": target})
+
+
 @method("message.react")
 def _(rid, params: dict) -> dict:
     """Set or clear one author's emoji reaction on a persisted message.

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1236,6 +1236,7 @@ def _(rid, params: dict) -> dict:
 
     if not changed:
         return _err(rid, 4007, "session not found")
+    _broadcast_global_event("sessions.changed", {})
     return _ok(rid, {"hidden": hidden, "session_id": target})
 
 


### PR DESCRIPTION
## Summary

The Bot Mode eye toggle claimed to hide canonical `Bot Chat` sessions from the global Sessions list, but the interaction could leave them visible.

Two boundaries were wrong:

1. `$botMeta.chat` retains a durable stored-session ID, while the plugin called `session.set_hidden`, which targets a live runtime session and can no longer resolve that ID after runtime reaping.
2. Even after the database marked a session hidden, Desktop's refresh path deliberately preserved the focused/working row as an in-flight survivor, so the visible Sessions cache could retain it.

## What changed

- Add profile-scoped `session.set_stored_hidden` for durable stored-session IDs.
- Route Bot Mode visibility writes through that RPC and report partial write failures instead of swallowing them.
- Route visibility mutations through credential-free `(connectionId, profile)` descriptors so duplicate profile names on multiple registered connections are reconciled on the backend that owns each durable session.
- Add a narrow plugin-host `hideSessionsFromRecents()` tombstone action so backend-confirmed `(profile, session_id)` pairs are evicted immediately, including compression-lineage matches without cross-profile ID collisions.
- Broadcast `sessions.changed` explicitly after a successful durable visibility write, including writes to secondary-profile databases the active-profile file watcher does not observe.
- Keep unhide authoritative through that backend change event.
- Replace the prior source-regex toggle test with behavioral RPC, profile-scope, cache-eviction, and failure tests.

## Why

The tooltip and local atom changed even when no durable session was updated. Source-level string tests passed while the user-visible list remained unchanged. This patch aligns runtime identity, persisted state, and renderer cache behavior.

## Test plan

- `python -m pytest tests/tui_gateway/test_session_stored_hidden.py tests/hermes_state/test_session_hidden.py -q -o addopts=` — 4 passed
- `node --test src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs` — 9 passed
- `vitest run --project ui src/sdk/index.test.ts` — 6 passed
- `tsc -p tsconfig.json --noEmit` — passed
- ESLint on changed Desktop source — 0 errors (direct JS plugin is intentionally ignored)
- `npm run build` in `apps/desktop` — passed
- Sabotage/RED gate: the new Bot Mode test against the pre-fix upstream plugin fails 2/4 and identifies the incorrect `session.set_hidden` calls.

## Scope / compatibility

- No public API or session-list default changes.
- Hidden sessions remain resumable by their owning plugin surface.
- The SDK cache action is hide-only; unhide returns from backend truth on the explicit change-event refresh.
- Older backends use the legacy live-session RPC when available; if a reaped chat cannot be reconciled, the future preference is retained and the user receives an update-backend warning.
- Non-compatibility write failures roll back successful writes and preserve the prior preference.
- `4007 session not found` is treated as “not owned by this route”; connection-qualified `profileRoutes()`/`requestProfile()` fan-out finds the owning backend without foregrounding it, while unresolved pointers are preserved and reported.
- PR #88292 addresses a related Bot Chat preview/pin identity mismatch. This change does not include or duplicate that PR's preview behavior.
