### PR TITLE
fix(agent): clarify file mutation verifier warnings

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3578,9 +3578,17 @@ class AIAgent:
                         mgr.record_agent_write(_p)
                     except Exception:
                         pass
+        changed = getattr(self, "_turn_file_mutation_paths", None)
         if is_error and not landed:
             preview = _extract_error_preview(result)
             for path in targets:
+                # If this exact target already landed earlier in the turn, a
+                # later failed edit attempt is not proof the file was unchanged.
+                # Avoid a stale turn-end warning for common recovery flows like
+                # write_file success -> follow-up patch no-op/failure.
+                if changed is not None and path in changed:
+                    state.pop(path, None)
+                    continue
                 # Keep the FIRST error we saw for a given path unless we
                 # later see success.  A repeated failure with a different
                 # message shouldn't silently overwrite the original.
@@ -3680,9 +3688,9 @@ class AIAgent:
             return ""
         lines = [
             "⚠️ File-mutation verifier: "
-            f"{len(failed)} file(s) were NOT modified this turn despite any "
-            "wording above that may suggest otherwise. Run `git status` or "
-            "`read_file` to confirm."
+            f"{len(failed)} tracked file mutation attempt(s) did not land. "
+            "The file may still have changed by another operation; run "
+            "`git status` or `read_file` to confirm."
         ]
         shown = 0
         for path, info in failed.items():

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -151,6 +151,31 @@ class TestRecordFileMutationResult:
         assert agent._turn_file_mutation_paths == {"/tmp/a.md"}
 
 
+    def test_later_failure_skipped_when_path_already_landed(self):
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "write_file",
+            {"path": "/tmp/a.md", "content": "done"},
+            json.dumps({"bytes_written": 4, "verified": True}),
+            is_error=False,
+        )
+        assert agent._turn_file_mutation_paths == {"/tmp/a.md"}
+
+        agent._record_file_mutation_result(
+            "patch",
+            {
+                "mode": "replace",
+                "path": "/tmp/a.md",
+                "old_string": "missing",
+                "new_string": "done",
+            },
+            json.dumps({"error": "Could not find old_string"}),
+            is_error=True,
+        )
+
+        assert agent._turn_failed_file_mutations == {}
+
+
     def test_landed_paths_prefer_resolved_tool_result(self):
         paths = _extract_landed_file_mutation_paths(
             "patch",
@@ -244,7 +269,8 @@ class TestFormatFooter:
         out = AIAgent._format_file_mutation_failure_footer(
             {"/tmp/a.md": {"tool": "patch", "error_preview": "Could not find old_string"}},
         )
-        assert "1 file(s) were NOT modified" in out
+        assert "1 tracked file mutation attempt(s) did not land" in out
+        assert "may still have changed by another operation" in out
         assert "/tmp/a.md" in out
         assert "Could not find old_string" in out
         assert "git status" in out  # user-actionable hint
@@ -255,7 +281,7 @@ class TestFormatFooter:
             for i in range(15)
         }
         out = AIAgent._format_file_mutation_failure_footer(failed)
-        assert "15 file(s) were NOT modified" in out
+        assert "15 tracked file mutation attempt(s) did not land" in out
         assert "… and 5 more" in out
         # Ten file bullets + header + "and X more" line
         lines = out.split("\n")

--- a/tests/tools/test_tts_prepare_spoken.py
+++ b/tests/tools/test_tts_prepare_spoken.py
@@ -44,8 +44,8 @@ class TestThinkBlockStrip:
 
 class TestVerifierFooterStrip:
     FOOTER = (
-        "⚠️ File-mutation verifier: 2 file(s) were NOT modified this turn "
-        "despite any wording above that may suggest otherwise. Run `git "
+        "⚠️ File-mutation verifier: 2 tracked file mutation attempt(s) did not land. "
+        "The file may still have changed by another operation; run `git "
         "status` or `read_file` to confirm.\n"
         "  • `tools/foo.py` — [patch] old_string not found\n"
         "  • `bar.md` — [write_file] failed"
@@ -55,7 +55,7 @@ class TestVerifierFooterStrip:
         raw = "I fixed the file.\n\n" + self.FOOTER
         spoken = prepare_spoken_text(raw)
         assert "File-mutation verifier" not in spoken
-        assert "NOT modified" not in spoken
+        assert "did not land" not in spoken
         assert "fixed the file" in spoken
 
 


### PR DESCRIPTION
## Summary
- stop reporting stale verifier failures when the same path already landed earlier in the turn
- reword the footer so it reports unresolved tracked mutation attempts, not a false global claim that files were not modified
- keep TTS stripping coverage aligned with the new footer wording

Fixes #72884.
Touches the false-positive shape described by #67657.

## Verification
- uv run --extra dev pytest tests/run_agent/test_file_mutation_verifier.py tests/tools/test_write_verification.py tests/agent/test_tool_result_classification.py tests/tools/test_tts_prepare_spoken.py -q -o 'addopts='\n- uv run --extra dev ruff check run_agent.py tests/run_agent/test_file_mutation_verifier.py tests/tools/test_tts_prepare_spoken.py\n- python -m py_compile run_agent.py agent/tool_result_classification.py tools/tts_text_normalize.py\n- git diff --check