### PR TITLE
fix(state): rebuild wrong-shaped FTS vtables before the optimize backfill

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -274,6 +274,69 @@ class SessionSearchMixin:
             logger.debug("FTS trash teardown chunk failed (will retry): %s", exc)
             return True
 
+    def _drop_mismatched_fts_vtables(self) -> None:
+        """Drop FTS vtables whose column set does not match the v23 schema.
+
+        ``_ensure_fts_schema``'s DDL is ``CREATE VIRTUAL TABLE IF NOT
+        EXISTS``, so an interrupted demote/resume can leave a v22-shaped
+        single-column ``content`` vtable that the IF NOT EXISTS silently
+        accepts — every later ``fts_rebuild_step`` INSERT then fails with
+        "no column named tool_name" and the resume can never complete
+        (#72716). A dropped table is re-created correctly by the ensure
+        that follows; the rebuild markers still present make the backfill
+        re-populate it, so reset ``fts_rebuild_progress`` to 0 whenever a
+        table was dropped (rows claimed under the wrong shape may be
+        missing even though the marker advanced). No-op when the shapes
+        already match. Caller holds ``self._lock`` and commits.
+        """
+        expected_columns = {"content", "tool_name", "tool_calls"}
+        dropped = False
+        try:
+            base_cursor = self._conn.execute(
+                "SELECT * FROM messages_fts LIMIT 0"
+            )
+            base_columns = {d[0] for d in base_cursor.description or []}
+        except sqlite3.OperationalError:
+            base_columns = None  # absent — ensure will create it
+        if base_columns is not None and not expected_columns.issubset(
+            base_columns
+        ):
+            logger.warning(
+                "FTS table messages_fts has an unexpected column set (%s); "
+                "rebuilding it to complete the optimize-storage resume",
+                sorted(base_columns),
+            )
+            self._drop_fts_triggers(self._conn)
+            self._conn.execute("DROP TABLE IF EXISTS messages_fts")
+            dropped = True
+        try:
+            tri_cursor = self._conn.execute(
+                "SELECT * FROM messages_fts_trigram LIMIT 0"
+            )
+            tri_columns = {d[0] for d in tri_cursor.description or []}
+        except sqlite3.OperationalError:
+            tri_columns = None
+        if tri_columns is not None and not expected_columns.issubset(
+            tri_columns
+        ):
+            logger.warning(
+                "FTS table messages_fts_trigram has an unexpected column "
+                "set (%s); rebuilding it to complete the optimize-storage "
+                "resume",
+                sorted(tri_columns),
+            )
+            self._drop_fts_triggers(self._conn)
+            self._conn.execute(
+                "DROP TABLE IF EXISTS messages_fts_trigram"
+            )
+            dropped = True
+        if dropped:
+            self._conn.execute(
+                "INSERT INTO state_meta (key, value) "
+                "VALUES ('fts_rebuild_progress', '0') "
+                "ON CONFLICT(key) DO UPDATE SET value = '0'"
+            )
+
     def fts_rebuild_step(self) -> bool:
         """Backfill one chunk of the deferred FTS rebuild.
 
@@ -800,6 +863,31 @@ class SessionSearchMixin:
                         "on optimize-storage resume"
                     )
                 self._conn.commit()
+
+        # Shape guard before ANY path reaches the backfill: the resume branch
+        # above (and the legacy+pending combination that skips both branches)
+        # can reach the backfill with a v22-shaped single-column `content`
+        # vtable — ``IF NOT EXISTS`` ensure silently accepts it, and every
+        # ``fts_rebuild_step`` INSERT then dies on "no column named
+        # tool_name" and retries forever (#72716). Validate the column set
+        # and rebuild mismatched vtables; markers survive so the backfill
+        # re-populates them from progress 0.
+        with self._lock:
+            self._drop_mismatched_fts_vtables()
+            base_ok = self._ensure_fts_schema(
+                self._conn, "messages_fts", FTS_SQL
+            )
+            trigram_ok = self._ensure_fts_schema(
+                self._conn, "messages_fts_trigram", FTS_TRIGRAM_SQL
+            )
+            if self._trigram_available is not False:
+                self._trigram_available = bool(trigram_ok)
+            if not base_ok and self.get_meta("fts_rebuild_high_water"):
+                raise sqlite3.OperationalError(
+                    "failed to re-create v23 messages_fts "
+                    "on optimize-storage resume"
+                )
+            self._conn.commit()
 
         # A stale CJK index (triggers dropped by a tokenizer-less process)
         # can only be recovered from scratch — reset it now so the cjk

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3286,6 +3286,73 @@ class TestFTSExternalContentMigration:
         finally:
             db.close()
 
+    def test_optimize_resume_rebuilds_wrong_shaped_vtables(self, tmp_path):
+        """#72716 follow-up shape: markers set but messages_fts is a v22
+        single-column `content` vtable. _ensure_fts_schema's IF NOT EXISTS
+        silently accepted it and the very first fts_rebuild_step INSERT
+        died on "no column named tool_name" — the resume could never
+        complete. The resume must validate the column set, rebuild the
+        vtable, and let the backfill re-populate it from progress 0."""
+        db_path = tmp_path / "v22.db"
+        self._build_v22_db(db_path)
+
+        db = SessionDB(db_path=db_path)
+        try:
+            self._simulate_pre_fix_demote_crash_window(db)
+            # Re-introduce the reporter's shape: single-column v22-shaped
+            # vtables (only the legacy `content` column) WITH markers set
+            # and progress advanced past some rows.
+            conn = db._conn
+            conn.execute("DROP TABLE IF EXISTS messages_fts")
+            conn.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+            conn.execute(
+                "CREATE VIRTUAL TABLE messages_fts USING fts5(content)"
+            )
+            conn.execute(
+                "CREATE VIRTUAL TABLE messages_fts_trigram USING "
+                "fts5(content, tokenize='trigram')"
+            )
+            hw = conn.execute(
+                "SELECT COALESCE(MAX(id), 0) FROM messages"
+            ).fetchone()[0]
+            conn.execute(
+                "INSERT INTO state_meta (key, value) VALUES "
+                "('fts_rebuild_high_water', ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (str(hw),),
+            )
+            conn.execute(
+                "INSERT INTO state_meta (key, value) VALUES "
+                "('fts_rebuild_progress', '1') "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+            )
+            conn.commit()
+
+            # Sanity: the wrong-shaped table cannot serve the v23 INSERT.
+            with pytest.raises(sqlite3.OperationalError):
+                conn.execute(
+                    "INSERT INTO messages_fts(rowid, content, tool_name, "
+                    "tool_calls) VALUES (1, 'a', NULL, NULL)"
+                )
+            conn.rollback()
+
+            result = db.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True
+            assert db.get_meta("fts_rebuild_high_water") is None
+            assert db.get_meta("fts_rebuild_progress") is None
+            # The vtable is now the v23 shape and fully populated.
+            n_msg = db._conn.execute(
+                "SELECT COUNT(*) FROM messages"
+            ).fetchone()[0]
+            n_fts = db._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts_docsize"
+            ).fetchone()[0]
+            assert n_fts == n_msg
+            assert len(db.search_messages("deployment")) == 1
+            assert db.fts_optimize_available() is False
+        finally:
+            db.close()
+
     def test_repair_rebuilds_partial_index_without_duplicates(self, tmp_path):
         """high_water without progress on a PARTIALLY indexed DB must not
         replay the backfill from zero on top of surviving rows: the chunk


### PR DESCRIPTION
## What does this PR do?

Fixes the interrupted-resume shape reported as a follow-up on #72716 (comment, 2026-08-17): `fts_rebuild_high_water`/`fts_rebuild_progress` markers are set while `messages_fts` / `messages_fts_trigram` exist as v22-shaped **single-column `content`** vtables. `_ensure_fts_schema`'s DDL is `CREATE VIRTUAL TABLE IF NOT EXISTS`, which silently **accepts** the wrong-shaped table — the first `fts_rebuild_step` INSERT then fails with `table messages_fts has no column named tool_name`, and because the step loop treats every `OperationalError` as retryable, `optimize-storage` hangs forever (reproduced: infinite retry on a 3-row database; the reporter hit it on a real DB with `high_water=60993`).

This PR adds `_drop_mismatched_fts_vtables()` — probe each FTS vtable's column set (via `SELECT ... LIMIT 0` description), drop any that lack the v23 columns, and reset `fts_rebuild_progress` to 0 (rows claimed under the wrong shape may be missing even though the marker advanced). The guard runs **after** the legacy/pending branch dispatch, so every path reaches the backfill with correctly-shaped tables — including the `legacy and pending` combination that previously skipped both branches and fell straight into the dead loop. The surviving markers drive a full re-population, so a resume now completes instead of hanging: search for historical rows is restored and the markers clear.

The original empty-stamp settle defect from #72716 was already fixed by #76832 (merged); this covers the shape that fix missed.

## Related Issue

Fixes #72716 (interrupted-resume shape)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_search.py`: new `_drop_mismatched_fts_vtables()` — column-set probe + drop + progress reset for both vtables; called after the legacy/pending dispatch in `optimize_fts_storage()` followed by a re-ensure, with docstrings documenting the IF-NOT-EXISTS blind spot and the #72716 follow-up shape
- `tests/test_hermes_state.py`: new `test_optimize_resume_rebuilds_wrong_shaped_vtables` — builds the reporter's exact durable state (single-column vtables + markers + advanced progress), asserts the v23 INSERT fails on the wrong shape (sanity), then asserts the optimize run completes, the vtable comes back with the v23 column set, the index is fully populated (docsize count == messages count), historical search works, and the markers clear

## How to Test

1. `python -m pytest tests/test_hermes_state.py::TestFTSExternalContentMigration -q` — Observed result: 15 passed (the #76832 regression tests continue to pass: the shape guard is a no-op on correctly-shaped tables).
2. `python -m pytest tests/test_hermes_state.py tests/test_state_db_malformed_repair.py tests/test_journal_mode_config.py -q` — Observed result: 272 passed, 1 failed — the single failure (`TestFTS5Search::test_search_projection_skips_context_enrichment_queries`) reproduces identically with this change stashed (pre-existing local environment noise, not a regression).
3. The new test pins the reporter's scenario: pre-fix, `optimize_fts_storage` on that state hangs in the retry loop (verified locally: the backfill step returns "more" forever with progress frozen); post-fix it completes in ~4s with search restored.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate (#76832 is the merged fix for the original shape; no open PR covers the wrong-shaped-vtable resume)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the FTS migration classes and the full hermes_state suite (272 passed; the one failure is pre-existing local noise verified via a stashed baseline)
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config keys or schemas changed; the helper and call site carry docstrings explaining the IF-NOT-EXISTS blind spot and the #72716 reference

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest "tests/test_hermes_state.py::TestFTSExternalContentMigration" -q
15 passed in 1.19s
# Reporter's shape, end-to-end (in-process):
optimize took 4.19 ok: True
search deployment: 1
markers: None None
```
