### PR TITLE
fix(desktop): don't treat a mid-switch 404 as session deletion (#88540)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -13,9 +13,16 @@ import { setSessionYolo } from '@/lib/yolo-session'
 import { normalizeChoices, setClarifyRequest } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
+import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
-import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $gatewaySwapTarget,
+  $newChatProfile,
+  ensureGatewayProfile,
+  normalizeProfileKey
+} from '@/store/profile'
 import {
   beginSessionMutation,
   endSessionMutation,
@@ -85,6 +92,7 @@ import {
   type BranchMessage,
   chatMessageArraysEquivalent,
   dedupeInflightUserAgainstTranscript,
+  goneSessionVerdict,
   isSessionGoneError,
   overlayConcurrentMessageChanges,
   patchSessionWorkspace,
@@ -1316,11 +1324,39 @@ export function useSessionActions({
         // permanently-dead id. (Booting straight into a no-longer-existent
         // last-session id is the common trigger.)
         if ($messages.get().length === 0 && isSessionGoneError(fallbackError)) {
-          // A session created THIS run isn't gone — its backend just flapped
-          // before the turn-less session persisted. Keep the empty view and arm
-          // the bounded retry to rebind, rather than yanking to a fresh draft.
-          // Only a stale id from a PRIOR run drops to a draft.
-          if (createdThisRun.has(storedSessionId)) {
+          // A 404 is only trustworthy from the backend that OWNS the session.
+          // A cross-profile open (Bots pane) races the gateway swap, so both
+          // lookups can land on a backend that never heard of the id (#88540).
+          // Re-resolve before discarding: a row still listed on any profile —
+          // or a swap in flight — means "retry once things settle", not gone.
+          let stillListed = false
+
+          try {
+            stillListed = Boolean(await resolveStoredSession(storedSessionId))
+          } catch {
+            // Resolution itself failed — inconclusive, treat as not listed.
+          }
+
+          if (!isCurrentResume()) {
+            return
+          }
+
+          const verdict = goneSessionVerdict({
+            createdThisRun: createdThisRun.has(storedSessionId),
+            stillListed,
+            switchInFlight:
+              $gatewaySwitching.get() ||
+              Boolean($gatewaySwapTarget.get()) ||
+              // Known owner ≠ active gateway: the 404 came from the wrong
+              // backend. An UNKNOWN owner must not count — it would block the
+              // draft fallback for genuinely dead ids on secondary profiles.
+              Boolean(
+                sessionProfile?.trim() &&
+                  normalizeProfileKey(sessionProfile) !== normalizeProfileKey($activeGatewayProfile.get())
+              )
+          })
+
+          if (verdict === 'retry') {
             setResumeFailedSessionId(storedSessionId)
 
             return

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -23,6 +23,7 @@ import {
   chatMessagesEquivalent,
   chatPartsEquivalent,
   dedupeInflightUserAgainstTranscript,
+  goneSessionVerdict,
   isSessionGoneError,
   overlayConcurrentMessageChanges,
   preserveLocalPendingTurnMessages,
@@ -236,6 +237,24 @@ describe('isSessionGoneError', () => {
     expect(isSessionGoneError(new Error('Session not found'))).toBe(true)
     expect(isSessionGoneError(new Error('ECONNREFUSED'))).toBe(false)
     expect(isSessionGoneError(null)).toBe(false)
+  })
+})
+
+describe('goneSessionVerdict', () => {
+  it('drafts only when the id is verifiably gone in calm conditions', () => {
+    expect(goneSessionVerdict({ createdThisRun: false, stillListed: false, switchInFlight: false })).toBe('draft')
+  })
+
+  it('retries when a profile/connection switch is in flight (#88540 route revert)', () => {
+    expect(goneSessionVerdict({ createdThisRun: false, stillListed: false, switchInFlight: true })).toBe('retry')
+  })
+
+  it('retries when the session is still listed on some profile', () => {
+    expect(goneSessionVerdict({ createdThisRun: false, stillListed: true, switchInFlight: false })).toBe('retry')
+  })
+
+  it('never discards a session created by this window in this run', () => {
+    expect(goneSessionVerdict({ createdThisRun: true, stillListed: false, switchInFlight: false })).toBe('retry')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1578,6 +1578,33 @@ export function isSessionGoneError(err: unknown): boolean {
 }
 
 /**
+ * What to do when a resume's RPC and REST fallback BOTH came back
+ * gone-looking (#88540).
+ *
+ * A 404 is only proof of deletion when it came from the backend that owns
+ * the session. During (or moments after) a profile/connection switch the
+ * request can land on a backend that has never heard of the id — the
+ * cross-profile Bots-pane open is the reproducer: the route is written
+ * correctly, the resume races the gateway swap, both lookups 404 on the
+ * wrong backend, and the "genuinely gone" branch yanks the window to the
+ * blank new-chat route while the target session is perfectly alive.
+ *
+ * `'retry'` keeps the route and arms the bounded auto-retry (which re-runs
+ * the resume once the swap settles); `'draft'` is reserved for a session
+ * that is verifiably gone in calm conditions.
+ */
+export function goneSessionVerdict(options: {
+  /** The session was created by this window in this run — never discard. */
+  createdThisRun: boolean
+  /** A post-failure re-resolve still finds the row on SOME profile. */
+  stillListed: boolean
+  /** A profile swap or connection switch is in flight (or just targeted). */
+  switchInFlight: boolean
+}): 'draft' | 'retry' {
+  return options.createdThisRun || options.stillListed || options.switchInFlight ? 'retry' : 'draft'
+}
+
+/**
  * The busy value a resume/activate response should land with (#70449).
  *
  * `running` in a `session.activate` / `session.resume` payload is a snapshot


### PR DESCRIPTION
## Summary

Opening a session across a profile switch no longer gets yanked to the blank new-chat route (`#/`): a 404 that arrives while a gateway/profile swap is in flight is treated as "retry once the swap settles," not "session deleted."

Root cause (#88540, instrumented by @zChrisCheng): `resumeSession`'s terminal-failure branch trusted `isSessionGoneError` unconditionally. During a cross-profile open (the Bots pane reproducer) the resume RPC and REST fallback can both land on a backend that has never heard of the id — both 404, the "genuinely gone" branch fires `startFreshSessionDraft(true)`, and the correctly-written session route reverts to `#/` while the target session is alive.

## Changes

- `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts`: new `goneSessionVerdict()` — pure precedence function: `retry` when the session was created this run, OR a post-failure `resolveStoredSession` still finds the row on some profile, OR a profile/connection switch is in flight (`$gatewaySwitching` / `$gatewaySwapTarget` / known owner ≠ active gateway); `draft` only for a verifiably dead id in calm conditions.
- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`: the gone-branch re-resolves the id and consults the verdict; `retry` arms the existing bounded auto-retry latch (`setResumeFailedSessionId`) so use-route-resume re-attempts with backoff instead of discarding the route.
- Tests: 4 new vitest cases for `goneSessionVerdict`.

The unknown-owner case deliberately does NOT count as switch-in-flight, so genuinely dead ids on secondary profiles still fall back to a draft instead of latching the loader.

## Validation

| Suite | Result |
|---|---|
| `vitest --project ui use-session-actions/utils.test.ts` | 111/111 pass (incl. 4 new) |
| `vitest --project ui resolve-stored-session + resume-structural-parts` | pass |
| `npm run check:lint` (tsc ×3 + eslint) | 0 errors |

Fixes #88540.

## Infographic

![Session resume no-false-gone blueprint](https://v3b.fal.media/files/b/0aa6c0c4/Qu6800pK-Ju0T9SplAthK_5wbdMNWO.png)
