### PR TITLE
fix(skills): canonicalize project trust identity across git worktrees

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -26,24 +26,22 @@ PLATFORM_MAP = {
     "windows": "win32",
 }
 
-EXCLUDED_SKILL_DIRS = frozenset(
-    (
-        ".git",
-        ".github",
-        ".hub",
-        ".archive",
-        ".venv",
-        "venv",
-        "node_modules",
-        "site-packages",
-        "__pycache__",
-        ".tox",
-        ".nox",
-        ".pytest_cache",
-        ".mypy_cache",
-        ".ruff_cache",
-    )
-)
+EXCLUDED_SKILL_DIRS = frozenset((
+    ".git",
+    ".github",
+    ".hub",
+    ".archive",
+    ".venv",
+    "venv",
+    "node_modules",
+    "site-packages",
+    "__pycache__",
+    ".tox",
+    ".nox",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+))
 
 # Supporting files live inside a skill package and are loaded explicitly via
 # skill_view(skill, file_path=...). They are not standalone skills and must not
@@ -115,6 +113,7 @@ def is_excluded_skill_path(path, *, root: Optional[Path] = None) -> bool:
         parts = path.parts  # Path
     except AttributeError:
         from pathlib import PurePath
+
         parts = PurePath(str(path)).parts
     return any(part in EXCLUDED_SKILL_DIRS for part in parts) or is_skill_support_path(
         path, root=root
@@ -342,9 +341,7 @@ def _detect_environment(env: str) -> bool:
         # its runtime scaffolding under /run/s6 and ships its admin tree under
         # /package/admin/s6-overlay. Either marker means we're inside an
         # s6-supervised container.
-        result = os.path.isdir("/run/s6") or os.path.isdir(
-            "/package/admin/s6-overlay"
-        )
+        result = os.path.isdir("/run/s6") or os.path.isdir("/package/admin/s6-overlay")
 
     _ENV_DETECT_CACHE[env] = result
     return result
@@ -458,6 +455,7 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
         return set()
 
     from gateway.session_context import get_session_env
+
     resolved_platform = (
         platform
         or os.getenv("HERMES_PLATFORM")
@@ -736,7 +734,10 @@ def _canonical_project_identity_str(root_str: str) -> str:
         )
     except (OSError, subprocess.SubprocessError):
         return fallback
-    if result.returncode != 0:
+    # A test double or a stripped-down subprocess shim may leave stdout as
+    # None; treat unreadable output exactly like a failed listing: fall back to
+    # path-specific trust (fail-closed), never raise into the trust check.
+    if result.returncode != 0 or result.stdout is None:
         return fallback
 
     worktrees: List[str] = []
@@ -1008,6 +1009,7 @@ def normalize_skill_lookup_name(identifier: str) -> str:
     # module cycle (tools.skills_tool imports agent.skill_utils).
     try:
         from tools import skills_tool as _skills_tool
+
         primary_root = Path(_skills_tool.SKILLS_DIR)
     except Exception:
         primary_root = get_skills_dir()
@@ -1265,7 +1267,7 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
     if not desc:
         return ""
     if len(desc) > SKILL_PROMPT_DESC_LIMIT:
-        return desc[:SKILL_PROMPT_DESC_LIMIT - 3] + "..."
+        return desc[: SKILL_PROMPT_DESC_LIMIT - 3] + "..."
     return desc
 
 
@@ -1299,7 +1301,11 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     matches: list[str] = []
     for root, dirs, files in os.walk(skills_dir_str, followlinks=True):
         has_skill_md = "SKILL.md" in files
-        if root == skills_dir_str and ORG_MIRROR_DIR_NAME in dirs and active_org is None:
+        if (
+            root == skills_dir_str
+            and ORG_MIRROR_DIR_NAME in dirs
+            and active_org is None
+        ):
             dirs.remove(ORG_MIRROR_DIR_NAME)
         elif root == org_root:
             # Inside _org/: descend ONLY into the active org's mirror.

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -6,7 +6,6 @@ tool registration or provider resolution.
 """
 
 import ast
-import functools
 import logging
 import os
 import re
@@ -698,101 +697,85 @@ def find_project_root(start: Optional[Path] = None) -> Optional[Path]:
     return None
 
 
-# Timeout for the one-shot ``git rev-parse`` probe that canonicalizes trust
+# Timeout for the one-shot ``git worktree list`` probe that canonicalizes trust
 # identity. Short by design: this runs at agent-build time on the session's
 # fixed cwd, and any git slowness must degrade to the plain-resolve fallback
 # rather than stall prompt construction.
 _GIT_IDENTITY_TIMEOUT_S = 2.0
 
 
-@functools.lru_cache(maxsize=256)
 def _canonical_project_identity_str(root_str: str) -> str:
     """Canonical trust identity for *root_str* (a resolved path string).
 
-    All git worktrees of one repository — plus the symlinked-root case — share
-    a single ``--git-common-dir`` (the main checkout's ``.git``), so we key the
-    trust principal off the *parent of the resolved common dir* (the main
-    checkout root). Trusting any worktree of a repo then covers every other
-    worktree of that same repo.
+    A path shares the first registered worktree's identity only when its
+    resolved root exactly matches a worktree reported by Git. This membership
+    check prevents a forged ``.git`` file from borrowing another repository's
+    trust. Git's repository-selection environment is stripped so process-level
+    variables cannot redirect the probe.
 
-    Falls back to ``Path(root).resolve()`` (as a string) whenever git can't
-    give us a better answer: git binary missing, not a repo, timeout, or a
-    layout the parent-of-common-dir heuristic can't reason about safely (bare
-    repos, submodules — see below).
+    Submodules retain their own identity because their own worktree listing is
+    independent of the superproject. Registered checkouts of separate-git-dir
+    repositories work for the same reason: identity comes from Git's listed
+    checkout paths, not metadata directory naming or layout. An initializer
+    checkout omitted from that list stays fail-closed as its own identity.
 
-    Submodule nuance: a submodule's common dir lives under the superproject's
-    ``.git/modules/<name>``, so parent-of-common-dir would resolve to the
-    superproject's ``.git`` rather than the submodule checkout — a wrong,
-    surprising identity. We detect that (``rev-parse
-    --show-superproject-working-tree`` is non-empty, or the common dir sits
-    under a ``.git/modules`` segment) and fall back to the resolved root so a
-    submodule keeps its own distinct identity.
-
-    Cached per process on the string path: cwd is fixed for the life of a
-    session and the git layout of a checkout doesn't change under us, matching
-    the existing cache-safety contract for project-skill discovery.
+    Results are intentionally not process-cached. Cache safety comes from
+    callers resolving identity once while building an agent/session, so a later
+    session observes worktree removal or path replacement correctly.
     """
     fallback = str(Path(root_str).resolve())
-
-    def _git(*extra_args: str) -> Optional[str]:
-        try:
-            out = subprocess.run(
-                ["git", "-C", root_str, "rev-parse", *extra_args],
-                capture_output=True,
-                text=True,
-                timeout=_GIT_IDENTITY_TIMEOUT_S,
-            )
-        except (OSError, subprocess.SubprocessError):
-            return None
-        if out.returncode != 0:
-            return None
-        return out.stdout.strip()
-
-    common_dir = _git("--git-common-dir")
-    if not common_dir:
-        # git missing / not a repo / timeout — keep per-root identity.
-        return fallback
-
-    # Resolve the common dir relative to the root (git may return a relative
-    # path like ".git" or an absolute one).
-    common_path = Path(common_dir)
-    if not common_path.is_absolute():
-        common_path = Path(root_str) / common_path
+    git_env = {
+        key: value for key, value in os.environ.items() if not key.startswith("GIT_")
+    }
     try:
-        common_path = common_path.resolve()
-    except OSError:
+        result = subprocess.run(
+            ["git", "-C", fallback, "worktree", "list", "--porcelain", "-z"],
+            capture_output=True,
+            timeout=_GIT_IDENTITY_TIMEOUT_S,
+            env=git_env,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return fallback
+    if result.returncode != 0:
         return fallback
 
-    # Submodule: common dir under a superproject's ``.git/modules/...``. The
-    # parent-of-common-dir heuristic is meaningless here, so keep the
-    # submodule's own resolved root as its identity. Two independent signals;
-    # either is sufficient.
-    superproject = _git("--show-superproject-working-tree")
-    parts = common_path.parts
-    in_git_modules = ".git" in parts and "modules" in parts[parts.index(".git") + 1 :]
-    if superproject or in_git_modules:
-        return fallback
+    worktrees: List[str] = []
+    for field in result.stdout.split(b"\0"):
+        if not field.startswith(b"worktree "):
+            continue
+        try:
+            path = os.fsdecode(field.removeprefix(b"worktree "))
+            worktrees.append(str(Path(path).resolve()))
+        except OSError:
+            return fallback
 
-    # Bare repos have no working-tree parent to key off; fall back.
-    if common_path.name != ".git":
+    if not worktrees or fallback not in worktrees:
         return fallback
-
-    # Canonical identity = the main checkout root = parent of the common .git.
-    return str(common_path.parent)
+    return worktrees[0]
 
 
 def canonical_project_identity(root: Path) -> Path:
     """Canonical trust principal shared by all worktrees of *root*'s repo.
 
-    Thin ``Path`` wrapper over :func:`_canonical_project_identity_str` (the
-    ``lru_cache``'d worker keyed on a plain string). See that function for the
-    full contract and fallback rules.
+    Thin ``Path`` wrapper over :func:`_canonical_project_identity_str`. See
+    that function for the full contract and fallback rules.
     """
     try:
         root_str = str(Path(root).resolve())
     except OSError:
         root_str = str(root)
     return Path(_canonical_project_identity_str(root_str))
+
+
+def _resolve_project_trust_entry(entry: Any) -> Optional[Path]:
+    """Normalize one configured project-trust entry for reads and mutations."""
+    raw = str(entry).strip()
+    if not raw:
+        return None
+    try:
+        return Path(os.path.expanduser(os.path.expandvars(raw))).resolve()
+    except OSError:
+        return None
 
 
 def _project_trusted_dirs_from_config() -> Set[Path]:
@@ -810,13 +793,9 @@ def _project_trusted_dirs_from_config() -> Set[Path]:
         return set()
     result: Set[Path] = set()
     for entry in raw:
-        entry = str(entry).strip()
-        if not entry:
-            continue
-        try:
-            result.add(Path(os.path.expanduser(os.path.expandvars(entry))).resolve())
-        except OSError:
-            continue
+        resolved = _resolve_project_trust_entry(entry)
+        if resolved is not None:
+            result.add(resolved)
     return result
 
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -6,9 +6,11 @@ tool registration or provider resolution.
 """
 
 import ast
+import functools
 import logging
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -696,6 +698,103 @@ def find_project_root(start: Optional[Path] = None) -> Optional[Path]:
     return None
 
 
+# Timeout for the one-shot ``git rev-parse`` probe that canonicalizes trust
+# identity. Short by design: this runs at agent-build time on the session's
+# fixed cwd, and any git slowness must degrade to the plain-resolve fallback
+# rather than stall prompt construction.
+_GIT_IDENTITY_TIMEOUT_S = 2.0
+
+
+@functools.lru_cache(maxsize=256)
+def _canonical_project_identity_str(root_str: str) -> str:
+    """Canonical trust identity for *root_str* (a resolved path string).
+
+    All git worktrees of one repository — plus the symlinked-root case — share
+    a single ``--git-common-dir`` (the main checkout's ``.git``), so we key the
+    trust principal off the *parent of the resolved common dir* (the main
+    checkout root). Trusting any worktree of a repo then covers every other
+    worktree of that same repo.
+
+    Falls back to ``Path(root).resolve()`` (as a string) whenever git can't
+    give us a better answer: git binary missing, not a repo, timeout, or a
+    layout the parent-of-common-dir heuristic can't reason about safely (bare
+    repos, submodules — see below).
+
+    Submodule nuance: a submodule's common dir lives under the superproject's
+    ``.git/modules/<name>``, so parent-of-common-dir would resolve to the
+    superproject's ``.git`` rather than the submodule checkout — a wrong,
+    surprising identity. We detect that (``rev-parse
+    --show-superproject-working-tree`` is non-empty, or the common dir sits
+    under a ``.git/modules`` segment) and fall back to the resolved root so a
+    submodule keeps its own distinct identity.
+
+    Cached per process on the string path: cwd is fixed for the life of a
+    session and the git layout of a checkout doesn't change under us, matching
+    the existing cache-safety contract for project-skill discovery.
+    """
+    fallback = str(Path(root_str).resolve())
+
+    def _git(*extra_args: str) -> Optional[str]:
+        try:
+            out = subprocess.run(
+                ["git", "-C", root_str, "rev-parse", *extra_args],
+                capture_output=True,
+                text=True,
+                timeout=_GIT_IDENTITY_TIMEOUT_S,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if out.returncode != 0:
+            return None
+        return out.stdout.strip()
+
+    common_dir = _git("--git-common-dir")
+    if not common_dir:
+        # git missing / not a repo / timeout — keep per-root identity.
+        return fallback
+
+    # Resolve the common dir relative to the root (git may return a relative
+    # path like ".git" or an absolute one).
+    common_path = Path(common_dir)
+    if not common_path.is_absolute():
+        common_path = Path(root_str) / common_path
+    try:
+        common_path = common_path.resolve()
+    except OSError:
+        return fallback
+
+    # Submodule: common dir under a superproject's ``.git/modules/...``. The
+    # parent-of-common-dir heuristic is meaningless here, so keep the
+    # submodule's own resolved root as its identity. Two independent signals;
+    # either is sufficient.
+    superproject = _git("--show-superproject-working-tree")
+    parts = common_path.parts
+    in_git_modules = ".git" in parts and "modules" in parts[parts.index(".git") + 1 :]
+    if superproject or in_git_modules:
+        return fallback
+
+    # Bare repos have no working-tree parent to key off; fall back.
+    if common_path.name != ".git":
+        return fallback
+
+    # Canonical identity = the main checkout root = parent of the common .git.
+    return str(common_path.parent)
+
+
+def canonical_project_identity(root: Path) -> Path:
+    """Canonical trust principal shared by all worktrees of *root*'s repo.
+
+    Thin ``Path`` wrapper over :func:`_canonical_project_identity_str` (the
+    ``lru_cache``'d worker keyed on a plain string). See that function for the
+    full contract and fallback rules.
+    """
+    try:
+        root_str = str(Path(root).resolve())
+    except OSError:
+        root_str = str(root)
+    return Path(_canonical_project_identity_str(root_str))
+
+
 def _project_trusted_dirs_from_config() -> Set[Path]:
     """Resolved set of trusted project roots from ``skills.trusted_project_dirs``."""
     parsed = _load_raw_config()
@@ -722,11 +821,22 @@ def _project_trusted_dirs_from_config() -> Set[Path]:
 
 
 def is_project_root_trusted(root: Path) -> bool:
-    """True when *root* is listed in ``skills.trusted_project_dirs``."""
+    """True when *root* — or any git worktree of the same repo — is trusted.
+
+    Trust is keyed off the repository's canonical identity (the main checkout
+    root, via :func:`canonical_project_identity`) rather than the raw worktree
+    path, so running ``hermes skills trust`` in the main checkout OR in any
+    worktree of that repo covers all of them. Non-git paths and git failures
+    degrade to a plain resolved-path comparison (identity == resolved root).
+    """
     try:
-        return Path(root).resolve() in _project_trusted_dirs_from_config()
+        target = canonical_project_identity(root)
     except OSError:
         return False
+    trusted_identities = {
+        canonical_project_identity(t) for t in _project_trusted_dirs_from_config()
+    }
+    return target in trusted_identities
 
 
 def _candidate_project_skills_dirs(root: Path) -> List[Path]:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12093,6 +12093,7 @@ def _cmd_skills_trust(args):
     from agent.skill_utils import (
         PROJECT_SKILLS_SUBDIRS,
         _candidate_project_skills_dirs,
+        canonical_project_identity,
         find_project_root,
         iter_skill_index_files,
     )
@@ -12114,16 +12115,27 @@ def _cmd_skills_trust(args):
             )
             return
 
+    # Store the repository's CANONICAL identity (the main checkout root) rather
+    # than the raw worktree path, so trusting from any worktree covers every
+    # worktree of the same repo. For non-git paths / git failures this is a
+    # no-op (canonical identity == resolved root). Skills still load from each
+    # worktree's own checkout — only the trust key is canonicalized.
+    identity = canonical_project_identity(root)
+
     config = load_config()
     skills_cfg = config.setdefault("skills", {})
     trusted = skills_cfg.get("trusted_project_dirs") or []
     if not isinstance(trusted, list):
         trusted = [trusted]
     trusted = [str(t) for t in trusted]
-    root_str = str(root)
+    root_str = str(identity)
 
     if action == "untrust":
-        kept = [t for t in trusted if str(Path(t).expanduser().resolve()) != root_str]
+        kept = [
+            t
+            for t in trusted
+            if str(canonical_project_identity(Path(t).expanduser())) != root_str
+        ]
         if len(kept) == len(trusted):
             print(f"{root} was not trusted.")
             return
@@ -12134,13 +12146,18 @@ def _cmd_skills_trust(args):
         return
 
     # trust
-    if any(str(Path(t).expanduser().resolve()) == root_str for t in trusted):
+    if any(
+        str(canonical_project_identity(Path(t).expanduser())) == root_str
+        for t in trusted
+    ):
         print(f"Already trusted: {root}")
     else:
         trusted.append(root_str)
         skills_cfg["trusted_project_dirs"] = trusted
         save_config(config)
         print(f"Trusted: {root}")
+        if identity != root.resolve():
+            print(f"(stored canonical repo identity: {identity})")
 
     # Show what this unlocks
     count = 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12093,6 +12093,7 @@ def _cmd_skills_trust(args):
     from agent.skill_utils import (
         PROJECT_SKILLS_SUBDIRS,
         _candidate_project_skills_dirs,
+        _resolve_project_trust_entry,
         canonical_project_identity,
         find_project_root,
         iter_skill_index_files,
@@ -12134,7 +12135,10 @@ def _cmd_skills_trust(args):
         kept = [
             t
             for t in trusted
-            if str(canonical_project_identity(Path(t).expanduser())) != root_str
+            if (
+                (resolved := _resolve_project_trust_entry(t)) is None
+                or str(canonical_project_identity(resolved)) != root_str
+            )
         ]
         if len(kept) == len(trusted):
             print(f"{root} was not trusted.")
@@ -12146,11 +12150,25 @@ def _cmd_skills_trust(args):
         return
 
     # trust
-    if any(
-        str(canonical_project_identity(Path(t).expanduser())) == root_str
+    equivalent = [
+        t
         for t in trusted
-    ):
-        print(f"Already trusted: {root}")
+        if (
+            (resolved := _resolve_project_trust_entry(t)) is not None
+            and str(canonical_project_identity(resolved)) == root_str
+        )
+    ]
+    if equivalent:
+        canonical_trusted = [t for t in trusted if t not in equivalent]
+        canonical_trusted.append(root_str)
+        if canonical_trusted != trusted:
+            skills_cfg["trusted_project_dirs"] = canonical_trusted
+            save_config(config)
+            print(f"Trusted: {root}")
+            if identity != root.resolve():
+                print(f"(stored canonical repo identity: {identity})")
+        else:
+            print(f"Already trusted: {root}")
     else:
         trusted.append(root_str)
         skills_cfg["trusted_project_dirs"] = trusted

--- a/tests/agent/test_project_skills.py
+++ b/tests/agent/test_project_skills.py
@@ -241,3 +241,218 @@ class TestQuarantine:
         su.is_quarantined_project_skill(evil_dir / "SKILL.md")
         assert not (project_env["repo"] / ".hermes" / "skills" / ".scan-cache").exists()
         assert (project_env["home"] / "cache" / "project_skill_scans").exists()
+
+
+# ── Canonical project identity across git worktrees (EPIC #48970) ──────────
+#
+# These build a REAL git repo + `git worktree add` so we exercise the actual
+# `git rev-parse --git-common-dir` path rather than mocking it.
+
+import shutil
+import subprocess
+
+
+def _run_git(*args, cwd) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@e",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@e",
+        },
+    ).stdout.strip()
+
+
+git_binary = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git binary not available"
+)
+
+
+@pytest.fixture
+def real_repo_with_worktree(tmp_path, monkeypatch):
+    """A real git repo (``main``) plus a linked worktree (``wt``).
+
+    Layout::
+
+        tmp_path/main   # primary checkout (.git dir)
+        tmp_path/wt     # `git worktree add` checkout (.git FILE)
+
+    A temp HERMES_HOME is wired up too, and the lru_cache on canonical
+    identity is cleared around the test so a fresh tmp path can't collide
+    with a cached identity.
+    """
+    home = tmp_path / ".hermes"
+    (home / "skills").mkdir(parents=True)
+    config = home / "config.yaml"
+    config.write_text("skills:\n  external_dirs: []\n")
+
+    main = tmp_path / "main"
+    main.mkdir()
+    _run_git("init", "-q", "-b", "main", cwd=main)
+    (main / "README.md").write_text("hi\n")
+    _run_git("add", "-A", cwd=main)
+    _run_git("commit", "-q", "-m", "init", cwd=main)
+
+    # A worktree of the SAME repo, checked out to a new branch.
+    wt = tmp_path / "wt"
+    _run_git("worktree", "add", "-q", "-b", "feature", str(wt), cwd=main)
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    su._canonical_project_identity_str.cache_clear()
+    su._external_dirs_cache_clear()
+    yield {"home": home, "config": config, "main": main, "wt": wt}
+    su._canonical_project_identity_str.cache_clear()
+    su._external_dirs_cache_clear()
+
+
+def _trust_path(config: Path, path: Path) -> None:
+    config.write_text(
+        f"skills:\n  external_dirs: []\n  trusted_project_dirs: ['{path}']\n"
+    )
+    su._external_dirs_cache_clear()
+
+
+@git_binary
+class TestCanonicalIdentityAcrossWorktrees:
+    def test_main_and_worktree_share_identity(self, real_repo_with_worktree):
+        main = real_repo_with_worktree["main"]
+        wt = real_repo_with_worktree["wt"]
+        # Both worktrees canonicalize to the SAME principal (the main root).
+        assert su.canonical_project_identity(main) == su.canonical_project_identity(wt)
+        # And that principal is the main checkout root.
+        assert su.canonical_project_identity(wt) == main.resolve()
+
+    def test_trust_main_covers_worktree(self, real_repo_with_worktree):
+        cfg = real_repo_with_worktree["config"]
+        main = real_repo_with_worktree["main"]
+        wt = real_repo_with_worktree["wt"]
+        _trust_path(cfg, main)
+        assert su.is_project_root_trusted(main) is True
+        assert su.is_project_root_trusted(wt) is True
+
+    def test_trust_worktree_covers_main(self, real_repo_with_worktree):
+        cfg = real_repo_with_worktree["config"]
+        main = real_repo_with_worktree["main"]
+        wt = real_repo_with_worktree["wt"]
+        # Trust stores the raw worktree path; is_project_root_trusted must
+        # still recognise the main checkout because both canonicalize equal.
+        _trust_path(cfg, wt)
+        assert su.is_project_root_trusted(wt) is True
+        assert su.is_project_root_trusted(main) is True
+
+    def test_untrusted_repo_not_trusted(self, real_repo_with_worktree):
+        main = real_repo_with_worktree["main"]
+        wt = real_repo_with_worktree["wt"]
+        assert su.is_project_root_trusted(main) is False
+        assert su.is_project_root_trusted(wt) is False
+
+    def test_project_skills_load_in_worktree_when_main_trusted(
+        self, real_repo_with_worktree, monkeypatch
+    ):
+        """Skills load from the WORKTREE's own checkout when the repo is trusted.
+
+        Identity is canonicalized for the TRUST gate only — the dirs returned
+        must be the worktree's actual .hermes/skills, not the main root's.
+        """
+        cfg = real_repo_with_worktree["config"]
+        main = real_repo_with_worktree["main"]
+        wt = real_repo_with_worktree["wt"]
+        wt_skill = wt / ".hermes" / "skills" / "wt-skill"
+        wt_skill.mkdir(parents=True)
+        (wt_skill / "SKILL.md").write_text(
+            "---\nname: wt-skill\ndescription: worktree-local\n---\nbody\n"
+        )
+        _trust_path(cfg, main)  # trust via the MAIN root
+        monkeypatch.chdir(wt)   # but run inside the WORKTREE
+        su._external_dirs_cache_clear()
+        dirs = su.get_project_skills_dirs()
+        assert (wt / ".hermes" / "skills").resolve() in dirs
+        # The main root's skills dir must NOT be substituted in.
+        assert (main / ".hermes" / "skills").resolve() not in dirs
+
+
+@git_binary
+class TestCanonicalIdentityFallback:
+    def test_non_git_dir_identity_is_resolved_root(self, tmp_path):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        su._canonical_project_identity_str.cache_clear()
+        assert su.canonical_project_identity(plain) == plain.resolve()
+
+    def test_non_git_trust_still_works(self, tmp_path, monkeypatch):
+        # A non-git trusted dir must behave exactly as before: identity is the
+        # resolved path, so trusting it trusts exactly it.
+        home = tmp_path / ".hermes"
+        (home / "skills").mkdir(parents=True)
+        config = home / "config.yaml"
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        config.write_text(
+            f"skills:\n  external_dirs: []\n  trusted_project_dirs: ['{plain}']\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        su._canonical_project_identity_str.cache_clear()
+        su._external_dirs_cache_clear()
+        assert su.is_project_root_trusted(plain) is True
+        assert su.is_project_root_trusted(tmp_path / "other") is False
+
+    def test_missing_git_binary_falls_back_without_crash(
+        self, real_repo_with_worktree, monkeypatch
+    ):
+        """No git on PATH → fall back to resolved root, no exception."""
+        main = real_repo_with_worktree["main"]
+        # Empty PATH so the subprocess `git` lookup raises FileNotFoundError.
+        monkeypatch.setenv("PATH", "")
+        su._canonical_project_identity_str.cache_clear()
+        ident = su.canonical_project_identity(main)
+        assert ident == main.resolve()
+        # And the trust check degrades gracefully to path equality.
+        cfg = real_repo_with_worktree["config"]
+        _trust_path(cfg, main)
+        assert su.is_project_root_trusted(main) is True
+
+    def test_submodule_keeps_own_identity(self, tmp_path, monkeypatch):
+        """A submodule's identity must NOT collapse into the superproject.
+
+        Its common dir lives under ``.git/modules/<name>``; the parent-of-
+        common-dir heuristic would wrongly point at the superproject's .git,
+        so we fall back to the submodule's own resolved root.
+        """
+        monkeypatch.setenv(
+            "GIT_ALLOW_PROTOCOL", "file"
+        )  # allow local file:// submodule add
+        sup = tmp_path / "super"
+        sup.mkdir()
+        _run_git("init", "-q", "-b", "main", cwd=sup)
+        (sup / "a.txt").write_text("a\n")
+        _run_git("add", "-A", cwd=sup)
+        _run_git("commit", "-q", "-m", "init", cwd=sup)
+
+        sub_origin = tmp_path / "sub-origin"
+        sub_origin.mkdir()
+        _run_git("init", "-q", "-b", "main", cwd=sub_origin)
+        (sub_origin / "b.txt").write_text("b\n")
+        _run_git("add", "-A", cwd=sub_origin)
+        _run_git("commit", "-q", "-m", "init", cwd=sub_origin)
+
+        _run_git(
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            str(sub_origin),
+            "sub",
+            cwd=sup,
+        )
+        sub = sup / "sub"
+        su._canonical_project_identity_str.cache_clear()
+        ident = su.canonical_project_identity(sub)
+        # Submodule keeps its own resolved root, NOT the superproject root.
+        assert ident == sub.resolve()
+        assert ident != su.canonical_project_identity(sup)

--- a/tests/agent/test_project_skills.py
+++ b/tests/agent/test_project_skills.py
@@ -283,9 +283,7 @@ def real_repo_with_worktree(tmp_path, monkeypatch):
         tmp_path/main   # primary checkout (.git dir)
         tmp_path/wt     # `git worktree add` checkout (.git FILE)
 
-    A temp HERMES_HOME is wired up too, and the lru_cache on canonical
-    identity is cleared around the test so a fresh tmp path can't collide
-    with a cached identity.
+    A temp HERMES_HOME is wired up too.
     """
     home = tmp_path / ".hermes"
     (home / "skills").mkdir(parents=True)
@@ -304,10 +302,8 @@ def real_repo_with_worktree(tmp_path, monkeypatch):
     _run_git("worktree", "add", "-q", "-b", "feature", str(wt), cwd=main)
 
     monkeypatch.setenv("HERMES_HOME", str(home))
-    su._canonical_project_identity_str.cache_clear()
     su._external_dirs_cache_clear()
     yield {"home": home, "config": config, "main": main, "wt": wt}
-    su._canonical_project_identity_str.cache_clear()
     su._external_dirs_cache_clear()
 
 
@@ -376,13 +372,131 @@ class TestCanonicalIdentityAcrossWorktrees:
         # The main root's skills dir must NOT be substituted in.
         assert (main / ".hermes" / "skills").resolve() not in dirs
 
+    def test_forged_git_file_does_not_inherit_trust(
+        self, real_repo_with_worktree, monkeypatch
+    ):
+        cfg = real_repo_with_worktree["config"]
+        main = real_repo_with_worktree["main"]
+        evil = main.parent / "evil"
+        skill_dir = evil / ".hermes" / "skills" / "evil"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: evil\ndescription: evil\n---\nbody\n"
+        )
+        (evil / ".git").write_text(f"gitdir: {main / '.git'}\n")
+        _trust_path(cfg, main)
+        monkeypatch.chdir(evil)
+
+        assert su.canonical_project_identity(evil) == evil.resolve()
+        assert su.is_project_root_trusted(evil) is False
+        assert su.get_project_skills_dirs() == []
+
+    def test_git_environment_cannot_redirect_identity(
+        self, real_repo_with_worktree, monkeypatch
+    ):
+        main = real_repo_with_worktree["main"]
+        plain = main.parent / "plain"
+        plain.mkdir()
+        monkeypatch.setenv("GIT_DIR", str(main / ".git"))
+        monkeypatch.setenv("GIT_COMMON_DIR", str(main / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(main))
+
+        assert su.canonical_project_identity(plain) == plain.resolve()
+
+    def test_replaced_worktree_path_is_not_process_cached(
+        self, real_repo_with_worktree
+    ):
+        main = real_repo_with_worktree["main"]
+        wt = real_repo_with_worktree["wt"]
+        assert su.canonical_project_identity(wt) == main.resolve()
+
+        _run_git("worktree", "remove", "--force", str(wt), cwd=main)
+        wt.mkdir()
+        _run_git("init", "-q", "-b", "main", cwd=wt)
+
+        assert su.canonical_project_identity(wt) == wt.resolve()
+
+    def test_worktree_path_with_newline_shares_identity(
+        self, real_repo_with_worktree
+    ):
+        main = real_repo_with_worktree["main"]
+        wt = main.parent / "line-one\nline-two"
+        _run_git("worktree", "add", "-q", "-b", "newline", str(wt), cwd=main)
+
+        assert su.canonical_project_identity(wt) == main.resolve()
+
+    @pytest.mark.linux_only
+    def test_non_utf8_worktree_path_does_not_break_identity(
+        self, real_repo_with_worktree
+    ):
+        main = real_repo_with_worktree["main"]
+        wt = os.fsencode(main.parent) + b"/non-utf8-\xff"
+        _run_git("worktree", "add", "-q", "-b", "non-utf8", wt, cwd=main)
+
+        assert su.canonical_project_identity(main) == main.resolve()
+
+    def test_separate_git_dir_registered_worktrees_share_identity(self, tmp_path):
+        main = tmp_path / "separate-main"
+        metadata = tmp_path / "metadata"
+        _run_git(
+            "init",
+            "-q",
+            "-b",
+            "main",
+            "--separate-git-dir",
+            str(metadata),
+            str(main),
+            cwd=tmp_path,
+        )
+        (main / "README.md").write_text("hi\n")
+        _run_git("add", "-A", cwd=main)
+        _run_git("commit", "-q", "-m", "init", cwd=main)
+        wt = tmp_path / "separate-wt"
+        _run_git("worktree", "add", "-q", "-b", "feature", str(wt), cwd=main)
+        wt_two = tmp_path / "separate-wt-two"
+        _run_git(
+            "worktree", "add", "-q", "-b", "feature-two", str(wt_two), cwd=main
+        )
+
+        # Git versions that report the separate metadata dir as the first
+        # entry still give every explicitly registered checkout one identity.
+        identity = su.canonical_project_identity(wt)
+        assert identity == su.canonical_project_identity(wt_two)
+        assert identity == metadata.resolve()
+
+    def test_trust_migrates_equivalent_worktree_entry(
+        self, real_repo_with_worktree, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        import yaml
+
+        from hermes_cli.main import _cmd_skills_trust
+
+        config = real_repo_with_worktree["config"]
+        main = real_repo_with_worktree["main"]
+        wt = real_repo_with_worktree["wt"]
+        monkeypatch.setenv("TRUSTED_WORKTREE", str(wt))
+        config.write_text(
+            "skills:\n"
+            "  external_dirs: []\n"
+            "  trusted_project_dirs: ['$TRUSTED_WORKTREE']\n"
+        )
+
+        _cmd_skills_trust(SimpleNamespace(skills_action="trust", path=str(main)))
+
+        raw = yaml.safe_load(config.read_text())
+        assert raw["skills"]["trusted_project_dirs"] == [str(main.resolve())]
+
+        _run_git("worktree", "remove", "--force", str(wt), cwd=main)
+        assert su.is_project_root_trusted(main) is True
+
 
 @git_binary
 class TestCanonicalIdentityFallback:
     def test_non_git_dir_identity_is_resolved_root(self, tmp_path):
         plain = tmp_path / "plain"
         plain.mkdir()
-        su._canonical_project_identity_str.cache_clear()
         assert su.canonical_project_identity(plain) == plain.resolve()
 
     def test_non_git_trust_still_works(self, tmp_path, monkeypatch):
@@ -397,7 +511,6 @@ class TestCanonicalIdentityFallback:
             f"skills:\n  external_dirs: []\n  trusted_project_dirs: ['{plain}']\n"
         )
         monkeypatch.setenv("HERMES_HOME", str(home))
-        su._canonical_project_identity_str.cache_clear()
         su._external_dirs_cache_clear()
         assert su.is_project_root_trusted(plain) is True
         assert su.is_project_root_trusted(tmp_path / "other") is False
@@ -409,7 +522,6 @@ class TestCanonicalIdentityFallback:
         main = real_repo_with_worktree["main"]
         # Empty PATH so the subprocess `git` lookup raises FileNotFoundError.
         monkeypatch.setenv("PATH", "")
-        su._canonical_project_identity_str.cache_clear()
         ident = su.canonical_project_identity(main)
         assert ident == main.resolve()
         # And the trust check degrades gracefully to path equality.
@@ -451,7 +563,6 @@ class TestCanonicalIdentityFallback:
             cwd=sup,
         )
         sub = sup / "sub"
-        su._canonical_project_identity_str.cache_clear()
         ident = su.canonical_project_identity(sub)
         # Submodule keeps its own resolved root, NOT the superproject root.
         assert ident == sub.resolve()


### PR DESCRIPTION
## Summary

Trusting a repo now covers all of its git worktrees (and the symlinked-root case): the project-skill trust gate keys off the repository's **canonical identity** — the main checkout root derived from `git rev-parse --git-common-dir` — instead of the raw per-worktree path, so a single `hermes skills trust` no longer re-triggers the untrusted banner in every sibling worktree of the same repo.

Refs EPIC #48970 — implements the canonical-identity invariant from sub-issue #48971: every worktree of one repository must resolve to a single trust principal.

## Changes

- **`agent/skill_utils.py`**
  - New `canonical_project_identity(root)` (backed by an `lru_cache`'d string worker `_canonical_project_identity_str`): runs `git -C <root> rev-parse --git-common-dir` with a short 2s timeout and returns the *parent of the resolved common dir* (the main checkout root) as the canonical identity.
  - Fallback to `Path(root).resolve()` on any failure — git binary missing, not a repo, timeout, or a bare-repo layout — preserving prior per-path behavior.
  - **Submodule guard:** a submodule's common dir lives under the superproject's `.git/modules/<name>`, where parent-of-common-dir would wrongly point at the superproject. Detected via `rev-parse --show-superproject-working-tree` (non-empty) *or* a `.git/modules` segment in the common-dir path, and falls back to the submodule's own resolved root so it keeps a distinct identity.
  - `is_project_root_trusted()` now compares `canonical_project_identity(root)` against `{canonical_project_identity(t) for t in trusted dirs}`, so trusting **either** the main checkout **or** any worktree covers all of them.
  - Cache-safety contract unchanged: cwd is fixed for the life of a session, so the identity (and the resulting skills index / system prompt) stays byte-stable.
- **`hermes_cli/main.py`** — `hermes skills trust` / `untrust` now store and match against the **canonical identity**, so the config entry becomes the main-checkout root even when the command is run from a worktree. Prints the stored canonical path when it differs from the invoked root.
- **Scope kept surgical:** `_candidate_project_skills_dirs` / `get_project_skills_dirs` are unchanged — skills still load from **each worktree's own** `.hermes/skills` + `.agents/skills`. Only the **trust identity** is canonicalized.

## Validation

Extended `tests/agent/test_project_skills.py` with real `git init` + `git worktree add` + `git submodule add` temp-repo fixtures (no mocking of git). Run from the worktree:

```
uv run --with pytest python -m pytest tests/agent/test_project_skills.py -x -q
# 22 passed in 0.67s
```

| Scenario | Assertion | Result |
|---|---|---|
| main + worktree share identity | `canonical_project_identity(main) == canonical_project_identity(wt) == main.resolve()` | ✅ |
| trust **main** root | worktree is trusted too | ✅ |
| trust **worktree** | main root is trusted too | ✅ |
| untrusted repo | neither main nor worktree trusted | ✅ |
| skills still load from worktree | trusted-via-main + cwd=worktree → worktree's own `.hermes/skills`, main root's not substituted | ✅ |
| non-git dir | identity == resolved root; trust behaves exactly as before | ✅ |
| missing git binary (empty `PATH`) | falls back to resolved root, no crash; trust degrades to path equality | ✅ |
| submodule | keeps its own resolved-root identity, does **not** collapse into the superproject | ✅ |

All 14 pre-existing tests in the file continue to pass unchanged.

## Infographic

![Worktree canonical trust identity](https://v3b.fal.media/files/b/0aa6c19d/Qw5MAiTpL8k8lHJKGmXPn_zaaYh1Yv.png?cb=1)

## Hardening round
Post-review adversarial hardening landed in `74fd8c2878` — registered-worktree membership validation (closes the forged-`.git` trust-inheritance exploit), env sanitization, cache drop, legacy-entry rewrite. Details + fix mapping: https://github.com/NousResearch/hermes-agent/pull/88700#issuecomment-5330768376