### PR TITLE
feat(sessions): add sanitized activity read model

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -15,12 +15,16 @@ the late-binding seam in :mod:`hermes_cli.web_deps` so tests that
 import asyncio  # noqa: F401 — used by handlers
 import json
 import logging
+import re
 import time  # noqa: F401
-from typing import Any, Dict, List, Optional  # noqa: F401
+from typing import Any, Dict, List, Literal, Optional, Union  # noqa: F401
 
 from fastapi import APIRouter, HTTPException, Query, Request  # noqa: F401
 from fastapi.encoders import jsonable_encoder
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+from agent.redact import redact_sensitive_text
 
 from hermes_cli.web_deps import late
 from hermes_cli.web_models import (
@@ -44,10 +48,190 @@ _cron_profile_home = late("_cron_profile_home")
 _import_sessions_for_profile = late("_import_sessions_for_profile")
 _maybe_auto_archive_for_profile = late("_maybe_auto_archive_for_profile")
 _open_session_db_for_profile = late("_open_session_db_for_profile")
+_open_session_db_strict_read_only = late("_open_session_db_strict_read_only")
 _prune_sessions = late("_prune_sessions")
 _read_session_import_body = late("_read_session_import_body")
 _session_latest_descendant = late("_session_latest_descendant")
 _strip_session_list_rows = late("_strip_session_list_rows")
+
+
+_SESSION_ACTIVITY_CAPABILITIES = ("sessions.activity.read_model.v1",)
+_SESSION_ACTIVITY_SCHEMA = "sessions.activity.read_model.v1"
+_SESSION_ACTIVITY_CONTENT_LIMIT = 500
+_SESSION_ACTIVITY_CONTENT_READ_BYTES = 8 * 1024
+_SESSION_ACTIVITY_PUBLIC_BLOCK_TYPES = frozenset({"text", "input_text", "output_text"})
+_SESSION_ACTIVITY_PATH_HINT_RE = re.compile(
+    r"(?i)(?:\bfile://|(?:^|[\s:(])(?:~[/\\]|[A-Z]:[/\\]|\\\\|\.{0,2}[/\\]|/)"
+    r"|(?:^|[\s:(])[^\s:/\\]+[/\\][^\s]+)"
+)
+
+
+class _StrictSessionActivityModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class SessionActivityCapabilitiesResponse(_StrictSessionActivityModel):
+    capabilities: List[Literal["sessions.activity.read_model.v1"]]
+
+
+class SessionActivitySessionResponse(_StrictSessionActivityModel):
+    session_id: str
+    profile_id: str
+    source: str
+    started_at: Optional[Union[str, int, float]] = None
+    last_activity_at: Optional[Union[str, int, float]] = None
+    ended_at: Optional[Union[str, int, float]] = None
+    state: Literal["open", "ended"]
+
+
+class SessionActivityMessageResponse(_StrictSessionActivityModel):
+    message_id: str
+    role: Literal["user", "assistant"]
+    content: str
+    occurred_at: Optional[Union[str, int, float]] = None
+    truncated: bool
+
+
+class SessionActivityWindowResponse(_StrictSessionActivityModel):
+    limit: int = Field(ge=1, le=200)
+    order: Literal["latest"]
+    source_rows: int = Field(ge=0, le=200)
+    returned: int = Field(ge=0, le=200)
+
+
+class SessionActivityResponse(_StrictSessionActivityModel):
+    schema: Literal["sessions.activity.read_model.v1"]
+    capabilities: List[Literal["sessions.activity.read_model.v1"]]
+    requested_session_id: str
+    session: SessionActivitySessionResponse
+    messages: List[SessionActivityMessageResponse]
+    window: SessionActivityWindowResponse
+
+
+def _session_activity_headers() -> Dict[str, str]:
+    return {
+        "Cache-Control": "private, no-store",
+        "X-Hermes-Session-Capabilities": ", ".join(
+            _SESSION_ACTIVITY_CAPABILITIES
+        ),
+    }
+
+
+def _validate_session_activity_query(request: Request) -> None:
+    pairs = list(request.query_params.multi_items())
+    counts: Dict[str, int] = {}
+    for key, _value in pairs:
+        counts[key] = counts.get(key, 0) + 1
+    unknown = sorted(set(counts) - {"profile", "limit"})
+    duplicates = sorted(key for key, count in counts.items() if count != 1)
+    if unknown or duplicates:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_query",
+                "unknown": unknown,
+                "duplicates": duplicates,
+            },
+        )
+
+
+def _session_activity_public_text(content: Any) -> Optional[str]:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return None
+    chunks = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") not in _SESSION_ACTIVITY_PUBLIC_BLOCK_TYPES:
+            continue
+        text = part.get("text")
+        if isinstance(text, str) and text:
+            chunks.append(text)
+    return "\n".join(chunks) if chunks else None
+
+
+def _session_activity_redact_paths(text: str) -> str:
+    if _SESSION_ACTIVITY_PATH_HINT_RE.search(text):
+        return "[REDACTED: path-like content]"
+    return text
+
+
+def _session_activity_message(row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    role = row.get("role")
+    if role not in {"user", "assistant"}:
+        return None
+    message_id = row.get("id")
+    if isinstance(message_id, bool) or not isinstance(message_id, (int, str)):
+        return None
+    if not str(message_id):
+        return None
+    oversized = row.get("content_oversized") is True or row.get("content_oversized") == 1
+    text = (
+        "[REDACTED: message exceeds public read limit]"
+        if oversized
+        else (_session_activity_public_text(row.get("content")) or "")
+    ).strip()
+    if not text:
+        return None
+    try:
+        text = redact_sensitive_text(
+            text,
+            force=True,
+            redact_url_credentials=True,
+        )
+        text = _session_activity_redact_paths(text)
+    except Exception:
+        text = "[REDACTED: content unavailable]"
+    truncated = oversized or len(text) > _SESSION_ACTIVITY_CONTENT_LIMIT
+    return {
+        "message_id": str(message_id),
+        "role": role,
+        "content": text[:_SESSION_ACTIVITY_CONTENT_LIMIT],
+        "occurred_at": row.get("timestamp"),
+        "truncated": truncated,
+    }
+
+
+def _session_activity_model(
+    *,
+    requested_session_id: str,
+    session_id: str,
+    profile_id: str,
+    session: Dict[str, Any],
+    source_rows: List[Dict[str, Any]],
+    limit: int,
+) -> Dict[str, Any]:
+    messages = []
+    for row in source_rows:
+        message = _session_activity_message(row)
+        if message is not None:
+            messages.append(message)
+    last_activity_at = session.get("last_activity_at")
+    if last_activity_at is None:
+        last_activity_at = session.get("last_active")
+    return {
+        "schema": _SESSION_ACTIVITY_SCHEMA,
+        "capabilities": list(_SESSION_ACTIVITY_CAPABILITIES),
+        "requested_session_id": requested_session_id,
+        "session": {
+            "session_id": session_id,
+            "profile_id": profile_id,
+            "source": session.get("source"),
+            "started_at": session.get("started_at"),
+            "last_activity_at": last_activity_at,
+            "ended_at": session.get("ended_at"),
+            "state": "ended" if session.get("ended_at") is not None else "open",
+        },
+        "messages": messages,
+        "window": {
+            "limit": limit,
+            "order": "latest",
+            "source_rows": len(source_rows),
+            "returned": len(messages),
+        },
+    }
 
 
 @list_router.get("/api/sessions")
@@ -520,6 +704,17 @@ async def delete_empty_sessions_endpoint(profile: Optional[str] = None):
     return {"ok": True, "deleted": deleted}
 
 
+@manage_router.get(
+    "/api/sessions/capabilities",
+    response_model=SessionActivityCapabilitiesResponse,
+)
+def get_session_capabilities():
+    return JSONResponse(
+        {"capabilities": list(_SESSION_ACTIVITY_CAPABILITIES)},
+        headers=_session_activity_headers(),
+    )
+
+
 @manage_router.get("/api/sessions/stats")
 async def get_session_stats(profile: Optional[str] = None):
     """Session-store statistics for the Sessions page (mirrors `hermes sessions stats`).
@@ -596,6 +791,90 @@ async def get_session_latest_descendant(
         "path": path,
         "changed": bool(path and latest != path[0]),
     }
+
+
+async def _session_activity_http_response(
+    request: Request,
+    session_id: str,
+    profile: Optional[str],
+    limit: int,
+):
+    _validate_session_activity_query(request)
+
+    def _read():
+        db = _open_session_db_strict_read_only(profile)
+        try:
+            requested_session_id = db.resolve_session_id(session_id)
+            if not requested_session_id:
+                return None
+            resolved_session_id = (
+                db.resolve_resume_session_id(requested_session_id)
+                or requested_session_id
+            )
+            session = db.get_session(resolved_session_id)
+            if not session:
+                return None
+            source_rows = db.get_activity_messages(
+                resolved_session_id,
+                limit=limit,
+                content_bytes=_SESSION_ACTIVITY_CONTENT_READ_BYTES,
+            )
+            profile_id = (
+                _cron_profile_home(profile)[0]
+                if profile
+                else _cron_default_profile()
+            )
+            return _session_activity_model(
+                requested_session_id=requested_session_id,
+                session_id=resolved_session_id,
+                profile_id=profile_id,
+                session=session,
+                source_rows=source_rows,
+                limit=limit,
+            )
+        finally:
+            db.close()
+
+    model = await asyncio.to_thread(_read)
+    if model is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    headers = _session_activity_headers()
+    if request.method == "HEAD":
+        return Response(status_code=200, headers=headers)
+    return JSONResponse(model, headers=headers)
+
+
+@manage_router.get(
+    "/api/sessions/{session_id}/activity",
+    response_model=SessionActivityResponse,
+)
+async def get_session_activity(
+    request: Request,
+    session_id: str,
+    profile: Optional[str] = None,
+    limit: int = Query(100, ge=1, le=200),
+):
+    return await _session_activity_http_response(
+        request,
+        session_id,
+        profile,
+        limit,
+    )
+
+
+@manage_router.head("/api/sessions/{session_id}/activity")
+async def head_session_activity(
+    request: Request,
+    session_id: str,
+    profile: Optional[str] = None,
+    limit: int = Query(100, ge=1, le=200),
+):
+    return await _session_activity_http_response(
+        request,
+        session_id,
+        profile,
+        limit,
+    )
 
 
 @manage_router.get("/api/sessions/{session_id}/messages")

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -179,6 +179,7 @@ def _session_activity_message(row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         text = redact_sensitive_text(
             text,
             force=True,
+            file_read=True,
             redact_url_credentials=True,
         )
         text = _session_activity_redact_paths(text)
@@ -839,9 +840,10 @@ async def _session_activity_http_response(
     if model is None:
         raise HTTPException(status_code=404, detail="Session not found")
     headers = _session_activity_headers()
+    response = JSONResponse(model, headers=headers)
     if request.method == "HEAD":
-        return Response(status_code=200, headers=headers)
-    return JSONResponse(model, headers=headers)
+        return Response(status_code=response.status_code, headers=dict(response.headers))
+    return response
 
 
 @manage_router.get(
@@ -862,7 +864,10 @@ async def get_session_activity(
     )
 
 
-@manage_router.head("/api/sessions/{session_id}/activity")
+@manage_router.head(
+    "/api/sessions/{session_id}/activity",
+    response_class=Response,
+)
 async def head_session_activity(
     request: Request,
     session_id: str,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11814,9 +11814,12 @@ from hermes_cli.web_routers.sessions import (  # noqa: E402,F401 — legacy re-e
     import_sessions_endpoint,
     count_empty_sessions_endpoint,
     delete_empty_sessions_endpoint,
+    get_session_capabilities,
     get_session_stats,
     get_session_detail,
     get_session_latest_descendant,
+    get_session_activity,
+    head_session_activity,
     get_session_messages,
     delete_session_endpoint,
     rename_session_endpoint,
@@ -11966,6 +11969,30 @@ def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
     else:
         db_path = Path(_default_db_path())
     return _open_session_db_at_path(db_path, read_only=read_only)
+
+
+def _open_session_db_strict_read_only(profile: Optional[str]):
+    """Open an existing profile store without bootstrap, heal, or writes."""
+    import sqlite3
+    import stat
+
+    from hermes_state import SessionDB, _default_db_path
+
+    if profile:
+        _name, home = _cron_profile_home(profile)
+        db_path = Path(home) / "state.db"
+    else:
+        db_path = Path(_default_db_path())
+    try:
+        metadata = db_path.stat()
+    except OSError as exc:
+        raise HTTPException(status_code=503, detail="Session store unavailable") from exc
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size <= 0:
+        raise HTTPException(status_code=503, detail="Session store unavailable")
+    try:
+        return SessionDB(db_path=db_path, read_only=True)
+    except (OSError, sqlite3.Error) as exc:
+        raise HTTPException(status_code=503, detail="Session store unavailable") from exc
 
 
 # In-process throttle for the opportunistic auto-archive trigger, keyed by

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9268,7 +9268,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self,
         session_id: str,
         role: str,
-        content: str = None,
+        content: Any = None,
         tool_name: str = None,
         tool_calls: Any = None,
         tool_call_id: str = None,
@@ -10263,6 +10263,73 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if msg.get("display_metadata") is not None:
                 msg["display_metadata"] = self._decode_display_metadata(msg["display_metadata"])
             result.append(msg)
+        return result
+
+    def get_activity_messages(
+        self,
+        session_id: str,
+        *,
+        limit: int = 100,
+        content_bytes: int = 8 * 1024,
+    ) -> List[Dict[str, Any]]:
+        """Return a bounded, display-only projection for activity surfaces.
+
+        The SQL excludes non-public roles and every tool/reasoning column. Message
+        content is opened through SQLite's incremental BLOB API and read only when
+        its encoded size fits the public boundary.
+        """
+        safe_limit = max(1, min(int(limit), 200))
+        safe_content_bytes = max(1, min(int(content_bytes), 64 * 1024))
+        result = []
+        with self._read_ctx() as conn:
+            assert conn is not None
+            rows = conn.execute(
+                """
+                SELECT
+                    id,
+                    role,
+                    timestamp,
+                    content IS NULL AS content_is_null
+                FROM messages
+                WHERE session_id = ?
+                  AND active = 1
+                  AND role IN ('user', 'assistant')
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (session_id, safe_limit),
+            ).fetchall()
+            rows.reverse()
+            for row in rows:
+                message = {
+                    "id": row["id"],
+                    "role": row["role"],
+                    "content": None,
+                    "content_oversized": 0,
+                    "timestamp": row["timestamp"],
+                }
+                if not row["content_is_null"]:
+                    blob = None
+                    try:
+                        blob = conn.blobopen(
+                            "messages",
+                            "content",
+                            row["id"],
+                            readonly=True,
+                        )
+                        if len(blob) > safe_content_bytes:
+                            message["content_oversized"] = 1
+                        else:
+                            raw = blob.read(safe_content_bytes + 1)
+                            message["content"] = self._decode_content(
+                                raw.decode("utf-8")
+                            )
+                    except (sqlite3.Error, UnicodeDecodeError):
+                        message["content_oversized"] = 1
+                    finally:
+                        if blob is not None:
+                            blob.close()
+                result.append(message)
         return result
 
     def find_pr_url_messages(self, session_ids: List[str]) -> List[Dict[str, Any]]:

--- a/tests/hermes_cli/test_session_activity_read_model.py
+++ b/tests/hermes_cli/test_session_activity_read_model.py
@@ -1,0 +1,504 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from hermes_state import SessionDB
+from hermes_cli import web_server
+from hermes_cli.web_routers import sessions as session_routes
+
+
+class _FakeSessionDB:
+    opened: list[tuple[str | None, bool]] = []
+    closed = 0
+    message_call: dict | None = None
+
+    def resolve_session_id(self, session_id: str):
+        return "session-root" if session_id == "short" else None
+
+    def resolve_resume_session_id(self, session_id: str):
+        assert session_id == "session-root"
+        return "session-tip"
+
+    def get_session(self, session_id: str):
+        assert session_id == "session-tip"
+        return {
+            "id": session_id,
+            "source": "telegram",
+            "started_at": 100.0,
+            "last_activity_at": 200.0,
+            "ended_at": None,
+            "system_prompt": "SYSTEM PROMPT MUST NOT LEAK",
+            "model_config": {"api_key": "MODEL CONFIG MUST NOT LEAK"},
+            "cwd": "/secret/path",
+        }
+
+    def get_activity_messages(self, session_id: str, **kwargs):
+        assert session_id == "session-tip"
+        type(self).message_call = kwargs
+        return [
+            {
+                "id": 1,
+                "role": "user",
+                "content": "token ghp_1234567890abcdefghijklmnopqrstuvwxyz",
+                "timestamp": 101.0,
+                "reasoning": "USER REASONING MUST NOT LEAK",
+            },
+            {
+                "id": 2,
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Visible answer"},
+                    {"type": "image_url", "image_url": {"url": "https://secret.invalid"}},
+                    {"type": "reasoning", "text": "PRIVATE CHAIN MUST NOT LEAK"},
+                    {"type": "tool_result", "content": "PRIVATE RESULT MUST NOT LEAK"},
+                    {"type": "unknown", "text": "PRIVATE UNKNOWN MUST NOT LEAK"},
+                    {"type": "text", "text": "x" * 600},
+                ],
+                "timestamp": 102.0,
+                "tool_calls": [{"function": {"name": "terminal", "arguments": "secret"}}],
+                "reasoning_content": "PRIVATE REASONING MUST NOT LEAK",
+            },
+            {
+                "id": 3,
+                "role": "tool",
+                "content": "TOOL OUTPUT MUST NOT LEAK",
+                "timestamp": 103.0,
+            },
+            {
+                "id": 4,
+                "role": "system",
+                "content": "SYSTEM MESSAGE MUST NOT LEAK",
+                "timestamp": 104.0,
+            },
+            {"id": 5, "role": "assistant", "content": "", "timestamp": 105.0},
+            {
+                "id": 6,
+                "role": "user",
+                "content": (
+                    "POSIX /home/alice/private/project "
+                    "WINDOWS C:\\Users\\Alice\\secret.txt "
+                    "HOME ~/private/key FILE file:///root/private/key"
+                ),
+                "timestamp": 106.0,
+            },
+        ]
+
+    def close(self):
+        type(self).closed += 1
+
+
+def _client(monkeypatch) -> TestClient:
+    _FakeSessionDB.opened = []
+    _FakeSessionDB.closed = 0
+    _FakeSessionDB.message_call = None
+
+    def _open(profile):
+        _FakeSessionDB.opened.append((profile, True))
+        return _FakeSessionDB()
+
+    monkeypatch.setattr(web_server, "_open_session_db_strict_read_only", _open)
+    client = TestClient(web_server.app)
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    return client
+
+
+def test_session_activity_capability_discovery(monkeypatch):
+    client = _client(monkeypatch)
+
+    response = client.get("/api/sessions/capabilities")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "capabilities": ["sessions.activity.read_model.v1"]
+    }
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["x-hermes-session-capabilities"] == (
+        "sessions.activity.read_model.v1"
+    )
+    assert _FakeSessionDB.opened == []
+
+
+def test_session_activity_openapi_publishes_closed_response_schemas():
+    schema = web_server.app.openapi()
+    capability_schema = schema["paths"]["/api/sessions/capabilities"]["get"][
+        "responses"
+    ]["200"]["content"]["application/json"]["schema"]
+    activity_schema = schema["paths"]["/api/sessions/{session_id}/activity"][
+        "get"
+    ]["responses"]["200"]["content"]["application/json"]["schema"]
+
+    assert capability_schema["$ref"].endswith(
+        "/SessionActivityCapabilitiesResponse"
+    )
+    assert activity_schema["$ref"].endswith("/SessionActivityResponse")
+
+    components = schema["components"]["schemas"]
+    activity = components["SessionActivityResponse"]
+    assert activity["additionalProperties"] is False
+    assert set(activity["properties"]) == {
+        "schema",
+        "capabilities",
+        "requested_session_id",
+        "session",
+        "messages",
+        "window",
+    }
+    assert set(activity["required"]) == set(activity["properties"])
+
+
+def test_session_activity_snapshot_is_bounded_sanitized_and_read_only(monkeypatch):
+    client = _client(monkeypatch)
+
+    response = client.get(
+        "/api/sessions/short/activity?profile=default&limit=10"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["schema"] == "sessions.activity.read_model.v1"
+    assert body["capabilities"] == ["sessions.activity.read_model.v1"]
+    assert body["requested_session_id"] == "session-root"
+    assert body["session"] == {
+        "session_id": "session-tip",
+        "profile_id": "default",
+        "source": "telegram",
+        "started_at": 100.0,
+        "last_activity_at": 200.0,
+        "ended_at": None,
+        "state": "open",
+    }
+    assert body["window"] == {
+        "limit": 10,
+        "order": "latest",
+        "source_rows": 6,
+        "returned": 3,
+    }
+    assert [message["role"] for message in body["messages"]] == [
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert [set(message) for message in body["messages"]] == [
+        {"message_id", "role", "content", "occurred_at", "truncated"},
+        {"message_id", "role", "content", "occurred_at", "truncated"},
+        {"message_id", "role", "content", "occurred_at", "truncated"},
+    ]
+    sanitized = body["messages"][0]["content"]
+    secret = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+    assert secret not in sanitized
+    assert sanitized.startswith("token ")
+    assert len(sanitized) < len(f"token {secret}")
+    assert body["messages"][0]["truncated"] is False
+    assert body["messages"][1]["content"].startswith("Visible answer\n")
+    assert len(body["messages"][1]["content"]) == 500
+    assert body["messages"][1]["truncated"] is True
+    assert body["messages"][2]["content"] == "[REDACTED: path-like content]"
+
+    serialized = response.text
+    for forbidden in (
+        "SYSTEM PROMPT MUST NOT LEAK",
+        "MODEL CONFIG MUST NOT LEAK",
+        "/secret/path",
+        "PRIVATE REASONING MUST NOT LEAK",
+        "PRIVATE CHAIN MUST NOT LEAK",
+        "PRIVATE RESULT MUST NOT LEAK",
+        "PRIVATE UNKNOWN MUST NOT LEAK",
+        "USER REASONING MUST NOT LEAK",
+        "TOOL OUTPUT MUST NOT LEAK",
+        "SYSTEM MESSAGE MUST NOT LEAK",
+        "terminal",
+        "https://secret.invalid",
+        "/home/alice/private/project",
+        "C:\\Users\\Alice\\secret.txt",
+        "~/private/key",
+        "file:///root/private/key",
+    ):
+        assert forbidden not in serialized
+
+    assert _FakeSessionDB.opened == [("default", True)]
+    assert _FakeSessionDB.closed == 1
+    assert _FakeSessionDB.message_call == {
+        "limit": 10,
+        "content_bytes": 8192,
+    }
+    assert response.headers["cache-control"] == "private, no-store"
+
+
+def test_session_activity_head_runs_same_authorized_read_without_body(monkeypatch):
+    client = _client(monkeypatch)
+
+    response = client.head("/api/sessions/short/activity?limit=7")
+
+    assert response.status_code == 200
+    assert response.content == b""
+    assert response.headers["x-hermes-session-capabilities"] == (
+        "sessions.activity.read_model.v1"
+    )
+    assert _FakeSessionDB.opened == [(None, True)]
+    assert _FakeSessionDB.message_call["limit"] == 7
+    assert _FakeSessionDB.closed == 1
+
+
+def test_session_activity_rejects_unknown_duplicate_and_out_of_range_query(monkeypatch):
+    client = _client(monkeypatch)
+
+    unknown = client.get("/api/sessions/short/activity?unexpected=1")
+    duplicate = client.get("/api/sessions/short/activity?limit=1&limit=2")
+    out_of_range = client.get("/api/sessions/short/activity?limit=201")
+
+    assert unknown.status_code == 400
+    assert duplicate.status_code == 400
+    assert out_of_range.status_code == 422
+    assert _FakeSessionDB.opened == []
+
+
+def test_session_activity_returns_404_and_closes_database(monkeypatch):
+    client = _client(monkeypatch)
+
+    response = client.get("/api/sessions/missing/activity")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Session not found"
+    assert _FakeSessionDB.opened == [(None, True)]
+    assert _FakeSessionDB.closed == 1
+
+
+def test_session_activity_redaction_failure_is_fail_closed(monkeypatch):
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("redactor unavailable")
+
+    monkeypatch.setattr(session_routes, "redact_sensitive_text", _raise)
+
+    message = session_routes._session_activity_message(
+        {
+            "id": 9,
+            "role": "assistant",
+            "content": "secret material",
+            "timestamp": 300.0,
+        }
+    )
+
+    assert message == {
+        "message_id": "9",
+        "role": "assistant",
+        "content": "[REDACTED: content unavailable]",
+        "occurred_at": 300.0,
+        "truncated": False,
+    }
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "/workspace",
+        "/data",
+        "/custom/file",
+        "relative/private.txt",
+        "./secret/file",
+        "../secret/file",
+        "path:/home/alice/private",
+        "/home/alice/My Project/key.txt",
+        r"C:\Users\Alice\secret.txt",
+        r"\\server\share\secret.txt",
+        "file:///root/key",
+        "https://example.com/private/path",
+    ],
+)
+def test_path_like_content_fails_closed(content):
+    assert session_routes._session_activity_redact_paths(content) == (
+        "[REDACTED: path-like content]"
+    )
+
+
+def test_plain_public_text_is_not_changed_by_path_redaction():
+    assert session_routes._session_activity_redact_paths("public answer") == (
+        "public answer"
+    )
+
+
+def test_activity_projection_never_reads_oversized_blob(monkeypatch):
+    class _OversizedBlob:
+        closed = False
+
+        def __len__(self):
+            return 9000
+
+        def read(self, _size=-1):
+            raise AssertionError("oversized content must not be read")
+
+        def close(self):
+            self.closed = True
+
+    blob = _OversizedBlob()
+
+    class _Connection:
+        def execute(self, _sql, _params):
+            return self
+
+        def fetchall(self):
+            return [
+                {
+                    "id": 1,
+                    "role": "assistant",
+                    "timestamp": 1.0,
+                    "content_is_null": 0,
+                }
+            ]
+
+        def blobopen(self, table, column, rowid, *, readonly):
+            assert (table, column, rowid, readonly) == (
+                "messages",
+                "content",
+                1,
+                True,
+            )
+            return blob
+
+    @contextmanager
+    def _read_ctx():
+        yield _Connection()
+
+    db = SessionDB.__new__(SessionDB)
+    monkeypatch.setattr(db, "_read_ctx", _read_ctx)
+
+    rows = db.get_activity_messages("session", content_bytes=8192)
+
+    assert rows == [
+        {
+            "id": 1,
+            "role": "assistant",
+            "content": None,
+            "content_oversized": 1,
+            "timestamp": 1.0,
+        }
+    ]
+    assert blob.closed is True
+
+
+def test_session_activity_omits_unknown_content_shapes():
+    message = session_routes._session_activity_message(
+        {
+            "id": 10,
+            "role": "user",
+            "content": {"image_url": "https://private.invalid/image.png"},
+            "timestamp": 301.0,
+        }
+    )
+
+    assert message is None
+
+
+def test_session_activity_omits_messages_without_explicit_id():
+    message = session_routes._session_activity_message(
+        {
+            "role": "assistant",
+            "content": "answer without evidence id",
+            "timestamp": 302.0,
+        }
+    )
+
+    assert message is None
+
+
+def test_session_activity_reads_real_sqlite_without_mutating_it(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session("real-session", "desktop")
+    db.append_message(
+        "real-session",
+        "user",
+        "visible token in /home/alice/private/project",
+    )
+    db.append_message(
+        "real-session",
+        "tool",
+        "private tool output",
+        tool_name="terminal",
+    )
+    db.append_message(
+        "real-session",
+        "assistant",
+        [
+            {"type": "text", "text": "public answer"},
+            {"type": "reasoning", "text": "private chain"},
+            {"type": "tool_result", "content": "private result"},
+        ],
+    )
+    db.append_message("real-session", "assistant", "z" * 9000)
+    db.close()
+
+    projection_db = SessionDB(db_path=db_path, read_only=True)
+    projected = projection_db.get_activity_messages(
+        "real-session",
+        limit=10,
+        content_bytes=8192,
+    )
+    projection_db.close()
+    assert [set(row) for row in projected] == [
+        {"id", "role", "content", "content_oversized", "timestamp"},
+        {"id", "role", "content", "content_oversized", "timestamp"},
+        {"id", "role", "content", "content_oversized", "timestamp"},
+    ]
+    assert [row["role"] for row in projected] == ["user", "assistant", "assistant"]
+    assert projected[-1]["content"] is None
+    assert projected[-1]["content_oversized"] == 1
+    before = db_path.stat().st_mtime_ns
+
+    def _open(_profile):
+        return SessionDB(db_path=db_path, read_only=True)
+
+    monkeypatch.setattr(web_server, "_open_session_db_strict_read_only", _open)
+    client = TestClient(web_server.app)
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+
+    response = client.get("/api/sessions/real-session/activity?limit=10")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [message["role"] for message in body["messages"]] == [
+        "user",
+        "assistant",
+        "assistant",
+    ]
+    assert "public answer" in response.text
+    assert "private tool output" not in response.text
+    assert "private chain" not in response.text
+    assert "private result" not in response.text
+    assert "terminal" not in response.text
+    assert "/home/alice/private/project" not in response.text
+    assert body["messages"][-1]["content"] == (
+        "[REDACTED: message exceeds public read limit]"
+    )
+    assert body["messages"][-1]["truncated"] is True
+    assert db_path.stat().st_mtime_ns == before
+
+
+def test_strict_read_only_open_does_not_bootstrap_missing_or_empty_store(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setattr(
+        web_server,
+        "_cron_profile_home",
+        lambda profile: (profile, str(tmp_path)),
+    )
+    db_path = tmp_path / "state.db"
+    initial_entries = {path.name for path in tmp_path.iterdir()}
+
+    with pytest.raises(HTTPException) as missing:
+        web_server._open_session_db_strict_read_only("ghost")
+    assert missing.value.status_code == 503
+    assert not db_path.exists()
+
+    db_path.write_bytes(b"")
+    before = db_path.stat().st_mtime_ns
+    with pytest.raises(HTTPException) as empty:
+        web_server._open_session_db_strict_read_only("ghost")
+    assert empty.value.status_code == 503
+    assert db_path.stat().st_size == 0
+    assert db_path.stat().st_mtime_ns == before
+    assert {path.name for path in tmp_path.iterdir()} == initial_entries | {"state.db"}

--- a/tests/hermes_cli/test_session_activity_read_model.py
+++ b/tests/hermes_cli/test_session_activity_read_model.py
@@ -130,11 +130,15 @@ def test_session_activity_openapi_publishes_closed_response_schemas():
     activity_schema = schema["paths"]["/api/sessions/{session_id}/activity"][
         "get"
     ]["responses"]["200"]["content"]["application/json"]["schema"]
+    head_response = schema["paths"]["/api/sessions/{session_id}/activity"][
+        "head"
+    ]["responses"]["200"]
 
     assert capability_schema["$ref"].endswith(
         "/SessionActivityCapabilitiesResponse"
     )
     assert activity_schema["$ref"].endswith("/SessionActivityResponse")
+    assert "content" not in head_response
 
     components = schema["components"]["schemas"]
     activity = components["SessionActivityResponse"]
@@ -231,16 +235,19 @@ def test_session_activity_snapshot_is_bounded_sanitized_and_read_only(monkeypatc
 def test_session_activity_head_runs_same_authorized_read_without_body(monkeypatch):
     client = _client(monkeypatch)
 
+    get_response = client.get("/api/sessions/short/activity?limit=7")
     response = client.head("/api/sessions/short/activity?limit=7")
 
     assert response.status_code == 200
     assert response.content == b""
+    assert response.headers["content-length"] == get_response.headers["content-length"]
+    assert response.headers["content-type"] == get_response.headers["content-type"]
     assert response.headers["x-hermes-session-capabilities"] == (
         "sessions.activity.read_model.v1"
     )
-    assert _FakeSessionDB.opened == [(None, True)]
+    assert _FakeSessionDB.opened == [(None, True), (None, True)]
     assert _FakeSessionDB.message_call["limit"] == 7
-    assert _FakeSessionDB.closed == 1
+    assert _FakeSessionDB.closed == 2
 
 
 def test_session_activity_rejects_unknown_duplicate_and_out_of_range_query(monkeypatch):
@@ -289,6 +296,25 @@ def test_session_activity_redaction_failure_is_fail_closed(monkeypatch):
         "occurred_at": 300.0,
         "truncated": False,
     }
+
+
+def test_session_activity_redaction_preserves_no_secret_fragments():
+    secret = "ghp_" + ("A" * 24) + "TAIL"
+
+    message = session_routes._session_activity_message(
+        {
+            "id": 10,
+            "role": "assistant",
+            "content": f"token {secret}",
+            "timestamp": 301.0,
+        }
+    )
+
+    assert message is not None
+    assert secret not in message["content"]
+    assert secret[:6] not in message["content"]
+    assert secret[-4:] not in message["content"]
+    assert "«redacted:ghp_…»" in message["content"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add `GET /api/sessions/capabilities` discovery for `sessions.activity.read_model.v1`
- add bounded `GET/HEAD /api/sessions/{session_id}/activity` snapshots
- expose closed OpenAPI response models for discovery and snapshots
- add a projected `SessionDB.get_activity_messages()` read path

## Safety boundary

- opens only an existing session store with `read_only=True`; no bootstrap or schema healing
- projects only public session metadata and `user`/`assistant` messages
- allowlists `text`, `input_text`, and `output_text` content blocks
- fully redacts secrets, URL credentials, and path-like content before returning text
- reads content through `sqlite3.Blob`; blobs above 8 KiB are never read
- caps snapshots at 200 source rows and returned text at 500 characters
- excludes tools, reasoning, prompts, filesystem paths, raw multimodal payloads, and mutation surfaces
- makes HEAD reuse GET representation headers without returning a body

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_session_activity_read_model.py -q` — 26 passed
- Sessions regression set — 347 passed, 1 skipped
- SessionDB regression set — 259 passed, 8 skipped, 1 deselected baseline failure
- `python -m py_compile` and `git diff --check` passed

## Baseline note

`tests/test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries` fails unchanged on clean `origin/main`. The focused SessionDB run deselects only that existing failure.