### PR TITLE
fix(update): stop a gateway we cannot relaunch instead of leaving it on stale code

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -829,12 +829,24 @@ def _prepare_profile_gateway_update_restart(profile: str, pid: int) -> str | Non
     manager. Starting Hermes's detached watcher as well would escape the
     manager and race its replacement process. Ordinary foreground gateways
     retain the existing detached-watcher behavior.
+
+    When the profile-derived relaunch cannot be armed -- typically because
+    ``_gateway_run_args_for_profile`` cannot rebuild a run argv for this
+    profile -- fall back to replaying the process's own captured command
+    line, which is what ``launch_detached_gateway_restart_by_cmdline``
+    exists for and what the Windows post-update path already does for its
+    unmapped gateways.  Without this the caller has no way to relaunch the
+    process and (before #88654) silently left it running pre-update modules
+    against post-update code on disk.  ``argv`` is already captured above,
+    so the fallback costs nothing extra.
     """
     argv = _capture_gateway_argv(pid)
     if argv and "--external-supervisor" in argv:
         return "external-supervisor"
     if launch_detached_profile_gateway_restart(profile, pid):
         return "detached"
+    if argv and launch_detached_gateway_restart_by_cmdline(pid, list(argv)):
+        return "detached-cmdline"
     return None
 
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6316,11 +6316,28 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 for proc in find_profile_gateway_processes(exclude_pids=service_pids)
                 if proc.pid in manual_pids
             }
+            # Profile gateways we could not arm a relaunch for.  These must
+            # NOT be left running: their modules are the pre-update ones and
+            # every lazy import from here on mixes versions against the new
+            # code on disk (#88654).  Handing them to the unmapped sweep
+            # below stops them and surfaces them in the "Stopped N manual
+            # gateway process(es) / Restart manually" summary, which is the
+            # contract already used for gateways with no profile mapping.
+            unrestartable_pids = set()
             for pid, proc in profile_processes.items():
                 restart_mode = _prepare_profile_gateway_update_restart(
                     proc.profile, pid
                 )
                 if restart_mode is None:
+                    # Previously a bare ``continue``: the gateway was neither
+                    # relaunched nor stopped nor mentioned, so it kept serving
+                    # from stale modules with no operator signal at all.
+                    print(
+                        f"  ⚠ {proc.profile}: could not arm an automatic "
+                        f"gateway restart for PID {pid} — stopping it instead "
+                        "so it cannot keep running pre-update code"
+                    )
+                    unrestartable_pids.add(pid)
                     continue
                 # Prefer a graceful SIGUSR1 drain so in-flight agent runs
                 # finish before the watcher respawns the gateway.  If the
@@ -6387,7 +6404,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     relaunched_profiles.append(proc.profile)
 
             for pid in manual_pids:
-                if pid in profile_processes:
+                if pid in profile_processes and pid not in unrestartable_pids:
                     continue
                 try:
                     os.kill(pid, _signal.SIGTERM)

--- a/tests/hermes_cli/test_update_gateway_restart_fallback.py
+++ b/tests/hermes_cli/test_update_gateway_restart_fallback.py
@@ -1,0 +1,120 @@
+"""Regression coverage for #88654.
+
+``hermes update`` relaunches manually-run profile gateways through
+``_prepare_profile_gateway_update_restart``.  When the profile-derived
+relaunch could not be armed the helper returned ``None``, and the update
+path's response to ``None`` was a bare ``continue`` -- so the gateway was
+neither relaunched, nor stopped, nor mentioned.  It kept serving from
+pre-update modules while the new code sat on disk, and every lazy import
+from that point mixed versions.
+
+The helper now falls back to replaying the process's own captured command
+line via ``launch_detached_gateway_restart_by_cmdline`` -- the companion
+that already exists for gateways with no profile mapping, and that the
+Windows post-update path already uses for exactly this case.
+"""
+
+import pytest
+
+import hermes_cli.gateway as gateway
+
+
+_ARGV = ["python", "-m", "hermes_cli.main", "gateway", "run"]
+
+
+def _stub_argv(monkeypatch, argv):
+    monkeypatch.setattr(gateway, "_capture_gateway_argv", lambda _pid: argv)
+
+
+def test_profile_relaunch_wins_and_skips_the_cmdline_replay(monkeypatch):
+    """The existing path is unchanged: a profile relaunch short-circuits."""
+    _stub_argv(monkeypatch, list(_ARGV))
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", lambda *_a: True
+    )
+    monkeypatch.setattr(
+        gateway,
+        "launch_detached_gateway_restart_by_cmdline",
+        lambda *_a: pytest.fail("cmdline replay must not run when the profile path works"),
+    )
+
+    assert gateway._prepare_profile_gateway_update_restart("fitness", 4242) == "detached"
+
+
+def test_falls_back_to_cmdline_replay_when_profile_relaunch_fails(monkeypatch):
+    """The #88654 fix: an unarmable profile relaunch still gets the gateway back."""
+    _stub_argv(monkeypatch, list(_ARGV))
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", lambda *_a: False
+    )
+    seen = []
+
+    def _by_cmdline(pid, argv):
+        seen.append((pid, argv))
+        return True
+
+    monkeypatch.setattr(
+        gateway, "launch_detached_gateway_restart_by_cmdline", _by_cmdline
+    )
+
+    assert (
+        gateway._prepare_profile_gateway_update_restart("fitness", 4242)
+        == "detached-cmdline"
+    )
+    # Replays the process's OWN argv, which is the whole point: the profile
+    # could not be mapped back to a run argv, so the captured one is the only
+    # faithful description of how to restart it.
+    assert seen == [(4242, _ARGV)]
+
+
+def test_returns_none_when_there_is_no_argv_to_replay(monkeypatch):
+    """No captured argv means no honest way to relaunch; caller must be told."""
+    _stub_argv(monkeypatch, [])
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", lambda *_a: False
+    )
+    monkeypatch.setattr(
+        gateway,
+        "launch_detached_gateway_restart_by_cmdline",
+        lambda *_a: pytest.fail("must not replay an empty argv"),
+    )
+
+    assert gateway._prepare_profile_gateway_update_restart("fitness", 4242) is None
+
+
+def test_returns_none_when_both_relaunch_paths_fail(monkeypatch):
+    """Both mechanisms failing is still reported as None, not a false success."""
+    _stub_argv(monkeypatch, list(_ARGV))
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", lambda *_a: False
+    )
+    monkeypatch.setattr(
+        gateway, "launch_detached_gateway_restart_by_cmdline", lambda *_a: False
+    )
+
+    assert gateway._prepare_profile_gateway_update_restart("fitness", 4242) is None
+
+
+def test_external_supervisor_still_short_circuits_before_any_replay(monkeypatch):
+    """Guardrail: the supervisor hand-back must not gain a replay behind it.
+
+    Replaying the argv for an externally supervised gateway would escape the
+    manager and race its replacement process, which is the exact hazard the
+    supervisor branch exists to avoid.
+    """
+    _stub_argv(monkeypatch, _ARGV + ["--external-supervisor"])
+    monkeypatch.setattr(
+        gateway,
+        "launch_detached_profile_gateway_restart",
+        lambda *_a: pytest.fail("detached watcher must not be launched"),
+    )
+    monkeypatch.setattr(
+        gateway,
+        "launch_detached_gateway_restart_by_cmdline",
+        lambda *_a: pytest.fail("cmdline replay must not be launched"),
+    )
+
+    assert (
+        gateway._prepare_profile_gateway_update_restart("fitness", 4242)
+        == "external-supervisor"
+    )


### PR DESCRIPTION
## What does this PR do?

After an in-place update, the restart phase walks the manually-run profile gateways and asks
`_prepare_profile_gateway_update_restart` to arm a relaunch for each one. Its response to a
failure was a bare `continue`:

```python
restart_mode = _prepare_profile_gateway_update_restart(proc.profile, pid)
if restart_mode is None:
    continue
```

`None` means *no relaunch could be armed*. That `continue` skipped the drain and the
`SIGTERM`, and the unmapped sweep a few lines below skips any pid already present in
`profile_processes`, so the process was never stopped and never counted into the
`Stopped N manual gateway process(es)` summary either.

The gateway therefore kept running with its **pre-update modules resident** while the new code
sat on disk. Every lazy import from that moment mixed versions:

```
cannot import name '_MAX_TOOL_ERROR_CHARS' from 'tools.registry'
```

and the update printed nothing at all about it. The operator's only signal was the crash,
later, from a component that had not been imported yet at update time.

Two changes, both small.

**1. Give the profile path the fallback that already exists.**
`_prepare_profile_gateway_update_restart` now replays the process's own captured command line
when the profile-derived relaunch cannot be armed.
`launch_detached_gateway_restart_by_cmdline` was written for exactly this case and documents
itself as the companion for gateways whose profile cannot be mapped; the Windows post-update
path already uses it the same way. The argv is captured a few lines earlier for the
`--external-supervisor` check, so the fallback costs no extra work.

The `--external-supervisor` branch still short-circuits **before** any replay. Replaying argv
under a supervisor would escape the manager and race its replacement process, which is the
precise hazard that branch exists to avoid — there is a guardrail test pinning this.

**2. Never fall through silently.**
When neither mechanism can arm a relaunch, the update path now says so, naming the profile and
the pid, and hands the process to the existing unmapped sweep so it is stopped and surfaced
through the established `Restart manually: hermes gateway run` contract.

Stopping it is the conservative choice, and I want to be explicit that it *is* a choice: a
gateway left alive on stale modules fails every lazy import for as long as it lives, whereas a
stopped one fails loudly, once, with an instruction attached. That reasoning matches how the
codebase already treats gateways it cannot map to a profile. **If maintainers would rather warn
and leave it running, that is a one-line change** — say the word and I will make it.

### Note on overlap with #82195

#82195 (`fix(update): avoid gateway-owned restart deadlock`) touches both of these files and
adds a `_prepare_unmapped_gateway_update_restart` helper that also uses
`launch_detached_gateway_restart_by_cmdline`. I checked whether it already covers this issue:
it does not. It preserves `if restart_mode is None: continue` verbatim on the profile leg, and
its new helper runs only in the unmapped loop, which a profile-mapped pid never reaches
(`if pid in profile_processes: continue` is unchanged there). A profile gateway whose relaunch
cannot be armed is still silently skipped with that PR applied.

The two are complementary but will conflict textually, since both edit this block. I am happy
to rebase on top of #82195 if it lands first — ping me and I will push the merge.

## Related Issue

Fixes #88654

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py` — `_prepare_profile_gateway_update_restart` falls back to
  `launch_detached_gateway_restart_by_cmdline(pid, argv)` when
  `launch_detached_profile_gateway_restart` fails, returning the new `"detached-cmdline"` mode.
  The `--external-supervisor` short-circuit is untouched and still runs first. Docstring
  records why.
- `hermes_cli/update_cmd.py` — the `restart_mode is None` branch now prints a warning naming the
  profile and pid, and collects the pid into `unrestartable_pids`.
- `hermes_cli/update_cmd.py` — the unmapped sweep's skip becomes
  `if pid in profile_processes and pid not in unrestartable_pids: continue`, so those pids are
  stopped and reported by machinery that already exists rather than by a new code path.
- `tests/hermes_cli/test_update_gateway_restart_fallback.py` — new, 5 tests.

## How to Test

1. Reproduce the silent skip on `main`: run `hermes update` with a manually-started profile
   gateway whose relaunch cannot be armed (e.g. its detached watcher fails to spawn). The update
   completes, prints nothing about that gateway, and the process is still alive on the old code
   — `hermes gateway status` shows it up, and the next lazy import in that process raises
   `cannot import name '_MAX_TOOL_ERROR_CHARS' from 'tools.registry'`.

2. Run the new tests:

   ```
   pytest tests/hermes_cli/test_update_gateway_restart_fallback.py -q
   ```

   `5 passed`.

3. **Sabotage proof** — the tests fail for the right reason, not incidentally. Revert only
   `hermes_cli/gateway.py` and re-run:

   ```
   git stash push -- hermes_cli/gateway.py
   pytest tests/hermes_cli/test_update_gateway_restart_fallback.py -q
   ```

   Exactly one test fails, with the exact assertion the fix is about:

   ```
   FAILED test_falls_back_to_cmdline_replay_when_profile_relaunch_fails
   AssertionError: assert None == 'detached-cmdline'
   ```

   The other four still pass — they are guardrails on behaviour this PR must *not* change
   (profile relaunch still wins, empty argv still yields `None`, both-paths-failed still yields
   `None`, and the external-supervisor branch still short-circuits ahead of any replay).

4. **Neighbouring suites, baselined.** I ran the 47 files matching
   `tests/hermes_cli/test_gateway*.py`, `test_update*.py`, `test_cmd_update.py` both with and
   without the change:

   | | result |
   |---|---|
   | both source files reverted | `30 failed, 481 passed, 26 skipped` |
   | with this PR | `29 failed, 487 passed, 26 skipped` |

   Every one of those failures is pre-existing and environmental, not caused by this PR. They
   are POSIX-only assertions that cannot hold on Windows — systemd units
   (`test_gateway_linger`, `test_gateway_restart_loop`), `XDG_RUNTIME_DIR` ownership and uid
   checks (`test_gateway_foreign_xdg_runtime`), executable-bit/shebang handling — plus a
   `UnicodeEncodeError: 'charmap' codec can't encode character '✓'` from an atexit callback
   writing a check mark to a cp1252 console. None are in the gateway-restart mechanism this PR
   touches, and the count goes **down**, never up.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — nearest is #82195, analysed above; it does not fix this issue
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — one commit, three files
- [x] I've run `pytest tests/ -q` and all tests pass — see the baselined run in step 4; the delta from this PR is `+6 passed, -1 failed`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro 26200, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring on
      `_prepare_profile_gateway_update_restart` records the fallback and why the supervisor
      branch stays ahead of it; the new branch in `update_cmd.py` carries a comment explaining
      what the bare `continue` used to cost
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the
      [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
      — no new platform-specific calls. `_capture_gateway_argv` and
      `launch_detached_gateway_restart_by_cmdline` are both existing cross-platform helpers, and
      the fallback runs the same on all three. The new tests monkeypatch every process-touching
      helper, so they carry no platform assumptions and spawn nothing.
- [x] N/A — no tool descriptions or schemas changed

## Screenshots / Logs

Sabotage proof, `hermes_cli/gateway.py` reverted and the rest of the PR in place:

```
FAILED tests/hermes_cli/test_update_gateway_restart_fallback.py::test_falls_back_to_cmdline_replay_when_profile_relaunch_fails
E       AssertionError: assert None == 'detached-cmdline'
E        +  where None = _prepare_profile_gateway_update_restart('fitness', 4242)

1 failed, 4 passed
```

Full PR applied:

```
tests/hermes_cli/test_update_gateway_restart_fallback.py .....           [100%]
5 passed
```
