### PR TITLE
feat(music): MiniMax music generation plugin (generate_music tool, music_gen toolset)

### DIFF
--- a/plugins/music_gen/minimax/__init__.py
+++ b/plugins/music_gen/minimax/__init__.py
@@ -1,0 +1,396 @@
+"""MiniMax Music 3.0 backend for Hermes.
+
+In-tree music counterpart of ``plugins/image_gen/krea`` and
+``plugins/video_gen/fal``. Registers a ``generate_music`` tool (toolset
+``music_gen``) that turns a style prompt + optional lyrics into a full
+produced song via MiniMax's hosted ``POST /v1/music_generation`` endpoint
+(model ``music-3.0``).
+
+Credential order: portal credits via the managed Nous gateway
+(``minimax`` vendor route) once tool-gateway onboards MiniMax — verified
+live by a reachability probe before steering calls at it; BYOK via
+``MINIMAX_API_KEY`` until then — the same key the built-in MiniMax TTS
+provider uses. The tool surfaces whenever either credential is resolvable.
+
+Why the blocking shape: MiniMax has no public async job API for music — the
+endpoint is synchronous and returns either hex-encoded audio bytes or a
+24h-expiring URL in one JSON response. A full song take is slow (tens of
+seconds to a few minutes), so the tool blocks with a generous timeout and
+always materializes the result to disk before returning.
+
+Cover generation (``model=music-cover``) and the lyrics helper
+(``POST /v1/lyrics_generation``) are exposed through the same tool via
+``mode=``; the two-step cover preprocess endpoint is intentionally left
+out of the agent surface (it belongs in a studio UI flow, not a chat
+tool).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from agent.secret_scope import get_secret
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# Versionless base — the /v1 prefix lives in the request paths so the same
+# path shape works against the managed gateway origin (which allowlists
+# POST /v1/music_generation exactly, with no /v1 prefix on the origin).
+API_BASE_DIRECT = "https://api.minimax.io"
+DEFAULT_MODEL = "music-3.0"
+# Music generation of a full multi-minute song is slow; the endpoint is
+# synchronous, so we need a long socket timeout but still bounded.
+REQUEST_TIMEOUT_S = 600
+
+ENV_KEY = "MINIMAX_API_KEY"
+# Managed-gateway vendor slug (mirrors resolve_managed_tool_gateway("fal-queue")
+# / krea). The route + meter land in Nous infra; when they do, this plugin
+# serves music on portal credits with zero keys, same as fal video today.
+_GATEWAY_VENDOR = "minimax"
+
+
+def _resolve_key() -> Optional[str]:
+    return (get_secret(ENV_KEY) or "").strip() or None
+
+
+def _resolve_gateway():
+    """Nous managed gateway config for MiniMax, or None when the user isn't on
+    the managed path (not signed in / managed tools off / no token). Kept as
+    the preferred credential when a MINIMAX_API_KEY is present — portal-credit
+    service is the default; the direct key is an explicit BYOK override."""
+    try:  # helper may be unavailable in stripped-down embeddings
+        from tools.managed_tool_gateway import resolve_managed_tool_gateway
+
+        return resolve_managed_tool_gateway(_GATEWAY_VENDOR)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _music_cache_dir() -> Path:
+    d = get_hermes_home() / "cache" / "music"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _slug(text: str, limit: int = 40) -> str:
+    s = re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-")
+    return (s[:limit].strip("-") or "song")
+
+
+def _gateway_host_reachable(origin: str) -> bool:
+    """The managed route exists iff the vendor gateway host resolves + answers.
+    Until tool-gateway onboards MiniMax, the minimax vendor host is NXDOMAIN
+    and we must not steer calls at it — that would break a working direct-key
+    setup the moment the user signs into Nous. Cheap probe (DNS only); any
+    resolvable host counts as reachable (401 = fronted, auth'd at app layer)."""
+    import socket
+    from urllib.parse import urlparse
+
+    try:
+        host = urlparse(origin).hostname or ""
+        socket.getaddrinfo(host, 443)
+    except OSError:
+        return False
+    return True
+
+
+def _auth_token() -> Dict[str, Any]:
+    """Resolve credential + base. Order:
+      1. `MINIMAX_GATEWAY_URL` override (staging) → nous token (trusted as-is)
+      2. managed gateway, ONLY if the vendor route resolves → portal token
+      3. direct MINIMAX_API_KEY                    → vendor token
+    Portal-credit service is the default ONCE THE ROUTE EXISTS; the direct key
+    is the live fallback until then, and is never shadowed by a dead route."""
+    override = os.environ.get("MINIMAX_GATEWAY_URL", "").strip().rstrip("/")
+    gw = _resolve_gateway()
+    if override and gw is not None:
+        return {"base": override, "token": gw.nous_user_token, "managed": True}
+    if gw is not None and gw.gateway_origin:
+        origin = gw.gateway_origin.rstrip("/")
+        if _gateway_host_reachable(origin):
+            return {"base": origin, "token": gw.nous_user_token, "managed": True}
+        # Route not onboarded yet — fall through to the direct key.
+    key = _resolve_key()
+    if key:
+        return {"base": API_BASE_DIRECT, "token": key, "managed": False}
+    return {"base": None, "token": None, "managed": False}
+
+
+def _post(path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """POST JSON to MiniMax (direct or via the managed Nous gateway) and
+    return the parsed body.
+
+    Auth and request-shape failures come back as HTTP 200 with a non-zero
+    ``base_resp.status_code`` — MiniMax does not use HTTP status for
+    application errors. We therefore never raise on HTTP 200 bodies; we
+    surface status_code/status_msg to the caller instead.
+    """
+    auth = _auth_token()
+    if not auth["token"]:
+        raise RuntimeError(
+            f"No MiniMax credential. Set {ENV_KEY} in your Hermes .env for BYOK, "
+            f"or sign in to Nous (`hermes auth add nous --type oauth`) to use the "
+            f"managed gateway once the MiniMax route is live."
+        )
+    req = urllib.request.Request(
+        f"{auth['base']}{path}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {auth['token']}",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_S) as resp:
+            body = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", "replace")[:500]
+        raise RuntimeError(f"MiniMax HTTP {e.code}: {detail}") from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"MiniMax request failed: {e.reason}") from e
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"MiniMax returned non-JSON body: {body[:300]}") from e
+
+
+_STATUS_HINTS: Dict[int, str] = {
+    1002: "Rate limited — slow down and retry.",
+    1004: "Auth failed — check MINIMAX_API_KEY in your Hermes .env.",
+    1008: "Insufficient balance — top up at platform.minimax.io.",
+    1026: "Content rejected by MiniMax moderation — reword the prompt/lyrics.",
+    2013: "Invalid parameters — check prompt/lyrics lengths (lyrics 1-3500 chars for music-3.0).",
+    2049: "Invalid API key format — check MINIMAX_API_KEY.",
+}
+
+
+def _check_base_resp(result: Dict[str, Any]) -> Optional[str]:
+    base = result.get("base_resp") or {}
+    code = base.get("status_code", 0)
+    if code in (0, None):
+        return None
+    msg = base.get("status_msg") or "unknown error"
+    hint = _STATUS_HINTS.get(code, "")
+    return f"MiniMax error {code}: {msg}" + (f" ({hint})" if hint else "")
+
+
+def _save_audio(result: Dict[str, Any], prompt: str, fmt: str) -> Dict[str, Any]:
+    """Materialize the audio from a successful response; return file info."""
+    data = result.get("data") or {}
+    extra = result.get("extra_info") or {}
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    stem = f"{ts}-{_slug(prompt)}.{fmt}"
+
+    # Preferred: server-hosted URL (output_format=url). Fallback: hex bytes.
+    audio_url = data.get("audio") or ""
+    out_path = _music_cache_dir() / stem
+    if isinstance(audio_url, str) and audio_url.startswith("http"):
+        # data.status 1 (in progress) means the URL pre-exists the file; poll
+        # briefly before giving up. status 2 = completed.
+        if data.get("status") == 1:
+            deadline = time.time() + 60
+            body = None
+            while time.time() < deadline:
+                try:
+                    with urllib.request.urlopen(audio_url, timeout=120) as r:
+                        body = r.read()
+                    break
+                except Exception:  # noqa: BLE001
+                    time.sleep(3)
+            if body is None:
+                return {"error": "audio still rendering at result URL after 60s", "audio_url": audio_url}
+            out_path.write_bytes(body)
+        else:
+            try:
+                with urllib.request.urlopen(audio_url, timeout=120) as r:
+                    out_path.write_bytes(r.read())
+            except Exception as e:  # noqa: BLE001
+                return {"error": f"generated OK but download from result URL failed: {e}", "audio_url": audio_url}
+    elif isinstance(audio_url, str) and audio_url:
+        # hex-encoded
+        try:
+            out_path.write_bytes(bytes.fromhex(audio_url))
+        except ValueError:
+            out_path.write_bytes(base64.b64decode(audio_url))
+    else:
+        return {"error": "response contained no audio payload", "raw_keys": list(data.keys())}
+
+    return {
+        "file": str(out_path),
+        "audio_url": audio_url if audio_url.startswith("http") else None,
+        "duration_s": round((extra.get("music_duration") or 0) / 1000.0, 2) or None,
+        "sample_rate": extra.get("music_sample_rate"),
+        "channels": extra.get("music_channel"),
+        "bitrate": extra.get("bitrate"),
+        "size_bytes": extra.get("music_size") or out_path.stat().st_size,
+        "trace_id": result.get("trace_id"),
+    }
+
+
+def generate_music(
+    prompt: str,
+    lyrics: Optional[str] = None,
+    mode: str = "song",
+    reference_audio_url: Optional[str] = None,
+    fmt: str = "mp3",
+    sample_rate: int = 44100,
+    bitrate: int = 256000,
+    model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Generate music with MiniMax.
+
+    mode:
+      - "song"         (default): full song. lyrics optional (auto-written if absent).
+      - "instrumental": no vocals; lyrics ignored.
+      - "lyrics":      text-only — return generated lyrics without rendering audio.
+      - "cover":       reinterpret reference_audio_url (6s-6min, <=50MB) in the style
+                       of `prompt`. lyrics optional (ASR-extracted if absent).
+    """
+    prompt = (prompt or "").strip()
+    if not prompt:
+        return {"error": "prompt is required (describe genre, mood, instruments, vocals, mix)."}
+
+    if mode == "lyrics":
+        try:
+            result = _post("/v1/lyrics_generation", {"mode": "write_full_song", "prompt": prompt})
+            err = _check_base_resp(result)
+            data = result.get("data") or {}
+            return {"mode": "lyrics", "lyrics": data.get("lyrics") or "",
+                    "error": err, "trace_id": result.get("trace_id"),
+                    "raw_keys": list(data.keys())}
+        except RuntimeError as e:
+            return {"error": str(e)}
+
+    resolved_model = model or DEFAULT_MODEL
+    payload: Dict[str, Any] = {
+        "model": resolved_model,
+        "prompt": prompt,
+        "audio_setting": {"sample_rate": sample_rate, "bitrate": bitrate, "format": fmt},
+        "output_format": "url",
+    }
+
+    if mode == "instrumental":
+        payload["is_instrumental"] = True
+    elif mode == "cover":
+        payload["model"] = "music-cover"
+        if not reference_audio_url:
+            return {"error": "mode='cover' requires reference_audio_url (http(s) URL, 6s-6min, <=50MB)."}
+        payload["audio_url"] = reference_audio_url
+        if lyrics:
+            payload["lyrics"] = lyrics
+    else:  # song
+        if lyrics and lyrics.strip():
+            payload["lyrics"] = lyrics.strip()
+        else:
+            # MiniMax 2013s on lyrics_optimizer:true sent with an explicit
+            # empty lyrics string — the field must be ABSENT for auto-write.
+            payload["lyrics_optimizer"] = True
+
+    try:
+        result = _post("/v1/music_generation", payload)
+    except RuntimeError as e:
+        return {"error": str(e), "mode": mode, "model": payload.get("model")}
+
+    err = _check_base_resp(result)
+    if err:
+        return {"error": err, "mode": mode, "model": payload.get("model"),
+                "trace_id": result.get("trace_id")}
+
+    saved = _save_audio(result, prompt, fmt)
+    saved.update({"mode": mode, "model": payload.get("model"), "prompt": prompt})
+    return saved
+
+
+# ---------------------------------------------------------------------------
+# Tool surface
+# ---------------------------------------------------------------------------
+
+
+def _check_music_tools() -> bool:
+    """Surface the tool only when a credential CAN resolve — keeps the core
+    toolset narrow for everyone else. A signed-in Nous sub counts: the managed
+    gateway path needs no MINIMAX_API_KEY."""
+    return bool(_resolve_key() or _resolve_gateway())
+
+
+_TOOL_SCHEMA: Dict[str, Any] = {
+    "name": "generate_music",
+    "description": (
+        "Compose and produce a full song (or instrumental) with MiniMax Music 3.0. "
+        "Give a style prompt (genre, mood, tempo, instruments, vocal character, mix) and "
+        "optionally structured lyrics ([Verse]/[Chorus]/[Bridge] tags); the model writes "
+        "lyrics itself when omitted. mode='lyrics' returns lyrics only, mode='cover' "
+        "reinterprets a reference audio URL in a new style. Saves the audio file locally "
+        "and returns its path plus duration/format metadata."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Style description: genre, mood, BPM, key, instruments, vocal character, mix. Be specific — this drives composition and production.",
+            },
+            "lyrics": {
+                "type": "string",
+                "description": "Optional lyrics with structure tags ([Verse] [Chorus] [Bridge] [Outro]). Omit to have lyrics written from the prompt (mode='song'). 1-3500 chars.",
+            },
+            "mode": {
+                "type": "string",
+                "enum": ["song", "instrumental", "lyrics", "cover"],
+                "default": "song",
+                "description": "song=full production, instrumental=no vocals, lyrics=text-only lyrics generation, cover=restyle reference_audio_url.",
+            },
+            "reference_audio_url": {
+                "type": "string",
+                "description": "Required for mode='cover': public URL of reference audio (6s-6min, <=50MB).",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["mp3", "wav", "pcm"],
+                "default": "mp3",
+                "description": "Output container. mp3 default; wav for further production; pcm raw.",
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+def _generate_music_handler(args: Dict[str, Any]) -> str:
+    result = generate_music(
+        prompt=args.get("prompt") or "",
+        lyrics=args.get("lyrics"),
+        mode=args.get("mode") or "song",
+        reference_audio_url=args.get("reference_audio_url"),
+        fmt=args.get("format") or "mp3",
+    )
+    if result.get("file"):
+        # Agent-facing surface mirrors text_to_speech: MEDIA: path so the
+        # desktop app / gateways can attach and play it natively.
+        result["MEDIA"] = result["file"]
+    return json.dumps(result, ensure_ascii=False, default=str)
+
+
+def register(ctx) -> None:
+    """Hermes plugin entry point."""
+    ctx.register_tool(
+        name="generate_music",
+        toolset="music_gen",
+        schema=_TOOL_SCHEMA,
+        handler=_generate_music_handler,
+        check_fn=_check_music_tools,
+        requires_env=[ENV_KEY],
+        description="Generate a full song or instrumental with MiniMax Music 3.0",
+        emoji="🎵",
+    )

--- a/plugins/music_gen/minimax/plugin.yaml
+++ b/plugins/music_gen/minimax/plugin.yaml
@@ -1,0 +1,7 @@
+name: minimax-music
+version: 1.0.0
+description: "MiniMax Music 3.0 music generation backend. Full songs (vocals, up to ~5 min) or instrumentals from a style prompt + lyrics, via POST /v1/music_generation. Direct MINIMAX_API_KEY (same key as the built-in MiniMax TTS provider) or managed Nous Subscription gateway."
+author: NousResearch
+kind: backend
+requires_env:
+  - MINIMAX_API_KEY

--- a/tests/plugins/music_gen/__init__.py
+++ b/tests/plugins/music_gen/__init__.py
@@ -1,0 +1,1 @@
+"""Make tests/plugins/music_gen a package."""

--- a/tests/plugins/music_gen/test_minimax_music.py
+++ b/tests/plugins/music_gen/test_minimax_music.py
@@ -1,0 +1,398 @@
+"""Tests for the MiniMax music generation plugin (plugins/music_gen/minimax).
+
+Covers the tool-availability ladder (BYOK key / managed Nous gateway /
+neither), the /v1/music_generation payload contract (lyrics verbatim,
+lyrics_optimizer without an empty lyrics field, instrumental mode),
+base_resp application-error mapping, and url-vs-hex audio materialization
+into HERMES_HOME. No live network — every seam is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    """Isolate credentials and HERMES_HOME for every test.
+
+    The plugin materializes audio under ``get_hermes_home()/cache/music`` —
+    point HERMES_HOME at a per-test tmpdir so nothing can land in the real
+    Hermes home, and start from a no-credential baseline.
+    """
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.delenv("MINIMAX_GATEWAY_URL", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+def _fake_gateway(origin: str = "https://minimax-gateway.nousresearch.com"):
+    gw = MagicMock()
+    gw.gateway_origin = origin
+    gw.nous_user_token = "nous-portal-token"
+    return gw
+
+
+def _ok_response(audio: str, status: int = 2, extra: dict | None = None) -> dict:
+    return {
+        "data": {"audio": audio, "status": status},
+        "extra_info": extra or {"music_duration": 185000, "music_sample_rate": 44100},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+        "trace_id": "trace-123",
+    }
+
+
+def _err_response(code: int, msg: str) -> dict:
+    return {
+        "data": None,
+        "base_resp": {"status_code": code, "status_msg": msg},
+        "trace_id": "trace-err",
+    }
+
+
+def _urlopen_returning(payload: bytes):
+    """Context-manager mock matching ``with urllib.request.urlopen(...) as r``."""
+    cm = MagicMock()
+    cm.__enter__.return_value.read.return_value = payload
+    cm.__exit__.return_value = False
+    return MagicMock(return_value=cm)
+
+
+# ---------------------------------------------------------------------------
+# Availability ladder (check_fn)
+# ---------------------------------------------------------------------------
+
+
+class TestAvailability:
+    def test_available_with_api_key(self, monkeypatch):
+        from plugins.music_gen import minimax
+
+        monkeypatch.setenv("MINIMAX_API_KEY", "mk-test-123")
+        with patch.object(minimax, "_resolve_gateway", return_value=None):
+            assert minimax._check_music_tools() is True
+
+    def test_available_with_managed_gateway_only(self):
+        from plugins.music_gen import minimax
+
+        with patch(
+            "tools.managed_tool_gateway.resolve_managed_tool_gateway",
+            return_value=_fake_gateway(),
+        ):
+            assert minimax._check_music_tools() is True
+
+    def test_hidden_without_any_credential(self):
+        from plugins.music_gen import minimax
+
+        with patch(
+            "tools.managed_tool_gateway.resolve_managed_tool_gateway",
+            return_value=None,
+        ):
+            assert minimax._check_music_tools() is False
+
+    def test_register_wires_tool_into_music_gen_toolset(self):
+        from plugins.music_gen import minimax
+
+        ctx = MagicMock()
+        minimax.register(ctx)
+
+        ctx.register_tool.assert_called_once()
+        kwargs = ctx.register_tool.call_args.kwargs
+        assert kwargs["name"] == "generate_music"
+        assert kwargs["toolset"] == "music_gen"
+        assert kwargs["check_fn"] is minimax._check_music_tools
+        assert kwargs["requires_env"] == ["MINIMAX_API_KEY"]
+        assert kwargs["schema"]["name"] == "generate_music"
+
+
+class TestAuthTokenLadder:
+    def test_gateway_preferred_when_route_reachable(self, monkeypatch):
+        from plugins.music_gen import minimax
+
+        monkeypatch.setenv("MINIMAX_API_KEY", "mk-byok")
+        with patch.object(minimax, "_resolve_gateway", return_value=_fake_gateway()), \
+             patch.object(minimax, "_gateway_host_reachable", return_value=True):
+            auth = minimax._auth_token()
+        assert auth["managed"] is True
+        assert auth["token"] == "nous-portal-token"
+        assert auth["base"] == "https://minimax-gateway.nousresearch.com"
+
+    def test_dead_gateway_route_falls_back_to_byok_key(self, monkeypatch):
+        """Until tool-gateway onboards MiniMax the vendor host is NXDOMAIN —
+        a signed-in Nous user with a working key must not be steered at it."""
+        from plugins.music_gen import minimax
+
+        monkeypatch.setenv("MINIMAX_API_KEY", "mk-byok")
+        with patch.object(minimax, "_resolve_gateway", return_value=_fake_gateway()), \
+             patch.object(minimax, "_gateway_host_reachable", return_value=False):
+            auth = minimax._auth_token()
+        assert auth["managed"] is False
+        assert auth["token"] == "mk-byok"
+        assert auth["base"] == minimax.API_BASE_DIRECT
+
+    def test_no_credential_yields_empty_auth(self):
+        from plugins.music_gen import minimax
+
+        with patch.object(minimax, "_resolve_gateway", return_value=None):
+            auth = minimax._auth_token()
+        assert auth["token"] is None and auth["base"] is None
+
+    def test_gateway_url_override_uses_nous_token(self, monkeypatch):
+        from plugins.music_gen import minimax
+
+        monkeypatch.setenv("MINIMAX_GATEWAY_URL", "https://staging.example/")
+        with patch.object(minimax, "_resolve_gateway", return_value=_fake_gateway()):
+            auth = minimax._auth_token()
+        assert auth["managed"] is True
+        assert auth["base"] == "https://staging.example"
+
+    def test_post_composes_versionless_base_with_v1_path(self, monkeypatch):
+        """Full URL = {base}{path}: direct base has no /v1 suffix, the request
+        path carries it — the shape the managed gateway allowlists."""
+        from plugins.music_gen import minimax
+
+        monkeypatch.setenv("MINIMAX_API_KEY", "mk-byok")
+        ok_body = json.dumps(_ok_response("cafe")).encode("utf-8")
+        with patch.object(minimax, "_resolve_gateway", return_value=None), \
+             patch(
+                 "plugins.music_gen.minimax.urllib.request.urlopen",
+                 _urlopen_returning(ok_body),
+             ) as fake_urlopen:
+            minimax._post("/v1/music_generation", {"model": "music-3.0"})
+
+        req = fake_urlopen.call_args.args[0]
+        assert req.full_url == "https://api.minimax.io/v1/music_generation"
+        assert req.get_header("Authorization") == "Bearer mk-byok"
+
+
+# ---------------------------------------------------------------------------
+# Payload contract
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadShape:
+    def _generate_capturing_payload(self, minimax, **kwargs):
+        captured = {}
+
+        def fake_post(path, payload):
+            captured["path"] = path
+            captured["payload"] = payload
+            return _ok_response("cafe")  # valid hex so _save_audio succeeds
+
+        with patch.object(minimax, "_post", side_effect=fake_post):
+            result = minimax.generate_music(**kwargs)
+        return captured, result
+
+    def test_explicit_lyrics_sent_verbatim(self):
+        from plugins.music_gen import minimax
+
+        lyrics = "[Verse]\nneon rain on the interstate\n[Chorus]\nrun the lights"
+        captured, _ = self._generate_capturing_payload(
+            minimax, prompt="synthwave, 100 BPM", lyrics=lyrics
+        )
+        payload = captured["payload"]
+        assert payload["lyrics"] == lyrics
+        assert "lyrics_optimizer" not in payload
+        assert payload["model"] == "music-3.0"
+        # /v1 lives in the request path, not the base — the managed gateway
+        # origin has no /v1 prefix and allowlists POST /v1/music_generation.
+        assert captured["path"] == "/v1/music_generation"
+
+    def test_absent_lyrics_uses_optimizer_without_empty_field(self):
+        """MiniMax 2013s when lyrics_optimizer:true is sent alongside an
+        explicit empty lyrics string — the field must be ABSENT."""
+        from plugins.music_gen import minimax
+
+        captured, _ = self._generate_capturing_payload(minimax, prompt="lofi hip hop")
+        payload = captured["payload"]
+        assert payload["lyrics_optimizer"] is True
+        assert "lyrics" not in payload
+
+    def test_whitespace_lyrics_treated_as_absent(self):
+        from plugins.music_gen import minimax
+
+        captured, _ = self._generate_capturing_payload(
+            minimax, prompt="lofi", lyrics="   \n  "
+        )
+        payload = captured["payload"]
+        assert payload["lyrics_optimizer"] is True
+        assert "lyrics" not in payload
+
+    def test_instrumental_mode_sets_flag_and_no_lyrics(self):
+        from plugins.music_gen import minimax
+
+        captured, _ = self._generate_capturing_payload(
+            minimax, prompt="cinematic strings", lyrics="ignored", mode="instrumental"
+        )
+        payload = captured["payload"]
+        assert payload["is_instrumental"] is True
+        assert "lyrics" not in payload
+        assert "lyrics_optimizer" not in payload
+
+    def test_cover_mode_requires_reference_audio(self):
+        from plugins.music_gen import minimax
+
+        with patch.object(minimax, "_post") as post:
+            result = minimax.generate_music(prompt="bossa nova", mode="cover")
+        post.assert_not_called()
+        assert "reference_audio_url" in result["error"]
+
+    def test_cover_mode_switches_model_and_carries_audio_url(self):
+        from plugins.music_gen import minimax
+
+        captured, _ = self._generate_capturing_payload(
+            minimax,
+            prompt="bossa nova",
+            mode="cover",
+            reference_audio_url="https://example.com/ref.mp3",
+        )
+        payload = captured["payload"]
+        assert payload["model"] == "music-cover"
+        assert payload["audio_url"] == "https://example.com/ref.mp3"
+
+    def test_empty_prompt_rejected_before_network(self):
+        from plugins.music_gen import minimax
+
+        with patch.object(minimax, "_post") as post:
+            result = minimax.generate_music(prompt="   ")
+        post.assert_not_called()
+        assert "prompt is required" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# base_resp application-error mapping
+# ---------------------------------------------------------------------------
+
+
+class TestBaseRespErrors:
+    def test_insufficient_balance_1008_maps_hint(self):
+        from plugins.music_gen import minimax
+
+        with patch.object(
+            minimax, "_post", return_value=_err_response(1008, "insufficient balance")
+        ):
+            result = minimax.generate_music(prompt="jazz")
+        assert "MiniMax error 1008" in result["error"]
+        assert "top up" in result["error"]
+        assert result["trace_id"] == "trace-err"
+
+    def test_moderation_1026_maps_hint(self):
+        from plugins.music_gen import minimax
+
+        with patch.object(
+            minimax, "_post", return_value=_err_response(1026, "content violation")
+        ):
+            result = minimax.generate_music(prompt="jazz")
+        assert "MiniMax error 1026" in result["error"]
+        assert "moderation" in result["error"]
+
+    def test_unknown_code_still_surfaces_msg(self):
+        from plugins.music_gen import minimax
+
+        with patch.object(
+            minimax, "_post", return_value=_err_response(9999, "mystery")
+        ):
+            result = minimax.generate_music(prompt="jazz")
+        assert "MiniMax error 9999: mystery" in result["error"]
+
+    def test_status_zero_is_success(self):
+        from plugins.music_gen import minimax
+
+        assert minimax._check_base_resp({"base_resp": {"status_code": 0}}) is None
+        assert minimax._check_base_resp({}) is None
+
+
+# ---------------------------------------------------------------------------
+# Audio materialization (url + hex) under HERMES_HOME
+# ---------------------------------------------------------------------------
+
+
+class TestAudioMaterialization:
+    def test_url_audio_downloaded_into_hermes_home(self, tmp_path):
+        from plugins.music_gen import minimax
+
+        fake_mp3 = b"ID3\x04fake-mp3-bytes"
+        with patch(
+            "plugins.music_gen.minimax.urllib.request.urlopen",
+            _urlopen_returning(fake_mp3),
+        ):
+            saved = minimax._save_audio(
+                _ok_response("https://cdn.minimax.io/song.mp3"), "test song", "mp3"
+            )
+
+        out = Path(saved["file"])
+        assert out.read_bytes() == fake_mp3
+        # Profile safety: everything lands under the mocked HERMES_HOME.
+        assert out.is_relative_to(tmp_path)
+        assert out.parent == tmp_path / "cache" / "music"
+        assert saved["audio_url"] == "https://cdn.minimax.io/song.mp3"
+        assert saved["duration_s"] == 185.0
+
+    def test_hex_audio_decoded_into_hermes_home(self, tmp_path):
+        from plugins.music_gen import minimax
+
+        hex_audio = b"RIFFfake-wav".hex()
+        saved = minimax._save_audio(_ok_response(hex_audio), "hex song", "wav")
+
+        out = Path(saved["file"])
+        assert out.read_bytes() == b"RIFFfake-wav"
+        assert out.is_relative_to(tmp_path)
+        assert out.suffix == ".wav"
+
+    def test_missing_audio_payload_is_error(self):
+        from plugins.music_gen import minimax
+
+        saved = minimax._save_audio(
+            {"data": {"status": 2}, "extra_info": {}}, "empty", "mp3"
+        )
+        assert "no audio payload" in saved["error"]
+
+    def test_handler_marks_media_for_gateway_delivery(self, tmp_path, monkeypatch):
+        from plugins.music_gen import minimax
+
+        monkeypatch.setenv("MINIMAX_API_KEY", "mk-test")
+        hex_audio = b"mp3-bytes".hex()
+        with patch.object(minimax, "_resolve_gateway", return_value=None), \
+             patch.object(minimax, "_post", return_value=_ok_response(hex_audio)):
+            out = minimax._generate_music_handler({"prompt": "chiptune"})
+
+        result = json.loads(out)
+        assert result["MEDIA"] == result["file"]
+        assert Path(result["file"]).is_relative_to(tmp_path)
+        assert result["mode"] == "song"
+
+    def test_handler_error_has_no_media_key(self):
+        from plugins.music_gen import minimax
+
+        with patch.object(minimax, "_resolve_gateway", return_value=None):
+            out = minimax._generate_music_handler({"prompt": "chiptune"})
+        result = json.loads(out)
+        assert "MEDIA" not in result
+        assert "No MiniMax credential" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Manifest sanity
+# ---------------------------------------------------------------------------
+
+
+class TestManifest:
+    def test_plugin_yaml_parses_with_backend_kind(self):
+        import yaml
+
+        manifest_path = (
+            Path(__file__).resolve().parents[3]
+            / "plugins" / "music_gen" / "minimax" / "plugin.yaml"
+        )
+        data = yaml.safe_load(manifest_path.read_text())
+        assert data["name"] == "minimax-music"
+        assert data["kind"] == "backend"
+        assert data["author"] == "NousResearch"
+        assert data["requires_env"] == ["MINIMAX_API_KEY"]


### PR DESCRIPTION
## Why

The Hermes Media Studio plugin (publishing soon) generates music through MiniMax — full-song renders (music-3.0), a lyrics helper, and a cover flow. The agent should be able to do the same from chat. This promotes the battle-tested user plugin in-tree as `plugins/music_gen/minimax`, the music counterpart of `plugins/image_gen/krea` and `plugins/video_gen/fal`.

Draft until the portal side lands: tool-gateway PR (managed `minimax` route — synchronous billed passthrough) + NousResearch/nous-account-service#928 (coverage category + pricing seams). The plugin works TODAY with BYOK (`MINIMAX_API_KEY`, the same key the built-in MiniMax TTS provider uses) and flips to portal credits automatically when the gateway route deploys.

## What

- `plugins/music_gen/minimax/` — registers a `generate_music` tool (toolset `music_gen`, plugin-discovered; zero core-schema footprint, no core file edits, `toolsets.py` untouched).
- Credential ladder: managed Nous gateway (`resolve_managed_tool_gateway("minimax")`) preferred, guarded by a reachability probe since the route doesn't exist yet (NXDOMAIN → steer BYOK, so no calls die at a dead origin); `MINIMAX_API_KEY` fallback. `check_fn` surfaces the tool only when either credential resolves.
- URL shape matches the gateway contract: versionless base (`https://api.minimax.io` / gateway origin), `/v1/...` in the request paths — the gateway allowlists `POST /v1/music_generation` exactly.
- Synchronous render materialized under `get_hermes_home()/cache/music` (profile-safe; MiniMax result URLs expire in 24h, so we always persist).
- MiniMax's in-body error contract handled: HTTP 200 with `base_resp.status_code != 0` maps to actionable hints (1002 rate limit, 1008 vendor balance, 1026 moderation, 2013 params). The lyrics-optimizer quirk is encoded: the `lyrics` field must be ABSENT (not empty) for auto-write, or MiniMax 2013s.
- Modes: song (lyrics or auto-written), instrumental (`is_instrumental`, no lyrics sent), cover (`music-cover` + reference URL/base64 ≤50MB).

## Tests

`tests/plugins/music_gen/test_minimax_music.py` — 26 tests, house idiom (stdlib + pytest + mock, no live network, temp `HERMES_HOME`): availability ladder (key / gateway / neither), payload shapes (lyrics verbatim vs optimizer-absent vs instrumental), base_resp error mapping, url-vs-hex materialization, profile-safe output paths.

`scripts/run_tests.sh tests/plugins/music_gen/` → 26/26. (`tests/tools/test_plugin_guard.py` has 5 pre-existing failures reproduced identically on clean origin/main — unrelated.)

## Footprint

Plugin rung of the ladder: no new core tool, no env-var docs pointing users at `.env` for behavior (the key IS a credential), no cross-toolset schema references. `hermes tools` picks up the `music_gen` toolset through existing plugin discovery.
