### PR TITLE
docs(sdk): document profiles.list preferred_session_ids lookup

### DIFF
--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -495,7 +495,12 @@ preserves backend identity without exposing connection secrets.
 Profile-shaped plugins get first-class methods too:
 `profiles.list` (each profile + its most recent conversation as
 `last_session`; pass `include_sessions: false` to skip the per-profile DB
-probe) and `profiles.create` (`name`, `description`, `clone_from`,
+probe; pass `preferred_session_ids: { profileName: sessionId }` for an
+exact, existence-checked lookup of one pinned session per profile — each
+named row gains a `preferred_session` summary that resolves hidden rows
+and compression lineages to their live tip, or `null` when the id is
+definitively gone; older gateways ignore the param and omit the field)
+and `profiles.create` (`name`, `description`, `clone_from`,
 `clone_all`, `no_skills`, `soul`, optional `model` + `provider` pin) — the
 ws twins of the dashboard's `/api/profiles` REST routes.
 `host.state.busy` is the focused chat's live turn (thinking and streaming).


### PR DESCRIPTION
## Summary

Documents the `preferred_session_ids` param on `profiles.list` that shipped in PR #88690 — the desktop-plugin-SDK page now covers the precise per-profile pinned-session lookup (hidden-row resolution, compression-lineage tips, `null` = definitively gone, older-gateway behavior).

## Changes

- `website/docs/developer-guide/desktop-plugin-sdk.md`: extend the `profiles.list` bullet with the `preferred_session_ids` request param and the `preferred_session` response field.

## Validation

Docs-only; wording matches the merged backend contract in `tui_gateway/methods_profiles.py`.

## Infographic

![profiles.list preferred_session docs](https://v3b.fal.media/files/b/0aa6c124/sxdoDRG3Y5E6H1UTcV5xI_ysKwBNbL.png)
