### PR TITLE
fix(sessions): fence reset lineage in display/resume walker

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -71,7 +71,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _PREVIEW_RAW_SELECT,
     _RECOVERABLE_END_REASONS,
     _RECOVERABLE_END_REASONS_SQL,
-    is_automatic_end_reason,
+    _RESET_CHILD_SQL,
     _RESET_END_REASONS,
     _RESET_END_REASONS_SQL,
     _ephemeral_child_sql,
@@ -80,6 +80,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _sql_session_last_active,
     _sql_session_last_active_by_id,
     escape_like as _escape_like,
+    is_automatic_end_reason,
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
     FTS_REBUILD_DEFERRAL_KEY,
@@ -14589,16 +14590,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         identifier — used for Nous Portal ``conversation=`` usage tagging.
         Returns *session_id* unchanged when it has no recorded parent.
         """
-        chain = self._session_lineage_root_to_tip(session_id)
+        chain = self._session_lineage_root_to_tip(session_id, stop_at_reset=False)
         return (chain[0] if chain and chain[0] else session_id)
 
-    def _session_lineage_root_to_tip(self, session_id: str) -> List[str]:
+    def _session_lineage_root_to_tip(self, session_id: str, stop_at_reset: bool = True) -> List[str]:
         if not session_id:
             return [session_id]
 
         chain = []
         current = session_id
         seen = set()
+        reset_clause = _RESET_CHILD_SQL.format(a="s")
         with self._read_ctx() as conn:
             for _ in range(100):
                 if not current or current in seen:
@@ -14606,10 +14608,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 seen.add(current)
                 chain.append(current)
                 row = conn.execute(
-                    "SELECT parent_session_id FROM sessions WHERE id = ?",
+                    f"SELECT s.parent_session_id, ({reset_clause}) AS is_reset_child "
+                    "FROM sessions AS s WHERE s.id = ?",
                     (current,),
                 ).fetchone()
                 if row is None:
+                    break
+                # A /new (or auto) reset starts a separate user-visible
+                # conversation; its parent's transcript must not be replayed
+                # into the child (hermes_state_common: "A reset starts a
+                # separate user-visible conversation..."). Mirror
+                # resolve_resume_session_id's reset-child exclusion.
+                if stop_at_reset and row["is_reset_child"]:
                     break
                 current = row["parent_session_id"] if hasattr(row, "keys") else row[0]
         return list(reversed(chain)) or [session_id]

--- a/tests/hermes_state/test_replay_lineage_reset_boundary.py
+++ b/tests/hermes_state/test_replay_lineage_reset_boundary.py
@@ -1,0 +1,91 @@
+"""Regression guard: reset lineage must not replay a parent's transcript.
+
+A ``/new`` (or auto) reset starts a separate user-visible conversation even
+though the gateway retains ``parent_session_id`` for durable lineage
+(``hermes_state_common._RESET_CHILD_SQL``). The backward lineage walker used
+by display/resume paths (``get_resume_conversations``,
+``get_ancestor_display_prefix``, ``get_messages_as_conversation(include_ancestors=True)``)
+used to follow reset edges all the way to the root, prepending the reset-away
+parent's messages to the child's transcript while ``sessions export`` showed
+only the child's own messages. These tests pin the reset fence and confirm
+compression continuations and ``get_conversation_root`` are unchanged.
+"""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _user_texts(messages):
+    return [m.get("content") for m in messages if m.get("role") == "user"]
+
+
+def test_reset_child_does_not_replay_parent_transcript(db):
+    db.create_session("parent", "telegram", session_key="lane")
+    db.append_message("parent", "user", "parent msg")
+    db.end_session("parent", "session_reset")
+    db.create_session(
+        "child",
+        "telegram",
+        session_key="lane",
+        parent_session_id="parent",
+        model_config={"_reset_from": "parent"},
+    )
+    db.append_message("child", "user", "child msg")
+
+    _, display = db.get_resume_conversations("child")
+    assert _user_texts(display) == ["child msg"]
+    assert db.get_ancestor_display_prefix("child") == []
+    assert _user_texts(
+        db.get_messages_as_conversation("child", include_ancestors=True)
+    ) == ["child msg"]
+
+
+def test_legacy_markerless_reset_child_does_not_replay_parent(db):
+    # Pre-marker on-disk shape: no ``_reset_from``, but the child rides the
+    # parent's exact routing key and the parent ended at a reset boundary.
+    db.create_session("parent", "telegram", session_key="lane")
+    db.append_message("parent", "user", "parent msg")
+    db.end_session("parent", "daily")
+    db.create_session(
+        "child", "telegram", session_key="lane", parent_session_id="parent"
+    )
+    db.append_message("child", "user", "child msg")
+
+    _, display = db.get_resume_conversations("child")
+    assert _user_texts(display) == ["child msg"]
+    assert db.get_ancestor_display_prefix("child") == []
+
+
+def test_compression_child_still_replays_ancestors(db):
+    db.create_session("parent", "telegram", session_key="lane")
+    db.append_message("parent", "user", "parent msg")
+    db.end_session("parent", "compression")
+    db.create_session(
+        "child", "telegram", session_key="lane", parent_session_id="parent"
+    )
+    db.append_message("child", "user", "child msg")
+
+    _, display = db.get_resume_conversations("child")
+    assert _user_texts(display) == ["parent msg", "child msg"]
+    assert _user_texts(db.get_ancestor_display_prefix("child")) == ["parent msg"]
+
+
+def test_conversation_root_still_walks_reset_boundary(db):
+    # get_conversation_root is the stable billing/usage-tag id; it must keep
+    # walking through reset edges (stop_at_reset=False), unlike display/resume.
+    db.create_session("parent", "telegram", session_key="lane")
+    db.end_session("parent", "session_reset")
+    db.create_session(
+        "child",
+        "telegram",
+        session_key="lane",
+        parent_session_id="parent",
+        model_config={"_reset_from": "parent"},
+    )
+    assert db.get_conversation_root("child") == "parent"


### PR DESCRIPTION
## Problem

Opening a `/new`- or auto-reset child session in the TUI/desktop prepends its reset-away parent's full transcript, while `sessions export` correctly shows only the child's own messages. The two surfaces disagree on what a session contains.

Concrete case: a Telegram daily-reset child (`parent_session_id` + `_reset_from` marker) shows the previous session's conversation stitched on top of its own "produce a chart…" conversation.

## Root cause

The backward lineage walker `SessionDB._session_lineage_root_to_tip()` follows every `parent_session_id` to the root without distinguishing edge type. It feeds the display/resume paths:

- `get_resume_conversations` (via `session.resume` → TUI/desktop)
- `get_ancestor_display_prefix`
- `get_messages_as_conversation(include_ancestors=True)`
- `get_resume_message_count` / `assert_resume_safe`

so a reset child replayed its parent's messages. The forward walker `resolve_resume_session_id` already excludes reset children (#84284, fixed in `91c7a67f4`), but the backward walker was left unfenced — the same root cause as #77375 (which covers the `_branched_from` edge) applied to the reset edge.

## Fix

Stop the walker at reset children, reusing the same `_RESET_CHILD_SQL` predicate the forward walker already applies (the `_reset_from` marker or the legacy same-key heuristic):

- `_session_lineage_root_to_tip(..., stop_at_reset=True)` — default fences reset edges.
- `get_conversation_root` passes `stop_at_reset=False` so the stable Portal `conversation=` billing id still walks to the root (unchanged).

Display/resume and export now agree: each reset segment shows only its own messages.

## Regression coverage

`tests/hermes_state/test_replay_lineage_reset_boundary.py`:

- reset child (marker shape) → parent transcript not replayed
- reset child (legacy markerless shape) → parent transcript not replayed
- compression continuation → still replays ancestors (no regression)
- `get_conversation_root` → still walks reset edges

## Related

- #77375 — branch edge leaks parent turns (same walker, `_branched_from` edge)
- #84284 — reset edge, forward walker (`resolve_resume_session_id`)
- #84870 / #84109 — reset lineage in session lists

## Open question

Should `get_conversation_root` (Portal `conversation=` billing id) also stop at reset boundaries? Kept as `stop_at_reset=False` to preserve current billing behavior; happy to flip if a reset should split the billing id.
