### PR TITLE
fix(compaction): unset native threshold follows the local trigger

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2205,20 +2205,26 @@ def init_agent(
         _compression_cfg.get("codex_responses_native", False)
     )
     _native_threshold_raw = _compression_cfg.get(
-        "codex_responses_compact_threshold", 200_000
+        "codex_responses_compact_threshold"
     )
-    try:
-        if isinstance(_native_threshold_raw, bool):
-            raise ValueError
-        codex_responses_compact_threshold = int(_native_threshold_raw)
-        if codex_responses_compact_threshold <= 0:
-            raise ValueError
-    except (TypeError, ValueError):
-        _ra().logger.warning(
-            "Invalid compression.codex_responses_compact_threshold=%r; using 200000.",
-            _native_threshold_raw,
-        )
-        codex_responses_compact_threshold = 200_000
+    codex_responses_compact_threshold = None  # unset → follow the local trigger
+    if _native_threshold_raw is not None:
+        try:
+            if isinstance(_native_threshold_raw, bool):
+                raise ValueError
+            codex_responses_compact_threshold = int(_native_threshold_raw)
+            if codex_responses_compact_threshold <= 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            _ra().logger.warning(
+                "Invalid compression.codex_responses_compact_threshold=%r; using 200000.",
+                _native_threshold_raw,
+            )
+            codex_responses_compact_threshold = 200_000
+    # A fixed 200K default predates the Codex OAuth 900K window and made
+    # server-side compaction fire ~565K below the window the model serves;
+    # None keeps the threshold tracking the local compressor trigger
+    # (#88695). An explicit value still wins.
     # Opt-in idle compaction: compact a session up front when it resumes after
     # this many seconds of inactivity (0 = disabled). Time-based, so it
     # complements the size-based threshold above. Consumed by build_turn_context().

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -76,19 +76,31 @@ def resolve_compact_threshold(
     configured_threshold: Any,
     local_trigger_tokens: Any = None,
 ) -> int:
-    """Clamp the configured native threshold below the local compressor trigger.
+    """Resolve the native compaction threshold, clamped below the local trigger.
 
     Without the clamp a native threshold above the local trigger would let the
     local summarizer fire first every time, making native compaction dead
     config. ``local_trigger_tokens`` is ``ContextCompressor.threshold_tokens``
     when a compressor is attached, else None.
+
+    ``configured_threshold=None`` means the user never set
+    ``compression.codex_responses_compact_threshold``: the threshold then
+    FOLLOWS the local compressor trigger (trigger − margin) instead of the
+    fixed 200K default. A fixed default that predates the Codex OAuth 900K
+    window made server-side compaction always fire first at ~200K, silently
+    cutting sessions ~565K tokens below the window the model actually serves
+    (#88695). An explicit configuration still wins exactly as before
+    (clamped below the local trigger).
     """
-    try:
-        configured = int(configured_threshold)
-    except (TypeError, ValueError):
-        configured = DEFAULT_COMPACT_THRESHOLD
-    if isinstance(configured_threshold, bool) or configured <= 0:
-        configured = DEFAULT_COMPACT_THRESHOLD
+    follows_local = configured_threshold is None
+    configured = DEFAULT_COMPACT_THRESHOLD
+    if not follows_local:
+        try:
+            configured = int(configured_threshold)
+        except (TypeError, ValueError):
+            configured = DEFAULT_COMPACT_THRESHOLD
+        if isinstance(configured_threshold, bool) or configured <= 0:
+            configured = DEFAULT_COMPACT_THRESHOLD
 
     local = None
     try:
@@ -103,6 +115,8 @@ def resolve_compact_threshold(
         upper = local - LOCAL_TRIGGER_SAFETY_MARGIN
     else:
         upper = max(1_024, int(local * 0.8))
+    if follows_local:
+        return upper
     return max(1_024, min(configured, upper))
 
 
@@ -138,7 +152,7 @@ def native_compaction_context_management(
 
     compressor = getattr(agent, "context_compressor", None)
     threshold = resolve_compact_threshold(
-        getattr(agent, "codex_responses_compact_threshold", DEFAULT_COMPACT_THRESHOLD),
+        getattr(agent, "codex_responses_compact_threshold", None),
         getattr(compressor, "threshold_tokens", None) if compressor is not None else None,
     )
     return [{"type": "compaction", "compact_threshold": threshold}]

--- a/tests/run_agent/test_native_compaction.py
+++ b/tests/run_agent/test_native_compaction.py
@@ -162,6 +162,55 @@ class TestThresholdClamp:
         assert resolve_compact_threshold(200_000, 4_000) >= 1_024
 
 
+class TestUnsetThresholdFollowsLocalTrigger:
+    """#88695 — unset config must track the local compressor trigger.
+
+    The fixed 200K default predates the Codex OAuth 900K window
+    (bab7be3ca7 raised the local trigger to ~765K): min(200K, local−margin)
+    always fired server-side first at ~200K, silently cutting sessions
+    ~565K tokens below the window the model serves. None (unset) now
+    follows local − margin; an explicit value still wins exactly as
+    before."""
+
+    def test_unset_follows_local_trigger_on_wide_window(self):
+        local = 765_000  # 85% of the 900K window
+        assert (
+            resolve_compact_threshold(None, local)
+            == local - 8_192
+        )
+
+    def test_unset_without_local_uses_default(self):
+        assert resolve_compact_threshold(None, None) == DEFAULT_COMPACT_THRESHOLD
+
+    def test_unset_tiny_local_stays_positive(self):
+        assert resolve_compact_threshold(None, 4_000) >= 1_024
+
+    def test_explicit_value_still_clamped_below_local(self):
+        # An explicit 300K on a 900K window is honored (below the 757K
+        # upper clamp) — the follow-local change must not override user
+        # configuration.
+        assert resolve_compact_threshold(300_000, 765_000) == 300_000
+        # ... and still clamped down when it would exceed the trigger.
+        assert (
+            resolve_compact_threshold(800_000, 765_000)
+            == 765_000 - 8_192
+        )
+
+    def test_agent_without_threshold_attribute_follows_trigger(self):
+        compressor = SimpleNamespace(threshold_tokens=765_000)
+        agent = SimpleNamespace(
+            model="gpt-5.6",
+            base_url="https://api.openai.com/v1",
+            codex_responses_native_compaction=True,
+            compression_enabled=True,
+            context_compressor=compressor,
+        )  # no codex_responses_compact_threshold attribute at all
+        payload = native_compaction_context_management(
+            agent, is_codex_backend=False
+        )
+        assert payload[0]["compact_threshold"] == 765_000 - 8_192
+
+
 class TestRejectionMatcher:
     def test_structured_param_rejection_matches(self):
         assert is_native_compaction_rejection(


### PR DESCRIPTION
## What does this PR do?

`bab7be3ca7` raised the Codex OAuth context window to 900K — the local compressor's trigger scaled up automatically (~765K at 85%), but the native Responses compaction threshold did not: whenever `compression.codex_responses_compact_threshold` is unset (the shipped default), the request sends the absolute `DEFAULT_COMPACT_THRESHOLD = 200_000`, a constant that predates the window lift. `resolve_compact_threshold` only clamps **down** (`min(configured, local − 8192)`), so `min(200K, 757K) = 200K`: server-side compaction always fired first at ~200K, and users running `compression.codex_responses_native: true` on gpt-5.6-family / gpt-.5.4 subscription models silently lost ~565K tokens of the window the model actually serves (the reporter's session was cut 193K → 38K at ~21% window usage) (#88695).

Unset config now **follows the local compressor trigger** (`trigger − 8192` margin): `agent_init` keeps the attribute `None` when the key is absent, the call site passes `None` through, and `resolve_compact_threshold` returns the upper clamp for `None`. Explicit configuration still wins exactly as before (clamped below the local trigger), and invalid values (bools, ≤0, garbage) still fall back to 200K with the same warning — those paths are byte-identical.

## Related Issue

Fixes #88695

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/native_compaction.py`: `resolve_compact_threshold` treats `None` (unset) as "follow the local trigger" and returns the upper clamp; docstring documents the 900K-window hazard (#88695); the call site's `getattr` fallback changed from `DEFAULT_COMPACT_THRESHOLD` to `None`
- `agent/agent_init.py`: the threshold is read with a `None` sentinel when `compression.codex_responses_compact_threshold` is absent (invalid values keep the existing 200K fallback + warning)
- `tests/run_agent/test_native_compaction.py`: new `TestUnsetThresholdFollowsLocalTrigger` class

## How to Test

1. `python -m pytest tests/run_agent/test_native_compaction.py -q` — Observed result: 57 passed (52 pre-existing + 5 new).
2. New tests pin: unset + 765K trigger → 756,808 (the 900K window is actually usable); unset + no compressor → 200K default; unset + tiny trigger stays positive; explicit 300K still honored below the clamp and explicit 800K still clamped to 757K; an agent without the attribute at all follows the trigger.
3. `python -m pytest tests/run_agent -q` — Observed result: 1609 passed, 89 failed — the failure set is byte-identical with this change stashed (89 failed / 1604 passed at baseline): pre-existing local environment noise, zero regressions from this change.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the native-compaction suite (57 passed) and the full run_agent suite with a stashed baseline comparison (identical failure set)
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — the shipped default semantics change is documented in the touched docstrings with the #88695 reference; `config_defaults.py`'s display value is left untouched (an explicit value still behaves identically)

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/run_agent/test_native_compaction.py -q
57 passed in 1.97s
```
