### PR TITLE
fix(agent): preserve delivered Codex commentary on empty continuation

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3173,6 +3173,65 @@ def run_conversation(
                             error_details.append("response.choices is empty")
 
                 if response_invalid:
+                    # Codex can emit a complete user-visible answer as a
+                    # ``phase=commentary`` item, which the continuation path
+                    # deliberately treats as incomplete and delivers
+                    # immediately.  If the requested continuation then comes
+                    # back as a successful but empty response, retrying cannot
+                    # improve the answer the user already saw.  Worse, the
+                    # terminal provider error replaces that transient bubble
+                    # and the commentary-only row can disappear on reload.
+                    #
+                    # Recover only text that this turn actually delivered.
+                    # Hidden reasoning/commentary must never be promoted to a
+                    # final answer, and failures before any visible progress
+                    # must retain the normal retry/fallback behaviour.
+                    _recovered_codex_commentary = False
+                    if (
+                        agent.api_mode == "codex_responses"
+                        and getattr(agent, "_codex_incomplete_retries", 0) > 0
+                    ):
+                        _tail = messages[-1] if messages else None
+                        if (
+                            isinstance(_tail, dict)
+                            and _tail.get("role") == "assistant"
+                            and _tail.get("finish_reason") == "incomplete"
+                        ):
+                            _visible = agent._interim_assistant_visible_text(_tail)
+                            if (
+                                _visible
+                                and agent._interim_text_was_delivered(_visible)
+                            ):
+                                _tail["content"] = _visible
+                                _tail["finish_reason"] = "stop"
+                                for _key in (
+                                    "reasoning",
+                                    "reasoning_content",
+                                    "reasoning_details",
+                                    "codex_reasoning_items",
+                                    "codex_message_items",
+                                    "api_content",
+                                ):
+                                    _tail.pop(_key, None)
+                                # The incomplete row may already have reached
+                                # SessionDB.  Force the final snapshot to
+                                # rewrite its now-durable content.
+                                _tail.pop("_db_persisted", None)
+                                agent._db_flush_scan_prefix = None
+                                agent._codex_incomplete_retries = 0
+                                agent._response_was_previewed = True
+                                final_response = _visible
+                                _turn_exit_reason = (
+                                    "codex_delivered_commentary_recovered_after_empty"
+                                )
+                                _recovered_codex_commentary = True
+                                logger.info(
+                                    "Recovered delivered Codex commentary as "
+                                    "the final response after an empty continuation"
+                                )
+                    if _recovered_codex_commentary:
+                        break
+
                     agent._invoke_api_request_error_hook(
                         task_id=effective_task_id,
                         turn_id=turn_id,
@@ -6424,6 +6483,9 @@ def run_conversation(
             agent.iteration_budget.refund()
             _retry.restart_with_redirected_messages = False
             continue
+
+        if _turn_exit_reason == "codex_delivered_commentary_recovered_after_empty":
+            break
 
         # If the API call was interrupted, skip response processing
         if interrupted:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -183,6 +183,16 @@ def _codex_commentary_message_response(text: str):
     )
 
 
+def _codex_empty_response():
+    return SimpleNamespace(
+        output=[],
+        output_text="",
+        usage=SimpleNamespace(input_tokens=4, output_tokens=0, total_tokens=4),
+        status="completed",
+        model="gpt-5-codex",
+    )
+
+
 def _codex_commentary_final_tool_response(commentary: str, final_answer: str = "Done."):
     return SimpleNamespace(
         output=[
@@ -1677,6 +1687,69 @@ def test_normalize_codex_response_does_not_fallback_to_output_text_for_commentar
     assert (assistant_message.content or "") == ""
     assert "call the tool" in (assistant_message.reasoning or "")
     assert assistant_message.codex_message_items[0]["phase"] == "commentary"
+
+
+def test_codex_empty_after_delivered_commentary_recovers_visible_response(monkeypatch):
+    """A completed commentary bubble must survive an empty continuation.
+
+    Codex can classify a short final answer as ``phase=commentary``. Hermes
+    displays that item, asks Codex for a separate final answer, and can then
+    receive a genuinely empty completion. Preserve the already-delivered text
+    as the durable final response instead of replacing it with a provider
+    error or dropping it when the session reloads.
+    """
+    agent = _build_agent(monkeypatch)
+    delivered = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: delivered.append(text)
+    )
+    responses = [
+        _codex_commentary_message_response("Pong."),
+        _codex_empty_response(),
+    ]
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: responses.pop(0),
+    )
+
+    result = agent.run_conversation("ping")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Pong."
+    assert result.get("error") is None
+    assert delivered == ["Pong."]
+    assistant_rows = [
+        message for message in result["messages"]
+        if message.get("role") == "assistant"
+    ]
+    assert [message.get("content") for message in assistant_rows] == ["Pong."]
+    assert assistant_rows[0].get("finish_reason") == "stop"
+    assert not assistant_rows[0].get("codex_message_items")
+    assert result["response_previewed"] is True
+
+
+def test_codex_empty_after_undelivered_commentary_keeps_retry_behaviour(monkeypatch):
+    """Never promote commentary that was not exposed to the user."""
+    agent = _build_agent(monkeypatch)
+    responses = [
+        _codex_commentary_message_response("Internal progress."),
+        _codex_empty_response(),
+        _codex_empty_response(),
+        _codex_empty_response(),
+    ]
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: responses.pop(0),
+    )
+
+    result = agent.run_conversation("ping")
+
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert "Invalid API response" in result["final_response"]
+    assert len(responses) == 0
 
 
 


### PR DESCRIPTION
## What does this PR do?

Preserves a user-visible Codex commentary answer when Hermes asks for a final-answer continuation and that continuation returns a successful but empty response.

Previously, a short answer such as `Pong.` could be emitted by Codex as `phase=commentary`. Hermes displayed it as an interim bubble, then requested a separate final answer. If that continuation was empty, the API validation retry path eventually replaced the visible answer with an `Invalid API response` / `No response from provider` failure. Because the commentary-only row remained incomplete, it could also disappear when the session was settled or reloaded.

The recovery is intentionally narrow: it only promotes an incomplete commentary row when Hermes recorded that exact text as already delivered during the current user turn. Undelivered commentary and hidden reasoning retain the existing retry and fallback behaviour.

## Related Issue

No matching upstream issue or PR found after searching the open tracker. Reproduced on a production WebUI/Desktop installation and captured in a regression test.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Recover already-delivered Codex commentary before the generic invalid-response retry path handles an empty continuation.
- Convert the recovered interim row into one durable `finish_reason=stop` assistant message.
- Remove Responses API commentary/reasoning sidecars and invalidate any incremental-persistence marker so reloads keep the final answer without replaying commentary.
- Add positive and negative regression coverage for delivered versus undelivered commentary.

## How to Test

1. Run `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -q`.
2. Run the adjacent adapter, persistence, interim-display, verification and gateway tests listed below.
3. With a Codex Responses provider, return a commentary-only `Pong.` followed by an empty completed response; confirm the turn completes with one durable assistant row containing `Pong.` and no provider error.

## Validation

- `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -q` — 49 passed.
- Seven adjacent test files covering the Responses adapter, interim delivery, persistence, verification and gateway settlement — 61 passed.
- `ruff check agent/conversation_loop.py tests/run_agent/test_run_agent_codex_responses.py` — passed.
- `git diff --check` — passed.
- Full test suite was started but intentionally interrupted; unrelated optional-dependency and sandbox-network failures had already appeared. No full-suite pass is claimed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete `scripts/run_tests.sh` suite successfully (targeted and adjacent suites pass; see Validation)
- [x] I've added tests for my changes
- [x] I've tested on macOS; the original symptom was observed on an Ubuntu-hosted Hermes WebUI

### Documentation & Housekeeping

- [x] Documentation update — N/A; no public interface or configuration changed
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no workflow or architecture change
- [x] Cross-platform impact considered; the change is platform-independent Python state handling
- [x] Tool descriptions/schemas update — N/A; no tool behaviour changed

## Screenshots / Logs

The regression test fails on unmodified upstream by exhausting the empty-response retry path and returning `completed=False`. With this commit it returns `completed=True`, `final_response="Pong."`, one durable assistant row, and `response_previewed=True` without re-emitting the response.
