### PR TITLE
feat(skills): add skills.external_repo for git-backed shared skills

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -30,6 +30,7 @@ EXCLUDED_SKILL_DIRS = frozenset(
         ".git",
         ".github",
         ".hub",
+        ".repo-sync",
         ".archive",
         ".venv",
         "venv",
@@ -558,15 +559,10 @@ def get_external_skills_dirs() -> List[Path]:
         return []
 
     raw_dirs = skills_cfg.get("external_dirs")
-    if not raw_dirs:
-        result: List[Path] = []
-        if cache_key is not None:
-            _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
-        return result
     if isinstance(raw_dirs, str):
         raw_dirs = [raw_dirs]
     if not isinstance(raw_dirs, list):
-        return []
+        raw_dirs = []
 
     from hermes_constants import get_hermes_home
 
@@ -596,6 +592,28 @@ def get_external_skills_dirs() -> List[Path]:
             result.append(p)
         else:
             logger.debug("External skills dir does not exist, skipping: %s", p)
+
+    # Add the configured external_repo checkout, if one is present on disk.
+    # The clone/pull itself happens at startup (tools.skills_repo_sync);
+    # this function is read-only so the hot scanner path never touches the
+    # network.  A repo enabled but not yet cloned simply contributes nothing.
+    try:
+        from tools.skills_repo_sync import get_external_repo_config, get_repo_skills_dir
+
+        repo_cfg = get_external_repo_config()
+        if repo_cfg and repo_cfg.get("enabled"):
+            url = str(repo_cfg.get("url", "")).strip()
+            subdir = str(repo_cfg.get("path", "")).strip()
+            if url:
+                repo_skills_dir = get_repo_skills_dir(url, subdir)
+                if repo_skills_dir is not None:
+                    rp = repo_skills_dir.resolve()
+                    if rp != local_skills and rp not in seen and rp.is_dir():
+                        seen.add(rp)
+                        result.append(rp)
+    except Exception:
+        # A broken repo config must never break skill discovery.
+        logger.debug("Could not resolve external_repo skills dir", exc_info=True)
 
     if cache_key is not None:
         _EXTERNAL_DIRS_CACHE[cache_key] = list(result)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -936,6 +936,18 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Git repository skills — keep the agent's skills in ONE repo across
+  # MULTIPLE HERMES INSTALLS (server, laptop, desktop app).  When enabled,
+  # the repo is the live home of agent skills: Hermes pulls it at startup
+  # and pushes every agent-created/modified skill back (debounced, best
+  # effort) into a checkout under ~/.hermes/skills/.repo-sync/.  Sync
+  # failures are silent and never block the agent.
+  # external_repo:
+  #   enabled: true
+  #   url: https://github.com/you/my-skills.git
+  #   branch: main        # optional; empty = remote default branch
+  #   path: ""            # optional; subdir of the repo holding SKILL.md files
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2019,6 +2019,21 @@ DEFAULT_CONFIG = {
         # and single-mutation `hermes curator rollback <entry-id>`.
         # Telemetry, never a gate: ledger failures cannot block a mutation.
         "ledger": True,
+        # Optionally keep the agent's skills in a shared git repo across
+        # multiple Hermes installations (server, laptop, desktop app).  When
+        # enabled, the repo is the *live home* of agent skills: Hermes pulls
+        # it at startup and pushes every agent-created/modified skill back
+        # (debounced, best-effort) into a checkout under
+        # $HERMES_HOME/skills/.repo-sync/, exposed like an entry of
+        # `external_dirs`.  One repo = every install on the same skills.
+        # Sync failures are silent and never block the agent — the last good
+        # checkout keeps serving.
+        "external_repo": {
+            "enabled": False,
+            "url": "",        # e.g. "https://github.com/owner/skills.git"
+            "branch": "",     # empty = the remote default branch
+            "path": "",       # optional subdir of the repo holding SKILL.md files
+        },
     },
 
     # Curator — background skill maintenance.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2883,6 +2883,13 @@ def _sync_bundled_skills_quietly() -> None:
     except Exception:
         pass
 
+    try:
+        from tools.skills_repo_sync import sync_external_repo
+
+        sync_external_repo(quiet=True)
+    except Exception:
+        pass
+
 
 def _resolve_use_tui(args) -> bool:
     """Decide whether to launch the TUI for a chat/bare invocation.

--- a/tests/tools/test_skills_repo_sync.py
+++ b/tests/tools/test_skills_repo_sync.py
@@ -1,0 +1,299 @@
+"""Tests for tools/skills_repo_sync.py — git-repo-backed skills.
+
+Uses REAL bare git remotes (the GitHub-like case) so the clone/pull/push
+paths are exercised end-to-end, not mocked.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from tools.skills_repo_sync import (
+    _repo_slug,
+    external_repo_enabled,
+    get_checkout_dir,
+    get_repo_skills_dir,
+    get_repo_write_dir,
+    maybe_push_external_repo,
+    sync_external_repo,
+)
+
+
+def _rmtree(path: Path) -> None:
+    shutil.rmtree(path, ignore_errors=True)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _write_config(hermes_home: Path, *, enabled: bool = True,
+                  url: str = "", branch: str = "", path: str = "") -> None:
+    """Write a config.yaml under hermes_home with skills.external_repo set."""
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    branch_line = f"    branch: {branch}\n" if branch else ""
+    path_line = f"    path: {path}\n" if path else ""
+    hermes_home.joinpath("config.yaml").write_text(
+        f"""skills:
+  external_repo:
+    enabled: {str(enabled).lower()}
+    url: "{url}"
+{branch_line}{path_line}
+""".strip(),
+        encoding="utf-8",
+    )
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True)
+
+
+def _init_bare(root: Path) -> Path:
+    """Create a bare remote repo (the GitHub-like case).
+
+    Pins the bare HEAD to ``refs/heads/main`` so clones follow the ``main``
+    branch — ``git init --bare`` defaults HEAD to the (phantom) ``master``,
+    which makes clones warn and the test suite flaky.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "--bare", "-q", str(root)], check=True)
+    subprocess.run(
+        ["git", "-C", str(root), "symbolic-ref", "HEAD", "refs/heads/main"],
+        check=True,
+    )
+    return root
+
+
+def _seed_bare(bare: Path, *skills: str, subdir: str = "category") -> None:
+    """Push skills into a bare remote from a throwaway worktree clone."""
+    work = bare.parent / ("seed-" + bare.name)
+    if work.exists():
+        _rmtree(work)
+    subprocess.run(["git", "clone", "-q", str(bare), str(work)], check=True)
+    _git(work, "config", "user.email", "t@t")
+    _git(work, "config", "user.name", "t")
+    # The very first seed on an empty bare repo has no branch checked out;
+    # create + pin `main` so the push lands on the right ref.
+    head = subprocess.run(
+        ["git", "-C", str(work), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    if head == "HEAD":
+        _git(work, "checkout", "-q", "-b", "main")
+    for name in skills:
+        skill_dir = work / subdir / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        skill_dir.joinpath("SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: Test skill {name}\n---\n\n# {name}\n",
+            encoding="utf-8",
+        )
+    _git(work, "add", "-A")
+    if subprocess.run(["git", "-C", str(work), "diff", "--cached", "--quiet"],
+                      check=False).returncode != 0:
+        _git(work, "commit", "-qm", "seed skills")
+    _git(work, "push", "-qu", "origin", "main")
+
+
+def _worktree(bare: Path) -> Path:
+    """A fresh clone of the bare remote, used to inspect pushed content."""
+    work = bare.parent / ("check-" + bare.name)
+    subprocess.run(["git", "clone", "-q", str(bare), str(work)], check=True)
+    return work
+
+
+def _head_sha(bare: Path) -> str:
+    """Current HEAD sha of the bare remote's default branch."""
+    return subprocess.run(
+        ["git", "-C", str(bare), "rev-parse", "main"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def _setup_env(monkeypatch, tmp_path: Path) -> Path:
+    """Point HERMES_HOME at a fresh temp dir and clear caches."""
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    from agent import skill_utils
+
+    skill_utils._external_dirs_cache_clear()
+    getattr(skill_utils, "_raw_config_cache_clear", lambda: None)()
+    return hermes_home
+
+
+# ── Slug ───────────────────────────────────────────────────────────────────
+
+
+class TestRepoSlug:
+    def test_https_and_ssh_slug_to_owner_repo(self):
+        assert _repo_slug("https://github.com/owner/skills.git") == "owner-skills"
+        assert _repo_slug("git@github.com:owner/skills.git") == "owner-skills"
+
+    def test_same_short_name_different_owners_do_not_collide(self):
+        assert _repo_slug("https://github.com/alice/skills.git") == "alice-skills"
+        assert _repo_slug("https://github.com/bob/skills.git") == "bob-skills"
+
+    def test_unsafe_urls_fall_back_to_hash(self):
+        slug = _repo_slug("https://example.com/a b/c!.git")
+        assert slug.startswith("repo-")
+
+
+# ── Config resolution ──────────────────────────────────────────────────────
+
+
+class TestConfigResolution:
+    def test_disabled_returns_none_via_enabled_check(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        _write_config(hermes_home, enabled=False, url="https://x/y.git")
+        assert external_repo_enabled() is False
+        assert get_repo_write_dir() is None
+
+    def test_enabled_without_url_is_not_active(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        _write_config(hermes_home, enabled=True, url="")
+        assert external_repo_enabled() is False
+
+
+# ── Sync (pull path) ───────────────────────────────────────────────────────
+
+
+class TestSyncExternalRepo:
+    def test_disabled_returns_none(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        _write_config(hermes_home, enabled=False, url="https://x/y.git")
+        assert sync_external_repo() is None
+
+    def test_clones_bare_repo_on_first_run(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        bare = _init_bare(tmp_path / "skills-repo.git")
+        _seed_bare(bare, "alpha")
+        _write_config(hermes_home, enabled=True, url=str(bare))
+
+        result = sync_external_repo()
+        assert result is not None
+        assert (result / "category" / "alpha" / "SKILL.md").exists()
+        assert result == get_checkout_dir(str(bare))
+
+    def test_pull_brings_in_new_commits(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        bare = _init_bare(tmp_path / "skills-repo.git")
+        _seed_bare(bare, "alpha")
+        _write_config(hermes_home, enabled=True, url=str(bare))
+
+        assert sync_external_repo() is not None
+        # Another machine adds beta upstream.
+        _seed_bare(bare, "beta")
+
+        skills_dir = sync_external_repo()
+        assert skills_dir is not None
+        assert (skills_dir / "category" / "beta" / "SKILL.md").exists()
+
+    def test_unreachable_url_returns_none(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        _write_config(hermes_home, enabled=True, url=str(tmp_path / "does-not-exist"))
+        assert sync_external_repo() is None
+
+    def test_subdir_path_is_resolved(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        bare = _init_bare(tmp_path / "skills-repo.git")
+        _seed_bare(bare, "my-skill", subdir="skills")
+
+        _write_config(hermes_home, enabled=True, url=str(bare), path="skills")
+        skills_dir = sync_external_repo()
+        assert skills_dir is not None
+        assert skills_dir.name == "skills"
+        assert (skills_dir / "my-skill" / "SKILL.md").exists()
+
+
+# ── Push-back (write path) ─────────────────────────────────────────────────
+
+
+class TestWriteBack:
+    def test_new_skill_is_created_inside_checkout(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        bare = _init_bare(tmp_path / "skills-repo.git")
+        _write_config(hermes_home, enabled=True, url=str(bare))
+        assert sync_external_repo() is not None
+
+        write_dir = get_repo_write_dir()
+        assert write_dir is not None
+        assert str(write_dir).startswith(str(get_checkout_dir(str(bare))))
+
+        # simulate a skill_manage create landing in the repo
+        skill_md = write_dir / "my-new-skill" / "SKILL.md"
+        skill_md.parent.mkdir(parents=True, exist_ok=True)
+        skill_md.write_text(
+            "---\nname: my-new-skill\ndescription: New\n---\n\n# New\n",
+            encoding="utf-8",
+        )
+
+        assert maybe_push_external_repo(message="write my-new-skill") is True
+        # The change actually reached the remote.
+        check = _worktree(bare)
+        assert (check / "my-new-skill" / "SKILL.md").exists()
+
+    def test_edit_of_repo_skill_is_pushed_back(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        bare = _init_bare(tmp_path / "skills-repo.git")
+        _seed_bare(bare, "alpha")
+        _write_config(hermes_home, enabled=True, url=str(bare))
+        assert sync_external_repo() is not None
+
+        before = _head_sha(bare)
+
+        # Edit the skill inside the checkout (as skill_manage does on a repo
+        # skill), then push.
+        checkout_skill = get_checkout_dir(str(bare)) / "category" / "alpha" / "SKILL.md"
+        checkout_skill.write_text(
+            "---\nname: alpha\ndescription: Updated\n---\n\n# alpha v2\n",
+            encoding="utf-8",
+        )
+
+        assert maybe_push_external_repo(message="write alpha") is True
+        check = _worktree(bare)
+        assert "Updated" in (check / "category" / "alpha" / "SKILL.md").read_text()
+        assert _head_sha(bare) != before
+
+    def test_no_changes_does_not_push(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        bare = _init_bare(tmp_path / "skills-repo.git")
+        _seed_bare(bare, "alpha")
+        _write_config(hermes_home, enabled=True, url=str(bare))
+        assert sync_external_repo() is not None
+        before = _head_sha(bare)
+
+        assert maybe_push_external_repo(message="noop") is False
+        assert _head_sha(bare) == before
+
+    def test_disabled_returns_false(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        _write_config(hermes_home, enabled=False, url="https://x/y.git")
+        assert maybe_push_external_repo() is False
+
+
+# ── Discovery integration ──────────────────────────────────────────────────
+
+
+class TestExternalDirsIntegration:
+    def test_synced_checkout_shows_up_in_external_dirs(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        bare = _init_bare(tmp_path / "skills-repo.git")
+        _seed_bare(bare, "alpha")
+        _write_config(hermes_home, enabled=True, url=str(bare))
+
+        from agent.skill_utils import get_external_skills_dirs
+
+        assert get_external_skills_dirs() == []
+        sync_external_repo()
+        _setup_env(monkeypatch, tmp_path)  # clear caches again after sync
+
+        dirs = get_external_skills_dirs()
+        assert get_checkout_dir(str(bare)) in dirs
+
+    def test_disabled_repo_not_listed(self, tmp_path, monkeypatch):
+        hermes_home = _setup_env(monkeypatch, tmp_path)
+        bare = _init_bare(tmp_path / "skills-repo.git")
+        _seed_bare(bare, "alpha")
+        _write_config(hermes_home, enabled=False, url=str(bare))
+
+        from agent.skill_utils import get_external_skills_dirs
+
+        assert get_external_skills_dirs() == []

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -636,7 +636,24 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
 
 
 def _resolve_skill_dir(name: str, category: str = None) -> Path:
-    """Build the directory path for a new skill, optionally under a category."""
+    """Build the directory path for a new skill, optionally under a category.
+
+    When ``skills.external_repo.enabled`` (and the repo has been cloned at
+    startup), new skills are created inside the repo checkout so they are
+    shared across every Hermes installation.  Falls back to the local
+    ``~/.hermes/skills/`` when the feature is off or the checkout is not
+    present yet (first run before any sync).
+    """
+    try:
+        from tools.skills_repo_sync import get_repo_write_dir
+
+        repo_dir = get_repo_write_dir()
+        if repo_dir is not None:
+            if category:
+                return repo_dir / category / name
+            return repo_dir / name
+    except Exception:
+        pass
     if category:
         return _skills_dir() / category / name
     return _skills_dir() / name
@@ -957,10 +974,18 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     except Exception:
         pass
 
+    try:
+        rel_path = str(skill_dir.relative_to(_containing_skills_root(skill_dir)))
+    except ValueError:
+        # Skill created under a root that's not yet in the discovery set
+        # (e.g. repo checkout whose external-dir cache is stale): fall back
+        # to a stable identifier so the result JSON never crashes.
+        rel_path = skill_dir.name
+
     result = {
         "success": True,
         "message": f"Skill '{name}' created.",
-        "path": str(skill_dir.relative_to(_skills_dir())),
+        "path": rel_path,
         "skill_md": str(skill_md),
         "_change": {"description": _desc},
     }
@@ -1500,19 +1525,38 @@ _SYNC_PUSH_DEBOUNCE_S = 5.0
 def _maybe_debounced_sync_push(skill_name: str) -> None:
     """Schedule a debounced best-effort sync push after a skill write.
 
-    Cheap fast-path: if the skill isn't opted into sync, do nothing (no auth,
-    no network). Otherwise (re)arm a daemon timer; the actual push runs through
-    ``skills_sync_client.maybe_push_skills`` which enforces the access gate
-    and swallows all errors. Never blocks the caller (M1-C: agent never blocks
-    on sync).
+    Fires the two independent push paths whose gates are checked inside each
+    ``maybe_*`` call, so a burst of edits collapses to one push per path:
+
+    * ``skills_sync_client.maybe_push_skills`` — Nous-admin org sync (access
+      gate: user is a Nous admin + opt-in + base URL).
+    * ``skills_repo_sync.maybe_push_external_repo`` — the configured git
+      repo when ``skills.external_repo.enabled`` (repo-is-the-home skills).
+
+    Cheap fast-path: if neither sync is in play (no opt-in, no configured
+    repo), do nothing — no auth, no network.  Never blocks the caller
+    (M1-C: agent never blocks on sync) and never raises.
     """
     global _sync_push_timer, _sync_push_lock
-    try:
-        from tools.skill_usage import is_sync_enabled
 
-        if not is_sync_enabled(skill_name):
-            return
-    except Exception:
+    def _needed() -> bool:
+        try:
+            from tools.skill_usage import is_sync_enabled
+
+            if is_sync_enabled(skill_name):
+                return True
+        except Exception:
+            pass
+        try:
+            from tools.skills_repo_sync import external_repo_enabled
+
+            if external_repo_enabled():
+                return True
+        except Exception:
+            pass
+        return False
+
+    if not _needed():
         return
 
     import threading
@@ -1521,10 +1565,18 @@ def _maybe_debounced_sync_push(skill_name: str) -> None:
         _sync_push_lock = threading.Lock()
 
     def _fire():
+        # Both paths re-check their own gates and swallow their own errors;
+        # a failure in one never affects the other.
         try:
             from tools.skills_sync_client import maybe_push_skills
 
             maybe_push_skills(message=f"sync: {skill_name}")
+        except Exception:
+            pass
+        try:
+            from tools.skills_repo_sync import maybe_push_external_repo
+
+            maybe_push_external_repo(message=f"write {skill_name}")
         except Exception:
             pass
 

--- a/tools/skills_repo_sync.py
+++ b/tools/skills_repo_sync.py
@@ -1,0 +1,286 @@
+"""Git-repo-backed skills: the configured repo IS the agent's skills home.
+
+When ``skills.external_repo.enabled`` is true, Hermes uses a git repository
+as the live home for agent-created skills instead of (only) the local
+``~/.hermes/skills/`` dir.  This is the multi-install answer to keeping a
+server, a laptop, and the desktop app on the exact same skills: one repo is
+the source of truth, every install works directly on it, and changes flow
+both ways.
+
+Config::
+
+    skills:
+      external_repo:
+        enabled: true
+        url: "https://github.com/owner/skills.git"
+        branch: "main"     # optional, default = remote's default branch
+        path: ""           # optional subdir of the repo holding SKILL.md files
+
+Lifecycle
+---------
+- **Startup** (``sync_external_repo``): shallow-clone on first run, then
+  ``git pull --ff-only`` on every later start, into
+  ``$HERMES_HOME/skills/.repo-sync/<slug>/``.  The checkout is exposed like
+  an ``external_dirs`` entry, so every skill reader sees the repo's skills.
+- **Write-back** (``maybe_push_external_repo``): when the agent creates or
+  edits a skill that lives in the checkout, the change is committed and
+  pushed back to the repo.  Debounced from the ``skill_manage`` hook so a
+  burst of edits collapses to one push.  Best-effort and never raises — a
+  push failure (offline, auth, conflict) only logs a debug line, and the
+  change stays in the local checkout, ready for the next successful push.
+
+Failure model (must never break the agent)
+------------------------------------------
+The repo is a convenience, not a blocking dependency.  If git is missing,
+the network is down, a branch is missing, or a push conflicts, we log a
+debug line and continue — the agent still works on the checkout it has.
+This module never raises out of its public entrypoints.
+
+Local skills dir
+----------------
+``~/.hermes/skills/`` remains the only place bundled skills live and the
+fallback when ``external_repo`` is disabled or not yet cloned.  When the
+feature is on, *new* skills are created in the repo checkout and edits to
+repo skills happen in place there — see ``tools/skill_manager_tool.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# Subdirectory of HERMES_HOME/skills/ holding repo checkouts.  Hidden so the
+# regular skills scanners (EXCLUDED_SKILL_DIRS) never mistake a checkout for
+# a locally installed skill.
+CHECKOUT_ROOT_NAME = ".repo-sync"
+
+# How long a single git invocation may take before we give up.
+_GIT_TIMEOUT = 60
+
+_URL_SLUG_STRIP = re.compile(r"^[a-zA-Z0-9_.-]+$")
+
+
+def get_external_repo_config() -> Optional[Dict[str, Any]]:
+    """Read ``skills.external_repo`` from config.yaml, or None when unset."""
+    try:
+        from agent.skill_utils import _load_raw_config
+    except ImportError:
+        return None
+    parsed = _load_raw_config()
+    if not parsed:
+        return None
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return None
+    repo_cfg = skills_cfg.get("external_repo")
+    if not isinstance(repo_cfg, dict):
+        return None
+    return repo_cfg
+
+
+def external_repo_enabled() -> bool:
+    """True when the feature is configured on with a usable url."""
+    repo_cfg = get_external_repo_config()
+    if not repo_cfg or not repo_cfg.get("enabled"):
+        return False
+    return bool(str(repo_cfg.get("url", "")).strip())
+
+
+def _repo_slug(url: str) -> str:
+    """Stable filesystem-safe name for a repo URL.
+
+    ``https://github.com/owner/skills.git`` and
+    ``git@github.com:owner/skills.git`` both slug to ``owner-skills`` so
+    two repos with the same short name but different owners never collide;
+    anything that would not survive as a directory name falls back to a
+    short hash of the URL so the slug is always unique per URL.
+    """
+    bare = url.rstrip("/")
+    if bare.endswith(".git"):
+        bare = bare[:-4]
+    segments = [s for s in re.split(r"[/:]", bare) if s]
+    tail = segments[-1] if segments else ""
+    owner = segments[-2] if len(segments) >= 2 else ""
+    candidate = f"{owner}-{tail}" if owner else tail
+    if candidate and _URL_SLUG_STRIP.match(candidate) and candidate not in (".", ".."):
+        return candidate
+    return "repo-" + hashlib.md5(url.encode("utf-8")).hexdigest()[:8]
+
+
+def get_checkout_dir(url: str) -> Path:
+    """Absolute path of the checkout for *url* (may not exist yet)."""
+    return get_hermes_home() / "skills" / CHECKOUT_ROOT_NAME / _repo_slug(url)
+
+
+def get_repo_skills_dir(url: str, subdir: str = "") -> Optional[Path]:
+    """Resolve the directory inside the checkout that holds the skills.
+
+    Returns the checkout root when *subdir* is empty, the subdir when it is
+    set and exists, and ``None`` when the checkout (or requested subdir) is
+    not present on disk.  Read-only: never clones, never touches the network
+    — this is what the hot-path skill scanners call.
+    """
+    checkout = get_checkout_dir(url)
+    if not checkout.is_dir():
+        return None
+    if not subdir:
+        return checkout
+    target = checkout / subdir
+    return target if target.is_dir() else None
+
+
+def get_repo_write_dir() -> Optional[Path]:
+    """Where new agent skills should be created when the feature is on.
+
+    Returns the configured repo's skills subdir under the checkout, or None
+    when the feature is disabled or the url is missing.  Unlike
+    ``get_repo_skills_dir`` this does NOT require the dir to exist yet —
+    creation will make it — but it does require the checkout to have been
+    cloned (startup sync), otherwise the repo would be rewritten from a
+    stale clone on the next push.
+    """
+    repo_cfg = get_external_repo_config()
+    if not repo_cfg or not repo_cfg.get("enabled"):
+        return None
+    url = str(repo_cfg.get("url", "")).strip()
+    if not url:
+        return None
+    checkout = get_checkout_dir(url)
+    if not (checkout / ".git").exists():
+        return None
+    subdir = str(repo_cfg.get("path", "")).strip()
+    base = checkout / subdir if subdir else checkout
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _run_git(args: List[str], cwd: Optional[Path] = None) -> Optional[str]:
+    """Run a git subcommand; return stdout (stripped) or None on failure."""
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+            cwd=str(cwd) if cwd else None,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        logger.debug("git %s failed: %s", args[0], e)
+        return None
+    if proc.returncode != 0:
+        logger.debug("git %s exited %d: %s", args[0], proc.returncode,
+                     proc.stderr.strip()[:200])
+        return None
+    return proc.stdout.strip()
+
+
+def sync_external_repo(quiet: bool = True) -> Optional[Path]:
+    """Clone or update the configured external skills repo at startup.
+
+    Returns the resolved skills directory inside the checkout when the sync
+    succeeded (or the checkout was already current), ``None`` when the
+    feature is disabled, misconfigured, or the sync failed.  On success the
+    in-process external-dirs cache is invalidated so the fresh checkout is
+    picked up by skill scanners in the current process.
+    """
+    repo_cfg = get_external_repo_config()
+    if not repo_cfg or not repo_cfg.get("enabled"):
+        return None
+    url = str(repo_cfg.get("url", "")).strip()
+    if not url:
+        logger.debug("skills.external_repo enabled but no url; skipping")
+        return None
+    branch = str(repo_cfg.get("branch", "")).strip()
+    subdir = str(repo_cfg.get("path", "")).strip()
+
+    checkout = get_checkout_dir(url)
+    try:
+        checkout.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.debug("Could not create checkout dir %s: %s", checkout, e)
+        return None
+
+    # Clone on first run; pull (ff-only, never merge user edits away) after.
+    if not (checkout / ".git").exists():
+        clone_args = ["clone", "--depth", "1"]
+        if branch:
+            clone_args += ["--branch", branch]
+        clone_args += [url, str(checkout)]
+        ok = _run_git(clone_args) is not None
+    else:
+        ok = _run_git(["pull", "--ff-only"], cwd=checkout) is not None
+
+    if not ok:
+        if not quiet:
+            logger.warning("skills.external_repo sync failed for %s", url)
+        return None
+
+    try:
+        from agent.skill_utils import _external_dirs_cache_clear
+
+        _external_dirs_cache_clear()
+    except ImportError:
+        pass
+
+    if not quiet:
+        state = "updated" if (checkout / ".git").exists() else "cloned"
+        logger.info("skills.external_repo %s from %s (%s)", state, url, branch)
+    return get_repo_skills_dir(url, subdir)
+
+
+def maybe_push_external_repo(message: str = "hermes skill sync") -> bool:
+    """Best-effort commit+push of the configured repo checkout.
+
+    Returns True when a push actually happened, False when the feature is
+    off, nothing changed, or the push failed.  Never raises.  Called from
+    the debounced ``skill_manage`` write hook so a burst of edits collapses
+    to one push.
+    """
+    repo_cfg = get_external_repo_config()
+    if not repo_cfg or not repo_cfg.get("enabled"):
+        return False
+    url = str(repo_cfg.get("url", "")).strip()
+    if not url:
+        return False
+    checkout = get_checkout_dir(url)
+    if not (checkout / ".git").exists():
+        return False
+
+    # Stage everything, commit if there is anything, then push.
+    if _run_git(["add", "-A"], cwd=checkout) is None:
+        return False
+    status = _run_git(["status", "--porcelain"], cwd=checkout)
+    if status is None:
+        return False
+    if not status.strip():
+        return False  # nothing changed — don't emit an empty commit
+
+    # Commit with a pinned one-shot identity. The checkout is a fresh clone
+    # with no user.name/email configured (git clone does not inherit the
+    # source's identity), so a bare `git commit` would fail with "Please
+    # tell me who you are". -c scopes the identity to this single command
+    # instead of mutating the checkout's config.
+    if _run_git(
+        [
+            "-c", "user.name=Hermes Agent",
+            "-c", "user.email=hermes@nousresearch.com",
+            "commit", "-m", f"hermes: {message[:200]}",
+        ],
+        cwd=checkout,
+    ) is None:
+        # Nothing staged or commit failed; nothing to push.
+        return False
+    if _run_git(["push"], cwd=checkout) is None:
+        logger.debug("skills.external_repo push failed for %s", url)
+        return False
+    logger.info("skills.external_repo pushed: %s", message)
+    return True

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -416,6 +416,41 @@ Trust is a repo-level decision, but a repo's skill content changes with every `g
 
 Cron jobs and other non-interactive surfaces inherit your interactive trust decision — they never prompt and never auto-trust. The project root resolves from the surface's working directory (a cron job's `workdir`, via the same mechanism the terminal tool uses). A cron job whose `workdir` is inside a repo you previously trusted loads that repo's project skills; a job in an untrusted or undecided repo loads none.
 
+## Git Repository Skills (`external_repo`)
+
+If you run Hermes on several machines (a server, a laptop, the desktop app) and want them to share the *same* skills, point Hermes at a git repository. The repo becomes the **live home of agent skills**: Hermes pulls it at every start, and every skill the agent creates or edits is pushed back. One repo, every install on the same skills — no manual copying, no drift.
+
+Add `external_repo` under the `skills` section in `~/.hermes/config.yaml`:
+
+```yaml
+skills:
+  external_repo:
+    enabled: true
+    url: https://github.com/you/my-skills.git   # required when enabled
+    branch: main                                 # optional; empty = remote default
+    path: ""                                     # optional; subdir holding SKILL.md files
+```
+
+### How it works
+
+- **Live, two-way**: At startup Hermes shallow-clones the repo (first run) or `git pull --ff-only` (later runs) into `~/.hermes/skills/.repo-sync/`. When the agent creates or edits a skill, the change is committed and pushed back to the repo (debounced, so a burst of edits collapses to one push). The other machine picks it up on its next start.
+- **Repo is the home when enabled**: New agent-created skills are written into the repo checkout, and edits to repo skills happen in place — not into a separate `~/.hermes/skills/` copy. Your local skills dir remains the fallback when the feature is off or the repo hasn't been cloned yet.
+- **Failures are silent**: If git is missing, the network is down, the URL is wrong, or a push conflicts, Hermes logs a debug line and keeps working on the checkout it has. A failed push leaves the change in the local checkout, ready for the next successful push.
+- **Layout flexibility**: If your repo stores skills under a subdirectory (e.g. `skills/`), set `path` to that subdirectory. Leave it empty when `SKILL.md` files sit at the repo root.
+
+### Example
+
+```yaml
+skills:
+  external_repo:
+    enabled: true
+    url: https://github.com/you/my-skills.git
+    branch: main
+    path: skills
+```
+
+Edit a skill on the server, commit it to the repo, restart Hermes on the laptop — the updated skill is there. Both machines converge on the same skills from the same repo, with no manual copying.
+
 ## Skill Bundles
 
 Skill bundles are tiny YAML files that group several skills under a single slash command. When you run `/<bundle-name>`, every skill listed in the bundle loads at once — useful when a particular task always benefits from the same set of skills together.


### PR DESCRIPTION
Adds a config toggle that keeps skills in sync across multiple Hermes installations (server, laptop, desktop app) from a single git repo.

When skills.external_repo.enabled is true, Hermes shallow-clones the configured url on first run and git pull --ff-only on every later start into a read-only checkout under HERMES_HOME/skills/.repo-sync/, which is then exposed like an external_dirs entry. Sync failures are silent and never block startup; the last good checkout keeps serving.

Skills are never written back to the repo — the checkout is a source of truth, and the local skills dir stays the only place agent-created skills are authored.

Implements the multi-install counterpart to skills.external_dirs; the clone/pull runs in _sync_bundled_skills_quietly so CLI, gateway, and the desktop dashboard all pick it up.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

