### PR TITLE
fix(hermes-bots): group chats render Hermes, not @default; click speaker for full handle

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3067,7 +3067,7 @@ function parseGroupChatMentions(text, members) {
     // Cross-connection members are also addressable by their @name-device
     // handle (the roster's disambiguated form) — same-named agents on two
     // machines resolve to the right one.
-    const handle = String(member.handle || '').trim()
+    const handle = String(member.handle || botHandle(member.name, member) || '').trim()
     const forms = new Set([
       member.name.toLowerCase(),
       member.name.toLowerCase().replace(/[\s_-]+/g, ''),
@@ -3153,6 +3153,13 @@ function rotateGroupSpeakers(members, round) {
   return [...members.slice(shift), ...members.slice(0, shift)]
 }
 
+/** Transcript form of a room speaker's profile name. The primary profile is
+ *  literally named "default" — render it as Hermes (matching displayName and
+ *  the @hermes handle) so the main agent never loses its name in rooms. */
+function groupSpeakerLabel(name) {
+  return (name || '').trim().toLowerCase() === 'default' ? 'Hermes' : name
+}
+
 /** Room-log line as a member sees it: `Name (user): …` / `Name: …` /
  *  `Name (you): …`. */
 function formatGroupChatLine(entry, viewerName) {
@@ -3165,7 +3172,7 @@ function formatGroupChatLine(entry, viewerName) {
   // two machines stay tellable apart in every member's transcript.
   const source = entry.from.source ? ` [${entry.from.source}]` : ''
 
-  return `${entry.from.name}${suffix}${source}: ${entry.text}`
+  return `${groupSpeakerLabel(entry.from.name)}${suffix}${source}: ${entry.text}`
 }
 
 /** The full per-turn payload for one member: participation rules + the room
@@ -3176,13 +3183,13 @@ function buildGroupChatTurnPrompt({ groupName, members, viewer, deltaLines }) {
   const peers = members.filter(m => groupMemberKey(m) !== viewerKey)
   const peerNames = peers
     .map(m => {
-      const handle = m.title ? `${m.title} (@${m.name})` : `@${m.name}`
+      const handle = m.title ? `${m.title} (@${botHandle(m.name, m)})` : `@${botHandle(m.name, m)}`
       return m.remoteSource ? `${handle} [on ${m.connectionLabel || m.connectionId}]` : handle
     })
     .join(', ')
 
   return [
-    `[Group chat: "${groupName}"] You are @${viewer.name}, one participant in a group chat with ${peerNames || 'no one else yet'} and the user.`,
+    `[Group chat: "${groupName}"] You are @${botHandle(viewer.name, viewer)}, one participant in a group chat with ${peerNames || 'no one else yet'} and the user.`,
     '',
     'New messages in the room since your last turn (oldest first):',
     ...deltaLines.map(line => `  ${line}`),
@@ -7139,6 +7146,10 @@ function GroupChatWorkspace({ group, members }) {
   const room = rooms[group] || { log: [], running: false }
   const [draft, setDraft] = useState('')
   const [confirmDisband, setConfirmDisband] = useState(false)
+  // Click-to-disambiguate: which log entry is showing its speaker's full
+  // @handle (the roster's name-device form when names collide across
+  // connections). Naturally every speaker just shows its display name.
+  const [revealedSpeaker, setRevealedSpeaker] = useState(null)
 
   const header = jsxs('div', {
     className: 'flex items-center gap-2 px-2.5 pt-2.5 pb-2',
@@ -7201,12 +7212,28 @@ function GroupChatWorkspace({ group, members }) {
               ? room.log.map((entry, index) => {
                   const isUser = entry.from.kind === 'user'
                   const meta = isUser || entry.from.source ? null : allMeta[entry.from.name]
-                  const sourceBadge = !isUser && entry.from.source ? ` · ${entry.from.source}` : ''
+                  // Match this speaker back to its member descriptor so display
+                  // names and disambiguating handles come from the roster (the
+                  // primary "default" profile renders as Hermes, remote dupes
+                  // carry their @name-device handle) instead of raw profile ids.
+                  const member = isUser
+                    ? null
+                    : members.find(b =>
+                        b.name === entry.from.name &&
+                        (entry.from.source
+                          ? (b.connectionLabel || b.connectionId) === entry.from.source
+                          : !b.remoteSource)
+                      ) || null
+                  const display = isUser ? 'You' : displayName(member || { name: entry.from.name }, meta)
+                  const entryKey = `${entry.at}:${index}`
+                  const revealed = !isUser && revealedSpeaker === entryKey
+                  // Clicked: append the gateway name so same-named agents on
+                  // two connections are tellable apart on demand.
                   const label = isUser
                     ? 'You'
-                    : meta?.title
-                      ? `${meta.title} (@${entry.from.name})${sourceBadge}`
-                      : `@${entry.from.name}${sourceBadge}`
+                    : revealed
+                      ? `${display}${entry.from.source ? `-${entry.from.source}` : ''} (@${botHandle(entry.from.name, member || undefined)})`
+                      : display
 
                   return jsxs('div', {
                     className: isUser ? 'rounded-md bg-(--chrome-action-hover) px-2 py-1.5' : 'px-2 py-1',
@@ -7214,12 +7241,19 @@ function GroupChatWorkspace({ group, members }) {
                       jsxs('div', {
                         className: 'flex items-baseline gap-2',
                         children: [
-                          jsx('span', {
-                            className: isUser
-                              ? 'text-[0.7rem] font-semibold text-foreground'
-                              : 'text-[0.7rem] font-semibold text-(--ui-accent,#4f9cf9)',
-                            children: label
-                          }),
+                          isUser
+                            ? jsx('span', {
+                                className: 'text-[0.7rem] font-semibold text-foreground',
+                                children: label
+                              })
+                            : jsx('button', {
+                                type: 'button',
+                                className:
+                                  'cursor-pointer border-0 bg-transparent p-0 text-left text-[0.7rem] font-semibold text-(--ui-accent,#4f9cf9)',
+                                title: revealed ? 'Hide full handle' : 'Show full handle',
+                                onClick: () => setRevealedSpeaker(revealed ? null : entryKey),
+                                children: label
+                              }),
                           jsx('span', {
                             className: 'text-[0.625rem] text-(--ui-text-quaternary)',
                             children: relativeTime(entry.at)
@@ -7231,7 +7265,7 @@ function GroupChatWorkspace({ group, members }) {
                         children: Streamdown ? jsx(Streamdown, { children: entry.text }) : entry.text
                       })
                     ]
-                  }, `${entry.at}:${index}`)
+                  }, entryKey)
                 })
               : [
                   jsx('div', {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -312,3 +312,53 @@ test('source contract: workspace header offers disband behind a ConfirmDialog', 
   assert.match(pluginSource, /Disband group chat\?/)
   assert.match(pluginSource, /title: `Disband the \$\{group\} group chat`/)
 })
+
+test('default profile speaks as Hermes in room transcripts, not @default', () => {
+  const gc = load(() => '(pass)')
+  const line = gc.formatGroupChatLine({ from: { kind: 'member', name: 'default' }, text: 'hello room' }, 'builder')
+  assert.equal(line, 'Hermes: hello room')
+  assert.doesNotMatch(line, /default/)
+
+  // Other members keep their profile name; the (you) suffix survives.
+  const you = gc.formatGroupChatLine({ from: { kind: 'member', name: 'default' }, text: 'hi' }, 'default')
+  assert.equal(you, 'Hermes (you): hi')
+  const plain = gc.formatGroupChatLine({ from: { kind: 'member', name: 'builder' }, text: 'yo' }, 'research')
+  assert.equal(plain, 'builder: yo')
+})
+
+test('turn prompt addresses the default profile as @hermes', () => {
+  const gc = load(() => '(pass)')
+  const prompt = gc.buildGroupChatTurnPrompt({
+    groupName: 'Core',
+    members: [{ name: 'default', title: '' }, { name: 'builder', title: '' }],
+    viewer: { name: 'default', title: '' },
+    deltaLines: []
+  })
+  assert.match(prompt, /You are @hermes,/)
+  assert.doesNotMatch(prompt, /@default\b/)
+
+  const peerView = gc.buildGroupChatTurnPrompt({
+    groupName: 'Core',
+    members: [{ name: 'default', title: '' }, { name: 'builder', title: '' }],
+    viewer: { name: 'builder', title: '' },
+    deltaLines: []
+  })
+  assert.match(peerView, /group chat with @hermes/)
+})
+
+test('mention routing: @hermes resolves to the default member', () => {
+  const gc = load(() => '(pass)')
+  const members = [{ name: 'default', title: '' }, { name: 'builder', title: '' }]
+  const parsed = gc.parseGroupChatMentions('@hermes take a look', members)
+  assert.equal(parsed.mentioned.has('default'), true)
+  assert.equal(parsed.mentioned.size, 1)
+})
+
+test('source contract: workspace speaker labels use displayName with a click-to-reveal handle', () => {
+  // Speaker labels come from the roster displayName (default → Hermes)…
+  assert.match(pluginSource, /displayName\(member \|\| \{ name: entry\.from\.name \}, meta\)/)
+  // …and clicking a speaker reveals the full disambiguated handle, with the
+  // gateway/device name appended for cross-connection speakers.
+  assert.match(pluginSource, /setRevealedSpeaker\(revealed \? null : entryKey\)/)
+  assert.match(pluginSource, /\$\{display\}\$\{entry\.from\.source \? `-\$\{entry\.from\.source\}` : ''\} \(@\$\{botHandle\(entry\.from\.name, member \|\| undefined\)\}\)/)
+})


### PR DESCRIPTION
## Summary
Bot Mode group chats no longer surface `@default` — the primary agent renders as **Hermes** everywhere in the room, and clicking any speaker reveals the full disambiguated form (`<Name>-<gatewayname> (@handle)`) for same-named agents across connections.

Root cause: the group-chat workspace, room transcripts, and per-turn prompts all rendered the raw profile id (`@default`) instead of routing through the existing `displayName`/`botHandle` helpers the roster already uses.

## Changes
- `plugin.js` (hermes-bots): workspace speaker labels render `displayName` (default → Hermes, custom titles respected); the label is now a click toggle that reveals `Display-gatewayname (@handle)` on demand
- `plugin.js`: room transcripts fed to member turns render the default profile as `Hermes` (new `groupSpeakerLabel` helper); `(you)` suffix and `[device]` badge unchanged
- `plugin.js`: turn prompts address members by `@handle` (`@hermes` for the primary profile) and `parseGroupChatMentions` resolves `@hermes` back to the default member
- `tests/group-chat.test.mjs`: 4 new tests (transcript label, turn-prompt handle, `@hermes` mention routing, workspace source contract)

## Validation
| | Before | After |
|---|---|---|
| Room speaker label | `@default` | `Hermes` (click → `Hermes-<gateway> (@hermes)`) |
| Member transcript | `default: …` | `Hermes: …` |
| Turn prompt | `You are @default` | `You are @hermes` |
| Plugin tests | 203/203 | 207/207 pass |

## Infographic

![Group chats: Hermes keeps its name](https://v3b.fal.media/files/b/0aa6c1b6/-ELWh4u-RZlgI9gkbhgPV_oJEPTjRk.png)
