### PR TITLE
fix(discord): require hard mentions from bots

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1224,6 +1224,7 @@ platform_toolsets:
 #
 # discord:
 #   require_mention: true            # Require @mention in server channels (default: true)
+#   bots_require_inline_mention: true  # Bot authors must type a literal @mention (default: true)
 #   auto_thread: true                # Auto-create thread on @mention (default: true)
 #   free_response_channels: ""       # Channel IDs where no mention is needed
 #   reactions: true                  # Show processing reactions (default: true)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2287,7 +2287,7 @@ DEFAULT_CONFIG = {
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
-        "bots_require_inline_mention": False,  # Multi-bot rooms: if True, another bot must type @thisbot in its message to trigger a reply; a Discord reply/quote alone won't. Prevents two bots auto-replying to each other forever. Does not affect humans.
+        "bots_require_inline_mention": True,  # Bot authors must type @thisbot to trigger a reply; Discord reply pings alone do not count. Set False only for trusted legacy relays. Does not affect humans.
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
         "missed_message_backfill": {

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6764,13 +6764,15 @@ class DiscordAdapter(BasePlatformAdapter):
     def _discord_bots_require_inline_mention(self) -> bool:
         """Whether another bot must type an inline @mention to trigger us.
 
-        Off by default. When on, a bot-authored message only wakes this bot
-        if its content contains a literal ``<@thisbot>`` token. A Discord
-        reply/quote to one of our messages is NOT enough on its own, because
-        Discord's reply-ping silently adds us to ``message.mentions`` even
-        though the author never typed our handle — which otherwise lets two
-        bots ping-pong replies at each other indefinitely. Humans are never
-        affected by this gate; it only applies to bot authors.
+        On by default. A bot-authored message only wakes this bot if its
+        content contains a literal ``<@thisbot>`` token. A Discord reply/quote
+        to one of our messages is NOT enough on its own, because Discord's
+        reply-ping silently adds us to ``message.mentions`` even though the
+        author never typed our handle — which otherwise lets two bots ping-pong
+        replies at each other indefinitely. Humans are never affected by this
+        gate; it only applies to bot authors. Set the option to false only for
+        trusted relay integrations that intentionally depend on reply pings or
+        unmentioned bot messages.
 
         Config: ``discord.bots_require_inline_mention`` (or env
         ``DISCORD_BOTS_REQUIRE_INLINE_MENTION``).
@@ -6780,7 +6782,7 @@ class DiscordAdapter(BasePlatformAdapter):
             if isinstance(configured, str):
                 return configured.lower() in {"true", "1", "yes", "on"}
             return bool(configured)
-        return os.getenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", "false").lower() in {
+        return os.getenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", "true").lower() in {
             "true",
             "1",
             "yes",

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -70,7 +70,7 @@ class TestDiscordBotFilter(unittest.TestCase):
         message,
         allow_bots="none",
         client_user=None,
-        bots_require_inline_mention=False,
+        bots_require_inline_mention=True,
     ):
         """Simulate the on_message filter logic and return whether message was accepted."""
         # Replicate the exact filter logic from discord.py on_message
@@ -117,7 +117,7 @@ class TestDiscordBotFilter(unittest.TestCase):
 
 
     def test_inline_mention_requirement_accepts_body_mention(self):
-        """Opt-in guard still admits intentional inline cross-bot mentions."""
+        """The default guard admits intentional inline cross-bot mentions."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(

--- a/tests/gateway/test_discord_bot_inline_mentions.py
+++ b/tests/gateway/test_discord_bot_inline_mentions.py
@@ -1,0 +1,102 @@
+"""Tests for hard-inline mention gating on bot-authored Discord messages."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import discord
+import pytest
+
+from gateway.platforms.helpers import MessageDeduplicator
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _adapter(*, allow_bots: str = "mentions", extra=None) -> DiscordAdapter:
+    adapter = object.__new__(DiscordAdapter)
+    setattr(adapter, "config", SimpleNamespace(extra=extra or {}))
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=99, bot=True))
+    adapter._dedup = MessageDeduplicator()
+    adapter._get_allow_bots = Mock(return_value=allow_bots)
+    adapter._is_allowed_user = Mock(return_value=True)
+    return adapter
+
+
+def _bot_message(adapter: DiscordAdapter, *, content: str, message_type):
+    return SimpleNamespace(
+        id=123,
+        author=SimpleNamespace(id=42, bot=True),
+        channel=SimpleNamespace(id=7),
+        content=content,
+        mentions=[getattr(adapter._client, "user")],
+        type=message_type,
+    )
+
+
+def test_bot_inline_mentions_are_required_by_default(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", raising=False)
+    adapter = _adapter()
+
+    assert adapter._discord_bots_require_inline_mention() is True
+    assert DEFAULT_CONFIG["discord"]["bots_require_inline_mention"] is True
+
+
+@pytest.mark.parametrize("allow_bots", ["mentions", "all"])
+def test_reply_ping_does_not_trigger_bot_by_default(monkeypatch, allow_bots):
+    monkeypatch.delenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", raising=False)
+    adapter = _adapter(allow_bots=allow_bots)
+    message = _bot_message(
+        adapter,
+        content="reply without a hard mention",
+        message_type=discord.MessageType.reply,
+    )
+
+    admitted, _ = adapter._discord_message_admission(message, claim=False)
+
+    assert admitted is False
+
+
+def test_hard_inline_mention_triggers_bot_by_default(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", raising=False)
+    adapter = _adapter(allow_bots="mentions")
+    message = _bot_message(
+        adapter,
+        content="<@99> intentional handoff",
+        message_type=discord.MessageType.default,
+    )
+
+    admitted, _ = adapter._discord_message_admission(message, claim=False)
+
+    assert admitted is True
+
+
+def test_human_messages_are_unaffected_by_inline_mention_gate(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", raising=False)
+    adapter = _adapter(allow_bots="none")
+    message = _bot_message(
+        adapter,
+        content="human reply without a hard mention",
+        message_type=discord.MessageType.reply,
+    )
+    message.author.bot = False
+    message.mentions = []
+
+    admitted, _ = adapter._discord_message_admission(message, claim=False)
+
+    assert admitted is True
+
+
+def test_explicit_false_restores_reply_ping_compatibility(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", raising=False)
+    adapter = _adapter(
+        allow_bots="mentions",
+        extra={"bots_require_inline_mention": False},
+    )
+    message = _bot_message(
+        adapter,
+        content="legacy reply handoff",
+        message_type=discord.MessageType.reply,
+    )
+
+    admitted, _ = adapter._discord_message_admission(message, claim=False)
+
+    assert admitted is True

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -301,7 +301,8 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
-| `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
+| `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. By default, either enabled mode still requires a literal inline mention; see the next setting. |
+| `DISCORD_BOTS_REQUIRE_INLINE_MENTION` | No | `true` | Require bot-authored messages to contain a literal `<@BOT_ID>` / `<@!BOT_ID>` token. Discord reply pings only populate mention metadata and do not trigger Hermes. Set to `false` only for trusted relay integrations that depend on unmentioned bot messages or reply pings. Human-authored messages are unaffected. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
@@ -319,10 +320,10 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` | No | `0.6` | Grace window the adapter waits before flushing a queued text chunk. Useful for smoothing streamed output. |
 | `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS` | No | `2.0` | Delay between split chunks when a single message exceeds Discord's length limit. |
 
-:::warning Bot-to-bot conversation is not supported
-`DISCORD_ALLOW_BOTS` exists to accept input from a specific trusted bot (e.g. a relay or webhook bot), not to let two Hermes profiles talk to each other. The default, `"none"`, ignores all other bots and is the safe setting.
+:::tip Bot-to-bot handoffs require hard mentions
+`DISCORD_ALLOW_BOTS` defaults to `"none"`. When you opt into `"mentions"` or `"all"`, bot-authored messages must contain a literal inline mention of Hermes by default. Discord's automatic replied-user ping does not count, so replying to another bot cannot silently invoke it again.
 
-Wiring multiple Hermes profiles to reply to one another in a shared channel — by setting `"mentions"` or `"all"` across several profiles — is an unsupported topology. Discord auto-`@mentions` the replied-to author on every reply, so under `"mentions"` two bots will satisfy each other's mention gate indefinitely and ack-loop. There is no circuit breaker for this because the supported configuration is simply to leave `DISCORD_ALLOW_BOTS` at `"none"`. If you must accept a particular bot, scope the acceptance narrowly and never to another auto-replying agent.
+This permits deliberate handoffs and multi-turn collaboration: each bot must explicitly type the next bot's mention on every turn it wants that bot to process. Set `discord.bots_require_inline_mention: false` only for a trusted relay integration that intentionally depends on unmentioned bot messages or reply pings; doing so restores the legacy reply-loop risk.
 :::
 
 ### Config File (`config.yaml`)
@@ -334,6 +335,7 @@ The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Con
 discord:
   require_mention: true           # Require @mention in server channels
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
+  bots_require_inline_mention: true  # Bot authors must type a literal @mention (default: true)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing


### PR DESCRIPTION
## Summary

- require bot-authored Discord messages to contain a literal inline `<@BOT_ID>` / `<@!BOT_ID>` mention by default
- prevent Discord reply metadata from silently invoking the replied-to bot and creating automatic reply loops
- preserve deliberate bot-to-bot handoffs and multi-turn collaboration through explicit hard mentions
- leave human-authored message handling unchanged
- retain `discord.bots_require_inline_mention: false` / `DISCORD_BOTS_REQUIRE_INLINE_MENTION=false` as a compatibility escape hatch for trusted relay integrations
- document the safety default in the Discord guide and example configuration

## Behavior

`DISCORD_ALLOW_BOTS=none` continues to reject all bot-authored input. When bot input is enabled with `mentions` or `all`, the bot author must type the target Hermes bot's literal mention. A Discord reply ping alone no longer has routing authority.

## Testing

- `env -u DISCORD_ALLOW_BOTS -u DISCORD_BOTS_REQUIRE_INLINE_MENTION python3 -m pytest tests/gateway/test_discord_bot_inline_mentions.py tests/gateway/test_discord_bot_filter.py tests/gateway/test_discord_bot_auth_bypass.py tests/gateway/test_discord_free_response.py tests/gateway/test_config.py -q` — **92 passed**
- Every `tests/gateway/test_discord*.py` module run in an isolated pytest process with Discord environment overrides removed — **256 passed, 1 skipped; 0 failed modules**
- `python3 -m ruff check plugins/platforms/discord/adapter.py hermes_cli/config_defaults.py tests/gateway/test_discord_bot_inline_mentions.py tests/gateway/test_discord_bot_filter.py` — passed
- `git diff --check` — passed

This supersedes the earlier reply-ancestry cap approach with a smaller causal rule: Discord-generated reply pings are not bot intent.