### PR TITLE
fix(bot-mode): Bots plugin — duplicate listeners after re-enable, Create Routine dialog stale state, orphaned OAuth poller

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1517,6 +1517,13 @@ function McpSetupButton({ profile, entry, onDone, ensureProfile }) {
   }
 
   const beginOAuth = async () => {
+    // A second click (retry, impatient double-click) must not orphan the
+    // previous poll interval — an overwritten pollRef leaks a 2s poller that
+    // runs until unmount and can flip phase from a stale OAuth session.
+    if (pollRef.current) {
+      clearInterval(pollRef.current)
+      pollRef.current = null
+    }
     setPhase('busy')
     setMessage('')
     const profile = await resolveProfile()
@@ -6638,14 +6645,15 @@ function RoutinesPane() {
               })
             }),
       jsx(CreateRoutineDialog, {
-        key: createTarget,
         bot: createTarget,
         open: createOpen,
         onClose: () => {
           setCreateOpen(false)
           setCreateOwner(null)
         }
-      })
+        // key is the jsx() THIRD argument — as a prop it is silently ignored
+        // and the dialog kept stale per-bot form state when the target changed.
+      }, createTarget)
     ]
   })
 }
@@ -7848,12 +7856,26 @@ export default {
     }
 
     // Routines follow the chat you're in: track the live gateway profile.
-    host.state.profile.listen(profile => {
+    // Capture the unbinds: without them a disable → re-enable cycle stacks a
+    // duplicate listener per cycle (same survives-disable class as the face
+    // clock before its onDispose hook — these kept firing until app restart).
+    const unbindProfileListener = host.state.profile.listen(profile => {
       if (profile && typeof profile === 'string') {
         $selectedBot.set(profile)
       }
     })
-    host.state.gateway.listen(handleSessionsGatewayTransition)
+    const unbindGatewayListener = host.state.gateway.listen(handleSessionsGatewayTransition)
+
+    if (typeof ctx.onDispose === 'function') {
+      ctx.onDispose(() => {
+        if (typeof unbindProfileListener === 'function') {
+          unbindProfileListener()
+        }
+        if (typeof unbindGatewayListener === 'function') {
+          unbindGatewayListener()
+        }
+      })
+    }
 
     ctx.register({
       id: 'pane',

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-owner.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-owner.test.mjs
@@ -79,7 +79,10 @@ test('source contract: create mutations and dialog state retain one owner', () =
   assert.match(pluginSource, /const \[createOwner, setCreateOwner\] = useState\(null\)/)
   assert.match(pluginSource, /const openCreate = \(\) => \{[\s\S]*setCreateOwner\(bot\)[\s\S]*setCreateOpen\(true\)/)
   assert.match(pluginSource, /const createTarget = routineCreateTarget\(createOwner, bot\)/)
-  assert.match(pluginSource, /key: createTarget/)
+  // key must be the jsx() THIRD argument (a `key:` prop is silently ignored
+  // by the react/jsx-runtime and the dialog would keep stale per-bot state).
+  assert.match(pluginSource, /jsx\(CreateRoutineDialog, \{[\s\S]*?\}, createTarget\)/)
+  assert.doesNotMatch(pluginSource, /key: createTarget/)
   assert.match(pluginSource, /bot: createTarget/)
   assert.doesNotMatch(pluginSource, /setCreateOwner\(owner =>/)
   assert.doesNotMatch(pluginSource, /onChanged: \(\) => void refetch\(\)/)


### PR DESCRIPTION
## Summary

Fixes three Bot Mode plugin bugs: plugin disable → re-enable no longer stacks duplicate state listeners, the Create Routine dialog remounts when its owner changes (the `key` was a silently-ignored jsx prop), and an OAuth retry no longer orphans the previous 2-second poll interval.

## Changes

- `apps/desktop/src/plugins/hermes-bots/plugin.js`:
  - `register()` captures the `host.state.profile` / `host.state.gateway` unbind functions and releases them via `ctx.onDispose` — previously every disable/re-enable cycle stacked one more listener that fired until app quit (same survives-disable class as the face-clock rAF loop fixed earlier).
  - `CreateRoutineDialog` key moved from a `key:` entry inside the jsx props object (silently ignored by react/jsx-runtime) to the jsx() third argument, so switching the routine owner actually remounts the dialog instead of keeping stale per-bot form state.
  - `beginOAuth()` clears any live poll interval before starting a new one — a retry or double-click previously overwrote `pollRef.current`, leaking a 2s poller that ran until unmount and could flip UI phase from a stale OAuth session.
- `tests/routine-owner.test.mjs`: source contract now pins the third-argument key shape and rejects the `key:` prop form.

## Validation

| | Before | After |
|---|---|---|
| `node --test tests/*.test.mjs` | 203 pass (pinning the buggy `key:` prop shape) | 203 pass (pinning the fixed shape) |
| `node --check plugin.js` | ok | ok |

## Infographic

![Bot Mode plugin: 3 bugs down](https://v3b.fal.media/files/b/0aa6c1d5/JjBULtsegrTB66efKOp6k_jEjB4ZnI.png)
