### PR TITLE
fix(profiles): Windows bot/profile delete no longer fails with WinError 32 — release memory_store.db handles before rmtree (#88347, salvage #88356)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1614,6 +1614,22 @@ def delete_profile(name: str, yes: bool = False) -> Path:
     # guard — resurrected the deleted tree.
     _stop_profile_backends(canon, profile_dir)
 
+    # 2c. Release this process's holographic memory-store connections into
+    # the profile. The Desktop's *main* serve process opens memory_store.db
+    # for every known profile and is deliberately not stopped above, so on
+    # Windows its open handles make the rmtree below fail with WinError 32
+    # (#88347). When this delete runs inside serve (the DELETE
+    # /api/profiles/<name> route) the handles live in this process and are
+    # closed here; from the CLI this finds nothing and is a no-op.
+    try:
+        from plugins.memory.holographic.store import MemoryStore as _MemoryStore
+
+        _released = _MemoryStore.release_all_under(profile_dir)
+        if _released:
+            print(f"✓ Released {_released} memory-store connection(s) held by this process")
+    except Exception:
+        pass  # best-effort: never block the delete on the release path
+
     # 3. Remove wrapper script
     if has_wrapper:
         if remove_wrapper_script(canon):

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -671,7 +671,14 @@ class MemoryStore:
                 try:
                     entry["conn"].close()
                 finally:
-                    MemoryStore._shared.pop(self._key, None)
+                    # Pop only OUR entry. After release_all_under() force-
+                    # closed this entry (profile delete, #88347) a same-path
+                    # store may have re-registered a FRESH entry under the
+                    # same key; a stale holder's late close() must not evict
+                    # it — that would silently reintroduce the multi-writer
+                    # contention this registry exists to prevent.
+                    if MemoryStore._shared.get(self._key) is entry:
+                        MemoryStore._shared.pop(self._key, None)
             self._entry = None
 
     def __enter__(self) -> "MemoryStore":

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -3,6 +3,7 @@ SQLite-backed fact store with entity resolution and trust scoring.
 Single-user Hermes memory store plugin.
 """
 
+import os
 import re
 import sqlite3
 import threading
@@ -615,6 +616,42 @@ class MemoryStore:
     def _row_to_dict(self, row: sqlite3.Row) -> dict:
         """Convert a sqlite3.Row to a plain dict."""
         return dict(row)
+
+    @classmethod
+    def release_all_under(cls, directory: "str | Path") -> int:
+        """Force-close every shared connection whose database lives under ``directory``.
+
+        ``close()`` is refcount-driven, so a live holder (e.g. an agent's
+        memory provider) keeps a profile's SQLite handle open indefinitely.
+        That is exactly what a profile delete must break on Windows: the
+        desktop's main ``serve`` process opens ``memory_store.db`` for every
+        known profile, and ``rmtree`` of the profile directory fails with
+        ``WinError 32`` while any of those handles is open (#88347). This
+        closes the matching connections unconditionally — the directory is
+        going away, so later use by a stale holder is expected to fail — and
+        returns how many were closed. In a process that holds none (e.g. the
+        CLI deleting from outside serve) this is a harmless no-op returning 0.
+        """
+        root = os.path.normcase(str(Path(directory).expanduser().resolve())) + os.sep
+        with cls._shared_guard:
+            # Snapshot the keys first so the registry stays stable while
+            # connections are closed inside their per-database locks (closing
+            # can run no user code, but this keeps the invariant obvious).
+            doomed = [
+                key
+                for key in cls._shared
+                if os.path.normcase(key).startswith(root)
+            ]
+            for key in doomed:
+                entry = cls._shared.pop(key)
+                try:
+                    with entry["lock"]:
+                        entry["conn"].close()
+                except Exception:
+                    # A connection that is already closed or broken must not
+                    # abort releasing its siblings.
+                    pass
+        return len(doomed)
 
     def close(self) -> None:
         """Release this instance's reference to the shared connection.

--- a/tests/plugins/memory/test_holographic_shutdown_closes_db.py
+++ b/tests/plugins/memory/test_holographic_shutdown_closes_db.py
@@ -91,3 +91,40 @@ def test_release_all_under_closes_connections_inside_directory_only(tmp_path):
         outside.close()
 
 
+
+
+def test_stale_holder_close_does_not_evict_fresh_registry_entry(tmp_path):
+    """Follow-up to #88347 — a stale holder's late ``close()`` must be inert.
+
+    After ``release_all_under`` force-closes a profile's connection, a store
+    re-created on the same path registers a FRESH shared entry under the same
+    key. If the stale holder (whose entry was force-closed) then calls
+    ``close()``, it must not pop the fresh entry out of the registry — that
+    would let a third store open a SECOND connection to the same database and
+    silently reintroduce the multi-writer contention the registry prevents.
+    """
+    from plugins.memory.holographic.store import MemoryStore
+
+    profile_dir = tmp_path / "profiles" / "default-2"
+    profile_dir.mkdir(parents=True)
+    db_path = profile_dir / "memory_store.db"
+
+    stale = MemoryStore(db_path=db_path, hrr_dim=64)
+    assert MemoryStore.release_all_under(profile_dir) == 1
+
+    fresh = MemoryStore(db_path=db_path, hrr_dim=64)
+    key = fresh._key
+    fresh_entry = MemoryStore._shared[key]
+
+    # The stale holder's late close must leave the fresh entry registered...
+    stale.close()
+    assert MemoryStore._shared.get(key) is fresh_entry
+    # ...and a third store must attach to the SAME shared connection.
+    third = MemoryStore(db_path=db_path, hrr_dim=64)
+    try:
+        assert third._conn is fresh._conn
+    finally:
+        third.close()
+        fresh.close()
+    # Normal last-holder close still evicts its own entry.
+    assert key not in MemoryStore._shared

--- a/tests/plugins/memory/test_holographic_shutdown_closes_db.py
+++ b/tests/plugins/memory/test_holographic_shutdown_closes_db.py
@@ -46,3 +46,48 @@ def test_shutdown_closes_store_connection(tmp_path):
         conn.execute("SELECT 1")
 
 
+def test_release_all_under_closes_connections_inside_directory_only(tmp_path):
+    """Regression test for #88347 — profile delete must break refcounted handles.
+
+    ``close()`` alone can never free a database held by a live agent (refs >= 1),
+    and on Windows an open SQLite handle makes rmtree of the profile directory
+    fail with WinError 32. ``release_all_under`` force-closes exactly the shared
+    connections under the doomed directory and leaves everything else alone.
+    """
+    from plugins.memory.holographic.store import MemoryStore
+
+    profile_dir = tmp_path / "profiles" / "default-2"
+    profile_dir.mkdir(parents=True)
+    inside = MemoryStore(db_path=profile_dir / "memory_store.db", hrr_dim=64)
+    outside = MemoryStore(db_path=tmp_path / "other" / "memory_store.db", hrr_dim=64)
+    inside_conn = inside._conn
+    outside_conn = outside._conn
+    # Both live before the release; the inside one is held "forever" (refs=1,
+    # like a live agent's provider — nobody calls close()).
+    inside_conn.execute("SELECT 1").fetchone()
+    outside_conn.execute("SELECT 1").fetchone()
+
+    try:
+        released = MemoryStore.release_all_under(profile_dir)
+        assert released == 1
+
+        # The doomed connection is really closed despite refs > 0 ...
+        with pytest.raises(sqlite3.ProgrammingError):
+            inside_conn.execute("SELECT 1")
+        # ... and the registry entry is gone, so a second release finds
+        # nothing (the CLI-process no-op case).
+        assert str((profile_dir / "memory_store.db").resolve()) not in MemoryStore._shared
+        assert MemoryStore.release_all_under(profile_dir) == 0
+        # A new store on the same path reopens fresh instead of reusing
+        # the dead connection.
+        reopened = MemoryStore(db_path=profile_dir / "memory_store.db", hrr_dim=64)
+        reopened._conn.execute("SELECT 1").fetchone()
+
+        # The sibling outside the directory is untouched.
+        outside_conn.execute("SELECT 1").fetchone()
+    finally:
+        inside.close()
+        reopened.close()
+        outside.close()
+
+


### PR DESCRIPTION
Deleting a profile on Windows no longer fails with `WinError 32`: `delete_profile()` now force-releases this process's holographic memory-store SQLite handles under the profile directory before running `rmtree`.

Salvages #88356 by @liuhao1024 — cherry-picked onto current main with authorship preserved. Fixes #88347.

## What was wrong

The desktop's main `serve` process opens `memory_store.db` for **every** known profile and nothing closed those connections before `delete_profile()`'s `rmtree`. On Windows an open SQLite handle makes directory removal fail hard with `WinError 32` (verified in #88347 via the Restart Manager API); on POSIX, unlinking an open file succeeds, which is why the leak was invisible on macOS/Linux. `MemoryStore.close()` cannot help: it is refcount-driven, so a live holder (an agent's memory provider) keeps the handle open forever.

## Contributor's fix (@liuhao1024, cherry-picked)

- `plugins/memory/holographic/store.py`: new `MemoryStore.release_all_under(directory)` — force-closes every shared-registry connection whose database lives under the directory (Windows-safe `os.path.normcase` prefix match on resolved paths, per-connection lock, per-connection exception isolation) and returns the count.
- `hermes_cli/profiles.py`: `delete_profile()` calls it after `_stop_profile_backends()` and before the `rmtree` — best-effort, wrapped in a quiet `try/except`. Inside serve (the `DELETE /api/profiles/<name>` route) the handles live in that process and get released; from the CLI it's a harmless no-op.
- Regression test pinning the semantics: refs>0 connection force-closed, registry entry removed, same-path reopen gets a fresh connection, sibling DB outside the directory untouched, repeat release is a no-op.

Review verdict: high-quality fix — correct root-cause analysis, Windows-safe path normalization, correct locking order (snapshot under `_shared_guard`, close under each entry's own lock), thorough test.

## Follow-up hardening (separate commit, ours)

One residual edge in the contributor's version: after `release_all_under()` force-closes an entry, a store re-created on the same path registers a **fresh** registry entry under the same key. A stale holder's late `close()` then popped that fresh entry unconditionally, letting a third store open a second connection to the same database — reintroducing the multi-writer contention the shared registry exists to prevent. `close()` now evicts the registry entry only when it is still its own (`is` check), with a regression test.

## Widening review (why no further sites)

Audited whether other per-profile DB handles held by the serve process would still block the `rmtree` on Windows:

- `hermes_cli/web_server.py` `_open_session_db_for_profile()` / `_open_session_db_at_path()` (state.db): opened per request and closed in `finally` blocks — no cached handles.
- `tui_gateway/` (`server.py`, `methods_session.py`, `methods_profiles.py`, `compute_host.py`): per-profile `SessionDB` handles are DEDICATED with explicit ownership-transfer/close discipline; the only long-lived handle (`_get_db()`) is the launch profile's own `state.db`, and the launch profile can't be deleted from itself.
- Kanban (`kanban_db.py`): `connect_closing()` closes per operation (#33159 already fixed the FD-accumulation there); observability `shared_metrics` opens/closes per query.

The holographic `MemoryStore._shared` registry is the only process-wide **cached** per-profile connection pool, so the contributor's fix covers the whole class.

## Related

- #87797 / #87761: Windows scheduled-task cleanup on profile delete — different issue in the same "profile delete on Windows" family; deliberately not absorbed here.
- #52279: the POSIX-side deletion/respawn fix this is the Windows file-lock counterpart to.

## Tests

```
tests/plugins/memory/ + tests/plugins/test_holographic_vector_storage.py
+ tests/hermes_cli/test_profiles.py + tests/hermes_cli/test_profiles_s6_hooks.py
→ 320 passed, 4 skipped
```

(`tests/plugins/memory/test_hindsight_provider.py` deselected — its 6 `TestPrefetchServerRetainVisibility` failures reproduce identically on pristine `origin/main`, unrelated to this change.)

## Infographic

![Windows profile delete fixed — DB handles released before rmtree](https://v3b.fal.media/files/b/0aa6c1db/xl5w4cRFDgUAGT-Zi0MDc_dRbTMhAI.png)
