### PR TITLE
fix(gateway): resolve the /save adapter through the adapters dict

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4652,7 +4652,11 @@ class GatewaySlashCommandsMixin:
             with open(temp_path, "w", encoding="utf-8") as f:
                 f.write(content)
 
-            adapter = self.get_adapter(source.platform)
+            # Sibling handlers all resolve through the runner's adapter
+            # dict — get_adapter() does not exist on GatewayRunner and the
+            # AttributeError surfaced as "Error exporting session" on
+            # every /save (#88713).
+            adapter = self.adapters.get(source.platform) if source else None
             if adapter:
                 await adapter.send_document(
                     chat_id=source.chat_id,

--- a/tests/gateway/test_save_command_adapter.py
+++ b/tests/gateway/test_save_command_adapter.py
@@ -1,0 +1,96 @@
+"""#88713 — /save must resolve its adapter the way every other handler does.
+
+``_handle_save_command`` called ``self.get_adapter(...)`` — a method that
+does not exist on GatewayRunner — so every export died as
+``Error exporting session: 'GatewayRunner' object has no attribute
+'get_adapter'`` before the document was ever sent.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+def _runner(tmp_path):
+    """Minimal runner exercising _handle_save_command's document branch."""
+
+    class _Runner(GatewaySlashCommandsMixin):
+        def __init__(self):
+            entry = SimpleNamespace(session_id="20260817_sess1")
+            self.async_session_store = MagicMock()
+            self.async_session_store.get_or_create_session = AsyncMock(
+                return_value=entry
+            )
+            self._session_db = MagicMock()
+            self._session_db.export_session = AsyncMock(
+                return_value={
+                    "id": "20260817_sess1",
+                    "title": "S",
+                    "model": "m",
+                    "started_at": 1755100000,
+                    "messages": [
+                        {"role": "user", "content": "hello"},
+                        {"role": "assistant", "content": "hi"},
+                    ],
+                }
+            )
+            self.adapters = MagicMock()
+
+    return _Runner()
+
+
+def _event(platform="telegram"):
+    event = MagicMock()
+    event.get_command_args.return_value = "json"
+    event.source = SimpleNamespace(
+        platform=platform, chat_id="12345", user_id="u1"
+    )
+    return event
+
+
+@pytest.mark.asyncio
+async def test_save_sends_document_via_adapters_dict(tmp_path):
+    runner = _runner(tmp_path)
+    adapter = MagicMock()
+    adapter.send_document = AsyncMock(return_value=True)
+    runner.adapters.get = MagicMock(return_value=adapter)
+
+    result = await runner._handle_save_command(_event())
+
+    assert result == "Export complete."
+    runner.adapters.get.assert_called_once_with("telegram")
+    adapter.send_document.assert_awaited_once()
+    kwargs = adapter.send_document.await_args.kwargs
+    assert kwargs["chat_id"] == "12345"
+    assert kwargs["file_name"].endswith(".json")
+
+
+@pytest.mark.asyncio
+async def test_save_reports_missing_adapter_without_raising(tmp_path):
+    runner = _runner(tmp_path)
+    runner.adapters.get = MagicMock(return_value=None)
+
+    result = await runner._handle_save_command(_event("signal"))
+
+    assert result == "Platform adapter not found to send the document."
+    runner.adapters.get.assert_called_once_with("signal")
+
+
+@pytest.mark.asyncio
+async def test_save_never_touches_nonexistent_get_adapter(tmp_path):
+    """The pre-fix crash: the mixin must not reference get_adapter at all."""
+    import inspect
+
+    src = inspect.getsource(
+        GatewaySlashCommandsMixin._handle_save_command
+    )
+    assert "self.get_adapter" not in src


### PR DESCRIPTION
## What does this PR do?

`/save` (session export) always failed with `Error exporting session: 'GatewayRunner' object has no attribute 'get_adapter'` — `_handle_save_command` called `self.get_adapter(source.platform)`, a method that does not exist anywhere on `GatewayRunner` (verified: `grep -rn "def get_adapter" gateway/` → 0 matches). The `AttributeError` was swallowed by the handler's broad `except` and surfaced as the export error, so the document was never sent on any platform (#88713).

Every sibling handler already resolves through the adapter dict (`self.adapters.get(...)` — used at `slash_commands.py:593`, `:5711`, `:5765`, `:2700` and elsewhere). This PR does the same in `_handle_save_command`, guarding for a missing source like the siblings do.

## Related Issue

Fixes #88713

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands.py`: `_handle_save_command` resolves the adapter via `self.adapters.get(source.platform) if source else None` instead of the nonexistent `self.get_adapter(...)`, with a comment referencing #88713
- `tests/gateway/test_save_command_adapter.py`: 3 regression tests (behavioral: document actually sent via the adapters dict with the right chat/file kwargs; missing adapter reports instead of raising; structural: the handler source must not reference `self.get_adapter` again)

## How to Test

1. `python -m pytest tests/gateway/test_save_command_adapter.py -q` — Observed result: 3 passed.
2. The same suite against the pre-fix code fails all 3 tests (verified by stashing the fix: 3 failed) — the tests genuinely pin the crash.
3. `python -m pytest tests/hermes_cli/test_session_save.py -q` — Observed result: 12 passed (the export/render helpers are unaffected).
4. Manual: on a Telegram (or any platform) gateway, `/save json` now sends the export document instead of erroring.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the new suite (3 passed) and the session-save helper suite (12 passed)
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — one-line pattern fix matching the siblings; the comment at the call site carries the #88713 reference

## For New Skills

N/A

## Screenshots / Logs

```
$ python -m pytest tests/gateway/test_save_command_adapter.py -q
3 passed in 2.94s
```
