### PR TITLE
fix(egress): detect podman bridges, add proxy.bind_host override

### DIFF
--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -999,16 +999,20 @@ def _default_http_listen(tunnel_port: int) -> List[str]:
     daemon process, so this returns a one-element list and the choice of
     host matters:
 
-    * **Linux:** bind the docker bridge gateway (``172.17.0.1`` by
+    * **Linux:** bind the container bridge gateway (``172.17.0.1`` by
       default).  Sandboxes reach the proxy via
       ``host.docker.internal:host-gateway``, which Docker resolves to
       exactly this bridge gateway IP on Linux — a loopback-only bind is
       unreachable from inside containers there.  The bridge IP is still
       host-local (it's an address on the host's ``docker0`` interface),
-      so host-side tooling and the status probe can reach it too.  When
-      no docker bridge is detected (docker not installed / not started),
-      fall back to loopback — there are no sandboxes to serve in that
-      state, and the operator gets a warning.
+      so host-side tooling and the status probe can reach it too.
+      ``podman0`` / ``cni-podman0`` are probed after ``docker0`` so
+      podman hosts without Docker installed work.  When no bridge is
+      detected at all — notably rootless podman with the **pasta** or
+      **slirp4netns** backend, which creates none — fall back to
+      loopback and warn; the operator should set ``proxy.bind_host``,
+      because loopback is not reachable from those sandboxes and the
+      container will fail closed.
     * **macOS / Windows Docker Desktop:** ``host.docker.internal``
       resolves via VPNkit to the host, so a loopback bind is reachable
       from containers and is the least-exposed choice.
@@ -1022,67 +1026,76 @@ def _default_http_listen(tunnel_port: int) -> List[str]:
     """
 
     if platform.system() == "Linux":
+        configured = _configured_bind_host()
+        if configured:
+            return [f"{configured}:{tunnel_port}"]
         bridge_ip = _detect_docker_bridge_ip()
         if bridge_ip and bridge_ip != "127.0.0.1":
             return [f"{bridge_ip}:{tunnel_port}"]
         logger.warning(
-            "No docker bridge (docker0) detected — binding iron-proxy to "
-            "loopback only.  Docker sandboxes will NOT be able to reach "
-            "the proxy until it is restarted with docker running."
+            "No container bridge (docker0 / podman0 / cni-podman0) detected "
+            "— binding iron-proxy to loopback only.  Sandboxes will NOT be "
+            "able to reach the proxy.  On rootless podman with the pasta or "
+            "slirp4netns network backend no bridge exists at all: set "
+            "proxy.bind_host to an address the sandbox can reach (and pass a "
+            "matching --add-host to the container) or the sandbox will fail "
+            "closed."
         )
     return [f"127.0.0.1:{tunnel_port}"]
 
 
-def _detect_docker_bridge_ip() -> Optional[str]:
-    """Return the docker0 bridge IPv4, if present, else None.
+def _configured_bind_host() -> Optional[str]:
+    """Return a validated ``proxy.bind_host`` override, or None.
 
-    Best-effort: we try ``ip -4 addr show docker0`` first.  Anything that
-    fails, doesn't parse as a strict IPv4, or parses as an address we
-    must NOT bind to (unspecified, loopback, multicast, reserved, public)
-    returns None — callers handle that as "no bridge bind".
-
-    SECURITY: a hostile ``ip`` shim earlier on the operator's PATH used
-    to be able to inject ``0.0.0.0`` here and re-open INADDR_ANY binding
-    that the rest of the bind-policy work explicitly closed.  We
-    validate via :mod:`ipaddress` and reject anything that isn't
-    plausibly a docker bridge IP (private + non-special).
+    Operators on container runtimes we can't auto-detect (rootless podman
+    with pasta, custom bridge names, remote daemons) need a way to pin the
+    sandbox-facing bind address.  The same bind policy applies as for
+    auto-detection: private, non-special addresses only, never
+    ``0.0.0.0`` — an INADDR_ANY bind would expose the proxy, and with a
+    leaked sandbox token the operator's API quota, to the local network.
     """
 
-    candidate: Optional[str] = None
     try:
-        res = subprocess.run(  # noqa: S603 — ip is a system binary
-            ["ip", "-4", "-o", "addr", "show", "docker0"],
-            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=2,
+        from hermes_cli.config import load_config
+    except ImportError:
+        return None
+
+    try:
+        cfg = load_config()
+    except Exception:  # noqa: BLE001 — a broken config must not wedge startup
+        return None
+
+    raw = ((cfg.get("proxy") or {}).get("bind_host") or "").strip()
+    if not raw:
+        return None
+
+    validated = _validate_bind_ip(raw)
+    if validated is None:
+        logger.warning(
+            "Ignoring proxy.bind_host=%r — not a bindable private IPv4 "
+            "address.  Falling back to auto-detection.", raw,
         )
-        if res.returncode == 0:
-            for line in res.stdout.splitlines():
-                parts = line.split()
-                # Expected: "<n>: docker0  inet 172.17.0.1/16 ..."
-                for i, tok in enumerate(parts):
-                    if tok == "inet" and i + 1 < len(parts):
-                        candidate = parts[i + 1].split("/")[0]
-                        break
-                if candidate is not None:
-                    break
-    except (OSError, subprocess.TimeoutExpired):
-        return None
+    return validated
 
-    if not candidate:
-        return None
 
-    # Stdlib validation: rejects garbage strings AND special-purpose
-    # addresses that must not be used as a bind target.
+def _validate_bind_ip(candidate: str) -> Optional[str]:
+    """Return ``candidate`` if it is a safe bind target, else None.
+
+    Rejects, via :mod:`ipaddress` rather than string matching:
+
+    * ``0.0.0.0`` / INADDR_ANY  (``is_unspecified``)
+    * ``127.0.0.0/8``           (``is_loopback`` — callers handle loopback
+      explicitly; it is never a *bridge* address)
+    * ``224.0.0.0/4``           (``is_multicast``)
+    * ``240.0.0.0/4``           (``is_reserved``)
+    * ``169.254.0.0/16``        (``is_link_local`` — IMDS range)
+    * global / public IPs       (``is_global``)
+    """
+
     try:
         addr = ipaddress.IPv4Address(candidate)
     except (ipaddress.AddressValueError, ValueError):
         return None
-    # Reject:
-    # - 0.0.0.0 / INADDR_ANY  (is_unspecified)
-    # - 127.0.0.0/8           (is_loopback — already in deny list)
-    # - 224.0.0.0/4           (is_multicast)
-    # - 240.0.0.0/4           (is_reserved)
-    # - 169.254.0.0/16        (is_link_local — IMDS range, never docker0)
-    # - global / public IPs   (is_global — docker0 must be RFC1918)
     if (
         addr.is_unspecified
         or addr.is_loopback
@@ -1091,13 +1104,71 @@ def _detect_docker_bridge_ip() -> Optional[str]:
         or addr.is_link_local
         or addr.is_global
     ):
-        logger.warning(
-            "Refusing suspicious docker bridge IP %s reported by `ip`; "
-            "skipping bridge bind.", candidate,
-        )
         return None
-
     return str(addr)
+
+
+# Bridge interfaces to probe, in priority order.  ``docker0`` first for
+# backwards compatibility, then the bridges podman creates under its
+# various network backends (netavark names it ``podman0``; the older CNI
+# plugin used ``cni-podman0``).
+_BRIDGE_INTERFACES: Tuple[str, ...] = ("docker0", "podman0", "cni-podman0")
+
+
+def _detect_docker_bridge_ip() -> Optional[str]:
+    """Return a container-bridge gateway IPv4, if present, else None.
+
+    Probes each interface in :data:`_BRIDGE_INTERFACES` in order and
+    returns the first bindable address.  Anything that fails, doesn't
+    parse as a strict IPv4, or parses as an address we must NOT bind to
+    (unspecified, loopback, multicast, reserved, link-local, public) is
+    skipped — callers handle an all-None result as "no bridge bind".
+
+    SECURITY: a hostile ``ip`` shim earlier on the operator's PATH used
+    to be able to inject ``0.0.0.0`` here and re-open INADDR_ANY binding
+    that the rest of the bind-policy work explicitly closed.  We
+    validate via :func:`_validate_bind_ip` and reject anything that
+    isn't plausibly a bridge IP (private + non-special).
+    """
+
+    for iface in _BRIDGE_INTERFACES:
+        candidate: Optional[str] = None
+        try:
+            res = subprocess.run(  # noqa: S603 — ip is a system binary
+                ["ip", "-4", "-o", "addr", "show", iface],
+                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=2,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+
+        if res.returncode != 0:
+            continue
+
+        for line in res.stdout.splitlines():
+            parts = line.split()
+            # Expected: "<n>: docker0  inet 172.17.0.1/16 ..."
+            for i, tok in enumerate(parts):
+                if tok == "inet" and i + 1 < len(parts):
+                    candidate = parts[i + 1].split("/")[0]
+                    break
+            if candidate is not None:
+                break
+
+        if not candidate:
+            continue
+
+        validated = _validate_bind_ip(candidate)
+        if validated is not None:
+            if iface != "docker0":
+                logger.debug("Using %s bridge gateway %s for proxy bind", iface, validated)
+            return validated
+
+        logger.warning(
+            "Refusing suspicious bridge IP %s reported by `ip` for %s; "
+            "skipping.", candidate, iface,
+        )
+
+    return None
 
 
 def build_proxy_config(

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3454,6 +3454,24 @@ DEFAULT_CONFIG = {
         # cover OpenRouter, OpenAI, Anthropic, Google, xAI, Mistral, Groq,
         # Together, DeepSeek, Nous).  Wildcards (`*.foo.com`) are supported.
         "extra_allowed_hosts": [],
+        # Sandbox-facing bind address override (Linux only).  Empty = probe
+        # docker0 / podman0 / cni-podman0 and bind the first bridge gateway
+        # found, else loopback.
+        #
+        # Set this when auto-detection can't find a reachable address:
+        # rootless podman with the pasta or slirp4netns backend creates NO
+        # host bridge, so there is nothing to detect and a loopback bind is
+        # unreachable from inside the container.  Point it at an address the
+        # sandbox can route to and add a matching
+        # `--add-host host.docker.internal:<ip>` to
+        # `terminal.docker_extra_args`.
+        #
+        # Must be a private, non-special IPv4 (RFC1918 or CGNAT).
+        # `0.0.0.0`, loopback, link-local, multicast, reserved and public
+        # addresses are rejected — an INADDR_ANY bind would expose the proxy
+        # (and, with a leaked sandbox token, the operator's API quota) to the
+        # local network.
+        "bind_host": "",
     },
 
     # Hermes Desktop (Electron app) launch options. These only affect

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -814,3 +814,136 @@ def test_bitwarden_importerror_raise_without_fallback(
         )
 
 
+
+
+# ---------------------------------------------------------------------------
+# Bind-address selection: bridge detection + proxy.bind_host override
+# ---------------------------------------------------------------------------
+
+
+def _ip_addr_stub(responses):
+    """Build a subprocess.run stub keyed on the interface name.
+
+    ``responses`` maps iface -> (returncode, stdout).  Unlisted ifaces
+    behave like a missing device (rc=1), which is what ``ip`` returns.
+    """
+
+    def _run(cmd, *a, **kw):
+        iface = cmd[-1]
+        rc, out = responses.get(iface, (1, ""))
+        return MagicMock(returncode=rc, stdout=out)
+
+    return _run
+
+
+def test_detect_bridge_prefers_docker0():
+    """docker0 wins when present — preserves pre-existing behaviour."""
+
+    stub = _ip_addr_stub({
+        "docker0": (0, "4: docker0    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0\n"),
+        "podman0": (0, "5: podman0    inet 10.88.0.1/16 brd 10.88.255.255 scope global podman0\n"),
+    })
+    with patch.object(ip.subprocess, "run", side_effect=stub):
+        assert ip._detect_docker_bridge_ip() == "172.17.0.1"
+
+
+def test_detect_bridge_falls_back_to_podman0():
+    """A podman host with no Docker installed still gets a bridge bind.
+
+    This is the regression: previously only docker0 was probed, so
+    podman-only hosts silently bound loopback and every sandbox lost
+    egress.
+    """
+
+    stub = _ip_addr_stub({
+        "podman0": (0, "5: podman0    inet 10.88.0.1/16 brd 10.88.255.255 scope global podman0\n"),
+    })
+    with patch.object(ip.subprocess, "run", side_effect=stub):
+        assert ip._detect_docker_bridge_ip() == "10.88.0.1"
+
+
+def test_detect_bridge_falls_back_to_cni_podman0():
+    """Older podman (CNI backend) names the bridge cni-podman0."""
+
+    stub = _ip_addr_stub({
+        "cni-podman0": (0, "6: cni-podman0    inet 10.88.0.1/16 scope global cni-podman0\n"),
+    })
+    with patch.object(ip.subprocess, "run", side_effect=stub):
+        assert ip._detect_docker_bridge_ip() == "10.88.0.1"
+
+
+def test_detect_bridge_none_when_no_bridge_exists():
+    """Rootless podman with pasta/slirp4netns has no bridge at all."""
+
+    with patch.object(ip.subprocess, "run", side_effect=_ip_addr_stub({})):
+        assert ip._detect_docker_bridge_ip() is None
+
+
+def test_detect_bridge_skips_unsafe_and_continues():
+    """A hostile/garbage address on one iface must not stop the probe."""
+
+    stub = _ip_addr_stub({
+        # 0.0.0.0 would re-open INADDR_ANY binding — must be rejected.
+        "docker0": (0, "4: docker0    inet 0.0.0.0/0 scope global docker0\n"),
+        "podman0": (0, "5: podman0    inet 10.88.0.1/16 scope global podman0\n"),
+    })
+    with patch.object(ip.subprocess, "run", side_effect=stub):
+        assert ip._detect_docker_bridge_ip() == "10.88.0.1"
+
+
+@pytest.mark.parametrize("bad", [
+    "0.0.0.0",          # INADDR_ANY
+    "127.0.0.1",        # loopback
+    "169.254.1.2",      # link-local / IMDS range
+    "8.8.8.8",          # public
+    "224.0.0.1",        # multicast
+    "240.0.0.1",        # reserved
+    "not-an-ip",
+    "",
+])
+def test_validate_bind_ip_rejects_unsafe(bad):
+    assert ip._validate_bind_ip(bad) is None
+
+
+@pytest.mark.parametrize("good", ["172.17.0.1", "10.88.0.1", "192.168.5.1", "100.64.0.1"])
+def test_validate_bind_ip_accepts_private(good):
+    assert ip._validate_bind_ip(good) == good
+
+
+def test_configured_bind_host_overrides_detection():
+    """proxy.bind_host wins over auto-detection on Linux."""
+
+    with patch.object(ip, "_configured_bind_host", return_value="10.88.0.1"), \
+         patch.object(ip, "_detect_docker_bridge_ip", return_value="172.17.0.1"), \
+         patch.object(ip.platform, "system", return_value="Linux"):
+        assert ip._default_http_listen(9090) == ["10.88.0.1:9090"]
+
+
+def test_bind_falls_back_to_loopback_without_bridge():
+    with patch.object(ip, "_configured_bind_host", return_value=None), \
+         patch.object(ip, "_detect_docker_bridge_ip", return_value=None), \
+         patch.object(ip.platform, "system", return_value="Linux"):
+        assert ip._default_http_listen(9090) == ["127.0.0.1:9090"]
+
+
+def test_configured_bind_host_rejects_unsafe_value(monkeypatch):
+    """An unsafe proxy.bind_host is ignored, not honoured."""
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda *a, **kw: {"proxy": {"bind_host": "0.0.0.0"}},
+    )
+    assert ip._configured_bind_host() is None
+
+
+def test_configured_bind_host_reads_valid_value(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda *a, **kw: {"proxy": {"bind_host": "10.88.0.1"}},
+    )
+    assert ip._configured_bind_host() == "10.88.0.1"
+
+
+def test_configured_bind_host_empty_by_default(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **kw: {"proxy": {}})
+    assert ip._configured_bind_host() is None


### PR DESCRIPTION
iron-proxy silently loses egress on podman hosts because bridge detection only looks for `docker0`.

## The bug

`_default_http_listen()` picks the sandbox-facing bind address via `_detect_docker_bridge_ip()`, which probes exactly one interface:

```python
["ip", "-4", "-o", "addr", "show", "docker0"]
```

But Hermes container backend is runtime-agnostic — `HERMES_DOCKER_BINARY` can point at `/usr/bin/podman`, and `terminal.backend: docker` then builds podman containers. On a podman host with no Docker installed, `docker0` does not exist, detection returns `None`, and the bind falls back to loopback. Every sandbox loses outbound access:

- with `proxy.enforce_on_docker: true` (the default) the docker backend raises and the sandbox refuses to start
- with it `false` the sandbox starts, but `HTTPS_PROXY` points at an address where nothing listens, so every request fails

The loopback fallback is not just unhelpful, it is **unreachable**. A rootless podman container cannot route to a host loopback bind, so the documented "fall back to loopback — there are no sandboxes to serve in that state" path can never serve a sandbox. Verified on Arch with podman 6.1.0 rootless: a host listener on `127.0.0.1:9099` is refused from inside the container, while an RFC1918 host address on the same port is reachable.

Worse, it fails *invisibly* on a mixed host. If Docker happens to be installed but unused, `docker0` exists (even `state DOWN`) and the bind works — so the whole egress-isolation guarantee quietly depends on an unrelated package being present. Uninstall Docker and a working podman sandbox setup breaks with no config change.

## The fix

- **Probe `docker0`, then `podman0`, then `cni-podman0`** (netavark and the older CNI backend), returning the first bindable gateway. `docker0` stays first, so existing Docker hosts are byte-for-byte unaffected.
- **Add `proxy.bind_host`** (default `""`) to pin the bind address where auto-detection cannot work at all — notably rootless podman with the **pasta** or **slirp4netns** backend, which creates no host bridge whatsoever. There is nothing to detect in that topology, so a config escape hatch is the only fix.
- **Extract `_validate_bind_ip()`** and reuse it for the override, so a hand-written config cannot widen the bind policy. `0.0.0.0`, loopback, link-local (IMDS), multicast, reserved and public addresses are all still rejected; an unsafe value is ignored with a warning rather than honoured. This preserves the existing hostile-`ip`-shim protection and extends it to the new input.
- **A rejected address on one interface no longer aborts the probe** — it warns and continues to the next candidate.
- **Correct the no-bridge warning**, which told operators to start Docker. That is wrong on podman and actively misleading for pasta/slirp4netns, where no bridge will ever appear no matter what is started. It now points at `proxy.bind_host`.

No behaviour change for Docker users: when `docker0` is present it is still chosen first and the emitted config is identical.

## Testing

12 new cases in `tests/test_iron_proxy.py` covering docker0 priority, `podman0` / `cni-podman0` fallback, the no-bridge case, skip-and-continue on an unsafe address, override precedence over detection, and validation of both accepted and rejected addresses (parametrized).

```
tests/test_iron_proxy.py tests/test_iron_proxy_cli.py
57 passed in 1.10s
```

Also verified against the real host: detection returns `172.17.0.1` unchanged with `docker0` present, and `10.88.0.1` on a simulated podman-only host where it previously returned `None`.

## Notes

- Found while hardening a real podman-backed maintainer profile: the sandbox reported `curl: (7) connection refused` for every request while `hermes egress status` cheerfully showed `listening yes`. The host-side status probe can reach a bridge bind, so status alone does not reveal the problem — worth considering a container-side reachability check in `hermes egress status` as a follow-up.
- Unrelated but adjacent: `_egress_proxy_args_for_docker()` hardcodes `--add-host host.docker.internal:host-gateway`. Podman maps `host-gateway` to its own `169.254.1.2` host alias rather than the bridge, so even with a correct bridge bind the hostname resolves somewhere with no listener. Operators currently need a manual `--add-host host.docker.internal:<bridge-ip>` in `terminal.docker_extra_args`. I left that out to keep this PR focused, but happy to fix it here or in a follow-up if you would prefer the runtime-aware mapping bundled in.

🤖 Generated with [Hermes Agent](https://github.com/NousResearch/hermes-agent)