### PR TITLE
fix(acp): recover cancelled prompt sessions

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2029,7 +2029,10 @@ class HermesACPAgent(acp.Agent):
                     exc_info=True,
                 )
 
-        final_response = result.get("final_response", "")
+        # Interrupted turns can legitimately return ``None`` when no assistant
+        # text was produced before the hard stop.  Normalize it before string
+        # handling so the cancellation path still reaches runtime release.
+        final_response = result.get("final_response") or ""
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         interrupted = bool(result.get("interrupted")) or cancelled
         # Hermes' local "waiting for model response" interrupt status is metadata,
@@ -2049,8 +2052,18 @@ class HermesACPAgent(acp.Agent):
             # or when a plugin hook transformed the response after streaming
             # finished (e.g. transform_llm_output) — otherwise the appended /
             # rewritten text never reaches the client.
-            update = acp.update_agent_message_text(final_response)
-            await conn.session_update(session_id, update)
+            try:
+                update = acp.update_agent_message_text(final_response)
+                await conn.session_update(session_id, update)
+            except Exception:
+                # A client can disconnect after the worker finishes but before
+                # the terminal response is delivered.  Delivery failure must
+                # not strand the session's runtime lease.
+                logger.debug(
+                    "Failed to deliver ACP final response for %s",
+                    session_id,
+                    exc_info=True,
+                )
 
         await self._mark_idle_and_drain_queued_prompts(
             state=state,

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1965,7 +1965,34 @@ class HermesACPAgent(acp.Agent):
             # stomp on each other's ContextVar writes (HERMES_SESSION_KEY in
             # particular — used by the interactive sudo password cache scope).
             ctx = contextvars.copy_context()
-            result = await loop.run_in_executor(_executor, ctx.run, _run_agent)
+            executor_future = loop.run_in_executor(_executor, ctx.run, _run_agent)
+            # Keep the executor future alive when the ACP request task is
+            # cancelled.  ``run_in_executor`` cannot stop a worker that is
+            # already running, and an unshielded await cancels only the
+            # asyncio wrapper.  The worker then continues while
+            # ``state.is_running`` stays true forever, so every later prompt
+            # is misreported as queued for a turn that no longer has an ACP
+            # owner.
+            result = await asyncio.shield(executor_future)
+        except asyncio.CancelledError:
+            # Publish the same hard interrupt as session/cancel, then wait for
+            # the worker to relinquish the per-session agent before making the
+            # session available again.  This prevents concurrent conversations
+            # on one agent while still guaranteeing that cancellation cannot
+            # strand the runtime lease.
+            await self.cancel(session_id)
+            try:
+                await executor_future
+            except Exception:
+                logger.exception(
+                    "Executor error while cancelling session %s", session_id
+                )
+            await self._mark_idle_and_drain_queued_prompts(
+                state=state,
+                session_id=session_id,
+                conn=conn,
+            )
+            raise
         except Exception:
             logger.exception("Executor error for session %s", session_id)
             with state.runtime_lock:
@@ -2025,6 +2052,35 @@ class HermesACPAgent(acp.Agent):
             update = acp.update_agent_message_text(final_response)
             await conn.session_update(session_id, update)
 
+        await self._mark_idle_and_drain_queued_prompts(
+            state=state,
+            session_id=session_id,
+            conn=conn,
+        )
+
+        usage = None
+        if any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):
+            usage = Usage(
+                input_tokens=result.get("prompt_tokens", 0),
+                output_tokens=result.get("completion_tokens", 0),
+                total_tokens=result.get("total_tokens", 0),
+                thought_tokens=result.get("reasoning_tokens"),
+                cached_read_tokens=result.get("cache_read_tokens"),
+            )
+
+        await self._send_usage_update(state)
+
+        stop_reason = "cancelled" if cancelled else "end_turn"
+        return PromptResponse(stop_reason=stop_reason, usage=usage)
+
+    async def _mark_idle_and_drain_queued_prompts(
+        self,
+        *,
+        state: SessionState,
+        session_id: str,
+        conn: Any | None,
+    ) -> None:
+        """Release a completed turn and run its queued follow-ups in order."""
         # Mark this turn idle before draining queued work so recursive prompt()
         # calls can acquire the session. Queued turns are intentionally run as
         # normal follow-up user prompts, preserving role alternation and history.
@@ -2046,21 +2102,6 @@ class HermesACPAgent(acp.Agent):
                 prompt=[TextContentBlock(type="text", text=next_prompt)],
                 session_id=session_id,
             )
-
-        usage = None
-        if any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):
-            usage = Usage(
-                input_tokens=result.get("prompt_tokens", 0),
-                output_tokens=result.get("completion_tokens", 0),
-                total_tokens=result.get("total_tokens", 0),
-                thought_tokens=result.get("reasoning_tokens"),
-                cached_read_tokens=result.get("cache_read_tokens"),
-            )
-
-        await self._send_usage_update(state)
-
-        stop_reason = "cancelled" if cancelled else "end_turn"
-        return PromptResponse(stop_reason=stop_reason, usage=usage)
 
     # ---- Slash commands (headless) -------------------------------------------
 

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -1,4 +1,6 @@
+import asyncio
 import sys
+import threading
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -163,6 +165,76 @@ async def test_acp_cancel_publishes_hard_stop_while_holding_runtime_lock():
     assert state.interrupted_prompt_text == "original request"
 
 
+@pytest.mark.asyncio
+async def test_cancelled_prompt_releases_runtime_and_drains_follow_up_queue():
+    class BlockingFirstRunAgent(FakeAgent):
+        def __init__(self):
+            super().__init__()
+            self._supports_active_turn_redirect = False
+            self.started = threading.Event()
+            self.release = threading.Event()
+            self.interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+
+        def run_conversation(
+            self, *, user_message, conversation_history, task_id, **kwargs
+        ):
+            self.runs.append(user_message)
+            if len(self.runs) == 1:
+                self.started.set()
+                assert self.release.wait(timeout=2), "test did not release first turn"
+                return {
+                    "final_response": "interrupted",
+                    "messages": list(conversation_history or []),
+                    "interrupted": True,
+                }
+            return {
+                "final_response": f"ran: {user_message}",
+                "messages": list(conversation_history or []),
+            }
+
+    fake = BlockingFirstRunAgent()
+    manager = SessionManager(agent_factory=lambda **kwargs: fake, db=NoopDb())
+    acp_agent = HermesACPAgent(session_manager=manager)
+    state = manager.create_session(cwd=".")
+    conn = CaptureConn()
+    acp_agent.on_connect(conn)
+
+    active_prompt = asyncio.create_task(
+        acp_agent.prompt(
+            session_id=state.session_id,
+            prompt=[TextContentBlock(type="text", text="review everything")],
+        )
+    )
+    assert await asyncio.to_thread(fake.started.wait, 1)
+
+    active_prompt.cancel()
+    await asyncio.sleep(0)
+    assert state.is_running is True
+    assert fake.interrupt_calls == 1
+
+    queued_response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="continue with the review")],
+    )
+    assert queued_response.stop_reason == "end_turn"
+    assert state.queued_prompts == ["continue with the review"]
+
+    fake.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(active_prompt, timeout=2)
+
+    assert state.is_running is False
+    assert state.queued_prompts == []
+    assert fake.runs == [
+        "review everything",
+        (
+            "review everything\n\n"
+            "User correction/guidance after interrupt: continue with the review"
+        ),
+    ]
 
 
 

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -237,5 +237,61 @@ async def test_cancelled_prompt_releases_runtime_and_drains_follow_up_queue():
     ]
 
 
+@pytest.mark.asyncio
+async def test_session_cancel_with_no_final_text_releases_runtime():
+    class InterruptedAgent(FakeAgent):
+        def __init__(self):
+            super().__init__()
+            self.started = threading.Event()
+            self.release = threading.Event()
+
+        def interrupt(self):
+            self.release.set()
+
+        def run_conversation(
+            self, *, user_message, conversation_history, task_id, **kwargs
+        ):
+            self.runs.append(user_message)
+            self.started.set()
+            assert self.release.wait(timeout=2), "test did not cancel first turn"
+            return {
+                "final_response": None,
+                "messages": list(conversation_history or []),
+                "interrupted": True,
+            }
+
+    fake = InterruptedAgent()
+    manager = SessionManager(agent_factory=lambda **kwargs: fake, db=NoopDb())
+    acp_agent = HermesACPAgent(session_manager=manager)
+    state = manager.create_session(cwd=".")
+    acp_agent.on_connect(CaptureConn())
+
+    active_prompt = asyncio.create_task(
+        acp_agent.prompt(
+            session_id=state.session_id,
+            prompt=[TextContentBlock(type="text", text="wait for cancellation")],
+        )
+    )
+    assert await asyncio.to_thread(fake.started.wait, 1)
+
+    await acp_agent.cancel(state.session_id)
+    response = await asyncio.wait_for(active_prompt, timeout=2)
+
+    assert response.stop_reason == "cancelled"
+    assert state.is_running is False
+    assert state.current_prompt_text == ""
+
+    follow_up = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="follow up")],
+    )
+    assert follow_up.stop_reason == "end_turn"
+    assert fake.runs == [
+        "wait for cancellation",
+        (
+            "wait for cancellation\n\n"
+            "User correction/guidance after interrupt: follow up"
+        ),
+    ]
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the ACP cancellation wedge reported in #79196 without releasing the per-session agent while its executor worker is still running.

When the ACP request task is cancelled, `run_in_executor()` cannot stop an already-running worker. Previously `asyncio.CancelledError` bypassed cleanup, leaving `state.is_running` true forever and causing every later prompt to be reported as queued. Simply clearing `is_running` in the cancellation handler (as proposed in #79215) creates a second race: a follow-up can start a concurrent conversation on the same agent while the cancelled worker is still unwinding.

This change shields the executor future, publishes the existing hard interrupt, waits for the worker to relinquish the agent, and only then releases the runtime and drains queued follow-ups. The normal completion and cancellation paths share one release-and-drain helper. It also normalizes an interrupted turn's nullable final response and makes terminal response delivery best-effort, so post-worker client disconnects cannot skip runtime release.

## Related Issue

Addresses #79196. Alternative to #79215 with worker-handoff coverage.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `acp_adapter/server.py`: shield cancelled executor work, issue the hard interrupt, wait for worker handoff, and centralize runtime release/queue draining.
- `tests/acp_adapter/test_acp_commands.py`: reproduce cancellation while a worker is blocked, queue a follow-up during unwind, and cover the ACP `session/cancel` path when the interrupted turn returns no final text.

## How to Test

1. Start an ACP prompt whose executor worker remains in `run_conversation()`.
2. Cancel the ACP prompt task, then submit a follow-up before the worker exits.
3. Verify the hard interrupt fires, the session remains leased until the worker exits, and the queued follow-up is drained afterward.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs and compared #79215.
- [x] My PR contains only changes related to this fix.
- [x] Focused ACP suite passes: `pytest -q tests/acp_adapter` (17 passed).
- [x] I've added regression coverage.
- [x] Tested on Linux with Python 3.11.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration or API change.
- [x] `cli-config.yaml.example`: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A.
- [x] Cross-platform impact considered; uses portable `asyncio` semantics.
- [x] Tool descriptions/schemas: N/A.

Additional checks: `ruff check acp_adapter/server.py tests/acp_adapter/test_acp_commands.py`, `python -m compileall -q acp_adapter/server.py tests/acp_adapter/test_acp_commands.py`, and `git diff --check`.
