### PR TITLE
fix(bot-mode): Routines pane no longer hides legacy untagged + profile-owned cron jobs (#88263, salvage #88614/#88458, credit #86803)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5992,7 +5992,7 @@ function selectRoutineJobs(data, error, lastJobs, bot) {
   return {
     live,
     all,
-    jobs: scopedToBot ? all : all.filter(job => routineBot(job) === bot)
+    jobs: scopedToBot ? all : all.filter(job => (routineBot(job) || 'default') === bot)
   }
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5988,10 +5988,11 @@ async function invalidateRoutineOwner(profile) {
 function selectRoutineJobs(data, error, lastJobs, bot) {
   const live = Array.isArray(data?.jobs) ? data.jobs : null
   const all = live ?? (error ? lastJobs : [])
+  const scopedToBot = normalizedProfileName(data?.scoped) === normalizedProfileName(bot)
   return {
     live,
     all,
-    jobs: all.filter(job => routineBot(job) === bot)
+    jobs: scopedToBot ? all : all.filter(job => routineBot(job) === bot)
   }
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5996,6 +5996,24 @@ function selectRoutineJobs(data, error, lastJobs, bot) {
   }
 }
 
+/**
+ * Why the Routines pane can be empty while the bot's cron store has jobs.
+ *
+ * On older gateways the pane only shows jobs namespaced `[bot:<name>]` for the
+ * active bot (plus untagged legacy jobs on the default bot). When jobs exist in
+ * the store but none surface for this bot, the user is left staring at the
+ * generic empty state with no hint that cronjobs are present but hidden.
+ * Return a short explanation string in that case, or null when the store is
+ * genuinely empty (or the active bot's jobs are already shown).
+ */
+function routineFilterHint(all, jobs) {
+  if (jobs.length !== 0 || !Array.isArray(all) || all.length === 0) {
+    return null
+  }
+  return 'Cronjobs exist in this profile but none are tagged for this bot. ' +
+    'Name a job "[bot:<name>] …" to show it here, or see them in Cron below.'
+}
+
 function normalizedProfileName(profile) {
   return typeof profile === 'string' ? profile.trim().toLowerCase() : ''
 }
@@ -6541,6 +6559,7 @@ function RoutinesPane() {
   const staleNotice = error && !view.live && view.all.length
     ? 'Could not refresh cronjobs. Showing the last list we had.'
     : null
+  const filterHint = routineFilterHint(view.all, jobs)
 
   return jsxs('div', {
     className: 'flex h-full flex-col',
@@ -6621,13 +6640,15 @@ function RoutinesPane() {
                 jsx(Codicon, { name: 'calendar', className: 'text-[1.6rem] text-(--ui-text-quaternary)' }),
                 jsx('div', {
                   className: 'text-xs leading-5 text-(--ui-text-tertiary)',
-                  children: 'Cronjobs are recurring tasks this agent runs on a schedule.'
+                  children: filterHint
+                    ? filterHint
+                    : 'Cronjobs are recurring tasks this agent runs on a schedule.'
                 }),
                 jsx(Button, {
                   variant: 'secondary',
                   size: 'sm',
                   onClick: openCreate,
-                  children: 'Create Cronjob'
+                  children: filterHint ? 'Create a cronjob for this bot' : 'Create Cronjob'
                 })
               ]
             })

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-error.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-error.test.mjs
@@ -43,6 +43,45 @@ test('unit: a live list is filtered to the current bot', () => {
   assert.equal(shown[0].job_id, '1')
 })
 
+test('regression: a profile-scoped list shows every job owned by that bot profile', () => {
+  const profileJobs = [
+    { name: 'ordinary profile cronjob', job_id: 'legacy' },
+    { name: '[bot:ops] Bot Mode routine', job_id: 'routine' }
+  ]
+  const view = load().__api.selectRoutineJobs({ jobs: profileJobs, scoped: 'ops' }, null, [], 'ops')
+
+  assert.deepEqual(
+    Array.from(view.jobs, job => job.job_id),
+    ['legacy', 'routine']
+  )
+})
+
+test('compatibility: an unmarked list keeps tag filtering for older gateways', () => {
+  const profileJobs = [
+    { name: 'ordinary launch-profile cronjob', job_id: 'legacy' },
+    { name: '[bot:ops] Bot Mode routine', job_id: 'routine' }
+  ]
+  const view = load().__api.selectRoutineJobs({ jobs: profileJobs }, null, [], 'ops')
+
+  assert.deepEqual(
+    Array.from(view.jobs, job => job.job_id),
+    ['routine']
+  )
+})
+
+test('compatibility: a stale scope marker cannot leak another profile\'s jobs', () => {
+  const profileJobs = [
+    { name: 'ordinary research cronjob', job_id: 'research' },
+    { name: '[bot:ops] Bot Mode routine', job_id: 'routine' }
+  ]
+  const view = load().__api.selectRoutineJobs({ jobs: profileJobs, scoped: 'research' }, null, [], 'ops')
+
+  assert.deepEqual(
+    Array.from(view.jobs, job => job.job_id),
+    ['routine']
+  )
+})
+
 test('unit: a failed refresh keeps the last good list', () => {
   const view = load().__api.selectRoutineJobs(undefined, new Error('down'), jobs, 'ops')
   assert.equal(view.live, null)

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-error.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-error.test.mjs
@@ -82,6 +82,14 @@ test('compatibility: a stale scope marker cannot leak another profile\'s jobs', 
   )
 })
 
+test('regression: untagged legacy cronjobs remain visible only on the default bot', () => {
+  const legacy = { name: 'Existing reminder', job_id: 'legacy' }
+  const api = load().__api
+
+  assert.deepEqual(api.selectRoutineJobs({ jobs: [legacy] }, null, [], 'default').jobs, [legacy])
+  assert.deepEqual(api.selectRoutineJobs({ jobs: [legacy] }, null, [], 'ops').jobs, [])
+})
+
 test('unit: a failed refresh keeps the last good list', () => {
   const view = load().__api.selectRoutineJobs(undefined, new Error('down'), jobs, 'ops')
   assert.equal(view.live, null)

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-filter-hint.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-filter-hint.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// UX improvement: when a bot's cron store HAS jobs but none are namespaced
+// `[bot:<name>]` for the active bot, the Routines pane now explains why it's
+// empty instead of showing the generic empty state with no hint.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: { state: { profile: { listen: () => undefined } } }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__api = { routineFilterHint };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context
+}
+
+test('hint: null when the active bot already has tagged jobs', () => {
+  const all = [{ name: '[bot:ops] Morning', job_id: '1' }]
+  assert.equal(load().__api.routineFilterHint(all, all), null)
+})
+
+test('hint: null when the store is genuinely empty', () => {
+  assert.equal(load().__api.routineFilterHint([], []), null)
+  assert.equal(load().__api.routineFilterHint(undefined, []), null)
+})
+
+test('hint: explains hidden jobs when store has jobs but none match the bot', () => {
+  const all = [
+    { name: '[bot:research] Digest', job_id: '2' },
+    { name: 'untagged job', job_id: '3' }
+  ]
+  const hint = load().__api.routineFilterHint(all, [])
+  assert.ok(hint)
+  assert.match(hint, /tagged for this bot/)
+})

--- a/contributors/emails/bkashjee@users.noreply.github.com
+++ b/contributors/emails/bkashjee@users.noreply.github.com
@@ -1,0 +1,1 @@
+BkashJEE

--- a/tests/test_cron_manage_profile_scope.py
+++ b/tests/test_cron_manage_profile_scope.py
@@ -47,6 +47,7 @@ def test_cron_manage_profile_reads_that_profiles_store(tmp_path, monkeypatch):
     )
 
     assert "result" in resp, resp
+    assert resp["result"]["scoped"] == "botA"
     names = [j.get("name") for j in resp["result"]["jobs"]]
     assert "botA-only-job" in names
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1699,15 +1699,19 @@ def _(rid, params: dict) -> dict:
         if action == "list":
             # Paused jobs are excluded by default, which reads as deletion in
             # any UI with an enable/disable toggle — forward the flag.
-            return _ok(
-                rid,
-                json.loads(
-                    cronjob(
-                        action="list",
-                        include_disabled=is_truthy_value(params.get("include_disabled", False)),
-                    )
-                ),
+            result = json.loads(
+                cronjob(
+                    action="list",
+                    include_disabled=is_truthy_value(params.get("include_disabled", False)),
+                )
             )
+            # This marker proves the gateway honored the optional profile
+            # scope. New clients may therefore treat every returned job as
+            # owned by that profile; older gateways omit it, preserving the
+            # safe [bot:<name>] compatibility filter.
+            if profile:
+                result["scoped"] = profile
+            return _ok(rid, result)
         if action == "add":
             return _ok(
                 rid,


### PR DESCRIPTION
Untagged/legacy cron jobs are no longer silently hidden by the Bot Mode Routines pane: they now show under the default bot, profile-owned jobs show for their bot (via the profile-scoped `cron.manage` list already on main), and when jobs exist but none surface for the active bot the empty state explains why instead of pretending the store is empty.

Fixes #88263

## What changed

Consolidated salvage of a 4-PR swarm onto current main, credits earliest submitter first:

- **@BowmanStephen** (#86803, Aug 15 — earliest): proposed profile-scoped cron listing (`cronjob(action='list', home=...)` + `profile` param on `cron.manage`). Its backend approach is **superseded by main**: #86796 landed the same `profile` param on `cron.manage` via `set_hermes_home_override`, mirroring `skills.manage`. No code from #86803 could be used, but the design it pioneered (and Bot Mode #37, which it implemented) is exactly what this branch builds on — credited here as the earliest submitter of the correct approach.
- **@capt-marbles** (#88614, cherry-picked with authorship): the gateway now stamps `scoped: <profile>` on profile-scoped `cron.manage` list responses, and `selectRoutineJobs` trusts a scoped list wholesale — profile-owned jobs (stored in a bot profile's own cron store, untagged) are shown for that bot. A stale/mismatched scope marker still falls back to the tag filter, so another profile's jobs can't leak.
- **@ScaleLeanChris** (#88458, cherry-picked with authorship): on unscoped (older-gateway / compatibility) lists, untagged legacy jobs are attributed to the **default** bot instead of nowhere — `(routineBot(job) || 'default') === bot`. The two plugin fixes were woven into one expression: `scopedToBot ? all : all.filter(job => (routineBot(job) || 'default') === bot)`.
- **@BkashJEE** (#88561, routines-filter-hint half only, re-applied with authorship): when jobs exist in the store but none surface for the active bot, the empty state now says so ("Cronjobs exist in this profile but none are tagged for this bot…") instead of the generic blurb. The pet-gallery pagination half of #88561 was **skipped as out of scope** for this issue.

## Acceptance behavior

- `[bot:<name>]`-tagged jobs show under that bot (unchanged).
- Untagged legacy jobs show under the default bot — never nowhere.
- Profile-owned jobs (a profile's own cron store) are listed for that profile's bot via the scoped list.
- No duplicate listing: a job is either taken from its scoped store or attributed to exactly one bot by tag/default; a stale scope marker cannot leak jobs across bots (regression-tested).

## PR disposition (for the parent to close with credit)

- #86803 — superseded (backend already on main via #86796); credited as earliest submitter of the approach.
- #88614 — used (cherry-picked).
- #88458 — used (cherry-picked, woven with #88614).
- #88561 — partially used (hint half re-applied under original authorship; pet gallery half out of scope).

## Tests

- `node --check plugin.js` clean; `node --test tests/*.test.mjs` — **210/210 pass** (includes 3 new scoped-list regressions from #88614, 1 legacy-default regression from #88458, 3 filter-hint tests from #88561).
- `pytest tests/tools/test_cronjob_tools.py tests/test_cron_manage_profile_scope.py` — **70/70 pass** (includes the new `scoped` marker assertion).
- `scripts/audit_pr_attribution.py` — all contributor emails mapped.

Plugin.js edits are strictly scoped to the Routines/cron logic (`selectRoutineJobs`, `routineFilterHint`, the RoutinesPane empty state) — no group-chat, capabilities, or other panel code touched.

## Infographic

![Routines pane now shows every cron job](https://v3b.fal.media/files/b/0aa6c1ec/VNDyqOHvtpDifDHiOEzlA_mVmc7twf.png)
