### PR TITLE
fix(desktop): re-home backend and retire sockets on profile rename

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -248,6 +248,7 @@ import {
   profileNameFromDeleteRequest,
   resolveRouteProfile
 } from './profile-delete-routing'
+import { prepareProfileRenameLifecycle, profileRenameFromRequest } from './profile-rename-routing'
 import {
   buildSidebarSessionSliceParams,
   fetchPrimaryProfileSessions,
@@ -265,7 +266,6 @@ import {
 } from './remote-liveness'
 import { missingRendererAssets } from './renderer-bundle'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
-import { prepareProfileRenameLifecycle, profileRenameFromRequest } from './profile-rename-routing'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -13260,6 +13260,7 @@ async function handleHermesApiRequest(request) {
   // primary rename the lifecycle has already made `default` the temporary
   // primary until the PATCH settles, so the request routes there.
   const apiRoute = resolveProfileApiRequest(profile, request.path, profileRouteOptions(profile, request))
+
   const routeProfile = profileRename
     ? profileRename.routeProfile
     : resolveRouteProfile(tornDownProfile, apiRoute.backendProfile)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -265,6 +265,7 @@ import {
 } from './remote-liveness'
 import { missingRendererAssets } from './renderer-bundle'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
+import { prepareProfileRenameLifecycle, profileRenameFromRequest } from './profile-rename-routing'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -10107,6 +10108,24 @@ async function prepareProfileDeleteRequest(request) {
   return decision.profile
 }
 
+async function prepareProfileRenameRequest(request) {
+  return prepareProfileRenameLifecycle(request, {
+    isValidProfileName: profile => PROFILE_NAME_RE.test(profile),
+    primaryProfileKey,
+    reloadPrimaryWindow: () => {
+      mainWindow?.reload()
+    },
+    restartPrimaryBackend: async () => {
+      await startHermes()
+    },
+    teardownPoolBackendAndWait,
+    teardownPrimaryBackendAndWait,
+    writeActiveDesktopProfile: profile => {
+      writeActiveDesktopProfile(profile)
+    }
+  })
+}
+
 async function startHermes() {
   // Only the single-instance lock holder may reap/spawn/claim the desktop
   // backend. A lock-losing instance must stay inert even if some path reaches
@@ -13224,6 +13243,7 @@ async function handleHermesApiRequest(request) {
     return rerouted
   }
 
+  const profileRename = await prepareProfileRenameRequest(request)
   const tornDownProfile = await prepareProfileDeleteRequest(request)
 
   const profile = request?.profile
@@ -13235,67 +13255,97 @@ async function handleHermesApiRequest(request) {
   // Safe local-profile REST calls also stay on the primary dashboard and carry
   // ?profile=. Endpoints that cannot honor that scope retain their pooled
   // backend so a destructive call can never fall through to the primary home.
+  //
+  // A profile rename tears down the old-name backend the same way; for a
+  // primary rename the lifecycle has already made `default` the temporary
+  // primary until the PATCH settles, so the request routes there.
   const apiRoute = resolveProfileApiRequest(profile, request.path, profileRouteOptions(profile, request))
-  const routeProfile = resolveRouteProfile(tornDownProfile, apiRoute.backendProfile)
+  const routeProfile = profileRename
+    ? profileRename.routeProfile
+    : resolveRouteProfile(tornDownProfile, apiRoute.backendProfile)
 
-  const connection = await ensureBackend(routeProfile)
-  const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
+  let response
 
-  const url = `${connection.baseUrl}${apiRoute.requestPath}`
+  try {
+    const connection = await ensureBackend(routeProfile)
+    const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
-  // OAuth gateways authenticate REST via EITHER a native bearer token
-  // (cookieless RFC 8252 flow) OR the HttpOnly session cookie held in the OAuth
-  // partition. Prefer the native bearer when present (mirroring
-  // mintGatewayWsTicket): the native flow never sets a cookie, so routing an
-  // oauth-mode REST call through the cookie-only path returns 401 no_cookie even
-  // though a valid bearer is held. Cookie mode rides Electron's net stack bound
-  // to the OAuth partition so the cookie attaches automatically. Token/local
-  // modes keep using the static session-token header.
-  if (connection.authMode === 'oauth') {
-    // The OAuth path rides electron.net with JSON headers; multipart isn't
-    // wired there. Fail loudly rather than corrupting the upload.
-    if (request?.upload) {
-      throw new Error('File uploads are not supported against OAuth-gated remote backends yet.')
-    }
+    const url = `${connection.baseUrl}${apiRoute.requestPath}`
 
-    // Native bearer first (cookieless). ensureNativeAccessToken transparently
-    // refreshes a near-expiry AT via /auth/native/refresh; a null return means
-    // no native session (resolveOauthRestAuth then selects the cookie path).
-    const nativeAt = await ensureNativeAccessToken(connection.baseUrl).catch(() => null)
-    const restAuth = resolveOauthRestAuth(nativeAt)
+    // OAuth gateways authenticate REST via EITHER a native bearer token
+    // (cookieless RFC 8252 flow) OR the HttpOnly session cookie held in the OAuth
+    // partition. Prefer the native bearer when present (mirroring
+    // mintGatewayWsTicket): the native flow never sets a cookie, so routing an
+    // oauth-mode REST call through the cookie-only path returns 401 no_cookie even
+    // though a valid bearer is held. Cookie mode rides Electron's net stack bound
+    // to the OAuth partition so the cookie attaches automatically. Token/local
+    // modes keep using the static session-token header.
+    if (connection.authMode === 'oauth') {
+      // The OAuth path rides electron.net with JSON headers; multipart isn't
+      // wired there. Fail loudly rather than corrupting the upload.
+      if (request?.upload) {
+        throw new Error('File uploads are not supported against OAuth-gated remote backends yet.')
+      }
 
-    if (restAuth.kind === 'bearer') {
-      return fetchJson(url, null, {
+      // Native bearer first (cookieless). ensureNativeAccessToken transparently
+      // refreshes a near-expiry AT via /auth/native/refresh; a null return means
+      // no native session (resolveOauthRestAuth then selects the cookie path).
+      const nativeAt = await ensureNativeAccessToken(connection.baseUrl).catch(() => null)
+      const restAuth = resolveOauthRestAuth(nativeAt)
+
+      if (restAuth.kind === 'bearer') {
+        response = await fetchJson(url, null, {
+          method: request?.method,
+          body: request?.body,
+          timeoutMs,
+          bearer: restAuth.token
+        })
+      } else {
+        response = await fetchJsonViaOauthSession(url, {
+          method: request?.method,
+          body: request?.body,
+          timeoutMs
+        })
+      }
+    } else {
+      response = await fetchJson(url, connection.token, {
         method: request?.method,
         body: request?.body,
-        timeoutMs,
-        bearer: restAuth.token
+        upload: request?.upload,
+        timeoutMs
       })
     }
+  } catch (error) {
+    // A failed rename PATCH must not strand the app on the temporary primary:
+    // restore the original active profile and restart its backend.
+    if (profileRename) {
+      try {
+        await profileRename.rollback()
+      } catch (rollbackError) {
+        rememberLog(`Failed to restore primary profile after rename error: ${String(rollbackError)}`)
+      }
+    }
 
-    return fetchJsonViaOauthSession(url, {
-      method: request?.method,
-      body: request?.body,
-      timeoutMs
-    })
+    throw error
   }
 
-  return fetchJson(url, connection.token, {
-    method: request?.method,
-    body: request?.body,
-    upload: request?.upload,
-    timeoutMs
-  })
+  await profileRename?.complete()
+
+  return response
 }
 
 ipcMain.handle('hermes:api', async (_event, request) => {
+  // Hold the deletion gate for BOTH profile deletes and renames: a concurrent
+  // renderer reconnect entering ensureBackend() mid-mutation would otherwise
+  // respawn the old-name backend and recreate its HERMES_HOME (#45474).
   const deletingProfile = profileNameFromDeleteRequest(request)
+  const mutatingProfile = deletingProfile || profileRenameFromRequest(request)?.oldName || null
 
-  if (!deletingProfile) {
+  if (!mutatingProfile) {
     return handleHermesApiRequest(request)
   }
 
-  const releaseProfileDeletion = profileDeletionGate.acquire(deletingProfile)
+  const releaseProfileDeletion = profileDeletionGate.acquire(mutatingProfile)
 
   return handleHermesApiRequest(request).finally(releaseProfileDeletion)
 })

--- a/apps/desktop/electron/profile-delete-routing.ts
+++ b/apps/desktop/electron/profile-delete-routing.ts
@@ -9,17 +9,9 @@
 //
 // These helpers are pure so they can be unit-tested without Electron.
 
-/**
- * Parse a `hermes:api` request into the profile name a DELETE targets, or
- * null when the request is not a profile-delete at all (wrong method, wrong
- * path, empty/invalid name).
- */
-export function profileNameFromDeleteRequest(request) {
-  if (!request || String(request.method || 'GET').toUpperCase() !== 'DELETE') {
-    return null
-  }
-
-  const match = String(request.path || '').match(/^\/api\/profiles\/([^/?#]+)(?:[?#].*)?$/)
+/** Parse a profile name from an `/api/profiles/<name>` request path. */
+export function profileNameFromPath(path: unknown): string | null {
+  const match = String(path || '').match(/^\/api\/profiles\/([^/?#]+)(?:[?#].*)?$/)
 
   if (!match) {
     return null
@@ -44,6 +36,15 @@ export function profileNameFromDeleteRequest(request) {
   }
 
   return name.toLowerCase()
+}
+
+/** Parse a `hermes:api` request into the profile name a DELETE targets. */
+export function profileNameFromDeleteRequest(request) {
+  if (!request || String(request.method || 'GET').toUpperCase() !== 'DELETE') {
+    return null
+  }
+
+  return profileNameFromPath(request.path)
 }
 
 export type ProfileDeleteAction = 'noop' | 'teardown-primary' | 'teardown-pool'

--- a/apps/desktop/electron/profile-rename-routing.test.ts
+++ b/apps/desktop/electron/profile-rename-routing.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  prepareProfileRenameLifecycle,
+  profileRenameFromRequest,
+  type ProfileRenameLifecycleDeps
+} from './profile-rename-routing'
+
+const renameRequest = {
+  body: { new_name: 'renamed-profile' },
+  method: 'PATCH',
+  path: '/api/profiles/primary-profile'
+}
+
+function lifecycleDeps(events: string[]): ProfileRenameLifecycleDeps {
+  return {
+    isValidProfileName: profile => /^[a-z0-9][a-z0-9_-]{0,63}$/.test(profile),
+    primaryProfileKey: () => 'primary-profile',
+    reloadPrimaryWindow: () => events.push('reload-primary-window'),
+    restartPrimaryBackend: async () => {
+      events.push('restart-primary-backend')
+    },
+    teardownPoolBackendAndWait: async profile => {
+      events.push(`teardown-pool:${profile}`)
+    },
+    teardownPrimaryBackendAndWait: async () => {
+      events.push('teardown-primary')
+    },
+    writeActiveDesktopProfile: profile => {
+      events.push(`write-active:${profile}`)
+    }
+  }
+}
+
+test('profileRenameFromRequest parses string and object JSON bodies', () => {
+  assert.deepEqual(profileRenameFromRequest(renameRequest), {
+    newName: 'renamed-profile',
+    oldName: 'primary-profile'
+  })
+  assert.deepEqual(profileRenameFromRequest({ ...renameRequest, body: JSON.stringify({ new_name: 'String-Body' }) }), {
+    newName: 'string-body',
+    oldName: 'primary-profile'
+  })
+})
+
+test('profileRenameFromRequest rejects malformed and reserved rename requests', () => {
+  assert.equal(profileRenameFromRequest({ ...renameRequest, method: 'DELETE' }), null)
+  assert.equal(profileRenameFromRequest({ ...renameRequest, body: '{' }), null)
+  assert.equal(profileRenameFromRequest({ ...renameRequest, body: { new_name: 'default' } }), null)
+  assert.equal(profileRenameFromRequest({ ...renameRequest, path: '/api/profiles/default' }), null)
+})
+
+test('prepareProfileRenameLifecycle tears down a pooled backend and routes through the primary', async () => {
+  const events: string[] = []
+
+  const lifecycle = await prepareProfileRenameLifecycle(
+    { ...renameRequest, path: '/api/profiles/worker-profile' },
+    lifecycleDeps(events)
+  )
+
+  assert.equal(lifecycle?.kind, 'pool')
+  assert.equal(lifecycle?.routeProfile, null)
+  assert.deepEqual(events, ['teardown-pool:worker-profile'])
+
+  await lifecycle?.complete()
+  await lifecycle?.rollback()
+  assert.deepEqual(events, ['teardown-pool:worker-profile'])
+})
+
+test('prepareProfileRenameLifecycle re-homes a renamed primary after success', async () => {
+  const events: string[] = []
+  const lifecycle = await prepareProfileRenameLifecycle(renameRequest, lifecycleDeps(events))
+
+  assert.equal(lifecycle?.kind, 'primary')
+  assert.equal(lifecycle?.routeProfile, null)
+  assert.deepEqual(events, ['write-active:default', 'teardown-primary'])
+
+  await lifecycle?.complete()
+  assert.deepEqual(events, [
+    'write-active:default',
+    'teardown-primary',
+    'write-active:renamed-profile',
+    'teardown-primary',
+    'reload-primary-window'
+  ])
+})
+
+test('prepareProfileRenameLifecycle restores the original primary after failure', async () => {
+  const events: string[] = []
+  const lifecycle = await prepareProfileRenameLifecycle(renameRequest, lifecycleDeps(events))
+
+  await lifecycle?.rollback()
+  assert.deepEqual(events, [
+    'write-active:default',
+    'teardown-primary',
+    'write-active:primary-profile',
+    'teardown-primary',
+    'restart-primary-backend'
+  ])
+})
+
+test('prepareProfileRenameLifecycle restores the original primary when initial teardown fails', async () => {
+  const events: string[] = []
+  const deps = lifecycleDeps(events)
+
+  deps.teardownPrimaryBackendAndWait = async () => {
+    events.push('teardown-primary')
+    throw new Error('teardown failed')
+  }
+
+  await assert.rejects(prepareProfileRenameLifecycle(renameRequest, deps), /teardown failed/)
+  assert.deepEqual(events, [
+    'write-active:default',
+    'teardown-primary',
+    'write-active:primary-profile',
+    'restart-primary-backend'
+  ])
+})
+
+test('prepareProfileRenameLifecycle ignores invalid profile names without side effects', async () => {
+  const events: string[] = []
+
+  const lifecycle = await prepareProfileRenameLifecycle(
+    { ...renameRequest, body: { new_name: 'Not Valid!' } },
+    lifecycleDeps(events)
+  )
+
+  assert.equal(lifecycle, null)
+  assert.deepEqual(events, [])
+})

--- a/apps/desktop/electron/profile-rename-routing.ts
+++ b/apps/desktop/electron/profile-rename-routing.ts
@@ -1,0 +1,138 @@
+import { profileNameFromPath } from './profile-delete-routing'
+
+export interface ProfileRenameRequest {
+  body?: unknown
+  method?: unknown
+  path?: unknown
+}
+
+export interface ProfileRename {
+  newName: string
+  oldName: string
+}
+
+export interface ProfileRenameLifecycleDeps {
+  isValidProfileName: (profile: string) => boolean
+  primaryProfileKey: () => string
+  reloadPrimaryWindow: () => void
+  restartPrimaryBackend: () => Promise<void>
+  teardownPoolBackendAndWait: (profile: string) => Promise<void>
+  teardownPrimaryBackendAndWait: () => Promise<void>
+  writeActiveDesktopProfile: (profile: string) => void
+}
+
+export interface ProfileRenameLifecycle {
+  complete: () => Promise<void>
+  kind: 'pool' | 'primary'
+  rename: ProfileRename
+  rollback: () => Promise<void>
+  routeProfile: null
+}
+
+function parseJsonBody(body: unknown): Record<string, unknown> {
+  if (body == null || body === '') {
+    return {}
+  }
+
+  if (typeof body === 'object' && !Array.isArray(body)) {
+    return body as Record<string, unknown>
+  }
+
+  try {
+    const parsed = JSON.parse(String(body))
+
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+export function profileRenameFromRequest(request: ProfileRenameRequest | null | undefined): ProfileRename | null {
+  if (!request || String(request.method || 'GET').toUpperCase() !== 'PATCH') {
+    return null
+  }
+
+  const oldName = profileNameFromPath(request.path)
+
+  if (!oldName || oldName === 'default') {
+    return null
+  }
+
+  const body = parseJsonBody(request.body)
+
+  const newName = String(body.new_name || '')
+    .trim()
+    .toLowerCase()
+
+  if (!newName || newName === 'default') {
+    return null
+  }
+
+  return { newName, oldName }
+}
+
+export async function prepareProfileRenameLifecycle(
+  request: ProfileRenameRequest | null | undefined,
+  deps: ProfileRenameLifecycleDeps
+): Promise<ProfileRenameLifecycle | null> {
+  const rename = profileRenameFromRequest(request)
+
+  if (!rename || !deps.isValidProfileName(rename.oldName) || !deps.isValidProfileName(rename.newName)) {
+    return null
+  }
+
+  if (rename.oldName !== deps.primaryProfileKey()) {
+    await deps.teardownPoolBackendAndWait(rename.oldName)
+
+    return {
+      complete: async () => {},
+      kind: 'pool',
+      rename,
+      rollback: async () => {},
+      routeProfile: null
+    }
+  }
+
+  // Make `default` the temporary primary before stopping the old backend.
+  // Concurrent primary requests then share the temporary connection instead
+  // of respawning the old profile and recreating its directory mid-rename.
+  deps.writeActiveDesktopProfile('default')
+
+  try {
+    await deps.teardownPrimaryBackendAndWait()
+  } catch (error) {
+    deps.writeActiveDesktopProfile(rename.oldName)
+
+    try {
+      await deps.restartPrimaryBackend()
+    } catch {
+      // Preserve the teardown error that prevented the rename from starting.
+    }
+
+    throw error
+  }
+
+  return {
+    complete: async () => {
+      deps.writeActiveDesktopProfile(rename.newName)
+
+      try {
+        await deps.teardownPrimaryBackendAndWait()
+      } finally {
+        deps.reloadPrimaryWindow()
+      }
+    },
+    kind: 'primary',
+    rename,
+    rollback: async () => {
+      deps.writeActiveDesktopProfile(rename.oldName)
+
+      try {
+        await deps.teardownPrimaryBackendAndWait()
+      } finally {
+        await deps.restartPrimaryBackend()
+      }
+    },
+    routeProfile: null
+  }
+}

--- a/apps/desktop/src/app/profiles/rename-profile-dialog.test.tsx
+++ b/apps/desktop/src/app/profiles/rename-profile-dialog.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { renameProfile } from '@/hermes'
+import { retireLocalProfileGateways } from '@/store/gateway'
+
+import { RenameProfileDialog } from './rename-profile-dialog'
+
+// Pins the rename half of the deleted-profile-resurrection class (#88638 fixed
+// the delete half): a retained renderer socket for the OLD profile name must be
+// retired BEFORE the rename PATCH tears down its backend, or the socket's
+// reconnect loop respawns the old-name backend and recreates the directory the
+// rename just moved.
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+vi.mock('@/hermes', () => ({
+  renameProfile: vi.fn(async () => ({ name: 'renamed', ok: true, path: '/x' }))
+}))
+
+vi.mock('@/store/gateway', () => ({
+  retireLocalProfileGateways: vi.fn()
+}))
+
+it('retires the old-name local gateways before issuing the rename', async () => {
+  const order: string[] = []
+
+  vi.mocked(retireLocalProfileGateways).mockImplementationOnce(() => {
+    order.push('retire')
+  })
+  vi.mocked(renameProfile).mockImplementationOnce(async () => {
+    order.push('rename')
+
+    return { name: 'renamed', ok: true, path: '/x' }
+  })
+
+  render(<RenameProfileDialog currentName="selena" onClose={vi.fn()} open />)
+
+  fireEvent.change(screen.getByLabelText(/new name/i), { target: { value: 'renamed' } })
+  fireEvent.click(screen.getByRole('button', { name: /^rename$/i }))
+
+  await waitFor(() => expect(renameProfile).toHaveBeenCalledWith('selena', 'renamed'))
+  expect(retireLocalProfileGateways).toHaveBeenCalledWith('selena')
+  expect(order).toEqual(['retire', 'rename'])
+})
+
+it('does not retire gateways when validation rejects the submit', async () => {
+  render(<RenameProfileDialog currentName="selena" onClose={vi.fn()} open />)
+
+  fireEvent.change(screen.getByLabelText(/new name/i), { target: { value: '' } })
+  fireEvent.click(screen.getByRole('button', { name: /^rename$/i }))
+
+  await waitFor(() => expect(screen.getByText('Name is required.')).toBeTruthy())
+  expect(retireLocalProfileGateways).not.toHaveBeenCalled()
+  expect(renameProfile).not.toHaveBeenCalled()
+})

--- a/apps/desktop/src/app/profiles/rename-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/rename-profile-dialog.tsx
@@ -16,6 +16,7 @@ import { renameProfile } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
 import { slug } from '@/lib/sanitize'
+import { retireLocalProfileGateways } from '@/store/gateway'
 
 import { isValidProfileName } from './create-profile-dialog'
 
@@ -72,6 +73,11 @@ export function RenameProfileDialog({
     setError(null)
 
     try {
+      // A retained renderer socket for the old name would treat the rename's
+      // backend teardown as a transient drop and redial, resurrecting the
+      // old-name backend whose ensure_hermes_home() recreates the directory
+      // the rename just moved (same class as the delete path, #88638).
+      retireLocalProfileGateways(currentName)
       await renameProfile(currentName, trimmed)
       await onRenamed?.(trimmed)
       setStatus('done')


### PR DESCRIPTION
## Summary

Renaming a named Desktop profile no longer leaves the old-name backend running to recreate the profile directory as a ghost profile. This salvages @wanglufei-567's rename lifecycle from #51852 onto current `main` and closes the rename half of the deleted-profile-resurrection class (the delete half landed in #88638).

Root cause: `PATCH /api/profiles/<oldName>` had none of the lifecycle protection the DELETE path has — no backend teardown, no deletion gate, no renderer-socket retirement. A backend (or retained renderer socket) pinned to the old name would respawn and `ensure_hermes_home()` recreated the old directory ("stale profile directory that GUI keeps reviving", #45474).

## Changes

- `apps/desktop/electron/profile-rename-routing.ts` (new): pure rename lifecycle — pooled old-name teardown for non-primary renames; for primary renames, re-home through a temporary `default` primary with complete/rollback hooks (salvaged from #51852, adapted to today's `handleHermesApiRequest` and native-OAuth split)
- `apps/desktop/electron/main.ts`: wire the lifecycle into the `hermes:api` handler; hold the profile deletion gate for renames too so a concurrent renderer reconnect can't respawn the old-name backend mid-PATCH
- `apps/desktop/electron/profile-delete-routing.ts`: extract `profileNameFromPath()` shared by delete + rename parsing
- `apps/desktop/src/app/profiles/rename-profile-dialog.tsx`: retire both local renderer socket scopes for the old name before the PATCH (same class as #88638's delete fix)
- Tests: contributor's 132-line lifecycle suite + new dialog ordering/validation tests

## Validation

| Check | Result |
|---|---|
| electron vitest (rename+delete routing) | 27/27 pass |
| ui vitest (rename dialog + profiles view) | 5/5 pass |
| `check:lint` on touched files | 0 errors |

Attribution: `fix(desktop): re-home backend after profile rename` cherry-picked with @wanglufei-567's authorship preserved; follow-ups in a separate commit.

Fixes #45474. Closes #51852.

## Infographic

![Profile rename lifecycle](https://v3b.fal.media/files/b/0aa6c1ec/y2FrzgCrCjJS7o9hsPzo4_d9rmqxXZ.png)
