### PR TITLE
fix(gateway): multiplex sessions now stored in the owning profile's state.db, not root (#88532, salvage #88632)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6525,6 +6525,14 @@ class TurnRunner:
 
 
 
+# Sentinel for "no explicit session DB has been pinned on this runner", so the
+# ``_session_db`` property can distinguish "resolve from the active profile
+# scope" from a deliberate ``runner._session_db = None`` (which disables
+# DB-backed commands and is how many suites construct a bare runner).  A plain
+# ``None`` cannot express both.  Mirrors ``gateway.session._DB_UNPINNED``.
+_SESSION_DB_UNPINNED = object()
+
+
 class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
     """
     Main gateway controller.
@@ -6933,11 +6941,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("approvals.mode startup check skipped", exc_info=True)
 
-        # Initialize session database for session_search tool support
-        self._session_db = None
+        # Initialize session database for session_search tool support.
+        #
+        # Same frozen-handle class of bug as SessionStore._db (#88532): a
+        # handle bound here is pinned to the process's root home, but
+        # /resume, /title, /history and session search all run inside
+        # _profile_runtime_scope on a multiplexed gateway and must see that
+        # profile's own state.db.  Resolve through a property that caches
+        # one AsyncSessionDB per resolved path; priming here keeps startup
+        # diagnostics (the #88235 broadcast) at construction time.
+        self._session_db_pinned: Any = _SESSION_DB_UNPINNED
+        self._session_db_handles: Dict[Path, Any] = {}
+        self._session_db_handles_lock = threading.Lock()
         try:
-            from hermes_state import AsyncSessionDB, SessionDB
-            self._session_db = AsyncSessionDB(SessionDB())
+            self._open_session_db_for_active_scope(raise_on_error=True)
         except Exception as e:
             # WARNING (not DEBUG) so the failure appears in errors.log — matches
             # cli.py's handling of the same init path.  Users hitting NFS-mounted
@@ -7049,6 +7066,78 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # dormant before the drained backlog has a chance to update the clock.
         self._scale_to_zero_cooldown_until: float = 0.0
 
+
+    def _open_session_db_for_active_scope(self, raise_on_error: bool = False) -> Any:
+        """Return the AsyncSessionDB for the profile scope active on this task.
+
+        Same per-path cache as ``SessionStore._open_session_db_for_active_scope``
+        (#88532): ``SessionDB()`` resolves ``_default_db_path()`` at call time
+        through the context-local HERMES_HOME override installed by
+        ``_profile_runtime_scope``, so resolving per access — instead of once
+        in ``__init__`` — is what lets /resume, /title, /history and session
+        search on a multiplexed gateway read the *serving profile's* store
+        rather than the root one.
+
+        One ``AsyncSessionDB`` is cached per resolved path under a lock, so
+        the wrapper identity is stable per profile (callers compare and stash
+        it) and two profiles never share a handle.  A construction failure is
+        cached as ``None`` for that path so a broken store degrades once, not
+        per command; ``raise_on_error=True`` (construction-time priming)
+        propagates the failure instead so ``__init__`` can record
+        ``_session_db_init_error`` for the #88235 broadcast.
+        """
+        from hermes_state import AsyncSessionDB, SessionDB, _default_db_path
+
+        path = Path(_default_db_path())
+        with self._session_db_handles_lock:
+            if path in self._session_db_handles:
+                return self._session_db_handles[path]
+            db = None
+            try:
+                db = AsyncSessionDB(SessionDB())
+            except Exception as e:
+                if raise_on_error:
+                    raise
+                logger.warning("SQLite session store not available: %s", e)
+            self._session_db_handles[path] = db
+            return db
+
+    @property
+    def _session_db(self) -> Any:
+        """The AsyncSessionDB for the active profile scope, or a pinned override.
+
+        Assigning ``runner._session_db`` pins that value for every subsequent
+        read — tests rely on installing fakes or ``None`` this way.  Unpinned
+        (the production path), each read resolves the active scope so a
+        multiplexed profile's slash commands and session search hit its own
+        store.
+        """
+        if self._session_db_pinned is not _SESSION_DB_UNPINNED:
+            return self._session_db_pinned
+        return self._open_session_db_for_active_scope()
+
+    @_session_db.setter
+    def _session_db(self, value) -> None:
+        self._session_db_pinned = value
+
+    def close_all_session_db_handles(self) -> None:
+        """Close every per-profile AsyncSessionDB this runner opened.
+
+        Shutdown counterpart of the per-path cache above; mirrors
+        ``SessionStore.close_all_db_handles``.  Handles are drained under the
+        lock and closed outside it; a pinned handle is the pinner's to close.
+        """
+        with self._session_db_handles_lock:
+            handles = [db for db in self._session_db_handles.values() if db is not None]
+            self._session_db_handles.clear()
+        for db in handles:
+            inner = getattr(db, "_db", db)
+            if inner is None or not hasattr(inner, "close"):
+                continue
+            try:
+                inner.close()
+            except Exception as exc:
+                logger.debug("SessionDB close error during handle sweep: %s", exc)
 
     def _wire_teams_pipeline_runtime(self) -> None:
         """Bind the Teams meeting pipeline runtime to Graph webhook ingress.
@@ -14681,6 +14770,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _db.close()
                 except Exception as _e:
                     logger.debug("SessionDB close error: %s", _e)
+            # A multiplexed session_store caches one SessionDB per profile
+            # path (#88532); reading ``_db`` above only resolved the handle
+            # for the shutdown task's own (root) scope. Sweep the rest so
+            # secondary profiles' WAL locks are released before --replace
+            # brings a new gateway up on the same files.
+            _sweep = getattr(
+                getattr(self, "session_store", None), "close_all_db_handles", None
+            )
+            if _sweep is not None:
+                try:
+                    _sweep()
+                except Exception as _e:
+                    logger.debug("SessionDB handle sweep error: %s", _e)
+            # Same sweep for the runner's own per-profile session_search
+            # handles (slash commands resolve them under profile scopes).
+            try:
+                GatewayRunner.close_all_session_db_handles(self)
+            except Exception as _e:
+                logger.debug("Runner SessionDB handle sweep error: %s", _e)
             GatewayRunner._shutdown_executor(self)
             logger.info(
                 "Shutdown phase: SessionDB close done at +%.2fs",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1235,6 +1235,13 @@ class AsyncSessionStore:
         return _offloaded
 
 
+# Sentinel for "no explicit SessionDB has been pinned on this store", so the
+# ``_db`` property can distinguish "resolve from the active profile scope"
+# from a deliberate ``store._db = None`` (which disables the DB and selects
+# the JSONL fallback).  A plain ``None`` cannot express both.
+_DB_UNPINNED = object()
+
+
 class SessionStore:
     """
     Manages session storage and retrieval.
@@ -1285,21 +1292,91 @@ class SessionStore:
             getattr(config, "write_sessions_json", True)
         )
         
-        # Initialize SQLite session database
-        self._db = None
-        try:
-            from hermes_state import SessionDB
-            self._db = SessionDB()
-        except RuntimeError as e:
-            if "live-system guard" in str(e):
-                # Test-isolation guard fired: a pytest-context process
-                # resolved the developer's production state.db. Never
-                # swallow this into the JSONL fallback — the whole point
-                # is a loud, hard failure.
-                raise
-            print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
-        except Exception as e:
-            print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+        # Initialize SQLite session database.
+        #
+        # Handles are cached per resolved path and looked up through the
+        # ``_db`` property instead of being bound to one handle here.  A
+        # multiplexed gateway serves every profile from a SINGLE process, so
+        # a handle bound during __init__ is frozen to the process's own root
+        # home; every profile's rows then land in the root state.db even
+        # though ``_profile_runtime_scope`` has already redirected
+        # ``get_hermes_home()`` for the turn (its docstring lists "sessions"
+        # among what it scopes).  The row still carries the right
+        # ``profile_name``, so the damage is invisible in the data and shows
+        # up only as the desktop listing a profile's session under the
+        # default bot -- ``_open_session_db_for_profile`` reads
+        # ``profiles/<name>/state.db``, which never received the write.
+        # See #88532.
+        #
+        # Priming the handle for the current scope here keeps the startup
+        # diagnostics exactly where they were: the live-DB isolation guard
+        # still raises during construction, and the JSONL-fallback warning
+        # is still printed once at startup rather than on first use.
+        self._db_pinned = _DB_UNPINNED
+        self._db_handles: Dict[Path, Any] = {}
+        self._db_handles_lock = threading.Lock()
+        self._open_session_db_for_active_scope()
+
+    def _open_session_db_for_active_scope(self):
+        """Return the SessionDB for the profile scope active on this task.
+
+        ``SessionDB(db_path=None)`` resolves ``_default_db_path()`` at call
+        time, and that helper follows the context-local HERMES_HOME override
+        installed by ``_profile_runtime_scope``.  Resolving here rather than
+        once in ``__init__`` is the whole fix for #88532: it lets the
+        scoping that the multiplexed inbound path already performs actually
+        reach session storage.
+
+        Handles are cached per resolved path, so a hot inbound path opens
+        SQLite once per profile rather than once per message, and two
+        profiles never share a handle.  Construction is done under the lock
+        so a concurrent first message on the same profile cannot open (and
+        then leak) a second handle for the same path.
+
+        A construction failure is cached as ``None`` for that path, matching
+        the previous behavior where a failed startup left ``_db`` None for
+        the life of the store and callers fell back to JSONL.
+        """
+        from hermes_state import SessionDB, _default_db_path
+
+        path = Path(_default_db_path())
+        with self._db_handles_lock:
+            if path in self._db_handles:
+                return self._db_handles[path]
+            db = None
+            try:
+                db = SessionDB()
+            except RuntimeError as e:
+                if "live-system guard" in str(e):
+                    # Test-isolation guard fired: a pytest-context process
+                    # resolved the developer's production state.db. Never
+                    # swallow this into the JSONL fallback — the whole point
+                    # is a loud, hard failure.  Deliberately not cached: the
+                    # guard must fire again on the next attempt.
+                    raise
+                print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+            except Exception as e:
+                print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+            self._db_handles[path] = db
+            return db
+
+    @property
+    def _db(self):
+        """The SessionDB for the active profile scope, or a pinned override.
+
+        Assigning ``store._db`` pins that value for every subsequent read,
+        which is what tests rely on to install a fake or to disable the DB
+        with ``store._db = None``.  Unpinned (the production path), each read
+        resolves the scope so a multiplexed profile's writes reach its own
+        store.
+        """
+        if self._db_pinned is not _DB_UNPINNED:
+            return self._db_pinned
+        return self._open_session_db_for_active_scope()
+
+    @_db.setter
+    def _db(self, value) -> None:
+        self._db_pinned = value
 
     def _has_active_processes_safe(self, session_key: str, *, context: str) -> bool:
         """Return whether a session has active work, failing closed on registry errors."""

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1378,6 +1378,36 @@ class SessionStore:
     def _db(self, value) -> None:
         self._db_pinned = value
 
+    def close_all_db_handles(self) -> None:
+        """Close every SessionDB handle this store opened, one per resolved path.
+
+        A multiplexed gateway accumulates one cached handle per profile it
+        served (see ``_open_session_db_for_active_scope``).  Reading ``_db``
+        at shutdown resolves only the handle for the scope active *then* —
+        the root home — so a shutdown that closes just ``store._db`` would
+        strand every secondary profile's handle with its WAL write lock held
+        until the interpreter exits, recreating the abandoned-handle leak
+        that ``SessionDB.close()`` exists to prevent.  Restart flows
+        (``--replace``) would then hit 'database is locked' opening those
+        profiles' stores.
+
+        Handles are drained under the lock but closed outside it, so a
+        concurrent resolver blocked in ``_open_session_db_for_active_scope``
+        is never made to wait on N ``close()`` calls; it simply opens a
+        fresh handle afterwards.  ``close()`` failures are swallowed the
+        same way the shutdown path treats the primary handle.  A pinned
+        handle (``store._db = fake``) is deliberately not closed here — the
+        pinner owns its lifecycle.
+        """
+        with self._db_handles_lock:
+            handles = [db for db in self._db_handles.values() if db is not None]
+            self._db_handles.clear()
+        for db in handles:
+            try:
+                db.close()
+            except Exception as exc:
+                logger.debug("SessionDB close error during handle sweep: %s", exc)
+
     def _has_active_processes_safe(self, session_key: str, *, context: str) -> bool:
         """Return whether a session has active work, failing closed on registry errors."""
         if self._has_active_processes_fn is None:

--- a/tests/gateway/test_multiplex_session_db_profile_scope.py
+++ b/tests/gateway/test_multiplex_session_db_profile_scope.py
@@ -170,3 +170,84 @@ def test_explicitly_pinned_handle_still_wins(multiplex_homes):
         assert store._db is None
     finally:
         reset_hermes_home_override(token)
+
+
+def test_close_all_db_handles_sweeps_every_profile_handle(multiplex_homes):
+    """Teardown must release every cached per-profile handle, not just the
+    one the tearing-down task's own scope resolves.
+
+    Follow-up hardening for the per-path cache: ``gateway/run.py``'s
+    teardown path closes ``store._db`` (root scope only); the sweep closes
+    the rest so secondary profiles' WAL locks are released before a
+    ``--replace`` restart reopens their stores.
+    """
+    root, profile = multiplex_homes
+    store = _make_store(root)
+
+    root_db = store._db
+    token = set_hermes_home_override(str(profile))
+    try:
+        profile_db = store._db
+    finally:
+        reset_hermes_home_override(token)
+    assert root_db is not profile_db
+
+    store.close_all_db_handles()
+
+    # Both handles are closed (connection released) and the cache is empty,
+    # so the next access opens a fresh handle rather than a dead one.
+    assert root_db._conn is None
+    assert profile_db._conn is None
+    assert store._db_handles == {}
+    fresh = store._db
+    assert fresh is not root_db
+    assert fresh._conn is not None
+    fresh.close()
+
+
+def test_runner_session_db_follows_the_active_profile_scope(multiplex_homes):
+    """GatewayRunner._session_db is the same frozen-handle class of bug.
+
+    /resume, /title, /history and session search run inside
+    ``_profile_runtime_scope`` on a multiplexed gateway and must read the
+    serving profile's state.db.  Exercise the property on a bare runner shell
+    (full construction wires adapters and is irrelevant to the seam under
+    test).
+    """
+    import threading
+
+    from gateway.run import GatewayRunner, _SESSION_DB_UNPINNED
+
+    root, profile = multiplex_homes
+    runner = object.__new__(GatewayRunner)
+    runner._session_db_pinned = _SESSION_DB_UNPINNED
+    runner._session_db_handles = {}
+    runner._session_db_handles_lock = threading.Lock()
+
+    root_db = runner._session_db
+    assert Path(root_db._db.db_path) == root / "state.db"
+
+    token = set_hermes_home_override(str(profile))
+    try:
+        profile_db = runner._session_db
+        assert Path(profile_db._db.db_path) == profile / "state.db"
+        # Cached per path: same wrapper identity on re-access.
+        assert runner._session_db is profile_db
+    finally:
+        reset_hermes_home_override(token)
+
+    assert runner._session_db is root_db
+
+    # Pinning (how suites install fakes / disable the DB) wins across scopes.
+    runner._session_db = None
+    token = set_hermes_home_override(str(profile))
+    try:
+        assert runner._session_db is None
+    finally:
+        reset_hermes_home_override(token)
+    runner._session_db_pinned = _SESSION_DB_UNPINNED
+
+    runner.close_all_session_db_handles()
+    assert runner._session_db_handles == {}
+    assert root_db._db._conn is None
+    assert profile_db._db._conn is None

--- a/tests/gateway/test_multiplex_session_db_profile_scope.py
+++ b/tests/gateway/test_multiplex_session_db_profile_scope.py
@@ -1,0 +1,172 @@
+"""Regression coverage for #88532.
+
+A multiplexed gateway serves every profile from one process.  ``SessionStore``
+used to bind a single ``SessionDB`` during ``__init__``, freezing it to the
+process's own root home, so a named profile's sessions were physically written
+to the root ``state.db`` even though ``_profile_runtime_scope`` had already
+redirected ``get_hermes_home()`` for that turn.  The rows carried the correct
+``profile_name``, which is why the only visible symptom was the desktop listing
+a profile's session under the default bot: the desktop reads
+``profiles/<name>/state.db``, which never received the write.
+
+These tests pin the handle to the *active* scope rather than to construction
+time.  ``test_write_under_profile_scope_lands_in_profile_store`` is the one
+that reproduces the report; it fails against the pre-fix code with the session
+row sitting in the root store.
+"""
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig
+from gateway.session import SessionStore
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture
+def multiplex_homes(tmp_path, monkeypatch):
+    """A root home plus a named profile home, with HERMES_HOME on the root.
+
+    Mirrors the reported layout: one gateway process launched under the root
+    home, serving a ``fitness`` profile whose store lives under
+    ``profiles/fitness``.
+    """
+    import hermes_state
+
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "fitness"
+    root.mkdir(parents=True)
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    # The suite-wide fixture in conftest re-points ``hermes_state.DEFAULT_DB_PATH``
+    # at a fake home, which trips the deliberate escape hatch in
+    # ``_default_db_path()``: a re-pointed constant wins over everything,
+    # including the context-local override.  That is correct for tests that
+    # want one fixed DB, but it would pin every lookup here to a single path
+    # and make these assertions vacuous.  Restore the import-time snapshot so
+    # the hatch is closed and resolution goes through ``get_hermes_home()``,
+    # which is what production does.  ``HERMES_HOME`` above still keeps that
+    # resolution inside ``tmp_path``, so no real store is ever opened.
+    monkeypatch.setattr(
+        hermes_state, "DEFAULT_DB_PATH", hermes_state._IMPORT_DEFAULT_DB_PATH
+    )
+    return root, profile
+
+
+def _make_store(root: Path) -> SessionStore:
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        store = SessionStore(sessions_dir=root / "sessions", config=GatewayConfig())
+    store._loaded = True
+    return store
+
+
+def _session_ids(db_path: Path) -> set:
+    """Read session ids straight out of a state.db, or empty if absent."""
+    if not db_path.exists():
+        return set()
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute("SELECT id FROM sessions").fetchall()
+    except sqlite3.OperationalError:
+        # No sessions table: nothing was ever written here.
+        return set()
+    finally:
+        conn.close()
+    return {r[0] for r in rows}
+
+
+def test_store_uses_root_db_when_no_profile_scope_is_active(multiplex_homes):
+    """Single-profile gateways are unaffected: no scope, same path as before."""
+    root, _profile = multiplex_homes
+    store = _make_store(root)
+
+    assert Path(store._db.db_path) == root / "state.db"
+
+
+def test_db_handle_follows_the_active_profile_scope(multiplex_homes):
+    """The handle is resolved per access, not frozen at construction."""
+    root, profile = multiplex_homes
+    store = _make_store(root)
+
+    # Constructed outside any scope, exactly as the gateway constructs it.
+    assert Path(store._db.db_path) == root / "state.db"
+
+    token = set_hermes_home_override(str(profile))
+    try:
+        assert Path(store._db.db_path) == profile / "state.db"
+    finally:
+        reset_hermes_home_override(token)
+
+    # And the scope is restored once the turn's scope exits.
+    assert Path(store._db.db_path) == root / "state.db"
+
+
+def test_write_under_profile_scope_lands_in_profile_store(multiplex_homes):
+    """The reported bug: the row must be in the profile's own file.
+
+    This is the assertion the issue makes by hand with ``sqlite3``: the
+    session for profile ``fitness`` belongs in ``profiles/fitness/state.db``
+    and must NOT be in the root store.
+    """
+    root, profile = multiplex_homes
+    store = _make_store(root)
+
+    token = set_hermes_home_override(str(profile))
+    try:
+        store._db.create_session("20260817_233028_542fda58", "feishu")
+    finally:
+        reset_hermes_home_override(token)
+
+    assert _session_ids(profile / "state.db") == {"20260817_233028_542fda58"}
+    assert _session_ids(root / "state.db") == set()
+
+
+def test_handles_are_cached_per_path(multiplex_homes):
+    """One handle per profile: no reopen per message, no sharing across profiles."""
+    root, profile = multiplex_homes
+    store = _make_store(root)
+
+    root_first = store._db
+    root_second = store._db
+    assert root_first is root_second
+
+    token = set_hermes_home_override(str(profile))
+    try:
+        profile_first = store._db
+        profile_second = store._db
+    finally:
+        reset_hermes_home_override(token)
+
+    assert profile_first is profile_second
+    assert profile_first is not root_first
+
+
+def test_explicitly_pinned_handle_still_wins(multiplex_homes):
+    """``store._db = ...`` remains authoritative for every subsequent read.
+
+    Guardrail rather than a bug reproduction: a large number of existing
+    tests install a fake handle or disable the DB this way, and the property
+    must not quietly resolve past a deliberate assignment.
+    """
+    root, profile = multiplex_homes
+    store = _make_store(root)
+
+    sentinel = object()
+    store._db = sentinel
+    token = set_hermes_home_override(str(profile))
+    try:
+        assert store._db is sentinel
+    finally:
+        reset_hermes_home_override(token)
+
+    # Disabling the DB (the JSONL-fallback path) must survive scope changes.
+    store._db = None
+    token = set_hermes_home_override(str(profile))
+    try:
+        assert store._db is None
+    finally:
+        reset_hermes_home_override(token)


### PR DESCRIPTION
## What does this PR do?

On a multiplexed gateway, every profile's sessions now land in **that profile's own `state.db`** instead of all being physically written to the root `~/.hermes/state.db`. The desktop's per-profile session listing (`profiles/<name>/state.db`) therefore shows each session under the right bot.

This salvages **#88632 by @jackulau** — cherry-picked onto current main with authorship preserved — and adds a widening/hardening follow-up commit.

Fixes #88532

## Root cause (from the contributor's excellent analysis)

`SessionStore.__init__` bound a single handle once, before any profile scope existed:

```python
self._db = SessionDB()
```

`SessionDB(db_path=None)` → `_default_db_path()` → `get_hermes_home()` already follows the context-local override installed by `set_hermes_home_override`, and the inbound path already wraps every event in `_profile_runtime_scope(profile_home)`. The path machinery was right; it just ran at construction time on the root home, so the frozen handle bypassed every later scope. The rows even carried the correct `profile_name` — the only visible symptom was the desktop listing the session under the wrong bot.

## The fix (contributor commit, @jackulau)

- `SessionStore._db` becomes a property that resolves `_default_db_path()` **per access** and caches **one `SessionDB` per resolved path** under a lock (open once per profile, not once per message; two profiles never share a handle; construction under the lock prevents a concurrent first message leaking a duplicate handle).
- Assignment is preserved as an explicit **pin** via a `_DB_UNPINNED` sentinel — the many suites that install fakes or disable the DB with `store._db = None` keep working, and a pin wins across scope changes.
- Startup diagnostics stay at construction (live-DB isolation guard still raises in `__init__`; JSONL-fallback warning still prints once; the guard's `RuntimeError` is deliberately never cached).
- Inert without an active profile scope — single-profile gateways resolve exactly the path they did before (test-pinned).
- 5 regression tests, including a byte-level sqlite reproduction of the report (3 of 5 fail with `gateway/session.py` reverted to main).

## Follow-up commit (ours): widen to the sibling site + handle lifecycle

Reviewing against current main surfaced two things the original PR predates/misses:

1. **`GatewayRunner._session_db` had the identical frozen-handle bug**: bound once as `AsyncSessionDB(SessionDB())` in `__init__`, while `/resume`, `/title`, `/history` and session search all run inside `_profile_runtime_scope` on a multiplexed gateway. It now uses the same property-with-pin, one-cached-handle-per-path pattern (`_SESSION_DB_UNPINNED` sentinel; priming in `__init__` keeps the #88235 init-failure broadcast at startup).
2. **Handle lifecycle**: the per-path caches accumulate one open `SessionDB` per profile served, but the shutdown path only closed `store._db` / `runner._session_db` — which now resolve just the shutdown task's own (root) scope. Secondary profiles' handles would strand WAL write locks until process exit, recreating the abandoned-handle leak b454e4da76 just fixed and breaking `--replace` restarts with `database is locked`. Added `SessionStore.close_all_db_handles()` and `GatewayRunner.close_all_session_db_handles()`, both called from the gateway teardown path (`SessionDB.close()` is idempotent, so the root handle being closed by both the legacy loop and the sweep is safe; pinned handles are the pinner's to close).

## Concurrency notes

- The cache dict is guarded by a `threading.Lock`; construction happens under the lock, so concurrent first access on the same path can't open duplicate handles.
- The scope itself is a `ContextVar`; `AsyncSessionStore` offloads via `asyncio.to_thread`, which copies the caller's context, so the profile override propagates correctly to worker threads.
- Verified with a 40-thread contention test across two scopes: exactly one handle per resolved path.

## Testing

- `tests/gateway/test_multiplex_session_db_profile_scope.py` — 7 passed (5 contributor + 2 follow-up: shutdown sweep, runner property scope/pin/cache).
- Targeted regression sweep across session-store / multiplex / shutdown / slash-command suites (`test_session.py`, `test_session_store_*`, `test_multiplex_*`, `test_gateway_shutdown.py`, `test_shutdown_flush.py`, `test_resume_command.py`, `test_hygiene_failure_cooldown_ladder.py`, and more): **300+ passed**, 0 new failures. The one combined-run failure (`test_session_store_default_db_uses_runtime_hermes_home`) is a pre-existing cross-file fixture-ordering interaction — reproduced identically on pristine `origin/main` and passes in isolation both ways.
- E2E with real imports against a temp `HERMES_HOME` + fake profile home: a `SessionStore` write inside `set_hermes_home_override(profile)` lands in `profiles/fitness/state.db`; the root `state.db` stays empty.
- `ruff` clean on all touched files.

## Scope notes

- Forward-only: rows already written to the root store are not migrated (matches the contributor's stated intent; a migration can be a follow-up).
- No overlap absorbed from open PRs #88437 (adapter-derived session keys profile namespace) or #80885 (cron multiplex session profile) — those address which profile a row is *labeled* with / cron-side scoping; this PR addresses which *file* the row physically lands in.

## Credit

Root-cause analysis, core fix, and the 5-test regression suite by **@jackulau** (#88632), cherry-picked with authorship preserved. Thank you for an unusually well-reasoned PR.

## Infographic

![Sessions stored in the owning profile's database](https://v3b.fal.media/files/b/0aa6c202/j2owm7dAEH61-oovozyZo_cCnhIv9A.png)
