### PR TITLE
test(agent): regression test for dict extra_content in streaming tool-call accumulator

### DIFF
--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -217,6 +217,56 @@ class TestStreamingAccumulator:
         assert tc[0].function.name == "terminal"
         assert tc[0].function.arguments == '{"command": "ls"}'
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_call_extra_content_dict_passthrough(self, mock_close, mock_create):
+        """extra_content delivered as a plain dict (MiniMax M2.7 via NVIDIA
+        NIM's OpenAI-compatible endpoint puts it under ``model_extra`` rather
+        than a Pydantic-typed ``extra_content`` attribute) must pass through
+        the streaming tool-call accumulator without calling ``.model_dump()``
+        on it. Regression test for NousResearch/hermes-agent#19968 (fixed
+        upstream via the ``_call_chat_completions`` extraction to
+        ``chat_completion_helpers.py``, already merged here)."""
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_minimax",
+                    name="search",
+                    model_extra={
+                        "extra_content": {"minimax": {"trace_id": "mm-abc"}}
+                    },
+                )
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"q": "test"}')
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        tc = response.choices[0].message.tool_calls
+        assert tc is not None
+        assert tc[0].extra_content == {"minimax": {"trace_id": "mm-abc"}}
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Adds a regression test for the `AttributeError: 'dict' object has no
attribute 'model_dump'` crash reported in #19968 (MiniMax M2.7 via
NVIDIA NIM's OpenAI-compatible endpoint delivers `extra_content` as a
plain `dict` under the tool-call delta's `model_extra`, not as a
Pydantic-typed `extra_content` attribute).

### Why now, if #19968 is already closed

#19968 was closed as "already fixed on `main`" (the transport refactor
in `0430e71ec971` extracted the streaming caller into
`agent/chat_completion_helpers.py` with a `hasattr(extra, "model_dump")`
+ `try/except` guard). That's correct — I verified it holds on current
`main`. But the standalone fix PR for the original bug, #19971, became
redundant once the refactor landed and was closed **unmerged** — so its
test never made it in either. The behavior has been correct on `main`
for a while with nothing locking it in.

I hit the same crash symptom (via a downstream project using this
repo through a fork) and went looking for what actually protects
against it. Finding "already fixed, no test" felt worth closing.

### Verification

I confirmed this test would have caught the original bug: temporarily
reverting the guard at the crash site to the raw `extra.model_dump()`
call reproduces the *exact* traceback and log line from #19968 —

```
ERROR agent.chat_completion_helpers: Streaming failed before delivery: 'dict' object has no attribute 'model_dump'
  File ".../agent/chat_completion_helpers.py", line 4263, in _call_chat_completions
    extra = extra.model_dump()
AttributeError: 'dict' object has no attribute 'model_dump'
```

— then restored the guard and confirmed green again.

## Type of Change

- [x] Tests (regression coverage for an already-fixed bug with no test)

## How to Test

```
pytest tests/run_agent/test_streaming.py -k extra_content_dict_passthrough -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#19971 covers the same symptom but targets pre-refactor `run_agent.py` locations that no longer exist, and was closed unmerged)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] N/A — test-only change