### PR TITLE
feat(delegation): opt-in SOUL identity for subagents

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1282,6 +1282,12 @@ DEFAULT_CONFIG = {
         # notifications to the PARENT; false suppresses them (the child's result is the
         # deliverable). Async-delegation results are NEVER suppressed.
         "surface_child_process_notifications": False,
+        # Opt-in: when True, delegated subagents load the parent's SOUL.md
+        # identity on top of the ephemeral "focused subagent" prompt (inherit
+        # operating loop, host routing, conventions). DELEGATE_WITH_SOUL env
+        # var is honored as a fallback. Default False (subagents stay
+        # ephemeral-prompt-only).
+        "load_soul_identity": False,
     },
     # Ephemeral prefill messages file — JSON list of {role, content} dicts injected at the start of
     # every API call for few-shot priming. Never saved to sessions/logs/trajectories.

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1790,6 +1790,51 @@ class TestMaxSpawnDepth(unittest.TestCase):
         self.assertTrue(any("below floor 1" in m for m in cm.output))
 
 # =========================================================================
+# load_soul_identity flag
+# =========================================================================
+
+class TestLoadSoulIdentity(unittest.TestCase):
+    """_get_load_soul_identity: config wins, DELEGATE_WITH_SOUL env fallback."""
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_default_false_when_absent(self, mock_cfg):
+        from tools.delegate_tool import _get_load_soul_identity
+        with patch.dict(os.environ):
+            os.environ.pop("DELEGATE_WITH_SOUL", None)
+            self.assertFalse(_get_load_soul_identity())
+
+    @patch("tools.delegate_tool._load_config",
+           return_value={"load_soul_identity": True})
+    def test_true_from_config(self, mock_cfg):
+        from tools.delegate_tool import _get_load_soul_identity
+        self.assertTrue(_get_load_soul_identity())
+
+    @patch("tools.delegate_tool._load_config",
+           return_value={"load_soul_identity": False})
+    def test_false_from_config(self, mock_cfg):
+        from tools.delegate_tool import _get_load_soul_identity
+        self.assertFalse(_get_load_soul_identity())
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_env_fallback_true(self, mock_cfg):
+        from tools.delegate_tool import _get_load_soul_identity
+        with patch.dict(os.environ, {"DELEGATE_WITH_SOUL": "true"}):
+            self.assertTrue(_get_load_soul_identity())
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_env_fallback_false(self, mock_cfg):
+        from tools.delegate_tool import _get_load_soul_identity
+        with patch.dict(os.environ, {"DELEGATE_WITH_SOUL": "false"}):
+            self.assertFalse(_get_load_soul_identity())
+
+    @patch("tools.delegate_tool._load_config",
+           return_value={"load_soul_identity": True})
+    def test_config_wins_over_env(self, mock_cfg):
+        from tools.delegate_tool import _get_load_soul_identity
+        with patch.dict(os.environ, {"DELEGATE_WITH_SOUL": "false"}):
+            self.assertTrue(_get_load_soul_identity())
+
+# =========================================================================
 # role param plumbing
 # =========================================================================
 #

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -28,7 +28,7 @@ from tools.delegate_tool_child_run import (  # noqa: F401
     _lease_child_credential, _merge_late_steer, _register_child, _start_heartbeat, _validate_child_output_schema,
 )
 from tools.delegate_tool_config import (  # noqa: F401
-    _DEFAULT_MAX_CONCURRENT_CHILDREN, _get_child_timeout, _get_max_async_children, _get_max_concurrent_children,
+    _DEFAULT_MAX_CONCURRENT_CHILDREN, _get_child_timeout, _get_load_soul_identity, _get_max_async_children, _get_max_concurrent_children,
     _get_max_spawn_depth, _get_orchestrator_enabled, _get_subagent_approval_callback, _get_worktree_isolation,
     _inherit_parent_capabilities, _load_config, _merge_request_overrides, _resolve_child_credential_pool,
     _resolve_child_runtime, _resolve_delegation_credentials,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -235,7 +235,7 @@ def _build_child_agent(
                 **rt, max_iterations=max_iterations, prefill_messages=getattr(parent_agent, "prefill_messages", None),
                 enabled_toolsets=child_toolsets, disabled_toolsets=child_disabled_toolsets, quiet_mode=True,
                 ephemeral_system_prompt=child_prompt, log_prefix=f"[subagent-{task_index}]", platform="subagent",
-                skip_context_files=True, skip_memory=True, clarify_callback=None,
+                skip_context_files=True, load_soul_identity=_get_load_soul_identity(), skip_memory=True, clarify_callback=None,
                 thinking_callback=(
                     (lambda text: _safe_progress(child_progress_cb, "_thinking", text) if text else None)
                     if child_progress_cb else None

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -110,6 +110,17 @@ def _get_worktree_isolation() -> bool:
     working copy. Git-only and local-backend-only; otherwise silently ignored."""
     return bool(_cfg().get("worktree_isolation", False))
 
+def _get_load_soul_identity() -> bool:
+    """delegation.load_soul_identity (bool, default False): when True, delegated subagents load the
+    parent's SOUL.md identity on top of the ephemeral "focused subagent" prompt, so children inherit the
+    operator's operating loop, host routing, and conventions. Opt-in because loading SOUL adds fixed prompt
+    tokens to every child and changes subagent behavior. ``DELEGATE_WITH_SOUL`` env var is a fallback so
+    operators can flip the flag without editing config.yaml (config.yaml wins when both are set)."""
+    val = _cfg().get("load_soul_identity")
+    if val is not None:
+        return is_truthy_value(val)
+    return is_truthy_value(os.getenv("DELEGATE_WITH_SOUL", ""), default=False)
+
 def _get_max_async_children() -> int:
     """Concurrency cap for background delegations == delegation.max_concurrent_children. At capacity a new async
     dispatch is REJECTED (not queued) so a runaway model can't pile up unbounded background work; the caller then


### PR DESCRIPTION
## Problem

Subagents spawned via `delegate_task` are constructed in-process and inherit the parent's environment, but they receive only the ephemeral "focused subagent" prompt — never the operator's `SOUL.md`. The cron scheduler and gateway entry points already load SOUL via `load_soul_identity=True`; the delegation path did not. Operators who want their subagents to inherit the same operating loop, host routing, and conventions had no way to opt in.

## Change

Add an opt-in flag that lets subagents load the parent's SOUL identity:

- `delegation.load_soul_identity` (config.yaml, canonical) — bool, default `false`.
- `DELEGATE_WITH_SOUL` env var honored as a fallback (config.yaml wins when both are set).

Read via a new `_get_load_soul_identity()` helper in `tools/delegate_tool.py`, mirroring the existing `delegation.*` config readers (`_get_worktree_isolation`, `_get_max_concurrent_children`, etc.), and wired into the child spawn as `load_soul_identity=_get_load_soul_identity()`.

Default `false` keeps the existing ephemeral-prompt-only behavior — no fixed prompt-token cost and no behavior change unless an operator opts in.

## Testing

- `ast.parse` on both edited files passes.
- No existing delegation tests assert the old (absent) `load_soul_identity` behavior.
