### PR TITLE
fix(gateway): allow approved sibling profile restarts

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -55,11 +55,10 @@ class GatewayLifecycleBlocked(ValueError):
 # actual shell-command-shaped strings, not on prose.
 _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     r"(?i)"
-    # Branch A: `hermes gateway restart|stop` — the canonical foot-gun.
-    # `start` is intentionally excluded: starting a gateway from inside a
-    # gateway is benign (a no-op or "already running" error), and a
-    # legitimate cron job might start a sibling profile's gateway.
-    r"(?:hermes\s+gateway\s+(?:restart|stop))"
+    # Branch A: `hermes [--profile NAME] gateway restart|stop`. Global profile
+    # flags must be part of the match so a self-targeting command cannot bypass
+    # the hard guard merely by spelling the current profile explicitly.
+    r"(?:hermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*gateway\s+(?:restart|stop))"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.
@@ -101,6 +100,56 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
         return False
     normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
     return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized))
+
+
+def explicit_cross_profile_gateway_lifecycle_details(
+    command: str, *, current_profile: str
+) -> Optional[tuple[str, str]]:
+    """Return ``(profile, action)`` for one literal sibling lifecycle command.
+
+    The sole accepted shape is ``hermes --profile NAME gateway restart|stop``.
+    Aliases, equals syntax, extra flags, wrappers, paths, and compound commands
+    fail closed so the terminal layer can bind one exact capability to the CLI
+    sink.
+    """
+    try:
+        segments = list(_iter_command_segments(command))
+    except Exception:
+        return None
+    if len(segments) != 1:
+        return None
+    tokens = segments[0]
+    if len(tokens) != 5 or tokens[:2] != ["hermes", "--profile"]:
+        return None
+    profile = tokens[2].strip().lower()
+    current_profile = current_profile.strip().lower()
+    if re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,63}", profile) is None:
+        return None
+    if profile == current_profile or tokens[3] != "gateway":
+        return None
+    action = tokens[4]
+    if action not in {"restart", "stop"}:
+        return None
+    return profile, action
+
+
+def explicit_cross_profile_gateway_lifecycle_target(
+    command: str, *, current_profile: str
+) -> Optional[str]:
+    """Return the sibling profile for one literal lifecycle command."""
+    details = explicit_cross_profile_gateway_lifecycle_details(
+        command, current_profile=current_profile
+    )
+    return details[0] if details is not None else None
+
+
+def is_explicit_cross_profile_gateway_lifecycle_command(
+    command: str, *, current_profile: str
+) -> bool:
+    """Whether *command* targets one explicit sibling through the Hermes CLI."""
+    return explicit_cross_profile_gateway_lifecycle_target(
+        command, current_profile=current_profile
+    ) is not None
 
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1872,8 +1872,17 @@ def _clear_planned_restart_notification() -> None:
 
 
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
-# knows not to clobber TERMINAL_CWD if lazily imported.
+# knows not to clobber TERMINAL_CWD if lazily imported. Preserve the immutable
+# origin profile as well: child management commands can then distinguish a
+# forbidden self-restart from an explicitly targeted sibling-profile restart.
 os.environ["_HERMES_GATEWAY"] = "1"
+try:
+    from hermes_cli.profiles import get_active_profile_name
+
+    _gateway_origin_profile = get_active_profile_name() or "default"
+except Exception:
+    _gateway_origin_profile = "default"
+os.environ["_HERMES_GATEWAY_PROFILE"] = _gateway_origin_profile
 
 _ensure_ssl_certs()
 
@@ -1884,6 +1893,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from hermes_constants import get_hermes_home, get_hermes_home_override
 from utils import atomic_json_write, base_url_hostname, is_truthy_value
 _hermes_home = get_hermes_home()
+_gateway_origin_home = str(_hermes_home.resolve())
+os.environ["_HERMES_GATEWAY_HOME"] = _gateway_origin_home
 
 # Load environment variables from ~/.hermes/.env first.
 # User-managed env files should override stale shell exports on restart.
@@ -1891,6 +1902,11 @@ from dotenv import load_dotenv  # noqa: F401  # backward-compat for tests that m
 from hermes_cli.env_loader import load_hermes_dotenv
 _env_path = _hermes_home / '.env'
 load_hermes_dotenv(hermes_home=_hermes_home, project_env=Path(__file__).resolve().parents[1] / '.env')
+# Internal routing identity is process-owned, never dotenv-owned.
+os.environ["_HERMES_GATEWAY"] = "1"
+os.environ["_HERMES_GATEWAY_PROFILE"] = _gateway_origin_profile
+os.environ["_HERMES_GATEWAY_HOME"] = _gateway_origin_home
+os.environ["HERMES_HOME"] = _gateway_origin_home
 
 
 def _reload_runtime_env_preserving_config_authority() -> None:
@@ -1919,6 +1935,10 @@ def _reload_runtime_env_preserving_config_authority() -> None:
         hermes_home=_hermes_home,
         project_env=Path(__file__).resolve().parents[1] / '.env',
     )
+    os.environ["_HERMES_GATEWAY"] = "1"
+    os.environ["_HERMES_GATEWAY_PROFILE"] = _gateway_origin_profile
+    os.environ["_HERMES_GATEWAY_HOME"] = _gateway_origin_home
+    os.environ["HERMES_HOME"] = _gateway_origin_home
     _bridge_max_turns_from_config(_hermes_home)
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5,6 +5,8 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 """
 
 import asyncio
+import hashlib
+import hmac
 import json
 import logging
 import os
@@ -7230,6 +7232,132 @@ def _dispatch_all_via_service_manager_if_s6(action: str) -> bool:
 
 
 
+def _gateway_lifecycle_targets_current_process(args=None) -> bool:
+    """Return whether a gateway lifecycle command would target this process.
+
+    Gateway children inherit ``_HERMES_GATEWAY_PROFILE`` from the parent
+    gateway.  The CLI's ``--profile`` handling changes the active target before
+    this function runs, so comparing the immutable origin marker with the
+    active profile distinguishes self-management from an explicitly targeted
+    sibling profile.  Missing origin identity fails closed for older gateways.
+    """
+    if os.getenv("_HERMES_GATEWAY") != "1":
+        return False
+
+    # An all-profile operation necessarily includes the origin gateway even
+    # when --profile selected a sibling before dispatch.
+    if args is not None and getattr(args, "all", False):
+        return True
+
+    origin_profile = os.getenv("_HERMES_GATEWAY_PROFILE", "").strip()
+    if not origin_profile:
+        return True
+
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        target_profile = (get_active_profile_name() or "default").strip()
+    except Exception:
+        return True
+    return target_profile == origin_profile
+
+
+_GATEWAY_LIFECYCLE_CAPABILITY_VARS = (
+    "_HERMES_GATEWAY_LIFECYCLE_KEY",
+    "_HERMES_GATEWAY_LIFECYCLE_PROOF",
+    "_HERMES_GATEWAY_LIFECYCLE_EXPIRES",
+    "_HERMES_GATEWAY_LIFECYCLE_NONCE",
+    "_HERMES_GATEWAY_LIFECYCLE_ORIGIN",
+    "_HERMES_GATEWAY_LIFECYCLE_TARGET",
+    "_HERMES_GATEWAY_LIFECYCLE_ACTION",
+)
+
+
+def _cross_profile_gateway_lifecycle_capability_valid(action: str) -> bool:
+    """Consume and verify the terminal-issued capability at the lifecycle sink."""
+    if os.getenv("_HERMES_GATEWAY") != "1":
+        return True
+    origin = os.getenv("_HERMES_GATEWAY_PROFILE", "").strip().lower()
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        target = (get_active_profile_name() or "default").strip().lower()
+        if not origin or target == origin:
+            return True
+        values = {name: os.getenv(name, "") for name in _GATEWAY_LIFECYCLE_CAPABILITY_VARS}
+        if any(not value for value in values.values()):
+            return False
+        if values["_HERMES_GATEWAY_LIFECYCLE_ORIGIN"] != origin:
+            return False
+        if values["_HERMES_GATEWAY_LIFECYCLE_TARGET"] != target:
+            return False
+        if values["_HERMES_GATEWAY_LIFECYCLE_ACTION"] != action:
+            return False
+        expires = int(values["_HERMES_GATEWAY_LIFECYCLE_EXPIRES"])
+        now = int(time.time())
+        if expires < now or expires > now + 120:
+            return False
+        nonce = values["_HERMES_GATEWAY_LIFECYCLE_NONCE"]
+        payload = f"v1\n{origin}\n{target}\n{action}\n{expires}\n{nonce}"
+        expected = hmac.new(
+            bytes.fromhex(values["_HERMES_GATEWAY_LIFECYCLE_KEY"]),
+            payload.encode(),
+            hashlib.sha256,
+        ).hexdigest()
+        return hmac.compare_digest(
+            expected, values["_HERMES_GATEWAY_LIFECYCLE_PROOF"]
+        )
+    except (TypeError, ValueError, OSError):
+        return False
+    finally:
+        for name in _GATEWAY_LIFECYCLE_CAPABILITY_VARS:
+            os.environ.pop(name, None)
+
+
+def _record_cross_profile_gateway_lifecycle_request(action: str) -> bool:
+    """Durably record sibling gateway management before execution.
+
+    Approval decisions are already emitted through the approval hook system.
+    This local JSONL record preserves the origin/target/action even when no
+    observer plugin is installed. Cross-profile lifecycle fails closed if this
+    record cannot be flushed to the origin profile's audit log.
+    """
+    if os.getenv("_HERMES_GATEWAY") != "1":
+        return True
+    origin_profile = os.getenv("_HERMES_GATEWAY_PROFILE", "").strip()
+    if not origin_profile:
+        return False
+    try:
+        from hermes_cli.profiles import get_active_profile_name, get_profile_dir
+
+        target_profile = (get_active_profile_name() or "default").strip()
+        if target_profile == origin_profile:
+            return True
+        origin_home = os.getenv("_HERMES_GATEWAY_HOME", "").strip()
+        if origin_home:
+            path = Path(origin_home) / "logs" / "gateway-lifecycle-audit.jsonl"
+        else:
+            path = get_profile_dir(origin_profile) / "logs" / "gateway-lifecycle-audit.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "origin_profile": origin_profile,
+            "target_profile": target_profile,
+            "action": action,
+            "pid": os.getpid(),
+            "session_key": os.getenv("HERMES_SESSION_KEY", ""),
+            "status": "requested",
+        }
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        return True
+    except Exception:
+        logger.debug("Failed to record cross-profile gateway lifecycle audit", exc_info=True)
+        return False
+
+
 def gateway_command(args):
     """Handle gateway subcommands."""
     try:
@@ -7610,11 +7738,24 @@ def _gateway_command_inner(args):
     elif subcmd == "stop":
         # Defense: refuse self-targeting gateway stop from inside the gateway.
         # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
-        if os.getenv("_HERMES_GATEWAY") == "1":
+        if _gateway_lifecycle_targets_current_process(args):
             print_error(
-                "Refusing to stop the gateway from inside the gateway process.\n"
+                "Refusing to stop the current gateway from inside its own process.\n"
                 "This command was blocked to prevent restart loops.\n"
-                "Use `hermes gateway stop` from a shell outside the running gateway."
+                "Target a different profile explicitly, or run this command from "
+                "a shell outside the current gateway."
+            )
+            sys.exit(1)
+        if not _cross_profile_gateway_lifecycle_capability_valid("stop"):
+            print_error(
+                "Refusing cross-profile gateway stop without a valid, exact "
+                "terminal approval capability."
+            )
+            sys.exit(1)
+        if not _record_cross_profile_gateway_lifecycle_request("stop"):
+            print_error(
+                "Refusing cross-profile gateway stop because the lifecycle audit "
+                "record could not be written to the origin profile."
             )
             sys.exit(1)
 
@@ -7703,11 +7844,24 @@ def _gateway_command_inner(args):
     elif subcmd == "restart":
         # Defense: refuse self-targeting gateway restart from inside the gateway.
         # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
-        if os.getenv("_HERMES_GATEWAY") == "1":
+        if _gateway_lifecycle_targets_current_process(args):
             print_error(
-                "Refusing to restart the gateway from inside the gateway process.\n"
+                "Refusing to restart the current gateway from inside its own process.\n"
                 "This command was blocked to prevent restart loops.\n"
-                "Use `hermes gateway restart` from a shell outside the running gateway."
+                "Target a different profile explicitly, or run this command from "
+                "a shell outside the current gateway."
+            )
+            sys.exit(1)
+        if not _cross_profile_gateway_lifecycle_capability_valid("restart"):
+            print_error(
+                "Refusing cross-profile gateway restart without a valid, exact "
+                "terminal approval capability."
+            )
+            sys.exit(1)
+        if not _record_cross_profile_gateway_lifecycle_request("restart"):
+            print_error(
+                "Refusing cross-profile gateway restart because the lifecycle audit "
+                "record could not be written to the origin profile."
             )
             sys.exit(1)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -691,6 +691,28 @@ def _apply_profile_override() -> None:
 
 _apply_profile_override()
 
+# Gateway child processes inherit a trusted origin marker, while an explicit
+# ``--profile`` above selects the lifecycle target. Profile dotenv files are
+# user-controlled and load with override semantics, so they must not be able to
+# rewrite either identity (or redirect HERMES_HOME back to the origin) before
+# gateway dispatch. Snapshot only in gateway children; normal CLI dotenv
+# precedence remains unchanged.
+_gateway_routing_snapshot = None
+if os.environ.get("_HERMES_GATEWAY") == "1":
+    _gateway_routing_snapshot = {
+        "_HERMES_GATEWAY": "1",
+        "_HERMES_GATEWAY_PROFILE": os.environ.get("_HERMES_GATEWAY_PROFILE", ""),
+        "_HERMES_GATEWAY_HOME": os.environ.get("_HERMES_GATEWAY_HOME", ""),
+        "_HERMES_GATEWAY_LIFECYCLE_KEY": os.environ.get("_HERMES_GATEWAY_LIFECYCLE_KEY", ""),
+        "_HERMES_GATEWAY_LIFECYCLE_PROOF": os.environ.get("_HERMES_GATEWAY_LIFECYCLE_PROOF", ""),
+        "_HERMES_GATEWAY_LIFECYCLE_EXPIRES": os.environ.get("_HERMES_GATEWAY_LIFECYCLE_EXPIRES", ""),
+        "_HERMES_GATEWAY_LIFECYCLE_NONCE": os.environ.get("_HERMES_GATEWAY_LIFECYCLE_NONCE", ""),
+        "_HERMES_GATEWAY_LIFECYCLE_ORIGIN": os.environ.get("_HERMES_GATEWAY_LIFECYCLE_ORIGIN", ""),
+        "_HERMES_GATEWAY_LIFECYCLE_TARGET": os.environ.get("_HERMES_GATEWAY_LIFECYCLE_TARGET", ""),
+        "_HERMES_GATEWAY_LIFECYCLE_ACTION": os.environ.get("_HERMES_GATEWAY_LIFECYCLE_ACTION", ""),
+        "HERMES_HOME": os.environ.get("HERMES_HOME", ""),
+    }
+
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.config import get_hermes_home
@@ -707,6 +729,12 @@ load_hermes_dotenv(
     project_env=PROJECT_ROOT / ".env",
     load_external_secrets=sys.argv[1:2] != ["update"],
 )
+if _gateway_routing_snapshot is not None:
+    for _routing_key, _routing_value in _gateway_routing_snapshot.items():
+        if _routing_value:
+            os.environ[_routing_key] = _routing_value
+        else:
+            os.environ.pop(_routing_key, None)
 
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
 # var BEFORE hermes_logging imports agent.redact (which snapshots the flag at

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -8,6 +8,9 @@ Covers:
 
 import json
 import os
+import shlex
+import subprocess
+import sys
 from argparse import Namespace
 
 import pytest
@@ -228,6 +231,225 @@ class TestGatewaySelfTargetingGuard:
         with pytest.raises(_Reached):
             gw.gateway_command(args)
 
+    @pytest.mark.parametrize("subcmd", ["stop", "restart"])
+    def test_lifecycle_allows_explicit_other_profile_inside_gateway(
+        self, monkeypatch, subcmd
+    ):
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setenv("_HERMES_GATEWAY_PROFILE", "caspian")
+
+        import hermes_cli.gateway as gw
+        import hermes_cli.profiles as profiles
+
+        class _Reached(Exception):
+            pass
+
+        def _sentinel(*args, **kwargs):
+            raise _Reached()
+
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "marin")
+        monkeypatch.setattr(
+            gw, "_cross_profile_gateway_lifecycle_capability_valid", lambda action: True
+        )
+        monkeypatch.setattr(
+            gw, "_record_cross_profile_gateway_lifecycle_request", lambda action: True
+        )
+        monkeypatch.setattr(gw, "_dispatch_via_service_manager_if_s6", _sentinel)
+        monkeypatch.setattr(gw, "_dispatch_all_via_service_manager_if_s6", _sentinel)
+        args = Namespace(gateway_command=subcmd, all=False, system=False)
+
+        with pytest.raises(_Reached):
+            gw.gateway_command(args)
+
+    @pytest.mark.parametrize("subcmd", ["stop", "restart"])
+    def test_cross_profile_all_still_blocks_origin_gateway(
+        self, monkeypatch, subcmd
+    ):
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setenv("_HERMES_GATEWAY_PROFILE", "caspian")
+
+        import hermes_cli.gateway as gw
+        import hermes_cli.profiles as profiles
+
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "marin")
+        args = Namespace(gateway_command=subcmd, all=True, system=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            gw.gateway_command(args)
+        assert exc_info.value.code == 1
+
+    def test_target_dotenv_cannot_rewrite_gateway_routing(self, tmp_path):
+        root = tmp_path / ".hermes"
+        origin = root / "profiles" / "caspian"
+        target = root / "profiles" / "marin"
+        origin.mkdir(parents=True)
+        target.mkdir(parents=True)
+        (target / ".env").write_text(
+            "_HERMES_GATEWAY=0\n"
+            "_HERMES_GATEWAY_PROFILE=marin\n"
+            f"HERMES_HOME={origin}\n",
+            encoding="utf-8",
+        )
+        script = (
+            "import json, os, sys; "
+            "sys.argv=['hermes','--profile','marin','gateway','status']; "
+            "import hermes_cli.main; "
+            "print(json.dumps({k: os.environ.get(k) for k in "
+            "['_HERMES_GATEWAY','_HERMES_GATEWAY_PROFILE','HERMES_HOME']}))"
+        )
+        env = os.environ.copy()
+        env.update({
+            "HOME": str(tmp_path),
+            "HERMES_HOME": str(origin),
+            "PYTHONPATH": os.pathsep.join(
+                filter(None, [os.getcwd(), env.get("PYTHONPATH", "")])
+            ),
+            "_HERMES_GATEWAY": "1",
+            "_HERMES_GATEWAY_PROFILE": "caspian",
+        })
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=os.fspath(tmp_path),
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        routing = json.loads(result.stdout.strip().splitlines()[-1])
+        assert routing == {
+            "_HERMES_GATEWAY": "1",
+            "_HERMES_GATEWAY_PROFILE": "caspian",
+            "HERMES_HOME": str(target),
+        }
+
+    def test_cross_profile_capability_is_action_bound_and_consumed(
+        self, monkeypatch
+    ):
+        import hermes_cli.gateway as gw
+        import hermes_cli.profiles as profiles
+        import tools.terminal_tool as tt
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setenv("_HERMES_GATEWAY_PROFILE", "caspian")
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "marin")
+        prefix = tt._gateway_lifecycle_capability_prefix(
+            origin="caspian", target="marin", action="restart"
+        )
+        for assignment in shlex.split(prefix)[1:]:
+            name, value = assignment.split("=", 1)
+            monkeypatch.setenv(name, value)
+
+        assert gw._cross_profile_gateway_lifecycle_capability_valid("restart") is True
+        assert all(os.getenv(name) is None for name in gw._GATEWAY_LIFECYCLE_CAPABILITY_VARS)
+
+    def test_cross_profile_capability_rejects_wrong_action(self, monkeypatch):
+        import hermes_cli.gateway as gw
+        import hermes_cli.profiles as profiles
+        import tools.terminal_tool as tt
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setenv("_HERMES_GATEWAY_PROFILE", "caspian")
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "marin")
+        prefix = tt._gateway_lifecycle_capability_prefix(
+            origin="caspian", target="marin", action="stop"
+        )
+        for assignment in shlex.split(prefix)[1:]:
+            name, value = assignment.split("=", 1)
+            monkeypatch.setenv(name, value)
+
+        assert gw._cross_profile_gateway_lifecycle_capability_valid("restart") is False
+
+    def test_cross_profile_lifecycle_fails_closed_when_audit_fails(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setenv("_HERMES_GATEWAY_PROFILE", "caspian")
+
+        import hermes_cli.gateway as gw
+        import hermes_cli.profiles as profiles
+
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "marin")
+        monkeypatch.setattr(
+            gw, "_cross_profile_gateway_lifecycle_capability_valid", lambda action: True
+        )
+        monkeypatch.setattr(
+            gw, "_record_cross_profile_gateway_lifecycle_request", lambda action: False
+        )
+        args = Namespace(gateway_command="restart", all=False, system=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            gw.gateway_command(args)
+        assert exc_info.value.code == 1
+
+    @pytest.mark.parametrize("subcmd", ["stop", "restart"])
+    def test_lifecycle_still_blocks_origin_profile_inside_gateway(
+        self, monkeypatch, subcmd
+    ):
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setenv("_HERMES_GATEWAY_PROFILE", "caspian")
+
+        import hermes_cli.gateway as gw
+        import hermes_cli.profiles as profiles
+
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "caspian")
+        args = Namespace(gateway_command=subcmd, all=False, system=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            gw.gateway_command(args)
+        assert exc_info.value.code == 1
+
+    def test_cross_profile_lifecycle_writes_origin_audit_record(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setenv("_HERMES_GATEWAY_PROFILE", "caspian")
+        monkeypatch.delenv("_HERMES_GATEWAY_HOME", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_KEY", "telegram:chat:thread")
+
+        import hermes_cli.gateway as gw
+        import hermes_cli.profiles as profiles
+
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "marin")
+        monkeypatch.setattr(profiles, "get_profile_dir", lambda name: tmp_path / name)
+
+        assert gw._record_cross_profile_gateway_lifecycle_request("restart") is True
+
+        audit_path = tmp_path / "caspian" / "logs" / "gateway-lifecycle-audit.jsonl"
+        record = json.loads(audit_path.read_text(encoding="utf-8"))
+        assert record["origin_profile"] == "caspian"
+        assert record["target_profile"] == "marin"
+        assert record["action"] == "restart"
+        assert record["session_key"] == "telegram:chat:thread"
+
+    def test_custom_origin_audit_uses_exact_gateway_home(
+        self, monkeypatch, tmp_path
+    ):
+        origin_home = tmp_path / "arbitrary-custom-home"
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setenv("_HERMES_GATEWAY_PROFILE", "custom")
+        monkeypatch.setenv("_HERMES_GATEWAY_HOME", str(origin_home))
+
+        import hermes_cli.gateway as gw
+        import hermes_cli.profiles as profiles
+
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "marin")
+        monkeypatch.setattr(
+            profiles,
+            "get_profile_dir",
+            lambda name: (_ for _ in ()).throw(
+                AssertionError("custom origin must not resolve through profiles/custom")
+            ),
+        )
+
+        assert gw._record_cross_profile_gateway_lifecycle_request("stop") is True
+
+        audit_path = origin_home / "logs" / "gateway-lifecycle-audit.jsonl"
+        record = json.loads(audit_path.read_text(encoding="utf-8"))
+        assert record["origin_profile"] == "custom"
+        assert record["target_profile"] == "marin"
+        assert record["action"] == "stop"
+
 
 # ---------------------------------------------------------------------------
 # Defense 3: terminal_tool hard-blocks gateway lifecycle commands inside gateway
@@ -261,8 +483,10 @@ class TestTerminalToolGatewayLifecycleGuard:
         monkeypatch.setattr(tt, "_get_env_config", self._minimal_config)
         if inside_gateway:
             monkeypatch.setenv("_HERMES_GATEWAY", "1")
+            monkeypatch.setenv("_HERMES_GATEWAY_PROFILE", "caspian")
         else:
             monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+            monkeypatch.delenv("_HERMES_GATEWAY_PROFILE", raising=False)
 
     @pytest.mark.parametrize("cmd", [
         "systemctl restart hermes-gateway",
@@ -292,6 +516,161 @@ class TestTerminalToolGatewayLifecycleGuard:
         result = json.loads(tt.terminal_tool(
             command="systemctl restart hermes-gateway", force=True
         ))
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+
+    def test_allows_explicit_other_profile_restart_through_approval_layer(
+        self, monkeypatch
+    ):
+        import tools.terminal_tool as tt
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "restarted and verified", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+        command = "hermes --profile marin gateway restart"
+
+        result = json.loads(tt.terminal_tool(command=command))
+
+        assert result["exit_code"] == 0
+        assert len(calls) == 1
+        assert calls[0].startswith("env _HERMES_GATEWAY_LIFECYCLE_KEY=")
+        assert calls[0].endswith(command)
+
+    @pytest.mark.parametrize("busy_state", [True, None])
+    def test_busy_or_unknown_other_profile_requires_fresh_nonpermanent_approval(
+        self, monkeypatch, busy_state
+    ):
+        import tools.approval as approval
+        import tools.terminal_tool as tt
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+
+            def execute(self, command, **kwargs):  # pragma: no cover
+                calls.append(command)
+                raise AssertionError("execute must not be reached before approval")
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(tt, "_profile_gateway_busy", lambda profile: busy_state)
+        monkeypatch.setattr(
+            approval,
+            "request_tool_approval",
+            lambda *args, **kwargs: {
+                "approved": False,
+                "status": "approval_required",
+                "command": "<terminal> (plugin approval rule)",
+                "description": "target gateway has active turns",
+                "pattern_key": "plugin_rule:busy-cross-profile:unique",
+            },
+        )
+
+        result = json.loads(
+            tt.terminal_tool(command="hermes --profile marin gateway restart")
+        )
+
+        assert result["status"] == "pending_approval"
+        assert result["approval_pending"] is True
+        assert result["allow_permanent"] is False
+        assert "active turns" in result["description"]
+        assert calls == []
+
+    def test_busy_fresh_approval_is_the_only_approval_prompt(
+        self, monkeypatch
+    ):
+        import tools.approval as approval
+        import tools.terminal_tool as tt
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "restarted", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(tt, "_profile_gateway_busy", lambda profile: True)
+        monkeypatch.setattr(
+            approval,
+            "request_tool_approval",
+            lambda *args, **kwargs: {"approved": True},
+        )
+        monkeypatch.setattr(
+            tt,
+            "_check_all_guards",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("fresh busy-target consent must not prompt twice")
+            ),
+        )
+        command = "hermes --profile marin gateway restart"
+
+        result = json.loads(tt.terminal_tool(command=command))
+
+        assert result["exit_code"] == 0
+        assert len(calls) == 1
+        assert calls[0].startswith("env _HERMES_GATEWAY_LIFECYCLE_KEY=")
+        assert calls[0].endswith(command)
+
+    def test_target_busy_probe_uses_profile_runtime_state(self, monkeypatch, tmp_path):
+        import gateway.status as status
+        import hermes_cli.profiles as profiles
+        import tools.terminal_tool as tt
+
+        runtime = {
+            "gateway_state": "running",
+            "active_agents": 2,
+            "pid": 123,
+        }
+        monkeypatch.setattr(profiles, "get_profile_dir", lambda name: tmp_path / name)
+        status_path = tmp_path / "marin" / "gateway_state.json"
+        status_path.parent.mkdir(parents=True)
+        status_path.write_text("{}", encoding="utf-8")
+        monkeypatch.setattr(status, "read_runtime_status", lambda path: runtime)
+        monkeypatch.setattr(status, "runtime_status_pid_is_live", lambda record: True)
+
+        assert tt._profile_gateway_busy("marin") is True
+
+        runtime["active_agents"] = 0
+        assert tt._profile_gateway_busy("marin") is False
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "hermes --profile caspian gateway restart",
+            "hermes -p caspian gateway stop",
+            "hermes -p marin gateway restart",
+            "hermes --profile=marin gateway stop",
+            "hermes gateway restart",
+            "launchctl kickstart -k gui/501/ai.hermes.gateway-marin",
+            "/tmp/hermes --profile marin gateway restart",
+            (
+                'hermes --profile "$(launchctl kickstart -k '
+                'gui/501/ai.hermes.gateway-caspian; printf marin)" gateway restart'
+            ),
+        ],
+    )
+    def test_still_blocks_self_or_noncanonical_lifecycle_commands(
+        self, monkeypatch, command
+    ):
+        import tools.terminal_tool as tt
+
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+
+        result = json.loads(tt.terminal_tool(command=command, force=True))
 
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1626,3 +1626,91 @@ class TestCliApprovalTimeoutClassifiedSeparately:
         assert result.get("user_consent") is False
         assert "timed out without user response" in result["message"]
         assert "Silence is not consent" in result["message"]
+
+
+class TestFreshOnceApproval:
+    def test_ignores_yolo_and_cached_grants_and_never_persists(self, monkeypatch):
+        from tools import approval as mod
+
+        pattern_key = "plugin_rule:busy_cross_profile_gateway:marin"
+        mod._session_approved.clear()
+        mod._permanent_approved.clear()
+        mod.approve_session("", pattern_key)
+        mod._permanent_approved.add(pattern_key)
+        monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", True)
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setattr(
+            mod,
+            "approve_session",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("fresh approval must not persist a session grant")
+            ),
+        )
+        monkeypatch.setattr(
+            mod,
+            "approve_permanent",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("fresh approval must not persist a permanent grant")
+            ),
+        )
+        seen = {}
+
+        def callback(command, description, **kwargs):
+            seen.update(kwargs)
+            return "session"
+
+        result = mod.request_tool_approval(
+            "terminal",
+            "target gateway has active turns",
+            rule_key="busy_cross_profile_gateway:marin",
+            approval_callback=callback,
+            fresh_once=True,
+        )
+
+        assert result["approved"] is True
+        assert seen["allow_permanent"] is False
+        assert seen["smart_denied"] is True
+
+    def test_pending_fresh_request_disables_session_and_permanent(self, monkeypatch):
+        from tools import approval as mod
+
+        mod._session_approved.clear()
+        mod._permanent_approved.clear()
+        monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", False)
+        monkeypatch.setattr(mod, "_is_gateway_approval_context", lambda: True)
+        monkeypatch.setattr(mod, "_should_fall_through_to_cli_approval", lambda **kw: False)
+        monkeypatch.setattr(mod, "get_current_session_key", lambda: "gateway-session")
+        monkeypatch.setattr(mod, "submit_pending", lambda *args, **kwargs: None)
+
+        result = mod.request_tool_approval(
+            "terminal",
+            "target gateway has active turns",
+            rule_key="busy_cross_profile_gateway:marin",
+            fresh_once=True,
+        )
+
+        assert result["status"] == "approval_required"
+        assert result["allow_session"] is False
+        assert result["allow_permanent"] is False
+
+    def test_fresh_once_blocks_cron_autoapprove_mode(self, monkeypatch):
+        from tools import approval as mod
+
+        mod._session_approved.clear()
+        mod._permanent_approved.clear()
+        monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", False)
+        monkeypatch.setattr(mod, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(mod, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(mod, "_is_cron_approval_context", lambda: True)
+        monkeypatch.setattr(mod, "_get_cron_approval_mode", lambda: "approve")
+
+        result = mod.request_tool_approval(
+            "terminal",
+            "target busy state is unknown",
+            rule_key="busy_cross_profile_gateway:caspian:marin:restart",
+            fresh_once=True,
+            display_target="hermes --profile marin gateway restart",
+        )
+
+        assert result["approved"] is False
+        assert "fresh human decision" in result["message"]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3315,6 +3315,7 @@ def _run_approval_gate(
     autoapprove_log_prefix: str,
     fail_closed_when_no_human: bool = False,
     no_human_block_message: str = "",
+    fresh_once: bool = False,
 ) -> dict:
     """Shared human-approval gate for a flagged action (command or tool).
 
@@ -3351,6 +3352,9 @@ def _run_approval_gate(
             plugin-flagged action never runs ungated without a human.
         no_human_block_message: Message returned when
             ``fail_closed_when_no_human`` blocks.
+        fresh_once: Require a new human decision for this exact operation.
+            Ignores YOLO and cached session/permanent approvals, and offers only
+            one-operation approval or denial.
 
     Returns:
         ``{"approved": bool, "message": str|None, ...}`` — shape shared with
@@ -3359,11 +3363,13 @@ def _run_approval_gate(
     # --yolo bypasses all approval prompts (session- or process-scoped).
     # Hardline blocks are handled by the caller BEFORE this gate, so yolo
     # here only skips the recoverable approval layer.
-    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
+    if not fresh_once and (
+        _YOLO_MODE_FROZEN or is_current_session_yolo_enabled()
+    ):
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
-    if is_approved(session_key, pattern_key):
+    if not fresh_once and is_approved(session_key, pattern_key):
         return {"approved": True, "message": None}
 
     approval_callback = _resolve_cli_approval_callback(approval_callback)
@@ -3372,6 +3378,16 @@ def _run_approval_gate(
     is_gateway = _is_gateway_approval_context()
 
     if not is_cli and not is_gateway:
+        if fresh_once:
+            return {
+                "approved": False,
+                "message": (
+                    "BLOCKED: this operation requires a fresh human decision, "
+                    "but no interactive user or gateway approval surface is present."
+                ),
+                "pattern_key": pattern_key,
+                "description": description,
+            }
         # Cron sessions: respect cron_mode config
         if _is_cron_approval_context():
             if _get_cron_approval_mode() == "deny":
@@ -3427,8 +3443,8 @@ def _run_approval_gate(
                 "pattern_key": pattern_key,
                 "pattern_keys": [pattern_key],
                 "description": redact_sensitive_text(description),
-                "allow_permanent": True,
-                "allow_session": True,
+                "allow_permanent": not fresh_once,
+                "allow_session": not fresh_once,
             }
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"
@@ -3467,9 +3483,9 @@ def _run_approval_gate(
                     "user_consent": False,
                 }
 
-            if choice == "session":
+            if not fresh_once and choice == "session":
                 approve_session(session_key, pattern_key)
-            elif choice == "always":
+            elif not fresh_once and choice == "always":
                 approve_session(session_key, pattern_key)
                 approve_permanent(pattern_key)
                 save_permanent_allowlist(_permanent_approved)
@@ -3489,6 +3505,8 @@ def _run_approval_gate(
                 "command": display_target,
                 "pattern_key": pattern_key,
                 "description": description,
+                "allow_permanent": not fresh_once,
+                "allow_session": not fresh_once,
             })
             return {
                 "approved": False,
@@ -3496,6 +3514,8 @@ def _run_approval_gate(
                 "status": "approval_required",
                 "command": display_target,
                 "description": description,
+                "allow_permanent": not fresh_once,
+                "allow_session": not fresh_once,
                 "message": (
                     f"⚠️ This action is potentially dangerous ({description}). "
                     f"Asking the user for approval.\n\n**Target:**\n```\n{display_target}\n```"
@@ -3511,8 +3531,13 @@ def _run_approval_gate(
         session_key=session_key,
         surface="cli",
     )
-    choice = prompt_dangerous_approval(display_target, description,
-                                       approval_callback=approval_callback)
+    choice = prompt_dangerous_approval(
+        display_target,
+        description,
+        allow_permanent=not fresh_once,
+        approval_callback=approval_callback,
+        smart_denied=fresh_once,
+    )
     _fire_approval_hook(
         "post_approval_response",
         command=display_target,
@@ -3553,9 +3578,9 @@ def _run_approval_gate(
             "user_consent": False,
         }
 
-    if choice == "session":
+    if not fresh_once and choice == "session":
         approve_session(session_key, pattern_key)
-    elif choice == "always":
+    elif not fresh_once and choice == "always":
         approve_session(session_key, pattern_key)
         approve_permanent(pattern_key)
         save_permanent_allowlist(_permanent_approved)
@@ -3653,6 +3678,8 @@ def request_tool_approval(
     *,
     rule_key: str = "",
     approval_callback=None,
+    fresh_once: bool = False,
+    display_target: str | None = None,
 ) -> dict:
     """Escalate an arbitrary tool call to the human-approval gate.
 
@@ -3680,6 +3707,10 @@ def request_tool_approval(
             on the same tool).
         approval_callback: Optional CLI callback for interactive prompts
             (same contract as ``check_dangerous_command``).
+        fresh_once: Require a new one-operation decision, ignoring YOLO and
+            cached approvals. Session/permanent choices are not offered or saved.
+        display_target: Optional exact operation shown to the user instead of
+            the generic synthetic tool label.
 
     Returns:
         ``{"approved": True, "message": None}`` when allowed, or
@@ -3708,7 +3739,7 @@ def request_tool_approval(
     pattern_key = f"plugin_rule:{key_suffix}"
     # A synthetic "command" string for the display/allowlist layer. It never
     # executes; it only labels the gate. Namespaced identically.
-    display_target = f"<{tool_name}> (plugin approval rule)"
+    display_target = display_target or f"<{tool_name}> (plugin approval rule)"
 
     return _run_approval_gate(
         pattern_key=pattern_key,
@@ -3731,6 +3762,7 @@ def request_tool_approval(
             "but no interactive user or gateway is present to approve it. "
             "A plugin flagged this action for human confirmation."
         ),
+        fresh_once=fresh_once,
     )
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -34,12 +34,15 @@ Usage:
 """
 
 import importlib.util
+import hashlib
+import hmac
 import json
 import logging
 import os
 import platform
 import re
 import shlex
+import secrets
 import stat
 import time
 import threading
@@ -379,6 +382,65 @@ def _check_all_guards(command: str, env_type: str,
     return _check_all_guards_impl(command, env_type,
                                   approval_callback=_get_approval_callback(),
                                   has_host_access=has_host_access)
+
+
+def _profile_gateway_busy(profile_name: str) -> Optional[bool]:
+    """Return target busy state, or ``None`` when inspection is unreliable."""
+    try:
+        from gateway.status import (
+            derive_gateway_busy,
+            read_runtime_status,
+            runtime_status_pid_is_live,
+        )
+        from hermes_cli.profiles import get_profile_dir
+
+        status_path = get_profile_dir(profile_name) / "gateway_state.json"
+        if not status_path.exists():
+            return False
+        runtime = read_runtime_status(status_path)
+        if not isinstance(runtime, dict):
+            return None
+        if not runtime_status_pid_is_live(runtime):
+            return False
+        if runtime.get("gateway_state") != "running":
+            return None
+        try:
+            active_agents = int(runtime["active_agents"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        return derive_gateway_busy(
+            gateway_running=True,
+            gateway_state="running",
+            active_agents=active_agents,
+        )
+    except Exception:
+        logger.debug(
+            "Could not inspect target profile %s busy state", profile_name, exc_info=True
+        )
+        return None
+
+
+def _gateway_lifecycle_capability_prefix(
+    *, origin: str, target: str, action: str
+) -> str:
+    """Build a short-lived action-bound capability for the CLI lifecycle sink."""
+    expires = int(time.time()) + 60
+    nonce = secrets.token_hex(16)
+    payload = f"v1\n{origin}\n{target}\n{action}\n{expires}\n{nonce}"
+    key = secrets.token_hex(32)
+    proof = hmac.new(bytes.fromhex(key), payload.encode(), hashlib.sha256).hexdigest()
+    values = {
+        "_HERMES_GATEWAY_LIFECYCLE_KEY": key,
+        "_HERMES_GATEWAY_LIFECYCLE_PROOF": proof,
+        "_HERMES_GATEWAY_LIFECYCLE_EXPIRES": str(expires),
+        "_HERMES_GATEWAY_LIFECYCLE_NONCE": nonce,
+        "_HERMES_GATEWAY_LIFECYCLE_ORIGIN": origin,
+        "_HERMES_GATEWAY_LIFECYCLE_TARGET": target,
+        "_HERMES_GATEWAY_LIFECYCLE_ACTION": action,
+    }
+    return "env " + " ".join(
+        f"{name}={shlex.quote(value)}" for name, value in values.items()
+    ) + " "
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
@@ -2782,11 +2844,15 @@ def terminal_tool(
         # never restart. This mirrors the `hermes gateway restart` guard in
         # hermes_cli/gateway.py and the cron-path guard in hermes_cli/cron.py,
         # but applies unconditionally (force=True cannot help here).
+        cross_profile_fresh_approved = False
+        cross_profile_details = None
+        execution_command = command
         if os.environ.get("_HERMES_GATEWAY") == "1":
             from cron.lifecycle_guard import (
                 _MAX_REFERENCED_SCRIPT_BYTES,
                 contains_gateway_lifecycle_command_or_referenced_script,
                 contains_launchctl_submit_command,
+                explicit_cross_profile_gateway_lifecycle_details,
             )
             if contains_launchctl_submit_command(command):
                 return json.dumps({
@@ -2865,23 +2931,96 @@ def terminal_tool(
                     pass
                 return None
 
-            if contains_gateway_lifecycle_command_or_referenced_script(
+            lifecycle_hit = contains_gateway_lifecycle_command_or_referenced_script(
                 command,
                 cwd=guard_cwd,
                 read_remote_script=_read_script_in_env,
-            ):
+            )
+            origin_profile = os.environ.get("_HERMES_GATEWAY_PROFILE", "").strip()
+            if origin_profile:
+                cross_profile_details = explicit_cross_profile_gateway_lifecycle_details(
+                    command, current_profile=origin_profile
+                )
+            cross_profile_target = (
+                cross_profile_details[0] if cross_profile_details is not None else None
+            )
+            if lifecycle_hit and cross_profile_details is None:
                 return json.dumps({
                     "output": "",
                     "exit_code": 1,
                     "error": (
-                        "Blocked: command or referenced script cannot restart or stop "
-                        "the gateway from inside the gateway process. The gateway would "
-                        "kill this command before it could complete (SIGTERM propagates "
-                        "to child processes). Run `hermes gateway restart` from a "
-                        "separate shell outside the running gateway."
+                        "Blocked: command or referenced script may restart or stop "
+                        "the current gateway from inside its own process. Self-targeted, "
+                        "wrapped, and raw service-manager lifecycle commands remain "
+                        "blocked. To manage a sibling profile, use one direct command: "
+                        "`hermes --profile <other> gateway restart|stop`."
                     ),
                     "status": "error",
                 }, ensure_ascii=False)
+
+            if cross_profile_details is not None and env_type != "local":
+                return json.dumps({
+                    "output": "",
+                    "exit_code": 1,
+                    "error": "Blocked: sibling gateway lifecycle is available only on the local host backend.",
+                    "status": "error",
+                }, ensure_ascii=False)
+
+            if cross_profile_details is not None:
+                cross_profile_target, cross_profile_action = cross_profile_details
+                busy_state = _profile_gateway_busy(cross_profile_target)
+                if not force and busy_state is not False:
+                    from tools.approval import request_tool_approval
+
+                    state_reason = (
+                        "has active turns" if busy_state is True
+                        else "busy state could not be verified"
+                    )
+                    exact_reason = (
+                        f"Gateway profile '{cross_profile_target}' {state_reason}. "
+                        f"Approve this exact {cross_profile_action} operation once: {command}"
+                    )
+                    busy_approval = request_tool_approval(
+                        "terminal",
+                        exact_reason,
+                        rule_key=(
+                            f"busy_cross_profile_gateway:{origin_profile}:"
+                            f"{cross_profile_target}:{cross_profile_action}"
+                        ),
+                        approval_callback=_get_approval_callback(),
+                        fresh_once=True,
+                        display_target=command,
+                    )
+                    if not busy_approval.get("approved"):
+                        approval_status = busy_approval.get("status")
+                        if approval_status in {"approval_required", "pending_approval"}:
+                            return json.dumps({
+                                "output": "",
+                                "exit_code": -1,
+                                "error": "",
+                                "status": "pending_approval",
+                                "approval_pending": True,
+                                "command": busy_approval.get("command", command),
+                                "description": busy_approval.get("description", exact_reason),
+                                "pattern_key": busy_approval.get("pattern_key", ""),
+                                "allow_permanent": False,
+                            }, ensure_ascii=False)
+                        return json.dumps({
+                            "output": "",
+                            "exit_code": 1,
+                            "error": busy_approval.get("message") or (
+                                "BLOCKED: fresh approval is required because the target "
+                                "gateway's busy state is active or unknown."
+                            ),
+                            "status": "error",
+                        }, ensure_ascii=False)
+                    cross_profile_fresh_approved = True
+
+                execution_command = _gateway_lifecycle_capability_prefix(
+                    origin=origin_profile,
+                    target=cross_profile_target,
+                    action=cross_profile_action,
+                ) + command
 
         # Validate before the source guard resolves an explicit workdir.
         if workdir:
@@ -2928,8 +3067,8 @@ def terminal_tool(
         # force).  Drives the clean-interrupt-slate clear before env.execute so
         # an approved command can't be SIGINT-killed by a bit that landed during
         # the approval-wait (see clear_current_thread_interrupt).
-        _approved_run = bool(force)
-        if not force:
+        _approved_run = bool(force or cross_profile_fresh_approved)
+        if not force and not cross_profile_fresh_approved:
             approval = _check_all_guards(
                 command, env_type,
                 has_host_access=_docker_has_host_access(config),
@@ -3278,7 +3417,7 @@ def terminal_tool(
                         # reads, RPC reads) intentionally stay unbounded.
                         "bounded_capture": True,
                     }
-                    result = env.execute(command, **execute_kwargs)
+                    result = env.execute(execution_command, **execute_kwargs)
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:


### PR DESCRIPTION
## Summary

- replace the blanket in-gateway lifecycle ban with profile-aware self-protection
- permit only literal `hermes --profile NAME gateway restart|stop` sibling operations
- bind terminal authorization to the CLI lifecycle sink with a short-lived origin/target/action capability
- require fresh one-operation approval when target busy state is active or unknown
- protect routing/capability identity from target dotenv overrides
- fsync origin-profile JSONL audit records and fail closed when audit delivery fails

## Security properties

- self-target and `--all` remain hard-blocked inside a gateway
- aliases, equals syntax, paths, wrappers, compound commands, scripts, and raw service-manager operations remain blocked
- busy-state inspection errors require human approval rather than failing open
- fresh approval ignores YOLO and cached/session/permanent grants; cron auto-approve cannot satisfy it
- target dotenv cannot rewrite gateway origin, selected target home, or lifecycle capability
- CLI sink consumes and verifies a 60-second HMAC capability bound to origin, target, action, expiry, and nonce

## Verification

- `tests/hermes_cli/test_gateway_restart_loop.py`: 150 passed
- gateway/status/ledger suites: 170 passed, 4 skipped
- approval suites: 121 passed, 1 unrelated baseline test deselected
- `compileall`: passed
- `git diff --check`: passed

The deselected pre-existing test is `TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`, whose `/tmp` expectation fails under macOS `/private/tmp` resolution on the unmodified base as well.
