### PR TITLE
fix(desktop): visible eye catchlights on dark-bodied Bot Mode avatars

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1326,6 +1326,11 @@ function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle'
 
   const working = mood === 'work'
   const eyeFill = isDarkColor(color) ? 'rgba(232,220,195,0.95)' : 'rgba(0,0,0,0.85)'
+  // Catchlight contrast follows the pupil, not the body: dark pupils get the
+  // white sparkle, light (cream) pupils on dark bodies get a dark one — a
+  // white dot on a cream pupil is invisible, which read as "no eye dots" on
+  // maroon/ink/oxblood avatars.
+  const hlFill = isDarkColor(color) ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.85)'
   const ring = sampleFaceRing(shape)
   const rest = facePose(working ? 'work' : 'idle', 0)
   // Shape-aware initial eye line — the cloud body sits lower, so its eyes
@@ -1356,8 +1361,8 @@ function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle'
         children: [
           jsx('ellipse', { 'data-hb-el': '1', cx: 15.4, cy: eyeY0, rx: 2.2, ry: working ? 2.6 : 2.3, fill: eyeFill }),
           jsx('ellipse', { 'data-hb-er': '1', cx: 24.6, cy: eyeY0, rx: 2.2, ry: working ? 2.6 : 2.3, fill: eyeFill }),
-          jsx('circle', { 'data-hb-hl-l': '1', cx: 14.8, cy: eyeY0 - 0.7, r: 0.65, fill: 'rgba(255,255,255,0.85)' }),
-          jsx('circle', { 'data-hb-hl-r': '1', cx: 24, cy: eyeY0 - 0.7, r: 0.65, fill: 'rgba(255,255,255,0.85)' })
+          jsx('circle', { 'data-hb-hl-l': '1', cx: 14.8, cy: eyeY0 - 0.7, r: 0.65, fill: hlFill }),
+          jsx('circle', { 'data-hb-hl-r': '1', cx: 24, cy: eyeY0 - 0.7, r: 0.65, fill: hlFill })
         ]
       }),
       jsx('path', {

--- a/apps/desktop/src/plugins/hermes-bots/tests/face-catchlight.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/face-catchlight.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+// Catchlight contrast follows the PUPIL, not the body (image14 report,
+// Aug 2026): dark bodies flip the pupils to light cream (`eyeFill`), and a
+// white catchlight on a cream pupil is invisible — maroon/ink/oxblood
+// avatars looked like they had "no dots in their eyes". The sparkle must be
+// dark on light pupils and light on dark pupils.
+
+test('catchlight fill flips with pupil polarity (hlFill), not hardcoded white', () => {
+  assert.match(pluginSource, /const hlFill = isDarkColor\(color\) \? 'rgba\(0,0,0,0\.6\)' : 'rgba\(255,255,255,0\.85\)'/)
+  // Both initial catchlight circles use it.
+  assert.match(pluginSource, /'data-hb-hl-l': '1', cx: 14\.8, cy: eyeY0 - 0\.7, r: 0\.65, fill: hlFill/)
+  assert.match(pluginSource, /'data-hb-hl-r': '1', cx: 24, cy: eyeY0 - 0\.7, r: 0\.65, fill: hlFill/)
+  // No stray hardcoded white catchlight remains on the hb-hl elements.
+  assert.doesNotMatch(pluginSource, /data-hb-hl-[lr]': '1'[^}]*rgba\(255,255,255/)
+})


### PR DESCRIPTION
## Summary

Dark-bodied Bot Mode shape avatars (maroon/ink/oxblood) now show their eye catchlights. The catchlight dots were hardcoded white, but `isDarkColor()` flips dark bodies' pupils to light cream — a white dot on a cream pupil is invisible, so those avatars looked like they had no dots in their eyes (reported with screenshot, Aug 17).

## Changes

- `apps/desktop/src/plugins/hermes-bots/plugin.js`: new `hlFill` — catchlight contrast follows the pupil, not the body (dark pupils keep the white sparkle, light cream pupils get `rgba(0,0,0,0.6)`); both initial `data-hb-hl-*` circles use it. The animation clock only moves the catchlights (cx/cy), never fill, so the initial fill carries through every frame.
- `tests/face-catchlight.test.mjs`: source contract — `hlFill` polarity flip present, both catchlights use it, no hardcoded-white catchlight remains.

## Validation

| | Before | After |
|---|---|---|
| Maroon hexagon (cream pupils) | no visible inner dots | clear dark dots |
| Light body (black pupils) | white catchlights | unchanged |

Verified with a rendered before/after/control strip (vision-checked); plugin suite green including the new test.

## Infographic

![Bot avatar eye catchlights](https://v3b.fal.media/files/b/0aa6c27b/X8lwCu_KueBn47eiwa9Md_0BK590MR.png)
