### PR TITLE
Fix file tool requirement lookup in workspaces

### DIFF
--- a/tests/tools/test_terminal_tool_requirements.py
+++ b/tests/tools/test_terminal_tool_requirements.py
@@ -31,6 +31,22 @@ class TestTerminalRequirements:
         )
         assert terminal_tool_module.check_terminal_requirements() is True
 
+    def test_file_requirements_resolve_from_the_current_package(self, monkeypatch):
+        import tools
+        from tools import file_tools
+
+        monkeypatch.setattr(
+            terminal_tool_module,
+            "check_terminal_requirements",
+            lambda: True,
+        )
+
+        def fail_package_export():
+            raise AssertionError("file requirements re-imported the tools package export")
+
+        monkeypatch.setattr(tools, "check_file_requirements", fail_package_export)
+        assert file_tools._check_file_reqs() is True
+
 
     def test_terminal_and_execute_code_tools_resolve_for_managed_modal(self, monkeypatch, tmp_path):
         monkeypatch.setattr("tools.tool_backend_helpers.managed_nous_tools_enabled", lambda: True)
@@ -269,12 +285,8 @@ class TestCheckFnTransientFailureSuppression:
         monkeypatch.setattr(
             terminal_tool_module, "check_terminal_requirements", flaky_terminal_check
         )
-        # file tools delegate to the same check via tools.check_file_requirements.
-        import tools as tools_pkg
-
-        monkeypatch.setattr(
-            tools_pkg, "check_file_requirements", flaky_terminal_check
-        )
+        # File tools resolve the terminal check from their own package. This
+        # stays reliable when a workspace also contains a top-level tools/ dir.
 
         t = {"now": 5000.0}
         monkeypatch.setattr(reg.time, "monotonic", lambda: t["now"])

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2646,8 +2646,9 @@ from tools.registry import registry, tool_error
 
 def _check_file_reqs():
     """Lazy wrapper to avoid circular import with tools/__init__.py."""
-    from tools import check_file_requirements
-    return check_file_requirements()
+    from .terminal_tool import check_terminal_requirements
+
+    return check_terminal_requirements()
 
 READ_FILE_SCHEMA = {
     "name": "read_file",


### PR DESCRIPTION
## Summary

- resolve the file tool requirement check from the current `tools` package
- avoid re-importing a workspace-level `tools` export during lazy tool discovery
- keep the file tool availability check aligned with the terminal backend

## Validation

- `python -m pytest tests/tools/test_terminal_tool_requirements.py -q` (13 passed)
- `python -m ruff check tools/file_tools.py tests/tools/test_terminal_tool_requirements.py`