### PR TITLE
fix(peer): live-verified cross-gateway bot DMs — session shape + virtual-model replay

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2320,6 +2320,21 @@ class APIServerAdapter(BasePlatformAdapter):
             return None
         return self._model_routes.get(model_alias)
 
+    def _stored_session_model(self, session: Any) -> Optional[str]:
+        """The model persisted on a session row, minus the virtual alias.
+
+        The advertised virtual model (usually ``hermes-agent``) means "use
+        the gateway default". Session creation persists it when the client
+        sent no model, and replaying it upstream as a raw provider model id
+        400s ("hermes-agent is not a valid model ID") — the same filter
+        ``_request_agent_overrides`` applies to per-request bodies. One
+        resolver for both session-chat sites (sync + stream).
+        """
+        stored = session.get("model") if isinstance(session, dict) else None
+        if not stored or stored == self._model_name:
+            return None
+        return stored
+
     @staticmethod
     def _clean_runtime_id(value: Any, *, max_len: int = 200) -> str:
         if value is None:
@@ -3740,7 +3755,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if runtime_request.get("model_options"):
                 agent_overrides["model_options"] = runtime_request["model_options"]
         else:
-            stored_model = session.get("model") if isinstance(session, dict) else None
+            stored_model = self._stored_session_model(session)
             stored_route = self._resolve_route(stored_model)
             route = stored_route or self._resolve_route(body.get("model"))
             session_model = stored_model if (stored_model and stored_route is None) else None
@@ -3850,7 +3865,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if runtime_request.get("model_options"):
                 agent_overrides["model_options"] = runtime_request["model_options"]
         else:
-            stored_model = session.get("model") if isinstance(session, dict) else None
+            stored_model = self._stored_session_model(session)
             stored_route = self._resolve_route(stored_model)
             route = stored_route or self._resolve_route(body.get("model"))
             session_model = stored_model if (stored_model and stored_route is None) else None

--- a/hermes_cli/subcommands/peer.py
+++ b/hermes_cli/subcommands/peer.py
@@ -126,7 +126,9 @@ def _ensure_bot_chat(base: str, key: str) -> str:
         method="POST",
         body={"title": BOT_CHAT_TITLE, "source": "bot_peer_dm"},
     )
-    session_id = str(created.get("id") or created.get("session_id") or "")
+    # Real api_server wraps the row: {"object": "hermes.session", "session": {...}}.
+    session = created.get("session") if isinstance(created.get("session"), dict) else created
+    session_id = str(session.get("id") or session.get("session_id") or "")
     if not session_id:
         raise RuntimeError("Peer did not return a session id for the new Bot Chat")
     return session_id

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2592,6 +2592,27 @@ class TestModelRoutesAgentCreation:
         assert captured["api_key"] == "sk-session"
 
 
+class TestStoredSessionModelFilter:
+    """A session row that persisted the advertised virtual model must read as
+    "no stored model" — replaying "hermes-agent" upstream 400s. Found live
+    (Aug 2026): the first cross-gateway `hermes peer dm` against a fresh
+    api_server failed every turn with "hermes-agent is not a valid model ID".
+    """
+
+    def test_virtual_model_is_filtered(self):
+        adapter = _make_routing_adapter({})
+        assert adapter._stored_session_model({"model": adapter._model_name}) is None
+
+    def test_real_model_passes_through(self):
+        adapter = _make_routing_adapter({})
+        assert adapter._stored_session_model({"model": "google/gemini-3.7-flash"}) == "google/gemini-3.7-flash"
+
+    def test_missing_or_bad_shapes(self):
+        adapter = _make_routing_adapter({})
+        assert adapter._stored_session_model({}) is None
+        assert adapter._stored_session_model(None) is None
+
+
 # ---------------------------------------------------------------------------
 # Event-loop offloading for synchronous SessionDB calls (P1)
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_peer_cmd.py
+++ b/tests/hermes_cli/test_peer_cmd.py
@@ -116,7 +116,9 @@ class _FakePeer(BaseHTTPRequestHandler):
 
         if self.path == "/api/sessions":
             type(self).sessions.append("bc_1")
-            return self._json({"id": "bc_1", "title": body.get("title")}, 201)
+            # REAL api_server create shape: the row is wrapped under "session"
+            # (verified live Aug 2026 — a flat fake hid a parser bug).
+            return self._json({"object": "hermes.session", "session": {"id": "bc_1", "title": body.get("title")}}, 201)
 
         if self.path.startswith("/api/sessions/") and self.path.endswith("/chat"):
             type(self).chats.append(body.get("message"))


### PR DESCRIPTION
## Summary
Cross-gateway bot-to-bot DMs are now LIVE-VERIFIED end to end, and the two bugs the live test caught are fixed. A real two-gateway rig (two isolated HERMES_HOMEs; bravo running the api_server platform on :18642; alpha's agent autonomously choosing `hermes peer dm` from its injected Bot Chat protocol) produced a confirmed round trip:

```
alpha's Bot Chat → hermes peer dm bravo → bravo's canonical Bot Chat
  user:      Message from 🤖 alpha (@alpha): What is your callsign?
  assistant: CALLSIGN-BRAVO-7        ← relayed back and persisted on bravo
```

## Changes
- `hermes_cli/subcommands/peer.py`: parse the real session-create response shape — api_server wraps the row (`{"object": "hermes.session", "session": {...}}`); the flat parse made every first DM to a fresh peer fail with "Peer did not return a session id" while orphaning a Bot Chat that then 400'd retries on duplicate-title.
- `gateway/platforms/api_server.py`: a session created with no model persists the advertised virtual model (`hermes-agent`); session chat replayed it upstream as a raw model id → `400 hermes-agent is not a valid model ID`. New `_stored_session_model()` helper filters the virtual alias — one resolver used by BOTH session-chat sites (sync + stream), matching the existing `_request_agent_overrides` behavior for request bodies.
- Tests: peer fake updated to the REAL wrapped create shape (the flat fake is what hid bug 1); `TestStoredSessionModelFilter` pins the virtual-model filter.

## Validation
| | Result |
|---|---|
| Live two-gateway E2E (real gateway, real model turns, autonomous agent-initiated DM) | round trip confirmed, transcript persisted in the peer's canonical Bot Chat, reply relayed |
| tests/gateway/test_api_server.py (routing/chat/filter selection) | 11 passed |
| tests/hermes_cli/test_peer_cmd.py | 10/10 |
| ruff | clean |

## Infographic

![Live-verified bot-to-bot DMs](https://v3b.fal.media/files/b/0aa6c281/F2pByGd70BniGPh11xbR4_cMmpqHe9.png)
