### PR TITLE
fix(gateway,state): SessionDB off the event-loop thread + contention-safe v25 migration

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -703,7 +703,7 @@ def _get_session_db() -> Optional[Any]:
     runs schema init, and a migration against a contended state.db blocks for
     seconds — on the gateway's loop thread that starves the loop-liveness
     watchdog, which hard-exits the process (exit 75) and crash-loops the
-    gateway (Coatue field report, 2026-08-14). On a cache miss with a running
+    gateway (enterprise field report, 2026-08-14). On a cache miss with a running
     loop we kick a one-shot background bootstrap and return None; every
     caller already degrades gracefully on None, and a later call returns the
     cached instance.

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -664,10 +664,17 @@ def _meta_key(session_id: str) -> str:
 
 _DB_CACHE: Dict[str, Any] = {}
 _DB_BOOTSTRAP_LOCK = threading.Lock()
-_DB_BOOTSTRAP_INFLIGHT: set = set()
+_DB_BOOTSTRAP_INFLIGHT: Dict[str, threading.Event] = {}
+
+# How long a loop-thread caller waits for the background bootstrap before
+# degrading to None. Normal SessionDB init is ~10-100ms, so the common case
+# still returns a real DB (no silently dropped goal writes); a contended
+# init (locked state.db mid-migration) blows past this and the caller
+# degrades, with the loop stalled far under the watchdog's probe window.
+_DB_BOOTSTRAP_LOOP_WAIT_S = 0.25
 
 
-def _bootstrap_session_db(home: str) -> None:
+def _bootstrap_session_db(home: str, done: threading.Event) -> None:
     """Construct SessionDB off-loop and populate the cache (worker thread)."""
     try:
         from hermes_state import SessionDB
@@ -679,7 +686,8 @@ def _bootstrap_session_db(home: str) -> None:
     with _DB_BOOTSTRAP_LOCK:
         if db is not None and home not in _DB_CACHE:
             _DB_CACHE[home] = db
-        _DB_BOOTSTRAP_INFLIGHT.discard(home)
+        _DB_BOOTSTRAP_INFLIGHT.pop(home, None)
+    done.set()
 
 
 def _get_session_db() -> Optional[Any]:
@@ -727,15 +735,23 @@ def _get_session_db() -> Optional[Any]:
             cached = _DB_CACHE.get(home)
             if cached is not None:
                 return cached
-            if home not in _DB_BOOTSTRAP_INFLIGHT:
-                _DB_BOOTSTRAP_INFLIGHT.add(home)
+            done = _DB_BOOTSTRAP_INFLIGHT.get(home)
+            if done is None:
+                done = threading.Event()
+                _DB_BOOTSTRAP_INFLIGHT[home] = done
                 threading.Thread(
                     target=_bootstrap_session_db,
-                    args=(home,),
+                    args=(home, done),
                     name="goals-sessiondb-bootstrap",
                     daemon=True,
                 ).start()
-        return None
+        # Grace window: a healthy init finishes in tens of ms, so waiting
+        # briefly keeps goal/heartbeat persistence working on the very first
+        # loop-thread call instead of silently dropping it. A contended init
+        # (the crash-loop scenario) exceeds the window and we degrade to
+        # None — a bounded stall far below the watchdog's probe timeout.
+        done.wait(_DB_BOOTSTRAP_LOOP_WAIT_S)
+        return _DB_CACHE.get(home)
 
     try:
         db = SessionDB()

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -29,12 +29,14 @@ Nothing in this module touches the agent's system prompt or toolset.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
 import os
 import re
 import subprocess
+import threading
 import time
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
@@ -661,6 +663,23 @@ def _meta_key(session_id: str) -> str:
 
 
 _DB_CACHE: Dict[str, Any] = {}
+_DB_BOOTSTRAP_LOCK = threading.Lock()
+_DB_BOOTSTRAP_INFLIGHT: set = set()
+
+
+def _bootstrap_session_db(home: str) -> None:
+    """Construct SessionDB off-loop and populate the cache (worker thread)."""
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+    except Exception as exc:  # pragma: no cover
+        logger.debug("GoalManager: background SessionDB() raised (%s)", exc)
+        db = None
+    with _DB_BOOTSTRAP_LOCK:
+        if db is not None and home not in _DB_CACHE:
+            _DB_CACHE[home] = db
+        _DB_BOOTSTRAP_INFLIGHT.discard(home)
 
 
 def _get_session_db() -> Optional[Any]:
@@ -671,6 +690,15 @@ def _get_session_db() -> Optional[Any]:
     ``hermes_home`` path so profile switches still pick up the right DB.
     Defensive against import/instantiation failures so tests and
     non-standard launchers can still use the GoalManager.
+
+    Never constructs SessionDB on an event-loop thread. ``SessionDB.__init__``
+    runs schema init, and a migration against a contended state.db blocks for
+    seconds — on the gateway's loop thread that starves the loop-liveness
+    watchdog, which hard-exits the process (exit 75) and crash-loops the
+    gateway (Coatue field report, 2026-08-14). On a cache miss with a running
+    loop we kick a one-shot background bootstrap and return None; every
+    caller already degrades gracefully on None, and a later call returns the
+    cached instance.
     """
     try:
         from hermes_constants import get_hermes_home
@@ -684,12 +712,47 @@ def _get_session_db() -> Optional[Any]:
     cached = _DB_CACHE.get(home)
     if cached is not None:
         return cached
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        on_loop_thread = False
+    else:
+        on_loop_thread = True
+
+    if on_loop_thread:
+        with _DB_BOOTSTRAP_LOCK:
+            # Re-check under the lock: a bootstrap may have finished between
+            # the unlocked read above and here.
+            cached = _DB_CACHE.get(home)
+            if cached is not None:
+                return cached
+            if home not in _DB_BOOTSTRAP_INFLIGHT:
+                _DB_BOOTSTRAP_INFLIGHT.add(home)
+                threading.Thread(
+                    target=_bootstrap_session_db,
+                    args=(home,),
+                    name="goals-sessiondb-bootstrap",
+                    daemon=True,
+                ).start()
+        return None
+
     try:
         db = SessionDB()
     except Exception as exc:  # pragma: no cover
         logger.debug("GoalManager: SessionDB() raised (%s)", exc)
         return None
-    _DB_CACHE[home] = db
+    with _DB_BOOTSTRAP_LOCK:
+        existing = _DB_CACHE.get(home)
+        if existing is not None:
+            # A concurrent bootstrap won the race; keep one instance and
+            # close ours so connections don't leak.
+            try:
+                db.close()
+            except Exception:
+                pass
+            return existing
+        _DB_CACHE[home] = db
     return db
 
 

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -86,7 +86,18 @@ class SessionSchemaMixin:
     """See module docstring — mixin for SessionDB (Schema cluster)."""
 
     def _dedupe_legacy_system_prompts(self, cursor: sqlite3.Cursor) -> None:
-        """Move inline prompt snapshots into the shared content-addressed table."""
+        """Move inline prompt snapshots into the shared content-addressed table.
+
+        Contention-safe by design: a ``database is locked`` (or any other
+        ``OperationalError``) mid-loop returns instead of raising. Partial
+        migration is safe — the legacy ``system_prompt`` column is kept as a
+        read fallback for unmigrated rows, and the next schema init picks up
+        the remainder. Letting the error propagate aborted schema init
+        entirely, left the version below 25, and made every subsequent
+        ``SessionDB.__init__`` re-enter this migration against the same
+        contended DB (Coatue field report, 2026-08-14: gateway watchdog
+        crash loop).
+        """
         try:
             rows = cursor.execute(
                 "SELECT id, system_prompt FROM sessions "
@@ -98,13 +109,22 @@ class SessionSchemaMixin:
         for row in rows:
             session_id = row["id"] if isinstance(row, sqlite3.Row) else row[0]
             prompt = row["system_prompt"] if isinstance(row, sqlite3.Row) else row[1]
-            prompt_hash = self._store_system_prompt(cursor, prompt)
-            cursor.execute(
-                "UPDATE sessions "
-                "SET system_prompt_hash = ?, system_prompt = NULL "
-                "WHERE id = ?",
-                (prompt_hash, session_id),
-            )
+            try:
+                prompt_hash = self._store_system_prompt(cursor, prompt)
+                cursor.execute(
+                    "UPDATE sessions "
+                    "SET system_prompt_hash = ?, system_prompt = NULL "
+                    "WHERE id = ?",
+                    (prompt_hash, session_id),
+                )
+            except sqlite3.OperationalError as exc:
+                logger.warning(
+                    "v25 prompt dedupe paused after contention (%s); "
+                    "unmigrated rows keep the legacy inline prompt and the "
+                    "next schema init resumes the migration.",
+                    exc,
+                )
+                return
 
     def _sqlite_supports_fts5(self, cursor: sqlite3.Cursor) -> bool:
         try:

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -95,7 +95,7 @@ class SessionSchemaMixin:
         the remainder. Letting the error propagate aborted schema init
         entirely, left the version below 25, and made every subsequent
         ``SessionDB.__init__`` re-enter this migration against the same
-        contended DB (Coatue field report, 2026-08-14: gateway watchdog
+        contended DB (enterprise field report, 2026-08-14: gateway watchdog
         crash loop).
         """
         try:

--- a/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
+++ b/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
@@ -53,9 +53,10 @@ def _patch_sessiondb(monkeypatch):
     monkeypatch.setattr(hermes_state, "SessionDB", _RecordingDB)
 
 
-def test_loop_thread_cache_miss_returns_none_without_constructing(monkeypatch):
-    """On the event-loop thread with a cold cache: no inline construction,
-    immediate None, background population."""
+def test_loop_thread_cache_miss_constructs_off_loop(monkeypatch):
+    """On the event-loop thread with a cold cache: construction happens on a
+    background thread (never the loop thread). A fast init is returned via
+    the grace window; either way the loop thread never runs SessionDB()."""
     _patch_sessiondb(monkeypatch)
     loop_thread_id = None
     inline_result = "UNSET"
@@ -67,9 +68,10 @@ def test_loop_thread_cache_miss_returns_none_without_constructing(monkeypatch):
 
     asyncio.run(main())
 
-    # The loop-thread call must not have blocked on construction.
-    assert inline_result is None
-    # Background thread eventually populates the cache, OFF the loop thread.
+    # Fast init: the grace window returns the real instance (no silent
+    # feature loss on the first call).
+    assert isinstance(inline_result, _RecordingDB)
+    # Cache populated for subsequent calls.
     deadline = time.monotonic() + 5
     while time.monotonic() < deadline and not goals._DB_CACHE:
         time.sleep(0.02)
@@ -108,7 +110,8 @@ def test_worker_thread_constructs_inline(monkeypatch):
 
 def test_slow_construction_does_not_block_the_loop(monkeypatch):
     """A SessionDB whose init blocks (locked-DB migration) must not stall
-    the event loop past the watchdog probe window."""
+    the event loop past the watchdog probe window: bounded grace wait,
+    then degrade to None."""
     import hermes_state
 
     class _BlockingDB:
@@ -120,14 +123,16 @@ def test_slow_construction_does_not_block_the_loop(monkeypatch):
 
     monkeypatch.setattr(hermes_state, "SessionDB", _BlockingDB)
     elapsed = None
+    result = "UNSET"
 
     async def main():
-        nonlocal elapsed
+        nonlocal elapsed, result
         t0 = time.monotonic()
-        goals._get_session_db()
+        result = goals._get_session_db()
         elapsed = time.monotonic() - t0
 
     asyncio.run(main())
-    assert elapsed is not None and elapsed < 0.5, (
+    assert result is None, "contended init must degrade to None"
+    assert elapsed is not None and elapsed < 1.0, (
         f"loop-thread call blocked for {elapsed:.2f}s — watchdog territory"
     )

--- a/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
+++ b/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
@@ -1,0 +1,133 @@
+"""SessionDB bootstrap must never run schema init on an event-loop thread.
+
+Coatue field report (2026-08-14): after an unclean shutdown plus a
+double-instance startup race, the v25 schema migration inside
+``SessionDB.__init__`` blocked the gateway's event-loop thread (reached via
+``_post_turn_goal_continuation`` → ``GoalManager()`` → ``load_goal`` →
+``_get_session_db``). The loop-liveness watchdog missed 3 probes and killed
+the process with exit 75; the supervisor restarted into the same state —
+an unbounded crash loop.
+
+Contract fixed here, at the shared boundary (goals.py ``_get_session_db``,
+which the heartbeat module reuses):
+
+- Called on a thread with a RUNNING event loop and no cached DB, it must
+  NOT construct SessionDB inline. It returns None immediately (callers
+  already degrade gracefully on None) and populates the cache from a
+  background thread.
+- Called on a plain worker thread, it constructs inline as before.
+- Once cached, every thread gets the cached instance.
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+import hermes_cli.goals as goals
+
+
+class _RecordingDB:
+    """Stands in for SessionDB; records which thread constructed it."""
+
+    constructed_on: list = []
+
+    def __init__(self):
+        _RecordingDB.constructed_on.append(threading.get_ident())
+
+    def get_meta(self, key):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache(monkeypatch):
+    _RecordingDB.constructed_on = []
+    monkeypatch.setattr(goals, "_DB_CACHE", {})
+    yield
+
+
+def _patch_sessiondb(monkeypatch):
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _RecordingDB)
+
+
+def test_loop_thread_cache_miss_returns_none_without_constructing(monkeypatch):
+    """On the event-loop thread with a cold cache: no inline construction,
+    immediate None, background population."""
+    _patch_sessiondb(monkeypatch)
+    loop_thread_id = None
+    inline_result = "UNSET"
+
+    async def main():
+        nonlocal loop_thread_id, inline_result
+        loop_thread_id = threading.get_ident()
+        inline_result = goals._get_session_db()
+
+    asyncio.run(main())
+
+    # The loop-thread call must not have blocked on construction.
+    assert inline_result is None
+    # Background thread eventually populates the cache, OFF the loop thread.
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not goals._DB_CACHE:
+        time.sleep(0.02)
+    assert goals._DB_CACHE, "background bootstrap never populated the cache"
+    assert _RecordingDB.constructed_on, "SessionDB never constructed"
+    assert all(t != loop_thread_id for t in _RecordingDB.constructed_on), (
+        "SessionDB was constructed on the event-loop thread"
+    )
+
+
+def test_loop_thread_cache_hit_returns_cached_instance(monkeypatch):
+    """A warm cache is returned directly even on the loop thread."""
+    _patch_sessiondb(monkeypatch)
+    sentinel = _RecordingDB()
+    from hermes_constants import get_hermes_home
+
+    goals._DB_CACHE[str(get_hermes_home())] = sentinel
+    result = "UNSET"
+
+    async def main():
+        nonlocal result
+        result = goals._get_session_db()
+
+    asyncio.run(main())
+    assert result is sentinel
+
+
+def test_worker_thread_constructs_inline(monkeypatch):
+    """No running loop on the calling thread → construct inline, return it."""
+    _patch_sessiondb(monkeypatch)
+    db = goals._get_session_db()
+    assert db is not None
+    assert isinstance(db, _RecordingDB)
+    assert _RecordingDB.constructed_on == [threading.get_ident()]
+
+
+def test_slow_construction_does_not_block_the_loop(monkeypatch):
+    """A SessionDB whose init blocks (locked-DB migration) must not stall
+    the event loop past the watchdog probe window."""
+    import hermes_state
+
+    class _BlockingDB:
+        def __init__(self):
+            time.sleep(2.0)  # simulated contended migration
+
+        def get_meta(self, key):
+            return None
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _BlockingDB)
+    elapsed = None
+
+    async def main():
+        nonlocal elapsed
+        t0 = time.monotonic()
+        goals._get_session_db()
+        elapsed = time.monotonic() - t0
+
+    asyncio.run(main())
+    assert elapsed is not None and elapsed < 0.5, (
+        f"loop-thread call blocked for {elapsed:.2f}s — watchdog territory"
+    )

--- a/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
+++ b/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
@@ -1,6 +1,6 @@
 """SessionDB bootstrap must never run schema init on an event-loop thread.
 
-Coatue field report (2026-08-14): after an unclean shutdown plus a
+Enterprise field report (2026-08-14): after an unclean shutdown plus a
 double-instance startup race, the v25 schema migration inside
 ``SessionDB.__init__`` blocked the gateway's event-loop thread (reached via
 ``_post_turn_goal_continuation`` → ``GoalManager()`` → ``load_goal`` →

--- a/tests/state/test_dedupe_migration_contention.py
+++ b/tests/state/test_dedupe_migration_contention.py
@@ -1,6 +1,6 @@
 """The v25 dedupe migration must degrade gracefully on a contended DB.
 
-Coatue field report (2026-08-14): with state.db locked by another process,
+Enterprise field report (2026-08-14): with state.db locked by another process,
 ``_dedupe_legacy_system_prompts`` raised ``sqlite3.OperationalError``
 mid-loop (only the initial SELECT was guarded), which aborted schema init,
 left the schema version below 25, and made EVERY subsequent

--- a/tests/state/test_dedupe_migration_contention.py
+++ b/tests/state/test_dedupe_migration_contention.py
@@ -1,0 +1,120 @@
+"""The v25 dedupe migration must degrade gracefully on a contended DB.
+
+Coatue field report (2026-08-14): with state.db locked by another process,
+``_dedupe_legacy_system_prompts`` raised ``sqlite3.OperationalError``
+mid-loop (only the initial SELECT was guarded), which aborted schema init,
+left the schema version below 25, and made EVERY subsequent
+``SessionDB.__init__`` re-enter the same blocking migration — the fuel of
+the gateway's watchdog crash loop.
+
+Contract:
+- A write failure mid-migration returns gracefully (no raise). Partial
+  migration is safe by design: the legacy ``system_prompt`` column is kept
+  as a read fallback for unmigrated rows.
+- Rows migrated before the failure stay migrated; unmigrated rows remain
+  readable and are picked up by a later successful run.
+"""
+
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _make_legacy_db(tmp_path, n_rows=5):
+    """Open a real SessionDB, then regress it to a pre-v25 shape."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.close()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    for i in range(n_rows):
+        cur.execute(
+            "INSERT OR IGNORE INTO sessions (id, source, started_at) "
+            "VALUES (?, 'test', 1.0)",
+            (f"sess-{i}",),
+        )
+        cur.execute(
+            "UPDATE sessions SET system_prompt = ?, system_prompt_hash = NULL "
+            "WHERE id = ?",
+            (f"legacy prompt {i}", f"sess-{i}"),
+        )
+    conn.commit()
+    inserted = cur.execute(
+        "SELECT COUNT(*) FROM sessions WHERE id LIKE 'sess-%'"
+    ).fetchone()[0]
+    conn.close()
+    assert inserted == n_rows, f"fixture only created {inserted}/{n_rows} rows"
+    return db_path
+
+
+class _FailAfterN:
+    """Cursor proxy: UPDATE statements start failing after N successes."""
+
+    def __init__(self, cursor, fail_after):
+        self._cursor = cursor
+        self._updates = 0
+        self._fail_after = fail_after
+
+    def execute(self, sql, *args, **kwargs):
+        if sql.lstrip().upper().startswith("UPDATE"):
+            if self._updates >= self._fail_after:
+                raise sqlite3.OperationalError("database is locked")
+            self._updates += 1
+        return self._cursor.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._cursor, name)
+
+
+def test_mid_loop_lock_error_returns_instead_of_raising(tmp_path):
+    db_path = _make_legacy_db(tmp_path)
+    db = SessionDB(db_path=db_path)
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        raw = conn.cursor()
+        proxy = _FailAfterN(raw, fail_after=2)
+        # Must NOT raise even though the third UPDATE hits "database is locked".
+        db._dedupe_legacy_system_prompts(proxy)
+        conn.commit()
+
+        rows = raw.execute(
+            "SELECT id, system_prompt, system_prompt_hash FROM sessions "
+            "WHERE id LIKE 'sess-%' ORDER BY id"
+        ).fetchall()
+        migrated = [r for r in rows if r["system_prompt"] is None]
+        legacy = [r for r in rows if r["system_prompt"] is not None]
+        assert migrated, "no rows migrated before the simulated lock"
+        assert legacy, "expected unmigrated remainder after the failure"
+        # Migrated rows carry a hash; legacy rows keep their readable prompt.
+        assert all(r["system_prompt_hash"] for r in migrated)
+        assert all(r["system_prompt"].startswith("legacy prompt") for r in legacy)
+        conn.close()
+    finally:
+        db.close()
+
+
+def test_later_run_completes_the_remainder(tmp_path):
+    db_path = _make_legacy_db(tmp_path)
+    db = SessionDB(db_path=db_path)
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        raw = conn.cursor()
+        db._dedupe_legacy_system_prompts(_FailAfterN(raw, fail_after=2))
+        conn.commit()
+        # Second run with no failures finishes the job.
+        db._dedupe_legacy_system_prompts(raw)
+        conn.commit()
+        remaining = raw.execute(
+            "SELECT COUNT(*) FROM sessions "
+            "WHERE id LIKE 'sess-%' AND system_prompt IS NOT NULL"
+        ).fetchone()[0]
+        assert remaining == 0
+        conn.close()
+    finally:
+        db.close()


### PR DESCRIPTION
An enterprise fleet reported a gateway that could not come back up: after an unclean shutdown raced a second gateway instance, every restart blocked inside the v25 schema migration on the event-loop thread, the loop-liveness watchdog fired exit 75, and the supervisor restarted straight back into the same state. Manual WAL surgery was the only way out.

Two independent defects compound into that loop; this PR fixes both.

## What changed

**1. `SessionDB` is never constructed on the event-loop thread** (`hermes_cli/goals.py`)

`SessionDB.__init__` runs schema init, and a migration against a contended `state.db` blocks for seconds. The goal/heartbeat path reached it synchronously on the loop thread: `GoalManager()` → `load_goal` → `_get_session_db` → `SessionDB()`. Notably, `_post_turn_goal_continuation` already offloads the judge call to an executor with a comment about not blocking Discord heartbeats — the constructor just sat outside the boundary it needed.

`_get_session_db` now detects a running loop on the calling thread. On a cache miss it starts a one-shot background bootstrap and waits up to 250ms on its completion event: a healthy init (tens of ms) finishes inside the window and the caller gets the real DB, so first-call goal persistence keeps working; a contended init exceeds it and the caller degrades to None (every caller already handles None), with the loop stalled far below the watchdog's probe timeout. Worker threads construct inline as before. The heartbeat module shares this boundary via the same `_get_session_db`.

**2. The v25 prompt-dedupe migration degrades gracefully under contention** (`hermes_state_schema.py`)

Only the migration's initial SELECT was guarded; a `database is locked` on any per-row write propagated out, aborted schema init, left the version below 25, and made every later `SessionDB.__init__` re-enter the same migration against the same contended DB. The per-row loop now catches `OperationalError`, logs once, and returns. Partial migration is safe by design — the legacy `system_prompt` column is the documented read fallback for unmigrated rows, and the next schema init resumes where contention stopped. Structural corruption (`DatabaseError`/`IntegrityError`) still propagates, matching the SELECT guard's class exactly.

## What we deliberately did not do

- No "stale lock detection / WAL deletion" recovery. POSIX locks die with their process — the reported persistent lock was a *live* second gateway from a supervisor-restart race, and deleting `-wal`/`-shm` next to a live holder corrupts the DB. The double-instance race itself is a separate defect worth its own issue.
- No change to the other gateway `SessionDB()` sites — audited all of them: they are executor closures, startup-time constructions, or explicitly off-loop paths.

## Verification

- 6 new tests across two files: thread-identity assertions (construction never on the loop thread), a 2s-blocking-init probe proving the loop stalls <1s and degrades to None, partial-migration survival, and a later run completing the remainder.
- Mutation checks: reverting fix 1 fails 2 tests; making the migration re-raise fails both contention tests.
- Full canonical-runner gates over `tests/state/ tests/hermes_cli/ tests/gateway/`: exit 0 (a mid-review run was also 7,642✓/0✗ at 64% before being restarted on the final tree).
