### PR TITLE
docs(cli): correct /model module docstring to match colon-syntax behavior

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Axl Ibiza (andrexibiza) — canonical author identity

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -13,9 +13,12 @@ This module ties together the foundation layers:
 - ``hermes_cli.providers``        -- canonical provider identity + overlays
 - ``hermes_cli.model_normalize``  -- per-provider name formatting
 
-Provider switching uses the ``--provider`` flag exclusively.
-No colon-based ``provider:model`` syntax — colons are reserved for
-OpenRouter variant suffixes (``:free``, ``:extended``, ``:fast``).
+Provider switching supports the ``--provider`` flag and the ``provider:model``
+colon shorthand. On aggregators, a colon form such as ``vendor:model`` is
+converted to the ``vendor/model`` slug when the input has no slash; when a
+slash is already present, the colon is treated as a variant suffix
+(``:free``, ``:extended``, ``:fast``) and preserved. Bare names resolve
+within the current provider first. See :func:`switch_model`.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What changed and why

`hermes_cli/model_switch.py` had a stale module docstring claiming colon-based `provider:model` syntax is **rejected** ("Provider switching uses the `--provider` flag exclusively. No colon-based `provider:model` syntax — colons are reserved for OpenRouter variant suffixes").

The implementation does the opposite: `switch_model` (step c) **converts `vendor:model` → `vendor/model`** on aggregators when no slash is present, and preserves the colon as a variant suffix (`:free`, `:extended`, `:fast`) when a slash already exists. The official docs reference (`website/docs/reference/slash-commands.md:77/231`) and the keystone README both document `/model provider:model` as supported. Only the code docstring was wrong.

This PR corrects the module docstring to describe the actual behavior, so code, docs reference, and README now agree.

## How to test

```bash
scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py \
  tests/hermes_cli/test_model_switch_configured_provider_routing.py \
  tests/gateway/test_model_switch_persistence.py
```

The change is documentation-only (module docstring), so no code behavior changes. Tests confirm the module still parses/imports and the colon-form model-switch paths remain green.

## Platforms tested

- Windows 11 (git-bash), Python 3.11. `git diff --check` clean.
- Note: `test_model_switch_persistence.py::test_once_skips_session_store_write_through` fails identically on pristine `origin/main` (pre-existing asyncio-mark environment artifact, verified on a clean worktree — unrelated to this doc change).

## Why this matters to users

The README and docs reference told users `/model provider:model` (e.g. `/model zai:glm-5`) works. But the code's own docstring — which surfaces in error/help contexts and to contributors reading the module — said it doesn't. That contradiction sent users and contributors in opposite directions. Now the documented syntax, the code, and the module docstring all agree that `provider:model` is supported, so nobody gets told one thing by the docs and another by the code.

Fixes #78567
