### PR TITLE
fix: align local channel runtime and output caps

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -52,7 +52,7 @@ from hermes_cli.config import cfg_get
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
-from utils import base_url_host_matches, is_truthy_value
+from utils import base_url_host_matches, is_truthy_value, positive_output_token_cap
 
 # Use the same logger name as run_agent so tests patching ``run_agent.logger``
 # capture our warnings.  (run_agent.py also does
@@ -65,6 +65,7 @@ logger = logging.getLogger("run_agent")
 # gateway builds a fresh AIAgent per message, so an un-deduped warning would
 # fire on every turn.
 _warned_unavailable_providers: set[str] = set()
+
 
 
 def _warn_memory_provider_unavailable(name: str, reason: str = "") -> None:
@@ -909,7 +910,8 @@ def init_agent(
     agent.disabled_toolsets = disabled_toolsets
     
     # Model response configuration
-    agent.max_tokens = max_tokens  # None = use model default
+    # None = use model default.
+    agent.max_tokens = positive_output_token_cap(max_tokens)
     agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
     agent.service_tier = service_tier
     agent.request_overrides = dict(request_overrides or {})
@@ -2250,14 +2252,10 @@ def init_agent(
     if agent.max_tokens is None and isinstance(_model_cfg, dict):
         _config_max_tokens = _model_cfg.get("max_tokens")
         if _config_max_tokens is not None:
-            try:
-                if isinstance(_config_max_tokens, bool):
-                    raise ValueError
-                _parsed_max_tokens = int(_config_max_tokens)
-                if _parsed_max_tokens <= 0:
-                    raise ValueError
+            _parsed_max_tokens = positive_output_token_cap(_config_max_tokens)
+            if _parsed_max_tokens is not None:
                 agent.max_tokens = _parsed_max_tokens
-            except (TypeError, ValueError):
+            else:
                 _ra().logger.warning(
                     "Invalid model.max_tokens in config.yaml: %r — "
                     "must be a positive integer (e.g. 4096). "
@@ -2269,6 +2267,55 @@ def init_agent(
                     f"  Must be a positive integer (e.g. 4096).\n"
                     f"  Falling back to provider default.\n",
                     file=sys.stderr,
+                )
+
+    # Match gateway runtime resolution for OpenAI-compatible custom providers.
+    # A local provider's ``max_output_tokens`` is deliberately a fallback: an
+    # explicit caller value and the documented global ``model.max_tokens`` both
+    # take precedence.  Without this, foreground CLI sessions omit the cap and
+    # llama.cpp falls back to its server-side n_predict default (8192), which
+    # can monopolize a single slot long after a small answer is available.
+    if agent.max_tokens is None:
+        _providers_cfg = _agent_cfg.get("providers", {})
+        # The runtime router normalizes user-defined OpenAI-compatible
+        # providers to ``custom`` while retaining the configured key as
+        # ``requested_provider``.  Prefer that key so a ``llamacpp`` cap is
+        # not lost after normalization; native providers still use
+        # ``agent.provider``.
+        _configured_provider = str(
+            getattr(agent, "requested_provider", None) or agent.provider or ""
+        ).strip()
+        _provider_key = _configured_provider
+        _provider_cfg = {}
+        _requested_ids = _custom_provider_runtime_ids(_configured_provider)
+        if isinstance(_providers_cfg, dict):
+            for _candidate_key, _candidate_cfg in _providers_cfg.items():
+                if not isinstance(_candidate_cfg, dict):
+                    continue
+                _candidate_ids = _custom_provider_runtime_ids(
+                    _candidate_key
+                ) | _custom_provider_runtime_ids(_candidate_cfg.get("name"))
+                if _requested_ids & _candidate_ids:
+                    _provider_key = str(_candidate_key)
+                    _provider_cfg = _candidate_cfg
+                    break
+        _provider_max_tokens = (
+            _provider_cfg.get("max_output_tokens")
+            if isinstance(_provider_cfg, dict)
+            else None
+        )
+        if _provider_max_tokens is not None:
+            _parsed_provider_max_tokens = positive_output_token_cap(
+                _provider_max_tokens
+            )
+            if _parsed_provider_max_tokens is not None:
+                agent.max_tokens = _parsed_provider_max_tokens
+            else:
+                _ra().logger.warning(
+                    "Invalid providers.%s.max_output_tokens in config.yaml: %r — "
+                    "must be a positive integer; falling back to provider default.",
+                    _provider_key,
+                    _provider_max_tokens,
                 )
     agent._session_init_model_config["max_tokens"] = agent.max_tokens
 

--- a/cli.py
+++ b/cli.py
@@ -226,7 +226,12 @@ from hermes_cli.browser_connect import (
     try_launch_chrome_debug,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
-from utils import base_url_host_matches, base_url_hostname, fast_safe_load
+from utils import (
+    base_url_host_matches,
+    base_url_hostname,
+    fast_safe_load,
+    positive_output_token_cap,
+)
 
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
@@ -4776,6 +4781,7 @@ class _VoiceInputMessage:
         return self.text
 
 
+
 class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     """
     Interactive CLI for the Hermes Agent.
@@ -4962,16 +4968,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _moa_provider_override, self.model = _normalize_moa_model(self.model)
         # Read max_tokens from config (env var override: HERMES_MAX_TOKENS)
         _env_mt = os.environ.get("HERMES_MAX_TOKENS")
-        if _env_mt:
-            try:
-                self.max_tokens = int(_env_mt)
-            except (ValueError, TypeError):
-                self.max_tokens = None
-        elif isinstance(_model_config, dict):
-            _mt = _model_config.get("max_tokens")
-            self.max_tokens = _mt if isinstance(_mt, int) else None
-        else:
-            self.max_tokens = None
+        self.max_tokens = positive_output_token_cap(_env_mt)
+        if self.max_tokens is None and isinstance(_model_config, dict):
+            self.max_tokens = positive_output_token_cap(
+                _model_config.get("max_tokens")
+            )
         # Auto-detect model from local server if still on default
         if self.model == _DEFAULT_CONFIG_MODEL:
             _base_url = (_model_config.get("base_url") or "") if isinstance(_model_config, dict) else ""

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -340,22 +340,14 @@ def _resolve_request_runtime_agent_kwargs(provider: str, target_model: Optional[
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
+    from utils import positive_output_token_cap
+
     model_cfg = _get_model_config()
-    max_tokens = None
-    env_max_tokens = os.environ.get("HERMES_MAX_TOKENS")
-    if env_max_tokens:
-        try:
-            max_tokens = int(env_max_tokens)
-        except (ValueError, TypeError):
-            max_tokens = None
-    elif isinstance(model_cfg, dict):
-        cfg_max_tokens = model_cfg.get("max_tokens")
-        if isinstance(cfg_max_tokens, int):
-            max_tokens = cfg_max_tokens
+    max_tokens = positive_output_token_cap(os.environ.get("HERMES_MAX_TOKENS"))
+    if max_tokens is None and isinstance(model_cfg, dict):
+        max_tokens = positive_output_token_cap(model_cfg.get("max_tokens"))
     if max_tokens is None:
-        runtime_max_tokens = runtime.get("max_output_tokens")
-        if isinstance(runtime_max_tokens, int) and runtime_max_tokens > 0:
-            max_tokens = runtime_max_tokens
+        max_tokens = positive_output_token_cap(runtime.get("max_output_tokens"))
 
     return {
         "api_key": runtime.get("api_key"),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1935,7 +1935,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home, get_hermes_home_override
-from utils import atomic_json_write, base_url_hostname, is_truthy_value
+from utils import (
+    atomic_json_write,
+    is_truthy_value,
+    positive_output_token_cap as _positive_output_token_cap,
+    sanitized_loopback_endpoint,
+)
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -2667,6 +2672,7 @@ _CONVERSATION_SCOPED_STATE: tuple = (
 _UNSET = object()
 
 
+
 def _resolve_runtime_agent_kwargs() -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances.
 
@@ -2700,32 +2706,24 @@ def _resolve_runtime_agent_kwargs() -> dict:
             logger.warning("Primary provider auth failed: %s — trying fallback", auth_exc)
         fb_config = _try_resolve_fallback_provider()
         if fb_config is not None:
-            return fb_config
-        raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
+            runtime = fb_config
+        else:
+            raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
     model_cfg = _get_model_config()
-    max_tokens = None
-    _env_mt = os.environ.get("HERMES_MAX_TOKENS")
-    if _env_mt:
-        try:
-            max_tokens = int(_env_mt)
-        except (ValueError, TypeError):
-            max_tokens = None
-    elif isinstance(model_cfg, dict):
-        mt = model_cfg.get("max_tokens")
-        if isinstance(mt, int):
-            max_tokens = mt
+    max_tokens = _positive_output_token_cap(os.environ.get("HERMES_MAX_TOKENS"))
+    if max_tokens is None and isinstance(model_cfg, dict):
+        max_tokens = _positive_output_token_cap(model_cfg.get("max_tokens"))
     # Fall back to a per-provider output cap (custom_providers max_output_tokens)
     # only when the documented global model.max_tokens isn't set, so the global
     # key always wins.
     if max_tokens is None:
-        _runtime_mot = runtime.get("max_output_tokens")
-        if isinstance(_runtime_mot, int) and _runtime_mot > 0:
-            max_tokens = _runtime_mot
+        max_tokens = _positive_output_token_cap(runtime.get("max_output_tokens"))
 
     return {
+        "model": runtime.get("model"),
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
@@ -2744,12 +2742,16 @@ class _GatewayModelContext:
 
     model: str
     provider: str
+    requested_provider: str
     base_url: str
     context_length: int
     context_source: str
 
 
-def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModelContext:
+def _resolve_gateway_model_context(
+    model: Optional[str] = None,
+    runtime: Optional[dict] = None,
+) -> _GatewayModelContext:
     """Resolve the configured gateway route and its effective context window.
 
     This is the shared non-resident authority for status/session banners and
@@ -2793,11 +2795,13 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
     except Exception:
         pass
 
+    requested_provider = None
     try:
-        runtime = _resolve_runtime_agent_kwargs()
-        provider = runtime.get("provider") or provider
-        base_url = runtime.get("base_url") or base_url
-        api_key = runtime.get("api_key")
+        effective_runtime = runtime if runtime is not None else _resolve_runtime_agent_kwargs()
+        provider = effective_runtime.get("provider") or provider
+        requested_provider = effective_runtime.get("requested_provider") or provider
+        base_url = effective_runtime.get("base_url") or base_url
+        api_key = effective_runtime.get("api_key")
     except Exception:
         pass
 
@@ -2849,6 +2853,7 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
     return _GatewayModelContext(
         model=resolved_model,
         provider=provider or "",
+        requested_provider=requested_provider or provider or "",
         base_url=base_url or "",
         context_length=context_length,
         context_source=context_source,
@@ -2860,12 +2865,20 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
+        _get_model_config,
     )
     try:
         runtime = resolve_runtime_provider(requested=provider)
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
+    model_cfg = _get_model_config()
+    max_tokens = _positive_output_token_cap(os.environ.get("HERMES_MAX_TOKENS"))
+    if max_tokens is None and isinstance(model_cfg, dict):
+        max_tokens = _positive_output_token_cap(model_cfg.get("max_tokens"))
+    if max_tokens is None:
+        max_tokens = _positive_output_token_cap(runtime.get("max_output_tokens"))
     return {
+        "model": runtime.get("model"),
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
@@ -2874,6 +2887,7 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "max_tokens": max_tokens,
     }
 
 
@@ -2933,6 +2947,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "args": list(runtime.get("args") or []),
                     "credential_pool": runtime.get("credential_pool"),
                     "model": entry.get("model"),
+                    "max_output_tokens": runtime.get("max_output_tokens"),
                 }
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)
@@ -20697,19 +20712,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
-                return self._format_session_info()
-        return self._format_session_info()
+                return self._format_session_info(source)
+        return self._format_session_info(source)
 
-    def _format_session_info(self) -> str:
+    def _format_session_info(self, source: Optional[SessionSource] = None) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
         users can immediately see if context detection went wrong (e.g.
         local models falling to the 128K default).
         """
-        resolved = _resolve_gateway_model_context()
+        if source is not None:
+            model, runtime = self._resolve_session_agent_runtime(source=source)
+            resolved = _resolve_gateway_model_context(model=model, runtime=runtime)
+        else:
+            resolved = _resolve_gateway_model_context()
         model = resolved.model
         provider = resolved.provider
+        display_provider = resolved.requested_provider
         base_url = resolved.base_url
         context_length = resolved.context_length
 
@@ -20731,13 +20751,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         lines = [
             f"◆ Model: `{model}`",
-            f"◆ Provider: {provider or 'openrouter'}",
+            f"◆ Provider: {display_provider or provider or 'openrouter'}",
             f"◆ Context: {ctx_display} tokens ({ctx_source})",
         ]
 
-        # Show endpoint for local/custom setups
-        if base_url and base_url_hostname(base_url) in ("localhost", "127.0.0.1", "0.0.0.0"):
-            lines.append(f"◆ Endpoint: {base_url}")
+        endpoint = sanitized_loopback_endpoint(base_url)
+        if endpoint:
+            lines.append(f"◆ Endpoint: {endpoint}")
 
         return "\n".join(lines)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -45,6 +45,7 @@ from utils import (
     atomic_json_write,
     base_url_host_matches,
     is_truthy_value,
+    sanitized_loopback_endpoint,
 )
 
 logger = logging.getLogger("gateway.run")
@@ -665,7 +666,10 @@ class GatewaySlashCommandsMixin:
         context_total = 0
         if status_agent is not None and status_agent is not _AGENT_PENDING_SENTINEL:
             live_model = _clean_str(getattr(status_agent, "model", ""))
-            live_provider = _clean_str(getattr(status_agent, "provider", ""))
+            live_provider = _clean_str(
+                getattr(status_agent, "requested_provider", "")
+                or getattr(status_agent, "provider", "")
+            )
             if live_model and live_provider:
                 model_name = live_model
                 provider_name = live_provider
@@ -695,6 +699,21 @@ class GatewaySlashCommandsMixin:
                 user_config = _load_gateway_config()
             except Exception:
                 user_config = {}
+        if not route_resolved:
+            try:
+                model_name, runtime = await asyncio.to_thread(
+                    self._resolve_session_agent_runtime,
+                    source=source,
+                    session_key=session_key,
+                    user_config=user_config,
+                )
+                provider_name = _clean_str(
+                    runtime.get("requested_provider") or runtime.get("provider")
+                )
+                base_url = _clean_str(runtime.get("base_url"))
+                route_resolved = bool(model_name and provider_name)
+            except Exception:
+                logger.debug("Status route resolution failed", exc_info=True)
         if not model_name:
             model_name = _resolve_gateway_model(user_config)
         if not provider_name:
@@ -739,6 +758,9 @@ class GatewaySlashCommandsMixin:
         ])
         if model_line:
             lines.append(model_line)
+        endpoint = sanitized_loopback_endpoint(base_url)
+        if endpoint:
+            lines.append(f"**Endpoint:** {endpoint}")
         if context_line:
             lines.append(context_line)
         lines.extend([

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1370,7 +1370,7 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "key_cmd",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "max_output_tokens", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
         "ssl_ca_cert", "ssl_verify",
@@ -1489,6 +1489,10 @@ def _normalize_custom_provider_entry(
     if isinstance(context_length, int) and context_length > 0:
         normalized["context_length"] = context_length
 
+    max_output_tokens = entry.get("max_output_tokens")
+    if isinstance(max_output_tokens, int) and not isinstance(max_output_tokens, bool) and max_output_tokens > 0:
+        normalized["max_output_tokens"] = max_output_tokens
+
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
@@ -1542,6 +1546,7 @@ def _custom_provider_entry_to_provider_config(
         "key_env",
         "models",
         "context_length",
+        "max_output_tokens",
         "rate_limit_delay",
         "discover_models",
         "extra_body",
@@ -1982,7 +1987,7 @@ _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay", "extra_body",
+    "context_length", "max_output_tokens", "rate_limit_delay", "extra_body",
     "ssl_ca_cert", "ssl_verify",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1162,6 +1162,7 @@ def _resolve_named_custom_runtime(
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
+        pool_result["requested_provider"] = requested_provider
         model_name = custom_provider.get("model")
         if model_name:
             pool_result["model"] = model_name
@@ -1214,6 +1215,7 @@ def _resolve_named_custom_runtime(
 
     result = {
         "provider": "custom",
+        "requested_provider": requested_provider,
         "api_mode": custom_provider.get("api_mode")
         or _detect_api_mode_for_url(base_url)
         or "chat_completions",

--- a/tests/agent/test_max_tokens_config.py
+++ b/tests/agent/test_max_tokens_config.py
@@ -1,0 +1,78 @@
+"""Focused regressions for model/provider output-token cap validation."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def _agent(config, *, max_tokens=None, requested_provider="custom:llamacpp"):
+    from run_agent import AIAgent
+
+    with patch("hermes_cli.config.load_config_readonly", return_value=config):
+        return AIAgent(
+            provider="custom",
+            requested_provider=requested_provider,
+            base_url="http://127.0.0.1:18080/v1",
+            api_key="local",
+            model="qwen-local",
+            max_tokens=max_tokens,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+@pytest.mark.parametrize("invalid_cap", [True, 0, -1, 12000.5])
+def test_invalid_caller_and_model_caps_fall_through_to_named_custom_provider(
+    invalid_cap,
+):
+    """Invalid CLI-originated caps must not suppress the provider fallback."""
+    agent = _agent(
+        {
+            "model": {"max_tokens": invalid_cap},
+            "providers": {"llamacpp": {"max_output_tokens": 9000}},
+        },
+        max_tokens=invalid_cap,
+    )
+
+    assert agent.max_tokens == 9000
+
+
+@pytest.mark.parametrize(
+    ("caller_cap", "model_cap", "provider_cap", "expected"),
+    [
+        (8000, 16000, 12000, 8000),
+        (None, "16000", 12000, 16000),
+        (None, None, "12000", 12000),
+        (None, None, 12000.5, None),
+    ],
+)
+def test_output_cap_precedence_and_strict_provider_validation(
+    caller_cap, model_cap, provider_cap, expected
+):
+    agent = _agent(
+        {
+            "model": {"max_tokens": model_cap},
+            "providers": {"llamacpp": {"max_output_tokens": provider_cap}},
+        },
+        max_tokens=caller_cap,
+    )
+
+    assert agent.max_tokens == expected
+
+
+@pytest.mark.parametrize("requested_provider", ["custom:LLAMACPP", "custom:Local Llama"])
+def test_named_custom_aliases_preserve_provider_cap(requested_provider):
+    agent = _agent(
+        {
+            "providers": {
+                "llamacpp": {
+                    "name": "Local Llama",
+                    "max_output_tokens": 9000,
+                }
+            }
+        },
+        requested_provider=requested_provider,
+    )
+
+    assert agent.max_tokens == 9000

--- a/tests/cli/test_max_tokens_config.py
+++ b/tests/cli/test_max_tokens_config.py
@@ -1,0 +1,23 @@
+"""Focused tests for CLI output-token cap parsing."""
+
+import pytest
+
+
+@pytest.mark.parametrize("value", [True, False, 0, -1, 12000.5, "12.5", "-12"])
+def test_cli_rejects_invalid_output_token_caps(value):
+    from utils import positive_output_token_cap
+
+    assert positive_output_token_cap(value) is None
+
+
+@pytest.mark.parametrize("value", [9000, "9000", " 9000 "])
+def test_cli_accepts_positive_integer_output_token_caps(value):
+    from utils import positive_output_token_cap
+
+    assert positive_output_token_cap(value) == 9000
+
+
+def test_oversized_decimal_output_token_cap_is_rejected():
+    from utils import positive_output_token_cap
+
+    assert positive_output_token_cap("9" * 5000) is None

--- a/tests/gateway/test_api_server_output_cap.py
+++ b/tests/gateway/test_api_server_output_cap.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+
+import pytest
+
+from gateway.platforms.api_server import _resolve_request_runtime_agent_kwargs
+
+
+def _resolve_cap(monkeypatch, *, env=None, model=None, provider=None):
+    if env is None:
+        monkeypatch.delenv("HERMES_MAX_TOKENS", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_MAX_TOKENS", env)
+    runtime = {"provider": "custom", "max_output_tokens": provider}
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", return_value=runtime
+    ), patch(
+        "hermes_cli.runtime_provider._get_model_config",
+        return_value={"max_tokens": model},
+    ):
+        return _resolve_request_runtime_agent_kwargs("llamacpp")["max_tokens"]
+
+
+def test_api_server_output_cap_precedence(monkeypatch):
+    assert _resolve_cap(monkeypatch, env="8000", model=16000, provider=12000) == 8000
+    assert _resolve_cap(monkeypatch, model=16000, provider=12000) == 16000
+    assert _resolve_cap(monkeypatch, provider=12000) == 12000
+
+
+@pytest.mark.parametrize("env", ["invalid", "0", "-1", "1.5", "true", ""])
+def test_api_server_invalid_environment_cap_falls_through(monkeypatch, env):
+    assert _resolve_cap(monkeypatch, env=env, model=16000, provider=12000) == 16000
+
+
+@pytest.mark.parametrize("invalid", [True, False, 0, -1, 1.5, "1.5"])
+def test_api_server_rejects_non_positive_or_non_integral_caps(monkeypatch, invalid):
+    assert _resolve_cap(monkeypatch, model=invalid, provider=12000) == 12000
+    assert _resolve_cap(monkeypatch, model=None, provider=invalid) is None

--- a/tests/gateway/test_max_tokens_propagation.py
+++ b/tests/gateway/test_max_tokens_propagation.py
@@ -95,3 +95,198 @@ def test_per_provider_max_output_tokens_fallback(isolated_home):
     assert kw["max_tokens"] == 12000
 
 
+def test_auth_fallback_uses_fallback_provider_output_cap(isolated_home, monkeypatch):
+    """Fallback runtime cap wins when environment and model caps are absent."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(
+        """
+        model:
+          default: primary-model
+          provider: primary
+        fallback_model:
+          provider: fallback
+          model: fallback-model
+        """
+    )
+    grun = fresh_gateway()
+    from hermes_cli.auth import AuthError
+
+    def _resolve_runtime_provider(*, requested=None, **_kwargs):
+        if requested is None:
+            raise AuthError("expired", code="auth_failed")
+        return {
+            "api_key": "fallback-key",
+            "base_url": "https://fallback.example/v1",
+            "provider": "fallback",
+            "requested_provider": requested,
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": ("--fallback",),
+            "credential_pool": "pool",
+            "max_output_tokens": 12000,
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _resolve_runtime_provider,
+    )
+
+    assert grun._resolve_runtime_agent_kwargs()["max_tokens"] == 12000
+
+
+def test_auth_fallback_model_reaches_session_runtime(isolated_home, monkeypatch):
+    """A fallback provider's distinct model replaces the primary model."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(
+        """
+        model:
+          default: primary-model
+          provider: primary
+        fallback_model:
+          provider: fallback
+          model: fallback-model
+        """
+    )
+    grun = fresh_gateway()
+    from hermes_cli.auth import AuthError
+
+    def _resolve_runtime_provider(*, requested=None, **_kwargs):
+        if requested is None:
+            raise AuthError("expired", code="auth_failed")
+        return {
+            "api_key": "fallback-key",
+            "base_url": "https://fallback.example/v1",
+            "provider": "fallback",
+            "requested_provider": requested,
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": (),
+            "credential_pool": None,
+            "max_output_tokens": 12000,
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _resolve_runtime_provider,
+    )
+    runner = object.__new__(grun.GatewayRunner)
+    runner._session_model_overrides = {}
+
+    model, _runtime = runner._resolve_session_agent_runtime(
+        user_config={"model": {"default": "primary-model"}}
+    )
+
+    assert model == "fallback-model"
+
+
+def test_explicit_provider_keeps_its_output_cap(isolated_home):
+    """A channel override must pass its provider output cap to the agent."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(
+        """
+        model:
+          default: cloud-model
+          provider: openai-codex
+        providers:
+          llamacpp:
+            api: http://127.0.0.1:18080/v1
+            api_key: local
+            default_model: qwen3.8-27b-q4_k_m-128k
+            max_output_tokens: 12000
+        """
+    )
+    grun = fresh_gateway()
+    kw = grun._resolve_runtime_agent_kwargs_for_provider("llamacpp")
+    assert kw["max_tokens"] == 12000
+    # The actual resolver canonicalizes the OpenAI-compatible endpoint to
+    # ``custom`` but preserves the configured alias for presentation and
+    # provider-specific config lookup.
+    assert kw["provider"] == "custom"
+    assert kw["requested_provider"] == "llamacpp"
+    assert kw["base_url"] == "http://127.0.0.1:18080/v1"
+
+
+def test_explicit_provider_honors_environment_output_cap(isolated_home, monkeypatch):
+    """A one-off cap must override channel-provider and global defaults."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(
+        """
+        model:
+          default: cloud-model
+          provider: openai-codex
+          max_tokens: 16000
+        providers:
+          llamacpp:
+            api: http://127.0.0.1:18080/v1
+            api_key: local
+            default_model: qwen3.8-27b-q4_k_m-128k
+            max_output_tokens: 12000
+        """
+    )
+    monkeypatch.setenv("HERMES_MAX_TOKENS", "8000")
+    grun = fresh_gateway()
+
+    kw = grun._resolve_runtime_agent_kwargs_for_provider("llamacpp")
+
+    assert kw["max_tokens"] == 8000
+
+
+def test_invalid_environment_cap_falls_through_to_model_cap(isolated_home, monkeypatch):
+    """An unusable HERMES_MAX_TOKENS must not skip model.max_tokens."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(
+        """
+        model:
+          default: cloud-model
+          provider: openai-codex
+          max_tokens: 16000
+        providers:
+          llamacpp:
+            api: http://127.0.0.1:18080/v1
+            default_model: qwen3.8-27b-q4_k_m-128k
+            max_output_tokens: 12000
+        """
+    )
+    monkeypatch.setenv("HERMES_MAX_TOKENS", "not-a-number")
+
+    assert fresh_gateway()._resolve_runtime_agent_kwargs_for_provider("llamacpp")["max_tokens"] == 16000
+
+
+@pytest.mark.parametrize(
+    ("model_cap", "provider_cap", "expected"),
+    [
+        (True, 12000, 12000),
+        (False, True, None),
+        (12000.5, 9000, 9000),
+        (None, 9000.5, None),
+    ],
+)
+def test_only_positive_integer_caps_are_accepted(
+    isolated_home, model_cap, provider_cap, expected
+):
+    """Booleans and floats are invalid; decimal integer strings are accepted."""
+    write_cfg, fresh_gateway = isolated_home
+    model_line = "" if model_cap is None else f"max_tokens: {str(model_cap).lower()}"
+    write_cfg(
+        f"""
+        model:
+          default: cloud-model
+          provider: openai-codex
+          {model_line}
+        providers:
+          llamacpp:
+            api: http://127.0.0.1:18080/v1
+            default_model: qwen3.8-27b-q4_k_m-128k
+            max_output_tokens: {str(provider_cap).lower() if isinstance(provider_cap, bool) else provider_cap}
+        """
+    )
+
+    assert fresh_gateway()._resolve_runtime_agent_kwargs_for_provider("llamacpp")["max_tokens"] == expected
+
+
+def test_gateway_cap_parser_accepts_decimal_integer_strings(isolated_home):
+    _, fresh_gateway = isolated_home
+
+    assert fresh_gateway()._positive_output_token_cap(" 9000 ") == 9000
+
+

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -25,6 +25,85 @@ def _patch_info(tmp_path, config_yaml, model, runtime):
 
 
 class TestFormatSessionInfo:
+    def test_channel_named_custom_runtime_displays_sanitized_loopback_endpoint(self, runner):
+        """Cold /new resolves a channel's named-custom route before display."""
+        from gateway.config import ChannelOverride, GatewayConfig, Platform, PlatformConfig
+        from gateway.session import SessionSource
+
+        config = {
+            "model": {
+                "default": "gpt-5.6",
+                "provider": "openai-codex",
+                "max_tokens": 16000,
+            },
+            "providers": {
+                "llamacpp": {
+                    "api": "http://operator:local-secret@127.0.0.1:18080/v1?access_token=secret#fragment",
+                    "api_key": "local",
+                    "default_model": "qwen3.8-27b-q4_k_m-128k",
+                    "max_output_tokens": 12000,
+                },
+            },
+        }
+        runner._session_model_overrides = {}
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.SLACK: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "C0BQDHWP3M0": ChannelOverride(provider="llamacpp"),
+                    },
+                ),
+            },
+        )
+        source = SessionSource(platform=Platform.SLACK, chat_id="C0BQDHWP3M0", user_id="u1")
+
+        with patch("gateway.run._resolve_gateway_model", return_value="gpt-5.6"), patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={"provider": "openai-codex", "base_url": "", "api_key": ""},
+        ), patch("gateway.run._load_gateway_config", return_value=config), patch(
+            "hermes_cli.runtime_provider.load_config", return_value=config
+        ), patch("agent.model_metadata.get_model_context_length", return_value=131072):
+            model, runtime = runner._resolve_session_agent_runtime(source=source)
+            info = runner._format_session_info(source)
+
+        assert model == "qwen3.8-27b-q4_k_m-128k", runtime
+        assert runtime["provider"] == "custom"
+        assert runtime["requested_provider"] == "llamacpp"
+        assert runtime["max_tokens"] == 16000
+        assert "qwen3.8-27b-q4_k_m-128k" in info
+        assert "◆ Provider: llamacpp" in info
+        assert "◆ Endpoint: http://127.0.0.1:18080/v1" in info
+        assert "operator" not in info
+        assert "local-secret" not in info
+        assert "access_token" not in info
+        assert "fragment" not in info
+
+    def test_channel_runtime_is_shown_in_new_session_info(self, runner):
+        """A /new banner must show the channel override, not the global route."""
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+
+        source = SessionSource(platform=Platform.SLACK, chat_id="C0BQDHWP3M0", user_id="u1")
+        runtime = {
+            "provider": "custom",
+            "requested_provider": "llamacpp",
+            "base_url": "http://127.0.0.1:18080/v1",
+            "api_key": "local",
+        }
+        with patch.object(
+            runner,
+            "_resolve_session_agent_runtime",
+            return_value=("qwen3.8-27b-q4_k_m-128k", runtime),
+        ), patch("gateway.run._load_gateway_config", return_value={"model": {}}), patch(
+            "agent.model_metadata.get_model_context_length", return_value=131072
+        ):
+            info = runner._format_session_info(source)
+
+        assert "qwen3.8-27b-q4_k_m-128k" in info
+        assert "llamacpp" in info
+        assert "127.0.0.1:18080" in info
+
 
     def test_includes_model_name(self, runner, tmp_path):
         p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: anthropic/claude-opus-4.6\n  provider: openrouter\n",

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -2,13 +2,14 @@ from hermes_state import AsyncSessionDB, SessionDB
 """Tests for gateway /status behavior and token persistence."""
 
 from datetime import datetime
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import ChannelOverride, GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
@@ -139,6 +140,131 @@ async def test_status_command_includes_live_agent_model_and_context():
     assert "**Model:** `openai/gpt-test` (openai)" in result
     assert "**Context:** 12,345 / 100,000 (12%)" in result
     assert "**Lifetime tokens billed:** 1,250" in result
+
+
+@pytest.mark.asyncio
+async def test_live_status_preserves_named_custom_provider_alias():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    running_agent = SimpleNamespace(
+        model="qwen3.8-27b-q4_k_m-128k",
+        provider="custom",
+        requested_provider="llamacpp",
+        base_url="http://127.0.0.1:18080/v1",
+        context_compressor=None,
+        interrupt=MagicMock(),
+    )
+    runner._running_agents[session_entry.session_key] = running_agent
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `qwen3.8-27b-q4_k_m-128k` (llamacpp)" in result
+    assert running_agent.provider == "custom"
+    assert running_agent.requested_provider == "llamacpp"
+
+
+@pytest.mark.asyncio
+async def test_cold_status_uses_named_custom_alias_and_resolved_local_endpoint(
+    tmp_path, monkeypatch
+):
+    """Cold /status resolves channel overrides without exposing endpoint secrets."""
+    import gateway.run as gateway_run
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  default: gpt-5.6\n"
+        "  provider: openai-codex\n"
+        "providers:\n"
+        "  llamacpp:\n"
+        "    api: http://operator:local-secret@127.0.0.1:18080/v1?access_token=secret#fragment\n"
+        "    api_key: local\n"
+        "    default_model: qwen3.8-27b-q4_k_m-128k\n"
+        "    max_output_tokens: 12000\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "openai-codex", "base_url": "", "api_key": ""},
+    )
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hermes_home)
+
+    source = _make_source(Platform.SLACK)
+    session_entry = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.SLACK,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry, platform=Platform.SLACK)
+    runner.config.platforms[Platform.SLACK].channel_overrides = {
+        "c1": ChannelOverride(provider="llamacpp")
+    }
+    runner.session_store.get_model_override.return_value = None
+
+    result = await runner._handle_message(_make_event("/status", platform=Platform.SLACK))
+
+    assert "**Model:** `qwen3.8-27b-q4_k_m-128k` (llamacpp)" in result, result
+    assert "**Endpoint:** http://127.0.0.1:18080/v1" in result
+    assert "operator" not in result
+    assert "local-secret" not in result
+    assert "access_token" not in result
+    assert "fragment" not in result
+
+
+@pytest.mark.asyncio
+async def test_cold_status_offloads_session_runtime_resolution(monkeypatch):
+    source = _make_source(Platform.SLACK)
+    session_entry = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.SLACK,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry, platform=Platform.SLACK)
+    event_loop_thread = threading.get_ident()
+    resolver_call = {}
+    user_config = {"model": {"default": "configured-model"}}
+
+    def _resolve_runtime(**kwargs):
+        resolver_call["thread"] = threading.get_ident()
+        resolver_call["kwargs"] = kwargs
+        return "resolved-model", {
+            "provider": "custom",
+            "requested_provider": "llamacpp",
+            "base_url": "http://127.0.0.1:18080/v1",
+        }
+
+    monkeypatch.setattr(runner, "_resolve_session_agent_runtime", _resolve_runtime)
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: user_config)
+
+    result = await runner._handle_message(
+        _make_event("/status", platform=Platform.SLACK)
+    )
+
+    assert resolver_call["kwargs"] == {
+        "source": source,
+        "session_key": session_entry.session_key,
+        "user_config": user_config,
+    }
+    assert resolver_call["thread"] != event_loop_thread
+    assert "**Model:** `resolved-model` (llamacpp)" in result
+    assert "**Endpoint:** http://127.0.0.1:18080/v1" in result
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -67,4 +67,22 @@ class TestNormalizeCustomProviderEntry:
         assert result is not None
         assert result["base_url"] == "${PROVIDER_A_BASE_URL}"
 
+    def test_max_output_tokens_is_supported_and_normalized(self, caplog):
+        """A per-provider output cap must survive compatibility normalization.
+
+        The foreground CLI reads this cap to constrain a single-slot local
+        OpenAI-compatible server; treating it as unknown both emits a noisy
+        warning and drops the cap from legacy-compatible provider entries.
+        """
+        entry = {
+            "base_url": "http://127.0.0.1:18080/v1",
+            "max_output_tokens": 1024,
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="llamacpp")
+
+        assert result is not None
+        assert result["max_output_tokens"] == 1024
+        assert "unknown config keys" not in caplog.text
+
 

--- a/tests/test_utils_sanitized_loopback_endpoint.py
+++ b/tests/test_utils_sanitized_loopback_endpoint.py
@@ -1,0 +1,26 @@
+import pytest
+
+from utils import sanitized_loopback_endpoint
+
+
+def test_sanitized_loopback_endpoint_preserves_generic_api_path():
+    assert (
+        sanitized_loopback_endpoint(
+            "http://user:password@127.0.0.1:18080/v1?token=secret#fragment"
+        )
+        == "http://127.0.0.1:18080/v1"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/sk-local-secret/v1",
+        "/token/abc123/v1",
+        "/users/operator:password/v1",
+    ],
+)
+def test_sanitized_loopback_endpoint_omits_unsafe_path(path):
+    endpoint = sanitized_loopback_endpoint(f"http://localhost:8000{path}")
+
+    assert endpoint == "http://localhost:8000"

--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,7 @@ import tempfile
 import time
 from pathlib import Path
 from typing import Any, Union
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit, urlunsplit
 
 import yaml
 
@@ -29,6 +29,22 @@ def is_truthy_value(value: Any, default: bool = False) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in TRUTHY_STRINGS
     return bool(value)
+
+
+def positive_output_token_cap(value: Any) -> "int | None":
+    """Return *value* only when it is a positive integral output-token cap."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        cap = value
+    elif isinstance(value, str) and value.strip().isdecimal():
+        try:
+            cap = int(value.strip())
+        except ValueError:
+            return None
+    else:
+        return None
+    return cap if cap > 0 else None
 
 
 def env_var_enabled(name: str, default: str = "") -> bool:
@@ -863,6 +879,38 @@ def base_url_hostname(base_url: str) -> str:
         return ""
     parsed = urlparse(raw if "://" in raw else f"//{raw}")
     return (parsed.hostname or "").lower().rstrip(".")
+
+
+def sanitized_loopback_endpoint(base_url: str) -> str:
+    """Return a credential-free HTTP(S) loopback endpoint, or ``""``.
+
+    Runtime base URLs may contain userinfo, query credentials, or fragments.
+    Status surfaces retain only the scheme, loopback host, port, and a path
+    made entirely of generic API/version components.
+    """
+    try:
+        parsed = urlsplit((base_url or "").strip())
+        hostname = (parsed.hostname or "").lower().rstrip(".")
+        if parsed.scheme not in ("http", "https") or hostname not in (
+            "localhost",
+            "127.0.0.1",
+            "0.0.0.0",
+            "::1",
+        ):
+            return ""
+        display_host = f"[{hostname}]" if ":" in hostname else hostname
+        if parsed.port is not None:
+            display_host = f"{display_host}:{parsed.port}"
+        path_components = [part.lower() for part in parsed.path.split("/") if part]
+        path_is_generic = all(
+            part in {"api", "openai"}
+            or (part.startswith("v") and part[1:].isdecimal())
+            for part in path_components
+        )
+        safe_path = parsed.path if path_is_generic else ""
+        return urlunsplit((parsed.scheme, display_host, safe_path, "", ""))
+    except (TypeError, ValueError):
+        return ""
 
 
 # ─── Model Capability Detection ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- resolve `/new` and cold/live `/status` from the actual channel runtime while preserving named custom aliases
- sanitize local endpoint display and prevent userinfo, query, fragment, or credential-like path disclosure
- enforce strict output-cap precedence (`HERMES_MAX_TOKENS` > model cap > provider cap), including authentication fallback model/provider caps
- offload cold `/status` runtime resolution from the gateway event loop
- preserve upstream shared model-context resolution

Replaces #88710, which became conflicting while upstream main advanced. Supersedes the stale candidates in #88570 and #88605.

## Verification
- focused llama.cpp/status/output-cap suite: 74 passed, 1 unrelated upstream Windows path-format test deselected after reproducing it on untouched main
- `python -m compileall -q ...` -> passed
- `git diff --check origin/main...HEAD` -> passed
- added-line security scan -> no secret/injection/eval/pickle/SQL matches
- independent fail-closed review -> PASS, no security or logic findings