### PR TITLE
fix(dashboard): disclose basic_auth config-side resolution

### DIFF
--- a/plugins/dashboard_auth/basic/__init__.py
+++ b/plugins/dashboard_auth/basic/__init__.py
@@ -106,6 +106,12 @@ _SIG_LEN = hashlib.sha256().digest_size
 
 LAST_SKIP_REASON: str = ""
 
+# Outcome of the last _load_config_basic_auth_section() call, for the
+# register() success log: "" (never consulted — e.g. tests stub the loader),
+# "ok:<path>", "no-section:<path>", or "load-failed". Paths are logged, never
+# credential values (#88657).
+LAST_CONFIG_STATUS: str = ""
+
 
 # ---------------------------------------------------------------------------
 # Password hashing (stdlib scrypt)
@@ -336,21 +342,47 @@ def _load_config_basic_auth_section() -> dict:
     """Return ``dashboard.basic_auth`` from config.yaml, or ``{}``.
 
     Robust to load_config() raising, the keys being absent, or the value
-    not being a dict — every shape falls through to ``{}``.
+    not being a dict — every shape falls through to ``{}``. The outcome is
+    recorded in ``LAST_CONFIG_STATUS`` (with the config path consulted) so
+    register() can disclose which side the credentials came from (#88657).
     """
+    global LAST_CONFIG_STATUS
+    LAST_CONFIG_STATUS = ""
     try:
-        from hermes_cli.config import cfg_get, load_config
+        from hermes_cli.config import cfg_get, get_config_path, load_config
 
         cfg = load_config()
     except Exception as exc:  # noqa: BLE001 — broad catch is intentional
-        logger.debug(
+        LAST_CONFIG_STATUS = "load-failed"
+        logger.warning(
             "dashboard-auth-basic: load_config() raised %s; "
-            "falling back to env-only configuration",
+            "dashboard.basic_auth from config.yaml is unavailable — only "
+            "HERMES_DASHBOARD_BASIC_AUTH_* env vars will be consulted.",
             exc,
         )
         return {}
     section = cfg_get(cfg, "dashboard", "basic_auth", default=None)
-    return section if isinstance(section, dict) else {}
+    try:
+        path = str(get_config_path())
+    except Exception:  # noqa: BLE001 — disclosure is best-effort
+        path = "<unresolved>"
+    if not isinstance(section, dict) or not _section_has_credentials(section):
+        # load_config() pre-fills an all-empty basic_auth schema template, so
+        # "section present but every credential key empty" is the same
+        # operator-facing question ("why were my config creds ignored?") as no
+        # section at all.
+        LAST_CONFIG_STATUS = f"no-section:{path}"
+        return {}
+    LAST_CONFIG_STATUS = f"ok:{path}"
+    return section
+
+
+def _section_has_credentials(section: dict) -> bool:
+    """True when any credential-bearing key holds a non-empty value."""
+    return any(
+        str(section.get(key, "") or "").strip()
+        for key in ("username", "password", "password_hash", "secret")
+    )
 
 
 def _resolve(env_name: str, cfg_section: dict, cfg_key: str) -> str:
@@ -400,8 +432,9 @@ def register(ctx) -> None:
     configured, it registers a password provider that the login page
     renders as a credential form.
     """
-    global LAST_SKIP_REASON
+    global LAST_SKIP_REASON, LAST_CONFIG_STATUS
     LAST_SKIP_REASON = ""
+    LAST_CONFIG_STATUS = ""
 
     section = _load_config_basic_auth_section()
     username = _resolve(
@@ -452,6 +485,7 @@ def register(ctx) -> None:
     ).strip()
     if plaintext_from_env:
         password_hash = hash_password(plaintext_from_env)
+        password_src = "env"
         logger.info(
             "dashboard-auth-basic: hashed env-supplied password in-memory "
             "(overrides any config password_hash)."
@@ -459,11 +493,14 @@ def register(ctx) -> None:
     elif not password_hash:
         # config-only plaintext password.
         password_hash = hash_password(plaintext)
+        password_src = "config (password)"
         logger.info(
             "dashboard-auth-basic: hashed plaintext password in-memory. "
             "For production, precompute dashboard.basic_auth.password_hash "
             "and remove the plaintext password from config."
         )
+    else:
+        password_src = "config (password_hash)"
 
     secret = _resolve_secret(section)
 
@@ -485,7 +522,29 @@ def register(ctx) -> None:
         return
 
     ctx.register_dashboard_auth_provider(provider)
+    username_src = (
+        "env"
+        if os.environ.get(
+            "HERMES_DASHBOARD_BASIC_AUTH_USERNAME", ""
+        ).strip()
+        else "config"
+    )
+    if LAST_CONFIG_STATUS == "load-failed":
+        config_note = "config.yaml load FAILED — env vars were the only source"
+    elif LAST_CONFIG_STATUS.startswith("no-section:"):
+        config_note = (
+            f"{LAST_CONFIG_STATUS.split(':', 1)[1]} has no "
+            "dashboard.basic_auth section — env vars were the only source"
+        )
+    elif LAST_CONFIG_STATUS.startswith("ok:"):
+        config_note = f"config consulted at {LAST_CONFIG_STATUS.split(':', 1)[1]}"
+    else:
+        config_note = "config source not identified"
     logger.info(
-        "dashboard-auth-basic: registered password provider (username=%s)",
+        "dashboard-auth-basic: registered password provider "
+        "(username=%s; username from %s; password from %s; %s)",
         username,
+        username_src,
+        password_src,
+        config_note,
     )

--- a/tests/plugins/dashboard_auth/test_basic_provider.py
+++ b/tests/plugins/dashboard_auth/test_basic_provider.py
@@ -219,3 +219,150 @@ class TestRegister:
         p2 = ctx2.register_dashboard_auth_provider.call_args.args[0]
         s = p1.complete_password_login(username="admin", password="hunter2")
         assert p2.verify_session(access_token=s.access_token) is not None
+
+
+# ---------------------------------------------------------------------------
+# Config-side disclosure (#88657) — every silent resolution step must say
+# what it consulted: load failure, absent section, credential source.
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSideDisclosure:
+    def test_load_config_failure_logs_warning_not_debug(
+        self, basic, monkeypatch, caplog
+    ):
+        import hermes_cli.config as config_mod
+
+        def _boom():
+            raise RuntimeError("bad hermes home")
+
+        monkeypatch.setattr(config_mod, "load_config", _boom)
+        monkeypatch.delenv("HERMES_DASHBOARD_BASIC_AUTH_USERNAME", raising=False)
+        monkeypatch.delenv("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD", raising=False)
+        with caplog.at_level("DEBUG", logger=basic.__name__):
+            section = basic._load_config_basic_auth_section()
+        assert section == {}
+        assert basic.LAST_CONFIG_STATUS == "load-failed"
+        warnings = [
+            r for r in caplog.records if r.levelname == "WARNING"
+        ]
+        assert warnings, "load_config() failure must log at WARNING, not DEBUG"
+        assert "env vars will be consulted" in warnings[0].getMessage()
+
+    def test_absent_section_records_config_path(
+        self, basic, monkeypatch, tmp_path
+    ):
+        import hermes_cli.config as config_mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(config_mod, "load_config", lambda: {})
+        section = basic._load_config_basic_auth_section()
+        assert section == {}
+        assert basic.LAST_CONFIG_STATUS == (
+            f"no-section:{tmp_path / 'config.yaml'}"
+        )
+
+    def test_all_empty_schema_template_counts_as_no_section(
+        self, basic, monkeypatch, tmp_path
+    ):
+        # load_config() pre-fills basic_auth with an all-empty template when
+        # the file/section is missing — that must not read as "config had a
+        # section" in the disclosure.
+        import hermes_cli.config as config_mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            config_mod,
+            "load_config",
+            lambda: {
+                "dashboard": {
+                    "basic_auth": {
+                        "username": "",
+                        "password": "",
+                        "password_hash": "",
+                        "secret": "",
+                        "session_ttl_seconds": 0,
+                    }
+                }
+            },
+        )
+        section = basic._load_config_basic_auth_section()
+        assert section == {}
+        assert basic.LAST_CONFIG_STATUS == (
+            f"no-section:{tmp_path / 'config.yaml'}"
+        )
+
+    def test_register_discloses_env_only_sources(
+        self, basic, monkeypatch, caplog, tmp_path
+    ):
+        import hermes_cli.config as config_mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(config_mod, "load_config", lambda: {})
+        monkeypatch.setenv("HERMES_DASHBOARD_BASIC_AUTH_USERNAME", "admin")
+        monkeypatch.setenv("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD", "hunter2")
+        with caplog.at_level("INFO", logger=basic.__name__):
+            basic.register(MagicMock())
+        msg = [
+            r.getMessage()
+            for r in caplog.records
+            if "registered password provider" in r.getMessage()
+        ][0]
+        assert "username from env" in msg
+        assert "password from env" in msg
+        assert f"{tmp_path / 'config.yaml'} has no dashboard.basic_auth section" in msg
+
+    def test_register_discloses_config_sources(self, basic, monkeypatch, caplog):
+        import hermes_cli.config as config_mod
+
+        monkeypatch.setattr(
+            config_mod,
+            "load_config",
+            lambda: {
+                "dashboard": {
+                    "basic_auth": {
+                        "username": "admin",
+                        "password_hash": basic.hash_password("cfg-pw"),
+                    }
+                }
+            },
+        )
+        monkeypatch.setenv("HERMES_HOME", "/home/u/.hermes")
+        with caplog.at_level("INFO", logger=basic.__name__):
+            basic.register(MagicMock())
+        msg = [
+            r.getMessage()
+            for r in caplog.records
+            if "registered password provider" in r.getMessage()
+        ][0]
+        assert "username from config" in msg
+        assert "password from config (password_hash)" in msg
+        assert "config consulted at /home/u/.hermes/config.yaml" in msg
+        # Never the credential values themselves.
+        assert "cfg-pw" not in msg
+
+    def test_register_discloses_config_plaintext_source(
+        self, basic, monkeypatch, caplog, tmp_path
+    ):
+        import hermes_cli.config as config_mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        plain = secrets.token_hex(8)  # generated, never a source literal
+        monkeypatch.setattr(
+            config_mod,
+            "load_config",
+            lambda: {
+                "dashboard": {
+                    "basic_auth": {"username": "admin", "password": plain}
+                }
+            },
+        )
+        with caplog.at_level("INFO", logger=basic.__name__):
+            basic.register(MagicMock())
+        msg = [
+            r.getMessage()
+            for r in caplog.records
+            if "registered password provider" in r.getMessage()
+        ][0]
+        assert "password from config (password)" in msg
+        assert plain not in msg


### PR DESCRIPTION
## What does this PR do?

Makes every config-side step of dashboard basic-auth credential resolution disclose what it consulted, so the #88657 scenario ("env creds keep working, config-side credentials silently ignored, nothing in the logs names the config file") becomes diagnosable from the log alone:

- `load_config()` failures in the basic-auth plugin now log at **WARNING** with the consequence stated (only `HERMES_DASHBOARD_BASIC_AUTH_*` env vars will be consulted) instead of DEBUG-only.
- The section loader records its outcome in `LAST_CONFIG_STATUS` along with the config path consulted. An all-empty schema template counts as "no section": `load_config()` pre-fills `dashboard.basic_auth` with empty-string keys when the file/section is missing, and that template loads no credentials — without this, the "absent section" shape could never be observed at all.
- The successful-registration log now discloses where the username and password came from (env / config `password_hash` / config plaintext) plus the config path and outcome. Credential values are never logged — only sources and paths.

Behavior is otherwise unchanged: resolution precedence, skip reasons, hashing, and provider construction are untouched.

## Related Issue

Fixes #88657

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/dashboard_auth/basic/__init__.py`
  - `_load_config_basic_auth_section()`: DEBUG→WARNING on `load_config()` failure; records `LAST_CONFIG_STATUS` (`ok:<path>` / `no-section:<path>` / `load-failed`); all-empty schema template falls through as no-section.
  - New `_section_has_credentials()` helper (any of username/password/password_hash/secret non-empty).
  - `register()`: success log now reports username source, password source, and the config-side outcome with the path consulted.
- `tests/plugins/dashboard_auth/test_basic_provider.py`
  - New `TestConfigSideDisclosure`: WARNING level on load failure, recorded path for absent-section and empty-template shapes, source disclosure for env-only, config-hash, and config-plaintext registrations, and no credential values in the log.

## How to Test

1. `python -m pytest tests/plugins/dashboard_auth/ tests/hermes_cli/test_dashboard_basic_auth_plugin_enable.py tests/hermes_cli/test_dashboard_auth_plugin_hook.py tests/hermes_cli/test_dashboard_token_auth.py tests/hermes_cli/test_dashboard_auth_status_endpoint.py -q`
   Observed result: 119 passed.
2. Reproduce the issue's env-masking scenario (fresh `HERMES_HOME`, env creds only, empty config template):
   ```python
   import logging, os, tempfile
   from unittest.mock import MagicMock
   logging.basicConfig(level=logging.INFO)
   os.environ["HERMES_HOME"] = tempfile.mkdtemp()
   os.environ["HERMES_DASHBOARD_BASIC_AUTH_USERNAME"] = "admin"
   os.environ["HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"] = "hunter2"
   import plugins.dashboard_auth.basic as basic
   basic.register(MagicMock())
   ```
   Observed result (after): `registered password provider (username=admin; username from env; password from env; <home>/config.yaml has no dashboard.basic_auth section — env vars were the only source)` — before the fix this line named no config path and no source. With credentials in config.yaml, the same line reports `config consulted at <path>` and the config-side password source.
3. Log-output check from the issue: `grep -cE "config\.yaml|load_config" agent.log` should now be ≥1 on registration instead of 0.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (dashboard-auth + plugin suites: 119 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated on the loader; or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — path disclosure uses `pathlib` rendering only; or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
