### PR TITLE
fix(desktop): make runtime provisioning primary-only

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -253,6 +253,7 @@ import {
   revalidateRemoteConnection
 } from './remote-liveness'
 import { missingRendererAssets } from './renderer-bundle'
+import { assertRuntimeProvisioningAllowed, type RuntimeProvisioningIntent } from './runtime-provisioning-policy'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
 import {
   buildSessionWindowUrl,
@@ -4570,7 +4571,9 @@ function resolveHermesBackend(backendArgs) {
   }
 }
 
-async function ensureRuntime(backend) {
+async function ensureRuntime(backend, intent: RuntimeProvisioningIntent) {
+  assertRuntimeProvisioningAllowed(backend, intent)
+
   if (!backend.bootstrap) {
     await advanceBootProgress('runtime.external', `Using ${backend.label}`, 32)
 
@@ -4680,7 +4683,7 @@ async function ensureRuntime(backend) {
 
     // Re-resolve now that the install exists. The new resolution lands in
     // step 3 (bootstrap-complete marker) and we recurse to wire venvPython.
-    return ensureRuntime(resolveHermesBackend(backend.args))
+    return ensureRuntime(resolveHermesBackend(backend.args), intent)
   }
 
   // bootstrap=true with a real backend (createActiveBackend path) means we
@@ -10071,7 +10074,10 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // step 3 in hermes_cli/main.py), so the child re-homes to this profile.
   // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
   const backendArgs = ['--profile', profile, 'serve', '--host', '127.0.0.1', '--port', '0']
-  const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
+  // A secondary source may activate an installed runtime, but it never owns
+  // first-run provisioning. The policy is enforced inside ensureRuntime so a
+  // future secondary caller cannot bypass it accidentally.
+  const backend = await ensureRuntime(resolveHermesBackend(backendArgs), 'secondary-activate')
   // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
   backend.args = getBackendArgsForRuntime(backend)
   const hermesCwd = resolveHermesCwd()
@@ -10408,7 +10414,9 @@ async function startHermes() {
 
     const setup = await runPrimaryBackendStartup({
       connectRemote,
-      ensureLocalRuntime: ensureRuntime,
+      // Primary startup is the sole Desktop authority allowed to cross the
+      // bootstrap-needed sentinel into the platform installer.
+      ensureLocalRuntime: backend => ensureRuntime(backend, 'primary-bootstrap'),
       prepareLocalBackend: async () => {
         await advanceBootProgress('backend.runtime', 'Resolving Hermes runtime', 28)
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -253,8 +253,8 @@ import {
   revalidateRemoteConnection
 } from './remote-liveness'
 import { missingRendererAssets } from './renderer-bundle'
-import { assertRuntimeProvisioningAllowed, type RuntimeProvisioningIntent } from './runtime-provisioning-policy'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
+import { assertRuntimeProvisioningAllowed, type RuntimeProvisioningIntent } from './runtime-provisioning-policy'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,

--- a/apps/desktop/electron/runtime-provisioning-policy.test.ts
+++ b/apps/desktop/electron/runtime-provisioning-policy.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  RuntimeProvisioningDeniedError,
+  SECONDARY_RUNTIME_NOT_INSTALLED,
+  assertRuntimeProvisioningAllowed,
+  runtimeNeedsProvisioning
+} from './runtime-provisioning-policy'
+
+test('only the unresolved bootstrap sentinel requires provisioning', () => {
+  assert.equal(runtimeNeedsProvisioning({ kind: 'bootstrap-needed' }), true)
+  assert.equal(runtimeNeedsProvisioning({ kind: 'python' }), false)
+  assert.equal(runtimeNeedsProvisioning({}), false)
+  assert.equal(runtimeNeedsProvisioning(null), false)
+  assert.equal(runtimeNeedsProvisioning(undefined), false)
+})
+
+test('primary startup may provision a missing local runtime', () => {
+  assert.doesNotThrow(() => assertRuntimeProvisioningAllowed({ kind: 'bootstrap-needed' }, 'primary-bootstrap'))
+})
+
+test('secondary backends refuse implicit provisioning with a typed actionable error', () => {
+  assert.throws(
+    () => assertRuntimeProvisioningAllowed({ kind: 'bootstrap-needed' }, 'secondary-activate'),
+    error => {
+      assert.ok(error instanceof RuntimeProvisioningDeniedError)
+      assert.equal(error.code, 'runtime-provisioning-not-allowed')
+      assert.equal(error.intent, 'secondary-activate')
+      assert.equal(error.message, SECONDARY_RUNTIME_NOT_INSTALLED)
+
+      return true
+    }
+  )
+})
+
+test('secondary backends may activate an already-installed managed runtime', () => {
+  // createActiveBackend() deliberately carries bootstrap=true while wiring the
+  // already-installed venv. Policy is keyed to the bootstrap-needed sentinel,
+  // not the broader bootstrap flag, so this remains usable.
+  assert.doesNotThrow(() => assertRuntimeProvisioningAllowed({ kind: 'python', bootstrap: true }, 'secondary-activate'))
+})
+
+test('external runtimes are valid for both intents', () => {
+  for (const intent of ['primary-bootstrap', 'secondary-activate'] as const) {
+    assert.doesNotThrow(() => assertRuntimeProvisioningAllowed({ kind: 'command' }, intent))
+  }
+})

--- a/apps/desktop/electron/runtime-provisioning-policy.test.ts
+++ b/apps/desktop/electron/runtime-provisioning-policy.test.ts
@@ -3,10 +3,10 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import {
-  RuntimeProvisioningDeniedError,
-  SECONDARY_RUNTIME_NOT_INSTALLED,
   assertRuntimeProvisioningAllowed,
-  runtimeNeedsProvisioning
+  runtimeNeedsProvisioning,
+  RuntimeProvisioningDeniedError,
+  SECONDARY_RUNTIME_NOT_INSTALLED
 } from './runtime-provisioning-policy'
 
 test('only the unresolved bootstrap sentinel requires provisioning', () => {

--- a/apps/desktop/electron/runtime-provisioning-policy.ts
+++ b/apps/desktop/electron/runtime-provisioning-policy.ts
@@ -1,0 +1,48 @@
+/**
+ * The Desktop resolves local runtimes for two materially different purposes:
+ *
+ * - primary-bootstrap: the user is starting the primary local Desktop backend,
+ *   so first-run provisioning is allowed;
+ * - secondary-activate: a background profile or registry source may reuse an
+ *   installed runtime, but must never turn observation/UI routing into an
+ *   implicit platform install.
+ *
+ * Keeping this policy inside ensureRuntime() means every current and future
+ * caller must declare its authority before the bootstrap sentinel can reach the
+ * installer. A caller-local guard can fix one path while the next secondary
+ * path reopens the same deployment-topology bug.
+ */
+
+export type RuntimeProvisioningIntent = 'primary-bootstrap' | 'secondary-activate'
+
+export interface ResolvedRuntimeLike {
+  bootstrap?: unknown
+  kind?: unknown
+}
+
+export const SECONDARY_RUNTIME_NOT_INSTALLED =
+  'No local Hermes runtime is installed on this machine. Install Hermes locally before using "This device" or a secondary local profile.'
+
+export class RuntimeProvisioningDeniedError extends Error {
+  readonly code = 'runtime-provisioning-not-allowed'
+  readonly intent: RuntimeProvisioningIntent
+
+  constructor(intent: RuntimeProvisioningIntent) {
+    super(SECONDARY_RUNTIME_NOT_INSTALLED)
+    this.name = 'RuntimeProvisioningDeniedError'
+    this.intent = intent
+  }
+}
+
+export function runtimeNeedsProvisioning(runtime: null | ResolvedRuntimeLike | undefined): boolean {
+  return Boolean(runtime && typeof runtime === 'object' && runtime.kind === 'bootstrap-needed')
+}
+
+export function assertRuntimeProvisioningAllowed(
+  runtime: null | ResolvedRuntimeLike | undefined,
+  intent: RuntimeProvisioningIntent
+): void {
+  if (runtimeNeedsProvisioning(runtime) && intent !== 'primary-bootstrap') {
+    throw new RuntimeProvisioningDeniedError(intent)
+  }
+}


### PR DESCRIPTION
## Current disposition

Exact current head: `06dca80cb32468b9ee508afa41f4ab178faafe6c`.

The proof-preserving rebase onto current main is complete. GitHub reports this head mergeable, and the exact-head hosted matrix is green:

- CI `32292450042`: success;
- Docker Build, Test, and Publish `32292449302`: success;
- Nix flake check `32292449268`: success.

This is the first enforcement slice under #88683 and remains intentionally narrow. It must retain `Refs #88683` rather than claiming to close the larger deployment-plan architecture.

## Rebase result

The rebase preserved only the provisioning-authority slice and its earned provenance:

- `runtime-provisioning-policy.ts`, its tests, and `main.ts` intent plumbing are retained;
- #88348/@james47kjv diagnosis and provenance remain intact;
- the branch uses current main’s canonical contributor mapping rather than replaying redundant hostname-derived mapping edits;
- unrelated contributor-map cleanup was dropped from this PR;
- the runtime policy/startup tests, Desktop typecheck, Prettier, `git diff --check`, attribution audit, and hosted CI/Docker/Nix all pass on the rebased work.

## Summary

Desktop previously had one `ensureRuntime()` function serving two materially different authorities:

- **primary local startup**, where first-run provisioning is legitimate;
- **secondary activation**, where a background profile or registry source may reuse an installed runtime but must not silently install one.

This PR makes that authority explicit and enforceable:

- every `ensureRuntime()` call declares `primary-bootstrap` or `secondary-activate`;
- only `primary-bootstrap` may cross `bootstrap-needed` into `runBootstrap()`;
- pool/registry/background sources may activate an already-installed managed or external runtime;
- the intent survives post-bootstrap re-resolution;
- denied secondary provisioning produces a typed actionable error before clone, venv, config, database, gateway, or dependency mutation.

## Why the guard belongs in `ensureRuntime()`

#88348 identified the pool-backend escape and proposed a caller-local guard. That blocks one manifestation but leaves shared mutation authority unchanged. This slice moves enforcement to the owner boundary:

```text
resolve runtime
  → declare provisioning intent
    → ensureRuntime enforces authority
      → installer reachable only from primary-bootstrap
```

The function has no default intent, so new callers cannot silently inherit bootstrap authority.

## Behavioral contract

| Desktop path | Missing local runtime | Installed managed runtime | External runtime |
|---|---:|---:|---:|
| Primary local startup | provisions | activates | activates |
| Secondary pool/profile source | **refuses before mutation** | activates | activates |
| Saved remote-primary startup | never enters local setup | unchanged | unchanged |

The policy keys on `kind === 'bootstrap-needed'`, not the broader `bootstrap` boolean. An already-installed managed backend may carry `bootstrap: true` while wiring its venv; secondary sources must still use that healthy runtime.

## Implementation

`runtime-provisioning-policy.ts` defines:

- `RuntimeProvisioningIntent`;
- `runtimeNeedsProvisioning()`;
- `assertRuntimeProvisioningAllowed()`;
- `RuntimeProvisioningDeniedError` with stable code/intent and actionable message.

`main.ts` enforces policy before bootstrap work; recursive re-resolution preserves intent; primary startup passes `primary-bootstrap`; pool activation passes `secondary-activate`.

## Exact-head verification

Current rebased head `06dca80cb32468b9ee508afa41f4ab178faafe6c`:

- focused runtime policy + primary-startup tests: green;
- Desktop typecheck: clean;
- Prettier: clean;
- `git diff --check`: clean;
- attribution audit: clean;
- CI: success;
- Docker: success;
- Nix: success;
- GitHub mergeability: mergeable.

## Non-goals

This slice does not implement #88683’s deployment plan representation, component planner, transactional activation/rollback, durable update journal, process-generation barrier, complete failure matrix, or broader update architecture. Those remain separate architecture work.

## Attribution and interlocks

- Refs #88683.
- Supersedes #88348 while preserving @james47kjv’s diagnosis and provenance.
- Related thin-client reports: #83021, #61329, #38602, #50643, #58799.
