### PR TITLE
fix(feishu): keep the lark-oapi proxy probe working through the WS override

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import asyncio
 import collections
 import concurrent.futures
+import functools
 import hashlib
 import hmac
 import itertools
@@ -1343,6 +1344,14 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             logger.debug("[Feishu] Failed to apply websocket runtime overrides", exc_info=True)
 
+    # functools.wraps keeps the original websockets.connect signature visible
+    # through __wrapped__: lark-oapi's _ws_connect_kwargs() probes
+    # inspect.signature(websockets.connect).parameters for a "proxy" parameter
+    # to pass proxy=None and opt out of websockets 15 environment proxy
+    # discovery. A bare *args/**kwargs wrapper hides every named parameter,
+    # so the probe fails, proxy discovery runs, and a system SOCKS proxy
+    # kills the Feishu WS loop with "python_socks is required" (#88545).
+    @functools.wraps(original_connect)
     def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
         if adapter._ws_ping_interval is not None and "ping_interval" not in kwargs:
             kwargs["ping_interval"] = adapter._ws_ping_interval

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -356,6 +356,69 @@ class TestAdapterModule(unittest.TestCase):
         self.assertEqual(fake_client._reconnect_interval, 3)
         self.assertEqual(fake_client._ping_interval, 4)
 
+    def test_ws_connect_override_keeps_proxy_visible_to_lark_probe(self):
+        """The patched websockets.connect must keep its named parameters
+        visible: lark-oapi's _ws_connect_kwargs() probes
+        inspect.signature(websockets.connect).parameters for ``proxy`` to
+        pass proxy=None and opt out of websockets 15 environment proxy
+        discovery. A bare *args/**kwargs wrapper hides every named parameter,
+        so the probe fails and a system SOCKS proxy kills the Feishu WS loop
+        with "python_socks is required" (#88545)."""
+        import inspect
+        import sys
+        from types import ModuleType
+
+        captured = {}
+
+        def _stub_connect(*args, proxy=None, **kwargs):
+            captured["call_args"] = args
+            captured["call_kwargs"] = {"proxy": proxy, **kwargs}
+            return "STUB_SENTINEL"
+
+        class _ProbeWSClient:
+            def start(self):
+                patched = sys.modules["lark_oapi.ws.client"].websockets.connect
+                captured["params"] = set(inspect.signature(patched).parameters)
+                captured["return"] = patched("wss://example.invalid", proxy=None)
+                raise RuntimeError("stop test client")
+
+        fake_adapter = SimpleNamespace(
+            _ws_thread_loop=None,
+            _ws_reconnect_nonce=2,
+            _ws_reconnect_interval=3,
+            _ws_ping_interval=4,
+            _ws_ping_timeout=5,
+        )
+        fake_client = _ProbeWSClient()
+        fake_client_module = ModuleType("lark_oapi.ws.client")
+        fake_client_module.loop = None
+        fake_client_module.websockets = SimpleNamespace(connect=_stub_connect)
+        fake_ws_module = ModuleType("lark_oapi.ws")
+        fake_ws_module.client = fake_client_module
+        fake_root_module = ModuleType("lark_oapi")
+        fake_root_module.ws = fake_ws_module
+
+        original_modules = sys.modules.copy()
+        sys.modules["lark_oapi"] = fake_root_module
+        sys.modules["lark_oapi.ws"] = fake_ws_module
+        sys.modules["lark_oapi.ws.client"] = fake_client_module
+        try:
+            from plugins.platforms.feishu.adapter import _run_official_feishu_ws_client
+
+            _run_official_feishu_ws_client(fake_client, fake_adapter)
+        finally:
+            sys.modules.clear()
+            sys.modules.update(original_modules)
+
+        # The lark-oapi signature probe sees the original named parameter.
+        self.assertIn("proxy", captured["params"])
+        # Forwarding is unchanged: ping overrides injected, proxy forwarded,
+        # and the wrapped callable's return value passes through untouched.
+        self.assertEqual(captured["return"], "STUB_SENTINEL")
+        self.assertEqual(captured["call_kwargs"]["proxy"], None)
+        self.assertEqual(captured["call_kwargs"]["ping_interval"], 4)
+        self.assertEqual(captured["call_kwargs"]["ping_timeout"], 5)
+
 
 def _admits_group(adapter, message, sender_id, chat_id=""):
     """Group-path shim: run a message through ``_admit`` and return a bool."""


### PR DESCRIPTION
## What does this PR do?

Fixes the Feishu websocket dying on every reconnect when the host has a system SOCKS proxy configured. The adapter monkey-patches `websockets.connect` inside `_run_official_feishu_ws_client` to inject `ping_interval`/`ping_timeout`, but the wrapper only declared `*args/**kwargs` — so `inspect.signature()` on the patched callable no longer listed any named parameters, including `proxy`. lark-oapi's `_ws_connect_kwargs()` probes exactly that signature to decide whether it can pass `proxy=None` (opting out of websockets 15's environment proxy discovery, which the SDK deliberately does to preserve its historical direct-connect behavior). Against the wrapper the probe returned `{}`, `proxy=None` was never forwarded, websockets 15 ran environment proxy discovery, hit the SOCKS proxy, and failed on `import python_socks` every ~2 minutes — while `gateway_state.json` kept reporting `feishu: connected`.

The fix is `@functools.wraps(original_connect)` on the wrapper: `inspect.signature()` follows `__wrapped__`, so the full original signature (including `proxy`, and anything lark-oapi may probe in the future) stays visible. Forwarding behavior is untouched — the wrapper still only injects the two ping kwargs when absent and passes everything else through.

Verified the full causal chain on the real dependencies (websockets 15.0.1, lark-oapi):
- bare `*args/**kwargs` wrapper → probe sees `{'args', 'kwargs'}` → `_ws_connect_kwargs()` returns `{}` (bug)
- `functools.wraps` wrapper → probe sees the original parameters → returns `{'proxy': None}` (fixed)

## Related Issue

Fixes #88545

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/feishu/adapter.py`
  - `import functools`; `@functools.wraps(original_connect)` on `_connect_with_overrides` with a comment explaining the lark-oapi signature probe this protects.
- `tests/gateway/test_feishu.py`
  - New `test_ws_connect_override_keeps_proxy_visible_to_lark_probe`: runs `_run_official_feishu_ws_client` against a stubbed `lark_oapi.ws.client` whose `websockets.connect` has a `proxy` parameter, samples the patched callable from inside `start()`, and asserts `proxy` is visible to the signature probe, ping overrides are still injected, and `proxy=None` plus the return value pass through unchanged. Fails on unpatched main with `'proxy' not found in {'kwargs', 'args'}`.

## How to Test

1. `python -m pytest tests/gateway/test_feishu.py -q`
   Observed result: 77 passed (1 pre-existing environment failure in `test_download_remote_document_blocks_connect_time_rebind`, an SSRF/httpcore test that fails identically on unpatched main in this environment — unrelated to this change).
2. Regression fails on main: `git stash` the adapter change and rerun the new test — Observed result: `AssertionError: 'proxy' not found in {'kwargs', 'args'}`.
3. Real-dependency probe check (websockets 15.0.1 + lark-oapi installed): wrap `websockets.connect` both ways and evaluate lark's probe semantics — bare wrapper yields `{}`, `functools.wraps` wrapper yields `{'proxy': None}` (script in the linked issue reproduces the original failure with a SOCKS proxy env).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full Feishu suite; 1 pre-existing env failure unrelated to this change, verified by baseline stash)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.14, websockets 15.0.1

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment documents the constraint)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `functools.wraps` is stdlib and skips missing attributes; or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
