### PR TITLE
fix(update): show live Desktop update progress

### DIFF
--- a/scripts/desktop-update/ui.html
+++ b/scripts/desktop-update/ui.html
@@ -3,8 +3,8 @@
   Quiet shim page for the desktop update hand-off (Windows + POSIX).
 
   Served over loopback by the orchestrator (windows.ps1 / posix.sh) into a
-  chromeless browser app window. Pure veneer: polls /progress for `done` or
-  `error` and reacts; owns nothing (relaunch, result file, marker hygiene
+  chromeless browser app window. Pure veneer: polls /progress for the current
+  hand-off stage or a terminal event and reacts; owns nothing (relaunch, result file, marker hygiene
   all live in the orchestrator, which runs identically with no UI at all).
 
   The visual is PR #75895's update hand-off screen, ported verbatim:
@@ -12,8 +12,8 @@
     apps/bootstrap-installer/src/components/loader.tsx (itself lifted from
     apps/desktop/src/components/ui/loader.tsx 'fourier-flow'). Keep the
     constants in sync if the desktop's curve is retuned.
-  - Layout: loader (size-20) + one title + one muted line. No progress bar,
-    no stage list, no log pane, no cancel (see #75895 for the arguments).
+  - Layout: loader (size-20) + one title + one muted stage/elapsed line. No
+    progress bar, stage list, log pane, or cancel (see #75895 for the arguments).
   - Appearance follows the OS. Dark seeds are the installer's neutral
     charcoal (#232323 base, foreground #d6d6d6) — never brand blue.
 -->
@@ -104,7 +104,7 @@
     <div id="loader" role="status" aria-label="Updating"></div>
     <div id="glyph"></div>
     <h2 id="title">Updating Hermes</h2>
-    <p id="line">Hermes will open once done.</p>
+    <p id="line">Preparing update<br>0s elapsed</p>
   </div>
 <script>
   /* ── Fourier Flow loader, ported verbatim from loader.tsx ─────────────── */
@@ -195,10 +195,11 @@
 
   render(performance.now())
 
-  /* ── Event listener: done | error, nothing else ───────────────────────── */
+  /* ── Event listener: running stage or terminal outcome ───────────────── */
   const titleEl = document.getElementById('title')
   const lineEl = document.getElementById('line')
   const glyphEl = document.getElementById('glyph')
+  const clientStartedAt = Date.now()
   let settled = false
 
   function settle(state) {
@@ -209,7 +210,17 @@
 
   function apply(state) {
     if (settled) return
-    if (state.status === 'done') {
+    if (state.status === 'running') {
+      const reported = Number(state.elapsed_seconds)
+      const elapsed = Number.isFinite(reported) && reported >= 0
+        ? Math.floor(reported)
+        : Math.floor((Date.now() - clientStartedAt) / 1000)
+      const elapsedText = elapsed < 60
+        ? `${elapsed}s elapsed`
+        : `${Math.floor(elapsed / 60)}m ${elapsed % 60}s elapsed`
+      lineEl.textContent = `${state.message || 'Updating Hermes'}\n${elapsedText}`
+      lineEl.style.whiteSpace = 'pre-line'
+    } else if (state.status === 'done') {
       settle('done')
       glyphEl.textContent = '\u2713'
       lineEl.textContent = 'Opening Hermes\u2026'

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -83,6 +83,8 @@ $LogDir = Join-Path $HermesHome "logs"
 $LogPath = Join-Path $LogDir "desktop-update-handoff.log"
 $ResultPath = Join-Path $HermesHome ".hermes-update-result.json"
 $script:Ui = $null
+$script:UiStage = "Preparing update"
+$script:UiStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
 function Write-HandoffLog([string]$Message) {
     $line = "{0:yyyy-MM-ddTHH:mm:ssK} {1}" -f (Get-Date), $Message
@@ -93,15 +95,16 @@ function Write-HandoffLog([string]$Message) {
 # ── The shim: repo-owned HTML in a chromeless Edge app window ──────────────
 # The window is a veneer, not a participant: the update runs identically with
 # or without it (Edge missing/failed degrades to the WinForms card below,
-# then log-only). It streams nothing and knows nothing — it polls /progress
-# for one of two events, `done` or `error`, and reacts. The loopback listener
+# then log-only). It never consumes child output; it polls /progress for the
+# current hand-off stage or a terminal event and reacts. The loopback listener
 # is not a web server in any meaningful sense; it exists because file:// pages
 # cannot receive events from a detached process. Salvaged from the web-shell
 # spike (Co-authored-by: teknium1), reshaped to the quiet update-surface
 # contract (#75895/#83634): loader, one title, one line, no dashboard.
 $script:UiState = [hashtable]::Synchronized(@{
-    status  = "running"      # running | done | error
-    message = ""
+    status     = "running"      # running | done | manual | error
+    message    = $script:UiStage
+    clock      = $script:UiStopwatch
 })
 $script:UiServer = $null     # @{ Listener; Runspace; PowerShell; Port; EdgeProc }
 
@@ -158,9 +161,11 @@ function Start-UiServer([string]$HtmlPath) {
                     # Drain headers so the client doesn't see a reset mid-send.
                     while ($true) { $h = $reader.ReadLine(); if ($null -eq $h -or $h -eq "") { break } }
                     if ($request -match "^GET /progress") {
+                        $elapsed = [Math]::Floor($State.clock.Elapsed.TotalSeconds)
                         $snapshot = @{
-                            status  = $State.status
-                            message = $State.message
+                            status          = $State.status
+                            message         = $State.message
+                            elapsed_seconds = $elapsed
                         } | ConvertTo-Json -Compress
                         Send-Response $stream "200 OK" "application/json; charset=utf-8" ([System.Text.Encoding]::UTF8.GetBytes($snapshot))
                     } elseif ($request -match "^GET / ") {
@@ -210,9 +215,36 @@ function Publish-UiEvent([string]$Status, [string]$Message) {
     if ($script:UiServer) { Start-Sleep -Milliseconds 900 }
 }
 
+function Get-UiElapsedText {
+    $elapsed = [Math]::Floor($script:UiStopwatch.Elapsed.TotalSeconds)
+    if ($elapsed -lt 60) { return "${elapsed}s elapsed" }
+    $minutes = [Math]::Floor($elapsed / 60)
+    $seconds = $elapsed % 60
+    return "${minutes}m ${seconds}s elapsed"
+}
+
+function Get-UiProgressLine {
+    return "$script:UiStage`r`n$(Get-UiElapsedText)"
+}
+
+function Publish-UiProgress([string]$Message) {
+    # Stages come from the orchestrator's own control flow. Child stdout and
+    # stderr remain asynchronously drained in Invoke-HermesStep and are never
+    # read or parsed for UI updates.
+    $script:UiStage = $Message
+    $script:UiState.message = $Message
+    $script:UiState.status = "running"
+    if ($script:Ui) {
+        try {
+            $script:Ui.Sub.Text = Get-UiProgressLine
+            [System.Windows.Forms.Application]::DoEvents()
+        } catch {}
+    }
+}
+
 # ── Fallback card (no Edge / no HTML): same shape in WinForms ──────────────
-# Matches the shim pixel-for-pixel in spirit -- loader, one title, one static
-# line, OS light/dark -- so degrading is invisible to the user.
+# Matches the shim pixel-for-pixel in spirit -- loader, one title, one live
+# stage/elapsed line, OS light/dark -- so degrading is invisible to the user.
 function Get-AppsUseLightTheme {
     try {
         $v = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize" -Name AppsUseLightTheme -ErrorAction Stop
@@ -291,7 +323,7 @@ function Show-ProgressWindow {
         $title.TextAlign = "MiddleCenter"
         $title.SetBounds(16, 156, 248, 28)
         $sub = New-Object System.Windows.Forms.Label
-        $sub.Text = "Hermes will open once done."
+        $sub.Text = Get-UiProgressLine
         $sub.Font = New-Object System.Drawing.Font("Segoe UI", 9)
         $sub.ForeColor = $mute
         $sub.TextAlign = "TopCenter"
@@ -309,7 +341,16 @@ function Show-ProgressWindow {
             if ($script:Win32) { [HermesHandoff.Win32]::SetForegroundWindow($form.Handle) | Out-Null }
         } catch {}
         [System.Windows.Forms.Application]::DoEvents()
-        $script:Ui = [pscustomobject]@{ Form = $form; Bar = $bar; Title = $title; Sub = $sub }
+        $script:Ui = [pscustomobject]@{ Form = $form; Bar = $bar; Title = $title; Sub = $sub; Timer = $null }
+        $timer = New-Object System.Windows.Forms.Timer
+        $timer.Interval = 1000
+        $timer.Add_Tick({
+            if ($script:Ui -and $script:Ui.Sub) {
+                $script:Ui.Sub.Text = Get-UiProgressLine
+            }
+        })
+        $script:Ui.Timer = $timer
+        $timer.Start()
     } catch {
         # Headless session / WinForms unavailable: degrade to log-only.
         $script:Ui = $null
@@ -331,6 +372,7 @@ function Show-ErrorFinale([string]$Message) {
     if (-not $script:Ui) { return }
     try {
         $ui = $script:Ui
+        if ($ui.Timer) { $ui.Timer.Stop() }
         $ui.Bar.Visible = $false
         $ui.Title.Text = "Failed to update"
         $ui.Sub.Text = "Run `"hermes debug share`" in a terminal to send a report."
@@ -372,6 +414,7 @@ function Show-ManualFinale([string]$Message) {
     if (-not $script:Ui) { return }
     try {
         $ui = $script:Ui
+        if ($ui.Timer) { $ui.Timer.Stop() }
         $ui.Bar.Visible = $false
         $ui.Title.Text = "Update complete"
         $ui.Sub.Text = $Message
@@ -404,7 +447,13 @@ function Close-ProgressWindow {
         Stop-UiServer
     }
     if ($script:Ui) {
-        try { $script:Ui.Form.Close() } catch {}
+        try {
+            if ($script:Ui.Timer) {
+                $script:Ui.Timer.Stop()
+                $script:Ui.Timer.Dispose()
+            }
+            $script:Ui.Form.Close()
+        } catch {}
         $script:Ui = $null
     }
 }
@@ -535,8 +584,8 @@ function Start-DesktopRelaunch {
 }
 
 function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
-    # The window shows nothing live, so no line-pump: both pipes drain
-    # asynchronously (no deadlock however chatty the child) while a small
+    # The window does not stream child output, so no line-pump: both pipes
+    # drain asynchronously (no deadlock however chatty the child) while a small
     # DoEvents loop keeps the marquee animating through long silent
     # stretches (pip installs) -- the old EndOfStream pump blocked on quiet
     # children and froze it. Full output still lands in the hand-off log
@@ -606,7 +655,17 @@ if ($SelfTestUi) {
     Write-HandoffLog "SELF-TEST: shim simulation (no update will run)"
     $hold = 6
     if ($env:HERMES_SELFTEST_HOLD_SECONDS) { $hold = [int]$env:HERMES_SELFTEST_HOLD_SECONDS }
-    Start-Sleep -Seconds $hold
+    Publish-UiProgress "Testing quiet update"
+    if ($env:HERMES_SELFTEST_SILENT_CHILD) {
+        $pythonExe = $env:HERMES_SELFTEST_PYTHON
+        if (-not $pythonExe -or -not (Test-Path -LiteralPath $pythonExe)) {
+            throw "HERMES_SELFTEST_PYTHON must name a Python executable for the silent-child self-test"
+        }
+        $quiet = Invoke-HermesStep $pythonExe @("-c", "import time; time.sleep($hold)") "self-test"
+        Write-HandoffLog "SELF-TEST: silent child exit code: $($quiet.Code)"
+    } else {
+        Start-Sleep -Seconds $hold
+    }
     if ($env:HERMES_SELFTEST_FAIL) {
         Show-ErrorFinale "self-test error state"
     } else {
@@ -633,6 +692,7 @@ try {
     }
 
     # -- 1. Wait for the Desktop to exit (FAIL CLOSED) ----------------------
+    Publish-UiProgress "Waiting for Hermes to close"
     if ($DesktopPid -gt 0) {
         $deadline = (Get-Date).AddSeconds(30)
         while ((Get-Date) -lt $deadline) {
@@ -653,6 +713,7 @@ try {
     }
 
     # -- 2. Wait for the venv shim to unlock (FAIL CLOSED) ------------------
+    Publish-UiProgress "Preparing Hermes files"
     $shim = Join-Path $InstallRoot "venv\Scripts\hermes.exe"
     if (Test-Path -LiteralPath $shim) {
         $unlocked = $false
@@ -725,6 +786,7 @@ try {
     }
     $updateArgs = @("-m", "hermes_cli.main", "update", "--yes", "--gateway", "--force", "--branch", $Branch)
     Write-HandoffLog ("running: python " + ($updateArgs -join " "))
+    Publish-UiProgress "Updating code and dependencies"
     $res = Invoke-HermesStep $pythonExe $updateArgs "update"
     Write-HandoffLog "hermes update exit code: $($res.Code)"
 
@@ -732,6 +794,7 @@ try {
         # One retry for the update-boundary class (fresh code on disk, stale
         # code in memory). Exit 2 ("close all Hermes windows") is not retryable.
         Write-HandoffLog "first attempt failed; retrying once (freshly pulled fix loads on the second run)"
+        Publish-UiProgress "Retrying update"
         $res = Invoke-HermesStep $pythonExe $updateArgs "update"
         Write-HandoffLog "retry exit code: $($res.Code)"
     }
@@ -744,6 +807,7 @@ try {
     $desktopBuildFailed = $false
     if ($res.Code -eq 0 -and $res.Output -match "Desktop build failed") {
         Write-HandoffLog "hermes update reported a desktop build failure (non-fatal there, fatal here); retrying build"
+        Publish-UiProgress "Rebuilding Desktop"
         $rebuild = Invoke-HermesStep $pythonExe @("-m", "hermes_cli.main", "desktop", "--force-build", "--build-only") "rebuild"
         Write-HandoffLog "desktop rebuild exit code: $($rebuild.Code)"
         if ($rebuild.Code -ne 0) { $desktopBuildFailed = $true }
@@ -775,6 +839,7 @@ try {
         Close-ProgressWindow
         [void](Start-DesktopRelaunch)
     } else {
+        Publish-UiProgress "Opening Hermes"
         $cameBack = Start-DesktopRelaunch
         if (-not $cameBack -and $RelaunchExe) {
             # Launch was due and did not verifiably land: truthful result

--- a/tests/test_desktop_update_windows_progress.py
+++ b/tests/test_desktop_update_windows_progress.py
@@ -1,0 +1,87 @@
+"""Behavioral coverage for quiet Windows Desktop updater progress."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import time
+from urllib.request import urlopen
+
+import pytest
+
+
+pytestmark = pytest.mark.windows_only
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_UPDATE_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def _read_progress(url: str) -> dict[str, object]:
+    with urlopen(f"{url}progress", timeout=2) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def test_progress_advances_while_update_child_is_silent(tmp_path: Path) -> None:
+    powershell = shutil.which("powershell.exe")
+    assert powershell, "Windows updater tests require Windows PowerShell."
+
+    output_path = tmp_path / "self-test-output.log"
+    env = os.environ.copy()
+    env["TEMP"] = str(tmp_path)
+    env["TMP"] = str(tmp_path)
+    env["HERMES_SELFTEST_HOLD_SECONDS"] = "3"
+    env["HERMES_SELFTEST_SILENT_CHILD"] = "1"
+    env["HERMES_SELFTEST_PYTHON"] = sys.executable
+
+    with output_path.open("wb") as output:
+        process = subprocess.Popen(
+            [
+                powershell,
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(WINDOWS_UPDATE_PS1),
+                "-SelfTestUi",
+                "-NoUi",
+            ],
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            env=env,
+        )
+
+    try:
+        deadline = time.monotonic() + 10
+        shim_url = None
+        while time.monotonic() < deadline:
+            text = output_path.read_text(encoding="utf-8", errors="replace")
+            match = re.search(r"SELF-TEST: shim at (http://127\.0\.0\.1:\d+/)", text)
+            if match:
+                shim_url = match.group(1)
+                break
+            if process.poll() is not None:
+                break
+            time.sleep(0.1)
+
+        assert shim_url, output_path.read_text(encoding="utf-8", errors="replace")
+        first = _read_progress(shim_url)
+        time.sleep(1.2)
+        second = _read_progress(shim_url)
+
+        assert first["status"] == "running"
+        assert first["message"] == "Testing quiet update"
+        assert second["message"] == first["message"]
+        assert int(second["elapsed_seconds"]) > int(first["elapsed_seconds"])
+
+        assert process.wait(timeout=10) == 0
+        final_output = output_path.read_text(encoding="utf-8", errors="replace")
+        assert "SELF-TEST: silent child exit code: 0" in final_output
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)


### PR DESCRIPTION
## What does this PR do?

Shows the current hand-off stage and elapsed time in the Desktop update window instead of leaving users on one unchanged spinner throughout a long Windows update.

A Discord support report showed the update completing successfully and restarting the gateway after roughly 18 minutes, while the update window gave no indication that the process was still advancing. This change keeps the quiet updater design and derives progress only from stages the hand-off orchestrator already controls.

The child-process safety behavior is unchanged: `Invoke-HermesStep` still drains stdout and stderr with `ReadToEndAsync()`, and the UI does not stream or parse child output. That preserves the fix for the old line pump freezing on quiet child processes.

## Related Issue

Discord support report: https://discord.com/channels/1053877538025386074/1539051636847022141

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/desktop-update/windows.ps1`
  - Publish only known hand-off stages: waiting for Desktop exit, preparing files, updating, retrying, rebuilding, and relaunching.
  - Track elapsed time with a monotonic stopwatch for the Edge shim and WinForms fallback.
  - Leave the asynchronous child-output drain unchanged.
- `scripts/desktop-update/ui.html`
  - Render the running stage and elapsed time while preserving the existing terminal outcome states.
  - Fall back to a client-side elapsed clock when the shared POSIX server does not provide one.
- `tests/test_desktop_update_windows_progress.py`
  - Run the real Windows hand-off helper against a silent child and prove the progress endpoint advances without blocking.

## How to Test

1. Run the focused Windows updater tests:
   ```bash
   scripts/run_tests.sh \
     tests/test_desktop_update_windows_python_handoff.py \
     tests/test_desktop_update_windows_timestamp.py \
     tests/test_desktop_update_windows_progress.py -q
   ```
2. Parse the Windows hand-off script with Windows PowerShell.
3. Parse the embedded JavaScript from `scripts/desktop-update/ui.html` with Node.js.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Focused updater tests pass; the full matrix is left to CI.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro build 26100

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; implementation comments describe the preserved safety contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the shared HTML accepts the existing POSIX response shape
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
3 files, 6 tests passed, 0 failed
POWERSHELL_PARSE_OK
UI_SCRIPT_PARSE_OK
```
