### PR TITLE
docs(readme): fix interrupt row for /busy steer model; add high-value quick starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ hermes setup        # Run the full setup wizard (configures everything at once)
 hermes claw migrate # Migrate from OpenClaw (if coming from OpenClaw)
 hermes update       # Update to the latest version
 hermes doctor       # Diagnose any issues
+hermes status       # Show current status (profile, gateway, model, session)
+hermes secrets bitwarden setup   # Connect Bitwarden Secrets Manager (install bws, store token, pick project)
+hermes security     # Security posture surface
+hermes egress       # Egress control surface
+hermes backup       # Back up sessions, config, and state
+hermes sessions     # List and manage sessions
+hermes insights     # Token/cost usage insights
 ```
 
 📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
@@ -153,7 +160,7 @@ Hermes has two entry points: start the terminal UI with `hermes`, or run the gat
 | Retry or undo the last turn    | `/retry`, `/undo`                             | `/retry`, `/undo`                                                                |
 | Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]`                                        |
 | Browse skills                  | `/skills` or `/<skill-name>`                  | `/<skill-name>`                                                                  |
-| Interrupt current work         | `Ctrl+C` or send a new message                | `/stop` or send a new message                                                    |
+| Interrupt current work         | `/busy steer` or `/stop`                     | `/stop` or send a new message                                                  |
 | Platform-specific status       | `/platforms`                                  | `/status`, `/sethome`                                                            |
 
 For the full command lists, see the [CLI guide](https://hermes-agent.nousresearch.com/docs/user-guide/cli) and the [Messaging Gateway guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging).

--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Axl Ibiza (andrexibiza) — canonical author identity


### PR DESCRIPTION
## What changed and why

The keystone README's quick-reference surfaces were stale against current `main`:

1. **"Interrupt current work" row contradicted the busy model.** It said `Ctrl+C` / "send a new message", but current main has a proper busy-input model: `/busy steer` injects your message into the running turn (no interrupt, no new turn), `/busy queue|interrupt|status` control what Enter does while working, and `/stop` is the hard stop. Updated the CLI column to `/busy steer` or `/stop`; the messaging column keeps `/stop`.

2. **High-value one-command quick starts were missing** from Getting Started. Added 7 commands that exist on main but weren't featured: `hermes status`, `hermes secrets bitwarden setup`, `hermes security`, `hermes egress`, `hermes backup`, `hermes sessions`, `hermes insights`.

Docs/README only — no behavior change.

## How to test

```bash
git diff README.md   # two changes: interrupt row + Getting Started quick starts
```

Verified each added quick-start command exists on main (`hermes status/security/egress/backup/sessions/insights/secrets` all resolve to CLI subcommands).

## Platforms tested

Docs-only; no code. `git diff --check` clean. Attribution audit green.

## Why this matters to users

Users looking up "how do I interrupt Hermes mid-task" were told `Ctrl+C` (which isn't the supported path) and "send a new message" (the disruptive behavior the release specifically replaced). Now the README points them at the real `/busy steer` and `/stop` model. And the new quick starts surface one-command entry points (`hermes secrets bitwarden setup`, `hermes security`, `hermes insights`, etc.) that otherwise required digging through prose or the docs site.

Fixes #78539
