### PR TITLE
docs(zh-Hans): remove machine-specific Hermes paths

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
@@ -36,13 +36,13 @@ description: "在仓库中编写 SKILL.md"
 SKILL.md 可以存放在两个位置：
 
 1. **用户本地：** `~/.hermes/skills/<maybe-category>/<name>/SKILL.md` — 个人使用，不共享。通过 `skill_manage(action='create')` 创建。
-2. **仓库内（本 skill 讨论此情况）：** `/home/bb/hermes-agent/skills/<category>/<name>/SKILL.md` — 已提交，随包一起发布。使用 `write_file` + `git add`。`skill_manage(action='create')` **不**针对此目录树。
+2. **仓库内（本 skill 讨论此情况）：** `skills/<category>/<name>/SKILL.md` 或 `optional-skills/<category>/<name>/SKILL.md`，位于 hermes-agent 仓库中——已提交，随包一起发布。使用 `write_file` + `git add`。`skill_manage(action='create')` **不**针对此目录树。
 
 ## 使用时机
 
 - 用户要求你"在此分支 / 仓库 / 提交中"添加一个 skill
 - 你正在提交一个应随 hermes-agent 一起发布的可复用工作流
-- 你正在编辑 `/home/bb/hermes-agent/skills/` 下的现有 skill（小改动用 `patch`，重写用 `write_file`；`skill_manage` 对仓库内 skill 的 `patch` 仍有效，但 `create` 无效）
+- 你正在编辑 `skills/` 或 `optional-skills/` 下的现有 skill（小改动用 `patch`，重写用 `write_file`；`skill_manage` 对仓库内 skill 的 `patch` 仍有效，但 `create` 无效）
 
 ## 必需的 Frontmatter
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger.md
@@ -201,7 +201,7 @@ TUI 基于 Ink + tsx 构建。两种常见场景：
 `ui-tui/package.json` 有 `npm run dev`（tsx --watch）。直接运行 tsx 并添加 `--inspect-brk`：
 
 ```bash
-cd /home/bb/hermes-agent/ui-tui
+cd <hermes-agent-repo>/ui-tui
 npm run build    # produce dist/ once so transpile isn't needed on first load
 node --inspect-brk dist/entry.js
 # In another terminal:
@@ -245,7 +245,7 @@ node inspect ws://127.0.0.1:9229/<uuid>
 ## 在调试器下运行 Vitest 测试
 
 ```bash
-cd /home/bb/hermes-agent/ui-tui
+cd <hermes-agent-repo>/ui-tui
 # Run a single test file paused on entry
 node --inspect-brk ./node_modules/vitest/vitest.mjs run --no-file-parallelism src/app/foo.test.tsx
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-python-debugpy.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-python-debugpy.md
@@ -167,7 +167,7 @@ sys.excepthook = excepthook
 ### 安装
 
 ```bash
-source /home/bb/hermes-agent/.venv/bin/activate
+source <hermes-agent-repo>/.venv/bin/activate
 pip install debugpy
 ```
 
@@ -264,7 +264,7 @@ send({"type": "request", "command": "configurationDone"})
   "connect": { "host": "127.0.0.1", "port": 5678 },
   "justMyCode": false,
   "pathMappings": [
-    { "localRoot": "${workspaceFolder}", "remoteRoot": "/home/bb/hermes-agent" }
+    { "localRoot": "${workspaceFolder}", "remoteRoot": "<hermes-agent-repo>" }
   ]
 }
 ```


### PR DESCRIPTION
## Hypothesis
The zh-Hans bundled skill docs still contain maintainer-specific `/home/bb/hermes-agent` paths after the English source docs were generalized, so Chinese readers get checkout-specific instructions that don't work outside one machine.

## Change
- Replaced hardcoded `/home/bb/hermes-agent` checkout paths with `<hermes-agent-repo>` in the zh-Hans Node inspector and debugpy docs.
- Updated the zh-Hans in-repo skill-authoring doc to reference `skills/` and `optional-skills/` generically instead of a maintainer home directory.

## Verification
- Compared each zh-Hans snippet against the current English source docs, which already use repo-relative placeholders.
- Re-grepped `website/i18n/zh-Hans` to confirm no `/home/bb/hermes-agent` references remain.
- No runtime tests run; docs-only change.

Linked: none

---
_Drafted by Hermes nightly-explore. Not for merge until Raphael verifies._
