### PR TITLE
docs: unified Gateways page, settings profile scope, plugins cleanup, Bot Mode group rows, host.openWorkspace

### DIFF
--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -407,6 +407,9 @@ host.openSession(id, { profile?, intent? }) // open a stored session core-style;
                                            //   profile: soft-swap to that profile's backend first
                                            //   intent: 'in-place' (default) | 'stack' | 'tab' | 'window'
 host.newChat(profile?)                     // fresh chat draft, optionally in another profile
+host.openWorkspace(id, { render, title?, minWidth?, onClose? })
+                                           // dock a plugin-rendered tab into the MAIN
+                                           //   workspace zone and reveal it; returns a disposer
 host.onEvent(type, fn)                     // gateway event stream ('*' = all); returns disposer
 host.logs(...)                             // tail an app log file
 host.status()                              // one-shot system status snapshot
@@ -423,6 +426,17 @@ cron, kanban, …). `host.requestProfile` accepts a descriptor from
 profile without changing the active chat or gateway. The profile-only overload is
 retained only for the sole-local/legacy topology; registry-aware plugins should pass
 the descriptor so two sources exposing the same profile name cannot collide.
+
+`host.openWorkspace(id, { render, title?, minWidth?, onClose? })` docks a
+plugin-rendered view into the **main workspace zone** — the same center area
+session tiles and previews use — as a tab, and reveals it. Re-calling it with
+the same `id` refreshes the content in place and re-fronts the tab instead of
+opening a duplicate. Closing the tab (the tab's Close control or ⌘W) tears the
+registration down and fires your `onClose`; the returned disposer closes it
+programmatically. Feature-detect it (`typeof host.openWorkspace ===
+'function'`) and fall back to a regular contributed pane on older desktop
+builds — Bot Mode's group-chat rooms are the reference consumer (main-window
+takeover when available, in-panel view otherwise).
 
 `host.profileRoutes()` inventories every registered source in the current connection
 registry. Connect-on-demand SSH sources expose a credential-free `default` seed

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -151,6 +151,17 @@ Manage providers, models, tools, and credentials from a real UI instead of editi
 
 First-run onboarding has been redesigned on a unified overlay design system, and you can pick **Choose provider later** to skip provider setup and get into the app first.
 
+#### Per-profile settings: the "Applies to" scope
+
+When you have two or more [profiles](./profiles.md), the config-backed settings pages — **Model, Workspace, Safety, Memory & Context, Voice, Chat, Advanced, and Tools & Keys** — and the **Messaging** overlay show a shared **Applies to** chip row at the top. It selects which profile your edits target:
+
+- The default selection **follows the active profile**, which behaves exactly as before — edit the profile you're using.
+- Pick another profile to view and edit *its* settings without switching the whole app; the selection persists as you move between settings pages.
+- Switching the app's active profile resets the selector, so edits can't silently keep landing on a previously selected profile.
+- With fewer than two profiles the chip row is hidden entirely.
+
+(The Gateways page handles profiles differently — via its **Per-profile overrides** subsection — and the Capabilities and Scheduled Jobs views have their own scope selectors.)
+
 ### Management panes
 
 The app also surfaces the broader Hermes management surface so you don't have to drop to a terminal:
@@ -172,6 +183,12 @@ pet), its own canonical **Bot Chat** conversation, and its own **Routines**
 Name / Title / Description plus an Advanced disclosure with the full
 capabilities surface (model, SOUL, skills, toolsets, MCP servers) — group
 them into sections, and open group chats where several bots deliberate.
+Group chats appear as standalone Discord-style rows in the roster — stacked
+member avatars, member count, a preview of the latest room line, and the
+"needs you" badge — interleaved with the bot rows in the same pin+recency
+ordering. Clicking a group row opens the room as a tab that takes over the
+**main chat window** (older desktop builds fall back to opening it inside the
+bots side panel).
 
 Bots message each other: type `@researcher have a look at this` in any chat
 and the active bot hands the message off and reports back, and bots reach
@@ -244,24 +261,26 @@ The packaged app ships the Electron shell and a native React chat surface. On fi
 
 By default the app starts and manages its own **local** backend. You can instead point it at a Hermes backend running on another machine — a VPS, a home server, or a Mini behind Tailscale.
 
-**Settings → Gateway → Connection mode** offers the alternatives to the local gateway:
+Everything connection-related lives on one settings page: **Settings → Gateways**. (Older builds split this across separate **Gateway** and **Connections** pages — those are now unified, and old `?tab=connections` deep links redirect to the unified page.)
+
+**Settings → Gateways → Connection mode** offers the alternatives to the local gateway:
 
 - **Remote gateway** — enter the URL of a `hermes serve` backend you run yourself and sign in. This is the mode the rest of this section walks through.
 - **Hermes Cloud** — sign in once to Hermes Cloud and pick from the agents on your account; no URL to paste. The app discovers your agents (with an organization picker if your account spans several orgs), and connecting to one switches the session over automatically. The status bar shows the cloud connection while it's active.
 
-Connection modes are configured **per profile** — a per-profile override can point one profile at a remote or cloud backend while others stay local (**Use default gateway** removes an override).
+Connection modes are configured **per profile** — the page's **Per-profile overrides** subsection lists the default connection and each named profile, with an **Edit** affordance per row, so one profile can point at a remote or cloud backend while others stay local (**Use default gateway** removes an override).
 
-### Settings → Connections: the multi-connection registry
+### The multi-connection registry
 
-Alongside the per-profile connection mode above, **Settings → Connections** manages a named registry of every agent source the app knows about — the local runtime, any number of remote gateways (LAN, Tailscale, internet), Hermes Cloud instances, and SSH hosts — all persisted together in one place. You can jump there from the plug button at the right end of the sidebar profile rail (**Connect another Hermes gateway…**) or via **⌘K → Connections**. The full guide, including the union agent roster, `@name-device` handles, fleet-wide updates, and the plugin SDK surface, is at [Connecting Desktop to Many Hermes Instances](./multi-connection-desktop.md).
+Further down the same **Settings → Gateways** page, the connections registry manages a named list of every agent source the app knows about — the local runtime, any number of remote gateways (LAN, Tailscale, internet), Hermes Cloud instances, and SSH hosts — all persisted together in one place. You can jump there from the plug button at the right end of the sidebar profile rail (**Connect another Hermes gateway…**) or via **⌘K → Gateways**. The full guide, including the union agent roster, `@name-device` handles, fleet-wide updates, and the plugin SDK surface, is at [Connecting Desktop to Many Hermes Instances](./multi-connection-desktop.md).
 
 - **Every connection needs a unique name** (a device name such as "Homelab" or "Work laptop"). When the same profile name exists on several registered sources, surfaces disambiguate it as `@profile-device` (e.g. `@research-homelab`).
-- **Add / edit / remove / test** connections from the panel. The local entry is managed by the app and cannot be removed. **Test** probes the connection's own HTTP and WebSocket legs directly.
+- **Add / edit / remove / test** connections from the panel. The **Add** flow offers all four kinds — **Local**, **Hermes Cloud**, **Remote gateway**, and **SSH** (the Local button is disabled while the app-managed local entry exists, and a hint points cloud adds at the sign-in/discovery flow above). The local entry is managed by the app and cannot be removed. **Test** probes the connection's own HTTP and WebSocket legs directly.
+- **Duplicates are rejected at save time**: only one **local** entry ever; remote and cloud entries are deduplicated on the normalized URL (trimmed, trailing slashes stripped, lowercased — across both kinds); SSH entries on the normalized `user@host:port` plus remote profile.
 - Existing settings are **imported automatically** the first time you run a build with the registry: your current global connection and any per-profile overrides become named entries. The legacy settings file is left untouched, so older builds keep working.
-- Cloud entries come from the Hermes Cloud sign-in/discovery flow above, not from a hand-typed URL.
-- Tokens are stored encrypted with the OS keyring (with the same explicit plain-text opt-in as Settings → Gateway on keyring-less Linux).
+- Tokens are stored encrypted with the OS keyring (with an explicit plain-text opt-in on keyring-less Linux).
 
-Side-by-side routing is live: each registered source dials its own backends and sockets on demand (keyed per connection + profile), the plugin SDK exposes the union agent roster (`host.agents()` / `host.ensureAgent()`), and **Update all instances** in the Connections panel dispatches `hermes update` to every eligible source at once — Hermes Cloud entries are skipped (the platform updates them), and each instance reports its own result.
+Side-by-side routing is live: each registered source dials its own backends and sockets on demand (keyed per connection + profile), the plugin SDK exposes the union agent roster (`host.agents()` / `host.ensureAgent()`), and **Update all instances** on the Gateways page dispatches `hermes update` to every eligible source at once — Hermes Cloud entries are skipped (the platform updates them), and each instance reports its own result.
 
 
 :::info The remote backend is a running `hermes serve` process
@@ -312,13 +331,13 @@ The backend reads and writes your `.env` (API keys, secrets) and can run agent c
 
 ### In the app
 
-**Settings → Gateway → Remote gateway:**
+**Settings → Gateways → Remote gateway:**
 
 1. **Remote URL** — `http://<backend-host>:9119` (path prefixes like `/hermes` work if you front it with a reverse proxy)
 2. **Sign in** — the app detects which provider the backend advertises and adapts the button. For a username/password backend it shows a **Sign in** button that opens a credential form (enter the credentials from step 1). For an OAuth backend it shows **Sign in with `<provider>`** (e.g. *Sign in with Nous Research*), which runs the provider's browser sign-in. Either way the app ends up with an authenticated session against the backend.
 3. **Save and reconnect** — switches the desktop shell onto the remote backend. The session refreshes automatically; you stay signed in across restarts when `HERMES_DASHBOARD_BASIC_AUTH_SECRET` is set.
 
-You can also set the backend URL without the UI via the `HERMES_DESKTOP_REMOTE_URL` environment variable before launching the app (it overrides the in-app setting); you still sign in from the Gateway settings panel.
+You can also set the backend URL without the UI via the `HERMES_DESKTOP_REMOTE_URL` environment variable before launching the app (it overrides the in-app setting); you still sign in from the Gateways settings panel.
 
 :::note Per-profile remote hosts
 The remote gateway host is configured per [profile](./profiles.md), so each profile can point at its own remote backend (or stay on its local one). Switching profiles switches which remote host the app connects to.
@@ -343,6 +362,16 @@ hot-reloads every save. Manage installed plugins live in **Settings → Plugins*
 
 See [Desktop Plugin SDK](../developer-guide/desktop-plugin-sdk.md) for the full
 reference. (This is separate from the [web dashboard plugin system](./features/extending-the-dashboard.md).)
+
+The **Agent plugins** section on the same Settings → Plugins page manages
+backend (agent-side) [plugins](./features/plugins.md) you installed — user,
+git, project, pip, and portable installs. Repo-bundled built-ins (platform
+adapters, provider plugins, and similar) are not listed there: they ship
+enabled by default and are configured from their own surfaces, so the section
+stays focused on what you added yourself. With two or more profiles the
+section also has its own **Applies to** selector, so you can list and toggle
+another profile's agent plugins without switching the whole app (the backend
+`plugins.manage` RPC accepts an optional `profile` parameter for this).
 
 ## Troubleshooting
 

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -153,7 +153,7 @@ To point [Hermes Desktop](#connecting-hermes-desktop-to-a-remote-backend) at a d
 
 ### Connecting Hermes Desktop to a remote backend
 
-Hermes Desktop normally launches its own local backend, but it can also attach to a dashboard running on a remote machine (a VM, a homelab box, etc.) via **Settings → Gateway → Remote gateway**. This is the most common source of "Desktop says the backend is ready but chat never works" reports, because Desktop's readiness check verifies less than the live chat connection actually needs.
+Hermes Desktop normally launches its own local backend, but it can also attach to a dashboard running on a remote machine (a VM, a homelab box, etc.) via **Settings → Gateways → Remote gateway**. This is the most common source of "Desktop says the backend is ready but chat never works" reports, because Desktop's readiness check verifies less than the live chat connection actually needs.
 
 :::info Prerequisite: a `hermes dashboard` must be running on the remote host
 The "remote backend" Desktop connects to **is** a `hermes dashboard` process running on the remote machine — the same server this page documents. It has to be up and reachable before any of the steps below matter; Desktop attaches to it, it doesn't start it for you. Keep it running under `systemd`/`tmux`/etc. so it survives logout and reboots. The **gateway** (Telegram/Discord/Slack/etc.) is a *separate* long-running process — start it independently if you rely on messaging channels; it is not the thing the desktop app connects to.
@@ -199,7 +199,7 @@ curl -s http://VM_IP:9119/api/status | jq '.auth_required, .auth_providers'
 - `auth_required: true` but no `"basic"` provider → the username/password env vars aren't loaded. Fix those first.
 :::
 
-If `/api/status` shows the gate is on with the `"basic"` provider and Desktop *still* fails to connect after signing in, the issue is past basic setup — grab a fresh `desktop.log` (Settings → Gateway → Open logs) plus the dashboard's logs from the same retry window and look for the `/api/ws` close code (4403 = chat WS rejected by the request guard, e.g. Host/peer mismatch; 4401 = the WS ticket didn't authenticate).
+If `/api/status` shows the gate is on with the `"basic"` provider and Desktop *still* fails to connect after signing in, the issue is past basic setup — grab a fresh `desktop.log` (Settings → Gateways → Open logs) plus the dashboard's logs from the same retry window and look for the `/api/ws` close code (4403 = chat WS rejected by the request guard, e.g. Host/peer mismatch; 4401 = the WS ticket didn't authenticate).
 
 ### Config
 
@@ -1040,7 +1040,7 @@ The dashboard's React StatusPage shows the same fields under "Web server". A sid
 
 ## Connecting Hermes Desktop to a remote backend
 
-Hermes Desktop can drive a Hermes backend running on another machine (a VPS, a home server, a Mini behind Tailscale). In the app this lives under **Settings → Gateway → Remote gateway**, which asks for a **Remote URL** and a way to **Sign in**. (For the desktop app itself — install, settings, chat — see the [Hermes Desktop](/user-guide/desktop) page.)
+Hermes Desktop can drive a Hermes backend running on another machine (a VPS, a home server, a Mini behind Tailscale). In the app this lives under **Settings → Gateways → Remote gateway**, which asks for a **Remote URL** and a way to **Sign in**. (For the desktop app itself — install, settings, chat — see the [Hermes Desktop](/user-guide/desktop) page.)
 
 You protect the remote dashboard with one of the bundled auth providers, and the desktop app signs in against whichever one the backend advertises. For a backend reachable beyond your own machine — a VPS, a public host, anything internet-facing — the recommended provider is **OAuth (Nous Portal)** (register it with [`hermes dashboard register`](#registering-a-dashboard) and sign in with *Sign in with Nous Research*). The bundled [username/password provider](#usernamepassword-provider-no-oauth-idp) is the quickest option when the backend is on a trusted LAN or reachable only over a VPN, but is **not suitable for direct public-internet exposure**. Binding the dashboard to a non-loopback address engages its auth gate; once signed in, Desktop reuses the session for the chat WebSocket automatically — there is no token to copy or paste.
 
@@ -1073,7 +1073,7 @@ The dashboard reads and writes your `.env` (API keys, secrets) and can run agent
 
 ### In Hermes Desktop
 
-**Settings → Gateway → Remote gateway:**
+**Settings → Gateways → Remote gateway:**
 
 - **Remote URL** — `http://<backend-host>:9119` (path prefixes like `/hermes` are supported if you front it with a reverse proxy)
 - **Sign in** — the app detects the username/password gateway and shows a **Sign in** button; click it and enter the credentials from step 1

--- a/website/docs/user-guide/multi-connection-desktop.md
+++ b/website/docs/user-guide/multi-connection-desktop.md
@@ -17,20 +17,24 @@ app talking to several machines.
 
 ## Where to find it
 
-Three doors lead to the same pane:
+Everything lives on the unified **Settings → Gateways** page (older builds had
+separate **Gateway** and **Connections** pages; legacy Connections deep links
+redirect there). Three doors lead to it:
 
-- **Settings → Connections** — the pane itself (**Cmd/Ctrl+,**, then
-  **Connections** in the settings nav).
+- **Settings → Gateways** — the page itself (**Cmd/Ctrl+,**, then
+  **Gateways** in the settings nav). The connections registry is a section
+  of that page, below the connection-mode and per-profile override controls.
 - **The sidebar profile rail** — the plug button at the right end of the rail
   (tooltip: **"Connect another Hermes gateway…"**) deep-links straight to
-  Settings → Connections. It is always visible, even before you have created
+  the Gateways page. It is always visible, even before you have created
   a second profile or a second connection.
-- **The command palette** — **Cmd/Ctrl+K**, then type *Connections* (also
-  matches *add gateway*, *remote*, *ssh*, *instances*).
+- **The command palette** — **Cmd/Ctrl+K**, then type *Gateways* (also
+  matches *connections*, *add gateway*, *remote*, *ssh*, *instances*).
 
 ## The connection registry
 
-**Settings → Connections** manages a named registry of agent sources. The
+The registry section of **Settings → Gateways** manages a named list of agent
+sources. The
 pane's intro says it plainly: *"Register every place your agents live — this
 device, remote gateways on your network, and Hermes Cloud instances. All of
 them are stored here."* Each entry is a *connection*:
@@ -58,19 +62,29 @@ Rules worth knowing:
 - **Test** probes the connection's own HTTP *and* WebSocket legs, so a pass
   (the *"Reachable"* toast) means chat will actually work — not just that the
   host pinged.
-- Cloud entries come from the Hermes Cloud sign-in/discovery flow
-  (Settings → Gateway), not a hand-typed URL — which is why the add-connection
-  editor only offers **Remote gateway** and **SSH**.
+- **Duplicates are rejected when you save**: there is only ever one **local**
+  entry; **remote** and **cloud** entries are deduplicated on the normalized
+  URL (trimmed, trailing slashes stripped, lowercased — and across both
+  kinds, so a cloud entry and a remote entry can't point at the same URL);
+  **SSH** entries are deduplicated on the normalized `user@host:port` plus
+  remote profile.
+- Cloud entries normally come from the Hermes Cloud sign-in/discovery flow at
+  the top of the Gateways page — the **Hermes Cloud** kind in the add-connection
+  editor points you there.
 
 As the pane's own caption notes: *"Chats and the agent roster follow the
-source you pick; the app-managed window backend is still chosen in
-Settings → Gateway."*
+source you pick; the app-managed window backend is still chosen by the
+connection-mode controls above."*
 
 ## Adding a connection, step by step
 
-1. Open **Settings → Connections** (or click the plug in the profile rail).
+1. Open **Settings → Gateways** and scroll to the connections registry (or
+   click the plug in the profile rail).
 2. Click **Add connection**.
-3. Pick the kind: **Remote gateway** or **SSH**.
+3. Pick the kind: **Local**, **Hermes Cloud**, **Remote gateway**, or **SSH**.
+   (**Local** is disabled while the app-managed local entry exists — which is
+   almost always; **Hermes Cloud** directs you to the cloud sign-in/discovery
+   flow above.)
 4. Fill the fields:
    - **Name** — required, unique; the "device name" shown everywhere this
      instance appears (placeholder: `Homelab`). Max 64 characters.
@@ -108,7 +122,8 @@ and Tailscale guidance.
 
 The first launch of a registry-capable build imports your existing settings
 automatically: the global connection mode and any per-profile overrides from
-Settings → Gateway become named registry entries (deduplicated by URL/host).
+the old Gateway settings become named registry entries (deduplicated by
+URL/host).
 The legacy settings file is left untouched, so older builds on the same
 machine keep working. If a migrated name collided, it was suffixed
 (`Homelab 2`).
@@ -153,7 +168,7 @@ Switching agents is the same gesture as switching profiles:
 
 ## Updating every instance at once
 
-**Settings → Connections → Update all instances** (shown once more than one
+**Settings → Gateways → Update all instances** (shown once more than one
 connection is registered) dispatches `hermes update` to every eligible
 connection in parallel:
 
@@ -178,7 +193,7 @@ with their own message, per row.
   refreshed automatically before expiry.
 - **Keyring-less Linux.** On a Linux session without a usable keychain the
   app cannot encrypt the token; saving one raises an explicit opt-in dialog
-  (the same consent flow as Settings → Gateway) before it will store the
+  before it will store the
   token in plain text.
 - **The registry file** (`connections.json` under the app's user-data
   directory) holds labels, URLs, and hosts — secrets only ever appear inside


### PR DESCRIPTION
Docs now match the five desktop changes that just merged: the unified **Gateways** settings page, the shared **Applies to** profile scope, the Agent-plugins cleanup, Bot Mode's group-chat rows opening in the main window, and the new `host.openWorkspace` plugin SDK door.

## What changed

### `user-guide/desktop.md`
- **Gateways page** — retitled every `Settings → Gateway` / `Settings → Connections` reference to the unified **Settings → Gateways** page, noted the legacy `?tab=connections` redirect, described the **Per-profile overrides** subsection, the Add flow's four kinds (Local / Hermes Cloud / Remote gateway / SSH), and the save-time duplicate rules (one local ever; URL-normalized dedupe across remote/cloud; `user@host:port` + remote profile for SSH).
- **New "Per-profile settings: the *Applies to* scope" section** — the shared chip row on Model / Workspace / Safety / Memory & Context / Voice / Chat / Advanced / Tools & Keys and the Messaging overlay: follows the active profile by default, hidden with <2 profiles, resets on profile switch.
- **Agent plugins** — documented that the section lists only user/git/project/pip/portable installs (bundled built-ins hidden), and its own Applies to selector backed by `plugins.manage`'s optional `profile` param.
- **Bot Mode** — group chats are standalone Discord-style roster rows and open as a tab in the **main chat window**, with the in-panel fallback on older builds.

### `user-guide/multi-connection-desktop.md`
- Reoriented the whole page onto **Settings → Gateways** (where-to-find-it doors, registry intro, add-connection steps with all four kinds, Update-all, security notes), and documented the duplicate-rejection rules.

### `developer-guide/desktop-plugin-sdk.md`
- Added `host.openWorkspace(id, { render, title?, minWidth?, onClose? })` to the Host API listing plus a paragraph on its semantics: docks into the main workspace zone, same-id re-open refreshes/re-fronts, Close/⌘W teardown + `onClose`, returned disposer, and feature-detection fallback (Bot Mode is the reference consumer).

### `user-guide/features/web-dashboard.md`
- Retitled its `Settings → Gateway → Remote gateway` / `Open logs` references to **Gateways**.

No new pages, so `sidebars.ts` is untouched. Skills Hub layout fix (#88737) needed no docs — nothing described the old layout.

## Validation
- `npx docusaurus build` passes (link/anchor check clean for the touched pages; the zh-Hans anchor warnings are pre-existing).

## Infographic
![Desktop Docs Refresh](https://v3b.fal.media/files/b/0aa6c388/4yukBoBPh0bbRRd0Jll9A_sjdakPrV.png)
