### PR TITLE
fix(desktop): fail-stop deleted-profile reconnects and evict the stale rail badge

### DIFF
--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -303,6 +303,12 @@ export const host = {
     retireLocalProfileGateways(name)
     await deleteProfile(name)
 
+    // The profile rail paints from the shared $profiles cache; without a
+    // refresh the deleted profile's badge survives and clicking it starts a
+    // doomed spawn-retry loop against Electron's deletion guard (#88769).
+    // Best-effort: the delete itself already succeeded.
+    await refreshProfiles().catch(() => undefined)
+
     if (wasActive) {
       selectProfile('default')
       setActiveProfile('default')

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -130,6 +130,9 @@ describe('connection-aware plugin host APIs', () => {
 
     expect(order).toEqual(['retire', 'delete'])
     expect(retireLocalProfileGateways).toHaveBeenCalledWith('worker')
+    // The rail paints from $profiles; skipping the refresh leaves a stale
+    // badge whose click hot-loops against the deletion guard (#88769).
+    expect(refreshProfiles).toHaveBeenCalled()
   })
 
   it('refreshes the profile inventory before asking Electron for routes', async () => {

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -51,6 +51,7 @@ const {
   disposeSecondariesForConnection,
   ensureActiveGatewayOpen,
   ensureGatewayForAgent,
+  ensureGatewayForProfile,
   openGatewayForProfile,
   reconnectSecondaryGateways,
   retireLocalProfileGateways,
@@ -240,5 +241,71 @@ describe('reconnect fail-stop on a removed connection', () => {
     const reopened = await ensureActiveGatewayOpen()
 
     expect(reopened).not.toBeNull()
+  })
+
+  it('evicts a LOCAL profile entry when the deletion guard reports the profile gone (#88769)', async () => {
+    // A stale rail badge clicked after deletion drives reconnects against
+    // Electron's spawn guard, which rejects every attempt. That rejection is
+    // permanent — the loop must fail-stop, not hammer the guard on backoff.
+    // sharedPrimaryRoute probes getConnection too, so resolve enough calls to
+    // get the socket open before the guard starts rejecting.
+    let connectionCalls = 0
+
+    const getConnection = vi.fn(async () => {
+      connectionCalls += 1
+
+      if (connectionCalls <= 3) {
+        return descriptorFor('legacy-local', 'selena')
+      }
+
+      throw new Error('Profile "selena" no longer exists.')
+    })
+
+    installDesktop({ getConnection })
+
+    await openGatewayForProfile('selena')
+    await ensureGatewayForProfile('selena')
+    expect(gatewayMocks.instances).toHaveLength(1)
+    connectionCalls = 99
+
+    const socket = gatewayMocks.instances[0] as unknown as { connectionState: string }
+    socket.connectionState = 'closed'
+
+    // Drive the reconnect: the guard rejection must dispose + evict.
+    const result = await ensureActiveGatewayOpen()
+
+    expect(result).toBeNull()
+    const callsAfterFailStop = getConnection.mock.calls.length
+    await ensureActiveGatewayOpen()
+    expect(getConnection.mock.calls.length).toBe(callsAfterFailStop)
+  })
+
+  it('fail-stops on the mid-delete guard rejection too', async () => {
+    let connectionCalls = 0
+
+    const getConnection = vi.fn(async () => {
+      connectionCalls += 1
+
+      if (connectionCalls <= 3) {
+        return descriptorFor('legacy-local', 'selena')
+      }
+
+      throw new Error('Profile "selena" is being deleted.')
+    })
+
+    installDesktop({ getConnection })
+
+    await openGatewayForProfile('selena')
+    await ensureGatewayForProfile('selena')
+    connectionCalls = 99
+
+    const socket = gatewayMocks.instances[0] as unknown as { connectionState: string }
+    socket.connectionState = 'closed'
+
+    await ensureActiveGatewayOpen()
+
+    const callsAfterFailStop = getConnection.mock.calls.length
+    await ensureActiveGatewayOpen()
+    expect(getConnection.mock.calls.length).toBe(callsAfterFailStop)
   })
 })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -325,12 +325,20 @@ async function reconnectSecondary(entry: Secondary): Promise<void> {
     entry.reconnectAttempt = 0
   } catch (error) {
     // The registry no longer knows this connection (removed while we were
-    // backing off). Retrying forever can never succeed — fail-stop: dispose
-    // the entry and evict it instead of an infinite 15s-cap retry loop.
-    if (entry.connectionId && isMissingConnectionError(error)) {
+    // backing off), or Electron's deletion guard reports the profile itself
+    // gone/mid-delete. Both are permanent for this scoped socket — retrying
+    // forever can never succeed and hammers the spawn guard every backoff
+    // tick (#88769). Fail-stop: dispose the entry and evict it instead of an
+    // infinite 15s-cap retry loop.
+    if ((entry.connectionId && isMissingConnectionError(error)) || isMissingProfileError(error)) {
       entry.reconnecting = false
       disposeSecondary(entry)
-      g.secondaries.delete(entry.scope)
+
+      if (g.secondaries.get(entry.scope) === entry) {
+        g.secondaries.delete(entry.scope)
+      }
+
+      restoreActiveToPrimaryIfEvicted()
 
       return
     }
@@ -351,6 +359,16 @@ function isMissingConnectionError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error ?? '')
 
   return message.includes('No connection with id')
+}
+
+// Electron's spawn guard (assertLocalProfileCanStart) rejects with these when
+// the profile's directory is gone or its DELETE is still in flight. For a
+// renderer socket that condition is permanent: the backend it reconnects to
+// can never come back, and every retry hammers the guard (#88769).
+function isMissingProfileError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return message.includes('no longer exists') || message.includes('is being deleted')
 }
 
 function createSecondary(profile: string, connectionId: null | string = null): Secondary {


### PR DESCRIPTION
## Summary

Fixes the renderer half of #88769: a deleted profile's ghost rail badge no longer survives Bot Mode deletion, and a renderer socket whose reconnect the deletion guard permanently rejects now fail-stops instead of hammering the spawn guard forever.

Root cause: the secondary-socket reconnect loop only fail-stopped on missing REGISTRY connections; Electron's spawn-guard rejections ("no longer exists" / "is being deleted") fell into the transient-transport bucket and retried on the 15s-cap backoff indefinitely (40+ rejected spawn attempts observed in 3 minutes during the live E2E). Separately, the Bot Mode SDK `deleteProfile` path never refreshed `$profiles`, so the rail kept painting a clickable badge for the dead profile — the thing that kicked the loop off.

## Changes

- `apps/desktop/src/store/gateway.ts`: `isMissingProfileError()` — the deletion-guard rejections join the missing-connection fail-stop in `reconnectSecondary()`; the entry is disposed, evicted (identity-checked), and the active key restored to the primary.
- `apps/desktop/src/sdk/index.ts`: `host.deleteProfile()` refreshes `$profiles` (best-effort) after a successful delete, matching the Desktop dialog path which already refreshed via `onDeleted`.
- Tests: two fail-stop regressions (profile-gone + mid-delete, sabotage-verified to fail without the fix) and a refresh assertion on the SDK delete ordering test.

## Validation

| Check | Result |
|---|---|
| ui vitest (lifecycle + sdk routing) | 17/17 pass |
| sabotage run (fix reverted) | exactly the 2 new tests fail |
| typecheck (all 3 tsconfigs) | pass |
| eslint on touched files | 0 errors |

Fixes #88769.

## Infographic

![Ghost badge neutralized](https://v3b.fal.media/files/b/0aa6c389/LmXenmkDWDEep6YElKozr_PRiSsd40.png)
