### PR TITLE
fix(plugins): hide bundled model providers from plugin list (salvage #27268)

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1857,11 +1857,14 @@ def _discover_all_plugins() -> list:
     """
     seen: dict = {}  # key -> (name, version, description, source, path, key)
 
-    # Bundled (<repo>/plugins/<name>/), excluding memory/ and context_engine/
+    # Bundled (<repo>/plugins/<name>/), excluding memory/, context_engine/
+    # and model-providers/ — model providers load through the dedicated
+    # provider registry (providers/__init__.py), not the general PluginManager
+    # opt-in surface, so listing them as toggleable plugins is misleading.
     from hermes_cli.plugins import get_bundled_plugins_dir
     repo_plugins = get_bundled_plugins_dir()
     for base, source, skip in (
-        (repo_plugins, "bundled", {"memory", "context_engine"}),
+        (repo_plugins, "bundled", {"memory", "context_engine", "model-providers"}),
         (_plugins_dir(), "user", set()),
     ):
         _scan_level(base, source, skip, "", 0, seen)

--- a/tests/hermes_cli/test_plugins_cmd_category_discovery.py
+++ b/tests/hermes_cli/test_plugins_cmd_category_discovery.py
@@ -146,6 +146,68 @@ class TestDiscoverAllPlugins:
         assert "web/tavily" in keys
         assert "a/b/c" not in keys
 
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_bundled_model_providers_skipped(self, mock_user_dir, mock_bundled_dir, tmp_path):
+        """``plugins/model-providers/`` has its own provider registry loader.
+
+        Bundled providers should not appear in ``hermes plugins list`` as
+        general opt-in plugins, or users get a misleading enable/disable
+        surface for providers selected via ``model.provider`` / ``--provider``.
+        Same rationale as the existing bundled memory/context_engine skip.
+        """
+        from hermes_cli.plugins_cmd import _discover_all_plugins
+
+        bundled = tmp_path / "bundled"
+        user = tmp_path / "user"
+        user.mkdir()
+        _make_category_plugin(bundled, "model-providers", "openrouter", {
+            "name": "openrouter-provider", "version": "1.0.0",
+            "kind": "model-provider",
+        })
+        _make_category_plugin(bundled, "memory", "letta", {
+            "name": "letta-memory", "version": "1.0.0"
+        })
+        _make_category_plugin(bundled, "context_engine", "compressor", {
+            "name": "compressor", "version": "1.0.0"
+        })
+        _make_category_plugin(bundled, "observability", "langfuse", {
+            "name": "langfuse", "version": "1.0.0"
+        })
+        mock_user_dir.return_value = user
+        mock_bundled_dir.return_value = bundled
+
+        entries = _discover_all_plugins()
+        keys = [e[5] for e in entries]
+        assert "model-providers/openrouter" not in keys
+        assert "memory/letta" not in keys
+        assert "context_engine/compressor" not in keys
+        assert "observability/langfuse" in keys
+
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_user_model_providers_subdir_is_still_scanned(
+        self, mock_user_dir, mock_bundled_dir, tmp_path
+    ):
+        """The model-providers skip only applies to *bundled* — a user plugin
+        at ``~/.hermes/plugins/model-providers/<x>/`` is still discovered so
+        ``hermes plugins list`` shows what the user installed."""
+        from hermes_cli.plugins_cmd import _discover_all_plugins
+
+        bundled = tmp_path / "bundled"
+        bundled.mkdir()
+        user = tmp_path / "user"
+        _make_category_plugin(user, "model-providers", "acme", {
+            "name": "acme-provider", "version": "0.1.0",
+            "kind": "model-provider",
+        })
+        mock_user_dir.return_value = user
+        mock_bundled_dir.return_value = bundled
+
+        entries = _discover_all_plugins()
+        keys = [e[5] for e in entries]
+        assert "model-providers/acme" in keys
+
 
 # ---------------------------------------------------------------------------
 # _plugin_status — key-aware status


### PR DESCRIPTION
Salvage of #27268 by @felix-windsor — bundled `plugins/model-providers/` entries no longer appear in `hermes plugins list`, removing a misleading enable/disable surface for providers that are actually selected via `model.provider` / `--provider`.

## Infographic

![Hide bundled model providers from plugin list](https://v3b.fal.media/files/b/0aa6c3c4/_HndSmmd_en6_r0rfz0tN_Jghx9vXH.png)

## Summary

- `hermes_cli/plugins_cmd.py::_discover_all_plugins` now skips the bundled `model-providers/` top-level directory, alongside the existing `memory` / `context_engine` skips. Model providers load exclusively through the dedicated provider registry (`providers/__init__.py` — `PluginManager` records their manifests but deliberately never imports them), so listing ~50 bundled providers as ordinary opt-in plugins gave users a toggle surface that does nothing.
- This mirrors decisions already made elsewhere on main: `PluginManager._collect_directory_manifests` already skips `model-providers` (`hermes_cli/plugins.py:4067`), and the desktop Agent Plugins section hides `model-providers/` keys (#88733). The CLI list was the remaining stragglers' surface.
- User-installed providers under `~/.hermes/plugins/model-providers/` are **still listed** — the skip applies to the bundled tree only, same as the memory/context_engine rule.
- Contributor's regression test rebased into `tests/hermes_cli/test_plugins_cmd_category_discovery.py` (the `TestDiscoverAllPlugins` suite the original test targeted was restructured since May) and widened with a user-subtree counterpart test.

## Salvage notes

Original PR #27268 (May 17) no longer applied — `_discover_all_plugins` was extracted into `_scan_level` helpers and the test module split. Cherry-picked @felix-windsor's commit preserving authorship and resolved onto the current structure. Sibling categories checked: `cron_providers`, `dashboard_auth`, `browser`, `image_gen` etc. all declare `kind: backend` and genuinely flow through `PluginManager` auto-load, so they stay listed; the gateway `plugins.manage` RPC path reuses `_discover_all_plugins` and inherits this fix automatically.

## Validation

| Check | Result |
|---|---|
| `pytest tests/hermes_cli/test_plugins_cmd_category_discovery.py tests/hermes_cli/test_plugins_cmd_list.py` | 17 passed |
| `pytest tests/hermes_cli/test_plugins_cmd.py` | 46 passed |
| `ruff check` on touched files | clean |
| E2E: real `_discover_all_plugins()` against the real bundled tree + temp `HERMES_HOME` with a fake user plugin | 56 entries, zero `model-providers/*`, zero `memory|context_engine/*`, user plugin present, other bundled categories still listed |
| `scripts/audit_pr_attribution.py --fix` | all contributor emails mapped |

Credit: first submitted by @felix-windsor in #27268; their commit authorship is preserved in this branch's history.
