### PR TITLE
feat(desktop): add a kill action to running subagents in the Agents panel

### DIFF
--- a/apps/desktop/src/app/agents/index.tsx
+++ b/apps/desktop/src/app/agents/index.tsx
@@ -1,17 +1,21 @@
 import { useStore } from '@nanostores/react'
-import { type ReactNode, useEffect, useMemo, useState } from 'react'
+import { type MouseEvent, type ReactNode, useEffect, useMemo, useState } from 'react'
 
+import { useGatewayRequest } from '@/app/gateway/hooks/use-gateway-request'
 import { useElapsedSeconds } from '@/components/chat/activity-timer'
 import { ActivityTimerText } from '@/components/chat/activity-timer-text'
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
+import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { FadeText } from '@/components/ui/fade-text'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
+import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { compactNumber } from '@/lib/format'
-import { AlertCircle, CheckCircle2 } from '@/lib/icons'
+import { AlertCircle, CheckCircle2, Square } from '@/lib/icons'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
+import { notifyError } from '@/store/notifications'
 import {
   $subagentsBySession,
   allSubagents,
@@ -294,6 +298,52 @@ function StreamLine({
   )
 }
 
+/**
+ * Stop a single running subagent on demand.
+ *
+ * Wires the panel to `subagent.interrupt`, the same gateway RPC the TUI's
+ * kill command already uses (tools/delegate_tool.py::interrupt_subagent) —
+ * no new backend surface, just a way to reach it from the desktop.
+ */
+function KillSubagentButton({ subagentId }: { subagentId: string }) {
+  const { t } = useI18n()
+  const { requestGateway } = useGatewayRequest()
+  const [killing, setKilling] = useState(false)
+
+  const handleKill = async (event: MouseEvent) => {
+    event.stopPropagation()
+
+    if (killing) {
+      return
+    }
+
+    setKilling(true)
+
+    try {
+      await requestGateway('subagent.interrupt', { subagent_id: subagentId })
+    } catch (error) {
+      notifyError(error, t.agents.killFailed)
+      setKilling(false)
+    }
+  }
+
+  return (
+    <Tip label={killing ? t.agents.killing : t.agents.kill}>
+      <Button
+        aria-label={killing ? t.agents.killing : t.agents.kill}
+        className="mt-0.5 shrink-0 text-muted-foreground/70 hover:text-destructive"
+        disabled={killing}
+        onClick={handleKill}
+        size="icon-xs"
+        type="button"
+        variant="ghost"
+      >
+        <Square className="fill-current" size={10} />
+      </Button>
+    </Tip>
+  )
+}
+
 function SubagentRow({ node, depth = 0, nowMs }: { node: SubagentNode; depth?: number; nowMs: number }) {
   const { t } = useI18n()
   const running = node.status === 'running' || node.status === 'queued'
@@ -324,30 +374,33 @@ function SubagentRow({ node, depth = 0, nowMs }: { node: SubagentNode; depth?: n
 
   return (
     <div className={cn('grid min-w-0 max-w-full gap-2', depth > 0 && 'pl-4')} data-slot="tool-block" ref={enterRef}>
-      <button
-        aria-expanded={open}
-        className="group flex w-full min-w-0 items-start gap-2.5 text-left"
-        onClick={() => setOpen(v => !v)}
-        type="button"
-      >
-        <span className="mt-0.5 flex h-[1.1rem] shrink-0 items-center">{statusGlyph(node.status, t.agents)}</span>
-        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <span
-            className={cn(
-              'wrap-anywhere text-[0.82rem] font-medium leading-[1.1rem] text-foreground/90 transition-colors group-hover:text-foreground',
-              running && 'shimmer text-foreground/65'
-            )}
-          >
-            {node.goal}
+      <div className="group flex w-full min-w-0 items-start gap-2.5">
+        <button
+          aria-expanded={open}
+          className="flex min-w-0 flex-1 items-start gap-2.5 text-left"
+          onClick={() => setOpen(v => !v)}
+          type="button"
+        >
+          <span className="mt-0.5 flex h-[1.1rem] shrink-0 items-center">{statusGlyph(node.status, t.agents)}</span>
+          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span
+              className={cn(
+                'wrap-anywhere text-[0.82rem] font-medium leading-[1.1rem] text-foreground/90 transition-colors group-hover:text-foreground',
+                running && 'shimmer text-foreground/65'
+              )}
+            >
+              {node.goal}
+            </span>
+            {subtitle.length > 0 ? (
+              <FadeText className="text-[0.66rem] leading-[1.05rem] text-muted-foreground/65">
+                {subtitle.join(' · ')}
+              </FadeText>
+            ) : null}
           </span>
-          {subtitle.length > 0 ? (
-            <FadeText className="text-[0.66rem] leading-[1.05rem] text-muted-foreground/65">
-              {subtitle.join(' · ')}
-            </FadeText>
-          ) : null}
-        </span>
+        </button>
         {running ? <ActivityTimerText className="mt-1 shrink-0 text-[0.6rem]" seconds={durationSeconds} /> : null}
-      </button>
+        {running ? <KillSubagentButton subagentId={node.id} /> : null}
+      </div>
 
       {visibleRows.length > 0 ? (
         <div className="grid min-w-0 gap-1 pl-6" data-selectable-text="true">

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1280,7 +1280,10 @@ export const en: Translations = {
     ageDays: days => `${days}d ago`,
     durationSeconds: seconds => `${seconds}s`,
     durationMinutes: (minutes, seconds) => `${minutes}m ${seconds}s`,
-    tokens: value => `${value} tok`
+    tokens: value => `${value} tok`,
+    kill: 'Kill subagent',
+    killing: 'Killing…',
+    killFailed: 'Failed to kill subagent'
   },
 
   commandCenter: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1124,6 +1124,9 @@ export interface Translations {
     durationSeconds: (seconds: string) => string
     durationMinutes: (minutes: number, seconds: number) => string
     tokens: (value: number | string) => string
+    kill: string
+    killing: string
+    killFailed: string
   }
 
   commandCenter: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1471,7 +1471,10 @@ export const zh: Translations = {
     ageDays: days => `${days} 天前`,
     durationSeconds: seconds => `${seconds} 秒`,
     durationMinutes: (minutes, seconds) => `${minutes} 分 ${seconds} 秒`,
-    tokens: value => `${value} 词元`
+    tokens: value => `${value} 词元`,
+    kill: '终止子代理',
+    killing: '正在终止…',
+    killFailed: '终止子代理失败'
   },
 
   commandCenter: {


### PR DESCRIPTION
Closes #88780

## What changed and why

The Agents panel streams live subagent activity but had no action on a row — you could watch a subagent loop or go unproductive with no way to stop it. The backend already supports this (`interrupt_subagent()` in `tools/delegate_tool.py`, exposed as the `subagent.interrupt` gateway RPC, already used by the TUI); this just wires the desktop panel to it.

## How to test

1. Delegate a task to a subagent from any chat.
2. Open the Agents panel (status bar robot icon).
3. Click the stop icon next to a running row's timer — the subagent should be interrupted and the row settle into its terminal state.

## Platforms tested

Linux (dev build).