### PR TITLE
fix(security): fail closed when requested docker resource limits cannot be enforced

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Axl Ibiza (andrexibiza) — canonical author identity

--- a/tests/tools/test_docker_cgroup_limits.py
+++ b/tests/tools/test_docker_cgroup_limits.py
@@ -59,3 +59,73 @@ def test_probe_result_is_cached(monkeypatch):
     docker_env._cgroup_limits_available("img")
     docker_env._cgroup_limits_available("img")
     assert len(calls) == 1  # probe runs once, then cached
+
+
+def _docker_available_but_cgroup_fails(calls):
+    """Mock docker: ``docker version`` succeeds (Docker present) but the
+    cgroup probe (docker run with --cpus/--memory/--pids-limit) fails with
+    exit 126 (OCI runtime error — controllers not delegated)."""
+    def _run(cmd, *a, **k):
+        calls.append(cmd)
+        if cmd and cmd[0].endswith("version") or (len(cmd) > 1 and cmd[1] == "version"):
+            return subprocess.CompletedProcess(cmd, 0, stdout="docker version...", stderr="")
+        return subprocess.CompletedProcess(
+            cmd, 126, stdout="", stderr="OCI runtime error: cgroup delegation"
+        )
+    return _run
+
+
+def test_fails_closed_when_limits_requested_but_cgroup_unavailable(monkeypatch):
+    """Requesting cpu/memory limits when the cgroup probe fails must raise an
+    isolation-unavailable error (fail-closed), never silently run the
+    container without the requested resource limits."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = []
+    monkeypatch.setattr(docker_env.subprocess, "run", _docker_available_but_cgroup_fails(calls))
+
+    assert docker_env._cgroup_limits_available("img") is False
+
+    with pytest.raises(RuntimeError, match="isolation unavailable"):
+        docker_env.DockerEnvironment(
+            image="img",
+            cpu=2,  # explicitly requested resource limit
+            cwd="/root",
+        )
+
+
+def test_no_raise_when_no_limits_requested_and_cgroup_unavailable(monkeypatch):
+    """When the caller requests no cpu/memory limits, a failed cgroup probe
+    must NOT raise — there is nothing to drop, so normal operation continues."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = []
+    monkeypatch.setattr(docker_env.subprocess, "run", _docker_available_but_cgroup_fails(calls))
+
+    assert docker_env._cgroup_limits_available("img") is False
+
+    # No cpu/memory requested -> should construct without raising.
+    env = docker_env.DockerEnvironment(
+        image="img",
+        cpu=0,
+        memory=0,
+        cwd="/root",
+    )
+    assert env is not None
+
+
+def test_raises_when_memory_requested_and_cgroup_unavailable(monkeypatch):
+    """Same fail-closed guarantee when it is the memory limit that is
+    requested (not just cpu)."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = []
+    monkeypatch.setattr(docker_env.subprocess, "run", _docker_available_but_cgroup_fails(calls))
+
+    assert docker_env._cgroup_limits_available("img") is False
+
+    with pytest.raises(RuntimeError, match="isolation unavailable"):
+        docker_env.DockerEnvironment(
+            image="img",
+            memory=512,  # explicitly requested memory limit
+            cwd="/root",
+        )
+
+

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -920,12 +920,28 @@ class DockerEnvironment(BaseEnvironment):
         # they degrade gracefully on hosts without controller delegation,
         # e.g. unprivileged LXCs). The probe runs once per process and is
         # cached host-wide.
+        #
+        # Fail closed when limits were explicitly REQUESTED but cannot be
+        # enforced: a caller that asked for cpu/memory limits must not get a
+        # container that silently runs without them (the requested isolation
+        # would be absent). When no limits are requested, there is nothing to
+        # drop and normal operation proceeds.
+        _limits_requested = cpu > 0 or memory > 0
+        _limits_available = _cgroup_limits_available(image)
+        if _limits_requested and not _limits_available:
+            raise RuntimeError(
+                "Docker isolation unavailable: cpu/memory/pids resource limits "
+                "were requested but this environment does not delegate the "
+                "cpu/memory/pids cgroup controllers. Re-run with limits "
+                "disabled, or delegate the controllers (--cap-add, LXC/cgroup "
+                "config) before requesting bounded execution."
+            )
         resource_args = []
-        if cpu > 0 and _cgroup_limits_available(image):
+        if cpu > 0 and _limits_available:
             resource_args.extend(["--cpus", str(cpu)])
-        if memory > 0 and _cgroup_limits_available(image):
+        if memory > 0 and _limits_available:
             resource_args.extend(["--memory", f"{memory}m"])
-        if _cgroup_limits_available(image):
+        if _limits_available:
             resource_args.extend(["--pids-limit", _DEFAULT_PIDS_LIMIT])
         # /dev/shm size (not cgroup-gated: --shm-size is a tmpfs mount option,
         # no controller delegation required). Skip when the user already sets


### PR DESCRIPTION
## What changed and why

The docker backend gated `--cpus`/`--memory`/`--pids-limit` flags on the cgroup availability probe, but **silently dropped them** when the probe failed (cgroup controllers not delegated, e.g. unprivileged LXCs/rootless setups). A caller that explicitly requested resource limits (`cpu>0` or `memory>0`) got a container running **without** those limits — the requested isolation was silently absent.

This PR fails closed: when resource limits are explicitly requested but the cgroup probe fails, `DockerEnvironment.__init__` raises an `isolation unavailable` error instead of silently dropping the limits. When no limits are requested (`cpu=0`, `memory=0`), behavior is unchanged — nothing to drop, normal operation proceeds.

## How to test

```bash
scripts/run_tests.sh tests/tools/test_docker_cgroup_limits.py
```

3 new regression tests:
- requested-cpu + probe-fail → **raises** `isolation unavailable`
- requested-memory + probe-fail → **raises** `isolation unavailable`
- no-limits-requested + probe-fail → **does not raise** (normal operation)

Plus the 3 existing probe tests still pass (6 total).

## Platforms tested

- Windows 11 (git-bash), Python 3.11 — cgroup suite green (6 passed).
- `test_docker_environment.py::test_wrapped_exec_scopes_explicit_forward_env_across_profiles` fails identically on pristine `origin/main` (pre-existing docker-mock exit-126 artifact, verified on a clean worktree — unrelated to this change).
- `git diff --check` clean; behavior verified by probe-failure simulation.

## Why this matters to users

If Hermes's sandbox requested a CPU/memory limit but the host couldn't enforce it (missing cgroup controller delegation), the container silently ran without any limit — a sub-agent that was supposed to be resource-bounded could consume unlimited CPU/memory. After this change, requesting a limit that can't be enforced is a visible error instead of a silent gap, so bounded execution is real or explicitly reported as unavailable — never silently dropped.

Fixes #84248

Part of #82591 (EPIC — security hardening campaign, contract R2-C-007)
