### PR TITLE
fix(bot-mode): ownership-based sweep hides CLI-born Bot Mode sessions from the global sidebar

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -273,7 +273,8 @@ async function saveBotMeta(name, patch) {
  *  and Bot Chats created before this policy (or while the old pref was off)
  *  left visible rows behind. On every plugin load, sweep every session id we
  *  own — canonical chats from bot meta plus each group room's member
- *  sessions — through the core session.set_hidden RPC. Idempotent (the DB
+ *  sessions — through the core session.set_hidden RPC, then run the
+ *  ownership-based sweep for the rows we DON'T know by id. Idempotent (the DB
  *  setter is a no-op on already-hidden rows) and feature-detected: older
  *  gateways lack session.set_hidden and simply keep the rows visible. */
 function hideOwnedBotSessions() {
@@ -285,10 +286,82 @@ function hideOwnedBotSessions() {
     .filter(sid => Boolean(sid) && sid !== true)
   const ids = [...new Set([...canonical, ...rooms])]
 
-  return Promise.all(
+  const known = Promise.all(
     ids.map(sid =>
       Promise.resolve(host.request('session.set_hidden', { session_id: sid, hidden: true })).catch(() => undefined)
     )
+  )
+
+  return Promise.all([known, sweepBotProfileSessions().catch(() => undefined)])
+}
+
+// Titles Bot Mode itself mints for its plumbing sessions. Bot-to-bot CLI
+// handoffs (`hermes -p <bot> chat --in ~ -c "Bot Chat" --create-if-missing`)
+// and mention handoffs create sessions with EXACTLY these titles; the
+// "Group: " prefix is the member-session title ensureGroupChatSession has
+// used since group chats shipped. Exact/prefix matching is deliberate — a
+// user's real conversation inside a bot profile keeps whatever title the
+// user gave it and is never touched.
+const BOT_MODE_SWEEP_TITLES = new Set(['Bot Chat', 'Agent Inbox'])
+
+function isBotModeSweepTitle(title) {
+  const t = String(title || '').trim()
+  return BOT_MODE_SWEEP_TITLES.has(t) || t.startsWith('Group: ')
+}
+
+/** Ownership-based sweep: the id-based sweep above only covers sessions the
+ *  plugin recorded ($botMeta canonical chats, $groupChats member sids), but
+ *  Bot Mode sessions are ALSO minted outside the plugin — bot-to-bot CLI
+ *  handoffs ("Agent Inbox" / extra "Bot Chat" rows born visible in a bot's
+ *  profile) — and those ids the plugin never learns. So: enumerate each
+ *  roster bot's OWN profile sessions (only bot profiles — a non-bot profile
+ *  is never listed, so its sessions are never touched) and hide any VISIBLE
+ *  row whose title is Bot Mode plumbing. session.list without include_hidden
+ *  returns only visible rows, which keeps the sweep naturally idempotent.
+ *  Remote-source bots route to their own connection via requestForBot.
+ *  Feature-detected + fire-and-forget: older gateways without per-profile
+ *  session.list / session.set_hidden simply reject and the sweep no-ops. */
+async function sweepBotProfileSessions() {
+  const cached = $lastRoster.get()
+  let roster = Array.isArray(cached) && cached.length ? cached : null
+
+  if (!roster) {
+    // Plugin load can run before the Bots pane hydrates $lastRoster — fall
+    // back to the active gateway's own profile list (local bots; remote
+    // sources get covered by the next sweep once the roster cache exists).
+    try {
+      const res = await host.request('profiles.list', {})
+      roster = Array.isArray(res?.profiles) ? res.profiles : []
+    } catch {
+      return
+    }
+  }
+
+  await Promise.all(
+    roster.map(async bot => {
+      const name = String(bot?.name || '').trim()
+
+      if (!name) {
+        return
+      }
+
+      try {
+        const res = await requestForBot(bot, 'session.list', { profile: name, limit: PROFILE_SESSION_LIST_LIMIT })
+        const rows = Array.isArray(res?.sessions) ? res.sessions : []
+
+        await Promise.all(
+          rows
+            .filter(row => row && row.id && isBotModeSweepTitle(row.title))
+            .map(row =>
+              Promise.resolve(
+                requestForBot(bot, 'session.set_hidden', { session_id: row.id, hidden: true, profile: name })
+              ).catch(() => undefined)
+            )
+        )
+      } catch {
+        /* older gateway / unreachable source — leave this profile alone */
+      }
+    })
   )
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-delete.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-delete.test.mjs
@@ -73,7 +73,11 @@ test('unit: older desktop without host.deleteProfile falls back to the non-inter
 
   await context.__delete.deleteBot({ name: 'researcher' })
 
-  assert.deepEqual(JSON.parse(JSON.stringify(requests[0])), {
+  // The load-time hide sweep (hideOwnedBotSessions/sweepBotProfileSessions)
+  // may interleave its own profiles.list / session.* traffic — filter to the
+  // delete path's request.
+  const exec = requests.filter(r => r.method === 'cli.exec')
+  assert.deepEqual(JSON.parse(JSON.stringify(exec[0])), {
     method: 'cli.exec',
     params: { argv: ['profile', 'delete', 'researcher', '--yes'] }
   })

--- a/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
@@ -80,6 +80,66 @@ test('hideOwnedBotSessions sweeps canonical chats AND room member sessions', asy
   assert.ok(calls.every(c => c.method === 'session.set_hidden' && c.params.hidden === true))
 })
 
+test('sweepBotProfileSessions hides Bot-Mode-titled rows per roster bot, and only those', async () => {
+  // Ownership-based half of the sweep: CLI-born "Agent Inbox" / extra
+  // "Bot Chat" rows live in bot profiles but are unknown to $botMeta /
+  // $groupChats, so the id-based sweep never reaches them. This sweep lists
+  // each roster bot's own sessions and hides rows by exact plumbing title
+  // ('Bot Chat', 'Agent Inbox', 'Group: …' prefix) — never a user-titled row.
+  const start = source.indexOf('function hideOwnedBotSessions()')
+  const end = source.indexOf('/** Fetch server-side avatars', start)
+  const calls = []
+  const rowsByProfile = {
+    alpha: [
+      { id: 'a-1', title: 'Bot Chat' },
+      { id: 'a-2', title: 'Agent Inbox' },
+      { id: 'a-3', title: 'Group: Core' },
+      { id: 'a-4', title: 'My real conversation' },
+      { id: 'a-5', title: 'Bot Chat notes' } // not an exact title — kept
+    ],
+    remy: [{ id: 'r-1', title: 'Agent Inbox' }]
+  }
+  const context = {
+    host: { request: async () => ({}) },
+    $botMeta: { get: () => ({}) },
+    $groupChats: { get: () => ({}) },
+    $lastRoster: { get: () => [{ name: 'alpha' }, { name: 'remy', remoteSource: true, connectionId: 'mini' }] },
+    PROFILE_SESSION_LIST_LIMIT: 200,
+    requestForBot: async (bot, method, params) => {
+      calls.push({ bot: bot.name, method, params })
+      if (method === 'session.list') {
+        return { sessions: rowsByProfile[params.profile] || [] }
+      }
+      return {}
+    }
+  }
+  const section = source.slice(start, end).concat('\nglobalThis.__h = { hideOwnedBotSessions, sweepBotProfileSessions };\n')
+  vm.runInNewContext(section, context, { filename: 's.js' })
+  await context.__h.sweepBotProfileSessions()
+
+  const lists = calls.filter(c => c.method === 'session.list')
+  assert.deepEqual(lists.map(c => c.params.profile).sort(), ['alpha', 'remy'])
+  // Visible-rows-only listing keeps the sweep idempotent.
+  assert.ok(lists.every(c => !c.params.include_hidden))
+
+  const hidden = calls.filter(c => c.method === 'session.set_hidden')
+  assert.deepEqual(
+    hidden.map(c => c.params.session_id).sort(),
+    ['a-1', 'a-2', 'a-3', 'r-1'],
+    'exact plumbing titles only — user-titled rows in bot profiles stay visible'
+  )
+  assert.ok(hidden.every(c => c.params.hidden === true))
+  // Remote-source bots route through requestForBot with their own bot row.
+  assert.equal(hidden.find(c => c.params.session_id === 'r-1').bot, 'remy')
+})
+
+test('hideOwnedBotSessions chains the ownership sweep and survives its absence of context', async () => {
+  // The load/reconnect entrypoint runs BOTH halves: known ids first, then
+  // the roster-wide title sweep (best-effort — a throwing sweep never
+  // breaks the id half).
+  assert.match(source, /return Promise\.all\(\[known, sweepBotProfileSessions\(\)\.catch\(\(\) => undefined\)\]\)/)
+})
+
 test('the Bots session browser lists with include_hidden', () => {
   // The one session.list consumer that must see the always-hidden rows.
   // (Canonical-chat recovery now goes through profiles.list


### PR DESCRIPTION
Leaked Bot Mode sessions — CLI-born "Agent Inbox" and extra "Bot Chat" rows sitting in bot profiles — no longer pollute the global Sessions sidebar: the hide sweep is now ownership-based, not just id-based.

## The bug

Commit 66221397a made Bot Mode sessions always-hidden and added `hideOwnedBotSessions()`, an idempotent sweep run on plugin load + gateway reconnect. But that sweep is **id-based**: it only touches session ids the plugin recorded — canonical Bot Chats from `$botMeta` and each group room's member sids from `$groupChats`.

Bot Mode sessions are also minted **outside the plugin**:

- bot-to-bot handoffs run `hermes -p <bot> chat --in ~ -c "Bot Chat" --create-if-missing` (and `-c "Agent Inbox"`) via CLI — the kickoff protocol text itself instructs agents to do this;
- the mention-handoff path can mint a fresh "Bot Chat" beyond the canonical one pinned in bot meta.

None of those ids ever enter plugin state, so the sweep never reached them and they sat visible in the sidebar forever (user report: five "Bot Chat" + two "Agent Inbox" rows, days old; local state.dbs had no such rows — they live in the bot-owned profiles).

## The fix

- **New `sweepBotProfileSessions()`**, chained from `hideOwnedBotSessions()` at the same two call sites (plugin load + reconnect), best-effort (`.catch(() => undefined)` so it can never break the id half).
- **Ownership-based enumeration**: for every roster bot (from `$lastRoster`, falling back to the active gateway's `profiles.list` when the cache hasn't hydrated yet), list that bot's own sessions via `session.list { profile, limit }` and `session.set_hidden` any row whose title marks it as Bot Mode plumbing.
- **Title discriminator, deliberately narrow**: exactly `'Bot Chat'`, exactly `'Agent Inbox'`, or the `'Group: '` prefix (the member-session title `ensureGroupChatSession` has used since group chats shipped — confirmed via history). A user's real conversation inside a bot profile keeps its own title and is never touched; e.g. "Bot Chat notes" is kept.
- **Bot profiles only**: only roster rows are enumerated, so sessions in non-bot profiles are never listed, let alone hidden.
- **Remote sources**: remote-source bots route through the existing `requestForBot` (→ `host.requestProfile` with the bot's connection route), so bots on other registered machines get swept on their own source; unreachable sources are skipped silently.
- **Idempotent by construction**: the listing omits `include_hidden`, so already-hidden rows never come back and repeat sweeps converge to zero RPCs.
- **Feature-detected**: older gateways without per-profile `session.list` / `session.set_hidden` reject and the sweep no-ops per profile / per row.

## Instruction text

Left unchanged: `hermes chat` has no hidden flag on `-c <name> --create-if-missing` session creation (checked `hermes_cli/_parser.py` / `cli.py` — nothing to pass), so the sweep is the cover for CLI-born rows. No new CLI flags added per scope.

## Validation

| Check | Result |
| --- | --- |
| `node --check plugin.js` | ✅ |
| `node --test tests/*.test.mjs` (plugin dir) | ✅ 221 pass / 0 fail |
| New source-shape + vm test: `sweepBotProfileSessions` hides exact plumbing titles only, per roster bot, remote rows routed via `requestForBot`, `include_hidden` omitted | ✅ added in `hide-bot-chats.test.mjs` |
| Chain assertion: `hideOwnedBotSessions` runs both halves, ownership half best-effort | ✅ |
| `bot-delete.test.mjs` fallback test updated to filter for its `cli.exec` request (the load-time sweep now interleaves its own `profiles.list` traffic) | ✅ |

Pure plugin change — no `apps/desktop` core files touched.

## Infographic

![Bot Mode session sweep mission patch](https://v3b.fal.media/files/b/0aa6c404/IYxw_8LSOOlJgu5WxIaaJ_xf8BrGn8.png)
