### PR TITLE
fix(compression): refuse guaranteed no-op summarization passes

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3203,7 +3203,9 @@ class ContextCompressor(ContextEngine):
         projected_real = self.last_real_prompt_tokens + growth
         return projected_real < self.threshold_tokens
 
-    def should_compress(self, prompt_tokens: int = None) -> bool:
+    def should_compress(
+        self, prompt_tokens: int = None, messages: List[Dict[str, Any]] = None
+    ) -> bool:
         """Check if context exceeds the compression threshold.
 
         Returns ``True`` when compression should run now. For the caller-facing
@@ -3211,15 +3213,18 @@ class ContextCompressor(ContextEngine):
         see :meth:`should_compress_info`, which returns a ``(bool, reason)``
         tuple without changing the decision logic here.
 
+        ``messages`` (optional) enables the structural-eligibility check
+        documented on :meth:`should_compress_info`.
+
         Includes anti-thrashing protection: if the last two compressions
         each saved less than 10%, skip compression to avoid infinite loops
         where each pass removes only 1-2 messages.
         """
-        decision, _reason = self.should_compress_info(prompt_tokens)
+        decision, _reason = self.should_compress_info(prompt_tokens, messages)
         return decision
 
     def should_compress_info(
-        self, prompt_tokens: int = None
+        self, prompt_tokens: int = None, messages: List[Dict[str, Any]] = None
     ) -> "tuple[bool, str | None]":
         """Check if context exceeds the compression threshold.
 
@@ -3240,12 +3245,26 @@ class ContextCompressor(ContextEngine):
         growing until it hits the hard provider limit). Without this signal an
         over-threshold session fails opaquely.
 
+        When ``messages`` is provided, mirrors the structural-eligibility bail
+        already present in :meth:`prune_tool_results_only`: if every message
+        falls inside the protected head/tail there is nothing eligible to
+        reclaim, and an LLM summarization pass is a guaranteed no-op that still
+        costs a real API round-trip (#88778). Callers on a live request path
+        should pass the working message list; ``None`` (the default) keeps the
+        token-only decision for legacy/plugin callers.
+
         Includes anti-thrashing protection: if the last two compressions
         each saved less than 10%, skip compression to avoid infinite loops
         where each pass removes only 1-2 messages.
         """
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         if tokens < self.threshold_tokens:
+            return False, None
+        if messages is not None and len(messages) <= (
+            self.protect_last_n + self._protect_head_size(messages) + 1
+        ):
+            # Nothing to reclaim until there are messages outside the
+            # protected head/tail — same contract as prune_tool_results_only.
             return False, None
         if self._automatic_compression_blocked():
             return False, self._compression_block_reason() or "blocked"

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -143,10 +143,16 @@ class ContextEngine(ABC):
         """
 
     @abstractmethod
-    def should_compress(self, prompt_tokens: int = None) -> bool:
-        """Return True if compaction should fire this turn."""
+    def should_compress(self, prompt_tokens: int = None, messages: List[Dict[str, Any]] = None) -> bool:
+        """Return True if compaction should fire this turn.
 
-    def should_compress_info(self, prompt_tokens: int = None) -> "tuple[bool, str | None]":
+        ``messages`` is optional: when provided, engines with a structural
+        eligibility view (e.g. protected head/tail windows) should return
+        False when every message is protected and a pass would be a
+        guaranteed no-op (#88778). Engines that can't use it may ignore it.
+        """
+
+    def should_compress_info(self, prompt_tokens: int = None, messages: List[Dict[str, Any]] = None) -> "tuple[bool, str | None]":
         """Return ``(should_compress, reason)``.
 
         The base implementation is backward-compatible: engines that only
@@ -157,7 +163,7 @@ class ContextEngine(ABC):
         of silently skipping compression. Added for the silent-overflow
         warning fix (#62625) so plugin engines don't raise AttributeError.
         """
-        return self.should_compress(prompt_tokens), None
+        return should_compress_with_messages(self, prompt_tokens, messages), None
 
     @abstractmethod
     def compress(
@@ -487,3 +493,18 @@ class ContextEngine(ABC):
         )
         self.threshold_percent = self._base_threshold_percent
         self.threshold_tokens = int(context_length * self.threshold_percent)
+
+
+def should_compress_with_messages(
+    compressor: Any, prompt_tokens: int, messages: List[Dict[str, Any]]
+) -> bool:
+    """Call ``should_compress`` with the structural-eligibility messages.
+
+    Engines predating the ``messages`` parameter (external plugin engines
+    overriding the one-argument signature) raise TypeError on the extra
+    argument — fall back to the token-only decision for them (#88778).
+    """
+    try:
+        return compressor.should_compress(prompt_tokens, messages)
+    except TypeError:
+        return compressor.should_compress(prompt_tokens)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -35,7 +35,10 @@ from agent.conversation_compression import (
     compression_skipped_due_to_lock,
     conversation_history_after_compression,
 )
-from agent.context_engine import automatic_compaction_status_message
+from agent.context_engine import (
+    automatic_compaction_status_message,
+    should_compress_with_messages,
+)
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.message_metadata import append_message
@@ -2528,7 +2531,9 @@ def run_conversation(
             and not _preflight_compression_blocked
             and not _defer_preflight(request_pressure_tokens)
             and not _compression_cooldown
-            and _compressor.should_compress(request_pressure_tokens)
+            and should_compress_with_messages(
+                _compressor, request_pressure_tokens, messages
+            )
         ):
             if _moa_prepared_request is not None:
                 pending_moa_prepared_request = _moa_prepared_request
@@ -2655,7 +2660,7 @@ def run_conversation(
             _block_reason = None
             try:
                 _block_reason = _compressor.should_compress_info(
-                    request_pressure_tokens
+                    request_pressure_tokens, messages
                 )[1]
             except Exception:
                 _block_reason = None

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -38,7 +38,10 @@ from agent.conversation_compression import (
     conversation_history_after_compression,
     recover_rotated_compression_session,
 )
-from agent.context_engine import automatic_compaction_status_message
+from agent.context_engine import (
+    automatic_compaction_status_message,
+    should_compress_with_messages,
+)
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
 from agent.memory_provider import is_trivial_prompt
@@ -946,7 +949,9 @@ def build_turn_context(
                 getattr(agent, "codex_app_server_auto_compaction", "native"),
             )
         else:
-            _should_compress_now = _compressor.should_compress(_preflight_tokens)
+            _should_compress_now = should_compress_with_messages(
+                _compressor, _preflight_tokens, messages
+            )
             if not _should_compress_now:
                 # Context is over threshold but compression is blocked
                 # (summary-LLM cooldown or anti-thrashing). Ask should_compress_info
@@ -957,7 +962,9 @@ def build_turn_context(
                 _info = getattr(_compressor, "should_compress_info", None)
                 if callable(_info):
                     try:
-                        _compress_block_reason = _info(_preflight_tokens)[1]
+                        _compress_block_reason = _info(
+                            _preflight_tokens, messages
+                        )[1]
                     except Exception:
                         _compress_block_reason = None
         if _should_compress_now:

--- a/tests/agent/test_turn_context_overflow_warning.py
+++ b/tests/agent/test_turn_context_overflow_warning.py
@@ -64,6 +64,43 @@ class TestShouldCompressInfo:
         assert result is False
         assert not isinstance(result, tuple)
 
+    def test_all_protected_messages_skip_compression(self):
+        """Over threshold but every message inside the protected head/tail:
+        an LLM summarization pass is a guaranteed no-op, so the gate must
+        refuse to run it instead of burning an API round-trip (#88778).
+        Mirrors prune_tool_results_only()'s eligibility bail."""
+        comp = _make_compressor()  # protect_first_n=2, protect_last_n=3
+        # head = 1 (system) + 2 = 3; full protection at len <= 3 + 3 + 1 = 7.
+        msgs = [{"role": "system", "content": "sys"}]
+        msgs += [{"role": "user", "content": f"m{i}"} for i in range(6)]
+        assert len(msgs) == 7
+        # Token-only decision would fire (73_000 >= 72_000 threshold)...
+        assert comp.should_compress_info(73_000) == (True, None)
+        # ...but with the message list it must refuse — nothing is eligible.
+        assert comp.should_compress_info(73_000, msgs) == (False, None)
+        assert comp.should_compress(73_000, msgs) is False
+
+    def test_long_history_still_compresses_over_threshold(self):
+        comp = _make_compressor()  # full protection at len <= 7
+        msgs = [{"role": "system", "content": "sys"}]
+        msgs += [{"role": "user", "content": f"m{i}"} for i in range(11)]
+        assert len(msgs) == 12
+        assert comp.should_compress_info(73_000, msgs) == (True, None)
+
+    def test_legacy_one_arg_engine_falls_back_to_token_only(self):
+        """External plugin engines may still override the one-argument
+        should_compress signature; the wiring helper must degrade to the
+        token-only decision for them instead of raising (#88778)."""
+        from agent.context_engine import should_compress_with_messages
+
+        class _LegacyEngine:
+            def should_compress(self, prompt_tokens=None):
+                return prompt_tokens >= 72_000
+
+        msgs = [{"role": "user", "content": "m"}]
+        assert should_compress_with_messages(_LegacyEngine(), 73_000, msgs) is True
+        assert should_compress_with_messages(_LegacyEngine(), 71_000, msgs) is False
+
 
 # ---------------------------------------------------------------------------
 # Integration tests: build_turn_context surfaces the warning
@@ -92,8 +129,13 @@ def _build_warn_agent(compressor: ContextCompressor) -> _WarnAgent:
     return agent
 
 
-def _run_build(agent):
-    """Run build_turn_context with the prologue-side effects stubbed."""
+def _run_build(agent, history=None):
+    """Run build_turn_context with the prologue-side effects stubbed.
+
+    ``history`` overrides conversation_history — pass a list long enough to
+    clear the protected head/tail window when a test needs the compression
+    branch to actually run (#88778 made should_compress structurally
+    eligibility-aware, so a short/empty history over threshold is refused)."""
     with patch("agent.auxiliary_client.set_runtime_main", lambda *a, **k: None), \
          patch("agent.turn_context._should_run_preflight_estimate", return_value=True), \
          patch("agent.turn_context.estimate_request_tokens_rough", return_value=999_999):
@@ -101,7 +143,7 @@ def _run_build(agent):
             agent=agent,
             user_message="hello",
             system_message=None,
-            conversation_history=None,
+            conversation_history=history,
             task_id=None,
             stream_callback=None,
             persist_user_message=None,
@@ -113,6 +155,12 @@ def _run_build(agent):
             set_current_write_origin=lambda _o: None,
             ra=lambda: type("R", (), {"_set_interrupt": lambda *a, **k: None})(),
         )
+
+
+# History long enough that messages exist outside the protected head/tail
+# (protect_first_n=2 + system head, protect_last_n=3) — required for the
+# compression branch to be structurally eligible (#88778).
+_LONG_HISTORY = [{"role": "user", "content": f"prior message {i}"} for i in range(12)]
 
 
 class TestTurnContextOverflowWarning:
@@ -143,12 +191,12 @@ class TestTurnContextOverflowWarning:
         comp._summary_failure_cooldown_until = time.monotonic() + 30
         agent = _build_warn_agent(comp)
         # Turn 1: over threshold + cooldown -> warn.
-        _run_build(agent)
+        _run_build(agent, history=_LONG_HISTORY)
         assert len(agent._warnings) == 1
         # Turn 2: cooldown expires while STILL over threshold -> compression
         # branch runs; the reset must happen there (not in the else branch).
         comp._summary_failure_cooldown_until = 0.0
-        _run_build(agent)
+        _run_build(agent, history=_LONG_HISTORY)
         assert agent._compress_calls > 0
         assert agent._last_ctx_overflow_warn is None
         # Turn 3: cooldown re-arms -> the warning must re-fire.

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -450,6 +450,10 @@ async def test_session_chat_stream_treats_pre_existing_poisoned_row_as_no_model(
                 json={"message": "hi"},
             )
             assert resp.status == 200
+            # Drain the SSE body to completion: _run_agent runs in a
+            # concurrent task behind the stream, so asserting on call_args
+            # after the 200 headers alone races the task scheduler.
+            await resp.read()
 
     _, kwargs = mock_run.call_args
     assert kwargs["session_model"] is None

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -590,9 +590,13 @@ class TestPreflightCompression:
         agent.context_compressor.threshold_tokens = 130_000
         agent.context_compressor.emit_automatic_compaction_status = False
 
+        # Long enough that messages exist outside the protected head/tail
+        # (production default protect_last_n=20 + head + 1 = window of 24) —
+        # the pre-API gate is structurally eligibility-aware (#88778), so a
+        # short history would be refused as a guaranteed no-op pass.
         history = [
-            {"role": "user", "content": "earlier question"},
-            {"role": "assistant", "content": "earlier answer"},
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"turn {i}"}
+            for i in range(30)
         ]
         ok_resp = _mock_response(content="After quiet pre-API", finish_reason="stop")
         agent.client.chat.completions.create.side_effect = [ok_resp]
@@ -1075,6 +1079,15 @@ class TestToolResultPreflightCompression:
         agent.context_compressor.context_length = 200_000
         agent.context_compressor.threshold_tokens = 130_000
 
+        # Long enough to clear the protected head/tail (production default
+        # protect_last_n=20 → window of 24) — the pre-API gate is structurally
+        # eligibility-aware (#88778) and would otherwise refuse the pass
+        # before the marginal-effectiveness logic under test runs.
+        history = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"turn {i}"}
+            for i in range(30)
+        ]
+
         tc = SimpleNamespace(
             id="tc1", type="function",
             function=SimpleNamespace(name="web_search", arguments='{"query":"test"}'),
@@ -1116,7 +1129,7 @@ class TestToolResultPreflightCompression:
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
         ):
-            result = agent.run_conversation("hello")
+            result = agent.run_conversation("hello", conversation_history=history)
 
         assert result["completed"] is True
         assert result["final_response"] == "Done after one compression"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1451,6 +1451,15 @@ def test_run_conversation_compresses_mid_turn_before_output_budget_exhaustion(mo
     agent.context_compressor.context_length = 20_000
     agent.context_compressor.threshold_tokens = 20_000
 
+    # Long enough to clear the protected head/tail window (production
+    # default protect_last_n=20): the pre-API gate is structurally
+    # eligibility-aware (#88778) and a turn-local-only message list would be
+    # refused as a guaranteed no-op before the wiring under test runs.
+    history = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"turn {i}"}
+        for i in range(30)
+    ]
+
     responses = [
         _codex_tool_call_response(),
         _codex_message_response("Summary after compaction."),
@@ -1483,7 +1492,9 @@ def test_run_conversation_compresses_mid_turn_before_output_budget_exhaustion(mo
     monkeypatch.setattr(agent, "_execute_tool_calls", _fake_execute_tool_calls)
     monkeypatch.setattr(agent, "_compress_context", _fake_compress_context)
 
-    result = agent.run_conversation("do a tool-heavy task")
+    result = agent.run_conversation(
+        "do a tool-heavy task", conversation_history=history
+    )
 
     assert result["completed"] is True
     assert result["final_response"] == "Summary after compaction."
@@ -1517,6 +1528,14 @@ def test_mid_turn_compaction_does_not_double_persist_in_place_rows(monkeypatch, 
     agent.context_compressor.context_length = 20_000
     agent.context_compressor.threshold_tokens = 20_000
 
+    # Same protection-window clearance as the sibling test above (#88778):
+    # the mid-turn pre-API gate refuses structurally ineligible passes, so
+    # the history must extend past the protected head/tail window.
+    history = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"turn {i}"}
+        for i in range(30)
+    ]
+
     agent._session_db = SessionDB()
     agent._ensure_db_session()
 
@@ -1548,7 +1567,9 @@ def test_mid_turn_compaction_does_not_double_persist_in_place_rows(monkeypatch, 
     monkeypatch.setattr(agent, "_execute_tool_calls", _fake_execute_tool_calls)
     monkeypatch.setattr(agent, "_compress_context", _fake_compress_context)
 
-    result = agent.run_conversation("do a tool-heavy task")
+    result = agent.run_conversation(
+        "do a tool-heavy task", conversation_history=history
+    )
     assert result["completed"] is True
 
     # The compacted summary row must appear exactly once in the active


### PR DESCRIPTION
## What does this PR do?

Stops the default `ContextCompressor` from running a guaranteed no-op LLM summarization pass. `prune_tool_results_only()` already bails when every message falls inside the protected head/tail ("Nothing to reclaim until there are messages outside the protected tail"), but `should_compress_info()` — the gate for the full LLM-based summarization invoked from the pre-API request-pressure path and the turn preflight — only compared token pressure and anti-thrash state. On a session's first over-threshold attempt with `len(messages) <= protect_first_n + protect_last_n` (defaults 3+6=9), every message is protected, nothing is eligible, yet the pass still ran: a real API round-trip that in both reproductions from the issue *increased* the estimated token count, with "insufficient progress" only detected after the fact (#88778).

The fix mirrors the existing eligibility bail into `should_compress_info()` behind an optional `messages` argument (`None` keeps the token-only decision for legacy callers), threads it through `should_compress()`, updates the `ContextEngine` ABC and its tuple default, and passes the working message list from the two live gates (conversation_loop pre-API + blocked-warning probe, turn_context preflight). A small wiring helper, `should_compress_with_messages()`, degrades to the token-only decision for external plugin engines that still override the one-argument signature, so no engine can raise TypeError on the new argument.

## Related Issue

Fixes #88778

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` — `should_compress()`/`should_compress_info()` accept optional `messages`; when provided and every message is inside the protected head/tail, return `(False, None)` (same contract as `prune_tool_results_only`).
- `agent/context_engine.py` — abstract `should_compress()` and the `should_compress_info()` tuple default gain the optional `messages` parameter; new `should_compress_with_messages()` helper with a TypeError fallback for one-argument legacy engines.
- `agent/conversation_loop.py` — pre-API compression gate and the blocked-warning `should_compress_info` probe pass `messages`.
- `agent/turn_context.py` — turn preflight `should_compress` and its reason probe pass `messages`.
- `tests/agent/test_turn_context_overflow_warning.py` — regressions for all-protected refusal (while the token-only decision is unchanged), long-history still compressing, legacy-engine fallback; the dedup-reset integration test now supplies a history long enough to clear the protection window.

## How to Test

1. `python -m pytest tests/agent/test_turn_context_overflow_warning.py tests/agent/test_turn_context.py tests/agent/test_proactive_tool_result_pruning.py tests/agent/test_compression_anti_thrash_persistence.py tests/agent/test_compression_anti_thrash_recovery.py tests/agent/test_engine_preflight_wire.py tests/agent/test_preflight_lock_defer.py tests/agent/test_context_compressor.py -q`
   Observed result: 191 passed.
2. Fail-on-main check: `git stash` the `agent/` changes and rerun `TestShouldCompressInfo` — Observed result: 3 failed (`test_all_protected_messages_skip_compression` asserts the with-messages gate must refuse while the token-only decision still fires).
3. Legacy-engine compatibility: `test_legacy_one_arg_engine_falls_back_to_token_only` exercises the TypeError fallback — Observed result: passes.
4. Baseline comparison for `tests/agent/test_api_content_sidecar.py` + run_agent wiring suites: identical 33 failed / 50 passed with and without this change in this environment (pre-existing local-environment failures, unrelated).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (compression/preflight suites: 191 passed; pre-existing env failures verified identical by baseline stash)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — method docstrings document the new parameter and contract; or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python signature change with backward-compatible defaults; or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
