### PR TITLE
fix(desktop): Bots pane is a Sessions-zone tab again (not stacked below) and the Cronjobs pane only appears in Bots mode

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/dock-heal.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/dock-heal.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// One-time dock heals: a pane already adopted under an OLD dock hint (Bot
+// Mode's Bots pane split BELOW sessions) re-homes onto its new center anchor
+// exactly once — persisted layouts otherwise pin the stale arrangement
+// forever, because adoption only ever places panes MISSING from the tree.
+// Guards under test: user-placed layouts are never touched, and a burned
+// token never re-fights the user across later adoption passes.
+
+const TREE_KEY = 'hermes.desktop.layoutTree.v2'
+const USER_PLACED_KEY = 'hermes.desktop.userPlacedPanes.v1'
+
+// The shipped regression shape: sessions and bots as SIBLING groups in a
+// column (the old `pos: 'bottom'` split), workspace beside them.
+const stackedTree = {
+  type: 'split',
+  id: 'root',
+  orientation: 'row',
+  weights: [1, 3],
+  children: [
+    {
+      type: 'split',
+      id: 'left-col',
+      orientation: 'column',
+      weights: [1, 1],
+      children: [
+        { type: 'group', id: 'g-sessions', panes: ['sessions'], active: 'sessions' },
+        { type: 'group', id: 'g-bots', panes: ['hermes-bots:pane'], active: 'hermes-bots:pane' }
+      ]
+    },
+    { type: 'group', id: 'g-main', panes: ['workspace'], active: 'workspace' }
+  ]
+}
+
+describe('one-time dock heal (stacked Bots pane → sessions-zone tab)', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  async function setup() {
+    window.localStorage.setItem(TREE_KEY, JSON.stringify(stackedTree))
+
+    const tree = await import('@/components/pane-shell/tree/store')
+    const model = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+
+    registry.register({
+      id: 'workspace',
+      area: 'panes',
+      title: 'chat',
+      data: { placement: 'main' },
+      render: () => null
+    })
+    registry.register({
+      id: 'sessions',
+      area: 'panes',
+      title: 'sessions',
+      data: { placement: 'left' },
+      render: () => null
+    })
+    registry.register({
+      id: 'hermes-bots:pane',
+      area: 'panes',
+      title: 'Bots',
+      data: {
+        placement: 'left',
+        dock: { pane: 'sessions', pos: 'center', heal: 'sessions-tab-v1' }
+      },
+      render: () => null
+    })
+
+    return { model, registry, tree }
+  }
+
+  it('re-homes a stacked bots pane into the sessions tab strip, keeping sessions active', async () => {
+    const { model, tree } = await setup()
+
+    tree.watchContributedPanes()
+
+    const group = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:pane')!
+
+    expect(group.panes).toEqual(['sessions', 'hermes-bots:pane'])
+    // Silent like adoption — the heal must not steal the sessions tab.
+    expect(group.active).toBe('sessions')
+    // The persisted tree carries the healed shape (survives the next boot).
+    const persisted = JSON.parse(window.localStorage.getItem(TREE_KEY)!) as { children?: unknown[] }
+
+    expect(JSON.stringify(persisted)).toContain('"panes":["sessions","hermes-bots:pane"]')
+  })
+
+  it('never touches a layout the user placed the pane in themselves', async () => {
+    window.localStorage.setItem(USER_PLACED_KEY, JSON.stringify(['hermes-bots:pane']))
+
+    const { model, tree } = await setup()
+
+    tree.watchContributedPanes()
+
+    const group = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:pane')!
+
+    // Still its own zone below sessions — the user's spot wins.
+    expect(group.panes).toEqual(['hermes-bots:pane'])
+  })
+
+  it('burns its token once: a user who re-stacks the pane afterward is not fought', async () => {
+    const { model, tree, registry } = await setup()
+
+    tree.watchContributedPanes()
+
+    // Sanity: healed.
+    expect(model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:pane')!.panes).toContain('sessions')
+
+    // The user drags the pane back out into its own zone below sessions.
+    tree.$layoutTree.set(JSON.parse(JSON.stringify(stackedTree)))
+
+    // A later registry mutation re-runs the adoption pass (the heal's caller).
+    registry.register({
+      id: 'other',
+      area: 'panes',
+      title: 'other',
+      data: { placement: 'right' },
+      render: () => null
+    })
+
+    const group = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:pane')!
+
+    expect(group.panes).toEqual(['hermes-bots:pane'])
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1105,6 +1105,86 @@ interface PaneDockHint {
   pos: DropPosition
   /** Center docks: stack BEFORE this pane id (the strip divider's slot). */
   before?: null | string
+  /** One-time re-home token: a pane ALREADY adopted under an older dock hint
+   *  moves onto this hint's center anchor once per token — never when the
+   *  user has placed the pane themselves. See `healDockedPanes`. */
+  heal?: string
+}
+
+// One-time dock heals already applied, persisted so a heal runs exactly once
+// per pane per token across boots (and never re-fights a user who re-arranges
+// the healed pane afterward).
+const DOCK_HEAL_KEY = 'hermes.desktop.paneDockHeals.v1'
+
+const appliedDockHeals = new Set<string>(readJson<string[]>(DOCK_HEAL_KEY) ?? [])
+
+function markDockHealApplied(token: string) {
+  appliedDockHeals.add(token)
+  writeJson(DOCK_HEAL_KEY, [...appliedDockHeals])
+}
+
+/**
+ * A `panes` contribution whose dock hint carries a `heal` token gets ONE
+ * chance to re-home its already-adopted pane onto the hint's anchor —
+ * adoption is once per pane lifetime (the persisted tree remembers it), so a
+ * contribution whose default dock CHANGED would otherwise never reach
+ * existing installs. Guarded hard:
+ *
+ *  - the token burns exactly once per pane (idempotent across boots), and it
+ *    burns even when the heal is skipped, so a user who later drags the pane
+ *    back to the old spot is never fought;
+ *  - a USER-PLACED pane ($userPlacedPanes) is never touched — their spot wins;
+ *  - center re-homes only: a heal exists to consolidate a stray split into
+ *    its anchor's tab strip, not to re-run arbitrary splits.
+ *
+ * Silent like adoption — the anchor zone keeps its active tab. The center
+ * insert pins the zone's header shown, which is the point: the strip is how
+ * the user finds the healed tab.
+ */
+function healDockedPanes(
+  tree: LayoutNode,
+  dataOf: (paneId: string) => { dock?: PaneDockHint; placement?: string } | undefined
+): LayoutNode {
+  let next = tree
+
+  for (const pane of registry.getArea('panes')) {
+    const dock = dataOf(pane.id)?.dock
+
+    if (!dock?.heal || dock.pos !== 'center' || !allPaneIds(next).includes(pane.id)) {
+      continue
+    }
+
+    const token = `${pane.id}:${dock.heal}`
+
+    if (appliedDockHeals.has(token)) {
+      continue
+    }
+
+    markDockHealApplied(token)
+
+    if ($userPlacedPanes.get().has(pane.id)) {
+      continue
+    }
+
+    const from = findGroupOfPane(next, pane.id)
+    const anchor = findGroupOfPane(next, dock.pane)
+
+    // Already stacked with its anchor, or the anchor isn't in the tree.
+    if (!from || !anchor || from.id === anchor.id) {
+      continue
+    }
+
+    const without = removePane(next, pane.id)
+    const target = without ? findGroupOfPane(without, dock.pane)?.id : undefined
+
+    if (!without || !target) {
+      continue
+    }
+
+    next = insertAtGroup(without, target, pane.id, 'center', dock.before, false) ?? next
+  }
+
+  return next
 }
 
 function adoptContributedPanes(): void {
@@ -1125,6 +1205,10 @@ function adoptContributedPanes(): void {
 
   const dismissed = $dismissedPanes.get()
 
+  // One-time dock heals run FIRST: a heal re-homes a pane that is ALREADY in
+  // the tree, so the missing-pane adoption below never sees it.
+  const healed = healDockedPanes(tree, dataOf)
+
   // `placement: 'floating'` opts OUT of the tree entirely — those panes render
   // as fixed cards above it (renderer/floating-panes.tsx). Adopting one would
   // turn it into a track that steals width from a zone, which is the whole
@@ -1134,10 +1218,14 @@ function adoptContributedPanes(): void {
   )
 
   if (missing.length === 0) {
+    if (healed !== tree) {
+      commit(healed)
+    }
+
     return
   }
 
-  let next = tree
+  let next = healed
 
   for (const pane of missing) {
     const dock = dataOf(pane.id)?.dock

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8165,30 +8165,70 @@ export default {
       id: 'pane',
       area: 'panes',
       title: 'Bots',
-      // dock: explicit adoption gesture. Without it the tree adopts a
-      // same-placement pane by CENTER-STACKING it into the sessions zone —
-      // and when that zone's header is hidden (lone-pane auto-hide is the
-      // default the user never changed), the sessions pane vanishes behind
-      // the Bots tab with no visible strip to switch back. Splitting below
-      // the sessions pane keeps both surfaces visible instead.
-      data: { placement: 'left', width: '260px', dock: { pane: 'sessions', pos: 'bottom' } },
+      // dock: explicit adoption gesture — CENTER-STACK into the sessions zone
+      // so the sidebar grows a SESSIONS | BOTS tab strip instead of splitting
+      // two cramped panes down the column. Center is safe now: insertAtGroup
+      // pins the zone's header explicitly shown on a center gain (and it
+      // stays shown once the zone has stacked), so the sessions pane can
+      // never vanish behind a stripless Bots tab — the lone-pane auto-hide
+      // trap this dock used to work around with a 'bottom' split.
+      // heal: one-shot re-home for installs that adopted under the old
+      // 'bottom' split — moves the pane into the sessions strip ONCE, never
+      // touching a user-placed layout (see healDockedPanes in the tree store).
+      data: { placement: 'left', width: '260px', dock: { pane: 'sessions', pos: 'center', heal: 'sessions-tab-v1' } },
       render: () => jsx(BotsPane, {})
     })
 
     // Routines — its OWN tiling pane splitting the workspace's right edge
     // (NOT the collapsible right sidebar; placement 'right' is that sidebar's
     // role and hides the pane until "Show Right Sidebar").
-    ctx.register({
-      id: 'routines',
-      area: 'panes',
-      title: 'Cronjobs',
-      data: {
-        placement: 'main',
-        dock: { pane: 'workspace', pos: 'right' },
-        width: '250px'
-      },
-      render: () => jsx(RoutinesPane, {})
-    })
+    //
+    // Registered ONLY while Bot Mode is on screen: the pane exists while the
+    // Bots pane is visible (its zone's active tab, or a lone pane in a
+    // stacked pre-heal layout) and unregisters when the user tabs back to
+    // Sessions — no Cronjobs tile squatting beside the chat outside Bot Mode.
+    // `ctx.register` returns the disposer that makes this cheap; the tree
+    // keeps the pane's spot, so re-registering re-adopts it where it was.
+    // host.paneVisibility is feature-detected: older desktops without the SDK
+    // export keep the always-registered behavior.
+    const registerRoutinesPane = () =>
+      ctx.register({
+        id: 'routines',
+        area: 'panes',
+        title: 'Cronjobs',
+        data: {
+          placement: 'main',
+          dock: { pane: 'workspace', pos: 'right' },
+          width: '250px'
+        },
+        render: () => jsx(RoutinesPane, {})
+      })
+
+    if (typeof host.paneVisibility === 'function') {
+      // The contribution-scoped pane id (`register` prefixes `${ID}:`).
+      const $botsPaneVisible = host.paneVisibility(`${ID}:pane`)
+      let unregisterRoutines = null
+
+      const syncRoutinesPane = visible => {
+        if (visible) {
+          unregisterRoutines ??= registerRoutinesPane()
+        } else if (unregisterRoutines) {
+          unregisterRoutines()
+          unregisterRoutines = null
+        }
+      }
+
+      const stopRoutinesSync = $botsPaneVisible.listen(syncRoutinesPane)
+      syncRoutinesPane($botsPaneVisible.get())
+
+      if (typeof ctx.onDispose === 'function') {
+        // The registration disposer is already tracked by ctx.register; only
+        // the listener needs explicit teardown or it survives plugin disable.
+        ctx.onDispose(stopRoutinesSync)
+      }
+    } else {
+      registerRoutinesPane()
+    }
 
     ctx.register({
       id: 'new-agent',

--- a/apps/desktop/src/plugins/hermes-bots/tests/pane-dock-layout.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/pane-dock-layout.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// Bot Mode layout contract:
+//  - the Bots pane center-stacks into the sessions zone (SESSIONS | BOTS tab
+//    strip), never splits below it, and carries a one-shot heal token so
+//    installs that adopted under the old 'bottom' split migrate;
+//  - the Cronjobs (routines) pane only exists while the Bots pane is on
+//    screen — registered/unregistered through the contribution disposer,
+//    driven by the feature-detected host.paneVisibility SDK export, with the
+//    always-registered fallback kept for older desktops.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+test('the Bots pane center-docks into the sessions zone with a heal token', () => {
+  assert.match(source, /dock: \{ pane: 'sessions', pos: 'center', heal: 'sessions-tab-v1' \}/)
+  // The old workaround split must not come back.
+  assert.doesNotMatch(source, /pane: 'sessions', pos: 'bottom'/)
+})
+
+test('routines registration is a reusable disposer-returning function', () => {
+  assert.match(source, /const registerRoutinesPane = \(\) =>\s*\n\s*ctx\.register\(\{\s*\n\s*id: 'routines'/)
+})
+
+test('routines pane rides Bots visibility via feature-detected host.paneVisibility', () => {
+  assert.match(source, /typeof host\.paneVisibility === 'function'/)
+  assert.match(source, /host\.paneVisibility\(`\$\{ID\}:pane`\)/)
+  // Transitions register/unregister through the tracked disposer.
+  assert.match(source, /unregisterRoutines \?\?= registerRoutinesPane\(\)/)
+  assert.match(source, /unregisterRoutines\(\)\s*\n\s*unregisterRoutines = null/)
+  // The visibility listener must not survive plugin disable.
+  assert.match(source, /ctx\.onDispose\(stopRoutinesSync\)/)
+})
+
+test('older desktops without the SDK export keep the always-registered pane', () => {
+  assert.match(source, /\} else \{\s*\n\s*registerRoutinesPane\(\)\s*\n\s*\}/)
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -24,7 +24,13 @@ import type { ReactNode } from 'react'
 import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
 import { openSession, type OpenSessionIntent } from '@/app/open-session'
 import type { ClientSessionState } from '@/app/types'
-import { $narrowViewport, registerPaneCloser, removeTreePane, revealTreePane } from '@/components/pane-shell/tree/store'
+import {
+  $narrowViewport,
+  $paneVisible,
+  registerPaneCloser,
+  removeTreePane,
+  revealTreePane
+} from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
 import { registry } from '@/contrib/registry'
 import { deleteProfile, getLogs, getStatus, type HermesGateway } from '@/hermes'
@@ -456,6 +462,14 @@ export const host = {
     newSessionInProfile((profile ?? '').trim() || $activeGatewayProfile.get())
     window.location.hash = '#/'
   },
+
+  /** Reactive on-screen visibility of a contributed pane: true while it is in
+   *  the layout tree, not dismissed/hidden, its zone un-minimized, AND holding
+   *  its zone's active tab slot (a lone pane in its own zone counts). The
+   *  contribution-scoped pane id is `<pluginId>:<paneId>`. Memoized per id —
+   *  safe to call in render. Feature-detect on older desktops
+   *  (`typeof host.paneVisibility === 'function'`). */
+  paneVisibility: (paneId: string): ReadableAtom<boolean> => $paneVisible(paneId),
 
   /** HEAR the gateway stream (message deltas, session lifecycle, tool
    *  activity, …) by event type — `'*'` for everything. Returns a disposer.


### PR DESCRIPTION
Bot Mode's sidebar behaves like Teknium's original install again: the **Bots pane center-stacks as a tab in the sessions zone** — a `SESSIONS | BOTS` tab strip in one sidebar — instead of splitting into a second cramped pane below Sessions. And the profile-scoped **Cronjobs (Routines) pane now only exists while Bots mode is on screen**: it registers when the Bots tab is active (or visible in a pre-heal stacked layout) and unregisters the moment you switch back to Sessions.

## What changed

### 1. Bots is a Sessions-zone tab, not a split below it
- `plugin.js` dock hint changes `pos: 'bottom'` → `pos: 'center'`. The old bottom-split was a workaround for the lone-pane header auto-hide trap (sessions vanishing behind a stripless Bots tab); that trap is fixed on main — `insertAtGroup` pins the zone header **explicitly shown** on any center gain, and it stays shown once a zone has stacked. The stale comment is replaced with why center is safe now.
- **One-time persisted-layout heal** (`healDockedPanes` in the pane-shell tree store): adoption only places panes *missing* from the tree, so existing installs would keep the stacked layout forever. A dock hint can now carry a `heal: '<token>'`; a pane already in the tree under the old arrangement re-homes onto its center anchor **exactly once per token**, silently (sessions keeps the active tab).
  - **User-placed guard**: a pane in `$userPlacedPanes` is never touched — their spot wins.
  - **Idempotent + non-fighting**: the token is burned into a persisted key (`hermes.desktop.paneDockHeals.v1`) even when the heal is skipped, so a user who deliberately re-stacks afterward is never fought on later adoption passes or reboots.
  - Center re-homes only — a heal consolidates a stray split into its anchor's strip, never re-runs arbitrary splits.

### 2. Cronjobs pane scoped to Bots mode
- New minimal SDK export: `host.paneVisibility(paneId)` in `sdk/index.ts` — a memoized readonly atom wrapping the tree store's existing `$paneVisible` (true while the pane holds its zone's active tab slot / is a visible lone pane, which keeps Routines reachable for stacked-layout users who haven't healed yet).
- `plugin.js` registers/unregisters the routines contribution dynamically through the `ctx.register()` disposer on visibility transitions. The tree remembers the pane's spot, so re-registering re-adopts it right where it was (no dead sliver on unregister — unregistered panes drop out of tracks via `paneGone`).
- **Feature-detected** (`typeof host.paneVisibility === 'function'`); older desktops keep the always-registered behavior. The listener tears down through `ctx.onDispose`, so disable/re-enable doesn't leak.

## Validation

| Check | Result |
| --- | --- |
| `apps/desktop` `npm run check:lint` (tsc ×3 + eslint) | ✅ 0 errors (124 pre-existing warnings) |
| `npx vitest run` — new `dock-heal.test.ts` + adjacent tree suites (floating-adoption, plugin-pane-close, remove-pane, pane-toggle-visibility) | ✅ 5 files, 16 tests |
| `node --test tests/*.test.mjs` (hermes-bots source-shape suite, incl. new `pane-dock-layout.test.mjs`) | ✅ 223 pass |
| `node --check plugin.js` | ✅ |
| Sabotage proof | Reverting the `healDockedPanes` call makes 2/3 heal tests fail (the user-placed guard test correctly still passes); restored ✅ |

New heal tests cover: stacked persisted tree → healed into the sessions strip with sessions still active and the healed shape persisted; user-placed pane → untouched; burned token → a user re-stack is not fought by later adoption passes.

## Infographic

![Bots is a tab next to Sessions again; Cronjobs only in Bots mode](https://v3b.fal.media/files/b/0aa6c421/36rD5BRR0du0egPAk0mxd_LnGIMOEY.png)
