### PR TITLE
fix(terminal): block unquoted heredoc file writes, use write_file instead

### DIFF
--- a/tests/tools/test_terminal_heredoc_file_write_guard.py
+++ b/tests/tools/test_terminal_heredoc_file_write_guard.py
@@ -1,0 +1,108 @@
+"""Regression tests for the unquoted-heredoc-file-write guardrail.
+
+Real-world trigger: a session wrote a Next.js page via
+``cat > page.tsx <<EOF ... EOF`` (unquoted delimiter) instead of
+``write_file``. The body contained a TypeScript template literal
+(`` `${something}` ``); bash expanded the backtick-quoted span as command
+substitution before the content ever reached the file, silently replacing
+it with the (empty) output of that "command." The write reported success --
+there was no error anywhere in the chain, only a wrong file on disk.
+
+``detect_unquoted_heredoc_file_write`` (``tools/shell_heredoc.py``) blocks
+this specific combination -- a heredoc feeding a file-write consumer
+(``cat >``/``cat >>``/a bare redirect) with an unquoted delimiter -- while
+leaving heredocs that feed an interpreter (python, psql, docker exec -i)
+untouched, since those are a common and legitimate pattern this guard must
+not break.
+"""
+
+from tools.shell_heredoc import detect_unquoted_heredoc_file_write
+from tools.terminal_tool import detect_unquoted_heredoc_file_write as guard
+
+BT = chr(96)
+NL = chr(10)
+
+
+class TestUnquotedFileWriteBlocked:
+    """The exact dangerous combination: unquoted delimiter + file-write consumer."""
+
+    def test_cat_redirect_unquoted_delimiter_with_backtick_body(self):
+        cmd = (
+            "cat > page.tsx <<EOF" + NL
+            + "title: " + BT + "${something}" + BT + "," + NL
+            + "EOF"
+        )
+        result = detect_unquoted_heredoc_file_write(cmd)
+        assert result is not None
+        assert "write_file" in result
+        assert "EOF" in result
+
+    def test_cat_append_redirect_unquoted_delimiter(self):
+        cmd = "cat >> notes.txt <<EOF" + NL + "some text" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is not None
+
+    def test_bare_redirect_no_cat_prefix(self):
+        cmd = "> out.txt <<EOF" + NL + "content" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is not None
+
+    def test_unquoted_delimiter_with_dollar_expansion_body(self):
+        cmd = "cat > deploy.sh <<EOF" + NL + "echo $HOME" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is not None
+
+    def test_env_prefix_before_cat(self):
+        cmd = "LC_ALL=C cat > out.txt <<EOF" + NL + "text" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is not None
+
+
+class TestQuotedFileWriteAllowed:
+    """A quoted delimiter is inert -- no shell expansion, safe as written."""
+
+    def test_single_quoted_delimiter(self):
+        cmd = (
+            "cat > page.tsx <<'EOF'" + NL
+            + "title: " + BT + "${something}" + BT + "," + NL
+            + "EOF"
+        )
+        assert detect_unquoted_heredoc_file_write(cmd) is None
+
+    def test_double_quoted_delimiter(self):
+        cmd = 'cat > page.tsx <<"EOF"' + NL + "content" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is None
+
+    def test_backslash_escaped_delimiter(self):
+        # `<<\EOF` -- a leading backslash marks the whole delimiter word
+        # quoted per bash heredoc rules, same as `<<'EOF'`.
+        cmd = "cat > page.tsx <<\\EOF" + NL + "content" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is None
+
+
+class TestNonFileWriteConsumersUntouched:
+    """Heredocs feeding an interpreter are a common pattern -- must not block them."""
+
+    def test_python_interpreter_unquoted(self):
+        cmd = "python3 <<EOF" + NL + "print(1)" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is None
+
+    def test_docker_exec_unquoted(self):
+        cmd = "docker exec -i mycontainer bash <<EOF" + NL + "ls" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is None
+
+    def test_psql_unquoted(self):
+        cmd = "psql -h localhost <<EOF" + NL + "SELECT 1;" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is None
+
+    def test_no_heredoc_at_all(self):
+        assert detect_unquoted_heredoc_file_write("cat file.txt") is None
+
+    def test_plain_redirect_no_heredoc(self):
+        assert detect_unquoted_heredoc_file_write("echo hello > file.txt") is None
+
+    def test_cat_reading_not_writing(self):
+        assert detect_unquoted_heredoc_file_write("cat file.txt | grep x") is None
+
+
+class TestTerminalToolReexport:
+    """terminal_tool.py imports and wires this in -- confirm the same function."""
+
+    def test_same_function_object(self):
+        assert guard is detect_unquoted_heredoc_file_write

--- a/tests/tools/test_terminal_heredoc_file_write_guard.py
+++ b/tests/tools/test_terminal_heredoc_file_write_guard.py
@@ -16,6 +16,8 @@ untouched, since those are a common and legitimate pattern this guard must
 not break.
 """
 
+import json
+
 from tools.shell_heredoc import detect_unquoted_heredoc_file_write
 from tools.terminal_tool import detect_unquoted_heredoc_file_write as guard
 
@@ -52,6 +54,32 @@ class TestUnquotedFileWriteBlocked:
     def test_env_prefix_before_cat(self):
         cmd = "LC_ALL=C cat > out.txt <<EOF" + NL + "text" + NL + "EOF"
         assert detect_unquoted_heredoc_file_write(cmd) is not None
+
+    def test_redirect_after_heredoc_operator(self):
+        # `cat <<EOF > file` -- the file redirect comes AFTER the heredoc
+        # operator on the opener line, not before it. Must be caught the
+        # same as `cat > file <<EOF`; the danger doesn't depend on order.
+        cmd = "cat <<EOF > file.txt" + NL + "content" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is not None
+
+
+class TestNonFileRedirectTargetsAllowed:
+    """A `>` that doesn't point at a plain file is not a file-write consumer."""
+
+    def test_fd_duplication_not_a_file(self):
+        # `>&2` duplicates stdout onto fd 2 (stderr) -- not a file target.
+        cmd = "cat >&2 <<EOF" + NL + "content" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is None
+
+    def test_process_substitution_not_a_file(self):
+        # `>(cmd)` is process substitution -- writes to a pipe feeding a
+        # subprocess, not a plain file.
+        cmd = "cat > >(tee log.txt) <<EOF" + NL + "content" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is None
+
+    def test_append_fd_duplication_not_a_file(self):
+        cmd = "cat >>&2 <<EOF" + NL + "content" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is None
 
 
 class TestQuotedFileWriteAllowed:
@@ -100,9 +128,52 @@ class TestNonFileWriteConsumersUntouched:
     def test_cat_reading_not_writing(self):
         assert detect_unquoted_heredoc_file_write("cat file.txt | grep x") is None
 
+    def test_interpreter_with_own_unrelated_output_redirect(self):
+        # `python3 <<EOF > out.log` -- the heredoc feeds python as its
+        # script (safe, same as any other interpreter case); the `>` on
+        # this line redirects PYTHON's own stdout, not the heredoc body.
+        # A file-write redirect being present somewhere on the opener must
+        # not be enough to flag this on its own.
+        cmd = "python3 <<EOF > out.log" + NL + "print(1)" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is None
+
+    def test_bash_interpreter_with_own_output_redirect(self):
+        cmd = "bash <<EOF > out.log" + NL + "echo hi" + NL + "EOF"
+        assert detect_unquoted_heredoc_file_write(cmd) is None
+
 
 class TestTerminalToolReexport:
     """terminal_tool.py imports and wires this in -- confirm the same function."""
 
     def test_same_function_object(self):
         assert guard is detect_unquoted_heredoc_file_write
+
+
+class TestTerminalToolActuallyBlocks:
+    """Integration-level: terminal_tool() itself hard-blocks before executing.
+
+    The unit tests above only exercise the detector function directly --
+    they protect the detection logic but not the wiring. A future refactor
+    could silently drop or reorder the guard inside terminal_tool() without
+    any of those tests catching it. These call terminal_tool() itself and
+    assert on its actual response, the same JSON contract an agent sees.
+    """
+
+    def test_dangerous_command_is_blocked_with_no_execution(self):
+        from tools.terminal_tool import terminal_tool
+
+        cmd = "cat > page.tsx <<EOF" + NL + "title: " + BT + "${x}" + BT + "," + NL + "EOF"
+        result = json.loads(terminal_tool(command=cmd))
+
+        assert result["status"] == "error"
+        assert result["exit_code"] == -1
+        assert "write_file" in result["error"]
+        assert result["output"] == ""
+
+    def test_safe_quoted_variant_is_not_blocked_by_this_guard(self):
+        # Deliberately NOT calling terminal_tool() here: the quoted variant is
+        # allowed, so a real call would execute the command and write a file
+        # as a test side effect. The guard's own decision is the thing under
+        # test, and the block above already proves terminal_tool() acts on it.
+        cmd = "cat > page.tsx <<'EOF'" + NL + "title: " + BT + "${x}" + BT + "," + NL + "EOF"
+        assert guard(cmd) is None

--- a/tools/shell_heredoc.py
+++ b/tools/shell_heredoc.py
@@ -159,6 +159,100 @@ def _find_heredoc_close(
         cursor = after
 
 
+# A heredoc whose output redirects to a file: `cat > path`, `cat >> path`,
+# or a bare redirect with no other consumer (`> path <<EOF`). Deliberately
+# narrow — this must not flag heredocs feeding an interpreter that legitimately
+# consumes stdin as input rather than writing it verbatim to disk (python,
+# psql, docker exec -i, ssh).
+_FILE_WRITE_HEREDOC_RE = re.compile(
+    r"^\s*"
+    r"(?:[A-Z_][A-Z0-9_]*=\S+\s+)*"
+    r"(?:cat\s+)?"
+    r">{1,2}\s*\S",
+    re.IGNORECASE,
+)
+
+
+def detect_unquoted_heredoc_file_write(command: str) -> str | None:
+    """Return a warning if COMMAND writes a file via an unquoted heredoc.
+
+    ``cat > path <<EOF ... EOF`` (unquoted delimiter) hands the body to bash
+    for backtick / ``$(...)`` / ``$VAR`` expansion before it reaches the file
+    — a TypeScript template literal or any shell-looking payload text
+    silently corrupts on write, with no error at all. ``write_file`` pipes
+    content as raw stdin, bypassing shell parsing entirely, and is what the
+    terminal tool's own description already tells the caller to use for
+    exactly this. This detects the specific dangerous combination
+    (file-write consumer + unquoted delimiter) rather than heredocs
+    generally — piping a heredoc to an interpreter (python, psql,
+    docker exec -i) is a common, legitimate pattern and stays untouched.
+
+    Conservative in the same direction as ``strip_inert_heredoc_bodies``:
+    on any parse ambiguity (unknown operator, unterminated heredoc), this
+    skips that occurrence rather than flagging it — a missed corruption
+    case is a worse outcome than a background one, but reliability here
+    still favors under-triggering over blocking valid commands on a parse
+    the module cannot stand behind.
+
+    Returns ``None`` when no unsafe pattern is found; otherwise a
+    human-readable reason naming the delimiter.
+    """
+    if "<<" not in command:
+        return None
+    command_start = 0
+    last_opener_index = command.rfind("<<")
+
+    while command_start < len(command):
+        if command_start > last_opener_index:
+            break
+        command_end, specs, unknown_operator, _has_list_operator = (
+            _scan_heredoc_command_unit(command, command_start)
+        )
+        if unknown_operator:
+            command_start = command_end + 1 if command_end < len(command) else command_end
+            if command_end >= len(command):
+                break
+            continue
+        if not specs:
+            if command_end >= len(command):
+                break
+            command_start = command_end + 1
+            continue
+        if command_end >= len(command):
+            break
+
+        opener = command[command_start:command_end]
+        masked_opener = _mask_simple_quotes(opener)
+        if _FILE_WRITE_HEREDOC_RE.search(masked_opener):
+            for delimiter, _strip_tabs, quoted in specs:
+                if not quoted:
+                    return (
+                        f"heredoc <<{delimiter} is unquoted while its output "
+                        "redirects to a file -- bash expands backticks/"
+                        "$()/$VAR in the body before it reaches disk, so "
+                        "content containing shell-active syntax (a "
+                        "TypeScript template literal, a Markdown code "
+                        "fence with $VAR, etc.) can silently corrupt on "
+                        f"write. Use write_file for file content instead, "
+                        f"or quote the delimiter (<<'{delimiter}') if the "
+                        "body genuinely needs to stay inert."
+                    )
+
+        body_cursor = command_end + 1
+        unterminated = False
+        for delimiter, strip_tabs, _quoted in specs:
+            close_end = _find_heredoc_close(command, body_cursor, delimiter, strip_tabs)
+            if close_end is None:
+                unterminated = True
+                break
+            body_cursor = close_end
+        if unterminated:
+            break
+        command_start = body_cursor
+
+    return None
+
+
 def strip_inert_heredoc_bodies(command: str) -> str:
     """Mask heredoc bodies that are provably inert data (see module docstring)."""
     # Runs on every terminal call: skip the state machine when no '<<' exists; stop past the last.

--- a/tools/shell_heredoc.py
+++ b/tools/shell_heredoc.py
@@ -160,15 +160,27 @@ def _find_heredoc_close(
 
 
 # A heredoc whose output redirects to a file: `cat > path`, `cat >> path`,
-# or a bare redirect with no other consumer (`> path <<EOF`). Deliberately
-# narrow — this must not flag heredocs feeding an interpreter that legitimately
-# consumes stdin as input rather than writing it verbatim to disk (python,
-# psql, docker exec -i, ssh).
-_FILE_WRITE_HEREDOC_RE = re.compile(
+# or a bare redirect with no other consumer (`> path <<EOF`). Matched
+# anywhere in the opener, not just at its start, so `cat <<EOF > path`
+# (redirect after the heredoc operator) is caught the same as
+# `cat > path <<EOF`. The lookahead excludes non-file redirect targets that
+# happen to start with `>`: `>&2` (fd duplication -- not a file), `>(cmd)`
+# (process substitution -- writes to a pipe, not a plain file), and `>>`
+# already covered by `{1,2}` so a second literal `>` can't be its own target.
+_FILE_WRITE_HEREDOC_RE = re.compile(r">{1,2}\s*(?![&()>])\S")
+
+# Interpreters whose heredoc body is fed to them as input/script text, not
+# copied verbatim to a file. A `>` elsewhere on the same command line
+# redirects THEIR output, not the heredoc body, and is unrelated to this
+# guard: `python3 <<EOF > out.log` must not be flagged just because a file
+# redirect is present somewhere on the line. Deliberately excludes `cat`:
+# `cat > path <<EOF` is exactly the pattern this guard exists to catch.
+_HEREDOC_INTERPRETER_CONSUMER_RE = re.compile(
     r"^\s*"
     r"(?:[A-Z_][A-Z0-9_]*=\S+\s+)*"
-    r"(?:cat\s+)?"
-    r">{1,2}\s*\S",
+    r"(?:env\s+)?"
+    r"(?:[A-Za-z0-9_./-]+/)?"
+    r"(?:python(?:3(?:\.\d+)*)?|node|osascript|psql|docker|ssh|bash|sh|zsh)(?=\s|$)",
     re.IGNORECASE,
 )
 
@@ -223,7 +235,10 @@ def detect_unquoted_heredoc_file_write(command: str) -> str | None:
 
         opener = command[command_start:command_end]
         masked_opener = _mask_simple_quotes(opener)
-        if _FILE_WRITE_HEREDOC_RE.search(masked_opener):
+        is_interpreter_consumer = bool(
+            _HEREDOC_INTERPRETER_CONSUMER_RE.search(masked_opener)
+        )
+        if not is_interpreter_consumer and _FILE_WRITE_HEREDOC_RE.search(masked_opener):
             for delimiter, _strip_tabs, quoted in specs:
                 if not quoted:
                     return (

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -978,6 +978,12 @@ def _plan_execution(
         guidance = _foreground_background_guidance(command)
         if guidance:
             raise _Rejected(_error_json(guidance, status="error"))
+        # An unquoted heredoc writing a file lets bash expand backticks/$()/$VAR in the
+        # body before it reaches disk, silently corrupting the content with no error.
+        # Refuse it in favour of write_file, which this tool's own description says to use.
+        heredoc_warning = detect_unquoted_heredoc_file_write(command)
+        if heredoc_warning:
+            raise _Rejected(_error_json(heredoc_warning, status="error"))
         if timeout and timeout > FOREGROUND_MAX_TIMEOUT:
             promoted = timeout
 
@@ -1403,6 +1409,7 @@ _PLUGIN_COMPAT_LAZY = {
     'is_persistent_env': ('tools.terminal_tool_lifecycle', 'is_persistent_env'),
     'nous_tool_gateway_unavailable_message': ('tools.tool_backend_helpers', 'nous_tool_gateway_unavailable_message'),
     'resolve_modal_backend_state': ('tools.tool_backend_helpers', 'resolve_modal_backend_state'),
+    'detect_unquoted_heredoc_file_write': ('tools.shell_heredoc', 'detect_unquoted_heredoc_file_write'),
     'strip_inert_heredoc_bodies': ('tools.shell_heredoc', 'strip_inert_heredoc_bodies'),
 }
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -981,6 +981,7 @@ def _plan_execution(
         # An unquoted heredoc writing a file lets bash expand backticks/$()/$VAR in the
         # body before it reaches disk, silently corrupting the content with no error.
         # Refuse it in favour of write_file, which this tool's own description says to use.
+        from tools.shell_heredoc import detect_unquoted_heredoc_file_write
         heredoc_warning = detect_unquoted_heredoc_file_write(command)
         if heredoc_warning:
             raise _Rejected(_error_json(heredoc_warning, status="error"))


### PR DESCRIPTION
## Problem

`cat > path <<EOF ... EOF` (unquoted heredoc delimiter) hands the body to bash for backtick/`$()`/`$VAR` expansion before it ever reaches disk. Reproduced live: a session wrote a Next.js page with a TypeScript template literal —

```
title: `${something}`,
```

— and the file on disk ended up with:

```
title: \,
```

The backtick-quoted span was read as shell command substitution; its (empty) output was substituted in. No error anywhere in the chain — the write reported success, and only a downstream `next build` type error surfaced the corruption several steps later.

`write_file` already exists and is immune to this class entirely: its local backend pipes content as raw stdin into `cat` (`_atomic_write`, `stdin_data=content`), never as parsed command text, so backticks inside it are inert. The terminal tool's own description already tells the caller *"Do NOT use... echo/heredoc file creation (use write_file)"* — this PR enforces that instead of only stating it, since the instruction alone didn't prevent the corruption.

## Fix

`detect_unquoted_heredoc_file_write()` in `tools/shell_heredoc.py` reuses the existing heredoc parser (`_scan_heredoc_command_unit`, built for #63788's background-`&` guard) rather than adding new parsing logic. It only fires on the specific dangerous combination — a heredoc feeding a file-write consumer (`cat >`, `cat >>`, a bare redirect) with an **unquoted** delimiter. Heredocs feeding an interpreter (`python`, `psql`, `docker exec -i`) are untouched, since piping input to those is common and safe.

Wired into `terminal_tool.py` as a hard block (same pattern as the existing `_foreground_background_guidance` guardrail immediately above it) — returns an actionable error naming the delimiter and pointing at `write_file`, rather than letting the command run and silently corrupt the target file.

## Testing

New `tests/tools/test_terminal_heredoc_file_write_guard.py` (15 cases): the exact reproduction command, append-mode, bare redirects, env-var prefixes, quoted delimiters (single/double/backslash-escaped) correctly allowed, and interpreter-consumer heredocs (python/docker exec/psql) correctly left untouched.

Existing `tests/tools/test_terminal_heredoc_background_guard.py` (30 cases, unrelated feature sharing the same parser) still passes — confirmed zero regressions by running both suites together, and separately verified the fix's diff against a clean `origin/main` checkout introduces no other changes.

_🤖 Investigated and fixed with [Claude Code](https://claude.com/claude-code)_