### PR TITLE
fix(arxiv): stop truncating old-style arXiv IDs with a v in the archive name

### DIFF
--- a/skills/research/arxiv/scripts/search_arxiv.py
+++ b/skills/research/arxiv/scripts/search_arxiv.py
@@ -26,6 +26,10 @@ def parse_arxiv_id(full_id):
     (solv-int, adap-org, chao-dyn, patt-sol, comp-gas), e.g.
     'solv-int/9701001v1' -> 'sol'. Anchor the version suffix to the
     end of the string instead.
+
+    A malformed suffix (e.g. a trailing bare 'v' with no digits, as in
+    '2402.03300v') rides along as part of the base id untouched, since
+    arXiv never emits ids in that form.
     """
     match = re.fullmatch(r"(.+?)(v\d+)?", full_id)
     return match.group(1), match.group(2) or ""

--- a/skills/research/arxiv/scripts/search_arxiv.py
+++ b/skills/research/arxiv/scripts/search_arxiv.py
@@ -10,12 +10,26 @@ Usage:
     python search_arxiv.py --id 2402.03300
     python search_arxiv.py --id 2402.03300,2401.12345
 """
+import re
 import sys
 import urllib.request
 import urllib.parse
 import xml.etree.ElementTree as ET
 
 NS = {'a': 'http://www.w3.org/2005/Atom'}
+
+
+def parse_arxiv_id(full_id):
+    """Split an arXiv id into (base id, version suffix).
+
+    A plain split on 'v' truncates archive names that contain a 'v'
+    (solv-int, adap-org, chao-dyn, patt-sol, comp-gas), e.g.
+    'solv-int/9701001v1' -> 'sol'. Anchor the version suffix to the
+    end of the string instead.
+    """
+    match = re.fullmatch(r"(.+?)(v\d+)?", full_id)
+    return match.group(1), match.group(2) or ""
+
 
 def search(query=None, author=None, category=None, ids=None, max_results=5, sort="relevance"):
     params = {}
@@ -62,20 +76,19 @@ def search(query=None, author=None, category=None, ids=None, max_results=5, sort
         title = entry.find('a:title', NS).text.strip().replace('\n', ' ')
         raw_id = entry.find('a:id', NS).text.strip()
         full_id = raw_id.split('/abs/')[-1] if '/abs/' in raw_id else raw_id
-        arxiv_id = full_id.split('v')[0]  # base ID for links
+        arxiv_id, version = parse_arxiv_id(full_id)
         published = entry.find('a:published', NS).text[:10]
         updated = entry.find('a:updated', NS).text[:10]
         authors = ', '.join(a.find('a:name', NS).text for a in entry.findall('a:author', NS))
         summary = entry.find('a:summary', NS).text.strip().replace('\n', ' ')
         cats = ', '.join(c.get('term') for c in entry.findall('a:category', NS))
-        
-        version = full_id[len(arxiv_id):] if full_id != arxiv_id else ""
+
         print(f"{i+1}. {title}")
         print(f"   ID: {arxiv_id}{version} | Published: {published} | Updated: {updated}")
         print(f"   Authors: {authors}")
         print(f"   Categories: {cats}")
         print(f"   Abstract: {summary[:300]}{'...' if len(summary) > 300 else ''}")
-        print(f"   Links: https://arxiv.org/abs/{arxiv_id} | https://arxiv.org/pdf/{arxiv_id}")
+        print(f"   Links: https://arxiv.org/abs/{full_id} | https://arxiv.org/pdf/{full_id}")
         print()
 
 

--- a/tests/skills/test_search_arxiv_skill.py
+++ b/tests/skills/test_search_arxiv_skill.py
@@ -1,0 +1,51 @@
+"""
+Tests for skills/research/arxiv/scripts/search_arxiv.py's arXiv id parsing.
+
+parse_arxiv_id() must split old-style ids (which may contain a literal 'v' in
+the archive name, e.g. solv-int, adap-org, chao-dyn, patt-sol, comp-gas) on
+the trailing version suffix only, not on the first 'v' anywhere in the string.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "research"
+    / "arxiv"
+    / "scripts"
+    / "search_arxiv.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("search_arxiv", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_arxiv_id_modern_versioned():
+    mod = load_module()
+    assert mod.parse_arxiv_id("2402.03300v2") == ("2402.03300", "v2")
+
+
+def test_parse_arxiv_id_modern_unversioned():
+    mod = load_module()
+    assert mod.parse_arxiv_id("2402.03300") == ("2402.03300", "")
+
+
+def test_parse_arxiv_id_old_style_archive_name_contains_v():
+    mod = load_module()
+    # Regression: a naive split on the first 'v' truncates this to 'sol'.
+    assert mod.parse_arxiv_id("solv-int/9701001v1") == ("solv-int/9701001", "v1")
+
+
+def test_parse_arxiv_id_old_style_no_v_in_archive_name():
+    mod = load_module()
+    assert mod.parse_arxiv_id("hep-th/0601001v3") == ("hep-th/0601001", "v3")


### PR DESCRIPTION
## What does this PR do?

Fixes ID truncation in the bundled `arxiv` skill's search helper. `search_arxiv.py` derived the base arXiv ID with `full_id.split('v')[0]`, which cuts at the **first** `v` anywhere in the string, not at the version suffix. Old-style arXiv identifiers whose archive name itself contains a `v` (`solv-int`, `adap-org`, `chao-dyn`, `patt-sol`, `comp-gas`) get truncated — e.g. `solv-int/9701001v1` becomes `sol` — and the printed abstract/PDF links point at a non-existent paper.

The fix replaces the split with `parse_arxiv_id()`, which anchors the version suffix (`v\d+`) to the end of the string via `re.fullmatch(r"(.+?)(v\d+)?", full_id)`, and prints links against the exact versioned ID (rather than the base ID) so a citation can't silently drift to a different revision than the one that was read.

This addresses item 1 of the 6 fixes described in the issue. Items 2–6 (the `grounded-citations` Sources-block/sentence-split bugs, the `_hermes_home.py` Windows fallback, and the doc corrections) are independent per the issue's own text ("splitting any combined change... is fine") and are left for separate PRs so each can be reviewed on its own.

## Related Issue

Fixes #88660

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `skills/research/arxiv/scripts/search_arxiv.py`: added `parse_arxiv_id()` to correctly split an arXiv ID into (base, version) by anchoring the version suffix to the end of the string instead of splitting on the first `v`; links now use the exact versioned ID.
- `tests/skills/test_search_arxiv_skill.py`: new regression tests for `parse_arxiv_id()` covering modern versioned/unversioned IDs and old-style IDs whose archive name contains a `v`.

## How to Test

1. `python3 -m pytest tests/skills/test_search_arxiv_skill.py -q`
2. Confirm the regression: `git checkout HEAD~1 -- skills/research/arxiv/scripts/search_arxiv.py && python3 -m pytest tests/skills/test_search_arxiv_skill.py -q` — fails (`parse_arxiv_id` doesn't exist / old code truncates `solv-int/9701001v1` to `sol`), then `git checkout HEAD -- skills/research/arxiv/scripts/search_arxiv.py` to restore the fix.

### Actual output

With the fix:
```
$ python3 -m pytest tests/skills/test_search_arxiv_skill.py -q
....                                                                     [100%]
4 passed in 0.18s
```

With the fix reverted (`git checkout HEAD~1 -- skills/research/arxiv/scripts/search_arxiv.py`):
```
$ python3 -m pytest tests/skills/test_search_arxiv_skill.py -q
FAILED tests/skills/test_search_arxiv_skill.py::test_parse_arxiv_id_modern_versioned - AttributeError: module 'search_arxiv' has no attribute 'parse_arxiv_id'
FAILED tests/skills/test_search_arxiv_skill.py::test_parse_arxiv_id_modern_unversioned - AttributeError: module 'search_arxiv' has no attribute 'parse_arxiv_id'
FAILED tests/skills/test_search_arxiv_skill.py::test_parse_arxiv_id_old_style_archive_name_contains_v - AttributeError: module 'search_arxiv' has no attribute 'parse_arxiv_id'
FAILED tests/skills/test_search_arxiv_skill.py::test_parse_arxiv_id_old_style_no_v_in_archive_name - AttributeError: module 'search_arxiv' has no attribute 'parse_arxiv_id'
4 failed in 0.20s
```

Also ran the broader skills authoring-standards suite to confirm no regression:
```
$ python3 -m pytest tests/skills/test_authoring_standards.py -q
1196 passed in 5.29s
```

`ruff check` on both changed files: `All checks passed!`. `git diff --check`: clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (checked open PRs touching the arxiv skill; none address this ID-parsing bug)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested on Linux only; the fix is a pure string-parsing change with no platform-specific behavior

### Documentation & Housekeeping

- [x] N/A — no config keys, architecture, or tool schemas changed

## Disclosure

This PR was prepared with AI assistance (an autonomous coding agent working from the issue text), with the diff reviewed and tests verified to fail without the change before submission.
