### PR TITLE
docs(desktop): document multiple Desktop clients connecting to one hermes serve backend

### DIFF
--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -352,6 +352,12 @@ You can also set the backend URL without the UI via the `HERMES_DESKTOP_REMOTE_U
 The remote gateway host is configured per [profile](./profiles.md), so each profile can point at its own remote backend (or stay on its local one). Switching profiles switches which remote host the app connects to.
 :::
 
+### Multiple Desktop clients, one backend
+
+Yes, several Desktop installations can connect to the same `hermes serve` process at once — that's the normal shape of a remote/shared backend, not an edge case. Each WebSocket connection gets its own transport, and sessions, approvals, and in-flight tool state are tracked per session id rather than globally, so concurrent clients don't step on each other's turns. Profile selection is also resolved per connection, so one unified backend can host a private profile per person plus a shared profile simultaneously — you don't need a separate `hermes serve` process just to add another profile.
+
+What a **unified** backend (the default; no `--isolated`) does not give you is per-person access control: it has one auth gate — one username/password pair, or one OAuth realm — for the whole process, not one per profile. Anyone who authenticates can see every profile's session list via the sidebar, not just the one they're working in. If the profiles genuinely need to stay private *from each other* (not just organized separately), don't rely on "different profile" as an access boundary between mutually-untrusted people on a unified server. The supported way to get a real auth boundary per profile is a dedicated `hermes serve --isolated` process per profile (its own port, its own credentials) — see `--isolated` under [Web Dashboard → Options](./features/web-dashboard.md#options). That mode currently has its own cross-profile visibility gap tracked in [#76932](https://github.com/NousResearch/hermes-agent/issues/76932); check its status before depending on it for isolation between people who shouldn't see each other's sessions.
+
 ### Troubleshooting
 
 - **Sign-in fails with 401 / "Invalid credentials"** — the username or password doesn't match the backend's `HERMES_DASHBOARD_BASIC_AUTH_USERNAME` / `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD`. The backend returns the same generic error for an unknown user and a wrong password (no enumeration oracle), so double-check both. Confirm the gate is on with `curl -s http://<host>:9119/api/status | jq '.auth_required, .auth_providers'` — it should report `true` and include `"basic"`.


### PR DESCRIPTION
## What does this PR do?

Answers #88650, which asked whether multiple independent Hermes Desktop
installations can safely connect to one shared `hermes serve` backend at
once (a multi-user deployment: one Linux VPS running the backend, several
Windows workstations each running Desktop, a private profile per person plus
one shared profile), and whether that's documented anywhere.

It wasn't — `desktop.md` and `multi-connection-desktop.md` only cover one
Desktop app talking to *many* backends, not the reverse (many Desktop
clients talking to *one* backend). This adds a short subsection, "Multiple
Desktop clients, one backend", to `website/docs/user-guide/desktop.md`
under "Connecting to a remote backend", right after the existing
per-profile note.

Verified against the current code before writing this, rather than
asserting from the issue's premise:

- `tui_gateway/ws.py` — `WSTransport` is explicitly "Per-connection WS
  transport"; each accepted WebSocket gets its own transport instance.
- `tui_gateway/server.py` — sessions live in a single process-wide table
  keyed by session id (not one global session), and approvals are keyed by
  `session_key`, so concurrent clients don't collide on turns/approvals.
- `hermes_constants.py` — `HERMES_HOME` is a `ContextVar` override applied
  at session-create time, so profile selection is resolved per connection,
  not fixed for the whole process. This backs up `hermes_cli/subcommands/dashboard.py`'s
  own description of the default "unified" server as one machine-level
  process meant to host multiple profiles at once.
- `hermes_cli/web_routers/profiles.py` — `GET /api/profiles` (`list_profiles_endpoint`)
  returns every profile unconditionally, with no scoping by caller. So a
  unified backend's one auth gate (one Basic-auth pair, or one OAuth realm)
  covers the whole process, not a profile — any authenticated client can see
  every profile's session list via the sidebar batched endpoint, not just
  the one it's working in.
- `website/docs/user-guide/features/web-dashboard.md` already documents
  `--isolated` as "useful if you deliberately expose different profiles'
  dashboards with different auth" — i.e. the existing, intended path to a
  real per-profile auth boundary. That mode has its own open cross-profile
  visibility bug, [#76932](https://github.com/NousResearch/hermes-agent/issues/76932)
  (still open on `main`), so the new text points readers at it instead of
  claiming isolation that doesn't fully exist yet.

So the added text answers the issue's four questions directly: yes, several
clients can connect concurrently and are isolated at the session/approval/
tool-state/profile-routing layer; but a *unified* backend does not provide
per-person access control between profiles, and getting one today means
per-profile `--isolated` servers with separate credentials (with the caveat
that #76932 currently undermines even that).

## Related Issue

Fixes #88650

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/desktop.md`: added a "Multiple Desktop clients,
  one backend" subsection (+6 lines) answering the multi-user topology
  question and cross-referencing `--isolated` and #76932.

## How to Test

1. Open `website/docs/user-guide/desktop.md` and read the new subsection
   under "Connecting to a remote backend" (between the "Per-profile remote
   hosts" note and "Troubleshooting").
2. Confirm the two links resolve: `./features/web-dashboard.md#options`
   (the `--isolated` flag row in the Quick Start → Options table) and
   `https://github.com/NousResearch/hermes-agent/issues/76932`.
3. This is a docs-only change (no Python/TS touched), so no test suite run
   is applicable; verified manually that the added markdown has balanced
   `[]`/`()` pairs and that both anchors/links point at real, existing
   targets in this checkout.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`docs(desktop): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, docs-only change, no Python touched
- [ ] I've added tests for my changes — N/A, prose documentation, not testable code behavior
- [x] I've tested on my platform: Linux (doc content verified by reading, no build tooling required for a markdown addition)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`docs/`)
- [ ] I've updated `cli-config.yaml.example` — N/A, no config keys changed
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A, no architecture/workflow change
- [x] I've considered cross-platform impact — N/A, documentation only
- [ ] I've updated tool descriptions/schemas — N/A, no tool behavior changed

## AI assistance disclosure

This PR was prepared by an AI coding agent (Claude), which read the issue,
verified the relevant claims against the current `main` source (files cited
above) and existing related issue #76932, and wrote the documentation
change. A human should review the framing before merge, especially the
characterization of #76932's current status.
