### PR TITLE
feat(desktop): expose host.revealPane() on the plugin SDK so commands can summon dismissed plugin panes

### DIFF
--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -150,4 +150,15 @@ describe('host.revealPane', () => {
     disposers.forEach(dispose => dispose())
     $dismissedPanes.set(new Set())
   })
+
+  it('un-hides a chrome-hidden plugin pane', async () => {
+    const { $hiddenTreePanes, setTreePaneHidden } = await import('@/components/pane-shell/tree/store')
+
+    setTreePaneHidden('plugin:reveal-target', true)
+    expect($hiddenTreePanes.get()).toContain('plugin:reveal-target')
+
+    host.revealPane('plugin:reveal-target')
+
+    expect($hiddenTreePanes.get()).not.toContain('plugin:reveal-target')
+  })
 })

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -107,3 +107,47 @@ describe('host.state turn flags', () => {
     $sessionTiles.set([])
   })
 })
+
+describe('host.revealPane', () => {
+  it('un-dismisses a closed plugin pane and puts it back in the layout tree', async () => {
+    const { allPaneIds, group, split } = await import('@/components/pane-shell/tree/model')
+    const { $dismissedPanes, $layoutTree, dismissTreePane } = await import('@/components/pane-shell/tree/store')
+    const { registry } = await import('@/contrib/registry')
+
+    const disposers = [
+      registry.register({
+        area: 'panes',
+        data: { placement: 'main' },
+        id: 'workspace',
+        render: () => null,
+        title: 'workspace'
+      }),
+      registry.register({
+        area: 'panes',
+        data: { placement: 'right' },
+        id: 'plugin:reveal-target',
+        render: () => null,
+        title: 'reveal-target'
+      })
+    ]
+
+    $layoutTree.set(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'grp-main' }),
+        group(['plugin:reveal-target'], { active: 'plugin:reveal-target', id: 'grp-side' })
+      ])
+    )
+
+    dismissTreePane('plugin:reveal-target')
+    expect($dismissedPanes.get()).toContain('plugin:reveal-target')
+    expect(allPaneIds($layoutTree.get()!)).not.toContain('plugin:reveal-target')
+
+    host.revealPane('plugin:reveal-target')
+
+    expect($dismissedPanes.get()).not.toContain('plugin:reveal-target')
+    expect(allPaneIds($layoutTree.get()!)).toContain('plugin:reveal-target')
+
+    disposers.forEach(dispose => dispose())
+    $dismissedPanes.set(new Set())
+  })
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -449,6 +449,15 @@ export const host = {
     return close
   },
 
+  /** Bring a pane back to the front: un-dismisses it, un-collapses its side,
+   *  un-hides it, un-minimizes its zone, and fronts its tab. Idempotent —
+   *  safe to call on a pane that is already visible. Use this so a plugin
+   *  command can route into its own dismissed pane instead of falling back
+   *  to `ctx.os.openExternal`. */
+  revealPane: (paneId: string): void => {
+    revealTreePane(paneId)
+  },
+
   /** Start a fresh chat draft, optionally pointed at another profile (its
    *  backend spins up in the background — same door the sidebar's per-profile
    *  "+" uses). */

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -462,6 +462,7 @@ host.openSession(id, { profile?, intent? }) // open a stored session core-style;
                                            //   profile: soft-swap to that profile's backend first
                                            //   intent: 'in-place' (default) | 'stack' | 'tab' | 'window'
 host.newChat(profile?)                     // fresh chat draft, optionally in another profile
+host.revealPane(paneId)                    // un-dismiss + front a contributed pane; idempotent
 host.openWorkspace(id, { render, title?, minWidth?, onClose? })
                                            // dock a plugin-rendered tab into the MAIN
                                            //   workspace zone and reveal it; returns a disposer
@@ -481,6 +482,12 @@ cron, kanban, …). `host.requestProfile` accepts a descriptor from
 profile without changing the active chat or gateway. The profile-only overload is
 retained only for the sole-local/legacy topology; registry-aware plugins should pass
 the descriptor so two sources exposing the same profile name cannot collide.
+
+`host.revealPane(paneId)` un-dismisses a plugin-contributed pane the user
+closed, un-collapses/un-hides/un-minimizes whatever is hiding it, and fronts
+its tab — the same verb the app's own toggles (⌘B, ⌘G, tool-pane toggles) use
+internally. A plugin command can route into its own pane unconditionally
+instead of falling back to `ctx.os.openExternal`.
 
 `host.openWorkspace(id, { render, title?, minWidth?, onClose? })` docks a
 plugin-rendered view into the **main workspace zone** — the same center area


### PR DESCRIPTION
Fixes #88658

## Problem

Desktop plugins can contribute panes, but a plugin command has no way to
bring its own pane back once the user dismisses it (or it's simply absent
from the active layout). The SDK's host surface is readonly state atoms plus
`notify`/`notifyError`/`navigate`/`logs`/`status`/`restartGateway`/`request` —
no layout/pane verbs — so the only plugin-visible fallback is
`ctx.os.openExternal`, opening a browser tab when the user explicitly wants
the in-app pane.

## Fix

`revealTreePane(paneId)` in `apps/desktop/src/components/pane-shell/tree/store.ts`
already does exactly this job — un-dismiss + re-adopt, un-collapse the side
column, un-hide, un-minimize the zone, and front the tab — and is already used
internally by the app's own toggles (⌘B, ⌘G, tool-pane toggles) and by
`host.openWorkspace`. This wraps it as a new host verb:

```ts
host.revealPane(paneId: string): void
```

Plugin commands can now route into their own pane unconditionally; the
browser fallback becomes an explicit user choice instead of the only option.

## Changes

- `apps/desktop/src/sdk/index.ts`: add `host.revealPane(paneId)`, backed by
  the existing (already-imported) `revealTreePane`.
- `apps/desktop/src/sdk/index.test.ts`: new test that dismisses a registered
  plugin pane via `dismissTreePane`, asserts it left `$dismissedPanes` and the
  layout tree, then calls `host.revealPane` and asserts the pane is back in
  both — an observable-behavior assertion, not a "was the function called"
  tautology.
- `website/docs/developer-guide/desktop-plugin-sdk.md`: document the new verb
  in the Host API reference and its own paragraph, next to `host.openWorkspace`.

## Test plan

Confirmed the new test fails without the fix (`host.revealPane is not a
function`) by reverting `index.ts` to HEAD and re-running:

```
$ npx vitest run src/sdk/index.test.ts
 FAIL  src/sdk/index.test.ts > host.revealPane > un-dismisses a closed plugin pane and puts it back in the layout tree
 TypeError: host.revealPane is not a function
```

With the fix restored:

```
$ npx vitest run src/sdk/index.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ npx vitest run src/sdk
 Test Files  3 passed (3)
      Tests  19 passed (19)

$ npx vitest run src/components/pane-shell/tree
 Test Files  20 passed (20)
      Tests  103 passed (103)

$ npx eslint src/sdk/index.ts src/sdk/index.test.ts
(clean)

$ npx tsc -p . --noEmit
(clean)
```

## AI disclosure

This change was drafted with AI assistance (Claude), then reviewed and
verified (tests run and confirmed to fail without the fix / pass with it,
lint and typecheck run clean) before pushing.
