### PR TITLE
feat(bot-mode): hide bots from the roster via right-click — header eye toggle reveals and unhides them

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -132,6 +132,12 @@ function trackInboundActivity(roster) {
 
     $botUnread.set({ ...$botUnread.get(), [bot.name]: true })
 
+    // Roster-hidden bots stay quiet: the unread flag above accumulates
+    // silently (unhiding reveals the badge) but a hidden bot never toasts.
+    if ($botMeta.get()[bot.name]?.hidden) {
+      continue
+    }
+
     // Toasts are opt-in: the unread badge is always set above, but the
     // per-message notification fires only when the user enabled it.
     if ($activityToasts.get()) {
@@ -267,6 +273,51 @@ async function saveBotMeta(name, patch) {
   }
 
   return { serverPersisted: serverOutcome === 'persisted', serverOutcome }
+}
+
+// ── hidden bots (right-click → Hide Bot) ────────────────────────────────────
+// Hiding is a ROSTER-DISPLAY concern only: a hidden bot keeps working —
+// @mentions still resolve, group-chat membership is untouched, its name
+// still counts as taken, and an open chat stays open. The flag lives in bot
+// meta (`hidden: true`), so it rides the same local-storage + server
+// ui_meta pipeline as pins/titles and follows the profile across machines.
+// Unhide writes `hidden: false` (never null): a null key survives the local
+// `{ ...prev, ...patch }` merge while the server DELETES None keys, and
+// that asymmetry lets mergeServerMeta resurrect a stale truthy copy. A
+// literal false round-trips identically through both stores.
+
+/** Session-only view toggle: reveal hidden bots (dimmed) in the roster. */
+const $showHiddenBots = atom(false)
+
+/** Hidden flag for a roster row. Thin remote-source rows never read local
+ *  meta (botRosterMeta returns null for them), so hide is by NAME on the
+ *  active source; remote rows of the same name stay visible. */
+function isBotHidden(bot, metaByName) {
+  return Boolean(botRosterMeta(bot, metaByName)?.hidden)
+}
+
+/** Hiding the selected bot re-homes the selection (the Routines pane
+ *  follows it): first visible bot wins, then 'default' — unless default is
+ *  itself hidden with nothing else visible, in which case the selection
+ *  stays put rather than pointing somewhere even less real. */
+function fallbackSelectionAfterHide(name) {
+  if ($selectedBot.get() !== name) {
+    return
+  }
+
+  const meta = $botMeta.get()
+  const visible = $lastRoster
+    .get()
+    .filter(bot => !bot.remoteSource && bot.name !== name && !meta[bot.name]?.hidden)
+
+  if (visible.length) {
+    $selectedBot.set(visible[0].name)
+    return
+  }
+
+  if (name !== 'default' && !meta.default?.hidden) {
+    $selectedBot.set('default')
+  }
 }
 
 /** One-time reconciliation: Bot Mode sessions are always hidden, but rooms
@@ -3953,7 +4004,10 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
     className: cn(
       'flex w-full min-w-0 max-w-full items-center gap-2.5 overflow-hidden rounded-md px-2 py-2 text-left transition-colors',
       'hover:bg-(--chrome-action-hover)',
-      isActive && 'bg-(--chrome-action-hover)'
+      isActive && 'bg-(--chrome-action-hover)',
+      // Hidden bots only render while the header eye toggle is on — dimmed,
+      // so the temporary reveal reads as a different state from the roster.
+      meta?.hidden && 'opacity-60'
     ),
     children: [
       jsx('div', {
@@ -3974,6 +4028,13 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
                         className: 'shrink-0 text-[0.6875rem] text-(--ui-text-quaternary)',
                         title: 'Pinned',
                         children: '📌'
+                      })
+                    : null,
+                  meta?.hidden
+                    ? jsx(Codicon, {
+                        name: 'eye-closed',
+                        className: 'shrink-0 text-[0.6875rem] text-(--ui-text-quaternary)',
+                        title: 'Hidden from the roster'
                       })
                     : null,
                   jsx('span', {
@@ -4063,6 +4124,26 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
               })
             },
             children: meta?.pinned ? 'Unpin' : 'Pin to top'
+          }),
+          jsx(ContextMenuItem, {
+            onSelect: () => {
+              const hidden = Boolean($botMeta.get()[bot.name]?.hidden)
+              // `hidden: false` (not null) so unhide round-trips through the
+              // server ui_meta merge the same way the local merge sees it.
+              saveBotMeta(bot.name, { hidden: !hidden })
+
+              if (!hidden) {
+                fallbackSelectionAfterHide(bot.name)
+              }
+
+              host.notify({
+                kind: 'info',
+                message: hidden
+                  ? `${displayName(bot, meta)} is back in the roster`
+                  : `${displayName(bot, meta)} hidden — use the eye button in the Bots header to see hidden bots`
+              })
+            },
+            children: meta?.hidden ? 'Unhide Bot' : 'Hide Bot'
           }),
           jsx(ContextMenuSeparator, {}),
           jsx(ContextMenuItem, {
@@ -7665,7 +7746,16 @@ function BotsPane() {
     return activityOf(b) - activityOf(a)
   })
   const activeSourceRoster = roster.filter(bot => !bot.remoteSource)
-  const filteredRoster = filterBots(roster, allMeta, query)
+  // Hidden bots (right-click → Hide Bot) drop out of the roster list unless
+  // the header eye toggle reveals them. Display-only: every other consumer
+  // (mentions, group chats, name-collision checks, merge/avatar/activity
+  // sweeps) keeps the FULL roster.
+  const showHidden = useValue($showHiddenBots)
+  const unreadByName = useValue($botUnread)
+  const hiddenBots = roster.filter(bot => isBotHidden(bot, allMeta))
+  const hiddenUnread = hiddenBots.some(bot => !bot.remoteSource && unreadByName[bot.name])
+  const visibleRoster = showHidden ? roster : roster.filter(bot => !isBotHidden(bot, allMeta))
+  const filteredRoster = filterBots(visibleRoster, allMeta, query)
   // Group chats are first-class roster rows (Discord-style): one standalone
   // row per room, competing in the SAME recency ordering as bot rows — a
   // group's activity is its newest room-log line. Pinned bots still lead;
@@ -7739,6 +7829,35 @@ function BotsPane() {
                   children: jsx(Codicon, { name: activityToasts ? 'bell' : 'bell-slash' })
                 })
               }),
+              // Eye toggle appears only once something is hidden — zero
+              // hidden bots means zero extra chrome. It stays visible while
+              // hidden rows are revealed, so Unhide is always reachable.
+              hiddenBots.length
+                ? jsx(Tip, {
+                    label: showHidden
+                      ? 'Hide hidden bots again'
+                      : `Show ${hiddenBots.length} hidden bot${hiddenBots.length === 1 ? '' : 's'}`,
+                    children: jsxs('button', {
+                      type: 'button',
+                      'aria-label': showHidden ? 'Hide hidden bots' : 'Show hidden bots',
+                      className: cn(
+                        'relative flex size-6 items-center justify-center rounded-md transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
+                        showHidden ? 'text-foreground' : 'text-(--ui-text-tertiary)'
+                      ),
+                      onClick: () => $showHiddenBots.set(!showHidden),
+                      children: [
+                        jsx(Codicon, { name: showHidden ? 'eye' : 'eye-closed' }),
+                        hiddenUnread && !showHidden
+                          ? jsx('span', {
+                              className:
+                                'absolute right-0.5 top-0.5 size-1.5 rounded-full bg-(--ui-accent,#4f9cf9)',
+                              'aria-label': 'a hidden bot has unread activity'
+                            })
+                          : null
+                      ]
+                    })
+                  })
+                : null,
               jsxs(DropdownMenu, {
                 children: [
                   jsx(Tip, {
@@ -7775,7 +7894,7 @@ function BotsPane() {
         ]
       }),
       jsx(ActiveNowStrip, {
-        roster,
+        roster: visibleRoster,
         activeProfile,
         gatewayState,
         metaByName: allMeta,
@@ -7882,7 +8001,9 @@ function BotsPane() {
                   className:
                     'flex flex-1 items-center justify-center px-4 text-center text-xs text-(--ui-text-tertiary)',
                   role: 'status',
-                  children: `No bots match “${query.trim()}”`
+                  children: query.trim()
+                    ? `No bots match “${query.trim()}”`
+                    : 'All bots are hidden — use the eye button above to show them.'
                 })
               : jsx(ScrollArea, {
                   className: 'hermes-bots-roster min-h-0 flex-1',

--- a/apps/desktop/src/plugins/hermes-bots/tests/hide-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hide-bots.test.mjs
@@ -1,0 +1,223 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// Per-bot Hide/Unhide: right-click → Hide Bot persists `hidden: true` in bot
+// meta (local ctx.storage + server ui_meta via saveBotMeta), hidden bots drop
+// out of the roster list, and a header eye toggle — rendered only while at
+// least one bot is hidden — reveals them dimmed for right-click → Unhide.
+// Hiding is a roster-DISPLAY concern only: mentions, group chats, and the
+// name-collision check keep the full roster.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load({ toastsOn = false } = {}) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const notifications = []
+  const requests = []
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      state: {
+        profile: { get: () => 'default', listen: () => undefined },
+        gateway: { get: () => 'open', listen: () => undefined }
+      },
+      request: (method, params) => {
+        requests.push({ method, params })
+        return Promise.resolve({ applied: { ui_meta: true } })
+      },
+      notify: params => notifications.push(params)
+    },
+    sdk: new Proxy({}, { get: () => undefined })
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(`
+globalThis.__hide = {
+  isBotHidden,
+  fallbackSelectionAfterHide,
+  mergeServerMeta,
+  saveBotMeta,
+  trackInboundActivity,
+  $botMeta,
+  $botUnread,
+  $selectedBot,
+  $lastRoster,
+  $showHiddenBots,
+  $activityToasts,
+  setPluginCtx: value => { pluginCtx = value }
+};
+`)
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  if (toastsOn) {
+    context.__hide.$activityToasts.set(true)
+  }
+  return { ...context.__hide, notifications, requests }
+}
+
+test('hide: saveBotMeta persists hidden:true locally and ships it in server ui_meta', async () => {
+  const t = load()
+  const writes = []
+  t.setPluginCtx({ storage: { set: (key, value) => writes.push({ key, value }) } })
+
+  await t.saveBotMeta('default', { hidden: true })
+
+  assert.equal(t.$botMeta.get().default.hidden, true)
+  assert.equal(writes.at(-1).key, 'bot-meta')
+  assert.equal(writes.at(-1).value.default.hidden, true)
+  const configure = t.requests.find(r => r.method === 'profiles.configure')
+  assert.equal(configure.params.ui_meta['hermes-bots'].hidden, true)
+})
+
+test('roster: hidden bots are filtered out; remote-source rows of the same name stay visible', () => {
+  const t = load()
+  t.$botMeta.set({ ghost: { hidden: true } })
+  const roster = [
+    { name: 'default' },
+    { name: 'ghost' },
+    { name: 'ghost', remoteSource: true, connectionId: 'mini' }
+  ]
+  const meta = t.$botMeta.get()
+  const visible = roster.filter(bot => !t.isBotHidden(bot, meta))
+
+  assert.equal(JSON.stringify(visible.map(b => `${b.remoteSource ? 'r:' : ''}${b.name}`)), JSON.stringify(['default', 'r:ghost']))
+})
+
+test('unhide: hidden:false clears locally AND survives a mergeServerMeta round-trip', async () => {
+  const t = load()
+  const writes = []
+  t.setPluginCtx({ storage: { set: (key, value) => writes.push({ key, value }) } })
+  t.$botMeta.set({ ghost: { hidden: true, title: 'Ghost' } })
+
+  await t.saveBotMeta('ghost', { hidden: false })
+  assert.equal(t.$botMeta.get().ghost.hidden, false, 'local merge must clear the flag')
+  const configure = t.requests.find(r => r.method === 'profiles.configure')
+  assert.equal(configure.params.ui_meta['hermes-bots'].hidden, false, 'server copy carries the literal false')
+
+  // Machine B: its stale local copy still says hidden:true; the server
+  // overlay (which merges OVER local) must win with the false.
+  t.$botMeta.set({ ghost: { hidden: true, title: 'Ghost' } })
+  t.mergeServerMeta([{ name: 'ghost', ui_meta: { 'hermes-bots': { hidden: false, title: 'Ghost' } } }])
+  assert.equal(t.$botMeta.get().ghost.hidden, false, 'server false must beat stale local true')
+})
+
+test('cross-machine: a hide done elsewhere lands via mergeServerMeta and persists to storage', () => {
+  const t = load()
+  const writes = []
+  t.setPluginCtx({ storage: { set: (key, value) => writes.push({ key, value }) } })
+  t.$botMeta.set({ ghost: { title: 'Ghost' } })
+
+  t.mergeServerMeta([{ name: 'ghost', ui_meta: { 'hermes-bots': { hidden: true, title: 'Ghost' } } }])
+
+  assert.equal(t.$botMeta.get().ghost.hidden, true)
+  assert.equal(writes.at(-1).value.ghost.hidden, true)
+})
+
+test('selection: hiding the selected bot falls back to the first visible bot', () => {
+  const t = load()
+  t.$selectedBot.set('ghost')
+  t.$botMeta.set({ ghost: { hidden: true } })
+  t.$lastRoster.set([{ name: 'ghost' }, { name: 'scribe' }, { name: 'default' }])
+
+  t.fallbackSelectionAfterHide('ghost')
+
+  assert.equal(t.$selectedBot.get(), 'scribe')
+})
+
+test('selection: falls back to default when nothing else is visible', () => {
+  const t = load()
+  t.$selectedBot.set('ghost')
+  t.$botMeta.set({ ghost: { hidden: true } })
+  t.$lastRoster.set([{ name: 'ghost' }])
+
+  t.fallbackSelectionAfterHide('ghost')
+
+  assert.equal(t.$selectedBot.get(), 'default')
+})
+
+test('selection: hiding default with nothing else visible keeps the selection (Routines must not chase a ghost)', () => {
+  const t = load()
+  t.$selectedBot.set('default')
+  t.$botMeta.set({ default: { hidden: true } })
+  t.$lastRoster.set([{ name: 'default' }])
+
+  t.fallbackSelectionAfterHide('default')
+
+  assert.equal(t.$selectedBot.get(), 'default')
+})
+
+test('selection: hiding an unselected bot never moves the selection', () => {
+  const t = load()
+  t.$selectedBot.set('scribe')
+  t.$botMeta.set({ ghost: { hidden: true } })
+  t.$lastRoster.set([{ name: 'ghost' }, { name: 'scribe' }])
+
+  t.fallbackSelectionAfterHide('ghost')
+
+  assert.equal(t.$selectedBot.get(), 'scribe')
+})
+
+test('activity: a hidden bot accumulates unread silently but never toasts, even with toasts on', () => {
+  const t = load({ toastsOn: true })
+  t.$botMeta.set({ ghost: { hidden: true } })
+  t.$selectedBot.set('default')
+
+  const rosterAt = ts => [{ name: 'ghost', last_session: { last_active: ts, preview: 'Message from writer: hi' } }]
+  t.trackInboundActivity(rosterAt(100)) // seeding poll
+  t.trackInboundActivity(rosterAt(200)) // activity past the watermark
+
+  assert.equal(t.$botUnread.get().ghost, true, 'unread must accumulate while hidden')
+  assert.equal(t.notifications.length, 0, 'hidden bots never toast')
+})
+
+// ── source shape ─────────────────────────────────────────────────────────────
+
+test('shape: roster list filters through isBotHidden unless the show-hidden toggle is on', () => {
+  assert.match(
+    pluginSource,
+    /const visibleRoster = showHidden \? roster : roster\.filter\(bot => !isBotHidden\(bot, allMeta\)\)/
+  )
+  assert.match(pluginSource, /const filteredRoster = filterBots\(visibleRoster, allMeta, query\)/)
+})
+
+test('shape: header eye toggle renders only when at least one bot is hidden', () => {
+  assert.match(pluginSource, /hiddenBots\.length\s*\n?\s*\? jsx\(Tip, \{/)
+  assert.match(pluginSource, /onClick: \(\) => \$showHiddenBots\.set\(!showHidden\)/)
+})
+
+test('shape: revealed hidden rows are dimmed and flagged with the eye-closed glyph', () => {
+  const botRow = pluginSource.slice(pluginSource.indexOf('function BotRow('), pluginSource.indexOf('// ── model picker'))
+  assert.match(botRow, /meta\?\.hidden && 'opacity-60'/)
+  assert.match(botRow, /name: 'eye-closed'/)
+  assert.match(botRow, /children: meta\?\.hidden \? 'Unhide Bot' : 'Hide Bot'/)
+  assert.match(botRow, /saveBotMeta\(bot\.name, \{ hidden: !hidden \}\)/)
+})
+
+test('shape: hiding never filters mentions, group flows, or the meta/activity sweeps', () => {
+  // The full-roster consumers keep the FULL roster: mergeServerMeta,
+  // avatar pulls, and activity tracking all run on activeSourceRoster —
+  // which is derived from the unfiltered roster, not visibleRoster.
+  assert.match(pluginSource, /const activeSourceRoster = roster\.filter\(bot => !bot\.remoteSource\)/)
+  assert.match(pluginSource, /mergeServerMeta\(activeSourceRoster\)/)
+  assert.match(pluginSource, /trackInboundActivity\(activeSourceRoster\)/)
+  // Mention resolution never consults the hidden flag.
+  const mentions = pluginSource.slice(
+    pluginSource.indexOf('function resolveRosterMentions('),
+    pluginSource.indexOf('const REMOTE_DM_TIMEOUT_MS')
+  )
+  assert.doesNotMatch(mentions, /hidden/i)
+})


### PR DESCRIPTION
Bots you don't use can now be hidden from the Bot Mode roster — right-click a bot row → **Hide Bot** — and brought back any time via a header eye toggle that reveals hidden bots dimmed, with right-click → **Unhide Bot**. Requested by Teknium, who doesn't use the local/default-profile bot and wanted it out of the roster "with some way to unhide them that is still accessible after hidden".

## What changed

- **Hide Bot** persists `hidden: true` through the existing bot-meta pipeline (`saveBotMeta`): local `ctx.storage` instantly, plus server-side `profile.yaml` `ui_meta['hermes-bots']` via `profiles.configure` — so the hidden state rides `mergeServerMeta` and follows the profile across machines.
- Hidden bots drop out of the roster list and the Active-now strip. Everything else keeps working: @mentions still resolve, group-chat membership is untouched, the New Agent name-collision check still counts them, and an open chat stays open.
- **Header eye toggle** renders only while ≥1 bot is hidden (zero hidden = zero new chrome). While on, hidden rows render dimmed (`opacity-60` + eye-closed glyph) and their context menu offers Unhide Bot. The eye badges with an unread dot when a hidden bot has silent activity.
- **Unhide writes `hidden: false`, never `null`.** The server deletes `None`-valued `ui_meta` keys while the local `{ ...prev, ...patch }` merge keeps `null` keys — that asymmetry would let `mergeServerMeta` resurrect a stale truthy copy on another machine. A literal `false` round-trips identically through both stores.
- **Selected-bot fallback:** hiding the selected bot re-homes selection to the first visible bot, then `'default'`; if default itself is hidden with nothing else visible, the selection stays put so the Routines pane never chases a ghost.
- **Toast suppression:** hidden bots never toast (even with activity toasts on) but keep accumulating the unread flag silently, so unhiding shows the state.
- Empty-roster copy: when everything is hidden and no search is active, the list explains "All bots are hidden — use the eye button above to show them."

### Known v1 simplification

Bot meta is keyed by bot **name**, so hiding a name hides every local row of that name. Thin remote-source rows never read local meta (`botRosterMeta` returns `null` for them) and stay visible; per-connection hide keying is deliberately out of scope for this PR.

## Validation

| Check | Result |
| --- | --- |
| `node --check plugin.js` | ✅ |
| `node --test tests/*.test.mjs` | ✅ 232 pass / 0 fail (219 existing + 13 new) |
| hide sets meta + ships in server ui_meta | ✅ new test |
| roster filters hidden; remote rows of same name stay visible | ✅ new test |
| unhide clears locally AND survives mergeServerMeta round-trip | ✅ new test |
| cross-machine hide lands via mergeServerMeta + persists to storage | ✅ new test |
| selected-bot fallback (visible-first / default / default-hidden stays) | ✅ 4 new tests |
| hidden bot suppresses toast but accumulates unread | ✅ new test |
| header eye renders only when ≥1 hidden; dimmed rows + Unhide item | ✅ source-shape tests |
| mentions/group/meta sweeps keep the full roster | ✅ source-shape test |
| `scripts/audit_pr_attribution.py --fix` | ✅ all mapped |

Files touched: `apps/desktop/src/plugins/hermes-bots/plugin.js`, `apps/desktop/src/plugins/hermes-bots/tests/hide-bots.test.mjs` (new).

## Infographic

![Hide Bots infographic](https://v3b.fal.media/files/b/0aa6c48b/fxi_dk_wpQRtiM5cPJevF_HUTaXuOd.png)
