### PR TITLE
fix(mcp): keepalive prober must not race an in-flight tool call

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -921,6 +921,42 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    def test_keepalive_skips_probe_while_rpc_lock_held(self):
+        """A long-running tool call must not race the keepalive prober (#88661).
+
+        Firing ``ping`` while a real RPC already holds ``_rpc_lock`` risks a
+        server that processes requests sequentially never answering the probe
+        until the in-flight call finishes -- timing out the probe and tearing
+        down (and deregistering) a perfectly healthy connection out from under
+        that still-running call.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("srv")
+            server._config = {"keepalive_interval": 0.02}
+            server.session = SimpleNamespace(
+                send_ping=AsyncMock(side_effect=RuntimeError("busy - no response"))
+            )
+
+            with patch("tools.mcp_tool._MIN_KEEPALIVE_INTERVAL", 0.01):
+                await server._rpc_lock.acquire()
+                task = asyncio.create_task(server._wait_for_lifecycle_event())
+                try:
+                    await asyncio.sleep(0.15)  # several keepalive intervals
+                    assert not task.done(), (
+                        "keepalive probe fired (and tore down the session) "
+                        "while a real RPC was still holding _rpc_lock"
+                    )
+                    assert server.session.send_ping.call_count == 0
+                finally:
+                    server._rpc_lock.release()
+                    server._shutdown_event.set()
+                    result = await asyncio.wait_for(task, timeout=2)
+                    assert result == "shutdown"
+
+        asyncio.run(_test())
+
 
 # ---------------------------------------------------------------------------
 # discover_mcp_tools toolset injection

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2885,6 +2885,16 @@ class MCPServerTask:
                 # tool-capable server that doesn't implement it answers -32601;
                 # in that case fall back to the pre-ping ``list_tools`` probe
                 # for the rest of this connection rather than reconnect-looping.
+                if self.session and self._rpc_lock.locked():
+                    # A real RPC is already exercising the session — stronger
+                    # proof of liveness than a probe, and firing one
+                    # concurrently races it: a server that processes
+                    # requests sequentially won't answer until the call
+                    # finishes, so the probe's 30s budget can time out well
+                    # before a longer tool timeout and tear down a healthy
+                    # connection out from under the still-running call
+                    # (#88661). Skip this cycle; the next one re-checks.
+                    continue
                 if self.session:
                     try:
                         await self._keepalive_probe()


### PR DESCRIPTION
## What does this PR do?

Fixes the root cause behind #88661: a long-running MCP tool call timing
out is followed, with no operator action, by the *entire* toolset from
that server vanishing from the live session with no automatic recovery
(only a gateway restart brings it back).

`MCPServerTask._wait_for_lifecycle_event`'s keepalive loop probes the
session (`send_ping`, falling back to `list_tools`) directly, without
acquiring `server._rpc_lock` — the lock every other call that touches
`self.session` (`call_tool`, `list_resources`, `list_prompts`,
`get_prompt`, `read_resource`, `_refresh_tools`) serializes on. The
codebase already has a matching precedent for this exact race:
`_stdio_recycle_reason()` / `_next_stdio_recycle_deadline()` both skip
their own maintenance action when `self._rpc_lock.locked()` (see
`tools/mcp_tool.py:2532` and `:2549`) — the keepalive prober was the one
caller that didn't follow that rule.

When a real tool call runs long (the reporter's timeout was 300s) and
the remote server processes requests sequentially (true of many simple
MCP servers, and plausible for the "verified healthy from outside"
remote HTTP+OAuth servers in the report), the keepalive probe fired
concurrently gets no answer until the in-flight call finishes. The probe
has its own 30s budget (`asyncio.wait_for(..., timeout=30.0)` in
`_keepalive_probe`), so it times out well before the tool call's own
(longer) timeout. The keepalive-failure path then does:

```python
self._reconnect_event.set()
break
```

which tears down and rebuilds the transport — out from under the still
-running tool call — and (per `_session_proven` / rapid-drop-budget
accounting in the reconnect loop) can go straight to parking and
`_deregister_tools()`, exactly matching the reported "immediately
afterwards, every tool from that server vanished" signature. Because the
underlying transport was never actually broken, this is entirely
self-inflicted.

### Fix

Skip the keepalive probe for this cycle whenever `_rpc_lock` is already
held: a real in-flight RPC is stronger proof of liveness than a probe,
and the call's own success path (`_mark_session_proven`) already credits
the session once it completes. The next keepalive cycle re-checks once
the lock is free.

## Related Issue

Fixes #88661

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: `_wait_for_lifecycle_event` skips the keepalive probe (`continue`) when `self._rpc_lock.locked()`, instead of firing it concurrently with a real RPC.
- `tests/tools/test_mcp_tool.py`: added `test_keepalive_skips_probe_while_rpc_lock_held`, which holds `_rpc_lock` (simulating an in-flight call) with a session whose `send_ping` raises, and asserts the keepalive loop neither calls it nor triggers a reconnect while the lock is held.

## How to Test

1. `git checkout HEAD~1 -- tools/mcp_tool.py && pytest tests/tools/test_mcp_tool.py -k test_keepalive_skips_probe_while_rpc_lock_held -v` → fails: `AssertionError: assert 'reconnect' == 'shutdown'` (keepalive fired concurrently, tore the connection down while the "call" was still in flight).
2. `git checkout HEAD -- tools/mcp_tool.py` (restore the fix) → same test passes.
3. Full file: `pytest tests/tools/test_mcp_tool.py -q` → `98 passed`.
4. Related MCP suites (session-expiry, probe, lazy-start, SSE transport, trust gating, initial-connect shutdown, loop-profile-override): `55 passed`.
5. `ruff check tools/mcp_tool.py tests/tools/test_mcp_tool.py` → `All checks passed!`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` (relevant subset — full suite covering MCP files listed above) and all tests pass
- [x] I've added tests for my changes
- [x] Tested on Linux (containerized), matching the reporter's environment

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed; behavior-only fix scoped to the keepalive loop

## Notes

- No dependency manifests or lockfiles were touched.
- This was investigated and written with AI assistance (Claude/Claude Code), with the root-cause analysis verified by reading the vendored MCP SDK's dispatcher (`mcp/shared/jsonrpc_dispatcher.py`) to confirm every other session-touching call path in this file already serializes on `_rpc_lock`, and by reverting the fix locally to confirm the added test fails without it (see "How to Test" above).
