### PR TITLE
fix(kanban): dedup decomposer children against open board cards (#88656)

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -447,11 +447,14 @@ def decompose_task(
     # this path to promote a root with zero new children.
     with kb.connect_closing() as conn:
         board_tasks = kb.list_tasks(conn, tenant=task.tenant)
-    existing_by_title = {
-        _normalize_title(t.title): t.id
-        for t in board_tasks
-        if t.id != task_id and t.status not in ("done", "archived") and t.title
-    }
+    # Sorted oldest-first so that when several open cards share a
+    # normalized title, the longest-standing one wins deterministically
+    # instead of whichever happened to sort last.
+    existing_by_title: dict[str, str] = {}
+    for t in sorted(board_tasks, key=lambda t: t.created_at):
+        if t.id == task_id or t.status in ("done", "archived") or not t.title:
+            continue
+        existing_by_title.setdefault(_normalize_title(t.title), t.id)
     duplicates: dict[int, str] = {
         idx: existing_by_title[_normalize_title(child["title"])]
         for idx, child in enumerate(children)

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -142,6 +142,14 @@ def _truncate(text: str, limit: int) -> str:
     return text[: limit - 1] + "…"
 
 
+_NORMALIZE_TITLE_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _normalize_title(text: str) -> str:
+    """Cheap normalized form of a title for exact-match dedup (#88656)."""
+    return _NORMALIZE_TITLE_RE.sub(" ", text.lower()).strip()
+
+
 def _extract_json_blob(raw: str) -> Optional[dict]:
     if not raw:
         return None
@@ -429,6 +437,40 @@ def decompose_task(
             "parents": clean_parents,
         })
 
+    # Cross-graph dedup (#88656): a child that exact-normalized-title
+    # matches a card already open elsewhere on the board is the same unit
+    # of work as that card, even though it came from a different
+    # decomposition. Skip creating a twin and link the existing card
+    # under this root instead. Only applies when at least one child
+    # survives — if every proposed child turns out to be a duplicate we
+    # fall back to the old create-everything behavior rather than teach
+    # this path to promote a root with zero new children.
+    with kb.connect_closing() as conn:
+        board_tasks = kb.list_tasks(conn, tenant=task.tenant)
+    existing_by_title = {
+        _normalize_title(t.title): t.id
+        for t in board_tasks
+        if t.id != task_id and t.status not in ("done", "archived") and t.title
+    }
+    duplicates: dict[int, str] = {
+        idx: existing_by_title[_normalize_title(child["title"])]
+        for idx, child in enumerate(children)
+        if _normalize_title(child["title"]) in existing_by_title
+    }
+    if duplicates and len(duplicates) < len(children):
+        index_map: dict[int, int] = {}
+        deduped_children: list[dict] = []
+        for idx, child in enumerate(children):
+            if idx in duplicates:
+                continue
+            index_map[idx] = len(deduped_children)
+            deduped_children.append(child)
+        for child in deduped_children:
+            child["parents"] = [index_map[p] for p in child["parents"] if p in index_map]
+        children = deduped_children
+    else:
+        duplicates = {}
+
     try:
         with kb.connect_closing() as conn:
             child_ids = kb.decompose_triage_task(
@@ -449,6 +491,17 @@ def decompose_task(
         return DecomposeOutcome(
             task_id, False, "task moved out of triage before decomposition",
         )
+
+    if duplicates:
+        with kb.connect_closing() as conn:
+            for existing_id in duplicates.values():
+                try:
+                    kb.link_tasks(conn, task_id, existing_id)
+                except ValueError as exc:
+                    logger.info(
+                        "decompose: could not link existing card %s under %s: %s",
+                        existing_id, task_id, exc,
+                    )
 
     return DecomposeOutcome(
         task_id, True, f"decomposed into {len(child_ids)} children",

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -457,6 +457,18 @@ def decompose_task(
         for idx, child in enumerate(children)
         if _normalize_title(child["title"]) in existing_by_title
     }
+    # A duplicate that a surviving sibling depends on can't be dropped:
+    # decompose_triage_task's children schema has no way to express
+    # "depend on an existing task id" (parents are indices into this same
+    # list), so the edge would either be silently dropped or need to be
+    # redirected onto the existing card after the fact — which conflicts
+    # with the existing card already being linked as a dependent of this
+    # root below. Rather than lose the dependency or fight that conflict,
+    # refuse to dedup a duplicate with dependents and let it be created as
+    # a twin — the same "don't lose data" principle as the all-duplicates
+    # fallback below.
+    depended_on = {p for child in children for p in child["parents"]}
+    duplicates = {idx: eid for idx, eid in duplicates.items() if idx not in depended_on}
     if duplicates and len(duplicates) < len(children):
         index_map: dict[int, int] = {}
         deduped_children: list[dict] = []

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -249,6 +249,49 @@ def test_decompose_keeps_duplicate_with_dependent_as_twin(kanban_home):
         assert kb.parent_ids(conn, existing_id) == []
 
 
+def test_decompose_dedup_picks_oldest_card_on_title_collision(kanban_home):
+    # Reviewer nit on #88656: if several open cards share a normalized
+    # title, the dedup must pick the same one every time rather than
+    # whichever the board query happened to return last.
+    with kb.connect() as conn:
+        older_id = kb.create_task(conn, title="Verify two consecutive scheduled imports in production")
+        conn.execute("UPDATE tasks SET created_at = ? WHERE id = ?", (1000, older_id))
+        newer_id = kb.create_task(conn, title="verify two consecutive scheduled imports in production")
+        conn.execute("UPDATE tasks SET created_at = ? WHERE id = ?", (2000, newer_id))
+        tid = kb.create_task(conn, title="production incident", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "test split",
+        "tasks": [
+            {"title": "Investigate the failure signature", "body": "look it up", "assignee": "researcher", "parents": []},
+            {
+                "title": "verify two consecutive scheduled imports in production",
+                "body": "watch the next two runs",
+                "assignee": "engineer",
+                "parents": [],
+            },
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "researcher", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    assert outcome.child_ids and len(outcome.child_ids) == 1
+
+    with kb.connect() as conn:
+        assert tid in kb.parent_ids(conn, older_id)
+        assert kb.parent_ids(conn, newer_id) == []
+
+
 def test_decompose_returns_false_when_task_not_triage(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="x")  # ready, not triage

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -188,6 +188,67 @@ def test_decompose_skips_duplicate_child_and_links_existing_card(kanban_home):
         assert tid in kb.parent_ids(conn, existing_id)
 
 
+def test_decompose_keeps_duplicate_with_dependent_as_twin(kanban_home):
+    # #88656 follow-up: a proposed child that duplicates an existing open
+    # card must NOT be deduped away if a sibling declares a dependency on
+    # it — decompose_triage_task's children schema can only express
+    # "depend on index N in this list", so a dropped duplicate has no way
+    # to redirect that edge onto the existing card without data loss.
+    # Refusing to dedup it (creating a twin, as before this PR) keeps the
+    # sibling's dependency intact instead of silently promoting it to
+    # `ready` ahead of the outstanding work it was supposed to wait on.
+    with kb.connect() as conn:
+        existing_id = kb.create_task(conn, title="Verify two consecutive scheduled imports in production")
+        tid = kb.create_task(conn, title="production incident", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "test split",
+        "tasks": [
+            {
+                "title": "verify two consecutive scheduled imports in production",
+                "body": "watch the next two runs",
+                "assignee": "engineer",
+                "parents": [],
+            },
+            {
+                "title": "Write followup report",
+                "body": "summarize findings",
+                "assignee": "researcher",
+                "parents": [0],
+            },
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "researcher", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    # Both children were created — the duplicate became a twin instead of
+    # being dropped, since "Write followup report" depends on it.
+    assert outcome.child_ids and len(outcome.child_ids) == 2
+
+    with kb.connect() as conn:
+        titles_by_id = {cid: kb.get_task(conn, cid).title for cid in outcome.child_ids}
+        report_id = next(cid for cid, t in titles_by_id.items() if t == "Write followup report")
+        twin_id = next(cid for cid, t in titles_by_id.items() if t != "Write followup report")
+        # The dependency on the sibling survives — pointed at the twin,
+        # not silently dropped.
+        assert twin_id in kb.parent_ids(conn, report_id)
+        assert kb.get_task(conn, report_id).status == "todo"
+        # The pre-existing card is untouched: no twin duplication of it was
+        # attempted, and it wasn't linked under the new root either, since
+        # it was never in the dedup set.
+        assert kb.parent_ids(conn, existing_id) == []
+
+
 def test_decompose_returns_false_when_task_not_triage(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="x")  # ready, not triage

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -145,6 +145,49 @@ def test_decompose_fanout_false_invalid_llm_assignee_uses_default(kanban_home):
     assert task.assignee == "fallback"
 
 
+def test_decompose_skips_duplicate_child_and_links_existing_card(kanban_home):
+    # Simulate #88656: a card produced by an earlier, unrelated decomposition
+    # is already open on the board with the same observation title the new
+    # decomposer is about to propose as a child.
+    with kb.connect() as conn:
+        existing_id = kb.create_task(conn, title="Verify two consecutive scheduled imports in production")
+        tid = kb.create_task(conn, title="production incident", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "test split",
+        "tasks": [
+            {"title": "Investigate the failure signature", "body": "look it up", "assignee": "researcher", "parents": []},
+            {
+                "title": "verify two consecutive scheduled imports in production",
+                "body": "watch the next two runs",
+                "assignee": "engineer",
+                "parents": [0],
+            },
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "researcher", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    # Only the non-duplicate child was created — no twin of the existing card.
+    assert outcome.child_ids and len(outcome.child_ids) == 1
+
+    with kb.connect() as conn:
+        created_titles = {kb.get_task(conn, cid).title for cid in outcome.child_ids}
+        assert created_titles == {"Investigate the failure signature"}
+        # The existing card is now linked under the new root instead of duplicated.
+        assert tid in kb.parent_ids(conn, existing_id)
+
+
 def test_decompose_returns_false_when_task_not_triage(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="x")  # ready, not triage


### PR DESCRIPTION
## What does this PR do?

The kanban auto-decomposer only dedupes children *within one decomposition
call* (via the `parents` index graph). It never checks whether a proposed
child duplicates a card that a *different* decomposition already created on
the board. Two triage tasks decomposed ~80 minutes apart can each independently
propose a child with the same observation (e.g. "verify two consecutive
scheduled imports in production"), so the board ends up with two near-identical
cards that would dispatch two workers to watch the same thing.

This adds a cheap board-wide dedup pass in `decompose_task()`, right before
the children are handed to `kb.decompose_triage_task()`:

- Build a normalized-title → task-id map of every open (non-`done`,
  non-`archived`) task currently on the board.
- For each proposed child, if its normalized title exact-matches an existing
  open card, drop it from the create list (remapping sibling `parents`
  indices to the compacted list) and remember the existing card's id.
- After the (remaining) children are created and the root is promoted, link
  each remembered existing card as an additional child of the new root via
  `kb.link_tasks()`, instead of creating a twin.
- If *every* proposed child turns out to be a duplicate, we skip the dedup
  entirely and fall back to the old create-everything behavior, so a root
  never gets promoted with zero children.
- **Follow-up fix**: a proposed child is only dropped as a duplicate if no
  surviving sibling declares a dependency on it. `decompose_triage_task`'s
  `children` schema can only express "depend on index N in this list," so a
  removed duplicate has no in-list target to redirect that edge to —
  dropping it silently promoted the dependent sibling straight to `ready`,
  ahead of the work it was supposed to wait on. (Redirecting the edge onto
  the existing card after creation was also considered, but it collides
  with the existing card already being linked as a dependent of the new
  root a few lines down, producing a genuine dependency cycle.) When a
  duplicate has dependents, it's now created as a twin instead — the same
  "don't lose data" principle as the all-duplicates fallback above.

## Related Issue

Fixes #88656

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_decompose.py`: added `_normalize_title()` and a
  cross-graph dedup step in `decompose_task()` that skips creating a
  duplicate child and links the existing card under the new root instead.
- `tests/hermes_cli/test_kanban_decompose.py`: added
  `test_decompose_skips_duplicate_child_and_links_existing_card`, which
  seeds an existing open task with the same (differently-cased) title as
  one of the LLM's proposed children and asserts only the non-duplicate
  child is created, and that the existing card is linked under the new root.
- `hermes_cli/kanban_decompose.py`: a duplicate's index is now excluded from
  the dedup set if any sibling's `parents` list references it, so it falls
  through to normal creation as a twin instead of being dropped.
- `tests/hermes_cli/test_kanban_decompose.py`: added
  `test_decompose_keeps_duplicate_with_dependent_as_twin`, reproducing the
  exact scenario a reviewer flagged — a duplicate at index 0 with a
  dependent sibling at index 1 — and asserting both children are created
  and the dependency edge survives, pointed at the twin.

## How to Test

1. `python -m pytest tests/hermes_cli/test_kanban_decompose.py -q`
2. Confirmed the new test fails without the source fix:
   ```
   git checkout HEAD~1 -- hermes_cli/kanban_decompose.py
   python -m pytest tests/hermes_cli/test_kanban_decompose.py -q
   # 1 failed, 4 passed — test_decompose_keeps_duplicate_with_dependent_as_twin
   # fails: only 1 child created instead of 2, dependency dropped
   git checkout HEAD -- hermes_cli/kanban_decompose.py
   ```

Test output with the fix applied:
```
$ TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0 python -m pytest tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py tests/hermes_cli/test_kanban_db.py tests/gateway/test_kanban_auto_decompose_live.py tests/agent/test_auxiliary_client.py -q
.......s................................................................ [ 32%]
........................................................................ [ 64%]
........................................................................ [ 97%]
......                                                                   [100%]
221 passed, 1 skipped
```
`ruff check` on the changed files reports no issues.

## Review History

An independent reviewer initially blocked this PR: the cross-graph dedup
correctly recognized a duplicate child but, when a *sibling* declared a
dependency on that duplicate (e.g. "verify X" → "write report based on X"),
the dependency edge was silently dropped instead of redirected — promoting
the dependent sibling straight to `ready` and racing it ahead of the
outstanding work it was supposed to wait on. See "Follow-up fix" above and
`test_decompose_keeps_duplicate_with_dependent_as_twin` for the fix and
regression test.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — CI-only run, no local platform to report

### Documentation & Housekeeping

- [x] N/A — no user-facing docs, config keys, or tool schemas changed

## AI assistance disclosure

This change was written by an AI coding agent (Claude, via an autonomous
contribution pipeline) based on the issue description, with the diff, tests,
and test output reviewed before pushing.
