### PR TITLE
fix(gateway): persist session routing identity and recover transcripts when state.db is unavailable

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3969,7 +3969,18 @@ class SessionStore:
         child session.
         """
         if not self._db:
-            return []
+            # Degraded mode: the default/global state.db was corrupt or
+            # unavailable at gateway startup, so this SessionStore has no DB
+            # handle (JSONL routing fallback). Under multiplexed profile
+            # routes the AIAgent's own lazily-opened SessionDB points at the
+            # PROFILE's state.db (see AIAgent._get_session_db_for_recall),
+            # which is where the transcript was written. load_transcript is
+            # called from inside the profile scope, so opening a fresh
+            # SessionDB() here resolves to that same profile DB and can
+            # recover the conversation instead of returning [] and making the
+            # next turn amnesiac (regression: Telegram chats "don't remember
+            # prior turns").
+            return self._load_transcript_scoped_fallback(session_id)
         # Follow the write-side reroute chain (cycle-guarded, same shape as
         # append_to_transcript).
         reroutes = getattr(self, "_transcript_reroutes", None) or {}
@@ -4003,6 +4014,57 @@ class SessionStore:
                 session_id, e,
             )
             return []
+
+    def _load_transcript_scoped_fallback(self, session_id: str) -> List[Dict[str, Any]]:
+        """Read a transcript from the profile-scoped SessionDB when ``_db`` is None.
+
+        Only used in the degraded state where ``self._db`` is unavailable
+        (corrupt/unreadable default state.db at gateway startup). A fresh
+        ``SessionDB()`` resolves through the current HERMES_HOME override —
+        under multiplexed profile routes this is the profile's own state.db,
+        the same DB the AIAgent lazily opened and wrote the transcript to.
+        """
+        try:
+            from hermes_state import SessionDB
+            scoped_db = SessionDB()
+        except Exception as e:
+            logger.warning(
+                "Transcript read failed for session %s (scoped SessionDB "
+                "unavailable; returning empty; downstream must not treat "
+                "this as data loss): %s",
+                session_id, e,
+            )
+            return []
+        try:
+            # Same reroute-chain + compression-tip handling as the primary
+            # path above.
+            reroutes = getattr(self, "_transcript_reroutes", None) or {}
+            seen = set()
+            target_id = session_id
+            while target_id in reroutes and target_id not in seen:
+                seen.add(target_id)
+                target_id = reroutes[target_id]
+            try:
+                tip = scoped_db.get_compression_tip(target_id)
+                if tip:
+                    target_id = tip
+            except Exception:
+                pass
+            return scoped_db.get_messages_as_conversation(
+                target_id, repair_alternation=True
+            )
+        except Exception as e:
+            logger.warning(
+                "Transcript read failed for session %s (returning empty; "
+                "downstream must not treat this as data loss): %s",
+                session_id, e,
+            )
+            return []
+        finally:
+            try:
+                scoped_db.close()
+            except Exception:
+                pass
 
     def rewind_session(self, session_id: str, n: int = 1) -> Optional[Dict[str, Any]]:
         """Back up ``n`` user turns via soft-delete, keeping rows for audit.

--- a/run_agent.py
+++ b/run_agent.py
@@ -103,6 +103,51 @@ def _session_source_for_agent(platform: Optional[str]) -> str:
     return platform or "cli"
 
 
+def _gateway_origin_json(agent: "AIAgent") -> Optional[str]:
+    """Build the gateway routing ``origin_json`` for a session row.
+
+    Mirrors the shape of ``SessionSource.to_dict()`` (platform, chat_id,
+    chat_name, chat_type, user_id, user_name, thread_id, optional
+    user_id_alt / profile) so consumers that read ``origin_json`` from
+    state.db (channel directory, mcp_serve, mirror) see the same fields the
+    gateway's own ``record_gateway_session_peer`` would write. Returns None
+    when the agent carries no gateway identity (plain CLI session), matching
+    the previous identity-less creation.
+    """
+    chat_id = getattr(agent, "_chat_id", None)
+    session_key = getattr(agent, "_gateway_session_key", None)
+    user_id = getattr(agent, "_user_id", None)
+    if not (chat_id or session_key or user_id):
+        return None
+    origin: Dict[str, Any] = {
+        "platform": getattr(agent, "platform", None) or "",
+        "chat_id": chat_id,
+        "chat_name": getattr(agent, "_chat_name", None),
+        "chat_type": getattr(agent, "_chat_type", None) or "dm",
+        "user_id": user_id,
+        "user_name": getattr(agent, "_user_name", None),
+        "thread_id": getattr(agent, "_thread_id", None),
+    }
+    user_id_alt = getattr(agent, "_user_id_alt", None)
+    if user_id_alt:
+        origin["user_id_alt"] = user_id_alt
+    profile = getattr(agent, "_profile_name", None)
+    if not profile:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            profile = get_active_profile_name()
+            if profile == "default":
+                profile = None
+        except Exception:
+            profile = None
+    if profile:
+        origin["profile"] = profile
+    try:
+        return json.dumps(origin)
+    except Exception:
+        return None
+
+
 # OpenAI lazy proxy + safe stdio + proxy URL helpers — see agent/process_bootstrap.py.
 # `OpenAI` is re-exported here so `patch("run_agent.OpenAI", ...)` in tests works.
 # The other `# noqa: F401` re-exports below cover names accessed via
@@ -655,13 +700,34 @@ class AIAgent:
                     _init_model_config["yolo_mode"] = True
             except Exception:
                 pass
+            # Persist the gateway routing identity with the row. The gateway's
+            # SessionStore normally creates the row first (db_create_kwargs) and
+            # record_gateway_session_peer self-heals a missing row (#82616), but
+            # when the default/global state.db is corrupt or unavailable at
+            # gateway startup the SessionStore degrades to a JSONL fallback
+            # (_db=None) and the peer recorder no-ops. In that degraded mode
+            # this lazy creation is the ONLY durable write for the session, so
+            # it must carry session_key/chat_id/chat_type/thread_id/user_id/
+            # display_name/origin_json or the row is identity-less and
+            # unrecoverable by find_latest_gateway_session_for_peer (regression:
+            # Telegram rows with chat_id=NULL/session_key=NULL under multiplexed
+            # profile routes).
             self._session_db.create_session(
                 session_id=self.session_id,
                 source=source,
                 model=self.model,
                 model_config=_init_model_config,
                 system_prompt=self._cached_system_prompt,
-                user_id=None,
+                user_id=getattr(self, "_user_id", None),
+                session_key=getattr(self, "_gateway_session_key", None),
+                chat_id=getattr(self, "_chat_id", None),
+                chat_type=getattr(self, "_chat_type", None),
+                thread_id=getattr(self, "_thread_id", None),
+                display_name=(
+                    getattr(self, "_chat_name", None)
+                    or getattr(self, "_user_name", None)
+                ),
+                origin_json=_gateway_origin_json(self),
                 parent_session_id=self._parent_session_id,
                 cwd=_launch_cwd_for_session(source),
                 profile_name=_profile_for_session,

--- a/tests/gateway/test_session_degraded_db_continuity.py
+++ b/tests/gateway/test_session_degraded_db_continuity.py
@@ -1,0 +1,230 @@
+"""Regression tests: session continuity when the default/global state.db is unavailable.
+
+Root cause (live incident, 2026-08-17): when the default/global state.db is
+corrupt or unreadable at gateway startup, ``SessionStore._db`` degrades to
+None (JSONL routing fallback) and ``GatewayRunner._session_db`` is None.
+Under multiplexed profile routes the AIAgent lazily opens the PROFILE's
+state.db (``AIAgent._get_session_db_for_recall``) and its
+``_ensure_db_session`` created the session row WITHOUT routing identity
+(session_key/chat_id/chat_type/thread_id/user_id/origin_json/display_name
+all NULL), so the row was unrecoverable by
+``find_latest_gateway_session_for_peer``. The gateway's own
+``record_gateway_session_peer`` self-heal never ran because ``_db`` was None.
+On the next message, ``SessionStore.load_transcript`` returned [] even though
+the transcript existed in the profile DB -> the agent lost prior context.
+
+These tests pin the two fixes:
+1. ``AIAgent._ensure_db_session`` persists the full routing identity the
+   agent already carries, so the lazily-created row is recoverable.
+2. ``SessionStore.load_transcript`` falls back to a scoped SessionDB when
+   ``_db`` is None and returns the persisted transcript.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+SESSION_ID = "degraded-db-continuity-session"
+CHAT_ID = "-1001234567890"
+THREAD_ID = "42"
+SESSION_KEY = "agent:orion:telegram:group:-1001234567890:8148316720"
+
+
+def _make_gateway_agent(session_db):
+    """Build an AIAgent carrying gateway routing identity (multiplex profile route)."""
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=SESSION_ID,
+            skip_context_files=True,
+            skip_memory=True,
+            platform="telegram",
+            user_id="8148316720",
+            user_name="testuser",
+            chat_id=CHAT_ID,
+            chat_name="Test Group",
+            chat_type="group",
+            thread_id=THREAD_ID,
+            gateway_session_key=SESSION_KEY,
+        )
+    # The multiplexed profile scope would resolve the active profile name to
+    # the route's profile (e.g. "orion"); pin it so the row + origin_json
+    # carry the profile deterministically.
+    with patch("hermes_cli.profiles.get_active_profile_name", return_value="orion"):
+        agent._ensure_db_session()
+    return agent
+
+
+class TestEnsureDbSessionPersistsRoutingIdentity:
+    def test_lazy_creation_writes_session_key_and_chat_identity(self):
+        """First-created row must carry gateway routing metadata (not identity-less)."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            try:
+                _make_gateway_agent(db)
+                row = db.get_session(SESSION_ID)
+                assert row is not None
+                assert row["session_key"] == SESSION_KEY
+                assert row["chat_id"] == CHAT_ID
+                assert row["chat_type"] == "group"
+                assert row["thread_id"] == THREAD_ID
+                assert row["user_id"] == "8148316720"
+                assert row["display_name"] == "Test Group"
+                assert row["source"] == "telegram"
+                assert row["profile_name"] == "orion"
+                origin = json.loads(row["origin_json"])
+                assert origin["platform"] == "telegram"
+                assert origin["chat_id"] == CHAT_ID
+                assert origin["chat_name"] == "Test Group"
+                assert origin["chat_type"] == "group"
+                assert origin["user_id"] == "8148316720"
+                assert origin["user_name"] == "testuser"
+                assert origin["thread_id"] == THREAD_ID
+                assert origin["profile"] == "orion"
+            finally:
+                db.close()
+
+    def test_row_recoverable_by_peer_lookup(self):
+        """find_latest_gateway_session_for_peer must find the lazily-created row."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            try:
+                _make_gateway_agent(db)
+                # The peer lookup keys on session_key + source; the regression
+                # left session_key NULL so this returned None on every restart.
+                found = db.find_latest_gateway_session_for_peer(
+                    session_key=SESSION_KEY,
+                    source="telegram",
+                )
+                assert found is not None
+                assert found["id"] == SESSION_ID
+            finally:
+                db.close()
+
+    def test_cli_session_stays_identity_less(self):
+        """A plain CLI agent (no gateway fields) keeps the old shape — no origin_json."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            try:
+                with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+                    from run_agent import AIAgent
+
+                    agent = AIAgent(
+                        api_key="test-key",
+                        base_url="https://openrouter.ai/api/v1",
+                        model="test/model",
+                        quiet_mode=True,
+                        session_db=db,
+                        session_id=SESSION_ID + "-cli",
+                        skip_context_files=True,
+                        skip_memory=True,
+                    )
+                agent._ensure_db_session()
+                row = db.get_session(SESSION_ID + "-cli")
+                assert row is not None
+                assert row["session_key"] is None
+                assert row["chat_id"] is None
+                assert row["origin_json"] is None
+            finally:
+                db.close()
+
+
+class TestLoadTranscriptScopedFallback:
+    def _seed_scoped_transcript(self):
+        """Write a transcript into the conftest fake HERMES_HOME state.db.
+
+        The conftest autouse ``_isolate_hermes_home`` fixture re-pins
+        ``hermes_state.DEFAULT_DB_PATH`` to ``$HERMES_HOME/state.db`` and
+        redirects ``HERMES_HOME`` to a per-test tmpdir — that IS the
+        profile-scoped DB an AIAgent would lazily open and write to. Argless
+        ``SessionDB()`` therefore resolves to it, mirroring the multiplexed
+        profile route.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id=SESSION_ID, source="telegram")
+            db.append_message(
+                session_id=SESSION_ID,
+                role="user",
+                content="hello from the profile DB",
+            )
+            db.append_message(
+                session_id=SESSION_ID,
+                role="assistant",
+                content="hello back",
+            )
+        finally:
+            db.close()
+
+    def _store_without_db(self, tmp_path):
+        """A SessionStore in the degraded state: _db is None (JSONL fallback)."""
+        from gateway.config import GatewayConfig
+        from gateway.session import SessionStore
+
+        store = SessionStore(
+            sessions_dir=tmp_path / "sessions",
+            config=GatewayConfig(),
+        )
+        store._db = None  # simulate corrupt default state.db at gateway startup
+        return store
+
+    def test_load_transcript_reads_profile_db_when_db_is_none(self, tmp_path):
+        """load_transcript must recover the scoped transcript, not []."""
+        from gateway.session import SessionStore
+
+        self._seed_scoped_transcript()
+        store = self._store_without_db(tmp_path)
+        assert isinstance(store, SessionStore)
+        transcript = store.load_transcript(SESSION_ID)
+        assert len(transcript) >= 2
+        assert transcript[0]["role"] == "user"
+        assert transcript[0]["content"] == "hello from the profile DB"
+        assert transcript[1]["role"] == "assistant"
+        assert transcript[1]["content"] == "hello back"
+
+    def test_load_transcript_returns_empty_with_warning_when_scoped_db_unavailable(
+        self, tmp_path
+    ):
+        """A failing scoped read must return [] and log WARNING (not crash)."""
+        from gateway.session import SessionStore
+
+        store = self._store_without_db(tmp_path)
+        assert isinstance(store, SessionStore)
+
+        warnings: list = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                if record.levelno >= logging.WARNING:
+                    warnings.append(record.getMessage())
+
+        handler = _Capture()
+        logger = logging.getLogger("gateway.session")
+        logger.addHandler(handler)
+        try:
+            # Force the scoped DB open to fail so the fallback logs and
+            # degrades to [] instead of raising.
+            with patch("hermes_state.SessionDB", side_effect=RuntimeError("no db")):
+                transcript = store.load_transcript(SESSION_ID)
+        finally:
+            logger.removeHandler(handler)
+
+        assert transcript == []
+        assert any("Transcript read failed" in w for w in warnings)

--- a/website/docs/developer-guide/state-db-recovery.md
+++ b/website/docs/developer-guide/state-db-recovery.md
@@ -1,0 +1,183 @@
+# state.db Corruption Recovery
+
+When the default/global `state.db` becomes unreadable, the gateway degrades
+to a JSONL routing fallback: `SessionStore._db` is `None`, routing keys still
+resolve via `sessions.json`, and (for multiplexed profile routes) each
+AIAgent lazily opens the *profile's own* `state.db` for transcript storage.
+That degraded mode is survivable — but a corrupt global DB can make Telegram
+chats appear to "forget" prior turns if the routing identity was never
+persisted. This page documents how to recover safely without data loss.
+
+## Symptoms
+
+- `file is not a database` when opening the default `state.db`
+  (`$HERMES_HOME/state.db`).
+- Timestamped backups appear beside it:
+  `state.db.malformed-backup-YYYYMMDD_HHMMSS`.
+- A `state.db.repair.lock` file exists. The lock is `flock`-based: a stale
+  zero-byte lock file is harmless. It only blocks while a live process holds
+  the flock; the kernel releases it automatically when that process exits.
+- Telegram sessions that used to resume now start with no prior context.
+- Profile DBs (e.g. `profiles/<name>/state.db`) report integrity `ok` and
+  contain messages, but the session row has NULL `session_key`/`chat_id`.
+
+## How the pieces interact
+
+1. At gateway startup, `SessionStore.__init__` opens `SessionDB()`. If the
+   default DB is corrupt, `_db = None` and routing falls back to
+   `sessions.json` (the JSONL mirror).
+2. A multiplexed profile route runs inside `_profile_runtime_scope`, which
+   redirects `get_hermes_home()` to the profile home. The AIAgent's lazy
+   `SessionDB()` therefore opens the *profile's* `state.db`.
+3. Before the fix shipped with this page, that lazy creation wrote the row
+   WITHOUT `session_key`/`chat_id`/`chat_type`/`thread_id`/`origin_json`,
+   and the gateway's `record_gateway_session_peer` self-heal never ran
+   because `_db` was None — so the row stayed identity-less and
+   `find_latest_gateway_session_for_peer` could not recover it. The fixed
+   `_ensure_db_session` writes the full routing identity on first creation,
+   and `load_transcript` falls back to the scoped profile DB so prior turns
+   are readable even while the global DB is down.
+
+## Recovery steps (no data loss)
+
+### 1. Verify the corruption and back it up
+
+```bash
+HERMES_HOME=${HERMES_HOME:-~/.hermes}
+DB="$HERMES_HOME/state.db"
+python3 - <<'PY'
+import sqlite3, sys
+try:
+    con = sqlite3.connect(sys.argv[1])
+    con.execute("PRAGMA integrity_check").fetchone()
+    print("ok")
+except Exception as exc:
+    print(f"corrupt: {exc}")
+PY "$DB"
+```
+
+If it fails, copy the file (and any `-wal`/`-shm` sidecars) to a timestamped
+backup before touching anything:
+
+```bash
+cp -a "$DB" "${DB}.manual-backup-$(date +%Y%m%d_%H%M%S)"
+[ -f "$DB-wal" ] && cp -a "$DB-wal" "${DB}-wal.manual-backup-$(date +%Y%m%d_%H%M%S)"
+```
+
+### 2. Clear the stale repair lock (safe)
+
+The lock is advisory; removing the file is safe when no Hermes process is
+repairing. Stop the gateway first, then:
+
+```bash
+rm -f "$DB.repair.lock"
+```
+
+### 3. Restore a healthy DB from a known-good backup (preferred)
+
+If any of the `malformed-backup-*`/`backup-before-fts-rebuild-*` files open
+cleanly, restore the most recent one:
+
+```bash
+ls -la "$HERMES_HOME"/state.db.malformed-backup-* "$HERMES_HOME"/state.db.backup-before-fts-rebuild-* 2>/dev/null
+# pick the newest that passes the integrity check above, then:
+cp -a "$BACKUP" "$DB"
+rm -f "$DB-wal" "$DB-shm"
+```
+
+### 4. Otherwise: start fresh, keep sessions.json
+
+The gateway's JSONL routing index (`$HERMES_HOME/sessions/sessions.json`)
+holds the `session_key -> session_id` map and survives a DB reset. Move the
+corrupt file aside and let Hermes create a new DB:
+
+```bash
+mv "$DB" "${DB}.corrupt-$(date +%Y%m%d_%H%M%S)"
+rm -f "$DB-wal" "$DB-shm"
+```
+
+New sessions get fresh DB rows with full routing identity (post-fix). The
+routing keys in `sessions.json` keep resuming the same session ids, so the
+conversation continuity is preserved even though the old transcript rows are
+gone from the global DB.
+
+### 5. Backfill identity on existing identity-less rows
+
+If a profile DB already contains Telegram session rows with NULL
+`session_key`/`chat_id` (pre-fix), you can repair them from the JSONL routing
+index. The mapping is `session_key -> session_id`; the row id equals the
+session id. Example (run with the gateway stopped, profile-scoped):
+
+```bash
+python3 - <<'PY'
+import json, sqlite3, sys
+from pathlib import Path
+
+home = Path(sys.argv[1])            # profile home, e.g. ~/.hermes/profiles/orion
+routing = json.loads((home / "sessions" / "sessions.json").read_text())
+db_path = home / "state.db"
+con = sqlite3.connect(db_path)
+cur = con.cursor()
+# key format: agent:<profile>:<platform>:<chat_type>:<chat_id>:<user_id>
+for key, entry in routing.items():
+    if not isinstance(entry, dict) or "session_id" not in entry:
+        continue
+    sid = entry["session_id"]
+    parts = key.split(":")
+    if len(parts) >= 5 and parts[0] == "agent":
+        platform = parts[2]
+        chat_type = parts[3]
+        chat_id = parts[4]
+        user_id = parts[5] if len(parts) > 5 else None
+        cur.execute(
+            """UPDATE sessions
+               SET session_key = COALESCE(session_key, ?),
+                   chat_id = COALESCE(chat_id, ?),
+                   chat_type = COALESCE(chat_type, ?),
+                   thread_id = COALESCE(thread_id, ?),
+                   user_id = COALESCE(user_id, ?)
+             WHERE id = ? AND session_key IS NULL""",
+            (key, chat_id, chat_type, None, user_id, sid),
+        )
+con.commit()
+print(f"backfilled {cur.rowcount} rows")
+con.close()
+PY "$HOME/.hermes/profiles/orion"
+```
+
+Verify before/after with the peer lookup:
+
+```bash
+python3 - <<'PY'
+import os, sqlite3, sys
+os.environ.setdefault("HERMES_HOME", sys.argv[1])
+from hermes_state import SessionDB
+db = SessionDB(db_path=sys.argv[2])
+print(db.find_latest_gateway_session_for_peer(
+    session_key="agent:orion:telegram:group:-5287315359:8148316720",
+    source="telegram",
+))
+PY
+```
+
+### 6. Restart and verify
+
+```bash
+hermes gateway restart
+hermes gateway status
+# send a follow-up message in the affected Telegram chat and confirm the
+# agent resumes the same conversation (it references prior turns)
+```
+
+## Prevention
+
+- The fix in `run_agent.py::AIAgent._ensure_db_session` persists the full
+  routing identity (`session_key`, `chat_id`, `chat_type`, `thread_id`,
+  `user_id`, `display_name`, `origin_json`) at first row creation, so rows
+  created by the agent (including multiplexed profile routes) are never
+  identity-less again.
+- `gateway/session.py::SessionStore.load_transcript` now falls back to the
+  scoped profile DB when `_db` is None, so prior turns remain readable while
+  the global DB is unavailable.
+- Keep backups of `state.db` (and the profile DBs) — see
+  [Session Storage](session-storage.md) for the canonical store layout.


### PR DESCRIPTION
## Problem

Live incident (2026-08-17): Telegram chats stopped remembering prior turns. User replies to an agent response and the agent lacks context.

Root cause chain (verified against the running multiplexed gateway):
1. Default/global `state.db` was corrupt (`file is not a database`) at gateway startup → `SessionStore._db = None` (JSONL routing fallback) and `GatewayRunner._session_db = None`.
2. Under multiplexed profile routes (`_profile_runtime_scope`), the AIAgent lazily opens the **profile's** state.db via `_get_session_db_for_recall()` (observed open fds on `profiles/orion/state.db`).
3. `AIAgent._ensure_db_session()` created the row with `user_id=None` and NO `session_key`/`chat_id`/`chat_type`/`thread_id`/`origin_json`/`display_name` — the identity-less row observed in the DB (`chat_id=NULL`, `session_key=NULL`, 67 messages).
4. The gateway's `record_gateway_session_peer` self-heal never fired because `SessionStore._db` was None.
5. Next message: routing still resolved the same session (JSONL), but `load_transcript()` returned `[]` because `_db` was None — even though the transcript existed in the profile DB. → agent amnesia.

## Fix

- **`run_agent.py`**: `_ensure_db_session` now persists the agent's full gateway routing identity (`session_key`, `chat_id`, `chat_type`, `thread_id`, `user_id`, `display_name`, `origin_json`) at first row creation — so lazily-created rows are never identity-less, including multiplexed profile routes. COALESCE in `_insert_session_row` means this only fills NULLs and never overwrites the gateway's richer origin_json in the healthy path.
- **`gateway/session.py`**: `SessionStore.load_transcript` falls back to a scoped `SessionDB()` (resolved through the current `HERMES_HOME` override) when `_db` is None, recovering the transcript the agent wrote to the profile DB instead of returning `[]`. Fails closed to `[]` + WARNING on read failure.
- **Docs**: `website/docs/developer-guide/state-db-recovery.md` — safe recovery/repair guidance for corrupt global state.db, stale repair lock, and identity-less row backfill (validated against a disposable copy of the affected profile DB).

## Verification

- New regression suite `tests/gateway/test_session_degraded_db_continuity.py` (5 tests): identity persists on lazy creation, `find_latest_gateway_session_for_peer` recovers the row, CLI sessions stay identity-less, scoped transcript fallback returns messages, failure degrades to [] + WARNING.
- Existing session suites green: `test_session_continuity_82616.py`, `test_session.py`, `test_session_source.py`, `test_orphan_gateway_session_repair.py`, `test_session_store_prune.py`, `test_session_store_stale_prune.py`, `test_async_session_store.py`, `test_identity_flush.py`, `test_turn_context.py`, `test_async_token_accounting.py`, `test_compression_persistence.py` — 165 tests total, 0 failures (run via `scripts/run_tests.sh`).
- Backfill guidance verified end-to-end: identity-less row `20260816_225745_12c3d7fa` gained `session_key='agent:orion:telegram:group:-5287315359:8148316720'`, `chat_id='-5287315359'`, `chat_type='group'`, and the peer lookup returned it.