### PR TITLE
chore(tui): build hermes-ink before running the tui test suite

### DIFF
--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -15,6 +15,7 @@
     "fmt": "prettier --write 'src/**/*.{ts,tsx}' 'packages/**/*.{ts,tsx}'",
     "fix": "npm run lint:fix && npm run fmt",
     "check": "npm run build:ink && npm run typecheck && npm run test && npm run lint",
+    "pretest": "npm run build:ink",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## What does this PR do?

`ui-tui`'s `test` script is a bare `vitest run`, but `@hermes/ink` resolves through `ui-tui/packages/hermes-ink/index.js`, a tracked shim that re-exports `./dist/entry-exports.js`. That bundle is produced by `build:ink` and is not committed, so running the suite without building first fails 61 of 156 test files.

The quieter failure mode is a stale bundle. When `dist/` exists but predates the source, the suite reports missing handle methods and array-length errors that read as product regressions, which is what happened in #88712. Adding a `pretest` hook makes `npm test` build the bundle the same way `check` already does, so the standalone command matches the gate.

## Related Issue

Related to #88712. That report is a stale bundle in the reporter's install tree rather than a defect in this repo, so this does not close it, it removes the footgun that produced it.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/package.json`: add `"pretest": "npm run build:ink"`

## How to Test

1. `npm run install:tui`
2. `rm -rf ui-tui/packages/hermes-ink/dist`
3. `cd ui-tui && npm test`

On `main` step 3 fails 61 of 156 files with `Cannot find module './dist/entry-exports.js'`. With this change it builds the bundle first, then passes 156 files and 1656 tests. `npm run check` still passes end to end from the same clean state, with the build running twice at about 20ms for the second one.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64, Node 22.23.2

Two boxes left unchecked on purpose. This touches only `ui-tui/package.json`, so the Python suite is not exercised by it and I ran the `ui-tui` suite instead. No new tests are added because the change is a build-script hook, and its effect is what makes the existing 156 files run at all.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

`pretest` is a standard npm lifecycle hook and `build:ink` already runs on every platform through `check`, so there is no platform-specific behaviour here.
