### PR TITLE
feat(desktop): custom HTTP headers field for custom endpoints

### DIFF
--- a/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import {
   activateCustomEndpoint,
   deleteCustomEndpoint,
@@ -28,6 +29,7 @@ interface EndpointForm {
   baseUrl: string
   contextLength: string
   discoverModels: boolean
+  headers: string
   id: string
   makeDefault: boolean
   model: string
@@ -39,10 +41,48 @@ const EMPTY_FORM: EndpointForm = {
   baseUrl: '',
   contextLength: '',
   discoverModels: true,
+  headers: '',
   id: '',
   makeDefault: true,
   model: '',
   name: ''
+}
+
+function headersToText(headers: Record<string, string> | undefined): string {
+  if (!headers) {
+    return ''
+  }
+
+  return Object.entries(headers)
+    .map(([name, value]) => `${name}: ${value}`)
+    .join('\n')
+}
+
+function parseHeaders(text: string): Record<string, string> {
+  const headers: Record<string, string> = {}
+
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim()
+
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
+    }
+
+    const separator = trimmed.indexOf(':')
+
+    if (separator <= 0) {
+      continue
+    }
+
+    const name = trimmed.slice(0, separator).trim()
+    const value = trimmed.slice(separator + 1).trim()
+
+    if (name) {
+      headers[name] = value
+    }
+  }
+
+  return headers
 }
 
 function formFromEndpoint(endpoint: CustomEndpoint): EndpointForm {
@@ -51,6 +91,7 @@ function formFromEndpoint(endpoint: CustomEndpoint): EndpointForm {
     baseUrl: endpoint.base_url,
     contextLength: endpoint.context_length ? String(endpoint.context_length) : '',
     discoverModels: endpoint.discover_models,
+    headers: headersToText(endpoint.extra_headers),
     id: endpoint.id,
     makeDefault: Boolean(endpoint.is_current),
     model: endpoint.model,
@@ -60,6 +101,7 @@ function formFromEndpoint(endpoint: CustomEndpoint): EndpointForm {
 
 function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate {
   const contextLength = Number.parseInt(form.contextLength, 10)
+  const headers = parseHeaders(form.headers)
 
   return {
     id: form.id.trim() || undefined,
@@ -69,6 +111,7 @@ function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate 
     api_key: form.apiKey.trim() || undefined,
     context_length: Number.isFinite(contextLength) && contextLength > 0 ? contextLength : undefined,
     discover_models: form.discoverModels,
+    extra_headers: headers,
     make_default: form.makeDefault,
     models: models?.length ? models : undefined
   }
@@ -353,6 +396,18 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                 type="password"
                 value={form.apiKey}
               />
+            </label>
+            <label className="grid gap-1.5 text-xs text-muted-foreground">
+              Custom Headers
+              <Textarea
+                className="resize-y font-mono text-[0.75rem]"
+                onChange={event => setForm(current => ({ ...current, headers: event.target.value }))}
+                placeholder={'One per line, e.g.\nX-Team-ID: hermes\nAuthorization: Bearer <token>'}
+                value={form.headers}
+              />
+              <span className="text-[0.65rem]">
+                Sent with every request to this endpoint. Leave blank for none.
+              </span>
             </label>
             <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
               <label className="flex items-center gap-2">

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -160,6 +160,7 @@ export interface CustomEndpoint {
   base_url: string
   context_length?: null | number
   discover_models: boolean
+  extra_headers: Record<string, string>
   has_api_key: boolean
   id: string
   is_current?: boolean
@@ -185,6 +186,8 @@ export interface CustomEndpointUpdate {
   base_url: string
   context_length?: number
   discover_models?: boolean
+  // Omitted = keep existing headers; {} = clear them.
+  extra_headers?: Record<string, string>
   id?: string
   make_default?: boolean
   model: string

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -60,6 +60,11 @@ class CustomEndpointUpdate(BaseModel):
     discover_models: bool = True
     make_default: bool = False
     models: Optional[List[str]] = None
+    # ``None`` = "leave existing headers alone"; a dict (possibly empty) =
+    # "replace with exactly these". The tri-state mirrors ``api_key`` so an
+    # edit that doesn't touch the headers field can't wipe credentials the
+    # user hand-wrote into config.yaml.
+    extra_headers: Optional[Dict[str, str]] = None
 
 
 class MessagingPlatformUpdate(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -82,6 +82,7 @@ from hermes_cli.config import (
     redact_key,
     write_platform_config_field,
     _deep_merge,
+    normalize_extra_headers,
 )
 from plugins.memory.config_schema import (
     ProviderConfigSchema,
@@ -7858,6 +7859,7 @@ def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
                 "discover_models": bool(raw_entry.get("discover_models", True)),
                 "has_api_key": has_api_key,
                 "api_key_preview": api_key_preview,
+                "extra_headers": normalize_extra_headers(raw_entry.get("extra_headers")),
                 "is_current": endpoint_id == current_provider,
                 "source": "providers",
             })
@@ -7874,6 +7876,9 @@ def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
             "discover_models": True,
             "has_api_key": has_api_key,
             "api_key_preview": api_key_preview,
+            # The bare ``model:`` block has no per-provider header field;
+            # headers live on ``providers.<name>`` entries.
+            "extra_headers": {},
             "is_current": True,
             "source": "direct-config",
         })
@@ -7966,6 +7971,18 @@ def _write_custom_endpoint(cfg: Dict[str, Any], body: CustomEndpointUpdate) -> T
     if body.context_length and body.context_length > 0:
         entry["context_length"] = int(body.context_length)
         entry["models"][model]["context_length"] = int(body.context_length)
+
+    # ``extra_headers`` is tri-state like ``api_key``: omitted (``None``)
+    # means "leave what's on disk alone" — the merge above already preserved
+    # hand-written headers — while a submitted dict (possibly empty) replaces
+    # them. Normalizing here keeps the on-disk shape identical to what the
+    # runtime's ``_lift_extra_headers`` will read back.
+    if body.extra_headers is not None:
+        normalized = normalize_extra_headers(body.extra_headers)
+        if normalized:
+            entry["extra_headers"] = normalized
+        else:
+            entry.pop("extra_headers", None)
 
     # API keys never belong in config.yaml (#69449). Write to .env and
     # reference it via ``key_env`` — the same indirection built-in providers
@@ -8114,6 +8131,11 @@ async def validate_custom_endpoint(body: CustomEndpointUpdate):
     headers = {"Accept": "application/json"}
     if body.api_key and body.api_key.strip():
         headers["Authorization"] = f"Bearer {body.api_key.strip()}"
+    # Custom headers (Cloudflare Access tokens, proxy auth, ...) are required
+    # by some gateways on EVERY request, including /models. Apply them after
+    # the bearer so a user-supplied Authorization header can override it.
+    for header_name, header_value in normalize_extra_headers(body.extra_headers).items():
+        headers[header_name] = header_value
 
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(8.0)) as client:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1840,6 +1840,207 @@ class TestWebServerEndpoints:
         assert endpoint["has_api_key"] is True
         assert "sk-in-env" not in (endpoint["api_key_preview"] or "")
 
+    def test_custom_endpoint_extra_headers_round_trip(self):
+        """Headers saved from the panel must come back through the GET.
+
+        The Desktop form submits ``extra_headers`` and re-reads the saved
+        entry to repopulate the field — a response that omits them would
+        silently wipe the user's headers on the next edit.
+        """
+        from hermes_cli.config import load_config
+
+        resp = self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "gateway",
+                "name": "Gateway",
+                "base_url": "https://llm.gw.example/v1",
+                "model": "m",
+                "extra_headers": {"X-Team-ID": "hermes", "X-Privacy-Tier": "enterprise"},
+            },
+        )
+        assert resp.status_code == 200
+
+        endpoint = next(e for e in resp.json()["endpoints"] if e["id"] == "gateway")
+        assert endpoint["extra_headers"] == {
+            "X-Team-ID": "hermes",
+            "X-Privacy-Tier": "enterprise",
+        }
+
+        # And the on-disk entry is what the runtime's _lift_extra_headers
+        # reads — same normalized shape, no drift.
+        entry = load_config()["providers"]["gateway"]
+        assert entry["extra_headers"] == {
+            "X-Team-ID": "hermes",
+            "X-Privacy-Tier": "enterprise",
+        }
+
+    def test_custom_endpoint_save_without_headers_preserves_hand_written(self):
+        """Omitting ``extra_headers`` from the payload must not wipe them.
+
+        The merge-not-replace contract on providers.<name> blocks means a
+        hand-written ``extra_headers`` (Cloudflare Access token, proxy auth)
+        survives an unrelated edit — the same guarantee the api_key field
+        gets via its tri-state.
+        """
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg["providers"] = {
+            "cf": {
+                "name": "CF",
+                "base_url": "https://llm.cf.example/v1",
+                "model": "m",
+                "extra_headers": {"Cf-Access-Client-Id": "abc", "Cf-Access-Client-Secret": "s3cr3t"},
+                "models": {"m": {}},
+            }
+        }
+        save_config(cfg)
+
+        # Edit that does NOT touch headers (payload omits the field).
+        resp = self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "cf",
+                "name": "CF",
+                "base_url": "https://llm.cf.example/v1",
+                "model": "m2",
+            },
+        )
+        assert resp.status_code == 200
+
+        entry = load_config()["providers"]["cf"]
+        assert entry["extra_headers"] == {
+            "Cf-Access-Client-Id": "abc",
+            "Cf-Access-Client-Secret": "s3cr3t",
+        }
+        assert entry["model"] == "m2"
+
+    def test_custom_endpoint_empty_headers_clears_existing(self):
+        """An explicit empty dict means "clear", not "leave alone"."""
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg["providers"] = {
+            "cf": {
+                "name": "CF",
+                "base_url": "https://llm.cf.example/v1",
+                "model": "m",
+                "extra_headers": {"X-Old": "stale"},
+                "models": {"m": {}},
+            }
+        }
+        save_config(cfg)
+
+        resp = self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "cf",
+                "name": "CF",
+                "base_url": "https://llm.cf.example/v1",
+                "model": "m",
+                "extra_headers": {},
+            },
+        )
+        assert resp.status_code == 200
+
+        entry = load_config()["providers"]["cf"]
+        assert "extra_headers" not in entry
+        endpoint = next(e for e in resp.json()["endpoints"] if e["id"] == "cf")
+        assert endpoint["extra_headers"] == {}
+
+    def test_custom_endpoint_validate_probe_sends_extra_headers(self, monkeypatch):
+        """The Test button must send the configured headers on /models.
+
+        Gateways that require a custom header on EVERY request (Cloudflare
+        Access, proxy auth) reject the probe without them, so the panel
+        would report "endpoint rejected" for a perfectly good endpoint.
+        """
+        captured = {}
+
+        class _Resp:
+            status_code = 200
+            is_success = True
+
+            def json(self):
+                return {"data": [{"id": "local-model"}]}
+
+        class _Client:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def get(self, url, *args, headers=None, **kwargs):
+                captured["headers"] = headers
+                return _Resp()
+
+        monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+        response = self.client.post(
+            "/api/providers/custom-endpoints/validate",
+            json={
+                "name": "Local",
+                "base_url": "http://localhost:8000/v1",
+                "model": "local-model",
+                "extra_headers": {"X-Team-ID": "hermes"},
+            },
+        )
+
+        assert response.json()["ok"] is True
+        assert captured["headers"]["X-Team-ID"] == "hermes"
+        assert captured["headers"]["Accept"] == "application/json"
+
+    def test_custom_endpoint_validate_probe_headers_can_override_bearer(self, monkeypatch):
+        """A user-supplied Authorization header wins over the derived one.
+
+        Some gateways take the credential in a custom header and reject a
+        second Authorization; the form's headers are applied after the
+        bearer so the user's value is the one that goes out.
+        """
+        captured = {}
+
+        class _Resp:
+            status_code = 200
+            is_success = True
+
+            def json(self):
+                return {"data": [{"id": "m"}]}
+
+        class _Client:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def get(self, url, *args, headers=None, **kwargs):
+                captured["headers"] = headers
+                return _Resp()
+
+        monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+        response = self.client.post(
+            "/api/providers/custom-endpoints/validate",
+            json={
+                "name": "Local",
+                "base_url": "http://localhost:8000/v1",
+                "model": "m",
+                "api_key": "sk-bearer",
+                "extra_headers": {"Authorization": "Token custom-scheme"},
+            },
+        )
+
+        assert response.json()["ok"] is True
+        assert captured["headers"]["Authorization"] == "Token custom-scheme"
+
     def test_activating_an_endpoint_carries_its_credential_either_way(self):
         """Activate must work for both key_env and pre-#69449 plaintext entries."""
         from hermes_cli.config import load_config, save_config


### PR DESCRIPTION
## Summary

Adds the missing **Custom Headers** field to the Desktop Custom Endpoints form (Settings → Providers → Custom Endpoints), end to end.

The agent runtime already honors `providers.<name>.extra_headers` for OpenAI-compatible providers (vLLM, gateways, Cloudflare-protected proxies), and the Desktop backend already *preserves* hand-written `extra_headers` on save — but the REST response and the form had no field for them, so a Desktop user couldn't set, view, or edit them from the UI. This exposes that existing config surface in the form.

## Changes

**Backend (`hermes_cli/web_models.py`, `hermes_cli/web_server.py`)**
- `CustomEndpointUpdate` gains an optional `extra_headers` dict — tri-state like `api_key`: omitted = keep existing, `{}` = clear, dict = replace. An edit that doesn't touch the field can't wipe hand-written headers.
- `GET /api/providers/custom-endpoints` now returns the normalized `extra_headers` so the form repopulates them on edit.
- The Test button's `/models` probe sends the configured headers, so header-gated endpoints (Cloudflare Access, proxy auth) validate instead of reporting "endpoint rejected". A user-supplied `Authorization` header overrides the derived bearer.

**Desktop (`apps/desktop/src/types/hermes.ts`, `apps/desktop/src/app/settings/custom-endpoints-settings.tsx`)**
- `CustomEndpoint` / `CustomEndpointUpdate` types gain `extra_headers`.
- New **Custom Headers** textarea (one `Name: value` per line) that parses to a dict and round-trips through the payload.

Agent-side header application is unchanged and already tested; this only surfaces the existing config in the Desktop UI.

## Test plan

- [x] Backend: 5 new tests in `tests/hermes_cli/test_web_server.py` — round-trip, preserve-on-omit, clear-on-empty, probe-sends-headers, probe-headers-override-bearer. All pass; sabotage run confirms 4/5 fail without the fix.
- [x] Full `test_web_server.py` suite: 166 passed.
- [x] Desktop `typecheck`: clean.
- [x] Desktop `lint`: 0 errors (only pre-existing repo-wide warnings).
- [x] Desktop UI test suite: 503 files / 4652 tests passed.

## Risk

Low. Additive only (286 insertions, 0 deletions). The tri-state mirrors the existing `api_key` contract, and the on-disk shape is normalized to exactly what the runtime's `_lift_extra_headers` reads back. No change to agent-side header application.

Closes #88806.

Related (agent-side, already landed in the runtime): #9398, #9721, #9589, #46877.
