### PR TITLE
docs(desktop): document the tabbed SESSIONS|BOTS sidebar, Bots-mode-only Cronjobs pane, per-bot Hide/Unhide, and host.paneVisibility (#88788, #88800)

### DIFF
--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -465,6 +465,8 @@ host.newChat(profile?)                     // fresh chat draft, optionally in an
 host.openWorkspace(id, { render, title?, minWidth?, onClose? })
                                            // dock a plugin-rendered tab into the MAIN
                                            //   workspace zone and reveal it; returns a disposer
+host.paneVisibility(paneId)                // ReadableAtom<boolean> — is a contributed pane
+                                           //   actually on screen (its zone's active tab)?
 host.onEvent(type, fn)                     // gateway event stream ('*' = all); returns disposer
 host.logs(...)                             // tail an app log file
 host.status()                              // one-shot system status snapshot
@@ -492,6 +494,18 @@ programmatically. Feature-detect it (`typeof host.openWorkspace ===
 'function'`) and fall back to a regular contributed pane on older desktop
 builds — Bot Mode's group-chat rooms are the reference consumer (main-window
 takeover when available, in-panel view otherwise).
+
+`host.paneVisibility(paneId)` returns a readonly reactive atom that is `true`
+while a contributed pane is actually on screen: present in the layout tree,
+not dismissed or hidden, its zone un-minimized, and holding its zone's active
+tab slot (a lone pane in its own zone counts). The id is the
+contribution-scoped pane id, `<pluginId>:<paneId>`. Atoms are memoized per id,
+so calling it in render is safe. Use it to register companion UI only while
+your pane is visible — Bot Mode's Cronjobs pane is the reference consumer: it
+registers while the Bots pane holds the sidebar tab and unregisters when the
+user tabs back to Sessions. Feature-detect on older desktops
+(`typeof host.paneVisibility === 'function'`) and fall back to
+always-registered behavior.
 
 `host.profileRoutes()` inventories every registered source in the current connection
 registry. Connect-on-demand SSH sources expose a credential-free `default` seed

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -7,7 +7,7 @@ description: "Turn your Hermes profiles into a roster of named Bots — each wit
 
 **Bot Mode** turns your [Hermes profiles](./profiles.md) into a roster of named **Bots**. Each Bot has its own role, model, memory, skills, and avatar; Bots run recurring routines, deliberate together in group chats, and message each other directly. Build a specialist Bot once and it is there forever, one click away.
 
-Bot Mode ships **built into the [desktop app](./desktop.md)** and is **on by default** — no install needed. It appears as a **Bots** tab next to Sessions, with a **Routines** tile docked beside the conversation.
+Bot Mode ships **built into the [desktop app](./desktop.md)** and is **on by default** — no install needed. It appears as a **Bots** tab next to Sessions in the left sidebar, with a **Routines** tile docked beside the conversation while the Bots tab is active.
 
 :::tip A Bot is a profile
 There is no new primitive to learn: a Bot **is** a Hermes profile — isolated config, memory, skills, credentials, and chat history under `~/.hermes/profiles/<name>/`. Bot Mode is a UI over that primitive, so everything you do in it is visible from the CLI too: `hermes -p <bot> chat` opens the same agent, and Bot routines appear in `hermes cron list`. No core patches, no background daemons, no extra storage.
@@ -21,6 +21,7 @@ The roster shows one row per agent profile: avatar, latest-message preview, and 
 - **Sessions** (from a Bot's context menu) browses and filters that profile's 200 most recent stored conversations, without changing the primary click-to-chat flow.
 - **Active now** — a presence strip above the roster shows every Bot currently working: the gateway-busy profile plus any Bot that wrote within the last 90 seconds. Each chip opens that Bot's chat. The strip never reorders the roster and disappears when the fleet is idle.
 - **Search** filters the roster as you type.
+- **Hide a Bot** — right-click a row → **Hide Bot** to take a Bot you don't use out of the roster and the Active-now strip. Hiding is display-only: @mentions still resolve, group-chat memberships are untouched, and routines keep running. Once at least one Bot is hidden, an **eye toggle** appears in the pane header — click it to reveal hidden Bots dimmed in place, then right-click → **Unhide Bot** to bring one back. Hidden Bots never toast, but they accumulate unread activity silently and the eye badges a dot so you know something happened. Hidden state is saved in the Bot's profile metadata, so it follows the Bot to every desktop connected to that backend.
 
 :::note The canonical Bot Chat is a forever-chat
 Typing `/new` (or `/reset`) inside a Bot's canonical chat would fork the relationship into a scratch session — the one thing Bot Mode promises never happens. The composer reroutes it to `/compact` instead: fresh working context, same conversation. Regular sessions on the same profile keep full `/new` freedom.
@@ -68,7 +69,7 @@ A Bot's look, title, and description are stored in the profile's metadata on the
 
 ## Routines
 
-The **Routines** pane attaches recurring tasks to the Bot that does them — "summarize my inbox every morning" lives next to the Bot responsible for it. A structured schedule picker builds the schedule (frequency first, then only the detail that matters), with an Advanced field exposing the raw Hermes schedule string.
+The **Routines** pane attaches recurring tasks to the Bot that does them — "summarize my inbox every morning" lives next to the Bot responsible for it. The pane docks beside the chat only while the Bots tab is active and steps aside when you switch back to Sessions (older desktop builds keep it always visible). A structured schedule picker builds the schedule (frequency first, then only the detail that matters), with an Advanced field exposing the raw Hermes schedule string.
 
 Routines are plain [Hermes cron jobs](./features/cron.md) namespaced `[bot:<name>] <routine>` — they also show up in `hermes cron list` and the core Cron page. Runs land in the Bot's own chat history, so the result is right where you would talk to that Bot anyway.
 

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -179,7 +179,16 @@ The app also surfaces the broader Hermes management surface so you don't have to
 roster where every [Hermes profile](./profiles.md) appears as a bot with its
 own avatar (geometric face, uploaded image, AI-generated portrait, or a pixel
 pet), its own canonical **Bot Chat** conversation, and its own **Routines**
-(recurring tasks backed by Hermes cron). Create new agents from the roster —
+(recurring tasks backed by Hermes cron). The roster lives in the left
+sidebar as a tab next to your conversations — a **Sessions | Bots** tab
+strip — rather than a second pane stacked below the session list. Installs
+that picked up the older stacked layout are re-homed into the tab strip
+automatically, once; if you've hand-placed panes yourself, your layout is
+left alone. The **Cronjobs** (Routines) pane docks beside the chat only
+while the Bots tab is active and disappears when you switch back to
+Sessions (older desktop builds keep it always visible).
+
+Create new agents from the roster —
 Name / Title / Description plus an Advanced disclosure with the full
 capabilities surface (model, SOUL, skills, toolsets, MCP servers) — group
 them into sections, and open group chats where several bots deliberate.
@@ -203,6 +212,15 @@ Bot Mode's sessions — each bot's canonical Bot Chat and every group-chat
 member session — are always hidden from the global Sessions sidebar. They
 live in the Bots pane (roster rows, room views, and each bot's session
 browser) instead of interleaving with your own conversations.
+
+Bots you don't use can be tucked away: right-click a bot row → **Hide
+Bot**. Hidden bots leave the roster but keep working — @mentions still
+resolve and group-chat membership is untouched. An eye toggle appears in
+the Bots header whenever at least one bot is hidden; click it to reveal
+hidden bots dimmed in place (right-click → **Unhide Bot** brings one back),
+and the eye shows a dot when a hidden bot has unread activity. Hidden
+state is stored in the bot's profile, so it follows the bot across
+machines.
 
 Don't want it? Flip it off in **Settings → Plugins → Bots** — the roster,
 routines pane, and composer middleware unregister live, no restart needed.


### PR DESCRIPTION
Refreshes the desktop docs for three Bot Mode desktop changes that landed after the last docs pass (24f7f9a9d): the tabbed sidebar re-home (#88788), the Bots-mode-only Cronjobs pane + `host.paneVisibility` SDK export (#88788), and per-bot Hide/Unhide (#88800).

## Pages touched

### `user-guide/desktop.md` — Bot Mode section
- The roster now lives in the left sidebar as a **Sessions | Bots** tab strip rather than a pane stacked below the session list; documents the one-time automatic re-home of old stacked layouts and that hand-placed panes are left alone.
- The **Cronjobs** (Routines) pane docks beside the chat only while the Bots tab is active (older builds keep it always visible).
- New paragraph on per-bot **Hide/Unhide**: right-click → Hide Bot, header eye toggle (appears only with ≥1 hidden bot), dimmed reveal + Unhide, unread dot on the eye, profile-synced hidden state, and that hidden bots keep working for @mentions and group chats.

### `user-guide/bot-mode.md`
- Intro line: Bots tab is "next to Sessions in the left sidebar", Routines tile docks "while the Bots tab is active".
- New **Hide a Bot** bullet in "The Bots pane": display-only hiding, eye toggle, unread badge, no toasts for hidden bots, cross-machine sync via profile metadata.
- **Routines** section notes the pane appears only in Bots mode, with the older-build fallback.

### `developer-guide/desktop-plugin-sdk.md`
- `host.paneVisibility(paneId)` added to the host API listing plus an explainer paragraph: readonly reactive atom, true while the pane holds its zone's active tab slot (lone pane counts), contribution-scoped `<pluginId>:<paneId>` id, memoized per id, feature-detection guidance, with Bot Mode's Cronjobs pane as the reference consumer.

All claims verified against merged code (`apps/desktop/src/sdk/index.ts`, `apps/desktop/src/plugins/hermes-bots/plugin.js` on main, and the #88800 diff). No zh-Hans mirror exists for any of the three pages, so no translation updates were needed. No sidebar changes (no new pages).

## Validation

| Check | Result |
| --- | --- |
| `docusaurus build` | ✅ [SUCCESS] for both locales (en + zh-Hans) |
| `scripts/audit_pr_attribution.py --fix` | ✅ |

## Infographic

![Bot Mode docs refreshed](https://v3b.fal.media/files/b/0aa6c4bc/iUuuimInKEPAO_p7lglqs_nYwcXPmB.png)
