### PR TITLE
fix(kanban): surface worker's own final text on protocol_violation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8849,7 +8849,7 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
-def _worker_final_output(task_id: str) -> str:
+def _worker_final_output(task_id: str, board: Optional[str] = None) -> str:
     """Best-effort read of a quiet-mode kanban worker's last printed text.
 
     ``hermes chat -q`` prints nothing but the final response (banner,
@@ -8861,9 +8861,15 @@ def _worker_final_output(task_id: str) -> str:
     couldn't comply — see #88603, where that text was discarded in
     favor of a canned diagnostic on every reap. Returns "" (never
     raises) on a missing/unreadable log or an empty tail.
+
+    ``board`` must be threaded through from the caller's dispatch tick
+    (see ``detect_crashed_workers``) — without it the log path falls back
+    to ambient current-board resolution, which is wrong for every board
+    other than whichever one happens to be "current" for the dispatching
+    thread.
     """
     try:
-        raw = read_worker_log(task_id, tail_bytes=2000)
+        raw = read_worker_log(task_id, tail_bytes=2000, board=board)
     except Exception:
         return ""
     if not raw:
@@ -8877,8 +8883,16 @@ def _worker_final_output(task_id: str) -> str:
     return "\n".join(lines).strip()[:400]
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(
+    conn: sqlite3.Connection, board: Optional[str] = None,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
+
+    ``board`` pins the worker-log lookup used to surface a crashed
+    worker's own final output (see ``_worker_final_output``) to the
+    board this tick is actually running for. When omitted, falls back to
+    ambient current-board resolution — only correct for single-board
+    callers.
 
     Appends a ``crashed`` event and restores the task's source phase.
     Different from ``release_stale_claims``: this checks liveness
@@ -8976,7 +8990,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # instruction and said so should have that surface on the
                 # board instead of being silently replaced by the canned
                 # message above on every retry.
-                worker_output = _worker_final_output(row["id"])
+                worker_output = _worker_final_output(row["id"], board=board)
                 if worker_output:
                     error_text += f" Worker's last output: {worker_output!r}"
                     event_payload["worker_output"] = worker_output
@@ -9988,7 +10002,7 @@ def _dispatch_once_locked(
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
-    result.crashed = detect_crashed_workers(conn)
+    result.crashed = detect_crashed_workers(conn, board=board)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
     # DispatchResult here so telemetry / tests see the trip.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8849,6 +8849,34 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
+def _worker_final_output(task_id: str) -> str:
+    """Best-effort read of a quiet-mode kanban worker's last printed text.
+
+    ``hermes chat -q`` prints nothing but the final response (banner,
+    spinner and tool previews are suppressed) followed by a
+    ``session_id: ...`` line, and both are redirected to the same
+    per-task log file (see ``_default_spawn``). When a worker exits
+    cleanly without a terminal ``kanban_complete``/``kanban_block`` call,
+    that response is often the worker's own explanation of why it
+    couldn't comply — see #88603, where that text was discarded in
+    favor of a canned diagnostic on every reap. Returns "" (never
+    raises) on a missing/unreadable log or an empty tail.
+    """
+    try:
+        raw = read_worker_log(task_id, tail_bytes=2000)
+    except Exception:
+        return ""
+    if not raw:
+        return ""
+    lines = [
+        ln for ln in raw.splitlines()
+        if ln.strip() and not ln.startswith("session_id:")
+    ]
+    if not lines:
+        return ""
+    return "\n".join(lines).strip()[:400]
+
+
 def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
@@ -8943,6 +8971,15 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     # the violation-only retry budget is derived later.
                     "protocol_violation": True,
                 }
+                # Fold the worker's own final words into the diagnostic
+                # (#88603): a worker that recognized an impossible
+                # instruction and said so should have that surface on the
+                # board instead of being silently replaced by the canned
+                # message above on every retry.
+                worker_output = _worker_final_output(row["id"])
+                if worker_output:
+                    error_text += f" Worker's last output: {worker_output!r}"
+                    event_payload["worker_output"] = worker_output
             elif kind == "rate_limited":
                 # Worker bailed because the provider rate-limited / exhausted
                 # quota (EX_TEMPFAIL sentinel). This is NOT a task failure —

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1368,6 +1368,40 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
         conn.close()
 
 
+def test_protocol_violation_surfaces_worker_final_output(kanban_home):
+    """Regression for #88603: a worker that recognized an impossible
+    instruction and explained why in its final response must have that
+    explanation surface on the board, not a bare canned diagnostic.
+
+    Quiet-mode workers print only their final response before exiting,
+    redirected to the per-task log file. On a clean-exit protocol
+    violation, ``detect_crashed_workers`` must fold that text into both
+    the failure error and the reap event payload.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="handoff", assignee="worker")
+        diagnosis = (
+            "the board protocol requires reassigning this card to "
+            "orchestrator, but the native kanban_* tools available here "
+            "have no reassignment operation."
+        )
+        log_path = kb.worker_log_path(tid)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(diagnosis + "\n\nsession_id: abc123\n")
+
+        _drive_protocol_violation(conn, tid, 991100)
+
+        task = kb.get_task(conn, tid)
+        assert diagnosis in (task.last_failure_error or "")
+
+        events = [e for e in kb.list_events(conn, tid) if e.kind == "protocol_violation"]
+        assert len(events) == 1
+        assert (events[0].payload or {}).get("worker_output") == diagnosis
+    finally:
+        conn.close()
+
+
 
 
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1402,6 +1402,61 @@ def test_protocol_violation_surfaces_worker_final_output(kanban_home):
         conn.close()
 
 
+def test_protocol_violation_surfaces_worker_final_output_non_current_board(kanban_home):
+    """Regression for the #88603 review finding: the fix must not silently
+    no-op on every board except whichever one ``get_current_board()``
+    resolves to.
+
+    Mirrors ``gateway.kanban_watchers._tick_once_for_board``, which calls
+    ``dispatch_once(conn, board=slug, ...)`` from a worker thread with no
+    ``board`` pinned via env var or current-board file — the ambient
+    "current" board stays "default" throughout. Without threading
+    ``board`` into ``detect_crashed_workers`` -> ``_worker_final_output``
+    -> ``read_worker_log``, the worker's log (written under the
+    non-default board's own log directory) is invisible and the diagnosis
+    silently falls back to the canned message.
+    """
+    import hermes_cli.kanban_db as _kb
+    assert _kb.get_current_board() == "default"
+
+    board = "other-board"
+    conn = kb.connect(board=board)
+    try:
+        tid = kb.create_task(conn, title="handoff", assignee="worker", board=board)
+        diagnosis = (
+            "the board protocol requires reassigning this card to "
+            "orchestrator, but the native kanban_* tools available here "
+            "have no reassignment operation."
+        )
+        log_path = kb.worker_log_path(tid, board=board)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(diagnosis + "\n\nsession_id: abc123\n")
+
+        # Still "default" here — matches the gateway's real thread-pool
+        # execution model where board resolution is only ever explicit.
+        assert _kb.get_current_board() == "default"
+
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        claimed = _kb.claim_task(conn, tid, claimer=f"{host_prefix}:mock")
+        assert claimed is not None
+        fake_pid = 991200
+        _kb._set_worker_pid(conn, tid, fake_pid)
+        _kb._record_worker_exit(fake_pid, 0)
+        original_alive = _kb._pid_alive
+        _kb._pid_alive = lambda p: False
+        try:
+            _kb.detect_crashed_workers(conn, board=board)
+        finally:
+            _kb._pid_alive = original_alive
+
+        task = kb.get_task(conn, tid)
+        assert diagnosis in (task.last_failure_error or "")
+
+        events = [e for e in kb.list_events(conn, tid) if e.kind == "protocol_violation"]
+        assert len(events) == 1
+        assert (events[0].payload or {}).get("worker_output") == diagnosis
+    finally:
+        conn.close()
 
 
 


### PR DESCRIPTION
## Fixes #88603

### Problem

A dispatcher-spawned Kanban worker was given an instruction it could not
carry out with the tools available to it (in the reported case: hand its
card to another profile, which the worker toolset has no verb for). The
worker recognized this, declined to complete or block, and explained the
problem in its final response — then ended its turn.

`hermes chat -q` (the quiet mode kanban workers run under) prints nothing
but that final response before exiting, and the worker's stdout/stderr are
both redirected to its per-task log file (`_default_spawn`). So the text
existed on disk, but `detect_crashed_workers()`'s `clean_exit` branch never
read it — it always stamped a fixed, generic
`"worker exited cleanly (rc=0) without calling kanban_complete or
kanban_block — protocol violation. ..."` message onto `last_failure_error`
and the `protocol_violation` event, regardless of what the worker actually
said. Three consecutive runs discarded the same accurate diagnosis and
respawned the worker each time.

### Fix

`hermes_cli/kanban_db.py`:

- New `_worker_final_output(task_id)`: reads the tail of the worker's log
  (via the existing `read_worker_log` accessor), strips the trailing
  `session_id: ...` line, and returns up to 400 chars of whatever text the
  worker printed. Returns `""` (never raises) if the log is missing/empty.
- In `detect_crashed_workers()`'s `clean_exit` branch, when this returns
  non-empty text, it's appended to `error_text` (so `last_failure_error`
  carries it) and stamped onto the `protocol_violation` event payload as
  `worker_output`.

This only changes what diagnostic text is shown — it does **not** change
the violation-streak retry bound (`_PROTOCOL_VIOLATION_FAILURE_LIMIT`,
currently 3). That bound is already tuned against the documented
observation that ~96% of clean-exit protocol violations self-resolve on
retry, so I left it alone; this PR is scoped to making the *existing*
canned message additive with the worker's own words instead of replacing
them.

### Update: board-scoping fix (review finding)

Review caught a real gap in the original version of this PR: `_worker_final_output()`
called `read_worker_log(task_id, tail_bytes=2000)` with no `board=`, so the
log lookup fell back to ambient current-board resolution
(`get_current_board()`) instead of the board the dispatch tick is actually
running for. Every other board-scoped call in this file (`worker_log_path`,
`dispatch_once`, etc.) threads `board` explicitly — this was the one
exception. On a multi-board gateway install (the documented, actively
maintained production dispatch path — `gateway/kanban_watchers.py`'s
`_tick_once_for_board` runs `dispatch_once(conn, board=slug, ...)` per
board in its own thread, with no board pinned via env var or ContextVar),
this meant the worker's diagnosis would never surface for any board other
than whichever one happened to be "current" for the dispatching thread —
silently falling back to the old canned-message behavior, exactly the bug
this PR claims to fix.

Fixed by threading `board` through the whole call chain:
`_dispatch_once_locked` (which already receives `board`) now passes it to
`detect_crashed_workers(conn, board=board)`, which passes it to
`_worker_final_output(task_id, board=board)`, which passes it to
`read_worker_log(..., board=board)`.

### Tests

Added `test_protocol_violation_surfaces_worker_final_output` in
`tests/hermes_cli/test_kanban_core_functionality.py`: writes a worker log
containing a handoff-style diagnosis, drives one `detect_crashed_workers`
reap pass via the existing `_drive_protocol_violation` helper, and asserts
the diagnosis text lands in both `task.last_failure_error` and the
`protocol_violation` event's `worker_output` payload key.

Added `test_protocol_violation_surfaces_worker_final_output_non_current_board`:
mirrors the reviewer's repro — creates a non-default board, writes the
worker log under that board's own log directory, drives
`detect_crashed_workers(conn, board="other-board")` while
`get_current_board()` stays `"default"` throughout (matching the gateway's
real thread-pool execution model), and asserts the diagnosis still
surfaces.

Verified both new-test failure modes directly:
- Checked out `hermes_cli/kanban_db.py` at the pre-fix commit (the version
  originally submitted, without board threading) and reran the new
  board-scoping test: fails with `TypeError: detect_crashed_workers() got
  an unexpected keyword argument 'board'` — confirms the test requires
  this fix.
- Restored the fix, reran both new tests: pass.

```
$ scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_dispatch_lock.py tests/hermes_cli/test_kanban_dispatch_tick_hook.py tests/hermes_cli/test_kanban_host_cap.py tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py tests/gateway/test_kanban_reconcile_orphans.py
=== Summary: 10 files, 112 tests passed, 0 failed, 1 skipped (100% complete) in 9.6s (8 workers) ===
```

`ruff check` on both changed files: all checks passed.

### AI assistance disclosure

This change was authored with AI assistance (Claude Code).

### Checklist

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits (`fix(kanban):`)
- [x] Only changes related to this fix (no unrelated commits, no
      dependency-manifest edits)
- [x] Ran the test suite; all tests touching this change pass
- [x] Added a test that fails without the fix and passes with it
- [x] Tested on Linux
