### PR TITLE
fix(desktop): keep mixed panes attached to sidebar toggles

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/reactive-unhide.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/reactive-unhide.test.ts
@@ -79,6 +79,51 @@ describe('reactive pane unhide', () => {
     return { tree, layout }
   }
 
+  it('treats a Files group with contributed panes as the right sidebar', async () => {
+    const tree = await import('@/components/pane-shell/tree/store')
+    const layout = await import('@/store/layout')
+    const model = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+
+    // A user can stack arbitrary contributed panes into the Files zone. Bots
+    // currently contributes as left and Cronjobs as main, but neither is the
+    // main workspace anchor: the whole group still belongs to the Files/right
+    // sidebar toggle.
+    for (const [id, data] of [
+      ['sessions', { placement: 'left' }],
+      ['workspace', { placement: 'main', uncloseable: true }],
+      // Match controller.tsx: Files is the collapsible edge-sidebar anchor;
+      // plain placement alone must not give arbitrary right panes precedence.
+      ['files', { collapsible: true, placement: 'right', revealAliases: ['file-browser'] }],
+      ['contributed-left', { placement: 'left' }],
+      ['contributed-main', { placement: 'main' }]
+    ] as const) {
+      registry.register({ id, area: 'panes', title: id, data, render: () => null })
+    }
+
+    tree.declareDefaultTree(
+      model.split(
+        'row',
+        [
+          model.group(['sessions'], { id: 'grp-sessions' }),
+          model.group(['workspace'], { id: 'grp-main' }),
+          model.group(['files', 'contributed-left', 'contributed-main'], { id: 'grp-custom-sidebar' })
+        ],
+        [1, 3, 1]
+      )
+    )
+    tree.bindTreeSideVisibility('right', layout.$fileBrowserOpen, layout.setFileBrowserOpen)
+
+    // The keybind must not take its terminal fallback, and the renderer must
+    // classify the entire custom group as the Files/right side rather than
+    // only hiding Files through bindPaneVisibility.
+    expect(tree.layoutHasRootSide('right')).toBe(true)
+    expect(tree.treeSideOfPane('files')).toBe('right')
+
+    layout.setFileBrowserOpen(false)
+    expect(tree.$collapsedTreeSides.get().has('right')).toBe(true)
+  })
+
   it('reactive unhide does NOT expand a user-collapsed side', async () => {
     const { tree, layout } = await setupWithFiles()
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/root-child-side.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/root-child-side.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Contribution } from '@/contrib/types'
+
+import { group } from '../model'
+
+import { rootChildSide } from './track-model'
+
+type PaneData = {
+  collapsible?: boolean
+  placement?: string
+  revealAliases?: string[]
+  uncloseable?: boolean
+}
+
+const pane = (id: string, data: PaneData): Contribution => ({ area: 'panes', data, id })
+
+const productionFiles: PaneData = {
+  collapsible: true,
+  placement: 'right',
+  revealAliases: ['file-browser']
+}
+
+describe('rootChildSide', () => {
+  it.each([
+    {
+      expected: 'right',
+      name: 'keeps a Files edge anchor right when ordinary left and main panes share its group',
+      panes: [
+        pane('files', productionFiles),
+        pane('contributed-left', { placement: 'left' }),
+        pane('contributed-main', { placement: 'main' })
+      ]
+    },
+    {
+      expected: 'left',
+      name: 'keeps the shipped Quad Sessions + Files group on the left',
+      panes: [
+        pane('sessions', { collapsible: true, placement: 'left', revealAliases: ['chat-sidebar'] }),
+        pane('files', productionFiles)
+      ]
+    },
+    {
+      expected: null,
+      name: 'keeps the Focus Workspace + Files group main-owned',
+      panes: [
+        pane('workspace', { placement: 'main', uncloseable: true }),
+        pane('files', productionFiles),
+        pane('review', { collapsible: true, placement: 'right' }),
+        pane('terminal', { placement: 'bottom' })
+      ]
+    },
+    {
+      expected: 'right',
+      name: 'keeps a bottom-only terminal group on its prior right side',
+      panes: [pane('terminal', { placement: 'bottom' })]
+    },
+    {
+      expected: null,
+      name: 'leaves a closeable main-only session tile group unowned',
+      panes: [pane('session-tile', { placement: 'main' })]
+    }
+  ])('$name', ({ expected, panes }) => {
+    const byId = new Map(panes.map(contribution => [contribution.id, contribution]))
+
+    expect(rootChildSide(group(panes.map(contribution => contribution.id)), id => byId.get(id))).toBe(expected)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
@@ -284,21 +284,30 @@ export function subtreeGone(node: LayoutNode, ctx: TrackContext): boolean {
 /**
  * Which chrome toggle owns a root-row child — SEMANTIC, not positional:
  * ⌘B is the sessions/nav column (any `placement: 'left'` pane) wherever a
- * flip or drag puts it; ⌘J is every other side column. `null` = contains
- * the main zone, never side-collapsed. This is what keeps the titlebar
- * toggles and reveals 100% main-compatible through ⌘\ flips.
+ * flip or drag puts it; ⌘J is every other side column. A collapsible right
+ * pane is the exception: it is a real Files-style sidebar anchor, so ordinary
+ * contributed left/main panes travel with it. Another collapsible left pane
+ * remains the competing Sessions anchor, and an uncloseable main pane remains
+ * the workspace anchor. This keeps titlebar toggles and reveals compatible
+ * through ⌘\ flips without reclassifying ordinary bottom/tool groups.
  */
 export function rootChildSide(
   child: LayoutNode,
   paneFor: (id: string) => Contribution | undefined
 ): 'left' | 'right' | null {
-  const placements = allPaneIds(child).map(id => paneChrome(paneFor(id)).placement)
+  const chrome = allPaneIds(child).map(id => paneChrome(paneFor(id)))
+  const hasRightSidebarAnchor = chrome.some(pane => pane.placement === 'right' && pane.collapsible)
+  const hasLeftSidebarAnchor = chrome.some(pane => pane.placement === 'left' && pane.collapsible)
 
-  if (placements.includes('main')) {
+  if (hasRightSidebarAnchor && !hasLeftSidebarAnchor && !chrome.some(pane => pane.uncloseable)) {
+    return 'right'
+  }
+
+  if (chrome.some(pane => pane.placement === 'main')) {
     return null
   }
 
-  return placements.includes('left') ? 'left' : 'right'
+  return chrome.some(pane => pane.placement === 'left') ? 'left' : 'right'
 }
 
 /**

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -895,8 +895,8 @@ export function bindTreeSideVisibility(
 
 /** The chrome toggle owning `paneId`'s root-row column — SEMANTIC, matching
  *  the renderer's `rootChildSide`: ⌘B ⇔ the sessions column (left-placement
- *  panes) wherever it sits, ⌘J ⇔ the other side columns. Null for the main
- *  column (never side-collapsed). */
+ *  panes) wherever it sits, ⌘J ⇔ a right-anchored group. Null for a main-root
+ *  group unless a sole right sidebar anchor owns its mixed tenants. */
 export function treeSideOfPane(paneId: string): TreeSide | null {
   const row = rootRow()
 
@@ -910,16 +910,7 @@ export function treeSideOfPane(paneId: string): TreeSide | null {
     return null
   }
 
-  const placementOf = (id: string) =>
-    (registry.getArea('panes').find(c => c.id === id)?.data as { placement?: string } | undefined)?.placement
-
-  const placements = allPaneIds(child).map(placementOf)
-
-  if (placements.includes('main')) {
-    return null
-  }
-
-  return placements.includes('left') ? 'left' : 'right'
+  return rootChildSide(child, id => registry.getArea('panes').find(c => c.id === id))
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

A custom layout can stack contributed panes such as Bots (`placement: left`) and Cronjobs (`placement: main`) into the Files sidebar group. The root-side classifier treated any `main` tenant as the workspace, so the right sidebar toggle hid Files through its pane binding but left the rest of the group visible.

This keeps mixed tenants attached to a real collapsible right-sidebar anchor. It preserves the existing precedence for the shipped Quad, Focus, terminal-only, and session-tile layouts, and routes `treeSideOfPane` through the same classifier used by the renderer and keybind fallback.

## Related Issue

Reported directly; no GitHub issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Recognize a sole collapsible right pane as the edge anchor for its mixed root group.
- Keep competing Sessions anchors and main workspace groups on their existing sides.
- Use one root-side classifier for rendering, side availability, and pane reveal behavior.
- Add pure precedence coverage plus a real store-binding regression for Files + contributed left/main panes.

## How to Test

1. Put Bots and Cronjobs in the same tab group as Files in a root-row sidebar.
2. Click the right titlebar **Hide Sidebar** control; the complete group should collapse.
3. Click **Show Sidebar**; the complete group should return.

Automated checks run on macOS 26.6.1:

- Focused classifier/store regressions: 12 tests passed.
- Pane-shell tree plus sidebar persistence: 114 tests passed.
- Bundled Bots pane-dock tests: 4 tests passed.
- Desktop typecheck, targeted ESLint, Prettier, and `git diff --check` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — Desktop-only TypeScript change; targeted Desktop suites were run instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.1 (automated Desktop suites)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — renderer-only, platform-neutral state logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual asset: the regression is covered deterministically at the shared classifier and real store-binding seams.
