### PR TITLE
fix(gateway): honor profile toolset capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1312,6 +1312,18 @@ automatically scope to the active profile.
      do not reintroduce the `except _UnscopedSecretError: val = os.getenv(...)`
      fallback-after-miss shape.
 
+8. **A profile's explicit capability pin is runtime-authoritative.**
+   `profiles.configure` stores a non-empty selection at
+   `tools.enabled_toolsets` inside that profile's `config.yaml`. The
+   TUI/Desktop gateway must resolve this from the active profile's
+   `HERMES_HOME` before applying coding-context posture; otherwise a Bot Chat
+   opened in a repository can show one capability set in its editor while the
+   runtime silently receives `coding` instead. Resolution precedence is:
+   `HERMES_TUI_TOOLSETS` operator override → profile capability pin → coding
+   posture → platform defaults. Enabled MCP servers and client-surface
+   toolsets still ride alongside the profile pin. An absent pin (including an
+   editor-cleared empty list) keeps the existing posture/platform behavior.
+
 ## Known Pitfalls
 
 ### DO NOT hardcode `~/.hermes` paths

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2373,6 +2373,67 @@ def test_load_enabled_toolsets_prefers_tui_env(monkeypatch):
     assert server._load_enabled_toolsets() == ["web", "terminal", "memory"]
 
 
+def test_load_enabled_toolsets_honors_profile_capability_pin_before_posture(
+    monkeypatch,
+):
+    monkeypatch.delenv("HERMES_TUI_TOOLSETS", raising=False)
+
+    import agent.coding_context as cc
+    import hermes_cli.config as config_mod
+    import hermes_cli.plugins as plugins_mod
+    import hermes_cli.tools_config as tools_config_mod
+
+    monkeypatch.setattr(cc, "coding_selection", lambda **_: ["coding"])
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"tools": {"enabled_toolsets": ["web", "plugin_demo"]}},
+    )
+    discovered = []
+    monkeypatch.setattr(plugins_mod, "discover_plugins", lambda: discovered.append(True))
+    monkeypatch.setattr(
+        tools_config_mod, "enabled_mcp_server_names", lambda _cfg: {"github"}
+    )
+
+    assert server._load_enabled_toolsets("desktop") == [
+        "desktop_ui",
+        "github",
+        "plugin_demo",
+        "project",
+        "web",
+    ]
+    assert discovered == [True]
+
+
+def test_load_enabled_toolsets_reads_pin_from_active_profile_config(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.delenv("HERMES_TUI_TOOLSETS", raising=False)
+
+    import agent.coding_context as cc
+    import hermes_cli.plugins as plugins_mod
+
+    profile_home = tmp_path / "profiles" / "reviewer"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "tools:\n"
+        "  enabled_toolsets:\n"
+        "    - memory\n"
+        "    - web\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(cc, "coding_selection", lambda **_: ["coding"])
+    monkeypatch.setattr(plugins_mod, "discover_plugins", lambda: None)
+
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        assert server._load_enabled_toolsets("tui") == ["memory", "project", "web"]
+    finally:
+        reset_hermes_home_override(token)
+
+
 def test_load_enabled_toolsets_filters_invalid_tui_env(monkeypatch, capsys):
     monkeypatch.setenv("HERMES_TUI_TOOLSETS", "web, nope")
     monkeypatch.setitem(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4482,6 +4482,17 @@ def _gui_surface_toolsets(platform: str) -> set[str]:
 
 
 def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
+    """Resolve session toolsets by operator, profile, posture, then platform.
+
+    The active ``HERMES_HOME`` may belong to a Bot/profile whose capability
+    editor wrote an explicit ``tools.enabled_toolsets`` pin.  That user choice
+    must survive an otherwise-applicable coding posture while still yielding
+    to the process-level ``HERMES_TUI_TOOLSETS`` operator override.
+    """
+    from hermes_cli.config import load_config
+    from hermes_cli.plugins import discover_plugins
+    from hermes_cli.tools_config import enabled_mcp_server_names
+
     session_platform = platform or _resolve_session_platform()
     explicit = [
         item.strip()
@@ -4490,6 +4501,40 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
     ]
     cfg = None
     fallback_notice = None
+
+    # Bot/profile capability editors persist an explicit per-profile pin at
+    # ``tools.enabled_toolsets``.  Resolve that before coding-context posture:
+    # a Bot Chat may happen to start in a repository, but that must not replace
+    # the profile's selected capabilities with the generic coding set.  The
+    # profile API already treats this field as authoritative when displaying
+    # its capability checkboxes, so the runtime must consume the same field.
+    # HERMES_TUI_TOOLSETS remains the operator-level override and wins above
+    # this block when present.
+    if not explicit:
+        try:
+            cfg = load_config()
+            tools_cfg = cfg.get("tools") if isinstance(cfg, dict) else None
+            pinned = (
+                tools_cfg.get("enabled_toolsets")
+                if isinstance(tools_cfg, dict)
+                else None
+            )
+            if isinstance(pinned, list) and pinned:
+                # Plugin toolsets are registry-backed. Ensure the active
+                # profile overlay is loaded before AIAgent snapshots schemas.
+                discover_plugins()
+                selected = {
+                    str(name).strip() for name in pinned if str(name).strip()
+                }
+                # MCP enablement is configured separately from the profile's
+                # native/plugin capability pin and must continue to ride along.
+                selected.update(enabled_mcp_server_names(cfg))
+                selected.update(_gui_surface_toolsets(session_platform))
+                return sorted(selected)
+        except Exception:
+            # Preserve the established posture/config fallback when a partial
+            # or older profile cannot resolve its capability pin.
+            cfg = None
 
     # Coding posture (base Hermes): with no explicit pin, collapse to the
     # coding toolset (+ enabled MCP servers) when sitting in a code workspace.


### PR DESCRIPTION
## What does this PR do?

Completes the runtime side of the profile capability editor contract introduced by #85216 and made user-honest by #86227.

`profiles.configure` persists a non-empty profile capability selection at `tools.enabled_toolsets`, and `profiles.describe` presents that pin as authoritative. The TUI/Desktop gateway did not consume it when constructing an agent. A Bot Chat opened in a code workspace could therefore show one capability set in the editor while receiving the generic `coding` toolset at runtime.

## Root cause

#43316 intentionally made focus-mode coding posture fill only an unpinned default selection. `_load_enabled_toolsets()` recognized `HERMES_TUI_TOOLSETS` as an explicit pin, but never checked the equivalent profile-scoped pin in the active `HERMES_HOME` before asking coding posture for a selection.

That made the editor and runtime disagree, and profile plugin tools disappeared from the model schema without an error.

## Fix

The gateway now resolves toolsets in this order:

1. `HERMES_TUI_TOOLSETS` operator override
2. Active profile `tools.enabled_toolsets` pin
3. Coding-context posture
4. Existing platform configuration fallback

For a profile pin, plugin discovery runs before the agent snapshots schemas. Enabled MCP servers and client-surface toolsets continue to ride alongside the selected profile capabilities. An absent pin, including an editor-cleared empty list, preserves the existing posture and platform behavior.

No config keys, model tools, plugin-specific behavior, or user-facing commands are added.

## Changes made

- `tui_gateway/server.py`: consume the active profile capability pin before coding posture and document the resolver contract.
- `tests/test_tui_gateway_server.py`: cover precedence, generic plugin discovery, MCP inclusion, desktop surface inclusion, and a real profile-scoped `config.yaml` load.
- `AGENTS.md`: record the capability-resolution precedence so future gateway changes preserve editor/runtime parity.

## How to test

1. Save a profile with `tools.enabled_toolsets: [memory, web]`.
2. Start a TUI/Desktop Bot Chat for that profile from a code workspace with `agent.coding_context: focus`.
3. Confirm the runtime receives `memory`, `web`, enabled MCP servers, and its client-surface tools rather than replacing the profile selection with `coding`.
4. Set `HERMES_TUI_TOOLSETS`; confirm that operator override still wins.

## Verification

- `scripts/run_tests.sh tests/test_tui_gateway_server.py -q` — 587 passed
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -k load_enabled_toolsets -q` — 13 passed
- `ruff check tui_gateway/server.py tests/test_tui_gateway_server.py` — passed
- Gateway import smoke test — passed
- `git diff --check upstream/main...HEAD` — passed

## Documentation

No user guide update is needed because this introduces no new setting or workflow. The existing setting now behaves as documented by the profile editor. The internal precedence invariant is recorded in `AGENTS.md`.