### PR TITLE
fix(web): load plugins before extract backend selection

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -861,6 +861,9 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
+            # Plugin-backed extract providers must be discovered before backend
+            # selection, matching the web search dispatch path.
+            _ensure_web_plugins_loaded()
             backend = _get_extract_backend()
 
             # All seven providers (brave-free, ddgs, searxng, exa, parallel,
@@ -870,7 +873,6 @@ async def web_extract_tool(
             # detect coroutine functions and await; sync functions run
             # inline (the policy gate, SSRF re-check, etc. live inside the
             # provider itself for the firecrawl per-URL loop).
-            _ensure_web_plugins_loaded()
             from agent.web_search_registry import (
                 get_active_extract_provider,
                 get_provider as _wsp_get_provider,


### PR DESCRIPTION
Fixes #88116

Ensure web extract plugins are discovered before resolving the configured extract backend.

On cold-start paths, `_get_extract_backend()` could run before plugin discovery, causing configured plugin-backed extract providers to be missed and the dispatcher to fall back incorrectly.

This moves `_ensure_web_plugins_loaded()` ahead of backend selection, matching the existing web search dispatch order.

Validation:
- Confirmed the current regression test already covers discovery-before-registry-lookup behavior in `tests/tools/test_web_providers.py`.
- Local full test execution was blocked by the repository requiring Python >=3.11 while the current Ubuntu environment has Python 3.10.