### PR TITLE
fix(desktop): bridge runtime plugin media

### DIFF
--- a/apps/desktop/electron/media-protocol.test.ts
+++ b/apps/desktop/electron/media-protocol.test.ts
@@ -108,6 +108,7 @@ describe('createMediaProtocolHandler', () => {
         authMode: 'token' as const,
         baseUrl: 'https://gateway.test/hermes',
         mode: 'remote' as const,
+        sharedPrimary: true,
         token: 's e/cret'
       }))
     })
@@ -125,6 +126,7 @@ describe('createMediaProtocolHandler', () => {
     const url = new URL(rawUrl)
     expect(url.pathname).toBe('/hermes/api/files/stream')
     expect(url.searchParams.get('path')).toBe('/root/outputs/render.mp4')
+    expect(url.searchParams.get('profile')).toBe('reviewer')
     expect(url.searchParams.has('token')).toBe(false)
     expect(headers.get('x-hermes-session-token')).toBe('s e/cret')
     expect(headers.get('range')).toBe('bytes=0-1023')
@@ -150,6 +152,25 @@ describe('createMediaProtocolHandler', () => {
 
     expect(url.searchParams.get('path')).toBe('/root/outputs/render.mp4')
     expect(url.searchParams.get('profile')).toBe('research')
+  })
+
+  it('does not add a second profile scope to a profile-owned remote backend', async () => {
+    const deps = dependencies({
+      resolveRemoteConnection: vi.fn(async () => ({
+        authMode: 'token' as const,
+        baseUrl: 'https://gateway.test/hermes',
+        mode: 'remote' as const,
+        token: 'secret'
+      }))
+    })
+
+    await createMediaProtocolHandler(deps)(
+      request('hermes-media://remote/%2Froot%2Foutputs%2Frender.mp4?profile=reviewer')
+    )
+
+    const [rawUrl] = vi.mocked(deps.fetchRemote).mock.calls[0]
+
+    expect(new URL(rawUrl).searchParams.get('profile')).toBeNull()
   })
 
   it('proxies plugin media through the scoped backend without placing its token in the URL', async () => {

--- a/apps/desktop/electron/media-protocol.test.ts
+++ b/apps/desktop/electron/media-protocol.test.ts
@@ -201,7 +201,10 @@ describe('createMediaProtocolHandler', () => {
 
     for (const rawUrl of [
       'hermes-media://plugin/studio-rail/outputs/%2e%2e/stream',
+      'hermes-media://plugin/%252e%252e/outputs/clip/stream',
       'hermes-media://plugin/studio-rail/outputs/%252e%252e/stream',
+      'hermes-media://plugin/studio-rail/outputs/%252F/stream',
+      'hermes-media://plugin/studio-rail/outputs/%255c/stream',
       'hermes-media://plugin/studio-rail/outputs/%zz/stream',
       'hermes-media://plugin/studio-rail/outputs/clip/stream?unexpected=value',
       'hermes-media://plugin/studio-rail/outputs/clip/stream?profile=one&profile=two',

--- a/apps/desktop/electron/media-protocol.test.ts
+++ b/apps/desktop/electron/media-protocol.test.ts
@@ -5,6 +5,7 @@ import {
   isStreamableMediaPath,
   type MediaProtocolDependencies,
   mediaRequestHeaders,
+  pluginMediaEndpoint,
   remoteMediaEndpoint
 } from './media-protocol'
 
@@ -55,6 +56,13 @@ describe('media protocol helpers', () => {
 
     expect(endpoint.pathname).toBe('/hermes/api/files/stream')
     expect(endpoint.searchParams.get('path')).toBe('/tmp/a b.mp4')
+  })
+
+  it('preserves a configured gateway path prefix and shared profile scope for plugin media', () => {
+    const endpoint = new URL(pluginMediaEndpoint('https://gateway.test/hermes/', 'studio rail', 'outputs/a b/clip', 'video'))
+
+    expect(endpoint.pathname).toBe('/hermes/api/plugins/studio%20rail/outputs/a%20b/clip')
+    expect(endpoint.searchParams.get('profile')).toBe('video')
   })
 })
 
@@ -142,6 +150,67 @@ describe('createMediaProtocolHandler', () => {
 
     expect(url.searchParams.get('path')).toBe('/root/outputs/render.mp4')
     expect(url.searchParams.get('profile')).toBe('research')
+  })
+
+  it('proxies plugin media through the scoped backend without placing its token in the URL', async () => {
+    const resolveRemoteConnection = vi.fn(async (_scope: { connectionId?: string; profile?: string }) => ({
+      authMode: 'token' as const,
+      baseUrl: 'https://gateway.test/hermes',
+      mode: 'remote' as const,
+      sharedRemote: true,
+      token: 'plugin-secret'
+    }))
+
+    const deps = dependencies({
+      fetchRemote: vi.fn(async () => new Response('remote', { headers: { 'content-type': 'video/mp4' }, status: 206 })),
+      resolveRemoteConnection
+    })
+
+    const response = await createMediaProtocolHandler(deps)(
+      request('hermes-media://plugin/studio-rail/outputs/clip/stream?profile=video&connectionId=mac-mini', {
+        Range: 'bytes=0-1023'
+      })
+    )
+
+    expect(response.status).toBe(206)
+    expect(resolveRemoteConnection).toHaveBeenCalledWith({ connectionId: 'mac-mini', profile: 'video' })
+    const [rawUrl, headers] = vi.mocked(deps.fetchRemote).mock.calls[0]
+    const url = new URL(rawUrl)
+    expect(url.pathname).toBe('/hermes/api/plugins/studio-rail/outputs/clip/stream')
+    expect(url.searchParams.get('profile')).toBe('video')
+    expect(url.searchParams.has('token')).toBe(false)
+    expect(headers.get('x-hermes-session-token')).toBe('plugin-secret')
+    expect(headers.get('range')).toBe('bytes=0-1023')
+  })
+
+  it('rejects successful plugin responses that are not audio or video', async () => {
+    const deps = dependencies({
+      fetchRemote: vi.fn(async () => new Response('<html>not media</html>', { headers: { 'content-type': 'text/html' } }))
+    })
+
+    const response = await createMediaProtocolHandler(deps)(
+      request('hermes-media://plugin/studio-rail/outputs/clip/stream')
+    )
+
+    expect(response.status).toBe(415)
+  })
+
+  it('rejects malformed plugin routes before resolving a backend', async () => {
+    const deps = dependencies()
+    const handler = createMediaProtocolHandler(deps)
+
+    for (const rawUrl of [
+      'hermes-media://plugin/studio-rail/outputs/%2e%2e/stream',
+      'hermes-media://plugin/studio-rail/outputs/%252e%252e/stream',
+      'hermes-media://plugin/studio-rail/outputs/%zz/stream',
+      'hermes-media://plugin/studio-rail/outputs/clip/stream?unexpected=value',
+      'hermes-media://plugin/studio-rail/outputs/clip/stream?profile=one&profile=two',
+      'hermes-media://plugin/studio-rail/outputs/clip/stream#fragment'
+    ]) {
+      expect((await handler(request(rawUrl))).status).toBe(404)
+    }
+
+    expect(deps.resolveRemoteConnection).not.toHaveBeenCalled()
   })
 
   it('preserves explicit HEAD requests through the token-auth remote proxy', async () => {

--- a/apps/desktop/electron/media-protocol.ts
+++ b/apps/desktop/electron/media-protocol.ts
@@ -1,3 +1,5 @@
+import { pathWithProfileScope, translateSelfProfileQuery } from './connection-config'
+
 const STREAMABLE_MEDIA_EXTENSIONS = [
   '.avi',
   '.flac',
@@ -35,8 +37,10 @@ export interface MediaRemoteConnection {
   authMode?: 'oauth' | 'token'
   baseUrl: string
   mode?: 'local' | 'remote'
-  token?: null | string
+  remoteProfile?: null | string
+  sharedPrimary?: boolean
   sharedRemote?: boolean
+  token?: null | string
 }
 
 type MediaRequestMethod = 'GET' | 'HEAD'
@@ -206,6 +210,27 @@ export function pluginMediaEndpoint(baseUrl: string, pluginId: string, filePath:
   return url.toString()
 }
 
+function profileScopedMediaEndpoint(endpoint: string, connection: MediaRemoteConnection, profile?: string): string {
+  const url = new URL(endpoint)
+  const requestPath = `${url.pathname}${url.search}`
+
+  const scopedPath =
+    connection.sharedPrimary || connection.sharedRemote
+      ? pathWithProfileScope(requestPath, profile)
+      : translateSelfProfileQuery(requestPath, profile, connection.remoteProfile)
+
+  if (scopedPath === requestPath) {
+    return endpoint
+  }
+
+  const scoped = new URL(scopedPath, url.origin)
+
+  url.pathname = scoped.pathname
+  url.search = scoped.search
+
+  return url.toString()
+}
+
 function validatePluginMediaResponse(target: MediaProtocolTarget, response: Response): Response {
   if (target.mode !== 'plugin' || !response.ok) {
     return response
@@ -270,10 +295,13 @@ export function createMediaProtocolHandler(dependencies: MediaProtocolDependenci
         return new Response('Remote media backend unavailable', { status: 404 })
       }
 
-      const endpoint =
+      const endpoint = profileScopedMediaEndpoint(
         target.mode === 'plugin'
-          ? pluginMediaEndpoint(connection.baseUrl, target.pluginId!, target.filePath, connection.sharedRemote ? target.profile : undefined)
-          : remoteMediaEndpoint(connection.baseUrl, target.filePath, connection.sharedRemote ? target.profile : undefined)
+          ? pluginMediaEndpoint(connection.baseUrl, target.pluginId!, target.filePath)
+          : remoteMediaEndpoint(connection.baseUrl, target.filePath),
+        connection,
+        target.profile
+      )
 
       if (connection.authMode === 'oauth') {
         const bearer = await dependencies.ensureRemoteBearer(connection.baseUrl)

--- a/apps/desktop/electron/media-protocol.ts
+++ b/apps/desktop/electron/media-protocol.ts
@@ -16,12 +16,13 @@ const FORWARDED_MEDIA_REQUEST_HEADERS = ['accept', 'if-modified-since', 'if-none
 
 export const MEDIA_PROTOCOL = 'hermes-media'
 
-type MediaProtocolMode = 'remote' | 'stream'
+type MediaProtocolMode = 'plugin' | 'remote' | 'stream'
 
 interface MediaProtocolTarget {
   connectionId?: string
   filePath: string
   mode: MediaProtocolMode
+  pluginId?: string
   profile?: string
 }
 
@@ -49,12 +50,95 @@ export interface MediaProtocolDependencies {
   resolveRemoteConnection: (scope: MediaRemoteScope) => Promise<MediaRemoteConnection>
 }
 
+const PLUGIN_MEDIA_QUERY_PARAMS = new Set(['connectionId', 'profile'])
+
+// Keep these segment rules in sync with the defense-in-depth URL minting check
+// in apps/desktop/src/api/plugins.ts::assertSafePluginMediaSegment.
+function assertSafePluginMediaSegment(segment: string, rawUrl: string): void {
+  let inspected = segment
+
+  while (true) {
+    if (!inspected || inspected === '.' || inspected === '..' || inspected.includes('/') || inspected.includes('\\')) {
+      throw new Error(`Unsafe plugin media URL: ${rawUrl}`)
+    }
+
+    // A raw `%252e` becomes `%2e` after the first decode. Inspect nested
+    // escapes solely for path syntax so a later URL/server decode cannot turn
+    // an accepted segment into traversal. A literal malformed percent is safe
+    // once the original URL segment itself decoded successfully.
+    if (!/%[0-9a-f]{2}/i.test(inspected)) {
+      return
+    }
+
+    try {
+      inspected = decodeURIComponent(inspected)
+    } catch {
+      return
+    }
+  }
+}
+
+function decodePluginMediaSegment(rawSegment: string, rawUrl: string): string {
+  let segment: string
+
+  try {
+    segment = decodeURIComponent(rawSegment)
+  } catch {
+    throw new Error(`Malformed plugin media URL: ${rawUrl}`)
+  }
+
+  assertSafePluginMediaSegment(segment, rawUrl)
+
+  return segment
+}
+
+function parsePluginMediaTarget(rawUrl: string, url: URL): MediaProtocolTarget {
+  const prefix = `${MEDIA_PROTOCOL}://plugin/`
+
+  if (!rawUrl.startsWith(prefix) || url.hash) {
+    throw new Error(`Malformed plugin media URL: ${rawUrl}`)
+  }
+
+  const rawPath = rawUrl.slice(prefix.length).split(/[?#]/, 1)[0]
+  const [rawPluginId, ...rawPluginPath] = rawPath.split('/')
+
+  if (!rawPluginId || rawPluginPath.length === 0) {
+    throw new Error(`Missing plugin media path: ${rawUrl}`)
+  }
+
+  const pluginId = decodePluginMediaSegment(rawPluginId, rawUrl)
+  const pluginPath = rawPluginPath.map(segment => decodePluginMediaSegment(segment, rawUrl))
+  const scope = new Map<string, string>()
+
+  for (const [key, rawValue] of url.searchParams) {
+    const value = rawValue.trim()
+
+    if (!PLUGIN_MEDIA_QUERY_PARAMS.has(key) || !value || value !== rawValue || scope.has(key)) {
+      throw new Error(`Unsafe plugin media URL: ${rawUrl}`)
+    }
+
+    scope.set(key, value)
+  }
+
+  return {
+    connectionId: scope.get('connectionId'),
+    filePath: pluginPath.join('/'),
+    mode: 'plugin',
+    pluginId,
+    profile: scope.get('profile')
+  }
+}
+
 function parseMediaProtocolTarget(rawUrl: string): MediaProtocolTarget {
   const url = new URL(rawUrl)
   const mode = url.hostname as MediaProtocolMode
 
-  if (mode !== 'remote' && mode !== 'stream') {
+  if (url.protocol !== `${MEDIA_PROTOCOL}:` || (mode !== 'plugin' && mode !== 'remote' && mode !== 'stream')) {
     throw new Error('Unsupported media protocol target')
+  }
+
+  if (mode === 'plugin') {
+    return parsePluginMediaTarget(rawUrl, url)
   }
 
   const filePath = decodeURIComponent(url.pathname.replace(/^\/+/, ''))
@@ -106,6 +190,38 @@ export function remoteMediaEndpoint(baseUrl: string, filePath: string, profile?:
   return url.toString()
 }
 
+export function pluginMediaEndpoint(baseUrl: string, pluginId: string, filePath: string, profile?: string): string {
+  const normalizedBase = baseUrl.replace(/\/+$/, '')
+  const pluginPath = filePath.split('/').map(encodeURIComponent).join('/')
+  const url = new URL(`${normalizedBase}/api/plugins/${encodeURIComponent(pluginId)}/${pluginPath}`)
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Unsupported Hermes backend URL protocol: ${url.protocol}`)
+  }
+
+  if (profile) {
+    url.searchParams.set('profile', profile)
+  }
+
+  return url.toString()
+}
+
+function validatePluginMediaResponse(target: MediaProtocolTarget, response: Response): Response {
+  if (target.mode !== 'plugin' || !response.ok) {
+    return response
+  }
+
+  const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase()
+
+  if (contentType?.startsWith('audio/') || contentType?.startsWith('video/')) {
+    return response
+  }
+
+  void response.body?.cancel().catch(() => undefined)
+
+  return new Response('Unsupported media type', { status: 415 })
+}
+
 export function createMediaProtocolHandler(dependencies: MediaProtocolDependencies) {
   return async (request: Pick<Request, 'headers' | 'method' | 'url'>): Promise<Response> => {
     if (request.method !== 'GET' && request.method !== 'HEAD') {
@@ -124,7 +240,7 @@ export function createMediaProtocolHandler(dependencies: MediaProtocolDependenci
       return new Response('Media not found', { status: 404 })
     }
 
-    if (!isStreamableMediaPath(target.filePath)) {
+    if (target.mode !== 'plugin' && !isStreamableMediaPath(target.filePath)) {
       return new Response('Unsupported media type', { status: 415 })
     }
 
@@ -150,15 +266,14 @@ export function createMediaProtocolHandler(dependencies: MediaProtocolDependenci
         profile: target.profile
       })
 
-      if (connection.mode !== 'remote') {
+      if (target.mode === 'remote' && connection.mode !== 'remote') {
         return new Response('Remote media backend unavailable', { status: 404 })
       }
 
-      const endpoint = remoteMediaEndpoint(
-        connection.baseUrl,
-        target.filePath,
-        connection.sharedRemote ? target.profile : undefined
-      )
+      const endpoint =
+        target.mode === 'plugin'
+          ? pluginMediaEndpoint(connection.baseUrl, target.pluginId!, target.filePath, connection.sharedRemote ? target.profile : undefined)
+          : remoteMediaEndpoint(connection.baseUrl, target.filePath, connection.sharedRemote ? target.profile : undefined)
 
       if (connection.authMode === 'oauth') {
         const bearer = await dependencies.ensureRemoteBearer(connection.baseUrl)
@@ -166,10 +281,10 @@ export function createMediaProtocolHandler(dependencies: MediaProtocolDependenci
         if (bearer) {
           headers.set('authorization', `Bearer ${bearer}`)
 
-          return await dependencies.fetchRemote(endpoint, headers, method)
+          return validatePluginMediaResponse(target, await dependencies.fetchRemote(endpoint, headers, method))
         }
 
-        return await dependencies.fetchRemoteWithCookies(endpoint, headers, method)
+        return validatePluginMediaResponse(target, await dependencies.fetchRemoteWithCookies(endpoint, headers, method))
       }
 
       if (!connection.token) {
@@ -178,7 +293,7 @@ export function createMediaProtocolHandler(dependencies: MediaProtocolDependenci
 
       headers.set('x-hermes-session-token', connection.token)
 
-      return await dependencies.fetchRemote(endpoint, headers, method)
+      return validatePluginMediaResponse(target, await dependencies.fetchRemote(endpoint, headers, method))
     } catch {
       return new Response('Remote media unavailable', { status: 502 })
     }

--- a/apps/desktop/src/api/plugins.ts
+++ b/apps/desktop/src/api/plugins.ts
@@ -50,6 +50,22 @@ function pluginMediaPathSuffix(path: string): string {
   return `/${segments.join('/')}`
 }
 
+function pluginMediaId(pluginId: string): string {
+  let decoded: string
+
+  try {
+    decoded = decodeURIComponent(pluginId)
+  } catch {
+    throw new Error(`pluginMediaUrl: invalid plugin id "${pluginId}"`)
+  }
+
+  if (!decoded || decoded === '.' || decoded === '..' || decoded.includes('/') || decoded.includes('\\')) {
+    throw new Error(`pluginMediaUrl: invalid plugin id "${pluginId}"`)
+  }
+
+  return encodeURIComponent(pluginId)
+}
+
 /** Build a seekable, authenticated media URL for a plugin-owned backend route.
  *  The custom protocol keeps gateway credentials out of the renderer and maps
  *  the URL back to `/api/plugins/<pluginId>` in Electron's main process. */
@@ -59,7 +75,7 @@ export function pluginMediaUrl(pluginId: string, path: string): null | string {
   }
 
   const suffix = pluginMediaPathSuffix(path)
-  const url = new URL(`hermes-media://plugin/${pluginId}${suffix}`)
+  const url = new URL(`hermes-media://plugin/${pluginMediaId(pluginId)}${suffix}`)
   const profile = getApiRequestProfile()
   const connectionId = getApiRequestConnection()
 

--- a/apps/desktop/src/api/plugins.ts
+++ b/apps/desktop/src/api/plugins.ts
@@ -20,6 +20,29 @@ async function activeConnection(): Promise<HermesConnection> {
   return window.hermesDesktop.getConnection(getApiRequestProfile())
 }
 
+function assertSafePluginMediaSegment(segment: string, path: string, message: string): void {
+  let inspected = segment
+
+  while (true) {
+    if (!inspected || inspected === '.' || inspected === '..' || inspected.includes('/') || inspected.includes('\\')) {
+      throw new Error(`${message} in "${path}"`)
+    }
+
+    // `%252e` decodes once to `%2e`. Inspect nested escapes for path syntax
+    // before minting a URL, while preserving literal percent filenames whose
+    // follow-up decode is malformed.
+    if (!/%[0-9a-f]{2}/i.test(inspected)) {
+      return
+    }
+
+    try {
+      inspected = decodeURIComponent(inspected)
+    } catch {
+      return
+    }
+  }
+}
+
 function pluginMediaPathSuffix(path: string): string {
   if (path.includes('?') || path.includes('#')) {
     throw new Error(`pluginMediaUrl: query and fragment are not allowed in "${path}"`)
@@ -40,9 +63,7 @@ function pluginMediaPathSuffix(path: string): string {
       throw new Error(`pluginMediaUrl: malformed path encoding in "${path}"`)
     }
 
-    if (!decoded || decoded === '.' || decoded === '..' || decoded.includes('/') || decoded.includes('\\')) {
-      throw new Error(`pluginMediaUrl: illegal path traversal in "${path}"`)
-    }
+    assertSafePluginMediaSegment(decoded, path, 'pluginMediaUrl: illegal path traversal')
 
     return encodeURIComponent(decoded)
   })
@@ -59,9 +80,7 @@ function pluginMediaId(pluginId: string): string {
     throw new Error(`pluginMediaUrl: invalid plugin id "${pluginId}"`)
   }
 
-  if (!decoded || decoded === '.' || decoded === '..' || decoded.includes('/') || decoded.includes('\\')) {
-    throw new Error(`pluginMediaUrl: invalid plugin id "${pluginId}"`)
-  }
+  assertSafePluginMediaSegment(decoded, pluginId, 'pluginMediaUrl: invalid plugin id')
 
   return encodeURIComponent(pluginId)
 }

--- a/apps/desktop/src/api/plugins.ts
+++ b/apps/desktop/src/api/plugins.ts
@@ -20,6 +20,60 @@ async function activeConnection(): Promise<HermesConnection> {
   return window.hermesDesktop.getConnection(getApiRequestProfile())
 }
 
+function pluginMediaPathSuffix(path: string): string {
+  if (path.includes('?') || path.includes('#')) {
+    throw new Error(`pluginMediaUrl: query and fragment are not allowed in "${path}"`)
+  }
+
+  const rawPath = path.replace(/^\/+/, '')
+
+  if (!rawPath) {
+    throw new Error('pluginMediaUrl: media path is required')
+  }
+
+  const segments = rawPath.split('/').map(segment => {
+    let decoded: string
+
+    try {
+      decoded = decodeURIComponent(segment)
+    } catch {
+      throw new Error(`pluginMediaUrl: malformed path encoding in "${path}"`)
+    }
+
+    if (!decoded || decoded === '.' || decoded === '..' || decoded.includes('/') || decoded.includes('\\')) {
+      throw new Error(`pluginMediaUrl: illegal path traversal in "${path}"`)
+    }
+
+    return encodeURIComponent(decoded)
+  })
+
+  return `/${segments.join('/')}`
+}
+
+/** Build a seekable, authenticated media URL for a plugin-owned backend route.
+ *  The custom protocol keeps gateway credentials out of the renderer and maps
+ *  the URL back to `/api/plugins/<pluginId>` in Electron's main process. */
+export function pluginMediaUrl(pluginId: string, path: string): null | string {
+  if (!window.hermesDesktop) {
+    return null
+  }
+
+  const suffix = pluginMediaPathSuffix(path)
+  const url = new URL(`hermes-media://plugin/${pluginId}${suffix}`)
+  const profile = getApiRequestProfile()
+  const connectionId = getApiRequestConnection()
+
+  if (profile) {
+    url.searchParams.set('profile', profile)
+  }
+
+  if (connectionId) {
+    url.searchParams.set('connectionId', connectionId)
+  }
+
+  return url.toString()
+}
+
 /** Options for a plugin REST call — mirrors the app's own `hermesDesktop.api`
  *  shape, minus the path (which is namespace-derived). */
 export interface PluginRestOptions {

--- a/apps/desktop/src/api/plugins.ts
+++ b/apps/desktop/src/api/plugins.ts
@@ -20,6 +20,8 @@ async function activeConnection(): Promise<HermesConnection> {
   return window.hermesDesktop.getConnection(getApiRequestProfile())
 }
 
+// Keep these segment rules in sync with the defense-in-depth URL parsing check
+// in apps/desktop/electron/media-protocol.ts::assertSafePluginMediaSegment.
 function assertSafePluginMediaSegment(segment: string, path: string, message: string): void {
   let inspected = segment
 

--- a/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
@@ -51,6 +51,24 @@ describe('MarkdownTextContent remote images', () => {
   })
 })
 
+describe('MarkdownTextContent custom media protocol safety', () => {
+  afterEach(cleanup)
+
+  it('does not expose a custom media source from assistant-authored HTML', () => {
+    const forgedPluginMedia = 'hermes-media://plugin/other-plugin/private/clip.mp4?profile=other&connectionId=other'
+
+    const { container } = render(
+      <MarkdownTextContent
+        isRunning={false}
+        text={`<video src="${forgedPluginMedia}"></video>\n<img alt="forged" src="${forgedPluginMedia}">`}
+      />
+    )
+
+    expect(container.querySelector('video')).toBeNull()
+    expect(container.querySelector('[src^="hermes-media:"]')).toBeNull()
+  })
+})
+
 // Regression for #40896: generated media often arrives as image markdown
 // (`![clip](clip.mp4)`). A raw <img> with a video/audio source paints a
 // broken-image icon even though the file is valid, so MarkdownImage must route

--- a/apps/desktop/src/contrib/plugin.test.ts
+++ b/apps/desktop/src/contrib/plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { setApiRequestConnection, setApiRequestProfile } from '@/hermes'
 import { dispatchPluginNativeNotification } from '@/store/native-notifications'
 
 import { createPluginContext } from './plugin'
@@ -21,6 +22,48 @@ describe('createPluginContext.onDispose', () => {
     expect(disposers).toHaveLength(1)
     disposers.forEach(dispose => dispose())
     expect(cleaned).toBe(true)
+  })
+})
+
+describe('createPluginContext.mediaUrl', () => {
+  it('returns null when the desktop media bridge is unavailable', () => {
+    const ctx = createPluginContext('studio-rail')
+
+    expect(ctx.mediaUrl('/outputs/clip/stream')).toBeNull()
+  })
+
+  it('creates a confined plugin-media URL scoped to the active profile and registry connection', () => {
+    const host = window as unknown as { hermesDesktop?: unknown }
+
+    host.hermesDesktop = {}
+    setApiRequestProfile('video')
+    setApiRequestConnection('mac-mini')
+
+    try {
+      const ctx = createPluginContext('studio-rail')
+
+      expect(ctx.mediaUrl('/outputs/clip 1/stream')).toBe(
+        'hermes-media://plugin/studio-rail/outputs/clip%201/stream?profile=video&connectionId=mac-mini'
+      )
+    } finally {
+      setApiRequestProfile(null)
+      setApiRequestConnection(null)
+      delete host.hermesDesktop
+    }
+  })
+
+  it('rejects encoded traversal in a media path', () => {
+    const host = window as unknown as { hermesDesktop?: unknown }
+
+    host.hermesDesktop = {}
+
+    try {
+      const ctx = createPluginContext('studio-rail')
+
+      expect(() => ctx.mediaUrl('/outputs/%2e%2e/stream')).toThrow('illegal path traversal')
+    } finally {
+      delete host.hermesDesktop
+    }
   })
 })
 

--- a/apps/desktop/src/contrib/plugin.test.ts
+++ b/apps/desktop/src/contrib/plugin.test.ts
@@ -65,6 +65,20 @@ describe('createPluginContext.mediaUrl', () => {
       delete host.hermesDesktop
     }
   })
+
+  it('rejects a plugin id that could escape its namespace', () => {
+    const host = window as unknown as { hermesDesktop?: unknown }
+
+    host.hermesDesktop = {}
+
+    try {
+      const ctx = createPluginContext('../other-plugin')
+
+      expect(() => ctx.mediaUrl('/outputs/clip/stream')).toThrow('invalid plugin id')
+    } finally {
+      delete host.hermesDesktop
+    }
+  })
 })
 
 describe('createPluginContext.os', () => {

--- a/apps/desktop/src/contrib/plugin.test.ts
+++ b/apps/desktop/src/contrib/plugin.test.ts
@@ -61,6 +61,7 @@ describe('createPluginContext.mediaUrl', () => {
       const ctx = createPluginContext('studio-rail')
 
       expect(() => ctx.mediaUrl('/outputs/%2e%2e/stream')).toThrow('illegal path traversal')
+      expect(() => ctx.mediaUrl('/outputs/%252e%252e/stream')).toThrow('illegal path traversal')
     } finally {
       delete host.hermesDesktop
     }
@@ -75,6 +76,7 @@ describe('createPluginContext.mediaUrl', () => {
       const ctx = createPluginContext('../other-plugin')
 
       expect(() => ctx.mediaUrl('/outputs/clip/stream')).toThrow('invalid plugin id')
+      expect(() => createPluginContext('%252e%252e').mediaUrl('/outputs/clip/stream')).toThrow('invalid plugin id')
     } finally {
       delete host.hermesDesktop
     }

--- a/apps/desktop/src/contrib/plugin.ts
+++ b/apps/desktop/src/contrib/plugin.ts
@@ -12,7 +12,7 @@
  * through the plugin host loader (next phase); this is that seam.
  */
 
-import { pluginRest, type PluginRestOptions, pluginSocket } from '@/hermes'
+import { pluginMediaUrl, pluginRest, type PluginRestOptions, pluginSocket } from '@/hermes'
 import { createPluginI18n, type PluginI18n } from '@/i18n'
 import { readKey, writeKey } from '@/lib/storage'
 import { dispatchPluginNativeNotification, type PluginNativeNotificationInput } from '@/store/native-notifications'
@@ -80,6 +80,10 @@ export interface PluginContext {
    *  returned. Resolves to a no-op on OAuth remotes — treat it as an
    *  accelerator over your polling, never a replacement. */
   socket: (path: string, onMessage: (data: unknown) => void) => () => void
+  /** Seekable URL for audio/video served by this plugin's own backend route.
+   *  The Desktop main process authenticates and Range-proxies it; resolves
+   *  null when this renderer has no Desktop media bridge. */
+  mediaUrl: (path: string) => null | string
   /** The curated OS door: native notification, open-external, reveal-in-file-
    *  manager, clipboard — attributed to this plugin, result-shaped (never
    *  throws for a missing capability). */
@@ -178,6 +182,7 @@ export function createPluginContext(pluginId: string, onDispose?: (dispose: () =
     onDispose: fn => void track(fn),
     rest: <T>(path: string, opts?: PluginRestOptions) => pluginRest<T>(pluginId, path, opts),
     socket: (path, onMessage) => track(pluginSocket(pluginId, path, onMessage)),
+    mediaUrl: path => pluginMediaUrl(pluginId, path),
     os: createPluginOs(pluginId),
     storage: createPluginStorage(pluginId),
     i18n: createPluginI18n(pluginId, track)

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -45,8 +45,9 @@ plugin, and fail to resolve in a disk plugin). Capability comes in tiers:
   restart the gateway, subscribe to the gateway event stream.
 - **`host.request`** — the gateway JSON-RPC door: sessions, config, skills,
   cron — everything the app itself calls.
-- **`ctx.rest` / `ctx.socket`** — your plugin's own backend namespace
-  (`/api/plugins/<id>`) if you ship a `plugin_api.py`.
+- **`ctx.rest` / `ctx.socket` / `ctx.mediaUrl`** — your plugin's own backend
+  namespace (`/api/plugins/<id>`), including authenticated seekable audio/video
+  streams, if you ship a `plugin_api.py`.
 - **`ui.*`** — the design language: the app's real components, theme variables,
   icons, and formatters, so your UI matches the app pixel-for-pixel.
 
@@ -173,6 +174,9 @@ interface PluginContext {
   rest: <T>(path: string, opts?: PluginRestOptions) => Promise<T>
   /** Live WebSocket to this plugin's own namespace. Returns a disposer. */
   socket: (path: string, onMessage: (data: unknown) => void) => () => void
+  /** Seekable URL for audio/video served by this plugin's own backend route.
+   *  Returns null outside a Desktop renderer. */
+  mediaUrl: (path: string) => string | null
   /** The curated OS door: native notification, open-external, reveal-in-file-manager, clipboard. */
   os: PluginOs
   /** Plugin-scoped JSON persistence (keys live under `hermes.plugin.<id>.`). */
@@ -798,12 +802,22 @@ register(ctx) {
   const stop = ctx.socket('/events', frame => {
     queryClient.invalidateQueries({ queryKey: [ctx.source, 'board'] })
   })
+
+  // Seekable audio/video — Electron authenticates this URL and forwards Range
+  // requests without exposing gateway credentials to the plugin or the DOM.
+  const clip = ctx.mediaUrl('/outputs/clip/stream')
 }
 ```
 
 `ctx.rest` is profile-aware and rejects path traversal (`..`) so you can never
 address another plugin's API or a core route through it. `PluginRestOptions` is
 `{ method?, body?, upload?: { filename, contentType?, bytes }, timeoutMs? }`.
+
+`ctx.mediaUrl` is the corresponding door for a `<audio>` or `<video>` element.
+It accepts only a route relative to your own plugin namespace, returns a
+credential-free seekable URL, and resolves to `null` outside a Desktop renderer.
+The backend route must return successful `audio/*` or `video/*` content; use a
+normal `ctx.rest` request for JSON or image data.
 
 `ctx.socket` auto-reconnects with backoff until disposed. **It resolves to a no-op
 on OAuth remotes** (single-use WS tickets are core-managed) — treat the socket as

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -819,6 +819,10 @@ credential-free seekable URL, and resolves to `null` outside a Desktop renderer.
 The backend route must return successful `audio/*` or `video/*` content; use a
 normal `ctx.rest` request for JSON or image data.
 
+Like the rest of the local runtime-plugin SDK, this is a convenience namespace
+scope, not an authorization boundary between local plugins: disk plugins run
+with full renderer authority. See [Security model](#security-model).
+
 `ctx.socket` auto-reconnects with backoff until disposed. **It resolves to a no-op
 on OAuth remotes** (single-use WS tickets are core-managed) — treat the socket as
 an accelerator over polling, never a replacement. Every consumer needs a polling


### PR DESCRIPTION
## What does this PR do?

Runtime Desktop plugins can use `ctx.rest()` for JSON, but an `<audio>` or `<video>` element needs a seekable URL and cannot safely attach gateway credentials. This PR restores the missing generic Desktop media bridge for plugin-owned output endpoints.

`ctx.mediaUrl(path)` creates a credential-free, profile- and connection-scoped `hermes-media://plugin/<plugin-id>/...` URL for the calling plugin's own `/api/plugins/<id>/...` route. Electron resolves and authenticates the selected backend in the main process, forwards Range/cache negotiation headers, and preserves the existing core remote/local media routes.

## Related Issue

No tracked issue. This is a Desktop update regression recovered from the previously working runtime-plugin media bridge. I searched open and merged PRs/issues for runtime-plugin media, Desktop media bridge, and remote video playback before implementing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `PluginContext.mediaUrl(path): string | null`, documented in the Desktop plugin SDK.
- Keep the media URL context in the refactored `src/api/plugins.ts` owner so the upstream `src/hermes.ts` compatibility barrel remains intact.
- Build a confined plugin-media URL from validated path segments and a validated/encoded plugin ID.
- Extend the existing Electron media protocol with a `plugin` target that maps only to `/api/plugins/<plugin-id>/...`.
- Resolve the active profile and registry connection, keeping token/OAuth handling in Electron rather than the renderer URL.
- Apply the same request-path profile scope as `hermes:api` for shared-primary and shared-registry remote gateways; keep profile-owned/SSH backends free of a second scope.
- Add a validated plugin-media target without changing the existing core `remote` and `stream` routing behavior.
- Preserve Range forwarding and reject malformed, raw, and nested-encoded traversal/query-abuse routes before backend resolution.
- Permit only successful `audio/*` or `video/*` plugin responses; preserve ordinary core media behavior unchanged.
- Prove assistant-authored raw HTML cannot mount a `hermes-media:` source; local disk plugins remain explicitly documented as trusted renderer code, not authorization principals.

## How to Test

1. Run `npx -y -p node@22 -p npm@10.9.2 -c 'npm --workspace apps/desktop run test'`.
2. Run `npx -y -p node@22 -p npm@10.9.2 -c 'npm --workspace apps/desktop run typecheck'` and `npm --workspace apps/desktop run lint`.
3. Run `npx -y -p node@22 -p npm@10.9.2 -c 'npm --workspace apps/desktop run pack'`, then inspect the unpacked `electron-main.mjs` for `parsePluginMediaTarget` and `pluginMediaEndpoint`.
4. In a Desktop runtime plugin with a seekable plugin-owned `audio/*` or `video/*` endpoint, set `<audio src={ctx.mediaUrl('/your-route')}>` or `<video src={ctx.mediaUrl('/your-route')}>`; verify playback and seeking under a local profile, a selected registry connection, and a named profile on a shared remote gateway.

## Validation performed

- `npm --workspace apps/desktop run test` — 6,531 passed, 2 skipped
- `npm --workspace apps/desktop run typecheck` — passed
- `npm --workspace apps/desktop run lint` — 0 errors; 118 upstream warnings
- `npm --workspace apps/desktop run pack` — arm64 package built successfully at `f19af186`
- Focused UI and Electron protocol regressions pass.
- Regression tests were proven to fail under the missing bridge, unsafe identity behavior, nested traversal, and missing shared-remote profile scope before the implementation was restored.
- Packaged `electron-main.mjs` contains the plugin parser and endpoint handler.
- After rebasing onto current `main`: `electron/media-protocol.test.ts` — 19 passed; plugin/Markdown UI regressions — 13 passed; Desktop typecheck passed; lint — 0 errors and 121 existing upstream warnings.

I did **not** restart or replace a live user Desktop app to perform manual playback here; that requires a user-facing app restart and is deliberately left to maintainer/CI validation or an explicitly approved local test.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs/issues to make sure this is not a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` — N/A: this is Desktop TypeScript/Electron-only; the full Desktop Vitest suite passed.
- [x] I've added tests for my changes.
- [x] I've tested on macOS 27.0 / arm64 with Node 22, including an unpacked package build.

### Documentation & Housekeeping

- [x] I've updated relevant documentation.
- [x] I've updated `cli-config.yaml.example` — N/A; no config changes.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; no architecture/workflow rule changed.
- [x] I've considered cross-platform impact — the route is URL/protocol logic using existing Electron abstractions; CI should exercise Windows/Linux.
- [x] I've updated tool descriptions/schemas — N/A; this changes the Desktop plugin SDK, which is documented.

## Security boundary

The renderer/plugin receives only a credential-free custom-protocol URL. Electron retains token/OAuth handling, constrains the endpoint to the SDK caller's plugin namespace, validates raw and nested percent-encoded segments before endpoint construction, and accepts only successful audio/video payloads. Shared-primary and shared-registry remote gateways receive the selected profile through the existing `?profile=` request-path scope; profile-owned/SSH backends do not receive a second scope. The plugin target accepts only its validated profile/connection scope; existing core media routing remains unchanged. Assistant-authored Markdown cannot mount arbitrary custom-protocol media sources. Local disk plugins are intentionally trusted renderer code, so plugin namespace scoping is a convenience API contract rather than a sandbox boundary. No Studio Rail-specific code, backend endpoint, or ordinary `MEDIA:` file behavior is changed.
