### PR TITLE
fix(gateway): keep operational prompts out of employee Slack

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2689,6 +2689,17 @@ def _resolve_runtime_agent_kwargs() -> dict:
             return fb_config
         raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
     except Exception as exc:
+        # Credential-pool exhaustion and provider-plugin failures are not
+        # always surfaced as AuthError. They are still primary-resolution
+        # failures and must be eligible for the configured fallback chain.
+        logger.warning(
+            "Primary provider resolution failed: %s — trying fallback",
+            exc,
+            exc_info=True,
+        )
+        fb_config = _try_resolve_fallback_provider()
+        if fb_config is not None:
+            return fb_config
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
     model_cfg = _get_model_config()
@@ -5138,6 +5149,31 @@ class TurnRunner:
         except Exception:
             logger.debug("Failed to attach session title callback", exc_info=True)
 
+    def _operational_admin_target(self):
+        """Route Slack infrastructure prompts away from employee conversations."""
+        ctx = self._ctx
+        origin = (ctx._status_chat_id, ctx._status_thread_metadata, False)
+        if ctx.source.platform != Platform.SLACK:
+            return origin
+        try:
+            home = self._runner.config.get_home_channel(ctx.source.platform)
+        except Exception:
+            home = None
+        if not home or not getattr(home, "chat_id", None):
+            return origin
+        if str(home.chat_id) == str(ctx._status_chat_id):
+            return origin
+        try:
+            metadata = self._runner._thread_metadata_for_target(
+                ctx.source.platform,
+                str(home.chat_id),
+                getattr(home, "thread_id", None),
+                adapter=ctx._status_adapter,
+            )
+        except Exception:
+            metadata = None
+        return str(home.chat_id), metadata, True
+
     def _status_callback_sync(self, event_type: str, message: str) -> None:
         ctx = self._ctx
         if not ctx._status_adapter or not ctx._run_still_current():
@@ -5155,8 +5191,26 @@ class TurnRunner:
                 _redact_gateway_user_facing_secrets(str(message or ""))[:160],
             )
             return
+        target_chat_id = ctx._status_chat_id
+        target_metadata = ctx._status_thread_metadata
+        if _looks_like_gateway_provider_error(
+            _redact_gateway_user_facing_secrets(str(message or ""))
+        ):
+            target_chat_id, target_metadata, rerouted = self._operational_admin_target()
+            if rerouted:
+                logger.warning(
+                    "Routed provider status alert away from Slack employee chat %s to %s",
+                    ctx._status_chat_id,
+                    target_chat_id,
+                )
         _fut = safe_schedule_threadsafe(
-            _send_or_update_status_coro(ctx._status_adapter, ctx._status_chat_id, event_type, prepared_message, ctx._status_thread_metadata),
+            _send_or_update_status_coro(
+                ctx._status_adapter,
+                target_chat_id,
+                event_type,
+                prepared_message,
+                target_metadata,
+            ),
             ctx._loop_for_step,
             logger=logger,
             log_message=f"status_callback ({event_type}) scheduling error",
@@ -5978,6 +6032,15 @@ class TurnRunner:
             # (send_exec_approval) and plain-text fallback paths below use
             # the redacted value.
             cmd = _redact_approval_command(cmd)
+            approval_chat_id, approval_metadata, approval_rerouted = (
+                self._operational_admin_target()
+            )
+            if approval_rerouted:
+                logger.warning(
+                    "Routed command approval away from Slack employee chat %s to %s",
+                    ctx._status_chat_id,
+                    approval_chat_id,
+                )
 
             # Prefer button-based approval when the adapter supports it.
             # Check the *class* for the method, not the instance — avoids
@@ -5986,11 +6049,11 @@ class TurnRunner:
                 try:
                     _approval_fut = safe_schedule_threadsafe(
                         ctx._status_adapter.send_exec_approval(
-                            chat_id=ctx._status_chat_id,
+                            chat_id=approval_chat_id,
                             command=cmd,
                             session_key=_approval_session_key,
                             description=desc,
-                            metadata=ctx._status_thread_metadata,
+                            metadata=approval_metadata,
                             allow_permanent=approval_data.get("allow_permanent", True),
                             allow_session=approval_data.get("allow_session", True),
                             smart_denied=approval_data.get("smart_denied", False),
@@ -6029,9 +6092,9 @@ class TurnRunner:
             try:
                 _approval_send_fut = safe_schedule_threadsafe(
                     ctx._status_adapter.send(
-                        ctx._status_chat_id,
+                        approval_chat_id,
                         msg,
-                        metadata=ctx._status_thread_metadata,
+                        metadata=approval_metadata,
                     ),
                     ctx._loop_for_step,
                     logger=logger,

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -54,4 +54,41 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
         # Should have been called at least twice (primary + fallback)
         assert call_count["n"] >= 2
 
+    def test_non_auth_resolution_error_tries_fallback(self, tmp_path, monkeypatch):
+        """Credential-pool/plugin errors must not bypass the fallback chain."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "model:\n  provider: openai-codex\n"
+            "fallback_model:\n  provider: nous\n  model: z-ai/glm-5.2\n"
+        )
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        call_count = {"n": 0}
+
+        def _mock_resolve(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("credential pool exhausted")
+            return {
+                "api_key": "fallback-key",
+                "base_url": "https://inference-api.nousresearch.com/v1",
+                "provider": "nous",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_mock_resolve,
+        ):
+            from gateway.run import _resolve_runtime_agent_kwargs
+
+            result = _resolve_runtime_agent_kwargs()
+
+        assert result["provider"] == "nous"
+        assert result["api_key"] == "fallback-key"
+        assert result["model"] == "z-ai/glm-5.2"
+        assert call_count["n"] >= 2
+
 

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -1,5 +1,7 @@
 """Gateway noise/secret filtering across chat surfaces (Telegram + siblings)."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from agent.conversation_compression import (
@@ -8,6 +10,7 @@ from agent.conversation_compression import (
 )
 from gateway.config import Platform
 from gateway.run import (
+    TurnRunner,
     _prepare_gateway_status_message,
     _sanitize_gateway_final_response,
 )
@@ -343,3 +346,77 @@ def test_chat_gateways_redact_all_issue_23810_credential_shapes(platform, shape_
     # Prose around the secret is preserved — redaction is surgical.
     assert "here is the token you asked me to echo" in sanitized
     assert sanitized.endswith("done.")
+
+
+def _turn_for_admin_target(platform, employee_chat="D_EMPLOYEE"):
+    class Config:
+        def get_home_channel(self, requested_platform):
+            assert requested_platform == platform
+            return SimpleNamespace(chat_id="C_ADMIN", thread_id=None)
+
+    ctx = SimpleNamespace(
+        source=SimpleNamespace(platform=platform),
+        _status_chat_id=employee_chat,
+        _status_thread_metadata={"thread_ts": "employee-thread"},
+        _status_adapter=object(),
+    )
+    runner = SimpleNamespace(
+        config=Config(),
+        _thread_metadata_for_target=lambda *args, **kwargs: {"admin": True},
+    )
+    turn = TurnRunner.__new__(TurnRunner)
+    object.__setattr__(turn, "_ctx", ctx)
+    object.__setattr__(turn, "_runner", runner)
+    return turn
+
+
+def test_slack_operational_prompts_route_to_home_admin():
+    turn = _turn_for_admin_target(Platform.SLACK)
+
+    chat_id, metadata, rerouted = turn._operational_admin_target()
+
+    assert chat_id == "C_ADMIN"
+    assert metadata == {"admin": True}
+    assert rerouted is True
+
+
+def test_non_slack_operational_prompts_stay_in_origin():
+    turn = _turn_for_admin_target(Platform.TELEGRAM)
+
+    chat_id, metadata, rerouted = turn._operational_admin_target()
+
+    assert chat_id == "D_EMPLOYEE"
+    assert metadata == {"thread_ts": "employee-thread"}
+    assert rerouted is False
+
+
+def test_slack_provider_status_is_sent_to_home_admin(monkeypatch):
+    turn = _turn_for_admin_target(Platform.SLACK)
+    turn._ctx._run_still_current = lambda: True
+    turn._ctx._loop_for_step = object()
+    turn._ctx._cleanup_progress = False
+    captured = {}
+
+    async def fake_status_send(adapter, chat_id, event_type, message, metadata):
+        captured.update(
+            chat_id=chat_id,
+            event_type=event_type,
+            message=message,
+            metadata=metadata,
+        )
+        return SimpleNamespace(success=True, message_id="m1")
+
+    def fake_schedule(coro, *args, **kwargs):
+        import asyncio
+
+        asyncio.run(coro)
+        return SimpleNamespace(add_done_callback=lambda callback: None)
+
+    monkeypatch.setattr("gateway.run._send_or_update_status_coro", fake_status_send)
+    monkeypatch.setattr("gateway.run.safe_schedule_threadsafe", fake_schedule)
+
+    turn._status_callback_sync("provider.error", "HTTP 401 Incorrect API key")
+
+    assert captured["chat_id"] == "C_ADMIN"
+    assert captured["metadata"] == {"admin": True}
+    assert "authentication failed" in captured["message"].lower()


### PR DESCRIPTION
## Summary

Slack employee conversations currently receive gateway infrastructure prompts (command approvals, provider/auth status). This PR routes those operational messages to the configured Slack home/admin channel, and lets non-`AuthError` primary-resolution failures still enter the configured fallback chain.

## Changes

- Route Slack command-approval and provider-status prompts to `get_home_channel()` when the origin chat is not already that home channel.
- Leave non-Slack platforms on the original chat (Telegram and siblings stay put).
- Treat credential-pool / provider-plugin failures as primary-resolution failures so they can fall through to the configured fallback provider instead of hard-failing.

## Tests

- `test_slack_operational_prompts_route_to_home_admin`
- `test_non_slack_operational_prompts_stay_in_origin`
- `test_slack_provider_status_is_sent_to_home_admin`
- `test_non_auth_resolution_error_tries_fallback`

`scripts/run_tests.sh tests/gateway/test_auth_fallback.py tests/gateway/test_telegram_noise_filter.py` — 138 passed on current `main`.

Made with [Cursor](https://cursor.com)