### PR TITLE
fix(titles): retry without response_format when the provider rejects it

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -400,17 +400,38 @@ def generate_title(
     ]
 
     try:
-        response = call_llm(
-            task="title_generation",
-            messages=messages,
-            # A title is a handful of tokens. The old 500-token ceiling let a
-            # chatty model burn seconds generating prose we then threw away.
-            max_tokens=64,
-            temperature=0.3,
-            timeout=timeout,
-            main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
-        )
+        try:
+            response = call_llm(
+                task="title_generation",
+                messages=messages,
+                # A title is a handful of tokens. The old 500-token ceiling let a
+                # chatty model burn seconds generating prose we then threw away.
+                max_tokens=64,
+                temperature=0.3,
+                timeout=timeout,
+                main_runtime=main_runtime,
+                extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            )
+        except Exception as e:
+            if "response_format" not in str(e).lower():
+                raise
+            # The provider rejected the structured-outputs format outright
+            # (DeepSeek &c. accept only json_object and 400 before the model
+            # ever runs). Retry without the parameter: the extraction
+            # fallbacks already handle non-structured responses, so titling
+            # still works instead of failing on every session (#88830).
+            logger.debug(
+                "Title generation retrying without response_format "
+                "after provider rejection: %s", e,
+            )
+            response = call_llm(
+                task="title_generation",
+                messages=messages,
+                max_tokens=64,
+                temperature=0.3,
+                timeout=timeout,
+                main_runtime=main_runtime,
+            )
         content = response.choices[0].message.content or ""
         title = _clean_title(_extract_title_text(content))
         # Answer-shaped output guard: titling is a 3-7 word task, so a title

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -46,6 +46,41 @@ class TestGenerateTitle:
         assert captured_kwargs["task"] == "title_generation"
         assert captured_kwargs["timeout"] is None
 
+    def test_retries_without_response_format_after_provider_rejection(self):
+        """DeepSeek-style providers 400 on json_schema response_format before
+        the model runs. The call must retry once without the parameter —
+        the extraction fallbacks handle non-structured responses — instead
+        of failing titling on every session (#88830)."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if "extra_body" in kwargs:
+                raise RuntimeError(
+                    "HTTP 400: This response_format type is unavailable now"
+                )
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Retry Title"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("question") == "Retry Title"
+
+        assert len(calls) == 2
+        assert "response_format" in calls[0]["extra_body"]
+        assert "extra_body" not in calls[1]
+
+    def test_unrelated_failure_does_not_retry_without_format(self):
+        """A failure that doesn't mention response_format (bad key, quota…)
+        must keep the single-attempt contract."""
+
+        def mock_call_llm(**kwargs):
+            raise RuntimeError("HTTP 401: invalid api key")
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("question") is None
+
 
 
     def test_strips_think_blocks(self):


### PR DESCRIPTION
## What does this PR do?

Makes session auto-titling work on providers that reject the OpenAI structured-outputs `response_format` (e.g. DeepSeek, which only accepts `json_object` and answers the `json_schema` form with HTTP 400 before the model ever runs). Title generation sent `extra_body={"response_format": _TITLE_RESPONSE_FORMAT}` unconditionally, so on such a provider every session logged `⚠ Auxiliary title generation failed: HTTP 400: This response_format type is unavailable now` and never got a title — the existing loose-JSON/prose extraction fallbacks never ran because the request itself was refused (#88830).

The fix is reactive rather than a provider capability table: when the failure text names `response_format`, retry the call once **without** `extra_body`. The extraction fallbacks already handle non-structured responses, so titling works on providers without structured outputs. Any other failure (bad key, quota, network) keeps the existing single-attempt contract — no extra requests.

## Related Issue

Fixes #88830

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/title_generator.py` — `generate_title()`'s LLM call is wrapped: a rejection mentioning `response_format` triggers one retry without `extra_body` (logged at debug); other exceptions propagate unchanged.
- `tests/agent/test_title_generator.py`
  - New: provider-rejection retry — first call (with `extra_body`) raises the DeepSeek-shaped 400, the retry without it returns a JSON title, and the title is extracted; exactly two calls are made.
  - New: an unrelated failure (`HTTP 401`) does not trigger the retry and still yields `None`.

## How to Test

1. `python -m pytest tests/agent/test_title_generator.py tests/gateway/test_title_command.py -q`
   Observed result: 45 passed.
2. Fail-on-main check: `git stash` the `agent/` change and rerun the retry regression — Observed result: 1 failed (the rejection surfaces as a warning and the title is lost).
3. Provider shape from the issue: on a DeepSeek-configured runtime the first title call fails with `HTTP 400: This response_format type is unavailable now` — Observed result after the fix: the retry without `response_format` succeeds and the session gets a title (the extraction fallbacks parse the non-structured reply).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (title generator + title command suites: 45 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment documents the retry contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — provider response text is matched case-insensitively; or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
