### PR TITLE
fix(update): repoint Windows managed runtime without renaming live venv

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -11,10 +11,11 @@ The Python backing the install is different: it is shared by every Hermes
 profile because the checkout's ``venv`` is shared.  Runtime repair therefore
 uses an install-scoped store under ``<checkout>/.hermes-runtime/python``. A
 vulnerable interpreter is never reinstalled in place. We provision a new
-immutable Python generation, build and smoke-test a relocatable sibling venv,
-then cut over with same-filesystem renames. The old venv remains available for
-synchronous rollback and is parked for cleanup after the updating process
-releases it.
+immutable Python generation and build and smoke-test a relocatable sibling
+venv. POSIX installs cut over with same-filesystem directory renames. Windows
+installs atomically repoint the live venv's ``pyvenv.cfg`` instead, because the
+updater itself maps executables and native extensions from that directory and
+Windows consequently refuses to rename it.
 """
 
 from __future__ import annotations
@@ -963,6 +964,72 @@ def _cut_over_candidate(
         raise
 
 
+def _replace_file_atomically(path: Path, data: bytes) -> None:
+    """Replace *path* from a same-directory temporary file."""
+    token = f"{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    temporary = path.with_name(f".{path.name}.runtime-{token}.tmp")
+    try:
+        with temporary.open("xb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _cut_over_windows_runtime_config(
+    candidate: Path,
+    *,
+    live: Path,
+) -> tuple[bool, bool, SQLiteRuntimeInfo | None, str]:
+    """Repoint a live Windows venv without renaming its locked directory.
+
+    A uv-created Windows venv keeps its base-runtime location in
+    ``pyvenv.cfg``. The updater can replace that text file while its current
+    interpreter and native extensions remain mapped from the venv; replacing
+    the containing directory cannot succeed under the same conditions.
+
+    The second return value reports whether the live config still references
+    the candidate generation. Callers must preserve that generation if a
+    failed smoke test could not restore the original config.
+    """
+    live_config = live / "pyvenv.cfg"
+    candidate_config = candidate / "pyvenv.cfg"
+    try:
+        original = live_config.read_bytes()
+        replacement = candidate_config.read_bytes()
+    except OSError as exc:
+        return False, False, None, f"could not read venv runtime config: {exc}"
+
+    try:
+        _replace_file_atomically(live_config, replacement)
+    except OSError as exc:
+        return False, False, None, f"could not repoint the existing venv: {exc}"
+
+    try:
+        healthy, detail, info = _smoke_candidate_venv(live)
+    except Exception as exc:
+        healthy, detail, info = False, f"candidate smoke raised: {exc}", None
+    if healthy:
+        return True, True, info, ""
+
+    try:
+        _replace_file_atomically(live_config, original)
+    except OSError as rollback_error:
+        return (
+            False,
+            True,
+            info,
+            "post-cutover smoke failed "
+            f"({detail}); runtime-config rollback failed ({rollback_error})",
+        )
+    return False, False, info, f"post-cutover smoke failed: {detail}"
+
+
 def _acquire_repair_lock(runtime_root: Path) -> _RepairLock | None:
     """Acquire an OS-held install lock that is released on process exit."""
     runtime_root.mkdir(parents=True, exist_ok=True)
@@ -1267,15 +1334,29 @@ def repair_vulnerable_runtime(
                 sqlite_after=candidate_info.sqlite_version_string,
             )
 
-        cut_over, backup, final_info, cutover_detail = _cut_over_candidate(
-            candidate,
-            project_root=root,
-            live=live,
-        )
+        runtime_generation_in_use = False
+        if platform.system() == "Windows":
+            (
+                cut_over,
+                runtime_generation_in_use,
+                final_info,
+                cutover_detail,
+            ) = _cut_over_windows_runtime_config(candidate, live=live)
+            backup = None
+        else:
+            cut_over, backup, final_info, cutover_detail = _cut_over_candidate(
+                candidate,
+                project_root=root,
+                live=live,
+            )
         if not cut_over:
             if backup is None:
                 _remove_tree(candidate, boundary=runtime_root)
-                _remove_tree(generation, boundary=managed_python_install_dir(root))
+                if not runtime_generation_in_use:
+                    _remove_tree(
+                        generation,
+                        boundary=managed_python_install_dir(root),
+                    )
             return RuntimeRepairResult(
                 "failed",
                 cutover_detail,
@@ -1297,6 +1378,8 @@ def repair_vulnerable_runtime(
         )
         if backup is not None and backup.exists():
             _remove_tree(backup, boundary=root)
+        elif platform.system() == "Windows":
+            _remove_tree(candidate, boundary=runtime_root)
         return RuntimeRepairResult(
             "repaired",
             sqlite_before=current.sqlite_version_string,

--- a/tests/hermes_cli/test_managed_uv_windows_cutover.py
+++ b/tests/hermes_cli/test_managed_uv_windows_cutover.py
@@ -1,0 +1,179 @@
+"""Native-Windows coverage for managed runtime cutover."""
+
+from __future__ import annotations
+
+import subprocess
+import venv
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _python(venv_dir: Path) -> Path:
+    return venv_dir / "Scripts" / "python.exe"
+
+
+@pytest.mark.windows_only
+def test_runtime_config_cutover_does_not_rename_running_venv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import managed_uv
+
+    live = tmp_path / "venv"
+    candidate = tmp_path / "candidate"
+    venv.EnvBuilder(with_pip=False).create(live)
+    venv.EnvBuilder(with_pip=False).create(candidate)
+
+    candidate_config = candidate / "pyvenv.cfg"
+    replacement = candidate_config.read_bytes() + b"runtime-cutover = candidate\n"
+    candidate_config.write_bytes(replacement)
+    info = SimpleNamespace(sqlite_version_string="3.53.1")
+    monkeypatch.setattr(
+        managed_uv,
+        "_smoke_candidate_venv",
+        lambda target: (True, "", info),
+    )
+
+    process = subprocess.Popen(
+        [str(_python(live)), "-c", "import time; time.sleep(30)"],
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+    )
+    try:
+        ok, runtime_in_use, final_info, detail = (
+            managed_uv._cut_over_windows_runtime_config(candidate, live=live)
+        )
+
+        assert process.poll() is None
+        assert ok is True
+        assert runtime_in_use is True
+        assert final_info is info
+        assert detail == ""
+        assert (live / "pyvenv.cfg").read_bytes() == replacement
+        assert live.is_dir()
+        probe = subprocess.run(
+            [str(_python(live)), "-I", "-c", "print('repointed')"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+        assert probe.returncode == 0
+        assert probe.stdout.strip() == "repointed"
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+@pytest.mark.windows_only
+def test_runtime_config_cutover_rolls_back_failed_live_smoke(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import managed_uv
+
+    live = tmp_path / "venv"
+    candidate = tmp_path / "candidate"
+    live.mkdir()
+    candidate.mkdir()
+    original = b"home = old-runtime\n"
+    (live / "pyvenv.cfg").write_bytes(original)
+    (candidate / "pyvenv.cfg").write_bytes(b"home = new-runtime\n")
+    monkeypatch.setattr(
+        managed_uv,
+        "_smoke_candidate_venv",
+        lambda target: (False, "core import smoke failed", None),
+    )
+
+    ok, runtime_in_use, info, detail = managed_uv._cut_over_windows_runtime_config(
+        candidate, live=live
+    )
+
+    assert ok is False
+    assert runtime_in_use is False
+    assert info is None
+    assert detail == "post-cutover smoke failed: core import smoke failed"
+    assert (live / "pyvenv.cfg").read_bytes() == original
+
+
+@pytest.mark.windows_only
+def test_runtime_repair_uses_config_cutover_on_windows(tmp_path: Path) -> None:
+    from hermes_cli.managed_uv import repair_vulnerable_runtime
+    from hermes_cli.sqlite_runtime import SQLiteRuntimeInfo
+
+    root = tmp_path / "checkout"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    live = root / "venv"
+    _python(live).parent.mkdir(parents=True)
+    _python(live).write_bytes(b"live")
+    (live / "pyvenv.cfg").write_text("home = old-runtime\n", encoding="utf-8")
+
+    generation = root / ".hermes-runtime" / "python" / "generation-test"
+    candidate_python = generation / "python.exe"
+    candidate_python.parent.mkdir(parents=True)
+    candidate_python.write_bytes(b"candidate")
+    candidate = root / ".hermes-runtime" / "venv-candidate-test"
+    _python(candidate).parent.mkdir(parents=True)
+    _python(candidate).write_bytes(b"candidate")
+    (candidate / "pyvenv.cfg").write_text(
+        f"home = {generation}\n",
+        encoding="utf-8",
+    )
+
+    current = SQLiteRuntimeInfo(
+        executable=_python(live),
+        base_prefix=live,
+        python_version=(3, 11, 15),
+        sqlite_version=(3, 50, 4),
+        sqlite_version_string="3.50.4",
+        sqlite_source_id="old",
+    )
+    fixed = SQLiteRuntimeInfo(
+        executable=candidate_python,
+        base_prefix=generation,
+        python_version=(3, 11, 15),
+        sqlite_version=(3, 53, 1),
+        sqlite_version_string="3.53.1",
+        sqlite_source_id="new",
+    )
+
+    with (
+        patch(
+            "hermes_cli.managed_uv.probe_sqlite_runtime",
+            side_effect=[current, current],
+        ),
+        patch(
+            "hermes_cli.managed_uv._windows_runtime_holders",
+            return_value=(False, ""),
+        ),
+        patch(
+            "hermes_cli.managed_uv._install_safe_python_generation",
+            return_value=(generation, candidate_python, fixed),
+        ),
+        patch(
+            "hermes_cli.managed_uv._stage_candidate_venv",
+            return_value=candidate,
+        ),
+        patch(
+            "hermes_cli.managed_uv._cut_over_windows_runtime_config",
+            return_value=(True, True, fixed, ""),
+        ) as windows_cutover,
+        patch("hermes_cli.managed_uv._cut_over_candidate") as directory_cutover,
+    ):
+        result = repair_vulnerable_runtime("uv", project_root=root)
+
+    assert result.status == "repaired"
+    assert result.sqlite_before == "3.50.4"
+    assert result.sqlite_after == "3.53.1"
+    windows_cutover.assert_called_once_with(candidate, live=live)
+    directory_cutover.assert_not_called()
+    assert not candidate.exists()
+    assert generation.exists()


### PR DESCRIPTION
## What does this PR do?

Windows updates that repair a vulnerable SQLite runtime currently stage and smoke-test a safe replacement, then try to rename the entire live venv. That cutover fails with `WinError 5` because the updater is itself running from that venv and Windows keeps its executables and native extensions mapped.

For Windows, this change atomically replaces the live venv's `pyvenv.cfg` so it points at the staged immutable runtime generation, then smoke-tests the live venv. A failed smoke restores the original config; if rollback itself fails, the referenced runtime generation is preserved. The existing directory-rename cutover remains unchanged on POSIX.

## Related Issue

N/A (Discord support report)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add an atomic same-directory file replacement helper in `hermes_cli/managed_uv.py`.
- Use a Windows-specific runtime-config cutover that repoints the live venv without renaming its locked directory.
- Smoke-test the repointed live venv, restore its original config on failure, and retain any generation still referenced after a failed rollback.
- Add native-Windows regression coverage for a running live venv, rollback behavior, and repair-path dispatch.

## How to Test

1. On a native Windows managed install whose current Python runtime has vulnerable SQLite, run `hermes update` while the updater is executing from the live venv.
2. Verify the staged runtime passes its pre-cutover smoke and the live venv is repointed without a `WinError 5` directory-rename failure.
3. Run `scripts/run_tests.sh tests/hermes_cli/test_managed_uv_windows_cutover.py -q` on Windows; the tests cover a running live process, post-cutover rollback, and full repair dispatch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Windows 11; static checks completed, Windows behavioral tests deferred to CI

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Static validation completed:

- `uv tool run --from ruff==0.15.10 ruff check hermes_cli/managed_uv.py tests/hermes_cli/test_managed_uv_windows_cutover.py`
- Python syntax compilation for both changed files
- `scripts/check-windows-footguns.py` over the two-file change
- `git diff --check`

The Python behavioral tests were not run locally. The new tests are marked `windows_only` for the Windows CI lane.