### PR TITLE
fix(ci): fail the aggregate gate on cancelled jobs, not just failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,15 +246,21 @@ jobs:
           print(f'needs-json={json.dumps(compact)}')
           with open('$GITHUB_OUTPUT', 'a') as f:
               f.write(f'needs-json={json.dumps(compact)}\n')
-          failed = [name for name, info in needs.items() if info['result'] == 'failure']
+          # Only an explicit success or an intentional skip (a job gated by a
+          # classifier output, e.g. `if: needs.detect.outputs.python`) counts
+          # as passing. A `failure` OR a `cancelled` job is a real problem —
+          # a cancelled run means a job died or was interrupted, never a clean
+          # pass (#84254). Nothing else is acceptable.
+          bad = [name for name, info in needs.items()
+                 if info['result'] not in ('success', 'skipped')]
           for name, info in sorted(needs.items()):
               result = info['result']
               icon = '✅' if result in ('success', 'skipped') else '❌'
               print(f'{icon} {name}: {result}')
-          if failed:
-              print(f'::error::{len(failed)} job(s) failed: {\", \".join(failed)}')
+          if bad:
+              print(f'::error::{len(bad)} job(s) did not pass: {\", \".join(bad)}')
               sys.exit(1)
-          print('All checks passed (or were skipped)')
+          print('All checks passed (or were intentionally skipped)')
           "
 
   # ─────────────────────────────────────────────────────────────────────

--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Axl Ibiza (andrexibiza) — canonical author identity


### PR DESCRIPTION
## What changed and why

The "All required checks pass" aggregate job in `.github/workflows/ci.yml` only failed when a job's result was `failure`. A **cancelled** job — a run that died or was interrupted (timeout, manual cancel, infra failure) — was treated as passing. Cancellation is never a clean pass: a cancelled test/lint job means the run was cut short and its result is unknown.

This PR changes the gate to fail on anything that is not an explicit `success` or an **intentional classifier skip** (`skipped`, produced by `if:` gating such as `needs.detect.outputs.<surface>`). Both `failure` and `cancelled` now fail the aggregate. Intentional skips still pass, so classifier-gated jobs (e.g. a docs-only PR skipping the Docker build) behave exactly as before.

## How to test

The evaluator is embedded in the workflow YAML. Logic verified by simulation:
- `success` + `skipped` → pass ([] bad)
- `cancelled` → fail
- `failure` → fail
- mixed (one cancelled) → fail

YAML parse-verified (`yaml.safe_load` succeeds; the `all-checks-pass` job + evaluate step parse).

## Platforms tested

- CI workflow YAML change; `git diff --check` clean; YAML parses; evaluator logic unit-verified. Runs on the CI runner itself once merged.

## Why this matters to users

If a required check was cancelled (e.g. the test job timed out or was killed mid-run), the aggregate previously reported "All checks passed" — letting a PR merge with unknown, possibly-broken test results. After this change, a cancelled job fails the gate, so the PR can't merge until every required check genuinely passed or was intentionally skipped. A user can trust that a green aggregate means the required jobs actually completed.

Fixes #84254

Part of #82591 (EPIC — security hardening campaign)
