### PR TITLE
fix(doctor): recognize user-configured aggregator providers for vendor slugs

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1315,10 +1315,18 @@ def run_doctor(args):
                 # meta-llama/Llama-3-…, anthropic/claude-opus-4-7, …).
                 "deepinfra",
             }
+            _user_provider_aggregator = False
+            if provider and _resolve_provider_full is not None and provider not in {"auto", "custom"}:
+                try:
+                    _pd = _resolve_provider_full(provider, user_providers, custom_providers)
+                    _user_provider_aggregator = bool(_pd is not None and getattr(_pd, "is_aggregator", False))
+                except Exception:
+                    _user_provider_aggregator = False
             provider_accepts_vendor_slug = (
                 provider_policy_id in providers_accepting_vendor_slugs
                 or provider_policy_id == "custom"
                 or provider_policy_id.startswith("custom:")
+                or _user_provider_aggregator
             )
             if (
                 default_model

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -747,7 +747,7 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
         transport=transport,
         api_key_env_vars=tuple(env_vars),
         base_url=api_url,
-        is_aggregator=False,
+        is_aggregator=bool(entry.get("is_aggregator", False)),
         auth_type="api_key",
         source="user-config",
     )


### PR DESCRIPTION
## Summary

Two small changes so that a user-configured aggregator provider declared under
`providers:` in `config.yaml` is correctly recognized as accepting
`vendor/model` slugs — instead of being flagged as a misconfiguration.

## Problem

A user who fronts an OpenAI-compatible aggregator gateway via the keyed
`providers:` section (e.g. `providers.orcarouter` with
`base_url: https://api.orcarouter.ai/v1` serving `deepseek/deepseek-v4-pro-free`)
gets a false-positive warning from `hermes doctor`:

```
model.default 'deepseek/deepseek-v4-pro-free' is vendor-prefixed but model.provider is 'orcarouter'
```

Root cause is two-fold:

1. `resolve_user_provider()` hardcodes `is_aggregator=False` and never reads an
   `is_aggregator` field from the provider config, so a keyed `providers:`
   entry can never be an aggregator.
2. `doctor` decides vendor-slug acceptance from a hardcoded
   `providers_accepting_vendor_slugs` set plus the `custom:` string prefix —
   neither of which covers a keyed `providers:` entry.

The deadlock: `orcarouter` resolves with a bare id (no `custom:` prefix, so
`is_aggregator` is False), while the `custom:orcarouter` alias does not resolve
back through the keyed `providers:` section at all.

## Change

- `hermes_cli/providers.py`: `resolve_user_provider()` now reads
  `is_aggregator` from the provider entry
  (`bool(entry.get("is_aggregator", False))`), defaulting to `False` for full
  backward compatibility.
- `hermes_cli/doctor.py`: the vendor-slug check now additionally resolves the
  configured provider and honors its `is_aggregator` flag.

With this, a user opts in by adding `is_aggregator: true` under their
`providers.<name>` entry, and `doctor` stops warning.

## Validation

- `py_compile` passes for both modified files.
- `resolve_provider_full("orcarouter").is_aggregator` is `True` once
  `is_aggregator: true` is set in config (verified locally against the current
  checkout).
- Backward compatible: absent the flag, behavior is unchanged.
