### PR TITLE
fix(gateway): sort /resume session list by last activity, not creation time (#88222)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4741,6 +4741,7 @@ class GatewaySlashCommandsMixin:
                 source=user_source,
                 session_key=None if widen else session_key,
                 limit=10,
+                order_by_last_active=True,
             )
             return [s for s in sessions if s.get("title")][:10]
 


### PR DESCRIPTION
## Problem

`/resume` session list in the messaging gateway sorts by **session creation time** (`ORDER BY s.started_at DESC`) and applies `limit=10` **before** filtering for titled sessions. Every other surface (desktop, dashboard, CLI) sorts by last activity (`order_by_last_active=True`).

This causes:
1. **Ordering divergence** — same conversation appears in different order depending on surface.
2. **Titled session starvation** — untitled `session_switch` shells consume slots in the `limit=10` window, pushing out old but actively-used titled sessions.

## Fix

Pass `order_by_last_active=True` to `list_sessions_rich()` in `_list_titled_sessions()`. This is the same parameter already used by:
- `tui_gateway/server.py` (~line 12846) — desktop session list
- `gateway/platforms/api_server.py` — dashboard API
- CLI search path

## Change

```python
# Before
sessions = await self._session_db.list_sessions_rich(
    source=user_source,
    session_key=None if widen else session_key,
    limit=10,
)

# After
sessions = await self._session_db.list_sessions_rich(
    source=user_source,
    session_key=None if widen else session_key,
    limit=10,
    order_by_last_active=True,
)
```

Fixes #88222
