### PR TITLE
fix(desktop): repair chrome-sandbox setuid perms on the --build-only path

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8028,6 +8028,15 @@ def cmd_gui(args: argparse.Namespace):
             sys.exit(1)
         else:
             print(f"✓ Desktop packaged app ready: {packaged_executable} (not launching; --build-only)")
+            # A rebuild recreates Electron's chrome-sandbox helper without its
+            # standard root:root 4755 setuid config (#58593). The launch path
+            # repairs this just before launching, but --build-only returns
+            # without launching — leaving the artifact unlaunchable for flows
+            # that exec it directly (the desktop-update relaunch gate checks
+            # exactly this and refuses to auto-relaunch). Best-effort: repair
+            # when sudo allows; the fixup prints its own diagnostics on
+            # failure, and the launch path remains a second chance.
+            _desktop_linux_sandbox_fixup(packaged_executable)
         return
 
     if source_mode:

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import os
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -564,14 +566,35 @@ def test_gui_build_only_repairs_chrome_sandbox(tmp_path, monkeypatch):
     monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
     packaged_exe = _make_packaged_executable(root, monkeypatch)
 
-    fixup_calls = []
+    # Exercise the real fixup against a hermetic artifact.  The sudo shim
+    # performs the harmless chmod for this unprivileged test process and logs
+    # both commands; production still discovers and executes real sudo.
+    sandbox = packaged_exe.parent / "chrome-sandbox"
+    sandbox.chmod(0o644)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    sudo_log = tmp_path / "sudo.log"
+    sudo = fake_bin / "sudo"
+    sudo.write_text(
+        "#!/bin/sh\n"
+        f"printf '%s\\n' \"$*\" >> {sudo_log}\n"
+        "if [ \"$1\" = chmod ]; then /bin/chmod \"$2\" \"$3\"; fi\n",
+        encoding="utf-8",
+    )
+    sudo.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+
     with patch("hermes_cli.main._desktop_build_needed", return_value=False), \
-         patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
-         patch("hermes_cli.main._desktop_linux_sandbox_fixup",
-               side_effect=lambda exe: fixup_calls.append(exe) or True):
+         patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"):
         cli_main.cmd_gui(_ns(build_only=True))
 
-    assert fixup_calls == [packaged_exe]
+    sandbox_stat = sandbox.stat()
+    assert stat.S_IMODE(sandbox_stat.st_mode) == 0o4755
+    assert sudo_log.read_text(encoding="utf-8").splitlines() == [
+        f"chown root:root {sandbox}",
+        f"chmod 4755 {sandbox}",
+    ]
 
 
 @pytest.mark.macos_only

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -550,6 +550,30 @@ def test_gui_launches_even_when_desktop_entry_install_fails(tmp_path, monkeypatc
     assert mock_run.call_args.args[0] == [str(packaged_exe)]
 
 
+@pytest.mark.linux_only
+def test_gui_build_only_repairs_chrome_sandbox(tmp_path, monkeypatch):
+    """--build-only must leave a launchable artifact, not just a built one.
+
+    A rebuild recreates chrome-sandbox without its root:root 4755 setuid
+    config (#58593); the launch path repairs it, but --build-only returns
+    before ever reaching that code. Headless update flows exec the artifact
+    directly and gate the relaunch on these exact perms, so the repair has
+    to happen here too.
+    """
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+
+    fixup_calls = []
+    with patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup",
+               side_effect=lambda exe: fixup_calls.append(exe) or True):
+        cli_main.cmd_gui(_ns(build_only=True))
+
+    assert fixup_calls == [packaged_exe]
+
+
 @pytest.mark.macos_only
 def test_gui_skips_desktop_entry_off_linux(tmp_path, monkeypatch):
     root = _make_desktop_tree(tmp_path)


### PR DESCRIPTION
Fixes #58593 (relaunch-gate half of the reported symptom — the other half, 'the update is offered again', was addressed by the detached-update rewrite in #83634).

## Problem

On Linux, every `hermes update` that triggers a desktop rebuild ends with the app refusing to auto-relaunch:

```
no relaunch (manual): Update complete, but the rebuilt app can't relaunch itself
(its sandbox helper needs root ownership). Reopen Hermes to finish.
```

Observed 8 times across one week of client updates on a source-install deployment (hand-off log excerpt available on request).

## Root cause

Two facts combine:

1. `electron-builder` recreates `release/linux-unpacked/chrome-sandbox` with normal user ownership and mode `0755` instead of the required `root:root` / `4755` setuid configuration.
2. The existing repair — `_desktop_linux_sandbox_fixup()` in `hermes_cli/main.py` — only runs on the **launch** path of `hermes desktop`. The `--build-only` path (used by `hermes update`'s rebuild step and the detached desktop-update hand-off) `return`s **before** that code, so the artifact is left with broken perms.

`scripts/desktop-update/posix.sh`'s relaunch gate then correctly refuses to relaunch an app whose sandbox helper lacks setuid (Electron refuses to boot otherwise), and the user must reopen manually. Nothing in the update flow ever repairs the perms.

## Fix

Call the existing `_desktop_linux_sandbox_fixup()` on the `--build-only` packaged branch, so the artifact is launchable the moment the build completes:

- Best-effort, same as on the launch path: when `sudo` is unavailable the fixup prints its own diagnostics and the launch path remains a second chance.
- No-op on non-Linux platforms (the fixup guards on `sys.platform`).
- No new code paths, no behavior change for the launch path, no `--no-sandbox` opt-in.

## Tests

New `test_gui_build_only_repairs_chrome_sandbox` exercises the real Linux fixup against a hermetic packaged artifact and verifies the resulting `4755` mode plus the expected privileged commands. Full existing suite passes:

```
tests/hermes_cli/test_gui_command.py: 27 passed, 5 skipped
```