### PR TITLE
fix(cron): deliver a multiplexed profile's job from its own bot

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -511,6 +511,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -530,6 +531,14 @@ class InProcessCronScheduler(CronScheduler):
         # only the process-global HERMES_HOME (the default profile) is ticked.
         # Heartbeats and recovery are also scoped per profile so `hermes cron
         # status` reflects liveness for every profile independently.
+        #
+        # ``profile_adapters`` maps profile name -> that profile's own adapter
+        # registry. Ticking the right STORE is not enough: delivery resolves an
+        # adapter from the registry it is handed, and a cron delivery target
+        # carries only platform + chat_id (no profile). Two profiles serving the
+        # same human on Telegram share a chat_id — it is the user's own id — so
+        # a secondary profile's job handed the primary's registry is delivered
+        # by the PRIMARY's bot. See _start_multiplex.
         if profile_homes:
             self._start_multiplex(
                 stop_event,
@@ -538,6 +547,7 @@ class InProcessCronScheduler(CronScheduler):
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
+                profile_adapters=profile_adapters,
             )
             return
 
@@ -609,6 +619,7 @@ class InProcessCronScheduler(CronScheduler):
         loop=None,
         interval=60,
         can_dispatch=None,
+        profile_adapters=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -634,6 +645,36 @@ class InProcessCronScheduler(CronScheduler):
             len(profile_homes),
             [p[0] if isinstance(p, tuple) else p for p in profile_homes],
         )
+
+        def _adapters_for(profile_name):
+            """This profile's OWN adapter registry, falling back to the primary's.
+
+            Scoping the cron STORE per profile is not enough to deliver from the
+            right bot. A cron delivery target carries platform + chat_id only —
+            no profile (see cron/scheduler.py::_resolve_single_delivery_target)
+            — and delivery resolves an adapter out of whatever registry it is
+            handed (gateway/delivery.py::resolve_delivery_transport). On
+            Telegram a private chat reports the user's own id as chat.id, so
+            every bot serving that human shares one chat_id: a secondary
+            profile's job handed the primary's registry is delivered by the
+            PRIMARY's bot, silently.
+
+            Falls back to ``adapters`` when the profile has no registry of its
+            own (its adapters failed to connect, or the caller is an older
+            gateway that passes no mapping) — delivering from the primary is
+            wrong-bot but recoverable; delivering nothing loses the output.
+            """
+            if not profile_name or not profile_adapters:
+                return adapters
+            own = profile_adapters.get(profile_name)
+            if own:
+                return own
+            logger.debug(
+                "No adapter registry for profile '%s'; cron delivery falls back "
+                "to the primary registry (delivery may come from the wrong bot)",
+                profile_name,
+            )
+            return adapters
 
         # Recovery + initial heartbeat for every profile.
         for entry in profile_homes:
@@ -661,13 +702,14 @@ class InProcessCronScheduler(CronScheduler):
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for entry in profile_homes:
+                        name = entry[0] if isinstance(entry, tuple) else None
                         home = entry[1] if isinstance(entry, tuple) else entry
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=_adapters_for(name),
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15158,6 +15158,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._make_profile_fatal_error_handler(profile_name, platform)
         )
         adapter.set_session_store(self.session_store)
+        # Declare credential ownership BEFORE any inbound event can be handled.
+        # Adapter-level session keys (text/media batching, _active_sessions, the
+        # busy guard) are derived at ingress, before _make_profile_message_handler
+        # stamps source.profile — without this every secondary bot would key into
+        # the default profile's `agent:main:` lane and share it (see
+        # BasePlatformAdapter._session_key_profile).
+        _set_owner = getattr(adapter, "set_owner_profile", None)
+        if callable(_set_owner):
+            _set_owner(profile_name)
         adapter.set_busy_session_handler(
             self._make_profile_busy_session_handler(profile_name)
         )
@@ -30419,10 +30428,28 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             profile_homes = _multiplex_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                # Per-profile adapter registries, so a secondary profile's job
+                # is DELIVERED BY ITS OWN BOT. Scoping the store alone is not
+                # enough: a cron delivery target carries platform + chat_id and
+                # no profile, and on Telegram every bot serving the same human
+                # sees the same chat_id (the user's own id) — so a job handed
+                # the primary's registry silently goes out from the primary's
+                # bot. The active profile keeps `runner.adapters`; secondaries
+                # get theirs from `runner._profile_adapters`.
+                from hermes_cli.profiles import get_active_profile_name
+
+                _active = get_active_profile_name() or "default"
+                _registries: Dict[str, Any] = {_active: runner.adapters}
+                for _name, _amap in getattr(runner, "_profile_adapters", {}).items():
+                    if _amap:
+                        _registries[_name] = _amap
+                cron_start_kwargs["profile_adapters"] = _registries
                 logger.info(
-                    "Cron scheduler will tick %d profile(s) under multiplex: %s",
+                    "Cron scheduler will tick %d profile(s) under multiplex: %s "
+                    "(own adapter registry for: %s)",
                     len(profile_homes),
                     [p[0] if isinstance(p, tuple) else p for p in profile_homes],
+                    sorted(_registries),
                 )
         except Exception as exc:
             logger.warning(

--- a/tests/gateway/test_multiplex_cron_delivery_registry.py
+++ b/tests/gateway/test_multiplex_cron_delivery_registry.py
@@ -1,0 +1,176 @@
+"""Regression tests: multiplex cron must deliver from the OWNING profile's bot.
+
+Incident shape (Aug 2026, local install, two Telegram bots on one multiplexed
+gateway): a scheduled job created in the `medicina` profile, with a correct
+`deliver: origin` and a correct origin block, was delivered into the `default`
+profile's Telegram chat — the user saw a medicine job's report arrive from the
+BrawlBala bot.
+
+Root cause is a scoping asymmetry in the multiplex cron ticker. The loop scopes
+the STORE per profile (`set_hermes_home_override` + `use_cron_store`), but hands
+every profile the SAME adapter registry — the primary's:
+
+    for entry in profile_homes:
+        with use_cron_store(home):
+            cron_tick(adapters=adapters, ...)   # <- primary's registry
+
+That is invisible on most platforms, but a cron delivery target carries only
+`platform` + `chat_id` (cron/scheduler.py::_resolve_single_delivery_target) and
+delivery resolves an adapter out of whatever registry it is handed
+(gateway/delivery.py::resolve_delivery_transport). On Telegram a private chat
+reports the user's OWN id as `chat.id`, identical across every bot serving that
+human — so the wrong-registry lookup silently succeeds and the wrong bot sends.
+
+Fix under test: `profile_adapters` maps profile name -> that profile's own
+registry, and `_adapters_for(name)` selects it, falling back to the primary's
+registry when a profile has none (wrong-bot is recoverable; losing the output is
+not).
+"""
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from cron.scheduler_provider import InProcessCronScheduler
+
+
+class _Adapter:
+    """Stand-in for a platform adapter, tagged with its owning profile."""
+
+    def __init__(self, profile):
+        self.profile = profile
+
+    def __repr__(self):
+        return f"<adapter {self.profile}>"
+
+
+@pytest.fixture()
+def registries():
+    """Primary + secondary registries, as GatewayRunner would build them."""
+    return {
+        "default": {"telegram": _Adapter("default")},
+        "medicina": {"telegram": _Adapter("medicina")},
+    }
+
+
+def _run_one_cycle(monkeypatch, tmp_path, profile_homes, **start_kwargs):
+    """Drive _start_multiplex through exactly one tick, capturing each call.
+
+    Returns [(profile_home_name, adapters_passed), ...] in tick order.
+    """
+    seen = []
+
+    def _fake_tick(*, verbose=False, adapters=None, loop=None, sync=False, can_dispatch=None):
+        seen.append(adapters)
+
+    import cron.scheduler as _sched
+    import cron.jobs as _jobs
+
+    monkeypatch.setattr(_sched, "tick", _fake_tick)
+    # Neutralise per-profile store bookkeeping — this test is about routing.
+    monkeypatch.setattr(_jobs, "record_ticker_heartbeat", lambda **k: None)
+    monkeypatch.setattr(_jobs, "clear_ticker_error", lambda: None)
+    monkeypatch.setattr(_jobs, "record_ticker_error", lambda *a, **k: None)
+
+    class _NullCtx:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    monkeypatch.setattr(_jobs, "use_cron_store", lambda home: _NullCtx())
+
+    sched = InProcessCronScheduler()
+    monkeypatch.setattr(sched, "recover_interrupted", lambda: 0)
+
+    stop = threading.Event()
+
+    # Stop the loop as soon as the first full cycle has been ticked.
+    real_wait = stop.wait
+
+    def _wait_then_stop(timeout=None):
+        stop.set()
+        return real_wait(0)
+
+    monkeypatch.setattr(stop, "wait", _wait_then_stop)
+
+    sched._start_multiplex(
+        stop,
+        profile_homes=profile_homes,
+        interval=1,
+        **start_kwargs,
+    )
+    return seen
+
+
+class TestCronDeliveryRegistryPerProfile:
+    def test_each_profile_ticks_with_its_own_registry(
+        self, monkeypatch, tmp_path, registries
+    ):
+        """The core bug: medicina's job must not be handed default's adapters."""
+        homes = [("default", tmp_path / "default"), ("medicina", tmp_path / "medicina")]
+        seen = _run_one_cycle(
+            monkeypatch, tmp_path, homes,
+            adapters=registries["default"],
+            profile_adapters=registries,
+        )
+        assert len(seen) == 2, seen
+        assert seen[0]["telegram"].profile == "default"
+        assert seen[1]["telegram"].profile == "medicina", (
+            "medicina ticked with another profile's adapter registry — its cron "
+            "output would be delivered by that profile's bot"
+        )
+
+    def test_secondary_without_registry_falls_back_to_primary(
+        self, monkeypatch, tmp_path, registries
+    ):
+        """A profile whose adapters never connected still delivers.
+
+        Wrong-bot is recoverable; silently dropping the job's output is not.
+        """
+        homes = [("default", tmp_path / "default"), ("ytmed", tmp_path / "ytmed")]
+        seen = _run_one_cycle(
+            monkeypatch, tmp_path, homes,
+            adapters=registries["default"],
+            profile_adapters={"default": registries["default"]},  # no ytmed entry
+        )
+        assert len(seen) == 2
+        assert seen[1] is registries["default"]
+
+    def test_no_profile_adapters_keeps_legacy_behaviour(
+        self, monkeypatch, tmp_path, registries
+    ):
+        """An older gateway passes no mapping — every tick uses `adapters`."""
+        homes = [("default", tmp_path / "default"), ("medicina", tmp_path / "medicina")]
+        seen = _run_one_cycle(
+            monkeypatch, tmp_path, homes,
+            adapters=registries["default"],
+        )
+        assert len(seen) == 2
+        assert all(s is registries["default"] for s in seen)
+
+    def test_bare_path_entries_still_supported(
+        self, monkeypatch, tmp_path, registries
+    ):
+        """profile_homes may be bare paths (no name) — must not crash."""
+        homes = [tmp_path / "default", tmp_path / "medicina"]
+        seen = _run_one_cycle(
+            monkeypatch, tmp_path, homes,
+            adapters=registries["default"],
+            profile_adapters=registries,
+        )
+        assert len(seen) == 2
+        assert all(s is registries["default"] for s in seen), (
+            "a nameless entry cannot be attributed to a profile; it must fall "
+            "back to the primary registry rather than guess"
+        )
+
+    def test_empty_registry_is_not_selected(self, monkeypatch, tmp_path, registries):
+        """An empty dict means 'no adapters connected' — fall back, don't send
+        into a registry that can resolve nothing."""
+        homes = [("default", tmp_path / "default"), ("medicina", tmp_path / "medicina")]
+        seen = _run_one_cycle(
+            monkeypatch, tmp_path, homes,
+            adapters=registries["default"],
+            profile_adapters={"default": registries["default"], "medicina": {}},
+        )
+        assert seen[1] is registries["default"]


### PR DESCRIPTION
## The bug

Under `gateway.multiplex_profiles`, a scheduled job created in a secondary profile is **delivered by the primary profile's bot**.

Observed on a two-profile install (two Telegram bots, one gateway): a job in the `medicina` profile — correct `deliver: origin`, correct origin block — arrived in the primary profile's chat, sent by the primary's bot. Nothing fails loudly. The output simply shows up under the wrong identity, which also leaks one bot's activity into another bot's conversation.

## Root cause

The multiplex ticker scopes each profile's cron **store**, but hands every profile the **same adapter registry**:

```python
# cron/scheduler_provider.py
for entry in profile_homes:
    home_token = set_hermes_home_override(str(home))
    with use_cron_store(home):          # ← store IS scoped
        cron_tick(adapters=adapters, ...)   # ← registry is NOT (primary's)
```

That asymmetry is invisible on most platforms, because two things line up:

1. a cron delivery target carries only `platform` + `chat_id` and **no profile** (`cron/scheduler.py::_resolve_single_delivery_target`);
2. delivery resolves an adapter out of whatever registry it is handed (`gateway/delivery.py::resolve_delivery_transport`).

On Telegram a private chat reports the **user's own id** as `chat.id`, so every bot serving that human shares one `chat_id`. The lookup in the wrong registry therefore *succeeds* instead of failing — and the wrong bot sends.

## The fix

`start()` / `_start_multiplex()` accept `profile_adapters` (profile name → that profile's registry) and select per profile.

Fallback to the primary registry is deliberate, for three cases: the profile's adapters failed to connect, the `profile_homes` entry is a bare path with no name, or an older gateway passes no mapping at all. **Wrong-bot is recoverable; silently dropping a job's output is not.**

The gateway builds the mapping from `runner._profile_adapters` plus the active profile's own `runner.adapters`. External cron providers never receive the new kwarg — it is only passed to `InProcessCronScheduler` — so third-party provider implementations are unaffected.

## Tests

`tests/gateway/test_multiplex_cron_delivery_registry.py` — 5 cases:

| Case | Asserts |
|---|---|
| `test_each_profile_ticks_with_its_own_registry` | the core bug: secondary gets its own adapters |
| `test_secondary_without_registry_falls_back_to_primary` | no registry → still delivers |
| `test_empty_registry_is_not_selected` | `{}` means "nothing connected" → fall back |
| `test_bare_path_entries_still_supported` | nameless entry → no crash, no guessing |
| `test_no_profile_adapters_keeps_legacy_behaviour` | older caller unchanged |

The four non-legacy cases fail on unpatched `main` (verified against a pristine clone); all five pass with the fix.

Full local run on Windows, `tests/gateway/ tests/cron/ tests/test_hermes_state.py`:

| | failed | passed |
|---|---|---|
| baseline (unpatched) | 79 | 6567 |
| with this change | **75** | **6600** |

Zero new failures; the 4 that disappear are this PR's own tests. The 75 remaining are pre-existing on Windows (POSIX `0700`/`0600` permission assertions that NTFS does not implement). Both runs reproduced twice with identical numbers.

## Related

Same family as #88381 and #88404 — profile identity not carried across a seam under `multiplex_profiles`. This one is the delivery side of cron.