### PR TITLE
fix(commandcode): accept base_url kwarg in fetch_models overrides

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -525,6 +525,31 @@ def get_provider(name: str, *, allow_network: bool = True) -> Optional[ProviderD
             source="hermes",
         )
 
+    # Plugin-registered provider profiles (plugins/model-providers/<name>/).
+    # Providers that ship only as plugin profiles (e.g. commandcode,
+    # tencent-tokenhub) are absent from models.dev and HERMES_OVERLAYS, so
+    # without this fallback they resolve as "Unknown provider" in /model,
+    # --provider, and the model-switch path even though the picker lists them
+    # (CANONICAL_PROVIDERS auto-extends from the same plugin registry).
+    try:
+        from providers import get_provider_profile as _profile
+
+        _prof = _profile(canonical)
+        if _prof is not None:
+            _api_mode_to_transport = {v: k for k, v in TRANSPORT_TO_API_MODE.items()}
+            _transport = _api_mode_to_transport.get(_prof.api_mode, "openai_chat")
+            return ProviderDef(
+                id=canonical,
+                name=_prof.display_name or _prof.name or canonical,
+                transport=_transport,
+                api_key_env_vars=tuple(_prof.env_vars or ()),
+                base_url=_prof.base_url or "",
+                auth_type=_prof.auth_type or "api_key",
+                source="plugin-profile",
+            )
+    except Exception:
+        pass
+
     return None
 
 

--- a/plugins/model-providers/commandcode/__init__.py
+++ b/plugins/model-providers/commandcode/__init__.py
@@ -79,6 +79,7 @@ class CommandCodeProfile(ProviderProfile):
         self,
         *,
         api_key: str | None = None,
+        base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
         """Fetch from the public CommandCode /models endpoint."""
@@ -126,6 +127,7 @@ class CommandCodeAnthropicProfile(ProviderProfile):
         self,
         *,
         api_key: str | None = None,
+        base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
         """Fetch from the public CommandCode /models endpoint.

--- a/tests/plugins/model_providers/test_commandcode_profile.py
+++ b/tests/plugins/model_providers/test_commandcode_profile.py
@@ -232,3 +232,27 @@ class TestCommandCodeModelFiltering:
         assert "startswith(\"claude-\")" in source or '"claude-" in m' in source, (
             "CommandCodeAnthropicProfile.fetch_models should filter to claude-* models"
         )
+
+
+# ── Picker contract ──────────────────────────────────────────────────────────
+
+class TestCommandCodeFetchModelsPickerContract:
+    """``fetch_models`` must accept the kwargs the model picker passes.
+
+    Regression: the generic live-fetch path in ``hermes_cli/models.py``
+    (``provider_model_ids``) calls ``profile.fetch_models(api_key=...,
+    base_url=...)``. The original CommandCode overrides only accepted
+    ``api_key``/``timeout``, so every picker open raised TypeError, which
+    was swallowed, leaving the provider with zero models.
+    """
+
+    @pytest.mark.parametrize("profile_name", ["commandcode", "commandcode-anthropic"])
+    def test_accepts_base_url_kwarg(self, profile_name):
+        import inspect
+
+        import model_tools  # noqa: F401 — triggers discovery
+        import providers
+
+        profile = providers.get_provider_profile(profile_name)
+        assert profile is not None
+        assert "base_url" in inspect.signature(profile.fetch_models).parameters

--- a/tests/plugins/model_providers/test_commandcode_profile.py
+++ b/tests/plugins/model_providers/test_commandcode_profile.py
@@ -256,3 +256,22 @@ class TestCommandCodeFetchModelsPickerContract:
         profile = providers.get_provider_profile(profile_name)
         assert profile is not None
         assert "base_url" in inspect.signature(profile.fetch_models).parameters
+
+    def test_resolve_provider_full(self):
+        """Both profiles must resolve through the model-switch path.
+
+        Regression: ``resolve_provider_full`` only knew models.dev + overlay
+        providers, so plugin-only providers (commandcode) failed with
+        "Unknown provider" on /model switches even though the picker listed
+        them.
+        """
+        from hermes_cli.providers import resolve_provider_full
+
+        chat = resolve_provider_full("commandcode", {}, [])
+        assert chat is not None and chat.id == "commandcode"
+        assert chat.transport == "openai_chat"
+        assert "COMMANDCODE_API_KEY" in chat.api_key_env_vars
+
+        anth = resolve_provider_full("commandcode-anthropic", {}, [])
+        assert anth is not None and anth.id == "commandcode-anthropic"
+        assert anth.transport == "anthropic_messages"


### PR DESCRIPTION
## Problem

The CommandCode provider profiles (`commandcode`, `commandcode-anthropic`) are unusable from the model picker and `/model` switch:

1. **Zero models in the picker.** The generic live-fetch path in `hermes_cli/models.py` (`provider_model_ids`) calls `profile.fetch_models(api_key=..., base_url=...)` for api_key plugin providers. Both CommandCode overrides only accepted `api_key`/`timeout`, so every call raised `TypeError`, which was silently swallowed — the provider ended up with an empty model list and never entered the disk cache.
2. **"Unknown provider" on switch.** `resolve_provider_full` / `get_provider` only knew models.dev + `HERMES_OVERLAYS`. Plugin-only providers (commandcode, tencent-tokenhub, ...) are absent from both, so `/model commandcode/...` failed even though the picker lists them (via `CANONICAL_PROVIDERS` auto-extension).

## Fix

- Both `fetch_models` overrides accept (and ignore) the `base_url` kwarg, matching the base `ProviderProfile.fetch_models` signature.
- `get_provider` falls back to `providers.get_provider_profile()` before giving up, mapping the profile's `api_mode` to the `ProviderDef` transport.

## Verification

- New regression tests: `fetch_models` accepts `base_url`; `resolve_provider_full` resolves both profiles with correct transports (`openai_chat` / `anthropic_messages`).
- `tests/plugins/model_providers/test_commandcode_profile.py` + `test_main_model_custom_provider_normalization.py`: 33 passed.
- End-to-end: `cached_provider_model_ids("commandcode")` returns the live 55-model list; `commandcode-anthropic` returns the 7 `claude-*` models.
