### PR TITLE
fix(nix): exclude test js files from src

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -216,13 +216,14 @@ let
   # root, preserving the workspace layout that buildNpmPackage and
   # npmConfigHook expect.  Callers pass the dirs they need (relative to
   # the repo root), so each package owns its own source scope.
+  testFileFilter = lib.fileset.fileFilter (file: lib.hasInfix ".test." file.name) repoRoot;
   mkNpmSrc =
     dirs:
     lib.fileset.toSource {
       root = repoRoot;
-      fileset = lib.fileset.union npmWorkspaceFiles (
+      fileset = lib.fileset.difference (lib.fileset.union npmWorkspaceFiles (
         lib.fileset.unions (map (d: repoRoot + "/${d}") dirs)
-      );
+      )) testFileFilter;
     };
 
   # Returns a buildNpmPackage-compatible function.


### PR DESCRIPTION
## What does this PR do?
fixes nix builds by excluding test js files from src

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- added a `testFileFilter` to `nix/lib.nix`

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `nix build .#desktop`