### PR TITLE
fix(cli): swallow KeyboardInterrupt during cleanup memory flush

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1257,7 +1257,11 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
                 if _mm is not None and hasattr(_mm, 'flush_pending'):
                     try:
                         _mm.flush_pending(timeout=10)
-                    except Exception:
+                    except (Exception, KeyboardInterrupt):
+                        # A second shutdown signal can arrive while the bounded
+                        # memory drain is waiting. The signal handler raises
+                        # KeyboardInterrupt (a BaseException, not Exception), so
+                        # continue the already-started cleanup without a traceback.
                         pass
                 # Forward the agent's own transcript so memory providers'
                 # on_session_end hooks see the real conversation instead of

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -223,6 +223,29 @@ def test_run_cleanup_flushes_pending_memory_manager_work(tmp_path):
     mm.flush_pending.assert_called_once_with(timeout=10)
 
 
+def test_run_cleanup_swallows_second_interrupt_during_memory_flush(tmp_path):
+    """A repeated Ctrl+C during cleanup must not print a shutdown traceback."""
+    import cli as _cli_mod
+
+    agent = MagicMock()
+    mm = MagicMock()
+    mm.flush_pending.side_effect = KeyboardInterrupt
+    agent._memory_manager = mm
+    agent._session_messages = []
+
+    old_ref = _cli_mod._active_agent_ref
+    _cli_mod._active_agent_ref = agent
+    _cli_mod._cleanup_done = False
+    try:
+        _cli_mod._run_cleanup(notify_session_finalize=False)
+    finally:
+        _cli_mod._cleanup_done = True
+        _cli_mod._active_agent_ref = old_ref
+
+    mm.flush_pending.assert_called_once_with(timeout=10)
+    agent.shutdown_memory_provider.assert_called_once_with([])
+
+
 
 
 
@@ -295,5 +318,4 @@ def test_new_session_with_title(capsys):
 
     captured = capsys.readouterr()
     assert "My Test Session" in captured.out
-
 


### PR DESCRIPTION
## Summary

- Swallow a repeated Ctrl+C while the CLI's bounded memory-manager drain is waiting during shutdown.
- Add a regression test proving cleanup continues to `shutdown_memory_provider()` after that interrupt.

## Root cause

`_run_cleanup()` calls `flush_pending(timeout=10)` before shutting down memory providers. That call is guarded by `except Exception`, but the CLI signal path raises `KeyboardInterrupt`, which inherits from `BaseException` rather than `Exception`. A second Ctrl+C during the wait can therefore escape cleanup, print a traceback, and skip the remaining memory-provider shutdown.

The bounded drain was introduced by #61139. The broader shutdown-hardening PRs #22876 and #25144 predate this specific call and do not cover the `flush_pending()` location.

## Change

Catch `(Exception, KeyboardInterrupt)` around only the bounded drain, preserving normal handling for other `BaseException` subclasses. The regression test makes `flush_pending()` raise `KeyboardInterrupt` and verifies the subsequent memory-provider shutdown still runs.

## User impact

Repeated Ctrl+C during CLI shutdown exits quietly and allows the already-started cleanup sequence to continue.

## Validation

- `python -m pytest tests/cli/test_cli_new_session.py -q` — 7 passed
- `python -m py_compile cli.py`
- `git diff --check upstream/main..HEAD`

Tested on Arch Linux x86_64 with Python 3.11.15.
