### PR TITLE
fix(kanban): expose dispatch skip reasons

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2663,6 +2663,13 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
             "auto_assigned_default": res.auto_assigned_default,
+            "reconciled_orphans": res.reconciled_orphans,
+            "respawn_guarded": [
+                {"task_id": tid, "reason": reason}
+                for (tid, reason) in res.respawn_guarded
+            ],
+            "rate_limited": res.rate_limited,
+            "skipped_locked": res.skipped_locked,
         }, indent=2))
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
@@ -2700,6 +2707,16 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
         )
+    if res.reconciled_orphans:
+        print(f"Reconciled orphans: {', '.join(res.reconciled_orphans)}")
+    if res.respawn_guarded:
+        print("Respawn-guarded:")
+        for tid, reason in res.respawn_guarded:
+            print(f"  - {tid} ({reason})")
+    if res.rate_limited:
+        print(f"Rate-limited: {', '.join(res.rate_limited)}")
+    if res.skipped_locked:
+        print("Skipped (dispatch lock held): yes")
     return 0
 
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -24,6 +24,58 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+def _dispatch_args(*, json_output: bool) -> argparse.Namespace:
+    return argparse.Namespace(
+        dry_run=True,
+        max=None,
+        failure_limit=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
+        json=json_output,
+    )
+
+
+def test_dispatch_json_reports_skipped_locked(kanban_home, capsys):
+    db_path = kb.kanban_db_path(board="default")
+
+    with kb._dispatch_tick_lock(db_path) as held:
+        assert held is True
+        assert kc._cmd_dispatch(_dispatch_args(json_output=True)) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["skipped_locked"] is True
+    assert payload["respawn_guarded"] == []
+    assert payload["rate_limited"] == []
+    assert payload["reconciled_orphans"] == []
+
+
+def test_dispatch_json_reports_respawn_guard_reason(
+    kanban_home, monkeypatch, capsys
+):
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="already opened", assignee="worker"
+        )
+        kb.add_comment(
+            conn,
+            task_id,
+            author="worker",
+            body="Opened https://github.com/example/repo/pull/123 for review.",
+        )
+
+    assert kc._cmd_dispatch(_dispatch_args(json_output=True)) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["spawned"] == []
+    assert payload["skipped_locked"] is False
+    assert payload["respawn_guarded"] == [
+        {"task_id": task_id, "reason": "active_pr"}
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Workspace flag parsing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Surface reconciled orphans, respawn guards, rate-limited tasks, and lock-skipped ticks in `hermes kanban dispatch` output.
- Keep existing JSON fields and serialize respawn guard entries as `{task_id, reason}` objects.
- Add locked-tick and active-PR regression coverage.

## Verification
- `HERMES_PYTHON=/root/.hermes/hermes-agent/venv-sqlite-3.51.3/bin/python scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_kanban_dispatch_lock.py tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_db.py tests/gateway/test_kanban_reconcile_orphans.py` (74 passed, 1 skipped)
- Ruff on changed Python files passed.
- Full Python runner and root `npm run check` remain blocked by unrelated pre-existing optional dependency/build failures in this checkout.