### PR TITLE
fix(desktop): preserve semantic image filenames on download

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -327,6 +327,7 @@ import {
 import { missingRendererAssets } from './renderer-bundle'
 import { loadRendererLoadErrorPage } from './renderer-load-error-page'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
+import { safeSuggestedImageName } from './safe-suggested-image-name'
 import {
   classifyStoredSecret,
   readSecretStoragePolicy,
@@ -5814,20 +5815,6 @@ async function resourceBufferFromUrl(rawUrl) {
 
     req.on('error', reject)
   })
-}
-
-function safeSuggestedImageName(value, extension) {
-  const base = Array.from(path.basename(String(value || '')).replace(/[<>:"/\\|?*]/g, '_'), char =>
-    char.charCodeAt(0) < 32 ? '_' : char
-  )
-    .join('')
-    .trim()
-
-  if (!base) {
-    return `image${extension}`
-  }
-
-  return path.extname(base) ? base : `${base}${extension}`
 }
 
 async function saveImageFromUrl(rawUrl, suggestedName?: string) {
@@ -16336,9 +16323,11 @@ ipcMain.handle('hermes:readClipboard', () => clipboard.readText())
 
 ipcMain.handle('hermes:saveGatewayFile', (_event, payload) => saveGatewayFile(payload))
 
-ipcMain.handle('hermes:saveImageFromUrl', (_event, payload) =>
-  saveImageFromUrl(String(payload?.url || ''), payload?.suggestedName)
-)
+ipcMain.handle('hermes:saveImageFromUrl', (_event, payload) => {
+  const url = typeof payload === 'string' ? payload : String(payload?.url || '')
+  const suggestedName = typeof payload === 'string' || payload == null ? undefined : payload.suggestedName
+  return saveImageFromUrl(url, suggestedName)
+})
 
 // The custom context menu's edit verbs. They act on the SENDER's focused
 // element, so the renderer restores focus to the editable before invoking.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5816,14 +5816,30 @@ async function resourceBufferFromUrl(rawUrl) {
   })
 }
 
-async function saveImageFromUrl(rawUrl) {
+function safeSuggestedImageName(value, extension) {
+  const base = Array.from(path.basename(String(value || '')).replace(/[<>:"/\\|?*]/g, '_'), char =>
+    char.charCodeAt(0) < 32 ? '_' : char
+  )
+    .join('')
+    .trim()
+
+  if (!base) {
+    return `image${extension}`
+  }
+
+  return path.extname(base) ? base : `${base}${extension}`
+}
+
+async function saveImageFromUrl(rawUrl, suggestedName?: string) {
   const { buffer, mimeType } = (await resourceBufferFromUrl(rawUrl)) as any
   const extension = extensionForMimeType(mimeType) || '.png'
   // Generated-image URLs (fal.media etc.) usually end in an extensionless
   // content hash. Keep the name but always guarantee an extension — without
   // one Windows saves an unopenable "All Files" blob (#image18 report).
-  const baseName = filenameFromUrl(rawUrl, `image${extension}`)
-  const fallbackName = path.extname(baseName) ? baseName : `${baseName}${extension}`
+
+  const fallbackName = suggestedName
+    ? safeSuggestedImageName(suggestedName, extension)
+    : filenameFromUrl(rawUrl, `image${extension}`)
 
   let downloadsDir = ''
 
@@ -16320,7 +16336,9 @@ ipcMain.handle('hermes:readClipboard', () => clipboard.readText())
 
 ipcMain.handle('hermes:saveGatewayFile', (_event, payload) => saveGatewayFile(payload))
 
-ipcMain.handle('hermes:saveImageFromUrl', (_event, url) => saveImageFromUrl(String(url || '')))
+ipcMain.handle('hermes:saveImageFromUrl', (_event, payload) =>
+  saveImageFromUrl(String(payload?.url || ''), payload?.suggestedName)
+)
 
 // The custom context menu's edit verbs. They act on the SENDER's focused
 // element, so the renderer restores focus to the editable before invoking.

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -238,7 +238,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   writeClipboard: text => ipcRenderer.invoke('hermes:writeClipboard', text),
   readClipboard: () => ipcRenderer.invoke('hermes:readClipboard'),
   saveGatewayFile: payload => ipcRenderer.invoke('hermes:saveGatewayFile', payload),
-  saveImageFromUrl: url => ipcRenderer.invoke('hermes:saveImageFromUrl', url),
+  saveImageFromUrl: payload => ipcRenderer.invoke('hermes:saveImageFromUrl', payload),
   contextMenuEdit: command => ipcRenderer.invoke('hermes:context-menu:edit', command),
   contextMenuCopyImage: () => ipcRenderer.invoke('hermes:context-menu:copy-image'),
   contextMenuSpellcheck: action => ipcRenderer.invoke('hermes:context-menu:spellcheck', action),

--- a/apps/desktop/electron/safe-suggested-image-name.test.ts
+++ b/apps/desktop/electron/safe-suggested-image-name.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { safeSuggestedImageName } from './safe-suggested-image-name'
+
+test('falls back to image plus extension when empty', () => {
+  assert.equal(safeSuggestedImageName('', '.png'), 'image.png')
+  assert.equal(safeSuggestedImageName(undefined, '.jpg'), 'image.jpg')
+})
+
+test('replaces Windows-invalid and control characters', () => {
+  assert.equal(safeSuggestedImageName('foo:bar*.png', '.png'), 'foo_bar_.png')
+  assert.equal(safeSuggestedImageName('hi\u0001there.png', '.png'), 'hi_there.png')
+})
+
+test('appends the mime extension when the name has none', () => {
+  assert.equal(safeSuggestedImageName('slashstack-worktree-feedback-2026-08-18', '.png'), 'slashstack-worktree-feedback-2026-08-18.png')
+})
+
+test('keeps an existing extension', () => {
+  assert.equal(safeSuggestedImageName('photo.webp', '.png'), 'photo.webp')
+})
+
+test('prefixes Windows reserved device names', () => {
+  assert.equal(safeSuggestedImageName('CON', '.png'), '_CON.png')
+  assert.equal(safeSuggestedImageName('NUL.txt', '.png'), '_NUL.txt')
+  assert.equal(safeSuggestedImageName('prn.png', '.png'), '_prn.png')
+  assert.equal(safeSuggestedImageName('COM1', '.jpg'), '_COM1.jpg')
+})
+
+test('caps the stem at 120 characters', () => {
+  const name = safeSuggestedImageName(`${'a'.repeat(300)}.png`, '.png')
+  assert.equal(name.length, 124)
+  assert.equal(name, `${'a'.repeat(120)}.png`)
+})
+
+test('treats trailing-dot and all-dot names as empty', () => {
+  assert.equal(safeSuggestedImageName('...', '.png'), 'image.png')
+  assert.equal(safeSuggestedImageName('photo...', '.png'), 'photo.png')
+})

--- a/apps/desktop/electron/safe-suggested-image-name.ts
+++ b/apps/desktop/electron/safe-suggested-image-name.ts
@@ -1,0 +1,38 @@
+import path from 'node:path'
+
+const WINDOWS_RESERVED_RE = /^(CON|PRN|AUX|NUL|COM\d|LPT\d)$/i
+const MAX_STEM = 120
+
+function stripTrailingDotsAndSpaces(value: string): string {
+  return value.replace(/[. ]+$/g, '')
+}
+
+function sanitizeBase(value: unknown): string {
+  return Array.from(path.basename(String(value || '')).replace(/[<>:"/\\|?*]/g, '_'), char =>
+    char.charCodeAt(0) < 32 ? '_' : char
+  )
+    .join('')
+    .trim()
+}
+
+export function safeSuggestedImageName(value: unknown, extension: string): string {
+  const fallbackExt = extension || '.png'
+  const base = stripTrailingDotsAndSpaces(sanitizeBase(value))
+
+  if (!base || !base.replace(/[._\s]/g, '')) {
+    return `image${fallbackExt}`
+  }
+
+  const currentExt = path.extname(base)
+  let stem = stripTrailingDotsAndSpaces(currentExt ? base.slice(0, -currentExt.length) : base)
+
+  if (!stem || WINDOWS_RESERVED_RE.test(stem)) {
+    stem = stem ? `_${stem}` : 'image'
+  }
+
+  if (stem.length > MAX_STEM) {
+    stem = stem.slice(0, MAX_STEM)
+  }
+
+  return `${stem}${currentExt || fallbackExt}`
+}

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -435,6 +435,7 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
         className
       )}
       containerClassName="my-2 block w-fit max-w-[min(100%,var(--image-preview-max-width))]"
+      downloadName={name}
       slot="aui_markdown-image"
       src={resolvedSrc}
       {...props}

--- a/apps/desktop/src/components/chat/generated-image-result.tsx
+++ b/apps/desktop/src/components/chat/generated-image-result.tsx
@@ -60,7 +60,7 @@ export const GeneratedImage: FC<{ aspectRatio?: string; result?: unknown }> = ({
   const [canvasGone, setCanvasGone] = useState(false)
   const [failed, setFailed] = useState(false)
   const [lightboxOpen, setLightboxOpen] = useState(false)
-  const { download, saving } = useImageDownload(src)
+  const { download, saving } = useImageDownload(src, image ? mediaName(image) : undefined)
 
   useEffect(() => setRatio(hintedRatio(aspectRatio)), [aspectRatio])
 

--- a/apps/desktop/src/components/chat/zoomable-image.tsx
+++ b/apps/desktop/src/components/chat/zoomable-image.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/lib/utils'
 
 export interface ZoomableImageProps extends ComponentProps<'img'> {
   containerClassName?: string
+  downloadName?: string
   slot?: string
 }
 
@@ -18,10 +19,10 @@ export interface ImageActionCopy {
   savingImage: string
 }
 
-export function ZoomableImage({ className, containerClassName, src, alt, slot, ...props }: ZoomableImageProps) {
+export function ZoomableImage({ className, containerClassName, downloadName, src, alt, slot, ...props }: ZoomableImageProps) {
   const { t } = useI18n()
   const copy = t.desktop
-  const { download, saving } = useImageDownload(src)
+  const { download, saving } = useImageDownload(src, downloadName)
   const [lightboxOpen, setLightboxOpen] = useState(false)
   const canOpen = Boolean(src)
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -261,7 +261,7 @@ declare global {
         path?: string
         saved: boolean
       }>
-      saveImageFromUrl: (url: string) => Promise<boolean>
+      saveImageFromUrl: (payload: { suggestedName?: string; url: string }) => Promise<boolean>
       /** Edit verb against the window's focused element (the custom context
        *  menu's Cut/Copy/Paste/Select all). */
       contextMenuEdit?: (command: 'copy' | 'cut' | 'paste' | 'selectAll') => Promise<void>

--- a/apps/desktop/src/hooks/use-image-download.test.ts
+++ b/apps/desktop/src/hooks/use-image-download.test.ts
@@ -11,6 +11,12 @@ describe('imageFilename', () => {
     expect(imageFilename('https://example.com/')).toBe('image')
     expect(imageFilename(undefined)).toBe('image')
   })
+
+  it('preserves the original filename when the display source is a data URL', () => {
+    expect(imageFilename('data:image/png;base64,AAAA', 'slashstack-worktree-feedback-2026-08-18.png')).toBe(
+      'slashstack-worktree-feedback-2026-08-18.png'
+    )
+  })
 })
 
 describe('downloadFilename', () => {
@@ -30,6 +36,12 @@ describe('downloadFilename', () => {
     expect(downloadFilename('https://cdn.example.com/abc123', 'image/png; charset=binary')).toBe('abc123.png')
     expect(downloadFilename('https://cdn.example.com/abc123', 'application/octet-stream')).toBe('abc123.png')
     expect(downloadFilename('https://cdn.example.com/abc123', undefined)).toBe('abc123.png')
+  })
+
+  it('uses a preferred semantic filename when the source has no filename', () => {
+    expect(downloadFilename('data:image/png;base64,AAAA', 'image/png', 'slashstack-worktree-feedback-2026-08-18.png')).toBe(
+      'slashstack-worktree-feedback-2026-08-18.png'
+    )
   })
 
   it('does not treat a dotted hash suffix as an extension', () => {

--- a/apps/desktop/src/hooks/use-image-download.ts
+++ b/apps/desktop/src/hooks/use-image-download.ts
@@ -14,15 +14,21 @@ const MIME_EXTENSIONS: Record<string, string> = {
 
 const KNOWN_IMAGE_EXTENSION_RE = /\.(?:apng|avif|bmp|gif|ico|jpe?g|png|svg|tiff?|webp)$/i
 
-export function imageFilename(src?: string): string {
-  if (!src) {
+function lastPathSegment(value: string): string {
+  return value.split(/[?#]/, 1)[0]?.split(/[\\/]/).filter(Boolean).pop() || ''
+}
+
+export function imageFilename(src?: string, preferredFilename?: string): string {
+  const candidate = preferredFilename || src
+
+  if (!candidate || candidate.startsWith('data:')) {
     return 'image'
   }
 
   try {
-    return new URL(src, window.location.href).pathname.split('/').filter(Boolean).pop() || 'image'
+    return new URL(candidate, window.location.href).pathname.split('/').filter(Boolean).pop() || 'image'
   } catch {
-    return src.split(/[\\/]/).filter(Boolean).pop() || 'image'
+    return lastPathSegment(candidate) || 'image'
   }
 }
 
@@ -30,8 +36,8 @@ export function imageFilename(src?: string): string {
  *  etc.) often end in an extensionless content hash — without an extension the
  *  OS save dialog shows "All Files" and the saved file won't open by
  *  double-click, so append one derived from the blob's MIME type. */
-export function downloadFilename(src: string, mimeType?: string): string {
-  const base = imageFilename(src)
+export function downloadFilename(src: string, mimeType?: string, preferredFilename?: string): string {
+  const base = imageFilename(src, preferredFilename)
 
   if (KNOWN_IMAGE_EXTENSION_RE.test(base)) {
     return base
@@ -51,7 +57,7 @@ function isMissingIpcHandler(error: unknown): boolean {
   return message.includes("No handler registered for 'hermes:saveImageFromUrl'")
 }
 
-async function startBrowserDownload(src: string) {
+async function startBrowserDownload(src: string, preferredFilename?: string) {
   const response = await fetch(src)
 
   if (!response.ok) {
@@ -62,7 +68,7 @@ async function startBrowserDownload(src: string) {
   const blobUrl = URL.createObjectURL(blob)
   const link = document.createElement('a')
   link.href = blobUrl
-  link.download = downloadFilename(src, blob.type)
+  link.download = downloadFilename(src, blob.type, preferredFilename)
   link.rel = 'noopener noreferrer'
   document.body.appendChild(link)
   link.click()
@@ -72,7 +78,7 @@ async function startBrowserDownload(src: string) {
 
 /** Save an image to disk via the desktop IPC bridge, falling back to a browser
  *  download when the handler is unavailable (older shell / web preview). */
-export function useImageDownload(src?: string) {
+export function useImageDownload(src?: string, preferredFilename?: string) {
   const { t } = useI18n()
   const copy = t.desktop
   const [saving, setSaving] = useState(false)
@@ -86,18 +92,23 @@ export function useImageDownload(src?: string) {
 
     try {
       if (window.hermesDesktop?.saveImageFromUrl) {
-        if (await window.hermesDesktop.saveImageFromUrl(src)) {
-          notify({ kind: 'success', title: copy.imageSaved, message: imageFilename(src) })
+        if (
+          await window.hermesDesktop.saveImageFromUrl({
+            url: src,
+            suggestedName: imageFilename(src, preferredFilename)
+          })
+        ) {
+          notify({ kind: 'success', title: copy.imageSaved, message: imageFilename(src, preferredFilename) })
         }
 
         return
       }
 
-      await startBrowserDownload(src)
+      await startBrowserDownload(src, preferredFilename)
     } catch (error) {
       if (isMissingIpcHandler(error)) {
         try {
-          await startBrowserDownload(src)
+          await startBrowserDownload(src, preferredFilename)
           notify({ kind: 'info', title: copy.downloadStarted, message: copy.restartToUseSaveImage })
         } catch (fallbackError) {
           notifyError(fallbackError, copy.restartToSaveImages)
@@ -110,7 +121,7 @@ export function useImageDownload(src?: string) {
     } finally {
       setSaving(false)
     }
-  }, [copy, saving, src])
+  }, [copy, preferredFilename, saving, src])
 
   return { download, saving }
 }


### PR DESCRIPTION
## Problem
Images delivered from local paths are resolved to `data:` URLs before rendering. The desktop image downloader then sees no path segment and opens the native Save dialog as `image.png`, even when the source file has a semantic name.

## Fix
- Carry the original/preferred filename through generated-image and Markdown-image renderers.
- Pass `suggestedName` through the renderer → preload → Electron IPC bridge.
- Make the native Save dialog and browser fallback use the semantic name.
- Sanitize native suggested names and preserve the existing URL-derived fallback for callers without a name.
- Add regressions for data URLs with preferred filenames.

## Verification
- `npm run test:ui -- src/hooks/use-image-download.test.ts` — 8 passed
- `npm run typecheck` — passed (renderer, Electron, E2E)
- `npx eslint <touched files>` — 0 errors
- `npm run build` — passed; Electron main and preload bundles generated
- `git diff --check` — passed

This fixes the desktop behavior shown in the report: the Save As dialog will suggest the original semantic filename instead of `image.png`.