### PR TITLE
fix(tui): honor agent.disabled_toolsets on desktop/TUI sessions

### DIFF
--- a/tests/tui_gateway/test_gui_surface_toolsets.py
+++ b/tests/tui_gateway/test_gui_surface_toolsets.py
@@ -117,6 +117,47 @@ class TestResolverPlumbing:
         assert "desktop_ui" in desktop
         assert "desktop_ui" not in tui
 
+    def test_disabled_agent_toolsets_subtracted_after_surface_fold(
+        self, no_desktop_env
+    ):
+        """agent.disabled_toolsets must hold on desktop/TUI sessions too: the
+        surface fold runs AFTER the platform resolution, so without the same
+        subtraction ``project`` (and any disabled posture toolset) comes back
+        on every GUI surface while the CLI honours the disable (#88857)."""
+        import agent.coding_context as cc
+        import hermes_cli.config as config_mod
+
+        cfg = {
+            "platform_toolsets": {"cli": ["memory"]},
+            "agent": {"disabled_toolsets": ["project", "terminal"]},
+        }
+        no_desktop_env.setattr(cc, "coding_selection", lambda **_: ["coding", "terminal"])
+        no_desktop_env.setattr(config_mod, "load_config", lambda: cfg)
+
+        for platform in ("desktop", "tui"):
+            resolved = server._load_enabled_toolsets(platform)
+            assert resolved is not None
+            assert "project" not in resolved, platform
+            assert "terminal" not in resolved, platform
+            assert "coding" in resolved, platform
+
+    def test_disabled_toolsets_parse_json_array_string(self, no_desktop_env):
+        """`hermes config set` persists the list as a JSON-array string — the
+        subtraction must parse it, not compare the raw string (#86661 parity)."""
+        import agent.coding_context as cc
+        import hermes_cli.config as config_mod
+
+        cfg = {
+            "platform_toolsets": {"cli": ["memory"]},
+            "agent": {"disabled_toolsets": "['project']"},
+        }
+        no_desktop_env.setattr(cc, "coding_selection", lambda **_: ["coding"])
+        no_desktop_env.setattr(config_mod, "load_config", lambda: cfg)
+
+        resolved = server._load_enabled_toolsets("desktop")
+        assert resolved is not None
+        assert "project" not in resolved
+
     def test_explicit_env_pin_still_wins(self, no_desktop_env):
         """HERMES_TUI_TOOLSETS is an operator override; surface can't re-add."""
         no_desktop_env.setenv("HERMES_TUI_TOOLSETS", "web,memory")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1814,11 +1814,37 @@ def _resolve_explicit_toolsets(explicit: list[str], validate_toolset) -> list[st
     return (built_in + mcp_valid) or False
 
 
+def _disabled_agent_toolsets() -> set[str]:
+    """``agent.disabled_toolsets`` from config.yaml, as a set (empty on error).
+
+    Mirrors the subtraction ``_get_platform_tools`` applies last ("runs last
+    so it overrides everything above"). The TUI/desktop resolver folds
+    client-surface toolsets in AFTER the platform resolution, so without the
+    same subtraction here a profile that disables e.g. ``project`` or
+    ``terminal`` keeps seeing those tools in desktop sessions while the CLI
+    honours the disable — the restriction has to hold on every surface
+    (#88857).
+    """
+    try:
+        from agent.skill_utils import parse_config_string_list
+        from hermes_cli.config import load_config
+
+        raw = (load_config().get("agent") or {}).get("disabled_toolsets") or []
+        return {
+            str(name).strip()
+            for name in parse_config_string_list(raw)
+            if str(name).strip()
+        }
+    except Exception:
+        return set()
+
+
 def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
     """The agent's toolsets for this session (None = all): an explicit HERMES_TUI_TOOLSETS pin; else the
     coding posture (coding_context collapses to coding toolset + enabled MCP servers in a code workspace);
     else the configured CLI toolsets. Client-surface toolsets fold in here — only this surface can answer them."""
     session_platform = platform or _resolve_session_platform()
+    disabled_agent_toolsets = _disabled_agent_toolsets()
     explicit = [item.strip() for item in os.environ.get("HERMES_TUI_TOOLSETS", "").split(",") if item.strip()]
     fallback_notice = None
     if not explicit:
@@ -1826,7 +1852,10 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
             from agent.coding_context import coding_selection
             selection = coding_selection(platform=session_platform)
             if selection is not None:
-                return sorted({*selection, *_gui_surface_toolsets(session_platform)})
+                # Apply the agent.disabled_toolsets subtraction AFTER folding
+                # so a client-surface toolset stays disable-able (#88857).
+                folded = {*selection, *_gui_surface_toolsets(session_platform)}
+                return sorted(folded - disabled_agent_toolsets)
     try:
         from toolsets import validate_toolset
     except Exception:
@@ -1848,7 +1877,13 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
         enabled = _get_platform_tools(cfg, "cli", include_default_mcp_servers=True)
         if fallback_notice is not None:
             _tui_notice(fallback_notice)
-        return sorted(enabled | _gui_surface_toolsets(session_platform)) if enabled else None
+        if not enabled:
+            return None
+        # Subtract agent.disabled_toolsets AFTER the fold:
+        # _get_platform_tools already applied it to its own result, but the
+        # fold would otherwise reintroduce a disabled surface toolset (#88857).
+        folded = enabled | _gui_surface_toolsets(session_platform)
+        return sorted(folded - disabled_agent_toolsets)
     except Exception:
         if fallback_notice is not None:
             _tui_notice("[tui] no valid HERMES_TUI_TOOLSETS entries and configured CLI toolsets could not be loaded; enabling all toolsets")


### PR DESCRIPTION
## What does this PR do?

Makes `agent.disabled_toolsets` hold on desktop/TUI sessions. The CLI platform path (`_get_platform_tools`) applies the disable list last — "runs last so it overrides everything above" — but the TUI/desktop resolver (`tui_gateway/server.py::_load_enabled_toolsets`) never consults it, and both of its paths fold the client-surface toolsets (`project`, `desktop_ui`) in **after** platform resolution:

- the coding-posture path (`coding_selection(...)`) returns without any disabled subtraction;
- the config path resolves via `_get_platform_tools(cfg, "cli", ...)`, which does subtract, but then `| _gui_surface_toolsets(...)` reintroduces `project` unconditionally.

Net effect (#88857): a profile that disables `project`/`terminal`/… keeps seeing those tools in desktop sessions while the CLI honours the disable — a deliberately restricted profile appears locked down under terminal testing while the GUI enforces nothing (the reporter watched the model create 18 junk projects through the reappearing `project_switch` tool).

The fix adds `_disabled_agent_toolsets()` (parses `agent.disabled_toolsets`, including the JSON-array-string form `hermes config set` writes — parity with #86661) and subtracts it after the surface fold on **both** resolver paths. The `HERMES_TUI_TOOLSETS` explicit pin keeps its escape-hatch semantics. Verified the bug premise still holds on current `main`: `_load_enabled_toolsets` read `disabled_toolsets` nowhere, and `_gui_surface_toolsets("desktop")` unconditionally returns `{"project", "desktop_ui"}`.

## Related Issue

Fixes #88857

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`
  - New `_disabled_agent_toolsets()`: parses `agent.disabled_toolsets` from config.yaml via `parse_config_string_list`, empty set on any error.
  - `_load_enabled_toolsets()`: subtracts the disabled set after the client-surface fold on the coding-posture path and on the `_get_platform_tools` fallback path.
- `tests/tui_gateway/test_gui_surface_toolsets.py`
  - New: a config disabling `project`+`terminal` removes both from desktop and TUI resolutions on the posture path (`coding` survives) — the surface fold may not resurrect a disabled toolset.
  - New: a JSON-array-string disable (`"['project']"`) is parsed, not compared raw.

## How to Test

1. `python -m pytest tests/tui_gateway/ -q`
   Observed result: 487 passed, 1 skipped.
2. Fail-on-main check: `git stash` the `tui_gateway/` change and rerun `TestResolverPlumbing` — Observed result: 2 failed (the disabled toolsets come back after the surface fold).
3. Live shape from the issue: a config with `agent.disabled_toolsets: [project, terminal, …]` on a desktop session — Observed result after the fix: `project_switch` no longer ships to the model, matching the CLI's behaviour for the same profile.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (tui_gateway suite: 487 passed, 1 skipped)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comments document the subtraction contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure config-read subtraction, platform-independent; or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
