### PR TITLE
fix(gateway): bind session cwd for the live system-prompt rebuild

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19780,6 +19780,70 @@ def test_persist_live_session_system_prompt_restores_pre_existing_override(tmp_p
     assert get_hermes_home_override() is None
 
 
+def test_persist_live_session_system_prompt_binds_session_cwd(monkeypatch, tmp_path):
+    """The prompt rebuild after a live model switch must record the SESSION's
+    working directory, not the process TERMINAL_CWD.
+
+    The function runs on the RPC dispatcher thread (model.switch, config.set
+    model). On that thread the _SESSION_CWD contextvar is not set, so
+    resolve_agent_cwd() falls back to TERMINAL_CWD, which the desktop pins
+    to the home directory. The wrong cwd line then persists into the stored
+    prompt. Later turns restore the stored bytes without change (the
+    prologue rebuilds only when _cached_system_prompt is None), so the
+    poisoned line never self-heals.
+    """
+    session_cwd = tmp_path / "project"
+    session_cwd.mkdir()
+    process_cwd = tmp_path / "home-fallback"
+    process_cwd.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(process_cwd))
+
+    persisted = {}
+
+    class FakeAgent:
+        model = "test-model"
+        provider = "test"
+        session_id = "cwd-test-session"
+        _cached_system_prompt = None
+        _session_db = None
+
+        def _build_system_prompt(self, system_message=None):
+            # The real builder embeds resolve_agent_cwd() via
+            # prompt_builder.build_environment_hints().
+            from agent.runtime_cwd import resolve_agent_cwd
+
+            return f"Current working directory: {resolve_agent_cwd()}"
+
+    class FakeDB:
+        def update_system_prompt(self, session_id, prompt):
+            persisted["prompt"] = prompt
+
+    agent = FakeAgent()
+    agent._session_db = FakeDB()
+    session = {
+        "agent": agent,
+        "session_key": "cwd-test-session",
+        "cwd": str(session_cwd),
+        "explicit_cwd": True,
+        "profile_home": None,
+    }
+
+    # A bare thread has no _SESSION_CWD contextvar — the RPC dispatcher shape.
+    result = {}
+
+    def dispatcher_thread():
+        server._persist_live_session_system_prompt(session)
+        result["cached"] = agent._cached_system_prompt
+
+    t = threading.Thread(target=dispatcher_thread)
+    t.start()
+    t.join()
+
+    expected = f"Current working directory: {session_cwd}"
+    assert result["cached"] == expected, result["cached"]
+    assert persisted["prompt"] == expected, persisted["prompt"]
+
+
 def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     """An explicit Move-to-project must win for a RUNNING session: the stored
     row and the live runtime session re-anchor together, never a UI-vs-db

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4181,6 +4181,16 @@ def _persist_live_session_system_prompt(session: dict | None) -> None:
     home_token = (
         set_hermes_home_override(profile_home) if profile_home else None
     )
+    # Bind the session context too. This function runs on the RPC dispatcher
+    # thread (model.switch, config.set model). On that thread the _SESSION_CWD
+    # contextvar is not set, so resolve_agent_cwd() falls back to the process
+    # TERMINAL_CWD, which the desktop pins to the home directory. The rebuilt
+    # prompt then records the wrong working directory and persists it. Later
+    # turns restore the stored bytes without change, because the turn
+    # prologue rebuilds only when _cached_system_prompt is None.
+    session_tokens = _set_session_context(
+        session_key, cwd=_session_cwd(session)
+    )
     try:
         prompt = agent._build_system_prompt(None)
         agent._cached_system_prompt = prompt
@@ -4192,6 +4202,7 @@ def _persist_live_session_system_prompt(session: dict | None) -> None:
             exc_info=True,
         )
     finally:
+        _clear_session_context(session_tokens)
         if home_token is not None:
             reset_hermes_home_override(home_token)
 


### PR DESCRIPTION
## What does this PR do?

A desktop session created inside a project can show the wrong working directory in its system prompt for its full life. The prompt says the home directory. The terminal tool and the session database row both say the project directory.

The cause is the live system-prompt rebuild after a model switch. The function `_persist_live_session_system_prompt` runs on the RPC dispatcher thread. On that thread the `_SESSION_CWD` contextvar is not set. Because of this, `resolve_agent_cwd()` falls back to the process `TERMINAL_CWD` value, and the desktop pins that value to the home directory (`main.ts`, `resolveHermesCwd`). The rebuilt prompt records the home directory, and the wrong prompt persists to the session database.

The wrong line never heals. The turn prologue (`agent/turn_context.py`) rebuilds the prompt only when `_cached_system_prompt` is None. The poisoned bytes replay on every later turn, because prompt byte-stability is the project invariant.

The trigger is common on the desktop. The composer sends a model switch before the first turn when its model differs from the config default. Because of this, a brand-new project session takes the poisoned path before the first correctly-bound turn thread can build the prompt.

The fix binds the session context around the rebuild, in the same way the function already binds the profile home (#50233). The bind gives `resolve_agent_cwd()` the session's own cwd. Every caller of the function gets the fix, including the MoA switch path in `methods_tools.py` and the `config.set model` path.

## Related Issue

No open issue found for this defect. Closest existing items are #38601 (`session.cwd.set` does not invalidate the stored prompt: a related class, but a different site) and #80878 (remote-backend `TERMINAL_CWD` during prompt construction: a different fallback rung).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — `_persist_live_session_system_prompt` now wraps the prompt rebuild in `_set_session_context(session_key, cwd=_session_cwd(session))`, cleared in the `finally` block. This is the same pattern `_sync_bot_capabilities` already uses.
- `tests/test_tui_gateway_server.py` — new test `test_persist_live_session_system_prompt_binds_session_cwd`. It drives the real function from a bare thread (the RPC dispatcher shape) with `TERMINAL_CWD` pointed at a decoy directory, and asserts both the cached and the persisted prompt carry the session's cwd.

## How to Test

1. Run the targeted tests: `pytest tests/test_tui_gateway_server.py -k persist_live_session_system_prompt -q` (4 pass).
2. Fault detection proof: revert the `server.py` hunk and run again. The new test fails with the decoy directory in the prompt. The three pre-existing tests for this function still pass.
3. Full file: `pytest tests/test_tui_gateway_server.py -q` (586 pass, 0 fail).
4. Live reproduction shape: in the desktop app, set the composer model to something other than the config default, create a new chat inside a project, and send a message. Before the fix the persisted system prompt records `$HOME` as the working directory while the session row and the terminal tool record the project path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test file and all tests pass (586 passed via the repo's `scripts/run_tests.sh`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux 7.1.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

## Notes for review

Deliberately left out, seen and scoped:

- `_reset_session_agent` (`server.py`) and the two `_make_agent` build paths already bind the session context. They are not affected.
- The `one_turn_restore` caller (`server.py`, turn `finally` block) runs before `_clear_session_context` on the turn thread, so it already has the bind.
- #38601 covers the separate defect where `session.cwd.set` does not refresh an already-persisted prompt. This PR does not change that behavior.
- The two defects documented from the earlier cwd investigation (detached-desktop `$HOME` attach through `_completion_cwd`, and the interrupted-command record leak fixed by #85654) are distinct resolver bugs and are not touched here.
