### PR TITLE
fix(desktop): SESSIONS | BOTS is always a tab strip — the Bots pane re-homes beside Sessions on every boot, no heal guards (follow-up to #88788)

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/dock-enforce.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/dock-enforce.test.ts
@@ -1,14 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// One-time dock heals: a pane already adopted under an OLD dock hint (Bot
-// Mode's Bots pane split BELOW sessions) re-homes onto its new center anchor
-// exactly once — persisted layouts otherwise pin the stale arrangement
-// forever, because adoption only ever places panes MISSING from the tree.
-// Guards under test: user-placed layouts are never touched, and a burned
-// token never re-fights the user across later adoption passes.
+// Enforced dock invariants: a pane whose dock hint carries `enforce: true`
+// (Bot Mode's Bots pane) re-homes onto its center anchor at EVERY boot's
+// first adoption pass — persisted layouts otherwise pin the stale stacked
+// arrangement forever, because adoption only ever places panes MISSING from
+// the tree. Unlike the retired one-time heal, nothing exempts the pane: not
+// a previously burned heal token, not $userPlacedPanes. The invariant is
+// boot-scoped, so an intra-session drag sticks until the next launch.
 
 const TREE_KEY = 'hermes.desktop.layoutTree.v2'
 const USER_PLACED_KEY = 'hermes.desktop.userPlacedPanes.v1'
+const LEGACY_HEAL_KEY = 'hermes.desktop.paneDockHeals.v1'
 
 // The shipped regression shape: sessions and bots as SIBLING groups in a
 // column (the old `pos: 'bottom'` split), workspace beside them.
@@ -32,7 +34,7 @@ const stackedTree = {
   ]
 }
 
-describe('one-time dock heal (stacked Bots pane → sessions-zone tab)', () => {
+describe('enforced dock (stacked Bots pane → sessions-zone tab, every boot)', () => {
   beforeEach(() => {
     window.localStorage.clear()
     vi.resetModules()
@@ -69,7 +71,7 @@ describe('one-time dock heal (stacked Bots pane → sessions-zone tab)', () => {
       title: 'Bots',
       data: {
         placement: 'left',
-        dock: { pane: 'sessions', pos: 'center', heal: 'sessions-tab-v1' }
+        dock: { pane: 'sessions', pos: 'center', enforce: true }
       },
       render: () => null
     })
@@ -85,15 +87,15 @@ describe('one-time dock heal (stacked Bots pane → sessions-zone tab)', () => {
     const group = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:pane')!
 
     expect(group.panes).toEqual(['sessions', 'hermes-bots:pane'])
-    // Silent like adoption — the heal must not steal the sessions tab.
+    // Silent like adoption — the enforce must not steal the sessions tab.
     expect(group.active).toBe('sessions')
-    // The persisted tree carries the healed shape (survives the next boot).
+    // The persisted tree carries the tabbed shape (survives the next boot).
     const persisted = JSON.parse(window.localStorage.getItem(TREE_KEY)!) as { children?: unknown[] }
 
     expect(JSON.stringify(persisted)).toContain('"panes":["sessions","hermes-bots:pane"]')
   })
 
-  it('never touches a layout the user placed the pane in themselves', async () => {
+  it('re-homes even a USER-PLACED pane — the owner invariant beats the drag record', async () => {
     window.localStorage.setItem(USER_PLACED_KEY, JSON.stringify(['hermes-bots:pane']))
 
     const { model, tree } = await setup()
@@ -102,22 +104,36 @@ describe('one-time dock heal (stacked Bots pane → sessions-zone tab)', () => {
 
     const group = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:pane')!
 
-    // Still its own zone below sessions — the user's spot wins.
-    expect(group.panes).toEqual(['hermes-bots:pane'])
+    expect(group.panes).toEqual(['sessions', 'hermes-bots:pane'])
   })
 
-  it('burns its token once: a user who re-stacks the pane afterward is not fought', async () => {
+  it('re-homes even when the retired heal token was already burned, and clears the stale ledger', async () => {
+    window.localStorage.setItem(LEGACY_HEAL_KEY, JSON.stringify(['hermes-bots:pane:sessions-tab-v1']))
+
+    const { model, tree } = await setup()
+
+    tree.watchContributedPanes()
+
+    const group = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:pane')!
+
+    expect(group.panes).toEqual(['sessions', 'hermes-bots:pane'])
+    // The one-time-heal ledger is dead state now — importing the store drops it.
+    expect(window.localStorage.getItem(LEGACY_HEAL_KEY)).toBeNull()
+  })
+
+  it('is idempotent within a boot and does not fight an intra-session drag', async () => {
     const { model, tree, registry } = await setup()
 
     tree.watchContributedPanes()
 
-    // Sanity: healed.
+    // Sanity: enforced into the strip.
     expect(model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:pane')!.panes).toContain('sessions')
 
     // The user drags the pane back out into its own zone below sessions.
     tree.$layoutTree.set(JSON.parse(JSON.stringify(stackedTree)))
 
-    // A later registry mutation re-runs the adoption pass (the heal's caller).
+    // A later registry mutation re-runs the adoption pass (the enforce's
+    // caller) — same boot, so the drag sticks until the next launch.
     registry.register({
       id: 'other',
       area: 'panes',
@@ -129,5 +145,24 @@ describe('one-time dock heal (stacked Bots pane → sessions-zone tab)', () => {
     const group = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:pane')!
 
     expect(group.panes).toEqual(['hermes-bots:pane'])
+  })
+
+  it('re-homes again on the NEXT boot after a drag persisted the stacked shape', async () => {
+    const first = await setup()
+
+    first.tree.watchContributedPanes()
+    first.tree.$layoutTree.set(JSON.parse(JSON.stringify(stackedTree)))
+    first.tree.persistTree()
+
+    // Simulate the next launch: fresh module graph, persisted stacked tree.
+    vi.resetModules()
+
+    const second = await setup()
+
+    second.tree.watchContributedPanes()
+
+    const group = second.model.findGroupOfPane(second.tree.$layoutTree.get()!, 'hermes-bots:pane')!
+
+    expect(group.panes).toEqual(['sessions', 'hermes-bots:pane'])
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/dock-enforce.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/dock-enforce.test.ts
@@ -165,4 +165,52 @@ describe('enforced dock (stacked Bots pane → sessions-zone tab, every boot)', 
 
     expect(group.panes).toEqual(['sessions', 'hermes-bots:pane'])
   })
+
+  it('forces the tab strip visible when already co-located but hidden with bots active (community "only Bots shows" regression)', async () => {
+    // The Aug 2026 field reports: sessions+bots already share one group, the
+    // strip is hidden (headerHidden), and bots holds the active tab — the
+    // sessions pane exists but is unreachable. The re-home path never runs
+    // (nothing to move), so the enforce must repair reachability directly.
+    const hiddenStackedTree = {
+      type: 'split',
+      id: 'root',
+      orientation: 'row',
+      weights: [1, 3],
+      children: [
+        {
+          type: 'group',
+          id: 'g-left',
+          panes: ['sessions', 'hermes-bots:pane'],
+          active: 'hermes-bots:pane',
+          headerHidden: true
+        },
+        { type: 'group', id: 'g-main', panes: ['workspace'], active: 'workspace' }
+      ]
+    }
+
+    window.localStorage.setItem(TREE_KEY, JSON.stringify(hiddenStackedTree))
+
+    const tree = await import('@/components/pane-shell/tree/store')
+    const model = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+
+    registry.register({ id: 'workspace', area: 'panes', title: 'chat', data: { placement: 'main' }, render: () => null })
+    registry.register({ id: 'sessions', area: 'panes', title: 'sessions', data: { placement: 'left' }, render: () => null })
+    registry.register({
+      id: 'hermes-bots:pane',
+      area: 'panes',
+      title: 'Bots',
+      data: { placement: 'left', dock: { pane: 'sessions', pos: 'center', enforce: true } },
+      render: () => null
+    })
+
+    tree.watchContributedPanes()
+
+    const group = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:pane')!
+
+    // Both panes stay put — but the strip is forced visible so SESSIONS is
+    // reachable again. The active tab is NOT stolen mid-boot.
+    expect(group.panes).toEqual(['sessions', 'hermes-bots:pane'])
+    expect(group.headerHidden).not.toBe(true)
+  })
 })

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1105,43 +1105,40 @@ interface PaneDockHint {
   pos: DropPosition
   /** Center docks: stack BEFORE this pane id (the strip divider's slot). */
   before?: null | string
-  /** One-time re-home token: a pane ALREADY adopted under an older dock hint
-   *  moves onto this hint's center anchor once per token — never when the
-   *  user has placed the pane themselves. See `healDockedPanes`. */
-  heal?: string
+  /** Enforced dock invariant: the pane is re-homed onto this hint's center
+   *  anchor on EVERY boot when it isn't already stacked with the anchor —
+   *  no one-time token, and user placement does not exempt it. Once per
+   *  adoption lifetime (per boot), so an intra-session drag sticks until the
+   *  next boot. See `enforceDockedPanes`. */
+  enforce?: boolean
 }
 
-// One-time dock heals already applied, persisted so a heal runs exactly once
-// per pane per token across boots (and never re-fights a user who re-arranges
-// the healed pane afterward).
-const DOCK_HEAL_KEY = 'hermes.desktop.paneDockHeals.v1'
+// The retired one-time dock-heal ledger (`heal: '<token>'` hints). Its guards
+// (token burned even when the heal was skipped; $userPlacedPanes exempt) left
+// exactly the users who had fought the old stacked layout stuck with it —
+// enforced docks (`enforce: true`) replaced it. Drop the stale key.
+writeKey('hermes.desktop.paneDockHeals.v1', null)
 
-const appliedDockHeals = new Set<string>(readJson<string[]>(DOCK_HEAL_KEY) ?? [])
-
-function markDockHealApplied(token: string) {
-  appliedDockHeals.add(token)
-  writeJson(DOCK_HEAL_KEY, [...appliedDockHeals])
-}
+// Panes already enforced THIS boot: the invariant re-asserts at boot, not
+// against a live user — a mid-session drag out of the anchor strip sticks
+// until the next launch, so there is never a tug-of-war.
+const enforcedDocksThisBoot = new Set<string>()
 
 /**
- * A `panes` contribution whose dock hint carries a `heal` token gets ONE
- * chance to re-home its already-adopted pane onto the hint's anchor —
- * adoption is once per pane lifetime (the persisted tree remembers it), so a
- * contribution whose default dock CHANGED would otherwise never reach
- * existing installs. Guarded hard:
- *
- *  - the token burns exactly once per pane (idempotent across boots), and it
- *    burns even when the heal is skipped, so a user who later drags the pane
- *    back to the old spot is never fought;
- *  - a USER-PLACED pane ($userPlacedPanes) is never touched — their spot wins;
- *  - center re-homes only: a heal exists to consolidate a stray split into
- *    its anchor's tab strip, not to re-run arbitrary splits.
+ * A `panes` contribution whose dock hint carries `enforce: true` is re-homed
+ * onto the hint's center anchor at every boot's first adoption pass when it
+ * isn't already stacked there. Unlike the retired one-time heal, nothing
+ * exempts the pane — not a burned token, not $userPlacedPanes — because the
+ * hint is the owner's standing invariant about where the pane lives
+ * (Bot Mode's Bots pane IS the SESSIONS | BOTS tab strip), not a one-shot
+ * migration. Center re-homes only: the invariant consolidates the pane into
+ * its anchor's tab strip, it never re-runs arbitrary splits.
  *
  * Silent like adoption — the anchor zone keeps its active tab. The center
  * insert pins the zone's header shown, which is the point: the strip is how
- * the user finds the healed tab.
+ * the user finds the tab.
  */
-function healDockedPanes(
+function enforceDockedPanes(
   tree: LayoutNode,
   dataOf: (paneId: string) => { dock?: PaneDockHint; placement?: string } | undefined
 ): LayoutNode {
@@ -1150,21 +1147,15 @@ function healDockedPanes(
   for (const pane of registry.getArea('panes')) {
     const dock = dataOf(pane.id)?.dock
 
-    if (!dock?.heal || dock.pos !== 'center' || !allPaneIds(next).includes(pane.id)) {
+    if (!dock?.enforce || dock.pos !== 'center' || !allPaneIds(next).includes(pane.id)) {
       continue
     }
 
-    const token = `${pane.id}:${dock.heal}`
-
-    if (appliedDockHeals.has(token)) {
+    if (enforcedDocksThisBoot.has(pane.id)) {
       continue
     }
 
-    markDockHealApplied(token)
-
-    if ($userPlacedPanes.get().has(pane.id)) {
-      continue
-    }
+    enforcedDocksThisBoot.add(pane.id)
 
     const from = findGroupOfPane(next, pane.id)
     const anchor = findGroupOfPane(next, dock.pane)
@@ -1205,9 +1196,9 @@ function adoptContributedPanes(): void {
 
   const dismissed = $dismissedPanes.get()
 
-  // One-time dock heals run FIRST: a heal re-homes a pane that is ALREADY in
-  // the tree, so the missing-pane adoption below never sees it.
-  const healed = healDockedPanes(tree, dataOf)
+  // Enforced dock invariants run FIRST: they re-home panes that are ALREADY
+  // in the tree, so the missing-pane adoption below never sees them.
+  const healed = enforceDockedPanes(tree, dataOf)
 
   // `placement: 'floating'` opts OUT of the tree entirely — those panes render
   // as fixed cards above it (renderer/floating-panes.tsx). Adopting one would

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1160,8 +1160,20 @@ function enforceDockedPanes(
     const from = findGroupOfPane(next, pane.id)
     const anchor = findGroupOfPane(next, dock.pane)
 
-    // Already stacked with its anchor, or the anchor isn't in the tree.
-    if (!from || !anchor || from.id === anchor.id) {
+    if (!from || !anchor) {
+      continue
+    }
+
+    if (from.id === anchor.id) {
+      // Already stacked with its anchor — but an enforced tab must be
+      // REACHABLE, not just co-located. Community regression (Aug 2026):
+      // persisted trees where the enforced pane was center-stacked with the
+      // strip hidden and itself active left the ANCHOR invisible with no
+      // strip to switch back ("my ui only shows bots now... cant find the
+      // sessions"). An enforced zone always shows its strip.
+      if (anchor.headerHidden === true) {
+        next = setGroupHeaderHiddenOp(next, anchor.id, false) ?? next
+      }
       continue
     }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8366,10 +8366,17 @@ export default {
       // stays shown once the zone has stacked), so the sessions pane can
       // never vanish behind a stripless Bots tab — the lone-pane auto-hide
       // trap this dock used to work around with a 'bottom' split.
-      // heal: one-shot re-home for installs that adopted under the old
-      // 'bottom' split — moves the pane into the sessions strip ONCE, never
-      // touching a user-placed layout (see healDockedPanes in the tree store).
-      data: { placement: 'left', width: '260px', dock: { pane: 'sessions', pos: 'center', heal: 'sessions-tab-v1' } },
+      // enforce: standing invariant, not a one-shot migration — the pane
+      // re-homes into the sessions strip at EVERY boot it isn't already
+      // there, whatever tokens or user placement an older install persisted.
+      // The one-time heal ('sessions-tab-v1') burned its token even when its
+      // guards skipped the move, so exactly the users who had fought the old
+      // stacked layout (dragged panes → $userPlacedPanes) stayed stacked
+      // forever. Owner's order: SESSIONS | BOTS is always a tab strip.
+      // An intra-session drag still sticks until the next launch (the
+      // invariant runs at adoption time only — see enforceDockedPanes in the
+      // tree store).
+      data: { placement: 'left', width: '260px', dock: { pane: 'sessions', pos: 'center', enforce: true } },
       render: () => jsx(BotsPane, {})
     })
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/pane-dock-layout.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/pane-dock-layout.test.mjs
@@ -4,8 +4,10 @@ import test from 'node:test'
 
 // Bot Mode layout contract:
 //  - the Bots pane center-stacks into the sessions zone (SESSIONS | BOTS tab
-//    strip), never splits below it, and carries a one-shot heal token so
-//    installs that adopted under the old 'bottom' split migrate;
+//    strip), never splits below it, and carries the ENFORCED dock invariant
+//    so every boot re-homes a stacked install — no heal token, no
+//    user-placed exemption (the retired one-shot heal left users who had
+//    dragged panes stuck stacked forever);
 //  - the Cronjobs (routines) pane only exists while the Bots pane is on
 //    screen — registered/unregistered through the contribution disposer,
 //    driven by the feature-detected host.paneVisibility SDK export, with the
@@ -13,10 +15,12 @@ import test from 'node:test'
 
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-test('the Bots pane center-docks into the sessions zone with a heal token', () => {
-  assert.match(source, /dock: \{ pane: 'sessions', pos: 'center', heal: 'sessions-tab-v1' \}/)
+test('the Bots pane center-docks into the sessions zone as an enforced invariant', () => {
+  assert.match(source, /dock: \{ pane: 'sessions', pos: 'center', enforce: true \}/)
   // The old workaround split must not come back.
   assert.doesNotMatch(source, /pane: 'sessions', pos: 'bottom'/)
+  // Neither may the retired one-shot heal token.
+  assert.doesNotMatch(source, /heal: 'sessions-tab-v1'/)
 })
 
 test('routines registration is a reusable disposer-returning function', () => {


### PR DESCRIPTION
## Outcome

The desktop's left sidebar now **always** boots with `SESSIONS | BOTS` as side-by-side tabs in one zone. The Bots pane carries an **enforced dock invariant** (`dock: { pane: 'sessions', pos: 'center', enforce: true }`): at every boot's first adoption pass, if the pane exists in the tree but is not in the sessions zone's group, it is re-homed as a center tab — no one-time heal token, no `$userPlacedPanes` exemption. This is the owner's explicit order: the stacked Sessions-over-Bots layout must never survive an update again.

Follow-up to #88788, which added the one-time heal that did not reach the affected installs.

## Infographic

![SESSIONS | BOTS — always a tab strip](https://v3b.fal.media/files/b/0aa6c7b4/GUykqFcHbZJJ2UZp6AutS_LYQKie0o.png)

## Empirical evidence (live desktop over CDP, Linux, current main @ c9ce66e25e)

Each scenario was seeded into `localStorage` of a real running dev Electron (isolated `--user-data-dir`), reloaded, and the persisted `hermes.desktop.layoutTree.v2` + a screenshot captured. "Tabbed" = `hermes-bots:pane` in the same group as `sessions`; "stacked" = its own group split below.

| Scenario | Seed | Before fix | After fix |
|---|---|---|---|
| **A** fresh install (empty storage) | none | ✅ tabbed — `panes:["sessions","hermes-bots:pane"]` | ✅ tabbed |
| **B** legacy stacked tree, clean guards | stacked tree, no heals, no userPlaced | ✅ tabbed (heal fired) | ✅ tabbed (enforce fired) |
| **C1** stacked tree + **burned heal token** | `paneDockHeals.v1=["hermes-bots:pane:sessions-tab-v1"]` | ❌ **stays stacked** | ✅ tabbed |
| **C2** stacked tree + **user-placed pane** | `userPlacedPanes.v1=["hermes-bots:pane"]` | ❌ **stays stacked** | ✅ tabbed |

Visual confirmation (vision analysis of screenshots): before-fix C1 shows a `SESSIONS`/`TERMINAL` panel with a separate `BOTS` panel stacked below it (g-sessions at y≈34, g-bots at y≈245 in the same 260px column); after-fix all scenarios show one left panel with a `SESSIONS | BOTS` tab strip, `SESSIONS` active.

Drag sanity on the patched build: `moveTreePane` of the bots pane into a bottom split sticks for the rest of the session (marked user-placed, enforce is once-per-boot), and the next reload re-homes it into the strip. No live tug-of-war.

## Windows-box postmortem

The fully-updated Windows install still showing the stacked layout is **scenario C** (either half). `healDockedPanes` burned its token *before* checking `$userPlacedPanes` and even when the move was skipped, and it exempted any pane the user had ever dragged. A user who fought the old stacked layout by dragging panes around is exactly a user with `hermes-bots:pane` in `userPlacedPanes.v1` — the heal skipped them, burned `sessions-tab-v1`, and no later boot would ever try again. The heal shipped correct for scenario B only; the population that most wanted the fix was designed out of it. (Scenarios A and B pass on current main, so there is no adoption-ordering or pane-id bug — the guards are the whole story.)

## Guard removal rationale

- `heal` tokens and the persisted `hermes.desktop.paneDockHeals.v1` ledger are removed outright: nothing uses one-shot heals anymore, and dead migration machinery whose semantics just misfired should not linger. The store drops the stale key on load.
- `$userPlacedPanes` no longer exempts an *enforced* pane. It still governs everything else (auto-docking via `dockPaneBeside`, adoption of non-enforced panes). The invariant is deliberately boot-scoped — it runs only in the adoption pass, so an intra-session drag is respected until the next launch. That satisfies "always the original way" without fighting the user mid-session.
- The Cronjobs/routines pane registration and its `paneVisibility` gating are untouched.

## Tests

- `src/components/pane-shell/tree/dock-enforce.test.ts` (replaces `dock-heal.test.ts`, 5 tests): re-homes stacked → sessions strip keeping sessions active; re-homes despite user-placed; re-homes despite burned legacy token + drops the stale ledger key; idempotent within a boot (drag sticks); re-homes again on the next boot after a persisted drag.
- Sabotage-proved: re-adding the `$userPlacedPanes` guard to `enforceDockedPanes` makes the user-placed test fail (1 failed / 4 passed), restored.
- Plugin source-shape test `pane-dock-layout.test.mjs` updated to pin `enforce: true` and reject both the old `bottom` split and the retired heal token.
- Full runs: tree suites 21 files / 108 tests pass; hermes-bots plugin suite 238 tests pass; `node --check plugin.js` OK; `npm run check:lint` (tsc + eslint) 0 errors.
