### PR TITLE
fix(memory): log OpenViking unavailability at ERROR on the lossy paths

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1356,6 +1356,33 @@ def _status_code_from_error(error: Exception) -> Optional[int]:
     return getattr(response, "status_code", None)
 
 
+def _is_unavailability_error(error: Exception) -> bool:
+    """True when *error* means the OpenViking server could not be reached.
+
+    Connection-level failures (refused, timeout, protocol reset) — as opposed
+    to an HTTP answer the server did return — are the ones that can persist
+    silently for days (#88868): the builtin memory provider keeps working, so
+    nothing else looks broken. Callers log these at ERROR (visible in
+    errors.log) while genuine per-call HTTP failures stay at WARNING.
+    """
+    if _status_code_from_error(error) is not None:
+        return False
+    httpx = _get_httpx()
+    if httpx is not None and isinstance(
+        error,
+        (
+            httpx.ConnectError,
+            httpx.ConnectTimeout,
+            httpx.PoolTimeout,
+            httpx.RemoteProtocolError,
+        ),
+    ):
+        return True
+    return isinstance(error, (ConnectionError, OSError)) and not isinstance(
+        error, _OpenVikingHTTPError
+    )
+
+
 def _admin_probe_means_regular_key(error: Exception) -> bool:
     return _status_code_from_error(error) in {401, 403, 404}
 
@@ -2957,6 +2984,14 @@ class OpenVikingMemoryProvider(MemoryProvider):
             )
         except Exception as e:
             logger.warning("OpenViking system_prompt_block failed: %s", e)
+            if _is_unavailability_error(e):
+                # Surface the degraded knowledge base at ERROR: the model
+                # silently loses the viking_* tool guidance for as long as the
+                # server is down (#88868).
+                logger.error(
+                    "OpenViking unavailable — knowledge-base prompt block "
+                    "degraded (server unreachable): %s", e,
+                )
             return (
                 "# OpenViking Knowledge Base\n"
                 f"Active. Endpoint: {self._endpoint}\n"
@@ -3507,6 +3542,15 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 logger.debug("OpenViking pending session %s no longer exists; dropped marker", sid)
                 return False
             logger.warning("OpenViking session commit failed for %s: %s", sid, e)
+            if _is_unavailability_error(e):
+                # The server is unreachable — memory writes for this session
+                # are being lost until it comes back. ERROR so the outage is
+                # visible in errors.log instead of rotting at WARNING while
+                # the builtin provider masks the degradation (#88868).
+                logger.error(
+                    "OpenViking unavailable — session %s memory not committed "
+                    "(server unreachable): %s", sid, e,
+                )
             return False
 
     def _finalize_session_async(self, sid: str, turn_count: int, *, context: str) -> None:

--- a/tests/openviking_plugin/test_unavailability_escalation.py
+++ b/tests/openviking_plugin/test_unavailability_escalation.py
@@ -1,0 +1,85 @@
+"""Unavailability failures surface at ERROR, not WARNING (#88868).
+
+The builtin memory provider keeps working when the OpenViking server is
+down, so WARNING-level swallows let the outage persist invisibly for days.
+Connection-level failures (the server could not be reached at all) on the
+two highest-impact paths — session commit and the system prompt block —
+must additionally log at ERROR so they land in errors.log.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+import plugins.memory.openviking as openviking_plugin
+from plugins.memory.openviking import OpenVikingMemoryProvider, _OpenVikingHTTPError
+
+
+class TestUnavailabilityClassifier:
+    def test_connection_errors_are_unavailability(self):
+        for exc in (
+            httpx.ConnectError("refused"),
+            httpx.ConnectTimeout("timed out"),
+            httpx.PoolTimeout("pool exhausted"),
+            ConnectionRefusedError(61),
+        ):
+            assert openviking_plugin._is_unavailability_error(exc), exc
+
+    def test_http_answers_are_not_unavailability(self):
+        """A server that ANSWERED (even with 5xx) is reachable — keep the
+        per-call failure at WARNING and do not double-log at ERROR."""
+        for exc in (
+            _OpenVikingHTTPError("boom", status_code=500),
+            _OpenVikingHTTPError("denied", status_code=403),
+        ):
+            assert not openviking_plugin._is_unavailability_error(exc), exc
+
+
+class TestEscalationPaths:
+    @pytest.fixture
+    def provider(self):
+        prov = OpenVikingMemoryProvider()
+        prov._client = MagicMock()
+        return prov
+
+    def test_commit_failure_escalates_when_unreachable(self, provider, caplog):
+        provider._client.post.side_effect = httpx.ConnectError("refused")
+
+        with caplog.at_level(logging.DEBUG, logger=openviking_plugin.__name__):
+            committed = provider._commit_session(
+                "s1", 2, context="test", clear_missing=True
+            )
+
+        assert committed is False
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors, "unreachable server must log at ERROR"
+        assert any("OpenViking unavailable" in r.getMessage() for r in errors)
+
+    def test_commit_http_failure_stays_warning(self, provider, caplog):
+        provider._client.post.side_effect = _OpenVikingHTTPError(
+            "boom", status_code=500
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=openviking_plugin.__name__):
+            committed = provider._commit_session(
+                "s1", 2, context="test", clear_missing=True
+            )
+
+        assert committed is False
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+    def test_prompt_block_degradation_escalates_when_unreachable(
+        self, provider, caplog, monkeypatch
+    ):
+        monkeypatch.setattr(provider, "_ensure_client", lambda: True)
+        provider._client.get.side_effect = httpx.ConnectError("refused")
+
+        with caplog.at_level(logging.DEBUG, logger=openviking_plugin.__name__):
+            block = provider.system_prompt_block()
+
+        assert block  # fallback prompt text still returned
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors
+        assert any("OpenViking unavailable" in r.getMessage() for r in errors)


### PR DESCRIPTION
## What does this PR do?

Implements the minimal layer of #88868's suggested fix: provider **connection/unavailability failures** on the two highest-impact paths now log at ERROR in addition to the existing WARNING, so a dead OpenViking server lands in `errors.log` instead of rotting invisibly while the builtin memory provider masks the degradation (the reporter's server was down ~2 days before anyone noticed).

The escalation is deliberately classified, not blanket:

- New `_is_unavailability_error()` returns True only for **connection-level** failures — `httpx.ConnectError` / `ConnectTimeout` / `PoolTimeout` / `RemoteProtocolError`, or a bare `ConnectionError`/`OSError` — with **no HTTP status code**. A server that *answered* (even with 5xx) is reachable: per-call HTTP failures keep the existing single WARNING.
- The two escalated paths are the lossy ones from the report:
  - `_commit_session` — the session's memory writes are being lost until the server returns;
  - `system_prompt_block` — the model silently loses the knowledge-base guidance (the fallback prompt text still ships).

The structured "unhealthy" event / gateway surfacing (option 2 in the issue) and docs (option 3) are intentionally left out — those are mechanism additions for a maintainer decision; this PR only fixes the log-level swallow.

## Related Issue

Fixes #88868

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/openviking/__init__.py`
  - New `_is_unavailability_error()`: connection-level classification (no HTTP status + transport/connect exceptions).
  - `_commit_session` and `system_prompt_block`: after the existing WARNING, an unreachable-server failure additionally logs `ERROR "OpenViking unavailable — …"`.
- `tests/openviking_plugin/test_unavailability_escalation.py` (new)
  - Classifier: connect-family exceptions are unavailability; `_OpenVikingHTTPError` with a status (403/500) is not.
  - Commit path: `httpx.ConnectError` → returns False AND logs at ERROR; an HTTP 500 stays WARNING-only (no ERROR record).
  - Prompt-block path: `httpx.ConnectError` → fallback prompt returned AND ERROR logged.

## How to Test

1. `python -m pytest tests/openviking_plugin/ tests/plugins/memory/test_openviking_provider.py tests/plugins/memory/test_openviking_shutdown.py -q`
   Observed result: 101 passed.
2. Fail-on-main check: `git stash` the plugin change and rerun the new file — Observed result: 4 failed (only WARNING lines are emitted; the assertions on ERROR records fail).
3. Incident shape from the issue: with the OpenViking server stopped, a session switch attempts the commit — Observed result after the fix: `errors.log` gains `OpenViking unavailable — session … memory not committed (server unreachable)` instead of the outage being WARNING-only.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (openviking suites: 101 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comments document the classification contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — httpx exception types are platform-independent; or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
