### PR TITLE
WIP(mcp): dual-era hardening — bounded -32602 proof probe pending

### DIFF
--- a/.github/workflows/mcp-dual-era-conformance.yml
+++ b/.github/workflows/mcp-dual-era-conformance.yml
@@ -1,0 +1,58 @@
+name: mcp-dual-era-conformance
+
+on:
+  pull_request:
+    paths:
+      - 'tools/mcp_*.py'
+      - 'tools/mcp_tool.py'
+      - 'mcp_serve.py'
+      - 'agent/transports/hermes_tools_mcp_server.py'
+      - 'tests/tools/test_mcp_*.py'
+      - 'tests/fixtures/mcp_*.py'
+      - '.github/workflows/mcp-dual-era-conformance.yml'
+  push:
+    branches: [main]
+    paths:
+      # Mirror of the pull_request filter — a workflow-file change merged to
+      # main must re-trigger the push lane too (#88698 R5).
+      - 'tools/mcp_*.py'
+      - 'tools/mcp_tool.py'
+      - 'mcp_serve.py'
+      - 'agent/transports/hermes_tools_mcp_server.py'
+      - 'tests/tools/test_mcp_*.py'
+      - 'tests/fixtures/mcp_*.py'
+      - '.github/workflows/mcp-dual-era-conformance.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  dual-era-wire:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Install repo env (pinned mcp==2.0.0)
+        run: uv sync --locked --extra dev --extra mcp
+
+      - name: Build isolated legacy SDK venv (mcp==1.28.1)
+        run: |
+          uv venv .mcp-legacy
+          uv pip install --python .mcp-legacy/bin/python "mcp==1.28.1"
+
+      - name: Run dual-era wire + negotiation conformance tests
+        env:
+          # Repo-standard --locked sync above keeps the main env pinned to
+          # mcp==2.0.0; MCP_LEGACY_PYTHON points the wire tests at the
+          # isolated 1.28.1 interpreter for the legacy client/server legs.
+          MCP_LEGACY_PYTHON: ${{ github.workspace }}/.mcp-legacy/bin/python
+        run: |
+          uv run --locked \
+            python -m pytest \
+              tests/tools/test_mcp_dual_era_wire.py \
+              tests/tools/test_mcp_protocol_negotiation.py \
+              -o addopts= \
+              -q

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -266,6 +266,16 @@ def main(argv: Optional[list[str]] = None) -> int:
     os.environ.setdefault("HERMES_QUIET", "1")
     os.environ.setdefault("HERMES_REDACT_SECRETS", "true")
 
+    # #88698 R5: surface the SDK/protocol version at startup so wire-level
+    # conformance issues are diagnosable from the server's own logs.
+    try:
+        from importlib.metadata import version as _pkg_version
+
+        _sdk_version = _pkg_version("mcp")
+    except Exception:
+        _sdk_version = "unknown"
+    logger.info("hermes-tools MCP server starting (mcp SDK %s)", _sdk_version)
+
     try:
         server = _build_server()
     except ImportError as exc:

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -741,6 +741,65 @@ def cmd_mcp_list(args=None):
     print()
 
 
+# ─── hermes mcp status ────────────────────────────────────────────────────────
+
+def cmd_mcp_status(args=None):
+    """Show live MCP connection status incl. negotiated protocol state.
+
+    Unlike ``hermes mcp list`` (config-only), this prints
+    ``tools.mcp_tool.get_mcp_status()`` — live per-server state plus the
+    negotiated protocol sub-dict (resolved policy, negotiated era/version,
+    fallback reason, server identity, connection generation, liveness
+    strategy, subscription state, cache state) added for #88698 R5.
+    """
+    try:
+        from tools.mcp_tool import get_mcp_status
+    except Exception as exc:
+        _error(f"Could not load MCP status: {exc}")
+        return
+
+    entries = get_mcp_status()
+    if not entries:
+        print()
+        _info("No MCP servers configured.")
+        print()
+        _info("Add one with:")
+        _info('  hermes mcp add <name> --url <endpoint>')
+        _info('  hermes mcp add <name> --command <cmd> --args <args...>')
+        print()
+        return
+
+    print()
+    print(color("  MCP Servers (live status):", Colors.CYAN + Colors.BOLD))
+    print()
+
+    for entry in entries:
+        name = entry.get("name", "?")
+        status = entry.get("status", "?")
+        transport = entry.get("transport", "?")
+        tools = entry.get("tools", 0)
+        print(f"  {name:<20} {status:<12} {transport:<30} {tools} tool(s)")
+
+        protocol = entry.get("protocol")
+        if protocol:
+            print(f"    protocol policy:       {protocol.get('policy') or 'n/a'}")
+            print(f"    negotiated era:        {protocol.get('negotiated_era') or 'n/a'}")
+            print(f"    protocol version:      {protocol.get('negotiated_protocol_version') or 'n/a'}")
+            print(f"    fallback reason:       {protocol.get('fallback_reason') or 'none'}")
+            identity = protocol.get("server_identity")
+            if identity:
+                print(f"    server identity:       {identity}")
+            print(f"    connection generation: {protocol.get('connection_generation', 0)}")
+            print(f"    liveness strategy:     {protocol.get('liveness_strategy') or 'none'}")
+            print(f"    subscription state:    {protocol.get('subscription_state') or 'none'}")
+            print(f"    cache state:           {protocol.get('cache_state') or 'none'}")
+        if entry.get("error"):
+            print(f"    error:                 {entry['error']}")
+        print()
+
+    print()
+
+
 # ─── hermes mcp test ──────────────────────────────────────────────────────────
 
 def cmd_mcp_test(args):
@@ -1126,6 +1185,7 @@ def mcp_command(args):
         "rm": cmd_mcp_remove,
         "list": cmd_mcp_list,
         "ls": cmd_mcp_list,
+        "status": cmd_mcp_status,
         "test": cmd_mcp_test,
         "configure": cmd_mcp_configure,
         "config": cmd_mcp_configure,

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -77,6 +77,11 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
 
     mcp_sub.add_parser("list", aliases=["ls"], help="List configured MCP servers")
 
+    mcp_sub.add_parser(
+        "status",
+        help="Show live MCP connection status incl. negotiated protocol state",
+    )
+
     mcp_test_p = mcp_sub.add_parser("test", help="Test MCP server connection")
     mcp_test_p.add_argument("name", help="Server name to test")
 

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -338,6 +338,7 @@ async def mcp_oauth_callback(
     code: Optional[str] = None,
     state: Optional[str] = None,
     error: Optional[str] = None,
+    iss: Optional[str] = None,
 ):
     _gc_mcp_oauth_flows()
     with _mcp_oauth_flows_lock:
@@ -360,7 +361,10 @@ async def mcp_oauth_callback(
     if flow is None:
         return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Hermes and try again.</p>", status_code=404)
     try:
-        flow.deliver_callback(code=code, state=state, error=error)
+        # RFC 9207 ``iss`` is forwarded verbatim (never normalized) so the
+        # dashboard relay satisfies authorization servers that advertise
+        # authorization_response_iss_parameter_supported (#88698 R4).
+        flow.deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         reason = str(exc)
         status_code = 409 if "already received" in reason else 400

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -1041,6 +1041,16 @@ def run_mcp_server(verbose: bool = False) -> None:
     else:
         logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
 
+    # #88698 R5: surface the SDK/protocol version at startup so wire-level
+    # conformance issues are diagnosable from the server's own logs.
+    try:
+        from importlib.metadata import version as _pkg_version
+
+        _sdk_version = _pkg_version("mcp")
+    except Exception:
+        _sdk_version = "unknown"
+    logger.info("Hermes MCP server starting (mcp SDK %s)", _sdk_version)
+
     bridge = EventBridge()
     bridge.start()
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -279,7 +279,12 @@ async def send_and_capture(adapter, text: str, platform: Platform, **event_kwarg
     event = make_event(platform, text, **event_kwargs)
     adapter.send.reset_mock()
     await adapter.handle_message(event)
-    for _ in range(40):  # up to ~2s; returns as soon as the send lands
+    # Poll up to ~6s for the send rather than waiting a fixed delay: handler
+    # DB work hops to worker threads (AsyncSessionDB) and the first telegram
+    # parametrization pays cold plugin-discovery/config cost on slow runners,
+    # so completion latency varies (flaked at the old ~2s window in
+    # runs 28856659216 and 32251425067). Returns as soon as the send lands.
+    for _ in range(120):  # up to ~6s
         if adapter.send.called:
             break
         await asyncio.sleep(0.05)

--- a/tests/fixtures/mcp_legacy_client.py
+++ b/tests/fixtures/mcp_legacy_client.py
@@ -1,0 +1,61 @@
+"""Standalone MCP client fixture for the dual-SDK wire matrix.
+
+Runs under the isolated mcp==1.28.1 interpreter (``MCP_LEGACY_PYTHON``).
+The server command is passed as argv — it may run under a DIFFERENT
+interpreter (the main env's python for the served surfaces, or
+``MCP_LEGACY_PYTHON`` for the legacy fixture server). Uses only the
+``ClientSession``/``StdioServerParameters`` API surface, which is stable
+across mcp 1.28.1 → 2.0.0.
+
+Usage::
+
+    mcp_legacy_client.py <tool_name> <server_cmd...>
+
+Exits 0 on a successful initialize → tools/list → tools/call round-trip.
+"""
+
+import asyncio
+import sys
+
+from mcp import ClientSession, StdioServerParameters, stdio_client
+
+
+async def _main(tool_name: str, server_argv) -> int:
+    params = StdioServerParameters(command=server_argv[0], args=server_argv[1:])
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            names = {t.name for t in tools.tools}
+            if tool_name not in names:
+                print(
+                    f"ERROR: {tool_name!r} missing from {sorted(names)}",
+                    file=sys.stderr,
+                )
+                return 3
+            call = await session.call_tool(tool_name, arguments={})
+            text = "".join(
+                getattr(block, "text", "") or ""
+                for block in (getattr(call, "content", None) or [])
+            )
+            if getattr(call, "is_error", False) or getattr(call, "isError", False):
+                print(f"ERROR: tool call failed: {text}", file=sys.stderr)
+                return 4
+            print(
+                f"OK legacy-client {tool_name} "
+                f"era={getattr(session, 'protocol_version', '?')} "
+                f"result={text.strip()!r}"
+            )
+            return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(
+            "usage: mcp_legacy_client.py <tool_name> <server_cmd...>",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    tool = sys.argv[1]
+    server_argv = sys.argv[2:]
+    sys.exit(asyncio.run(_main(tool, server_argv)))

--- a/tests/fixtures/mcp_legacy_server.py
+++ b/tests/fixtures/mcp_legacy_server.py
@@ -1,0 +1,23 @@
+"""Minimal FastMCP legacy-era server fixture for the dual-SDK wire matrix.
+
+Runs ONLY under the isolated mcp==1.28.1 venv (``MCP_LEGACY_PYTHON``):
+``mcp.server.fastmcp`` was removed in mcp 2.0, so this file must never be
+imported by the main env. Exposes one arg-less tool for side-effect-free
+probing from either era client.
+"""
+
+import sys
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("legacy-fixture")
+
+
+@mcp.tool()
+def ping_echo() -> str:
+    """Arg-less echo tool — safe to call from either era client."""
+    return "pong"
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/hermes_cli/test_mcp_dashboard_oauth.py
+++ b/tests/hermes_cli/test_mcp_dashboard_oauth.py
@@ -80,10 +80,12 @@ def test_hosted_callback_bypasses_gated_cookie_auth(monkeypatch):
 
     response = TestClient(web_server.app).get(
         "/api/mcp/oauth/callback/reports?code=abc&state=expected"
+        "&iss=https%3A%2F%2Fidp.example"
     )
 
     assert response.status_code == 200
-    assert flow._callback == ("abc", "expected")
+    # #88698 R4: RFC 9207 ``iss`` survives the dashboard relay verbatim.
+    assert flow._callback == ("abc", "expected", "https://idp.example")
 
 
 def test_hosted_auth_allows_same_server_name_in_different_profiles(tmp_path, monkeypatch):
@@ -130,7 +132,7 @@ def test_flow_status_does_not_expose_authorization_code():
     )
     flow.authorization_url = "https://idp.example/authorize"
     flow.status = "approved"
-    flow._callback = ("secret-code", "secret-state")
+    flow._callback = ("secret-code", "secret-state", None)
     web_server._mcp_oauth_flows[flow.flow_id] = flow
 
     response = _client().get("/api/mcp/oauth/flows/flow-status")

--- a/tests/tools/test_mcp_dashboard_oauth.py
+++ b/tests/tools/test_mcp_dashboard_oauth.py
@@ -27,7 +27,8 @@ def test_dashboard_flow_exposes_authorization_url_and_accepts_callback():
     }
 
     flow.deliver_callback(code="code-1", state="s1", error=None)
-    assert asyncio.run(flow.wait_for_callback()) == ("code-1", "s1")
+    # #88698 R4: the bridge callback is a (code, state, iss) 3-tuple.
+    assert asyncio.run(flow.wait_for_callback()) == ("code-1", "s1", None)
 
 
 def test_dashboard_flow_accepts_only_one_concurrent_callback():
@@ -91,11 +92,18 @@ def test_mcp_oauth_helpers_use_dashboard_flow_without_loopback_port():
                 "https://idp.example/authorize?state=state-4"
             )
         )
-        flow.deliver_callback(code="code-4", state="state-4", error=None)
+        # RFC 9207 ``iss``: delivered verbatim through the bridge and fed
+        # into the SDK's AuthorizationCodeResult (#88698 R4) — this is the
+        # waiter's dashboard branch (the site where the drop used to land).
+        flow.deliver_callback(
+            code="code-4", state="state-4", error=None,
+            iss="https://idp.example",
+        )
         # mcp 2.0's callback_handler contract returns an
         # AuthorizationCodeResult, not the legacy (code, state) tuple.
         result = asyncio.run(_make_callback_waiter(0)())
         assert (result.code, result.state) == ("code-4", "state-4")
+        assert result.iss == "https://idp.example"
 
     assert flow.authorization_url == "https://idp.example/authorize?state=state-4"
 

--- a/tests/tools/test_mcp_dual_era_wire.py
+++ b/tests/tools/test_mcp_dual_era_wire.py
@@ -1,0 +1,281 @@
+"""Dual-SDK wire conformance tests (#88698 R4/R5).
+
+Runs in the dedicated ``mcp-dual-era-conformance`` CI job: the main env
+carries ``mcp==2.0.0`` and ``MCP_LEGACY_PYTHON`` points at an isolated
+``mcp==1.28.1`` venv (built by the workflow). These tests exercise REAL
+legacy (1.28.1) and REAL modern (2.0.0) wires against both served surfaces
+(``mcp_serve`` and ``agent.transports.hermes_tools_mcp_server``) plus the
+isolated legacy fixture server, and assert the observable negotiated state
+exposed by ``get_mcp_status()``'s protocol sub-dict.
+
+Skips cleanly everywhere else: the general sliced lane has no
+``MCP_LEGACY_PYTHON`` (and honors ``-m 'not integration'``), so these tests
+are no-ops there by design.
+"""
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+LEGACY_FIXTURE_SERVER = os.path.join(REPO_ROOT, "tests", "fixtures", "mcp_legacy_server.py")
+LEGACY_FIXTURE_CLIENT = os.path.join(REPO_ROOT, "tests", "fixtures", "mcp_legacy_client.py")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _dual_sdk_required(tmp_path_factory):
+    """Skip unless the dedicated dual-SDK job is present (MCP_LEGACY_PYTHON)."""
+    legacy_python = os.environ.get("MCP_LEGACY_PYTHON") or ""
+    if not legacy_python or not os.path.exists(legacy_python):
+        pytest.skip(
+            "dual-SDK wire tests require MCP_LEGACY_PYTHON (mcp==1.28.1 venv); "
+            "see .github/workflows/mcp-dual-era-conformance.yml"
+        )
+    # Isolate HERMES_HOME so spawned mcp_serve processes touch nothing real.
+    hermes_home = tmp_path_factory.mktemp("wire-hermes-home")
+    os.environ["HERMES_HOME"] = str(hermes_home)
+    return legacy_python
+
+
+def _main_python() -> str:
+    """The interpreter running this test (the repo env, mcp==2.0.0)."""
+    return sys.executable
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# No-initialize rejection (pinned JSON-RPC error)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "server_argv,label",
+    [
+        (
+            [sys.executable, "-c", "import mcp_serve; mcp_serve.run_mcp_server()"],
+            "mcp_serve",
+        ),
+        (
+            [sys.executable, "-m", "agent.transports.hermes_tools_mcp_server"],
+            "hermes-tools",
+        ),
+    ],
+    ids=["mcp_serve", "hermes-tools"],
+)
+def test_no_initialize_rejected(server_argv, label):
+    """A bare ``tools/list`` without ``initialize`` is refused with -32602.
+
+    Pins the exact JSON-RPC error both dual-era served surfaces emit for an
+    un-initialized legacy-shaped request (#88698 R4/R5). The 2026-07-28 era
+    classifies the FIRST request: a non-initialize, non-enveloped request
+    never reaches the tools kernel.
+    """
+    proc = subprocess.Popen(
+        server_argv,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, "HERMES_QUIET": "1"},
+    )
+    try:
+        req = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+        proc.stdin.write((json.dumps(req) + "\n").encode())
+        proc.stdin.flush()
+        line = proc.stdout.readline()
+        assert line, f"{label}: server exited without a response"
+        resp = json.loads(line.decode("utf-8"))
+        assert resp.get("id") == 1
+        error = resp.get("error") or {}
+        assert error.get("code") == -32602, f"{label}: unexpected error {error}"
+        assert "Invalid request parameters" in error.get("message", "")
+    finally:
+        proc.kill()
+        proc.wait()
+
+
+# ---------------------------------------------------------------------------
+# Modern (2.0.0) client ↔ legacy (1.28.1) fixture server
+# ---------------------------------------------------------------------------
+
+def test_modern_client_legacy_fixture_server(_dual_sdk_required):
+    """A mcp 2.0.0 client initializes and calls tools on a 1.28.1 server."""
+    from mcp import ClientSession, StdioServerParameters, stdio_client
+
+    legacy_python = _dual_sdk_required
+    params = StdioServerParameters(
+        command=legacy_python, args=[LEGACY_FIXTURE_SERVER]
+    )
+
+    async def drive():
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                init = await session.initialize()
+                assert getattr(init, "protocol_version", None) == "2025-11-25"
+                tools = await session.list_tools()
+                names = {t.name for t in tools.tools}
+                assert "ping_echo" in names
+                call = await session.call_tool("ping_echo", arguments={})
+                text = "".join(
+                    getattr(b, "text", "") or ""
+                    for b in (getattr(call, "content", None) or [])
+                )
+                assert text.strip() == "pong"
+
+    _run(drive())
+
+
+# ---------------------------------------------------------------------------
+# Legacy (1.28.1) client ↔ modern (2.0.0) served surfaces
+# ---------------------------------------------------------------------------
+
+def test_legacy_client_modern_hermes_tools_surface(_dual_sdk_required):
+    """The 1.28.1 fixture client speaks to the 2.0 hermes-tools surface.
+
+    Uses ``skills_list`` — a read-only, arg-less Hermes tool with no side
+    effects (never ``web_search`` etc.).
+    """
+    legacy_python = _dual_sdk_required
+    proc = subprocess.run(
+        [
+            legacy_python, LEGACY_FIXTURE_CLIENT,
+            "skills_list",
+            _main_python(), "-m", "agent.transports.hermes_tools_mcp_server",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={**os.environ, "HERMES_QUIET": "1", "HERMES_HOME": os.environ.get("HERMES_HOME", "")},
+    )
+    assert proc.returncode == 0, f"legacy client failed:\n{proc.stdout}\n{proc.stderr}"
+    assert "OK legacy-client skills_list" in proc.stdout
+
+
+def test_legacy_client_legacy_fixture_server(_dual_sdk_required):
+    """Legacy client ↔ legacy fixture server, both under the 1.28.1 venv."""
+    legacy_python = _dual_sdk_required
+    proc = subprocess.run(
+        [
+            legacy_python, LEGACY_FIXTURE_CLIENT,
+            "ping_echo",
+            legacy_python, LEGACY_FIXTURE_SERVER,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={**os.environ, "HERMES_HOME": os.environ.get("HERMES_HOME", "")},
+    )
+    assert proc.returncode == 0, f"legacy client failed:\n{proc.stdout}\n{proc.stderr}"
+    assert "OK legacy-client ping_echo" in proc.stdout
+    assert "pong" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Negotiated-state observability across real legacy + stateless wires
+# ---------------------------------------------------------------------------
+
+def test_negotiated_state_observable_after_legacy_and_stateless_wires(
+    _dual_sdk_required, monkeypatch
+):
+    """#88698 R5: negotiated-era state lands in get_mcp_status()'s protocol
+    sub-dict after REAL legacy-wire and REAL stateless-wire connects (plus a
+    cross-era fallback leg), via the client-side surface (MCPServerTask
+    ``_negotiate_session`` on real SDK sessions).
+    """
+    from mcp import ClientSession, StdioServerParameters, stdio_client
+
+    import tools.mcp_tool as mcp_tool
+
+    legacy_python = _dual_sdk_required
+    legacy_params = StdioServerParameters(
+        command=legacy_python, args=[LEGACY_FIXTURE_SERVER]
+    )
+    modern_params = StdioServerParameters(
+        command=_main_python(),
+        args=["-c", "import mcp_serve; mcp_serve.run_mcp_server()"],
+    )
+
+    results: dict = {}
+
+    async def connect_legacy_wire():
+        async with stdio_client(legacy_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                task = mcp_tool.MCPServerTask("wire-legacy")
+                task._config = {"protocol": "legacy", "command": "x"}
+                out = await task._negotiate_session(session, 30)
+                assert out is not None
+                task.session = session
+                results["legacy"] = task
+
+    async def connect_stateless_wire():
+        async with stdio_client(modern_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                task = mcp_tool.MCPServerTask("wire-stateless")
+                task._config = {"protocol": "prefer-modern", "command": "x"}
+                out = await task._negotiate_session(session, 30)
+                assert out is not None
+                task.session = session
+                results["stateless"] = task
+
+    async def connect_cross_era_fallback():
+        # prefer-modern client against a LEGACY (1.28.1) server: discover is
+        # rejected with the exact -32601 signal → recorded fallback.
+        async with stdio_client(legacy_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                task = mcp_tool.MCPServerTask("wire-cross-era")
+                task._config = {"protocol": "prefer-modern", "command": "x"}
+                out = await task._negotiate_session(session, 30)
+                assert out is not None
+                task.session = session
+                results["cross-era"] = task
+
+    _run(connect_legacy_wire())
+    _run(connect_stateless_wire())
+    _run(connect_cross_era_fallback())
+
+    monkeypatch.setattr(
+        mcp_tool, "_load_mcp_config",
+        lambda: {
+            "wire-legacy": {"command": "x"},
+            "wire-stateless": {"command": "x"},
+            "wire-cross-era": {"command": "x"},
+        },
+    )
+    with mcp_tool._lock:
+        saved_servers = dict(mcp_tool._servers)
+        mcp_tool._servers.clear()
+        mcp_tool._servers.update(results)
+
+    try:
+        statuses = {e["name"]: e for e in mcp_tool.get_mcp_status()}
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._servers.clear()
+            mcp_tool._servers.update(saved_servers)
+
+    legacy_proto = statuses["wire-legacy"]["protocol"]
+    assert legacy_proto["policy"] == "legacy"
+    assert legacy_proto["negotiated_era"] == "legacy"
+    assert legacy_proto["negotiated_protocol_version"] == "2025-11-25"
+    assert legacy_proto["fallback_reason"] == "none"
+    assert legacy_proto["connection_generation"] >= 1
+    assert legacy_proto["liveness_strategy"] == "none"
+    assert legacy_proto["subscription_state"] == "none"
+    assert legacy_proto["cache_state"] == "none"
+    assert legacy_proto["server_identity"] is not None
+
+    stateless_proto = statuses["wire-stateless"]["protocol"]
+    assert stateless_proto["policy"] == "prefer-modern"
+    assert stateless_proto["negotiated_era"] == "stateless"
+    assert stateless_proto["negotiated_protocol_version"] == "2026-07-28"
+    assert stateless_proto["fallback_reason"] == "none"
+
+    cross_era_proto = statuses["wire-cross-era"]["protocol"]
+    assert cross_era_proto["policy"] == "prefer-modern"
+    assert cross_era_proto["negotiated_era"] == "legacy"
+    assert cross_era_proto["fallback_reason"] == "discover_rejected"

--- a/tests/tools/test_mcp_dual_era_wire.py
+++ b/tests/tools/test_mcp_dual_era_wire.py
@@ -222,21 +222,30 @@ def test_negotiated_state_observable_after_legacy_and_stateless_wires(
                 task.session = session
                 results["stateless"] = task
 
-    async def connect_cross_era_fallback():
-        # prefer-modern client against a LEGACY (1.28.1) server: discover is
-        # rejected with the exact -32601 signal → recorded fallback.
+    async def connect_cross_era_no_downgrade():
+        # prefer-modern client against a LEGACY (1.28.1) server: FastMCP 1.x
+        # rejects the unknown `server/discover` method with -32602
+        # (INVALID_PARAMS — its typed request union does not know the method),
+        # NOT the exact modern-rejection signals (-32022/-32601). Per the
+        # exact-signal-only fallback rule the client must NOT silently
+        # downgrade to the handshake era on INVALID_PARAMS: the error
+        # propagates and the connection stays unnegotiated.
+        from mcp.shared.exceptions import MCPError
+
         async with stdio_client(legacy_params) as (read, write):
             async with ClientSession(read, write) as session:
                 task = mcp_tool.MCPServerTask("wire-cross-era")
                 task._config = {"protocol": "prefer-modern", "command": "x"}
-                out = await task._negotiate_session(session, 30)
-                assert out is not None
+                with pytest.raises(MCPError):
+                    await task._negotiate_session(session, 30)
+                assert task.negotiated_era == "none"
+                assert task.fallback_reason == "none"
                 task.session = session
                 results["cross-era"] = task
 
     _run(connect_legacy_wire())
     _run(connect_stateless_wire())
-    _run(connect_cross_era_fallback())
+    _run(connect_cross_era_no_downgrade())
 
     monkeypatch.setattr(
         mcp_tool, "_load_mcp_config",
@@ -277,5 +286,9 @@ def test_negotiated_state_observable_after_legacy_and_stateless_wires(
 
     cross_era_proto = statuses["wire-cross-era"]["protocol"]
     assert cross_era_proto["policy"] == "prefer-modern"
-    assert cross_era_proto["negotiated_era"] == "legacy"
-    assert cross_era_proto["fallback_reason"] == "discover_rejected"
+    # A real legacy 1.28.1 server rejects `server/discover` with -32602, so
+    # the exact-signal-only fallback correctly leaves the connection
+    # unnegotiated (no silent downgrade to the handshake era).
+    assert cross_era_proto["negotiated_era"] == "none"
+    assert cross_era_proto["fallback_reason"] == "none"
+    assert cross_era_proto["connection_generation"] >= 1

--- a/tests/tools/test_mcp_dual_era_wire.py
+++ b/tests/tools/test_mcp_dual_era_wire.py
@@ -210,7 +210,7 @@ def test_negotiated_state_observable_after_legacy_and_stateless_wires(
                 out = await task._negotiate_session(session, 30)
                 assert out is not None
                 task.session = session
-                results["legacy"] = task
+                results["wire-legacy"] = task
 
     async def connect_stateless_wire():
         async with stdio_client(modern_params) as (read, write):
@@ -220,7 +220,7 @@ def test_negotiated_state_observable_after_legacy_and_stateless_wires(
                 out = await task._negotiate_session(session, 30)
                 assert out is not None
                 task.session = session
-                results["stateless"] = task
+                results["wire-stateless"] = task
 
     async def connect_cross_era_no_downgrade():
         # prefer-modern client against a LEGACY (1.28.1) server: FastMCP 1.x
@@ -241,7 +241,7 @@ def test_negotiated_state_observable_after_legacy_and_stateless_wires(
                 assert task.negotiated_era == "none"
                 assert task.fallback_reason == "none"
                 task.session = session
-                results["cross-era"] = task
+                results["wire-cross-era"] = task
 
     _run(connect_legacy_wire())
     _run(connect_stateless_wire())

--- a/tests/tools/test_mcp_initial_connect_shutdown.py
+++ b/tests/tools/test_mcp_initial_connect_shutdown.py
@@ -118,7 +118,7 @@ def test_initial_connect_failure_revives_same_registered_server(monkeypatch, tmp
     mock_registry = ToolRegistry()
 
     class _Session:
-        async def call_tool(self, name, arguments):
+        async def call_tool(self, name, arguments, **kwargs):
             state["tool_calls"] += 1
             return SimpleNamespace(
                 isError=False,

--- a/tests/tools/test_mcp_input_required.py
+++ b/tests/tools/test_mcp_input_required.py
@@ -1,0 +1,358 @@
+"""Bounded ``input_required`` (MRTR) continuation + supervised subscriptions/listen.
+
+Acceptance tests for #88698 R2 Slices A/B/C — Hermes-owned SEP-2322
+multi-round-trip continuation (``_call_with_input_required``), connection
+generation binding, the supervised modern-era ``subscriptions/listen``
+stream with visible recovery, and the liveness tie-in. All duck-typed —
+no real MCP servers or subprocesses.
+"""
+
+import asyncio
+import contextvars
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import tools.mcp_tool as mcp_tool
+from tools.mcp_tool import (
+    MCPServerTask,
+    _LISTEN_RETRY_BACKOFFS,
+    _call_with_input_required,
+)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _task(**cfg):
+    t = MCPServerTask("mrtr-test")
+    t._config = cfg
+    return t
+
+
+def _ir(request_state="rs-1", key="elicit"):
+    """Build a real InputRequiredResult carrying one ElicitRequest."""
+    from mcp.types import ElicitRequest, InputRequiredResult
+    from mcp_types import ElicitRequestFormParams
+
+    req = ElicitRequest(
+        params=ElicitRequestFormParams(
+            message="Approve?", requestedSchema={"type": "object"}
+        )
+    )
+    return InputRequiredResult(input_requests={key: req}, request_state=request_state)
+
+
+class _FakeSession:
+    """Scripted ClientSession stand-in: records kwargs, pops scripted results."""
+
+    def __init__(self, *results):
+        self.results = list(results)
+        self.calls = []  # list of (args, kwargs)
+        self.dispatch_calls = []
+        self.dispatch_outcome = None  # None = default InputResponse, or ErrorData
+        self.replay_var = contextvars.ContextVar("mrtr-replay", default="unset")
+        self.replay_seen = None
+
+    async def call_tool(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return self.results.pop(0)
+
+    async def dispatch_input_request(self, ctx, request):
+        self.dispatch_calls.append((ctx, request))
+        self.replay_seen = self.replay_var.get()
+        return self.dispatch_outcome
+
+
+# ---------------------------------------------------------------------------
+# Slice A — bounded MRTR continuation (T1–T4)
+# ---------------------------------------------------------------------------
+
+class TestInputRequiredContinuation:
+    def test_opt_in_and_retry_carries_request_state_verbatim(self):
+        session = _FakeSession(
+            _ir(request_state="rs-original"),
+            SimpleNamespace(result="terminal"),
+        )
+        session.dispatch_outcome = SimpleNamespace(input_response=True)
+        server = _task()
+        server.session = session
+
+        async def drive():
+            # Snapshot a context whose contextvar carries the gateway session;
+            # the helper replays it into the dispatch path (T1).
+            token = session.replay_var.set("gateway-session-7")
+            server._pending_call_context = contextvars.copy_context()
+            session.replay_var.reset(token)
+            return await _call_with_input_required(
+                server, session.call_tool, "pay", arguments={"amt": 1},
+                timeout=30,
+            )
+
+        result = _run(drive())
+        assert result.result == "terminal"
+
+        # First call carried the allow_input_required opt-in.
+        first_args, first_kwargs = session.calls[0]
+        assert first_kwargs.get("allow_input_required") is True
+        assert "input_responses" not in first_kwargs
+        assert "request_state" not in first_kwargs
+
+        # Retry carried (input_responses, request_state) with request_state
+        # string-identical to what the server sent.
+        retry_args, retry_kwargs = session.calls[1]
+        assert retry_kwargs.get("request_state") == "rs-original"
+        responses = retry_kwargs.get("input_responses")
+        assert responses is not None
+        assert "elicit" in responses
+        assert retry_kwargs.get("allow_input_required") is True
+
+        # The embedded request was dispatched through dispatch_input_request
+        # with the replayed context (T1 contextvars replay).
+        assert len(session.dispatch_calls) == 1
+        ctx, request = session.dispatch_calls[0]
+        assert ctx.request_id == "elicit"
+        assert session.replay_seen == "gateway-session-7"
+
+    def test_bounded_rounds_default_cap(self):
+        server = _task()
+        session = _FakeSession(*[_ir(request_state=f"rs-{i}") for i in range(20)])
+        server.session = session
+
+        with pytest.raises(RuntimeError, match="more than 10 rounds"):
+            _run(
+                _call_with_input_required(
+                    server, session.call_tool, "pay", arguments={}, timeout=30,
+                )
+            )
+        # SDK semantics: initial call + 10 retry rounds = 11 InputRequiredResult
+        # legs max; the 12th call is never issued.
+        assert len(session.calls) == 11
+
+    def test_bounded_rounds_configurable(self):
+        server = _task(input_required_max_rounds=3)
+        session = _FakeSession(*[_ir(request_state=f"rs-{i}") for i in range(10)])
+        server.session = session
+
+        with pytest.raises(RuntimeError, match="more than 3 rounds"):
+            _run(
+                _call_with_input_required(
+                    server, session.call_tool, "pay", arguments={}, timeout=30,
+                )
+            )
+        assert len(session.calls) == 4
+
+    def test_fail_closed_refusal_aborts_no_retry(self):
+        from mcp.types import ErrorData
+
+        server = _task()
+        session = _FakeSession(_ir(request_state="rs-1"))
+        session.dispatch_outcome = ErrorData(code=-32000, message="declined")
+        server.session = session
+
+        with pytest.raises(RuntimeError, match="refused input request"):
+            _run(
+                _call_with_input_required(
+                    server, session.call_tool, "pay", arguments={}, timeout=30,
+                )
+            )
+        # The refused input was never retried: exactly one call, no retry.
+        assert len(session.calls) == 1
+
+    def test_generation_change_aborts_mid_loop(self):
+        server = _task()
+        session = _FakeSession(_ir(request_state="rs-1"))
+        server.session = session
+        original_generation = server._connection_generation
+
+        async def drive():
+            # Bump the generation between the first call and the dispatch.
+            class _BumpingSession(_FakeSession):
+                def __init__(self):
+                    super().__init__(_ir(request_state="rs-1"))
+                    self.bumped = False
+
+                async def dispatch_input_request(self, ctx, request):
+                    if not self.bumped:
+                        self.bumped = True
+                        server._connection_generation += 1
+                    return SimpleNamespace()
+
+            s = _BumpingSession()
+            server.session = s
+            with pytest.raises(RuntimeError, match="connection generation changed"):
+                await _call_with_input_required(
+                    server, s.call_tool, "pay", arguments={}, timeout=30,
+                )
+
+        _run(drive())
+        assert server._connection_generation == original_generation + 1
+
+    def test_terminal_result_passthrough_no_opt_in_flag_on_plain_result(self):
+        session = _FakeSession(SimpleNamespace(result="plain"))
+        server = _task()
+        server.session = session
+
+        out = _run(
+            _call_with_input_required(
+                server, session.call_tool, "echo", arguments={}, timeout=30,
+            )
+        )
+        assert out.result == "plain"
+        assert session.calls[0][1].get("allow_input_required") is True
+
+
+# ---------------------------------------------------------------------------
+# Slice B — supervised subscriptions/listen (T5–T7)
+# ---------------------------------------------------------------------------
+
+def _modern_session():
+    return SimpleNamespace(protocol_version="2026-07-28")
+
+
+def _handshake_session():
+    return SimpleNamespace(protocol_version="2025-11-25")
+
+
+class _FakeSubscription:
+    """Async iterator of listen events (duck-typed Subscription)."""
+
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+
+class _FakeListenStream:
+    """Async context manager yielding a _FakeSubscription (duck-typed listen())."""
+
+    def __init__(self, *events):
+        self._events = list(events)
+        self.enters = 0
+
+    async def __aenter__(self):
+        self.enters += 1
+        return _FakeSubscription(self._events)
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class TestListenSupervision:
+    def test_refetches_tools_on_list_changed(self, monkeypatch):
+        server = _task()
+        server.session = _modern_session()
+        # MCPServerTask is slotted: patch the method at class level.
+        refresh_mock = AsyncMock()
+        monkeypatch.setattr(mcp_tool.MCPServerTask, "_refresh_tools", refresh_mock)
+        changed = SimpleNamespace(type="tools/list_changed")
+        monkeypatch.setattr(
+            mcp_tool, "_open_listen_stream",
+            lambda session: _FakeListenStream(changed),
+        )
+        monkeypatch.setattr(mcp_tool, "_LISTEN_RETRY_BACKOFFS", (0.0, 0.0, 0.0))
+
+        _run(server._supervise_listen_stream())
+        refresh_mock.assert_awaited_once()
+        assert server.subscription_state == "closed"
+
+    def test_subscription_lost_recovers_with_relisten_and_refetch(self, monkeypatch):
+        server = _task()
+        server.session = _modern_session()
+        refresh_mock = AsyncMock()
+        monkeypatch.setattr(mcp_tool.MCPServerTask, "_refresh_tools", refresh_mock)
+        from mcp.client.subscriptions import SubscriptionLost
+
+        calls = {"n": 0}
+
+        def _flaky_listen(session):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise SubscriptionLost("stream dropped")
+            return _FakeListenStream(SimpleNamespace(type="tools/list_changed"))
+
+        monkeypatch.setattr(mcp_tool, "_open_listen_stream", _flaky_listen)
+        monkeypatch.setattr(mcp_tool, "_LISTEN_RETRY_BACKOFFS", (0.0, 0.0, 0.0))
+
+        _run(server._supervise_listen_stream())
+        assert calls["n"] == 2
+        assert server._listen_recovery_count >= 1
+        refresh_mock.assert_awaited_once()
+        assert server.subscription_state == "closed"
+
+    def test_listen_guard_handshake_era_no_stream(self):
+        server = _task()
+        server.session = _handshake_session()
+
+        server._start_listen_supervision()
+        assert server.subscription_state == "none"
+        assert server._listen_task is None
+
+    def test_listen_loss_exhausted_budget_triggers_reconnect(self, monkeypatch):
+        from mcp.client.subscriptions import SubscriptionLost
+
+        server = _task()
+        server.session = _modern_session()
+        refresh_mock = AsyncMock()
+        monkeypatch.setattr(mcp_tool.MCPServerTask, "_refresh_tools", refresh_mock)
+
+        def _always_lost(session):
+            raise SubscriptionLost("dead stream")
+
+        monkeypatch.setattr(mcp_tool, "_open_listen_stream", _always_lost)
+        monkeypatch.setattr(mcp_tool, "_LISTEN_RETRY_BACKOFFS", (0.0, 0.0, 0.0))
+
+        _run(server._supervise_listen_stream())
+        assert server.subscription_state == "lost"
+        assert server._reconnect_event.is_set()
+        assert server._listen_recovery_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Slice C — era-aware liveness (T8 second clause)
+# ---------------------------------------------------------------------------
+
+class TestKeepaliveEraSemantics:
+    def test_modern_era_keepalive_logs_request_level_semantics(self, caplog):
+        server = _task()
+        server.session = MagicMock()
+        server.negotiated_era = "stateless"
+        server._ping_unsupported = False
+        server.session.send_ping = AsyncMock()
+
+        with caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+            _run(server._keepalive_probe())
+
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        assert "request-level health only" in joined
+        assert server.liveness_strategy == "ping"
+
+    def test_ping_unsupported_latches_list_tools_strategy(self, monkeypatch):
+        from mcp.shared.exceptions import MCPError
+        from mcp.types import ErrorData
+
+        server = _task()
+        server.session = MagicMock()
+        server.negotiated_era = "legacy"
+        server.session.send_ping = AsyncMock(
+            side_effect=MCPError.from_error_data(
+                ErrorData(code=-32601, message="Method not found: ping")
+            )
+        )
+        server.session.list_tools = AsyncMock()
+        monkeypatch.setattr(
+            mcp_tool.MCPServerTask, "_advertises_tools", lambda self: True
+        )
+
+        _run(server._keepalive_probe())
+        assert server._ping_unsupported is True
+        assert server.liveness_strategy == "list_tools"

--- a/tests/tools/test_mcp_list_pagination.py
+++ b/tests/tools/test_mcp_list_pagination.py
@@ -45,6 +45,135 @@ class TestPaginateFullList:
         assert len(items) == _MCP_LIST_MAX_PAGES
 
 
+class TestCacheMetaAggregation:
+    """#88698 R3: SEP-2549 hints aggregate conservatively across ALL pages."""
+
+    def _page(self, ttl=None, scope=None, cursor=None):
+        return SimpleNamespace(
+            tools=[_tool("a")],
+            ttl_ms=ttl,
+            cache_scope=scope,
+            nextCursor=cursor,
+        )
+
+    def test_ttl_aggregates_min_across_pages(self):
+        meta = {}
+        pages = {
+            None: self._page(ttl=60_000, cursor="p2"),
+            "p2": self._page(ttl=5_000),
+        }
+
+        async def list_method(cursor=None):
+            return pages[cursor]
+
+        asyncio.run(
+            _paginate_full_list(list_method, "tools", "srv", cache_meta_out=meta)
+        )
+        assert meta["ttl_ms"] == 5_000
+
+    def test_zero_ttl_wins(self):
+        meta = {}
+        pages = {
+            None: self._page(ttl=60_000, cursor="p2"),
+            "p2": self._page(ttl=0),
+        }
+
+        async def list_method(cursor=None):
+            return pages[cursor]
+
+        asyncio.run(
+            _paginate_full_list(list_method, "tools", "srv", cache_meta_out=meta)
+        )
+        assert meta["ttl_ms"] == 0
+
+    def test_page1_ttl_still_captured(self):
+        # Regression for the old ``not items`` path: a single page's hint
+        # must still be recorded.
+        meta = {}
+
+        async def list_method(cursor=None):
+            return self._page(ttl=60_000)
+
+        asyncio.run(
+            _paginate_full_list(list_method, "tools", "srv", cache_meta_out=meta)
+        )
+        assert meta["ttl_ms"] == 60_000
+
+    def test_numeric_string_ttl_coerced(self):
+        meta = {}
+
+        async def list_method(cursor=None):
+            return self._page(ttl="5000")
+
+        asyncio.run(
+            _paginate_full_list(list_method, "tools", "srv", cache_meta_out=meta)
+        )
+        assert meta["ttl_ms"] == 5000.0
+
+        meta2 = {}
+
+        async def list_method2(cursor=None):
+            return self._page(ttl="soon")
+
+        asyncio.run(
+            _paginate_full_list(list_method2, "tools", "srv", cache_meta_out=meta2)
+        )
+        assert "ttl_ms" not in meta2
+
+    def test_scope_conflict_fails_closed(self):
+        meta = {}
+        pages = {
+            None: self._page(ttl=60_000, scope="public", cursor="p2"),
+            "p2": self._page(ttl=60_000, scope="private"),
+        }
+
+        async def list_method(cursor=None):
+            return pages[cursor]
+
+        asyncio.run(
+            _paginate_full_list(list_method, "tools", "srv", cache_meta_out=meta)
+        )
+        assert meta["cache_scope"] == "private"
+
+        meta2 = {}
+
+        async def list_method2(cursor=None):
+            return self._page(ttl=60_000, scope="public")
+
+        asyncio.run(
+            _paginate_full_list(list_method2, "tools", "srv", cache_meta_out=meta2)
+        )
+        assert meta2["cache_scope"] == "public"
+
+    def test_scope_captured_from_any_page(self):
+        # Fixes the page-1-missing case: the hint may arrive on page 2.
+        meta = {}
+        pages = {
+            None: self._page(ttl=60_000, cursor="p2"),
+            "p2": self._page(ttl=60_000, scope="public"),
+        }
+
+        async def list_method(cursor=None):
+            return pages[cursor]
+
+        asyncio.run(
+            _paginate_full_list(list_method, "tools", "srv", cache_meta_out=meta)
+        )
+        assert meta["cache_scope"] == "public"
+
+    def test_no_cache_meta_out_is_noop(self):
+        pages = {
+            None: self._page(ttl=60_000, cursor="p2"),
+            "p2": self._page(ttl=5_000),
+        }
+
+        async def list_method(cursor=None):
+            return pages[cursor]
+
+        items = asyncio.run(_paginate_full_list(list_method, "tools", "srv"))
+        assert len(items) == 2
+
+
 class TestDiscoveryUsesPagination:
     def test_discover_tools_drains_all_pages(self):
         """MCPServerTask._discover_tools registers tools from every page."""

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -447,6 +447,26 @@ class TestCallbackHandlerIsolation:
         assert result["auth_code"] is None
         assert result["error"] == "access_denied"
 
+    def test_handler_captures_iss(self):
+        # #88698 R4: RFC 9207 authorization-response issuer must survive the
+        # loopback callback handler and reach the SDK's
+        # AuthorizationCodeResult.iss.
+        HandlerClass, result = _make_callback_handler()
+
+        self._fake_get(
+            HandlerClass,
+            "/callback?code=t&state=s&iss=https%3A%2F%2Fidp.example",
+        )
+
+        assert result["auth_code"] == "t"
+        assert result["state"] == "s"
+        assert result["iss"] == "https://idp.example"
+
+    def test_handler_without_iss_records_none(self):
+        HandlerClass, result = _make_callback_handler()
+        self._fake_get(HandlerClass, "/callback?code=t&state=s")
+        assert result["iss"] is None
+
 
 # ---------------------------------------------------------------------------
 # TOCTOU port reservation (#22161)
@@ -506,7 +526,10 @@ class TestCallbackPortReservation:
             task = asyncio.create_task(mod._wait_for_callback())
             threading.Thread(
                 target=_hit_callback_when_ready,
-                args=(f"http://127.0.0.1:{port}/callback?code=abc123&state=xyz",),
+                args=(
+                    "http://127.0.0.1:{port}/callback?code=abc123&state=xyz"
+                    "&iss=https%3A%2F%2Fidp.example".format(port=port),
+                ),
                 daemon=True,
             ).start()
             return await asyncio.wait_for(task, timeout=20)
@@ -516,6 +539,8 @@ class TestCallbackPortReservation:
         result = asyncio.run(drive())
         assert result.code == "abc123"
         assert result.state == "xyz"
+        # RFC 9207 ``iss`` survives the full loopback path (#88698 R4).
+        assert result.iss == "https://idp.example"
         # Reservation was consumed by adoption.
         assert port not in mod._reserved_sockets
 
@@ -929,7 +954,9 @@ class TestPasteCallbackReader:
     """_paste_callback_reader parses redirect URLs / query strings from stdin."""
 
     def _empty_result(self):
-        return {"auth_code": None, "state": None, "error": None}
+        # Mirrors _make_callback_handler's production slot shape incl. the
+        # RFC 9207 ``iss`` slot (#88698 R4).
+        return {"auth_code": None, "state": None, "error": None, "iss": None}
 
     def test_parses_pasted_callback(self, monkeypatch):
         result = self._empty_result()
@@ -939,6 +966,19 @@ class TestPasteCallbackReader:
         assert result["auth_code"] == "abc"
         assert result["state"] == "xyz"
         assert result["error"] is None
+
+    def test_pasted_callback_preserves_iss(self, monkeypatch):
+        # #88698 R4: RFC 9207 ``iss`` survives the paste path.
+        result = self._empty_result()
+        pasted = (
+            "http://127.0.0.1:37949/callback?code=abc&state=xyz"
+            "&iss=https%3A%2F%2Fidp.example\n"
+        )
+        monkeypatch.setattr("sys.stdin", MagicMock(readline=lambda: pasted))
+        _paste_callback_reader(result)
+        assert result["auth_code"] == "abc"
+        assert result["state"] == "xyz"
+        assert result["iss"] == "https://idp.example"
 
 
     def test_swallows_stdin_errors(self, monkeypatch):
@@ -998,7 +1038,9 @@ class TestPasteCallbackSkipToken:
     """User can type `skip` (or similar) at the paste prompt to bail out."""
 
     def _empty_result(self):
-        return {"auth_code": None, "state": None, "error": None}
+        # Mirrors _make_callback_handler's production slot shape incl. the
+        # RFC 9207 ``iss`` slot (#88698 R4).
+        return {"auth_code": None, "state": None, "error": None, "iss": None}
 
     @pytest.mark.parametrize("token", ["skip", "QUIT"])
     def test_skip_tokens_set_sentinel(self, monkeypatch, token):

--- a/tests/tools/test_mcp_protocol_negotiation.py
+++ b/tests/tools/test_mcp_protocol_negotiation.py
@@ -3,7 +3,9 @@
 The negotiation helper decides between the legacy ``initialize`` handshake
 and the stateless ``server/discover`` probe (SEP-2575) per the per-server
 ``protocol`` config key. These tests drive it with duck-typed sessions —
-the live-path integration is covered by the real-server E2E in the PR.
+the live-path integration is covered by the real-server dual-SDK E2E in
+``tests/tools/test_mcp_dual_era_wire.py`` (runs under the
+mcp-dual-era-conformance CI job; skips where MCP_LEGACY_PYTHON is unset).
 """
 
 import asyncio
@@ -14,6 +16,7 @@ from tools.mcp_tool import (
     MCPServerTask,
     _handshake_rejected_as_modern,
     _JSONRPC_UNSUPPORTED_PROTOCOL_VERSION,
+    _resolve_protocol_policy,
 )
 
 
@@ -118,10 +121,20 @@ class TestExplicitModes:
             _run(_task("legacy")._negotiate_session(s, 5))
         assert s.calls == ["initialize"]
 
-    def test_unknown_mode_treated_as_auto(self):
+    def test_unknown_mode_rejected(self):
         s = _Session(init="INIT_RESULT")
-        out = _run(_task("bogus")._negotiate_session(s, 5))
-        assert out == "INIT_RESULT"
+        with pytest.raises(ValueError, match="not a valid policy"):
+            _run(_task("bogus")._negotiate_session(s, 5))
+        assert s.calls == []
+
+    def test_non_string_protocol_rejected(self):
+        for bad in (None, 42):
+            t = _task()
+            t._config = {"protocol": bad}
+            s = _Session(init="INIT_RESULT")
+            with pytest.raises(ValueError, match="protocol must be a string"):
+                _run(t._negotiate_session(s, 5))
+            assert s.calls == []
 
     def test_legacy_sdk_session_without_discover_reraises(self):
         # mcp 1.x ClientSession has no .discover(): the auto fallback must
@@ -142,3 +155,147 @@ class TestModernRejectionClassifier:
         assert _handshake_rejected_as_modern(Exception("Unsupported protocol version"))
         assert _handshake_rejected_as_modern(Exception("Unknown method: initialize"))
         assert not _handshake_rejected_as_modern(Exception("connection reset by peer"))
+
+
+class TestPolicyResolution:
+    def test_aliases_map(self):
+        assert _resolve_protocol_policy("auto") == "prefer-legacy"
+        assert _resolve_protocol_policy("handshake") == "legacy"
+        assert _resolve_protocol_policy("stateless") == "prefer-modern"
+        assert _resolve_protocol_policy("modern") == "prefer-modern"
+        assert _resolve_protocol_policy("2026-07-28") == "prefer-modern"
+        assert _resolve_protocol_policy("legacy") == "legacy"
+        assert _resolve_protocol_policy("prefer-legacy") == "prefer-legacy"
+        assert _resolve_protocol_policy("prefer-modern") == "prefer-modern"
+        assert _resolve_protocol_policy("strict-modern") == "strict-modern"
+        # Case/whitespace tolerance, like the old mode normalization.
+        assert _resolve_protocol_policy("  AUTO ") == "prefer-legacy"
+
+    def test_unknown_value_rejected(self):
+        for bad in ("bogus", "dual", "hybrid", ""):
+            with pytest.raises(ValueError, match="not a valid policy"):
+                _resolve_protocol_policy(bad)
+
+    def test_non_string_rejected(self):
+        for bad in (None, 42, ["auto"], {"protocol": "legacy"}):
+            with pytest.raises(ValueError, match="protocol must be a string"):
+                _resolve_protocol_policy(bad)
+
+
+class TestPreferModernMode:
+    def test_discover_first_success(self):
+        s = _Session(init="INIT_RESULT", disc="DISC_RESULT")
+        out = _run(_task("prefer-modern")._negotiate_session(s, 5))
+        assert out == "DISC_RESULT"
+        assert s.calls == ["discover"]
+
+    def test_falls_back_on_method_not_found(self):
+        s = _Session(init="INIT_RESULT", disc=_Err(-32601))
+        out = _run(_task("prefer-modern")._negotiate_session(s, 5))
+        assert out == "INIT_RESULT"
+        assert s.calls == ["discover", "initialize"]
+
+    def test_falls_back_on_unsupported_protocol_version(self):
+        s = _Session(init="INIT_RESULT", disc=_Err(_JSONRPC_UNSUPPORTED_PROTOCOL_VERSION))
+        out = _run(_task("prefer-modern")._negotiate_session(s, 5))
+        assert out == "INIT_RESULT"
+        assert s.calls == ["discover", "initialize"]
+
+    def test_invalid_params_propagates_without_fallback(self):
+        # NEW BEHAVIOR (the #88698 defect fix): a non-exact signal must NOT
+        # silently downgrade the connection to the handshake era.
+        s = _Session(init="INIT_RESULT", disc=_Err(-32602))
+        with pytest.raises(_Err):
+            _run(_task("prefer-modern")._negotiate_session(s, 5))
+        assert s.calls == ["discover"]
+
+    def test_internal_error_propagates_without_fallback(self):
+        s = _Session(init="INIT_RESULT", disc=_Err(-32000, "borked"))
+        with pytest.raises(_Err):
+            _run(_task("prefer-modern")._negotiate_session(s, 5))
+        assert s.calls == ["discover"]
+
+    def test_timeout_propagates_without_fallback(self):
+        class _Hang(_Session):
+            async def discover(self):
+                await asyncio.sleep(30)
+
+        with pytest.raises(asyncio.TimeoutError):
+            _run(_task("prefer-modern")._negotiate_session(_Hang(), 0.05))
+
+
+class TestStrictModernMode:
+    def test_discover_first_success(self):
+        s = _Session(init="INIT_RESULT", disc="DISC_RESULT")
+        out = _run(_task("strict-modern")._negotiate_session(s, 5))
+        assert out == "DISC_RESULT"
+        assert s.calls == ["discover"]
+
+    def test_method_not_found_propagates_no_downgrade(self):
+        # strict-modern refuses to downgrade even on the exact modern
+        # rejection signals.
+        s = _Session(init="INIT_RESULT", disc=_Err(-32601))
+        with pytest.raises(_Err):
+            _run(_task("strict-modern")._negotiate_session(s, 5))
+        assert s.calls == ["discover"]
+
+    def test_unsupported_protocol_version_propagates(self):
+        s = _Session(init="INIT_RESULT", disc=_Err(_JSONRPC_UNSUPPORTED_PROTOCOL_VERSION))
+        with pytest.raises(_Err):
+            _run(_task("strict-modern")._negotiate_session(s, 5))
+        assert s.calls == ["discover"]
+
+
+class TestPreferLegacyMode:
+    def test_initialize_first_success(self):
+        s = _Session(init="INIT_RESULT", disc="DISC_RESULT")
+        out = _run(_task("prefer-legacy")._negotiate_session(s, 5))
+        assert out == "INIT_RESULT"
+        assert s.calls == ["initialize"]
+
+    def test_falls_back_to_discover_on_unsupported_protocol_version(self):
+        s = _Session(init=_Err(_JSONRPC_UNSUPPORTED_PROTOCOL_VERSION), disc="DISC_RESULT")
+        out = _run(_task("prefer-legacy")._negotiate_session(s, 5))
+        assert out == "DISC_RESULT"
+        assert s.calls == ["initialize", "discover"]
+
+    def test_falls_back_to_discover_on_method_not_found(self):
+        s = _Session(init=_Err(-32601, "Method not found: initialize"), disc="DISC_RESULT")
+        out = _run(_task("prefer-legacy")._negotiate_session(s, 5))
+        assert out == "DISC_RESULT"
+
+    def test_unrelated_error_propagates(self):
+        s = _Session(init=_Err(-32000, "borked"), disc="DISC_RESULT")
+        with pytest.raises(_Err):
+            _run(_task("prefer-legacy")._negotiate_session(s, 5))
+        assert s.calls == ["initialize"]
+
+    def test_legacy_sdk_session_without_discover_reraises(self):
+        s = _LegacySession(init=_Err(_JSONRPC_UNSUPPORTED_PROTOCOL_VERSION))
+        with pytest.raises(_Err):
+            _run(_task("prefer-legacy")._negotiate_session(s, 5))
+        assert s.calls == ["initialize"]
+
+
+class TestNegotiationObservability:
+    def test_success_logs_policy_and_dialect(self, caplog):
+        import logging
+
+        s = _Session(init="INIT_RESULT")
+        with caplog.at_level(logging.INFO, logger="tools.mcp_tool"):
+            out = _run(_task("prefer-legacy")._negotiate_session(s, 5))
+        assert out == "INIT_RESULT"
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        assert "protocol policy=prefer-legacy" in joined
+        assert "connected via legacy initialize handshake" in joined
+
+    def test_fallback_logs_trigger_signal(self, caplog):
+        import logging
+
+        s = _Session(init=_Err(_JSONRPC_UNSUPPORTED_PROTOCOL_VERSION), disc="DISC_RESULT")
+        with caplog.at_level(logging.INFO, logger="tools.mcp_tool"):
+            out = _run(_task("prefer-legacy")._negotiate_session(s, 5))
+        assert out == "DISC_RESULT"
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        assert "after fallback signal" in joined
+        assert str(_JSONRPC_UNSUPPORTED_PROTOCOL_VERSION) in joined

--- a/tests/tools/test_mcp_schema_cache.py
+++ b/tests/tools/test_mcp_schema_cache.py
@@ -30,6 +30,109 @@ class TestConfigFingerprint:
             {**base, "timeout": 5, "enabled": True, "lazy": True}
         )
 
+    def test_changes_when_headers_change(self):
+        base = {"command": "npx", "args": []}
+        assert msc.config_fingerprint(base) != msc.config_fingerprint(
+            {**base, "headers": {"X-Tenant": "a"}}
+        )
+        # Header NAMES are case-insensitive (casing-only edits are stable).
+        assert msc.config_fingerprint(
+            {**base, "headers": {"X-Tenant": "a"}}
+        ) == msc.config_fingerprint(
+            {**base, "headers": {"x-tenant": "a"}}
+        )
+        # Header VALUES are hashed: changing the value changes the partition.
+        assert msc.config_fingerprint(
+            {**base, "headers": {"X-Tenant": "a"}}
+        ) != msc.config_fingerprint(
+            {**base, "headers": {"X-Tenant": "b"}}
+        )
+
+    def test_changes_when_env_changes(self):
+        base = {"command": "npx", "args": []}
+        assert msc.config_fingerprint(
+            {**base, "env": {"FOO": "a"}}
+        ) != msc.config_fingerprint(
+            {**base, "env": {"FOO": "b"}}
+        )
+        # Key order must not change the fingerprint.
+        assert msc.config_fingerprint(
+            {**base, "env": {"FOO": "a", "BAR": "b"}}
+        ) == msc.config_fingerprint(
+            {**base, "env": {"BAR": "b", "FOO": "a"}}
+        )
+
+    def test_changes_when_auth_context_changes(self):
+        base = {"command": "npx", "args": []}
+        assert msc.config_fingerprint(
+            {**base, "auth": "bearer"}
+        ) != msc.config_fingerprint(
+            {**base, "auth": "none"}
+        )
+        assert msc.config_fingerprint(
+            {**base, "oauth": {"audience": "x"}}
+        ) != msc.config_fingerprint(
+            {**base, "oauth": {"audience": "y"}}
+        )
+
+    def test_changes_when_identity_header_changes(self, monkeypatch):
+        base = {"command": "npx", "args": []}
+        alice = {"identity_header": {"name": "X-User-Id", "value_from": "static", "value": "alice"}}
+        bob = {"identity_header": {"name": "X-User-Id", "value_from": "static", "value": "bob"}}
+        assert msc.config_fingerprint({**base, **alice}) != msc.config_fingerprint(
+            {**base, **bob}
+        )
+        # profile mode resolves to the active profile name — a different
+        # principal partitions differently.
+        import hermes_cli.profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "work")
+        profile_cfg = {"identity_header": {"name": "X-User-Id", "value_from": "profile"}}
+        work_fp = msc.config_fingerprint({**base, **profile_cfg})
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "personal")
+        personal_fp = msc.config_fingerprint({**base, **profile_cfg})
+        assert work_fp != personal_fp
+        assert work_fp != msc.config_fingerprint({**base, **alice})
+
+    def test_changes_when_protocol_era_changes(self, monkeypatch):
+        base = {"command": "npx", "args": []}
+        monkeypatch.setattr(msc, "_resolve_protocol_era", lambda: "2025-11-25")
+        legacy_fp = msc.config_fingerprint(base)
+        monkeypatch.setattr(msc, "_resolve_protocol_era", lambda: "2026-07-28")
+        assert msc.config_fingerprint(base) != legacy_fp
+
+    def test_changes_when_epoch_bumps(self, monkeypatch):
+        base = {"command": "npx", "args": []}
+        v1 = msc.config_fingerprint(base)
+        monkeypatch.setattr(msc, "CACHE_SCHEMA_VERSION", 99)
+        assert msc.config_fingerprint(base) != v1
+
+    def test_changes_on_ssl_and_cert(self):
+        base = {"command": "npx", "args": []}
+        assert msc.config_fingerprint(base) != msc.config_fingerprint(
+            {**base, "ssl_verify": False}
+        )
+        assert msc.config_fingerprint(base) != msc.config_fingerprint(
+            {**base, "client_cert": "/x.pem"}
+        )
+
+    def test_preserves_ignored_keys(self):
+        # Non-schema-affecting keys stay out of the fingerprint …
+        base = {"command": "npx", "args": []}
+        assert msc.config_fingerprint(base) == msc.config_fingerprint(
+            {**base, "connect_timeout": 5}
+        )
+        # … while schema-affecting context keys are covered by it.
+        assert msc.config_fingerprint(base) != msc.config_fingerprint(
+            {**base, "strict_redirect_headers": True}
+        )
+
+    def test_protocol_pin_partitions(self):
+        base = {"command": "npx", "args": []}
+        assert msc.config_fingerprint(base) != msc.config_fingerprint(
+            {**base, "protocol_version": "2025-11-25"}
+        )
+
 
 class TestCacheRoundTrip:
     def _isolate(self, monkeypatch, tmp_path):

--- a/tests/tools/test_mcp_schema_cache_ttl.py
+++ b/tests/tools/test_mcp_schema_cache_ttl.py
@@ -115,9 +115,10 @@ def test_config_digest_mismatch_is_a_miss():
     assert sc.get_cached_entry("srv", "fp") is not None
     assert sc.get_cached_entry("srv", "fp", config_digest="B") is None
     assert sc.get_cached_entry("srv", "fp", config_digest="A") is not None
-    # An entry written WITHOUT a digest is served for any read digest.
+    # A read with a digest never matches an entry written without one
+    # (stored None) — fail closed on hand-written/legacy entries.
     sc.write_cache_entry("srv2", "fp", tools=[{"name": "t"}])
-    assert sc.get_cached_entry("srv2", "fp", config_digest="X") is not None
+    assert sc.get_cached_entry("srv2", "fp", config_digest="X") is None
 
 
 def test_partition_keying_no_eviction():

--- a/tests/tools/test_mcp_schema_cache_ttl.py
+++ b/tests/tools/test_mcp_schema_cache_ttl.py
@@ -49,3 +49,109 @@ def test_cache_scope_round_trips():
         "srv", "fp", tools=[{"name": "t"}], ttl_ms=60_000, cache_scope="private"
     )
     assert sc.get_cached_entry("srv", "fp")["cache_scope"] == "private"
+
+
+def test_max_ttl_caps_write():
+    sc.write_cache_entry("srv", "fp", tools=[{"name": "t"}], ttl_ms=1e12)
+    entry = sc.get_cached_entry("srv", "fp")
+    assert entry is not None
+    assert entry["ttl_ms"] == sc.MAX_TTL_MS
+
+
+def test_max_ttl_caps_read():
+    # Hand-write an entry whose stored ttl_ms exceeds the cap (legacy raw
+    # value or hand-edited file): the read treats the effective TTL as
+    # MAX_TTL_MS, so an entry older than 24 h is a miss.
+    import json
+
+    path = sc._cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    stale_written_at = time.time() - (sc.MAX_TTL_MS / 1000.0) - 1.0
+    path.write_text(
+        json.dumps(
+            {
+                "srv::fp": {
+                    "epoch": sc.CACHE_SCHEMA_VERSION,
+                    "fingerprint": "fp",
+                    "ttl_ms": 1e12,
+                    "written_at": stale_written_at,
+                    "tools": [{"name": "t"}],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert sc.get_cached_entry("srv", "fp") is None
+    # And a fresh entry under the same raw value IS served (effective TTL
+    # clamped to MAX_TTL_MS, still in the future).
+    fresh = time.time()
+    path.write_text(
+        json.dumps(
+            {
+                "srv::fp": {
+                    "epoch": sc.CACHE_SCHEMA_VERSION,
+                    "fingerprint": "fp",
+                    "ttl_ms": 1e12,
+                    "written_at": fresh,
+                    "tools": [{"name": "t"}],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert sc.get_cached_entry("srv", "fp") is not None
+
+
+def test_epoch_mismatch_is_a_miss(monkeypatch):
+    sc.write_cache_entry("srv", "fp", tools=[{"name": "t"}])
+    assert sc.get_cached_entry("srv", "fp") is not None
+    monkeypatch.setattr(sc, "CACHE_SCHEMA_VERSION", 99)
+    assert sc.get_cached_entry("srv", "fp") is None
+
+
+def test_config_digest_mismatch_is_a_miss():
+    sc.write_cache_entry("srv", "fp", tools=[{"name": "t"}], config_digest="A")
+    # config_digest=None (omitted) skips gate 4 — back-compat, served.
+    assert sc.get_cached_entry("srv", "fp") is not None
+    assert sc.get_cached_entry("srv", "fp", config_digest="B") is None
+    assert sc.get_cached_entry("srv", "fp", config_digest="A") is not None
+    # An entry written WITHOUT a digest is served for any read digest.
+    sc.write_cache_entry("srv2", "fp", tools=[{"name": "t"}])
+    assert sc.get_cached_entry("srv2", "fp", config_digest="X") is not None
+
+
+def test_partition_keying_no_eviction():
+    sc.write_cache_entry("srv", "fpA", tools=[{"name": "a"}])
+    sc.write_cache_entry("srv", "fpB", tools=[{"name": "b"}])
+    assert sc.tools_from_cache_entry(sc.get_cached_entry("srv", "fpA")) == [
+        {"name": "a"}
+    ]
+    assert sc.tools_from_cache_entry(sc.get_cached_entry("srv", "fpB")) == [
+        {"name": "b"}
+    ]
+
+
+def test_clear_cache_entry_clears_all_partitions():
+    sc.write_cache_entry("srv", "fpA", tools=[{"name": "a"}])
+    sc.write_cache_entry("srv", "fpB", tools=[{"name": "b"}])
+    sc.write_cache_entry("other", "fpA", tools=[{"name": "o"}])
+    sc.clear_cache_entry("srv")
+    assert sc.get_cached_entry("srv", "fpA") is None
+    assert sc.get_cached_entry("srv", "fpB") is None
+    assert sc.get_cached_entry("other", "fpA") is not None
+
+
+def test_config_digest_hashes_values():
+    digest = sc.config_digest({"auth_token": "sekret"})
+    assert "sekret" not in digest
+    import hashlib
+    import json as _json
+
+    raw_hash = hashlib.sha256(
+        _json.dumps({"auth_token": "sekret"}, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    assert digest != raw_hash[:16]
+    # Stable across key order.
+    assert sc.config_digest({"a": 1, "b": 2}) == sc.config_digest({"b": 2, "a": 1})
+    # Any config edit (even non-fingerprinted keys) changes the digest.
+    assert sc.config_digest({"timeout": 5}) != sc.config_digest({"timeout": 6})

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -312,6 +312,59 @@ class TestMCPStatus:
         assert statuses["disabled"]["status"] == "disabled"
         assert statuses["disabled"]["disabled"] is True
 
+    def test_connected_server_exposes_protocol_subdict(self, monkeypatch):
+        """#88698 R5: connected servers carry the negotiated protocol sub-dict."""
+        import tools.mcp_tool as mcp_tool
+
+        server = SimpleNamespace(
+            session=object(),
+            _registered_tool_names=["mcp--t"],
+            _tools=[],
+            _sampling=None,
+            _protocol_policy="prefer-modern",
+            negotiated_era="stateless",
+            negotiated_protocol_version="2026-07-28",
+            fallback_reason="none",
+            server_identity={"name": "hermes-test", "version": "1.0.0"},
+            _connection_generation=3,
+            liveness_strategy="ping",
+            subscription_state="active",
+            cache_state="live",
+        )
+        monkeypatch.setattr(
+            mcp_tool, "_load_mcp_config",
+            lambda: {"connected": {"command": "docker"}},
+        )
+        with mcp_tool._lock:
+            saved_servers = dict(mcp_tool._servers)
+            mcp_tool._servers.clear()
+            mcp_tool._servers["connected"] = server
+
+        try:
+            statuses = {
+                entry["name"]: entry
+                for entry in mcp_tool.get_mcp_status()
+            }
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._servers.clear()
+                mcp_tool._servers.update(saved_servers)
+
+        entry = statuses["connected"]
+        assert entry["status"] == "connected"
+        protocol = entry["protocol"]
+        assert protocol["policy"] == "prefer-modern"
+        assert protocol["negotiated_era"] == "stateless"
+        assert protocol["negotiated_protocol_version"] == "2026-07-28"
+        assert protocol["fallback_reason"] == "none"
+        assert protocol["server_identity"] == {
+            "name": "hermes-test", "version": "1.0.0",
+        }
+        assert protocol["connection_generation"] == 3
+        assert protocol["liveness_strategy"] == "ping"
+        assert protocol["subscription_state"] == "active"
+        assert protocol["cache_state"] == "live"
+
 
 class TestLifecycleConfig:
     def test_get_lifecycle_seconds_accepts_top_level_and_nested_values(self):

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -625,7 +625,11 @@ class TestToolHandler:
             with self._patch_mcp_loop():
                 result = json.loads(handler({"name": "world"}))
             assert result["result"] == "hello world"
-            mock_session.call_tool.assert_called_once_with("greet", arguments={"name": "world"})
+            # #88698 R2: the MRTR opt-in (allow_input_required=True) is now
+            # always passed on the result-bearing call sites.
+            mock_session.call_tool.assert_called_once_with(
+                "greet", arguments={"name": "world"}, allow_input_required=True
+            )
         finally:
             _servers.pop("test_srv", None)
 
@@ -656,7 +660,11 @@ class TestToolHandler:
                 result = json.loads(handler({"name": "world"}))
             assert result["result"] == "reconnected"
             reconnect.assert_called_once()
-            mock_session.call_tool.assert_called_once_with("greet", arguments={"name": "world"})
+            # #88698 R2: the MRTR opt-in (allow_input_required=True) is now
+            # always passed on the result-bearing call sites.
+            mock_session.call_tool.assert_called_once_with(
+                "greet", arguments={"name": "world"}, allow_input_required=True
+            )
         finally:
             _servers.pop("test_srv", None)
 
@@ -1677,8 +1685,10 @@ class TestUtilityHandlers:
             assert len(result["messages"]) == 1
             assert result["messages"][0]["role"] == "assistant"
             assert "summary" in result["messages"][0]["content"].lower()
+            # #88698 R2: the MRTR opt-in (allow_input_required=True) is now
+            # always passed on the result-bearing call sites.
             mock_session.get_prompt.assert_called_once_with(
-                "summarize", arguments={"text": "hello"}
+                "summarize", arguments={"text": "hello"}, allow_input_required=True
             )
         finally:
             _servers.pop("srv", None)

--- a/tests/tui_gateway/test_mcp_oauth_sessions.py
+++ b/tests/tui_gateway/test_mcp_oauth_sessions.py
@@ -1,0 +1,121 @@
+"""TUI gateway MCP OAuth loopback relay — RFC 9207 ``iss`` survival.
+
+There is zero coverage of ``tui_gateway.mcp_oauth_sessions`` in the tree;
+this file drives the real loopback listener with a real
+``DashboardOAuthFlow`` and pins the RFC 9207 authorization-response issuer
+surviving the relay (#88698 R4).
+"""
+
+import asyncio
+import http.client
+
+import pytest
+
+
+def test_loopback_listener_forwards_iss():
+    from tui_gateway.mcp_oauth_sessions import (
+        _shutdown_listener,
+        _start_loopback_listener,
+    )
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    flow = DashboardOAuthFlow(
+        flow_id="tui-iss",
+        server_name="reports",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="http://127.0.0.1:1/callback",
+    )
+    asyncio.run(flow.publish_authorization_url("https://idp.example/authorize?state=s1"))
+
+    rec = {"httpd": None}
+    try:
+        server = _start_loopback_listener(flow)
+        rec["httpd"] = server
+        port = server.server_address[1]
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+        conn.request(
+            "GET",
+            "/callback?code=tui-code&state=s1&iss=https%3A%2F%2Fidp.example",
+        )
+        resp = conn.getresponse()
+        assert resp.status == 200
+        resp.read()
+        conn.close()
+
+        # The 3-tuple (code, state, iss) with iss intact — the shape the
+        # waiter's dashboard branch feeds into AuthorizationCodeResult.
+        assert asyncio.run(flow.wait_for_callback()) == (
+            "tui-code",
+            "s1",
+            "https://idp.example",
+        )
+    finally:
+        _shutdown_listener(rec)
+
+
+def test_loopback_listener_without_iss_records_none():
+    from tui_gateway.mcp_oauth_sessions import (
+        _shutdown_listener,
+        _start_loopback_listener,
+    )
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    flow = DashboardOAuthFlow(
+        flow_id="tui-no-iss",
+        server_name="reports",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="http://127.0.0.1:1/callback",
+    )
+    asyncio.run(flow.publish_authorization_url("https://idp.example/authorize?state=s1"))
+
+    rec = {"httpd": None}
+    try:
+        server = _start_loopback_listener(flow)
+        rec["httpd"] = server
+        port = server.server_address[1]
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+        conn.request("GET", "/callback?code=tui-code&state=s1")
+        resp = conn.getresponse()
+        assert resp.status == 200
+        resp.read()
+        conn.close()
+
+        assert asyncio.run(flow.wait_for_callback()) == ("tui-code", "s1", None)
+    finally:
+        _shutdown_listener(rec)
+
+
+def test_loopback_listener_rejects_state_mismatch():
+    from tui_gateway.mcp_oauth_sessions import (
+        _shutdown_listener,
+        _start_loopback_listener,
+    )
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    flow = DashboardOAuthFlow(
+        flow_id="tui-bad-state",
+        server_name="reports",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="http://127.0.0.1:1/callback",
+    )
+    asyncio.run(flow.publish_authorization_url("https://idp.example/authorize?state=s1"))
+
+    rec = {"httpd": None}
+    try:
+        server = _start_loopback_listener(flow)
+        rec["httpd"] = server
+        port = server.server_address[1]
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+        conn.request("GET", "/callback?code=tui-code&state=WRONG")
+        resp = conn.getresponse()
+        assert resp.status == 400
+        resp.read()
+        conn.close()
+    finally:
+        _shutdown_listener(rec)

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -685,7 +685,7 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
             "prompt", "aspect_ratio", "num_images", "output_format",
             "resolution", "quality", "sync_mode",
         },
-        "upscale": True,   # 1k native is sub-2MP
+        "upscale": False,  # opt-in per call (Aug 2026 policy); 1k native is sub-2MP
         # Edit endpoint takes `image_urls` (max 3) + the same knobs;
         # aspect_ratio defaults to "auto" (follows the first input image),
         # so we don't send it on edits.

--- a/tools/mcp_dashboard_oauth.py
+++ b/tools/mcp_dashboard_oauth.py
@@ -32,7 +32,9 @@ class DashboardOAuthFlow:
     error: str | None = None
     tools: list[dict] = field(default_factory=list)
     expected_state: str | None = field(default=None, init=False)
-    _callback: tuple[str, str | None] | None = field(default=None, init=False, repr=False)
+    _callback: tuple[str, str | None, str | None] | None = field(
+        default=None, init=False, repr=False
+    )
     _callback_error: str | None = field(default=None, init=False, repr=False)
     _authorization_ready: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
     _callback_ready: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
@@ -65,6 +67,7 @@ class DashboardOAuthFlow:
         code: str | None,
         state: str | None,
         error: str | None,
+        iss: str | None = None,
     ) -> None:
         with self._lock:
             if self._callback_ready.is_set():
@@ -78,12 +81,19 @@ class DashboardOAuthFlow:
             if error:
                 self._callback_error = error
             elif code:
-                self._callback = (code, state)
+                # RFC 9207 authorization-response issuer: carried verbatim
+                # (never normalized — the SDK compares it literally against
+                # the discovered metadata) so dashboard/TUI relays satisfy
+                # ASs that advertise
+                # authorization_response_iss_parameter_supported (#88698 R4).
+                self._callback = (code, state, iss)
             else:
                 self._callback_error = "OAuth callback did not include code or error"
             self._callback_ready.set()
 
-    async def wait_for_callback(self, timeout: float = 300.0) -> tuple[str, str | None]:
+    async def wait_for_callback(
+        self, timeout: float = 300.0
+    ) -> tuple[str, str | None, str | None]:
         ready = await asyncio.to_thread(self._callback_ready.wait, timeout)
         if not ready:
             raise TimeoutError("Timed out waiting for MCP OAuth callback")

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -951,10 +951,12 @@ def _make_callback_waiter(
 
         dashboard_flow = get_dashboard_oauth_flow()
         if dashboard_flow is not None:
-            # The dashboard flow still speaks the legacy tuple; normalize it
-            # here so both callback sources hand the SDK one shape.
-            dash_code, dash_state = await dashboard_flow.wait_for_callback()
-            return _authorization_code_result(dash_code, dash_state)
+            # #88698 R4: the dashboard bridge now carries the RFC 9207
+            # ``iss`` slot (code, state, iss) — feed it into the SDK's
+            # AuthorizationCodeResult so RFC 9207-adopting ASs don't reject
+            # the response at the SDK boundary after the user authorized.
+            dash_code, dash_state, dash_iss = await dashboard_flow.wait_for_callback()
+            return _authorization_code_result(dash_code, dash_state, dash_iss)
 
         # Reject before binding the callback listener in non-interactive
         # contexts. Reaching here means the SDK entered the authorization-code

--- a/tools/mcp_schema_cache.py
+++ b/tools/mcp_schema_cache.py
@@ -3,7 +3,13 @@
 Stores per-server tool manifests on disk so Hermes can register MCP tools
 into the agent snapshot without spawning the stdio child process at idle
 dashboard startup. Cache entries are keyed by server name + a fingerprint
-of the connection config (command/args/url/tools filters).
+of the connection config (command/args/url/tools filters, protocol era,
+auth/identity context, headers/env).
+
+Schema identity (#88698, R3): entries are stamped with
+``CACHE_SCHEMA_VERSION`` and partitioned by ``server_name::fingerprint``,
+so a context that differs in any schema-affecting dimension (protocol era,
+auth context, headers, env) can never read another context's entries.
 """
 
 from __future__ import annotations
@@ -21,6 +27,18 @@ logger = logging.getLogger(__name__)
 _CACHE_FILENAME = "mcp_schema_cache.json"
 _cache_lock = threading.Lock()
 
+# Epoch for the on-disk entry schema. Any future semantic change to the
+# entry schema / TTL semantics / scope enforcement MUST bump this constant
+# in the same change: it is folded into every fingerprint (so every old
+# entry misses on next read) and stamped onto every entry (hard read gate).
+CACHE_SCHEMA_VERSION = 2
+
+# Upper bound on how long a cached tool manifest may be trusted without a
+# live reconfirmation, regardless of what the server advertised (SDK parity:
+# mcp/client/caching.py clamps the response cache to 24 h). Applied on write
+# AND read (defense in depth against hand-edited entries).
+MAX_TTL_MS = 24 * 60 * 60 * 1000
+
 
 def _cache_path() -> Path:
     from hermes_constants import get_hermes_home
@@ -28,19 +46,167 @@ def _cache_path() -> Path:
     return get_hermes_home() / "cache" / _CACHE_FILENAME
 
 
+def _h(value: Any) -> str:
+    """Hash a scalar value for fingerprint/digest payloads (never plaintext)."""
+    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()
+
+
+def _hash_leaves(value: Any) -> Any:
+    """Recursively replace every scalar leaf with its sha256 hash.
+
+    Used for secret-bearing config surfaces (oauth, env, headers): the
+    structure (key names) stays readable, values never appear in plaintext.
+    """
+    if isinstance(value, dict):
+        return {str(k): _hash_leaves(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_hash_leaves(v) for v in value]
+    return _h(value)
+
+
+def _resolve_protocol_era() -> str:
+    """Return the handshake protocol era this codebase actually speaks.
+
+    Mirrors tools/mcp_tool.py's header seeding: the MCP-Protocol-Version
+    header is seeded from ``LATEST_HANDSHAKE_VERSION`` (2025-11-25), so that
+    constant is the era string used in the fingerprint. Falls back to the
+    installed SDK package version, then ``"unknown"`` — the value must be
+    stable within a process (the SDK version cannot change mid-process).
+    """
+    try:
+        from mcp.client.session import LATEST_HANDSHAKE_VERSION
+
+        return str(LATEST_HANDSHAKE_VERSION)
+    except Exception:
+        pass
+    try:
+        from importlib.metadata import version as _pkg_version
+
+        return _pkg_version("mcp") or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _resolve_identity_header_term(config: dict) -> Optional[list]:
+    """Resolve the ``identity_header`` config to ``[name.lower(), hash(value)]``.
+
+    Same pure-config resolver semantics as
+    ``tools.mcp_tool._resolve_identity_header`` (static value / active
+    profile name), reimplemented locally to avoid a circular import: the
+    profile name is a principal identifier, not a secret, so it is hashed
+    here only for payload uniformity. Invalid config → omitted sub-term.
+    """
+    raw = config.get("identity_header")
+    if not isinstance(raw, dict):
+        return None
+    name = raw.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    value_from = (raw.get("value_from") or "static").strip().lower()
+    if value_from == "static":
+        value = raw.get("value")
+        if not isinstance(value, str) or not value.strip():
+            return None
+        return [name.strip().lower(), _h(value)]
+    if value_from == "profile":
+        try:
+            from hermes_cli import profiles as _profiles
+
+            value = _profiles.get_active_profile_name()
+        except Exception:
+            return None
+        if not value:
+            return None
+        return [name.strip().lower(), _h(value)]
+    return None
+
+
+def _auth_context_term(config: dict) -> dict:
+    """Build the auth-context fingerprint sub-terms (never token bytes)."""
+    term: dict = {}
+    auth_type = (config.get("auth") or "").lower().strip()
+    if auth_type:
+        term["auth_type"] = auth_type
+    oauth = config.get("oauth")
+    if isinstance(oauth, dict) and oauth:
+        term["oauth"] = _hash_leaves(oauth)
+    # Token-file rotation discriminator: a refreshed token changes the file's
+    # mtime → new partition → safe re-probe, with no secret persisted.
+    for key in ("auth_token_file", "token_file"):
+        token_path = config.get(key)
+        if not isinstance(token_path, (str, Path)) or not str(token_path):
+            continue
+        try:
+            stat = Path(str(token_path)).stat()
+            term["token_file"] = [str(token_path), stat.st_mtime_ns]
+        except OSError:
+            continue
+        break
+    identity_term = _resolve_identity_header_term(config)
+    if identity_term is not None:
+        term["identity_header"] = identity_term
+    term["tls"] = [config.get("ssl_verify", True), config.get("client_cert")]
+    return term
+
+
+def config_digest(config: dict) -> str:
+    """Hash the ENTIRE config dict (every key), value-hashed, canonical JSON.
+
+    Complements ``config_fingerprint``: the fingerprint is the
+    schema-affecting partition key (non-schema-affecting keys such as
+    ``timeout``/``enabled``/``lazy`` stay out of it), while this digest
+    invalidates the entry on ANY config edit — an operator editing
+    ``timeout`` expects the cached manifest to be re-verified too. Values
+    are hashed so no secret plaintext is added to the cache file.
+    """
+    hashed = _hash_leaves(config)
+    raw = json.dumps(hashed, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
 def config_fingerprint(config: dict) -> str:
-    """Stable hash of the connection-defining parts of an MCP server config."""
+    """Stable hash of the connection-defining parts of an MCP server config.
+
+    The fingerprint is the schema-affecting partition key: connection
+    shape (command/args/url/transport), tool filters, protocol era + pin,
+    headers, env, redirect-header strictness, and the auth/identity context
+    (so principal A can never read principal B's entries). Secret-bearing
+    values enter only as sha256 hashes; non-schema-affecting keys
+    (``timeout``, ``enabled``, ``lazy``) stay out — they are covered by
+    :func:`config_digest` at the entry level instead.
+    """
     tools_filter = config.get("tools") or {}
     payload = {
+        # existing (unchanged)
         "command": config.get("command"),
         "args": config.get("args") or [],
         "url": config.get("url"),
         "transport": config.get("transport"),
         "tools_include": sorted(tools_filter.get("include") or []),
         "tools_exclude": sorted(tools_filter.get("exclude") or []),
+        # C1 epoch: bumping CACHE_SCHEMA_VERSION atomically changes every
+        # fingerprint, so every existing entry misses on next read.
+        "cache_schema_version": CACHE_SCHEMA_VERSION,
+        # new context terms (#88698 R3)
+        "headers": sorted(
+            (k.lower(), _h(v))
+            for k, v in (config.get("headers") or {}).items()
+        ),
+        "env": sorted(
+            (k, _h(v)) for k, v in (config.get("env") or {}).items()
+        ),
+        "strict_redirect_headers": bool(config.get("strict_redirect_headers")),
+        "auth_context": _auth_context_term(config),
+        "protocol_era": _resolve_protocol_era(),
+        "protocol_pin": config.get("protocol_version"),
     }
     raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _entry_key(server_name: str, fingerprint: str) -> str:
+    """Partition key: one server may hold several context partitions."""
+    return f"{server_name}::{fingerprint}"
 
 
 def _load_all() -> Dict[str, Any]:
@@ -64,27 +230,51 @@ def _save_all(data: Dict[str, Any]) -> None:
     atomic_json_write(_cache_path(), data, mode=0o600)
 
 
-def get_cached_entry(server_name: str, fingerprint: str) -> Optional[dict]:
-    """Return cached entry when fingerprint matches (and TTL holds), else None.
+def get_cached_entry(
+    server_name: str,
+    fingerprint: str,
+    *,
+    config_digest: Optional[str] = None,
+) -> Optional[dict]:
+    """Return cached entry when identity holds (and TTL holds), else None.
+
+    Fail-closed read gate order (first miss wins):
+
+    1. partition-key lookup (``server_name::fingerprint``);
+    2. ``epoch`` must equal :data:`CACHE_SCHEMA_VERSION`;
+    3. stored ``fingerprint`` must equal the recomputed one;
+    4. when *config_digest* is given, it must match the stored digest (a
+       ``config_digest=None`` read skips this gate for back-compat);
+    5. TTL check with :data:`MAX_TTL_MS` clamping (an entry is never trusted
+       past 24 h no matter what the server advertised or a hand-edit wrote).
 
     MCP 2026-07-28 (SEP-2549): ``tools/list`` results carry ``ttlMs`` as a
     freshness hint. When the live discovery path recorded one, an entry
     older than its TTL is treated as a miss so the next startup re-probes
     the server instead of serving a stale manifest forever. Entries without
-    a recorded TTL (pre-2026 servers) keep the old never-expires behavior.
-    ``cacheScope`` is irrelevant here: this cache is per-user local disk,
-    which satisfies even ``private``.
+    a recorded TTL (pre-2026 servers) keep the old never-expires behavior
+    (bounded only by :data:`MAX_TTL_MS` once a TTL exists).
+
+    ``cacheScope`` is recorded for diagnostics only; enforcement is
+    structural — the fingerprint partitions by auth/identity context, so a
+    ``private``-scoped entry written under one principal is unreachable
+    from another.
     """
     with _cache_lock:
-        entry = _load_all().get(server_name)
+        entry = _load_all().get(_entry_key(server_name, fingerprint))
     if not isinstance(entry, dict):
         return None
+    if entry.get("epoch") != CACHE_SCHEMA_VERSION:
+        return None
     if entry.get("fingerprint") != fingerprint:
+        return None
+    if config_digest is not None and entry.get("config_digest") != config_digest:
         return None
     ttl_ms = entry.get("ttl_ms")
     written_at = entry.get("written_at")
     if isinstance(ttl_ms, (int, float)) and isinstance(written_at, (int, float)):
-        if (time.time() - written_at) * 1000.0 >= float(ttl_ms):
+        effective_ttl = min(float(ttl_ms), MAX_TTL_MS)
+        if (time.time() - written_at) * 1000.0 >= effective_ttl:
             return None
     return entry
 
@@ -97,6 +287,9 @@ def write_cache_entry(
     server_name: str,
     fingerprint: str,
     *,
+    config_digest: Optional[str] = None,
+    protocol_era: Optional[str] = None,
+    negotiated_era: Optional[str] = None,
     tools: List[dict],
     utility_tools: Optional[List[dict]] = None,
     ttl_ms: Optional[float] = None,
@@ -105,19 +298,29 @@ def write_cache_entry(
     """Persist tool schemas after a successful live connect.
 
     ``ttl_ms``/``cache_scope`` are the SEP-2549 hints from the server's
-    ``tools/list`` result (2026-07-28 servers). ``written_at`` anchors TTL
-    expiry in :func:`get_cached_entry`.
+    ``tools/list`` result (2026-07-28 servers); ``ttl_ms`` is clamped to
+    :data:`MAX_TTL_MS`. ``written_at`` anchors TTL expiry in
+    :func:`get_cached_entry`. ``config_digest`` and ``protocol_era`` are
+    identity fields: ``protocol_era`` is the client-side era the manifest
+    was fetched under (diagnostic + partition documentation), and
+    ``config_digest`` lets any config edit invalidate the entry on read.
     """
     entry = {
+        "epoch": CACHE_SCHEMA_VERSION,
         "fingerprint": fingerprint,
+        "config_digest": config_digest,
+        "protocol_era": protocol_era,
         "tools": tools,
         "utility_tools": utility_tools or [],
     }
+    if negotiated_era is not None:
+        entry["negotiated_era"] = negotiated_era
     if isinstance(ttl_ms, (int, float)):
-        entry["ttl_ms"] = ttl_ms
+        entry["ttl_ms"] = min(float(ttl_ms), MAX_TTL_MS)
         entry["written_at"] = time.time()
     if cache_scope:
         entry["cache_scope"] = cache_scope
+    key = _entry_key(server_name, fingerprint)
     with _cache_lock:
         data = _load_all()
         # Write-through fires on every registration (reconnects,
@@ -126,18 +329,23 @@ def write_cache_entry(
         # always rewrite: written_at must advance or the entry would expire
         # at its ORIGINAL write time no matter how many live reconnects
         # confirmed it since.
-        if "written_at" not in entry and data.get(server_name) == entry:
+        if "written_at" not in entry and data.get(key) == entry:
             return
-        data[server_name] = entry
+        data[key] = entry
         _save_all(data)
 
 
 def clear_cache_entry(server_name: str) -> None:
+    """Clear every context partition recorded for *server_name*."""
+    prefix = f"{server_name}::"
     with _cache_lock:
         data = _load_all()
-        if server_name in data:
-            del data[server_name]
-            _save_all(data)
+        stale = [key for key in data if key.startswith(prefix)]
+        if not stale:
+            return
+        for key in stale:
+            del data[key]
+        _save_all(data)
 
 
 def tools_from_cache_entry(entry: dict) -> List[dict]:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -761,6 +761,38 @@ def _handshake_rejected_as_modern(exc: BaseException) -> bool:
     )
 
 
+def _resolve_protocol_policy(raw) -> str:
+    """Canonicalize a per-server ``protocol`` config value to a policy.
+
+    Accepts the issue vocabulary plus deprecated aliases; raises
+    ValueError for unknown/non-string values (fail-closed validation,
+    mirroring the client-side SDK pattern at mcp/client/client.py:377-386).
+
+    Returns one of ``legacy`` | ``prefer-legacy`` | ``prefer-modern`` |
+    ``strict-modern``.
+    """
+    if not isinstance(raw, str):
+        raise ValueError(
+            f"mcp_servers protocol must be a string, got {type(raw).__name__}"
+        )
+    mode = raw.strip().lower()
+    _ALIASES = {
+        "auto": "prefer-legacy",        # legacy default: initialize-first
+        "handshake": "legacy",
+        "stateless": "prefer-modern",   # discover-first with exact-signal fallback
+        "modern": "prefer-modern",
+        "2026-07-28": "prefer-modern",  # today's discover-first-with-retry behavior
+    }
+    canonical = _ALIASES.get(mode, mode)
+    _VALID = ("legacy", "prefer-legacy", "prefer-modern", "strict-modern")
+    if canonical not in _VALID:
+        raise ValueError(
+            f"mcp server protocol={raw!r} is not a valid policy; valid values: "
+            f"{', '.join(_VALID)} (aliases: auto, handshake, stateless, modern, 2026-07-28)"
+        )
+    return canonical
+
+
 def _is_method_not_found_error(exc: BaseException) -> bool:
     """Return True if *exc* is a JSON-RPC ``method not found`` (-32601).
 
@@ -882,10 +914,10 @@ async def _paginate_full_list(list_method, items_attr: str, server_name: str,
         items_attr: Result attribute holding the page's items
             (``"tools"``, ``"resources"``, or ``"prompts"``).
         server_name: For log messages.
-        cache_meta_out: Optional dict that receives the first page's
-            SEP-2549 cache hints (``ttl_ms``, ``cache_scope``) when the
-            server provides them (2026-07-28 servers MUST; earlier ones
-            won't). Callers use ``ttl_ms`` to bound the schema cache.
+        cache_meta_out: Optional dict that receives the conservatively
+            aggregated SEP-2549 cache hints (``ttl_ms``, ``cache_scope``):
+            min TTL across all pages, fail-closed scope when pages
+            disagree. Callers use ``ttl_ms`` to bound the schema cache.
 
     Returns:
         Combined list of items across all pages. Callers must hold the
@@ -909,13 +941,24 @@ async def _paginate_full_list(list_method, items_attr: str, server_name: str,
                     result = await list_method(cursor=cursor)
             except TypeError:
                 result = await list_method(cursor=cursor)
-        if cache_meta_out is not None and not items:
-            _ttl = mcp_field(result, "ttl_ms", "ttlMs")
+        if cache_meta_out is not None:
+            # #88698 R3: conservatively aggregate the SEP-2549 cache hints
+            # across EVERY page (not just page 1): the min TTL wins (a
+            # page 2..N advertising a shorter TTL bounds the entry; 0 —
+            # immediately stale — wins outright), and conflicting scopes
+            # fail closed to "private".
+            _ttl = _coerce_ttl(mcp_field(result, "ttl_ms", "ttlMs"))
             _scope = mcp_field(result, "cache_scope", "cacheScope")
             if _ttl is not None:
-                cache_meta_out["ttl_ms"] = _ttl
+                prev = cache_meta_out.get("ttl_ms")
+                cache_meta_out["ttl_ms"] = (
+                    _ttl if prev is None else min(prev, _ttl)
+                )
             if _scope is not None:
-                cache_meta_out["cache_scope"] = _scope
+                prev = cache_meta_out.get("cache_scope")
+                cache_meta_out["cache_scope"] = (
+                    _scope if prev is None or prev == _scope else "private"
+                )
         items.extend(getattr(result, items_attr, None) or [])
         cursor = mcp_field(result, "next_cursor", "nextCursor")
         # Per the MCP spec the cursor is an opaque string; anything else
@@ -935,6 +978,63 @@ def _mcp_types():
     """Late import of ``mcp.types`` (module keeps the SDK import lazy)."""
     import mcp.types as _t
     return _t
+
+
+# Re-listen backoff schedule (seconds) for the supervised
+# subscriptions/listen recovery loop (#88698 R2 Slice B). Bounded: at most
+# 3 attempts, so a dead modern stream reaches the reconnect path promptly.
+_LISTEN_RETRY_BACKOFFS = (1.0, 5.0, 15.0)
+
+
+def _is_tools_list_changed_event(event) -> bool:
+    """True when a ``subscriptions/listen`` event is a tools/list_changed.
+
+    Uses the SDK's typed ``ToolsListChanged`` when available (mcp >= 2.0
+    subscriptions surface), with a duck-typed fallback so the supervision
+    loop stays testable with plain namespaces.
+    """
+    try:
+        from mcp.client.subscriptions import ToolsListChanged
+    except Exception:
+        ToolsListChanged = None
+    if ToolsListChanged is not None and isinstance(event, ToolsListChanged):
+        return True
+    return (
+        getattr(event, "type", None) == "tools/list_changed"
+        or type(event).__name__ == "ToolsListChanged"
+    )
+
+
+def _coerce_ttl(value):
+    """Coerce a SEP-2549 ``ttl_ms`` hint to float, or None when unusable.
+
+    Numeric strings (YAML/JSON drift) are coerced; anything non-numeric
+    means the server sent no usable hint, preserving the legacy
+    never-expires behavior for pre-2026 servers.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _negotiated_era_of(server) -> Optional[str]:
+    """Return the server-negotiated protocol version for the schema cache.
+
+    Diagnostic only (stored as the entry's ``negotiated_era``); None when
+    unavailable. No read gate — a server legitimately negotiating an older
+    era must still serve.
+    """
+    result = getattr(server, "initialize_result", None)
+    if result is None:
+        return None
+    return mcp_field(result, "protocol_version", "protocolVersion")
 
 
 def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
@@ -1715,7 +1815,10 @@ class SamplingHandler:
        deprecation window because handshake-era servers in the wild still
        issue sampling/createMessage — but do NOT grow new capability here;
        modern servers use MRTR (``resultType: "input_required"``) instead of
-       server-initiated requests, which the SDK's session layer handles.
+       server-initiated requests, which Hermes' bounded continuation loop
+       (:func:`_call_with_input_required`) fulfils — embedded sampling
+       requests route through this handler, embedded elicitation requests
+       through the ElicitationHandler.
 
     Each MCPServerTask that has sampling enabled creates one SamplingHandler.
     The handler is callable and passed directly to ``ClientSession`` as
@@ -2333,6 +2436,18 @@ class MCPServerTask:
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported", "_list_cache_meta",
         "_reconnect_retries", "_session_proven", "_was_parked",
+        # R1: resolved per-server protocol policy (fail-fast validation).
+        "_protocol_policy",
+        # R2/R5: connection-generation binding for the bounded MRTR
+        # continuation loop (bumped at each transport re-entry).
+        "_connection_generation",
+        # R5: observable negotiated-state slots (get_mcp_status protocol
+        # sub-dict). Populated at the connect/fallback sites.
+        "negotiated_era", "negotiated_protocol_version",
+        "fallback_reason", "server_identity",
+        "liveness_strategy", "subscription_state", "cache_state",
+        # R2 Slice B: supervised subscriptions/listen task + recovery counter.
+        "_listen_task", "_listen_recovery_count",
     )
 
     def __init__(self, name: str):
@@ -2407,6 +2522,34 @@ class MCPServerTask:
         # back to ``list_tools`` (the pre-ping probe) so we neither spam pings
         # nor reconnect-loop. Reset on each fresh transport connection.
         self._ping_unsupported: bool = False
+        # R1: resolved protocol policy. Set by run() BEFORE any connection
+        # I/O so unknown ``protocol`` config values fail fast on every
+        # (re)connect attempt; kept None until then so the duck-typed test
+        # harness (which drives _negotiate_session directly) resolves from
+        # config instead.
+        self._protocol_policy: Optional[str] = None
+        # R2/R5: monotonic connection generation. Bumped at each transport
+        # re-entry (every _negotiate_session call corresponds to a fresh
+        # session); the bounded input_required continuation loop binds to it
+        # so a mid-loop reconnect aborts instead of retrying on a stale
+        # session.
+        self._connection_generation: int = 0
+        # R5: observable negotiated-state (exposed via get_mcp_status).
+        # negotiated_era: "legacy" | "stateless" | "none" (no successful
+        # negotiation yet); fallback_reason: "none" | "handshake_rejected" |
+        # "discover_rejected"; liveness_strategy: "none" | "ping" |
+        # "list_tools"; subscription_state: "none" | "active" | "recovering"
+        # | "lost" | "closed"; cache_state: last tools/list cache status.
+        self.negotiated_era: str = "none"
+        self.negotiated_protocol_version: Optional[str] = None
+        self.fallback_reason: str = "none"
+        self.server_identity: Optional[Any] = None
+        self.liveness_strategy: str = "none"
+        self.subscription_state: str = "none"
+        self.cache_state: str = "none"
+        # R2 Slice B: supervised subscriptions/listen task + recovery counter.
+        self._listen_task: Optional[asyncio.Task] = None
+        self._listen_recovery_count: int = 0
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
@@ -2442,29 +2585,89 @@ class MCPServerTask:
         and ``adopt()``s whichever result installs the outbound stamp, so
         the rest of this file is era-agnostic.
 
-        Per-server ``protocol`` config key:
+        Per-server ``protocol`` config key (canonicalized by
+        :func:`_resolve_protocol_policy`; unknown values FAIL validation
+        instead of being silently treated as auto):
 
-        - ``auto`` (default): try the legacy handshake FIRST, and fall back
-          to ``server/discover`` when the server signals it is modern-only
-          (``UnsupportedProtocolVersion`` -32022, or ``initialize`` missing
-          -32601). This is the reverse of the SDK's own discover-first auto
-          mode, on purpose: nearly every configured/catalog server today
-          speaks the handshake era, and initialize-first means ZERO extra
-          round-trips and zero behavior change for all of them, while
-          stateless-only servers still connect via the fallback.
-        - ``stateless``: probe ``server/discover`` first (one legacy retry
-          on MCPError, so a handshake-only server still connects).
-        - ``legacy``: handshake only, no fallback (escape hatch for servers
-          that misbehave on unknown methods).
+        - ``legacy`` (alias ``handshake``): ``initialize()`` only, no
+          fallback (escape hatch for servers that misbehave on unknown
+          methods).
+        - ``prefer-legacy`` (alias ``auto`` — the default): try the legacy
+          handshake FIRST, and fall back to ``server/discover`` only when
+          the server signals it is modern-only (``UnsupportedProtocolVersion``
+          -32022, or ``initialize`` missing -32601). This is the reverse of
+          the SDK's own discover-first auto mode, on purpose: nearly every
+          configured/catalog server today speaks the handshake era, and
+          initialize-first means ZERO extra round-trips and zero behavior
+          change for all of them, while stateless-only servers still connect
+          via the fallback.
+        - ``prefer-modern`` (aliases ``stateless``/``modern``/``2026-07-28``):
+          probe ``server/discover`` first; fall back to ``initialize()`` only
+          on the exact modern-rejection signals (-32022/-32601) — any other
+          error (INVALID_PARAMS, INTERNAL_ERROR, transport, timeout)
+          propagates instead of silently downgrading.
+        - ``strict-modern``: ``server/discover`` only, NO fallback —
+          a modern-only server policy that refuses to downgrade.
 
         Both result types expose ``.capabilities``, so downstream gates
         (``_advertises_tools``, ``_select_utility_schemas``, the config
         probe) work unchanged on either.
         """
-        mode = str((self._config or {}).get("protocol", "auto")).lower().strip()
-        if mode in ("stateless", "modern", "2026-07-28"):
+        raw_value = (self._config or {}).get("protocol", "auto")
+        policy = self._protocol_policy or _resolve_protocol_policy(raw_value)
+        # Fresh transport re-entry: reset per-connection negotiated state and
+        # bump the connection generation the MRTR continuation binds to.
+        self.negotiated_era = "none"
+        self.fallback_reason = "none"
+        self._connection_generation += 1
+        self._listen_task = None
+
+        def _record(result) -> None:
+            version = mcp_field(result, "protocol_version", "protocolVersion")
+            if version is None:
+                # DiscoverResult has no protocolVersion field; the SDK records
+                # the negotiated era on the session instead.
+                version = getattr(session, "_negotiated_version", None)
+            self.negotiated_protocol_version = version
+            self.server_identity = mcp_field(
+                result, "server_info", "serverInfo"
+            )
+
+        def _signal(exc) -> Optional[int]:
+            err = getattr(exc, "error", None)
+            return getattr(err, "code", None) or getattr(exc, "code", None)
+
+        def _log_completed(dialect: str, trigger: Optional[int] = None) -> None:
+            version = getattr(session, "_negotiated_version", None)
+            version_suffix = (
+                f", negotiated protocol version {version}" if version else ""
+            )
+            logger.info(
+                "MCP server '%s': protocol policy=%s (config value=%r) — "
+                "connected via %s%s%s",
+                self.name, policy, raw_value, dialect,
+                f" after fallback signal {trigger}" if trigger else "",
+                version_suffix,
+            )
+
+        if policy == "strict-modern":
+            # discover-only; every failure propagates (no downgrade path).
             try:
-                return await asyncio.wait_for(
+                result = await asyncio.wait_for(
+                    session.discover(), timeout=connect_timeout
+                )
+            except asyncio.TimeoutError:
+                raise
+            except asyncio.CancelledError:
+                raise
+            self.negotiated_era = "stateless"
+            _record(result)
+            _log_completed("modern server/discover")
+            return result
+
+        if policy == "prefer-modern":
+            try:
+                result = await asyncio.wait_for(
                     session.discover(), timeout=connect_timeout
                 )
             except asyncio.TimeoutError:
@@ -2472,25 +2675,34 @@ class MCPServerTask:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
+                # Exact-signal-only fallback (#88698): only a modern-rejection
+                # signal (structural -32022/-32601 or its wrapped shape)
+                # permits downgrading to the handshake; everything else
+                # propagates.
+                if not _handshake_rejected_as_modern(exc):
+                    raise
                 logger.info(
                     "MCP server '%s': server/discover rejected (%s) despite "
                     "protocol=%s — falling back to the legacy handshake",
-                    self.name, exc, mode,
+                    self.name, exc, raw_value,
                 )
-                return await asyncio.wait_for(
+                self.fallback_reason = "discover_rejected"
+                trigger = _signal(exc)
+                result = await asyncio.wait_for(
                     session.initialize(), timeout=connect_timeout
                 )
-        if mode in ("legacy", "handshake"):
-            return await asyncio.wait_for(
-                session.initialize(), timeout=connect_timeout
-            )
-        if mode != "auto":
-            logger.warning(
-                "MCP server '%s': unknown protocol=%r — treating as 'auto' "
-                "(valid: auto, stateless, legacy)", self.name, mode,
-            )
+                self.negotiated_era = "legacy"
+                _record(result)
+                _log_completed("legacy initialize handshake", trigger)
+                return result
+            self.negotiated_era = "stateless"
+            _record(result)
+            _log_completed("modern server/discover")
+            return result
+
+        # legacy / prefer-legacy: handshake first.
         try:
-            return await asyncio.wait_for(
+            result = await asyncio.wait_for(
                 session.initialize(), timeout=connect_timeout
             )
         except asyncio.TimeoutError:
@@ -2498,6 +2710,8 @@ class MCPServerTask:
         except asyncio.CancelledError:
             raise
         except Exception as exc:
+            if policy != "prefer-legacy":
+                raise
             if not _handshake_rejected_as_modern(exc):
                 raise
             if not hasattr(session, "discover"):
@@ -2509,9 +2723,19 @@ class MCPServerTask:
                 "retrying via server/discover (2026-07-28 stateless server)",
                 self.name, exc,
             )
-            return await asyncio.wait_for(
+            self.fallback_reason = "handshake_rejected"
+            trigger = _signal(exc)
+            result = await asyncio.wait_for(
                 session.discover(), timeout=connect_timeout
             )
+            self.negotiated_era = "stateless"
+            _record(result)
+            _log_completed("modern server/discover", trigger)
+            return result
+        self.negotiated_era = "legacy"
+        _record(result)
+        _log_completed("legacy initialize handshake")
+        return result
 
     def _is_recycled_stdio(self) -> bool:
         """Return True when a stdio server was intentionally recycled."""
@@ -2685,8 +2909,14 @@ class MCPServerTask:
 
             # 1. Fetch current tool list from server (follow nextCursor)
             async with self._rpc_lock:
+                # #88698 R3: refresh the SEP-2549 cache hints on dynamic
+                # refresh too, so a tools/list_changed that shortens the
+                # server-advertised TTL is persisted instead of stale
+                # initial-discovery values.
+                self._list_cache_meta = {}
                 new_mcp_tools = await _paginate_full_list(
-                    self.session.list_tools, "tools", self.name
+                    self.session.list_tools, "tools", self.name,
+                    cache_meta_out=self._list_cache_meta,
                 )
 
             # 2. Re-register with fresh tool list. Avoid nuke-and-repave for
@@ -2748,6 +2978,121 @@ class MCPServerTask:
                     "MCP server '%s': dynamically refreshed %d tool(s) (no changes)",
                     self.name, len(self._registered_tool_names),
                 )
+            self.cache_state = "live"
+
+    # ----- Supervised subscriptions/listen (2026-07-28 stateless era) ------
+
+    def _start_listen_supervision(self) -> None:
+        """Open the supervised ``subscriptions/listen`` stream, modern era only.
+
+        Handshake-era connections keep the legacy ``message_handler`` refresh
+        path (``notifications/tools/list_changed``) — ``listen()`` is a no-op
+        there by design, and ``ListenNotSupportedError`` is swallowed so this
+        is a zero-regression guard (#88698 R2 Slice B).
+        """
+        session = self.session
+        if session is None:
+            return
+        try:
+            from mcp.client.subscriptions import MODERN_PROTOCOL_VERSIONS
+        except Exception:
+            MODERN_PROTOCOL_VERSIONS = ()
+        version = getattr(session, "protocol_version", None)
+        if version not in MODERN_PROTOCOL_VERSIONS:
+            self.subscription_state = "none"
+            return
+        old = self._listen_task
+        if old is not None and not old.done():
+            old.cancel()
+        self._listen_task = asyncio.create_task(self._supervise_listen_stream())
+
+    async def _supervise_listen_stream(self) -> None:
+        """Supervise one ``subscriptions/listen`` stream (modern era only).
+
+        Refetches tools on ``tools/list_changed`` via the existing
+        ``_refresh_tools`` (under ``_rpc_lock`` — one stream per modern
+        connection). On ``SubscriptionLost``/abrupt drop, performs visible
+        recovery: log + bounded re-listen with backoff (≤3 attempts), refetch
+        after re-listen, and expose a recovery counter/state on the server
+        object. When the re-listen budget is exhausted the stream is treated
+        as dead: the same recovery signal keepalive failure uses
+        (``_reconnect_event.set()``) triggers the existing reconnect/budget
+        machinery — liveness and subscriptions become one path (#88698 C2).
+        """
+        try:
+            from mcp.client.subscriptions import (
+                listen,
+                ListenNotSupportedError,
+                SubscriptionLost,
+                ToolsListChanged,
+            )
+        except Exception:
+            return
+        session = self.session
+        if session is None:
+            return
+        max_attempts = 3
+        attempt = 0
+        while attempt < max_attempts and self.session is session:
+            attempt += 1
+            try:
+                async with listen(session, tools_list_changed=True) as sub:
+                    self.subscription_state = "active"
+                    self._listen_recovery_count = 0
+                    async for event in sub:
+                        if not _is_tools_list_changed_event(event):
+                            continue
+                        logger.info(
+                            "MCP server '%s': tools/list_changed via "
+                            "subscriptions/listen — refetching tools",
+                            self.name,
+                        )
+                        try:
+                            await self._refresh_tools()
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:
+                            logger.exception(
+                                "MCP server '%s': tools refetch after "
+                                "subscriptions/listen change failed", self.name,
+                            )
+                # Graceful close (server ended the subscription).
+                self.subscription_state = "closed"
+                return
+            except asyncio.CancelledError:
+                raise
+            except ListenNotSupportedError:
+                self.subscription_state = "none"
+                return
+            except SubscriptionLost:
+                self._listen_recovery_count += 1
+                self.subscription_state = "recovering"
+                logger.warning(
+                    "MCP server '%s': subscriptions/listen stream lost — "
+                    "re-listening (attempt %d/%d)",
+                    self.name, attempt, max_attempts,
+                )
+            except Exception as exc:
+                self._listen_recovery_count += 1
+                self.subscription_state = "recovering"
+                logger.warning(
+                    "MCP server '%s': subscriptions/listen stream ended "
+                    "(%s: %s) — re-listening (attempt %d/%d)",
+                    self.name, type(exc).__name__, _exc_str(exc),
+                    attempt, max_attempts,
+                )
+            if attempt < max_attempts:
+                await asyncio.sleep(_LISTEN_RETRY_BACKOFFS[attempt - 1])
+        if self.session is session:
+            # Re-listen budget exhausted: the modern stream is dead. Trigger
+            # the same recovery signal as keepalive failure so the transport
+            # is rebuilt by the existing reconnect machinery (#88698 C2).
+            self.subscription_state = "lost"
+            logger.warning(
+                "MCP server '%s': subscriptions/listen re-listen budget "
+                "exhausted — triggering reconnect", self.name,
+            )
+            self._reconnect_event.set()
 
     async def _keepalive_probe(self) -> None:
         """Exercise the session to detect a stale/expired connection.
@@ -2764,10 +3109,31 @@ class MCPServerTask:
 
         Raises on a genuine connection failure so the caller triggers a
         reconnect; returns normally when the session is alive.
+
+        Era semantics (#88698 R2 Slice C): on 2026-07-28 stateless-core
+        connections the keepalive ``ping`` is REQUEST-LEVEL health only —
+        there is no server-side session TTL to refresh, so a successful ping
+        proves the transport is alive, nothing more. The supervised
+        ``subscriptions/listen`` stream (``_supervise_listen_stream``) is the
+        connection-liveness signal on modern connections; its loss routes
+        through the same ``_reconnect_event`` recovery as keepalive failure.
         """
+        # Era-aware liveness semantics (#88698 R2 C1): on 2026-07-28
+        # stateless-core connections the keepalive ping is request-level
+        # health only (no session TTL to refresh); the supervised listen
+        # stream is the connection-liveness signal.
+        if self.negotiated_era == "stateless":
+            logger.debug(
+                "MCP server '%s': keepalive ping on a 2026-07-28 stateless "
+                "connection is request-level health only (no session TTL to "
+                "refresh); the supervised subscriptions/listen stream is the "
+                "connection-liveness signal",
+                self.name,
+            )
         if not self._ping_unsupported:
             try:
                 await asyncio.wait_for(self.session.send_ping(), timeout=30.0)
+                self.liveness_strategy = "ping"
                 return
             except Exception as exc:
                 # Only a "method not found" means ping is unsupported. Any
@@ -2779,6 +3145,7 @@ class MCPServerTask:
                     # No ping, no tools → no cheaper probe to fall back to.
                     raise
                 self._ping_unsupported = True
+                self.liveness_strategy = "list_tools"
                 logger.info(
                     "MCP server '%s': does not implement the optional 'ping' "
                     "utility (-32601); using 'list_tools' for keepalive on "
@@ -3117,6 +3484,7 @@ class MCPServerTask:
                         session, connect_timeout
                     )
                     self.session = session
+                    self._start_listen_supervision()
                     self._mark_lifecycle_started()
                     await self._discover_tools()
                     self._ready.set()
@@ -3489,6 +3857,7 @@ class MCPServerTask:
                             session, float(connect_timeout)
                         )
                         self.session = session
+                        self._start_listen_supervision()
                         await self._discover_tools()
                         self._ready.set()
                         # Session is live again: clear any breaker state from a
@@ -3554,6 +3923,7 @@ class MCPServerTask:
                                 session, float(connect_timeout)
                             )
                             self.session = session
+                            self._start_listen_supervision()
                             await self._discover_tools()
                             self._ready.set()
                             # Session is live again: clear any breaker state from
@@ -3601,6 +3971,7 @@ class MCPServerTask:
                             session, float(connect_timeout)
                         )
                         self.session = session
+                        self._start_listen_supervision()
                         await self._discover_tools()
                         self._ready.set()
                         # Session is live again: clear any breaker state from a
@@ -3635,6 +4006,7 @@ class MCPServerTask:
         # Clears any latch from a prior connection in case the server gained
         # ping support across the reconnect.
         self._ping_unsupported = False
+        self.liveness_strategy = "none"
         if self.session is None:
             return
         if not self._advertises_tools():
@@ -3652,6 +4024,7 @@ class MCPServerTask:
                 self.session.list_tools, "tools", self.name,
                 cache_meta_out=self._list_cache_meta,
             )
+        self.cache_state = "live"
         self._register_discovered_tools_if_needed()
 
     def _register_discovered_tools_if_needed(self) -> None:
@@ -3692,6 +4065,13 @@ class MCPServerTask:
         self._config = config
         self.tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
         self._auth_type = (config.get("auth") or "").lower().strip()
+        # Fail-fast protocol-policy validation (#88698 R1): raises ValueError
+        # BEFORE any connection I/O on every (re)connect attempt so an unknown
+        # per-server ``protocol`` value is surfaced instead of silently
+        # treated as auto.
+        self._protocol_policy = _resolve_protocol_policy(
+            config.get("protocol", "auto")
+        )
         self._idle_timeout_seconds = _get_lifecycle_seconds(config, "idle_timeout_seconds")
         self._max_lifetime_seconds = _get_lifecycle_seconds(config, "max_lifetime_seconds")
 
@@ -5708,6 +6088,160 @@ def _mark_server_call_started(server: Any) -> None:
         mark_tool_call()
 
 
+async def _call_with_input_required(
+    server,
+    session_method,
+    *args,
+    timeout: Optional[float] = None,
+    **kwargs,
+):
+    """Call an MCP session method with a Hermes-owned bounded MRTR loop.
+
+    SEP-2322 multi-round-trip (MRTR): a 2026-07-28 server may answer
+    ``tools/call`` / ``resources/read`` / ``prompts/get`` with an
+    ``InputRequiredResult`` carrying embedded ``input_requests`` plus an
+    opaque ``request_state``. The client must fulfil each embedded request
+    (sampling / elicitation / roots) and retry with the collected responses
+    and the UNMODIFIED ``request_state`` — repeating until a terminal result
+    arrives. The SDK only drives this loop on its ``Client`` wrapper (which
+    conflicts with Hermes' reconnect/session lifecycle), so Hermes implements
+    the loop itself (#88698 R2 Slice A):
+
+    - ``allow_input_required=True`` opt-in on the result-bearing call sites;
+    - bounded fan-out: embedded requests are dispatched SEQUENTIALLY (the
+      SDK's ``_dispatch_all`` runs them concurrently);
+    - round cap: per-server ``input_required_max_rounds`` (default 10,
+      matching the SDK's ``DEFAULT_INPUT_REQUIRED_MAX_ROUNDS``);
+    - connection-generation binding: a reconnect mid-loop aborts with an
+      explicit error instead of retrying on a stale session;
+    - fail-closed on refusal: a callback returning ``ErrorData`` aborts the
+      continuation (no retry of the refused input);
+    - whole loop bounded by *timeout* (the tool timeout), with per-round read
+      timeouts derived from the remaining budget.
+
+    ``request_state`` is passed through byte-exact, never inspected, and
+    never cached beyond the loop frame.
+    """
+    try:
+        from mcp.types import ErrorData, InputRequiredResult
+        from mcp.client.session import ClientRequestContext
+    except Exception:
+        # SDK generation without MRTR machinery: plain call, no opt-in.
+        return await session_method(*args, **kwargs)
+
+    session = server.session if hasattr(server, "session") else None
+    generation = getattr(server, "_connection_generation", None)
+    max_rounds = int((server._config or {}).get("input_required_max_rounds", 10) or 10)
+    max_rounds = max(1, max_rounds)
+    supports_read_timeout = (
+        "read_timeout_seconds" in _method_params(session_method)
+    )
+    deadline = None if timeout is None else time.monotonic() + float(timeout)
+
+    def _per_round_read_timeout(rounds_done: int) -> Optional[float]:
+        if deadline is None:
+            return None
+        remaining = deadline - time.monotonic()
+        rounds_left = max(1, max_rounds - rounds_done)
+        return max(1.0, remaining / rounds_left)
+
+    def _check_generation() -> None:
+        if (
+            generation is not None
+            and getattr(server, "_connection_generation", None) != generation
+        ):
+            raise RuntimeError(
+                "connection generation changed mid-continuation; retry the tool call"
+            )
+
+    async def _invoke(*, input_responses=None, request_state=None, rounds_done=0):
+        _check_generation()
+        call_kwargs = dict(kwargs)
+        call_kwargs["allow_input_required"] = True
+        if input_responses is not None:
+            call_kwargs["input_responses"] = input_responses
+        if request_state is not None:
+            call_kwargs["request_state"] = request_state
+        read_timeout = _per_round_read_timeout(rounds_done)
+        if supports_read_timeout and read_timeout is not None:
+            call_kwargs["read_timeout_seconds"] = read_timeout
+        return await session_method(*args, **call_kwargs)
+
+    async def _dispatch(key: str, req) -> Any:
+        _check_generation()
+        ctx = ClientRequestContext(
+            session=session,
+            request_id=key,
+            meta=getattr(getattr(req, "params", None), "meta", None),
+        )
+        captured = getattr(server, "_pending_call_context", None)
+        if captured is None:
+            return await session.dispatch_input_request(ctx, req)
+        # Replay the agent's contextvars (gateway-platform attribution) —
+        # same pattern as ElicitationHandler._invoke_consent.
+        return await captured.copy().run(session.dispatch_input_request, ctx, req)
+
+    result = await _invoke()
+    rounds = 0
+    while isinstance(result, InputRequiredResult):
+        rounds += 1
+        if rounds > max_rounds:
+            raise RuntimeError(
+                f"Server returned InputRequiredResult for more than {max_rounds} "
+                f"rounds; raise input_required_max_rounds on the server config "
+                f"if this server legitimately needs more"
+            )
+        _check_generation()
+        input_requests = getattr(result, "input_requests", None) or {}
+        if input_requests:
+            logger.info(
+                "MCP server '%s': MRTR round %d/%d — dispatching %s",
+                server.name, rounds, max_rounds,
+                ", ".join(sorted(input_requests.keys())),
+            )
+            responses = {}
+            for key, req in input_requests.items():
+                _check_generation()
+                outcome = await _dispatch(key, req)
+                if isinstance(outcome, ErrorData):
+                    raise RuntimeError(
+                        f"MCP server '{server.name}' refused input request "
+                        f"{key!r} (decline/cancel) — aborting the tool call "
+                        f"(no retry of refused input)"
+                    )
+                responses[key] = outcome
+        else:
+            # State-only leg: no embedded requests; retry empty. The SDK
+            # backoff (50→250 ms) is skipped — Hermes' own round cap bounds
+            # the loop; log the leg for observability.
+            logger.info(
+                "MCP server '%s': MRTR round %d/%d — state-only leg "
+                "(no input requests), retrying",
+                server.name, rounds, max_rounds,
+            )
+            responses = None
+        result = await _invoke(
+            input_responses=responses,
+            request_state=getattr(result, "request_state", None),
+            rounds_done=rounds,
+        )
+    logger.info(
+        "MCP server '%s': MRTR continuation completed after %d round(s)",
+        server.name, rounds,
+    )
+    return result
+
+
+def _method_params(session_method) -> set:
+    """Parameter names of a bound session method (cached-free, cheap)."""
+    try:
+        import inspect
+
+        return set(inspect.signature(session_method).parameters)
+    except (TypeError, ValueError):
+        return set()
+
+
 def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     """Return a sync handler that calls an MCP tool via the background loop.
 
@@ -5792,7 +6326,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    result = await _call_with_input_required(
+                        server, server.session.call_tool,
+                        tool_name, arguments=args, timeout=tool_timeout,
+                    )
                 finally:
                     server._pending_call_context = None
             # The RPC round-trip completed — the session is demonstrably
@@ -6031,7 +6568,10 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
-                result = await server.session.read_resource(uri)
+                result = await _call_with_input_required(
+                    server, server.session.read_resource,
+                    uri, timeout=tool_timeout,
+                )
             # read_resource returns ReadResourceResult with .contents list
             parts: List[str] = []
             contents = result.contents if hasattr(result, "contents") else []
@@ -6154,7 +6694,10 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
-                result = await server.session.get_prompt(name, arguments=arguments)
+                result = await _call_with_input_required(
+                    server, server.session.get_prompt,
+                    name, arguments=arguments, timeout=tool_timeout,
+                )
             # GetPromptResult has .messages list
             messages = []
             for msg in (result.messages if hasattr(result, "messages") else []):
@@ -6921,7 +7464,12 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
         # live connect so the next startup can lazily register this server
         # without spawning it. Cache failures never break registration.
         try:
-            from tools.mcp_schema_cache import config_fingerprint, write_cache_entry
+            from tools.mcp_schema_cache import (
+                config_digest,
+                config_fingerprint,
+                write_cache_entry,
+                _resolve_protocol_era,
+            )
 
             tools_payload: List[dict] = []
             for mcp_tool in server._tools:
@@ -6950,6 +7498,12 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
                 utility_tools=utility_payload,
                 ttl_ms=(getattr(server, "_list_cache_meta", None) or {}).get("ttl_ms"),
                 cache_scope=(getattr(server, "_list_cache_meta", None) or {}).get("cache_scope"),
+                # #88698 R3: epoch-versioned identity — any config edit
+                # (config_digest) or client-side era change (protocol_era)
+                # invalidates the entry on next read.
+                config_digest=config_digest(config),
+                protocol_era=_resolve_protocol_era(),
+                negotiated_era=_negotiated_era_of(server),
             )
         except Exception as exc:
             logger.debug("MCP schema cache write failed for '%s': %s", name, exc)
@@ -7247,15 +7801,22 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     lazy_registered = 0
     lazy_server_count = 0
     try:
-        from tools.mcp_schema_cache import config_fingerprint, get_cached_entry
+        from tools.mcp_schema_cache import (
+            config_digest,
+            config_fingerprint,
+            get_cached_entry,
+        )
     except Exception:  # pragma: no cover - cache module missing
+        config_digest = None  # type: ignore[assignment]
         config_fingerprint = None  # type: ignore[assignment]
         get_cached_entry = None  # type: ignore[assignment]
     if config_fingerprint is not None and get_cached_entry is not None:
         for name, cfg in new_servers.items():
             if not _resolve_server_lazy(name, cfg):
                 continue
-            entry = get_cached_entry(name, config_fingerprint(cfg))
+            entry = get_cached_entry(
+                name, config_fingerprint(cfg), config_digest=config_digest(cfg)
+            )
             if not entry:
                 continue
             with _lock:
@@ -7521,6 +8082,30 @@ def get_mcp_status() -> List[dict]:
             }
             if server._sampling:
                 entry["sampling"] = dict(server._sampling.metrics)
+            # #88698 R5: negotiated protocol state — additive, so existing
+            # key-specific consumers are unaffected. Exposes the resolved
+            # policy, negotiated era/version, fallback reason, server
+            # identity, connection generation, liveness strategy,
+            # subscription state, and last tools/list cache state.
+            entry["protocol"] = {
+                "policy": getattr(server, "_protocol_policy", None),
+                "negotiated_era": getattr(server, "negotiated_era", "none"),
+                "negotiated_protocol_version": getattr(
+                    server, "negotiated_protocol_version", None
+                ),
+                "fallback_reason": getattr(server, "fallback_reason", "none"),
+                "server_identity": getattr(server, "server_identity", None),
+                "connection_generation": getattr(
+                    server, "_connection_generation", 0
+                ),
+                "liveness_strategy": getattr(
+                    server, "liveness_strategy", "none"
+                ),
+                "subscription_state": getattr(
+                    server, "subscription_state", "none"
+                ),
+                "cache_state": getattr(server, "cache_state", "none"),
+            }
             result.append(entry)
         elif not enabled:
             # A server with enabled: false is intentionally not connected — it is

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2626,6 +2626,11 @@ class MCPServerTask:
         """
         raw_value = (self._config or {}).get("protocol", "auto")
         policy = self._protocol_policy or _resolve_protocol_policy(raw_value)
+        # Record the resolved policy on the server object so the status
+        # surface (get_mcp_status protocol.policy) is correct regardless of
+        # entry path — run() sets it, but a directly-driven _negotiate_session
+        # (tests, embedded reuse) must too.
+        self._protocol_policy = policy
         # Fresh transport re-entry: reset per-connection negotiated state and
         # bump the connection generation the MRTR continuation binds to.
         self.negotiated_era = "none"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -986,6 +986,17 @@ def _mcp_types():
 _LISTEN_RETRY_BACKOFFS = (1.0, 5.0, 15.0)
 
 
+def _open_listen_stream(session):
+    """Open one ``subscriptions/listen`` stream on *session* (modern era only).
+
+    Thin seam over ``mcp.client.subscriptions.listen`` so the supervision
+    loop stays testable with duck-typed sessions.
+    """
+    from mcp.client.subscriptions import listen
+
+    return listen(session, tools_list_changed=True)
+
+
 def _is_tools_list_changed_event(event) -> bool:
     """True when a ``subscriptions/listen`` event is a tools/list_changed.
 
@@ -3021,7 +3032,6 @@ class MCPServerTask:
         """
         try:
             from mcp.client.subscriptions import (
-                listen,
                 ListenNotSupportedError,
                 SubscriptionLost,
                 ToolsListChanged,
@@ -3031,14 +3041,17 @@ class MCPServerTask:
         session = self.session
         if session is None:
             return
+        # Per-supervision recovery counter: reset when this supervision
+        # starts, incremented on every SubscriptionLost/abrupt drop, and
+        # left visible after recovery so operators can observe re-listens.
+        self._listen_recovery_count = 0
         max_attempts = 3
         attempt = 0
         while attempt < max_attempts and self.session is session:
             attempt += 1
             try:
-                async with listen(session, tools_list_changed=True) as sub:
+                async with _open_listen_stream(session) as sub:
                     self.subscription_state = "active"
-                    self._listen_recovery_count = 0
                     async for event in sub:
                         if not _is_tools_list_changed_event(event):
                             continue
@@ -6130,8 +6143,11 @@ async def _call_with_input_required(
         return await session_method(*args, **kwargs)
 
     session = server.session if hasattr(server, "session") else None
+    server_name = getattr(server, "name", "?")
     generation = getattr(server, "_connection_generation", None)
-    max_rounds = int((server._config or {}).get("input_required_max_rounds", 10) or 10)
+    max_rounds = int(
+        (getattr(server, "_config", None) or {}).get("input_required_max_rounds", 10) or 10
+    )
     max_rounds = max(1, max_rounds)
     supports_read_timeout = (
         "read_timeout_seconds" in _method_params(session_method)
@@ -6178,8 +6194,14 @@ async def _call_with_input_required(
         if captured is None:
             return await session.dispatch_input_request(ctx, req)
         # Replay the agent's contextvars (gateway-platform attribution) —
-        # same pattern as ElicitationHandler._invoke_consent.
-        return await captured.copy().run(session.dispatch_input_request, ctx, req)
+        # same intent as ElicitationHandler._invoke_consent. Context.run()
+        # only propagates context to SYNC callables; for the async dispatch
+        # the coroutine must be run as a task bound to the captured context.
+        task = asyncio.create_task(
+            session.dispatch_input_request(ctx, req),
+            context=captured.copy(),
+        )
+        return await task
 
     result = await _invoke()
     rounds = 0
@@ -6196,7 +6218,7 @@ async def _call_with_input_required(
         if input_requests:
             logger.info(
                 "MCP server '%s': MRTR round %d/%d — dispatching %s",
-                server.name, rounds, max_rounds,
+                server_name, rounds, max_rounds,
                 ", ".join(sorted(input_requests.keys())),
             )
             responses = {}
@@ -6205,7 +6227,7 @@ async def _call_with_input_required(
                 outcome = await _dispatch(key, req)
                 if isinstance(outcome, ErrorData):
                     raise RuntimeError(
-                        f"MCP server '{server.name}' refused input request "
+                        f"MCP server '{server_name}' refused input request "
                         f"{key!r} (decline/cancel) — aborting the tool call "
                         f"(no retry of refused input)"
                     )
@@ -6217,7 +6239,7 @@ async def _call_with_input_required(
             logger.info(
                 "MCP server '%s': MRTR round %d/%d — state-only leg "
                 "(no input requests), retrying",
-                server.name, rounds, max_rounds,
+                server_name, rounds, max_rounds,
             )
             responses = None
         result = await _invoke(
@@ -6227,7 +6249,7 @@ async def _call_with_input_required(
         )
     logger.info(
         "MCP server '%s': MRTR continuation completed after %d round(s)",
-        server.name, rounds,
+        server_name, rounds,
     )
     return result
 

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -95,10 +95,14 @@ def _start_loopback_listener(flow) -> "http.server.HTTPServer":
             code = (qs.get("code") or [None])[0]
             state = (qs.get("state") or [None])[0]
             error = (qs.get("error") or [None])[0]
+            # RFC 9207 authorization-response issuer — mcp 2.0 rejects a
+            # response missing it when the AS advertises the parameter, so
+            # the TUI gateway relay must forward it verbatim (#88698 R4).
+            iss = (qs.get("iss") or [None])[0]
             body = b"<h1>Authorization received</h1><p>You can close this tab and return to Hermes.</p>"
             status = 200
             try:
-                flow.deliver_callback(code=code, state=state, error=error)
+                flow.deliver_callback(code=code, state=state, error=error, iss=iss)
             except Exception:
                 body = b"<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>"
                 status = 400


### PR DESCRIPTION
Refs #88698.

## Current disposition

This is a substantial first dual-era hardening slice, not class closure. Exact head `31589910cdbccde76aa2a07a438e5ae5bcedb4bd` is green in the dedicated real dual-SDK workflow, Docker, Nix, and every ordinary-CI job exposed by the connector; the ordinary aggregate remains red at the maintainer review-label gate.

One protocol-policy change remains required before this slice is merge-ready:

> Under `prefer-modern`, the exact canonical first-flight `server/discover` `-32602 INVALID_PARAMS` emitted by the supported MCP 1.28.1 peer is a **candidate legacy-era fingerprint**. Hermes should perform one bounded legacy `initialize` proof probe on the same connection generation. The peer becomes `legacy` only if that initialize succeeds. `strict-modern` still propagates the original `-32602` immediately.

This is not a global “`-32602` means legacy” rule. The fallback is permitted only:

1. before any era is negotiated;
2. for the exact SDK-generated canonical `server/discover` first request;
3. once, on the same connection generation;
4. under `prefer-modern` only;
5. with `fallback_reason` recorded as legacy only after initialize succeeds;
6. with both the discovery rejection and initialize failure surfaced if the proof probe also fails.

The current head still implements and tests the older negative rule—propagate `-32602` under `prefer-modern`. Its green wire job therefore proves the current behavior, not the required proof-probe behavior.

## Implemented slice

### R1 — protocol policy framework

Canonicalizes per-server `protocol` configuration to `legacy`, `prefer-legacy`, `prefer-modern`, or `strict-modern`, with fail-fast validation for unknown/non-string values and observable negotiated state.

### R2 — bounded MRTR + supervised listen

- Hermes-owned SEP-2322 continuation loop for tools, prompts, and resources;
- sequential embedded-request dispatch;
- configurable bounded round count;
- whole-loop timeout and connection-generation binding;
- fail-closed refusal handling;
- supervised modern `subscriptions/listen`, bounded re-listen, and reconnect escalation.

### R3 — schema-cache epoch and partitioning

- cache schema epoch folded into identity;
- partitions on headers/env/auth context/identity/TLS/protocol era without storing plaintext secrets;
- min TTL across pages, fail-closed scope disagreement, max-TTL clamp;
- dynamic refresh updates cache metadata;
- config digest and negotiated-era evidence recorded.

### R4 — RFC 9207 `iss` parity

Carries the authorization-response issuer through dashboard bridge, web route, TUI gateway relay, waiter, and SDK `AuthorizationCodeResult`.

### R5 — status and executable wire coverage

- additive protocol status surface and `hermes mcp status`;
- SDK-version and negotiation logs;
- dedicated `mcp-dual-era-conformance` workflow with real MCP 2.0 ↔ 1.28.1 peers.

## Exact-head evidence

At `31589910cdbccde76aa2a07a438e5ae5bcedb4bd`:

- `mcp-dual-era-conformance` run `32252868294`: success;
- Docker run `32252868314`: success;
- Nix run `32252868445`: success;
- ordinary CI run `32252869225`: every exposed job green, including OSV, attribution, e2e, Python/JS/TS, Windows/macOS, lint, installer, docs, lockfile, and supply-chain; aggregate red at the hidden review-control gate.

The stale fake-session signature blocker from the earlier head is fixed: the recovery fixture accepts the MRTR `allow_input_required=` argument.

## Remaining #88698 gates

- Implement the bounded contextual `-32602` proof probe above and add positive/negative real-wire witnesses.
- Complete the production-lifecycle wire matrix for both Hermes-served MCP surfaces: connect, discover/initialize, list, call, cancellation, shutdown, reconnect, and no-initialize modern behavior.
- Complete MRTR approval/denial/timeout/cancellation/malformed-state/disconnect/round-limit/generation isolation across tools, prompts, and resources.
- Prove listen clean-EOF recovery, catalog reconciliation after a listen gap, bounded exhaustion, and transport-aware stateless liveness.
- Bound no-TTL cache entries and finish remaining dynamic-refresh/cache-metadata cases.
- Rebase on the current main and attach a complete exact-head CI receipt after the policy change.

Keep `Refs #88698`; do not restore a closing keyword until the class-level matrix is actually satisfied.
