### PR TITLE
fix(desktop): stop workspace edits from reloading external preview tabs

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -110,6 +110,50 @@ describe('PreviewPane console state', () => {
     forgetPreviewStripTools(tabId)
   })
 
+  it('does not workspace-reload an external browser page', async () => {
+    const target = {
+      kind: 'url' as const,
+      label: 'X',
+      source: 'https://x.com',
+      url: 'https://x.com'
+    }
+
+    const rendered = render(<PreviewPane reloadRequest={0} target={target} />)
+
+    const reloadIgnoringCache = vi.fn()
+
+    Object.defineProperty(rendered.container.querySelector('webview'), 'reloadIgnoringCache', {
+      configurable: true,
+      value: reloadIgnoringCache
+    })
+
+    await act(async () => rendered.rerender(<PreviewPane reloadRequest={1} target={target} />))
+
+    expect(reloadIgnoringCache).not.toHaveBeenCalled()
+  })
+
+  it('keeps workspace reload for a local development page', async () => {
+    const target = {
+      kind: 'url' as const,
+      label: 'Preview',
+      source: 'http://localhost:5174',
+      url: 'http://localhost:5174'
+    }
+
+    const rendered = render(<PreviewPane reloadRequest={0} target={target} />)
+
+    const reloadIgnoringCache = vi.fn()
+
+    Object.defineProperty(rendered.container.querySelector('webview'), 'reloadIgnoringCache', {
+      configurable: true,
+      value: reloadIgnoringCache
+    })
+
+    await act(async () => rendered.rerender(<PreviewPane reloadRequest={1} target={target} />))
+
+    expect(reloadIgnoringCache).toHaveBeenCalledOnce()
+  })
+
   it('renders authenticated remote HTML safely and honors source mode', async () => {
     const dataUrl = `data:text/html;base64,${btoa('<h1>remote</h1>')}`
 

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -6,7 +6,7 @@ import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { guardGuestPointers } from '@/lib/guest-pointer-guard'
-import { openPreviewTargetInBrowser, remoteHtmlPreviewDocument } from '@/lib/local-preview'
+import { isWorkspaceLiveReloadUrl, openPreviewTargetInBrowser, remoteHtmlPreviewDocument } from '@/lib/local-preview'
 import { rafCoalesce } from '@/lib/raf-coalesce'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -433,7 +433,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
 
     lastReloadRequestRef.current = reloadRequest
 
-    if (target.kind !== 'url') {
+    if (target.kind !== 'url' || !isWorkspaceLiveReloadUrl(currentUrl)) {
       return
     }
 
@@ -442,7 +442,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       message: copy.workspaceReloading
     })
     reloadPreview()
-  }, [appendConsoleEntry, copy.workspaceReloading, reloadPreview, reloadRequest, target.kind])
+  }, [appendConsoleEntry, copy.workspaceReloading, currentUrl, reloadPreview, reloadRequest, target.kind])
 
   useEffect(() => {
     if (

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -9,12 +9,32 @@ vi.mock('@/lib/desktop-fs', () => ({
 }))
 
 import {
+  isWorkspaceLiveReloadUrl,
   localPreviewTarget,
   normalizeOrLocalPreviewTarget,
   openPreviewTargetInBrowser,
   remoteHtmlPreviewDocument,
   validatedRemoteHtmlDataUrl
 } from './local-preview'
+
+describe('workspace live reload URLs', () => {
+  it.each([
+    'http://localhost:5173',
+    'https://127.0.0.1:8443/app',
+    'http://0.0.0.0:3000',
+    'http://[::1]:4173',
+    'http://demo.local:8080'
+  ])('accepts local development origin %s', url => {
+    expect(isWorkspaceLiveReloadUrl(url)).toBe(true)
+  })
+
+  it.each(['https://x.com', 'https://localhost.example.com', 'https://demo.local.example.com', 'not a URL'])(
+    'rejects external or malformed origin %s',
+    url => {
+      expect(isWorkspaceLiveReloadUrl(url)).toBe(false)
+    }
+  )
+})
 
 const remoteTarget = {
   kind: 'file' as const,

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -21,19 +21,33 @@ describe('workspace live reload URLs', () => {
   it.each([
     'http://localhost:5173',
     'https://127.0.0.1:8443/app',
+    'http://127.26.5.4:3000', // any 127/8 loopback, not just 127.0.0.1
     'http://0.0.0.0:3000',
     'http://[::1]:4173',
-    'http://demo.local:8080'
+    'http://demo.local:8080',
+    'http://app.localhost:3000',
+    'http://LOCALHOST.:5173', // case + trailing dot normalization
+    'http://10.0.0.8:3000', // private LAN dev server
+    'http://172.16.1.20:5173',
+    'http://172.31.255.255:8080',
+    'http://192.168.1.100:3000',
+    'http://169.254.1.1:9000' // link-local
   ])('accepts local development origin %s', url => {
     expect(isWorkspaceLiveReloadUrl(url)).toBe(true)
   })
 
-  it.each(['https://x.com', 'https://localhost.example.com', 'https://demo.local.example.com', 'not a URL'])(
-    'rejects external or malformed origin %s',
-    url => {
-      expect(isWorkspaceLiveReloadUrl(url)).toBe(false)
-    }
-  )
+  it.each([
+    'https://x.com',
+    'https://localhost.example.com',
+    'https://demo.local.example.com',
+    'http://user@evil.test:3000', // userinfo must not smuggle a public host
+    'http://172.32.0.1:3000', // just outside 172.16/12
+    'http://11.0.0.1:3000', // just outside 10/8
+    'http://256.1.1.1', // not a valid IPv4 octet
+    'not a URL'
+  ])('rejects external or malformed origin %s', url => {
+    expect(isWorkspaceLiveReloadUrl(url)).toBe(false)
+  })
 })
 
 const remoteTarget = {

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -9,6 +9,7 @@ const PDF_EXTENSIONS = new Set(['.pdf'])
 // Mirrors `_FS_DATA_URL_MAX_BYTES` in the backend filesystem endpoint.
 const REMOTE_HTML_PREVIEW_MAX_BYTES = 16 * 1024 * 1024
 const REMOTE_HTML_PREVIEW_MAX_BASE64_BYTES = Math.ceil(REMOTE_HTML_PREVIEW_MAX_BYTES / 3) * 4
+const WORKSPACE_RELOAD_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1'])
 
 const LANGUAGE_BY_EXT: Record<string, string> = {
   '.c': 'c',
@@ -78,6 +79,25 @@ function pathToFileUrl(path: string) {
   }
 
   return `file://${encoded.startsWith('/') ? encoded : `/${encoded}`}`
+}
+
+export function isWorkspaceLiveReloadUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return false
+    }
+
+    const hostname = url.hostname
+      .toLowerCase()
+      .replace(/^\[|\]$/g, '')
+      .replace(/\.$/, '')
+
+    return WORKSPACE_RELOAD_HOSTS.has(hostname) || hostname.endsWith('.local')
+  } catch {
+    return false
+  }
 }
 
 export function validatedRemoteHtmlDataUrl(value: string): string | null {

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -9,7 +9,7 @@ const PDF_EXTENSIONS = new Set(['.pdf'])
 // Mirrors `_FS_DATA_URL_MAX_BYTES` in the backend filesystem endpoint.
 const REMOTE_HTML_PREVIEW_MAX_BYTES = 16 * 1024 * 1024
 const REMOTE_HTML_PREVIEW_MAX_BASE64_BYTES = Math.ceil(REMOTE_HTML_PREVIEW_MAX_BYTES / 3) * 4
-const WORKSPACE_RELOAD_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1'])
+const WORKSPACE_RELOAD_HOSTS = new Set(['localhost', '0.0.0.0', '::1'])
 
 const LANGUAGE_BY_EXT: Record<string, string> = {
   '.c': 'c',
@@ -81,6 +81,33 @@ function pathToFileUrl(path: string) {
   return `file://${encoded.startsWith('/') ? encoded : `/${encoded}`}`
 }
 
+// Dev servers the workspace live-reload should keep working for: loopback,
+// private LAN, and link-local addresses. A file edit can plausibly affect what
+// these serve; a public origin (x.com etc.) can never depend on workspace files.
+function isLocalOrPrivateIpv4(hostname: string): boolean {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(hostname)
+
+  if (!match) {
+    return false
+  }
+
+  const octets = match.slice(1).map(Number)
+
+  if (octets.some(octet => octet > 255)) {
+    return false
+  }
+
+  const [a, b] = octets
+
+  return (
+    a === 127 || // loopback 127.0.0.0/8
+    a === 10 || // private 10.0.0.0/8
+    (a === 172 && b >= 16 && b <= 31) || // private 172.16.0.0/12
+    (a === 192 && b === 168) || // private 192.168.0.0/16
+    (a === 169 && b === 254) // link-local 169.254.0.0/16
+  )
+}
+
 export function isWorkspaceLiveReloadUrl(value: string): boolean {
   try {
     const url = new URL(value)
@@ -94,7 +121,12 @@ export function isWorkspaceLiveReloadUrl(value: string): boolean {
       .replace(/^\[|\]$/g, '')
       .replace(/\.$/, '')
 
-    return WORKSPACE_RELOAD_HOSTS.has(hostname) || hostname.endsWith('.local')
+    return (
+      WORKSPACE_RELOAD_HOSTS.has(hostname) ||
+      hostname.endsWith('.localhost') ||
+      hostname.endsWith('.local') ||
+      isLocalOrPrivateIpv4(hostname)
+    )
   } catch {
     return false
   }


### PR DESCRIPTION
Salvages #81503 (original author credit preserved via cherry-pick), rebased onto current main.

## Problem

Any completed file diff force-reloads **every** URL-kind preview tab in the right rail — browsing x.com loses scroll position and feed state whenever the agent edits any workspace file, even files completely unrelated to the open page (`use-preview-routing.ts` bumps one global reload counter; `preview-pane.tsx` reloads any `target.kind === 'url'` pane unconditionally).

## Fix

Gate workspace live-reload to origins that can plausibly depend on workspace files, via a new `isWorkspaceLiveReloadUrl()`:

- loopback (full 127.0.0.0/8, `::1`, `0.0.0.0`)
- RFC 1918 private ranges (10/8, 172.16/12, 192.168/16) and link-local (169.254/16) — LAN-served dev servers keep working
- `localhost`, `*.localhost`, `*.local`

External origins (x.com etc.) are never auto-reloaded by workspace edits. Manual refresh, the file-watcher path (`kind === 'file'`), and dev-server restart reloads are unaffected.

## Changes beyond the salvaged commit

Cold review flagged that a localhost-only allowlist would regress LAN-served dev previews, so the second commit widens the allowlist as above and adds boundary tests: userinfo smuggling (`http://user@evil.test`), just-outside ranges (`172.32.x`, `11.x`), invalid octets, case and trailing-dot normalization.

## Test plan

- Targeted vitest 49/49 — including a RED check that the external-tab test fails without the gate
- Full UI suite 4709/4709
- `tsc --noEmit`, eslint, prettier all clean

Closes #81487