### PR TITLE
fix: remove stale duplicate contributor email path

### DIFF
--- a/contributors/emails/agent@agents-Mac-mini.local
+++ b/contributors/emails/agent@agents-Mac-mini.local
@@ -1,1 +1,0 @@
-momomojo


### PR DESCRIPTION
## Summary
- Remove the stale lowercase contributor email path.
- Keep the canonical case-sensitive path.

## Motivation
On case-insensitive filesystems such as macOS, both paths resolve to the same file and cause checkout or modification conflicts.

## Implementation
Delete only the stale lowercase path. No application code is changed.

## Validation
- PR diff contains one deleted file only.
- Canonical uppercase path remains.
- Patch matches 4ed73024b9 exactly.

## Impact
Prevents contributor email path collisions on case-insensitive filesystems. No runtime behavior change.