### PR TITLE
fix(desktop): auto-link absolute file paths in kanban comments to the file tree

### DIFF
--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -45,6 +45,7 @@ import {
   taskKey,
   uploadAttachment
 } from './api'
+import { LinkifiedFilePath } from './filepath-links'
 import { ModelOverrideField, overridePatch } from './model-override'
 import {
   type Diagnostic,
@@ -856,7 +857,9 @@ export function TaskDrawer({
                       <span className="ml-2 text-[0.625rem] text-(--ui-text-quaternary)">
                         {ago(comment.created_at)}
                       </span>
-                      <p className="whitespace-pre-wrap text-(--ui-text-tertiary)">{comment.body}</p>
+                      <p className="whitespace-pre-wrap text-(--ui-text-tertiary)">
+                        <LinkifiedFilePath text={comment.body} />
+                      </p>
                     </li>
                   ))}
                 </ul>

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -398,7 +398,9 @@ function DescriptionSection({ body, onSave }: { body: null | string | undefined;
           </Button>
         </div>
       ) : body ? (
-        <p className="whitespace-pre-wrap text-[0.8125rem] text-(--ui-text-secondary)">{body}</p>
+        <p className="whitespace-pre-wrap text-[0.8125rem] text-(--ui-text-secondary)">
+          <LinkifiedFilePath text={body} />
+        </p>
       ) : (
         <p className="text-[0.8125rem] text-(--ui-text-quaternary)">{k.noDescription}</p>
       )}

--- a/apps/desktop/src/plugins/kanban/filepath-links.test.tsx
+++ b/apps/desktop/src/plugins/kanban/filepath-links.test.tsx
@@ -1,12 +1,12 @@
 /**
  * Focused tests for the kanban comment file-path linkifier.
  *
- * The @hermes/plugin-sdk host is mocked so revealFileInTree calls are asserted,
- * never really executed against a store.
+ * The @hermes/plugin-sdk host is mocked so revealFileInTree calls are
+ * asserted, never really executed against a store.
  */
 
-import { renderToStaticMarkup } from 'react-dom/server'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { isAbsoluteFilePath, LinkifiedFilePath } from './filepath-links'
 
@@ -18,25 +18,20 @@ vi.mock('@hermes/plugin-sdk', () => ({
   host: hostMock
 }))
 
-/** Render the component to static HTML and return the markup string. */
-function renderHtml(text: string): string {
-  const out = LinkifiedFilePath({ text })
-
-  return typeof out === 'string' ? out : renderToStaticMarkup(<>{out}</>)
+/** Render the component and return its accessible text content. */
+function renderText(text: string): string {
+  const { container } = render(<LinkifiedFilePath text={text} />)
+  return container.textContent ?? ''
 }
 
-/** Extract the path labels of every rendered file-path button. */
+/** Click every rendered file-path button and return the paths passed to the host. */
 function linkLabels(text: string): string[] {
-  const html = renderHtml(text)
-  const labels: string[] = []
-  const re = /aria-label="Reveal ([^"]*) in file tree"/g
-  let match: RegExpExecArray | null
-
-  while ((match = re.exec(html)) !== null) {
-    labels.push(match[1])
-  }
-
-  return labels
+  render(<LinkifiedFilePath text={text} />)
+  return screen
+    .queryAllByRole('button')
+    .map(button => button.getAttribute('aria-label') ?? '')
+    .filter(label => label.startsWith('Reveal '))
+    .map(label => label.replace(/^Reveal /, '').replace(/ in file tree$/, ''))
 }
 
 describe('isAbsoluteFilePath', () => {
@@ -65,8 +60,12 @@ describe('LinkifiedFilePath', () => {
     hostMock.revealFileInTree.mockClear()
   })
 
+  afterEach(() => {
+    cleanup()
+  })
+
   it('renders plain text unchanged when there are no absolute paths', () => {
-    expect(renderHtml('Updated the worker to v1.4.1')).toBe('Updated the worker to v1.4.1')
+    expect(renderText('Updated the worker to v1.4.1')).toBe('Updated the worker to v1.4.1')
   })
 
   it('wraps an absolute POSIX path in a reveal link', () => {
@@ -80,13 +79,12 @@ describe('LinkifiedFilePath', () => {
   })
 
   it('renders every file-path link as a clickable button', () => {
-    const html = renderHtml('Updated `/opt/data/skills/x/SKILL.md` to v1.4.1')
-    expect(html).toContain('kanban-filepath-link')
-    expect(html).toContain('<button')
+    render(<LinkifiedFilePath text="Updated `/opt/data/skills/x/SKILL.md`" />)
+    expect(screen.getByRole('button')).toBeTruthy()
   })
 
   it('does not call revealFileInTree at render time', () => {
-    renderHtml('Updated `/opt/data/skills/x/SKILL.md` to v1.4.1')
+    render(<LinkifiedFilePath text="Updated `/opt/data/skills/x/SKILL.md`" />)
     expect(hostMock.revealFileInTree).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/plugins/kanban/filepath-links.test.tsx
+++ b/apps/desktop/src/plugins/kanban/filepath-links.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Focused tests for the kanban comment file-path linkifier.
+ *
+ * The @hermes/plugin-sdk host is mocked so revealFileInTree calls are asserted,
+ * never really executed against a store.
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { isAbsoluteFilePath, LinkifiedFilePath } from './filepath-links'
+
+const { hostMock } = vi.hoisted(() => ({
+  hostMock: { revealFileInTree: vi.fn() }
+}))
+
+vi.mock('@hermes/plugin-sdk', () => ({
+  host: hostMock
+}))
+
+/** Render the component to static HTML and return the markup string. */
+function renderHtml(text: string): string {
+  const out = LinkifiedFilePath({ text })
+
+  return typeof out === 'string' ? out : renderToStaticMarkup(<>{out}</>)
+}
+
+/** Extract the path labels of every rendered file-path button. */
+function linkLabels(text: string): string[] {
+  const html = renderHtml(text)
+  const labels: string[] = []
+  const re = /aria-label="Reveal ([^"]*) in file tree"/g
+  let match: RegExpExecArray | null
+
+  while ((match = re.exec(html)) !== null) {
+    labels.push(match[1])
+  }
+
+  return labels
+}
+
+describe('isAbsoluteFilePath', () => {
+  it('accepts POSIX absolute paths', () => {
+    expect(isAbsoluteFilePath('/opt/data/skills/x/SKILL.md')).toBe(true)
+    expect(isAbsoluteFilePath('/opt/hermes/agent.log')).toBe(true)
+    expect(isAbsoluteFilePath('/opt/data/receipt-processing/')).toBe(true)
+    expect(isAbsoluteFilePath('/')).toBe(false)
+  })
+
+  it('accepts Windows absolute paths', () => {
+    expect(isAbsoluteFilePath('C:/Users/me/src/a.ts')).toBe(true)
+    expect(isAbsoluteFilePath('C:\\Users\\me\\src\\a.ts')).toBe(true)
+    expect(isAbsoluteFilePath('\\\\server\\share\\file.md')).toBe(true)
+  })
+
+  it('rejects relative paths and bare words', () => {
+    expect(isAbsoluteFilePath('src/a.ts')).toBe(false)
+    expect(isAbsoluteFilePath('SKILL.md')).toBe(false)
+    expect(isAbsoluteFilePath('Updated')).toBe(false)
+  })
+})
+
+describe('LinkifiedFilePath', () => {
+  beforeEach(() => {
+    hostMock.revealFileInTree.mockClear()
+  })
+
+  it('renders plain text unchanged when there are no absolute paths', () => {
+    expect(renderHtml('Updated the worker to v1.4.1')).toBe('Updated the worker to v1.4.1')
+  })
+
+  it('wraps an absolute POSIX path in a reveal link', () => {
+    const labels = linkLabels('Updated `/opt/data/skills/x/SKILL.md` to v1.4.1')
+    expect(labels).toContain('/opt/data/skills/x/SKILL.md')
+  })
+
+  it('does not linkify a relative path', () => {
+    const labels = linkLabels('see skills/x/SKILL.md for details')
+    expect(labels).not.toContain('skills/x/SKILL.md')
+  })
+
+  it('renders every file-path link as a clickable button', () => {
+    const html = renderHtml('Updated `/opt/data/skills/x/SKILL.md` to v1.4.1')
+    expect(html).toContain('kanban-filepath-link')
+    expect(html).toContain('<button')
+  })
+
+  it('does not call revealFileInTree at render time', () => {
+    renderHtml('Updated `/opt/data/skills/x/SKILL.md` to v1.4.1')
+    expect(hostMock.revealFileInTree).not.toHaveBeenCalled()
+  })
+
+  it('stops the path at sentence punctuation, not mid-filename', () => {
+    const labels = linkLabels('see /opt/data/file.sh! and /opt/data/file.tar.gz.')
+    expect(labels).toContain('/opt/data/file.sh')
+    expect(labels).toContain('/opt/data/file.tar.gz')
+  })
+
+  it('links a directory reference ending in a slash', () => {
+    const labels = linkLabels('Everything in /opt/data/receipt-processing/ now')
+    expect(labels).toContain('/opt/data/receipt-processing/')
+  })
+
+  it('links Windows drive and UNC paths', () => {
+    const labels = linkLabels('edit C:/Users/me/src/a.ts and \\\\server\\share\\file.md')
+    expect(labels).toContain('C:/Users/me/src/a.ts')
+    expect(labels).toContain('\\\\server\\share\\file.md')
+  })
+
+  it('does not linkify a bare slash or a leading double-slash', () => {
+    expect(linkLabels('/ alone')).toEqual([])
+    expect(linkLabels('see //share/x.ts')).toEqual([])
+  })
+})

--- a/apps/desktop/src/plugins/kanban/filepath-links.tsx
+++ b/apps/desktop/src/plugins/kanban/filepath-links.tsx
@@ -1,0 +1,108 @@
+import { host } from '@hermes/plugin-sdk'
+import type { ReactNode } from 'react'
+
+/**
+ * Linkify absolute filesystem paths inside a kanban comment body.
+ *
+ * When a worker mentions a file (e.g. "Updated `/opt/data/skills/x/SKILL.md` to
+ * v1.4.1"), the plain path is a dead end — the reviewer has to hunt the file
+ * browser manually. This renders recognized absolute paths as distinct-styled,
+ * clickable affordances that reveal + select the file in the workspace tree via
+ * `host.revealFileInTree`, so review → open file is one click.
+ *
+ * Only ABSOLUTE paths are matched (POSIX `/…` and Windows `C:\…` / `C:/…` /
+ * UNC `\\server\share\…`), and the reveal door is workspace-scoped — the tree
+ * ignores paths outside the active workspace cwd — so arbitrary system paths
+ * never become clickable.
+ */
+
+// One run of path characters: letters, digits, `_`, `.`, `~`, `+`, `@`, `/` and
+// a literal backslash, with `-` last. Deliberately excludes sentence/delimiter
+// punctuation and quotes so prose like "see /a/b.txt!" or "(/c/d.ts)" stops
+// exactly at the path, not mid-filename. A trailing `/` (directory reference)
+// is allowed.
+const PATH_RUN = "[A-Za-z0-9_.~+@/\\\\-]+"
+
+// Anchor candidates at a boundary: start of string, or after whitespace /
+// `(` / `[` / backtick / single or double quote.
+const BOUNDARY = "(?:^|(?<=[\\s(\\[{`\"']))"
+
+// POSIX absolute path: `/` + a path-char run. The negative lookahead after the
+// opening `/` rejects a bare `/` and a leading `//`.
+const POSIX_ABS_PATH_RE = new RegExp(BOUNDARY + "/(?!/)" + PATH_RUN, 'g')
+
+// Windows drive path: `C:` + `/` or `\` + a path-char run.
+const WINDOWS_DRIVE_RE = new RegExp(BOUNDARY + "[A-Za-z]:[/\\]" + PATH_RUN, 'g')
+
+// Windows UNC path: `\\server\share\…` — two backslashes, a server name, a
+// backslash, a share name, then a path-char run.
+const WINDOWS_UNC_RE = new RegExp(BOUNDARY + "\\\\[^\\/\\s]+\\\\[^\\/\\s]+" + PATH_RUN, 'g')
+
+const ABS_PATH_RE = new RegExp(
+  `(?:${POSIX_ABS_PATH_RE.source})|(?:${WINDOWS_DRIVE_RE.source})|(?:${WINDOWS_UNC_RE.source})`,
+  'g'
+)
+
+/** Does `value` look like a filesystem path a reviewer would want to open? */
+export function isAbsoluteFilePath(value: string): boolean {
+  const trimmed = (value || '').trim()
+
+  return (
+    (trimmed.startsWith('/') && trimmed.length > 1) ||
+    /^[A-Za-z]:[\\/]/.test(trimmed) ||
+    /^\\\\[^\\/]+\\[^\\/]+/.test(trimmed)
+  )
+}
+
+interface LinkifiedFilePathProps {
+  text: string
+}
+
+/**
+ * Render a comment body with absolute file paths turned into clickable links.
+ * Every other token stays literal text (no markdown interpretation), matching
+ * the plain-text rendering kanban comments use today.
+ */
+export function LinkifiedFilePath({ text }: LinkifiedFilePathProps): ReactNode {
+  const nodes: ReactNode[] = []
+  let cursor = 0
+
+  for (const match of text.matchAll(ABS_PATH_RE)) {
+    const raw = match[0]
+    const index = match.index ?? 0
+
+    if (index > cursor) {
+      nodes.push(text.slice(cursor, index))
+    }
+
+    // A trailing period from sentence punctuation (e.g. "…file.tar.gz.") is not
+    // part of a filename; drop it before linking.
+    const path = raw.replace(/[.]+$/, '')
+
+    if (path && isAbsoluteFilePath(path)) {
+      nodes.push(
+        <button
+          aria-label={`Reveal ${path} in file tree`}
+          className="ref kanban-filepath-link cursor-pointer"
+          key={`${path}-${index}`}
+          onClick={() => host.revealFileInTree(path)}
+          title={path}
+          type="button"
+        >
+          {path}
+        </button>
+      )
+      cursor = index + raw.length
+    } else {
+      // Not a linkable path — keep the raw match literal.
+      nodes.push(text.slice(index, index + raw.length))
+      cursor = index + raw.length
+    }
+  }
+
+  if (cursor < text.length) {
+    nodes.push(text.slice(cursor))
+  }
+
+  return nodes.length ? <>{nodes}</> : text
+}

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -43,6 +43,7 @@ import {
   requestGatewayForProfile,
   retireLocalProfileGateways
 } from '@/store/gateway'
+import { revealFileInTree } from '@/store/layout'
 import { notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
@@ -443,6 +444,12 @@ export const host = {
     window.location.hash = path.startsWith('#') ? path : `#${path}`
   },
 
+  /** Open the file-browser pane and reveal + select `path` in the workspace
+   *  tree (expanding ancestor folders, scrolling it into view) — the same
+   *  door the sidebar's "Reveal in file tree" command uses. Paths outside the
+   *  active workspace's cwd are safely ignored by the tree, so callers can
+   *  link any absolute path without worrying about arbitrary system files. */
+  revealFileInTree: (path: string): void => revealFileInTree(path),
   /** Pre-dial a profile's gateway socket in the background — pool-only, no
    *  activation, no navigation, no scope change (openGatewayForProfile; it
    *  already no-ops for shared-remote routes and the primary). Roster UIs

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -64,6 +64,7 @@ vi.mock('@/store/profile', async () => {
     $activeGatewayProfile: atom('remote-worker'),
     $gatewaySwapTarget: atom(null),
     $profiles: profiles,
+    $showAllProfiles: atom(false),
     ensureGatewayAgent: vi.fn(),
     ensureGatewayProfile: vi.fn(),
     newSessionInProfile: vi.fn(),


### PR DESCRIPTION
## What

When a kanban worker mentions a file path in a task comment (e.g. "Updated `/opt/data/skills/x/SKILL.md` to v1.4.1"), the path renders as plain text — the reviewer has to manually hunt the file browser to look at it. This PR linkifies recognized absolute paths in comments into a clickable affordance that reveals + selects the file in the workspace file tree.

Implements #88527.

## Why

Review flows like the one in the issue: an orchestrator comments "Updated `/opt/data/skills/receipt-processing/SKILL.md`", and the user has to dig through the file browser to review the change. Turning the path into a one-click reveal makes the review → open-file cycle much faster.

## How

- **New plugin-SDK door `host.revealFileInTree(path)`** in `apps/desktop/src/sdk/index.ts`. It wraps the existing `revealFileInTree` store action (the same door the sidebar's "Reveal in file tree" command uses). It's workspace-scoped: the file tree ignores paths outside the active workspace cwd, so linking arbitrary system paths is safe by construction.
- **New `LinkifiedFilePath` component** in `apps/desktop/src/plugins/kanban/filepath-links.tsx` that renders a comment body with recognized absolute paths turned into `.ref`-styled clickable buttons.
- **Wired into the task drawer** (`apps/desktop/src/plugins/kanban/drawer.tsx`) so comment bodies now go through the linkifier.

### Path matching

Only ABSOLUTE paths anchored at a text boundary are linked:

- POSIX: `/opt/data/skills/x/SKILL.md`
- Windows drive: `C:/Users/me/src/a.ts`, `C:\Users\me\src\a.ts`
- Windows UNC: `\\server\share\file.md`

Relative paths, bare slashes, and `//` prefixes stay literal text. Sentence punctuation (`see /a/b.txt!`) doesn't bleed into the path, and multi-dot filenames (`/x/file.tar.gz`) aren't truncated. A trailing `/` (directory reference) is allowed.

## Tests

- `apps/desktop/src/plugins/kanban/filepath-links.test.tsx` — 12 unit tests covering `isAbsoluteFilePath` and the linkifier: plain text passthrough, POSIX/drive/UNC linking, relative-path exclusion, trailing punctuation, directory refs, and render-time behavior (no reveal fires until click; the host is mocked).

Verified locally: `vitest run --project ui src/plugins/kanban/` → 3 files / 49 tests pass. `eslint` clean on the touched files. Renderer `tsc --noEmit` clean for the touched files (the only tsc errors in this tree are in pre-existing untracked `.test 2.ts`/`… 2.tsx` sync artifacts, unrelated to this change).

## Risk

Low. The match is display-only — it never mutates data, only renders comment bodies. Non-matching text is rendered exactly as before. The new SDK door is additive and mirrors an existing curated path.
