### PR TITLE
fix(curator): stop teaching the model a delete the guard always refuses

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -544,10 +544,12 @@ CURATOR_REVIEW_PROMPT = (
     "  - skill_manage action=write_file — add a references/, templates/, "
     "or scripts/ file under an existing skill (the skill must already "
     "exist)\n"
-    "  - skill_manage action=delete     — archive a skill. MUST pass "
-    "`absorbed_into=<umbrella>` when you've merged its content into another "
-    "skill, or `absorbed_into=\"\"` when you're truly pruning with no "
-    "forwarding target. This drives cron-job skill-reference migration — "
+    "  - skill_manage action=delete     — archive a skill you have merged "
+    "into an umbrella. MUST pass `absorbed_into=<umbrella>` (the umbrella "
+    "must already exist on disk); a delete without a verified consolidation "
+    "target is rejected fail-closed. Pruning with no forwarding target is "
+    "NOT part of this pass — the deterministic inactivity prune handles "
+    "that. This drives cron-job skill-reference migration — "
     "guessing from your YAML summary after the fact is fragile.\n"
     "  - terminal                       — move LOCAL candidate content into "
     "a support subfile when package integrity requires it; never mv, cp, rm, "
@@ -838,8 +840,12 @@ def _extract_absorbed_into_declarations(
     """Walk this run's tool calls and extract model-declared absorption targets.
 
     The curator prompt requires every ``skill_manage(action='delete')`` call
-    to pass ``absorbed_into=<umbrella>`` when consolidating, or
-    ``absorbed_into=""`` when truly pruning. This is the single authoritative
+    to pass ``absorbed_into=<umbrella>`` — a verified consolidation. The
+    background-pass guard rejects deletes with an empty/omitted target
+    fail-closed (#29912), so current runs only produce declared
+    consolidations; ``absorbed_into=""`` values are still parsed as explicit
+    prunings for backward compat with pre-guard runs and non-background
+    callers. This is the single authoritative
     signal for classification — the model's own declaration at the moment of
     deletion, which beats both post-hoc YAML summary parsing and substring
     heuristics on other tool calls.

--- a/tests/agent/test_curator_classification.py
+++ b/tests/agent/test_curator_classification.py
@@ -516,6 +516,32 @@ def test_rename_summary_mixed_consolidation_and_pruning(curator_env):
 # ---------------------------------------------------------------------------
 
 
+class TestConsolidationPromptMatchesDeleteGuard:
+    """The consolidation prompt must not instruct the model to make calls the
+    fail-closed guard deterministically refuses (#88882).
+
+    ``_curator_consolidation_delete_guard`` rejects a background-pass delete
+    with an empty/omitted ``absorbed_into`` (bare prune, #29912) — the prompt
+    used to teach exactly that call ("pass an empty absorbed_into when truly
+    pruning"), so an obedient model hit a guaranteed refusal. The prompt must
+    only advertise declared-consolidation deletes and point pruning at the
+    deterministic inactivity prune.
+    """
+
+    def test_prompt_never_advertises_empty_target_delete(self):
+        from agent.curator import CURATOR_REVIEW_PROMPT
+
+        assert 'absorbed_into=""' not in CURATOR_REVIEW_PROMPT
+        assert "truly pruning" not in CURATOR_REVIEW_PROMPT
+
+    def test_prompt_states_fail_closed_and_prune_outlet(self):
+        from agent.curator import CURATOR_REVIEW_PROMPT
+
+        assert "rejected fail-closed" in CURATOR_REVIEW_PROMPT
+        assert "inactivity prune" in CURATOR_REVIEW_PROMPT
+        assert "MUST pass `absorbed_into=<umbrella>`" in CURATOR_REVIEW_PROMPT
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Aligns the curator consolidation prompt with the fail-closed delete guard. `_curator_consolidation_delete_guard` rejects a background-pass `skill_manage(action="delete")` whose `absorbed_into` is omitted **or empty** — a bare prune is refused to keep the skill active (#29912's fail-open lesson), and the deterministic inactivity prune is the only legitimate prune path. But the prompt (`agent/curator.py`, `CURATOR_REVIEW_PROMPT`) still instructed the model: *"or `absorbed_into=\"\"` when you're truly pruning with no forwarding target"* — so an obedient model made exactly the call the guard deterministically refuses (#88882).

The prompt now advertises only declared-consolidation deletes: `MUST pass absorbed_into=<umbrella>` (umbrella must already exist on disk), states that a delete without a verified consolidation target is **rejected fail-closed**, and points no-target pruning at the deterministic inactivity prune instead. The `_extract_absorbed_into_declarations` docstring is updated to describe the guard contract rather than the retired instruction — the parser itself still accepts empty-string values so pre-guard curator runs and non-background callers keep classifying correctly.

No behavior change to the guard or the tool — this is the prompt/tool contract becoming self-consistent.

## Related Issue

Fixes #88882

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/curator.py`
  - `CURATOR_REVIEW_PROMPT` delete bullet: removed the empty-`absorbed_into` instruction; now states the umbrella requirement, the fail-closed rejection, and the inactivity-prune outlet for no-target pruning.
  - `_extract_absorbed_into_declarations` docstring: describes the guard contract; notes empty-string values remain parsed for backward compat.
- `tests/agent/test_curator_classification.py`
  - New `TestConsolidationPromptMatchesDeleteGuard`: the prompt never advertises an empty-target delete; it states the fail-closed rejection, the inactivity-prune outlet, and the `MUST pass absorbed_into=<umbrella>` requirement.

## How to Test

1. `python -m pytest tests/agent/test_curator_classification.py tests/tools/test_skill_manager_tool.py -q`
   Observed result: 62 passed.
2. `python -m pytest tests/agent/ -q -k curator`
   Observed result: 59 passed, 4 skipped.
3. Fail-on-main check: `git stash` the `agent/` change and rerun the new test class — Observed result: 2 failed (the prompt still contains the retired instruction).
4. Guard side already pinned: `test_bare_prune_during_curator_pass_refused` (unchanged) asserts the empty-target delete is refused — the two sides of the contract now agree.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (curator classification + skill manager + curator keyword suites: 121 passed, 4 skipped)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the extractor docstring now describes the guard contract; or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — prompt text only; or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
