### PR TITLE
fix(desktop): stop the composite scope key leaking into remote --profile (#88625)

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -17,6 +17,7 @@ import {
   buildAgentRoster,
   connectionDialFieldsChanged,
   connectionIdForLabel,
+  isBackendScopeKey,
   labelKey,
   labelSlug,
   LOCAL_CONNECTION_ID,
@@ -128,6 +129,25 @@ test('backendScopeKey: non-local connections get an unambiguous composite', () =
   assert.ok(backendScopeKey('homelab', 'research').startsWith(backendScopePrefix('homelab')))
   assert.ok(!backendScopeKey('homelab-2', 'research').startsWith(backendScopePrefix('homelab')))
   assert.ok(!'research'.startsWith(backendScopePrefix('homelab')))
+})
+
+// --- isBackendScopeKey (composite scope key vs bare profile name) ---
+
+test('isBackendScopeKey: true only for composite conn:<id>::<profile> keys', () => {
+  // Every composite the builder can emit is detected...
+  assert.equal(isBackendScopeKey(backendScopeKey('homelab', 'research')), true)
+  assert.equal(isBackendScopeKey(backendScopeKey('homelab', '')), true)
+  assert.equal(isBackendScopeKey('conn:yun3d::default'), true)
+  assert.equal(isBackendScopeKey('conn:local::default'), true)
+  // ...while bare profile names (v1 / settings callers) are not, so their
+  // connectionScopeKey fallback is preserved.
+  assert.equal(isBackendScopeKey('research'), false)
+  assert.equal(isBackendScopeKey('default'), false)
+  assert.equal(isBackendScopeKey(''), false)
+  assert.equal(isBackendScopeKey(null), false)
+  assert.equal(isBackendScopeKey(undefined), false)
+  // The local/primary connection keeps the BARE profile key — not a composite.
+  assert.equal(isBackendScopeKey(backendScopeKey(LOCAL_CONNECTION_ID, 'research')), false)
 })
 
 // --- resolveRegistryLocalRoute (registry 'local' entry vs the v1 route) ---

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -170,6 +170,24 @@ export function backendScopePrefix(connectionId: string): string {
   return `conn:${String(connectionId).trim()}::`
 }
 
+/**
+ * True when `key` is a composite backend scope key (`conn:<id>::<profile>`)
+ * rather than a bare profile name.
+ *
+ * The composite doubles as a pool/ssh scope so each (connection, profile) pair
+ * owns its own backend — but it is NOT a profile name and must never leak into
+ * a place that expects one. In particular the remote SSH `--profile` value: a
+ * remote `hermes --profile 'conn:<id>::<profile>' serve …` makes the remote CLI
+ * reject the composite as an invalid subcommand (colons are invalid in profile
+ * names), so the backend never starts. Callers use this to fall back to the
+ * empty/real profile instead of forwarding the scope key.
+ */
+export function isBackendScopeKey(key: null | string | undefined): boolean {
+  const s = String(key ?? '')
+
+  return s.startsWith('conn:') && s.includes('::')
+}
+
 export interface RegistryLocalRoute {
   /** Reuse the legacy v1 ensureBackend path — it already resolves to the
    * app's own local runtime, so single-source behavior stays byte-identical. */

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -96,6 +96,7 @@ import {
   backendScopePrefix,
   buildAgentRoster,
   connectionDialFieldsChanged,
+  isBackendScopeKey,
   mergeConnectionInput,
   migrateV1ToRegistry,
   normalizeConnectionInput,
@@ -8844,7 +8845,17 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     const lifecycle = platform.os === 'Windows' ? connectWindowsRemote : remoteLifecycle.connect
     result = await lifecycle({
       ssh,
-      profile: sshConfig.remoteProfile || connectionScopeKey(profile) || '',
+      // The remote --profile value. Registry dials pass the composite scope key
+      // (`conn:<id>::<profile>`) as `profile`; that key must never reach the
+      // remote CLI (it rejects it as an invalid subcommand). The registry path
+      // already resolved the real remote profile into sshConfig.remoteProfile
+      // (empty = let the remote pick its own active_profile), so fall back to ''
+      // for a composite instead of forwarding the scope key. Bare-name callers
+      // (v1 per-profile / settings overrides) keep the connectionScopeKey path.
+      profile:
+        sshConfig.remoteProfile ||
+        (isBackendScopeKey(profile) ? '' : connectionScopeKey(profile)) ||
+        '',
       remoteHermesPath: sshConfig.remoteHermesPath || '',
       ownershipId: sshOwnershipKey(profile),
       reuseToken: reuseToken || '',


### PR DESCRIPTION
## Problem

Fixes #88625.

Dialing an **SSH** registry connection spawns the remote Hermes backend with the desktop's **internal composite scope key** as the value of `--profile`:

```
hermes --profile 'conn:yun3d::default' serve --isolated --host 127.0.0.1 --port 0 --ssh-owner-nonce <nonce>
```

The remote CLI's argparse rejects the composite as an invalid subcommand, the backend never starts, ownership verification then fails with the misleading `Could not verify SSH backend process ownership.`, and the connection's bots never appear in the **Bots** roster (`hermes:agents:roster` keeps returning `connect-on-demand`).

## Root cause

`ensureRegistryBackend` → `connectRegistryBackend` pools each `(connection, profile)` pair under a composite scope key `conn:<id>::<profile>` (`backendScopeKey`). That key doubles as the ssh scope and is passed as `profile` into `bootstrapSshConnectionInner`, which resolves the remote `--profile` value as:

```js
profile: sshConfig.remoteProfile || connectionScopeKey(profile) || '',
```

For a **default-profile** registry dial, `sshConfig.remoteProfile` is empty *by design* — `source.remoteProfile || (profileKey === 'default' ? '' : profileKey)` — so the remote uses its own `active_profile`/default. But `connectionScopeKey` is identity-or-`null` (it does not decompose the composite), so the fallback returned the scope key **verbatim** and forwarded `conn:<id>::default` to the remote CLI.

The invariant is already spelled out in the code — the comment above the lifecycle call says the remote profile is *"the entry's remoteProfile or the requested one — never the composite string."* The fallback simply wasn't fail-closed for composite keys.

## Fix

Never let a composite scope key reach the remote as a profile name:

```js
profile:
  sshConfig.remoteProfile ||
  (isBackendScopeKey(profile) ? '' : connectionScopeKey(profile)) ||
  '',
```

- **Registry default dial** → `remoteProfile` empty, composite detected → falls back to `''` → no `--profile`, so the remote picks its own `active_profile` (the intended behavior).
- **Registry non-default dial** (`work`) → `remoteProfile` is `work` → `--profile work`, unchanged.
- **Bare-name callers** (v1 per-profile / settings overrides) → not a composite → keep the `connectionScopeKey(profile)` path, unchanged.

`isBackendScopeKey()` is added next to its composite-key siblings `backendScopeKey`/`backendScopePrefix` in `connection-registry.ts`, with unit coverage.

## Testing

- `vitest run --project electron electron/connection-registry.test.ts` — all pass, incl. the new `isBackendScopeKey` cases (composite keys detected; bare names, empty, and the local/primary bare key are not).
- `tsc -p tsconfig.electron.json --noEmit` — clean.

No behavior change for local/primary connections or bare-name profile callers; the only change is that a composite scope key can no longer leak into `--profile`.
