### PR TITLE
feat(evals): benchmark Stagehand behind browser_exec

### DIFF
--- a/evals/browser_use/README.md
+++ b/evals/browser_use/README.md
@@ -103,6 +103,79 @@ Caveats: toscrape-family sites (no anti-bot, no heavy SPA); n<=3 per cell;
 success-rate deltas at this n are noise — audit sub-100% cells run-by-run
 before calling a regression.
 
+## Stagehand single-tool benchmark spike
+
+The `feat/stagehand-single-tool-facade` branch adds a `stagehand` arm that
+keeps the exact `browser_exec` tool name and swaps Browser Use's Python CLI
+for a JavaScript Playwright-shaped facade executed by Stagehand V4
+`experimentalBatch`. It is benchmark wiring, not a production installer:
+the arm points at a separately built Stagehand checkout.
+
+Prepare Stagehand V4:
+
+```bash
+git clone https://github.com/browserbase/stagehand.git /path/to/stagehand
+git -C /path/to/stagehand checkout c6d9baacd5fb668a71a4300436a45ae319660d5c
+pnpm --dir /path/to/stagehand install --frozen-lockfile
+pnpm --dir /path/to/stagehand --filter @browserbasehq/stagehand build
+pnpm --dir /path/to/stagehand --filter @browserbasehq/stagehand-integrations build
+
+# Match the Browser Use CLI used by the reference run. browser-use 0.13.7
+# installs browser-harness 0.1.8, whose executable is named browser-use.
+uv tool install --force browser-use==0.13.7
+```
+
+Run Browser Use 3.0 and Stagehand on the official six-task hard battery using
+fresh Browserbase browsers. This example is one model × six tasks × two arms
+× three repetitions = 36 trajectories, with no automatic trajectory retry:
+
+```bash
+export BUBENCH_BROWSER_USE_TREE=/path/to/hermes-agent-current-main
+export BUBENCH_PR_TREE=/path/to/hermes-agent-stagehand-branch
+export BUBENCH_STAGEHAND_ROOT=/path/to/stagehand
+export BROWSERBASE_API_KEY=...
+export BROWSERBASE_PROJECT_ID=...
+export BUBENCH_MODEL_PROVIDER=ai-gateway
+export AI_GATEWAY_API_KEY=...
+
+# Optional non-billable plan check; must print scheduled_cells: 36.
+python3 evals/browser_use/orchestrate_cloud.py \
+  --backend browserbase \
+  --tasks evals/browser_use/tasks/hard.json \
+  --arms pr,stagehand \
+  --models anthropic/claude-opus-4.8 \
+  --reps 3 \
+  --dry-run
+
+python3 evals/browser_use/orchestrate_cloud.py \
+  --backend browserbase \
+  --tasks evals/browser_use/tasks/hard.json \
+  --arms pr,stagehand \
+  --models anthropic/claude-opus-4.8 \
+  --reps 3 \
+  --results evals/browser_use/results/stagehand-vs-browser-use.jsonl
+
+python3 evals/browser_use/report.py \
+  evals/browser_use/results/stagehand-vs-browser-use.jsonl
+```
+
+The Browser Use arm imports Hermes from `BUBENCH_BROWSER_USE_TREE` and attaches
+its CLI to the session provisioned by the orchestrator. The Stagehand arm
+imports Hermes from `BUBENCH_PR_TREE` and launches and closes its own
+Browserbase session inside the cell subprocess. Both therefore get a fresh
+Browserbase browser for every trajectory while preserving their native
+execution paths; the baseline is not silently affected by the Stagehand diff.
+
+The commit above is the Stagehand checkout used for the facade smoke test. Pin
+both Hermes trees as well (`git rev-parse HEAD`) when publishing results. Live
+model serving and Browserbase sessions are nondeterministic, so exact token and
+latency values will vary; the task file, arm code, model, repetitions, and
+dependency versions remain fixed.
+
+Set `BUBENCH_MODEL_PROVIDER=openrouter` and `OPENROUTER_API_KEY` instead to run
+the same arm/task matrix through OpenRouter. Do not mix providers within a
+comparison.
+
 ## Provenance
 
 The original per-run `results*.jsonl` files lived in `/tmp/bu-bench/` (tmpfs)

--- a/evals/browser_use/orchestrate_cloud.py
+++ b/evals/browser_use/orchestrate_cloud.py
@@ -1,4 +1,4 @@
-"""Cloud-backend battery: pr arm attached to a provisioned cloud browser per cell.
+"""Cloud-backend battery for Browser Use and Stagehand single-tool arms.
 
 Backends:
     nous-cloud   - Nous Portal-provisioned Browser Use cloud browser
@@ -11,8 +11,9 @@ Usage:
         python3 orchestrate_cloud.py --backend nous-cloud [--reps 2]
         python3 orchestrate_cloud.py --backend browserbase [--reps 1]
 
-Per cell: provision a session, export its CDP endpoint via BENCH_CDP_URL /
-BU_CDP_WS, run single_run.py (pr arm), close the session. Resume-safe.
+Per Browser Use cell: provision a session, export its CDP endpoint via
+BENCH_CDP_URL / BU_CDP_WS, run single_run.py, close the session. Stagehand
+cells launch and close their own fresh Browserbase session. Resume-safe.
 """
 
 import argparse
@@ -35,14 +36,22 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--backend", required=True, choices=["nous-cloud", "browserbase"])
 parser.add_argument("--tasks", default=os.path.join(ROOT, "tasks", "hard.json"))
 parser.add_argument("--models", default="anthropic/claude-opus-4.8,moonshotai/kimi-k3")
+parser.add_argument("--arms", default="pr", help="Comma-separated: pr,stagehand")
 parser.add_argument("--reps", type=int, default=2)
 parser.add_argument("--results", default=None)
 parser.add_argument("--run-timeout", type=int, default=1200)
+parser.add_argument("--dry-run", action="store_true")
 args = parser.parse_args()
 
 RESULTS = args.results or os.path.join(ROOT, "results", f"results_{args.backend}.jsonl")
 os.makedirs(os.path.dirname(RESULTS), exist_ok=True)
 MODELS = args.models.split(",")
+ARMS = args.arms.split(",")
+unknown_arms = set(ARMS) - {"pr", "stagehand"}
+if unknown_arms:
+    parser.error(f"unknown arm(s): {','.join(sorted(unknown_arms))}")
+if "stagehand" in ARMS and args.backend != "browserbase":
+    parser.error("the stagehand arm requires --backend browserbase")
 TASKS = list(json.load(open(args.tasks, encoding="utf-8")).keys())
 REPS = list(range(1, args.reps + 1))
 
@@ -51,7 +60,7 @@ if os.path.exists(RESULTS):
     for line in open(RESULTS, encoding="utf-8"):
         try:
             r = json.loads(line)
-            done.add((r["task"], r["model"], r["rep"]))
+            done.add((r["arm"], r["task"], r["model"], r["rep"]))
         except Exception:
             pass
 
@@ -112,35 +121,55 @@ class Browserbase:
 
 provider = NousCloud() if args.backend == "nous-cloud" else Browserbase()
 
-cells = [(t, m, rep) for m, t, rep in itertools.product(MODELS, TASKS, REPS)]
+cells = [
+    (arm, task, model, rep)
+    for model, task, rep, arm in itertools.product(MODELS, TASKS, REPS, ARMS)
+]
+if args.dry_run:
+    print(json.dumps({
+        "backend": args.backend,
+        "tasks": TASKS,
+        "models": MODELS,
+        "arms": ARMS,
+        "reps": args.reps,
+        "scheduled_cells": len(cells),
+    }, indent=2))
+    raise SystemExit(0)
 total = len(cells)
 n = 0
-for task, model, rep in cells:
+for arm, task, model, rep in cells:
     n += 1
-    if (task, model, rep) in done:
+    arm_label = f"{arm}-{args.backend}"
+    if (arm_label, task, model, rep) in done:
         continue
-    print(f"[{n}/{total}] {args.backend} pr {task} {model} rep{rep}", flush=True)
+    print(
+        f"[{n}/{total}] {args.backend} {arm} {task} {model} rep{rep}",
+        flush=True,
+    )
     sess = None
     t0 = time.time()
-    try:
-        sess, extra_env = provider.create(f"bubench-{task}-{rep}")
-    except Exception as e:  # noqa: BLE001
-        rec = {
-            "arm": f"pr-{args.backend}",
-            "task": task,
-            "model": model,
-            "rep": rep,
-            "ok": False,
-            "error": f"session-create: {e}",
-        }
-        with open(RESULTS, "a", encoding="utf-8") as f:
-            f.write(json.dumps(rec) + "\n")
-        continue
+    extra_env = {}
+    if arm == "pr":
+        try:
+            sess, extra_env = provider.create(f"bubench-{task}-{rep}")
+        except Exception as e:  # noqa: BLE001
+            rec = {
+                "arm": arm_label,
+                "task": task,
+                "model": model,
+                "rep": rep,
+                "ok": False,
+                "error": f"session-create: {e}",
+            }
+            with open(RESULTS, "a", encoding="utf-8") as f:
+                f.write(json.dumps(rec) + "\n")
+            continue
     env = {**ENV_BASE, **extra_env, "BUBENCH_TASKS": args.tasks}
-    subprocess.run(["pkill", "-f", "browser_harness"], capture_output=True)
+    if arm == "pr":
+        subprocess.run(["pkill", "-f", "browser_harness"], capture_output=True)
     try:
         proc = subprocess.run(
-            [PY, os.path.join(ROOT, "single_run.py"), "pr", task, model, str(rep)],
+            [PY, os.path.join(ROOT, "single_run.py"), arm, task, model, str(rep)],
             capture_output=True,
             text=True,
             timeout=args.run_timeout,
@@ -168,11 +197,12 @@ for task, model, rep in cells:
             "error": f"timeout-{args.run_timeout}s",
         }
     finally:
-        try:
-            provider.close(sess)
-        except Exception as e:  # noqa: BLE001
-            print(f"  close warning: {e}", flush=True)
-    rec["arm"] = f"pr-{args.backend}"
+        if sess is not None:
+            try:
+                provider.close(sess)
+            except Exception as e:  # noqa: BLE001
+                print(f"  close warning: {e}", flush=True)
+    rec["arm"] = arm_label
     rec["cell_wall_s"] = round(time.time() - t0, 1)
     with open(RESULTS, "a", encoding="utf-8") as f:
         f.write(json.dumps(rec, ensure_ascii=False) + "\n")

--- a/evals/browser_use/single_run.py
+++ b/evals/browser_use/single_run.py
@@ -8,14 +8,20 @@ Arms:
     pr    - Browser Use CLI mode (single ``browser_exec`` tool), pinned tree $BUBENCH_PR_TREE
     prns  - same as pr but with the schema description stripped to the header only
             (isolates the value of the helpers digest in the tool description)
+    stagehand - Stagehand V4 Playwright facade behind the same single
+                ``browser_exec`` contract, pinned tree $BUBENCH_PR_TREE
 
 Environment:
     BUBENCH_ROOT       workspace dir (default: dir containing this script)
     BUBENCH_BASE_TREE  checkout used for the ``base`` arm (e.g. a merge-base worktree)
-    BUBENCH_PR_TREE    checkout used for the ``pr``/``prns`` arms
+    BUBENCH_BROWSER_USE_TREE exact current-main checkout used for ``pr``/``prns``
+    BUBENCH_PR_TREE    checkout containing the ``stagehand`` implementation
+    BUBENCH_STAGEHAND_ROOT built Stagehand V4 checkout used by ``stagehand``
     BUBENCH_TASKS      tasks json (default: $BUBENCH_ROOT/tasks/hard.json)
     BENCH_CDP_URL      CDP endpoint both arms drive (default http://127.0.0.1:9333)
-    OPENROUTER_API_KEY provider credential for the runs
+    BUBENCH_MODEL_PROVIDER inference route: ai-gateway (default) or openrouter
+    AI_GATEWAY_API_KEY Vercel AI Gateway credential for the default route
+    OPENROUTER_API_KEY provider credential when using the openrouter route
 
 The run gets a throwaway HERMES_HOME so no local config leaks in, and the
 web-fetch credential env vars are stripped so every arm must actually drive
@@ -24,35 +30,75 @@ the browser (no web_extract shortcuts).
 Prints one line: ``RESULT_JSON:{...}`` consumed by orchestrate.py.
 """
 
+import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 import tempfile
 import time
+from urllib.parse import urlsplit
 
 ARM, TASK_KEY, MODEL, REP = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 
 ROOT = os.environ.get("BUBENCH_ROOT", os.path.dirname(os.path.abspath(__file__)))
-BASE_TREE = os.environ["BUBENCH_BASE_TREE"]
 PR_TREE = os.environ["BUBENCH_PR_TREE"]
-WT = {"base": BASE_TREE, "pr": PR_TREE, "prns": PR_TREE}[ARM]
+BASE_TREE = os.environ.get("BUBENCH_BASE_TREE", PR_TREE)
+BROWSER_USE_TREE = os.environ.get("BUBENCH_BROWSER_USE_TREE", PR_TREE)
+WT = {
+    "base": BASE_TREE,
+    "pr": BROWSER_USE_TREE,
+    "prns": BROWSER_USE_TREE,
+    "stagehand": PR_TREE,
+}[ARM]
 
 TASKS_PATH = os.environ.get("BUBENCH_TASKS", os.path.join(ROOT, "tasks", "hard.json"))
 TASKS = json.load(open(TASKS_PATH, encoding="utf-8"))
 task = TASKS[TASK_KEY]
 
+MODEL_PROVIDER = os.environ.get("BUBENCH_MODEL_PROVIDER", "ai-gateway").strip()
+MODEL_ROUTES = {
+    "ai-gateway": (
+        "https://ai-gateway.vercel.sh/v1",
+        "AI_GATEWAY_API_KEY",
+    ),
+    "openrouter": (
+        "https://openrouter.ai/api/v1",
+        "OPENROUTER_API_KEY",
+    ),
+}
+if MODEL_PROVIDER not in MODEL_ROUTES:
+    raise RuntimeError(
+        "BUBENCH_MODEL_PROVIDER must be one of: "
+        + ", ".join(sorted(MODEL_ROUTES))
+    )
+MODEL_BASE_URL, MODEL_API_KEY_ENV = MODEL_ROUTES[MODEL_PROVIDER]
+MODEL_API_KEY = os.environ.get(MODEL_API_KEY_ENV, "").strip()
+if not MODEL_API_KEY:
+    raise RuntimeError(f"{MODEL_API_KEY_ENV} is required for {MODEL_PROVIDER}")
+
 home = tempfile.mkdtemp(prefix=f"buhome-{ARM}-")
 hh = os.path.join(home, ".hermes")
 os.makedirs(os.path.join(hh, "logs"), exist_ok=True)
 cdp = os.environ.get("BENCH_CDP_URL", "http://127.0.0.1:9333")
-browser_cfg = (
-    {"cloud_provider": "local", "cdp_url": cdp}
-    if ARM == "base"
-    else {"backend": "browser-use"}
-)
+if ARM == "base":
+    browser_cfg = {"cloud_provider": "local", "cdp_url": cdp}
+elif ARM == "stagehand":
+    stagehand_root = os.environ.get("BUBENCH_STAGEHAND_ROOT", "").strip()
+    if not stagehand_root:
+        raise RuntimeError(
+            "BUBENCH_STAGEHAND_ROOT must point at a built Stagehand V4 checkout"
+        )
+    browser_cfg = {
+        "backend": "stagehand",
+        "cloud_provider": "browserbase",
+        "stagehand_root": stagehand_root,
+    }
+else:
+    browser_cfg = {"backend": "browser-use"}
 cfg = {
-    "model": {"provider": "openrouter", "default": MODEL},
+    "model": {"provider": MODEL_PROVIDER, "default": MODEL},
     "browser": browser_cfg,
     "display": {"quiet": True},
 }
@@ -90,9 +136,9 @@ if ARM == "prns":
 from run_agent import AIAgent  # noqa: E402
 
 agent = AIAgent(
-    base_url="https://openrouter.ai/api/v1",
-    api_key=os.environ["OPENROUTER_API_KEY"],
-    provider="openrouter",
+    base_url=MODEL_BASE_URL,
+    api_key=MODEL_API_KEY,
+    provider=MODEL_PROVIDER,
     model=MODEL,
     max_iterations=30,
     quiet_mode=True,
@@ -172,5 +218,17 @@ out = {
     "browser_schema_chars": schema_desc_len,
     "error": error,
     "final_snippet": (final or "")[-400:],
+    "task_file_sha256": hashlib.sha256(
+        open(TASKS_PATH, "rb").read()
+    ).hexdigest(),
+    "runtime_tree": WT,
+    "runtime_commit": subprocess.run(
+        ["git", "-C", WT, "rev-parse", "HEAD"],
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout.strip(),
+    "model_provider": MODEL_PROVIDER,
+    "model_base_url_host": urlsplit(MODEL_BASE_URL).netloc,
 }
 print("RESULT_JSON:" + json.dumps(out, ensure_ascii=False))

--- a/model_tools.py
+++ b/model_tools.py
@@ -577,14 +577,12 @@ def _compute_tool_definitions(
                     }
                     break
 
-    # browser_exec (Browser Use mode) runs arbitrary Python on the host via
-    # the browser-use CLI subprocess.  A session whose toolset selection
-    # excludes the terminal surface (e.g. a messaging platform configured
-    # without terminal access) must not regain host code execution through
-    # the browser toolset — that would silently widen the operator's chosen
-    # security posture.  Session-level gate, NOT a check_fn: check_fn results
-    # are TTL-cached process-wide while one gateway process serves many
-    # sessions with different toolset configs.
+    # browser_exec runs model-authored code through the selected browser
+    # backend. A session whose toolset selection excludes the terminal surface
+    # must not regain a code-execution surface through the browser toolset.
+    # Session-level gate, NOT a check_fn: check_fn results are TTL-cached
+    # process-wide while one gateway process serves many sessions with
+    # different toolset configs.
     if "browser_exec" in available_tool_names and "terminal" not in available_tool_names:
         filtered_tools = [
             td for td in filtered_tools

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -128,7 +128,7 @@ class TestToolSurfaceSwap:
     def test_legacy_browser_tools_hidden_in_cli_mode(self, monkeypatch):
         import tools.browser_tool as browser_tool
 
-        monkeypatch.setattr(browser_tool, "_is_browser_use_cli_mode", lambda: True)
+        monkeypatch.setattr(browser_tool, "_is_browser_exec_mode", lambda: True)
         assert browser_tool.check_browser_requirements() is False
         assert browser_tool.check_browser_vision_requirements() is False
 
@@ -137,7 +137,7 @@ class TestToolSurfaceSwap:
 
         entry = registry.get_entry("browser_exec")
         assert entry is not None
-        assert entry.check_fn is bu_cli.is_browser_use_cli_mode
+        assert entry.check_fn is bu_cli.is_browser_exec_mode
         assert entry.toolset == "browser-use"
 
     def test_browser_exec_in_browser_toolsets(self):

--- a/tests/tools/test_stagehand_facade.py
+++ b/tests/tools/test_stagehand_facade.py
@@ -1,0 +1,146 @@
+"""Behavior contracts for the Stagehand ``browser_exec`` backend."""
+
+from __future__ import annotations
+
+import json
+
+import tools.browser_use_cli as browser_exec
+import tools.stagehand_facade as stagehand
+import tools.stagehand_facade_client as client
+
+
+def _select_stagehand(monkeypatch):
+    monkeypatch.setattr(
+        browser_exec,
+        "_read_browser_cfg",
+        lambda: {"backend": "stagehand"},
+    )
+
+
+def test_stagehand_is_an_explicit_browser_exec_backend(monkeypatch):
+    _select_stagehand(monkeypatch)
+
+    assert browser_exec.is_stagehand_facade_mode() is True
+    assert browser_exec.is_browser_use_cli_mode() is False
+    assert browser_exec.is_browser_exec_mode() is True
+
+
+def test_stagehand_schema_keeps_one_tool_and_switches_code_language(monkeypatch):
+    _select_stagehand(monkeypatch)
+
+    overrides = browser_exec._dynamic_schema_overrides()
+    properties = overrides["parameters"]["properties"]
+
+    assert "Playwright-shaped facade" in overrides["description"]
+    assert "JavaScript" in properties["code"]["description"]
+    assert "session" not in properties
+    assert set(properties) == {"code", "timeout_s"}
+
+
+def test_browser_exec_dispatches_to_stagehand_without_browser_use_cli(
+    monkeypatch,
+):
+    _select_stagehand(monkeypatch)
+    monkeypatch.setattr(browser_exec, "_blocked_url_in_code", lambda _code: None)
+    captured = {}
+
+    def fake_stagehand_browser_exec(**kwargs):
+        captured.update(kwargs)
+        return '{"success": true, "exit_code": 0, "output": "ok"}'
+
+    monkeypatch.setattr(stagehand, "stagehand_browser_exec", fake_stagehand_browser_exec)
+
+    result = browser_exec.browser_exec(
+        code="return await page.title();",
+        timeout_s=30,
+        task_id="conversation-7",
+    )
+
+    assert json.loads(result) == {
+        "success": True,
+        "exit_code": 0,
+        "output": "ok",
+    }
+    assert captured == {
+        "code": "return await page.title();",
+        "timeout_s": 30,
+        "task_id": "conversation-7",
+    }
+
+
+def test_stagehand_success_matches_browser_use_model_visible_envelope(monkeypatch):
+    monkeypatch.setattr(stagehand, "_stagehand_root", lambda: "/stagehand")
+    monkeypatch.setattr(stagehand, "_node_executable", lambda: "/usr/bin/node")
+    monkeypatch.setattr(
+        stagehand,
+        "call_stagehand_facade",
+        lambda **_kwargs: {"success": True, "output": '{"title":"Example"}'},
+    )
+
+    result = json.loads(
+        stagehand.stagehand_browser_exec(
+            code="return { title: await page.title() };",
+            timeout_s=60,
+            task_id="task-a",
+        )
+    )
+
+    assert result == {
+        "success": True,
+        "exit_code": 0,
+        "output": '{"title":"Example"}',
+    }
+
+
+def test_stagehand_failure_preserves_same_envelope(monkeypatch):
+    monkeypatch.setattr(stagehand, "_stagehand_root", lambda: "/stagehand")
+    monkeypatch.setattr(stagehand, "_node_executable", lambda: "/usr/bin/node")
+    monkeypatch.setattr(
+        stagehand,
+        "call_stagehand_facade",
+        lambda **_kwargs: {"success": False, "error": "locator was not found"},
+    )
+
+    result = json.loads(
+        stagehand.stagehand_browser_exec(
+            code="await page.locator('#missing').click();",
+            task_id="task-a",
+        )
+    )
+
+    assert result == {
+        "success": False,
+        "exit_code": 1,
+        "output": "",
+        "stderr": "locator was not found",
+    }
+
+
+def test_worker_environment_is_least_privilege_and_scope_aware(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        client,
+        "hermes_subprocess_env",
+        lambda **_kwargs: {"PATH": "/usr/bin"},
+    )
+    secrets = {
+        "BROWSERBASE_API_KEY": "bb_test_value",
+        "BROWSERBASE_PROJECT_ID": "project-value",
+        "OPENAI_API_KEY": "must-not-leak",
+    }
+    monkeypatch.setattr(
+        client,
+        "get_secret",
+        lambda name, default="": secrets.get(name, default),
+    )
+
+    env = client._worker_environment(tmp_path)
+
+    assert env == {
+        "PATH": "/usr/bin",
+        "BROWSERBASE_API_KEY": "bb_test_value",
+        "BROWSERBASE_PROJECT_ID": "project-value",
+        "STAGEHAND_FACADE_ROOT": str(tmp_path),
+    }

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -197,9 +197,9 @@ except ImportError:
     _is_camofox_mode = lambda: False  # noqa: E731
 # Browser Use CLI (optional)
 try:
-    from tools.browser_use_cli import is_browser_use_cli_mode as _is_browser_use_cli_mode
+    from tools.browser_use_cli import is_browser_exec_mode as _is_browser_exec_mode
 except ImportError:
-    _is_browser_use_cli_mode = lambda: False  # noqa: E731
+    _is_browser_exec_mode = lambda: False  # noqa: E731
 
 logger = logging.getLogger(__name__)
 
@@ -5248,10 +5248,10 @@ def check_browser_requirements() -> bool:
     Returns:
         True if all requirements are met, False otherwise
     """
-    # Browser Use CLI backend — browser_exec replaces the whole browser_*
+    # Single-tool backend — browser_exec replaces the whole browser_*
     # surface (including browser_cdp/browser_dialog, whose check_fns funnel
     # through here), so hide these tools from the model.
-    if _is_browser_use_cli_mode():
+    if _is_browser_exec_mode():
         return False
 
     # Camofox backend — only needs the server URL, no agent-browser CLI

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -19,6 +19,7 @@ from utils import is_truthy_value
 logger = logging.getLogger(__name__)
 
 _BACKEND_KEY = "browser-use"
+_STAGEHAND_BACKEND_KEY = "stagehand"
 BACKEND_DISABLED = "off"
 
 # Cloud daemon names become the BU_NAME env var
@@ -199,6 +200,16 @@ def is_browser_use_cli_mode() -> bool:
     # Default (backend unset): Browser Use mode when the CLI can run at all;
     # otherwise keep the built-in tools so browsing never silently breaks.
     return _find_cli() is not None
+
+
+def is_stagehand_facade_mode() -> bool:
+    """True when Stagehand replaces Browser Use behind ``browser_exec``."""
+    return get_browser_backend() == _STAGEHAND_BACKEND_KEY
+
+
+def is_browser_exec_mode() -> bool:
+    """True when either single-tool browser backend is selected."""
+    return is_stagehand_facade_mode() or is_browser_use_cli_mode()
 
 
 _NOTICE_STAMP_NAME = ".browser_use_default_notice"
@@ -552,15 +563,34 @@ def browser_exec(
     timeout_s: int = _DEFAULT_TIMEOUT_S,
     task_id: Optional[str] = None,
 ):
-    """Run Python code through the browser-use CLI, and return its output"""
+    """Run code through the configured single-tool browser backend."""
     from tools.registry import tool_error, tool_result
 
     if not code or not code.strip():
+        if is_stagehand_facade_mode():
+            return tool_error(
+                "No code provided. Pass a JavaScript async-workflow body using "
+                "the prebound page, context, and browser variables."
+            )
         return tool_error("No code provided. Pass Python that uses the pre-imported helpers, e.g. new_tab(\"https://example.com\") then print(page_info()).")
 
     blocked = _blocked_url_in_code(code)
     if blocked:
         return tool_error(blocked)
+
+    if is_stagehand_facade_mode():
+        if session:
+            return tool_error(
+                "Stagehand browser_exec owns one persistent browser per Hermes task; "
+                "the session argument is not supported."
+            )
+        from tools.stagehand_facade import stagehand_browser_exec
+
+        return stagehand_browser_exec(
+            code=code,
+            timeout_s=timeout_s,
+            task_id=task_id,
+        )
 
     cmd = _find_cli()
     if not cmd:
@@ -778,6 +808,10 @@ def _cli_skill_text() -> str:
 
 
 def _dynamic_schema_overrides() -> dict:
+    if is_stagehand_facade_mode():
+        from tools.stagehand_facade import stagehand_schema_overrides
+
+        return stagehand_schema_overrides(BROWSER_EXEC_SCHEMA)
     return {"description": _description_header() + _HELPERS_DIGEST}
 
 
@@ -827,7 +861,7 @@ registry.register(
         timeout_s=args.get("timeout_s", _DEFAULT_TIMEOUT_S),
         task_id=kw.get("task_id"),
     ),
-    check_fn=is_browser_use_cli_mode,
+    check_fn=is_browser_exec_mode,
     dynamic_schema_overrides=_dynamic_schema_overrides,
     emoji="🌐",
 )

--- a/tools/stagehand_facade.py
+++ b/tools/stagehand_facade.py
@@ -1,0 +1,170 @@
+"""Stagehand V4 implementation of Hermes's single ``browser_exec`` tool.
+
+The model-facing contract stays identical to Browser Use mode: one tool with
+``code`` and ``timeout_s`` arguments, returning only ``success``,
+``exit_code``, and ``output``. The implementation swaps Python/browser-harness
+for a JavaScript Playwright-shaped facade executed by Stagehand V4's
+``experimentalBatch`` on Browserbase.
+
+This integration intentionally consumes the production facade from a built
+Stagehand checkout instead of carrying a second copy in Hermes. Configure:
+
+    browser:
+      backend: stagehand
+      stagehand_root: /absolute/path/to/stagehand
+
+The checkout must contain built ``packages/sdk-ts/dist`` and
+``packages/integrations/core/dist/facade`` artifacts.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import Any, Mapping
+
+from tools.registry import tool_result
+from tools.stagehand_facade_client import call_stagehand_facade
+
+_DEFAULT_TIMEOUT_S = 60
+_MIN_TIMEOUT_S = 5
+_MAX_TIMEOUT_S = 60
+
+
+_STAGEHAND_DESCRIPTION = (
+    "Drive one persistent Browserbase browser by writing JavaScript against "
+    "Stagehand V4's Playwright-shaped facade. The `code` argument is the BODY "
+    "of an async workflow, not Python and not an `async () => {}` wrapper. "
+    "The variables `page`, `context`, and `browser` are prebound. Use familiar "
+    "Playwright operations such as `await page.goto(url)`, "
+    "`page.locator(selector)`, `page.getByRole(role, options)`, "
+    "`await locator.click()`, and `await page.evaluate(...)`. Do not import "
+    "packages, launch another browser, or close the provided browser.\n\n"
+    "STATE: pages, cookies, and navigation persist across calls; JavaScript "
+    "variables do not. Inspect an unfamiliar page before acting: return a "
+    "compact result from `await page.accessibility.snapshot()`, `await "
+    "page.content()`, or a targeted `page.evaluate(...)`, then use what you "
+    "observed in the next call. For deterministic tasks, navigation, "
+    "inspection, interaction, extraction, filtering, and aggregation may be "
+    "combined in one workflow. Return only compact JSON-serializable data "
+    "needed for the answer.\n\n"
+    "The facade translates this Playwright-shaped workflow to Stagehand V4 "
+    "experimental batch execution. Login walls: stop and ask the user; never "
+    "guess credentials."
+)
+
+
+def _browser_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import cfg_get, read_raw_config
+
+        value = cfg_get(read_raw_config(), "browser", default={})
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
+
+
+def _stagehand_root() -> str:
+    return str(_browser_config().get("stagehand_root") or "").strip()
+
+
+def _node_executable() -> str:
+    configured = str(
+        _browser_config().get("stagehand_node_executable") or ""
+    ).strip()
+    if configured:
+        return configured
+    return shutil.which("node") or "node"
+
+
+def _timeout(value: Any) -> int:
+    try:
+        return max(_MIN_TIMEOUT_S, min(int(value), _MAX_TIMEOUT_S))
+    except (TypeError, ValueError):
+        return _DEFAULT_TIMEOUT_S
+
+
+def stagehand_browser_exec(
+    *,
+    code: str,
+    timeout_s: int = _DEFAULT_TIMEOUT_S,
+    task_id: str | None = None,
+) -> str:
+    """Execute one JavaScript workflow and return Browser Use's envelope."""
+    root = _stagehand_root()
+    if not root:
+        return tool_result(
+            {
+                "success": False,
+                "exit_code": 1,
+                "output": "",
+                "stderr": (
+                    "Stagehand browser_exec is selected but browser.stagehand_root "
+                    "is not configured. Point it at a built Stagehand V4 checkout."
+                ),
+            }
+        )
+
+    try:
+        response = call_stagehand_facade(
+            code=code,
+            timeout_s=_timeout(timeout_s),
+            node_executable=_node_executable(),
+            stagehand_root=root,
+            task_key=str(task_id or "default"),
+        )
+    except Exception as error:
+        return tool_result(
+            {
+                "success": False,
+                "exit_code": 1,
+                "output": "",
+                "stderr": f"{type(error).__name__}: {str(error)[:1000]}",
+            }
+        )
+
+    if response.get("success") is not True:
+        return tool_result(
+            {
+                "success": False,
+                "exit_code": 1,
+                "output": "",
+                "stderr": str(
+                    response.get("error") or "Stagehand facade execution failed"
+                )[:1000],
+            }
+        )
+
+    return tool_result(
+        {
+            "success": True,
+            "exit_code": 0,
+            "output": str(response.get("output") or ""),
+        }
+    )
+
+
+def stagehand_schema_overrides(
+    browser_exec_schema: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return the Stagehand-specific schema while preserving one tool name."""
+    parameters = dict(browser_exec_schema["parameters"])
+    properties = dict(parameters["properties"])
+    properties["code"] = {
+        "type": "string",
+        "description": (
+            "JavaScript async-workflow body using the prebound Playwright-shaped "
+            "page, context, and browser variables. Await operations and return "
+            "compact JSON-serializable data."
+        ),
+    }
+    properties.pop("session", None)
+    properties["timeout_s"] = {
+        "type": "integer",
+        "description": (
+            f"Max seconds to wait for the workflow (default {_DEFAULT_TIMEOUT_S}, "
+            f"max {_MAX_TIMEOUT_S})."
+        ),
+        "default": _DEFAULT_TIMEOUT_S,
+    }
+    parameters["properties"] = properties
+    return {"description": _STAGEHAND_DESCRIPTION, "parameters": parameters}

--- a/tools/stagehand_facade_client.py
+++ b/tools/stagehand_facade_client.py
@@ -1,0 +1,253 @@
+"""Persistent, profile-scoped bridge to Stagehand's production facade."""
+
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import queue
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any, Mapping, TextIO
+
+from agent.secret_scope import get_secret
+from hermes_constants import hermes_home_key
+from tools.environments.local import hermes_subprocess_env
+
+logger = logging.getLogger(__name__)
+
+_PROTOCOL = "hermes-stagehand-facade-v1"
+_INITIALIZATION_ALLOWANCE_S = 180
+
+
+def _worker_environment(stagehand_root: Path) -> dict[str, str]:
+    """Expose only the two Browserbase credentials the worker requires."""
+    env = hermes_subprocess_env(inherit_credentials=False)
+    for name in ("BROWSERBASE_API_KEY", "BROWSERBASE_PROJECT_ID"):
+        value = (get_secret(name, "") or "").strip()
+        if value:
+            env[name] = value
+    env["STAGEHAND_FACADE_ROOT"] = str(stagehand_root)
+    return env
+
+
+class _FacadeWorkerClient:
+    def __init__(self, *, node_executable: str, stagehand_root: str) -> None:
+        self._lock = threading.RLock()
+        self._process: subprocess.Popen[str] | None = None
+        self._queue: queue.Queue[dict[str, Any] | BaseException] = queue.Queue()
+        self._request_id = 0
+        self._node = str(Path(node_executable).expanduser().resolve())
+        self._stagehand_root = str(Path(stagehand_root).expanduser().resolve())
+
+    def call(self, *, code: str, timeout_s: int) -> dict[str, Any]:
+        with self._lock:
+            self._ensure_worker()
+            self._request_id += 1
+            request_id = self._request_id
+            self._send(
+                {
+                    "protocol": _PROTOCOL,
+                    "type": "call",
+                    "request_id": request_id,
+                    "code": code,
+                }
+            )
+            response = self._receive(timeout_s + _INITIALIZATION_ALLOWANCE_S)
+            if (
+                response.get("type") != "response"
+                or response.get("request_id") != request_id
+            ):
+                raise RuntimeError(
+                    "Stagehand facade returned an out-of-order response"
+                )
+            return response
+
+    def _ensure_worker(self) -> None:
+        process = self._process
+        if process is not None and process.poll() is None:
+            return
+
+        node = Path(self._node)
+        root = Path(self._stagehand_root)
+        if not node.is_file():
+            raise RuntimeError(
+                f"Stagehand facade Node executable is missing: {node}"
+            )
+        required = (
+            root
+            / "packages"
+            / "integrations"
+            / "core"
+            / "dist"
+            / "facade"
+            / "index.mjs"
+        )
+        sdk = root / "packages" / "sdk-ts" / "dist" / "index.mjs"
+        if not required.is_file() or not sdk.is_file():
+            raise RuntimeError(
+                "Built Stagehand V4 facade artifacts are missing under "
+                f"{root}. Build @browserbasehq/stagehand and "
+                "@browserbasehq/stagehand-integrations first."
+            )
+
+        worker = Path(__file__).with_name("stagehand_facade_worker.mjs")
+        self._queue = queue.Queue()
+        popen_extra: dict[str, Any] = {}
+        if hasattr(subprocess, "STARTUPINFO"):
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
+            startup_info = subprocess.STARTUPINFO()
+            startup_info.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            popen_extra = {
+                "creationflags": windows_hide_flags(),
+                "startupinfo": startup_info,
+            }
+        self._process = subprocess.Popen(
+            [str(node), str(worker)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            env=_worker_environment(root),
+            **popen_extra,
+        )
+        assert self._process.stdout is not None
+        assert self._process.stderr is not None
+        threading.Thread(
+            target=self._read_stdout,
+            args=(self._process.stdout,),
+            name="stagehand-facade-stdout",
+            daemon=True,
+        ).start()
+        threading.Thread(
+            target=self._read_stderr,
+            args=(self._process.stderr,),
+            name="stagehand-facade-stderr",
+            daemon=True,
+        ).start()
+        ready = self._receive(30)
+        if ready.get("type") != "ready" or ready.get("protocol") != _PROTOCOL:
+            self.close()
+            raise RuntimeError("Stagehand facade did not complete its handshake")
+
+    def _read_stdout(self, stream: TextIO) -> None:
+        try:
+            for line in stream:
+                try:
+                    value = json.loads(line)
+                except json.JSONDecodeError as error:
+                    self._queue.put(
+                        RuntimeError(
+                            f"Stagehand facade emitted invalid JSON: {error}"
+                        )
+                    )
+                    continue
+                self._queue.put(
+                    value
+                    if isinstance(value, dict)
+                    else RuntimeError(
+                        "Stagehand facade emitted a non-object response"
+                    )
+                )
+            self._queue.put(RuntimeError("Stagehand facade stdout closed"))
+        except BaseException as error:
+            self._queue.put(error)
+
+    @staticmethod
+    def _read_stderr(stream: TextIO) -> None:
+        for line in stream:
+            if line.strip():
+                logger.debug("Stagehand facade: %s", line.strip()[:1000])
+
+    def _send(self, value: Mapping[str, Any]) -> None:
+        process = self._process
+        if process is None or process.poll() is not None or process.stdin is None:
+            raise RuntimeError("Stagehand facade is not running")
+        process.stdin.write(json.dumps(value, separators=(",", ":")) + "\n")
+        process.stdin.flush()
+
+    def _receive(self, timeout_s: int) -> dict[str, Any]:
+        try:
+            value = self._queue.get(timeout=timeout_s)
+        except queue.Empty as error:
+            raise TimeoutError(
+                f"Stagehand facade did not respond within {timeout_s}s"
+            ) from error
+        if isinstance(value, BaseException):
+            raise RuntimeError(str(value)[:1000]) from value
+        return value
+
+    def close(self) -> None:
+        with self._lock:
+            process = self._process
+            if process is None:
+                return
+            try:
+                if process.poll() is None:
+                    self._request_id += 1
+                    self._send(
+                        {
+                            "protocol": _PROTOCOL,
+                            "type": "shutdown",
+                            "request_id": self._request_id,
+                        }
+                    )
+                    self._receive(35)
+                    process.wait(timeout=5)
+            except Exception:
+                logger.debug("Stagehand facade cleanup failed", exc_info=True)
+            finally:
+                if process.poll() is None:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=5)
+                self._process = None
+
+
+_CLIENTS: dict[tuple[str, str, str, str], _FacadeWorkerClient] = {}
+_CLIENTS_LOCK = threading.RLock()
+
+
+def _close_all_workers() -> None:
+    with _CLIENTS_LOCK:
+        clients = list(_CLIENTS.values())
+        _CLIENTS.clear()
+    for client in clients:
+        client.close()
+
+
+atexit.register(_close_all_workers)
+
+
+def close_stagehand_facade_workers() -> None:
+    """Close all profile/task-scoped browser workers (primarily for tests)."""
+    _close_all_workers()
+
+
+def call_stagehand_facade(
+    *,
+    code: str,
+    timeout_s: int,
+    node_executable: str,
+    stagehand_root: str,
+    task_key: str,
+) -> dict[str, Any]:
+    """Call the persistent worker isolated to the active profile and task."""
+    node = str(Path(node_executable).expanduser().resolve())
+    root = str(Path(stagehand_root).expanduser().resolve())
+    key = (hermes_home_key(), task_key, node, root)
+    with _CLIENTS_LOCK:
+        client = _CLIENTS.get(key)
+        if client is None:
+            client = _FacadeWorkerClient(
+                node_executable=node,
+                stagehand_root=root,
+            )
+            _CLIENTS[key] = client
+    return client.call(code=code, timeout_s=timeout_s)

--- a/tools/stagehand_facade_worker.mjs
+++ b/tools/stagehand_facade_worker.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+/**
+ * Persistent bridge from Hermes browser_exec to Stagehand's production
+ * Playwright facade. Protocol messages stay on stdout; diagnostics use stderr.
+ */
+
+import { createInterface } from "node:readline";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const PROTOCOL = "hermes-stagehand-facade-v1";
+let resourcesPromise;
+let closing = false;
+
+function write(value) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+function requiredEnv(name) {
+  const value = String(process.env[name] ?? "").trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function sanitize(message) {
+  return String(message)
+    .replace(/([?&](?:signingKey|apiKey|api_key|token|key)=)[^&\s"']+/gi, "$1[redacted]")
+    .replace(/\b(sk-[A-Za-z0-9_-]{6})[A-Za-z0-9_-]+/g, "$1[redacted]")
+    .replace(/\b(bb_(?:live|test)_[A-Za-z0-9]{4})[A-Za-z0-9_-]+/g, "$1[redacted]")
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{8,}/gi, "$1[redacted]")
+    .slice(0, 1000);
+}
+
+function stringifyResult(value) {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+async function createResources() {
+  const root = requiredEnv("STAGEHAND_FACADE_ROOT");
+  const sdkUrl = pathToFileURL(join(root, "packages/sdk-ts/dist/index.mjs")).href;
+  const facadeUrl = pathToFileURL(
+    join(root, "packages/integrations/core/dist/facade/index.mjs"),
+  ).href;
+  const [{ browserbase, Stagehand }, facade] = await Promise.all([
+    import(sdkUrl),
+    import(facadeUrl),
+  ]);
+  const browser = await browserbase.launch({
+    apiKey: requiredEnv("BROWSERBASE_API_KEY"),
+    ...(String(process.env.BROWSERBASE_PROJECT_ID ?? "").trim()
+      ? { projectId: String(process.env.BROWSERBASE_PROJECT_ID).trim() }
+      : {}),
+    keepAlive: false,
+  });
+  try {
+    const stagehand = await Stagehand.create({ browser, logging: { level: "off" } });
+    return {
+      browser,
+      stagehand,
+      tools: new facade.StagehandFacadeTools(stagehand),
+      runSchema: facade.CodeModeRunInputSchema,
+    };
+  } catch (error) {
+    await browser.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function resources() {
+  resourcesPromise ??= createResources().catch((error) => {
+    resourcesPromise = undefined;
+    throw error;
+  });
+  return await resourcesPromise;
+}
+
+async function call(code) {
+  const active = await resources();
+  const input = active.runSchema.parse({ code });
+  return stringifyResult(await active.tools.run(input.code));
+}
+
+async function shutdown() {
+  if (closing) return;
+  closing = true;
+  const active = await Promise.race([
+    resourcesPromise?.catch(() => undefined),
+    new Promise((resolve) => setTimeout(() => resolve(undefined), 5000)),
+  ]);
+  if (active) {
+    await active.stagehand.close().catch(() => undefined);
+    await active.browser.close().catch(() => undefined);
+  }
+}
+
+const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
+write({ protocol: PROTOCOL, type: "ready" });
+
+for await (const line of lines) {
+  let request;
+  try {
+    request = JSON.parse(line);
+    if (!request || request.protocol !== PROTOCOL) {
+      throw new Error("invalid facade request");
+    }
+    if (request.type === "shutdown") {
+      await shutdown();
+      write({ protocol: PROTOCOL, type: "shutdown", request_id: request.request_id });
+      process.exit(0);
+    }
+    if (request.type !== "call") throw new Error("unknown facade request type");
+    const output = await call(String(request.code ?? ""));
+    write({
+      protocol: PROTOCOL,
+      type: "response",
+      request_id: request.request_id,
+      success: true,
+      output,
+    });
+  } catch (error) {
+    write({
+      protocol: PROTOCOL,
+      type: "response",
+      request_id: request?.request_id,
+      success: false,
+      error: sanitize(error instanceof Error ? error.message : String(error)),
+      error_type: error instanceof Error ? error.name : "Error",
+    });
+  }
+}
+
+await shutdown();


### PR DESCRIPTION
## Summary

This benchmark spike keeps Hermes' existing one-tool `browser_exec` interface and swaps Browser Use's Python CLI implementation for a Stagehand V4 JavaScript facade backed by `experimentalBatch` on Browserbase.

Both arms expose one tool with the same `{success, exit_code, output}` result envelope. Browser Use receives Python; Stagehand receives an async JavaScript workflow with prebound Playwright-shaped `page`, `context`, and `browser` objects. Richer execution telemetry remains out of the model context.

## Results

Opus 4.8 through Vercel AI Gateway, fresh Browserbase browser per trajectory, all six `hard.json` tasks, three trials per task and arm, and zero automatic trajectory retries:

| Arm | Accuracy | Mean tokens | Mean tool calls | Mean agent wall | Mean end-to-end cell wall | Tool schema |
|---|---:|---:|---:|---:|---:|---:|
| Browser Use 3.0 `browser_exec` | 18/18 | 22,378 | 2.44 | 20.27s | 22.53s | 3,686 chars |
| Stagehand one-shot facade | **18/18** | **13,626 (-39.1%)** | **1.61 (-34.1%)** | **17.11s (-15.6%)** | **19.93s (-11.6%)** | **1,660 chars (-55.0%)** |

Stagehand matched Browser Use accuracy and improved every measured efficiency metric. Both arms scored 3/3 on each task:

- `multi_page_filter`
- `rating_aggregate`
- `js_rendered`
- `delayed_render`
- `login_then_extract`
- `cross_category_compare`

## Methodology and provenance

- Tasks: `evals/browser_use/tasks/hard.json`
- Matrix: 6 tasks x 2 arms x 3 trials = 36 trajectories
- Browser environment: one fresh Browserbase browser per trajectory
- Model: `anthropic/claude-opus-4.8` through `ai-gateway.vercel.sh`
- Retries: none
- Grading: checked-in string oracles over each final response
- Browser Use tree: `bdc9a810f3990597b3f26203348e849e5128afb6`
- Stagehand facade tree: `1c2851b1d4acea78e74b31d229e76766381f6593`
- Stagehand checkout: `c6d9baacd5fb668a71a4300436a45ae319660d5c`
- Browser Use runtime: `browser-use==0.13.7`, `browser-harness==0.1.8`
- Task-file SHA-256: `c123579f17b75a86a20bcda4b27372f6ea2e870931c6748b78ba5632b67eab1a`
- Raw-record SHA-256: `4062ac682daa07abb5ec9fe26327b882e17ecfb169eb22d7143deb5591538c3a`
- Record audit: 36 unique cells, 36 rows, zero errors, and only `browser_exec` tool calls

## Changes

- Add an explicit `browser.backend: stagehand` path behind Hermes' existing `browser_exec` model tool.
- Add a persistent Python-to-Node bridge and Stagehand V4 facade worker.
- Give the model a concise JavaScript facade contract while preserving Browser Use's result envelope.
- Extend `evals/browser_use` with isolated Browser Use and Stagehand arms, Vercel AI Gateway routing, dry-run planning, resume-safe records, and commit/task/provider provenance.
- Add focused coverage for backend selection, schema shape, dispatch, response envelopes, and worker lifecycle.

## Reproduce

Setup, dependency pins, environment variables, and full commands are documented in `evals/browser_use/README.md`.

The non-billable gate must report `scheduled_cells: 36`:

```bash
python3 evals/browser_use/orchestrate_cloud.py \
  --backend browserbase \
  --tasks evals/browser_use/tasks/hard.json \
  --arms pr,stagehand \
  --models anthropic/claude-opus-4.8 \
  --reps 3 \
  --dry-run
```

Run the matrix:

```bash
python3 evals/browser_use/orchestrate_cloud.py \
  --backend browserbase \
  --tasks evals/browser_use/tasks/hard.json \
  --arms pr,stagehand \
  --models anthropic/claude-opus-4.8 \
  --reps 3 \
  --results evals/browser_use/results/stagehand-vs-browser-use.jsonl
```

## Validation

| Check | Observed result |
|---|---|
| Focused Python tests | 98/98 passed |
| Runner compile and diff hygiene | Both runner files compiled; `git diff --check` passed |
| Exact dry-run | Six tasks, two arms, one model, three trials; 36 scheduled cells |
| Full Browserbase matrix | 36/36 oracle hits; zero errors |
| Provenance audit | Expected task and commit hashes; only `browser_exec` tool calls |

## Scope

This is benchmark wiring, not production installation or configuration UX. The six tasks are stable toscrape-family tasks rather than anti-bot or heavy-SPA workloads, and three trials per task is directional rather than statistically decisive. Live model serving and Browserbase sessions remain nondeterministic, so exact token and latency values will vary on rerun.
