### PR TITLE
fix(journey): parse quoted editor commands

### DIFF
--- a/hermes_cli/journey.py
+++ b/hermes_cli/journey.py
@@ -290,6 +290,7 @@ def _cmd_edit(args: argparse.Namespace) -> int:
 
 def _open_in_editor(initial: str, *, suffix: str) -> Optional[str]:
     import os
+    import shlex
     import subprocess
     import tempfile
 
@@ -298,7 +299,7 @@ def _open_in_editor(initial: str, *, suffix: str) -> Optional[str]:
         fh.write(initial)
         path = fh.name
     try:
-        subprocess.call([*editor.split(), path])
+        subprocess.call([*shlex.split(editor, posix=(os.name != "nt")), path])
         with open(path, encoding="utf-8") as fh:
             return fh.read()
     except OSError as exc:

--- a/tests/hermes_cli/test_journey.py
+++ b/tests/hermes_cli/test_journey.py
@@ -1,0 +1,15 @@
+def test_open_in_editor_supports_quoted_executable_path(tmp_path, monkeypatch):
+    from hermes_cli.journey import _open_in_editor
+
+    editor = tmp_path / "fake editor"
+    editor.write_text(
+        "#!/bin/sh\n"
+        "printf 'edited\\n' > \"$1\"\n",
+        encoding="utf-8",
+    )
+    editor.chmod(0o755)
+
+    monkeypatch.setenv("EDITOR", f'"{editor}"')
+    monkeypatch.delenv("VISUAL", raising=False)
+
+    assert _open_in_editor("original\n", suffix=".txt") == "edited\n"


### PR DESCRIPTION
Fix quoted editor command parsing in `hermes journey edit`.

`_open_in_editor()` previously used `editor.split()`, which splits purely on whitespace. As a result, an `EDITOR` value containing a quoted executable path with spaces could not be launched.

Use `shlex.split()` to preserve quoted command components while still supporting editor arguments.

A regression test covers an editor executable whose path contains a space.

Validation:
- Reproduced the failure on current `main` with a quoted editor path containing a space.
- Verified the same reproducer succeeds after the change.
- `git diff --check` passes.