### PR TITLE
fix(ntfy): fall back to the publish topic for the unset home channel

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -502,7 +502,13 @@ def _env_enablement() -> dict | None:
     markdown = os.getenv("NTFY_MARKDOWN", "").strip().lower()
     if markdown:
         seed["markdown"] = markdown in ("1", "true", "yes")
-    home = os.getenv("NTFY_HOME_CHANNEL", "").strip() or topic
+    # Home-channel fallback order when NTFY_HOME_CHANNEL is unset: a split
+    # publish topic is the delivery surface (subscribers listen there), so
+    # bare `deliver: ntfy` cron jobs must land on it — falling back to the
+    # subscribe topic silently delivers to a topic nobody watches while the
+    # scheduler reports ok (#88893). Single-topic setups keep today's
+    # behaviour (publish_topic empty → topic).
+    home = os.getenv("NTFY_HOME_CHANNEL", "").strip() or publish_topic or topic
     if home:
         seed["home_channel"] = {
             "chat_id": home,

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -111,6 +111,49 @@ class TestNtfyAdapterInit:
 # ---------------------------------------------------------------------------
 
 
+class TestEnvEnablementHomeChannel:
+    """Bare ``deliver: ntfy`` resolves through the seeded home_channel.
+
+    With split subscribe/publish topics and NTFY_HOME_CHANNEL unset, the
+    fallback must be the PUBLISH topic (the delivery surface subscribers
+    watch) — falling back to the subscribe topic delivers to a topic nobody
+    watches while the scheduler reports ok (#88893).
+    """
+
+    def test_unset_home_falls_back_to_publish_topic(self, monkeypatch):
+        from plugins.platforms.ntfy.adapter import _env_enablement
+
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        monkeypatch.setenv("NTFY_PUBLISH_TOPIC", "hermes-out")
+        monkeypatch.delenv("NTFY_HOME_CHANNEL", raising=False)
+
+        seed = _env_enablement()
+
+        assert seed["home_channel"]["chat_id"] == "hermes-out"
+
+    def test_explicit_home_channel_wins(self, monkeypatch):
+        from plugins.platforms.ntfy.adapter import _env_enablement
+
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        monkeypatch.setenv("NTFY_PUBLISH_TOPIC", "hermes-out")
+        monkeypatch.setenv("NTFY_HOME_CHANNEL", "my-alerts")
+
+        seed = _env_enablement()
+
+        assert seed["home_channel"]["chat_id"] == "my-alerts"
+
+    def test_single_topic_setup_keeps_topic_fallback(self, monkeypatch):
+        from plugins.platforms.ntfy.adapter import _env_enablement
+
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-both")
+        monkeypatch.delenv("NTFY_PUBLISH_TOPIC", raising=False)
+        monkeypatch.delenv("NTFY_HOME_CHANNEL", raising=False)
+
+        seed = _env_enablement()
+
+        assert seed["home_channel"]["chat_id"] == "hermes-both"
+
+
 class TestAuthHeaders:
 
     def _make_adapter(self, token=""):


### PR DESCRIPTION
## What does this PR do?

Fixes bare `deliver: ntfy` cron jobs publishing to the **subscribe** topic when ntfy runs with split subscribe/publish topics and `NTFY_HOME_CHANNEL` is unset (#88893). The env-enablement seed (`_env_enablement`) computed `home = NTFY_HOME_CHANNEL or NTFY_TOPIC` — with the subscribe/publish split, that fallback is the topic **nobody watches** (subscribers listen on the publish topic), so deliveries silently went to a dead topic while the scheduler reported `delivered … ok`.

The fallback now prefers the publish topic: `NTFY_HOME_CHANNEL or NTFY_PUBLISH_TOPIC or NTFY_TOPIC`. Rationale: a split publish topic exists precisely to be the delivery surface; single-topic setups are unchanged (publish topic empty → subscribe topic, which is also the delivery surface there); an explicit home channel still wins. Distinct from #79190 / #47102, which fix *honoring an already-resolved* delivery target — this fixes *which target the unset-home fallback picks*.

## Related Issue

Fixes #88893

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/ntfy/adapter.py` — `_env_enablement()`: the home-channel fallback becomes `NTFY_HOME_CHANNEL or publish_topic or topic`, with a comment explaining the split-topic delivery-surface rule.
- `tests/gateway/test_ntfy_plugin.py` — new `TestEnvEnablementHomeChannel`: unset home + split topics → home falls back to the publish topic; explicit `NTFY_HOME_CHANNEL` wins; single-topic setup keeps the topic fallback.

## How to Test

1. `python -m pytest tests/gateway/test_ntfy_plugin.py -q`
   Observed result: 33 passed.
2. Fail-on-main check: `git stash` the adapter change and rerun `TestEnvEnablementHomeChannel` — Observed result: 1 failed (split-topic fallback seeds the subscribe topic).
3. Repro from the issue: `NTFY_TOPIC=hermes-in`, `NTFY_PUBLISH_TOPIC=hermes-out`, home unset, phone subscribed to `hermes-out`, a cron job with `deliver: ntfy` — Observed result after the fix: the job publishes to `hermes-out` and the phone receives it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ntfy plugin suite: 33 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment documents the fallback rule)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — env-var fallback order only; or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
