### PR TITLE
fix(telegram): handle channel posts in media handler and thread interim replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20560,6 +20560,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _status_adapter.send(
                         _status_chat_id,
                         display_text,
+                        reply_to=event_message_id,
                         metadata=_status_thread_metadata,
                     ),
                     _loop_for_step,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1515,6 +1515,7 @@ class GatewayStreamConsumer:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
+                reply_to=self._initial_reply_to_id,
                 metadata=self.metadata,
             )
             # Note: do NOT set _already_sent = True here.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8417,18 +8417,22 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
-        if not update.message:
+        # Use effective_message so channel posts (update.channel_post) are
+        # handled too — plain update.message is None for channel broadcasts,
+        # which silently dropped forwarded media in channels.
+        msg = self._effective_update_message(update)
+        if not msg:
             return
-        if not self._is_user_authorized_from_message(update.message):
+        if not self._is_user_authorized_from_message(msg):
             logger.info(
                 "[Telegram] Blocked media from unauthorized user %s in chat %s",
-                getattr(getattr(update.message, "from_user", None), "id", None),
-                getattr(getattr(update.message, "chat", None), "id", None),
+                getattr(getattr(msg, "from_user", None), "id", None),
+                getattr(getattr(msg, "chat", None), "id", None),
             )
             return
-        if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                _m = msg
                 _observe_type = self._media_message_type(_m)
                 _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
                 if _m.caption:
@@ -8439,7 +8443,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return
 
-        msg = update.message
+        # msg already resolved via _effective_update_message above (handles
+        # channel posts); keep the local reference for the rest of the handler.
 
         msg_type = self._media_message_type(msg)
 


### PR DESCRIPTION
## Summary

Two related Telegram fixes for **channel (broadcast) chats**, found while using a Hermes bot in a Telegram channel:

### 1. Forwarded media silently dropped in channels
`_handle_media_message` checked `update.message` directly, which is `None` for channel posts (Telegram delivers those via `update.channel_post`). Any photo/video/document forwarded into a channel was dropped at the first guard — no log, no event, nothing. The text handler already used `_effective_update_message()`; the media handler did not.

**Fix:** resolve `msg = self._effective_update_message(update)` at the top of `_handle_media_message` (same as the text/command/location handlers) and use it throughout.

### 2. Interim replies not threaded to the triggering message in channels
Interim assistant messages (commentary between tool calls) were sent via `adapter.send()` **without `reply_to`**:
- `GatewayStreamConsumer._send_commentary()` — the streamed path
- `GatewayRunner._interim_assistant_cb()` — the non-streaming fallback path

In a channel (no `thread_id`), the metadata path also produced no reply anchor, so every interim status message appeared as an unthreaded standalone message. The final reply was threaded correctly (via `_reply_anchor_for_event`), which made the mid-response messages look inconsistent.

**Fix:** pass `reply_to=self._initial_reply_to_id` in `_send_commentary()` and `reply_to=event_message_id` in the fallback `send()` call.

## Verification

Live-tested against a real Telegram channel:
- Forwarded photo into channel → now cached and processed (before: silently dropped, `update.message` was None)
- Mid-response commentary messages → now carry `reply_to=<triggering message id>` (verified via send-path debug logging: `reply_to='415'` etc.)
- Final replies → unchanged (already threaded)

## Files changed

- `gateway/stream_consumer.py` — thread `_send_commentary` sends
- `gateway/run.py` — thread non-streaming interim fallback sends
- `plugins/platforms/telegram/adapter.py` — handle channel posts in `_handle_media_message`
