### PR TITLE
feat(mcp): add Context.dev catalog integration

### DIFF
--- a/optional-mcps/context/manifest.yaml
+++ b/optional-mcps/context/manifest.yaml
@@ -1,0 +1,25 @@
+manifest_version: 1
+
+name: context
+description: Search, scrape, crawl, extract, parse, monitor, and process the live web with Context.dev.
+source: https://docs.context.dev
+
+transport:
+  type: http
+  url: https://mcp.context.dev/mcp
+
+auth:
+  type: oauth
+
+suggest:
+  keywords:
+    - context.dev
+  hosts:
+    - context.dev
+
+post_install: |
+  On first connection, Hermes opens a browser to authenticate with Context.dev.
+  Approve access, then restart the Hermes session so the tools load.
+
+  Re-run the tool checklist at any time with:
+    hermes mcp configure context


### PR DESCRIPTION
## Summary

Adds Context.dev to the curated Hermes MCP catalog.

Context.dev exposes live web search, scraping, crawling, structured extraction, document parsing, brand intelligence, monitoring, screenshots, and asynchronous batch processing through its hosted MCP server. The catalog entry uses Hermes's native remote OAuth flow and suggestion metadata for Context.dev mentions and links.

## Validation

- `HERMES_PYTHON=/Users/nair/.hermes/venvs/hermes-context-pr/bin/python scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q` — 25 tests passed
- loaded the manifest through `hermes_cli.mcp_catalog` and verified its HTTP transport, OAuth auth type, and suggestion metadata
- verified the live MCP endpoint returns an RFC 9728 protected-resource challenge
- verified authorization-server discovery advertises dynamic client registration, PKCE S256, authorization-code grants, and refresh tokens

## Scope

This adds one catalog manifest only. It does not add a core tool, dependency, or local bootstrap command.