### PR TITLE
test(api-server): drain the SSE stream before asserting on _run_agent in the poisoned-row test

### DIFF
--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -450,6 +450,10 @@ async def test_session_chat_stream_treats_pre_existing_poisoned_row_as_no_model(
                 json={"message": "hi"},
             )
             assert resp.status == 200
+            # The SSE handler runs _run_agent in a background task after the
+            # headers are sent; drain the stream so the call has happened
+            # before we inspect the mock (otherwise call_args is a race).
+            await resp.text()
 
     _, kwargs = mock_run.call_args
     assert kwargs["session_model"] is None


### PR DESCRIPTION
## What does this PR do?

Fixes #88907.

`test_session_chat_stream_treats_pre_existing_poisoned_row_as_no_model` inspected `mock_run.call_args` right after `await cli.post(...)` returned. For the SSE endpoint that return happens once the headers are sent, while `_run_agent` is called later inside the handler's background task (after `await self._conversation_history_for_session(...)`), so the assertion raced the task and failed on slower runners with `TypeError: cannot unpack non-iterable NoneType object` (two consecutive runs on #68908, a memory-plugin PR).

The fix drains the stream (`await resp.text()`) before leaving the client context, exactly what the neighbouring stream tests in this file already do (lines 345 and 660 on main; 664 after this change). Test-only change; no production code touched.

## Verification

- `tests/gateway/test_session_api.py`: 20 passed locally, run 5 times (Windows).
- The race cannot be forced deterministically from the test side without changing the handler; the evidence is the two CI jobs linked in the issue plus the handler ordering (`asyncio.create_task(_run_and_signal())` at `gateway/platforms/api_server.py:4056`, `await response.prepare(request)` at :4073, `_run_agent` reached only after :3964).
