### PR TITLE
fix(doctor): scope workspace npm audits to runtime deps

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -240,6 +240,19 @@ def _safe_which(cmd: str) -> str | None:
         return None
 
 
+def _npm_audit_omit_args(audit_extra: list[str]) -> list[str]:
+    """Return omit flags for doctor npm audits.
+
+    Workspace audits report runtime/browser-impacting dependencies. Dev-only
+    lint/build-tool advisories are noisy in this monorepo and can require major
+    upgrades unrelated to Hermes runtime health, so doctor omits them while
+    leaving explicit remediation work to npm audit.
+    """
+    if audit_extra and audit_extra[0] == "--workspace":
+        return ["--omit=dev", "--omit=optional"]
+    return ["--omit=optional"]
+
+
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     steps: list[str] = []
     step = 1
@@ -2279,7 +2292,7 @@ def run_doctor(args):
                 # Use resolved absolute path so Windows can execute
                 # npm.cmd (CreateProcessW can't run bare .cmd names).
                 audit_result = subprocess.run(
-                    [_npm_bin, "audit", "--json", *audit_extra],
+                    [_npm_bin, "audit", "--json", *audit_extra, *_npm_audit_omit_args(audit_extra)],
                     cwd=str(npm_dir),
                     capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=30,
                 )
@@ -2290,16 +2303,14 @@ def run_doctor(args):
                 high = vuln_count.get("high", 0)
                 moderate = vuln_count.get("moderate", 0)
                 total = critical + high + moderate
-                # Determine a scoped fix command for the remediation hint.
-                if audit_extra and audit_extra[0] == "--workspace":
-                    # Detection (`npm audit --workspace <name>`) is read-only and
-                    # safe, but `npm audit fix --workspace <name>` crashes on
-                    # current npm with "Cannot read properties of null (reading
-                    # 'edgesOut')" — an arborist bug with workspace-filtered
-                    # audit fix. The root-level `npm audit fix` can crash on the
-                    # same tree with "isDescendantOf", so do not hand the user a
-                    # manual fix command for these build-tool advisories.
-                    fix_cmd = None
+                # Determine a scoped check/remediation command for the hint.
+                workspace_audit = audit_extra and audit_extra[0] == "--workspace"
+                if workspace_audit:
+                    workspace_name = audit_extra[1] if len(audit_extra) > 1 else "<workspace>"
+                    fix_cmd = (
+                        f"cd {PROJECT_ROOT} && npm audit --workspace {workspace_name} "
+                        "--omit=dev --omit=optional"
+                    )
                 elif audit_extra == ["--workspaces=false"]:
                     fix_cmd = f"cd {npm_dir} && npm audit fix --workspaces=false"
                 else:
@@ -2314,22 +2325,16 @@ def run_doctor(args):
                     else:
                         vuln_detail = (
                             f"{critical} critical, {high} high, {moderate} moderate — "
-                            "build-tool advisory; clears via lockfile bump"
+                            f"review runtime advisory: {fix_cmd}"
                         )
                     check_warn(
                         f"{label} deps",
                         f"({vuln_detail})"
                     )
-                    if audit_extra and audit_extra[0] == "--workspace":
-                        # The web/ui-tui workspace advisories are in build-time
-                        # tooling (esbuild/vite, etc.), not runtime code that ships
-                        # to users. Manual npm remediation may error with a known
-                        # arborist crash (edgesOut / isDescendantOf) on this monorepo
-                        # tree — in that case it is an npm bug, not a Hermes one.
+                    if workspace_audit:
                         check_info(
-                            "  ^ build-time tooling (not runtime); if manual npm remediation "
-                            "errors with an arborist crash it's a known npm bug — clears "
-                            "via a lockfile bump"
+                            "  ^ dev-only lint/build tooling is omitted here; doctor reports "
+                            "runtime workspace advisories only"
                         )
                     issues.append(
                         f"{label} has {total} npm "

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1471,3 +1471,13 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+def test_workspace_npm_audit_omits_dev_and_optional_deps():
+    assert doctor_mod._npm_audit_omit_args(["--workspace", "web"]) == [
+        "--omit=dev",
+        "--omit=optional",
+    ]
+    assert doctor_mod._npm_audit_omit_args(["--workspaces=false"]) == [
+        "--omit=optional"
+    ]


### PR DESCRIPTION
## Summary

- Reworks the useful part of #74671 onto current `origin/main` as a small doctor-only change.
- Keeps package manifests and router migration changes out of scope; current main already carries the react-router migration.
- Omits dev and optional dependencies for workspace npm audit checks so `doctor` reports runtime-relevant workspace advisories without noisy lint/build-tool findings.

## Scope

Changed files:

- `hermes_cli/doctor.py`
- `tests/hermes_cli/test_doctor.py`

## Validation

- `python -m py_compile hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`
- `python -m pytest tests/hermes_cli/test_doctor.py::test_workspace_npm_audit_omits_dev_and_optional_deps -q -o 'addopts='` — 1 passed
- `python -m pytest tests/hermes_cli/test_doctor.py -q -o 'addopts='` — 55 passed, 1 warning

## Notes

This intentionally does not reuse #74671 as-is because that branch contains a stale router migration commit and package-lock/package manifest conflicts against current main.
