### PR TITLE
fix: recover interrupted updates and support Python 3.14 workers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8512,6 +8512,46 @@ def _clear_update_incomplete_marker() -> None:
     _clear_marker_file(_update_marker_path(), label="update-incomplete")
 
 
+def _reset_update_recovery_state() -> bool:
+    """Clear a resolved core-install marker after verifying core imports.
+
+    A failed update deliberately leaves ``.update-incomplete`` behind so the
+    next launch can retry recovery. Once a user has repaired the environment
+    manually, there must be a supported way to stop that retry loop without
+    deleting the marker by hand. Do not clear it unless the same venv health
+    probe used by the updater confirms the core runtime imports cleanly.
+    """
+    from hermes_cli.update_lock import UpdateLock, describe_holder
+
+    update_lock = UpdateLock()
+    if not update_lock.acquire():
+        print(describe_holder(update_lock.holder))
+        return False
+
+    try:
+        marker = _update_marker_path()
+        if not marker.exists():
+            print("No pending interrupted-update recovery state found.")
+            return True
+
+        healthy, detail = _self()._venv_core_imports_healthy(strict=True)
+        if not healthy:
+            print("✗ Cannot reset update recovery state: core imports are unhealthy.")
+            if detail:
+                print(f"  {detail}")
+            print("  Repair the environment first, then retry `hermes update --reset-state`.")
+            return False
+
+        _clear_update_incomplete_marker()
+        if marker.exists():
+            print(f"✗ Could not remove {marker}.")
+            return False
+        print("✓ Cleared interrupted-update recovery state.")
+        return True
+    finally:
+        update_lock.release()
+
+
 def _clear_lazy_refresh_incomplete_marker() -> None:
     """Remove the interrupted lazy-refresh breadcrumb. Never raises."""
     _clear_marker_file(_lazy_refresh_marker_path(), label="lazy-refresh-incomplete")
@@ -9895,6 +9935,11 @@ def cmd_update(args):
     runs the update, then restores stdio on the way out (even on
     ``sys.exit`` or unhandled exceptions).
     """
+    if getattr(args, "reset_state", False):
+        if not _reset_update_recovery_state():
+            sys.exit(1)
+        return
+
     from hermes_cli.config import (
         detect_install_method,
         format_docker_update_message,

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -32,6 +32,15 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         help="Check whether an update is available without installing anything",
     )
     update_parser.add_argument(
+        "--reset-state",
+        action="store_true",
+        default=False,
+        help=(
+            "Clear a resolved .update-incomplete recovery marker after verifying "
+            "that the core environment imports cleanly"
+        ),
+    )
+    update_parser.add_argument(
         "--no-backup",
         action="store_true",
         default=False,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3122,7 +3122,7 @@ def _wait_for_windows_update_gateway_exit(
             pass
     return survivors
 
-def _venv_core_imports_healthy() -> tuple[bool, str]:
+def _venv_core_imports_healthy(*, strict: bool = False) -> tuple[bool, str]:
     """Probe the project venv for the core imports the backend needs to boot.
 
     Runs a tiny import check inside the venv interpreter (NOT this process —
@@ -3136,7 +3136,9 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     (ryanc's incident, July 2026).
 
     Returns ``(healthy, detail)``. Never raises; unknown states report
-    healthy so a probe failure can't force needless reinstalls.
+    healthy so a probe failure can't force needless reinstalls during the
+    normal update path. Callers that need affirmative proof can pass
+    ``strict=True`` to treat an unavailable probe as unhealthy.
     """
     venv_dir = _m().PROJECT_ROOT / "venv"
     venv_python = venv_python_path(venv_dir, windows=_m()._is_windows())
@@ -3179,6 +3181,8 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
         )
     except Exception as exc:
         logger.debug("venv health probe failed to run: %s", exc)
+        if strict:
+            return False, f"core import probe failed: {exc}"
         return True, ""
 
     missing = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -781,6 +781,67 @@ termux = ["rich>=14"]
     assert hm._load_installable_optional_extras(group="termux-all") == ["termux", "mcp"]
 
 
+class TestUpdateRecoveryReset:
+    class _Lock:
+        holder = None
+
+        def __init__(self):
+            self.released = False
+
+        def acquire(self):
+            return True
+
+        def release(self):
+            self.released = True
+
+    def test_reset_state_clears_marker_after_healthy_probe(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        from hermes_cli import main as hm
+
+        marker = tmp_path / ".update-incomplete"
+        marker.write_text('{"attempts": 3}', encoding="utf-8")
+        probe_kwargs = {}
+
+        def healthy_probe(**kwargs):
+            probe_kwargs.update(kwargs)
+            return True, ""
+
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm, "_venv_core_imports_healthy", healthy_probe)
+        monkeypatch.setattr("hermes_cli.update_lock.UpdateLock", self._Lock)
+
+        cmd_update(SimpleNamespace(reset_state=True))
+
+        assert not marker.exists()
+        assert probe_kwargs == {"strict": True}
+        assert "Cleared interrupted-update recovery state" in capsys.readouterr().out
+
+    def test_reset_state_keeps_marker_when_probe_fails(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        from hermes_cli import main as hm
+
+        marker = tmp_path / ".update-incomplete"
+        marker.write_text('{"attempts": 3}', encoding="utf-8")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(
+            hm,
+            "_venv_core_imports_healthy",
+            lambda **_kwargs: (False, "yaml: No module named yaml"),
+        )
+        monkeypatch.setattr("hermes_cli.update_lock.UpdateLock", self._Lock)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update(SimpleNamespace(reset_state=True))
+
+        assert exc_info.value.code == 1
+        assert marker.exists()
+        out = capsys.readouterr().out
+        assert "core imports are unhealthy" in out
+        assert "yaml: No module named yaml" in out
+
+
 class TestNodeRuntimeNpmResolution:
     """Regression tests for #30271 — WSL must not run Windows npm against the
     Linux checkout, and a failed Node refresh must not report success."""

--- a/tests/tools/test_daemon_pool.py
+++ b/tests/tools/test_daemon_pool.py
@@ -42,6 +42,31 @@ def test_idle_worker_reuse():
         pool.shutdown(wait=True)
 
 
+def test_worker_initializer_and_submit_follow_stdlib_contract():
+    """The custom pool must track CPython's private worker contract.
+
+    Python 3.14 replaced the legacy initializer/initargs arguments with a
+    WorkerContext. This exercises both the worker startup and the initializer
+    so the old four-argument call cannot regress silently into a dead worker.
+    """
+    initialized = threading.Event()
+
+    def initializer(value):
+        assert value == "ready"
+        initialized.set()
+
+    pool = DaemonThreadPoolExecutor(
+        max_workers=1,
+        initializer=initializer,
+        initargs=("ready",),
+    )
+    try:
+        assert pool.submit(lambda: 42).result(timeout=10) == 42
+        assert initialized.wait(timeout=10)
+    finally:
+        pool.shutdown(wait=True)
+
+
 def test_wedged_worker_does_not_block_interpreter_exit():
     """A worker stuck in a long sleep must not hold the process open.
 

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -38,8 +38,10 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
-        # daemon=True and no _threads_queues registration.
+        # Mirrors CPython's implementation with two changes: daemon=True and
+        # no _threads_queues registration. CPython 3.14 replaced the legacy
+        # initializer/initargs pair with a WorkerContext, so keep both worker
+        # argument layouts here rather than assuming one interpreter version.
         if self._idle_semaphore.acquire(timeout=0):
             return
 
@@ -49,15 +51,24 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
-                    weakref.ref(self, weakref_cb),
+            executor_reference = weakref.ref(self, weakref_cb)
+            if hasattr(self, "_create_worker_context"):
+                worker_args = (
+                    executor_reference,
+                    self._create_worker_context(),
+                    self._work_queue,
+                )
+            else:
+                worker_args = (
+                    executor_reference,
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=worker_args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
## Summary

- Add `hermes update --reset-state` to safely clear a resolved `.update-incomplete` marker.
- Make `DaemonThreadPoolExecutor` compatible with both the legacy CPython worker contract and Python 3.14's `WorkerContext`.
- The current upstream early-recovery path already selects the Termux-safe `termux-all` extras group, so this PR does not duplicate that existing fix.

## Root cause

The daemon pool copied CPython 3.8–3.13 internals and passed four arguments directly to the private `_worker` function. Python 3.14 changed that contract to `(executor_reference, worker_context, work_queue)`, causing workers to fail before processing submitted work.

Interrupted updates persist `.update-incomplete` so the next launch can retry recovery, but there was no supported command to clear that marker after the environment had been repaired.

## Fix

The pool now feature-detects `_create_worker_context` and uses the matching worker argument layout while preserving daemon-thread behavior and initializer support.

`hermes update --reset-state` acquires the shared update lock, requires a strict successful core-import health probe, and only then removes the recovery marker. If the probe fails, the marker remains and the command reports the reason.

## Testing

- `scripts/run_tests.sh tests/tools/test_daemon_pool.py -q` — 4 passed
- `scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py -q` — 37 passed
- `./.venv/bin/python -m pytest tests/hermes_cli/test_cmd_update.py -q -k UpdateRecoveryReset` — 2 passed
- `scripts/run_tests.sh tests/hermes_cli/test_early_recovery.py tests/hermes_cli/test_update_interrupted_recovery.py -q` — 19 passed
- Ruff, bytecode compilation, and `git diff --check` — passed
- The Windows-footgun checker reports 23 pre-existing findings on unchanged test lines; no changed-line findings were reported.
- Python 3.14 was not installed in the local environment; the compatibility path is feature-detected and covered by the worker contract regression test.

## Issue

Fixes #88896