### PR TITLE
feat(desktop): fold durable groups into bundled Bot Mode

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -48,8 +48,10 @@ import {
   profileColor,
   queryClient,
   relativeTime,
+  ROUTES_AREA,
   ScrollArea,
   SearchField,
+  SIDEBAR_NAV_AREA,
   Select,
   SelectContent,
   SelectItem,
@@ -75,6 +77,8 @@ const createBudgetedLoop = typeof sdk === 'undefined' ? undefined : sdk.createBu
 const ID = 'hermes-bots'
 const ROSTER_KEY = [ID, 'roster']
 const ROUTINES_KEY = [ID, 'routines']
+const GROUPS_KEY = [ID, 'groups']
+const GROUP_ROUTE = '/bot-groups'
 const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
 
 /** Captured in register() so components can reach plugin storage. */
@@ -170,6 +174,7 @@ const $lastJobs = atom([])
 /** Bot the Routines tile is scoped to. Follows the live gateway profile
  *  (the bot you're actually chatting with) and roster clicks. */
 const $selectedBot = atom('default')
+const $selectedGroupId = atom(null)
 
 /** Optional secondary navigation inside the Bots pane. Primary row clicks still
  * open the bot's canonical chat; this state opens its stored-session browser. */
@@ -203,6 +208,68 @@ function handleSessionsGatewayTransition() {
 /** Per-bot appearance + display meta, persisted via ctx.storage:
  *  { [botName]: { shape, color, title } } */
 const $botMeta = atom({})
+
+/** Per-group chat-only preferences. These never rewrite member profiles.
+ *  { [groupId]: { modelOverride?: { provider, model } } } */
+const $groupChatPrefs = atom({})
+
+function canonicalGroupModelId(model) {
+  const raw = String(model || '').trim()
+  if (/^katana-qwen(?::latest)?$/i.test(raw)) {
+    return raw.toLowerCase().endsWith(':latest') ? 'qwen3.5-9b:latest' : 'qwen3.5-9b'
+  }
+  return raw
+}
+
+function groupModelKey(model) {
+  return canonicalGroupModelId(model).toLowerCase().replace(/:latest$/, '')
+}
+
+function canonicalGroupModelOverride(value) {
+  if (!value?.model) {
+    return value || null
+  }
+  return { ...value, model: canonicalGroupModelId(value.model) }
+}
+
+function migrateGroupChatPrefs(value) {
+  if (!value || typeof value !== 'object') {
+    return {}
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([groupId, prefs]) => [
+      groupId,
+      prefs && typeof prefs === 'object'
+        ? { ...prefs, modelOverride: canonicalGroupModelOverride(prefs.modelOverride) }
+        : prefs
+    ])
+  )
+}
+
+function saveGroupChatPrefs(groupId, patch) {
+  const current = $groupChatPrefs.get()
+  const normalizedPatch = {
+    ...patch,
+    ...(Object.prototype.hasOwnProperty.call(patch, 'modelOverride')
+      ? { modelOverride: canonicalGroupModelOverride(patch.modelOverride) }
+      : {})
+  }
+  const next = { ...current, [groupId]: { ...(current[groupId] || {}), ...normalizedPatch } }
+  $groupChatPrefs.set(next)
+  try {
+    Promise.resolve(pluginCtx?.storage?.set?.('group-chat-prefs', next)).catch(() => undefined)
+  } catch {
+    /* local persistence is best-effort */
+  }
+}
+
+function newBotInstanceId() {
+  try {
+    return globalThis.crypto?.randomUUID?.() || null
+  } catch {
+    return null
+  }
+}
 
 async function saveBotMeta(name, patch) {
   const prevMeta = $botMeta.get()[name] || {}
@@ -697,6 +764,688 @@ async function deleteBot(bot) {
 
   if (host.state.profile.get?.() === bot.name && typeof host.newChat === 'function') {
     host.newChat('default')
+  }
+}
+
+// ── durable Groups: stable identities, model/slash helpers, transcript API ──
+
+let identityReconcileInFlight = null
+let identityReconcileFingerprint = ''
+
+/** Reconcile immutable bot IDs with the installation-wide Groups backend.
+ *  Returns the assignments so Groups can await identity readiness instead of
+ *  disabling membership controls while reconciliation is still in flight. */
+function reconcileBotIdentities(roster) {
+  if (!pluginCtx?.rest) {
+    return Promise.reject(new Error('Groups backend is unavailable.'))
+  }
+
+  if (identityReconcileInFlight) {
+    return identityReconcileInFlight
+  }
+
+  const bots = roster.filter(bot => !bot.remoteSource).map(bot => ({
+    profile_name: bot.name,
+    instance_id: $botMeta.get()[bot.name]?.instanceId || null
+  }))
+  const fingerprint = JSON.stringify(bots)
+  const allReady = bots.every(bot => Boolean(bot.instance_id))
+
+  if (allReady && fingerprint === identityReconcileFingerprint) {
+    return Promise.resolve(bots)
+  }
+
+  identityReconcileInFlight = pluginCtx
+    .rest('/bots/reconcile', { method: 'POST', body: { bots } })
+    .then(result => {
+      const assignments = Array.isArray(result?.bots) ? result.bots : []
+
+      if (assignments.length !== bots.length) {
+        throw new Error('Groups backend returned an incomplete bot identity set.')
+      }
+
+      for (const assignment of assignments) {
+        if (!assignment?.profile_name || !assignment?.instance_id) {
+          throw new Error('Groups backend returned an invalid bot identity.')
+        }
+        if ($botMeta.get()[assignment.profile_name]?.instanceId !== assignment.instance_id) {
+          void saveBotMeta(assignment.profile_name, { instanceId: assignment.instance_id })
+        }
+      }
+
+      identityReconcileFingerprint = JSON.stringify(
+        assignments.map(assignment => ({
+          profile_name: assignment.profile_name,
+          instance_id: assignment.instance_id
+        }))
+      )
+      return assignments
+    })
+    .finally(() => {
+      identityReconcileInFlight = null
+    })
+
+  return identityReconcileInFlight
+}
+
+function newGroupMutationKey(action) {
+  const random = newBotInstanceId()
+  return `${action}:${random || `${Date.now()}-${Math.random().toString(36).slice(2)}`}`
+}
+
+async function groupMembersForNames(names, roster) {
+  await reconcileBotIdentities(roster)
+  const known = new Set(roster.map(bot => bot.name))
+  return names.map(name => {
+    if (!known.has(name)) {
+      throw new Error(`Bot ${name} is no longer in the live roster.`)
+    }
+    const instanceId = $botMeta.get()[name]?.instanceId
+    if (!instanceId) {
+      throw new Error(`Could not prepare a stable identity for ${name}. Retry the group action.`)
+    }
+    return { bot_instance_id: instanceId, profile_name: name }
+  })
+}
+
+function useGroups() {
+  return useQuery({
+    queryKey: GROUPS_KEY,
+    queryFn: () => pluginCtx.rest('/groups'),
+    staleTime: 3000,
+    retry: false
+  })
+}
+
+function useGroupModelOptions() {
+  return useQuery({
+    queryKey: [ID, 'group-model-options'],
+    queryFn: () => host.request('model.options', { explicit_only: true }),
+    staleTime: 30_000,
+    retry: false
+  })
+}
+
+function groupModelRows(data) {
+  const providers = Array.isArray(data?.providers) ? data.providers : []
+  return providers.flatMap(provider =>
+    (Array.isArray(provider.models) ? provider.models : []).map(model => ({
+      provider: provider.slug || provider.name,
+      providerName: provider.name || provider.slug,
+      model
+    }))
+  )
+}
+
+function groupModelDisplayName(model) {
+  const canonical = canonicalGroupModelId(model)
+  if (groupModelKey(canonical) === 'qwen3.5-9b') {
+    return 'Qwen3.5-9B'
+  }
+  return canonical
+}
+
+function groupModelLabel(value) {
+  if (!value?.model) {
+    return 'Profile default'
+  }
+  const label = groupModelDisplayName(value.model)
+  return value.provider ? `${value.provider} · ${label}` : label
+}
+
+function groupModelMatch(data, value) {
+  if (!value?.model) {
+    return null
+  }
+  const wantedModel = groupModelKey(value.model)
+  const wantedProvider = String(value.provider || '').toLowerCase()
+  const candidates = groupModelRows(data).filter(row => groupModelKey(row.model) === wantedModel)
+  if (!candidates.length) {
+    return null
+  }
+
+  if (wantedProvider) {
+    const exact = candidates.find(row => String(row.provider || '').toLowerCase() === wantedProvider)
+    if (exact) {
+      return exact
+    }
+
+    // A profile whose current model is a raw custom endpoint surfaces as
+    // provider `custom`, while the same shared endpoint saved under providers:
+    // gets the stable slug `custom:local-qwen`. Treat those as the same custom
+    // provider family for a matching model, then pass the member's concrete
+    // slug into session.create so Hermes resolves the correct endpoint.
+    if (wantedProvider === 'custom') {
+      const customCandidates = candidates.filter(row => {
+        const provider = String(row.provider || '').toLowerCase()
+        return provider === 'custom' || provider === 'local-qwen' || provider.startsWith('custom:')
+      })
+      const localQwen = customCandidates.find(row => {
+        const provider = String(row.provider || '').toLowerCase()
+        return provider === 'local-qwen' || provider === 'custom:local-qwen'
+      })
+      if (localQwen) {
+        return localQwen
+      }
+      if (customCandidates.length === 1) {
+        return customCandidates[0]
+      }
+    }
+  }
+
+  return wantedProvider ? null : candidates[0]
+}
+
+function groupModelSupported(data, value) {
+  return !value?.model || Boolean(groupModelMatch(data, value))
+}
+
+function groupSlashQuery(text) {
+  const match = String(text || '').match(/^\/([^\n]*)$/)
+  return match ? match[1] : null
+}
+
+function slashTextValue(value, fallback = '') {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (Array.isArray(value)) {
+    return value.map(part => (Array.isArray(part) ? String(part[1] ?? '') : typeof part === 'string' ? part : '')).join('').trim()
+  }
+  return fallback
+}
+
+async function fetchGroupSlashSuggestions(text) {
+  const query = groupSlashQuery(text)
+  if (query === null) {
+    return []
+  }
+  const slashText = `/${query}`
+  if (!query) {
+    const catalog = await host.request('commands.catalog')
+    const sections = Array.isArray(catalog?.categories) && catalog.categories.length
+      ? catalog.categories
+      : [{ name: 'Commands', pairs: Array.isArray(catalog?.pairs) ? catalog.pairs : [] }]
+    const seen = new Set()
+    const rows = []
+    for (const section of sections) {
+      for (const pair of Array.isArray(section?.pairs) ? section.pairs : []) {
+        const command = slashTextValue(pair?.[0])
+        if (!command || seen.has(command.toLowerCase())) {
+          continue
+        }
+        seen.add(command.toLowerCase())
+        rows.push({ text: command.startsWith('/') ? command : `/${command}`, display: command, meta: slashTextValue(pair?.[1]), group: section.name || 'Commands' })
+      }
+    }
+    for (const pair of Array.isArray(catalog?.pairs) ? catalog.pairs : []) {
+      const command = slashTextValue(pair?.[0])
+      if (!command || seen.has(command.toLowerCase())) {
+        continue
+      }
+      seen.add(command.toLowerCase())
+      rows.push({ text: command.startsWith('/') ? command : `/${command}`, display: command, meta: slashTextValue(pair?.[1]), group: 'Skills' })
+    }
+    return rows.slice(0, 60)
+  }
+
+  const result = await host.request('complete.slash', { text: slashText })
+  const replaceFrom = typeof result?.replace_from === 'number' ? result.replace_from : 1
+  const isArgCompletion = replaceFrom > 1
+  const prefix = isArgCompletion ? slashText.slice(0, replaceFrom) : ''
+  return (Array.isArray(result?.items) ? result.items : []).map(item => {
+    const raw = slashTextValue(item?.text)
+    const completed = isArgCompletion ? `${prefix}${raw}` : raw.startsWith('/') ? raw : `/${raw}`
+    return {
+      text: completed,
+      display: slashTextValue(item?.display, completed),
+      meta: slashTextValue(item?.meta),
+      group: slashTextValue(item?.group, isArgCompletion ? 'Options' : 'Commands')
+    }
+  }).slice(0, 30)
+}
+
+function useGroupSlashSuggestions(text) {
+  const query = groupSlashQuery(text)
+  return useQuery({
+    queryKey: [ID, 'group-slash', query ?? 'off'],
+    queryFn: () => fetchGroupSlashSuggestions(text),
+    enabled: query !== null,
+    staleTime: query ? 1_500 : 15_000,
+    retry: false
+  })
+}
+
+function groupMessagesKey(groupId) {
+  return [ID, 'group-messages', groupId]
+}
+
+function useGroupMessages(groupId) {
+  return useQuery({
+    queryKey: groupMessagesKey(groupId),
+    queryFn: () => (groupId ? pluginCtx.rest(`/groups/${groupId}/messages`) : Promise.resolve([])),
+    enabled: Boolean(groupId),
+    staleTime: 1000,
+    retry: false
+  })
+}
+
+async function appendGroupTranscriptMessage(groupId, { content, senderBotInstanceId = null }) {
+  return pluginCtx.rest(`/groups/${groupId}/messages`, {
+    method: 'POST',
+    body: {
+      content,
+      sender_bot_instance_id: senderBotInstanceId,
+      idempotency_key: newGroupMutationKey('group-message')
+    }
+  })
+}
+
+function orderedGroupMembers(group) {
+  const members = Array.isArray(group?.members) ? group.members : []
+  const leader = members.find(member => member.bot_instance_id === group?.leader_bot_instance_id)
+  if (!leader) {
+    return members
+  }
+  return [leader, ...members.filter(member => member.bot_instance_id !== leader.bot_instance_id)]
+}
+
+function groupMentionQuery(text) {
+  const match = String(text || '').match(/(^|\s)@([a-z0-9_-]*)$/i)
+  return match ? match[2].toLowerCase() : null
+}
+
+function groupMentionSuggestions(group, roster, metaByName, text) {
+  const query = groupMentionQuery(text)
+  if (query === null) {
+    return []
+  }
+  const byName = new Map((Array.isArray(roster) ? roster : []).map(bot => [bot.name, bot]))
+  return (Array.isArray(group?.members) ? group.members : [])
+    .filter(member => {
+      const bot = byName.get(member.profile_name) || { name: member.profile_name }
+      const haystack = [
+        member.profile_name,
+        botHandle(member.profile_name),
+        displayName(bot, metaByName?.[member.profile_name])
+      ]
+        .join(' ')
+        .toLowerCase()
+      return !query || haystack.includes(query)
+    })
+    .slice(0, 8)
+}
+
+function completeGroupMention(text, profileName) {
+  return String(text || '').replace(/(^|\s)@[a-z0-9_-]*$/i, `$1@${botHandle(profileName)} `)
+}
+
+function mentionedGroupMembers(group, text) {
+  const members = Array.isArray(group?.members) ? group.members : []
+  const byHandle = new Map(members.map(member => [botHandle(member.profile_name).toLowerCase(), member]))
+  const found = []
+  const seen = new Set()
+  const pattern = /(?:^|[\s(])@([a-z0-9_-]+)/gi
+  let match
+  while ((match = pattern.exec(String(text || '')))) {
+    const member = byHandle.get(match[1].toLowerCase())
+    if (member && !seen.has(member.bot_instance_id)) {
+      seen.add(member.bot_instance_id)
+      found.push(member)
+    }
+  }
+  return found
+}
+
+function groupTurnMembers(group, text) {
+  const mentioned = mentionedGroupMembers(group, text)
+  return mentioned.length ? mentioned : orderedGroupMembers(group)
+}
+
+function groupTranscriptText(messages) {
+  const lines = (Array.isArray(messages) ? messages : []).slice(-80).map(message => {
+    const speaker = message.sender_profile_name ? `@${botHandle(message.sender_profile_name)}` : 'User'
+    return `${speaker}: ${String(message.content || '').trim()}`
+  })
+  while (lines.length > 1 && lines.join('\n\n').length > 24_000) {
+    lines.shift()
+  }
+  return lines.join('\n\n') || '(No messages yet.)'
+}
+
+function groupMemberPrompt(group, member, messages) {
+  const leader = (group.members || []).find(item => item.bot_instance_id === group.leader_bot_instance_id)
+  const isLeader = member.bot_instance_id === group.leader_bot_instance_id
+  const members = (group.members || []).map(item => `@${botHandle(item.profile_name)}`).join(', ')
+  return [
+    `You are @${botHandle(member.profile_name)}, participating in the persistent Hermes group chat “${group.name}”.`,
+    `Members: ${members}.`,
+    leader ? `Group leader: @${botHandle(leader.profile_name)}.${isLeader ? ' You are the leader and speak first on each user turn.' : ''}` : '',
+    '',
+    'This is a real shared group conversation. Read the transcript before answering.',
+    'Reply as yourself, not as a narrator or as the whole team. You may address the user or another member naturally.',
+    isLeader
+      ? 'Set a useful direction for the turn, but do not pretend the other members have already agreed with you.'
+      : 'Build on, refine, question, or disagree with earlier replies when useful instead of merely repeating them.',
+    'Do not run Hermes commands to message teammates from this turn; the group host will post your response directly into the shared room.',
+    'Keep the response focused and conversational unless the task genuinely needs detail.',
+    '',
+    'GROUP TRANSCRIPT',
+    '----------------',
+    groupTranscriptText(messages),
+    '----------------',
+    '',
+    `Reply now as @${botHandle(member.profile_name)}.`
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+const GROUP_MEMBER_TURN_TIMEOUT_MS = 75_000
+
+function terminalGroupStatusError(payload) {
+  const text = String(payload?.text || payload?.message || payload?.error || '').trim()
+  if (!text) {
+    return null
+  }
+
+  const lower = text.toLowerCase()
+  // Auxiliary helpers (title generation, summaries, etc.) may fail while the
+  // primary conversation remains perfectly healthy. Never let those abort a
+  // group member turn.
+  if (lower.includes('auxiliary title generation failed')) {
+    return null
+  }
+
+  // Let Hermes try a configured fallback first. Only cut the turn short once
+  // the runtime says the provider path is terminal, rather than on a transient
+  // 429 attempt that Hermes may still recover from.
+  if (lower.includes('switching to fallback')) {
+    return null
+  }
+
+  const terminal =
+    lower.includes('final error:') ||
+    lower.includes('rate limited after') ||
+    lower.includes("plan's usage limit has been reached") ||
+    lower.includes('no allowed providers are available') ||
+    lower.includes('billing wall')
+
+  return terminal ? new Error(text.replace(/\s+/g, ' ').slice(0, 500)) : null
+}
+
+function runHiddenGroupPrompt(sessionId, text) {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let terminal = null
+    let infoSeen = false
+    let timer = null
+    let terminalGrace = null
+    let offComplete = () => undefined
+    let offInfo = () => undefined
+    let offStatus = () => undefined
+    let offError = () => undefined
+
+    const finish = (error, value) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timer !== null) {
+        window.clearTimeout(timer)
+      }
+      if (terminalGrace !== null) {
+        window.clearTimeout(terminalGrace)
+      }
+      offComplete()
+      offInfo()
+      offStatus()
+      offError()
+      if (error) {
+        reject(error)
+      } else {
+        resolve(value)
+      }
+    }
+
+    const settleAfterTurn = () => {
+      if (!terminal) {
+        return
+      }
+      if (terminal.error) {
+        finish(terminal.error)
+      } else {
+        finish(null, terminal.response)
+      }
+    }
+
+    offComplete = host.onEvent('message.complete', event => {
+      if (event?.session_id !== sessionId) {
+        return
+      }
+      const payload = event.payload || {}
+      const response = String(payload.text || '').trim()
+      if (payload.status === 'error') {
+        terminal = {
+          error: new Error(String(payload.error || response || 'Group member turn failed.'))
+        }
+      } else if (!response) {
+        terminal = { error: new Error('Group member returned an empty response.') }
+      } else {
+        terminal = { response }
+      }
+
+      if (infoSeen) {
+        settleAfterTurn()
+        return
+      }
+
+      // Error paths on older gateways do not always emit the settled session.info
+      // frame. Give normal teardown a moment, then use the terminal frame itself.
+      terminalGrace = window.setTimeout(settleAfterTurn, 1_500)
+    })
+
+    // Hermes normally emits this after session.running is cleared and per-turn
+    // profile, transport, approval, and secret scopes have been restored.
+    offInfo = host.onEvent('session.info', event => {
+      if (event?.session_id !== sessionId) {
+        return
+      }
+      infoSeen = true
+      if (terminal) {
+        settleAfterTurn()
+      }
+    })
+
+    const stopOnTerminalRuntimeError = payload => {
+      const error = terminalGroupStatusError(payload)
+      if (!error) {
+        return
+      }
+      void host.request('session.interrupt', { session_id: sessionId }).catch(() => undefined)
+      finish(error)
+    }
+
+    offStatus = host.onEvent('status.update', event => {
+      if (event?.session_id === sessionId) {
+        stopOnTerminalRuntimeError(event.payload)
+      }
+    })
+
+    offError = host.onEvent('error', event => {
+      if (event?.session_id !== sessionId) {
+        return
+      }
+      const error = terminalGroupStatusError(event.payload)
+      if (!error) {
+        return
+      }
+      void host.request('session.interrupt', { session_id: sessionId }).catch(() => undefined)
+      finish(error)
+    })
+
+    timer = window.setTimeout(() => {
+      void host.request('session.interrupt', { session_id: sessionId }).catch(() => undefined)
+      finish(new Error('No reply after 75 seconds. This member was skipped so the rest of the group can continue.'))
+    }, GROUP_MEMBER_TURN_TIMEOUT_MS)
+
+    host
+      .request('prompt.submit', { session_id: sessionId, text })
+      .catch(error => finish(error instanceof Error ? error : new Error(String(error))))
+  })
+}
+
+async function cleanupGroupRuntimeSession(created, profileName) {
+  const sessionId = created?.session_id
+  const storedSessionId = created?.stored_session_id
+  if (sessionId) {
+    try {
+      await host.request('session.close', { session_id: sessionId })
+    } catch {
+      // Cleanup is best-effort; the gateway also reaps detached sessions.
+    }
+  }
+  if (storedSessionId) {
+    try {
+      await host.request('session.delete', { session_id: storedSessionId, profile: profileName })
+    } catch {
+      // Source "tool" stays hidden from normal session lists if cleanup loses a race.
+    }
+  }
+}
+
+function waitForGroupSessionReady(sessionId, timeoutMs = 12_000) {
+  return new Promise(resolve => {
+    let settled = false
+    let timer = null
+    let offInfo = () => undefined
+
+    const finish = payload => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timer !== null) {
+        window.clearTimeout(timer)
+      }
+      offInfo()
+      resolve(payload || null)
+    }
+
+    offInfo = host.onEvent('session.info', event => {
+      if (event?.session_id !== sessionId) {
+        return
+      }
+      const payload = event.payload || {}
+      const model = String(payload.model || '').trim()
+      const provider = String(payload.provider || '').trim()
+      if (model && model !== '(unknown)' && provider && provider !== 'unknown') {
+        finish(payload)
+      }
+    })
+
+    void host.request('session.status', { session_id: sessionId })
+      .then(status => {
+        const output = String(status?.output || '')
+        const match = /^Model:\s+(.+?)\s+\((.+?)\)$/m.exec(output)
+        if (match && match[1] !== '(unknown)' && match[2] !== 'unknown') {
+          finish({ model: match[1], provider: match[2] })
+        }
+      })
+      .catch(() => undefined)
+
+    timer = window.setTimeout(() => finish(null), timeoutMs)
+  })
+}
+
+async function createGroupRuntimeSession({ profileName, title, modelOverride }) {
+  const baseParams = {
+    profile: profileName,
+    title,
+    source: 'tool',
+    close_on_disconnect: true
+  }
+
+  if (!modelOverride?.model) {
+    return { created: await host.request('session.create', baseParams), modelNotice: null }
+  }
+
+  // A room model is selected from the active profile's picker, but group members
+  // may have different provider catalogs. Probe the member's own hidden session
+  // before applying the override so one profile's custom provider can never brick
+  // the rest of a heterogeneous group.
+  const probe = await host.request('session.create', baseParams)
+  const probeSessionId = probe?.session_id
+  if (!probeSessionId) {
+    throw new Error(`Could not start @${botHandle(profileName)}.`)
+  }
+
+  let supported = false
+  let resolvedModelOverride = null
+  let validationError = null
+  const readyInfo = await waitForGroupSessionReady(probeSessionId)
+  if (!readyInfo) {
+    validationError = 'member session did not become ready for room-model validation'
+  } else {
+    try {
+      const options = await host.request('model.options', { session_id: probeSessionId, explicit_only: true })
+      const match = groupModelMatch(options, modelOverride)
+      supported = Boolean(match)
+      if (match) {
+        resolvedModelOverride = { provider: match.provider, model: match.model }
+      }
+    } catch (error) {
+      validationError = error instanceof Error ? error.message : String(error)
+    }
+  }
+
+  if (!supported) {
+    const reason = validationError
+      ? `could not verify ${groupModelLabel(modelOverride)} (${validationError})`
+      : `does not support ${groupModelLabel(modelOverride)}`
+    return {
+      created: probe,
+      modelNotice: `@${botHandle(profileName)} ${reason}; using profile default.`
+    }
+  }
+
+  await cleanupGroupRuntimeSession(probe, profileName)
+
+  const effectiveOverride = resolvedModelOverride || modelOverride
+  const overrideParams = { ...baseParams, model: effectiveOverride.model }
+  if (effectiveOverride.provider) {
+    overrideParams.provider = effectiveOverride.provider
+  }
+
+  try {
+    return { created: await host.request('session.create', overrideParams), modelNotice: null }
+  } catch (error) {
+    const fallback = await host.request('session.create', baseParams)
+    const detail = error instanceof Error ? error.message : String(error)
+    return {
+      created: fallback,
+      modelNotice: `@${botHandle(profileName)} could not start ${groupModelLabel(modelOverride)} (${detail}); using profile default.`
+    }
+  }
+}
+
+async function runGroupMemberTurn({ group, member, messages, modelOverride }) {
+  const prepared = await createGroupRuntimeSession({
+    profileName: member.profile_name,
+    title: `Group · ${group.name}`,
+    modelOverride
+  })
+  const created = prepared.created
+  const sessionId = created?.session_id
+  if (!sessionId) {
+    throw new Error(`Could not start @${botHandle(member.profile_name)}.`)
+  }
+
+  try {
+    const response = await runHiddenGroupPrompt(sessionId, groupMemberPrompt(group, member, messages))
+    return { response, modelNotice: prepared.modelNotice }
+  } finally {
+    await cleanupGroupRuntimeSession(created, member.profile_name)
   }
 }
 
@@ -3997,29 +4746,6 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
       : previewSession?.preview || bot.description || 'No conversations yet — say hi'
   )
 
-  const warm = () => {
-    // Multi-source row: pre-dial the agent's OWN source (feature-detected).
-    if (bot.sourceScoped && typeof host.warmAgent === 'function') {
-      try {
-        host.warmAgent(bot.connectionId, bot.name)
-      } catch {
-        /* warm is best-effort */
-      }
-
-      return
-    }
-
-    if (typeof host.warmProfile !== 'function') {
-      return
-    }
-
-    try {
-      host.warmProfile(bot.name)
-    } catch {
-      /* warm is best-effort */
-    }
-  }
-
   const open = async () => {
     haptic('tap')
     $selectedBot.set(bot.name)
@@ -4072,7 +4798,6 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
 
   const row = jsxs('button', {
     type: 'button',
-    onPointerEnter: warm,
     onClick: open,
     className: cn(
       'flex w-full min-w-0 max-w-full items-center gap-2.5 overflow-hidden rounded-md px-2 py-2 text-left transition-colors',
@@ -7032,6 +7757,1602 @@ function ProfileSessionsWorkspace({ bot }) {
   })
 }
 
+// ── persistent managed Groups (durable team records) ───────────────────────────────────────────────────────────────────
+
+const GROUP_COLORS = ['blue', 'green', 'yellow', 'orange', 'red', 'purple', 'pink', 'gray']
+const GROUP_EMOJIS = [
+  '👥', '🤖', '🛠️', '🚀', '🧠', '⚡', '🔥', '🎯',
+  '🧭', '🛡️', '🔬', '💡', '🎨', '📣', '📦', '🧰',
+  '⚙️', '🌐', '💻', '🧪', '📝', '📊', '🏗️', '✨'
+]
+const GROUP_COLOR_HEX = {
+  blue: '#3b82f6',
+  green: '#22c55e',
+  yellow: '#eab308',
+  orange: '#f97316',
+  red: '#ef4444',
+  purple: '#8b5cf6',
+  pink: '#ec4899',
+  gray: '#6b7280'
+}
+
+function DurableGroupEmojiPicker({ value, onChange }) {
+  return jsx('div', {
+    role: 'group',
+    'aria-label': 'Choose group emoji',
+    className: 'grid grid-cols-8 gap-1 rounded-md border border-(--ui-stroke-secondary) p-2',
+    children: GROUP_EMOJIS.map(emoji =>
+      jsx(
+        'button',
+        {
+          type: 'button',
+          'aria-label': `Use ${emoji}`,
+          'aria-pressed': value === emoji,
+          className: cn(
+            'flex size-8 items-center justify-center rounded-md text-lg transition-colors hover:bg-(--chrome-action-hover)',
+            value === emoji && 'bg-(--chrome-action-hover) ring-1 ring-(--ui-stroke-primary)'
+          ),
+          onClick: () => onChange(emoji),
+          children: emoji
+        },
+        emoji
+      )
+    )
+  })
+}
+
+function filterGroupMemberRoster(roster, metaByName, query) {
+  return filterBots(roster, metaByName, query)
+}
+
+function DurableGroupGlyph({ group, size = 32 }) {
+  const style = {
+    width: `${size}px`,
+    height: `${size}px`,
+    backgroundColor: GROUP_COLOR_HEX[group?.color] || GROUP_COLOR_HEX.blue
+  }
+  return jsx('div', {
+    className: 'flex shrink-0 items-center justify-center rounded-lg text-white shadow-sm',
+    style,
+    children:
+      group?.icon_kind === 'codicon'
+        ? jsx(Codicon, { name: group.icon_value || 'organization' })
+        : jsx('span', { className: 'leading-none', children: group?.icon_value || '👥' })
+  })
+}
+
+function DurableBotsGroupsSwitch({ mode, onChange }) {
+  return jsxs('div', {
+    className: 'flex rounded-md bg-(--chrome-action-hover) p-0.5',
+    children: [
+      jsx('button', {
+        type: 'button',
+        className: cn(
+          'rounded px-2 py-1 text-[0.6875rem] font-semibold transition-colors',
+          mode === 'bots' ? 'bg-background text-foreground shadow-sm' : 'text-(--ui-text-tertiary)'
+        ),
+        onClick: () => onChange('bots'),
+        children: 'Bots'
+      }),
+      jsx('button', {
+        type: 'button',
+        className: cn(
+          'rounded px-2 py-1 text-[0.6875rem] font-semibold transition-colors',
+          mode === 'groups' ? 'bg-background text-foreground shadow-sm' : 'text-(--ui-text-tertiary)'
+        ),
+        onClick: () => onChange('groups'),
+        children: 'Groups'
+      })
+    ]
+  })
+}
+
+function DurableGroupModelPicker({ value, onChange, open, onOpenChange }) {
+  const { data, error, isLoading, refetch } = useGroupModelOptions()
+  const [query, setQuery] = useState('')
+  const needle = query.trim().toLowerCase()
+  const rows = groupModelRows(data).filter(row =>
+    !needle || `${row.providerName} ${row.provider} ${row.model}`.toLowerCase().includes(needle)
+  )
+  const choose = next => {
+    onChange(next)
+    setQuery('')
+    onOpenChange(false)
+  }
+
+  return jsxs('div', {
+    children: [
+      jsxs(Button, {
+        variant: 'secondary',
+        size: 'sm',
+        onClick: () => onOpenChange(true),
+        children: [jsx(Codicon, { name: 'sparkle' }), groupModelLabel(value)]
+      }),
+      jsx(Dialog, {
+        open,
+        onOpenChange: next => {
+          if (!next) {
+            setQuery('')
+          }
+          onOpenChange(next)
+        },
+        children: jsxs(DialogContent, {
+          className: 'max-w-xl',
+          children: [
+            jsxs(DialogHeader, {
+              children: [
+                jsx(DialogTitle, { children: 'Group model' }),
+                jsx(DialogDescription, {
+                  children: 'Choose a model for this group chat only. Member profile defaults are not changed.'
+                })
+              ]
+            }),
+            jsx(SearchField, {
+              'aria-label': 'Search group models',
+              containerClassName: 'w-full',
+              inputClassName: 'w-full',
+              placeholder: 'Search models…',
+              value: query,
+              onChange: setQuery
+            }),
+            jsx(ScrollArea, {
+              className: 'max-h-[55vh] rounded-lg border border-(--ui-stroke-secondary)',
+              children: jsxs('div', {
+                className: 'grid gap-1 p-2',
+                children: [
+                  jsxs('button', {
+                    type: 'button',
+                    className: cn(
+                      'flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left hover:bg-(--chrome-action-hover)',
+                      !value?.model && 'bg-(--chrome-action-hover)'
+                    ),
+                    onClick: () => choose(null),
+                    children: [
+                      jsx(Codicon, { name: 'settings-gear' }),
+                      jsxs('div', {
+                        className: 'min-w-0 flex-1',
+                        children: [
+                          jsx('div', { className: 'text-sm font-medium', children: 'Profile default' }),
+                          jsx('div', { className: 'text-xs text-(--ui-text-tertiary)', children: 'Each member uses its own configured default model.' })
+                        ]
+                      })
+                    ]
+                  }),
+                  isLoading
+                    ? jsx('div', { className: 'flex justify-center py-6', children: jsx(GlyphSpinner, { spinner: 'breathe' }) })
+                    : error
+                      ? jsxs('div', {
+                          className: 'grid gap-2 p-3 text-xs text-(--ui-text-tertiary)',
+                          children: [
+                            jsx('span', { children: 'Model options are unavailable.' }),
+                            jsx(Button, { size: 'sm', variant: 'secondary', onClick: () => void refetch(), children: 'Retry' })
+                          ]
+                        })
+                      : rows.length
+                        ? rows.map(row =>
+                            jsxs('button', {
+                              type: 'button',
+                              className: cn(
+                                'flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left hover:bg-(--chrome-action-hover)',
+                                value?.provider === row.provider && value?.model === row.model && 'bg-(--chrome-action-hover)'
+                              ),
+                              onClick: () => choose({ provider: row.provider, model: row.model }),
+                              children: [
+                                jsx(Codicon, { name: 'symbol-keyword' }),
+                                jsxs('div', {
+                                  className: 'min-w-0 flex-1',
+                                  children: [
+                                    jsx('div', { className: 'truncate text-sm font-medium', children: row.model }),
+                                    jsx('div', { className: 'truncate text-xs text-(--ui-text-tertiary)', children: row.providerName })
+                                  ]
+                                }),
+                                value?.provider === row.provider && value?.model === row.model
+                                  ? jsx(Codicon, { name: 'check' })
+                                  : null
+                              ]
+                            }, `${row.provider}:${row.model}`)
+                          )
+                        : jsx('div', { className: 'p-4 text-center text-xs text-(--ui-text-tertiary)', children: `No models match “${query.trim()}”` })
+                ]
+              })
+            })
+          ]
+        })
+      })
+    ]
+  })
+}
+
+function DurableGroupSlashMenu({ slashSuggestions, selectedIndex, onChoose }) {
+  if (!slashSuggestions.length) {
+    return null
+  }
+  return jsx('div', {
+    className: 'mx-auto mb-2 max-h-72 w-full max-w-4xl overflow-auto rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-sidebar-surface-background) p-1.5 shadow-lg',
+    children: slashSuggestions.map((item, index) =>
+      jsxs('button', {
+        type: 'button',
+        'aria-label': 'Group slash command',
+        className: cn(
+          'flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left',
+          index === selectedIndex ? 'bg-(--chrome-action-hover)' : 'hover:bg-(--chrome-action-hover)'
+        ),
+        onMouseDown: event => event.preventDefault(),
+        onClick: () => onChoose(item),
+        children: [
+          jsx(Codicon, { name: item.group === 'Skills' ? 'zap' : 'terminal' }),
+          jsxs('div', {
+            className: 'min-w-0 flex-1',
+            children: [
+              jsx('div', { className: 'truncate font-mono text-xs font-semibold', children: item.display || item.text }),
+              item.meta ? jsx('div', { className: 'truncate text-[0.65rem] text-(--ui-text-tertiary)', children: item.meta }) : null
+            ]
+          }),
+          item.group ? jsx('span', { className: 'shrink-0 text-[0.6rem] text-(--ui-text-quaternary)', children: item.group }) : null
+        ]
+      }, `${item.text}:${index}`)
+    )
+  })
+}
+
+function DurableCreateGroupDialog({ open, onClose, roster }) {
+  const [name, setName] = useState('')
+  const [color, setColor] = useState('blue')
+  const [iconKind, setIconKind] = useState('emoji')
+  const [iconValue, setIconValue] = useState('👥')
+  const [memberNames, setMemberNames] = useState([])
+  const [memberQuery, setMemberQuery] = useState('')
+  const [leaderName, setLeaderName] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(null)
+  const botMeta = useValue($botMeta)
+  const filteredMemberRoster = filterGroupMemberRoster(roster, botMeta, memberQuery)
+
+  const reset = () => {
+    setName('')
+    setColor('blue')
+    setIconKind('emoji')
+    setIconValue('👥')
+    setMemberNames([])
+    setMemberQuery('')
+    setLeaderName('')
+    setBusy(false)
+    setError(null)
+  }
+
+  const toggleMember = (botName, checked) => {
+    const next = checked
+      ? memberNames.includes(botName)
+        ? memberNames
+        : [...memberNames, botName]
+      : memberNames.filter(name => name !== botName)
+    setMemberNames(next)
+    if (!next.includes(leaderName)) {
+      setLeaderName(next[0] || '')
+    }
+  }
+
+  const submit = async () => {
+    if (!name.trim() || !memberNames.length || !leaderName || busy) {
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      const members = await groupMembersForNames(memberNames, roster)
+      const leader = members.find(member => member.profile_name === leaderName)
+      if (!leader) {
+        throw new Error('Choose a leader from the selected members.')
+      }
+      const created = await pluginCtx.rest('/groups', {
+        method: 'POST',
+        body: {
+          name: name.trim(),
+          color,
+          icon_kind: iconKind,
+          icon_value: iconValue.trim() || (iconKind === 'emoji' ? '👥' : 'organization'),
+          members,
+          leader_bot_instance_id: leader.bot_instance_id,
+          idempotency_key: newGroupMutationKey('create-group')
+        }
+      })
+      queryClient.invalidateQueries({ queryKey: GROUPS_KEY })
+      $selectedGroupId.set(created.id)
+      host.notify({ kind: 'success', message: `Group “${created.name}” created` })
+      reset()
+      onClose()
+      host.navigate(GROUP_ROUTE)
+    } catch (err) {
+      setBusy(false)
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return jsx(Dialog, {
+    open,
+    onOpenChange: value => {
+      if (!value && !busy) {
+        reset()
+        onClose()
+      }
+    },
+    children: jsxs(DialogContent, {
+      className: 'max-w-lg',
+      children: [
+        jsxs(DialogHeader, {
+          children: [
+            jsx(DialogTitle, { children: 'New Group' }),
+            jsx(DialogDescription, {
+              children: 'Choose a persistent team of bots and one leader. Membership is stored installation-wide.'
+            })
+          ]
+        }),
+        jsxs('div', {
+          className: 'grid gap-3.5',
+          children: [
+            labeled(
+              'Name',
+              jsx(Input, {
+                autoFocus: true,
+                maxLength: 120,
+                placeholder: 'Support Crew',
+                value: name,
+                onChange: event => setName(event.target.value)
+              })
+            ),
+            jsxs('div', {
+              className: 'grid grid-cols-2 gap-3',
+              children: [
+                labeled(
+                  'Color',
+                  jsxs(Select, {
+                    value: color,
+                    onValueChange: setColor,
+                    children: [
+                      jsx(SelectTrigger, { children: jsx(SelectValue, {}) }),
+                      jsx(SelectContent, {
+                        children: GROUP_COLORS.map(value =>
+                          jsx(SelectItem, { value, children: value[0].toUpperCase() + value.slice(1) }, value)
+                        )
+                      })
+                    ]
+                  })
+                ),
+                labeled(
+                  'Icon type',
+                  jsxs(Select, {
+                    value: iconKind,
+                    onValueChange: value => {
+                      setIconKind(value)
+                      setIconValue(value === 'emoji' ? '👥' : 'organization')
+                    },
+                    children: [
+                      jsx(SelectTrigger, { children: jsx(SelectValue, {}) }),
+                      jsxs(SelectContent, {
+                        children: [
+                          jsx(SelectItem, { value: 'emoji', children: 'Emoji' }),
+                          jsx(SelectItem, { value: 'codicon', children: 'Codicon' })
+                        ]
+                      })
+                    ]
+                  })
+                )
+              ]
+            }),
+            iconKind === 'emoji'
+              ? jsxs('div', {
+                  className: 'grid gap-1.5',
+                  children: [
+                    jsx('div', { className: 'text-xs font-medium text-(--ui-text-secondary)', children: 'Emoji' }),
+                    jsx(DurableGroupEmojiPicker, { value: iconValue, onChange: setIconValue }),
+                    labeled(
+                      'Custom emoji',
+                      jsx(Input, {
+                        maxLength: 64,
+                        placeholder: 'Paste any emoji',
+                        value: iconValue,
+                        onChange: event => setIconValue(event.target.value)
+                      })
+                    )
+                  ]
+                })
+              : labeled(
+                  'Codicon name',
+                  jsx(Input, {
+                    maxLength: 64,
+                    placeholder: 'organization',
+                    value: iconValue,
+                    onChange: event => setIconValue(event.target.value)
+                  })
+                ),
+            jsxs('div', {
+              className: 'grid gap-1.5',
+              children: [
+                jsx('div', {
+                  className: 'text-xs font-medium text-(--ui-text-secondary)',
+                  children: `Members${memberNames.length ? ` · ${memberNames.length} selected` : ''}`
+                }),
+                jsx(SearchField, {
+                  'aria-label': 'Search group members',
+                  containerClassName: 'w-full',
+                  inputClassName: 'w-full',
+                  placeholder: 'Search bots…',
+                  value: memberQuery,
+                  onChange: setMemberQuery
+                }),
+                filteredMemberRoster.length
+                  ? jsx(ScrollArea, {
+                      className: 'max-h-44 rounded-md border border-(--ui-stroke-secondary)',
+                      children: jsx('div', {
+                        className: 'grid gap-0.5 p-2',
+                        children: filteredMemberRoster.map(bot => {
+                          const meta = botMeta[bot.name]
+                          const ready = Boolean(meta?.instanceId)
+                          return jsxs(
+                            'label',
+                            {
+                              className: cn(
+                                'flex cursor-pointer items-center gap-2 rounded px-1.5 py-1 text-xs hover:bg-(--chrome-action-hover)',
+                                !ready && 'text-(--ui-text-tertiary)'
+                              ),
+                              title: ready ? bot.name : `${bot.name} · stable identity will be prepared automatically`,
+                              children: [
+                                jsx(Checkbox, {
+                                  checked: memberNames.includes(bot.name),
+                                  onCheckedChange: value => toggleMember(bot.name, Boolean(value))
+                                }),
+                                jsx('span', { className: 'min-w-0 flex-1 truncate', children: displayName(bot, meta) }),
+                                jsx('span', {
+                                  className: 'font-mono text-[0.6rem] text-(--ui-text-quaternary)',
+                                  children: `@${botHandle(bot.name)}`
+                                })
+                              ]
+                            },
+                            bot.name
+                          )
+                        })
+                      })
+                    })
+                  : jsx('div', {
+                      'aria-live': 'polite',
+                      className: 'rounded-md border border-(--ui-stroke-secondary) px-3 py-3 text-center text-xs text-(--ui-text-tertiary)',
+                      children: `No bots match “${memberQuery.trim()}”`
+                    })
+              ]
+            }),
+            memberNames.length
+              ? labeled(
+                  'Leader',
+                  jsxs(Select, {
+                    value: leaderName,
+                    onValueChange: setLeaderName,
+                    children: [
+                      jsx(SelectTrigger, { children: jsx(SelectValue, { placeholder: 'Choose a leader' }) }),
+                      jsx(SelectContent, {
+                        children: memberNames.map(memberName =>
+                          jsx(SelectItem, { value: memberName, children: `@${botHandle(memberName)}` }, memberName)
+                        )
+                      })
+                    ]
+                  })
+                )
+              : null,
+            error
+              ? jsx('div', { className: 'text-xs text-(--ui-accent)', children: error })
+              : null
+          ]
+        }),
+        jsxs(DialogFooter, {
+          children: [
+            jsx(Button, { variant: 'secondary', disabled: busy, onClick: onClose, children: 'Cancel' }),
+            jsx(Button, {
+              disabled: busy || !name.trim() || !memberNames.length || !leaderName,
+              onClick: submit,
+              children: busy ? 'Creating…' : 'Create Group'
+            })
+          ]
+        })
+      ]
+    })
+  })
+}
+
+function DurableGroupSettingsDialog({ group, open, onClose, roster }) {
+  const [name, setName] = useState('')
+  const [color, setColor] = useState('blue')
+  const [iconKind, setIconKind] = useState('emoji')
+  const [iconValue, setIconValue] = useState('👥')
+  const [memberNames, setMemberNames] = useState([])
+  const [memberQuery, setMemberQuery] = useState('')
+  const [leaderName, setLeaderName] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(null)
+  const [deleteArmed, setDeleteArmed] = useState(false)
+  const botMeta = useValue($botMeta)
+  const filteredMemberRoster = filterGroupMemberRoster(roster, botMeta, memberQuery)
+
+  useEffect(() => {
+    if (!open || !group) {
+      return
+    }
+    setName(group.name || '')
+    setColor(group.color || 'blue')
+    setIconKind(group.icon_kind || 'emoji')
+    setIconValue(group.icon_value || '👥')
+    setMemberNames((group.members || []).map(member => member.profile_name))
+    setMemberQuery('')
+    setLeaderName(
+      (group.members || []).find(member => member.bot_instance_id === group.leader_bot_instance_id)?.profile_name || ''
+    )
+    setBusy(false)
+    setError(null)
+    setDeleteArmed(false)
+  }, [open, group?.id, group?.revision])
+
+  if (!group) {
+    return null
+  }
+
+  const toggleMember = (botName, checked) => {
+    const next = checked
+      ? memberNames.includes(botName)
+        ? memberNames
+        : [...memberNames, botName]
+      : memberNames.filter(name => name !== botName)
+    setMemberNames(next)
+    if (!next.includes(leaderName)) {
+      setLeaderName(next[0] || '')
+    }
+  }
+
+  const save = async () => {
+    if (!name.trim() || !memberNames.length || !leaderName || busy) {
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      let revision = group.revision
+      const metadataChanged =
+        name.trim() !== group.name ||
+        color !== group.color ||
+        iconKind !== group.icon_kind ||
+        iconValue.trim() !== group.icon_value
+      if (metadataChanged) {
+        const updated = await pluginCtx.rest(`/groups/${group.id}`, {
+          method: 'PATCH',
+          body: {
+            expected_revision: group.revision,
+            name: name.trim(),
+            color,
+            icon_kind: iconKind,
+            icon_value: iconValue.trim() || (iconKind === 'emoji' ? '👥' : 'organization'),
+            idempotency_key: newGroupMutationKey('group-metadata')
+          }
+        })
+        revision = updated.revision
+      }
+
+      const members = await groupMembersForNames(memberNames, roster)
+      const leader = members.find(member => member.profile_name === leaderName)
+      if (!leader) {
+        throw new Error('Choose a leader from the selected members.')
+      }
+      const previousMembers = (group.members || []).map(member => member.bot_instance_id).sort().join('|')
+      const nextMembers = members.map(member => member.bot_instance_id).sort().join('|')
+      const membershipChanged =
+        previousMembers !== nextMembers || leader.bot_instance_id !== group.leader_bot_instance_id
+      if (membershipChanged) {
+        await pluginCtx.rest(`/groups/${group.id}/membership`, {
+          method: 'PUT',
+          body: {
+            expected_revision: revision,
+            members,
+            leader_bot_instance_id: leader.bot_instance_id,
+            idempotency_key: newGroupMutationKey('group-membership')
+          }
+        })
+      }
+
+      queryClient.invalidateQueries({ queryKey: GROUPS_KEY })
+      queryClient.invalidateQueries({ queryKey: [ID, 'group', group.id] })
+      host.notify({ kind: 'success', message: `Saved “${name.trim()}”` })
+      setBusy(false)
+      onClose()
+    } catch (err) {
+      setBusy(false)
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const remove = async () => {
+    if (!deleteArmed) {
+      setDeleteArmed(true)
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      await pluginCtx.rest(`/groups/${group.id}`, {
+        method: 'DELETE',
+        body: {
+          expected_revision: group.revision,
+          idempotency_key: newGroupMutationKey('delete-group')
+        }
+      })
+      if ($selectedGroupId.get() === group.id) {
+        $selectedGroupId.set(null)
+      }
+      queryClient.invalidateQueries({ queryKey: GROUPS_KEY })
+      host.notify({ kind: 'success', message: `Deleted “${group.name}”` })
+      onClose()
+    } catch (err) {
+      setBusy(false)
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return jsx(Dialog, {
+    open,
+    onOpenChange: value => {
+      if (!value && !busy) {
+        onClose()
+      }
+    },
+    children: jsxs(DialogContent, {
+      className: 'max-w-lg',
+      children: [
+        jsxs(DialogHeader, {
+          children: [
+            jsx(DialogTitle, { children: 'Group Settings' }),
+            jsx(DialogDescription, { children: 'Edit identity, membership, and the group leader.' })
+          ]
+        }),
+        jsxs('div', {
+          className: 'grid gap-3.5',
+          children: [
+            labeled(
+              'Name',
+              jsx(Input, { maxLength: 120, value: name, onChange: event => setName(event.target.value) })
+            ),
+            jsxs('div', {
+              className: 'grid grid-cols-2 gap-3',
+              children: [
+                labeled(
+                  'Color',
+                  jsxs(Select, {
+                    value: color,
+                    onValueChange: setColor,
+                    children: [
+                      jsx(SelectTrigger, { children: jsx(SelectValue, {}) }),
+                      jsx(SelectContent, {
+                        children: GROUP_COLORS.map(value =>
+                          jsx(SelectItem, { value, children: value[0].toUpperCase() + value.slice(1) }, value)
+                        )
+                      })
+                    ]
+                  })
+                ),
+                labeled(
+                  'Icon type',
+                  jsxs(Select, {
+                    value: iconKind,
+                    onValueChange: setIconKind,
+                    children: [
+                      jsx(SelectTrigger, { children: jsx(SelectValue, {}) }),
+                      jsxs(SelectContent, {
+                        children: [
+                          jsx(SelectItem, { value: 'emoji', children: 'Emoji' }),
+                          jsx(SelectItem, { value: 'codicon', children: 'Codicon' })
+                        ]
+                      })
+                    ]
+                  })
+                )
+              ]
+            }),
+            iconKind === 'emoji'
+              ? jsxs('div', {
+                  className: 'grid gap-1.5',
+                  children: [
+                    jsx('div', { className: 'text-xs font-medium text-(--ui-text-secondary)', children: 'Emoji' }),
+                    jsx(DurableGroupEmojiPicker, { value: iconValue, onChange: setIconValue }),
+                    labeled(
+                      'Custom emoji',
+                      jsx(Input, {
+                        maxLength: 64,
+                        placeholder: 'Paste any emoji',
+                        value: iconValue,
+                        onChange: event => setIconValue(event.target.value)
+                      })
+                    )
+                  ]
+                })
+              : labeled(
+                  'Codicon name',
+                  jsx(Input, {
+                    maxLength: 64,
+                    placeholder: 'organization',
+                    value: iconValue,
+                    onChange: event => setIconValue(event.target.value)
+                  })
+                ),
+            jsxs('div', {
+              className: 'grid gap-1.5',
+              children: [
+                jsx('div', {
+                  className: 'text-xs font-medium text-(--ui-text-secondary)',
+                  children: `Members${memberNames.length ? ` · ${memberNames.length} selected` : ''}`
+                }),
+                jsx(SearchField, {
+                  'aria-label': 'Search group members',
+                  containerClassName: 'w-full',
+                  inputClassName: 'w-full',
+                  placeholder: 'Search bots…',
+                  value: memberQuery,
+                  onChange: setMemberQuery
+                }),
+                filteredMemberRoster.length
+                  ? jsx(ScrollArea, {
+                      className: 'max-h-44 rounded-md border border-(--ui-stroke-secondary)',
+                      children: jsx('div', {
+                        className: 'grid gap-0.5 p-2',
+                        children: filteredMemberRoster.map(bot => {
+                          const ready = Boolean(botMeta[bot.name]?.instanceId)
+                          return jsxs(
+                            'label',
+                            {
+                              className: cn(
+                                'flex cursor-pointer items-center gap-2 rounded px-1.5 py-1 text-xs hover:bg-(--chrome-action-hover)',
+                                !ready && 'text-(--ui-text-tertiary)'
+                              ),
+                              title: ready ? bot.name : `${bot.name} · stable identity will be prepared automatically`,
+                              children: [
+                                jsx(Checkbox, {
+                                  checked: memberNames.includes(bot.name),
+                                  onCheckedChange: value => toggleMember(bot.name, Boolean(value))
+                                }),
+                                jsx('span', { className: 'min-w-0 flex-1 truncate', children: displayName(bot, botMeta[bot.name]) }),
+                                jsx('span', {
+                                  className: 'font-mono text-[0.6rem] text-(--ui-text-quaternary)',
+                                  children: `@${botHandle(bot.name)}`
+                                })
+                              ]
+                            },
+                            bot.name
+                          )
+                        })
+                      })
+                    })
+                  : jsx('div', {
+                      'aria-live': 'polite',
+                      className: 'rounded-md border border-(--ui-stroke-secondary) px-3 py-3 text-center text-xs text-(--ui-text-tertiary)',
+                      children: `No bots match “${memberQuery.trim()}”`
+                    })
+              ]
+            }),
+            memberNames.length
+              ? labeled(
+                  'Leader',
+                  jsxs(Select, {
+                    value: leaderName,
+                    onValueChange: setLeaderName,
+                    children: [
+                      jsx(SelectTrigger, { children: jsx(SelectValue, { placeholder: 'Choose a leader' }) }),
+                      jsx(SelectContent, {
+                        children: memberNames.map(memberName =>
+                          jsx(SelectItem, { value: memberName, children: `@${botHandle(memberName)}` }, memberName)
+                        )
+                      })
+                    ]
+                  })
+                )
+              : null,
+            error ? jsx('div', { className: 'text-xs text-(--ui-accent)', children: error }) : null
+          ]
+        }),
+        jsxs(DialogFooter, {
+          className: 'justify-between sm:justify-between',
+          children: [
+            jsx(Button, {
+              variant: 'secondary',
+              disabled: busy,
+              onClick: remove,
+              children: deleteArmed ? 'Click again to delete' : 'Delete Group'
+            }),
+            jsxs('div', {
+              className: 'flex gap-2',
+              children: [
+                jsx(Button, { variant: 'secondary', disabled: busy, onClick: onClose, children: 'Cancel' }),
+                jsx(Button, {
+                  disabled: busy || !name.trim() || !memberNames.length || !leaderName,
+                  onClick: save,
+                  children: busy ? 'Saving…' : 'Save'
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    })
+  })
+}
+
+function DurableGroupRow({ group, onEdit }) {
+  const leader = (group.members || []).find(member => member.bot_instance_id === group.leader_bot_instance_id)
+  const open = () => {
+    haptic('tap')
+    $selectedGroupId.set(group.id)
+    host.navigate(GROUP_ROUTE)
+  }
+  const row = jsxs('button', {
+    type: 'button',
+    onClick: open,
+    className: 'flex w-full min-w-0 items-center gap-2.5 rounded-md px-2 py-2 text-left transition-colors hover:bg-(--chrome-action-hover)',
+    children: [
+      jsx(DurableGroupGlyph, { group, size: 34 }),
+      jsxs('div', {
+        className: 'min-w-0 flex-1',
+        children: [
+          jsx('div', { className: 'truncate text-[0.8125rem] font-medium', children: group.name }),
+          jsx('div', {
+            className: 'truncate text-xs text-(--ui-text-tertiary)',
+            children: `${group.members?.length || 0} members${leader ? ` · leader @${botHandle(leader.profile_name)}` : ''}`
+          })
+        ]
+      })
+    ]
+  })
+
+  if (!onEdit) {
+    return row
+  }
+  return jsxs(ContextMenu, {
+    children: [
+      jsx(ContextMenuTrigger, { asChild: true, children: row }),
+      jsx(ContextMenuContent, {
+        children: jsx(ContextMenuItem, { onSelect: () => onEdit(group), children: 'Group Settings' })
+      })
+    ]
+  })
+}
+
+function DurableGroupsPane({ roster, onShowBots }) {
+  const { data, error, isLoading, refetch } = useGroups()
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editing, setEditing] = useState(null)
+  const groups = Array.isArray(data) ? data : []
+
+  return jsxs('div', {
+    className: 'flex h-full flex-col',
+    children: [
+      jsxs('div', {
+        className: 'flex items-center justify-between gap-2 px-2.5 pt-2.5 pb-1.5',
+        children: [
+          jsx(DurableBotsGroupsSwitch, { mode: 'groups', onChange: mode => mode === 'bots' && onShowBots() }),
+          jsx(Tip, {
+            label: 'New Group',
+            children: jsx('button', {
+              type: 'button',
+              className: 'flex size-6 items-center justify-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
+              onClick: () => setCreateOpen(true),
+              children: jsx(Codicon, { name: 'add' })
+            })
+          })
+        ]
+      }),
+      isLoading
+        ? jsx('div', {
+            className: 'flex flex-1 items-center justify-center',
+            children: jsx(GlyphSpinner, { spinner: 'breathe', className: 'text-(--ui-text-tertiary)' })
+          })
+        : error
+          ? jsxs('div', {
+              className: 'grid gap-2 px-3 py-4 text-xs text-(--ui-text-tertiary)',
+              children: [
+                jsx('div', { children: 'Persistent Groups are unavailable from the Bot Mode backend.' }),
+                jsx(Button, { variant: 'secondary', size: 'sm', onClick: () => void refetch(), children: 'Retry' })
+              ]
+            })
+          : groups.length
+            ? jsx(ScrollArea, {
+                className: 'min-h-0 flex-1',
+                children: jsx('div', {
+                  className: 'grid gap-0.5 px-1.5 pb-2',
+                  children: groups.map(group => jsx(DurableGroupRow, { group, onEdit: setEditing }, group.id))
+                })
+              })
+            : jsx(EmptyState, {
+                icon: 'organization',
+                title: 'No groups yet',
+                description: 'Assemble a few bots into a persistent team.'
+              }),
+      jsx('div', {
+        className: 'border-t border-(--ui-stroke-secondary) p-2',
+        children: jsxs(Button, {
+          className: 'w-full justify-center gap-1.5',
+          variant: 'secondary',
+          onClick: () => setCreateOpen(true),
+          children: [jsx(Codicon, { name: 'add' }), 'New Group']
+        })
+      }),
+      jsx(DurableCreateGroupDialog, { open: createOpen, onClose: () => setCreateOpen(false), roster }),
+      jsx(DurableGroupSettingsDialog, {
+        group: editing,
+        open: Boolean(editing),
+        onClose: () => setEditing(null),
+        roster
+      })
+    ]
+  })
+}
+
+function DurableGroupMessageRow({ message, group, roster, botMeta }) {
+  const fromBot = Boolean(message?.sender_bot_instance_id)
+  if (!fromBot) {
+    return jsxs('div', {
+      className: 'flex justify-end',
+      children: [
+        jsxs('div', {
+          className: 'max-w-[82%] rounded-2xl rounded-br-md bg-(--chrome-action-hover) px-3.5 py-2.5',
+          children: [
+            jsx('div', { className: 'mb-1 text-[0.65rem] font-semibold text-(--ui-text-tertiary)', children: 'You' }),
+            jsx('div', { className: 'whitespace-pre-wrap text-sm leading-6', children: message.content }),
+            jsx('div', {
+              className: 'mt-1 text-right text-[0.6rem] text-(--ui-text-quaternary)',
+              children: relativeTime(message.created_at_ms)
+            })
+          ]
+        })
+      ]
+    })
+  }
+
+  const profileName = message.sender_profile_name || 'unknown'
+  const bot = roster.find(item => item.name === profileName) || { name: profileName }
+  const meta = botMeta[profileName]
+  const appearance = botAppearance(profileName, meta)
+  const isLeader = message.sender_bot_instance_id === group.leader_bot_instance_id
+  return jsxs('div', {
+    className: 'flex items-start gap-2.5',
+    children: [
+      jsx(BotFace, {
+        shape: appearance.shape,
+        color: appearance.color,
+        image: appearance.image,
+        size: 32,
+        name: profileName
+      }),
+      jsxs('div', {
+        className: 'min-w-0 max-w-[82%]',
+        children: [
+          jsxs('div', {
+            className: 'mb-1 flex items-center gap-1.5',
+            children: [
+              jsx('span', { className: 'truncate text-xs font-semibold', children: displayName(bot, meta) }),
+              jsx('span', {
+                className: 'font-mono text-[0.6rem] text-(--ui-text-quaternary)',
+                children: `@${botHandle(profileName)}`
+              }),
+              isLeader
+                ? jsx('span', {
+                    className: 'rounded-full border border-(--ui-stroke-secondary) px-1.5 py-0.5 text-[0.55rem] font-semibold uppercase tracking-wide text-(--ui-text-tertiary)',
+                    children: 'Leader'
+                  })
+                : null
+            ]
+          }),
+          jsxs('div', {
+            className: 'rounded-2xl rounded-tl-md border border-(--ui-stroke-secondary) px-3.5 py-2.5',
+            children: [
+              jsx('div', { className: 'whitespace-pre-wrap text-sm leading-6', children: message.content }),
+              jsx('div', {
+                className: 'mt-1 text-[0.6rem] text-(--ui-text-quaternary)',
+                children: relativeTime(message.created_at_ms)
+              })
+            ]
+          })
+        ]
+      })
+    ]
+  })
+}
+
+function DurableGroupRoomPage() {
+  const selectedGroupId = useValue($selectedGroupId)
+  const { data: rosterData } = useRoster()
+  const liveRoster = Array.isArray(rosterData?.profiles) ? rosterData.profiles.filter(bot => !bot.remoteSource) : null
+  const roster = liveRoster ?? $lastRoster.get().filter(bot => !bot.remoteSource)
+
+  if (liveRoster) {
+    $lastRoster.set(liveRoster)
+    mergeServerMeta(liveRoster)
+    void reconcileBotIdentities(liveRoster).catch(() => undefined)
+  }
+  const botMeta = useValue($botMeta)
+  const groupsQuery = useGroups()
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editing, setEditing] = useState(null)
+  const groupQuery = useQuery({
+    queryKey: [ID, 'group', selectedGroupId],
+    queryFn: () => (selectedGroupId ? pluginCtx.rest(`/groups/${selectedGroupId}`) : Promise.resolve(null)),
+    enabled: Boolean(selectedGroupId),
+    retry: false
+  })
+  const messagesQuery = useGroupMessages(selectedGroupId)
+  const [draft, setDraft] = useState('')
+  const [sending, setSending] = useState(false)
+  const [activeSpeaker, setActiveSpeaker] = useState(null)
+  const [sendError, setSendError] = useState(null)
+  const [commandNotice, setCommandNotice] = useState(null)
+  const [modelPickerOpen, setModelPickerOpen] = useState(false)
+  const [slashIndex, setSlashIndex] = useState(0)
+  const groupChatPrefs = useValue($groupChatPrefs)
+  const slashQuery = useGroupSlashSuggestions(draft)
+
+  useEffect(() => {
+    setSlashIndex(0)
+  }, [draft])
+
+  if (!selectedGroupId) {
+    const groups = Array.isArray(groupsQuery.data) ? groupsQuery.data : []
+    return jsxs('div', {
+      className: 'flex h-full min-h-0 flex-col',
+      children: [
+        jsxs('div', {
+          className: 'flex items-center justify-between border-b border-(--ui-stroke-secondary) px-6 py-4',
+          children: [
+            jsxs('div', {
+              children: [
+                jsx('h1', { className: 'text-lg font-semibold', children: 'Groups' }),
+                jsx('p', {
+                  className: 'mt-0.5 text-xs text-(--ui-text-tertiary)',
+                  children: 'Persistent bot teams with stable membership and leaders.'
+                })
+              ]
+            }),
+            jsxs(Button, {
+              onClick: () => setCreateOpen(true),
+              children: [jsx(Codicon, { name: 'add' }), 'New Group']
+            })
+          ]
+        }),
+        groupsQuery.isLoading
+          ? jsx('div', {
+              className: 'flex flex-1 items-center justify-center',
+              children: jsx(GlyphSpinner, { spinner: 'breathe', className: 'text-(--ui-text-tertiary)' })
+            })
+          : groups.length
+            ? jsx(ScrollArea, {
+                className: 'min-h-0 flex-1',
+                children: jsx('div', {
+                  className: 'mx-auto grid w-full max-w-4xl gap-3 p-6 md:grid-cols-2',
+                  children: groups.map(group =>
+                    jsx('div', {
+                      className: 'rounded-xl border border-(--ui-stroke-secondary) p-2',
+                      children: jsx(DurableGroupRow, { group, onEdit: setEditing })
+                    }, group.id)
+                  )
+                })
+              })
+            : jsx(EmptyState, {
+                icon: 'organization',
+                title: 'No groups yet',
+                description: 'Create a team from your existing Bots.'
+              }),
+        jsx(DurableCreateGroupDialog, { open: createOpen, onClose: () => setCreateOpen(false), roster }),
+        jsx(DurableGroupSettingsDialog, {
+          group: editing,
+          open: Boolean(editing),
+          onClose: () => setEditing(null),
+          roster
+        })
+      ]
+    })
+  }
+
+  if (groupQuery.isLoading) {
+    return jsx('div', {
+      className: 'flex h-full items-center justify-center',
+      children: jsx(GlyphSpinner, { spinner: 'breathe', className: 'text-(--ui-text-tertiary)' })
+    })
+  }
+  if (groupQuery.error || !groupQuery.data) {
+    return jsxs('div', {
+      className: 'flex h-full flex-col items-center justify-center gap-3 px-6 text-center',
+      children: [
+        jsx(Codicon, { name: 'warning', className: 'text-xl text-(--ui-text-tertiary)' }),
+        jsx('div', { className: 'text-sm font-medium', children: 'This group could not be loaded.' }),
+        jsx(Button, {
+          variant: 'secondary',
+          onClick: () => $selectedGroupId.set(null),
+          children: 'Back to Groups'
+        })
+      ]
+    })
+  }
+
+  const group = groupQuery.data
+  const leader = (group.members || []).find(member => member.bot_instance_id === group.leader_bot_instance_id)
+  const messages = Array.isArray(messagesQuery.data) ? messagesQuery.data : []
+  const messageKey = groupMessagesKey(group.id)
+  const mentionSuggestions = groupMentionSuggestions(group, roster, botMeta, draft)
+  const slashSuggestions = Array.isArray(slashQuery.data) ? slashQuery.data : []
+  const modelOverride = groupChatPrefs[group.id]?.modelOverride || null
+
+  const chooseMention = member => {
+    setDraft(current => completeGroupMention(current, member.profile_name))
+  }
+
+  const chooseSlash = item => {
+    const next = String(item?.text || '').trim()
+    if (!next) {
+      return
+    }
+    setDraft(`${next}${next.includes(' ') ? '' : ' '}`)
+  }
+
+  const setGroupModel = next => {
+    saveGroupChatPrefs(group.id, { modelOverride: next })
+    setCommandNotice(next?.model ? `Group model set to ${groupModelLabel(next)}.` : 'Group model reset to member profile defaults.')
+  }
+
+  const publishTranscript = next => {
+    queryClient.setQueryData(messageKey, next)
+  }
+
+  async function executeGroupSlashCommand(commandText) {
+    const command = String(commandText || '').trim()
+    const match = /^\/([^\s]+)(?:\s+([\s\S]*))?$/.exec(command)
+    if (!match) {
+      throw new Error('Invalid slash command.')
+    }
+    const name = match[1].toLowerCase()
+    const arg = (match[2] || '').trim()
+
+    if (name === 'model') {
+      if (!arg) {
+        setDraft('')
+        setModelPickerOpen(true)
+        setCommandNotice('Choose a model for this group chat.')
+        return
+      }
+      if (['default', 'profile', 'reset'].includes(arg.toLowerCase())) {
+        setGroupModel(null)
+        setDraft('')
+        return
+      }
+      const options = await host.request('model.options', { explicit_only: true })
+      const rows = groupModelRows(options)
+      const needle = arg.toLowerCase()
+      const chosen = rows.find(row =>
+        row.model.toLowerCase() === needle ||
+        `${row.provider}:${row.model}`.toLowerCase() === needle ||
+        `${row.providerName}:${row.model}`.toLowerCase() === needle
+      )
+      if (!chosen) {
+        throw new Error(`Model “${arg}” is not available. Type /model to open the picker.`)
+      }
+      setGroupModel({ provider: chosen.provider, model: chosen.model })
+      setDraft('')
+      return
+    }
+
+    if (name === 'help' || name === 'commands') {
+      setCommandNotice('Type / to browse live Hermes commands and skills. Use /model to change this room’s model; @ mentions target specific group members.')
+      setDraft('')
+      return
+    }
+
+    if (!leader) {
+      throw new Error('This group has no active leader for slash-command execution.')
+    }
+
+    const prepared = await createGroupRuntimeSession({
+      profileName: leader.profile_name,
+      title: `Group command · ${group.name}`,
+      modelOverride
+    })
+    const created = prepared.created
+    const sessionId = created?.session_id
+    if (!sessionId) {
+      throw new Error('Could not start the group command session.')
+    }
+    if (prepared.modelNotice) {
+      setCommandNotice(`Room model fallback: ${prepared.modelNotice}`)
+    }
+
+    try {
+      let dispatch
+      try {
+        dispatch = await host.request('slash.exec', { session_id: sessionId, command: command.replace(/^\/+/, '') })
+      } catch (slashError) {
+        try {
+          dispatch = await host.request('command.dispatch', { session_id: sessionId, name, arg })
+        } catch {
+          throw slashError
+        }
+      }
+
+      if (dispatch?.type === 'alias' && dispatch.target) {
+        setDraft(`/${dispatch.target}${arg ? ` ${arg}` : ''}`)
+        setCommandNotice(`/${name} redirects to /${dispatch.target}. Press Enter to run it.`)
+        return
+      }
+
+      if (dispatch?.type === 'prefill' && dispatch.message) {
+        setDraft(String(dispatch.message))
+        setCommandNotice(dispatch.notice || `/${name} prepared text in the composer.`)
+        return
+      }
+
+      if (dispatch?.type === 'skill' || dispatch?.type === 'send') {
+        const userMessage = await appendGroupTranscriptMessage(group.id, { content: command })
+        let transcript = [...messages, userMessage]
+        publishTranscript(transcript)
+        setDraft('')
+        const response = await runHiddenGroupPrompt(
+          sessionId,
+          [
+            String(dispatch.message || ''),
+            '',
+            `This command was invoked from the persistent Hermes group chat “${group.name}”.`,
+            'Use the shared group transcript below as additional conversation context.',
+            '',
+            groupTranscriptText(transcript)
+          ].join('\n')
+        )
+        const botMessage = await appendGroupTranscriptMessage(group.id, {
+          content: response,
+          senderBotInstanceId: leader.bot_instance_id
+        })
+        transcript = [...transcript, botMessage]
+        publishTranscript(transcript)
+        setCommandNotice(dispatch.notice || null)
+        return
+      }
+
+      const output = String(dispatch?.output || dispatch?.notice || '').trim()
+      setCommandNotice(output || `/${name} completed.`)
+      setDraft('')
+    } finally {
+      await cleanupGroupRuntimeSession(created, leader.profile_name)
+    }
+  }
+
+  const sendGroupMessage = async () => {
+    const text = draft.trim()
+    if (!text || sending) {
+      return
+    }
+
+    setSending(true)
+    setSendError(null)
+    setCommandNotice(null)
+    setActiveSpeaker(null)
+
+    if (text.startsWith('/')) {
+      try {
+        await executeGroupSlashCommand(text)
+      } catch (error) {
+        setSendError(error instanceof Error ? error.message : String(error))
+      } finally {
+        setSending(false)
+      }
+      return
+    }
+
+    try {
+      await reconcileBotIdentities(roster)
+      const userMessage = await appendGroupTranscriptMessage(group.id, { content: text })
+      let transcript = [...messages, userMessage]
+      publishTranscript(transcript)
+      setDraft('')
+
+      const failures = []
+      const modelNotices = []
+      for (const member of groupTurnMembers(group, text)) {
+        setActiveSpeaker(member.profile_name)
+        try {
+          const turn = await runGroupMemberTurn({ group, member, messages: transcript, modelOverride })
+          if (turn.modelNotice) {
+            modelNotices.push(turn.modelNotice)
+            setCommandNotice(`Room model fallback: ${turn.modelNotice}`)
+          }
+          const botMessage = await appendGroupTranscriptMessage(group.id, {
+            content: turn.response,
+            senderBotInstanceId: member.bot_instance_id
+          })
+          transcript = [...transcript, botMessage]
+          publishTranscript(transcript)
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error)
+          failures.push(`@${botHandle(member.profile_name)}: ${detail}`)
+          setSendError(`@${botHandle(member.profile_name)} could not reply: ${detail} Continuing with the rest of the group…`)
+        }
+      }
+
+      if (modelNotices.length) {
+        setCommandNotice(`Room model fallback: ${modelNotices.join(' · ')}`)
+      }
+      if (failures.length) {
+        setSendError(`Some group members could not reply. ${failures.join(' · ')}`)
+      }
+    } catch (error) {
+      setSendError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setActiveSpeaker(null)
+      setSending(false)
+      void messagesQuery.refetch()
+    }
+  }
+
+  return jsxs('div', {
+    className: 'flex h-full min-h-0 flex-col',
+    children: [
+      jsxs('div', {
+        className: 'flex items-center justify-between gap-4 border-b border-(--ui-stroke-secondary) px-6 py-4',
+        children: [
+          jsxs('div', {
+            className: 'flex min-w-0 items-center gap-3',
+            children: [
+              jsx('button', {
+                type: 'button',
+                className: 'flex size-8 items-center justify-center rounded-md text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover)',
+                onClick: () => $selectedGroupId.set(null),
+                children: jsx(Codicon, { name: 'arrow-left' })
+              }),
+              jsx(DurableGroupGlyph, { group, size: 42 }),
+              jsxs('div', {
+                className: 'min-w-0',
+                children: [
+                  jsx('h1', { className: 'truncate text-lg font-semibold', children: group.name }),
+                  jsx('div', {
+                    className: 'text-xs text-(--ui-text-tertiary)',
+                    children: `${group.members?.length || 0} members${leader ? ` · leader @${botHandle(leader.profile_name)}` : ''}`
+                  })
+                ]
+              })
+            ]
+          }),
+          jsx(Button, { variant: 'secondary', onClick: () => setEditing(group), children: 'Settings' })
+        ]
+      }),
+      jsx(ScrollArea, {
+        className: 'min-h-0 flex-1',
+        children: jsxs('div', {
+          className: 'mx-auto grid w-full max-w-4xl gap-5 p-6',
+          children: [
+            jsxs('section', {
+              className: 'rounded-xl border border-(--ui-stroke-secondary) p-4',
+              children: [
+                jsx('div', {
+                  className: 'mb-3 text-xs font-semibold uppercase tracking-wider text-(--ui-text-quaternary)',
+                  children: 'Members'
+                }),
+                jsx('div', {
+                  className: 'grid gap-2 sm:grid-cols-2',
+                  children: (group.members || []).map(member => {
+                    const bot = roster.find(item => item.name === member.profile_name) || { name: member.profile_name }
+                    const meta = botMeta[member.profile_name]
+                    const appearance = botAppearance(member.profile_name, meta)
+                    const isLeader = member.bot_instance_id === group.leader_bot_instance_id
+                    return jsxs(
+                      'div',
+                      {
+                        className: 'flex min-w-0 items-center gap-2.5 rounded-lg bg-(--chrome-action-hover) px-3 py-2.5',
+                        children: [
+                          jsx(BotFace, {
+                            shape: appearance.shape,
+                            color: appearance.color,
+                            image: appearance.image,
+                            size: 32,
+                            name: member.profile_name
+                          }),
+                          jsxs('div', {
+                            className: 'min-w-0 flex-1',
+                            children: [
+                              jsx('div', {
+                                className: 'truncate text-sm font-medium',
+                                children: displayName(bot, meta)
+                              }),
+                              jsx('div', {
+                                className: 'truncate font-mono text-[0.65rem] text-(--ui-text-quaternary)',
+                                children: `@${botHandle(member.profile_name)}`
+                              })
+                            ]
+                          }),
+                          isLeader
+                            ? jsx('span', {
+                                className: 'rounded-full border border-(--ui-stroke-secondary) px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-wide text-(--ui-text-tertiary)',
+                                children: 'Leader'
+                              })
+                            : null
+                        ]
+                      },
+                      member.bot_instance_id
+                    )
+                  })
+                })
+              ]
+            }),
+            jsxs('section', {
+              className: 'grid gap-4',
+              children: [
+                messagesQuery.isLoading
+                  ? jsx('div', {
+                      className: 'flex justify-center py-10',
+                      children: jsx(GlyphSpinner, { spinner: 'breathe', className: 'text-(--ui-text-tertiary)' })
+                    })
+                  : messagesQuery.error
+                    ? jsx('div', {
+                        className: 'rounded-xl border border-(--ui-stroke-secondary) p-4 text-sm text-(--ui-text-tertiary)',
+                        children: 'The group transcript could not be loaded.'
+                      })
+                    : messages.length
+                      ? jsx('div', {
+                          className: 'grid gap-4',
+                          children: messages.map(message =>
+                            jsx(DurableGroupMessageRow, { message, group, roster, botMeta }, message.id)
+                          )
+                        })
+                      : jsxs('div', {
+                          className: 'rounded-xl border border-dashed border-(--ui-stroke-secondary) p-8 text-center',
+                          children: [
+                            jsx(Codicon, { name: 'comment-discussion', className: 'text-xl text-(--ui-text-tertiary)' }),
+                            jsx('div', { className: 'mt-2 text-sm font-medium', children: 'Start the conversation' }),
+                            jsx('p', {
+                              className: 'mx-auto mt-1 max-w-lg text-xs leading-5 text-(--ui-text-tertiary)',
+                              children: 'Send one message to the room. The leader replies first, then the other members join the same shared turn.'
+                            })
+                          ]
+                        }),
+                sending
+                  ? jsxs('div', {
+                      className: 'flex items-center gap-2 rounded-lg border border-(--ui-stroke-secondary) px-3 py-2 text-xs text-(--ui-text-tertiary)',
+                      children: [
+                        jsx(GlyphSpinner, { spinner: 'breathe' }),
+                        activeSpeaker ? `@${botHandle(activeSpeaker)} is replying…` : 'Starting group turn…'
+                      ]
+                    })
+                  : null
+              ]
+            })
+          ]
+        })
+      }),
+      jsxs('div', {
+        className: 'border-t border-(--ui-stroke-secondary) px-4 py-3',
+        children: [
+          sendError
+            ? jsx('div', {
+                className: 'mx-auto mb-2 w-full max-w-4xl rounded-md border border-(--ui-stroke-secondary) px-3 py-2 text-xs text-(--ui-text-tertiary)',
+                children: sendError
+              })
+            : null,
+          commandNotice
+            ? jsx('div', {
+                className: 'mx-auto mb-2 w-full max-w-4xl rounded-md bg-(--chrome-action-hover) px-3 py-2 text-xs text-(--ui-text-tertiary)',
+                children: commandNotice
+              })
+            : null,
+          jsx(DurableGroupSlashMenu, {
+            slashSuggestions,
+            selectedIndex: Math.min(slashIndex, Math.max(0, slashSuggestions.length - 1)),
+            onChoose: chooseSlash
+          }),
+          slashQuery.isLoading && groupSlashQuery(draft) !== null && !slashSuggestions.length
+            ? jsx('div', {
+                className: 'mx-auto mb-2 flex w-full max-w-4xl items-center gap-2 rounded-md border border-(--ui-stroke-secondary) px-3 py-2 text-xs text-(--ui-text-tertiary)',
+                children: [jsx(GlyphSpinner, { spinner: 'breathe' }), 'Loading commands…']
+              })
+            : null,
+          !slashSuggestions.length && mentionSuggestions.length
+            ? jsx('div', {
+                className: 'mx-auto mb-2 grid w-full max-w-4xl gap-1 rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-sidebar-surface-background) p-1.5 shadow-lg',
+                children: mentionSuggestions.map(member => {
+                  const bot = roster.find(item => item.name === member.profile_name) || { name: member.profile_name }
+                  return jsxs(
+                    'button',
+                    {
+                      type: 'button',
+                      'aria-label': 'Mention group member',
+                      className: 'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-(--chrome-action-hover)',
+                      onMouseDown: event => event.preventDefault(),
+                      onClick: () => chooseMention(member),
+                      children: [
+                        jsx('span', { className: 'min-w-0 flex-1 truncate text-xs font-medium', children: displayName(bot, botMeta[member.profile_name]) }),
+                        jsx('span', { className: 'shrink-0 font-mono text-[0.65rem] text-(--ui-text-quaternary)', children: `@${botHandle(member.profile_name)}` })
+                      ]
+                    },
+                    member.bot_instance_id
+                  )
+                })
+              })
+            : null,
+          jsxs('div', {
+            className: 'mx-auto mb-2 flex w-full max-w-4xl items-center justify-between gap-2',
+            children: [
+              jsx(DurableGroupModelPicker, {
+                value: modelOverride,
+                onChange: setGroupModel,
+                open: modelPickerOpen,
+                onOpenChange: setModelPickerOpen
+              }),
+              jsx('div', {
+                className: 'text-[0.6rem] text-(--ui-text-quaternary)',
+                children: 'Room model · unsupported members use profile default · does not change profiles'
+              })
+            ]
+          }),
+          jsxs('div', {
+            className: 'mx-auto flex w-full max-w-4xl items-end gap-2',
+            children: [
+              jsx(Textarea, {
+                'aria-label': 'Message the group',
+                className: 'min-h-11 max-h-40 flex-1 resize-none',
+                disabled: sending,
+                placeholder: 'Message the group…',
+                value: draft,
+                onChange: event => setDraft(event.target.value),
+                onKeyDown: event => {
+                  if (slashSuggestions.length) {
+                    if (event.key === 'ArrowDown') {
+                      event.preventDefault()
+                      setSlashIndex(index => (index + 1) % slashSuggestions.length)
+                      return
+                    }
+                    if (event.key === 'ArrowUp') {
+                      event.preventDefault()
+                      setSlashIndex(index => (index - 1 + slashSuggestions.length) % slashSuggestions.length)
+                      return
+                    }
+                    const selectedSlash = slashSuggestions[slashIndex] || slashSuggestions[0]
+                    if (event.key === 'Enter' && !event.shiftKey && draft.trim() === String(selectedSlash?.text || '').trim()) {
+                      event.preventDefault()
+                      void sendGroupMessage()
+                      return
+                    }
+                    if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
+                      event.preventDefault()
+                      chooseSlash(selectedSlash)
+                      return
+                    }
+                  }
+                  if (mentionSuggestions.length && (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey))) {
+                    event.preventDefault()
+                    chooseMention(mentionSuggestions[0])
+                    return
+                  }
+                  if (event.key === 'Enter' && !event.shiftKey) {
+                    event.preventDefault()
+                    void sendGroupMessage()
+                  }
+                }
+              }),
+              jsx(Button, {
+                disabled: sending || !draft.trim(),
+                onClick: () => void sendGroupMessage(),
+                children: sending ? 'Group replying…' : 'Send to group'
+              })
+            ]
+          }),
+          jsx('div', {
+            className: 'mx-auto mt-1 w-full max-w-4xl text-[0.6rem] text-(--ui-text-quaternary)',
+            children: 'Enter to send · Shift+Enter for a new line · / commands · @ members'
+          })
+        ]
+      }),
+      jsx(DurableGroupSettingsDialog, {
+        group: editing,
+        open: Boolean(editing),
+        onClose: () => setEditing(null),
+        roster
+      })
+    ]
+  })
+}
+
 // ── roster pane ──────────────────────────────────────────────────────────────
 
 /** "Active now" presence strip above the roster: chips for every bot that is
@@ -7774,6 +10095,7 @@ function BotsPane() {
   const [deleting, setDeleting] = useState(null)
   const [grouping, setGrouping] = useState(null)
   const [query, setQuery] = useState('')
+  const [mode, setMode] = useState('bots')
   const activityToasts = useValue($activityToasts)
   const sessionsWorkspaceName = useValue($botSessionsWorkspace)
   const groupChatName = useValue($groupChatWorkspace)
@@ -7869,6 +10191,10 @@ function BotsPane() {
     : null
   const sessionsWorkspaceBot = roster.find(bot => bot.name === sessionsWorkspaceName)
 
+  if (mode === 'groups') {
+    return jsx(DurableGroupsPane, { roster: activeSourceRoster, onShowBots: () => setMode('bots') })
+  }
+
   if (sessionsWorkspaceBot) {
     return jsx(ProfileSessionsWorkspace, { bot: sessionsWorkspaceBot })
   }
@@ -7885,10 +10211,7 @@ function BotsPane() {
       jsxs('div', {
         className: 'flex items-center justify-between gap-2 px-2.5 pt-2.5 pb-1.5',
         children: [
-          jsx('span', {
-            className: 'text-[0.6875rem] font-semibold uppercase tracking-wider text-(--ui-text-quaternary)',
-            children: 'Bots'
-          }),
+          jsx(DurableBotsGroupsSwitch, { mode: 'bots', onChange: setMode }),
           jsxs('div', {
             className: 'flex items-center gap-0.5',
             children: [
@@ -8268,6 +10591,22 @@ export default {
       /* no storage on this shell — defaults stay */
     }
 
+    try {
+      Promise.resolve(ctx.storage?.get?.('group-chat-prefs'))
+        .then(value => {
+          if (value && typeof value === 'object') {
+            const migrated = migrateGroupChatPrefs(value)
+            $groupChatPrefs.set(migrated)
+            if (JSON.stringify(migrated) !== JSON.stringify(value)) {
+              Promise.resolve(ctx.storage?.set?.('group-chat-prefs', migrated)).catch(() => undefined)
+            }
+          }
+        })
+        .catch(() => undefined)
+    } catch {
+      /* durable group chat preferences stay at defaults */
+    }
+
     // Bot Mode sessions are always hidden now — the old "hide Bot Chats"
     // pref is gone (its stored key is simply ignored). The reconciliation
     // sweep below hides any rows born visible under the old pref.
@@ -8379,6 +10718,25 @@ export default {
       data: { placement: 'left', width: '260px', dock: { pane: 'sessions', pos: 'center', enforce: true } },
       render: () => jsx(BotsPane, {})
     })
+
+    if (typeof ROUTES_AREA !== 'undefined') {
+      ctx.register({
+        id: 'groups-page',
+        area: ROUTES_AREA,
+        title: 'Groups',
+        data: { path: GROUP_ROUTE },
+        render: () => jsx(DurableGroupRoomPage, {})
+      })
+    }
+
+    if (typeof SIDEBAR_NAV_AREA !== 'undefined') {
+      ctx.register({
+        id: 'groups-nav',
+        area: SIDEBAR_NAV_AREA,
+        order: 45,
+        data: { codicon: 'organization', label: 'Groups', path: GROUP_ROUTE }
+      })
+    }
 
     // Routines — its OWN tiling pane splitting the workspace's right edge
     // (NOT the collapsible right sidebar; placement 'right' is that sidebar's

--- a/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
@@ -75,12 +75,17 @@ test('roster without profiles never throws', () => {
 })
 
 test('ActiveNowStrip renders above the roster, is a live region, and is click-accessible', () => {
-  // Strip is placed between the pane header and the search field.
-  const headerEnd = source.indexOf("children: 'Bots'")
-  const searchField = source.indexOf("placeholder: 'Search bots…'")
+  // Inspect BotsPane specifically. Durable Groups has its own search field and
+  // header switch earlier in the source, so whole-file first-match ordering is
+  // no longer a meaningful layout assertion.
+  const paneStart = source.indexOf('function BotsPane(')
+  const paneEnd = source.indexOf('// ── plugin', paneStart)
+  const pane = source.slice(paneStart, paneEnd)
+  const headerEnd = pane.indexOf("jsx(DurableBotsGroupsSwitch, { mode: 'bots'")
+  const searchField = pane.indexOf("placeholder: 'Search bots…'")
   assert.ok(headerEnd >= 0 && searchField > headerEnd)
 
-  const stripStart = source.indexOf('jsx(ActiveNowStrip')
+  const stripStart = pane.indexOf('jsx(ActiveNowStrip')
   assert.ok(stripStart > headerEnd && stripStart < searchField, 'strip sits between header and search')
 
   // Live region announces membership changes politely.

--- a/apps/desktop/src/plugins/hermes-bots/tests/durable-groups.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/durable-groups.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function section(start, end) {
+  const from = source.indexOf(start)
+  assert.notEqual(from, -1, `missing section start: ${start}`)
+  const to = source.indexOf(end, from)
+  assert.notEqual(to, -1, `missing section end: ${end}`)
+  return source.slice(from, to)
+}
+
+test('durable Groups is part of the bundled hermes-bots plugin, not a second desktop plugin id', () => {
+  assert.match(source, /const ID = 'hermes-bots'/)
+  assert.match(source, /const GROUPS_KEY = \[ID, 'groups'\]/)
+  assert.match(source, /const GROUP_ROUTE = '\/bot-groups'/)
+  assert.match(source, /id: 'groups-page'/)
+  assert.match(source, /id: 'groups-nav'/)
+  assert.match(source, /render: \(\) => jsx\(DurableGroupRoomPage/)
+})
+
+test('durable Groups keeps stable bot-instance identities and excludes remote thin rows', () => {
+  const block = section('function reconcileBotIdentities', 'function newGroupMutationKey')
+  assert.match(block, /roster\.filter\(bot => !bot\.remoteSource\)/)
+  assert.match(block, /\/bots\/reconcile/)
+  assert.match(block, /instanceId/)
+  assert.match(block, /void saveBotMeta\(assignment\.profile_name/)
+})
+
+test('durable Groups supports managed identity, leader, icons, membership, and durable messages', () => {
+  assert.match(source, /const GROUP_COLORS = \[/)
+  assert.match(source, /const GROUP_EMOJIS = \[/)
+  assert.match(source, /function DurableCreateGroupDialog/)
+  assert.match(source, /function DurableGroupSettingsDialog/)
+  assert.match(source, /leader_bot_instance_id/)
+  assert.match(source, /\/membership/)
+  assert.match(source, /groupMessagesKey/)
+  assert.match(source, /appendGroupTranscriptMessage/)
+})
+
+test('durable Groups restores room-scoped model selection and slash completion', () => {
+  assert.match(source, /group-chat-prefs/)
+  assert.match(source, /host\.request\('model\.options'/)
+  assert.match(source, /function DurableGroupModelPicker/)
+  assert.match(source, /host\.request\('commands\.catalog'\)/)
+  assert.match(source, /host\.request\('complete\.slash'/)
+  assert.match(source, /function DurableGroupSlashMenu/)
+})
+
+test('persistent Groups never prewarm members and Bot rows wake on click, not hover', () => {
+  const durable = section('// ── persistent managed Groups', '// ── roster pane')
+  assert.doesNotMatch(durable, /warmGroupMembers/)
+  assert.doesNotMatch(durable, /warmProfile|warmAgent/)
+
+  const botRow = section('function BotRow(', '// ── model picker')
+  assert.doesNotMatch(botRow, /onPointerEnter:\s*warm/)
+  assert.doesNotMatch(botRow, /host\.warmProfile|host\.warmAgent/)
+  assert.match(botRow, /onClick:\s*open/)
+})
+
+test('quick upstream Group Chat remains present alongside persistent managed Groups', () => {
+  assert.match(source, /const GROUP_CHAT_MAX_ROUNDS = 3/)
+  assert.match(source, /const GROUP_CHAT_MAX_MESSAGES = 10/)
+  assert.match(source, /function GroupChatWorkspace/)
+  assert.match(source, /function runGroupChatRounds/)
+  assert.match(source, /requestForBot\(member, 'session\.create'/)
+})
+
+test('route registration is optional for stripped-down SDK test harnesses', () => {
+  assert.match(source, /if \(typeof ROUTES_AREA !== 'undefined'\)/)
+  assert.match(source, /if \(typeof SIDEBAR_NAV_AREA !== 'undefined'\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -110,16 +110,14 @@ test('regression: source transitions keep BotRow hook order stable', () => {
   assert.doesNotMatch(botRowSource, /remoteSource && Boolean\(useValue/)
 })
 
-test('behavior: pointer entry prewarms only the hovered bot', () => {
+test('behavior: pointer entry never prewarms; activation is click-driven', () => {
   const { row, warmed } = renderBotRow('alpha')
 
   assert.deepEqual(warmed, [])
-  assert.equal(typeof row.props.onPointerEnter, 'function')
-  row.props.onPointerEnter()
-  assert.deepEqual(warmed, ['alpha'])
+  assert.equal(row.props.onPointerEnter, undefined)
 })
 
-test('behavior: a remote Connections row stays in this chat instead of hopping SSH', async () => {
+test('behavior: a remote Connections row stays dormant on hover and in this chat on click', async () => {
   const { ensured, opened, row, warmed } = renderBotRow({
     connectionId: 'work',
     connectionLabel: 'Work',
@@ -128,8 +126,8 @@ test('behavior: a remote Connections row stays in this chat instead of hopping S
     sourceScoped: true
   })
 
-  row.props.onPointerEnter()
-  assert.deepEqual(warmed, [['work', 'research']])
+  assert.equal(row.props.onPointerEnter, undefined)
+  assert.deepEqual(warmed, [])
 
   await row.props.onClick()
   assert.deepEqual(ensured, [])

--- a/plugins/hermes-bots/__init__.py
+++ b/plugins/hermes-bots/__init__.py
@@ -1,0 +1,12 @@
+"""Hermes Bot Mode unified plugin entry point.
+
+Bot Mode contributes its user interface through ``desktop/plugin.js`` and its
+private group API through ``dashboard/plugin_api.py``. It intentionally adds no
+model-facing tools to the core agent schema.
+"""
+
+from __future__ import annotations
+
+
+def register(_context) -> None:
+    """Register no model tools; Desktop and dashboard discovery are declarative."""

--- a/plugins/hermes-bots/dashboard/bot_groups/__init__.py
+++ b/plugins/hermes-bots/dashboard/bot_groups/__init__.py
@@ -1,0 +1,22 @@
+"""Durable bot-group domain primitives."""
+
+from .models import (
+    BotMemberInput,
+    ConflictError,
+    DeletedError,
+    Group,
+    GroupError,
+    GroupMember,
+    GroupMessage,
+    NotFoundError,
+    SchemaUnsupportedError,
+    ValidationError,
+)
+from .service import GroupService
+from .store import GroupStore
+
+__all__ = [
+    "BotMemberInput", "ConflictError", "DeletedError", "Group", "GroupError",
+    "GroupMember", "GroupMessage", "GroupService", "GroupStore", "NotFoundError",
+    "SchemaUnsupportedError", "ValidationError",
+]

--- a/plugins/hermes-bots/dashboard/bot_groups/models.py
+++ b/plugins/hermes-bots/dashboard/bot_groups/models.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class GroupError(Exception):
+    code = "group_error"
+
+
+class ValidationError(GroupError):
+    code = "validation"
+
+
+class NotFoundError(GroupError):
+    code = "not_found"
+
+
+class ConflictError(GroupError):
+    code = "conflict"
+
+
+class DeletedError(GroupError):
+    code = "deleted"
+
+
+class SchemaUnsupportedError(GroupError):
+    code = "schema_unsupported"
+
+
+@dataclass(frozen=True)
+class BotMemberInput:
+    bot_instance_id: str
+    profile_name: str
+
+
+@dataclass(frozen=True)
+class GroupMember:
+    bot_instance_id: str
+    profile_name: str
+
+
+@dataclass(frozen=True)
+class Group:
+    id: str
+    name: str
+    color: str
+    icon_kind: str
+    icon_value: str
+    leader_bot_instance_id: str
+    revision: int
+    created_at_ms: int
+    updated_at_ms: int
+    members: tuple[GroupMember, ...]
+
+
+@dataclass(frozen=True)
+class GroupMessage:
+    id: str
+    conversation_id: str
+    sender_bot_instance_id: str | None
+    sender_profile_name: str | None
+    content: str
+    created_at_ms: int

--- a/plugins/hermes-bots/dashboard/bot_groups/service.py
+++ b/plugins/hermes-bots/dashboard/bot_groups/service.py
@@ -1,0 +1,335 @@
+"""Validation and domain-error mapping for bot-group operations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from typing import Any
+
+from .models import (
+    BotMemberInput,
+    ConflictError,
+    DeletedError,
+    Group,
+    GroupMember,
+    GroupMessage,
+    NotFoundError,
+    ValidationError,
+)
+from .store import GroupStore
+
+_COLORS = frozenset({"blue", "green", "yellow", "orange", "red", "purple", "pink", "gray"})
+_ICON_KINDS = frozenset({"emoji", "codicon"})
+
+
+class GroupService:
+    """Apply public validation before delegating durable work to ``GroupStore``."""
+
+    def __init__(self, store: GroupStore) -> None:
+        self.store = store
+
+    @staticmethod
+    def _hash(payload: dict[str, Any]) -> str:
+        serialized = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        return hashlib.sha256(serialized.encode()).hexdigest()
+
+    @classmethod
+    def _idempotency_hash(
+        cls, scope: str | None, payload: dict[str, Any]
+    ) -> str | None:
+        """Only provide a hash when the optional idempotency tuple is enabled."""
+        return cls._hash(payload) if scope is not None else None
+
+    @staticmethod
+    def _validate_idempotency(scope: object, key: object) -> None:
+        if (scope is None) != (key is None):
+            raise ValidationError("idempotency scope and key must be supplied together")
+        if scope is not None and (
+            not isinstance(scope, str)
+            or not scope.strip()
+            or not isinstance(key, str)
+            or not key.strip()
+        ):
+            raise ValidationError("idempotency scope and key must be nonblank strings")
+
+    def _raise_mutation_failure(self, group_id: str) -> None:
+        state = self.store.group_state(group_id)
+        if state == "deleted":
+            raise DeletedError("group is deleted")
+        if state == "missing":
+            raise NotFoundError("group was not found")
+        raise ConflictError("group revision is stale")
+
+    @staticmethod
+    def _name(value: object) -> str:
+        if not isinstance(value, str):
+            raise ValidationError("name must be nonblank and at most 120 characters")
+        name = value.strip()
+        if not name or len(name) > 120:
+            raise ValidationError("name must be nonblank and at most 120 characters")
+        return name
+
+    @staticmethod
+    def _message_content(value: object) -> str:
+        if not isinstance(value, str):
+            raise ValidationError("message content must be a nonblank string")
+        content = value.strip()
+        if not content or len(content) > 32_768:
+            raise ValidationError("message content must be between 1 and 32768 characters")
+        return content
+
+    @staticmethod
+    def _icon(
+        color: object, icon_kind: object, icon_value: object
+    ) -> tuple[str, str, str]:
+        if (
+            not isinstance(color, str)
+            or not isinstance(icon_kind, str)
+            or color not in _COLORS
+            or icon_kind not in _ICON_KINDS
+            or not isinstance(icon_value, str)
+            or not icon_value
+            or len(icon_value) > 64
+        ):
+            raise ValidationError("invalid icon")
+        return color, icon_kind, icon_value
+
+    @staticmethod
+    def _members(members: object) -> tuple[GroupMember, ...]:
+        if not isinstance(members, list) or not members:
+            raise ValidationError("at least one member is required")
+
+        normalized: list[GroupMember] = []
+        seen_ids: set[str] = set()
+        for member in members:
+            if (
+                not isinstance(member, BotMemberInput)
+                or not isinstance(member.bot_instance_id, str)
+                or not member.bot_instance_id
+                or not isinstance(member.profile_name, str)
+                or not member.profile_name.strip()
+                or member.bot_instance_id in seen_ids
+            ):
+                raise ValidationError("members must be distinct valid bot instances")
+            seen_ids.add(member.bot_instance_id)
+            normalized.append(
+                GroupMember(member.bot_instance_id, member.profile_name.strip())
+            )
+        return tuple(normalized)
+
+    @staticmethod
+    def _require_member_leader(
+        members: tuple[GroupMember, ...], leader_bot_instance_id: str
+    ) -> None:
+        if leader_bot_instance_id not in {member.bot_instance_id for member in members}:
+            raise ValidationError("leader must be an active member")
+
+    def create_group(
+        self,
+        *,
+        name: object,
+        color: object,
+        icon_kind: object,
+        icon_value: object,
+        members: object,
+        leader_bot_instance_id: str,
+        idempotency_scope: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> Group:
+        normalized_name = self._name(name)
+        normalized_color, normalized_icon_kind, normalized_icon_value = self._icon(
+            color, icon_kind, icon_value
+        )
+        normalized_members = self._members(members)
+        self._require_member_leader(normalized_members, leader_bot_instance_id)
+        self._validate_idempotency(idempotency_scope, idempotency_key)
+        request_hash = self._idempotency_hash(
+            idempotency_scope,
+            {
+                "operation": "create_group",
+                "name": normalized_name,
+                "color": normalized_color,
+                "icon_kind": normalized_icon_kind,
+                "icon_value": normalized_icon_value,
+                "members": [
+                    (member.bot_instance_id, member.profile_name)
+                    for member in normalized_members
+                ],
+                "leader_bot_instance_id": leader_bot_instance_id,
+            },
+        )
+        return self.store.create_group(
+            group_id=str(uuid.uuid4()),
+            name=normalized_name,
+            color=normalized_color,
+            icon_kind=normalized_icon_kind,
+            icon_value=normalized_icon_value,
+            members=normalized_members,
+            leader_bot_instance_id=leader_bot_instance_id,
+            idempotency_scope=idempotency_scope,
+            idempotency_key=idempotency_key,
+            request_hash=request_hash,
+        )
+
+    def update_metadata(
+        self,
+        group_id: str,
+        *,
+        expected_revision: int,
+        name: object,
+        color: object,
+        icon_kind: object,
+        icon_value: object,
+        idempotency_scope: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> Group:
+        normalized_name = self._name(name)
+        normalized_color, normalized_icon_kind, normalized_icon_value = self._icon(
+            color, icon_kind, icon_value
+        )
+        self._validate_idempotency(idempotency_scope, idempotency_key)
+        request_hash = self._idempotency_hash(
+            idempotency_scope,
+            {
+                "operation": "metadata",
+                "group_id": group_id,
+                "expected_revision": expected_revision,
+                "name": normalized_name,
+                "color": normalized_color,
+                "icon_kind": normalized_icon_kind,
+                "icon_value": normalized_icon_value,
+            },
+        )
+        group = self.store.update_metadata(
+            group_id=group_id,
+            expected_revision=expected_revision,
+            name=normalized_name,
+            color=normalized_color,
+            icon_kind=normalized_icon_kind,
+            icon_value=normalized_icon_value,
+            idempotency_scope=idempotency_scope,
+            idempotency_key=idempotency_key,
+            request_hash=request_hash,
+        )
+        if group is None:
+            self._raise_mutation_failure(group_id)
+        assert group is not None
+        return group
+
+    def replace_membership(
+        self,
+        group_id: str,
+        *,
+        expected_revision: int,
+        members: object,
+        leader_bot_instance_id: str,
+        idempotency_scope: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> Group:
+        normalized_members = self._members(members)
+        self._require_member_leader(normalized_members, leader_bot_instance_id)
+        self._validate_idempotency(idempotency_scope, idempotency_key)
+        request_hash = self._idempotency_hash(
+            idempotency_scope,
+            {
+                "operation": "membership",
+                "group_id": group_id,
+                "expected_revision": expected_revision,
+                "members": [
+                    (member.bot_instance_id, member.profile_name)
+                    for member in normalized_members
+                ],
+                "leader_bot_instance_id": leader_bot_instance_id,
+            },
+        )
+        group = self.store.replace_membership(
+            group_id=group_id,
+            expected_revision=expected_revision,
+            members=normalized_members,
+            leader_bot_instance_id=leader_bot_instance_id,
+            idempotency_scope=idempotency_scope,
+            idempotency_key=idempotency_key,
+            request_hash=request_hash,
+        )
+        if group is None:
+            self._raise_mutation_failure(group_id)
+        assert group is not None
+        return group
+
+    def delete_group(
+        self,
+        group_id: str,
+        *,
+        expected_revision: int,
+        idempotency_scope: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> None:
+        self._validate_idempotency(idempotency_scope, idempotency_key)
+        request_hash = self._idempotency_hash(
+            idempotency_scope,
+            {
+                "operation": "delete_group",
+                "group_id": group_id,
+                "expected_revision": expected_revision,
+            },
+        )
+        deleted = self.store.delete_group(
+            group_id=group_id,
+            expected_revision=expected_revision,
+            idempotency_scope=idempotency_scope,
+            idempotency_key=idempotency_key,
+            request_hash=request_hash,
+        )
+        if not deleted:
+            self._raise_mutation_failure(group_id)
+
+    def list_messages(self, group_id: str) -> list[GroupMessage]:
+        state = self.store.group_state(group_id)
+        if state == "deleted":
+            raise DeletedError("group is deleted")
+        if state == "missing":
+            raise NotFoundError("group was not found")
+        return self.store.list_messages(group_id)
+
+    def append_message(
+        self,
+        group_id: str,
+        *,
+        content: object,
+        sender_bot_instance_id: str | None = None,
+        idempotency_scope: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> GroupMessage:
+        normalized_content = self._message_content(content)
+        if sender_bot_instance_id is not None and (
+            not isinstance(sender_bot_instance_id, str) or not sender_bot_instance_id.strip()
+        ):
+            raise ValidationError("message sender must be a valid bot instance id")
+        self._validate_idempotency(idempotency_scope, idempotency_key)
+        request_hash = self._idempotency_hash(
+            idempotency_scope,
+            {
+                "operation": "append_message",
+                "group_id": group_id,
+                "sender_bot_instance_id": sender_bot_instance_id,
+                "content": normalized_content,
+            },
+        )
+        message = self.store.append_message(
+            group_id=group_id,
+            sender_bot_instance_id=sender_bot_instance_id,
+            content=normalized_content,
+            idempotency_scope=idempotency_scope,
+            idempotency_key=idempotency_key,
+            request_hash=request_hash,
+        )
+        if message is None:
+            self._raise_mutation_failure(group_id)
+        assert message is not None
+        return message

--- a/plugins/hermes-bots/dashboard/bot_groups/store.py
+++ b/plugins/hermes-bots/dashboard/bot_groups/store.py
@@ -1,0 +1,936 @@
+"""SQLite persistence for durable bot groups."""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import time
+import uuid
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from .models import (
+    ConflictError,
+    Group,
+    GroupMember,
+    GroupMessage,
+    SchemaUnsupportedError,
+    ValidationError,
+)
+
+SCHEMA_VERSION = 1
+
+V1_TABLE_SHAPES = {
+    "bot_instances": (
+        ("id", "TEXT", 0, 1),
+        ("profile_name", "TEXT", 1, 0),
+        ("created_at_ms", "INTEGER", 1, 0),
+        ("updated_at_ms", "INTEGER", 1, 0),
+    ),
+    "bot_groups": (
+        ("id", "TEXT", 0, 1),
+        ("name", "TEXT", 1, 0),
+        ("color", "TEXT", 1, 0),
+        ("icon_kind", "TEXT", 1, 0),
+        ("icon_value", "TEXT", 1, 0),
+        ("leader_bot_instance_id", "TEXT", 1, 0),
+        ("revision", "INTEGER", 1, 0),
+        ("created_at_ms", "INTEGER", 1, 0),
+        ("updated_at_ms", "INTEGER", 1, 0),
+        ("deleted_at_ms", "INTEGER", 0, 0),
+    ),
+    "bot_group_members": (
+        ("id", "TEXT", 0, 1),
+        ("group_id", "TEXT", 1, 0),
+        ("bot_instance_id", "TEXT", 1, 0),
+        ("membership_epoch", "INTEGER", 1, 0),
+        ("display_order", "INTEGER", 1, 0),
+        ("added_at_ms", "INTEGER", 1, 0),
+        ("removed_at_ms", "INTEGER", 0, 0),
+    ),
+    "bot_group_conversations": (
+        ("id", "TEXT", 0, 1),
+        ("group_id", "TEXT", 1, 0),
+        ("created_at_ms", "INTEGER", 1, 0),
+    ),
+    "bot_group_messages": (
+        ("id", "TEXT", 0, 1),
+        ("conversation_id", "TEXT", 1, 0),
+        ("sender_bot_instance_id", "TEXT", 0, 0),
+        ("content", "TEXT", 1, 0),
+        ("created_at_ms", "INTEGER", 1, 0),
+    ),
+    "bot_group_audit_events": (
+        ("id", "TEXT", 0, 1),
+        ("group_id", "TEXT", 1, 0),
+        ("event_type", "TEXT", 1, 0),
+        ("payload_json", "TEXT", 1, 0),
+        ("created_at_ms", "INTEGER", 1, 0),
+    ),
+    "idempotency_keys": (
+        ("scope", "TEXT", 1, 1),
+        ("key", "TEXT", 1, 2),
+        ("request_hash", "TEXT", 1, 0),
+        ("response_json", "TEXT", 1, 0),
+        ("created_at_ms", "INTEGER", 1, 0),
+    ),
+}
+
+V1_FOREIGN_KEYS = {
+    "bot_groups": {("leader_bot_instance_id", "bot_instances", "id")},
+    "bot_group_members": {
+        ("group_id", "bot_groups", "id"),
+        ("bot_instance_id", "bot_instances", "id"),
+    },
+    "bot_group_conversations": {("group_id", "bot_groups", "id")},
+    "bot_group_messages": {
+        ("conversation_id", "bot_group_conversations", "id"),
+        ("sender_bot_instance_id", "bot_instances", "id"),
+    },
+    "bot_group_audit_events": {("group_id", "bot_groups", "id")},
+}
+
+PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def utc_ms() -> int:
+    """Return the current UTC timestamp in milliseconds."""
+    return time.time_ns() // 1_000_000
+
+
+class GroupStore:
+    """Persist bot-group state and idempotent mutation receipts."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = str(path)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path, isolation_level=None)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute("PRAGMA busy_timeout=5000")
+        try:
+            connection.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.DatabaseError:
+            # Some SQLite hosts do not support WAL. The transaction still works.
+            pass
+        return connection
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            transaction_started = False
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                transaction_started = True
+                connection.execute(
+                    "CREATE TABLE IF NOT EXISTS schema_migrations ("
+                    "version INTEGER PRIMARY KEY, applied_at_ms INTEGER NOT NULL)"
+                )
+                versions = [
+                    row["version"]
+                    for row in connection.execute(
+                        "SELECT version FROM schema_migrations ORDER BY version"
+                    )
+                ]
+                if any(
+                    not isinstance(version, int)
+                    or version < 0
+                    or version > SCHEMA_VERSION
+                    for version in versions
+                ):
+                    raise SchemaUnsupportedError("database schema is unsupported")
+
+                if not versions or versions == [0]:
+                    self._create_v1(connection)
+                    connection.execute("DELETE FROM schema_migrations WHERE version=0")
+                    connection.execute(
+                        "INSERT OR REPLACE INTO schema_migrations VALUES (?, ?)",
+                        (SCHEMA_VERSION, utc_ms()),
+                    )
+                elif versions == [SCHEMA_VERSION]:
+                    self._validate_v1(connection)
+                else:
+                    raise SchemaUnsupportedError("database schema is unsupported")
+
+                connection.execute("COMMIT")
+                transaction_started = False
+            except Exception:
+                if transaction_started:
+                    connection.execute("ROLLBACK")
+                raise
+
+    @staticmethod
+    def _create_v1(connection: sqlite3.Connection) -> None:
+        statements = (
+            "CREATE TABLE IF NOT EXISTS bot_instances ("
+            "id TEXT PRIMARY KEY, profile_name TEXT NOT NULL, "
+            "created_at_ms INTEGER NOT NULL, updated_at_ms INTEGER NOT NULL)",
+            "CREATE TABLE IF NOT EXISTS bot_groups ("
+            "id TEXT PRIMARY KEY, name TEXT NOT NULL, color TEXT NOT NULL, "
+            "icon_kind TEXT NOT NULL, icon_value TEXT NOT NULL, "
+            "leader_bot_instance_id TEXT NOT NULL REFERENCES bot_instances(id), "
+            "revision INTEGER NOT NULL, created_at_ms INTEGER NOT NULL, "
+            "updated_at_ms INTEGER NOT NULL, deleted_at_ms INTEGER)",
+            "CREATE TABLE IF NOT EXISTS bot_group_members ("
+            "id TEXT PRIMARY KEY, group_id TEXT NOT NULL REFERENCES bot_groups(id), "
+            "bot_instance_id TEXT NOT NULL REFERENCES bot_instances(id), "
+            "membership_epoch INTEGER NOT NULL, display_order INTEGER NOT NULL, "
+            "added_at_ms INTEGER NOT NULL, removed_at_ms INTEGER)",
+            "CREATE UNIQUE INDEX IF NOT EXISTS bot_group_members_active_unique "
+            "ON bot_group_members(group_id, bot_instance_id) "
+            "WHERE removed_at_ms IS NULL",
+            "CREATE TABLE IF NOT EXISTS bot_group_conversations ("
+            "id TEXT PRIMARY KEY, group_id TEXT NOT NULL UNIQUE REFERENCES bot_groups(id), "
+            "created_at_ms INTEGER NOT NULL)",
+            "CREATE TABLE IF NOT EXISTS bot_group_messages ("
+            "id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL "
+            "REFERENCES bot_group_conversations(id), sender_bot_instance_id TEXT "
+            "REFERENCES bot_instances(id), content TEXT NOT NULL, "
+            "created_at_ms INTEGER NOT NULL)",
+            "CREATE TABLE IF NOT EXISTS bot_group_audit_events ("
+            "id TEXT PRIMARY KEY, group_id TEXT NOT NULL REFERENCES bot_groups(id), "
+            "event_type TEXT NOT NULL, payload_json TEXT NOT NULL, "
+            "created_at_ms INTEGER NOT NULL)",
+            "CREATE TABLE IF NOT EXISTS idempotency_keys ("
+            "scope TEXT NOT NULL, key TEXT NOT NULL, request_hash TEXT NOT NULL, "
+            "response_json TEXT NOT NULL, created_at_ms INTEGER NOT NULL, "
+            "PRIMARY KEY(scope, key))",
+        )
+        for statement in statements:
+            connection.execute(statement)
+
+    @staticmethod
+    def _validate_v1(connection: sqlite3.Connection) -> None:
+        present_tables = {
+            row["name"]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        if not V1_TABLE_SHAPES.keys() <= present_tables:
+            raise SchemaUnsupportedError("database schema is unsupported")
+
+        for table, expected_shape in V1_TABLE_SHAPES.items():
+            actual_shape = tuple(
+                (row["name"], row["type"].upper(), row["notnull"], row["pk"])
+                for row in connection.execute(f"PRAGMA table_info({table})")
+            )
+            if actual_shape != expected_shape:
+                raise SchemaUnsupportedError("database schema is unsupported")
+
+            actual_foreign_keys = {
+                (row["from"], row["table"], row["to"])
+                for row in connection.execute(f"PRAGMA foreign_key_list({table})")
+            }
+            if actual_foreign_keys != V1_FOREIGN_KEYS.get(table, set()):
+                raise SchemaUnsupportedError("database schema is unsupported")
+
+        conversation_indexes = connection.execute(
+            "PRAGMA index_list(bot_group_conversations)"
+        ).fetchall()
+        if not any(
+            row["unique"]
+            and tuple(
+                column["name"]
+                for column in connection.execute(f"PRAGMA index_info({row['name']})")
+            )
+            == ("group_id",)
+            for row in conversation_indexes
+        ):
+            raise SchemaUnsupportedError("database schema is unsupported")
+
+        active_index = next(
+            (
+                row
+                for row in connection.execute("PRAGMA index_list(bot_group_members)")
+                if row["name"] == "bot_group_members_active_unique"
+            ),
+            None,
+        )
+        if active_index is None or not active_index["unique"] or not active_index["partial"]:
+            raise SchemaUnsupportedError("database schema is unsupported")
+        active_index_columns = tuple(
+            row["name"]
+            for row in connection.execute(
+                "PRAGMA index_info(bot_group_members_active_unique)"
+            )
+        )
+        active_index_sql = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name=?",
+            ("bot_group_members_active_unique",),
+        ).fetchone()["sql"]
+        normalized_active_index_sql = " ".join(active_index_sql.upper().split()).rstrip(";")
+        expected_active_index_sql = (
+            "CREATE UNIQUE INDEX BOT_GROUP_MEMBERS_ACTIVE_UNIQUE "
+            "ON BOT_GROUP_MEMBERS(GROUP_ID, BOT_INSTANCE_ID) "
+            "WHERE REMOVED_AT_MS IS NULL"
+        )
+        if (
+            active_index_columns != ("group_id", "bot_instance_id")
+            or normalized_active_index_sql != expected_active_index_sql
+        ):
+            raise SchemaUnsupportedError("database schema is unsupported")
+
+    @contextmanager
+    def transaction(self) -> Iterator[sqlite3.Connection]:
+        connection = self._connect()
+        transaction_started = False
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            transaction_started = True
+            yield connection
+            connection.execute("COMMIT")
+            transaction_started = False
+        except Exception:
+            if transaction_started:
+                connection.execute("ROLLBACK")
+            raise
+        finally:
+            connection.close()
+
+    @staticmethod
+    def _validate_idempotency(
+        scope: object, key: object, request_hash: object
+    ) -> None:
+        values = (scope, key, request_hash)
+        if values == (None, None, None):
+            return
+        if all(isinstance(value, str) and value.strip() for value in values):
+            return
+        raise ValidationError(
+            "idempotency scope, key, and request hash must be supplied together "
+            "as nonblank strings"
+        )
+
+    def _group(self, connection: sqlite3.Connection, group_id: str) -> Group | None:
+        row = connection.execute(
+            "SELECT * FROM bot_groups WHERE id=? AND deleted_at_ms IS NULL", (group_id,)
+        ).fetchone()
+        if row is None:
+            return None
+
+        members = connection.execute(
+            "SELECT i.id, i.profile_name FROM bot_group_members m "
+            "JOIN bot_instances i ON i.id=m.bot_instance_id "
+            "WHERE m.group_id=? AND m.removed_at_ms IS NULL "
+            "ORDER BY m.display_order",
+            (group_id,),
+        ).fetchall()
+        return Group(
+            row["id"],
+            row["name"],
+            row["color"],
+            row["icon_kind"],
+            row["icon_value"],
+            row["leader_bot_instance_id"],
+            row["revision"],
+            row["created_at_ms"],
+            row["updated_at_ms"],
+            tuple(GroupMember(member["id"], member["profile_name"]) for member in members),
+        )
+
+    @staticmethod
+    def _pack(group: Group) -> dict[str, Any]:
+        return {
+            "group": {
+                "id": group.id,
+                "name": group.name,
+                "color": group.color,
+                "icon_kind": group.icon_kind,
+                "icon_value": group.icon_value,
+                "leader_bot_instance_id": group.leader_bot_instance_id,
+                "revision": group.revision,
+                "created_at_ms": group.created_at_ms,
+                "updated_at_ms": group.updated_at_ms,
+                "members": [
+                    [member.bot_instance_id, member.profile_name]
+                    for member in group.members
+                ],
+            }
+        }
+
+    @staticmethod
+    def _unpack(payload: dict[str, Any]) -> Group:
+        group = payload["group"]
+        return Group(
+            group["id"],
+            group["name"],
+            group["color"],
+            group["icon_kind"],
+            group["icon_value"],
+            group["leader_bot_instance_id"],
+            group["revision"],
+            group["created_at_ms"],
+            group["updated_at_ms"],
+            tuple(GroupMember(*member) for member in group["members"]),
+        )
+
+    @staticmethod
+    def _message_from_row(row: sqlite3.Row) -> GroupMessage:
+        return GroupMessage(
+            row["id"],
+            row["conversation_id"],
+            row["sender_bot_instance_id"],
+            row["sender_profile_name"],
+            row["content"],
+            row["created_at_ms"],
+        )
+
+    @staticmethod
+    def _pack_message(message: GroupMessage) -> dict[str, Any]:
+        return {
+            "message": {
+                "id": message.id,
+                "conversation_id": message.conversation_id,
+                "sender_bot_instance_id": message.sender_bot_instance_id,
+                "sender_profile_name": message.sender_profile_name,
+                "content": message.content,
+                "created_at_ms": message.created_at_ms,
+            }
+        }
+
+    @staticmethod
+    def _unpack_message(payload: dict[str, Any]) -> GroupMessage:
+        message = payload["message"]
+        return GroupMessage(
+            message["id"],
+            message["conversation_id"],
+            message["sender_bot_instance_id"],
+            message["sender_profile_name"],
+            message["content"],
+            message["created_at_ms"],
+        )
+
+    @staticmethod
+    def _replay(
+        connection: sqlite3.Connection, scope: str | None, key: str | None, request_hash: str | None
+    ) -> dict[str, Any] | None:
+        if scope is None:
+            return None
+        row = connection.execute(
+            "SELECT request_hash, response_json FROM idempotency_keys "
+            "WHERE scope=? AND key=?",
+            (scope, key),
+        ).fetchone()
+        if row is None:
+            return None
+        if row["request_hash"] != request_hash:
+            raise ConflictError("idempotency key was used for a different request")
+        return json.loads(row["response_json"])
+
+    @staticmethod
+    def _receipt(
+        connection: sqlite3.Connection,
+        scope: str | None,
+        key: str | None,
+        request_hash: str | None,
+        response: dict[str, Any],
+    ) -> None:
+        if scope is None:
+            return
+        connection.execute(
+            "INSERT INTO idempotency_keys VALUES (?, ?, ?, ?, ?)",
+            (
+                scope,
+                key,
+                request_hash,
+                json.dumps(response, sort_keys=True, separators=(",", ":")),
+                utc_ms(),
+            ),
+        )
+
+    @staticmethod
+    def _members(
+        connection: sqlite3.Connection, members: Sequence[GroupMember], now: int
+    ) -> None:
+        for member in members:
+            connection.execute(
+                "INSERT INTO bot_instances VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(id) DO UPDATE SET profile_name=excluded.profile_name, "
+                "updated_at_ms=excluded.updated_at_ms",
+                (member.bot_instance_id, member.profile_name, now, now),
+            )
+
+    @staticmethod
+    def _assert_leader_is_member(
+        members: Sequence[GroupMember], leader_bot_instance_id: str
+    ) -> None:
+        if leader_bot_instance_id not in {
+            member.bot_instance_id for member in members
+        }:
+            raise ValidationError("leader must be an active member")
+
+    def create_group(
+        self,
+        *,
+        group_id: str,
+        name: str,
+        color: str,
+        icon_kind: str,
+        icon_value: str,
+        members: Sequence[GroupMember],
+        leader_bot_instance_id: str,
+        idempotency_scope: str | None = None,
+        idempotency_key: str | None = None,
+        request_hash: str | None = None,
+    ) -> Group:
+        self._validate_idempotency(idempotency_scope, idempotency_key, request_hash)
+        self._assert_leader_is_member(members, leader_bot_instance_id)
+
+        with self.transaction() as connection:
+            replay = self._replay(
+                connection, idempotency_scope, idempotency_key, request_hash
+            )
+            if replay is not None:
+                return self._unpack(replay)
+
+            now = utc_ms()
+            self._members(connection, members, now)
+            connection.execute(
+                "INSERT INTO bot_groups VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, NULL)",
+                (
+                    group_id,
+                    name,
+                    color,
+                    icon_kind,
+                    icon_value,
+                    leader_bot_instance_id,
+                    now,
+                    now,
+                ),
+            )
+            for display_order, member in enumerate(members):
+                connection.execute(
+                    "INSERT INTO bot_group_members VALUES (?, ?, ?, 1, ?, ?, NULL)",
+                    (
+                        str(uuid.uuid4()),
+                        group_id,
+                        member.bot_instance_id,
+                        display_order,
+                        now,
+                    ),
+                )
+            connection.execute(
+                "INSERT INTO bot_group_conversations VALUES (?, ?, ?)",
+                (str(uuid.uuid4()), group_id, now),
+            )
+            connection.execute(
+                "INSERT INTO bot_group_audit_events VALUES (?, ?, ?, ?, ?)",
+                (str(uuid.uuid4()), group_id, "group_created", "{}", now),
+            )
+            group = self._group(connection, group_id)
+            assert group is not None
+            self._receipt(
+                connection,
+                idempotency_scope,
+                idempotency_key,
+                request_hash,
+                self._pack(group),
+            )
+            return group
+
+    def update_metadata(
+        self,
+        *,
+        group_id: str,
+        expected_revision: int,
+        name: str,
+        color: str,
+        icon_kind: str,
+        icon_value: str,
+        idempotency_scope: str | None = None,
+        idempotency_key: str | None = None,
+        request_hash: str | None = None,
+    ) -> Group | None:
+        self._validate_idempotency(idempotency_scope, idempotency_key, request_hash)
+        return self._mutate_metadata(
+            group_id,
+            expected_revision,
+            name,
+            color,
+            icon_kind,
+            icon_value,
+            idempotency_scope,
+            idempotency_key,
+            request_hash,
+        )
+
+    def _mutate_metadata(
+        self,
+        group_id: str,
+        expected_revision: int,
+        name: str,
+        color: str,
+        icon_kind: str,
+        icon_value: str,
+        idempotency_scope: str | None,
+        idempotency_key: str | None,
+        request_hash: str | None,
+    ) -> Group | None:
+        with self.transaction() as connection:
+            replay = self._replay(
+                connection, idempotency_scope, idempotency_key, request_hash
+            )
+            if replay is not None:
+                return self._unpack(replay)
+
+            now = utc_ms()
+            result = connection.execute(
+                "UPDATE bot_groups SET name=?, color=?, icon_kind=?, icon_value=?, "
+                "revision=revision+1, updated_at_ms=? "
+                "WHERE id=? AND deleted_at_ms IS NULL AND revision=?",
+                (name, color, icon_kind, icon_value, now, group_id, expected_revision),
+            )
+            if result.rowcount != 1:
+                return None
+
+            connection.execute(
+                "INSERT INTO bot_group_audit_events VALUES (?, ?, ?, ?, ?)",
+                (str(uuid.uuid4()), group_id, "metadata_updated", "{}", now),
+            )
+            group = self._group(connection, group_id)
+            assert group is not None
+            self._receipt(
+                connection,
+                idempotency_scope,
+                idempotency_key,
+                request_hash,
+                self._pack(group),
+            )
+            return group
+
+    def replace_membership(
+        self,
+        *,
+        group_id: str,
+        expected_revision: int,
+        members: Sequence[GroupMember],
+        leader_bot_instance_id: str,
+        idempotency_scope: str | None = None,
+        idempotency_key: str | None = None,
+        request_hash: str | None = None,
+    ) -> Group | None:
+        self._validate_idempotency(idempotency_scope, idempotency_key, request_hash)
+        self._assert_leader_is_member(members, leader_bot_instance_id)
+
+        with self.transaction() as connection:
+            replay = self._replay(
+                connection, idempotency_scope, idempotency_key, request_hash
+            )
+            if replay is not None:
+                return self._unpack(replay)
+
+            # This guard must precede every related-row write. Returning None from
+            # this transaction commits, so a stale request cannot have side effects.
+            current = connection.execute(
+                "SELECT revision FROM bot_groups "
+                "WHERE id=? AND deleted_at_ms IS NULL",
+                (group_id,),
+            ).fetchone()
+            if current is None or current["revision"] != expected_revision:
+                return None
+
+            now = utc_ms()
+            self._members(connection, members, now)
+            result = connection.execute(
+                "UPDATE bot_groups SET leader_bot_instance_id=?, revision=revision+1, "
+                "updated_at_ms=? WHERE id=? AND deleted_at_ms IS NULL AND revision=?",
+                (leader_bot_instance_id, now, group_id, expected_revision),
+            )
+            if result.rowcount != 1:
+                raise RuntimeError("membership revision changed during immediate transaction")
+
+            epoch = expected_revision + 1
+            connection.execute(
+                "UPDATE bot_group_members SET removed_at_ms=? "
+                "WHERE group_id=? AND removed_at_ms IS NULL",
+                (now, group_id),
+            )
+            for display_order, member in enumerate(members):
+                connection.execute(
+                    "INSERT INTO bot_group_members VALUES (?, ?, ?, ?, ?, ?, NULL)",
+                    (
+                        str(uuid.uuid4()),
+                        group_id,
+                        member.bot_instance_id,
+                        epoch,
+                        display_order,
+                        now,
+                    ),
+                )
+            connection.execute(
+                "INSERT INTO bot_group_audit_events VALUES (?, ?, ?, ?, ?)",
+                (str(uuid.uuid4()), group_id, "membership_replaced", "{}", now),
+            )
+            group = self._group(connection, group_id)
+            assert group is not None
+            self._receipt(
+                connection,
+                idempotency_scope,
+                idempotency_key,
+                request_hash,
+                self._pack(group),
+            )
+            return group
+
+    def delete_group(
+        self,
+        *,
+        group_id: str,
+        expected_revision: int,
+        idempotency_scope: str | None = None,
+        idempotency_key: str | None = None,
+        request_hash: str | None = None,
+    ) -> bool:
+        self._validate_idempotency(idempotency_scope, idempotency_key, request_hash)
+
+        with self.transaction() as connection:
+            replay = self._replay(
+                connection, idempotency_scope, idempotency_key, request_hash
+            )
+            if replay is not None:
+                return bool(replay["deleted"])
+
+            now = utc_ms()
+            result = connection.execute(
+                "UPDATE bot_groups SET deleted_at_ms=?, revision=revision+1, "
+                "updated_at_ms=? WHERE id=? AND deleted_at_ms IS NULL AND revision=?",
+                (now, now, group_id, expected_revision),
+            )
+            if result.rowcount != 1:
+                return False
+
+            connection.execute(
+                "INSERT INTO bot_group_audit_events VALUES (?, ?, ?, ?, ?)",
+                (str(uuid.uuid4()), group_id, "group_deleted", "{}", now),
+            )
+            self._receipt(
+                connection,
+                idempotency_scope,
+                idempotency_key,
+                request_hash,
+                {"deleted": True},
+            )
+            return True
+
+    def load_idempotency(
+        self, *, scope: str, key: str
+    ) -> tuple[str, dict[str, Any]] | None:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT request_hash, response_json FROM idempotency_keys "
+                "WHERE scope=? AND key=?",
+                (scope, key),
+            ).fetchone()
+        if row is None:
+            return None
+        return row["request_hash"], json.loads(row["response_json"])
+
+    def save_idempotency(self, **_: object) -> None:
+        raise RuntimeError("use atomic mutator receipt")
+
+    def group_state(self, group_id: str) -> str:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT deleted_at_ms FROM bot_groups WHERE id=?", (group_id,)
+            ).fetchone()
+        if row is None:
+            return "missing"
+        return "deleted" if row["deleted_at_ms"] is not None else "active"
+
+    def get_group(self, group_id: str) -> Group | None:
+        with self._connect() as connection:
+            return self._group(connection, group_id)
+
+    def list_groups(self) -> list[Group]:
+        with self._connect() as connection:
+            group_ids = [
+                row["id"]
+                for row in connection.execute(
+                    "SELECT id FROM bot_groups WHERE deleted_at_ms IS NULL "
+                    "ORDER BY created_at_ms, id"
+                )
+            ]
+            return [
+                group
+                for group_id in group_ids
+                if (group := self._group(connection, group_id)) is not None
+            ]
+
+    def list_messages(self, group_id: str) -> list[GroupMessage]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT m.id, m.conversation_id, m.sender_bot_instance_id, "
+                "i.profile_name AS sender_profile_name, m.content, m.created_at_ms "
+                "FROM bot_group_messages m "
+                "JOIN bot_group_conversations c ON c.id=m.conversation_id "
+                "LEFT JOIN bot_instances i ON i.id=m.sender_bot_instance_id "
+                "WHERE c.group_id=? ORDER BY m.created_at_ms, m.id",
+                (group_id,),
+            ).fetchall()
+        return [self._message_from_row(row) for row in rows]
+
+    def append_message(
+        self,
+        *,
+        group_id: str,
+        sender_bot_instance_id: str | None,
+        content: str,
+        idempotency_scope: str | None = None,
+        idempotency_key: str | None = None,
+        request_hash: str | None = None,
+    ) -> GroupMessage | None:
+        self._validate_idempotency(idempotency_scope, idempotency_key, request_hash)
+        with self.transaction() as connection:
+            replay = self._replay(
+                connection, idempotency_scope, idempotency_key, request_hash
+            )
+            if replay is not None:
+                return self._unpack_message(replay)
+
+            conversation = connection.execute(
+                "SELECT c.id FROM bot_group_conversations c "
+                "JOIN bot_groups g ON g.id=c.group_id "
+                "WHERE c.group_id=? AND g.deleted_at_ms IS NULL",
+                (group_id,),
+            ).fetchone()
+            if conversation is None:
+                return None
+
+            sender_profile_name: str | None = None
+            if sender_bot_instance_id is not None:
+                sender = connection.execute(
+                    "SELECT i.profile_name FROM bot_group_members m "
+                    "JOIN bot_instances i ON i.id=m.bot_instance_id "
+                    "WHERE m.group_id=? AND m.bot_instance_id=? "
+                    "AND m.removed_at_ms IS NULL",
+                    (group_id, sender_bot_instance_id),
+                ).fetchone()
+                if sender is None:
+                    raise ValidationError("message sender must be an active group member")
+                sender_profile_name = sender["profile_name"]
+
+            message = GroupMessage(
+                str(uuid.uuid4()),
+                conversation["id"],
+                sender_bot_instance_id,
+                sender_profile_name,
+                content,
+                utc_ms(),
+            )
+            connection.execute(
+                "INSERT INTO bot_group_messages VALUES (?, ?, ?, ?, ?)",
+                (
+                    message.id,
+                    message.conversation_id,
+                    message.sender_bot_instance_id,
+                    message.content,
+                    message.created_at_ms,
+                ),
+            )
+            self._receipt(
+                connection,
+                idempotency_scope,
+                idempotency_key,
+                request_hash,
+                self._pack_message(message),
+            )
+            return message
+
+    def reconcile_bot_instances(
+        self, bots: Sequence[tuple[str, str | None]]
+    ) -> list[dict[str, str | bool]]:
+        """Return stable instance IDs while separating copied profile metadata."""
+        profile_names = [profile_name for profile_name, _ in bots]
+        if len(profile_names) != len(set(profile_names)):
+            raise ValidationError("bot profile names must be distinct")
+        if any(not PROFILE_NAME_RE.fullmatch(name) for name in profile_names):
+            raise ValidationError("bot profile name is invalid")
+
+        with self.transaction() as connection:
+            rows = connection.execute(
+                "SELECT id, profile_name FROM bot_instances"
+            ).fetchall()
+            by_id = {row["id"]: row["profile_name"] for row in rows}
+            by_profile = {row["profile_name"]: row["id"] for row in rows}
+            incoming_names = set(profile_names)
+            assignments: dict[str, str] = {}
+            claimed_ids: set[str] = set()
+
+            # Recorded profile ownership wins over copied UI metadata.
+            for profile_name, _ in bots:
+                known_id = by_profile.get(profile_name)
+                if known_id is not None:
+                    assignments[profile_name] = known_id
+                    claimed_ids.add(known_id)
+
+            # A supplied ID may establish a bot or rename its absent owner. If
+            # the recorded owner is also present, this row is a clone.
+            for profile_name, supplied_id in bots:
+                if profile_name in assignments or not self._is_uuid(supplied_id):
+                    continue
+                assert isinstance(supplied_id, str)
+                recorded_owner = by_id.get(supplied_id)
+                if supplied_id in claimed_ids:
+                    continue
+                if recorded_owner is None or recorded_owner not in incoming_names:
+                    assignments[profile_name] = supplied_id
+                    claimed_ids.add(supplied_id)
+
+            for profile_name, _ in bots:
+                if profile_name in assignments:
+                    continue
+                instance_id = str(uuid.uuid4())
+                while instance_id in by_id or instance_id in claimed_ids:
+                    instance_id = str(uuid.uuid4())
+                assignments[profile_name] = instance_id
+                claimed_ids.add(instance_id)
+
+            now = utc_ms()
+            for profile_name, instance_id in assignments.items():
+                connection.execute(
+                    "INSERT INTO bot_instances VALUES (?, ?, ?, ?) "
+                    "ON CONFLICT(id) DO UPDATE SET "
+                    "profile_name=excluded.profile_name, updated_at_ms=excluded.updated_at_ms",
+                    (instance_id, profile_name, now, now),
+                )
+
+            supplied_by_profile = dict(bots)
+            return [
+                {
+                    "profile_name": profile_name,
+                    "instance_id": assignments[profile_name],
+                    "changed": supplied_by_profile[profile_name]
+                    != assignments[profile_name],
+                }
+                for profile_name in profile_names
+            ]
+
+    @staticmethod
+    def _is_uuid(value: object) -> bool:
+        if not isinstance(value, str):
+            return False
+        try:
+            return str(uuid.UUID(value)) == value.lower()
+        except ValueError:
+            return False
+
+    def count_rows(self, table: str) -> int:
+        allowed_tables = {
+            "bot_instances",
+            "bot_groups",
+            "bot_group_members",
+            "bot_group_conversations",
+            "bot_group_messages",
+            "bot_group_audit_events",
+            "idempotency_keys",
+            "schema_migrations",
+        }
+        if table not in allowed_tables:
+            raise ValueError("unknown table")
+        with self._connect() as connection:
+            return connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]

--- a/plugins/hermes-bots/dashboard/dist/index.js
+++ b/plugins/hermes-bots/dashboard/dist/index.js
@@ -1,0 +1,6 @@
+// Hermes Bot Mode exposes its operator UI through the native Desktop plugin.
+// The legacy web dashboard still loads every enabled dashboard manifest,
+// including hidden tabs, and expects each script to register successfully.
+// Register a non-visible component so backend API discovery stays healthy
+// without exposing a duplicate web-dashboard surface.
+window.__HERMES_PLUGINS__?.register("hermes-bots", () => null)

--- a/plugins/hermes-bots/dashboard/manifest.json
+++ b/plugins/hermes-bots/dashboard/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "hermes-bots",
+  "label": "Hermes Bot Mode",
+  "description": "Private durable state and routing API for Bot Mode groups.",
+  "icon": "people",
+  "version": "0.2.0",
+  "tab": {
+    "hidden": true
+  },
+  "entry": "dist/index.js",
+  "api": "plugin_api.py"
+}

--- a/plugins/hermes-bots/dashboard/plugin_api.py
+++ b/plugins/hermes-bots/dashboard/plugin_api.py
@@ -1,0 +1,366 @@
+"""Private FastAPI surface for the Hermes Bot Mode desktop plugin."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import lru_cache
+from pathlib import Path
+import sys
+
+from fastapi import APIRouter, Body, Header, HTTPException, Response, status
+from pydantic import BaseModel, ConfigDict
+
+# Hermes loads dashboard/plugin_api.py as a standalone module via
+# importlib.util.spec_from_file_location(), while tests and normal Python users
+# may import it as dashboard.plugin_api. Keep exactly one bot_groups module
+# identity in either mode so dataclass/isinstance/error checks stay coherent.
+if __package__:
+    from .bot_groups import (
+        BotMemberInput,
+        ConflictError,
+        DeletedError,
+        Group,
+        GroupError,
+        GroupMessage,
+        GroupService,
+        GroupStore,
+        NotFoundError,
+        ValidationError,
+    )
+    from .bot_groups.store import SCHEMA_VERSION
+else:
+    _DASHBOARD_DIR = Path(__file__).resolve().parent
+    if str(_DASHBOARD_DIR) not in sys.path:
+        sys.path.insert(0, str(_DASHBOARD_DIR))
+
+    from bot_groups import (
+        BotMemberInput,
+        ConflictError,
+        DeletedError,
+        Group,
+        GroupError,
+        GroupMessage,
+        GroupService,
+        GroupStore,
+        NotFoundError,
+        ValidationError,
+    )
+    from bot_groups.store import SCHEMA_VERSION
+
+
+class MemberPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bot_instance_id: str
+    profile_name: str
+
+
+class CreateGroupPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    color: str
+    icon_kind: str
+    icon_value: str
+    members: list[MemberPayload]
+    leader_bot_instance_id: str
+    idempotency_key: str | None = None
+
+
+class UpdateGroupPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_revision: int
+    name: str
+    color: str
+    icon_kind: str
+    icon_value: str
+    idempotency_key: str | None = None
+
+
+class ReplaceMembershipPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_revision: int
+    members: list[MemberPayload]
+    leader_bot_instance_id: str
+    idempotency_key: str | None = None
+
+
+class DeleteGroupPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_revision: int
+    idempotency_key: str | None = None
+
+
+class BotIdentityPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    profile_name: str
+    instance_id: str | None = None
+
+
+class ReconcileBotsPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bots: list[BotIdentityPayload]
+
+
+class GroupMessagePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    content: str
+    sender_bot_instance_id: str | None = None
+    idempotency_key: str | None = None
+
+
+def default_group_db_path() -> Path:
+    """Return one installation-wide database path, independent of active profile."""
+    from hermes_constants import get_default_hermes_root
+
+    data_dir = get_default_hermes_root() / "plugins" / "hermes-bots"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir / "bot-groups.sqlite3"
+
+
+@lru_cache(maxsize=1)
+def get_group_service() -> GroupService:
+    return GroupService(GroupStore(default_group_db_path()))
+
+
+def _member_inputs(members: list[MemberPayload]) -> list[BotMemberInput]:
+    return [
+        BotMemberInput(
+            bot_instance_id=member.bot_instance_id,
+            profile_name=member.profile_name,
+        )
+        for member in members
+    ]
+
+
+def _group_payload(group: Group) -> dict:
+    return {
+        "id": group.id,
+        "name": group.name,
+        "color": group.color,
+        "icon_kind": group.icon_kind,
+        "icon_value": group.icon_value,
+        "leader_bot_instance_id": group.leader_bot_instance_id,
+        "revision": group.revision,
+        "created_at_ms": group.created_at_ms,
+        "updated_at_ms": group.updated_at_ms,
+        "members": [
+            {
+                "bot_instance_id": member.bot_instance_id,
+                "profile_name": member.profile_name,
+            }
+            for member in group.members
+        ],
+    }
+
+
+def _message_payload(message: GroupMessage) -> dict:
+    return {
+        "id": message.id,
+        "conversation_id": message.conversation_id,
+        "sender_bot_instance_id": message.sender_bot_instance_id,
+        "sender_profile_name": message.sender_profile_name,
+        "content": message.content,
+        "created_at_ms": message.created_at_ms,
+    }
+
+
+def _idempotency_key(header_key: str | None, body_key: str | None) -> str | None:
+    if header_key and body_key and header_key != body_key:
+        raise ValidationError("idempotency key header and body must match")
+    return header_key or body_key
+
+
+def _http_error(error: GroupError) -> HTTPException:
+    if isinstance(error, ConflictError):
+        status_code = status.HTTP_409_CONFLICT
+    elif isinstance(error, DeletedError):
+        status_code = status.HTTP_410_GONE
+    elif isinstance(error, NotFoundError):
+        status_code = status.HTTP_404_NOT_FOUND
+    elif isinstance(error, ValidationError):
+        status_code = status.HTTP_400_BAD_REQUEST
+    else:
+        status_code = status.HTTP_400_BAD_REQUEST
+    return HTTPException(
+        status_code=status_code,
+        detail={"code": error.code, "message": str(error)},
+    )
+
+
+def create_router(
+    service_provider: Callable[[], GroupService] = get_group_service,
+) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/health")
+    def health() -> dict:
+        service_provider()
+        return {"status": "ok", "schema_version": SCHEMA_VERSION}
+
+    @router.get("/groups")
+    def list_groups() -> list[dict]:
+        return [_group_payload(group) for group in service_provider().store.list_groups()]
+
+    @router.post("/bots/reconcile")
+    def reconcile_bots(payload: ReconcileBotsPayload) -> dict:
+        try:
+            bots = service_provider().store.reconcile_bot_instances(
+                [(bot.profile_name, bot.instance_id) for bot in payload.bots]
+            )
+        except GroupError as error:
+            raise _http_error(error) from error
+        return {"bots": bots}
+
+    @router.post("/groups", status_code=status.HTTP_201_CREATED)
+    def create_group(
+        payload: CreateGroupPayload,
+        idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    ) -> dict:
+        try:
+            idempotency_key = _idempotency_key(
+                idempotency_key, payload.idempotency_key
+            )
+            group = service_provider().create_group(
+                name=payload.name,
+                color=payload.color,
+                icon_kind=payload.icon_kind,
+                icon_value=payload.icon_value,
+                members=_member_inputs(payload.members),
+                leader_bot_instance_id=payload.leader_bot_instance_id,
+                idempotency_scope="api:create-group" if idempotency_key else None,
+                idempotency_key=idempotency_key,
+            )
+        except GroupError as error:
+            raise _http_error(error) from error
+        return _group_payload(group)
+
+    @router.get("/groups/{group_id}")
+    def get_group(group_id: str) -> dict:
+        service = service_provider()
+        group = service.store.get_group(group_id)
+        if group is not None:
+            return _group_payload(group)
+        state = service.store.group_state(group_id)
+        error: GroupError
+        if state == "deleted":
+            error = DeletedError("group is deleted")
+        else:
+            error = NotFoundError("group was not found")
+        raise _http_error(error)
+
+    @router.get("/groups/{group_id}/messages")
+    def list_group_messages(group_id: str) -> list[dict]:
+        try:
+            messages = service_provider().list_messages(group_id)
+        except GroupError as error:
+            raise _http_error(error) from error
+        return [_message_payload(message) for message in messages]
+
+    @router.post(
+        "/groups/{group_id}/messages", status_code=status.HTTP_201_CREATED
+    )
+    def append_group_message(
+        group_id: str,
+        payload: GroupMessagePayload,
+        idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    ) -> dict:
+        try:
+            idempotency_key = _idempotency_key(
+                idempotency_key, payload.idempotency_key
+            )
+            message = service_provider().append_message(
+                group_id,
+                content=payload.content,
+                sender_bot_instance_id=payload.sender_bot_instance_id,
+                idempotency_scope=(
+                    f"api:group:{group_id}:message" if idempotency_key else None
+                ),
+                idempotency_key=idempotency_key,
+            )
+        except GroupError as error:
+            raise _http_error(error) from error
+        return _message_payload(message)
+
+    @router.patch("/groups/{group_id}")
+    def update_group(
+        group_id: str,
+        payload: UpdateGroupPayload,
+        idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    ) -> dict:
+        try:
+            idempotency_key = _idempotency_key(
+                idempotency_key, payload.idempotency_key
+            )
+            group = service_provider().update_metadata(
+                group_id,
+                expected_revision=payload.expected_revision,
+                name=payload.name,
+                color=payload.color,
+                icon_kind=payload.icon_kind,
+                icon_value=payload.icon_value,
+                idempotency_scope=(
+                    f"api:group:{group_id}:metadata" if idempotency_key else None
+                ),
+                idempotency_key=idempotency_key,
+            )
+        except GroupError as error:
+            raise _http_error(error) from error
+        return _group_payload(group)
+
+    @router.put("/groups/{group_id}/membership")
+    def replace_membership(
+        group_id: str,
+        payload: ReplaceMembershipPayload,
+        idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    ) -> dict:
+        try:
+            idempotency_key = _idempotency_key(
+                idempotency_key, payload.idempotency_key
+            )
+            group = service_provider().replace_membership(
+                group_id,
+                expected_revision=payload.expected_revision,
+                members=_member_inputs(payload.members),
+                leader_bot_instance_id=payload.leader_bot_instance_id,
+                idempotency_scope=(
+                    f"api:group:{group_id}:membership" if idempotency_key else None
+                ),
+                idempotency_key=idempotency_key,
+            )
+        except GroupError as error:
+            raise _http_error(error) from error
+        return _group_payload(group)
+
+    @router.delete("/groups/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
+    def delete_group(
+        group_id: str,
+        payload: DeleteGroupPayload = Body(...),
+        idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    ) -> Response:
+        try:
+            idempotency_key = _idempotency_key(
+                idempotency_key, payload.idempotency_key
+            )
+            service_provider().delete_group(
+                group_id,
+                expected_revision=payload.expected_revision,
+                idempotency_scope=(
+                    f"api:group:{group_id}:delete" if idempotency_key else None
+                ),
+                idempotency_key=idempotency_key,
+            )
+        except GroupError as error:
+            raise _http_error(error) from error
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    return router
+
+
+router = create_router()

--- a/plugins/hermes-bots/plugin.yaml
+++ b/plugins/hermes-bots/plugin.yaml
@@ -1,0 +1,9 @@
+name: hermes-bots
+version: 0.2.0
+description: "Bot Mode roster, durable bot groups, and bounded multi-agent collaboration for Hermes Desktop."
+author: NousResearch
+kind: standalone
+platforms:
+  - linux
+  - macos
+  - windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -455,7 +455,14 @@ gateway = ["assets/**/*"]
 # Bundled plugin discovery reads these manifests at runtime. Keep them in
 # sealed wheels with the plugin Python modules; without this declaration the
 # wheel contains adapters but discovery finds zero bundled plugins.
-plugins = ["**/plugin.yaml", "**/plugin.yml"]
+plugins = [
+  "**/plugin.yaml",
+  "**/plugin.yml",
+  "**/dashboard/manifest.json",
+  "**/dashboard/plugin_api.py",
+  "**/dashboard/*/*.py",
+  "**/dashboard/dist/*",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_bot_mode_groups_backend.py
+++ b/tests/test_bot_mode_groups_backend.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_API = ROOT / "plugins" / "hermes-bots" / "dashboard" / "plugin_api.py"
+
+
+def _load_api():
+    spec = importlib.util.spec_from_file_location("hermes_bots_groups_plugin_api_test", PLUGIN_API)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _client(tmp_path: Path):
+    api = _load_api()
+    service = api.GroupService(api.GroupStore(tmp_path / "groups.sqlite3"))
+    app = FastAPI()
+    app.include_router(api.create_router(lambda: service))
+    return TestClient(app), service
+
+
+def test_durable_groups_api_full_lifecycle(tmp_path: Path) -> None:
+    client, _service = _client(tmp_path)
+
+    health = client.get("/health")
+    assert health.status_code == 200
+    assert health.json()["status"] == "ok"
+
+    reconciled = client.post(
+        "/bots/reconcile",
+        json={
+            "bots": [
+                {"profile_name": "alpha", "instance_id": None},
+                {"profile_name": "beta", "instance_id": None},
+                {"profile_name": "gamma", "instance_id": None},
+            ]
+        },
+    )
+    assert reconciled.status_code == 200
+    identities = {row["profile_name"]: row["instance_id"] for row in reconciled.json()["bots"]}
+    assert set(identities) == {"alpha", "beta", "gamma"}
+    assert len(set(identities.values())) == 3
+
+    create_payload = {
+        "name": "Build Crew",
+        "color": "purple",
+        "icon_kind": "emoji",
+        "icon_value": "🛠️",
+        "members": [
+            {"profile_name": "alpha", "bot_instance_id": identities["alpha"]},
+            {"profile_name": "beta", "bot_instance_id": identities["beta"]},
+        ],
+        "leader_bot_instance_id": identities["alpha"],
+        "idempotency_key": "create-build-crew",
+    }
+    created = client.post("/groups", json=create_payload)
+    assert created.status_code == 201
+    group = created.json()
+    group_id = group["id"]
+    assert group["revision"] == 1
+    assert group["leader_bot_instance_id"] == identities["alpha"]
+    assert [member["profile_name"] for member in group["members"]] == ["alpha", "beta"]
+
+    replay = client.post("/groups", json=create_payload)
+    assert replay.status_code == 201
+    assert replay.json()["id"] == group_id
+    assert len(client.get("/groups").json()) == 1
+
+    renamed = client.patch(
+        f"/groups/{group_id}",
+        json={
+            "expected_revision": 1,
+            "name": "Ship Crew",
+            "color": "green",
+            "icon_kind": "emoji",
+            "icon_value": "🚀",
+            "idempotency_key": "rename-build-crew",
+        },
+    )
+    assert renamed.status_code == 200
+    group = renamed.json()
+    assert group["name"] == "Ship Crew"
+    assert group["revision"] == 2
+
+    stale = client.patch(
+        f"/groups/{group_id}",
+        json={
+            "expected_revision": 1,
+            "name": "Should Fail",
+            "color": "green",
+            "icon_kind": "emoji",
+            "icon_value": "🚀",
+        },
+    )
+    assert stale.status_code == 409
+
+    membership = client.put(
+        f"/groups/{group_id}/membership",
+        json={
+            "expected_revision": 2,
+            "members": [
+                {"profile_name": "beta", "bot_instance_id": identities["beta"]},
+                {"profile_name": "gamma", "bot_instance_id": identities["gamma"]},
+            ],
+            "leader_bot_instance_id": identities["beta"],
+            "idempotency_key": "replace-members",
+        },
+    )
+    assert membership.status_code == 200
+    group = membership.json()
+    assert group["revision"] == 3
+    assert group["leader_bot_instance_id"] == identities["beta"]
+    assert [member["profile_name"] for member in group["members"]] == ["beta", "gamma"]
+
+    user_message = client.post(
+        f"/groups/{group_id}/messages",
+        json={"content": "Ship it.", "idempotency_key": "user-message"},
+    )
+    assert user_message.status_code == 201
+    assert user_message.json()["sender_profile_name"] is None
+
+    bot_message = client.post(
+        f"/groups/{group_id}/messages",
+        json={
+            "content": "On it.",
+            "sender_bot_instance_id": identities["beta"],
+            "idempotency_key": "bot-message",
+        },
+    )
+    assert bot_message.status_code == 201
+    assert bot_message.json()["sender_profile_name"] == "beta"
+
+    messages = client.get(f"/groups/{group_id}/messages")
+    assert messages.status_code == 200
+    assert [message["content"] for message in messages.json()] == ["Ship it.", "On it."]
+
+    deleted = client.request(
+        "DELETE",
+        f"/groups/{group_id}",
+        json={"expected_revision": 3, "idempotency_key": "delete-group"},
+    )
+    assert deleted.status_code == 204
+    assert client.get("/groups").json() == []
+    assert client.get(f"/groups/{group_id}").status_code == 410
+
+
+def test_bot_identity_reconciliation_is_stable_and_clone_safe(tmp_path: Path) -> None:
+    client, _service = _client(tmp_path)
+
+    first = client.post(
+        "/bots/reconcile",
+        json={"bots": [{"profile_name": "alpha", "instance_id": None}]},
+    ).json()["bots"][0]
+    same = client.post(
+        "/bots/reconcile",
+        json={"bots": [{"profile_name": "alpha", "instance_id": first["instance_id"]}]},
+    ).json()["bots"][0]
+    assert same["instance_id"] == first["instance_id"]
+
+    # Simulate profile metadata copied while cloning alpha -> alpha-copy. The
+    # backend must split identity rather than let two durable members alias.
+    clone_rows = client.post(
+        "/bots/reconcile",
+        json={
+            "bots": [
+                {"profile_name": "alpha", "instance_id": first["instance_id"]},
+                {"profile_name": "alpha-copy", "instance_id": first["instance_id"]},
+            ]
+        },
+    ).json()["bots"]
+    by_name = {row["profile_name"]: row["instance_id"] for row in clone_rows}
+    assert by_name["alpha"] == first["instance_id"]
+    assert by_name["alpha-copy"] != first["instance_id"]


### PR DESCRIPTION
## Summary

Fold persistent managed Groups into the **bundled** Hermes Desktop Bot Mode instead of relying on a second standalone Bot Mode install.

This keeps the in-tree `hermes-bots` plugin canonical while adding the richer durable team-management layer that had previously lived only in a local standalone customization.

## What changes

- add persistent managed Groups inside bundled Bot Mode
  - stable bot instance identities
  - named teams with leader + managed membership
  - color + emoji/Codicon identity
  - durable shared transcript
  - edit/delete with optimistic revision checks and idempotent mutations
- add a bundled `plugins/hermes-bots` backend
  - SQLite-backed group state
  - private dashboard REST API consumed through `ctx.rest`
  - install-wide database path, independent of active profile
  - package dashboard API/assets in sealed/Nix builds
- add a Bots / Groups switch to the native Bot Mode pane and a Groups route/nav entry when the SDK exposes those surfaces
- restore room-scoped model selection, `/` command completion/dispatch, and `@member` completion for persistent Groups without rewriting member profile defaults
- keep the existing upstream quick Group Chat implementation intact, including its bounded coordination, cross-connection members, long-running-turn handling, and fresh-state behavior when groups are remade
- keep current upstream's enforced `SESSIONS | BOTS` docking invariant intact
- remove Bot-row hover prewarming so merely moving the pointer across the roster does not wake profiles; activation remains click-driven

## Architecture

A Bot remains a Hermes profile and the bundled `hermes-bots` plugin remains the one Bot Mode UI.

There are now two complementary collaboration shapes:

1. **Quick Group Chat**: the existing lightweight/cross-machine room flow.
2. **Managed Groups**: durable named teams with stable identity, leader, membership, preferences, and transcript state.

No second desktop Bot Mode plugin is introduced.

## Verification

- `node --check apps/desktop/src/plugins/hermes-bots/plugin.js`
- `node --test apps/desktop/src/plugins/hermes-bots/tests/*.test.mjs`
  - **252 passed / 0 failed**
- `pytest -q tests/test_bot_mode_groups_backend.py`
  - **2 passed** (one Starlette TestClient deprecation warning)
- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/desktop run pack`
- Nix-style wheel build with `HERMES_NIX_BUILD=1`
  - all `plugins/hermes-bots` backend/API/assets present
  - zero packaged `__pycache__` / `.pyc`
- live Linux Desktop validation on Katana
  - packaged build stamp `4d0984e67a98`
  - native `SESSIONS | BOTS` tab strip visible
  - real `BOTS` tab click renders native roster, Bots/Groups switch, New Agent, and Cronjobs
  - existing durable Groups remained intact across migration/restarts
