### PR TITLE
Fix causal tool-result ordering before API calls

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3733,6 +3733,86 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
+
+    # 4. Enforce causal adjacency. OpenAI-compatible providers require every
+    # assistant(tool_calls) batch to be followed immediately by one tool
+    # result for each call before any user/assistant/system message. The set
+    # checks above only prove that an id exists *somewhere* in the transcript;
+    # after compression/recovery a result can precede its call, satisfy those
+    # sets, then be dropped by the outstanding-call deduper above. That leaves
+    # the later call unanswered and strict providers reject the entire request.
+    #
+    # Walk each batch in wire order. Preserve valid contiguous results, drop
+    # unrelated tool rows, and synthesize a bounded placeholder for every
+    # unanswered call before the next non-tool message. This is intentionally
+    # the final pre-API pass: persisted history remains untouched while every
+    # provider receives a causally valid sequence.
+    causally_repaired: List[Dict[str, Any]] = []
+    inserted_stubs = 0
+    dropped_noncausal_results = 0
+    idx = 0
+    while idx < len(messages):
+        msg = messages[idx]
+        if msg.get("role") != "assistant" or not msg.get("tool_calls"):
+            if msg.get("role") == "tool":
+                # A tool row not consumed by the immediately preceding
+                # assistant batch is non-causal, even if its id appears in a
+                # different part of the transcript.
+                dropped_noncausal_results += 1
+            else:
+                causally_repaired.append(msg)
+            idx += 1
+            continue
+
+        causally_repaired.append(msg)
+        calls = []
+        aliases: Dict[str, str] = {}
+        for tc in msg.get("tool_calls") or []:
+            canonical_id = _ra().AIAgent._get_tool_call_id_static(tc)
+            if not canonical_id:
+                continue
+            calls.append((canonical_id, tc))
+            aliases[canonical_id] = canonical_id
+            if isinstance(tc, dict):
+                for key in ("id", "call_id"):
+                    alias = tc.get(key)
+                    if alias:
+                        aliases[str(alias)] = canonical_id
+
+        answered: set[str] = set()
+        cursor = idx + 1
+        while cursor < len(messages) and messages[cursor].get("role") == "tool":
+            tool_msg = messages[cursor]
+            result_id = str(tool_msg.get("tool_call_id") or "").strip()
+            canonical_id = aliases.get(result_id)
+            if canonical_id and canonical_id not in answered:
+                causally_repaired.append(tool_msg)
+                answered.add(canonical_id)
+            else:
+                dropped_noncausal_results += 1
+            cursor += 1
+
+        for canonical_id, tc in calls:
+            if canonical_id in answered:
+                continue
+            causally_repaired.append({
+                "role": "tool",
+                "name": _ra().AIAgent._get_tool_call_name_static(tc),
+                "content": "[Result unavailable — see context summary above]",
+                "tool_call_id": canonical_id,
+            })
+            inserted_stubs += 1
+
+        idx = cursor
+
+    if inserted_stubs or dropped_noncausal_results:
+        messages = causally_repaired
+        _ra().logger.warning(
+            "Pre-call sanitizer: repaired non-causal tool sequence "
+            "(%d stub result(s) added, %d misplaced result(s) removed)",
+            inserted_stubs,
+            dropped_noncausal_results,
+        )
     return messages
 
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -456,6 +456,82 @@ def test_sanitize_drops_result_with_no_preceding_call():
     assert [m for m in out if m.get("role") == "tool"] == []
 
 
+def test_sanitize_repairs_result_that_precedes_its_call():
+    """A matching id elsewhere is not enough: results must follow the call.
+
+    Compression can move a historical tool result before a synthetic
+    assistant message that still carries the original tool_call. The old
+    global-set sanitizer considered that pair complete, then the causal
+    deduper removed the early result and left the call unanswered.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "continue"},
+        _result("call_reordered", "completed before the compressed call"),
+        _call("call_reordered"),
+        {"role": "assistant", "content": "next assistant turn"},
+    ]
+
+    out = sanitize_api_messages(list(messages))
+
+    call_idx = next(
+        i for i, msg in enumerate(out)
+        if msg.get("role") == "assistant" and msg.get("tool_calls")
+    )
+    assert out[call_idx + 1] == {
+        "role": "tool",
+        "name": "terminal",
+        "content": "[Result unavailable — see context summary above]",
+        "tool_call_id": "call_reordered",
+    }
+    assert out[call_idx + 2]["role"] == "assistant"
+    assert not any(
+        msg.get("content") == "completed before the compressed call"
+        for msg in out
+    )
+
+
+def test_sanitize_closes_partial_multi_call_batch_before_next_assistant():
+    """Every call in a batch gets a result before the next non-tool turn."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    call_ids = [f"call_{i}" for i in range(7)]
+    calls = {
+        "role": "assistant",
+        "content": "compressed task state",
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"},
+            }
+            for call_id in call_ids
+        ],
+    }
+    messages = [
+        {"role": "user", "content": "continue"},
+        *[_result(call_id, f"misplaced-{call_id}") for call_id in call_ids[:5]],
+        calls,
+        _result(call_ids[5], "valid-5"),
+        _result(call_ids[6], "valid-6"),
+        {"role": "assistant", "content": "next assistant turn"},
+    ]
+
+    out = sanitize_api_messages(list(messages))
+
+    call_idx = next(
+        i for i, msg in enumerate(out)
+        if msg.get("role") == "assistant"
+        and msg.get("content") == "compressed task state"
+    )
+    results = out[call_idx + 1:call_idx + 8]
+    assert [msg["role"] for msg in results] == ["tool"] * 7
+    assert {msg["tool_call_id"] for msg in results} == set(call_ids)
+    assert sum("Result unavailable" in msg["content"] for msg in results) == 5
+    assert out[call_idx + 8]["role"] == "assistant"
+
+
 def test_sanitize_drops_empty_tool_calls_array():
     """sanitize_api_messages strips ``tool_calls: []`` from assistant messages.
 


### PR DESCRIPTION
## What changed

- add a final wire-order pass to `sanitize_api_messages`
- require every `assistant(tool_calls)` batch to be followed immediately by one result per call
- remove misplaced/non-causal tool results and insert bounded placeholders for missing results
- accept both `id` and `call_id` aliases while matching results
- add regressions for a result-before-call history and a seven-call partially answered batch

## Why

The existing sanitizer compares global sets of tool-call IDs and result IDs. A compressed or recovered transcript can therefore contain a result *before* its corresponding call and still appear complete. The later outstanding-call pass removes that early result, leaving the call unanswered. Strict OpenAI-compatible providers then reject the whole request with:

> An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'.

This was reproduced from a long-running WebUI session after context compression: seven calls survived in one assistant message, two results followed it, and five matching results appeared earlier in the history.

The new pass runs at the final pre-API chokepoint, so persisted history remains unchanged while every provider receives a causally valid sequence.

## Validation

- `uv run --extra dev pytest tests/run_agent/test_message_sequence_repair.py -q` — 23 passed
- related sanitizer/compressor selection — 29 passed, 146 deselected
- `uv run --extra dev ruff check agent/agent_runtime_helpers.py tests/run_agent/test_message_sequence_repair.py` — passed

Note: uv emits the repository's existing warning for `exclude-newer = "14 days"`; it did not affect the test results, and generated lockfile drift was excluded from this PR.
