### PR TITLE
fix(tools): keep consumed markers alive while their completion event is queued

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -701,6 +701,61 @@ class TestPruning:
         total = len(registry._running) + len(registry._finished)
         assert total <= MAX_PROCESSES
 
+    def test_prune_keeps_consumed_marker_while_event_queued(self, registry):
+        """A consumed completion must not replay after pruning (#88905).
+
+        wait() records consumption in _completion_consumed; pruning used to
+        discard that marker together with the finished session while the
+        matching completion event could still sit in completion_queue (the
+        TUI poller requeues it while the owning session is busy). After the
+        prune the stale event passed the consumed check and was delivered as
+        a fresh synthetic turn. The marker must survive until the event is
+        gone."""
+        sid = "proc_ttl_dedup_proof"
+        old_session = _make_session(
+            sid=sid,
+            exited=True,
+            started_at=time.time() - FINISHED_TTL_SECONDS - 100,
+        )
+        registry._finished[sid] = old_session
+        registry._completion_consumed.add(sid)
+
+        # Drain, then queue the stale completion event the way the poller does.
+        while not registry.completion_queue.empty():
+            registry.completion_queue.get_nowait()
+        registry.completion_queue.put({"type": "completion", "session_id": sid})
+
+        with registry._lock:
+            registry._prune_if_needed()
+
+        assert sid not in registry._finished  # session record is gone…
+        assert sid in registry._completion_consumed  # …but the marker holds
+
+        # Once the event is delivered/removed, a later prune drops the marker
+        # (no unbounded growth).
+        evt = registry.completion_queue.get_nowait()
+        assert evt["session_id"] == sid
+        with registry._lock:
+            registry._prune_if_needed()
+        assert sid not in registry._completion_consumed
+
+    def test_prune_keeps_consumed_marker_via_belt_and_suspenders(self, registry):
+        """The untracked-entry sweep must honour a queued event too — it runs
+        on lookup paths that never hit the dict prunes (#88905)."""
+        sid = "proc_belt_proof"
+        registry._completion_consumed.add(sid)  # session never tracked
+        registry.completion_queue.put({"type": "completion", "session_id": sid})
+
+        with registry._lock:
+            registry._prune_if_needed()
+
+        assert sid in registry._completion_consumed
+
+        registry.completion_queue.get_nowait()
+        with registry._lock:
+            registry._prune_if_needed()
+        assert sid not in registry._completion_consumed
+
 
 # =========================================================================
 # Spawn env sanitization

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2495,6 +2495,23 @@ class ProcessRegistry:
 
     # ----- Cleanup / Pruning -----
 
+    def _completion_event_pending(self, session_id: str) -> bool:
+        """True if a completion event for *session_id* still sits in the queue.
+
+        Must hold _lock. A consumed marker must outlive any queued completion
+        event for the same session: dropping the marker while the event is
+        still queued (e.g. the TUI poller requeuing it because the owning
+        session is busy) re-arms the stale event for delivery as a fresh
+        synthetic turn (#88905).
+        """
+        for evt in list(self.completion_queue.queue):
+            if (
+                evt.get("type") == "completion"
+                and evt.get("session_id") == session_id
+            ):
+                return True
+        return False
+
     def _prune_if_needed(self):
         """Remove oldest finished sessions if over MAX_PROCESSES. Must hold _lock."""
         # First prune expired finished sessions
@@ -2505,7 +2522,10 @@ class ProcessRegistry:
         ]
         for sid in expired:
             del self._finished[sid]
-            self._completion_consumed.discard(sid)
+            # Keep the consumed marker while a matching completion event is
+            # still queued — dropping it re-arms the stale event (#88905).
+            if not self._completion_event_pending(sid):
+                self._completion_consumed.discard(sid)
             self._poll_observed.discard(sid)
 
         # If still over limit, remove oldest finished
@@ -2513,15 +2533,21 @@ class ProcessRegistry:
         if total >= MAX_PROCESSES and self._finished:
             oldest_id = min(self._finished, key=lambda sid: self._finished[sid].started_at)
             del self._finished[oldest_id]
-            self._completion_consumed.discard(oldest_id)
+            if not self._completion_event_pending(oldest_id):
+                self._completion_consumed.discard(oldest_id)
             self._poll_observed.discard(oldest_id)
 
         # Drop any _completion_consumed / _poll_observed entries whose sessions
         # are no longer tracked at all — belt-and-suspenders against
         # module-lifetime growth on registry lookup paths that don't reach the
-        # dict prunes.
+        # dict prunes. Consumed markers additionally survive while a matching
+        # completion event remains queued (#88905); the next prune drops them
+        # once the event is delivered or skipped.
         tracked = self._running.keys() | self._finished.keys()
-        stale = self._completion_consumed - tracked
+        stale = {
+            sid for sid in (self._completion_consumed - tracked)
+            if not self._completion_event_pending(sid)
+        }
         if stale:
             self._completion_consumed -= stale
         stale_polls = self._poll_observed - tracked


### PR DESCRIPTION
## What does this PR do?

Stops consumed background-process completions from replaying as fresh synthetic turns after pruning (#88905). `wait()` records consumption in `_completion_consumed`, but `_prune_if_needed()` discarded that marker together with the finished session — via TTL expiry, capacity eviction, **and** the untracked-entry belt-and-suspenders sweep — while the matching completion event could still sit in `completion_queue` (the TUI poller requeues it for as long as the owning session is busy). After the prune, `is_completion_consumed()` flipped back to false and the stale event sailed through the drain loop's consumed check, delivered as a new `[IMPORTANT: Background process …]` turn — potentially tens of minutes after the agent already consumed the result, each replay costing a full-context turn.

The fix makes the consumed marker outlive the session record whenever a completion event for the same `session_id` is still queued (`_completion_event_pending()`, called under the registry lock from all three discard sites). The next prune drops the marker once the event has been delivered or skipped, preserving the sweep's unbounded-growth guarantee.

Not addressed here (separate concern, noted in the issue): the TTL is measured from `started_at`, so a process that ran longer than `FINISHED_TTL_SECONDS` is prune-eligible immediately on completion — fixing that needs an `ended_at` field threaded through every exit path, which is a bigger change than this replay fix.

## Related Issue

Fixes #88905

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py`
  - New `_completion_event_pending(session_id)`: under the registry lock, scans `completion_queue` for a queued `completion` event with the session's id.
  - `_prune_if_needed()`: all three `_completion_consumed.discard` sites (TTL expiry, capacity eviction, untracked sweep) keep the marker while a matching event is queued; `_poll_observed` is unaffected.
- `tests/tools/test_process_registry.py`
  - `test_prune_keeps_consumed_marker_while_event_queued`: an expired finished session with a consumed marker and a queued event prunes the record but keeps the marker; once the event is taken, a later prune drops the marker (no growth).
  - `test_prune_keeps_consumed_marker_via_belt_and_suspenders`: the untracked sweep (lookup paths that never hit the dict prunes) honours the queued event the same way.

## How to Test

1. `python -m pytest tests/tools/test_process_registry.py -q`
   Observed result: 87 passed, 5 skipped.
2. Fail-on-main check: `git stash` the `tools/` change and rerun `TestPruning` — Observed result: 2 failed (the marker is discarded and the queued event is re-armed).
3. Repro shape from the issue: consume a completion via `wait()`, leave a copy of the event in `completion_queue`, let the finished session pass `FINISHED_TTL_SECONDS`, trigger a prune — Observed result after the fix: `is_completion_consumed(sid)` stays true and the drain loop skips the stale event.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (process registry suite: 87 passed, 5 skipped)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comments document the marker-lifetime rule)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — queue scan under the registry lock is platform-independent; or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
