### PR TITLE
fix: Bot Mode cronjobs panel no longer shows two empty-state markers

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6967,13 +6967,16 @@ function RoutinesPane() {
           ? jsxs('div', {
               className: 'flex flex-1 flex-col items-center justify-center gap-3 px-4 text-center',
               children: [
-                jsx(Codicon, { name: 'calendar', className: 'text-[1.6rem] text-(--ui-text-quaternary)' }),
-                jsx('div', {
-                  className: 'text-xs leading-5 text-(--ui-text-tertiary)',
-                  children: filterHint
-                    ? filterHint
-                    : 'Cronjobs are recurring tasks this agent runs on a schedule.'
-                }),
+                // No generic placeholder here: an icon + "cronjobs are…" blurb and the
+                // create button both just said "empty" (Teknium, Aug 2026). The hint
+                // text stays only when jobs exist but are hidden by the bot filter —
+                // that carries real information, not an empty-state marker.
+                filterHint
+                  ? jsx('div', {
+                      className: 'text-xs leading-5 text-(--ui-text-tertiary)',
+                      children: filterHint
+                    })
+                  : null,
                 jsx(Button, {
                   variant: 'secondary',
                   size: 'sm',


### PR DESCRIPTION
## Summary
The Bot Mode cronjobs panel no longer renders two elements that both mean "empty" — the generic calendar-icon placeholder blurb is removed and the empty state is just the **Create Cronjob** button (Teknium UI review, Aug 17 2026).

## Changes
- `apps/desktop/src/plugins/hermes-bots/plugin.js`: drop the calendar `Codicon` + "Cronjobs are recurring tasks this agent runs on a schedule." placeholder from the empty-jobs branch. The `filterHint` text ("jobs exist but are hidden by the bot filter") still renders when applicable, since it carries real information rather than just restating emptiness. The create button (with its filter-aware label) is unchanged.

## Validation
| | Before | After |
|---|---|---|
| Empty list, no filter | icon + blurb + Create Cronjob button | Create Cronjob button only |
| Jobs hidden by filter | hint text + button | hint text + button (unchanged) |

`node --check` passes; the placeholder string no longer appears anywhere under `apps/desktop`.

## Infographic

![One empty state, not two](https://v3b.fal.media/files/b/0aa6c9f6/jI-cNcko6P59ylO0OSF4s_MOM5h6fJ.png)
