### PR TITLE
fix(display): gate diff ANSI on tty-ness and NO_COLOR

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -91,11 +91,32 @@ def _diff_ansi() -> dict[str, str]:
 
 
 # Module-level helpers — each call resolves from the active skin lazily.
-def _diff_dim():   return _diff_ansi()["dim"]
-def _diff_file():  return _diff_ansi()["file"]
-def _diff_hunk():  return _diff_ansi()["hunk"]
-def _diff_minus(): return _diff_ansi()["minus"]
-def _diff_plus():  return _diff_ansi()["plus"]
+def _diff_ansi_enabled() -> bool:
+    """Whether diff rendering may emit ANSI: a real terminal and no NO_COLOR.
+
+    Rendered diffs end up wherever stdout points — Kanban dispatches workers
+    with a plain file handle as stdout, and escape bytes were 31% of worker
+    log volume (#88920). NO_COLOR is the standard opt-out
+    (https://no-color.org). Checked per call (never cached): unlike the skin
+    colors, tty-ness and NO_COLOR can change within a process lifetime.
+    """
+    import sys as _sys
+
+    if os.environ.get("NO_COLOR", ""):
+        return False
+    try:
+        out = _sys.stdout
+        return bool(out is not None and getattr(out, "isatty", lambda: False)())
+    except (ValueError, OSError):
+        return False
+
+
+def _diff_dim():   return _diff_ansi()["dim"] if _diff_ansi_enabled() else ""
+def _diff_file():  return _diff_ansi()["file"] if _diff_ansi_enabled() else ""
+def _diff_hunk():  return _diff_ansi()["hunk"] if _diff_ansi_enabled() else ""
+def _diff_minus(): return _diff_ansi()["minus"] if _diff_ansi_enabled() else ""
+def _diff_plus():  return _diff_ansi()["plus"] if _diff_ansi_enabled() else ""
+def _diff_reset(): return _ANSI_RESET if _diff_ansi_enabled() else ""
 _MAX_INLINE_DIFF_FILES = 6
 _MAX_INLINE_DIFF_LINES = 80
 
@@ -968,19 +989,19 @@ def _render_inline_unified_diff(diff: str) -> list[str]:
         if raw_line.startswith("+++ "):
             to_file = raw_line[4:].strip()
             if from_file or to_file:
-                rendered.append(f"{_diff_file()}{from_file or 'a/?'} → {to_file or 'b/?'}{_ANSI_RESET}")
+                rendered.append(f"{_diff_file()}{from_file or 'a/?'} → {to_file or 'b/?'}{_diff_reset()}")
             continue
         if raw_line.startswith("@@"):
-            rendered.append(f"{_diff_hunk()}{raw_line}{_ANSI_RESET}")
+            rendered.append(f"{_diff_hunk()}{raw_line}{_diff_reset()}")
             continue
         if raw_line.startswith("-"):
-            rendered.append(f"{_diff_minus()}{raw_line}{_ANSI_RESET}")
+            rendered.append(f"{_diff_minus()}{raw_line}{_diff_reset()}")
             continue
         if raw_line.startswith("+"):
-            rendered.append(f"{_diff_plus()}{raw_line}{_ANSI_RESET}")
+            rendered.append(f"{_diff_plus()}{raw_line}{_diff_reset()}")
             continue
         if raw_line.startswith(" "):
-            rendered.append(f"{_diff_dim()}{raw_line}{_ANSI_RESET}")
+            rendered.append(f"{_diff_dim()}{raw_line}{_diff_reset()}")
             continue
         if raw_line:
             rendered.append(raw_line)

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -4,6 +4,57 @@ import json
 import pytest
 from unittest.mock import MagicMock
 
+
+class TestDiffAnsiGating:
+    """Diff rendering must not emit ANSI escapes into non-tty output, and
+    NO_COLOR must disable them even on a terminal (#88920) — Kanban workers
+    run with a plain file handle as stdout and 31% of worker log volume was
+    escape bytes."""
+
+    _DIFF = "--- a/x.ts\n+++ b/x.ts\n@@ -1 +1 @@\n-old line\n+new line\n"
+
+    def test_non_tty_stdout_has_no_escapes(self, monkeypatch):
+        import agent.display as display_mod
+
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        lines = display_mod._render_inline_unified_diff(self._DIFF)
+        joined = "\n".join(lines)
+        assert "\033[" not in joined
+
+    def test_no_color_env_disables_escapes(self, monkeypatch):
+        import agent.display as display_mod
+
+        monkeypatch.setenv("NO_COLOR", "1")
+        assert display_mod._diff_ansi_enabled() is False
+        joined = "\n".join(
+            display_mod._render_inline_unified_diff(self._DIFF)
+        )
+        assert "\033[" not in joined
+
+    def test_tty_keeps_escapes(self, monkeypatch):
+        import agent.display as display_mod
+
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setattr(
+            "sys.stdout", type("FakeTTY", (), {"isatty": lambda self: True})()
+        )
+        assert display_mod._diff_ansi_enabled() is True
+        joined = "\n".join(
+            display_mod._render_inline_unified_diff(self._DIFF)
+        )
+        assert "\033[" in joined
+
+    def test_plain_render_still_marks_diff_lines(self, monkeypatch):
+        """Gating must not lose the content: +/-/hunk lines still render."""
+        import agent.display as display_mod
+
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        lines = display_mod._render_inline_unified_diff(self._DIFF)
+        assert any("-old line" in l for l in lines)
+        assert any("+new line" in l for l in lines)
+        assert any("@@ -1 +1 @@" in l for l in lines)
+
+
 import agent.display as display_module
 from agent.display import (
     build_tool_preview,


### PR DESCRIPTION
## What does this PR do?

Stops `_render_inline_unified_diff()` from writing skin ANSI escapes into non-terminal output (#88920). The renderer wrapped every diff line in truecolor SGR unconditionally — Kanban dispatches workers with a plain file handle as stdout (`hermes_cli/kanban_db.py`), so every diff-bearing task log accumulated literal escape bytes: **31% of one profile's worker-log volume was escapes, 38.9% in the worst file**. `NO_COLOR` (the standard opt-out) was also ignored.

The diff color helpers (`_diff_dim/_diff_file/_diff_hunk/_diff_minus/_diff_plus`, plus a new gated `_diff_reset`) now return empty strings when stdout is not a tty or `NO_COLOR` is set. The gate is checked per call and deliberately never cached — unlike the skin colors, tty-ness and `NO_COLOR` can change within a process lifetime. Content is unchanged: `+`/`-`/hunk lines still render, just unstyled.

No consumer regresses:
- the TUI frontend already `stripAnsi()`es `inline_diff` payloads (`createGatewayEventHandler.ts`) and paints diff colors itself (`markdown.tsx`) — stripping server-side just saves the bytes it would discard;
- the CLI's `render_edit_diff_with_delta` path keeps full colors on a real terminal and degrades to plain text exactly when stdout is piped/redirected.

## Related Issue

Fixes #88920

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/display.py`
  - New `_diff_ansi_enabled()`: true only when stdout `isatty()` and `NO_COLOR` is unset; per-call (uncached).
  - The five `_diff_*()` color helpers return `""` when gated; new `_diff_reset()` gates the reset escape too.
  - `_render_inline_unified_diff()` uses `_diff_reset()` in place of the raw reset.
- `tests/agent/test_display.py`
  - New `TestDiffAnsiGating`: non-tty stdout produces zero escapes (the issue's repro shape); `NO_COLOR=1` disables even with a tty; a fake tty keeps colors; plain rendering still emits the `+`/`-`/hunk content lines.

## How to Test

1. `python -m pytest tests/agent/test_display.py tests/agent/test_plugin_prompt_sections.py -q`
   Observed result: 29 passed.
2. Fail-on-main check: `git stash` the `agent/` change and rerun `TestDiffAnsiGating` — Observed result: 3 failed (all lines carry ANSI under pytest's non-tty stdout, matching the issue's repro).
3. Repro from the issue: `python repro.py > out.txt` (non-tty) and `NO_COLOR=1 python repro.py > out.txt` — Observed result after the fix: `grep -c $'\033\[' out.txt` → 0 in both; the `+old line`/`-new line`/`@@` content is all still present.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (display + plugin prompt suites: 29 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline docstring documents the gating rule)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — tty/NO_COLOR checks are platform-independent and fail safe (closed streams → no ANSI); or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
