### PR TITLE
fix(display): suppress ANSI in non-TTY diff output

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -42,9 +42,30 @@ def _display_url(value: Any) -> str:
 _diff_colors_cached: dict[str, str] | None = None
 
 
+def _diff_color_enabled() -> bool:
+    """Return whether inline diff colors should be emitted."""
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    try:
+        return bool(sys.stdout.isatty())
+    except Exception:
+        return False
+
+
 def _diff_ansi() -> dict[str, str]:
     """Return ANSI escapes for diff display, resolved from the active skin."""
     global _diff_colors_cached
+    if not _diff_color_enabled():
+        return {
+            "dim": "",
+            "file": "",
+            "hunk": "",
+            "minus": "",
+            "plus": "",
+            "reset": "",
+        }
     if _diff_colors_cached is not None:
         return _diff_colors_cached
 
@@ -85,7 +106,7 @@ def _diff_ansi() -> dict[str, str]:
 
     _diff_colors_cached = {
         "dim": dim, "file": file_c, "hunk": hunk,
-        "minus": minus, "plus": plus,
+        "minus": minus, "plus": plus, "reset": _ANSI_RESET,
     }
     return _diff_colors_cached
 
@@ -96,6 +117,7 @@ def _diff_file():  return _diff_ansi()["file"]
 def _diff_hunk():  return _diff_ansi()["hunk"]
 def _diff_minus(): return _diff_ansi()["minus"]
 def _diff_plus():  return _diff_ansi()["plus"]
+def _diff_reset(): return _diff_ansi()["reset"]
 _MAX_INLINE_DIFF_FILES = 6
 _MAX_INLINE_DIFF_LINES = 80
 
@@ -968,19 +990,22 @@ def _render_inline_unified_diff(diff: str) -> list[str]:
         if raw_line.startswith("+++ "):
             to_file = raw_line[4:].strip()
             if from_file or to_file:
-                rendered.append(f"{_diff_file()}{from_file or 'a/?'} → {to_file or 'b/?'}{_ANSI_RESET}")
+                rendered.append(
+                    f"{_diff_file()}{from_file or 'a/?'} → "
+                    f"{to_file or 'b/?'}{_diff_reset()}"
+                )
             continue
         if raw_line.startswith("@@"):
-            rendered.append(f"{_diff_hunk()}{raw_line}{_ANSI_RESET}")
+            rendered.append(f"{_diff_hunk()}{raw_line}{_diff_reset()}")
             continue
         if raw_line.startswith("-"):
-            rendered.append(f"{_diff_minus()}{raw_line}{_ANSI_RESET}")
+            rendered.append(f"{_diff_minus()}{raw_line}{_diff_reset()}")
             continue
         if raw_line.startswith("+"):
-            rendered.append(f"{_diff_plus()}{raw_line}{_ANSI_RESET}")
+            rendered.append(f"{_diff_plus()}{raw_line}{_diff_reset()}")
             continue
         if raw_line.startswith(" "):
-            rendered.append(f"{_diff_dim()}{raw_line}{_ANSI_RESET}")
+            rendered.append(f"{_diff_dim()}{raw_line}{_diff_reset()}")
             continue
         if raw_line:
             rendered.append(raw_line)
@@ -1046,7 +1071,7 @@ def _summarize_rendered_diff_sections(
         summary = f"… omitted {omitted_lines} diff line(s)"
         if omitted_files:
             summary += f" across {omitted_files} additional file(s)/section(s)"
-        rendered.append(f"{_diff_hunk()}{summary}{_ANSI_RESET}")
+        rendered.append(f"{_diff_hunk()}{summary}{_diff_reset()}")
 
     return rendered
 

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -1,6 +1,7 @@
 """Tests for agent/display.py — build_tool_preview() and inline diff previews."""
 
 import json
+import re
 import pytest
 from unittest.mock import MagicMock
 
@@ -240,6 +241,102 @@ class TestEditDiffPreview:
         assert any("a/file2.py" in line for line in rendered)
         assert not any("a/file7.py" in line for line in rendered)
         assert "additional file" in rendered[-1]
+
+
+class TestInlineDiffColors:
+    """Inline diffs are colored only when the output supports it."""
+
+    @pytest.fixture(autouse=True)
+    def reset_diff_colors(self, monkeypatch):
+        monkeypatch.setattr(display_module, "_diff_colors_cached", None)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.delenv("FORCE_COLOR", raising=False)
+
+    @staticmethod
+    def _diff():
+        return (
+            "--- a/x.ts\n"
+            "+++ b/x.ts\n"
+            "@@ -1 +1 @@\n"
+            " context\n"
+            "-old line\n"
+            "+new line\n"
+        )
+
+    @staticmethod
+    def _stdout(is_tty):
+        class _Stdout:
+            def isatty(self):
+                return is_tty
+
+        return _Stdout()
+
+    @staticmethod
+    def _strip_ansi(line):
+        return re.sub(r"\x1b\[[0-9;]*m", "", line)
+
+    def test_non_tty_output_has_no_ansi(self, monkeypatch):
+        monkeypatch.setattr(display_module.sys, "stdout", self._stdout(False))
+
+        rendered = _render_inline_unified_diff(self._diff())
+
+        assert rendered == [
+            "a/x.ts → b/x.ts",
+            "@@ -1 +1 @@",
+            " context",
+            "-old line",
+            "+new line",
+        ]
+        assert all("\x1b" not in line for line in rendered)
+
+    def test_no_color_overrides_tty_and_force_color(self, monkeypatch):
+        monkeypatch.setattr(display_module.sys, "stdout", self._stdout(True))
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setenv("FORCE_COLOR", "1")
+
+        rendered = _render_inline_unified_diff(self._diff())
+
+        assert all("\x1b" not in line for line in rendered)
+
+    def test_force_color_overrides_non_tty(self, monkeypatch):
+        monkeypatch.setattr(display_module.sys, "stdout", self._stdout(False))
+        monkeypatch.setenv("FORCE_COLOR", "1")
+
+        rendered = _render_inline_unified_diff(self._diff())
+
+        assert all("\x1b[" in line for line in rendered)
+        assert all(line.endswith("\x1b[0m") for line in rendered)
+
+    def test_tty_output_preserves_text_and_adds_color(self, monkeypatch):
+        monkeypatch.setattr(display_module.sys, "stdout", self._stdout(False))
+        plain = _render_inline_unified_diff(self._diff())
+
+        monkeypatch.setattr(display_module.sys, "stdout", self._stdout(True))
+        colored = _render_inline_unified_diff(self._diff())
+
+        assert [self._strip_ansi(line) for line in colored] == plain
+        assert all("\x1b[0m" not in line for line in plain)
+
+    def test_non_tty_summary_has_no_dangling_reset(self, monkeypatch):
+        monkeypatch.setattr(display_module.sys, "stdout", self._stdout(False))
+
+        rendered = _summarize_rendered_diff_sections(self._diff(), max_lines=0)
+
+        assert rendered == [
+            "… omitted 5 diff line(s) across 1 additional file(s)/section(s)"
+        ]
+        assert all("\x1b" not in line for line in rendered)
+
+    def test_broken_isatty_is_treated_as_non_tty(self, monkeypatch):
+        class _BrokenStdout:
+            def isatty(self):
+                raise RuntimeError("isatty unavailable")
+
+        monkeypatch.setattr(display_module.sys, "stdout", _BrokenStdout())
+
+        rendered = _render_inline_unified_diff(self._diff())
+
+        assert all("\x1b" not in line for line in rendered)
 
 
 class TestBuildToolLabel:


### PR DESCRIPTION
## Summary

Suppress inline diff ANSI escape sequences when output is not a terminal, preventing color codes from being persisted in Kanban worker logs and other redirected output.

## Root cause

`agent.display._diff_ansi()` always generated skin-derived ANSI codes, and all inline diff rendering paths appended `\033[0m` unconditionally. There was no TTY or `NO_COLOR` handling.

## Fix

- Add centralized `NO_COLOR`, `FORCE_COLOR`, and TTY detection with a safe non-color fallback.
- Emit the reset sequence only when diff colors are enabled.
- Preserve the existing colored output for TTYs and explicit `FORCE_COLOR` usage.
- Add regression coverage for non-TTY output, `NO_COLOR`, `FORCE_COLOR`, TTY text preservation, summaries, and unavailable `isatty()`.

## Testing

- `scripts/run_tests.sh tests/agent/test_display.py -q` — 29 passed
- `scripts/run_tests.sh tests/cli/test_resume_display.py tests/test_cli_skin_integration.py -q` — 23 passed
- `./.venv/bin/ruff check agent/display.py tests/agent/test_display.py` — passed
- `python scripts/check-windows-footguns.py --all` — passed

## Issue

Fixes #88920
