### PR TITLE
fix(cli): resolve .CMD shim resolution for external editor on Windows

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -3109,7 +3109,14 @@ class CLICommandsMixin:
                 if initial_text:
                     fh.write(initial_text)
             try:
-                subprocess.call([*shlex.split(editor), path])
+                # On Windows, shell=True lets subprocess.call resolve
+                # .CMD/.BAT shims (e.g. VS Code's `code` is `code.CMD`).
+                # Without it, CreateProcess only appends .exe and returns
+                # WinError 2, so the editor never opens.
+                if os.name == "nt":
+                    subprocess.call([*shlex.split(editor), path], shell=True)
+                else:
+                    subprocess.call([*shlex.split(editor), path])
             except Exception:
                 # Fall back to a bare invocation (editor value may not be a
                 # simple argv-splittable string on some platforms).

--- a/tests/hermes_cli/test_prompt_compose_command.py
+++ b/tests/hermes_cli/test_prompt_compose_command.py
@@ -59,3 +59,40 @@ def test_empty_buffer_does_not_seed(monkeypatch):
     s = _Stub()
     s._handle_prompt_compose_command("/prompt")
     assert s._pending_agent_seed is None
+
+
+def test_compose_uses_shell_on_windows(monkeypatch):
+    """On Windows, subprocess.call must use shell=True so .CMD/.BAT shims
+    (e.g. VS Code's `code` is `code.CMD`) resolve. CreateProcess only
+    appends .exe, not .cmd, so without shell=True the editor never opens.
+    """
+    monkeypatch.setenv("EDITOR", "echo")
+    calls = []
+
+    def spy_call(*args, **kwargs):
+        calls.append(kwargs.get("shell", False))
+        return 0
+
+    monkeypatch.setattr("subprocess.call", spy_call)
+    monkeypatch.setattr("os.name", "nt")
+    _Stub()._compose_in_editor("")
+    assert calls, "subprocess.call was never invoked"
+    assert calls[0] is True, f"shell=True expected on Windows, got {calls[0]}"
+
+
+def test_compose_no_shell_on_posix(monkeypatch):
+    """On POSIX, subprocess.call must NOT use shell=True to avoid shell
+    injection via $EDITOR. The editor command is invoked directly.
+    """
+    monkeypatch.setenv("EDITOR", _fake_editor("test"))
+    calls = []
+
+    def spy_call(*args, **kwargs):
+        calls.append(kwargs.get("shell", False))
+        return 0
+
+    monkeypatch.setattr("subprocess.call", spy_call)
+    monkeypatch.setattr("os.name", "posix")
+    _Stub()._compose_in_editor("")
+    assert calls, "subprocess.call was never invoked"
+    assert calls[0] is False, f"shell=False expected on POSIX, got {calls[0]}"

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -398,7 +398,17 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
     let exitCode: null | number = null
 
     await withInkSuspended(async () => {
-      exitCode = spawnSync(cmd!, [...args, file], { stdio: 'inherit' }).status
+      const result = spawnSync(cmd!, [...args, file], {
+        // On Windows, shell:true lets spawnSync resolve .CMD/.BAT shims
+        // (e.g. VS Code's `code` is `code.CMD`). Without it, CreateProcess
+        // only appends .exe and returns ENOENT, so the editor never opens.
+        shell: process.platform === 'win32',
+        stdio: 'inherit'
+      })
+      exitCode = result.status
+      if (result.error && exitCode === null) {
+        throw result.error
+      }
     })
 
     try {

--- a/ui-tui/src/lib/editor.test.ts
+++ b/ui-tui/src/lib/editor.test.ts
@@ -71,4 +71,13 @@ describe('resolveEditor', () => {
   it('uses notepad.exe on Windows when no env override', () => {
     expect(resolveEditor({ PATH: dir }, 'win32')).toEqual(['notepad.exe'])
   })
+
+  it('resolves editor args with shell:true on win32 (regression: .CMD shims)', () => {
+    // VS Code's `code` is `code.CMD` on Windows. Without shell:true,
+    // spawnSync returns ENOENT because CreateProcess only appends .exe.
+    // This test verifies resolveEditor returns the correct argv; the
+    // shell:true guard lives in openInEditor() where spawnSync is called.
+    const argv = resolveEditor({ EDITOR: 'code --wait', PATH: dir }, 'win32')
+    expect(argv).toEqual(['code', '--wait'])
+  })
 })

--- a/ui-tui/src/lib/editor.ts
+++ b/ui-tui/src/lib/editor.ts
@@ -59,7 +59,17 @@ export async function openInEditor(initial: string, suffix = '.txt'): Promise<nu
   let status: null | number = null
 
   await withInkSuspended(async () => {
-    status = spawnSync(cmd!, [...args, file], { stdio: 'inherit' }).status
+    const result = spawnSync(cmd!, [...args, file], {
+      // On Windows, shell:true lets spawnSync resolve .CMD/.BAT shims
+      // (e.g. VS Code's `code` is `code.CMD`). Without it, CreateProcess
+      // only appends .exe and returns ENOENT, so the editor never opens.
+      shell: process.platform === 'win32',
+      stdio: 'inherit'
+    })
+    status = result.status
+    if (result.error && status === null) {
+      throw result.error
+    }
   })
 
   try {


### PR DESCRIPTION
## What does this PR do?

On Windows, `/prompt`, `/compose`, and Ctrl+G silently fail to open the editor. No error, no editor window. The command appears to complete without doing anything.

This happens when `$EDITOR` or `$VISUAL` points to a `.CMD` batch wrapper, which is the case for VS Code (`code` resolves to `code.CMD`) and many other Windows CLI tools.

Windows `CreateProcess` auto-appends `.exe` but not `.cmd` or `.bat`. Both `spawnSync` (Node, TUI) and `subprocess.call` (Python, CLI) invoke the editor without `shell: true`, so Windows returns ENOENT. The spawn fails, `.status` stays null, and the editor never opens.

This PR adds `shell: process.platform === "win32"` to the primary spawn path on Windows only. POSIX behavior is unchanged. It also surfaces spawn errors instead of silently swallowing them.

If this lands before #81366, #83732, or #59506 (which remove the `shell=True` fallback for security), those PRs can remove the fallback without breaking Windows users, since the primary path already handles `.CMD` resolution.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/lib/editor.ts` — added `shell: process.platform === "win32"` to `spawnSync` in `openInEditor()`, plus error surfacing on null status
- `ui-tui/src/app/useComposerState.ts` — same `shell` guard and error surfacing in the inline `openEditor()` copy
- `hermes_cli/cli_commands_mixin.py` — added `shell=True` on Windows to the primary `subprocess.call` in `_compose_in_editor()`
- `tests/hermes_cli/test_prompt_compose_command.py` — regression tests: `test_compose_uses_shell_on_windows`, `test_compose_no_shell_on_posix`
- `ui-tui/src/lib/editor.test.ts` — regression test for `.CMD` argv resolution on win32

## How to Test

1. On Windows, set `EDITOR=code --wait`
2. Run `hermes --tui`, type `/prompt`, press Enter
3. VS Code opens a temp markdown file
4. Edit, save (Ctrl+S), close the tab (Ctrl+W)
5. The text submits as your next prompt

Before this fix: nothing happens at step 3. After: editor opens and the prompt submits on close.

Also verify on Linux/macOS that `/prompt` still works (shell stays false there, no behavior change).

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A