### PR TITLE
feat(gateway): add --at-boot install option for Windows Scheduled Task

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7569,6 +7569,7 @@ def _gateway_command_inner(args):
                 force=force,
                 start_now=getattr(args, 'start_now', None),
                 start_on_login=getattr(args, 'start_on_login', None),
+                at_boot=getattr(args, 'at_boot', False),
                 elevated_handoff=getattr(args, 'elevated_handoff', False),
             )
         elif is_wsl():

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -246,21 +246,43 @@ def _launch_elevated_gateway_command(command: str, extra_args: list[str] | None 
     return True
 
 
+def _prompt_task_password(user: str) -> str | None:
+    """Prompt (hidden input) for the Windows account password of a boot task.
+
+    Boot tasks run before any user logs on, so Task Scheduler needs the
+    account password stored (``/RP``). Returns ``None`` when the user
+    cancels or no password is entered.
+    """
+    import getpass
+
+    try:
+        password = getpass.getpass(
+            f"Password for Windows account '{user}' (stored encrypted in Task Scheduler for boot start): "
+        )
+    except (EOFError, KeyboardInterrupt):
+        return None
+    return password or None
+
+
 def _launch_elevated_install(
     force: bool = False,
     *,
     start_now: bool | None = None,
     start_on_login: bool | None = None,
+    at_boot: bool = False,
 ) -> bool:
     """Launch an elevated gateway install via UAC and return True on handoff."""
     old_start_now = os.environ.get("HERMES_GATEWAY_INSTALL_START_NOW")
     old_start_on_login = os.environ.get("HERMES_GATEWAY_INSTALL_START_ON_LOGIN")
+    old_at_boot = os.environ.get("HERMES_GATEWAY_INSTALL_AT_BOOT")
     old_handoff = os.environ.get("HERMES_GATEWAY_ELEVATED_HANDOFF")
     try:
         if start_now is not None:
             os.environ["HERMES_GATEWAY_INSTALL_START_NOW"] = "1" if start_now else "0"
         if start_on_login is not None:
             os.environ["HERMES_GATEWAY_INSTALL_START_ON_LOGIN"] = "1" if start_on_login else "0"
+        if at_boot:
+            os.environ["HERMES_GATEWAY_INSTALL_AT_BOOT"] = "1"
         os.environ["HERMES_GATEWAY_ELEVATED_HANDOFF"] = "1"
         extra_args = ["--elevated-handoff"]
         if force:
@@ -269,11 +291,14 @@ def _launch_elevated_install(
             extra_args.append("--start-now" if start_now else "--no-start-now")
         if start_on_login is not None:
             extra_args.append("--start-on-login" if start_on_login else "--no-start-on-login")
+        if at_boot:
+            extra_args.append("--at-boot")
         return _launch_elevated_gateway_command("install", extra_args)
     finally:
         for key, old in (
             ("HERMES_GATEWAY_INSTALL_START_NOW", old_start_now),
             ("HERMES_GATEWAY_INSTALL_START_ON_LOGIN", old_start_on_login),
+            ("HERMES_GATEWAY_INSTALL_AT_BOOT", old_at_boot),
             ("HERMES_GATEWAY_ELEVATED_HANDOFF", old_handoff),
         ):
             if old is None:
@@ -590,28 +615,50 @@ def _resolve_task_user() -> str | None:
     return f"{domain}\\{username}" if domain else username
 
 
-def _build_scheduled_task_xml(task_name: str, launcher_path: Path, user: str | None) -> str:
+def _build_scheduled_task_xml(
+    task_name: str, launcher_path: Path, user: str | None, at_boot: bool = False
+) -> str:
     """Render a Task Scheduler XML definition with safe long-running defaults.
 
     ``launcher_path`` is the console-less ``.vbs`` the task runs via
     ``wscript.exe`` — not the ``.cmd`` (see ``_build_gateway_vbs_script`` /
     issue #45599 root cause #1).
+
+    ``at_boot`` switches the trigger from logon to system startup so the
+    gateway starts before any user logs on (headless/RDP boxes). A boot task
+    must run with stored credentials (``LogonType=Password``), which
+    ``_install_scheduled_task`` supplies via ``/RU`` + ``/RP``.
     """
     user_principal = f"\n      <UserId>{escape(user)}</UserId>" if user else ""
+    if at_boot:
+        trigger = (
+            "  <Triggers>\n"
+            "    <BootTrigger>\n"
+            "      <Enabled>true</Enabled>\n"
+            f"      <Delay>{_TASK_LOGON_DELAY}</Delay>\n"
+            "    </BootTrigger>\n"
+            "  </Triggers>"
+        )
+        logon_type = "Password"
+    else:
+        trigger = (
+            "  <Triggers>\n"
+            "    <LogonTrigger>\n"
+            "      <Enabled>true</Enabled>\n"
+            f"      <Delay>{_TASK_LOGON_DELAY}</Delay>\n"
+            "    </LogonTrigger>\n"
+            "  </Triggers>"
+        )
+        logon_type = "InteractiveToken"
     return f"""<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
     <Description>{escape(_TASK_DESCRIPTION)}</Description>
   </RegistrationInfo>
-  <Triggers>
-    <LogonTrigger>
-      <Enabled>true</Enabled>
-      <Delay>{_TASK_LOGON_DELAY}</Delay>
-    </LogonTrigger>
-  </Triggers>
+{trigger}
   <Principals>
     <Principal id="Author">{user_principal}
-      <LogonType>InteractiveToken</LogonType>
+      <LogonType>{logon_type}</LogonType>
       <RunLevel>LeastPrivilege</RunLevel>
     </Principal>
   </Principals>
@@ -648,23 +695,32 @@ def _build_scheduled_task_xml(task_name: str, launcher_path: Path, user: str | N
 """
 
 
-def _write_scheduled_task_xml(task_name: str, launcher_path: Path, user: str | None) -> Path:
+def _write_scheduled_task_xml(
+    task_name: str, launcher_path: Path, user: str | None, at_boot: bool = False
+) -> Path:
     xml_path = launcher_path.with_suffix(".task.xml")
     xml_path.write_text(
-        _build_scheduled_task_xml(task_name, launcher_path, user),
+        _build_scheduled_task_xml(task_name, launcher_path, user, at_boot=at_boot),
         encoding="utf-16",
         newline="",
     )
     return xml_path
 
 
-def _install_scheduled_task(task_name: str, script_path: Path) -> tuple[bool, str]:
+def _install_scheduled_task(
+    task_name: str, script_path: Path, at_boot: bool = False
+) -> tuple[bool, str]:
     """Create or replace the Scheduled Task. Returns (success, detail).
 
     Always recreate instead of ``/Change``. Older Hermes builds and failed
     experiments may have left repeat/restart settings on the task; ``/Change``
     preserves those stale triggers and can make the gateway relaunch every
     minute. Delete+create gives us a clean ONLOGON task every install.
+
+    ``at_boot`` renders a ``BootTrigger`` task. Boot tasks run before any
+    user logs on, so they need stored credentials: we pass ``/RU <user>``
+    plus ``/RP <password>`` (prompted for in ``install()``). The XML uses
+    ``LogonType=Password`` to match.
     """
     delete_code, delete_out, delete_err = _exec_schtasks(["/Delete", "/F", "/TN", task_name])
     delete_detail = (delete_err or delete_out or "").strip()
@@ -677,10 +733,23 @@ def _install_scheduled_task(task_name: str, script_path: Path) -> tuple[bool, st
     # The Scheduled Task launches the console-less .vbs (issue #45599 fix A), not
     # the .cmd. Immediate manual starts use _spawn_detached().
     launcher_path = script_path.with_suffix(".vbs")
-    xml_path = _write_scheduled_task_xml(task_name, launcher_path, user)
+    xml_path = _write_scheduled_task_xml(task_name, launcher_path, user, at_boot=at_boot)
     base = ["/Create", "/F", "/TN", task_name, "/XML", str(xml_path)]
-    variants = [[*base, "/RU", user, "/NP", "/IT"]] if user else []
-    variants.append(base)
+    if at_boot:
+        # Boot tasks run before any logon, so they need stored credentials.
+        # /NP (no password) is incompatible with that; the caller supplies
+        # the password via /RP. /IT is meaningless for a boot task.
+        variants = []
+        if user:
+            password = _prompt_task_password(user)
+            if password is None:
+                return (False, "Scheduled Task creation cancelled: no password provided for boot task.")
+            variants.append([*base, "/RU", user, "/RP", password])
+        else:
+            return (False, "Scheduled Task creation cancelled: could not resolve the Windows user for boot task.")
+    else:
+        variants = [[*base, "/RU", user, "/NP", "/IT"]] if user else []
+        variants.append(base)
 
     last_code = 1
     last_err = ""
@@ -1054,6 +1123,7 @@ def install(
     *,
     start_now: bool | None = None,
     start_on_login: bool | None = None,
+    at_boot: bool = False,
     elevated_handoff: bool = False,
 ) -> None:
     """Install the gateway as a Windows Scheduled Task (with Startup fallback).
@@ -1061,9 +1131,16 @@ def install(
     Idempotent: re-running updates the task to point at the current python/
     project paths. ``force`` is accepted for API parity with ``launchd_install``
     / ``systemd_install`` but isn't needed — we always reconcile.
+
+    ``at_boot`` installs a system-startup (``BootTrigger``) task instead of a
+    logon task, so the gateway starts before any user logs on — useful on
+    headless/RDP boxes. Boot tasks require the account password (stored
+    encrypted by Task Scheduler); the user is prompted for it.
     """
     _assert_windows()
     start_now, start_on_login = _prompt_install_choices(start_now, start_on_login)
+    if at_boot:
+        start_on_login = True  # a boot task is a superset of login auto-start
 
     if not start_on_login:
         print("ℹ Skipped Windows login auto-start install.")
@@ -1092,7 +1169,9 @@ def install(
         print("↻ Scheduled Task install may need administrator approval on this Windows account.")
         print("  UAC is Windows' admin approval prompt; it is needed to create/update the Scheduled Task.")
         if prompt_yes_no("  Open the UAC prompt now?", False):
-            if _launch_elevated_install(force=force, start_now=start_now, start_on_login=start_on_login):
+            if _launch_elevated_install(
+                force=force, start_now=start_now, start_on_login=start_on_login, at_boot=at_boot
+            ):
                 print("✓ Launched elevated Hermes gateway install prompt.")
                 if start_now:
                     print("  Approve the Windows UAC prompt; the elevated install will start the gateway afterwards.")
@@ -1105,11 +1184,14 @@ def install(
         _install_startup_fallback(script_path, start_now, "administrator approval was not used")
         return
 
-    ok, detail = _install_scheduled_task(task_name, script_path)
+    ok, detail = _install_scheduled_task(task_name, script_path, at_boot=at_boot)
     if ok:
         print(f"✓ {detail}")
         print(f"  Task script: {script_path}")
-        print("ℹ Gateway auto-start installed for Windows login.")
+        if at_boot:
+            print("ℹ Gateway auto-start installed for system startup (runs before login).")
+        else:
+            print("ℹ Gateway auto-start installed for Windows login.")
         if start_now:
             running_pids = _gateway_pids()
             if running_pids:
@@ -1133,7 +1215,9 @@ def install(
         print(f"↻ Scheduled Task install needs administrator approval ({detail.splitlines()[0]})")
         print("  UAC is Windows' admin approval prompt; it is needed to create/update the Scheduled Task.")
         if prompt_yes_no("  Open the UAC prompt now?", False):
-            if _launch_elevated_install(force=force, start_now=start_now, start_on_login=start_on_login):
+            if _launch_elevated_install(
+                force=force, start_now=start_now, start_on_login=start_on_login, at_boot=at_boot
+            ):
                 print("✓ Launched elevated Hermes gateway install prompt.")
                 if start_now:
                     print("  Approve the Windows UAC prompt; the elevated install will start the gateway afterwards.")
@@ -1302,6 +1386,18 @@ def query_task_status() -> dict[str, str]:
     return info
 
 
+def _task_has_boot_trigger(task_name: str) -> bool:
+    """True when the registered task uses a BootTrigger (installed --at-boot).
+
+    Parses ``schtasks /Query /V /FO LIST`` output; the schedule-type line is
+    localized, so we match on the trigger XML instead, which is stable.
+    """
+    code, out, _err = _exec_schtasks(["/Query", "/TN", task_name, "/XML"])
+    if code != 0:
+        return False
+    return "<BootTrigger>" in out
+
+
 def _gateway_pids() -> list[int]:
     """Reuse the cross-platform PID scanner in gateway.py."""
     from hermes_cli.gateway import find_gateway_pids
@@ -1457,6 +1553,12 @@ def status(deep: bool = False) -> None:
             for key in ("status", "last run time", "last run result"):
                 if key in info:
                     print(f"  {key.title()}: {info[key]}")
+        # A task registered with a BootTrigger (installed via --at-boot) is
+        # a valid auto-start mechanism even though it is not the logon task
+        # this status command historically reports. Surface it so headless
+        # installs don't look "not installed" (issues #55710 / #25502).
+        if _task_has_boot_trigger(task_name):
+            print("  Trigger: system startup (runs before login)")
     elif startup_installed:
         entry = get_startup_entry_path()
         if not entry.exists():

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -270,19 +270,25 @@ def _launch_elevated_install(
     start_now: bool | None = None,
     start_on_login: bool | None = None,
     at_boot: bool = False,
+    password: str | None = None,
 ) -> bool:
-    """Launch an elevated gateway install via UAC and return True on handoff."""
+    """Launch an elevated gateway install via UAC and return True on handoff.
+
+    ``password`` (boot-task account password, already prompted for in the
+    parent) is passed to the elevated child via an environment variable, not
+    the command line, so it does not show up in process listings / ETW.
+    """
     old_start_now = os.environ.get("HERMES_GATEWAY_INSTALL_START_NOW")
     old_start_on_login = os.environ.get("HERMES_GATEWAY_INSTALL_START_ON_LOGIN")
-    old_at_boot = os.environ.get("HERMES_GATEWAY_INSTALL_AT_BOOT")
+    old_password = os.environ.get("HERMES_GATEWAY_INSTALL_PASSWORD")
     old_handoff = os.environ.get("HERMES_GATEWAY_ELEVATED_HANDOFF")
     try:
         if start_now is not None:
             os.environ["HERMES_GATEWAY_INSTALL_START_NOW"] = "1" if start_now else "0"
         if start_on_login is not None:
             os.environ["HERMES_GATEWAY_INSTALL_START_ON_LOGIN"] = "1" if start_on_login else "0"
-        if at_boot:
-            os.environ["HERMES_GATEWAY_INSTALL_AT_BOOT"] = "1"
+        if password is not None:
+            os.environ["HERMES_GATEWAY_INSTALL_PASSWORD"] = password
         os.environ["HERMES_GATEWAY_ELEVATED_HANDOFF"] = "1"
         extra_args = ["--elevated-handoff"]
         if force:
@@ -298,7 +304,7 @@ def _launch_elevated_install(
         for key, old in (
             ("HERMES_GATEWAY_INSTALL_START_NOW", old_start_now),
             ("HERMES_GATEWAY_INSTALL_START_ON_LOGIN", old_start_on_login),
-            ("HERMES_GATEWAY_INSTALL_AT_BOOT", old_at_boot),
+            ("HERMES_GATEWAY_INSTALL_PASSWORD", old_password),
             ("HERMES_GATEWAY_ELEVATED_HANDOFF", old_handoff),
         ):
             if old is None:
@@ -741,7 +747,12 @@ def _install_scheduled_task(
         # the password via /RP. /IT is meaningless for a boot task.
         variants = []
         if user:
-            password = _prompt_task_password(user)
+            # Elevated handoff passes the password via env (never the
+            # command line, which is visible to process inspection/ETW);
+            # a direct (non-elevated) run prompts here.
+            password = os.environ.get("HERMES_GATEWAY_INSTALL_PASSWORD")
+            if password is None:
+                password = _prompt_task_password(user)
             if password is None:
                 return (False, "Scheduled Task creation cancelled: no password provided for boot task.")
             variants.append([*base, "/RU", user, "/RP", password])
@@ -1159,6 +1170,20 @@ def install(
     task_name = get_task_name()
     script_path = _write_task_script()
 
+    # Boot tasks need the account password stored in Task Scheduler. Prompt
+    # for it in the parent (visible console) BEFORE any UAC handoff so the
+    # elevated child never has to prompt, and pass it via env (not argv).
+    boot_password: str | None = None
+    if at_boot:
+        user = _resolve_task_user()
+        if not user:
+            print("✗ Could not resolve the Windows user for the boot task.")
+            return
+        boot_password = _prompt_task_password(user)
+        if boot_password is None:
+            print("✗ Boot-task install cancelled: no password provided.")
+            return
+
     # On machines where the current user's scheduled-task ACL is locked down,
     # schtasks /Create or /Change can sit for the timeout before returning
     # Access Denied. We already collected all intent questions above, so avoid
@@ -1170,7 +1195,11 @@ def install(
         print("  UAC is Windows' admin approval prompt; it is needed to create/update the Scheduled Task.")
         if prompt_yes_no("  Open the UAC prompt now?", False):
             if _launch_elevated_install(
-                force=force, start_now=start_now, start_on_login=start_on_login, at_boot=at_boot
+                force=force,
+                start_now=start_now,
+                start_on_login=start_on_login,
+                at_boot=at_boot,
+                password=boot_password,
             ):
                 print("✓ Launched elevated Hermes gateway install prompt.")
                 if start_now:
@@ -1216,7 +1245,11 @@ def install(
         print("  UAC is Windows' admin approval prompt; it is needed to create/update the Scheduled Task.")
         if prompt_yes_no("  Open the UAC prompt now?", False):
             if _launch_elevated_install(
-                force=force, start_now=start_now, start_on_login=start_on_login, at_boot=at_boot
+                force=force,
+                start_now=start_now,
+                start_on_login=start_on_login,
+                at_boot=at_boot,
+                password=boot_password,
             ):
                 print("✓ Launched elevated Hermes gateway install prompt.")
                 if start_now:
@@ -1389,8 +1422,9 @@ def query_task_status() -> dict[str, str]:
 def _task_has_boot_trigger(task_name: str) -> bool:
     """True when the registered task uses a BootTrigger (installed --at-boot).
 
-    Parses ``schtasks /Query /V /FO LIST`` output; the schedule-type line is
-    localized, so we match on the trigger XML instead, which is stable.
+    Queries ``schtasks /Query /TN <name> /XML`` and matches on the trigger
+    XML, which is stable across locales (unlike the localized schedule-type
+    text in ``/V /FO LIST`` output).
     """
     code, out, _err = _exec_schtasks(["/Query", "/TN", task_name, "/XML"])
     if code != 0:

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -201,6 +201,13 @@ def build_gateway_parser(
         help="Do not enable the service to start on login/boot",
     )
     gateway_install.add_argument(
+        "--at-boot",
+        dest="at_boot",
+        action="store_true",
+        default=False,
+        help="Windows: install as a system-startup Scheduled Task that runs before any user logs on (headless/RDP). Requires the account password, stored encrypted by Task Scheduler.",
+    )
+    gateway_install.add_argument(
         "--elevated-handoff",
         dest="elevated_handoff",
         action="store_true",

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -314,6 +314,93 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert "cmd.exe" not in xml_seen["text"]
 
 
+def test_install_scheduled_task_at_boot_uses_boot_trigger_and_password(monkeypatch, tmp_path):
+    """--at-boot installs a BootTrigger task with stored credentials (/RP).
+
+    Boot tasks run before any user logs on, so they need the account password
+    stored in Task Scheduler. The XML must use a BootTrigger and
+    LogonType=Password, and the schtasks invocation must pass /RP (not /NP).
+    """
+    calls = []
+    script_path = tmp_path / "Hermes_Gateway_alice.cmd"
+    xml_seen = {}
+
+    monkeypatch.setattr(gateway_windows, "_resolve_task_user", lambda: r"DOMAIN\\alice")
+    monkeypatch.setattr(gateway_windows, "_prompt_task_password", lambda user: "s3cret")
+
+    def fake_schtasks(args):
+        calls.append(tuple(args))
+        if args[0] == "/Delete":
+            return (0, "SUCCESS", "")
+        if args[0] == "/Create":
+            xml_path = Path(args[args.index("/XML") + 1])
+            xml_seen["text"] = xml_path.read_text(encoding="utf-16")
+            return (0, "SUCCESS", "")
+        raise AssertionError(f"unexpected schtasks args: {args}")
+
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", fake_schtasks)
+    ok, detail = gateway_windows._install_scheduled_task(
+        "Hermes_Gateway_alice", script_path, at_boot=True
+    )
+
+    assert ok is True
+    assert "<BootTrigger>" in xml_seen["text"]
+    assert "<LogonTrigger>" not in xml_seen["text"]
+    assert "<LogonType>Password</LogonType>" in xml_seen["text"]
+    assert "<LogonType>InteractiveToken</LogonType>" not in xml_seen["text"]
+    # The boot variant must carry /RP with the prompted password, never /NP.
+    create_call = [c for c in calls if c[0] == "/Create"][0]
+    assert "/RP" in create_call
+    assert "s3cret" in create_call
+    assert "/NP" not in create_call
+    assert "/IT" not in create_call
+
+
+def test_install_scheduled_task_at_boot_cancelled_without_password(monkeypatch, tmp_path):
+    """A boot install with no password must fail cleanly, not fall through to a
+    credential-less /NP variant that Task Scheduler would reject."""
+    script_path = tmp_path / "Hermes_Gateway_alice.cmd"
+    monkeypatch.setattr(gateway_windows, "_resolve_task_user", lambda: r"DOMAIN\\alice")
+    monkeypatch.setattr(gateway_windows, "_prompt_task_password", lambda user: None)
+
+    ok, detail = gateway_windows._install_scheduled_task(
+        "Hermes_Gateway_alice", script_path, at_boot=True
+    )
+    assert ok is False
+    assert "no password" in detail
+
+
+def test_build_scheduled_task_xml_defaults_to_logon_trigger():
+    """The default (non --at-boot) XML keeps the historical LogonTrigger."""
+    xml = gateway_windows._build_scheduled_task_xml(
+        "Hermes_Gateway", Path("C:/Hermes/gateway-service/Hermes_Gateway.vbs"), "alice"
+    )
+    assert "<LogonTrigger>" in xml
+    assert "<BootTrigger>" not in xml
+    assert "<LogonType>InteractiveToken</LogonType>" in xml
+
+
+def test_task_has_boot_trigger_detects_boot_xml(monkeypatch):
+    """_task_has_boot_trigger matches the stable trigger XML, not localized
+    schedule-type text."""
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: (0, "<Task><Triggers><BootTrigger><Enabled>true</Enabled></BootTrigger></Triggers></Task>", ""),
+    )
+    assert gateway_windows._task_has_boot_trigger("Hermes_Gateway") is True
+
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: (0, "<Task><Triggers><LogonTrigger><Enabled>true</Enabled></LogonTrigger></Triggers></Task>", ""),
+    )
+    assert gateway_windows._task_has_boot_trigger("Hermes_Gateway") is False
+
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", lambda args: (1, "", "error"))
+    assert gateway_windows._task_has_boot_trigger("Hermes_Gateway") is False
+
+
 def test_gateway_vbs_script_is_console_less(monkeypatch):
     """The .vbs launcher must avoid cmd.exe entirely and Run pythonw hidden
     (issue #45599 fix A: no console -> no logon CTRL_CLOSE_EVENT / 0xC000013A)."""

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -212,7 +212,7 @@ def _arrange_startup_fallback(monkeypatch, tmp_path, running_pids):
     monkeypatch.setattr(
         gateway_windows,
         "_launch_elevated_install",
-        lambda force=False, start_now=None, start_on_login=None: calls.append(("elevate", force, start_now, start_on_login)) or True,
+        lambda force=False, start_now=None, start_on_login=None, at_boot=False, password=None: calls.append(("elevate", force, start_now, start_on_login, at_boot, password)) or True,
     )
 
     def fake_install_startup_entry(path: Path) -> Path:
@@ -362,12 +362,40 @@ def test_install_scheduled_task_at_boot_cancelled_without_password(monkeypatch, 
     script_path = tmp_path / "Hermes_Gateway_alice.cmd"
     monkeypatch.setattr(gateway_windows, "_resolve_task_user", lambda: r"DOMAIN\\alice")
     monkeypatch.setattr(gateway_windows, "_prompt_task_password", lambda user: None)
+    monkeypatch.delenv("HERMES_GATEWAY_INSTALL_PASSWORD", raising=False)
 
     ok, detail = gateway_windows._install_scheduled_task(
         "Hermes_Gateway_alice", script_path, at_boot=True
     )
     assert ok is False
     assert "no password" in detail
+
+
+def test_install_scheduled_task_at_boot_reads_password_from_env(monkeypatch, tmp_path):
+    """The elevated handoff passes the password via env (never argv); the
+    boot install must use it without prompting."""
+    calls = []
+    script_path = tmp_path / "Hermes_Gateway_alice.cmd"
+    monkeypatch.setattr(gateway_windows, "_resolve_task_user", lambda: r"DOMAIN\\alice")
+    monkeypatch.setattr(gateway_windows, "_prompt_task_password", lambda user: (_ for _ in ()).throw(AssertionError("must not prompt when env password is set")))
+    monkeypatch.setenv("HERMES_GATEWAY_INSTALL_PASSWORD", "env-s3cret")
+
+    def fake_schtasks(args):
+        calls.append(tuple(args))
+        if args[0] == "/Delete":
+            return (0, "SUCCESS", "")
+        if args[0] == "/Create":
+            return (0, "SUCCESS", "")
+        raise AssertionError(f"unexpected schtasks args: {args}")
+
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", fake_schtasks)
+    ok, detail = gateway_windows._install_scheduled_task(
+        "Hermes_Gateway_alice", script_path, at_boot=True
+    )
+    assert ok is True
+    create_call = [c for c in calls if c[0] == "/Create"][0]
+    assert "/RP" in create_call
+    assert "env-s3cret" in create_call
 
 
 def test_build_scheduled_task_xml_defaults_to_logon_trigger():


### PR DESCRIPTION
## Summary

Adds a `--at-boot` option to `hermes gateway install` on Windows so the gateway can start **before any user logs on** — the missing Windows counterpart to Linux's `--system` scope. Useful for headless/RDP boxes where cron jobs must fire even when nobody is logged in.

## What changed

- **`_build_scheduled_task_xml()`** gains an `at_boot` flag: renders a `BootTrigger` + `LogonType=Password` instead of `LogonTrigger` + `InteractiveToken`
- **`_install_scheduled_task()`** prompts for the account password (hidden input via `getpass`) and passes `/RP` so Task Scheduler can start the task without a logon; `/NP` is incompatible with boot tasks
- **`install()`** threads `at_boot` through the UAC elevated handoff (`HERMES_GATEWAY_INSTALL_AT_BOOT` env + `--at-boot` arg)
- **`status()`** now recognizes a registered `BootTrigger` task and reports `Trigger: system startup (runs before login)` instead of implying nothing is installed
- **CLI**: `--at-boot` flag on `hermes gateway install` (Windows only)

## Why

On Windows, `hermes gateway install` only ever created a logon-triggered Scheduled Task. On a headless RDP server (or any box that boots to a lock screen), that task never fires, so cron jobs silently stop. The workaround was a manual `schtasks /Create /SC ONSTART /RU <user> /RP <password>` — this PR makes it a first-class option.

## Test plan

- [x] Unit tests: XML rendering (BootTrigger vs LogonTrigger), `/RP` credential flow, cancelled-password fail-safe, boot-trigger detection
- [x] `pytest tests/hermes_cli/test_gateway_windows.py` — 13 passed
- [x] Manually verified on a real Windows 11 box: task registered with `Schedule Type: At system start up`, gateway running before login

## Related

- #55710 — Windows gateway status hides stale Scheduled Task definitions
- #25502 — Windows gateway runtime detection reports Scheduled Task gateway as stopped
