### PR TITLE
fix(gateway): don't delete shared task scripts on Windows uninstall

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1214,6 +1214,39 @@ def _print_next_steps() -> None:
     print(f"  type {hermes_home}\\logs\\gateway.log       # View logs")
 
 
+def _tasks_referencing_script(script_path: Path) -> list[str] | None:
+    """Names of Scheduled Tasks whose action references ``script_path``.
+
+    The ``.cmd``/``.vbs`` pair under ``gateway-service/`` is shared
+    infrastructure: a manually-created boot task (e.g.
+    ``Hermes_Gateway_OnStart``) may still point at it after the standard
+    task is uninstalled. Scan ``schtasks /Query /FO CSV /V`` and match on
+    the script path substring (CSV column headers are localized, the path
+    is not).
+
+    Returns ``None`` when the scan itself fails (timeout, access denied) so
+    callers can fail safe instead of deleting shared files on a guess.
+    """
+    import csv
+    import io
+
+    code, out, _err = _exec_schtasks(["/Query", "/FO", "CSV", "/V"])
+    if code != 0:
+        return None
+    needles = [str(script_path).lower(), str(script_path.with_suffix(".vbs")).lower()]
+    referencing: list[str] = []
+    for row in csv.reader(io.StringIO(out)):
+        if not row:
+            continue
+        name = row[0].strip()
+        if not name:
+            continue
+        if any(needle in " ".join(row).lower() for needle in needles):
+            if name not in referencing:
+                referencing.append(name)
+    return referencing
+
+
 def uninstall() -> None:
     """Remove both the Scheduled Task and the Startup-folder fallback, if present."""
     _assert_windows()
@@ -1249,14 +1282,38 @@ def uninstall() -> None:
     for path, label in [
         (startup_entry, "Windows login item"),
         (legacy_startup_entry, "legacy Windows login item"),
-        (script_path, "Task script"),
-        (vbs_script_path, "Task launcher"),
     ]:
         try:
             path.unlink()
             print(f"✓ Removed {label}: {path}")
         except FileNotFoundError:
             pass
+
+    # The .cmd/.vbs pair is shared infrastructure: a manually-created boot
+    # task (e.g. Hermes_Gateway_OnStart) may still reference it. Only remove
+    # the files when no other registered task uses them, and never delete
+    # them when the scan failed (fail safe).
+    referencing = _tasks_referencing_script(script_path)
+    if referencing is None:
+        print(
+            f"⚠ Could not scan Scheduled Tasks; kept task scripts "
+            f"({script_path.name}, {vbs_script_path.name}) to be safe."
+        )
+    elif referencing:
+        print(
+            f"⚠ Kept task scripts ({script_path.name}, {vbs_script_path.name}): "
+            f"still referenced by Scheduled Task(s): {', '.join(referencing)}"
+        )
+    else:
+        for path, label in [
+            (script_path, "Task script"),
+            (vbs_script_path, "Task launcher"),
+        ]:
+            try:
+                path.unlink()
+                print(f"✓ Removed {label}: {path}")
+            except FileNotFoundError:
+                pass
 
     if is_task_registered() and not scheduled_task_removed:
         print(f"⚠ Scheduled Task still registered: {task_name}")

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -330,12 +330,14 @@ def test_tasks_referencing_script_finds_other_tasks(monkeypatch):
     assert "Hermes_Gateway_OnStart" in referencing
 
 
+@pytest.mark.windows_only
 def test_tasks_referencing_script_none_when_scan_fails(monkeypatch):
     """A failed scan must return None (fail safe), not an empty list."""
     monkeypatch.setattr(gateway_windows, "_exec_schtasks", lambda args: (1, "", "access denied"))
     assert gateway_windows._tasks_referencing_script(Path("C:/Hermes/gateway-service/Hermes_Gateway.cmd")) is None
 
 
+@pytest.mark.windows_only
 def test_uninstall_keeps_scripts_referenced_by_other_tasks(monkeypatch, tmp_path, capsys):
     """uninstall() must not delete the shared .cmd/.vbs when another task
     (e.g. a manual boot task) still references them."""
@@ -367,6 +369,7 @@ def test_uninstall_keeps_scripts_referenced_by_other_tasks(monkeypatch, tmp_path
     assert "Hermes_Gateway_OnStart" in out
 
 
+@pytest.mark.windows_only
 def test_uninstall_removes_scripts_when_unreferenced(monkeypatch, tmp_path, capsys):
     """uninstall() deletes the .cmd/.vbs when no other task references them."""
     script_path = tmp_path / "Hermes_Gateway_alice.cmd"

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -314,6 +314,85 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert "cmd.exe" not in xml_seen["text"]
 
 
+def test_tasks_referencing_script_finds_other_tasks(monkeypatch):
+    """A manually-created boot task referencing the shared .vbs must be
+    detected so uninstall does not delete files it still needs."""
+    csv_out = (
+        '"TaskName","Next Run Time","Status","Task To Run"\r\n'
+        '"Hermes_Gateway","N/A","Ready","wscript.exe //B //Nologo \\"C:\\Hermes\\gateway-service\\Hermes_Gateway.vbs\\""\r\n'
+        '"Hermes_Gateway_OnStart","N/A","Ready","wscript.exe //B //Nologo \\"C:\\Hermes\\gateway-service\\Hermes_Gateway.vbs\\""\r\n'
+    )
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", lambda args: (0, csv_out, ""))
+    referencing = gateway_windows._tasks_referencing_script(
+        Path("C:/Hermes/gateway-service/Hermes_Gateway.cmd")
+    )
+    assert referencing is not None
+    assert "Hermes_Gateway_OnStart" in referencing
+
+
+def test_tasks_referencing_script_none_when_scan_fails(monkeypatch):
+    """A failed scan must return None (fail safe), not an empty list."""
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", lambda args: (1, "", "access denied"))
+    assert gateway_windows._tasks_referencing_script(Path("C:/Hermes/gateway-service/Hermes_Gateway.cmd")) is None
+
+
+def test_uninstall_keeps_scripts_referenced_by_other_tasks(monkeypatch, tmp_path, capsys):
+    """uninstall() must not delete the shared .cmd/.vbs when another task
+    (e.g. a manual boot task) still references them."""
+    script_path = tmp_path / "Hermes_Gateway_alice.cmd"
+    vbs_path = tmp_path / "Hermes_Gateway_alice.vbs"
+    script_path.write_text("rem gateway wrapper")
+    vbs_path.write_text("' gateway launcher")
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway_alice")
+    monkeypatch.setattr(gateway_windows, "get_task_script_path", lambda: script_path)
+    monkeypatch.setattr(gateway_windows, "get_startup_entry_path", lambda: tmp_path / "Startup" / "Hermes_Gateway_alice.vbs")
+    monkeypatch.setattr(gateway_windows, "_legacy_startup_entry_path", lambda: tmp_path / "Startup" / "Hermes_Gateway_alice.cmd")
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", lambda args: (0, "", ""))
+    monkeypatch.setattr(gateway_windows, "_is_running_as_admin", lambda: True)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_tasks_referencing_script",
+        lambda path: ["Hermes_Gateway_OnStart"],
+    )
+
+    gateway_windows.uninstall()
+
+    assert script_path.exists()
+    assert vbs_path.exists()
+    out = capsys.readouterr().out
+    assert "Kept task scripts" in out
+    assert "Hermes_Gateway_OnStart" in out
+
+
+def test_uninstall_removes_scripts_when_unreferenced(monkeypatch, tmp_path, capsys):
+    """uninstall() deletes the .cmd/.vbs when no other task references them."""
+    script_path = tmp_path / "Hermes_Gateway_alice.cmd"
+    vbs_path = tmp_path / "Hermes_Gateway_alice.vbs"
+    script_path.write_text("rem gateway wrapper")
+    vbs_path.write_text("' gateway launcher")
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway_alice")
+    monkeypatch.setattr(gateway_windows, "get_task_script_path", lambda: script_path)
+    monkeypatch.setattr(gateway_windows, "get_startup_entry_path", lambda: tmp_path / "Startup" / "Hermes_Gateway_alice.vbs")
+    monkeypatch.setattr(gateway_windows, "_legacy_startup_entry_path", lambda: tmp_path / "Startup" / "Hermes_Gateway_alice.cmd")
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", lambda args: (0, "", ""))
+    monkeypatch.setattr(gateway_windows, "_is_running_as_admin", lambda: True)
+    monkeypatch.setattr(gateway_windows, "_tasks_referencing_script", lambda path: [])
+
+    gateway_windows.uninstall()
+
+    assert not script_path.exists()
+    assert not vbs_path.exists()
+    out = capsys.readouterr().out
+    assert "Removed Task script" in out
+    assert "Removed Task launcher" in out
+
+
 def test_gateway_vbs_script_is_console_less(monkeypatch):
     """The .vbs launcher must avoid cmd.exe entirely and Run pythonw hidden
     (issue #45599 fix A: no console -> no logon CTRL_CLOSE_EVENT / 0xC000013A)."""


### PR DESCRIPTION
## Summary

Fixes a data-loss bug in `hermes gateway uninstall` on Windows: it deleted the shared `gateway-service/*.cmd` / `*.vbs` launcher files **unconditionally**, even when another Scheduled Task (e.g. a manually-created boot task like `Hermes_Gateway_OnStart`) still referenced them — breaking that task's ability to start the gateway.

## What changed

- **`_tasks_referencing_script()`** (new): scans `schtasks /Query /FO CSV /V` and matches on the script path. CSV column headers are localized, the path is not, so matching on the path is locale-safe.
- **`uninstall()`** now only removes the `.cmd`/`.vbs` pair when **no other registered task references them**. On scan failure (timeout/access denied) it keeps the files and warns — fail safe.

## Why

The launcher scripts are shared infrastructure between the standard logon task and any manually-created boot task. Deleting them on uninstall silently breaks the remaining task. This was discovered while setting up a headless gateway (see the `--at-boot` PR) where `uninstall` would have destroyed the working boot task.

## Test plan

- [x] Unit tests: reference detection, fail-safe on scan failure, keep-on-reference, delete-when-unreferenced
- [x] `pytest tests/hermes_cli/test_gateway_windows.py` — 13 passed
