### PR TITLE
fix(tui): drain stdin buffer before re-attaching listeners in resumeStdin

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/app-resume-stdin-drain.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/app-resume-stdin-drain.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import App from './components/App.js'
+
+// Regression: resumeStdin() re-attaches 'readable' listeners without
+// draining stdin first. Bytes buffered during the external editor session
+// (the Enter that submitted /prompt, keystrokes typed while VS Code was
+// open) replay through the re-attached listener and re-trigger handlers,
+// causing the editor to open N times and the prompt to send N times.
+// Fix: call drainStdin() before re-attaching listeners, same as unmount().
+
+const makeFakeStdin = (initialChunks: Array<string | null>) => {
+  const queue: Array<string | null> = [...initialChunks]
+  const readableListeners: Array<() => void> = []
+
+  return {
+    addListener: vi.fn((event: string, fn: () => void) => {
+      if (event === 'readable') {
+        readableListeners.push(fn)
+      }
+    }),
+    removeListener: vi.fn((event: string, fn: () => void) => {
+      if (event === 'readable') {
+        const i = readableListeners.indexOf(fn)
+        if (i >= 0) readableListeners.splice(i, 1)
+      }
+    }),
+    listeners: vi.fn((event: string) => (event === 'readable' ? [...readableListeners] : [])),
+    read: vi.fn(() => (queue.length > 0 ? queue.shift()! : null)),
+    isTTY: true,
+    isRaw: false,
+    setRawMode: vi.fn((mode: boolean) => {
+      // Track raw mode state for the test
+      ;(this as any).isRaw = mode
+    }),
+    get readableLength() {
+      return queue.filter(c => c !== null).reduce((n, c) => n + (c as string).length, 0)
+    }
+  }
+}
+
+const noopStream = { isTTY: false, write: () => true } as unknown as NodeJS.WriteStream
+
+const makeApp = (stdin: ReturnType<typeof makeFakeStdin>) => {
+  const app = new App({
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: noopStream,
+    stderr: noopStream,
+    exitOnCtrlC: false,
+    onExit: vi.fn(),
+    terminalColumns: 80,
+    terminalRows: 24,
+    selection: undefined as any,
+    onSelectionChange: vi.fn(),
+    onClickAt: vi.fn(() => false),
+    onMouseDownAt: vi.fn(() => undefined),
+    onMouseUpAt: vi.fn(),
+    onMouseDragAt: vi.fn(),
+    onHoverAt: vi.fn(),
+    onCopySelectionNoClear: vi.fn(async () => ''),
+    getSelectedText: vi.fn(() => ''),
+    getHyperlinkAt: vi.fn(() => undefined),
+    onOpenHyperlink: vi.fn(),
+    onMultiClick: vi.fn(),
+    onSelectionDrag: vi.fn(),
+    onStdinResume: vi.fn(),
+    dispatchKeyboardEvent: vi.fn(),
+    children: null as any
+  } as any)
+
+  ;(app as any).rawModeEnabledCount = 1
+
+  return app
+}
+
+describe('App.resumeStdin drains buffered stdin (editor replay regression)', () => {
+  it('drains buffered bytes before re-attaching listeners', () => {
+    // Simulate bytes that arrived while the external editor was open:
+    // the Enter key that submitted /prompt, plus a stray keystroke.
+    const stdin = makeFakeStdin(['\r', 'x', null])
+    const app = makeApp(stdin)
+
+    // Simulate suspendStdin: attach a listener, then suspend
+    const listener = vi.fn()
+    ;(stdin.addListener as any)('readable', listener)
+    ;(app as any).suspendStdin()
+
+    // After suspend, the listener should be removed
+    expect(stdin.listeners('readable')).toHaveLength(0)
+
+    // Now resume: should drain the buffer BEFORE re-attaching
+    ;(app as any).resumeStdin()
+
+    // The listener is re-attached
+    expect(stdin.listeners('readable')).toHaveLength(1)
+
+    // But the buffered bytes were drained, so read() consumed them.
+    // The listener should NOT fire with the old buffered data.
+    expect(stdin.read).toHaveBeenCalled()
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('does not drain when stdin is not a TTY', () => {
+    const stdin = makeFakeStdin(['\r', null])
+    ;(stdin as any).isTTY = false
+    const app = makeApp(stdin)
+
+    const listener = vi.fn()
+    ;(stdin.addListener as any)('readable', listener)
+    ;(app as any).suspendStdin()
+    ;(app as any).resumeStdin()
+
+    // Non-TTY stdin: resumeStdin returns early, no drain, no re-attach
+    expect(stdin.read).not.toHaveBeenCalled()
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -2280,6 +2280,14 @@ export default class Ink {
       return
     }
 
+    // Drain bytes buffered during suspension BEFORE re-attaching listeners.
+    // Without this, keystrokes that arrived while the external process owned
+    // stdin (e.g. the Enter that submitted /prompt, or keys typed while VS Code
+    // was open) replay through the re-attached 'readable' listener and
+    // re-trigger handlers, causing the editor to open N times and the prompt
+    // to send N times. Same drain unmount() does at line ~2481.
+    this.drainStdin()
+
     // Re-attach all the stored listeners
     if (this.stdinListeners.length === 0 && !this.wasRawMode) {
       logForDebugging('[stdin] resumeStdin: called with no stored listeners and wasRawMode=false (possible desync)', {


### PR DESCRIPTION
## What does this PR do?

When using `/prompt`, `/compose`, or Ctrl+G to compose a prompt in an external editor, the editor opens multiple times and the composed text gets submitted multiple times. The user has to close the editor 2-3 times and sees duplicate messages.

`withInkSuspended` calls `enterAlternateScreen()` which calls `suspendStdin()`. That removes Ink's `readable` listeners from stdin and disables raw mode. Correct so far.

The problem is on resume. `exitAlternateScreen()` calls `resumeStdin()`, which re-attaches the stored listeners without draining stdin first. Bytes that arrived while the editor was open (the Enter that submitted `/prompt`, keystrokes typed while VS Code was focused) are still in Node's stdin buffer. When the listeners go back on, those bytes fire immediately, replaying as keystrokes through Ink's input handler. Each replay re-triggers `openEditor()` and re-submits the text.

The codebase already has `drainStdin()` for this. It is called in `unmount()` and in the mouse-tracking disable path. It just was never called in `resumeStdin()`.

This PR adds one call to `this.drainStdin()` at the top of `resumeStdin()`, before re-attaching listeners.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/packages/hermes-ink/src/ink/ink.tsx` — added `this.drainStdin()` call at the top of `resumeStdin()`, before re-attaching stored stdin listeners
- `ui-tui/packages/hermes-ink/src/ink/app-resume-stdin-drain.test.ts` — regression test verifying buffered bytes are drained before listeners re-attach

## How to Test

1. Set `EDITOR` to a GUI editor like VS Code (`code --wait`)
2. Run `hermes --tui`, type `/prompt`, press Enter
3. The editor opens exactly once
4. Edit, save, close the tab
5. The text submits exactly once

Before this fix: editor opens 2-3 times, text submits 2-3 times. After: once each.

Also verify that normal typing after the editor closes still works (the drain discards only bytes that arrived during suspension, not keystrokes typed after resume).

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: Windows 11

### Documentation and Housekeeping

- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A