### PR TITLE
feat(cli): surface Windows gateway health in doctor and status

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -773,6 +773,50 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
         check_warn("Could not verify systemd linger", f"({linger_detail})")
 
 
+def _report_windows_gateway_health(health, issues: list[str], should_fix: bool = False) -> None:
+    """Print Windows gateway doctor lines from a canned health snapshot."""
+    _section("Gateway Service")
+    if health.installed and health.running_pids and not health.stale_launchers:
+        pids = ", ".join(str(pid) for pid in health.running_pids)
+        check_ok("Windows gateway installed and running", f"(PID {pids})")
+        return
+    if health.installed_but_not_running:
+        check_warn("Gateway is installed but not running")
+        check_info("Run: hermes gateway start")
+        issues.append("Start the Windows gateway: hermes gateway start")
+    if not health.stale_launchers:
+        return
+    if should_fix:
+        try:
+            from hermes_cli.gateway_windows import refresh_windows_gateway_launchers
+
+            refresh_windows_gateway_launchers()
+            check_ok("Refreshed Windows gateway launcher scripts")
+        except Exception as exc:
+            check_fail("Could not refresh gateway launchers", str(exc))
+            issues.append("Refresh Windows gateway launchers: hermes gateway install")
+        return
+    check_warn("Gateway launcher scripts are stale")
+    check_info("Run: hermes doctor --fix")
+    issues.append("Refresh Windows gateway launchers: hermes doctor --fix")
+
+
+def _check_windows_gateway_service(issues: list[str], should_fix: bool = False) -> None:
+    """Warn when a Windows gateway is installed but dead, or launchers are stale."""
+    if sys.platform != "win32":
+        return
+    try:
+        from hermes_cli.gateway_windows import inspect_windows_gateway
+
+        health = inspect_windows_gateway()
+    except Exception as exc:
+        check_warn("Windows gateway", f"(could not inspect: {exc})")
+        return
+    if not health.installed:
+        return
+    _report_windows_gateway_health(health, issues, should_fix=should_fix)
+
+
 _APIKEY_PROVIDERS_CACHE: list | None = None
 
 
@@ -1843,6 +1887,7 @@ def run_doctor(args):
             pass
 
     _check_gateway_service_linger(issues)
+    _check_windows_gateway_service(issues, should_fix=should_fix)
     _check_s6_supervision(issues)
 
     if sys.platform != "win32":

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -36,6 +36,7 @@ import shutil
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from xml.sax.saxutils import escape
 
@@ -1295,6 +1296,74 @@ def _gateway_pids() -> list[int]:
     return list(find_gateway_pids())
 
 
+@dataclass(frozen=True)
+class WindowsGatewayHealth:
+    """Snapshot of Windows gateway install + process + launcher health."""
+
+    task_registered: bool
+    startup_vbs: bool
+    startup_legacy_cmd: bool
+    running_pids: tuple[int, ...]
+    task_vbs_missing: bool
+    pythonw_in_launchers: bool
+
+    @property
+    def installed(self) -> bool:
+        return self.task_registered or self.startup_vbs or self.startup_legacy_cmd
+
+    @property
+    def installed_but_not_running(self) -> bool:
+        return self.installed and not self.running_pids
+
+    @property
+    def stale_launchers(self) -> bool:
+        return self.startup_legacy_cmd or self.task_vbs_missing or self.pythonw_in_launchers
+
+
+def _task_cmd_path() -> Path:
+    """Task ``.cmd`` path without creating ``gateway-service/``."""
+    from hermes_cli.config import get_hermes_home
+
+    return Path(get_hermes_home()) / "gateway-service" / f"{_sanitize_filename(get_task_name())}.cmd"
+
+
+def _launcher_mentions_pythonw(*paths: Path) -> bool:
+    for path in paths:
+        try:
+            if path.is_file() and "pythonw" in path.read_text(encoding="utf-8", errors="replace").lower():
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def inspect_windows_gateway() -> WindowsGatewayHealth:
+    """Read task / Startup / process / launcher state. Does not mutate disk."""
+    _assert_windows()
+    cmd_path = _task_cmd_path()
+    vbs_path = cmd_path.with_suffix(".vbs")
+    startup_vbs = get_startup_entry_path()
+    legacy_cmd = _legacy_startup_entry_path()
+    return WindowsGatewayHealth(
+        task_registered=is_task_registered(),
+        startup_vbs=startup_vbs.exists(),
+        startup_legacy_cmd=legacy_cmd.exists(),
+        running_pids=tuple(_gateway_pids()),
+        task_vbs_missing=cmd_path.exists() and not vbs_path.exists(),
+        pythonw_in_launchers=_launcher_mentions_pythonw(
+            cmd_path, vbs_path, startup_vbs, legacy_cmd
+        ),
+    )
+
+
+def refresh_windows_gateway_launchers() -> None:
+    """Rewrite task scripts; migrate a leftover Startup ``.cmd`` to ``.vbs``."""
+    _assert_windows()
+    script_path = _write_task_script()
+    if get_startup_entry_path().exists() or _legacy_startup_entry_path().exists():
+        _install_startup_entry(script_path)
+
+
 def _print_deep_probes() -> None:
     """Print PASS/FAIL per individual probe of gateway liveness.
 
@@ -1431,30 +1500,33 @@ def _print_deep_probes() -> None:
 def status(deep: bool = False) -> None:
     """Print a status report for the Windows gateway service."""
     _assert_windows()
+    health = inspect_windows_gateway()
     task_name = get_task_name()
-    task_installed = is_task_registered()
-    startup_installed = is_startup_entry_installed()
-    pids = _gateway_pids()
 
-    if task_installed:
+    if health.task_registered:
         print(f"✓ Scheduled Task registered: {task_name}")
         info = query_task_status()
         if info:
             for key in ("status", "last run time", "last run result"):
                 if key in info:
                     print(f"  {key.title()}: {info[key]}")
-    elif startup_installed:
-        entry = get_startup_entry_path()
-        if not entry.exists():
-            entry = _legacy_startup_entry_path()
+    elif health.startup_vbs or health.startup_legacy_cmd:
+        entry = get_startup_entry_path() if health.startup_vbs else _legacy_startup_entry_path()
         print(f"✓ Windows login item installed: {entry}")
     else:
         print("✗ Gateway service not installed")
 
-    if pids:
-        print(f"✓ Gateway process running (PID: {', '.join(map(str, pids))})")
+    if health.running_pids:
+        print(f"✓ Gateway process running (PID: {', '.join(map(str, health.running_pids))})")
     else:
         print("✗ No gateway process detected")
+
+    if health.installed_but_not_running:
+        print("⚠ Gateway is installed but not running")
+        print("  Start it with: hermes gateway start")
+    if health.stale_launchers:
+        print("⚠ Gateway launcher scripts are stale")
+        print("  Refresh with: hermes doctor --fix")
 
     if deep:
         print()
@@ -1465,7 +1537,7 @@ def status(deep: bool = False) -> None:
         # is lying when the high-level summary disagrees with reality.
         _print_deep_probes()
 
-    if not task_installed and not startup_installed and not pids:
+    if not health.installed and not health.running_pids:
         print()
         print("To install:")
         print("  hermes gateway install")

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -14,6 +14,7 @@ import hermes_cli.doctor as doctor
 import hermes_cli.gateway as gateway_cli
 from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
+from hermes_cli.gateway_windows import WindowsGatewayHealth
 
 
 class TestDoctorPlatformHints:
@@ -1457,3 +1458,44 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+def _gateway_health(**overrides):
+    fields = dict(
+        task_registered=False,
+        startup_vbs=False,
+        startup_legacy_cmd=False,
+        running_pids=(),
+        task_vbs_missing=False,
+        pythonw_in_launchers=False,
+    )
+    fields.update(overrides)
+    return WindowsGatewayHealth(**fields)
+
+
+class TestDoctorWindowsGatewayHealth:
+    def test_warns_when_installed_but_not_running(self, capsys):
+        issues = []
+        doctor_mod._report_windows_gateway_health(
+            _gateway_health(task_registered=True), issues
+        )
+        out = capsys.readouterr().out
+        assert "Gateway Service" in out
+        assert "installed but not running" in out
+        assert "hermes gateway start" in issues[0]
+
+    def test_fix_refreshes_stale_launchers(self, monkeypatch, capsys):
+        called = []
+        monkeypatch.setattr(
+            "hermes_cli.gateway_windows.refresh_windows_gateway_launchers",
+            lambda: called.append(True),
+        )
+        issues = []
+        doctor_mod._report_windows_gateway_health(
+            _gateway_health(startup_legacy_cmd=True, running_pids=(9,)),
+            issues,
+            should_fix=True,
+        )
+        assert called == [True]
+        assert "Refreshed Windows gateway launcher scripts" in capsys.readouterr().out
+        assert issues == []

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -7,6 +7,7 @@ import pytest
 import hermes_cli.gateway as gateway
 import hermes_cli.gateway_windows as gateway_windows
 import hermes_cli.setup as setup
+from hermes_cli.gateway_windows import WindowsGatewayHealth
 
 
 
@@ -237,6 +238,53 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
         assert var in content
     assert "--profile" in content and "work" in content
     assert content.endswith("\r\n")
+
+
+def _health(**overrides):
+    fields = dict(
+        task_registered=False,
+        startup_vbs=False,
+        startup_legacy_cmd=False,
+        running_pids=(),
+        task_vbs_missing=False,
+        pythonw_in_launchers=False,
+    )
+    fields.update(overrides)
+    return WindowsGatewayHealth(**fields)
+
+
+def test_windows_gateway_health_installed_but_not_running():
+    dead = _health(task_registered=True)
+    assert dead.installed
+    assert dead.installed_but_not_running
+    assert not dead.stale_launchers
+
+    live = _health(task_registered=True, running_pids=(1234,))
+    assert live.installed
+    assert not live.installed_but_not_running
+
+
+def test_windows_gateway_health_stale_launchers():
+    assert _health(startup_legacy_cmd=True).stale_launchers
+    assert _health(task_vbs_missing=True).stale_launchers
+    assert _health(pythonw_in_launchers=True).stale_launchers
+    assert not _health(task_registered=True, running_pids=(1,)).stale_launchers
+
+
+def test_launcher_mentions_pythonw(tmp_path):
+    stale = tmp_path / "Hermes_Gateway.vbs"
+    stale.write_text(
+        'sh.Run "C:\\venv\\pythonw.exe -m hermes_cli.main gateway run", 0, False\r\n',
+        encoding="utf-8",
+    )
+    clean = tmp_path / "ok.vbs"
+    clean.write_text(
+        'sh.Run "C:\\venv\\python.exe -m hermes_cli.main gateway run", 0, False\r\n',
+        encoding="utf-8",
+    )
+    missing = tmp_path / "nope.vbs"
+    assert gateway_windows._launcher_mentions_pythonw(stale, missing) is True
+    assert gateway_windows._launcher_mentions_pythonw(clean, missing) is False
 
 
 


### PR DESCRIPTION
## What does this PR do?

Linux `hermes doctor` already warns when a gateway service is installed but linger is off. Windows doctor did not mention the gateway at all, even when a Scheduled Task was registered and the process was dead. `hermes gateway status` printed task vs process as two unrelated check/fail lines and never said the gateway was installed but not running, or that launcher scripts were stale (`pythonw`, missing `.vbs`, leftover Startup `.cmd`).

This adds a read-only health snapshot and uses it in both commands. `hermes doctor --fix` rewrites those launcher files. It does not auto-start the gateway (use `hermes gateway start`) and does not re-register the Scheduled Task (use `hermes gateway install` if the task action still points at `.cmd`).

## Related Issue

No open issue claimed. This is the Windows doctor/status visibility gap.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/gateway_windows.py` — `WindowsGatewayHealth`, `inspect_windows_gateway()`, `refresh_windows_gateway_launchers()`; `status()` warns on installed-but-not-running and stale launchers
- `hermes_cli/doctor.py` — Windows gateway section; `--fix` refreshes launcher scripts only
- `tests/hermes_cli/test_gateway_windows.py` — health flags and `pythonw` detection
- `tests/hermes_cli/test_doctor.py` — doctor warn / `--fix` refresh

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py tests/hermes_cli/test_doctor.py -k TestDoctorWindowsGatewayHealth`
2. On Windows with a registered task and no process: `hermes gateway status` and `hermes doctor` should warn that the gateway is installed but not running
3. With a `pythonw` launcher or missing `.vbs`: doctor/status should warn stale launchers; `hermes doctor --fix` from the installed Hermes (not a git checkout) should rewrite the scripts

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered (Windows-only check is gated on `sys.platform`)
- [x] Tool descriptions/schemas — N/A
