### PR TITLE
fix(gateway): measure auto-resume freshness on the durable transcript clock

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2372,6 +2372,16 @@ class MessageEvent:
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
 
+    # Set on the synthetic empty-text continuation event that
+    # ``_schedule_resume_pending_sessions`` fires after a gateway restart to
+    # auto-continue a restart-interrupted turn.  It is ``internal`` (bypasses
+    # auth) yet carries the highest risk of any internal event: with no user
+    # text, the agent continues whatever unfinished work it finds in history.
+    # ``pre_gateway_dispatch`` plugins therefore MUST see it — guard plugins
+    # that constrain stale/empty-body resumes are otherwise blind to the one
+    # path that most needs them.
+    auto_resume: bool = False
+
     # Free-form per-event metadata.  Adapters may set platform-specific
     # signals here (e.g. WhatsApp sets ``whatsapp_from_owner=True`` when
     # the bridge is configured to forward owner-typed messages).  Plugins

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1159,6 +1159,28 @@ def _is_fresh_gateway_interruption(
     return current - timestamp <= window
 
 
+def should_run_pre_gateway_dispatch_hook(event: Any, is_internal: bool) -> bool:
+    """Whether ``pre_gateway_dispatch`` plugins should see this event.
+
+    User-originated events always qualify.  Internal/synthetic events normally
+    do NOT — background-process completion notices and similar machinery are
+    not user input and plugins should not be asked to police them.
+
+    The ONE exception is the startup auto-resume continuation event
+    (``auto_resume=True``, fired by ``_schedule_resume_pending_sessions``).  It
+    is synthetic and carries no user text, yet it makes the agent continue
+    whatever unfinished work it finds in history — the single highest-risk
+    dispatch path in the gateway, and precisely what guard plugins exist to
+    constrain.  Excluding it left e.g. ``stale-session-guard`` blind while a
+    six-week-old task was silently resumed (2026-08-18 incident).  It is also
+    user-attributable (it replays that user's own session), so running the hook
+    on it is consistent with the "user-originated" intent.
+    """
+    if not is_internal:
+        return True
+    return bool(getattr(event, "auto_resume", False))
+
+
 def build_resume_recovery_note(
     reason: Optional[str],
     message: str = "",
@@ -11882,6 +11904,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
         return redelivered
 
+    def _resume_transcript_marker_ts(self, entry) -> Optional[float]:
+        """Newest durable transcript timestamp for ``entry``, or None.
+
+        None means "no durable signal available" — the caller then falls back
+        to the in-memory ``last_resume_marked_at``/``updated_at`` markers.
+        Never raises: a DB hiccup must not block gateway startup recovery.
+        """
+        session_id = getattr(entry, "session_id", None)
+        if not session_id:
+            return None
+        db = getattr(self, "session_db", None) or getattr(
+            getattr(self, "session_store", None), "_db", None
+        )
+        getter = getattr(db, "get_last_message_timestamp", None)
+        if not callable(getter):
+            return None
+        try:
+            value = getter(str(session_id))
+        except Exception as exc:  # noqa: BLE001 — freshness probe must fail soft
+            logger.debug(
+                "Transcript freshness probe failed for %s: %s", session_id, exc
+            )
+            return None
+        # Only accept a genuine numeric epoch. Duck-typed coercion (``float(x)``)
+        # is unsafe here: test doubles / proxies expose ``__float__`` and would
+        # silently yield a bogus epoch (e.g. 1.0 -> 1970), turning every session
+        # stale and disabling auto-resume entirely.
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        return float(value)
+
     def _schedule_resume_pending_sessions(self, platform=None) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.
 
@@ -11946,9 +11999,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         now = datetime.now()
         scheduled = 0
         for entry in candidates:
-            marker = entry.last_resume_marked_at or entry.updated_at
-            if marker is not None and (now - marker).total_seconds() > window:
-                continue
+            # Freshness marker: prefer the newest DURABLE transcript timestamp.
+            #
+            # ``last_resume_marked_at``/``updated_at`` are routing bookkeeping
+            # that a gateway restart (and DB session recovery, which sets
+            # ``updated_at=now``) resets to the boot time.  Reading those made
+            # the freshness gate self-defeating: right after every restart every
+            # resume-pending session looked 0s idle, so a session interrupted
+            # weeks earlier was auto-resumed and silently continued old work
+            # with no user request (2026-08-18 incident).  The module comment
+            # above always specified "the timestamp of the last transcript
+            # row" — this reads that.  Falls back to the in-memory markers when
+            # the transcript timestamp is unavailable (legacy/no-DB), so
+            # behaviour is unchanged where there is nothing better to read.
+            marker_ts = self._resume_transcript_marker_ts(entry)
+            if marker_ts is not None:
+                if (now.timestamp() - marker_ts) > window:
+                    logger.info(
+                        "Skipping auto-resume for %s: last transcript activity "
+                        "%.1fh ago exceeds the %.1fh freshness window",
+                        entry.session_key,
+                        (now.timestamp() - marker_ts) / 3600.0,
+                        window / 3600.0,
+                    )
+                    continue
+            else:
+                marker = entry.last_resume_marked_at or entry.updated_at
+                if marker is not None and (now - marker).total_seconds() > window:
+                    continue
 
             # Already being resumed (e.g. scheduled at startup and still
             # in-flight) — don't synthesize a second continuation turn.
@@ -12004,6 +12082,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message_type=MessageType.TEXT,
                 source=source,
                 internal=True,
+                auto_resume=True,
             )
             task = asyncio.create_task(
                 self._run_startup_resume_event(adapter, event, entry.session_key)
@@ -16313,7 +16392,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         #   {"action": "allow"}   /   None          -> normal dispatch
         # Hook runs BEFORE auth so plugins can handle unauthorized senders
         # (e.g. customer handover ingest) without triggering the pairing flow.
-        if not is_internal:
+        #
+        # Internal events are normally excluded (background-process completions
+        # etc. are not user input).  The one exception is the synthetic
+        # auto-resume continuation turn — see
+        # ``should_run_pre_gateway_dispatch_hook`` for why.
+        if should_run_pre_gateway_dispatch_hook(event, is_internal):
             try:
                 from hermes_cli.lifecycle import invoke_hook as _invoke_hook
                 _hook_results = _invoke_hook(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10135,6 +10135,32 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return self._execute_write(_do)
 
+    def get_last_message_timestamp(self, session_id: str) -> Optional[float]:
+        """Return the newest transcript timestamp for ``session_id``.
+
+        Used by the gateway auto-resume freshness gate: "when did we last do
+        anything on this transcript" must be read from the durable transcript,
+        NOT from in-memory routing bookkeeping (which a gateway restart resets
+        to ``now`` and thereby makes every stale session look fresh).
+
+        Returns None when the session has no messages or on any DB error —
+        callers treat None as "unknown" and fall back to their previous signal.
+        """
+        try:
+            with self._lock:
+                row = self._conn.execute(
+                    "SELECT MAX(timestamp) FROM messages WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+        except Exception:
+            return None
+        if not row or row[0] is None:
+            return None
+        try:
+            return float(row[0])
+        except (TypeError, ValueError):
+            return None
+
     def get_messages(
         self,
         session_id: str,

--- a/tests/gateway/test_auto_resume_transcript_freshness.py
+++ b/tests/gateway/test_auto_resume_transcript_freshness.py
@@ -1,0 +1,277 @@
+"""Auto-resume freshness must be measured on the DURABLE transcript clock.
+
+Regression for the 2026-08-18 incident:
+
+A Telegram thread's session was interrupted on 2026-07-07 mid-``pip install``
+and left ``resume_pending`` for six weeks.  On the next gateway restart the
+startup auto-resume pass fired a synthetic empty-text continuation turn for it,
+and the agent silently resumed and completed that six-week-old task with no
+user request.
+
+Two independent defects made this possible, and this module locks both:
+
+1. ``_schedule_resume_pending_sessions`` read freshness from
+   ``last_resume_marked_at`` / ``updated_at``.  Both are routing bookkeeping
+   that a restart resets to the boot time (``mark_resume_pending`` stamps
+   ``_now()``; DB session recovery builds the entry with ``updated_at=now``).
+   So *every* resume-pending session looked 0s idle right after a restart and
+   the 1-hour freshness window could never reject anything.  The module comment
+   in ``gateway/run.py`` always specified "the timestamp of the last transcript
+   row" — the code did not read it.
+
+2. The synthetic continuation event was ``internal=True``, and the
+   ``pre_gateway_dispatch`` plugin hook was skipped for all internal events.
+   Guard plugins (e.g. ``stale-session-guard``) were therefore blind to the
+   single highest-risk dispatch path.  The event now carries
+   ``auto_resume=True`` and the hook runs for it.
+"""
+
+import asyncio
+import time
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import should_run_pre_gateway_dispatch_hook
+from gateway.session import SessionEntry
+from tests.gateway.restart_test_helpers import (
+    make_restart_runner,
+    make_restart_source,
+)
+
+
+SIX_WEEKS_SECS = 42 * 86400
+
+
+def _pending_entry(source, *, session_id="sid", marked_at=None):
+    """A resume-pending entry whose in-memory markers all say "just now".
+
+    This is precisely the post-restart shape: the restart watchdog stamped
+    ``last_resume_marked_at`` at boot, and DB recovery set ``updated_at=now``,
+    regardless of how old the transcript actually is.
+    """
+    now = marked_at or datetime.now()
+    return SessionEntry(
+        session_key="agent:main:telegram:group:resume-chat:227",
+        session_id=session_id,
+        created_at=now - timedelta(days=42),
+        updated_at=now,
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=now,
+    )
+
+
+def _attach_db(runner, *, last_ts):
+    """Give the runner a session DB whose transcript clock returns ``last_ts``."""
+    db = MagicMock()
+    db.get_last_message_timestamp = MagicMock(return_value=last_ts)
+    runner.session_db = db
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 — freshness must come from the transcript, not the restart marker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stale_transcript_is_not_auto_resumed_despite_fresh_restart_marker():
+    """The incident case: 6-week-old transcript, restart-fresh markers.
+
+    Before the fix this scheduled 1 resume and silently continued the old task.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="resume-chat", thread_id="227")
+    entry = _pending_entry(source)
+    runner.session_store._entries = {entry.session_key: entry}
+    _attach_db(runner, last_ts=time.time() - SIX_WEEKS_SECS)
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 0, "a six-week-old transcript must not auto-resume"
+    adapter.handle_message.assert_not_awaited()
+    # The marker itself is preserved: a real human message can still continue
+    # the session deliberately.  We only refuse to continue it unprompted.
+    assert entry.resume_pending is True
+    # And the runner slot must not be left claimed by a resume we never ran.
+    assert entry.session_key not in runner._running_agents
+
+
+@pytest.mark.asyncio
+async def test_genuinely_fresh_transcript_still_auto_resumes():
+    """The legitimate case must keep working — this is a gate, not a kill switch."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="resume-chat", thread_id="227")
+    entry = _pending_entry(source)
+    runner.session_store._entries = {entry.session_key: entry}
+    _attach_db(runner, last_ts=time.time() - 120)  # interrupted 2 minutes ago
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_transcript_clock_falls_back_to_in_memory_markers():
+    """No durable signal (legacy transcript / no DB) => previous behaviour.
+
+    The fallback must not silently disable auto-resume for setups where the
+    transcript timestamp is simply unavailable.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="resume-chat", thread_id="227")
+    entry = _pending_entry(source)
+    runner.session_store._entries = {entry.session_key: entry}
+    _attach_db(runner, last_ts=None)
+    adapter.handle_message = AsyncMock()
+
+    assert runner._schedule_resume_pending_sessions() == 1
+    await asyncio.sleep(0)
+    adapter.handle_message.assert_awaited_once()
+
+
+def test_transcript_marker_rejects_non_numeric_values():
+    """A duck-typed proxy must never be coerced into a bogus 1970 epoch.
+
+    ``float(MagicMock())`` succeeds and yields 1.0, which would date every
+    session to 1970 and disable auto-resume wholesale.  Only real numbers count.
+    """
+    runner, _adapter = make_restart_runner()
+    source = make_restart_source(chat_id="resume-chat", thread_id="227")
+    entry = _pending_entry(source)
+
+    _attach_db(runner, last_ts=MagicMock())
+    assert runner._resume_transcript_marker_ts(entry) is None
+
+    _attach_db(runner, last_ts="not-a-timestamp")
+    assert runner._resume_transcript_marker_ts(entry) is None
+
+    _attach_db(runner, last_ts=True)  # bool is an int subclass — reject it
+    assert runner._resume_transcript_marker_ts(entry) is None
+
+    _attach_db(runner, last_ts=1787014699.93238)
+    assert runner._resume_transcript_marker_ts(entry) == pytest.approx(1787014699.93238)
+
+
+def test_transcript_marker_probe_fails_soft():
+    """A DB error must not break startup recovery — it degrades to fallback."""
+    runner, _adapter = make_restart_runner()
+    source = make_restart_source(chat_id="resume-chat", thread_id="227")
+    entry = _pending_entry(source)
+
+    db = MagicMock()
+    db.get_last_message_timestamp = MagicMock(side_effect=RuntimeError("db locked"))
+    runner.session_db = db
+
+    assert runner._resume_transcript_marker_ts(entry) is None
+
+
+def test_transcript_marker_reads_the_production_db_handle():
+    """Locks the handle the PRODUCTION path actually uses.
+
+    ``GatewayRunner`` has no ``session_db`` attribute — the live DB handle is
+    ``session_store._db`` (same handle ``gateway.session`` itself reads).  If
+    the lookup only checked ``runner.session_db`` the probe would silently
+    return None on every real gateway and the freshness gate would degrade back
+    to the buggy in-memory markers while all tests stayed green.
+    """
+    runner, _adapter = make_restart_runner()
+    source = make_restart_source(chat_id="resume-chat", thread_id="227")
+    entry = _pending_entry(source)
+
+    assert not hasattr(runner, "session_db"), (
+        "if GatewayRunner ever grows a real session_db attribute, revisit the "
+        "lookup order in _resume_transcript_marker_ts"
+    )
+    db = MagicMock()
+    db.get_last_message_timestamp = MagicMock(return_value=1787014699.93238)
+    runner.session_store._db = db
+
+    assert runner._resume_transcript_marker_ts(entry) == pytest.approx(
+        1787014699.93238
+    )
+    db.get_last_message_timestamp.assert_called_once_with(entry.session_id)
+
+
+def test_transcript_marker_returns_none_without_any_db():
+    """No DB handle at all (unit scaffolding, SQLite unavailable) => fallback."""
+    runner, _adapter = make_restart_runner()
+    source = make_restart_source(chat_id="resume-chat", thread_id="227")
+    entry = _pending_entry(source)
+    runner.session_store._db = None
+
+    assert runner._resume_transcript_marker_ts(entry) is None
+
+
+# ---------------------------------------------------------------------------
+# Defect 2 — guard plugins must see the synthetic auto-resume event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_event_is_flagged_for_plugin_hooks():
+    """The synthetic continuation event must be distinguishable from other
+    internal events so ``pre_gateway_dispatch`` can run on it."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="resume-chat", thread_id="227")
+    entry = _pending_entry(source)
+    runner.session_store._entries = {entry.session_key: entry}
+    _attach_db(runner, last_ts=time.time() - 120)
+    adapter.handle_message = AsyncMock()
+
+    runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    event = adapter.handle_message.await_args.args[0]
+    assert isinstance(event, MessageEvent)
+    assert event.internal is True, "still bypasses auth — it is synthetic"
+    assert event.auto_resume is True, (
+        "must be flagged so pre_gateway_dispatch guard plugins are not blind "
+        "to the highest-risk dispatch path"
+    )
+    assert event.text == ""
+
+
+def test_default_message_event_is_not_flagged_auto_resume():
+    """Only the startup resume path sets the flag; ordinary events must not."""
+    source = make_restart_source()
+    assert MessageEvent(text="hi", source=source).auto_resume is False
+    assert MessageEvent(text="", source=source, internal=True).auto_resume is False
+
+
+def test_hook_eligibility_predicate():
+    """The gate itself: user events always, internal only when auto_resume."""
+    source = make_restart_source()
+
+    user_event = MessageEvent(text="hi", source=source)
+    assert should_run_pre_gateway_dispatch_hook(user_event, False) is True
+
+    # Ordinary internal event (background-process completion) stays excluded —
+    # this fix must not widen the hook to all machinery traffic.
+    bg_event = MessageEvent(text="job done", source=source, internal=True)
+    assert should_run_pre_gateway_dispatch_hook(bg_event, True) is False
+
+    # The auto-resume continuation event is the single admitted exception.
+    resume_event = MessageEvent(
+        text="", source=source, internal=True, auto_resume=True
+    )
+    assert should_run_pre_gateway_dispatch_hook(resume_event, True) is True
+
+    # Legacy event objects without the attribute must not raise.
+    class Bare:
+        pass
+
+    assert should_run_pre_gateway_dispatch_hook(Bare(), True) is False
+    assert should_run_pre_gateway_dispatch_hook(Bare(), False) is True

--- a/tests/test_session_db_last_message_timestamp.py
+++ b/tests/test_session_db_last_message_timestamp.py
@@ -1,0 +1,85 @@
+"""Unit tests for ``SessionDB.get_last_message_timestamp``.
+
+This is the durable freshness signal the gateway auto-resume gate reads
+(``gateway.run._resume_transcript_marker_ts``).  It must answer "when did we
+last do anything on this transcript" from the messages table — the in-memory
+routing markers it replaced were reset to boot time on every gateway restart,
+which let a six-week-old interrupted session auto-resume (2026-08-18 incident).
+"""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "freshness.db")
+    yield session_db
+    session_db.close()
+
+
+def _session(db, sid="s1"):
+    db.create_session(session_id=sid, source="telegram", model="test-model")
+    return sid
+
+
+def test_returns_newest_timestamp(db):
+    sid = _session(db)
+    db.append_message(sid, "user", content="first", timestamp=1000.0)
+    db.append_message(sid, "assistant", content="second", timestamp=3000.5)
+    db.append_message(sid, "user", content="third", timestamp=2000.0)
+
+    # MAX, not last-inserted — out-of-order writes must not fool the gate.
+    assert db.get_last_message_timestamp(sid) == pytest.approx(3000.5)
+
+
+def test_returns_none_for_session_without_messages(db):
+    sid = _session(db)
+    assert db.get_last_message_timestamp(sid) is None
+
+
+def test_returns_none_for_unknown_session(db):
+    assert db.get_last_message_timestamp("no-such-session") is None
+
+
+def test_is_scoped_to_the_requested_session(db):
+    old = _session(db, "old-session")
+    new = _session(db, "new-session")
+    db.append_message(old, "user", content="six weeks ago", timestamp=1000.0)
+    db.append_message(new, "user", content="just now", timestamp=9000.0)
+
+    # A neighbouring fresh session must never make a stale one look fresh.
+    assert db.get_last_message_timestamp(old) == pytest.approx(1000.0)
+    assert db.get_last_message_timestamp(new) == pytest.approx(9000.0)
+
+
+def test_counts_inactive_and_compacted_rows(db):
+    """Compaction must not reset the transcript clock.
+
+    Compressed/inactive rows still represent work done on this transcript. If
+    they were excluded, a heavily compacted-but-recent session could look
+    ancient and its legitimate resume would be refused.
+    """
+    sid = _session(db)
+    db.append_message(sid, "user", content="old", timestamp=1000.0)
+    mid = db.append_message(sid, "assistant", content="recent", timestamp=8000.0)
+    with db._lock:
+        db._conn.execute(
+            "UPDATE messages SET active = 0, compacted = 1 WHERE id = ?", (mid,)
+        )
+        db._conn.commit()
+
+    assert db.get_last_message_timestamp(sid) == pytest.approx(8000.0)
+
+
+def test_never_raises_on_a_closed_db(db):
+    """The probe is best-effort: a broken handle degrades to None, not a crash.
+
+    Gateway startup recovery calls this; an exception here would break boot.
+    """
+    sid = _session(db)
+    db.append_message(sid, "user", content="hi", timestamp=1000.0)
+    db.close()
+
+    assert db.get_last_message_timestamp(sid) is None


### PR DESCRIPTION
## Symptom

A gateway restart silently resumed and completed a task the user had abandoned **six weeks earlier**, with no request from them in that session.

The session was interrupted on 2026-07-07 mid-`pip install` and left `resume_pending`. It sat untouched for six weeks. On the next gateway restart, `_schedule_resume_pending_sessions` fired a synthetic empty-text continuation turn for it, `build_resume_recovery_note` injected *"CONTINUE the interrupted task to completion"*, and the agent resumed the six-week-old work — installing packages and patching files. The user's reaction was "why did this just start, I never asked for it".

Reproduced on current `main` (`6680afba4a`).

## Root cause 1 — the freshness gate reads a clock that the restart itself resets

`_schedule_resume_pending_sessions` already has a freshness window (1h default), and the module comment above it is explicit about what the signal is meant to be:

> The freshness signal is the **timestamp of the last transcript row**

But the code reads in-memory routing bookkeeping instead:

```python
marker = entry.last_resume_marked_at or entry.updated_at
if marker is not None and (now - marker).total_seconds() > window:
    continue
```

Both of those are stamped at boot time, by the restart path itself:

- `SessionStore.mark_resume_pending()` sets `entry.last_resume_marked_at = _now()`
- `_create_entry_from_recovered_row()` (DB session recovery) builds the entry with `updated_at=now`

So immediately after a restart **every** resume-pending session reports ~0s idle, regardless of its real age. The window can never reject anything — the gate is structurally dead, and gets deader the more reliably the restart path runs. A session interrupted six weeks ago is indistinguishable from one interrupted six seconds ago.

This is also why the bug is invisible in normal operation: it only manifests when a stale `resume_pending` marker survives long enough for a restart to find it.

### Fix

Read the durable transcript clock, which is what the comment always specified.

- Adds `SessionDB.get_last_message_timestamp(session_id)` — `MAX(timestamp)` over that session's messages.
- Adds `GatewayRunner._resume_transcript_marker_ts(entry)`, which prefers that signal and **falls back to the previous in-memory markers** when no transcript timestamp is available (legacy rows, no DB, SQLite unavailable). Behaviour is unchanged wherever there is nothing better to read.
- The probe never raises — a DB hiccup must not break gateway startup recovery.

Inactive/compacted rows are deliberately counted: they still represent work done on that transcript, and excluding them would make a heavily-compacted but recent session look ancient and wrongly refuse its legitimate resume.

One subtle trap worth calling out for reviewers: the marker must reject non-numeric values rather than coerce with `float(x)`. `float(MagicMock())` succeeds and returns `1.0`, which would date every session to 1970 and disable auto-resume wholesale — this broke 8 existing tests before the type check was tightened. There is a regression test for it.

## Root cause 2 — guard plugins are blind to the highest-risk dispatch path

The synthetic continuation event is `internal=True`, and `pre_gateway_dispatch` was skipped for all internal events:

```python
if not is_internal:
    _invoke_hook("pre_gateway_dispatch", ...)
```

That exclusion is right for background-process completion notices, which are machinery rather than user input. But it also excluded the one internal event that carries the most risk: an event with **no user text** that causes the agent to continue whatever unfinished work it finds in history. That is exactly what a guard plugin exists to constrain, and it never got the chance — a local stale-session guard logged zero banners during the incident because the hook was never called, not because it evaluated and allowed the event.

### Fix

- Adds `MessageEvent.auto_resume`, set only by `_schedule_resume_pending_sessions`.
- Adds `should_run_pre_gateway_dispatch_hook(event, is_internal)` and uses it at the call site: user events always qualify, internal events only when `auto_resume` is set.

Ordinary internal traffic stays excluded — the existing `test_internal_events_bypass_hook` still passes unchanged. The event is user-attributable anyway (it replays that user's own session), so running the hook on it is consistent with the "user-originated" intent of the gate.

## These are gates, not refusals

`resume_pending` is preserved in both cases. A real user message still continues the session deliberately, and the reconnect path still retries. The only thing that changes is that Hermes declines to continue stale work **unprompted**. A human is put back in the loop for exactly the case where the machine has no evidence the work is still wanted.

## Tests

`tests/gateway/test_auto_resume_transcript_freshness.py` (10) and `tests/test_session_db_last_message_timestamp.py` (6).

Verified RED on the pre-fix tree: reverting the three source files fails 7 of them, including `test_stale_transcript_is_not_auto_resumed_despite_fresh_restart_marker`, which is a direct reproduction of the incident shape (six-week-old transcript, restart-fresh in-memory markers).

Coverage includes the stale case, the genuinely-fresh case still resuming, the no-DB fallback, the non-numeric rejection above, the production DB handle (`session_store._db` — a test that only mocked `runner.session_db` would pass while the probe silently returned `None` on every real gateway), and the hook-eligibility predicate.

```
tests/gateway/test_auto_resume_transcript_freshness.py  10 passed
tests/test_session_db_last_message_timestamp.py          6 passed
tests/gateway/test_restart_resume_pending.py            39 passed
tests/gateway/test_pre_gateway_dispatch.py + restart/startup suites  48 passed, 2 skipped
```

All run against this branch on top of `6680afba4a`.
