### PR TITLE
fix: validate skills before approval staging

### DIFF
--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -145,6 +145,28 @@ _SKILL = (
 )
 
 
+def test_invalid_skill_is_rejected_before_staging(hermes_home):
+    """An invalid skill must fail immediately, not sit in pending until approval."""
+    from tools.skill_manager_tool import skill_manage
+    from tools import write_approval as wa
+
+    _set_approval("skills", True)
+    long_description = "Use when " + "doing a very specific deployment task " * 8
+    invalid_skill = (
+        "---\n"
+        "name: invalid-skill\n"
+        f"description: {long_description}\n"
+        "---\n\n"
+        "# Invalid\nbody\n"
+    )
+
+    result = json.loads(skill_manage("create", "invalid-skill", content=invalid_skill))
+
+    assert result["success"] is False
+    assert "60-char system-prompt budget" in result["error"]
+    assert wa.pending_count("skills") == 0
+
+
 # ---------------------------------------------------------------------------
 # Pending store CRUD
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1449,6 +1449,13 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
     if decision.blocked:
         return tool_error(decision.message, success=False)
 
+    # Validate BEFORE staging so invalid skill content is rejected immediately
+    # instead of failing later when an approval replays the staged write.
+    if action in {"create", "edit"} and payload_kwargs.get("content"):
+        err = _validate_frontmatter(payload_kwargs["content"], new_skill=(action == "create"))
+        if err:
+            return tool_error(err, success=False)
+
     # stage — record the full skill_manage kwargs so approval can replay it.
     payload = {"action": action, "name": name}
     payload.update({k: v for k, v in payload_kwargs.items() if v is not None})


### PR DESCRIPTION
## Summary

When skill write approval is enabled, invalid skill content could be staged before validation and fail only when approval replayed the write.

This validates `create` and full-content `edit` operations before staging, so invalid frontmatter is rejected immediately and never enters the pending queue.

## Test plan

- `scripts/run_tests.sh tests/tools/test_write_approval.py tests/tools/test_skill_manager_tool.py tests/tools/test_skill_size_limits.py`
- 73 tests passed
- Added regression test proving an over-limit description is rejected before staging
- `git diff --check` passed
- Secret-pattern scan passed