### PR TITLE
test(gateway): stop the TTS pipeline test calling a live provider

### DIFF
--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1066,9 +1066,13 @@ class TestStreamTtsToSpeaker:
         text_q.put("Hello world.")
         text_q.put(None)
 
-        stream_tts_to_speaker(text_q, stop_evt, done_evt, display_callback=display)
+        # The sentinel flush is all this asserts; synthesising it for real
+        # would call out to the TTS provider and open the speakers.
+        with patch("tools.tts_tool.text_to_speech_tool") as mock_tts:
+            stream_tts_to_speaker(text_q, stop_evt, done_evt, display_callback=display)
         assert done_evt.is_set()
         assert any("Hello" in s for s in spoken)
+        assert mock_tts.call_count <= 1
 
     def test_stop_event_aborts_early(self):
         """Setting stop_event causes early exit."""


### PR DESCRIPTION
## What does this PR do?

`tests/gateway/test_voice_command.py::TestStreamTtsToSpeaker::test_none_sentinel_flushes_buffer` drives `stream_tts_to_speaker` with nothing stubbed. The default provider is keyless, so no credential gate stops it: the sentinel flush reaches `_SyncSentencePipeline._synthesize_to_tmp`, which calls the real `text_to_speech_tool` over the network, and `_drain` then hands the resulting file to `play_audio_file`. Running `pytest tests/gateway` says "Hello world." out loud.

The test asserts two things, that `tts_done_event` is set and that the buffered text reached the display callback. Neither needs real synthesis, so stubbing it keeps the test's subject intact while closing the leak.

## Related Issue

Part of #88898

That issue lists three findings. This PR fixes the first, which is the only one that leaks in the default suite. The other two are left alone deliberately, see Notes on scope.

## Type of Change

- [x] Tests (adding or improving test coverage)

## Changes Made

- `tests/gateway/test_voice_command.py`: stub `tools.tts_tool.text_to_speech_tool` for the duration of the `stream_tts_to_speaker` call, and assert the pipeline attempts at most one synthesis

## How to Test

Record what the pipeline reaches by spying on both boundaries, then run the class before and after this change:

```python
# leakspy.py, loaded with -p leakspy
import pytest
hits = {"synth": [], "play": []}

def _fake(text=None, output_path=None, **kw):
    hits["synth"].append(text)
    if output_path:
        open(output_path, "wb").write(b"\xff\xfb\x90\x00" * 64)
    return output_path

@pytest.fixture(autouse=True)
def spy(monkeypatch):
    import tools.tts_tool as T, tools.voice_mode as V
    monkeypatch.setattr(T, "text_to_speech_tool", _fake)
    monkeypatch.setattr(V, "play_audio_file", lambda p, *a, **k: hits["play"].append(p))
    yield

def pytest_sessionfinish(session, exitstatus):
    print(f"provider={hits['synth']} speaker={len(hits['play'])}")
```

```
pytest "tests/gateway/test_voice_command.py::TestStreamTtsToSpeaker" -q -p leakspy
```

Before: `provider=['Hello world.'] speaker=1`
After: `provider=[] speaker=0`

The class still passes both ways, which is the point: the assertions never depended on the provider.

## Notes on scope

The issue also proposes widening the autouse `_audio_playback_guard` to cover `tools.voice_mode.play_audio_file`, since `hermes_cli.voice` imported the player by value and the pipeline resolves it through a function-local import. I tried that and it breaks four tests that call `play_audio_file` directly as the unit under test, three in `TestWSL2PowerShellFallback` plus `test_play_audio_file_scrubbed_env`. Any guard that replaces that function breaks them by construction, so it needs a different boundary and belongs in its own PR.

The third finding, `TestPlayBeep::test_beep_calls_sounddevice_play` spawning `afplay` on Darwin, is macOS-only and untouched here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu, Python 3.12

I did not run the whole suite, so that box stays unchecked. I ran `tests/gateway/test_voice_command.py` (70 passed, 7 skipped) and the six voice-related files under `tests/tools` and `tests/hermes_cli` (94 passed, 25 skipped, identical to the counts on `main`), plus `ruff check` on the changed file.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact: the change removes a platform-dependent call, and the stub is platform-neutral
