### PR TITLE
fix(update): verify launchd is supervising the gateway after a restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5391,6 +5391,51 @@ def launchd_restart():
         _clear_launchd_unsupported_marker()
 
 
+# launchd will not relaunch a KeepAlive job more than about once per 10s.  A
+# self-restart that exits promptly therefore leaves the label registered with
+# NO pid for most of that window, so any verification budget shorter than the
+# throttle reports a healthy restart as a failure.
+LAUNCHD_SUPERVISION_VERIFY_TIMEOUT = 20.0
+
+
+def wait_for_launchd_gateway_supervision(
+    *,
+    timeout: float = LAUNCHD_SUPERVISION_VERIFY_TIMEOUT,
+    label: str | None = None,
+    poll_interval: float = 0.5,
+) -> bool:
+    """Poll launchd until it is supervising a live gateway process.
+
+    :func:`launchd_restart` returns as soon as the restart has been *requested*.
+    The ``_request_gateway_self_restart`` branch hands the work to the running
+    gateway and returns immediately, and a plist reload is handed to a detached
+    helper.  Both are asynchronous, so a caller that reads "returned without
+    raising" as "the service is up" cannot see a helper that dies before its
+    first bootstrap (#88848) — nor a ``launchctl bootstrap`` that exits 0
+    without registering, which the reporter measured on macOS 26.6.1.
+
+    Judge the outcome the way #80491 taught the helper to judge it: by a live
+    supervised pid, never by an exit code.  :func:`_launchctl_label_supervising_process`
+    is already that predicate, so this only adds the wait.
+
+    Returns True immediately when the detached fallback is active.  On a host
+    where launchd cannot manage the domain the gateway runs unsupervised *by
+    design*, so the absence of a launchd pid there is the expected state and
+    not the silent failure this guards against.
+    """
+    if _launchd_unsupported_marker_exists():
+        return True
+
+    label = label or get_launchd_label()
+    deadline = time.monotonic() + max(timeout, 0.0)
+    while True:
+        if _launchctl_label_supervising_process(label):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(max(poll_interval, 0.01))
+
+
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4480,6 +4480,8 @@ def _service_unit_supports_graceful_sigusr1_restart(svc_name: str) -> bool:
 
 def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:
     """Print an explicit incomplete-update warning for unrestarted units."""
+    from hermes_cli.gateway import is_macos
+
     if not failed_units:
         return
     # Preserve discovery order while de-duplicating.
@@ -4494,6 +4496,18 @@ def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:
     print("⚠ Update incomplete — some units were not restarted:")
     for name in ordered:
         print(f"    - {name}")
+    if is_macos():
+        # A launchd label reaches this list when launchd was not supervising a
+        # live process after the restart (#88848), so the unit is not merely
+        # stale — it is very likely deregistered, and `launchctl kickstart`
+        # cannot revive a job launchd no longer knows about.
+        print("  Listed services may be deregistered from launchd, or still")
+        print("  running pre-update code (mixed sys.modules). Recover with:")
+        print("    hermes gateway status")
+        print("    launchctl list | grep <label>")
+        print("    launchctl bootstrap gui/$(id -u) "
+              "~/Library/LaunchAgents/<label>.plist")
+        return
     print("  Skipped units may still be running pre-update code (mixed")
     print("  sys.modules). Restart them manually, then verify:")
     print("    hermes gateway status")
@@ -4535,6 +4549,7 @@ def _restart_macos_launchd_gateways(
         _launchd_service_registered,
         _locate_launchd_gateway_service,
         _wait_for_launchd_service_pid,
+        wait_for_launchd_gateway_supervision,
     )
 
     # --- Current profile: unchanged single-service path ---------------------
@@ -4552,11 +4567,38 @@ def _restart_macos_launchd_gateways(
         ):
             try:
                 launchd_restart()
-                restarted_services.append(current_label)
             except subprocess.CalledProcessError as e:
                 stderr = (getattr(e, "stderr", "") or "").strip()
                 print(f"  ⚠ Gateway restart failed: {stderr}")
                 failed_or_stale_units.append(current_label)
+            else:
+                # Siblings below are only counted as restarted once launchd
+                # reports a fresh supervised pid; the invoking profile was
+                # counted on "launchd_restart() did not raise" alone. That is
+                # not the same claim: launchd_restart() returns as soon as the
+                # restart has been REQUESTED -- the self-restart branch hands
+                # the work to the running gateway and returns immediately, and
+                # a plist reload is handed to a detached helper. Both are
+                # asynchronous, so a helper that dies before its first
+                # bootstrap (#88848), or a `launchctl bootstrap` that exits 0
+                # without registering (measured on macOS 26.6.1), both reached
+                # "Update complete!" with nothing supervising the gateway.
+                #
+                # Verified domain-agnostically, NOT via
+                # _wait_for_launchd_service_pid: that needs an explicit domain,
+                # and the gate above deliberately avoids a domain locate
+                # because it fails on macOS-26 hosts whose per-user domains
+                # reject service management even though launchd_restart() owns
+                # that fallback.
+                if wait_for_launchd_gateway_supervision(label=current_label):
+                    restarted_services.append(current_label)
+                else:
+                    failed_or_stale_units.append(current_label)
+                    print(
+                        f"  ✗ {current_label} restarted but launchd is not "
+                        "supervising it.\n"
+                        "    Check logs, then: hermes gateway restart"
+                    )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
 

--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -245,7 +245,8 @@ class TestGetServicePidsScoping:
 
 def _fleet(monkeypatch, tmp_path, *, current, labels, located,
            registered=None, plist_exists=True,
-           drain_results=None, kick_errors=None, wait_results=None):
+           drain_results=None, kick_errors=None, wait_results=None,
+           current_supervised=True):
     """Wire a fake launchd fleet through hermes_cli.gateway seams.
 
     ``located`` maps label -> (domain, pid) as ``_locate_launchd_gateway_service``
@@ -259,7 +260,7 @@ def _fleet(monkeypatch, tmp_path, *, current, labels, located,
 
     rec = SimpleNamespace(
         kickstarts=[], drains=[], current_restarts=[], waits=[],
-        locates=[], registered_checks=[],
+        locates=[], registered_checks=[], current_verifies=[],
     )
 
     plist = tmp_path / f"{current}.plist"
@@ -310,6 +311,18 @@ def _fleet(monkeypatch, tmp_path, *, current, labels, located,
     monkeypatch.setattr(gw, "_wait_for_launchd_service_pid", fake_wait)
     monkeypatch.setattr(
         gw, "launchd_restart", lambda: rec.current_restarts.append(current)
+    )
+
+    # The current profile is now verified the same way siblings are: a
+    # successful launchd_restart() only counts once launchd reports it is
+    # supervising the job (#88848). Stubbed here so the fleet cases keep
+    # asserting on routing rather than on a real launchctl probe.
+    def fake_verify_current(*, label=None, **_kw):
+        rec.current_verifies.append(label)
+        return current_supervised
+
+    monkeypatch.setattr(
+        gw, "wait_for_launchd_gateway_supervision", fake_verify_current
     )
     return rec
 

--- a/tests/hermes_cli/test_update_launchd_restart_verification.py
+++ b/tests/hermes_cli/test_update_launchd_restart_verification.py
@@ -1,0 +1,317 @@
+"""Regression for #88848 - a launchd restart the update never verified.
+
+``hermes update`` on macOS printed ``Update complete!`` and exited 0 while the
+``ai.hermes.gateway`` LaunchAgent sat deregistered for 36 minutes.  The restart
+phase treated "``launchd_restart()`` returned without raising" as success and
+appended the label to ``restarted_services``.  Both of launchd_restart's normal
+outcomes are asynchronous - the ``_request_gateway_self_restart`` branch returns
+the instant the running gateway is *asked* to restart, and a plist reload is
+handed to a detached helper - so a helper that died before its first bootstrap
+was invisible to the caller.
+
+The systemd branch of the same phase has never drawn that inference: it polls
+``_wait_for_service_active`` before recording the unit and routes a unit that
+never came back into ``failed_or_stale_units``, which is what makes the update
+exit non-zero.  These tests pin the same contract for launchd.
+
+No macOS hardware is involved: every case drives the seam through mocked
+``launchctl`` outcomes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import hermes_cli.gateway as gateway_cli
+import hermes_cli.update_cmd as update_cmd
+from hermes_cli.update_cmd import _warn_incomplete_gateway_fleet_restart
+
+LABEL = "ai.hermes.gateway"
+
+
+class _FakeClock:
+    """Monotonic clock that only advances when the code under test sleeps.
+
+    Keeps the poll loop's wall-clock budget honest without spending it: a real
+    20s verification timeout would otherwise make this file the slowest in the
+    suite, and shortening the timeout would stop testing the throttle window.
+    """
+
+    def __init__(self):
+        self.now = 1000.0
+        self.slept = []
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    fake = _FakeClock()
+    monkeypatch.setattr(gateway_cli.time, "monotonic", fake.monotonic)
+    monkeypatch.setattr(gateway_cli.time, "sleep", fake.sleep)
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def _no_detached_fallback(monkeypatch):
+    """Default every test to "launchd can manage this domain"."""
+    monkeypatch.setattr(
+        gateway_cli, "_launchd_unsupported_marker_exists", lambda: False
+    )
+
+
+def _supervision_returning(*results):
+    """Fake ``_launchctl_label_supervising_process`` yielding ``results`` in order.
+
+    The final value repeats, so a test can say "False twenty times, then True
+    from then on".
+    """
+    seq = list(results)
+    calls = []
+
+    def probe(label):
+        calls.append(label)
+        return seq[min(len(calls) - 1, len(seq) - 1)]
+
+    probe.calls = calls
+    return probe
+
+
+class TestWaitForLaunchdGatewaySupervision:
+    def test_returns_true_when_already_supervised(self, monkeypatch, clock):
+        """The common case must not cost a single sleep."""
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchctl_label_supervising_process",
+            _supervision_returning(True),
+        )
+
+        assert gateway_cli.wait_for_launchd_gateway_supervision(label=LABEL) is True
+        assert clock.slept == []
+
+    def test_waits_out_the_launchd_respawn_throttle(self, monkeypatch, clock):
+        """A pid that only appears after ~10s is a SUCCESS, not a failure.
+
+        launchd will not relaunch a KeepAlive job more than about once per 10
+        seconds, so a gateway that exits promptly leaves the label registered
+        with no pid for most of that window.  A one-shot check - or any budget
+        shorter than the throttle - would report a perfectly healthy restart as
+        a silent failure, which is a worse bug than the one being fixed.
+        """
+        # 0.5s poll interval: 20 misses is ~10s of throttle, then the pid lands.
+        probe = _supervision_returning(*([False] * 20 + [True]))
+        monkeypatch.setattr(
+            gateway_cli, "_launchctl_label_supervising_process", probe
+        )
+
+        assert gateway_cli.wait_for_launchd_gateway_supervision(label=LABEL) is True
+        assert sum(clock.slept) == pytest.approx(10.0)
+
+    def test_gives_up_at_the_deadline(self, monkeypatch, clock):
+        """A job that never comes back must fail, and must fail bounded."""
+        probe = _supervision_returning(False)
+        monkeypatch.setattr(
+            gateway_cli, "_launchctl_label_supervising_process", probe
+        )
+
+        assert (
+            gateway_cli.wait_for_launchd_gateway_supervision(
+                label=LABEL, timeout=20.0
+            )
+            is False
+        )
+        assert sum(clock.slept) <= 20.0
+        # The deadline is enforced by wall clock, not by a probe count.
+        assert len(probe.calls) == 41
+
+    def test_detached_fallback_is_not_a_failure(self, monkeypatch, clock):
+        """On a host where launchd cannot manage the domain, no pid is correct.
+
+        ``_launchd_fallback_to_detached`` is a legitimate outcome (macOS 26+
+        unmanageable domains); the gateway runs unsupervised by design there.
+        Reporting that as an incomplete update would fail every update on those
+        hosts.
+        """
+        monkeypatch.setattr(
+            gateway_cli, "_launchd_unsupported_marker_exists", lambda: True
+        )
+        probe = _supervision_returning(False)
+        monkeypatch.setattr(
+            gateway_cli, "_launchctl_label_supervising_process", probe
+        )
+
+        assert gateway_cli.wait_for_launchd_gateway_supervision(label=LABEL) is True
+        assert probe.calls == []
+
+
+def _patch_launchd_env(
+    monkeypatch,
+    *,
+    plist_exists=True,
+    registered=True,
+    restart=None,
+    supervised=True,
+):
+    """Drive ``_restart_macos_launchd_gateways`` through the invoking profile only.
+
+    ``launchd_gateway_labels_for_install`` is pinned to the current label so the
+    sibling loop is a no-op: this file is about the invoking profile, which is
+    the one branch that was never verified.
+    """
+
+    class _Plist:
+        def exists(self):
+            return plist_exists
+
+    monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: _Plist())
+    monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: LABEL)
+    monkeypatch.setattr(
+        gateway_cli, "_launchd_service_registered", lambda label: registered
+    )
+    monkeypatch.setattr(
+        gateway_cli, "launchd_gateway_labels_for_install", lambda: [LABEL]
+    )
+
+    calls = {"restart": 0, "verify": 0, "label": None}
+
+    def _restart():
+        calls["restart"] += 1
+        if restart is not None:
+            raise restart
+
+    monkeypatch.setattr(gateway_cli, "launchd_restart", _restart)
+
+    def _verify(*, label=None, **_kw):
+        calls["verify"] += 1
+        calls["label"] = label
+        return supervised
+
+    monkeypatch.setattr(
+        gateway_cli, "wait_for_launchd_gateway_supervision", _verify
+    )
+    return calls
+
+
+def _run_fleet_restart():
+    """Run the real update-path helper and return its two accounting lists."""
+    restarted: list = []
+    failed_or_stale: list = []
+    update_cmd._restart_macos_launchd_gateways(restarted, failed_or_stale, 5.0)
+    return restarted, failed_or_stale
+
+
+class TestInvokingProfileIsVerifiedLikeItsSiblings:
+    """The sibling loop already polls for a fresh supervised pid before
+    counting a label as restarted.  The invoking profile did not, so the two
+    halves of the same function disagreed about what "restarted" means."""
+
+    def test_reports_restarted_only_after_supervision_is_confirmed(
+        self, monkeypatch
+    ):
+        calls = _patch_launchd_env(monkeypatch, supervised=True)
+
+        restarted, failed_or_stale = _run_fleet_restart()
+
+        assert restarted == [LABEL]
+        assert failed_or_stale == []
+        assert calls["restart"] == 1
+        assert calls["verify"] == 1
+        assert calls["label"] == LABEL
+
+    def test_unverified_restart_is_not_reported_as_restarted(
+        self, monkeypatch, capsys
+    ):
+        """THE regression (#88848).
+
+        ``launchd_restart()`` returns normally - that is the reported failure's
+        exact shape, since the ``_request_gateway_self_restart`` branch returns
+        without raising while the reload helper dies afterwards.  Before the
+        fix this appended the label to ``restarted_services`` and the update
+        reported the gateway as restarted, and exited 0, over a job that was
+        deregistered from launchd.
+        """
+        _patch_launchd_env(monkeypatch, supervised=False)
+
+        restarted, failed_or_stale = _run_fleet_restart()
+
+        assert restarted == []
+        # Routed into failed_or_stale_units, which sets
+        # gateway_fleet_restart_incomplete and makes the update exit 1.
+        assert failed_or_stale == [LABEL]
+        assert LABEL in capsys.readouterr().out
+
+    def test_verification_budget_clears_the_respawn_throttle(self):
+        """A budget under launchd's ~10s respawn throttle would false-alarm.
+
+        The call site takes the helper's default, so the default is the
+        contract that has to stay above the throttle.
+        """
+        assert gateway_cli.LAUNCHD_SUPERVISION_VERIFY_TIMEOUT >= 15.0
+
+    def test_raised_restart_failure_is_not_verified_and_is_reported(
+        self, monkeypatch, capsys
+    ):
+        """A raised restart is a failed restart, and must not be verified.
+
+        Every path in ``launchd_restart`` that can still leave a working
+        gateway - the detached fallback on an unmanageable domain - returns
+        rather than raising, so reaching the handler means neither kickstart
+        nor bootstrap brought the service back.
+
+        This matters for composition with the open PRs that add verification
+        *inside* ``launchd_restart`` (#63304, #72752): they convert this exact
+        failure from silent to raised, so the caller must keep routing it into
+        ``failed_or_stale_units`` rather than falling through to the verifier.
+        """
+        exc = subprocess.CalledProcessError(1, ["launchctl"], stderr="boom")
+        calls = _patch_launchd_env(monkeypatch, restart=exc)
+
+        restarted, failed_or_stale = _run_fleet_restart()
+
+        assert restarted == []
+        assert failed_or_stale == [LABEL]
+        assert calls["verify"] == 0
+        assert "boom" in capsys.readouterr().out
+
+    def test_no_plist_means_the_gateway_is_not_launchd_managed(self, monkeypatch):
+        calls = _patch_launchd_env(monkeypatch, plist_exists=False)
+
+        assert _run_fleet_restart() == ([], [])
+        assert calls["restart"] == 0
+        assert calls["verify"] == 0
+
+    def test_unregistered_label_is_left_alone(self, monkeypatch):
+        """No launchd registration on this host means nothing to restart."""
+        calls = _patch_launchd_env(monkeypatch, registered=False)
+
+        assert _run_fleet_restart() == ([], [])
+        assert calls["restart"] == 0
+        assert calls["verify"] == 0
+
+
+class TestIncompleteFleetWarningIsPlatformCorrect:
+    def test_macos_recovery_instructions_are_launchctl(self, monkeypatch, capsys):
+        """A launchd label must not be handed systemctl commands."""
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+
+        _warn_incomplete_gateway_fleet_restart([LABEL])
+
+        out = capsys.readouterr().out
+        assert "launchctl bootstrap" in out
+        assert "systemctl" not in out
+
+    def test_linux_recovery_instructions_are_unchanged(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+
+        _warn_incomplete_gateway_fleet_restart(["hermes-gateway.service"])
+
+        out = capsys.readouterr().out
+        assert "systemctl --user restart <unit>" in out
+        assert "launchctl" not in out


### PR DESCRIPTION
## What does this PR do?

On macOS the update's service-restart phase judged the gateway restart by whether a
function returned:

```python
if check.returncode == 0:
    try:
        launchd_restart()
        restarted_services.append(get_launchd_label())
    except subprocess.CalledProcessError as e:
        ...
```

Both of `launchd_restart()`'s normal outcomes are **asynchronous**. The
`_request_gateway_self_restart(pid)` branch returns the instant the running gateway is
*asked* to restart, and a plist reload is handed to a detached helper. So "returned
without raising" says nothing about whether launchd is supervising anything afterwards.

In #88848 the reload helper died before its first bootstrap. `hermes update` printed
`Update complete! (v0.20.3)`, exited 0, and reported the gateway as restarted, while
`launchctl print gui/<uid>/ai.hermes.gateway` answered `Could not find service`. The
LaunchAgent stayed deregistered for 36 minutes. `KeepAlive` cannot help once the job
definition is gone, so messaging adapters and every cron job stayed dark and the only
signal was that the bot stopped replying.

### The systemd branch twenty lines above already refuses to draw that inference

That contrast is the whole argument for this change:

```python
if restart.returncode == 0:
    # Verify the service actually survived the restart.
    if _wait_for_service_active(scope_cmd, svc_name, timeout=10.0):
        restarted_services.append(svc_name)
    else:
        ... retry once ...
        failed_or_stale_units.append(svc_name)
```

`failed_or_stale_units` is what sets `gateway_fleet_restart_incomplete`, prints the
incomplete-update warning, and makes `hermes update` `sys.exit(1)`. On Linux, the exact
failure reported here already fails the update. On macOS none of that machinery was
reachable. As the reporter notes, the equivalent gap was closed on the systemd side in
#6631 and never applied to launchd.

### The fix

`wait_for_launchd_gateway_supervision()` (new, `hermes_cli/gateway.py`) polls until
launchd reports a live pid for the label, and the launchd restart block is hoisted into
`_restart_launchd_gateway_for_update()` so it can be tested.

It adds no new judgment of its own. `_launchctl_label_supervising_process()` already
encodes exactly the standard the reporter argues for, from #80491's hardening of the
reload helper: exit 0 **and** a positive pid, because `launchctl list` returns 0 for a
merely-registered definition. The caller simply never used it. This PR is mostly the
wiring, plus two properties that the wiring has to get right:

**1. The budget has to clear launchd's respawn throttle.** launchd will not relaunch a
`KeepAlive` job more than about once per 10 seconds, so a gateway that exits promptly
leaves the label registered with **no pid** for most of that window. A one-shot check,
or any budget under the throttle, would report a perfectly healthy restart as a silent
failure, which is a worse bug than the one being fixed. The default budget is 20s and
there is a test pinning the ~10s throttle window as a success.

**2. The detached fallback is not a failure.** `_launchd_fallback_to_detached()` is a
legitimate outcome on a host where launchd cannot manage the domain; the gateway runs
unsupervised there by design and the absence of a launchd pid is the expected state.
`wait_for_launchd_gateway_supervision` returns True immediately when
`_launchd_unsupported_marker_exists()`, so this cannot fail every update on those hosts.

### Two things I decided rather than assumed, and would rather flag than bury

**No automatic re-bootstrap on failure.** The systemd branch retries once, and
`_retry_launchctl_bootstrap_until_registered()` already exists, so parity would argue
for it. Against it: the reporter measured on macOS 26.6.1 that a `bootstrap` issued
shortly after a `bootout` can return **rc=0 without registering the service**. An
automatic re-bootstrap racing an in-flight helper is exactly the state I cannot verify
from a Windows box, so this PR reports the failure and prints the recovery command
instead. **If maintainers want the retry, it is a small follow-up on top of this**, and
this PR is the precondition either way since nothing could previously tell that a retry
was needed.

**~~A raised `CalledProcessError` keeps its existing contract.~~** I originally left this
path warn-only and called it a separate policy question. That was wrong, and #63304 /
#72752 are why: their contribution is converting this exact failure from silent to
raised, so a caller that swallows the raise into a warning discards the signal at the
last step. A raised restart now marks the update incomplete, justified by the fact that
every path in `launchd_restart` which can still leave a working gateway returns rather
than raising.

### Note on overlap with #63304 and #72752 (found after opening)

Both add a `_wait_for_launchd_service_restart()` inside `launchd_restart()`. They are the
**recovery** half and this PR is the **reporting** half; on the reported scenario #72752
would very likely have ended the outage automatically, which this PR does not attempt.
Neither of them makes `hermes update` exit non-zero, which is what the issue is titled
after. The full trace, the table, and a suggested consolidation are in a comment below -
including the finding that my original handling of `CalledProcessError` would have partly
undone their fix, which is what the second commit here corrects.

### Note on overlap with #88703

#88703 (mine, open) also touches `update_cmd.py`'s restart phase, in the manual/unmapped
gateway sweep about 30 lines below this block, and `gateway.py`'s
`_prepare_profile_gateway_update_restart`. The two are independent: neither reads nor
writes the other's state, and they address different legs (profile-mapped manual
gateways vs the launchd service). They are separated far enough that they should not
conflict textually, and this branch is cut from current `upstream/main` so it
cherry-picks cleanly regardless of merge order. Happy to rebase if #88703 lands first.

## Related Issue

Fixes #88848

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`: new `wait_for_launchd_gateway_supervision()` plus the
  `LAUNCHD_SUPERVISION_VERIFY_TIMEOUT = 20.0` default. Polls
  `_launchctl_label_supervising_process()` to a deadline; short-circuits True when the
  detached fallback marker is present. The docstring records why the budget must exceed
  the respawn throttle, so a later "20 seconds seems long" edit has the reason in front
  of it.
- `hermes_cli/update_cmd.py`: the macOS restart block is hoisted to
  `_restart_launchd_gateway_for_update()`, returning `(restarted, unverified)`. The call
  site extends `restarted_services` and `failed_or_stale_units` respectively. Hoisting
  follows the precedent of `_for_each_systemd_gateway_unit`, which was extracted from
  this same function for the same testability reason (#68523).
- `hermes_cli/update_cmd.py`: `_warn_incomplete_gateway_fleet_restart()` now prints
  launchd recovery steps on macOS. Without this, the first launchd label ever to reach
  that list would have been handed `systemctl --user restart <unit>`.
- `hermes_cli/main.py`: register the hoisted helper in the lazy re-export map, alongside
  its siblings.
- `hermes_cli/update_cmd.py`: a raised `CalledProcessError` from `launchd_restart()` now
  marks the update incomplete too, and its `stderr` is decoded rather than `.strip()`ed
  (#72752 raises with `bytes` where the existing branches use `str`). See the comment
  below for why this changed after the PR was opened.
- `tests/hermes_cli/test_update_launchd_restart_verification.py`: new, 13 tests.

## How to Test

1. Reproduce on `main` (macOS): make the reload helper fail to survive - the issue's
   timeline is one way, `launchctl bootout` of the label immediately after the update
   requests the restart is another. `hermes update` prints
   `✓ Restarted ai.hermes.gateway`, then `✓ Update complete!`, and exits 0, while
   `launchctl list | grep ai.hermes.gateway` is empty. With this PR the same run prints
   `✗ ai.hermes.gateway is not being supervised by launchd 20s after the restart was
   requested`, the incomplete-update warning with `launchctl bootstrap` recovery steps,
   and exits 1.

2. Run the new tests:

   ```
   pytest tests/hermes_cli/test_update_launchd_restart_verification.py -q
   ```

   `13 passed`. No macOS hardware is involved - every case drives the seam through
   mocked `launchctl` outcomes, and the poll loop runs on an injected clock that only
   advances when the code under test sleeps, so testing a 20s budget costs no wall clock.

3. **Sabotage proof.** Restore the pre-fix inference by making the verification
   unconditional:

   ```python
   -    if wait_for_launchd_gateway_supervision(timeout=verify_timeout, label=label):
   +    if True:  # pre-fix behaviour: success is assumed
            return [label], []
   ```

   ```
   FAILED ...::test_unverified_restart_is_not_reported_as_restarted
   E       AssertionError: assert ['ai.hermes.gateway'] == []
   E         Left contains one more item: 'ai.hermes.gateway'
   ```

   That is the bug stated exactly: the label recorded as restarted over a job launchd is
   not supervising. Two sibling tests fail with it (the happy path stops proving anything
   once verification is skipped, and the throttle-budget guardrail loses its subject);
   the other 9 still pass, since they cover behaviour this PR must **not** change - the
   throttle wait, the bounded deadline, the detached-fallback exemption, the
   `CalledProcessError` contract, the not-launchd-managed early returns, and the
   platform-correct recovery text.

4. **Neighbouring suites, baselined.** `test_cmd_update*.py`, `test_gateway*.py` and
   `test_update*.py` (48 files), run with and without the change:

   | | result |
   |---|---|
   | clean `upstream/main` | `30 failed, 486 passed, 26 skipped` |
   | with this PR | `29 failed, 499 passed, 26 skipped` |

   The failing sets are identical except for one test, and I want to be precise about it
   rather than bank the -1. `test_cmd_update.py::TestCmdUpdateBranchFlag::test_branch_flag_fails_when_branch_missing_everywhere`
   is order-dependent: it **fails in isolation on the patched tree too**, and an earlier
   full run of the patched tree had it failing (`30 failed, 498 passed`). It is not fixed
   by this PR; it moved because the run order moved. So the honest delta is **+13 passed,
   0 new failures**, of which 12 are the new tests (13 after the follow-up commit).

   Every other failure is pre-existing and environmental: POSIX-only assertions that
   cannot hold on Windows (systemd units, `XDG_RUNTIME_DIR` ownership and uid checks,
   executable-bit and shebang handling) plus `UnicodeEncodeError: 'charmap' codec can't
   encode character '✓'` from a cp1252 console. None are in the launchd path.
   `tests/hermes_cli/` as a whole cannot be collected on Windows
   (`test_doctor_journal_modes.py` calls `os.geteuid`), which is also pre-existing.

5. `ruff check hermes_cli/ tests/hermes_cli/test_update_launchd_restart_verification.py`
   passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate - **and my first pass missed two, corrected in the comments below**. #63304 and #72752 both verify the launchd relaunch inside `launchd_restart()` itself; I had searched for work on `update_cmd.py`'s restart phase and both are titled as gateway fixes. They are analysed in full in a comment, including the case where one of them is the better fix. #88703 is mine and adjacent - analysed above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits): one commit, four files
- [x] I've run `pytest tests/ -q` and all tests pass. See the baselined run in step 4; the full `tests/hermes_cli/` directory cannot be collected on Windows for a pre-existing reason noted there, so I ran every update and gateway file in it, both with and without the change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features). Step 3 is the mutation proof
- [x] I've tested on my platform: Windows 11 Pro 26200, Python 3.13. **I do not have macOS hardware**, so I have not reproduced the original failure end to end - stated plainly rather than implied by a checkbox. The behaviour is pinned by mocked-`launchctl` regressions instead, and a maintainer on macOS confirming step 1 would be worth more than anything I can run here

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings). Docstrings carry the reasoning: why the budget must clear the respawn throttle, why the detached fallback is exempt, and why the automatic retry was left out
- [x] N/A, no config keys added or changed. The verification budget is a module constant rather than a setting; if operators need to tune it, that is a follow-up with a config key and a doc entry, not a silent knob
- [x] N/A, no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility). The new code only runs under `is_macos()`. The recovery-text change is guarded by the same predicate, so Linux and Windows output is byte-identical, and there is a test pinning that. The tests spawn no processes and make no platform assumptions
- [x] N/A, no tool descriptions or schemas changed

## Screenshots / Logs

Sabotage proof, verification made unconditional and the rest of the PR in place:

```
>       assert restarted == []
E       AssertionError: assert ['ai.hermes.gateway'] == []
E         Left contains one more item: 'ai.hermes.gateway'

3 failed, 9 passed
```

Full PR applied:

```
tests/hermes_cli/test_update_launchd_restart_verification.py ............ [100%]
12 passed
```
