### PR TITLE
fix(aux): downgrade json_schema response_format to json_object for DeepSeek

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8560,6 +8560,19 @@ def _build_call_kwargs(
                 sticky_key = None
             if sticky_key:
                 merged_extra["session_id"] = sticky_key
+    # DeepSeek's OpenAI-compatible API only supports response_format
+    # {"type": "json_object"} — json_schema (used by aux tasks like title
+    # generation) is rejected with HTTP 400 "This response_format type is
+    # unavailable now". Downgrade so DeepSeek-based aux setups keep working
+    # without pinning a non-DeepSeek model for those tasks.
+    _rf = merged_extra.get("response_format") if isinstance(merged_extra, dict) else None
+    if isinstance(_rf, dict) and _rf.get("type") == "json_schema":
+        _provider_for_json = str(provider or "").strip().lower()
+        if (
+            _provider_for_json in {"deepseek", "deepseek-chat", "deepseek-reasoner"}
+            or base_url_host_matches(effective_base, "api.deepseek.com")
+        ):
+            merged_extra["response_format"] = {"type": "json_object"}
     if merged_extra:
         kwargs["extra_body"] = merged_extra
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2722,6 +2722,49 @@ class TestAnthropicAuxiliaryReasoningTranslation:
         assert "_reasoning_config" not in openai_wire_kwargs
 
 
+class TestDeepSeekJsonSchemaDowngrade:
+    """DeepSeek's API only supports response_format json_object.
+
+    Aux tasks that send json_schema (title generation) must be downgraded to
+    json_object for DeepSeek instead of 400ing with "This response_format
+    type is unavailable now".
+    """
+
+    @staticmethod
+    def _schema_extra_body():
+        return {"response_format": {"type": "json_schema", "json_schema": {"name": "t"}}}
+
+    def test_deepseek_provider_downgrades_to_json_object(self):
+        kwargs = _build_call_kwargs(
+            "deepseek",
+            "deepseek-v4-flash",
+            [{"role": "user", "content": "hi"}],
+            extra_body=self._schema_extra_body(),
+            base_url="https://api.deepseek.com/v1",
+        )
+        assert kwargs["extra_body"]["response_format"] == {"type": "json_object"}
+
+    def test_deepseek_base_url_downgrades_regardless_of_provider_name(self):
+        kwargs = _build_call_kwargs(
+            "custom",
+            "deepseek-v4-flash",
+            [{"role": "user", "content": "hi"}],
+            extra_body=self._schema_extra_body(),
+            base_url="https://api.deepseek.com/v1",
+        )
+        assert kwargs["extra_body"]["response_format"] == {"type": "json_object"}
+
+    def test_other_providers_keep_json_schema(self):
+        kwargs = _build_call_kwargs(
+            "openai",
+            "gpt-5",
+            [{"role": "user", "content": "hi"}],
+            extra_body=self._schema_extra_body(),
+            base_url="https://api.openai.com/v1",
+        )
+        assert kwargs["extra_body"]["response_format"]["type"] == "json_schema"
+
+
 class TestAuxiliaryProviderProfileReasoning:
     """Auxiliary calls must reuse provider-profile reasoning wire shapes."""
 


### PR DESCRIPTION
## Bug Description

Auxiliary title generation fails on DeepSeek with HTTP 400:

```
Auxiliary title generation failed: HTTP 400: This response_format type is unavailable now
```

Sessions get no model-generated title (only the instant derived title); the error is logged on every title attempt.

## Root Cause

`agent/title_generator.py` sends `response_format: {"type": "json_schema", ...}` via `extra_body` (line 412). The DeepSeek API (`api.deepseek.com`) only supports `response_format` of type `json_object` — `json_schema` is rejected with a hard 400 *"This response_format type is unavailable now"*. Reproduced directly against the API:

- `response_format: {"type": "json_schema", ...}` → 400 `This response_format type is unavailable now`
- `response_format: {"type": "json_object"}` → 200

`_build_call_kwargs` in `agent/auxiliary_client.py` passes the caller's `extra_body` through untouched, so the unsupported type reaches the wire for every DeepSeek-based aux setup (`auxiliary.*.provider: deepseek`, the default for title_generation).

## Fix

In `agent/auxiliary_client.py::_build_call_kwargs`, at the `extra_body` merge point, downgrade `response_format` from `json_schema` to `json_object` when the provider is DeepSeek (provider name `deepseek`/aliases, or base_url host `api.deepseek.com`). Other providers keep `json_schema` untouched.

The title extractor already tolerates `json_object` output (it parses the JSON object and falls back through a loose scan), so no title-quality regression on DeepSeek.

## How to Verify

1. Configure `auxiliary.title_generation.provider: deepseek` (default).
2. Start a session; send a message; observe the session title is generated (previously: `HTTP 400: This response_format type is unavailable now` in `agent.log`).

## Test Plan

- [x] Added regression tests: `tests/agent/test_auxiliary_client.py::TestDeepSeekJsonSchemaDowngrade` (provider-name downgrade, base_url downgrade, other providers unaffected)
- [x] Full `tests/agent/test_auxiliary_client.py` passes (185 tests)
- [x] Manual verification: real DeepSeek title-generation call returns a title (e.g. `分析磁盘流量日志目的IP和端口分布`)

## Risk Assessment

Low — the change only rewrites `response_format.type` from `json_schema` to `json_object` when the request targets DeepSeek (by provider name or `api.deepseek.com` host). OpenAI/Anthropic/OpenRouter/etc. requests are byte-identical to before. DeepSeek `json_object` still guarantees valid JSON output, which the title parser handles.
