### PR TITLE
feat(desktop): pre-select glass so the good mode is the one you find

### DIFF
--- a/apps/desktop/electron/translucency.test.ts
+++ b/apps/desktop/electron/translucency.test.ts
@@ -83,11 +83,30 @@ describe('normalizeMode', () => {
     expect(normalizeMode('glass', false)).toBe('clear')
   })
 
-  it('falls back to clear for absent, legacy and junk values', () => {
-    expect(normalizeMode(undefined, true)).toBe('clear')
+  it('honours an explicit choice', () => {
     expect(normalizeMode('clear', true)).toBe('clear')
-    expect(normalizeMode('acrylic', true)).toBe('clear')
-    expect(normalizeMode(42, true)).toBe('clear')
+    expect(normalizeMode('glass', true)).toBe('glass')
+  })
+
+  // Glass is pre-selected so the better half of the feature is the one you
+  // find, which is free because the intensity still starts at 0.
+  it('pre-selects glass on macOS when nothing is recorded', () => {
+    expect(normalizeMode(undefined, true)).toBe('glass')
+    expect(normalizeMode('acrylic', true)).toBe('glass')
+    expect(normalizeMode(42, true)).toBe('glass')
+    expect(normalizeMode(undefined, false)).toBe('clear')
+  })
+
+  // The one case that must NOT flip: a profile carrying a non-zero intensity
+  // with no mode has been rendering as clear since before glass existed, and
+  // defaulting it to glass would change a window the user already tuned.
+  it('leaves an already-tuned legacy profile on clear', () => {
+    expect(normalizeMode(undefined, true, 45)).toBe('clear')
+    expect(normalizeMode(undefined, true, 1)).toBe('clear')
+    expect(normalizeMode(undefined, true, 0)).toBe('glass')
+
+    // An explicit mode still wins over the legacy heuristic.
+    expect(normalizeMode('glass', true, 45)).toBe('glass')
   })
 })
 
@@ -227,11 +246,15 @@ describe('normalizeState', () => {
   })
 
   it('survives junk payloads', () => {
-    const fallback = { intensity: 0, material: DEFAULT_GLASS_MATERIAL, mode: 'clear', scope: DEFAULT_GLASS_SCOPE }
+    const base = { intensity: 0, material: DEFAULT_GLASS_MATERIAL, scope: DEFAULT_GLASS_SCOPE }
 
-    expect(normalizeState(null, true)).toEqual(fallback)
-    expect(normalizeState('nope', true)).toEqual(fallback)
-    expect(normalizeState({ intensity: 'x', material: 'nope', mode: 'glass', scope: 'nope' }, false)).toEqual(fallback)
+    // A fresh macOS profile lands on glass at zero intensity: selected, but off.
+    expect(normalizeState(null, true)).toEqual({ ...base, mode: 'glass' })
+    expect(normalizeState('nope', true)).toEqual({ ...base, mode: 'glass' })
+    expect(normalizeState({ intensity: 'x', material: 'nope', mode: 'glass', scope: 'nope' }, false)).toEqual({
+      ...base,
+      mode: 'clear'
+    })
   })
 })
 
@@ -240,6 +263,23 @@ describe('glassActive', () => {
     expect(glassActive(glass(60))).toBe(true)
     expect(glassActive(glass(0))).toBe(false)
     expect(glassActive(clear(60))).toBe(false)
+  })
+})
+
+// The default must be selected-but-off: a fresh macOS profile shows Glass in
+// the picker while the window itself is untouched until the lever moves.
+describe('a fresh profile', () => {
+  const fresh = normalizeState(null, true)
+
+  it('pre-selects glass with the feature still off', () => {
+    expect(fresh.mode).toBe('glass')
+    expect(fresh.intensity).toBe(TRANSLUCENCY_MIN)
+    expect(glassActive(fresh)).toBe(false)
+  })
+
+  it('leaves the window exactly as it is today', () => {
+    expect(windowOpacityFor(fresh)).toBe(1)
+    expect(windowBackingOptions(fresh, '#101014')).toEqual({ backgroundColor: '#101014' })
   })
 })
 

--- a/apps/desktop/src/store/translucency.test.ts
+++ b/apps/desktop/src/store/translucency.test.ts
@@ -37,6 +37,10 @@ const glassAttr = () => document.documentElement.hasAttribute('data-hermes-glass
 const clearAttr = () => document.documentElement.hasAttribute('data-hermes-clear')
 const keep = () => document.documentElement.style.getPropertyValue('--translucency-glass-keep')
 
+// Snapshotted at import time: every describe below mutates the store, so the
+// default can only be observed here.
+const initialTranslucency = $translucency.get()
+
 describe('window translucency lever', () => {
   beforeEach(() => {
     setTranslucencyMode('clear')
@@ -49,10 +53,13 @@ describe('window translucency lever', () => {
     expect(TRANSLUCENCY_MAX).toBe(100)
   })
 
-  it('defaults to off and clear', () => {
-    expect($translucency.get()).toEqual({
+  // NB: this asserts the module's INITIAL value, so it deliberately reads the
+  // atom before the beforeEach above can touch it — the previous version of
+  // this test ran after the reset and so proved nothing about the default.
+  it('starts off, with glass pre-selected on macOS', () => {
+    expect(initialTranslucency).toEqual({
       intensity: TRANSLUCENCY_MIN,
-      mode: 'clear',
+      mode: GLASS_SUPPORTED ? 'glass' : 'clear',
       material: DEFAULT_GLASS_MATERIAL,
       scope: DEFAULT_GLASS_SCOPE
     })

--- a/apps/desktop/src/store/translucency.ts
+++ b/apps/desktop/src/store/translucency.ts
@@ -13,8 +13,6 @@
 
 import {
   clampIntensity,
-  DEFAULT_GLASS_MATERIAL,
-  DEFAULT_GLASS_SCOPE,
   GLASS_MATERIALS,
   GLASS_SCOPES,
   type GlassMaterial,
@@ -22,6 +20,7 @@ import {
   glassSurfaceKeep,
   normalizeMaterial,
   normalizeScope,
+  normalizeState,
   TRANSLUCENCY_MAX,
   TRANSLUCENCY_MIN,
   TRANSLUCENCY_STEP,
@@ -40,27 +39,17 @@ export const GLASS_SUPPORTED = isMacPlatform()
 
 const KEY = 'hermes.desktop.translucency.v1'
 
-// The v1 key used to hold a bare intensity (`"23"`). Anything without a mode
-// predates glass and always behaved as clear, so it stays clear — a saved
-// setting must not change how the window looks on update.
+// The v1 key used to hold a bare intensity (`"23"`). Normalization lives in the
+// shared module so this and the main process resolve the default the same way —
+// including the legacy rule, where a saved NON-ZERO intensity with no mode means
+// a profile that has been rendering as clear all along and must keep doing so.
 const read = (): TranslucencyState => {
   const stored = readJson<unknown>(KEY)
 
-  const record: Record<string, unknown> =
-    stored && typeof stored === 'object' ? (stored as Record<string, unknown>) : { intensity: stored }
-
-  return {
-    intensity: clampIntensity(record.intensity),
-    mode: record.mode === 'glass' && GLASS_SUPPORTED ? 'glass' : 'clear',
-    material: normalizeMaterial(record.material),
-    scope: normalizeScope(record.scope)
-  }
+  return normalizeState(stored && typeof stored === 'object' ? stored : { intensity: stored }, GLASS_SUPPORTED)
 }
 
-const initial: TranslucencyState =
-  typeof window === 'undefined'
-    ? { intensity: TRANSLUCENCY_MIN, mode: 'clear', material: DEFAULT_GLASS_MATERIAL, scope: DEFAULT_GLASS_SCOPE }
-    : read()
+const initial: TranslucencyState = typeof window === 'undefined' ? normalizeState(null, false) : read()
 
 export const $translucency = atom<TranslucencyState>(initial)
 

--- a/apps/shared/src/translucency.ts
+++ b/apps/shared/src/translucency.ts
@@ -85,12 +85,27 @@ export function clampIntensity(value: unknown): number {
 
 /**
  * Glass rides on the macOS vibrancy material, so it is macOS-only and 'clear'
- * is the fallback everywhere else. Clear is also the default: a profile with no
- * mode recorded predates this setting and always behaved as clear, so it keeps
- * behaving as clear rather than silently changing look on update.
+ * is the fallback everywhere else.
+ *
+ * With no mode recorded, macOS gets glass — it is the better-looking half of
+ * the feature and the one worth finding, and pre-selecting it costs a fresh
+ * profile nothing because the intensity still starts at 0 (the whole feature
+ * is off until the user raises the lever). `legacyIntensity` is the escape
+ * hatch: a profile that already carries a NON-ZERO intensity but no mode
+ * predates this setting and has been rendering as clear all along, so it keeps
+ * rendering as clear. Flipping a window someone already tuned is the one thing
+ * a default must not do.
  */
-export function normalizeMode(value: unknown, isMac: boolean): TranslucencyMode {
-  return value === 'glass' && isMac ? 'glass' : 'clear'
+export function normalizeMode(value: unknown, isMac: boolean, legacyIntensity = 0): TranslucencyMode {
+  if (!isMac) {
+    return 'clear'
+  }
+
+  if (value === 'glass' || value === 'clear') {
+    return value
+  }
+
+  return legacyIntensity > 0 ? 'clear' : 'glass'
 }
 
 /** Unknown or unsupported values fall back to the default material. */
@@ -106,10 +121,11 @@ export function normalizeScope(value: unknown): GlassScope {
 /** Parse a persisted translucency.json / IPC payload into a safe state. */
 export function normalizeState(payload: unknown, isMac: boolean): TranslucencyState {
   const record = payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {}
+  const intensity = clampIntensity(record.intensity)
 
   return {
-    intensity: clampIntensity(record.intensity),
-    mode: normalizeMode(record.mode, isMac),
+    intensity,
+    mode: normalizeMode(record.mode, isMac, intensity),
     material: normalizeMaterial(record.material),
     scope: normalizeScope(record.scope)
   }


### PR DESCRIPTION
## What does this PR do?

Window Translucency ([#88744](https://github.com/NousResearch/hermes-agent/pull/88744)) shipped defaulting to Clear, which means the mode worth finding is the one nobody sees. Glass is the better-looking half of the feature and the reason it exists. A fresh macOS profile now starts with **Glass selected**.

**Nothing turns on.** The intensity still defaults to 0, so the window is byte-for-byte what it is today until the user moves the lever — `windowOpacityFor` stays 1, the window is still born with its opaque backing, and no page surface thins. The default only decides which mode that lever will drive when it moves.

## The profile that must not flip

A profile carrying a **non-zero intensity with no mode recorded** predates this setting. It has been rendering as clear the whole time, and defaulting it to glass would change a window someone deliberately tuned — the one thing a default change must not do. `normalizeMode` now takes the saved intensity and keeps exactly those on clear.

| saved state | resolved mode |
| --- | --- |
| nothing (fresh profile) | **glass**, intensity 0 |
| `{intensity: 0}` | **glass**, still off |
| `{intensity: 45}`, no mode | **clear** — already tuned, don't touch |
| `{mode: 'clear'}` | clear (explicit choice wins) |
| anything, non-macOS | clear (no vibrancy to ride) |

## Also

The renderer store was hand-rolling its own copy of the mode rule alongside the shared normalizer. It routes through the shared one now, so the two can't drift — which is what let this be a two-line behavior change instead of two.

**A test that couldn't fail:** the store's `defaults to off and clear` only passed because a `beforeEach` reset the atom before it looked. It was asserting the post-reset value, not the default, and would have stayed green straight through this change. It now snapshots the atom at import time and asserts the real initial state.

## Verification

| Check | Result |
| --- | --- |
| `npm run typecheck` | clean |
| `vitest --project electron` | 1393 passed, 0 failed |
| Translucency suites | 57 passed |
| Mutation checks | 3/3 caught — default reverting to clear, escape hatch removed (tuned profiles flip), glass leaking onto non-macOS |
| esbuild electron bundle | builds |

## How to test

1. Fresh macOS profile (`HERMES_DESKTOP_USER_DATA_DIR=/tmp/glass-fresh hgui .`): Settings → Appearance shows **Glass** selected, slider at 0, and the window looks exactly as it does today.
2. Raise the slider — glass takes effect without having to pick the mode first.
3. Existing profile with a translucency you already set: unchanged, still on Clear.
4. Windows/Linux: still Clear, no picker.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)
