### PR TITLE
fix(tui): preserve Ctrl+J newline across extended keys and tmux

### DIFF
--- a/ui-tui/src/__tests__/textInputReturnAction.test.ts
+++ b/ui-tui/src/__tests__/textInputReturnAction.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { INITIAL_STATE, parseMultipleKeypresses } from '../../packages/hermes-ink/src/ink/parse-keypress.js'
+
 const originalPlatform = process.platform
 
 async function importTextInput(platform: NodeJS.Platform) {
@@ -18,10 +20,21 @@ const key = (overrides: Record<string, unknown> = {}) =>
   ({ ctrl: false, meta: false, return: true, shift: false, super: false, ...overrides }) as any
 
 describe('isCtrlJNewline', () => {
-  it('recognizes the normalized Ctrl+J event emitted by extended-key protocols', async () => {
+  it.each([
+    ['Kitty CSI-u', '\x1b[106;5u'],
+    ['modifyOtherKeys', '\x1b[27;5;106~']
+  ])('recognizes Ctrl+J parsed from %s', async (_label, sequence) => {
     const { isCtrlJNewline } = await importTextInput('linux')
+    const [[parsed]] = parseMultipleKeypresses(INITIAL_STATE, sequence)
 
-    expect(isCtrlJNewline('j', key({ ctrl: true, return: false }))).toBe(true)
+    expect(parsed).toMatchObject({ ctrl: true, name: 'j' })
+    expect(parsed.kind).toBe('key')
+
+    if (parsed.kind !== 'key') {
+      throw new Error('expected a parsed key event')
+    }
+
+    expect(isCtrlJNewline(parsed.name ?? '', parsed)).toBe(true)
   })
 
   it('does not consume plain J or chords with additional modifiers', async () => {
@@ -106,6 +119,19 @@ describe('shouldInsertNewlineOnReturn', () => {
 
   it('accepts a bare LF as a multiline fallback under tmux on non-macOS', async () => {
     const prev = { ...process.env }
+
+    for (const k of [
+      'SSH_CONNECTION',
+      'SSH_CLIENT',
+      'SSH_TTY',
+      'WT_SESSION',
+      'GHOSTTY_RESOURCES_DIR',
+      'GHOSTTY_BIN_DIR',
+      'WSL_DISTRO_NAME'
+    ]) {
+      delete process.env[k]
+    }
+
     process.env.TMUX = '/tmp/tmux-1000/default,1234,0'
 
     try {

--- a/ui-tui/src/__tests__/textInputReturnAction.test.ts
+++ b/ui-tui/src/__tests__/textInputReturnAction.test.ts
@@ -17,6 +17,22 @@ afterEach(() => {
 const key = (overrides: Record<string, unknown> = {}) =>
   ({ ctrl: false, meta: false, return: true, shift: false, super: false, ...overrides }) as any
 
+describe('isCtrlJNewline', () => {
+  it('recognizes the normalized Ctrl+J event emitted by extended-key protocols', async () => {
+    const { isCtrlJNewline } = await importTextInput('linux')
+
+    expect(isCtrlJNewline('j', key({ ctrl: true, return: false }))).toBe(true)
+  })
+
+  it('does not consume plain J or chords with additional modifiers', async () => {
+    const { isCtrlJNewline } = await importTextInput('linux')
+
+    expect(isCtrlJNewline('j', key({ return: false }))).toBe(false)
+    expect(isCtrlJNewline('j', key({ ctrl: true, meta: true, return: false }))).toBe(false)
+    expect(isCtrlJNewline('j', key({ ctrl: true, return: false, shift: true }))).toBe(false)
+  })
+})
+
 describe('shouldInsertNewlineOnReturn', () => {
   it('keeps plain Enter (CR) as submit on macOS', async () => {
     const { shouldInsertNewlineOnReturn } = await importTextInput('darwin')

--- a/ui-tui/src/__tests__/textInputReturnAction.test.ts
+++ b/ui-tui/src/__tests__/textInputReturnAction.test.ts
@@ -70,6 +70,7 @@ describe('shouldInsertNewlineOnReturn', () => {
       'SSH_CLIENT',
       'SSH_TTY',
       'WT_SESSION',
+      'TMUX',
       'GHOSTTY_RESOURCES_DIR',
       'GHOSTTY_BIN_DIR',
       'WSL_DISTRO_NAME'
@@ -98,6 +99,20 @@ describe('shouldInsertNewlineOnReturn', () => {
       const { shouldInsertNewlineOnReturn } = await importTextInput('linux')
 
       expect(shouldInsertNewlineOnReturn(key(), '\n')).toBe(true)
+    } finally {
+      process.env = prev
+    }
+  })
+
+  it('accepts a bare LF as a multiline fallback under tmux on non-macOS', async () => {
+    const prev = { ...process.env }
+    process.env.TMUX = '/tmp/tmux-1000/default,1234,0'
+
+    try {
+      const { shouldInsertNewlineOnReturn } = await importTextInput('linux')
+
+      expect(shouldInsertNewlineOnReturn(key(), '\n')).toBe(true)
+      expect(shouldInsertNewlineOnReturn(key(), '\r')).toBe(false)
     } finally {
       process.env = prev
     }

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -206,6 +206,10 @@ export async function cutSelection(
 }
 
 export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boolean {
+  if (env.TMUX) {
+    return true
+  }
+
   if (env.WT_SESSION) {
     return true
   }
@@ -250,8 +254,8 @@ export function isCtrlJNewline(input: string, key: ReturnDecisionKey): boolean {
  * submitting. An explicit modified Enter (Shift/Ctrl, or the platform action
  * modifier) always inserts a newline. Beyond that, terminals that can't send a
  * distinct Shift+Enter collapse a modified Enter / Ctrl+J down to a bare LF —
- * shouldPreserveCtrlJNewline() detects that via env (SSH, Windows Terminal,
- * Ghostty, WSL), and macOS terminals (Terminal.app, iTerm2 defaults) do it too
+ * shouldPreserveCtrlJNewline() detects that via env (tmux, SSH, Windows
+ * Terminal, Ghostty, WSL), and macOS terminals (Terminal.app, iTerm2 defaults) do it too
  * but aren't env-detectable, so a bare LF is treated as a newline there as well.
  * Plain Enter (CR) stays submit everywhere.
  */

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -230,11 +230,19 @@ export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boole
 }
 
 type ReturnDecisionKey = {
+  alt?: boolean
   ctrl: boolean
   meta: boolean
   return?: boolean
   shift?: boolean
   super?: boolean
+}
+
+/** Extended-key protocols report Ctrl+J as a modified printable key instead
+ * of the legacy LF byte. Keep the documented Ctrl+J newline binding without
+ * consuming Ctrl+Shift+J or other modified chords. */
+export function isCtrlJNewline(input: string, key: ReturnDecisionKey): boolean {
+  return input.toLowerCase() === 'j' && key.ctrl && !key.alt && !key.meta && !key.shift && !key.super
 }
 
 /**
@@ -1304,6 +1312,13 @@ export function TextInput({
 
           return
         }
+
+        return
+      }
+
+      if (isCtrlJNewline(inp, k)) {
+        flushKeyBurst()
+        pastePlainText('\n')
 
         return
       }


### PR DESCRIPTION
## Summary

- treat normalized `Ctrl+J` events from Kitty CSI-u / modifyOtherKeys as a composer newline
- preserve bare LF as `Ctrl+J` under tmux when extended keys are disabled
- keep plain Return (`CR`) as submit and leave extra-modifier chords untouched

## Root cause

Extended-key protocols report `Ctrl+J` as `input = "j"` with `ctrl = true`, not as a Return/LF event. The composer had no binding for that normalized form, so it inserted a literal `j`.

With tmux `extended-keys=off`, `Ctrl+J` instead collapses to bare LF. `shouldPreserveCtrlJNewline()` did not recognize tmux, so that LF followed the submit path.

This is separate from #51546, which only adds VTE detection for bare LF, and from the classic CLI fixes in #32860 / #75473.

## Behavior

- Kitty CSI-u / modifyOtherKeys `Ctrl+J`: insert newline
- tmux bare LF `Ctrl+J`: insert newline
- plain Return (`CR`): submit
- `Ctrl+Shift+J` and other extra-modifier chords: unchanged

## Testing

- `npm test --workspace ui-tui -- --run src/__tests__/textInputReturnAction.test.ts src/__tests__/textInputPassThrough.test.ts` (16 passed, including parsed CSI-u and modifyOtherKeys wire forms)
- `npm run typecheck --workspace ui-tui`
- `npm run lint --workspace ui-tui` (0 errors; 2 pre-existing warnings)
- `npx prettier --check ui-tui/src/components/textInput.tsx ui-tui/src/__tests__/textInputReturnAction.test.ts`
- `npm run build --workspace ui-tui`
- `git diff --check upstream/main...HEAD`

## Dogfood

Verified on Alacritty 0.16.1 both directly and under tmux 3.7b (`extended-keys=off`): `Ctrl+J` inserts a newline, `Shift+Return` inserts a newline, and normal Return still submits.
