### PR TITLE
fix(tui): enable extended keys in Alacritty

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from 'vitest'
 
-import { isSynchronizedOutputSupported, needsAltScreenResizeScrollbackClear, writeDiffToTerminal } from './terminal.js'
+import {
+  isSynchronizedOutputSupported,
+  needsAltScreenResizeScrollbackClear,
+  supportsExtendedKeys,
+  writeDiffToTerminal
+} from './terminal.js'
 import { BSU, ESU } from './termio/dec.js'
+
+describe('extended key reporting', () => {
+  it('supports Alacritty while remaining conservative for unknown terminals', () => {
+    expect(supportsExtendedKeys('alacritty')).toBe(true)
+    expect(supportsExtendedKeys('unknown-terminal')).toBe(false)
+  })
+})
 
 describe('terminal resize quirks', () => {
   it('uses a deeper alt-screen resize clear for Apple Terminal', () => {

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.ts
@@ -318,12 +318,21 @@ export function parseOscColor(data: string): string | undefined {
 // in xterm.js-based terminals like VS Code). tmux is allowlisted because it
 // accepts modifyOtherKeys and doesn't forward the kitty sequence to the outer
 // terminal.
-const EXTENDED_KEYS_TERMINALS = ['iTerm.app', 'kitty', 'WezTerm', 'ghostty', 'tmux', 'windows-terminal', 'vscode']
+const EXTENDED_KEYS_TERMINALS = [
+  'iTerm.app',
+  'kitty',
+  'WezTerm',
+  'alacritty',
+  'ghostty',
+  'tmux',
+  'windows-terminal',
+  'vscode'
+]
 
 /** True if this terminal correctly handles extended key reporting
  *  (Kitty keyboard protocol + xterm modifyOtherKeys). */
-export function supportsExtendedKeys(): boolean {
-  return EXTENDED_KEYS_TERMINALS.includes(env.terminal ?? '')
+export function supportsExtendedKeys(terminal: string | null = env.terminal): boolean {
+  return EXTENDED_KEYS_TERMINALS.includes(terminal ?? '')
 }
 
 /** True if the terminal scrolls the viewport when it receives cursor-up


### PR DESCRIPTION
## Summary

- recognize Alacritty as an extended-key-capable terminal in the Ink TUI
- request Kitty keyboard protocol / modifyOtherKeys reporting there
- cover Alacritty capability detection while keeping unknown terminals disabled

Depends on #88957. Enabling extended keys makes Alacritty report `Ctrl+J` as a normalized modified key; #88957 preserves its documented newline behavior.

## Root cause

Alacritty 0.16 implements the Kitty keyboard protocol, but Hermes omitted it from `EXTENDED_KEYS_TERMINALS`. As a result, Hermes did not request distinct modified-key reporting, and `Shift+Return` could collapse to ordinary Return.

No existing open PR adds Alacritty to the Ink TUI extended-key allowlist. Related CLI protocol work such as #87630 changes the classic Python CLI, not `@hermes/ink`.

## Behavior

Alacritty now receives the same extended-key activation as Kitty, WezTerm, Ghostty, and the other existing allowlisted terminals. Unknown terminals remain opt-out.

This should land after #88957: enabling extended keys causes Alacritty to report `Ctrl+J` as a normalized modified key, which that PR maps to the documented newline behavior.

## Testing

- `npm test --workspace ui-tui -- --run packages/hermes-ink/src/ink/terminal.test.ts` (9 passed)
- `npm run typecheck --workspace ui-tui`
- `npm run lint --workspace ui-tui` (0 errors; 2 pre-existing warnings)
- `npx prettier --check ui-tui/packages/hermes-ink/src/ink/terminal.ts ui-tui/packages/hermes-ink/src/ink/terminal.test.ts`
- `npm run build --workspace ui-tui`
- `git diff --check upstream/main...HEAD`

## Dogfood

Verified on Alacritty 0.16.1: after extended-key activation, `Shift+Return` is distinguishable and inserts a newline. With the companion Ctrl+J patch applied, `Ctrl+J` also inserts a newline and normal Return still submits.
