### PR TITLE
fix(agent): recover from image-dominated 413 payloads

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -58,7 +58,23 @@ from agent.message_sanitization import (
     _sanitize_tools_non_ascii,
     _strip_images_from_messages,
     _strip_non_ascii,
+    strip_oversized_image_parts,
 )
+
+# 413 image-payload recovery thresholds.
+#
+# A 413 is a byte-size error, but the context estimator prices images at a
+# flat per-image token cost (see estimate_messages_tokens_rough) so that a
+# screenshot doesn't trigger premature compaction.  That leaves text
+# compression structurally unable to clear an image-dominated 413, so the
+# recovery path measures actual payload bytes instead.
+#
+# 256KB: comfortably above a normal screenshot's base64 size, low enough that
+# a couple of full-resolution captures are caught before they dominate a
+# request.  Recent messages are protected so an image the user just attached
+# isn't removed out from under the current turn.
+_MAX_INLINE_IMAGE_BYTES_ON_413 = 256 * 1024
+_PROTECT_RECENT_IMAGES_ON_413 = 4
 # Must mirror _STALE_TOOL_CALL_MARKER_RE in hermes_state.py — kept local
 # to avoid importing hermes_state at module load time (its module-level
 # DEFAULT_DB_PATH = get_hermes_home() / "state.db" breaks tests that
@@ -5479,6 +5495,52 @@ def run_conversation(
                         _retry.restart_with_compressed_messages = True
                         break
                     else:
+                        # Compression scored "no progress".  Before declaring
+                        # the turn dead, check whether the payload is actually
+                        # dominated by inline base64 images rather than text.
+                        #
+                        # A 413 is a BYTE-size error, but the estimator above
+                        # prices each image at a flat per-image token cost so
+                        # screenshots don't trigger premature compaction.  That
+                        # makes text compression structurally incapable of
+                        # clearing an image-heavy 413: two ~3MB screenshots can
+                        # be >95% of the request while contributing ~3K to the
+                        # estimate, so every attempt reports "no progress" and
+                        # the session wedges permanently — /compress and /retry
+                        # can't help either, because the images are re-sent from
+                        # stored history every turn.
+                        #
+                        # Strip oversized image parts from ``messages`` (the
+                        # persisted history), not just ``api_messages``, so the
+                        # reduction survives into subsequent turns.  Recent
+                        # messages are protected so an image the user just
+                        # attached isn't removed out from under this turn.
+                        _stripped, _reclaimed = strip_oversized_image_parts(
+                            messages,
+                            max_image_bytes=_MAX_INLINE_IMAGE_BYTES_ON_413,
+                            protect_last_n=_PROTECT_RECENT_IMAGES_ON_413,
+                        )
+                        if _stripped:
+                            agent._buffer_status(
+                                f"🖼️  Request payload is image-dominated — removed "
+                                f"{_reclaimed // 1024}KB of oversized inline images "
+                                f"from history and retrying..."
+                            )
+                            logger.warning(
+                                "%s413 recovery: stripped %d bytes of oversized inline "
+                                "image payloads from history (text compression reported "
+                                "no progress because images are excluded from the token "
+                                "estimate).",
+                                agent.log_prefix,
+                                _reclaimed,
+                            )
+                            conversation_history = conversation_history_after_compression(
+                                agent, messages, conversation_history
+                            )
+                            agent._persist_session(messages, conversation_history)
+                            _retry.restart_with_compressed_messages = True
+                            break
+
                         if agent._try_strip_image_parts_from_tool_messages(
                             api_messages,
                             remember_model=False,

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -400,6 +400,102 @@ def _sanitize_tools_non_ascii(tools: list) -> bool:
     return _sanitize_structure_non_ascii(tools)
 
 
+def _image_part_payload_bytes(part: Any) -> int:
+    """Serialized byte cost of a single image content part.
+
+    Inline ``data:`` URLs carry the entire base64 image in the request body,
+    so their real wire cost is the URL length — not the flat per-image token
+    estimate used for context budgeting.  Remote (http/https) image URLs cost
+    only their reference length.
+    """
+    if not isinstance(part, dict):
+        return 0
+    if part.get("type") not in {"image_url", "image", "input_image"}:
+        return 0
+    url = part.get("image_url")
+    if isinstance(url, dict):
+        url = url.get("url")
+    if not isinstance(url, str):
+        url = part.get("data") if isinstance(part.get("data"), str) else ""
+    return len(url or "")
+
+
+def strip_oversized_image_parts(
+    messages: list,
+    *,
+    max_image_bytes: int,
+    protect_last_n: int = 0,
+) -> "tuple[bool, int]":
+    """Drop inline image parts whose payload exceeds ``max_image_bytes``.
+
+    Recovery path for HTTP 413 (payload too large).  A 413 is a *byte*-size
+    error, but Hermes' context estimator deliberately prices an image at a
+    flat per-image token cost so that a screenshot does not trigger premature
+    compaction (see ``estimate_messages_tokens_rough``).  That makes text
+    compression structurally unable to fix a 413 whose payload is dominated by
+    base64 images: summarizing every text turn cannot move an estimate that
+    never counted the megabytes in the first place, so compression reports
+    "no progress" and the turn dies permanently.
+
+    This walks history and removes only the oversized *image* parts, leaving
+    all text intact.  Alternation invariants are preserved exactly as in
+    ``_strip_images_from_messages``: a ``tool``-role message stripped to
+    nothing becomes a plaintext placeholder rather than being deleted, so the
+    paired ``tool_call_id`` on the prior assistant message stays matched.
+
+    ``protect_last_n`` shields the most recent N messages, so an image the
+    user just attached is not silently removed out from under the current
+    turn; recovery reaches for older history first.
+
+    Returns ``(changed, bytes_reclaimed)``.
+    """
+    if not isinstance(messages, list) or max_image_bytes <= 0:
+        return False, 0
+
+    cutoff = len(messages) - protect_last_n if protect_last_n > 0 else len(messages)
+    changed = False
+    reclaimed = 0
+    to_delete = []
+
+    for i, msg in enumerate(messages):
+        if i >= cutoff:
+            break
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+
+        new_parts = []
+        for part in content:
+            size = _image_part_payload_bytes(part)
+            if size > max_image_bytes:
+                reclaimed += size
+                changed = True
+            else:
+                new_parts.append(part)
+
+        if len(new_parts) == len(content):
+            continue
+
+        if new_parts:
+            msg["content"] = new_parts
+        elif msg.get("role") == "tool":
+            # Preserve tool_call_id linkage — providers require every
+            # assistant tool_call to have a matching tool response.
+            msg["content"] = (
+                "[image content removed — payload exceeded the provider's "
+                "request size limit]"
+            )
+        else:
+            to_delete.append(i)
+
+    for i in reversed(to_delete):
+        del messages[i]
+
+    return changed, reclaimed
+
+
 def _strip_images_from_messages(messages: list) -> bool:
     """Remove image_url content parts from all messages in-place.
 

--- a/tests/agent/test_413_image_payload_recovery.py
+++ b/tests/agent/test_413_image_payload_recovery.py
@@ -1,0 +1,175 @@
+"""Regression tests: HTTP 413 recovery when the payload is image-dominated.
+
+Bug: a 413 is a *byte*-size error, but ``estimate_messages_tokens_rough``
+prices every image at a flat per-image token cost so that screenshots don't
+trigger premature compaction.  That makes text compression structurally
+unable to clear an image-dominated 413 — two ~3MB base64 screenshots can be
+>95% of the request body while contributing only ~3K to the token estimate,
+so every compression attempt reports "no progress", the attempt budget is
+burned, and the session wedges permanently (images are re-sent from stored
+history on every subsequent turn, so /compress and /retry can't help either).
+
+These tests assert the invariant that actually matters: recovery must be
+driven by measured payload BYTES, not by the token estimate.
+"""
+
+import pytest
+
+from agent.message_sanitization import (
+    _image_part_payload_bytes,
+    strip_oversized_image_parts,
+)
+from agent.model_metadata import estimate_messages_tokens_rough
+
+
+def _data_url_image(size_bytes: int) -> dict:
+    """An image part whose inline data URL is ~``size_bytes`` long."""
+    return {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64," + ("A" * size_bytes)},
+    }
+
+
+def _tool_msg_with_image(size_bytes: int, text: str = "screenshot captured") -> dict:
+    return {
+        "role": "tool",
+        "tool_call_id": "call_abc123",
+        "content": [
+            {"type": "text", "text": text},
+            _data_url_image(size_bytes),
+        ],
+    }
+
+
+class TestImagePartPayloadBytes:
+    def test_measures_inline_data_url_length(self):
+        part = _data_url_image(1000)
+        assert _image_part_payload_bytes(part) >= 1000
+
+    def test_remote_url_costs_only_its_reference(self):
+        part = {"type": "image_url", "image_url": {"url": "https://x.test/a.png"}}
+        assert _image_part_payload_bytes(part) < 100
+
+    def test_non_image_parts_cost_nothing(self):
+        assert _image_part_payload_bytes({"type": "text", "text": "x" * 5000}) == 0
+        assert _image_part_payload_bytes("not-a-dict") == 0
+        assert _image_part_payload_bytes({"type": "image_url"}) == 0
+
+
+class TestTokenEstimateIsBlindToImageBytes:
+    """The root cause, asserted directly.
+
+    This is why compression can never clear an image-dominated 413: the
+    estimate barely moves regardless of how many megabytes are on the wire.
+    """
+
+    def test_estimate_barely_moves_as_image_bytes_explode(self):
+        small = [_tool_msg_with_image(1_000)]
+        huge = [_tool_msg_with_image(3_000_000)]
+
+        small_tokens = estimate_messages_tokens_rough(small)
+        huge_tokens = estimate_messages_tokens_rough(huge)
+
+        # ~3000x more bytes on the wire...
+        assert len(huge[0]["content"][1]["image_url"]["url"]) > 2_000_000
+
+        # ...but the token estimate is essentially unchanged, so the
+        # "did compression make progress?" test (new < original * 0.95)
+        # can never be satisfied by summarizing text.
+        assert huge_tokens < small_tokens * 2
+
+
+class TestStripOversizedImageParts:
+    def test_strips_image_exceeding_the_byte_budget(self):
+        messages = [_tool_msg_with_image(3_000_000)]
+        changed, reclaimed = strip_oversized_image_parts(
+            messages, max_image_bytes=256 * 1024
+        )
+        assert changed is True
+        assert reclaimed > 2_000_000
+
+    def test_preserves_small_images(self):
+        messages = [_tool_msg_with_image(1_000)]
+        changed, reclaimed = strip_oversized_image_parts(
+            messages, max_image_bytes=256 * 1024
+        )
+        assert changed is False
+        assert reclaimed == 0
+        assert any(
+            p.get("type") == "image_url" for p in messages[0]["content"]
+        ), "small image must survive"
+
+    def test_preserves_text_alongside_a_stripped_image(self):
+        messages = [_tool_msg_with_image(3_000_000, text="the important finding")]
+        strip_oversized_image_parts(messages, max_image_bytes=256 * 1024)
+        remaining = messages[0]["content"]
+        assert any(
+            isinstance(p, dict) and p.get("text") == "the important finding"
+            for p in remaining
+        ), "text must survive image stripping"
+
+    def test_tool_message_stripped_to_nothing_keeps_its_slot(self):
+        """Deleting it would orphan the assistant's tool_call_id -> HTTP 400."""
+        messages = [
+            {
+                "role": "tool",
+                "tool_call_id": "call_xyz",
+                "content": [_data_url_image(3_000_000)],
+            }
+        ]
+        changed, _ = strip_oversized_image_parts(
+            messages, max_image_bytes=256 * 1024
+        )
+        assert changed is True
+        assert len(messages) == 1, "tool message must not be deleted"
+        assert messages[0]["tool_call_id"] == "call_xyz"
+        assert isinstance(messages[0]["content"], str)
+
+    def test_protect_last_n_shields_the_current_turn(self):
+        """An image the user just attached must not vanish mid-turn."""
+        messages = [
+            _tool_msg_with_image(3_000_000, text="old"),
+            _tool_msg_with_image(3_000_000, text="recent"),
+        ]
+        changed, _ = strip_oversized_image_parts(
+            messages, max_image_bytes=256 * 1024, protect_last_n=1
+        )
+        assert changed is True
+        # Older one stripped, most recent preserved.
+        assert isinstance(messages[0]["content"], list)
+        assert not any(
+            p.get("type") == "image_url" for p in messages[0]["content"]
+        )
+        assert any(
+            p.get("type") == "image_url" for p in messages[1]["content"]
+        ), "protected recent image must survive"
+
+    def test_reclaims_enough_to_clear_a_realistic_413(self):
+        """End-to-end sizing: the real-world shape that wedged a session."""
+        messages = [{"role": "user", "content": "text turn"} for _ in range(190)]
+        messages.insert(50, _tool_msg_with_image(2_756_000))
+        messages.insert(80, _tool_msg_with_image(2_871_000))
+
+        before = sum(
+            _image_part_payload_bytes(p)
+            for m in messages
+            if isinstance(m.get("content"), list)
+            for p in m["content"]
+        )
+        assert before > 5_000_000
+
+        changed, reclaimed = strip_oversized_image_parts(
+            messages, max_image_bytes=256 * 1024, protect_last_n=4
+        )
+        assert changed is True
+        assert reclaimed > 5_000_000
+
+    def test_no_op_on_degenerate_input(self):
+        assert strip_oversized_image_parts([], max_image_bytes=1024) == (False, 0)
+        assert strip_oversized_image_parts(
+            [_tool_msg_with_image(3_000_000)], max_image_bytes=0
+        ) == (False, 0)
+        assert strip_oversized_image_parts(
+            "not-a-list",  # type: ignore[arg-type]
+            max_image_bytes=1024,
+        ) == (False, 0)


### PR DESCRIPTION
## What does this PR do?

A session with plenty of context left dies permanently on `413`:

```
Request payload too large: max compression attempts (3) reached.
```

Status bar at the time: `122k/936k │ 13%`. Once hit, the session is unrecoverable — `/compress` and `/retry` both fail the same way, because the oversized content is re-sent from stored history on every subsequent turn.

**Root cause.** A `413` is a **byte**-size error, but the recovery path decides whether it made progress using the **token estimate**, which is deliberately blind to image bytes.

`agent/model_metadata.py`:

```python
_IMAGE_TOKEN_COST = 1500   # flat, per image
```

That flat cost is correct and intentional for context budgeting — without it a 1MB screenshot would estimate at ~250K tokens and trigger premature compaction. But `agent/conversation_loop.py` reuses that same estimate to score 413 recovery:

```python
new_tokens = estimate_messages_tokens_rough(messages)
if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95):
    # retry with compressed messages
else:
    # -> "cannot compress further", turn is dead
```

When the payload is image-dominated, that test can never be satisfied. Real numbers from an affected session:

| | bytes | contribution to estimate |
|---|---|---|
| 2 × `vision_analyze` results | 5,627,202 | ~3,000 tokens |
| all 193 other messages | ~193,000 | ~77,000 tokens |

The images are **96.6% of the request body** and **~3.7% of the token estimate**. Compression can summarize away every text turn and still not move the estimate by 5%, so it reports `no_progress`, burns all three attempts, and gives up. Telemetry from the failing session:

```json
{"failure_class":"no_progress","commit_status":"aborted",
 "current_estimated_tokens":80453,"effective_threshold":234000,
 "main_context_limit":936000}
```

Note `80453 < 234000` — compression doesn't even believe it should be running.

There is an existing image-strip fallback in the `else` branch, but it doesn't resolve this for two reasons:
1. it only mutates `api_messages` (the transient per-call copy), so the megabytes return from stored history on the very next turn
2. it's reached only *after* the attempt budget is spent

**Why this approach.** The fix measures the thing the provider is actually rejecting (bytes) rather than a proxy that is designed to ignore it, and it mutates `messages` so the reduction survives into the next turn. It is additive and scoped to the no-progress branch, so every non-image-dominated 413 keeps its current behavior exactly.

## Related Issue

This PR was opened before I searched the tracker properly — that was my mistake, and the search turns up substantial prior art. Recording it honestly rather than quietly claiming the ground:

- **#47339** (closed) — the original report of this exact symptom on Copilot: 413 at ~44k tokens, "cannot compress further", `browser_vision` screenshots. Same bug class.
- **#89286** (open) — same branch in `conversation_loop.py`, proposes **reordering** it so the image strip runs *before* text compression rather than after the budget is spent.
- **#89938** (open) — the upstream cause: `_strip_historical_media` misses tool-result images and first-message images, so base64 accumulates in `messages` and re-ships every turn.
- **#89296** (open) — the proactive complement: evict stale vision payloads on the outbound path so the oversized body is never serialized at all.

Fixes #47339

**Overlapping open PRs** (maintainers: this needs a consolidation decision, not four parallel merges):

- **#52444** (@Caoxuyang, 2026-06-25, +186/-1) — predates this PR by two months and edits the same branch, but with a **different mechanism: it shrinks, this one strips.** #52444 re-encodes every embedded image progressively smaller via Pillow (≤512KB, then ≤256KB) so the images survive at lower fidelity; this PR removes oversized image parts entirely and leaves a placeholder. Two substantive differences beyond that: (a) #52444 mutates `api_messages` only, so the full-size base64 remains in stored history and the next turn rebuilds an oversized body — recovering the turn but paying a 413 round-trip plus a re-encode pass on every subsequent turn, whereas this PR mutates `messages` so the reduction persists; (b) #52444 leaves the `new_tokens < original_tokens * 0.95` progress check unfixed and instead tries never to reach it, so if the shrink no-ops (both passes spent, Pillow unavailable, or images already small) it still falls through to the same false-negative that bricks the session. **These are complementary, not competing** — shrink first to preserve fidelity, strip as the correctness floor when shrinking can't get under the limit. Where a screenshot is still decision-relevant, #52444's behavior is clearly better than mine.
- **#89776** (@AP3X-Dev, +147/-20) — implements the #89286 reordering.
- **#89965** (@Kewe63, +390/-0) — implements the #89296 per-request eviction.

These are not all mutually exclusive, and none of them is a strict duplicate of another. #89965 is proactive (don't send it), #89776 is ordering (try the cheap fix first), #52444 is fidelity-preserving reduction (shrink the images), and this PR is the correctness floor (make the progress check measure bytes so recovery can't false-negative even when the others no-op). But all four touch the `is_payload_too_large` branch in `conversation_loop.py` and will conflict textually, so this wants a consolidation decision rather than four independent merges. **The coherent stack, in my view, is #89965 → #52444 → this PR** (avoid the oversized body; if it happens, shrink; if shrinking can't get under the limit, strip and make the progress check honest). I'm happy to rebase this into a narrower change on top of whichever lands first, or to close it if a maintainer would rather fold `strip_oversized_image_parts()` into one of the others — the byte-measurement tests are useful under any ordering. Say the word and I'll do the work.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/message_sanitization.py` — new `strip_oversized_image_parts()`. Measures actual payload bytes of inline `data:` URLs and removes only image parts above the byte budget.
  - **Preserves alternation invariants**: a `tool`-role message stripped to nothing becomes a plaintext placeholder rather than being deleted, keeping the paired `tool_call_id` on the prior assistant message matched. Deleting it would produce a `400`. Same contract as the neighbouring `_strip_images_from_messages`.
  - **`protect_last_n=4`** — an image the user just attached isn't removed out from under the current turn; recovery reaches for older history first.
  - **Text is never touched** — only oversized image parts are removed, so the model keeps the surrounding reasoning.
  - **Threshold 256KB** — above a normal screenshot's base64 size, low enough to catch full-resolution captures before they dominate a request.
- `agent/conversation_loop.py` — call it in the 413 no-progress branch before declaring the turn dead, mutating `messages` (not just `api_messages`) so the reduction persists across turns.
- `tests/agent/test_413_image_payload_recovery.py` — 11 tests, new file.

Behavior is unchanged for every non-image-dominated 413: if nothing exceeds the byte budget, the function reports no change and the existing fallback and terminal error fire exactly as before.

## How to Test

Reproduction:

1. Start a session with a vision-capable model on a provider that enforces a request body limit (reproduced on `copilot`).
2. Call `vision_analyze` on two full-resolution screenshots (~2MB PNGs, ~2.7MB each as base64).
3. Continue the conversation for a few turns.
4. **Before this PR:** the turn dies with `Request payload too large: max compression attempts (3) reached` while the status bar still reads ~13% context, and `/compress` and `/retry` both re-fail because history re-ships the base64.
5. **After this PR:** the no-progress branch strips the oversized image parts from `messages`, the retry succeeds, and the session continues with its text intact.

Automated:

```bash
PYTHONPATH="$PWD:$PWD/venv/lib/python3.11/site-packages" \
  pytest tests/agent/test_413_image_payload_recovery.py -q
# 11 passed
```

The tests assert invariants rather than snapshots:

- `TestTokenEstimateIsBlindToImageBytes` pins the root cause directly: a ~3000x increase in image bytes leaves the token estimate essentially unchanged, which is *why* text compression can't clear this class of 413.
- Alternation safety: a tool message stripped to nothing keeps its slot and `tool_call_id`.
- `protect_last_n` shields the current turn.
- Text survives image stripping.
- Realistic end-to-end sizing based on the session that produced this report (>5MB reclaimed).
- Degenerate inputs (empty list, zero budget, non-list) are no-ops.

**Verified these tests actually fail without the fix** — sabotage run with the byte-measurement neutered gave 5 failed / 6 passed — rather than trusting a green run on code I just wrote.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — **done late; it surfaced three overlapping PRs, analyzed in Related Issue above. Not a duplicate of any of them, but it does need a consolidation decision.**
- [x] My PR contains **only** changes related to this fix (3 files, +333/-0, no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **partial, see note below**
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), Python 3.13.5

**Note on the full suite.** I ran the 11 new tests (pass) and a clean upstream baseline of `tests/run_agent/` (1694/1694 in 224s). I have *not* got a clean full-repo `pytest tests/ -q` on the branch: my first attempt was run while switching branches underneath the process, which produced 254 uninterpretable failures for a tree that didn't even contain the fix. I discarded that result rather than report it. Flagging the gap honestly instead of checking the box. The branch is also currently based ~35 commits behind `main` and I'll rebase on request.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, internal recovery-path fix with no user-facing config or docs surface
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys (threshold and `protect_last_n` are internal constants; happy to promote them to `config.yaml` under `compression.` if maintainers prefer)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture change
- [x] I've considered cross-platform impact — N/A for OS specifics: pure in-memory string/dict manipulation, no file I/O, no process or path handling. Provider-specific though, since body limits differ; tested against `copilot`.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schema change

## Screenshots / Logs

Failing session, before the fix:

```
⚠️  API call failed (attempt 1/3): APIStatusError [HTTP 413]
   🔌 Provider: copilot  Model: claude-opus-5
   📝 Error: HTTP 413: Request Entity Too Large
   ⏱️  Context: 195 msgs, ~80,453 tokens
⚠️  Request payload too large (413) — compression attempt 3/3...
❌ Payload too large and cannot compress further.
```

Measured payload composition of that same session, from `~/.hermes/state.db`:

```
2 vision_analyze tool results : 5,627,202 bytes  (96.6% of body)
193 other messages            :   ~193,000 bytes ( 3.4% of body)
```

