### PR TITLE
fix(agent): require exact match in _interim_content_fully_streamed to prevent commentary truncation (#88954)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6563,14 +6563,30 @@ class AIAgent:
         )
         # Prefix match (not exact equality): the final response may be the
         # streamed text plus a trailing delta, or the stream may have been
-        # partial when the verify nudge fired.  In both cases the streamed
+        # partial when the verify nudge fired. In both cases the streamed
         # content is a prefix of the final — that's enough to mark it
-        # previewed (fails safe to a benign duplicate, never loses text).
-        # The reverse direction (streamed longer than final) is NOT matched:
-        # that could suppress a needed resend in the gateway path where
-        # already_streamed=True calls on_segment_break() instead of
-        # on_commentary() (#65919 review).
+        # previewed for internal conversation-loop tracking.
         return bool(streamed) and visible_content.startswith(streamed)
+
+    def _interim_content_fully_streamed(self, content: str) -> bool:
+        """True only when the stream delivered the exact visible content.
+
+        Used for gateway delivery decisions (#88954): a partial/prefix match marks a
+        truncated commentary as fully streamed when the delta stream cuts off at a
+        tool-call boundary. In that scenario, marking already_streamed=True causes
+        gateway/run.py to invoke on_segment_break() instead of on_commentary(),
+        permanently losing the tail of the text. Exact equality ensures that any
+        truncated delta triggers a full commentary delivery with the intact text.
+        """
+        visible_content = self._normalize_interim_visible_text(
+            self._strip_think_blocks(content or "")
+        )
+        if not visible_content:
+            return False
+        streamed = self._normalize_interim_visible_text(
+            self._strip_think_blocks(getattr(self, "_current_streamed_assistant_text", "") or "")
+        )
+        return bool(streamed) and visible_content == streamed
 
     def _extract_codex_interim_visible_parts(
         self,
@@ -6714,7 +6730,7 @@ class AIAgent:
             or self._interim_text_was_delivered(visible)
         ):
             return
-        already_streamed = self._interim_content_was_streamed(visible)
+        already_streamed = self._interim_content_fully_streamed(visible)
         try:
             from agent.plugin_stream_hooks import enqueue_plugin_stream_hook
 

--- a/tests/agent/test_interim_stream_truncation.py
+++ b/tests/agent/test_interim_stream_truncation.py
@@ -1,0 +1,123 @@
+"""
+Tests for interim commentary streaming and truncation handling (#88954).
+
+Ensures that partial streams truncated at tool-call boundaries are not falsely
+marked as `already_streamed` via `_interim_content_fully_streamed`, preventing
+tail-character data loss on streaming platforms like Telegram.
+"""
+
+import pytest
+from run_agent import AIAgent
+
+
+class TestInterimStreamTruncation:
+    def test_interim_content_fully_streamed_exact_match(self):
+        agent = AIAgent.__new__(AIAgent)
+        agent._current_streamed_assistant_text = "I am going to check the weather in Tokyo."
+        
+        # Exact match
+        assert agent._interim_content_fully_streamed("I am going to check the weather in Tokyo.") is True
+
+    def test_interim_content_fully_streamed_with_think_blocks(self):
+        agent = AIAgent.__new__(AIAgent)
+        agent._current_streamed_assistant_text = "<think>Let me see</think>I will search for the file."
+        
+        # Exact match after think-block stripping
+        assert agent._interim_content_fully_streamed("<think>Thinking...</think>I will search for the file.") is True
+
+    def test_interim_content_fully_streamed_truncated_prefix_returns_false(self):
+        """Regression test for #88954:
+        Partial stream truncated at tool-call boundary must return False in _interim_content_fully_streamed.
+        """
+        agent = AIAgent.__new__(AIAgent)
+        agent._current_streamed_assistant_text = "...to pick it u"
+        full_content = "...to pick it up"
+        
+        assert agent._interim_content_fully_streamed(full_content) is False
+
+    def test_interim_content_fully_streamed_empty_stream(self):
+        agent = AIAgent.__new__(AIAgent)
+        agent._current_streamed_assistant_text = ""
+        assert agent._interim_content_fully_streamed("Some content") is False
+        
+        agent._current_streamed_assistant_text = None
+        assert agent._interim_content_fully_streamed("Some content") is False
+
+    def test_interim_content_fully_streamed_empty_content(self):
+        agent = AIAgent.__new__(AIAgent)
+        agent._current_streamed_assistant_text = "Some streamed text"
+        assert agent._interim_content_fully_streamed("") is False
+        assert agent._interim_content_fully_streamed(None) is False
+
+    def test_interim_content_was_streamed_preserves_prefix_for_preview(self):
+        """_interim_content_was_streamed preserves prefix-match contract for internal preview marking."""
+        agent = AIAgent.__new__(AIAgent)
+        agent._current_streamed_assistant_text = "hello"
+        assert agent._interim_content_was_streamed("hello world") is True
+
+    def test_emit_interim_assistant_message_passes_already_streamed_false_on_truncation(self):
+        """When commentary is truncated in stream, _emit_interim_assistant_message
+        must pass already_streamed=False to callback so on_commentary delivers full text.
+        """
+        agent = AIAgent.__new__(AIAgent)
+        agent.show_commentary = True
+        agent.session_id = "test-session"
+        agent.model = "test-model"
+        agent.provider = "test-provider"
+        agent.platform = "telegram"
+        agent._delivered_interim_texts = set()
+        
+        # Stream got cut off
+        agent._current_streamed_assistant_text = "Checking database with a delayed sta"
+        
+        delivered_calls = []
+        def mock_callback(text, already_streamed=False):
+            delivered_calls.append((text, already_streamed))
+            
+        agent.interim_assistant_callback = mock_callback
+        
+        full_message = {
+            "role": "assistant",
+            "content": "Checking database with a delayed start",
+            "tool_calls": [{"id": "call_1", "function": {"name": "db_query", "arguments": "{}"}}],
+        }
+        
+        agent._emit_interim_assistant_message(full_message)
+        
+        assert len(delivered_calls) == 1
+        text, already_streamed = delivered_calls[0]
+        assert text == "Checking database with a delayed start"
+        assert already_streamed is False  # Must be False so gateway calls on_commentary()
+
+    def test_emit_interim_assistant_message_passes_already_streamed_true_on_complete_stream(self):
+        """When commentary is fully streamed, _emit_interim_assistant_message
+        passes already_streamed=True so gateway calls on_segment_break() without duplicate send.
+        """
+        agent = AIAgent.__new__(AIAgent)
+        agent.show_commentary = True
+        agent.session_id = "test-session"
+        agent.model = "test-model"
+        agent.provider = "test-provider"
+        agent.platform = "telegram"
+        agent._delivered_interim_texts = set()
+        
+        agent._current_streamed_assistant_text = "Checking database with a delayed start"
+        
+        delivered_calls = []
+        def mock_callback(text, already_streamed=False):
+            delivered_calls.append((text, already_streamed))
+            
+        agent.interim_assistant_callback = mock_callback
+        
+        full_message = {
+            "role": "assistant",
+            "content": "Checking database with a delayed start",
+            "tool_calls": [{"id": "call_1", "function": {"name": "db_query", "arguments": "{}"}}],
+        }
+        
+        agent._emit_interim_assistant_message(full_message)
+        
+        assert len(delivered_calls) == 1
+        text, already_streamed = delivered_calls[0]
+        assert text == "Checking database with a delayed start"
+        assert already_streamed is True  # True -> on_segment_break()

--- a/tests/gateway/test_loop_command.py
+++ b/tests/gateway/test_loop_command.py
@@ -33,9 +33,17 @@ def loop_env(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli import goals
+    from hermes_state import SessionDB
+
     loops._DB_CACHE.clear()
+    goals._DB_CACHE.clear()
+    db = SessionDB()
+    loops._DB_CACHE[str(home)] = db
+    goals._DB_CACHE[str(home)] = db
     yield home
     loops._DB_CACHE.clear()
+    goals._DB_CACHE.clear()
 
 
 def _make_runner():

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -450,6 +450,7 @@ async def test_session_chat_stream_treats_pre_existing_poisoned_row_as_no_model(
                 json={"message": "hi"},
             )
             assert resp.status == 200
+            await resp.read()
 
     _, kwargs = mock_run.call_args
     assert kwargs["session_model"] is None

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1738,10 +1738,23 @@ def test_interim_content_was_streamed_matches_prefix_not_exact(monkeypatch):
     assert agent._interim_content_was_streamed("") is False
 
     # Streamed is LONGER than final (reverse direction) — should NOT match.
-    # This is the unsafe direction: it could suppress a needed resend in the
-    # gateway path where already_streamed=True calls on_segment_break().
     agent._current_streamed_assistant_text = "hello world extra"
     assert agent._interim_content_was_streamed("hello") is False
+
+
+def test_interim_content_fully_streamed_requires_exact_match(monkeypatch):
+    """_interim_content_fully_streamed requires exact equality after normalization (#88954).
+    A strict prefix match marks truncated commentary as fully streamed, causing gateway
+    on_segment_break() to permanently drop trailing text on Telegram."""
+    agent = _build_agent(monkeypatch)
+
+    # Exact match works
+    agent._current_streamed_assistant_text = "hello world"
+    assert agent._interim_content_fully_streamed("hello world") is True
+
+    # Streamed is only a strict prefix of the final — must NOT match (#88954)
+    agent._current_streamed_assistant_text = "hello"
+    assert agent._interim_content_fully_streamed("hello world") is False
 
 
 


### PR DESCRIPTION
## Summary

Fixes #88954 where intermediate commentary (interim assistant messages preceding a tool call) gets truncated on streaming platforms (such as Telegram), permanently losing the tail characters of the message.

## How to Reproduce
1. Enable streaming on Telegram / Gateway (`display.platforms.telegram.streaming: true`).
2. Run a query where the model produces commentary text followed by an immediate tool call (e.g. `"Checking server logs with a delayed start"` followed by `run_command(...)`).
3. Observe that on Telegram, the stream cuts off before the tool call begins, leaving a truncated message in the chat (e.g. `"...to pick it u"` instead of `"...to pick it up"`, or `"...with a delayed sta"` instead of `"...with a delayed start"`).

## Root Cause
When the LLM finishes outputting text commentary and switches to `tool_calls` (`finish_reason="tool_calls"`), the streaming delta flow terminates. If the stream buffer held a partial delta prefix (e.g. `streamed = "...to pick it u"`), the completed assistant message in memory contains the intact full text (`visible_content = "...to pick it up"`).

In `run_agent.py`, `_interim_content_was_streamed()` used a prefix match (`visible_content.startswith(streamed)`). Because `"...to pick it up".startswith("...to pick it u")` evaluates to `True`, `_emit_interim_assistant_message()` erroneously reported `already_streamed = True`. 

Consequently:
- In `gateway/run.py:_interim_assistant_cb`, `already_streamed=True` caused `_stream_consumer.on_segment_break()` to be invoked instead of `_stream_consumer.on_commentary(display_text)`.
- `on_segment_break()` simply finalizes whatever draft was accumulated in the stream consumer (the truncated prefix), while `on_commentary()` (which would deliver or edit the full message) was never called.
- The trailing characters after the prefix were permanently lost in the chat.

## Changes Made
- Added `_interim_content_fully_streamed()` in `run_agent.py` enforcing **exact normalized equality** (`visible_content == streamed`) specifically for gateway commentary delivery decisions.
- Preserved `_interim_content_was_streamed()` (prefix match) for internal conversation-loop preview tracking.
- When stream text is truncated or missing the tail (`streamed != visible_content`), `already_streamed` evaluates to `False`, allowing `_stream_consumer.on_commentary(display_text)` to deliver the full completed message to Telegram.
- When the stream was 100% complete (`streamed == visible_content`), `already_streamed` evaluates to `True`, invoking `on_segment_break()` to finalize the draft without duplicate re-sends.

## Verification
- Added comprehensive unit test suite in `tests/agent/test_interim_stream_truncation.py` (8 tests):
  - Verified exact match returns `True` for `_interim_content_fully_streamed`.
  - Verified exact match with `<think>` blocks returns `True`.
  - Verified truncated stream prefixes return `False` (the #88954 regression test).
  - Verified empty/None streams return `False`.
  - Verified prefix match is preserved for `_interim_content_was_streamed`.
  - Verified `_emit_interim_assistant_message` passes `already_streamed=False` on truncated streams and `already_streamed=True` on fully streamed commentary.
- Updated `tests/run_agent/test_run_agent_codex_responses.py` with both prefix-preview and fully-streamed exact match tests.
- Full test pass:
  ```bash
  pytest tests/agent/test_interim_stream_truncation.py -v
  # 8 passed
  pytest tests/run_agent/test_run_agent_codex_responses.py -k "streamed"
  # 3 passed
  ```

## Infographic  

<img width="1376" height="768" alt="infographic_88954_visual" src="https://github.com/user-attachments/assets/39476698-f364-44a5-94cb-cf5716621366" />

Closes #88954
