### PR TITLE
fix(desktop): hide remote git subprocess consoles

### DIFF
--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -19,7 +19,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from hermes_cli._subprocess_compat import noninteractive_git_env
+from hermes_cli._subprocess_compat import noninteractive_git_env, windows_hide_flags
 
 _GIT_TIMEOUT = 30
 _GH_TIMEOUT = 30
@@ -49,6 +49,7 @@ def _git(cwd: str, args: list[str], *, timeout: int = _GIT_TIMEOUT) -> tuple[int
             timeout=timeout,
             stdin=subprocess.DEVNULL,
             env=noninteractive_git_env(),
+            creationflags=windows_hide_flags(),
         )
     except (OSError, subprocess.SubprocessError):
         return 1, "", "git invocation failed"

--- a/tests/hermes_cli/test_web_git_windows_console.py
+++ b/tests/hermes_cli/test_web_git_windows_console.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from hermes_cli import web_git
+
+
+class WebGitWindowsConsoleTests(unittest.TestCase):
+    def test_git_forwards_windows_hide_flags_to_subprocess(self) -> None:
+        sentinel = 0x08000000
+        completed = subprocess.CompletedProcess(
+            args=["git", "status"], returncode=0, stdout="ok", stderr=""
+        )
+
+        with (
+            patch.object(web_git, "windows_hide_flags", return_value=sentinel, create=True),
+            patch.object(web_git.subprocess, "run", return_value=completed) as run,
+        ):
+            code, stdout, stderr = web_git._git("C:/repo", ["status"])
+
+        self.assertEqual((code, stdout, stderr), (0, "ok", ""))
+        self.assertEqual(run.call_args.kwargs["creationflags"], sentinel)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Pass `CREATE_NO_WINDOW` through the remote Desktop Git REST helper on Windows.
- Add a regression test that asserts the flag reaches the Git subprocess.

## Why
Remote-gateway Git status and worktree refreshes are intentionally triggered by workspace/session UI updates. When the backend lacks a usable hidden console, these short-lived Git calls can allocate visible Windows Terminal windows repeatedly.

## Verification
- `python -m unittest tests.hermes_cli.test_web_git_windows_console -v`
- `python -m py_compile hermes_cli/web_git.py`
- Manual Windows observation: Git child processes continued to run while Windows Terminal/OpenConsole creation remained at zero after the launch-path fix.
