### PR TITLE
fix(streaming): stop losing the tail of commentary truncated at a tool-call boundary

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6572,6 +6572,31 @@ class AIAgent:
         # on_commentary() (#65919 review).
         return bool(streamed) and visible_content.startswith(streamed)
 
+    def _interim_content_fully_streamed(self, content: str) -> bool:
+        """Exact-equality variant for the gateway interim-message decision.
+
+        ``_interim_content_was_streamed`` keeps its prefix semantics for the
+        conversation-loop "previewed" marks (the streamed prefix IS on the
+        user's screen there). The gateway interim path is different: a True
+        verdict makes ``_interim_assistant_cb`` call ``on_segment_break()``,
+        which finalizes the streaming bubble as-is — anything after the
+        streamed prefix is never delivered. On Telegram the stream is
+        routinely truncated at the text→tool_calls boundary, so the prefix
+        match marked a truncated bubble complete and the tail was lost
+        (#88954). Only an exact match may skip the full-text resend; a
+        partial prefix falls through to ``on_commentary`` and re-delivers
+        the complete text (benign duplicate, never lost text).
+        """
+        visible_content = self._normalize_interim_visible_text(
+            self._strip_think_blocks(content or "")
+        )
+        if not visible_content:
+            return False
+        streamed = self._normalize_interim_visible_text(
+            self._strip_think_blocks(getattr(self, "_current_streamed_assistant_text", "") or "")
+        )
+        return bool(streamed) and streamed == visible_content
+
     def _extract_codex_interim_visible_parts(
         self,
         assistant_msg: Dict[str, Any],
@@ -6714,7 +6739,7 @@ class AIAgent:
             or self._interim_text_was_delivered(visible)
         ):
             return
-        already_streamed = self._interim_content_was_streamed(visible)
+        already_streamed = self._interim_content_fully_streamed(visible)
         try:
             from agent.plugin_stream_hooks import enqueue_plugin_stream_hook
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1771,10 +1771,65 @@ def test_interim_commentary_precedes_content_from_real_codex_normalization(monke
     }
 
 
+def test_interim_commentary_partial_stream_receives_full_text(monkeypatch):
+    """A stream truncated at the text→tool_calls boundary must not be marked
+    already_streamed (#88954).
+
+    On Telegram the streamed commentary is routinely cut mid-text when the
+    tool_calls finish arrives; the partial stream IS a prefix of the full
+    commentary. The old prefix-based verdict set already_streamed=True, the
+    gateway called on_segment_break() finalizing the truncated bubble, and
+    the tail ("...pick it u" vs "...pick it up") was permanently lost. Only
+    an exact match may skip the full-text resend."""
+    agent = _build_agent(monkeypatch)
+    observed = {}
+    agent.interim_assistant_callback = lambda text, *, already_streamed=False: observed.update(
+        {"text": text, "already_streamed": already_streamed}
+    )
+
+    agent._current_streamed_assistant_text = "checking the queue to pick it u"
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    normalized, finish_reason = _normalize_codex_response(
+        _codex_commentary_final_tool_response("checking the queue to pick it up")
+    )
+    assert finish_reason == "tool_calls"
+    agent._emit_interim_assistant_message(
+        agent._build_assistant_message(normalized, finish_reason)
+    )
+
+    # Prefix-only match: the gateway must receive the FULL text with
+    # already_streamed=False so on_commentary() re-delivers it.
+    assert observed == {
+        "text": "checking the queue to pick it up",
+        "already_streamed": False,
+    }
 
 
+def test_interim_commentary_exact_stream_still_marks_streamed(monkeypatch):
+    """The exact-equality fast path is preserved: a fully streamed commentary
+    keeps already_streamed=True so the gateway settles the bubble without a
+    duplicate resend."""
+    agent = _build_agent(monkeypatch)
+    observed = {}
+    agent.interim_assistant_callback = lambda text, *, already_streamed=False: observed.update(
+        {"text": text, "already_streamed": already_streamed}
+    )
 
+    agent._current_streamed_assistant_text = "checking the queue to pick it up"
+    from agent.codex_responses_adapter import _normalize_codex_response
 
+    normalized, finish_reason = _normalize_codex_response(
+        _codex_commentary_final_tool_response("checking the queue to pick it up")
+    )
+    agent._emit_interim_assistant_message(
+        agent._build_assistant_message(normalized, finish_reason)
+    )
+
+    assert observed == {
+        "text": "checking the queue to pick it up",
+        "already_streamed": True,
+    }
 
 
 


### PR DESCRIPTION
## What does this PR do?

Stops permanently losing the tail of streamed commentary when the stream is truncated at the text→tool_calls boundary (#88954). With streaming enabled on Telegram, the streamed commentary is routinely cut mid-text when the `tool_calls` finish arrives — the partial stream is a **prefix** of the full commentary. The interim-message path used the prefix-based `_interim_content_was_streamed` verdict, so the gateway's `_interim_assistant_cb` received `already_streamed=True` and called `on_segment_break()` — finalizing the truncated bubble as-is. The tail ("...to pick it u" instead of "...to pick it up") was never delivered. The reporter verified the provider is not at fault: the same proxy with tools streams the complete text.

The fix keeps the two consumers' semantics distinct:

- `_interim_content_was_streamed` (prefix match) **stays unchanged** — for the conversation-loop "previewed" marks the streamed prefix IS on the user's screen, and the contract test (`test_interim_content_was_streamed_matches_prefix_not_exact`, per the #65919 review) pins that behavior.
- New `_interim_content_fully_streamed` (exact normalized equality) is used for the **interim-message** verdict that feeds the gateway callback. Only an exact match may skip the full-text resend; a partial prefix falls through to `on_commentary()`, which re-delivers the complete text — a benign duplicate, never lost text (the outcome the old comment claimed but did not deliver on this path).

## Related Issue

Fixes #88954

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`
  - New `_interim_content_fully_streamed()`: same normalization pipeline, exact-equality verdict, with a docstring explaining why the gateway decision needs the stricter test.
  - `_emit_interim_assistant_message` uses the exact verdict for `already_streamed`.
- `tests/run_agent/test_run_agent_codex_responses.py`
  - `test_interim_commentary_partial_stream_receives_full_text`: a streamed prefix ("...pick it u") of the full commentary must yield `already_streamed=False` with the FULL text, so the gateway re-delivers it.
  - `test_interim_commentary_exact_stream_still_marks_streamed`: an exactly-streamed commentary keeps `already_streamed=True` (no duplicate resend).
  - The existing prefix-contract test is untouched and still passes.

## How to Test

1. `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q`
   Observed result: 49 passed (includes the untouched prefix-contract test).
2. Fail-on-main check: `git stash` the `run_agent.py` change and rerun `test_interim_commentary_partial_stream_receives_full_text` — Observed result: 1 failed (the truncated prefix is marked already_streamed, matching the reported loss).
3. Adjacent consumers: `pytest tests/run_agent/test_plugin_stream_hooks.py tests/run_agent/test_verification_continuation_budget.py tests/run_agent/test_tool_call_incremental_persistence.py -q` — Observed result: 25 passed, 7 failed; the same 7 fail identically on a stashed baseline (pre-existing local-environment failures, unrelated).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (codex responses suite: 49 passed; adjacent suites match the stashed baseline)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper's docstring documents the two-consumer split; or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string-comparison change; or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
