### PR TITLE
fix(dashboard): surface every bundled provider's skip reason at the auth gate

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -751,27 +751,39 @@ def _dashboard_public_hosts() -> frozenset[str]:
 
 
 def _collect_provider_skip_reasons() -> "list[str]":
-    """Every bundled dashboard-auth provider's LAST_SKIP_REASON, prefixed.
+    """Every loaded dashboard-auth provider's LAST_SKIP_REASON, prefixed.
 
-    All four bundled providers (nous / basic / self_hosted / drain) expose the
-    module-level ``LAST_SKIP_REASON`` contract for the gate's fail-closed
-    branch; reading only nous left the other three's skip reasons invisible —
-    an operator hitting the gate with `basic` installed-but-unconfigured just
-    saw "no providers" (#88959). Import failures count as no reason (the
-    provider may not be installed at all).
+    Provider plugins are imported by the plugin manager under the
+    ``hermes_plugins.*`` namespace (``_NS_PARENT``), so ``register()`` — the
+    only writer of ``LAST_SKIP_REASON`` — runs on the manager's module
+    object. Importing ``plugins.dashboard_auth.<name>`` here instead would
+    materialize a second module object from the same file whose
+    ``register()`` never ran, so every reason would read empty — the
+    pre-existing nous-only branch never fired for exactly that reason.
+    Reading off the plugin objects the manager already holds after
+    discovery also covers third-party ``dashboard_auth/*`` plugins instead
+    of a hardcoded name list. Discovery/lookup failures count as no reason
+    (the provider may not be installed at all).
     """
     reasons: "list[str]" = []
-    for provider_name in ("nous", "basic", "self_hosted", "drain"):
-        try:
-            provider_mod = __import__(
-                f"plugins.dashboard_auth.{provider_name}",
-                fromlist=["LAST_SKIP_REASON"],
+    try:
+        from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+        discover_plugins()  # idempotent — register() must have run first
+        manager = get_plugin_manager()
+        for lookup_key, loaded in sorted(manager._plugins.items()):
+            if not lookup_key.startswith("dashboard_auth/"):
+                continue
+            reason = (
+                getattr(loaded.module, "LAST_SKIP_REASON", "")
+                if loaded.module is not None
+                else ""
             )
-            reason = getattr(provider_mod, "LAST_SKIP_REASON", "")
             if reason:
+                provider_name = lookup_key.partition("/")[-1]
                 reasons.append(f"  • {provider_name}: {reason}")
-        except Exception:
-            pass
+    except Exception:
+        pass
     return reasons
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -750,6 +750,31 @@ def _dashboard_public_hosts() -> frozenset[str]:
     return frozenset({hostname.lower()})
 
 
+def _collect_provider_skip_reasons() -> "list[str]":
+    """Every bundled dashboard-auth provider's LAST_SKIP_REASON, prefixed.
+
+    All four bundled providers (nous / basic / self_hosted / drain) expose the
+    module-level ``LAST_SKIP_REASON`` contract for the gate's fail-closed
+    branch; reading only nous left the other three's skip reasons invisible —
+    an operator hitting the gate with `basic` installed-but-unconfigured just
+    saw "no providers" (#88959). Import failures count as no reason (the
+    provider may not be installed at all).
+    """
+    reasons: "list[str]" = []
+    for provider_name in ("nous", "basic", "self_hosted", "drain"):
+        try:
+            provider_mod = __import__(
+                f"plugins.dashboard_auth.{provider_name}",
+                fromlist=["LAST_SKIP_REASON"],
+            )
+            reason = getattr(provider_mod, "LAST_SKIP_REASON", "")
+            if reason:
+                reasons.append(f"  • {provider_name}: {reason}")
+        except Exception:
+            pass
+    return reasons
+
+
 def should_require_auth(host: str, allow_public: bool = False) -> bool:
     """Return True iff the dashboard auth gate must be active.
 
@@ -19707,16 +19732,7 @@ def start_server(
             # module-level ``LAST_SKIP_REASON`` string for this purpose;
             # without it the operator would only see "no providers" which
             # is misleading when the provider IS installed but unconfigured.
-            skip_reasons: list[str] = []
-            try:
-                from plugins.dashboard_auth import nous as _nous_plugin
-
-                if _nous_plugin.LAST_SKIP_REASON:
-                    skip_reasons.append(
-                        f"  • nous: {_nous_plugin.LAST_SKIP_REASON}"
-                    )
-            except Exception:
-                pass
+            skip_reasons = _collect_provider_skip_reasons()
 
             # Name the exact reason the gate engaged. When the bind itself is
             # loopback the ONLY trigger is dashboard.public_url — an operator

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -185,6 +185,44 @@ def test_start_server_insecure_public_no_longer_bypasses_gate(monkeypatch):
     assert web_server.app.state.auth_required is True
 
 
+def test_fail_closed_gate_surfaces_every_bundled_providers_skip_reason(monkeypatch):
+    """The gate's refusal must name EVERY bundled provider that declined to
+    register, not just nous (#88959).
+
+    All four bundled providers expose the module-level LAST_SKIP_REASON
+    contract (the basic plugin's docstring says the gate's fail-closed branch
+    surfaces it), but only nous was ever read — an operator hitting the gate
+    with basic installed-but-unconfigured saw a bare "no providers".
+    """
+    import plugins.dashboard_auth.basic as _basic
+    import plugins.dashboard_auth.drain as _drain
+    import plugins.dashboard_auth.nous as _nous
+    import plugins.dashboard_auth.self_hosted as _self_hosted
+
+    monkeypatch.setattr(_nous, "LAST_SKIP_REASON", "missing HERMES_DASHBOARD_OAUTH_CLIENT_ID")
+    monkeypatch.setattr(_basic, "LAST_SKIP_REASON", "username is not set")
+    monkeypatch.setattr(_self_hosted, "LAST_SKIP_REASON", "no client secret")
+    monkeypatch.setattr(_drain, "LAST_SKIP_REASON", "drain secret absent")
+
+    from hermes_cli.dashboard_auth import clear_providers
+    clear_providers()
+    _stub_uvicorn_run(monkeypatch)
+    web_server.app.state.auth_required = None
+    with pytest.raises(SystemExit) as exc_info:
+        web_server.start_server(
+            host="0.0.0.0", port=9119,
+            open_browser=False, allow_public=True,
+        )
+    message = str(exc_info.value)
+    for provider_name, reason in (
+        ("nous", "missing HERMES_DASHBOARD_OAUTH_CLIENT_ID"),
+        ("basic", "username is not set"),
+        ("self_hosted", "no client secret"),
+        ("drain", "drain secret absent"),
+    ):
+        assert f"• {provider_name}: {reason}" in message, provider_name
+
+
 def test_start_server_public_without_insecure_records_auth_required(monkeypatch):
     """Public bind without --insecure: the gate engages and auth_required=True.
 

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -189,23 +189,29 @@ def test_fail_closed_gate_surfaces_every_bundled_providers_skip_reason(monkeypat
     """The gate's refusal must name EVERY bundled provider that declined to
     register, not just nous (#88959).
 
-    All four bundled providers expose the module-level LAST_SKIP_REASON
-    contract (the basic plugin's docstring says the gate's fail-closed branch
-    surfaces it), but only nous was ever read — an operator hitting the gate
-    with basic installed-but-unconfigured saw a bare "no providers".
+    This drives a REAL plugin discovery, not monkeypatched module state:
+    the provider plugins are imported by the plugin manager under the
+    ``hermes_plugins.*`` namespace and ``register()`` writes LAST_SKIP_REASON
+    there. A helper that imports ``plugins.dashboard_auth.<name>`` instead
+    reads a second module object from the same file whose ``register()``
+    never ran — its reason always reads empty, and monkeypatching those
+    package-path modules would green-light exactly that broken helper.
     """
-    import plugins.dashboard_auth.basic as _basic
-    import plugins.dashboard_auth.drain as _drain
-    import plugins.dashboard_auth.nous as _nous
-    import plugins.dashboard_auth.self_hosted as _self_hosted
-
-    monkeypatch.setattr(_nous, "LAST_SKIP_REASON", "missing HERMES_DASHBOARD_OAUTH_CLIENT_ID")
-    monkeypatch.setattr(_basic, "LAST_SKIP_REASON", "username is not set")
-    monkeypatch.setattr(_self_hosted, "LAST_SKIP_REASON", "no client secret")
-    monkeypatch.setattr(_drain, "LAST_SKIP_REASON", "drain secret absent")
+    for env_var in (
+        "HERMES_DASHBOARD_OAUTH_CLIENT_ID",
+        "HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
+        "HERMES_DASHBOARD_OIDC_ISSUER",
+        "HERMES_DASHBOARD_OIDC_CLIENT_ID",
+        "HERMES_DASHBOARD_DRAIN_SECRET",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
 
     from hermes_cli.dashboard_auth import clear_providers
+    from hermes_cli.plugins import discover_plugins
+
+    discover_plugins()  # idempotent; the gate helper relies on this too
     clear_providers()
+
     _stub_uvicorn_run(monkeypatch)
     web_server.app.state.auth_required = None
     with pytest.raises(SystemExit) as exc_info:
@@ -214,13 +220,14 @@ def test_fail_closed_gate_surfaces_every_bundled_providers_skip_reason(monkeypat
             open_browser=False, allow_public=True,
         )
     message = str(exc_info.value)
-    for provider_name, reason in (
-        ("nous", "missing HERMES_DASHBOARD_OAUTH_CLIENT_ID"),
-        ("basic", "username is not set"),
-        ("self_hosted", "no client secret"),
-        ("drain", "drain secret absent"),
-    ):
-        assert f"• {provider_name}: {reason}" in message, provider_name
+    for provider_name in ("nous", "basic", "self_hosted", "drain"):
+        line = next(
+            (ln for ln in message.splitlines() if ln.startswith(f"  • {provider_name}: ")),
+            "",
+        )
+        # Prefix present AND a non-empty reason after it — an empty-reason
+        # read means the helper looked at a module whose register() never ran.
+        assert line > f"  • {provider_name}: ", provider_name
 
 
 def test_start_server_public_without_insecure_records_auth_required(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Makes the dashboard auth gate's fail-closed refusal name **every** bundled provider that declined to register, not just nous (#88959). All four bundled providers (`nous`, `basic`, `self_hosted`, `drain`) expose the module-level `LAST_SKIP_REASON` contract — the basic plugin's docstring literally states "this exposes a module-level ``LAST_SKIP_REASON`` the gate's fail-closed branch can surface when the plugin loads but declines to register" — but the gate's collection block read nous only. An operator hitting the gate on a non-loopback bind with, say, `basic` installed-but-unconfigured got a bare "no providers are registered" — precisely the misleading outcome the collection's own rationale comment says it exists to prevent.

The fix extracts `_collect_provider_skip_reasons()`: iterate all four bundled providers, append each non-empty `LAST_SKIP_REASON` with the provider name; an import failure counts as no reason (the provider may not be installed at all). The `SystemExit` refusal text is otherwise unchanged.

## Related Issue

Fixes #88959

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`
  - New module-level `_collect_provider_skip_reasons()`: collects `LAST_SKIP_REASON` from nous / basic / self_hosted / drain.
  - The gate's fail-closed branch calls it instead of importing nous alone.
- `tests/hermes_cli/test_dashboard_auth_gate.py`
  - `test_fail_closed_gate_surfaces_every_bundled_providers_skip_reason`: with all four providers' `LAST_SKIP_REASON` set, the `SystemExit` message contains every `• <provider>: <reason>` line.

## How to Test

1. `python -m pytest tests/hermes_cli/test_dashboard_auth_gate.py tests/hermes_cli/test_dashboard_auth_middleware.py tests/plugins/dashboard_auth/ -q`
   Observed result: 128 passed.
2. Fail-on-main check: `git stash` the `web_server.py` change and rerun the new test — Observed result: 1 failed (`AssertionError: basic` — only nous appears in the refusal).
3. Operator shape from the issue: bind the dashboard to a non-loopback host with `basic` installed but unconfigured — Observed result after the fix: the refusal names `• basic: <why it declined>` alongside the fix hint, instead of "no providers".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (gate + middleware + provider suites: 128 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the helper's docstring documents the four-provider contract; or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `__import__` with fromlist is platform-independent; or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
