### PR TITLE
feat(mcp): add Magnific to the MCP catalog

### DIFF
--- a/contributors/emails/dfradejas@magnific.com
+++ b/contributors/emails/dfradejas@magnific.com
@@ -1,0 +1,1 @@
+dfradehubs

--- a/optional-mcps/magnific/manifest.yaml
+++ b/optional-mcps/magnific/manifest.yaml
@@ -1,0 +1,145 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: magnific
+description: >-
+  Image, video, and audio generation plus Magnific upscaling, on your
+  Magnific/Freepik account.
+source: https://mcp.magnific.com
+
+# Official vendor-hosted remote MCP (URL-only — Hermes never spawns a local
+# process for this entry). Native MCP OAuth 2.1 + Dynamic Client Registration
+# against a Keycloak realm, so Hermes's MCP client + mcp_oauth_manager handle
+# discovery, PKCE, token exchange, and refresh with nothing to install.
+#
+#   401 www-authenticate  → resource_metadata=/.well-known/oauth-protected-resource
+#   protected resource    → authorization_servers: https://auth.magnific.com/realms/mcp
+#   registration_endpoint → .../clients-registrations/openid-connect
+#
+# Anonymous DCR is open here and accepts Hermes's default client_name
+# ("Hermes Agent"), so — unlike the figma entry — no client_name override is
+# needed. Scopes come from the server's scopes_supported; no oauth.scope pin.
+transport:
+  type: http
+  url: https://mcp.magnific.com
+
+auth:
+  type: oauth
+  # No `provider:` — native MCP OAuth, not a third-party provider like Google.
+  # The MCP client triggers the browser flow on the first probe / first connect.
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - magnific
+  hosts:
+    - magnific.com
+
+# Tool selection at install time:
+# Hermes discovers this server's tools itself — install_entry probes it and
+# shows the live checklist, so the list below is NOT the source of truth for
+# what exists. It does exactly two things (see _apply_tool_selection):
+#
+#   1. sets which rows come pre-checked in that live checklist, and
+#   2. is the fallback applied when the probe fails.
+#
+# (2) is the reason it is here rather than omitted. `_probe_tools` names
+# "OAuth not yet completed" as a failure cause, and this entry authorizes in
+# the browser on FIRST CONNECT — so at install time the probe is expected to
+# fail. With no list the fallback writes no `tools.include` at all, which
+# leaves every tool enabled: the server exposes ~100 of them, and at Hermes's
+# measured ~600 tokens/tool schema average that is ~60k tokens added to EVERY
+# API call, several times the entire Hermes core toolset. The curated 24 below
+# hold that to ~14k until the user refines it.
+#
+# The list therefore rots in the safe direction only. A name that no longer
+# exists upstream is dropped by the intersection in _apply_tool_selection; a
+# newly added tool simply is not pre-checked. Both are recovered with
+# `hermes mcp configure magnific`, which re-probes and re-opens the checklist.
+# The real fix — re-probing automatically once the OAuth flow lands — belongs
+# in the install path, not in a manifest.
+#
+# Deliberately excluded from the default (opt back in any time with
+# `hermes mcp configure magnific`):
+#   - creations_show, creations_upload_show, creations_list, library_show,
+#     mockups_show, flows_show, spaces_show, stock_show, images_models_show,
+#     video_models_show, audio_voices_show, design_auto_resize_show
+#                                     — inline MCP-UI widgets. They render an
+#     iframe for Apps-UI clients and their results carry no asset URL, so a
+#     terminal/TUI agent gets nothing back. The data-only twins
+#     (creations_get, creations_search, images_models_list, audio_voices_list, …)
+#     are included instead. Note creations_list is a widget despite the name
+#     ("filterable gallery widget" — it is creations_search that returns data).
+#   - creations_upload_image, creations_upload_file
+#                                     — superseded by the headless
+#     request_upload + finalize_upload pair, which is the documented path for
+#     non-UI clients.
+#   - spaces_*, flows_*, design_auto_*, projects_move, folders_*,
+#     library_*, mockups_*, models3d_*, stock_*, video_speak,
+#     video_dubbing, video_concatenate, images_generate_svg, images_to_svg,
+#     images_variations, images_relight, images_change_camera,
+#     images_skin_enhancer, images_crop, images_resize
+#                                     — Magnific product surfaces and niche
+#     transforms beyond the core generate/upscale loop.
+#   - team_activity, team_groups, team_members, team_usage_report,
+#     project_report, account_permissions, account_profile,
+#     creations_like, creations_comment, creations_move,
+#     creations_register_download, creation_status, simulate_flows,
+#     simulate_spaces                 — org admin, reporting, and social
+#     surfaces with no agent use case.
+tools:
+  default_enabled:
+    # Discovery — model slugs, per-mode params, and voice ids must be read
+    # before the generators below can be called correctly
+    - images_models_list
+    - images_upscale_modes_list
+    - video_models_list
+    - audio_voices_list
+    # Cost guardrail — every generation below spends credits
+    - simulate_cost
+    - account_balance
+    # Images
+    - images_generate
+    - images_upscale
+    - images_expand
+    - images_retouch
+    - images_remove_background
+    # Video — video_plan resolves the brief + model slug for video_generate,
+    # and video_upscale's required `mode` params come from its modes list
+    - video_plan
+    - video_generate
+    - video_upscale
+    - video_upscale_models_list
+    # Audio
+    - audio_tts
+    - audio_music_generate
+    - audio_sfx_generate
+    # Creation lifecycle (headless: submit → wait → fetch URL)
+    - creations_get
+    - creations_wait
+    - creations_search
+    - creations_tags
+    - creations_request_upload
+    - creations_finalize_upload
+
+post_install: |
+  On first connection Hermes opens a browser to authorize with Magnific
+  (or run `hermes mcp login magnific`). Approve access, then restart the
+  session so tools load.
+
+  Generation tools spend Magnific credits. `simulate_cost` prices a call
+  before you make it — pass the target tool name and the same arguments —
+  and `account_balance` reports what is left. See
+  https://magnific.com/pricing for plans.
+
+  Generation is asynchronous: the generate tools return creation
+  identifiers, `creations_wait` long-polls them (up to 8 per call, 25s
+  budget), and `creations_get` returns the final asset URLs. Chain steps by
+  passing the creation identifier, never a web URL.
+
+  A curated 24-tool subset is enabled by default (discovery, images, video,
+  audio, creation lifecycle). Spaces, flows, brand/library assets, mockups,
+  3D, stock, and team reporting are available but unchecked — enable them
+  any time with:
+    hermes mcp configure magnific


### PR DESCRIPTION
## What does this PR do?

Adds Magnific's official vendor-hosted remote MCP server (`https://mcp.magnific.com`) to the Nous-approved catalog as `optional-mcps/magnific/manifest.yaml` — image, video, and audio generation plus the Magnific upscalers, against the user's own Magnific (Freepik) account.

Manifest-only. No core changes: `transport: http` + `auth: oauth` means the existing MCP client and `mcp_oauth_manager` already cover this end to end, the same slot as `notion`, `stripe`, `linear`, and `comfy-cloud`.

**Placement note:** `CONTRIBUTING.md` routes third-party *product plugins* under `plugins/` to standalone repos. This is not that — it is a reviewed manifest for a hosted remote MCP, which is the documented path for vendor MCPs, with zero coupling into the tree.

## Related Issue

Fixes #88968

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/magnific/manifest.yaml` — new catalog entry
- `contributors/emails/dfradejas@magnific.com` — email → login mapping required by the `Contributor Attribution Check` CI job

### Auth — native MCP OAuth 2.1, verified against the live endpoint

```
POST https://mcp.magnific.com
  → 401 www-authenticate: Bearer resource_metadata="https://mcp.magnific.com/.well-known/oauth-protected-resource"
protected resource metadata
  → authorization_servers: ["https://auth.magnific.com/realms/mcp"]
  → scopes_supported: [openid, profile, email, mcp:custom-audience]
auth server metadata (Keycloak realm)
  → registration_endpoint: .../clients-registrations/openid-connect
  → code_challenge_methods_supported: [plain, S256]
```

Anonymous DCR is open and returns 201 for Hermes's default `client_name` (`"Hermes Agent"`) — verified with a throwaway registration. So unlike the `figma` entry this needs **no** `client_name` override in `apply_oauth_provider_defaults`, and **no** `oauth.scope` pin: scopes come from the server's `scopes_supported`. The manifest documents the whole chain inline so a reviewer can re-run it.

### Tool surface — curated 24-tool default

The server exposes ~100 tools. At the ~600 tokens/tool schema average cited in the `comfy-cloud` manifest that is ~60k tokens added to **every** API call while enabled, several times the entire Hermes core toolset. So the entry declares `tools.default_enabled` (~14k tokens) covering the headless *generate → poll → fetch-URL* loop:

| Group | Tools |
|---|---|
| Discovery | `images_models_list`, `images_upscale_modes_list`, `video_models_list`, `audio_voices_list` |
| Cost guardrail | `simulate_cost`, `account_balance` |
| Images | `images_generate`, `images_upscale`, `images_expand`, `images_retouch`, `images_remove_background` |
| Video | `video_plan`, `video_generate`, `video_upscale`, `video_upscale_models_list` |
| Audio | `audio_tts`, `audio_music_generate`, `audio_sfx_generate` |
| Creation lifecycle | `creations_get`, `creations_wait`, `creations_search`, `creations_tags`, `creations_request_upload`, `creations_finalize_upload` |

Discovery is not padding — `images_generate` needs a model `slug`, `images_upscale` and `video_upscale` need per-mode params, `audio_tts` needs a numeric `voiceId`, and `video_generate` resolves its brief and slug through `video_plan`; all of that only comes from those calls. Every enabled tool's schema was read individually to place it, which is how `creations_list` ended up excluded (it is a filterable gallery *widget* despite the name — `creations_search` is the data tool). `simulate_cost` / `account_balance` are in by default because every generation tool spends credits.

Two exclusions are Hermes-specific rather than taste, and are documented inline in the manifest:

- **The widget tools are MCP-UI, not data.** `creations_show`, `creations_list`, `library_show`, `mockups_show`, `flows_show`, `audio_voices_show`, `images_models_show`, etc. render an inline iframe for Apps-UI-capable clients and, per the server's own instructions, *carry no asset URL*. A terminal/TUI agent gets nothing usable back, so the data-only twins are enabled instead.
- **The UI upload path is superseded.** `creations_upload_image` / `creations_upload_file` are Apps-UI flows; the server documents `creations_request_upload` + `creations_finalize_upload` as the headless path, which is what ships enabled.

Also excluded by default (all one `hermes mcp configure magnific` away): Spaces, Flows, library/brand assets, mockups, 3D, stock, design auto-layout, `video_speak` / `video_dubbing` / `video_concatenate`, the niche image transforms, and every team-admin / reporting / social tool.

## How to Test

1. `python3 -m pytest tests/hermes_cli/test_mcp_catalog.py -q` — 25 passed, including `TestShippedCatalog::test_all_shipped_manifests_parse` and `…_are_version_locked` (the http transport has nothing to pin, so the version-lock contract is satisfied by exemption, same as the other hosted entries).
2. `hermes mcp catalog` — `magnific` appears as `available`.
3. `hermes mcp install magnific` — browser opens on `auth.magnific.com`; after approving, the tool checklist comes up with the 23 defaults pre-checked. Restart the session and the tools load.
4. Sanity round-trip: `images_generate` → `creations_wait` → `creations_get` returns the asset URL. `simulate_cost` first if you would rather not spend credits blind.
5. Reviewer check without an account: the four `curl` probes in the manifest header reproduce the auth chain above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (`gh search issues/prs --repo NousResearch/hermes-agent magnific` — nothing related)
- [x] My PR contains **only** changes related to this feature
- [x] I've run the relevant suites (`tests/hermes_cli/test_mcp_catalog.py`, `tests/ci/test_classify_changes.py`) and they pass
- [x] Tests: covered by the existing catalog contract tests, which parse and version-lock-check every shipped manifest. A per-entry test would be the change-detector pattern those tests explicitly avoid.
- [x] I've tested on my platform: macOS 15 (Darwin 25.6)

### Documentation & Housekeeping

- [x] Documentation — N/A. `website/docs/user-guide/features/mcp.md` describes the catalog generically and does not enumerate entries; the manifest carries its own `post_install` notes.
- [x] `cli-config.yaml.example` — N/A, no config keys.
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change.
- [x] Cross-platform — N/A. URL-only HTTP transport, no local process, no paths.

Note on the desktop surfaces: `apps/desktop/src/lib/mcp-directory.ts` says not to add new vendors (the catalog's `suggest:` block is the source of truth), and `mcp-brands.tsx` has no Magnific glyph in `@icons-pack/react-simple-icons`, so the pill falls back to a letter monogram — same as `comfy-cloud` and `n8n` today. Both deliberately untouched.
