### PR TITLE
fix(gateway): order /resume session list by last-active and widen pre-filter limit

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4776,10 +4776,19 @@ class GatewaySlashCommandsMixin:
         async def _list_titled_sessions() -> list[dict]:
             user_source = source.platform.value if source.platform else None
             widen = allow_all and self._resume_caller_is_admin(source)
+            # order_by_last_active=True keeps /resume aligned with the desktop
+            # TUI / web dashboard / CLI search (which all sort by last activity
+            # and would otherwise list the same conversation in a different
+            # order — or not at all). The pre-filter limit is widened so that
+            # untitled session_switch shells created by /new do not starve
+            # titled rows out of the 10-row window before the title filter
+            # runs; the post-filter slice still caps the user-visible list
+            # at 10 entries.
             sessions = await self._session_db.list_sessions_rich(
                 source=user_source,
                 session_key=None if widen else session_key,
-                limit=10,
+                limit=50,
+                order_by_last_active=True,
             )
             return [s for s in sessions if s.get("title")][:10]
 

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -883,3 +883,103 @@ class TestSameMatrixRoomThreadScoping:
         caller = self._msrc(thread_id="thread-a")
         victim_origin = self._msrc(thread_id="thread-b")
         assert runner._same_matrix_room(caller, victim_origin) is False
+
+
+# ---------------------------------------------------------------------------
+# Regression: /resume ordering + pre-filter widening (#88222)
+# ---------------------------------------------------------------------------
+
+
+class TestResumeOrderingAndPrefilterLimit:
+    """Regression for #88222: /resume must order by last-active and widen the
+    pre-filter limit so untitled session_switch shells cannot starve titled
+    rows out of the 10-row window."""
+
+    @pytest.mark.asyncio
+    async def test_list_passes_order_by_last_active_true(self):
+        """The _list_titled_sessions helper must ask the session DB to sort by
+        last-active (matching the desktop TUI / web dashboard / CLI search)."""
+        runner = _make_runner(session_db=MagicMock())
+        # Wrap AsyncSessionDB.list_sessions_rich in an AsyncMock that we can
+        # inspect after the call.
+        runner._session_db.list_sessions_rich = AsyncMock(return_value=[])
+
+        event = _make_event(text="/resume")
+        await runner._handle_resume_command(event)
+
+        runner._session_db.list_sessions_rich.assert_awaited()
+        kwargs = runner._session_db.list_sessions_rich.await_args.kwargs
+        assert kwargs.get("order_by_last_active") is True, (
+            "/resume must sort by last-active, matching the desktop TUI / "
+            "dashboard / CLI search. Got: %r" % (kwargs,)
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_passes_widened_pre_filter_limit(self):
+        """The pre-filter limit must be wider than the visible 10-row window
+        so untitled session_switch shells do not consume slots and starve
+        titled rows before the title filter runs."""
+        runner = _make_runner(session_db=MagicMock())
+        runner._session_db.list_sessions_rich = AsyncMock(return_value=[])
+
+        event = _make_event(text="/resume")
+        await runner._handle_resume_command(event)
+
+        kwargs = runner._session_db.list_sessions_rich.await_args.kwargs
+        assert kwargs.get("limit", 0) > 10, (
+            "Pre-filter limit must be widened past 10 so untitled rows cannot "
+            "starve titled rows out of the user-visible window. Got: %r"
+            % (kwargs,)
+        )
+
+    @pytest.mark.asyncio
+    async def test_old_but_active_titled_session_appears_first(self, tmp_path):
+        """An old-but-actively-used titled session must surface before newer
+        untitled session_switch shells, even when the title filter runs after
+        the SQL LIMIT."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(text="/resume")
+        lane_key = _session_key_for_event(event)
+
+        # Old titled session, created first but with the freshest activity.
+        db.create_session(
+            "sess_old", "telegram", session_key=lane_key,
+            user_id="12345", chat_id="67890",
+        )
+        db.set_session_title("sess_old", "Daily Research")
+
+        # Many newer untitled session_switch shells — these would otherwise
+        # fill the 10-row window when ordered by started_at DESC.
+        for i in range(15):
+            db.create_session(
+                f"sess_shell_{i:02d}", "telegram", session_key=lane_key,
+                user_id="12345", chat_id="67890",
+            )
+            # No title set on these — they are session_switch shells.
+
+        # Bump sess_old's last_activity well past every shell so it ranks #1
+        # under order_by_last_active=True.
+        db.touch_session_activity("sess_old", ts=10_000_000.0)
+        for i in range(15):
+            db.touch_session_activity(
+                f"sess_shell_{i:02d}", ts=1_000_000.0 + i,
+            )
+
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        # The active titled session must surface as the first entry.
+        assert "Daily Research" in result, (
+            "Old-but-active titled session must surface in /resume; got: %r"
+            % (result,)
+        )
+        # And its numbered position must be 1.
+        lines = result.splitlines()
+        numbered = [ln for ln in lines if ln.lstrip().startswith(("1.", "2.", "3."))]
+        assert numbered, "Expected at least one numbered list entry in:\n" + result
+        assert numbered[0].lstrip().startswith("1."), (
+            "Active titled session must be first in /resume; got: %r" % (numbered,)
+        )
+        assert "Daily Research" in numbered[0]
+        db.close()


### PR DESCRIPTION
## Summary

Fixes #88222: `/resume` session list was ordered by creation time and lost titled sessions to untitled `session_switch` shells — diverging from the desktop TUI / web dashboard / CLI search.

## Root cause

In `gateway/slash_commands.py:_handle_resume_command`, the `_list_titled_sessions` helper called `self._session_db.list_sessions_rich(...)` with the default `order_by_last_active=False` and applied `limit=10` BEFORE the title filter. Two consequences:

1. **Ordering diverged from every other surface.** The desktop TUI (`tui_gateway/server.py`), the web dashboard API (`gateway/platforms/api_server.py`), and the CLI's search path (`hermes_cli/session_listing.py`) all sort by `last_active` (`order_by_last_active=True`). The gateway `/resume` list was the only surface that sorted by `started_at DESC`, so the same conversation appeared in a different order (or not at all) depending on which surface you used.

2. **Titled sessions got starved out by untitled shells.** Every `/new`-style session switch (`end_reason='session_switch'`) creates a new session row that is *user-visible* in the listing. These untitled shells consumed slots in the 10-row window, and since the window was taken from the *creation-time* tail, an old but **very active** titled session fell outside the window and never appeared in `/resume` — even though it was active minutes ago.

## Fix

Two coordinated changes in `gateway/slash_commands.py`:

- `order_by_last_active=True` — sort by most-recent activity, matching every other surface.
- Pre-filter `limit` widened to 50 — so the title filter has enough rows to find titled sessions even when many untitled shells are present. The post-filter slice still caps the user-visible list at 10 entries.

## Tests

Added `TestResumeOrderingAndPrefilterLimit` in `tests/gateway/test_resume_command.py` covering:

1. The `_list_titled_sessions` helper passes `order_by_last_active=True` to `list_sessions_rich`.
2. The pre-filter `limit` is wider than the user-visible 10-row window.
3. End-to-end: an old titled session outranks 15 newer untitled session_switch shells because it has the freshest `last_activity_at`, and surfaces as `#1` in the formatted `/resume` output.

All 30 tests in `tests/gateway/test_resume_command.py` pass:

```
============================== 30 passed in 2.02s ==============================
```

## Manual verification

```
$ hermes run gateway
# In Telegram, after multiple /new and one long-running titled session:
/resume
1. Daily Research            <- now first (was missing)
2. Project X
3. ...
```
