### PR TITLE
fix(cron): route webui-origin jobs to home channels

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2145,6 +2145,76 @@ def _origin_delivery_thread(origin: dict):
     return origin.get("thread_id")
 
 
+def _resolve_origin_delivery_targets(job: dict) -> list[dict]:
+    """Resolve one or more possible delivery targets for `deliver=origin` jobs.
+
+    Known platforms resolve back to the exact origin chat/thread. Unknown origin
+    platforms (for example, the Hermes WebUI session platform) now fall back to
+    every connected home channel so the job still reaches users instead of
+    failing with an unrecognized platform error.
+    """
+    origin = _resolve_origin(job)
+    job_id = job.get("id") or job.get("name", "?")
+
+    if not origin:
+        # Origin missing (e.g. job created via API/script) — try each platform's
+        # home channel as a fallback instead of silently dropping.
+        for platform_name in _iter_home_target_platforms():
+            chat_id = _get_home_target_chat_id(platform_name)
+            if chat_id:
+                logger.info(
+                    "Job '%s' has deliver=origin but no origin; falling back to %s home channel",
+                    job_id,
+                    platform_name,
+                )
+                return [
+                    {
+                        "platform": platform_name,
+                        "chat_id": chat_id,
+                        "thread_id": _get_home_target_thread_id(platform_name),
+                    }
+                ]
+        return []
+
+    platform_name = str(origin.get("platform") or "").lower()
+    if not platform_name:
+        return []
+
+    if _is_known_delivery_platform(platform_name):
+        chat_id = origin.get("chat_id")
+        if chat_id is None:
+            return []
+        return [
+            {
+                "platform": platform_name,
+                "chat_id": str(chat_id),
+                "thread_id": _origin_delivery_thread(origin),
+            }
+        ]
+
+    logger.info(
+        "Job '%s' has deliver=origin from unsupported platform '%s'; falling back to home channels",
+        job_id,
+        platform_name,
+    )
+
+    # Preserve existing behavior for webui/other non-scheduled platforms by
+    # delivering to every configured home channel.
+    targets: list[dict] = []
+    for fallback_platform in _iter_home_target_platforms():
+        chat_id = _get_home_target_chat_id(fallback_platform)
+        if not chat_id:
+            continue
+        targets.append(
+            {
+                "platform": fallback_platform,
+                "chat_id": chat_id,
+                "thread_id": _get_home_target_thread_id(fallback_platform),
+            }
+        )
+    return targets
+
+
 def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[dict]:
     """Resolve one concrete auto-delivery target for a cron job."""
 
@@ -2154,27 +2224,18 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         return None
 
     if deliver_value == "origin":
-        if origin:
+        if not origin:
+            return None
+        platform_name = str(origin.get("platform") or "").lower()
+        if platform_name and _is_known_delivery_platform(platform_name):
+            chat_id = origin.get("chat_id")
+            if chat_id is None:
+                return None
             return {
-                "platform": origin["platform"],
-                "chat_id": str(origin["chat_id"]),
+                "platform": platform_name,
+                "chat_id": str(chat_id),
                 "thread_id": _origin_delivery_thread(origin),
             }
-        # Origin missing (e.g. job created via API/script) — try each
-        # platform's home channel as a fallback instead of silently dropping.
-        for platform_name in _iter_home_target_platforms():
-            chat_id = _get_home_target_chat_id(platform_name)
-            if chat_id:
-                logger.info(
-                    "Job '%s' has deliver=origin but no origin; falling back to %s home channel",
-                    job.get("name", job.get("id", "?")),
-                    platform_name,
-                )
-                return {
-                    "platform": platform_name,
-                    "chat_id": chat_id,
-                    "thread_id": _get_home_target_thread_id(platform_name),
-                }
         return None
 
     if ":" in deliver_value:
@@ -2317,6 +2378,18 @@ def _resolve_delivery_targets(job: dict) -> List[dict]:
     seen = set()
     targets = []
     for part in parts:
+        if part == "origin":
+            for target in _resolve_origin_delivery_targets(job):
+                key = (
+                    target["platform"].lower(),
+                    str(target["chat_id"]),
+                    target.get("thread_id"),
+                )
+                if key not in seen:
+                    seen.add(key)
+                    targets.append(target)
+            continue
+
         target = _resolve_single_delivery_target(job, part)
         if target:
             key = (target["platform"].lower(), str(target["chat_id"]), target.get("thread_id"))

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -16,9 +16,12 @@ from cron.scheduler import (
     _merge_mcp_into_per_job_toolsets,
     _resolve_cron_enabled_toolsets,
     _resolve_delivery_target,
+    _resolve_delivery_targets,
     _resolve_origin,
     _send_media_via_adapter,
     _summarize_cron_failure_for_delivery,
+    _HOME_TARGET_ENV_VARS,
+    _LEGACY_HOME_TARGET_ENV_VARS,
     run_job,
 )
 from tools.env_passthrough import clear_env_passthrough
@@ -178,6 +181,38 @@ class TestResolveDeliveryTarget:
             "chat_id": "-1001",
             "thread_id": "17585",
         }
+
+    def test_origin_delivery_from_unknown_platform_falls_back_to_all_home_channels(self, monkeypatch):
+        for var in set(_HOME_TARGET_ENV_VARS.values()) | set(_LEGACY_HOME_TARGET_ENV_VARS.values()):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-111")
+        monkeypatch.setenv("WHATSAPP_HOME_CHANNEL", "+999")
+
+        job = {
+            "deliver": "origin",
+            "origin": {
+                "platform": "webui",
+                "chat_id": "home-chat",
+            },
+        }
+
+        targets = _resolve_delivery_targets(job)
+        assert {target["platform"] for target in targets} == {"telegram", "whatsapp"}
+        assert {target["chat_id"] for target in targets} == {"-111", "+999"}
+
+    def test_origin_delivery_from_unknown_platform_without_home_channels_drops_target(self, monkeypatch):
+        for var in set(_HOME_TARGET_ENV_VARS.values()) | set(_LEGACY_HOME_TARGET_ENV_VARS.values()):
+            monkeypatch.delenv(var, raising=False)
+
+        job = {
+            "deliver": "origin",
+            "origin": {
+                "platform": "webui",
+                "chat_id": "home-chat",
+            },
+        }
+
+        assert _resolve_delivery_targets(job) == []
 
 
     def test_bare_platform_delivery_uses_home_root_instead_of_origin_thread(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Fix cron `deliver=origin` resolution when origin platform is not a known delivery platform (for example `webui`).
- Keep existing behavior for known platforms while routing unknown-origin jobs to all configured home channels instead of dropping delivery.
- Add regression tests for webui-origin fallback and no-home-channel behavior.

## Test Plan
- [x] python3 -m py_compile cron/scheduler.py tests/cron/test_scheduler.py
- [x] pytest -q tests/cron/test_scheduler.py -k "origin_delivery"
- [x] pytest -q tests/cron/test_scheduler.py

Closes #87932
