### PR TITLE
fix(cli): correct compact banner border width

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4611,7 +4611,7 @@ def _build_compact_banner() -> str:
         return f"\n[{title_color}]{tiny_line}[/] [dim {dim_color}]- Nous Research[/]\n"
 
     inner = w - 2  # inside the box border
-    bar = "═" * w
+    bar = "═" * inner
     content_width = inner - 2
 
     # Truncate and pad to fit


### PR DESCRIPTION
## Summary

The compact/minimal startup banner box renders two columns too wide on its top and bottom borders, so the corners (`╔ ╗ ╚ ╝`) stick out past the `║` side edges instead of forming a clean rectangle.

## Root cause

In `_build_compact_banner()` (`cli.py`), the border bar was sized as `"═" * w`:

- top/bottom border = `╔` + `═`×w + `╗` = `w + 2` columns
- content lines = `║` + ` ` + `w - 4` + ` ` + `║` = `w` columns

`inner` (`w - 2`) was already computed but never used. The border must be `w - 2` characters so the full box is `w` columns wide and aligns with the vertical edges.

## Change

```diff
-    bar = "═" * w
+    bar = "═" * inner
```

## Before / after (w = 40)

```
Before                          After
╔═══════════════════════════════╗  ╔══════════════════════════════╗
║ Sisyphus Agent - AI Agent F…  ║  ║ Sisyphus Agent - AI Agent F… ║
╚═══════════════════════════════╝  ╚══════════════════════════════╝
  42 cols (corners jut out)        40 cols (aligned)
```

## Test plan

- Rebuilt the box math for `w = 40` and `w = 88`; top/mid/bottom lines all equal `w` columns after the change.
- No behavior change for the full (non-compact) banner path.