### PR TITLE
fix(desktop): map URL-remote per-profile label to backend profile via remoteProfile (#88282)

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -233,6 +233,37 @@ test('SSH remains separate from URL-shaped remote modes and preserves an explici
   })
 })
 
+test('profileRemoteOverride preserves an explicit remote profile mapping on a URL override', () => {
+  const config = {
+    profiles: { gris: { mode: 'remote', url: 'https://agent.example.com/hermes', remoteProfile: 'main-gris' } }
+  }
+
+  assert.deepEqual(profileRemoteOverride(config, 'gris'), {
+    url: 'https://agent.example.com/hermes',
+    authMode: 'token',
+    token: undefined,
+    remoteProfile: 'main-gris'
+  })
+})
+
+test('profileRemoteOverride drops invalid or reserved remote profile mappings', () => {
+  assert.equal(
+    profileRemoteOverride({ profiles: { p: { mode: 'remote', url: 'https://x', remoteProfile: 'bad profile' } } }, 'p')
+      ?.remoteProfile,
+    undefined
+  )
+  assert.equal(
+    profileRemoteOverride({ profiles: { p: { mode: 'cloud', url: 'https://x', remoteProfile: 'root' } } }, 'p')
+      ?.remoteProfile,
+    undefined
+  )
+  assert.equal(
+    profileRemoteOverride({ profiles: { p: { mode: 'remote', url: 'https://x', remoteProfile: '' } } }, 'p')
+      ?.remoteProfile,
+    undefined
+  )
+})
+
 test('normalizeSshConfig rejects unsafe remote profile mappings', () => {
   assert.deepEqual(normalizeSshConfig({ mode: 'ssh', host: 'box', remoteProfile: 'writer_2' }), {
     mode: 'ssh',
@@ -550,6 +581,32 @@ test('pathWithGlobalRemoteProfile translates a desktop SSH alias in an explicit 
       backendProfile: 'default'
     }),
     '/api/cron/jobs?profile=default'
+  )
+})
+
+test('pathWithGlobalRemoteProfile translates a URL-remote override alias via backendProfile', () => {
+  // A URL-remote per-profile override (gris → main-gris) must rewrite the
+  // self-profile scope the same way the SSH mapping does, or the backend 404s
+  // on a profile it does not have (#88282).
+  assert.equal(
+    pathWithGlobalRemoteProfile('/api/cron/jobs?profile=gris', 'gris', {
+      globalRemote: false,
+      profileRemoteOverride: true,
+      backendProfile: 'main-gris'
+    }),
+    '/api/cron/jobs?profile=main-gris'
+  )
+})
+
+test('pathWithGlobalRemoteProfile keeps the local label when a URL override has no mapping', () => {
+  // Blank remoteProfile → the label itself is the scope (historical behavior).
+  assert.equal(
+    pathWithGlobalRemoteProfile('/api/cron/jobs?profile=gris', 'gris', {
+      globalRemote: false,
+      profileRemoteOverride: true,
+      backendProfile: undefined
+    }),
+    '/api/cron/jobs?profile=gris'
   )
 })
 

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -491,8 +491,26 @@ function profileRemoteOverride(config, profile) {
     url,
     authMode: normAuthMode(entry.authMode),
     token: entry.token,
-    ...(Object.keys(headers).length > 0 ? { headers } : {})
+    ...(Object.keys(headers).length > 0 ? { headers } : {}),
+    // A URL-remote/cloud host serves every profile via ?profile=, so a Desktop
+    // profile that is only a routing label (e.g. `gris` for the backend's
+    // `main-gris`) can map its explicit self-profile scope into the backend's
+    // namespace — same contract as the managed-SSH `remoteProfile`.
+    ...(normalizeRemoteProfileName(entry.remoteProfile) ?? {})
   }
+}
+
+// Validate a remote profile mapping the same way the SSH path does (a valid
+// Hermes profile identifier, never a reserved alias). Invalid/blank → no
+// mapping, so callers fall back to the historical same-name behavior.
+function normalizeRemoteProfileName(value) {
+  const remoteProfile = String(value || '').trim()
+
+  if (/^[a-z0-9][a-z0-9_-]{0,63}$/.test(remoteProfile) && !RESERVED_REMOTE_PROFILES.has(remoteProfile)) {
+    return { remoteProfile }
+  }
+
+  return null
 }
 
 export interface ProfileRouteOptions {
@@ -934,6 +952,7 @@ export {
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
   normalizeRemoteHeaders,
+  normalizeRemoteProfileName,
   normalizeSshConfig,
   normAuthMode,
   pathWithGlobalRemoteProfile,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -78,6 +78,7 @@ import {
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
   normalizeRemoteHeaders,
+  normalizeRemoteProfileName,
   normalizeSshConfig,
   normAuthMode,
   pathWithGlobalRemoteProfile,
@@ -8129,6 +8130,7 @@ function sanitizeConnectionProfiles(raw: Record<string, any>) {
       token?: object
       headers?: object
       org?: string
+      remoteProfile?: string
       savedSsh?: object
     } = {
       mode: modeIsRemoteLike(entry.mode) ? entry.mode : 'local'
@@ -8152,6 +8154,14 @@ function sanitizeConnectionProfiles(raw: Record<string, any>) {
 
     if ((entry as any).token && typeof entry.token === 'object') {
       cleaned.token = entry.token
+    }
+
+    // A URL-remote/cloud per-profile override can map its Desktop routing label
+    // onto the backend's profile namespace (same contract as SSH remoteProfile).
+    const remoteProfileName = normalizeRemoteProfileName((entry as any).remoteProfile)
+
+    if (remoteProfileName) {
+      cleaned.remoteProfile = remoteProfileName.remoteProfile
     }
 
     const headers = normalizeRemoteHeaders((entry as any).headers)
@@ -8553,12 +8563,19 @@ async function sanitizeDesktopConnectionConfig(config = readDesktopConnectionCon
 // `org` (optional) is the Hermes Cloud org slug/id the instance was discovered
 // under — persisted so Settings can reopen into the same org; omitted from the
 // block when empty so plain remote connections stay unchanged.
-function buildRemoteBlock(remoteUrl, authMode, token, org?: string, headers?: object) {
+function buildRemoteBlock(remoteUrl, authMode, token, org?: string, headers?: object, remoteProfile?: string) {
   if (authMode !== 'oauth' && !decryptDesktopSecret(token)) {
     throw new Error('Remote gateway session token is required.')
   }
 
-  const block: { url: string; authMode: string; token: object; headers?: object; org?: string } = {
+  const block: {
+    url: string
+    authMode: string
+    token: object
+    headers?: object
+    org?: string
+    remoteProfile?: string
+  } = {
     url: normalizeRemoteBaseUrl(remoteUrl),
     authMode,
     token
@@ -8574,6 +8591,12 @@ function buildRemoteBlock(remoteUrl, authMode, token, org?: string, headers?: ob
 
   if (orgValue) {
     block.org = orgValue
+  }
+
+  const remoteProfileName = normalizeRemoteProfileName(remoteProfile)
+
+  if (remoteProfileName) {
+    block.remoteProfile = remoteProfileName.remoteProfile
   }
 
   return block
@@ -8650,7 +8673,7 @@ function coerceDesktopConnectionConfig(input: any = {}, existing = readDesktopCo
     if (remoteLike) {
       profiles[key] = {
         mode,
-        ...buildRemoteBlock(remoteUrl, authMode, nextToken, cloudOrg, remoteHeaders)
+        ...buildRemoteBlock(remoteUrl, authMode, nextToken, cloudOrg, remoteHeaders, input.remoteProfile)
       }
     } else {
       const localEntry = localProfileEntry(rawExistingBlock)
@@ -9655,15 +9678,17 @@ function primaryProfileKey() {
 function profileRouteOptions(profile, request?) {
   const config = readDesktopConnectionConfig()
   const sshOverride = profileSshOverride(config, profile)
+  const urlOverride = profileRemoteOverride(config, profile)
   const key = connectionScopeKey(profile) || primaryProfileKey()
 
   return {
     // A desktop profile can be only a client-side routing alias. Keep backend
-    // endpoint filters in the SSH target's namespace (e.g. mara → default).
-    backendProfile: sshOverride?.remoteProfile,
+    // endpoint filters in the target's namespace (e.g. mara → default for a
+    // managed SSH, gris → main-gris for a URL-remote/cloud per-profile host).
+    backendProfile: sshOverride?.remoteProfile || urlOverride?.remoteProfile,
     globalRemote: globalRemoteActive(),
     primaryProfile: primaryProfileKey(),
-    profileRemoteOverride: Boolean(profileRemoteOverride(config, profile) || sshOverride),
+    profileRemoteOverride: Boolean(urlOverride || sshOverride),
     // The primary profile's own backend resolves to a remote host (its
     // per-profile override, env, or global). Unknown sub-profiles on that
     // gateway must route THROUGH it, not spawn local backends (#88296).

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -762,6 +762,9 @@ export interface DesktopConnectionConfigInput {
   sshKeyPath?: string
   sshRemoteHermesPath?: string
   sshRemoteProfile?: string
+  // For a URL-remote/cloud per-profile override: the profile name on the remote
+  // host when it differs from this Desktop routing label.
+  remoteProfile?: string
 }
 
 export interface DesktopConnectionTestResult {


### PR DESCRIPTION
Fixes #88282.

**Root cause:** A Desktop profile with a per-profile URL-remote/cloud gateway override sent its own routing label as the `?profile=` scope on every scoped REST call (e.g. `/api/cron/jobs?profile=gris`). On a remote backend whose actual profiles are named differently (e.g. `main-gris`), every scoped request 404'd — cron lists, bot chats, and session listings. The managed-SSH path already handled this via a `remoteProfile` mapping fed into `translateSelfProfileQuery`/backendProfile, but URL-remote overrides had no equivalent field and dropped any such value on read/save.

**Fix:** Mirror the SSH mapping for URL-remote/cloud per-profile overrides, entirely in the routing/config layer:
- `connection-config.ts`: `normalizeRemoteProfileName()` validates a remote profile name (same rules as SSH), and `profileRemoteOverride()` now preserves it on the resolved override.
- `main.ts`: `profileRouteOptions()` feeds the URL override's `remoteProfile` into `backendProfile`, so the existing `translateSelfProfileQuery` path rewrites the self-profile scope (`?profile=gris` → `?profile=main-gris`); `sanitizeConnectionProfiles`, `buildRemoteBlock`, and `coerceDesktopConnectionConfig` now round-trip the field so it survives saves. The upstream #88296 routing additions are preserved.
- `global.d.ts`: `DesktopConnectionConfigInput.remoteProfile?` documents the save-payload field.
- Tests: 5 new `connection-config` tests covering preservation, invalid/reserved rejection, and the translate-vs-fallback path.

The per-profile settings UI was removed upstream (commit 6170f844c), so there is no Settings field for this; the mapping is configured via the connection config file's `profiles.<name>.remoteProfile`, consistent with how per-profile overrides are stored.

**Verification:** electron vitest `connection-config` (109 pass incl. 5 new), ui settings + boot-failure tests (24 pass), `tsc -p .` and `tsc -p tsconfig.electron.json` clean, eslint + prettier clean on touched files.
