### PR TITLE
chore: release v0.20.4 (2026.8.18)

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.20.3"
-__release_date__ = "2026.8.16.2"
+__version__ = "0.20.4"
+__release_date__ = "2026.8.18"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "hermes-agent"
-version = "0.20.3"
+version = "0.20.4"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-03T10:31:33.382785373Z"
+exclude-newer = "2026-08-04T07:06:16.774262776Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -1569,7 +1569,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.20.3"
+version = "0.20.4"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
Version bump for the v0.20.4 rollup patch release (CalVer v2026.8.18). Rolls up the ~74 PRs (~146 commits) merged since v0.20.3 into a stable tagged release. Full curated notes for the whole 0.20.x window ship with v0.21.0 per standing patch-release policy.

## Changes
- `hermes_cli/__init__.py`: `__version__` 0.20.3 → 0.20.4, `__release_date__` → 2026.8.18
- `pyproject.toml`: version 0.20.4
- `uv.lock`: regenerated (self-reference bump; `uv lock --check` clean under uv 0.9.28, the CI pin)

## Validation
| Gate | Result |
|---|---|
| Anchored stale-version grep (`0.20.3`) | zero hits |
| `uv lock --check` (uv 0.9.28) | clean |
| Revert scan (window) | 1 revert — a ci.yml cache-bust nudge reverting itself; no shipped-feature loss |
| Commit staged set | exactly `__init__.py` + `pyproject.toml` + `uv.lock` |

## Infographic

![v0.20.4 patch release](https://v3b.fal.media/files/b/0aa6cd4d/95QzWxW_BxwROgCcv5i3L_UuTcnm69.png)
